### PR TITLE
fix(tui): restore persisted tool durations on transcript replay

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -282,7 +282,7 @@ from local_operator.tui.widgets.toast import (
     format_mcp_startup,
 )
 from local_operator.tui.widgets.todo_panel import TodoPanel
-from local_operator.tui.widgets.tool_card import ToolCard, clean_intent
+from local_operator.tui.widgets.tool_card import ToolCard, clean_intent, parse_duration
 from local_operator.tui.widgets.transcript import (
     BOOT_COLUMN_CLASS,
     DEFAULT_ACTIVITY,
@@ -7448,12 +7448,31 @@ class OperatorApp(App[None]):
         ``_replay_tool_call`` — a call killed mid-execution persists as an
         error result whose text starts with ``aborted (``, which the live
         frame renders as ``interrupted``, not an error.
+
+        "Same derivation" includes the persisted ``duration_s``: this is the
+        SECOND settled-replay path (``replay_history`` picks between it and
+        ``replay_tool_call`` by whether a card is already painted), and a row
+        that reads blank here while a cold resume of the same transcript reads
+        ``7.2s`` is the live/replay gap reopened one file over. Both paths read
+        the same key off the same payload through the same parser.
         """
         result_text = getattr(result, "text", "") or ""
         payload = getattr(result, "provider_payload", None) or {}
-        details = payload.get("details") if isinstance(payload, dict) else None
+        is_dict = isinstance(payload, dict)
+        details = payload.get("details") if is_dict else None
+        # Validated, never trusted, and for the same reason as in
+        # `replay_tool_call`: the value arrives from a durable transcript
+        # another process may have written, so anything that is not a finite
+        # non-negative number degrades to the blank column rather than
+        # crashing the formatter or inventing a `0.0s`.
+        duration_s = parse_duration(payload.get("duration_s")) if is_dict else None
         if getattr(result, "is_error", False) and result_text.startswith("aborted ("):
-            card.restore(state="interrupted")
+            # The duration IS known here: a bang command the user stopped
+            # parks a synthetic aborted result carrying the measured interval,
+            # and the live card `mark_interrupted()` painted showed it. The
+            # dim `interrupted ⊘` presentation stays (design round 1, D1) —
+            # only the number it was dropping comes back.
+            card.restore(state="interrupted", duration_s=duration_s)
             return
         if getattr(result, "is_error", False):
             card.restore(
@@ -7461,9 +7480,15 @@ class OperatorApp(App[None]):
                 result_text=result_text,
                 details=details,
                 error=_first_line(result_text),
+                duration_s=duration_s,
             )
         else:
-            card.restore(state="success", result_text=result_text, details=details)
+            card.restore(
+                state="success",
+                result_text=result_text,
+                details=details,
+                duration_s=duration_s,
+            )
         self._append_image_blocks(
             [
                 block

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -7467,11 +7467,14 @@ class OperatorApp(App[None]):
         # crashing the formatter or inventing a `0.0s`.
         duration_s = parse_duration(payload.get("duration_s")) if is_dict else None
         if getattr(result, "is_error", False) and result_text.startswith("aborted ("):
-            # The duration IS known here: a bang command the user stopped
-            # parks a synthetic aborted result carrying the measured interval,
-            # and the live card `mark_interrupted()` painted showed it. The
-            # dim `interrupted ⊘` presentation stays (design round 1, D1) —
-            # only the number it was dropping comes back.
+            # Symmetric with `replay_tool_call`'s aborted arm, including its
+            # limits — see the long note there for the provenance. In short:
+            # the parenthesised text is `execute_bash`/`eval`'s own, built by
+            # `_error(...)`, which stamps no `duration_s`; the loop's
+            # `ABORTED_RESULT_TEXT` has no paren and takes the error arm. So
+            # this restore is inert on every producer known today and exists
+            # so the row stays faithful if one ever carries the interval.
+            # The dim `interrupted ⊘` presentation stays (design round 1, D1).
             card.restore(state="interrupted", duration_s=duration_s)
             return
         if getattr(result, "is_error", False):

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -814,12 +814,16 @@ def replay_tool_call(
     result = results.get(getattr(call, "id", "") or "")
     if result is None:
         # No result recorded: the session ended between the call and its
-        # answer. Showing it as complete would invent an outcome.
+        # answer. Showing it as complete would invent an outcome, and there is
+        # no measured interval to restore either — the distinction that governs
+        # the duration column is result-present vs result-absent, and this is
+        # the only arm on the absent side.
         card.restore(state="interrupted")
         return
     result_text = getattr(result, "text", "") or ""
     payload = getattr(result, "provider_payload", None) or {}
-    details = payload.get("details") if isinstance(payload, dict) else None
+    is_dict = isinstance(payload, dict)
+    details = payload.get("details") if is_dict else None
     # Validated, never trusted: the key is absent on every row written before
     # durations were persisted, and a transcript is an on-disk file another
     # process may have written. `parse_duration` degrades anything that is not
@@ -827,14 +831,23 @@ def replay_tool_call(
     # column a legacy row paints — the one honest answer when the interval is
     # unknown. Replay must not fail on a bad value, and must not invent a
     # ``0.0s`` that says the tool returned instantly.
-    duration_s = parse_duration(payload.get("duration_s")) if isinstance(payload, dict) else None
+    duration_s = parse_duration(payload.get("duration_s")) if is_dict else None
     if getattr(result, "is_error", False) and result_text.startswith("aborted ("):
         # A user-stopped bang command persists as an error result (the
         # model-facing shape), but the LIVE frame it came from was the dim
         # shut `interrupted ⊘` row. Replaying it through the error branch
         # would reopen the user's own Esc as a red failure (design round
         # 1, D1). The aborted prefix is execute_bash's stable contract.
-        card.restore(state="interrupted")
+        #
+        # The duration still comes back. Unlike the `result is None` arm
+        # above, this row HAS a recorded result and it carries the interval:
+        # `harness/loop.py` parks the synthetic aborted result with
+        # `duration_s=time.monotonic() - started_at`, and the live card's
+        # `mark_interrupted()` stamped the same elapsed time on screen. "How
+        # long did it run before I killed it" is the question this row exists
+        # to answer, and one Esc marks EVERY tool in flight — so blanking it
+        # opens the hole across a whole run of rows.
+        card.restore(state="interrupted", duration_s=duration_s)
         return
     if getattr(result, "is_error", False):
         card.restore(

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -796,10 +796,13 @@ def replay_tool_call(
 
     The card is built exactly as a live one is — same constructor, same
     summary derivation from the arguments — so a resumed row is
-    indistinguishable from the row the user watched run, apart from the
-    duration the transcript never recorded.
+    indistinguishable from the row the user watched run, including its
+    duration: the harness persists the executor's measured interval as
+    ``provider_payload.duration_s`` beside the result's ``details``, and it is
+    restored here rather than recomputed from when this row was mounted.
     """
     from local_operator.tui.app import ImageContent, ToolCard, _first_line
+    from local_operator.tui.widgets.tool_card import parse_duration
 
     card = ToolCard(
         getattr(call, "id", "") or "",
@@ -817,6 +820,14 @@ def replay_tool_call(
     result_text = getattr(result, "text", "") or ""
     payload = getattr(result, "provider_payload", None) or {}
     details = payload.get("details") if isinstance(payload, dict) else None
+    # Validated, never trusted: the key is absent on every row written before
+    # durations were persisted, and a transcript is an on-disk file another
+    # process may have written. `parse_duration` degrades anything that is not
+    # a finite non-negative number to ``None``, which paints the same blank
+    # column a legacy row paints — the one honest answer when the interval is
+    # unknown. Replay must not fail on a bad value, and must not invent a
+    # ``0.0s`` that says the tool returned instantly.
+    duration_s = parse_duration(payload.get("duration_s")) if isinstance(payload, dict) else None
     if getattr(result, "is_error", False) and result_text.startswith("aborted ("):
         # A user-stopped bang command persists as an error result (the
         # model-facing shape), but the LIVE frame it came from was the dim
@@ -831,9 +842,15 @@ def replay_tool_call(
             result_text=result_text,
             details=details,
             error=_first_line(result_text),
+            duration_s=duration_s,
         )
     else:
-        card.restore(state="success", result_text=result_text, details=details)
+        card.restore(
+            state="success",
+            result_text=result_text,
+            details=details,
+            duration_s=duration_s,
+        )
     # Same rule as `on_tool_ended`: a result carrying image blocks shows
     # them under the settled card, so a resumed session's screenshots are
     # back on screen exactly where the live session showed them.

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -833,20 +833,37 @@ def replay_tool_call(
     # ``0.0s`` that says the tool returned instantly.
     duration_s = parse_duration(payload.get("duration_s")) if is_dict else None
     if getattr(result, "is_error", False) and result_text.startswith("aborted ("):
-        # A user-stopped bang command persists as an error result (the
-        # model-facing shape), but the LIVE frame it came from was the dim
-        # shut `interrupted ⊘` row. Replaying it through the error branch
-        # would reopen the user's own Esc as a red failure (design round
-        # 1, D1). The aborted prefix is execute_bash's stable contract.
+        # An aborted call persists as an error result (the model-facing
+        # shape), but the LIVE frame it came from was the dim shut
+        # `interrupted ⊘` row. Replaying it through the error branch would
+        # reopen the user's own Esc as a red failure (design round 1, D1).
         #
-        # The duration still comes back. Unlike the `result is None` arm
-        # above, this row HAS a recorded result and it carries the interval:
-        # `harness/loop.py` parks the synthetic aborted result with
-        # `duration_s=time.monotonic() - started_at`, and the live card's
-        # `mark_interrupted()` stamped the same elapsed time on screen. "How
-        # long did it run before I killed it" is the question this row exists
-        # to answer, and one Esc marks EVERY tool in flight — so blanking it
-        # opens the hole across a whole run of rows.
+        # The parenthesised prefix identifies ONE producer, and it is not the
+        # agent loop: `execute_bash` builds this text itself via `_error(...)`
+        # (`tools/builtin.py:1478`, `:1990`), as does `tools/eval.py:882`.
+        # `harness/loop.py`'s synthetic abort is `ABORTED_RESULT_TEXT =
+        # "aborted"` with NO parenthesis, so every result the loop parks a
+        # duration onto fails this guard and takes the plain error arm below.
+        #
+        # So `duration_s` is passed for faithfulness, not for a population we
+        # can point at today. `_error(...)` sets no `duration_s`, and only
+        # `loop.py::_append_results` writes the `provider_payload` this reads
+        # — review round 2 swept 37 real aborted runs (model-issued bash,
+        # parallel-batch races, eval kernel aborts) and produced the
+        # `aborted (` + `duration_s` conjunction zero times. The arm is
+        # therefore inert but correct: `park()` stamps any NORMALLY returned
+        # result, so the moment a producer returns this text with a measured
+        # interval the row shows it instead of silently dropping it.
+        # `tools/eval.py:1004` (`aborted (…): kernel killed mid-run`) is the
+        # plausible future one — it returns normally rather than by
+        # cancellation — but neither reviewer could drive a turn into that
+        # branch or prove it unreachable, so its status is unsettled.
+        #
+        # Not covered here: a bang-mode `! cmd` the user stopped. That row
+        # persists through `session/shell_record.py` →
+        # `Message.tool_result`, which copies content/ids/`is_error` and
+        # never writes `provider_payload` at all — so it replays blank, as a
+        # successful `! echo hi` also does. Pre-existing and out of scope.
         card.restore(state="interrupted", duration_s=duration_s)
         return
     if getattr(result, "is_error", False):

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -49,7 +49,6 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-import math
 import reprlib
 from collections import Counter
 from collections.abc import Mapping, Sequence
@@ -138,6 +137,12 @@ INSTRUCTION_ROWS = 3
 #: more lines from fifty, and that is the difference between bothering and not.
 EXPAND_HINT = tool_card.EXPAND_HINT
 COLLAPSE_AFFORDANCE = tool_card.COLLAPSE_HINT
+
+#: Producer durations arrive here from a child's trajectory and, in the parent
+#: transcript, from a persisted ``provider_payload``. Both restore the same
+#: ToolCard, so both validate through the one parser that lives beside the
+#: formatter it feeds — see :func:`tool_card.parse_duration`.
+_duration = tool_card.parse_duration
 
 #: Cells the body's scrollbar gutter occupies, named after the
 #: ``scrollbar-size-vertical: 1`` the ``TranscriptView`` rule declares. The
@@ -429,20 +434,6 @@ def _first_line(text: str) -> str:
         if line.strip():
             return line.strip()
     return ""
-
-
-def _duration(value: Any) -> float | None:
-    """A trustworthy elapsed time, or ``None`` for malformed producer data.
-
-    JSON accepts numbers that Python also treats as booleans, while in-memory
-    trajectories can carry NaN or infinities that JSON would reject. None of
-    those values, nor a negative interval, describes elapsed wall time; letting
-    one reach ToolCard can print nonsense or fail while formatting a replay.
-    """
-    if not isinstance(value, (int, float)) or isinstance(value, bool):
-        return None
-    duration = float(value)
-    return duration if math.isfinite(duration) and duration >= 0 else None
 
 
 @dataclass(frozen=True)

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -85,6 +85,7 @@ Widths measured through ``rich.cells.cell_len`` only (one width model).
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 import time
@@ -333,6 +334,29 @@ def _format_bytes(count: int) -> str:
     if count < 1024 * 1024:
         return f"{count / 1024:.1f} KB"
     return f"{count / (1024 * 1024):.1f} MB"
+
+
+def parse_duration(value: Any) -> float | None:
+    """A trustworthy elapsed time, or ``None`` for malformed producer data.
+
+    Lives beside :func:`format_duration` because every duration that reaches a
+    ToolCard from OUTSIDE this process — a persisted ``provider_payload``, a
+    child agent's trajectory event — has to pass through here first. Both the
+    parent transcript replay and :mod:`subagent_view` call it, so there is one
+    definition of what counts as a usable interval rather than a second,
+    divergent parser next to the first.
+
+    JSON accepts numbers that Python also treats as booleans, while in-memory
+    trajectories can carry NaN or infinities that JSON would reject. None of
+    those values, nor a negative interval, describes elapsed wall time; letting
+    one reach ToolCard can print nonsense or fail while formatting a replay.
+    ``None`` is the degraded answer, and it paints the same blank column a row
+    written before durations were persisted paints.
+    """
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return None
+    duration = float(value)
+    return duration if math.isfinite(duration) and duration >= 0 else None
 
 
 def format_duration(seconds: float) -> str:
@@ -1122,8 +1146,14 @@ class ToolCard(ExpandableActionBlock):
         row mounted during replay is the moment the row was mounted. That is
         not how long the tool took, it is how long ago the app painted the row,
         and it renders as ``0.0s`` on every card in a resumed conversation.
-        The transcript does not record durations, so replay leaves
-        ``_duration`` at ``None`` and the column paints blank.
+
+        ``duration_s`` is the executor's MEASURED interval, which the harness
+        persists under the tool result's ``provider_payload`` and replay reads
+        back, so a resumed row shows the same receipt the live row showed.
+        Callers must pass it through :func:`parse_duration`; the column paints
+        blank only where there is genuinely no number to show — a legacy row
+        written before durations were persisted, a malformed value, or a call
+        whose result never reached the transcript.
 
         ``state`` is ``"success"``, ``"error"``, ``"interrupted"`` — the third
         for a call whose result is not in the transcript, which is what a
@@ -2374,11 +2404,12 @@ class ToolCard(ExpandableActionBlock):
         """
         dim = bindings.style("tool.status.duration")
         if self._duration is None:
-            # A REPLAYED row: the transcript records what a tool did, never how
-            # long it took. `self._duration or 0.0` rendered that as `0.0s`,
-            # which is not a missing number, it is a wrong one — it says every
-            # tool in a resumed conversation returned instantly. Blank keeps
-            # the column aligned and says nothing, which is the truth.
+            # No interval to show: a legacy row written before the harness
+            # persisted `duration_s`, a value that failed `parse_duration`, or
+            # a call whose result never reached the transcript. `self._duration
+            # or 0.0` rendered those as `0.0s`, which is not a missing number,
+            # it is a wrong one — it says the tool returned instantly. Blank
+            # keeps the column aligned and says nothing, which is the truth.
             duration = " " * DURATION_COL
         else:
             elapsed = self._duration

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -10521,8 +10521,11 @@ class TestResumeReplaysTheWholeConversation:
 
     @pytest.mark.asyncio
     async def test_a_replayed_card_reports_no_duration(self) -> None:
-        """The transcript records what a tool did, never how long it took.
-        ``0.0s`` on every row is a wrong number, not a missing one."""
+        """A result with no persisted ``duration_s`` — a legacy row — has no
+        interval to restore. Replay must not fall back to timing the row from
+        when it was mounted: ``0.0s`` on every row is a wrong number, not a
+        missing one. (A row that DOES carry the key is covered in
+        ``test_resume_render``.)"""
         from local_operator.harness.types import Message, ToolCall
         from local_operator.tui.widgets.tool_card import ToolCard
 

--- a/tests/unit/tui/test_reconnect_parity.py
+++ b/tests/unit/tui/test_reconnect_parity.py
@@ -13,6 +13,15 @@ transcript and assert the block classes and order are identical.
 Semantic block-class assertions, deliberately: design round 3 required that
 reconnect evidence not rely on text content alone, because the text survives
 misattribution — the block type is what carries the speaker.
+
+Block classes alone were not enough. The two paths this file compares are two
+DIFFERENT functions — ``app._settle_painted_tool_card`` for a card already on
+screen, ``session_presentation.replay_tool_call`` for a cold boot — and a
+change that taught only one of them to restore ``provider_payload.duration_s``
+left the reconnected row painting a blank duration column beside a cold boot
+showing ``7.2s``, with the class signature identical and this test green. So
+the parity assertion now covers the ToolCard's rendered duration cell as well
+(review round 1, MAJOR-1/D2/Q1).
 """
 
 from __future__ import annotations
@@ -30,12 +39,15 @@ from local_operator.harness.types import (
     Message,
     TextContent,
     ToolCall,
+    ToolExecutionStartEvent,
     ToolResult,
 )
 from local_operator.session.remote import RemoteSession
 from local_operator.session.runtime.server import RuntimeServer
 from local_operator.session.transcript import Transcript
 from local_operator.tui.app import OperatorApp
+from local_operator.tui.events import ToolStarted
+from local_operator.tui.widgets.tool_card import ToolCard
 from local_operator.tui.widgets.transcript import TranscriptView
 from tests.unit.session.runtime.test_server import FakeHandle
 from tests.unit.session.test_remote import _never_take_over, _wait_record
@@ -57,6 +69,45 @@ def _remote_factory(remote: RemoteSession) -> Any:
     return factory
 
 
+#: The interval the gap's tool result carries on disk. Both settle paths must
+#: read it back, so it is asserted rather than merely present.
+_GAP_DURATION_S = 7.25
+
+_DURATION_CALL_ID = "call-duration-1"
+
+
+def _duration_call_row() -> Message:
+    """The assistant turn that ISSUES the call, persisted BEFORE the gap.
+
+    Order matters for which settle path the result takes. In production the
+    call row lands durably when the model emits it, so a terminal that was
+    connected then already has the card on screen and the gap carries only the
+    RESULT — which is what routes it through ``_settle_painted_tool_card``.
+    Putting the call row in the gap instead would replay it as a fresh card and
+    exercise the cold path twice, testing nothing about the divergence.
+    """
+    return Message(
+        role="assistant",
+        content=[TextContent(text="reading the file")],
+        tool_calls=[ToolCall(id=_DURATION_CALL_ID, name="read", arguments={"path": "/tmp/x"})],
+    )
+
+
+def _duration_result_row() -> Message:
+    """The durable result that landed during the gap, carrying its interval."""
+    return _with_payload(
+        Message.tool_result(
+            ToolResult(
+                tool_call_id=_DURATION_CALL_ID,
+                tool_name="read",
+                content=[TextContent(text="file contents")],
+                duration_s=_GAP_DURATION_S,
+            )
+        ),
+        {"details": None, "useless": False, "duration_s": _GAP_DURATION_S},
+    )
+
+
 def _gap_rows() -> list[Any]:
     """The interleaving that reconnect must survive with roles intact."""
     call = ToolCall(id="call-parity-1", name="read", arguments={"path": "/tmp/x"})
@@ -70,15 +121,21 @@ def _gap_rows() -> list[Any]:
             content=[TextContent(text="answer while disconnected")],
             tool_calls=[call],
         ),
-        Message.tool_result(
-            ToolResult(
-                tool_call_id="call-parity-1",
-                tool_name="read",
-                content=[
-                    TextContent(text="tool output"),
-                    ImageContent(data=_PNG_1X1, mime_type="image/png"),
-                ],
-            )
+        _with_payload(
+            Message.tool_result(
+                ToolResult(
+                    tool_call_id="call-parity-1",
+                    tool_name="read",
+                    content=[
+                        TextContent(text="tool output"),
+                        ImageContent(data=_PNG_1X1, mime_type="image/png"),
+                    ],
+                    duration_s=_GAP_DURATION_S,
+                )
+            ),
+            # Same payload shape the harness writes, so this leg crosses the
+            # duration restore rather than only the blank-column case.
+            {"details": None, "useless": False, "duration_s": _GAP_DURATION_S},
         ),
         CustomMessage(
             custom_type="peer_message",
@@ -96,9 +153,26 @@ async def _boot(app: OperatorApp, pilot: Any) -> None:
     raise RuntimeError("app did not boot")
 
 
+def _with_payload(message: Message, payload: dict[str, Any]) -> Message:
+    """Attach the ``provider_payload`` the harness writes beside a tool result.
+
+    ``Message.tool_result`` does not carry it — ``harness/loop.py`` sets it on
+    the message after construction — so the fixture reproduces that shape here
+    rather than asserting against a row no real transcript holds.
+    """
+    message.provider_payload = payload
+    return message
+
+
 def _block_signature(app: OperatorApp) -> list[str]:
     view = app.query_one(TranscriptView)
     return [type(block).__name__ for block in view.blocks()]
+
+
+def _duration_cells(app: OperatorApp) -> list[float | None]:
+    """The restored interval on every ToolCard, in transcript order."""
+    view = app.query_one(TranscriptView)
+    return [block._duration for block in view.blocks() if isinstance(block, ToolCard)]
 
 
 async def _fresh_boot_signature(tmp_path: Path) -> list[str]:
@@ -118,6 +192,30 @@ async def _fresh_boot_signature(tmp_path: Path) -> list[str]:
             for _ in range(5):
                 await pilot.pause()
             return _block_signature(app)
+    finally:
+        if remote is not None:
+            await remote.dispose()
+        registrant.close()
+
+
+async def _fresh_boot_durations(tmp_path: Path) -> list[float | None]:
+    """Boot a cold follower app on the finished transcript; return its
+    restored tool durations — the cold-resume side of the parity."""
+    handle = FakeHandle()
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    remote = None
+    try:
+        record = await _wait_record(tmp_path)
+        remote = await RemoteSession.connect(
+            record, "s1", config_dir=tmp_path, takeover_factory=_never_take_over
+        )
+        app = OperatorApp(_remote_factory(remote))
+        async with app.run_test(size=(118, 32)) as pilot:
+            await _boot(app, pilot)
+            for _ in range(5):
+                await pilot.pause()
+            return _duration_cells(app)
     finally:
         if remote is not None:
             await remote.dispose()
@@ -196,3 +294,105 @@ async def test_reconnect_paints_gap_rows_with_fresh_boot_block_parity(
     # through the gap.
     fresh_signature = await _fresh_boot_signature(tmp_path)
     assert reconnect_signature == fresh_signature
+
+
+@pytest.mark.asyncio
+async def test_a_settled_painted_card_restores_the_same_duration_a_cold_boot_shows(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The duration column is part of "reads identically", and it is the one
+    part the block-class signature above cannot see.
+
+    ``replay_history`` settles a tool row through one of TWO functions, chosen
+    by whether a card for that call is already painted: ``replay_tool_call``
+    for a cold boot, ``_settle_painted_tool_card`` for a terminal that painted
+    the row live and then lost the connection. Teaching only the first to read
+    ``provider_payload.duration_s`` made the same transcript row show ``7.2s``
+    on one path and blank on the other while every block class matched, which
+    is the divergence this file exists to catch (review round 1,
+    MAJOR-1/D2/Q1).
+
+    So this drives the painted-card route specifically: paint the call live
+    through the production ``on_tool_started``, retire it the way the
+    disconnect handler does, then let the reconnect settle it from the durable
+    result — and compare the restored interval against a cold boot of the same
+    bytes.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    transcript = Transcript(tmp_path / "sessions" / "s1")
+    await transcript.append_message(Message.user("visible before disconnect"))
+    # The call is durable BEFORE the gap; only its result lands during it.
+    await transcript.append_message(_duration_call_row())
+
+    handle = FakeHandle()
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    remote = None
+    settled_durations: list[float | None] = []
+    try:
+        record = await _wait_record(tmp_path)
+        remote = await RemoteSession.connect(
+            record, "s1", config_dir=tmp_path, takeover_factory=_never_take_over
+        )
+        app = OperatorApp(_remote_factory(remote))
+        async with app.run_test(size=(118, 32)) as pilot:
+            await _boot(app, pilot)
+            for _ in range(5):
+                await pilot.pause()
+
+            # Paint the call LIVE, so the reconnect finds a card on screen and
+            # routes its result through `_settle_painted_tool_card` rather than
+            # mounting a fresh row.
+            app.on_tool_started(
+                ToolStarted(
+                    ToolExecutionStartEvent(
+                        tool_call_id=_DURATION_CALL_ID,
+                        tool_name="read",
+                        args={"path": "/tmp/x"},
+                    )
+                )
+            )
+            await pilot.pause()
+            assert app._painted_tool_card(_DURATION_CALL_ID) is not None
+
+            registrant.close()
+            (tmp_path / "sessions" / "s1" / ".session.pid").write_text(str(os.getpid()))
+            for _ in range(100):
+                if remote._recovering:
+                    break
+                await asyncio.sleep(0.02)
+            assert remote._recovering is True
+            # What the disconnect handler does to a live card: mark it
+            # interrupted and retire it out of `_tool_cards`, leaving it
+            # mounted for the recovered result to settle.
+            app._retire_live_tool_cards()
+            await transcript.append_message(_duration_result_row())
+
+            replacement = RuntimeServer(handle, kind="tui")
+            replacement.start()
+            try:
+                deadline = asyncio.get_running_loop().time() + 15
+                while asyncio.get_running_loop().time() < deadline:
+                    await pilot.pause()
+                    if not remote._recovering and len(remote.history()) == 3:
+                        break
+                    await asyncio.sleep(0.02)
+                assert remote._recovering is False
+                for _ in range(10):
+                    await pilot.pause()
+                settled_durations = _duration_cells(app)
+            finally:
+                replacement.close()
+    finally:
+        if remote is not None:
+            await remote.dispose()
+        registrant.close()
+
+    # The settled card carries the persisted interval, not a blank and not a
+    # clock started when this terminal painted the row.
+    assert settled_durations == [pytest.approx(_GAP_DURATION_S)], settled_durations
+
+    # And it agrees with the other path over the identical transcript.
+    cold_durations = await _fresh_boot_durations(tmp_path)
+    assert settled_durations == cold_durations

--- a/tests/unit/tui/test_resume_render.py
+++ b/tests/unit/tui/test_resume_render.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from rich.cells import cell_len
 from textual.events import Key, MouseScrollUp
 
 import local_operator.tui.app as app_module
@@ -26,7 +27,7 @@ from local_operator.tui.app import (
 )
 from local_operator.tui.session_presentation import OlderHistoryNotice
 from local_operator.tui.widgets.assistant import AssistantBlock
-from local_operator.tui.widgets.tool_card import ToolCard
+from local_operator.tui.widgets.tool_card import DURATION_COL, ToolCard
 from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView, UserBlock
 
 from .test_app_pilot import FakeSession, _factory, _transcript_text
@@ -1585,3 +1586,126 @@ async def test_a_tail_following_insert_holds_no_anchor() -> None:
         "clamps a not-yet-scrollable frame to row 0 and the resume opens on "
         "the OLDEST row instead of the newest"
     )
+
+
+def _durable_turn(
+    call_id: str,
+    *,
+    payload: Any,
+    is_error: bool = False,
+    with_result: bool = True,
+) -> list[Any]:
+    """An assistant call plus its persisted result, carrying ``payload`` verbatim.
+
+    ``payload`` is placed on the result unmodified so a test can hand replay the
+    exact shape a transcript row holds — including shapes a well-behaved harness
+    never writes, which is the point of the malformed cases below.
+    """
+    rows: list[Any] = [
+        SimpleNamespace(
+            role="assistant",
+            id=f"a-{call_id}",
+            text="",
+            tool_calls=[SimpleNamespace(id=call_id, name="bash", arguments={"command": "ls"})],
+            custom_type=None,
+            stop_reason=None,
+            provider_payload=None,
+        )
+    ]
+    if with_result:
+        rows.append(
+            SimpleNamespace(
+                role="tool",
+                id=f"t-{call_id}",
+                tool_call_id=call_id,
+                text="boom" if is_error else "exit code: 0",
+                is_error=is_error,
+                provider_payload=payload,
+                content=[],
+                custom_type=None,
+            )
+        )
+    return rows
+
+
+async def _replayed_cards(rows: list[Any]) -> list[ToolCard]:
+    """Every ToolCard a resume of ``rows`` paints, in transcript order."""
+    session = FakeSession()
+    session._history = rows
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _wait_for_resume(pilot, app, min_blocks=1)
+        for _ in range(60):
+            cards = [b for b in app.query_one(TranscriptView).blocks() if isinstance(b, ToolCard)]
+            if len(cards) == len([r for r in rows if getattr(r, "tool_calls", None)]):
+                break
+            await pilot.pause()
+        return [b for b in app.query_one(TranscriptView).blocks() if isinstance(b, ToolCard)]
+
+
+@pytest.mark.asyncio
+async def test_a_persisted_duration_is_restored_onto_the_replayed_card() -> None:
+    """The harness measures the interval and persists it under
+    ``provider_payload``; a resumed row showed a blank column because replay
+    read ``details`` out of that payload and dropped ``duration_s`` beside it."""
+    cards = await _replayed_cards(_durable_turn("c1", payload={"duration_s": 2.4}))
+    assert len(cards) == 1
+    assert cards[0]._duration == pytest.approx(2.4)
+    assert "2.4s" in cards[0]._build_row(100).plain
+
+
+@pytest.mark.asyncio
+async def test_a_restored_duration_uses_the_live_grammar_and_column() -> None:
+    """A restored value goes through the SAME formatting the live card uses —
+    sub-second precision only below ten seconds, then whole seconds, then
+    ``format_duration``. The column is width-reserved rather than measured, so
+    a wide restored value is the case that could push its row over the
+    terminal; every one of these must still fit ``DURATION_COL``."""
+    for seconds, expected in ((2.4, "2.4s"), (36.4, "36s"), (3725.0, "1h2m")):
+        cards = await _replayed_cards(_durable_turn("c1", payload={"duration_s": seconds}))
+        rendered = cards[0]._build_row(100).plain
+        assert expected in rendered, (seconds, rendered)
+        assert len(expected) <= DURATION_COL, expected
+        # The row is built for a 100-cell terminal and must not exceed it.
+        assert cell_len(rendered) <= 100, (seconds, rendered)
+
+
+@pytest.mark.asyncio
+async def test_a_failed_call_restores_its_duration_too() -> None:
+    """A tool that failed still took time, and the error arm restores it from
+    the same key the success arm reads."""
+    cards = await _replayed_cards(_durable_turn("c1", payload={"duration_s": 1.5}, is_error=True))
+    assert cards[0]._state == "error"
+    assert cards[0]._duration == pytest.approx(1.5)
+
+
+@pytest.mark.asyncio
+async def test_a_legacy_row_without_a_duration_still_paints_blank() -> None:
+    """Rows written before durations were persisted carry no key at all. The
+    honest answer is a blank column, never a fabricated ``0.0s``."""
+    for payload in (None, {}, {"details": {"path": "x"}}):
+        cards = await _replayed_cards(_durable_turn("c1", payload=payload))
+        assert cards[0]._duration is None, payload
+        assert "0.0s" not in cards[0]._build_row(100).plain, payload
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_duration_degrades_to_blank_instead_of_raising() -> None:
+    """A transcript is an on-disk file another process may have written, so the
+    value is validated rather than trusted. Each of these would either crash the
+    formatter or print nonsense; all must land on the legacy blank column."""
+    for bad in ("2.4", -1.0, float("nan"), float("inf"), True, [2.4], {"s": 2.4}):
+        cards = await _replayed_cards(_durable_turn("c1", payload={"duration_s": bad}))
+        assert len(cards) == 1, bad
+        assert cards[0]._duration is None, bad
+        assert "0.0s" not in cards[0]._build_row(100).plain, bad
+
+
+@pytest.mark.asyncio
+async def test_an_interrupted_call_never_invents_a_duration() -> None:
+    """A session killed between the call and its answer has no recorded result
+    and therefore no measured interval. Nothing to restore, nothing to show."""
+    cards = await _replayed_cards(_durable_turn("c1", payload=None, with_result=False))
+    assert cards[0]._state == "interrupted"
+    assert cards[0]._duration is None
+    assert "0.0s" not in cards[0]._build_row(100).plain

--- a/tests/unit/tui/test_resume_render.py
+++ b/tests/unit/tui/test_resume_render.py
@@ -1594,6 +1594,7 @@ def _durable_turn(
     payload: Any,
     is_error: bool = False,
     with_result: bool = True,
+    text: str | None = None,
 ) -> list[Any]:
     """An assistant call plus its persisted result, carrying ``payload`` verbatim.
 
@@ -1618,7 +1619,7 @@ def _durable_turn(
                 role="tool",
                 id=f"t-{call_id}",
                 tool_call_id=call_id,
-                text="boom" if is_error else "exit code: 0",
+                text=text if text is not None else ("boom" if is_error else "exit code: 0"),
                 is_error=is_error,
                 provider_payload=payload,
                 content=[],
@@ -1660,12 +1661,27 @@ async def test_a_restored_duration_uses_the_live_grammar_and_column() -> None:
     sub-second precision only below ten seconds, then whole seconds, then
     ``format_duration``. The column is width-reserved rather than measured, so
     a wide restored value is the case that could push its row over the
-    terminal; every one of these must still fit ``DURATION_COL``."""
-    for seconds, expected in ((2.4, "2.4s"), (36.4, "36s"), (3725.0, "1h2m")):
+    terminal — which is why the sample includes ``59m59s`` and ``23h59m``,
+    ``format_duration``'s widest strings. An earlier version of this test
+    sampled only values of four cells or fewer and so asserted a width bound
+    the genuinely worst case violates (review round 1, MINOR-2)."""
+    for seconds, expected in (
+        (2.4, "2.4s"),
+        (36.4, "36s"),
+        (3599.0, "59m59s"),
+        (3725.0, "1h2m"),
+        (86_399.0, "23h59m"),
+    ):
         cards = await _replayed_cards(_durable_turn("c1", payload={"duration_s": seconds}))
         rendered = cards[0]._build_row(100).plain
         assert expected in rendered, (seconds, rendered)
-        assert len(expected) <= DURATION_COL, expected
+        # DURATION_COL is the rjust MINIMUM, not a cap: `format_duration` is
+        # bounded at six cells and `rjust(5)` on a six-cell string is a no-op,
+        # so the real invariant is the formatter's documented bound plus the
+        # row fitting the terminal — not `<= DURATION_COL`, which `59m59s`
+        # and `23h59m` legitimately exceed by one.
+        assert DURATION_COL <= 6
+        assert len(expected) <= 6, expected
         # The row is built for a 100-cell terminal and must not exceed it.
         assert cell_len(rendered) <= 100, (seconds, rendered)
 
@@ -1709,3 +1725,27 @@ async def test_an_interrupted_call_never_invents_a_duration() -> None:
     assert cards[0]._state == "interrupted"
     assert cards[0]._duration is None
     assert "0.0s" not in cards[0]._build_row(100).plain
+
+
+@pytest.mark.asyncio
+async def test_a_user_aborted_call_restores_the_duration_it_ran_for() -> None:
+    """The other interrupted arm, and the opposite answer. A bang command the
+    user stopped DOES have a recorded result: the harness parks a synthetic
+    aborted result carrying the interval it ran for, and the live card stamped
+    that same elapsed time via ``mark_interrupted()``. Blanking it on replay
+    dropped a number the live frame showed, on the row where "how long did it
+    run before I killed it" is the whole question (review round 1, MAJOR-2).
+
+    The dim ``interrupted ⊘`` presentation is unchanged — a user's own Esc
+    must not reopen as a red error (design round 1, D1)."""
+    cards = await _replayed_cards(
+        _durable_turn(
+            "c1",
+            payload={"duration_s": 2.5},
+            is_error=True,
+            text="aborted (interrupted by user)",
+        )
+    )
+    assert cards[0]._state == "interrupted"
+    assert cards[0]._duration == pytest.approx(2.5)
+    assert "2.5s" in cards[0]._build_row(100).plain


### PR DESCRIPTION
## What and why

**C1 — standard UI defect fix.** Every tool card in a resumed conversation painted a **blank duration column**, while the same card during the live turn showed `0.0s` / `2.4s`. The number was not missing from disk — it was being dropped one call short of the card.

### Root cause: persisted, but never read

The three pieces of the chain were already in place, and the last link was simply absent:

1. `harness/loop.py::_append_results` **writes** the executor's measured interval into the persisted tool result:
   ```python
   if result.details is not None or result.useless or result.duration_s is not None:
       message.provider_payload = {"details": ..., "useless": ..., "duration_s": result.duration_s}
   ```
2. `session/transcript.py::encode_message_payload` serializes via `model_dump`, so `provider_payload.duration_s` **lands on disk verbatim**.
3. `ToolCard.restore` has **always accepted** a `duration_s` keyword and handles it correctly; `subagent_view.py` already passes it, which is why a child agent's folded trajectory showed durations while the parent transcript did not.

The gap was in the RENDERERS, and **there are two of them** — a correction to this description's original claim that only one path was affected (review round 1, MAJOR-1/D2/Q1). `replay_history` settles a tool row through one of two functions, chosen by whether a card for that call is already on screen:

- `tui/session_presentation.py::replay_tool_call` — **cold resume**, no card painted yet.
- `tui/app.py::_settle_painted_tool_card` — **reconnect**, where this terminal painted the row live before a disconnect and the durable result recovered from the gap settles that same card.

Both reached into `provider_payload` for `details` and walked straight past `duration_s` sitting beside it, then called `card.restore(...)` without it. So the value survived the whole persistence path and was discarded at the point of render, on both routes.

This PR reads the key through `parse_duration` and passes it to every `restore(...)` arm that has a result to read it from, on **both** renderers. `_settle_painted_tool_card`'s docstring promised the "same state derivation as `_replay_tool_call`"; fixing only one would have made that false and left a reconnected row blank beside a cold-resumed `7.2s` for the identical transcript.

### Why the value is validated rather than trusted

`parse_duration` degrades anything that is not a finite, non-negative, non-boolean number to `None`:

- A transcript is an **on-disk file another process may have written**. `json` will happily hand back `"2.4"`, `-1`, or `true`; an in-memory trajectory can carry `NaN`/`inf` that JSON would reject. Each would either crash the formatter mid-replay or print nonsense into the ledger.
- `None` degrades to **exactly the blank column a legacy row paints**. That is the honest answer when the interval is unknown, and it is the same rule the column already enforced: `self._duration or 0.0` would render a missing value as `0.0s`, which is not a missing number, it is a wrong one — it claims the tool returned instantly.

**Legacy rows keep painting blank.** Transcripts written before durations were persisted have no key at all, so they take the `None` path unchanged.

**The interrupted arms split, and the line between them is result-present vs result-absent** — not success/error vs interrupted, which is where this description originally drew it (review round 1, MAJOR-2/D1/Q2). A call whose result never reached the transcript has no measured interval and stays blank; inventing one is the exact failure the existing code guards against.

**The `aborted (` arm restores a duration if one is present, and today none is** — a correction to this description's round-1 claim that a user-stopped bang command carries the interval (review round 2, MAJOR-3; QA round 2, Q4, reached independently). That claim was wrong on every producer that exists:

- The parenthesised prefix is **not** the agent loop's. `execute_bash` builds that text itself through `_error(...)` (`tools/builtin.py:1478`, `:1990`), as does `tools/eval.py:882`, and `_error(...)` stamps no `duration_s`.
- `harness/loop.py`'s synthetic abort is `ABORTED_RESULT_TEXT = "aborted"` with **no** parenthesis, so exactly the results the loop parks a duration onto fail this guard and take the plain error arm below.
- **Bang mode never reaches `provider_payload` at all.** A `! cmd` row persists through `session/shell_record.py` → `Message.tool_result`, which copies content/ids/`is_error` and never writes `provider_payload` — so a stopped `! sleep 60` replays blank, exactly as a successful `! echo hi` does. QA measured this live: `1.9s` on the live card, `provider_payload: null` on disk, blank on resume.
- Across three sweeps, **37 real aborted runs** (model-issued bash, parallel-batch races, eval kernel aborts) produced the `aborted (` + `duration_s` conjunction **zero** times.

So the arm is **inert but correct**, and it is kept for that reason rather than removed: `park()` stamps any normally-returned result, so the moment a producer returns this text with a measured interval the row shows it instead of silently dropping it. `tools/eval.py:1004` (`aborted (…): kernel killed mid-run`) is the plausible future one — it returns normally rather than by cancellation — but neither reviewer could drive a turn into that branch or prove it unreachable, so its status is recorded as unsettled rather than claimed either way.

What is unchanged and load-bearing is the **presentation**: an aborted row replays as the dim `interrupted ⊘` it was live, not as a red error (design round 1, D1 — a user's own Esc must not reopen as a failure). Making a stopped bang command actually carry a duration is a separate change to the persistence path, deferred here.

### One parser, not two

`subagent_view._duration` was already this exact function. Rather than let replay grow a second, divergent copy beside the established one, it **moves to `tool_card.parse_duration`** — beside `format_duration`, the formatter it feeds — and `subagent_view` aliases it, matching the `EXPAND_HINT = tool_card.EXPAND_HINT` pattern already in that module. Both producers of an out-of-process duration now validate through one definition.

### Three comments asserted the opposite of the truth

`tool_card.py` said *"The transcript does not record durations"*, `session_presentation.py` said *"apart from the duration the transcript never recorded"*, and the settled-row branch explained its blank as *"a REPLAYED row"*. All three were false and would have misled the next reader into re-deriving this bug as intended behaviour. Rewritten to state what is now true.

**Round 2 corrected a fourth** (`25f7eb63a`, comment-only — the parsed AST of both touched files is byte-identical to `91462919d`). Round 1's own new comments on the `aborted (` arm, in both renderers, asserted that the loop parks a duration onto that row; review MAJOR-3 and QA Q4 independently disproved it. Both comments now state the real provenance — which producer builds the parenthesised text, why the loop's `ABORTED_RESULT_TEXT` cannot match it, that bang mode never writes `provider_payload`, and that `eval.py:1004` is unsettled rather than ruled out.

### Delivery contract
- A replayed tool row shows the same duration receipt its live twin showed, in the same grammar and the same 5-cell column.
- The same row reads the same whether it was resumed cold or recovered after a disconnect — the two settle paths agree, and `test_reconnect_parity.py` now asserts the duration column, not only the block classes.
- Legacy rows, malformed values, and calls with no recorded result paint blank — never a fabricated `0.0s`.
- No version bump; `pyproject.toml` stays at the last released version (`0.51.28`).
- No change to what is persisted, to the live path, to `subagent_view` behaviour, or to any interaction flow.

## Testing evidence

### The real path, end to end — not a mocked one

A **real `Message`** written to a **real `Transcript`**, read back through the **real loader** (`build_llm_history`), and pushed through the **real `replay_tool_call`** into a **real `ToolCard`**. Only the fixture data is synthetic; every piece of machinery is production code. This is what proves `duration_s` actually survives `model_dump(exclude_defaults=True)` and JSON round-tripping, which the widget-level fixtures cannot show.

Identical script, identical data, run against both trees:

```
                          this branch          origin/main
on-disk rows with key     6                    6            (identical input)
good      (2.4)           _duration=2.4        _duration=None
wide      (36.4)          _duration=36.4       _duration=None
zero      (0.0)           _duration=0.0        _duration=None
legacy    (no key)        _duration=None       _duration=None
bad-str   ("2.4")         _duration=None       _duration=None
bad-neg   (-1.0)          _duration=None       _duration=None
bad-bool  (True)          _duration=None       _duration=None
```

The on-disk bytes are the same in both columns — six rows carry `duration_s`, the legacy row correctly does not. `main` renders every one of them blank; this branch renders the three valid intervals and correctly blanks the four that must stay blank.

### Rendered frames — before and after, same fixture

Captured with `scripts.visual_capture.save_capture` (the faithful helper, native 8×17px cells) driving the **real `OperatorApp`** at 100×30 — the app that loads `local_operator.tcss`, not a bare test host. `isolate_capture()` runs before app imports (HOME, config and caches redirected); all `CMUX_*` variables scrubbed and only synthetic ids used, so no live operator session was read or touched. The BEFORE frame comes from a throwaway `origin/main` worktree replaying the **same fixture transcript**.

Cell-exact contents of the duration column, both trees, same seven calls:

| Row | `duration_s` on disk | Before (`main`) | After (this branch) |
|---|---|---|---|
| `read local_operator/tui/app.py` | `0.0` | `'      '` | `' 0.0s'` |
| `bash git status --short` | `2.4` | `'      '` | `' 2.4s'` |
| `grep duration_s` | `7.9` | `'      '` | `' 7.9s'` |
| `bash pytest tests/unit/tui -q` | `36.4` | `'      '` | `'  36s'` |
| `bash uv pip install …` | `3725.0` | `'      '` | `' 1h2m'` |
| `write /tmp/out.txt` (**error row**) | `1.5` | `'      '` | `' 1.5s'` |
| `read docs/REWRITE.md` (**legacy, no key**) | *absent* | `'      '` | `'      '` |

The spread is deliberate: it exercises the card's whole formatting grammar — `.1f` below 10s, whole seconds to 60s, then `format_duration` (`1h2m`) — because a restored value must go through the **same** formatter the live card uses, not a second one. `36.4 → 36s` and `3725.0 → 1h2m` are that rule, not truncation.

**Alignment did not regress.** Every value is right-aligned within `DURATION_COL = 5`; the widest (`1h2m`, `0.0s`) still fits. Geometry sidecars are byte-identical between the two frames — screen `98×28`, virtual size `98×28`, **no scrollbar in either** — so nothing reflowed and no row was pushed over the terminal. The frames were **rasterized and visually inspected**, not merely diffed.

Artifacts retained on the capture host, outside the repository (nothing committed, no pretend attachment URLs):
- `/tmp/lo-duration-evidence/before.svg` · `before.png` · `before.geometry.json`
- `/tmp/lo-duration-evidence/after.svg` · `after.png` · `after.geometry.json`
- Capture script: `/tmp/lo-duration-evidence/dur_shot.py` (synthetic fixture, isolated)
- Round-trip proof: `/tmp/lo-duration-evidence/roundtrip_check.py`

**Round 1 re-capture.** Per the design round, only the surfaces the remediation changes were re-shot; the populated-success frames above are approved and unchanged (`mixed-before.svg` and `mixed-after.svg` re-rendered on both trees are **byte-identical**, sha256 `a0cbfbca9619c6b4…`, confirming the fixed surfaces did not move).

*Esc / aborted frame* — **a synthetic-fixture demonstration of the arm's behaviour, not a capture of a user's Esc.** The payloads were hand-built in the model-issued result shape (`aborted (…)` text plus a `provider_payload.duration_s`) precisely to drive the `aborted (` branch and show what it renders. As established above, **no production producer emits that conjunction today**, and a real bang-mode Esc persists no `provider_payload` at all — so this pair shows the branch is faithful when fed such a row, not that stopping a command today fills that column. The rows below carry `duration_s` because the fixture put it there:

```
BEFORE  bash   sleep 60                interrupted ⊘
        bash   pytest tests/unit -q    interrupted ⊘
        write  /tmp/out.txt            interrupted ⊘
        read   docs/REWRITE.md         interrupted ⊘      ← no result on disk

AFTER   bash   sleep 60                interrupted ⊘   18s
        bash   pytest tests/unit -q    interrupted ⊘  4.2s
        write  /tmp/out.txt            interrupted ⊘  0.4s
        read   docs/REWRITE.md         interrupted ⊘      ← still blank, correctly
```

The dangling row (no result recorded) stays blank beside them, which is the control: the change is result-present vs result-absent, not "interrupted now shows a number". The dim `interrupted ⊘` presentation is untouched — the rasterized frames were **inspected**, and the row ink, glyph and weight are identical to before; only the column is filled.

To be explicit about what this frame does and does not establish: it demonstrates the branch's rendering given a duration-bearing aborted result. It is **not** evidence that any current code path produces one. A real user Esc — in bang mode or through the loop's `ABORTED_RESULT_TEXT` — still replays with a blank column on this branch, unchanged from `main`.

*Reconnect frame* — the `_settle_painted_tool_card` route, driven through its production entry points (`on_tool_started` → `_retire_live_tool_cards` → `_settle_painted_tool_card`, the exact call `replay_history` makes):

```
BEFORE  read   local_operator/tui/app.py    ✓
        grep   duration_s                   ✓
        bash   pytest tests/unit -q         ✓
        bash   sleep 60          interrupted ⊘
        write  /tmp/out.txt   permission denied ✗
        read   docs/REWRITE.md              ✓          ← legacy, no key

AFTER   read   local_operator/tui/app.py    ✓  2.4s
        grep   duration_s                   ✓  7.9s
        bash   pytest tests/unit -q         ✓   36s
        bash   sleep 60          interrupted ⊘   18s
        write  /tmp/out.txt   permission denied ✗  1.5s
        read   docs/REWRITE.md              ✓          ← legacy, still blank
```

That "BEFORE" column is the whole of D2/Q1: it is this branch's *previous* head, i.e. the blank column a reconnected terminal painted while a cold resume of the same transcript showed the numbers.

**Geometry unchanged in both pairs.** Screen `98×28`, virtual size `98×28`, **no scrollbar in either frame** — the sidecars are byte-identical across before/after, so nothing reflowed and no row was pushed over the terminal.

- `/tmp/lo-duration-evidence/abort-before.svg` · `abort-before.png` · `.geometry.json` (+ `abort-after.*`)
- `/tmp/lo-duration-evidence/reconnect-before.svg` · `reconnect-before.png` · `.geometry.json` (+ `reconnect-after.*`)
- Capture scripts: `abort_shot.py`, `reconnect_shot.py` (synthetic fixtures, `isolate_capture()`, no operator session content read)

### The new tests can actually fail

Reverting only the two `duration_s=` arguments in `replay_tool_call`, leaving everything else in place:

```
FAILED test_a_persisted_duration_is_restored_onto_the_replayed_card - assert None == 2.4 ± 2.4e-06
FAILED test_a_failed_call_restores_its_duration_too         - assert None == 1.5 ± 1.5e-06
FAILED test_a_restored_duration_uses_the_live_grammar_and_column
3 failed, 3 passed
```

The three that still pass are the negative guards (legacy / malformed / no-recorded-result stay blank) — correct, since those assert the behaviour the fix must *not* change. Round 1's two fixes carry their own controls: reverting the three `duration_s=` arguments in `_settle_painted_tool_card` fails the new parity test with `assert [None] == [7.25 ± 7.3e-06]`, and reverting the `aborted (` arm fails the new aborted test with `assert None == 2.5 ± 2.5e-06`.

Added to `tests/unit/tui/test_resume_render.py`: a persisted duration restoring onto the card; the live grammar and column bound across `2.4s`/`36s`/`1h2m`; the error arm restoring its own duration; a legacy row (no key, empty payload, `details`-only payload) staying blank; seven malformed values (`"2.4"`, `-1.0`, `NaN`, `inf`, `True`, list, dict) degrading to blank rather than raising; and a call with no recorded result never inventing one. Round 1 adds an aborted-shape result (a synthetic fixture carrying both the `aborted (…)` text and a `duration_s`, since no production producer emits that pair — see round 2 above) restoring the interval rather than blanking it, and widens the grammar/column sample to `59m59s` and `23h59m` — `format_duration`'s genuinely widest strings, which the original `len(expected) <= DURATION_COL` assertion would have failed (MINOR-2); the assertion now states the real invariant, the formatter's six-cell bound plus the row fitting its terminal. `tests/unit/tui/test_reconnect_parity.py` gains a duration-column parity test driven through the painted-card route (`on_tool_started` → `_retire_live_tool_cards` → reconnect settle), since the existing block-class comparison stayed green while the column diverged. The stale docstring on `test_app_pilot.py::test_a_replayed_card_reports_no_duration` — which asserted the transcript never records durations — now correctly describes it as the legacy-row case.

### Gates

Re-run over the whole tree on the round-1 head (`91462919d`), exactly as CI:

| Gate | Actual result |
|---|---|
| `.venv/bin/python -m flake8 .` | clean, exit 0 |
| `uvx --from black==26.1.0 black --check .` | 1123 files unchanged, exit 0 |
| `uvx isort==5.13.2 --check .` | clean, exit 0 |
| `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | **0 errors, 0 warnings, 0 informations** |
| `tests/unit` (full tree) | **16714 passed, 18 skipped, 0 failed** in 19:13 |
| `tests/e2e -m e2e -n0` | **93 passed**, 7 skipped in 2:13 |

The round-0 run's two disclosed flakes (X11 clipboard, reaper wall-clock margin — both on unchanged surfaces, both disjoint between runs) did **not** recur on this head; the full suite came back clean. They are left described below because the diagnosis stands, not because they are outstanding.

The worktree has its **own** venv installed editable from itself (never symlinked), verified: `import local_operator` resolves to `…/lo-tool-duration/local_operator/__init__.py`.

### Full-suite failures: disclosed, not called green

The full local suite is **not clean**, and neither failure touches this diff. This host runs many concurrent worktree suites.

- Run 1: 3 failures in `tests/unit/test_computer_input.py` (X11 clipboard: `RuntimeError: clipboard paste failed`).
- Run 2, same head: those 3 **passed**; instead `test_process_reaper.py::test_phone_watchers_do_not_change_idle_timing` failed on a wall-clock margin (`0.141 - 0.099 < 0.04`).

Neither reproduces, they are disjoint between runs, and both files pass together in isolation on this head:

```
tests/unit/session/runtime/test_process_reaper.py tests/unit/test_computer_input.py
33 passed in 18.17s
```

Both are wall-clock/subprocess contention flakes on unchanged surfaces — one X11 clipboard, one timing margin, and both absent from the clean round-1 run above. This diff touches only `session_presentation.py`, `tool_card.py`, `subagent_view.py` and `app.py::_settle_painted_tool_card`. Recorded here rather than written off silently.


