### PR TITLE
feat(sidebar): float sessions with armed wakes to the top of Previous

### DIFF
--- a/local_operator/session/catalog.py
+++ b/local_operator/session/catalog.py
@@ -115,9 +115,10 @@ class CatalogEntry:
 
         One consequence reaches MEMBERSHIP, not just order: :func:`load_catalog`
         ranks before applying ``[:limit]``, so at the ``CATALOG_SCAN_LIMIT``
-        boundary an ancient session with an armed wake can now enter the window
-        and displace a newer row that would otherwise have made it (measured at
-        251 sessions). That is arguably the point of the feature — a scheduled
+        boundary an ancient session carrying a wake — armed or dormant, since
+        both bands outrank a plain row — can now enter the window and displace
+        a newer row that would otherwise have made it (measured at 251
+        sessions). That is arguably the point of the feature — a scheduled
         session is usually an old one, and being unfindable is the report — but
         it is a real behaviour change beyond reordering, so it is recorded here.
         """

--- a/local_operator/session/catalog.py
+++ b/local_operator/session/catalog.py
@@ -40,7 +40,87 @@ class CatalogEntry:
         return self.row.id
 
     @property
-    def rank(self) -> tuple[int, float, str]:
+    def rank(self) -> tuple[int, int, float, str]:
+        """``(tier, wake_rank, -birth, id)`` — a wake orders the PREVIOUS group only.
+
+        ``wake_rank`` is scoped to cold rows (``not self.active``): inside
+        Previous an armed wake leads, then a dormant one, then everything else.
+        Every ACTIVE row gets the same constant, so the key cannot reorder
+        anything the user is currently working with.
+
+        **Why scoped rather than uniform.** The first cut applied the key in
+        every tier, on the reasoning that it "only breaks ties within one
+        category" and so was free. That premise is empirically false, and three
+        reviewers independently reproduced the consequences: rows inside a tier
+        are NOT interchangeable, because a tier mixes states that
+        :func:`~local_operator.tui.widgets.session_picker.row_state_mark`
+        deliberately ranks against each other.
+
+        * tier 5 mixes ``attached`` with ``idle``, so an idle session owning a
+          timer sorted above the user's own ATTACHED current session — order
+          contradicting the glyph ladder, where ``○`` means *a terminal is
+          watching this session* and answers "where am I?".
+        * tier 4 mixes ``busy`` with ``wedged``, so a WEDGED (broken) session
+          needing a person sank below a merely-busy neighbour with a wake.
+        * tier 0 mixes the approval and answer gates, so an armed pending row
+          displaced an OLDER pending one — and note this third case defeats a
+          guard written as "presence outranks a wake", because a pending row can
+          carry an empty ``live_state``.
+
+        Scoping to Previous removes all three at the root instead of enumerating
+        the states to dodge. That distinction is the real lesson: an enumerated
+        guard has to be updated every time the ``live_state`` vocabulary grows,
+        and the tier-0 case above is exactly what such a guard silently misses.
+
+        It is also what the operator actually asked for, which was scoped from
+        the start — "under Previous Sessions ... sorted to the top". Tiers 0/4/5
+        were never in scope, and reordering them is unrequested behaviour change.
+
+        **Glyph/order parity, stated precisely.** In Active, order defers
+        entirely to the existing precedence in ``row_state_mark``; this key
+        abstains. In Previous every row is cold, so ``row_state_mark`` paints
+        only the wake glyph or nothing at all — the wake is the sole
+        forward-looking fact a row can carry, so it leads.
+
+        **Dormant ranks below armed, not nowhere.** ``wakes_dormant`` means the
+        session was deliberately stopped and the schedule will never fire, so it
+        stays under every armed row: floating it would advertise a future that is
+        not coming. It still gets its own band so that every clock glyph in the
+        group is CONTIGUOUS. The dim-vs-muted separation between an armed ``◷``
+        and a dormant one measures 1.77:1 at the 8x17px cell this UI renders —
+        below any discrimination threshold — so a dormant row stranded among the
+        plain rows reads as a broken sort rather than as a distinct state.
+        Banding it directly under the armed rows puts the block boundary where
+        the glyph changes, and costs no row and no chrome.
+
+        The key lives HERE rather than in :func:`session_category` because that
+        function is shared with the mobile daemon, whose summaries carry no wake
+        data at all (durable rows come from ``recent_session_rows``, not
+        ``decorate_rows``, so ``wakes`` is always 0 there). Moving the key into
+        the shared categoriser would either be a no-op on mobile or force wake
+        plumbing into the daemon; keeping it in the catalog leaves both surfaces
+        agreeing on the tier, which is the partition they actually share.
+
+        Stability: a wake is as durable a fact as ``live_state`` and ``pending``,
+        and shares their best-effort read — ``decorate_rows`` zeroes ``wakes``
+        for a poll whose wake-index read raises, exactly as it empties the live
+        map when the registry scan raises, so a transient failure can bounce a
+        row for one poll and put it back on the next. That tolerance is
+        deliberate (a picker that cannot read either source still lists every
+        session), and this key inherits it rather than adding a new fragility.
+        What IS new is an asymmetry worth naming: a cold Previous row previously
+        had no poll-varying ordering input at all, and now has one. When a wake
+        genuinely fires the session becomes live and changes tier, which is a
+        real state change rather than churn.
+
+        One consequence reaches MEMBERSHIP, not just order: :func:`load_catalog`
+        ranks before applying ``[:limit]``, so at the ``CATALOG_SCAN_LIMIT``
+        boundary an ancient session with an armed wake can now enter the window
+        and displace a newer row that would otherwise have made it (measured at
+        251 sessions). That is arguably the point of the feature — a scheduled
+        session is usually an old one, and being unfindable is the report — but
+        it is a real behaviour change beyond reordering, so it is recorded here.
+        """
         tier = session_category(
             pending=bool(self.row.pending),
             busy=self.row.live_state in ("busy", "wedged"),
@@ -48,8 +128,14 @@ class CatalogEntry:
             kind=self.completion_kind,
             live=bool(self.row.live_state),
         )
+        # Cold rows only. An active row takes the constant, which is what makes
+        # the key structurally unable to reorder Active rather than merely
+        # declining to today.
+        armed = not self.active and bool(self.row.wakes) and not self.row.wakes_dormant
+        dormant = not self.active and bool(self.row.wakes) and self.row.wakes_dormant
+        wake_rank = 0 if armed else 1 if dormant else 2
         # Activity may update ages and badges, but must not move a click target.
-        return tier, -self.row.created_at, self.id
+        return tier, wake_rank, -self.row.created_at, self.id
 
     @property
     def active(self) -> bool:

--- a/local_operator/tui/widgets/session_sidebar.py
+++ b/local_operator/tui/widgets/session_sidebar.py
@@ -298,10 +298,14 @@ class SessionSidebar(Widget, can_focus=True):
         presentational is also what makes keyboard traversal cross a boundary
         as an ordinary step, with no stall and no skip.
 
-        The boundary is ``CatalogEntry.rank``'s existing tier — 0-2 (pending,
-        unseen, live) is active, 3 is previous — which is the same partition
-        the mobile relay draws, so the two surfaces agree without a new field.
-        An empty section contributes no header.
+        The boundary is ``CatalogEntry.active``, i.e. the tier
+        ``session_category`` assigns — 0 pending, 1 unseen-complete, 2 error,
+        3 interrupted, 4 busy and 5 live are active; 6 previous is not — which
+        is the same partition the mobile relay draws, so the two surfaces agree
+        without a new field. Ordering carries one further key than the tier (an
+        armed wake floats within PREVIOUS, where every row is cold), but it never
+        crosses this boundary and never applies above it. An empty section
+        contributes no header.
         """
         rows: list[tuple[str, CatalogEntry | None]] = []
         section: str | None = None

--- a/tests/unit/server/test_desktop_sessions.py
+++ b/tests/unit/server/test_desktop_sessions.py
@@ -1,6 +1,7 @@
 """Desktop stream algebra, resource bounds and durable retry invariants."""
 
 import asyncio
+import json
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -422,3 +423,43 @@ async def test_only_a_typed_actionable_error_reaches_the_user(tmp_path):
         "then send the message again."
     )
     assert await relay(ActionableConnectionError(vetted)) == vetted
+
+
+@pytest.mark.asyncio
+async def test_served_list_order_is_the_catalogs_rank(tmp_path):
+    """The HTTP surface inherits `rank_entries`, wake key included.
+
+    `DesktopSessions.list` orders through `load_catalog` -> `rank_entries`, so
+    every ordering key the sidebar gains lands on this endpoint too -- the wake
+    key among them. That is easy to miss because the mobile daemon has its OWN
+    sort and is genuinely untouched by the same change, so "the catalog decides"
+    holds for one remote surface and not the other. Asserting the served order
+    IS `rank_entries` keeps the desktop half honest without restating the ladder
+    here: if the two ever diverge this fails, whichever one moved.
+    """
+    from local_operator.session.catalog import load_catalog, rank_entries
+    from local_operator.wakes import store as wake_store
+
+    # Cold sessions only, so the tier ties and the wake key is what decides.
+    # The armed session is the OLDEST, which is exactly where birth date alone
+    # would sort it last.
+    for session_id, created in [("newest", 300), ("middle", 200), ("armed", 100)]:
+        path = tmp_path / "sessions" / session_id
+        path.mkdir(parents=True)
+        (path / "created_at.json").write_text(str(created))
+        (path / "desktop.json").write_text(json.dumps({"version": 1, "cwd": str(tmp_path)}))
+    wake_store.write_entry(
+        tmp_path,
+        "armed",
+        cwd=str(tmp_path),
+        schedules=[{"id": "w1", "next_due_at": 10**12}],
+    )
+
+    served = [row["id"] for row in await DesktopSessions(tmp_path).list(50)]
+    catalog = load_catalog(tmp_path, limit=50)
+    assert served == [entry.id for entry in catalog]
+    # Re-ranked from a SHUFFLED input, so this pins the sort rather than merely
+    # agreeing that two calls returned the same list.
+    assert served == [entry.id for entry in rank_entries(catalog[::-1])]
+    # And concretely: the armed row leads despite being the oldest.
+    assert served == ["armed", "newest", "middle"]

--- a/tests/unit/tui/test_session_order.py
+++ b/tests/unit/tui/test_session_order.py
@@ -96,6 +96,221 @@ def test_category_birth_id_order_ignores_activity_and_input_order():
     assert rank_entries([cold, *rows])[-1] == cold
 
 
+def wake_rows():
+    """Cold rows whose armed wakes are deliberately the OLDEST in the group.
+
+    Birth date is the only other key inside Previous, so making the armed rows
+    the oldest is what forces the assertion to be about the wake: under the
+    previous ``(tier, -birth, id)`` they sorted LAST, which is the behaviour
+    reported.
+    """
+    return [
+        CatalogEntry(SessionRow("plain-new", 100, "Newest, no wake", created_at=90)),
+        CatalogEntry(
+            SessionRow(
+                "dormant-mid",
+                100,
+                "Stopped, wake dormant",
+                created_at=50,
+                wakes=1,
+                wakes_dormant=True,
+            )
+        ),
+        CatalogEntry(SessionRow("plain-old", 100, "Oldest, no wake", created_at=30)),
+        CatalogEntry(SessionRow("armed-b", 100, "Armed wake, older", created_at=20, wakes=1)),
+        CatalogEntry(SessionRow("armed-a", 100, "Armed wake, oldest", created_at=10, wakes=2)),
+    ]
+
+
+# ``(live_state, pending, wakes, wakes_dormant)`` -> the band ``rank`` assigns.
+# Band 0/1 are reachable ONLY from a cold row; every active row takes the same
+# constant 2 whatever its wake. Pinning the band rather than only an order is
+# what makes a regression name itself: an order-only assertion reports "the list
+# is wrong", this reports that an active row became distinguishable at all.
+WAKE_BANDS = [
+    # Active rows: the wake is inert, whatever the state or the timer.
+    ("attached", None, 0, False, 2),
+    ("attached", None, 2, False, 2),
+    ("attached", None, 1, True, 2),
+    ("busy", None, 0, False, 2),
+    ("busy", None, 2, False, 2),
+    ("wedged", None, 0, False, 2),
+    ("wedged", None, 2, False, 2),
+    ("idle", None, 0, False, 2),
+    ("idle", None, 2, False, 2),
+    ("idle", None, 1, True, 2),
+    # A PENDING row is active even with an empty live_state -- the case a
+    # "presence outranks a wake" guard silently misses.
+    ("", "ask", 2, False, 2),
+    ("", "approval", 2, False, 2),
+    ("", "ask", 0, False, 2),
+    # Cold history, the only group the key speaks about.
+    ("", None, 2, False, 0),
+    ("", None, 1, True, 1),
+    ("", None, 0, False, 2),
+]
+
+
+@pytest.mark.parametrize("live_state,pending,wakes,dormant,band", WAKE_BANDS)
+def test_wake_rank_is_scoped_to_cold_rows(live_state, pending, wakes, dormant, band):
+    entry = CatalogEntry(
+        SessionRow(
+            "s",
+            100,
+            "row",
+            live_state=live_state,
+            pending=pending,
+            wakes=wakes,
+            wakes_dormant=dormant,
+            created_at=1,
+        )
+    )
+    assert entry.rank[1] == band
+    # The structural claim behind the scoping: an active row ALWAYS lands on the
+    # constant, so no wake can make one distinguishable from another.
+    if entry.active:
+        assert entry.rank[1] == 2
+
+
+# ``(case, rows, expected)`` for the three inversions a uniform key produced.
+# Each was reproduced independently before the key was scoped; they are the
+# regression tests for tiers 5, 4 and 0 respectively.
+#
+# In every case the ARMED row is the OLDER one, so birth date alone already puts
+# it second and the wake is the only thing that could lift it. That construction
+# is what makes these able to fail: with the armed row newest they would pass
+# under either key and pin nothing.
+ACTIVE_TIER_CASES = [
+    (
+        "tier5-attached-above-armed-idle",
+        [
+            ("idle-armed", "idle", None, 2, False, 10),
+            ("attached", "attached", None, 0, False, 90),
+        ],
+        ["attached", "idle-armed"],
+    ),
+    (
+        "tier4-wedged-above-armed-busy",
+        [
+            ("busy-timer", "busy", None, 3, False, 20),
+            ("wedged", "wedged", None, 0, False, 50),
+        ],
+        ["wedged", "busy-timer"],
+    ),
+    (
+        "tier0-plain-pending-above-armed-pending",
+        [
+            ("pending-armed", "", "ask", 2, False, 10),
+            ("pending-plain", "", "approval", 0, False, 90),
+        ],
+        ["pending-plain", "pending-armed"],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "case,rows,expected", ACTIVE_TIER_CASES, ids=[c[0] for c in ACTIVE_TIER_CASES]
+)
+def test_an_armed_wake_never_reorders_an_active_tier(case, rows, expected):
+    """The INVERSE property: inside Active, the wake must change nothing.
+
+    A uniform wake key looked free because it "only breaks ties within one
+    category". Rows inside a tier are not interchangeable, though: tier 5 mixes
+    ``attached`` with ``idle``, tier 4 mixes ``busy`` with ``wedged``, and tier 0
+    mixes the two gates. Each inversion below was reproduced against the uniform
+    key, and the tier-0 one is the reason the fix is scoping rather than a
+    presence check — a pending row can carry an empty ``live_state``.
+    """
+    entries = [
+        CatalogEntry(
+            SessionRow(
+                sid,
+                100,
+                sid,
+                live_state=state,
+                pending=pending,
+                wakes=wakes,
+                wakes_dormant=dormant,
+                created_at=created,
+            )
+        )
+        for sid, state, pending, wakes, dormant, created in rows
+    ]
+    assert [e.id for e in rank_entries(entries)] == expected
+    # Same order with the wakes stripped: proof the wake is inert here rather
+    # than merely losing to another key that happens to agree today.
+    stripped = [replace(e, row=e.row._replace(wakes=0, wakes_dormant=False)) for e in entries]
+    assert [e.id for e in rank_entries(stripped)] == expected
+    assert len({e.rank[1] for e in entries}) == 1
+
+
+def test_armed_wake_floats_to_top_of_previous_above_dormant():
+    rows = wake_rows()
+    # Armed rows first (the oldest-birth ones, so this cannot be a birth-date
+    # artefact), then the dormant row, then the plain rows by birth date.
+    assert [e.id for e in rank_entries(rows)] == [
+        "armed-b",
+        "armed-a",
+        "dormant-mid",
+        "plain-new",
+        "plain-old",
+    ]
+
+
+def test_every_clock_glyph_is_contiguous_with_armed_above_dormant():
+    """The block boundary must land where the GLYPH changes, not inside it.
+
+    A dormant wake still ranks below every armed one — it is not a future that is
+    coming — but it ranks directly UNDER them rather than nowhere. The dim-vs-
+    muted separation between two ``WAKE_MARKER`` glyphs measures 1.77:1 at this
+    UI's 8x17px cell, which is below any discrimination threshold, so a dormant
+    row stranded among the plain rows is an identical-looking glyph mid-list and
+    reads as a broken sort rather than as a distinct state.
+    """
+    order = rank_entries(wake_rows())
+    marked = [index for index, entry in enumerate(order) if entry.row.wakes]
+    assert marked == list(range(marked[0], marked[0] + len(marked)))
+    armed = [index for index in marked if not order[index].row.wakes_dormant]
+    dormant = [index for index in marked if order[index].row.wakes_dormant]
+    assert max(armed) < min(dormant)
+
+
+def test_armed_wake_floats_without_changing_section_membership():
+    """Floating is an ORDER change only; a cold row must stay under Previous."""
+    rows = wake_rows()
+    assert not any(e.active for e in rows)
+    assert all(not e.active for e in rank_entries(rows))
+    # And it must not overtake a genuinely active row: the tier still leads.
+    live = CatalogEntry(SessionRow("live", 100, "Resident", created_at=1, live_state="idle"))
+    assert rank_entries([*rows, live])[0].id == "live"
+
+
+def test_armed_wake_order_is_stable_across_activity_churn():
+    """Same invariant as the category test: a refresh must not move a target."""
+    rows = wake_rows()
+    # Pinned literally rather than read back from the first sort, so this also
+    # fails if the wake key stops applying — a dynamically derived expectation
+    # would agree with any order at all as long as it never changed.
+    expected_order = ["armed-b", "armed-a", "dormant-mid", "plain-new", "plain-old"]
+    assert [e.id for e in rank_entries(rows)] == expected_order
+    for tick in range(8):
+        rows = [
+            replace(e, row=e.row._replace(mtime=(index + tick) * 777))
+            for index, e in enumerate(reversed(rows))
+        ]
+        assert [e.id for e in rank_entries(rows)] == expected_order
+
+
+def test_armed_wake_ties_fall_back_to_birth_then_id():
+    """The wake key only breaks ties; it never replaces the durable ordering."""
+    rows = [
+        CatalogEntry(SessionRow("w-old", 100, "Armed, older", created_at=5, wakes=1)),
+        CatalogEntry(SessionRow("w-b", 100, "Armed, newer b", created_at=9, wakes=3)),
+        CatalogEntry(SessionRow("w-a", 100, "Armed, newer a", created_at=9, wakes=1)),
+    ]
+    assert [e.id for e in rank_entries(rows)] == ["w-a", "w-b", "w-old"]
+
+
 def test_mobile_uses_same_categories_birth_and_ties():
     table = SessionTable()
     durable = {}


### PR DESCRIPTION
## What

Sessions with an **armed wake** now sort to the top of **Previous Sessions** in the TUI sidebar, so a session that will act on its own is visible without scrolling. A **dormant** wake (a deliberately stopped session) ranks just beneath the armed ones rather than floating.

`CatalogEntry.rank` goes from `(tier, -birth, id)` to `(tier, wake_rank, -birth, id)`. The key is **scoped to cold rows** (`not self.active`): every Active row takes a constant, so the ladder inside Active is left entirely to `row_state_mark`.

## Why

Within Previous every row is tier 6, so the only sort keys were birth date and id — an armed wake sorted wherever its birth date happened to put it, in practice at the **bottom**. Measured on the pre-change tree:

```
rows: none(born 100), armed(born 10, wakes=2), dormant(born 50, dormant)
before: ['none', 'dormant', 'armed']     <- armed wake last
after:  ['armed', 'dormant', 'none']     <- armed leads, dormant contiguous
```

An armed wake is the one forward-looking fact on a cold row, and nothing else on the row conveys it. A dormant wake will never fire, so floating it would advertise a future that is not coming — the same call `row_state_mark` already makes for the glyph, where a dormant wake sits below presence.

**Why scoped to Previous rather than applied uniformly.** The first implementation applied the key to every tier on the theory that it "only breaks ties within a category, so it costs nothing". Three independent review streams reproduced that premise being false — rows within a tier are *not* interchangeable, and the uniform key inverted urgency in three places:

| tier | inversion |
|---|---|
| 5 | armed idle outranked the user's **attached** current session — the row that answers "where am I?" |
| 4 | busy-with-a-timer outranked a **wedged** (broken) session |
| 0 | an armed pending row outranked an **older** row already blocking a person |

That also contradicted the precedent the change cites: `row_state_mark` documents `attached` staying **above** the wake ("a wake is worth more than bare residency and less than presence"), so mark and order disagreed about the same row. Scoping to `not self.active` removes all three at the root rather than enumerating states to dodge — a future `live_state` cannot silently reintroduce one. The operator's request was scoped to Previous in the first place.

## Evidence

**The order itself** — verified against the real `load_catalog` on an on-disk store, and Active proven unchanged against the base commit across a mixed 8-row fleet:

```
Previous:  ['armed', 'dormant', 'plain-new', 'plain-old']
Active  (base 46b6dfc7f): ['act6','act5','act2','act3','act7','act0','act4','act1']
Active  (branch 2aa0fd157): ['act6','act5','act2','act3','act7','act0','act4','act1']   <- identical
active rows with a non-constant wake_rank: NONE
```

**Rendered frames** (real `OperatorApp` + `run_test` + `save_screenshot`, isolated `HOME`/config, `CMUX_*` unset, spinner pinned):

| | Previous group | Active |
|---|---|---|
| before | armed ◷ rows at the **bottom** | — |
| after | armed ◷ rows lead; dormant ◷ directly beneath, all four contiguous | **byte-identical to base** |

**Degradation** — with `read_index` monkeypatched to raise, every session still lists (`wakes=0`, birth-date order, no exception). Corrupt and orphaned wake entries return normally.

**Neighbours confirmed unchanged** — the mobile daemon keeps its own sort via `session_category` (untouched; wake data provably never reaches it, since durable rows come from `recent_session_rows`), and `/resume` does not consume `CatalogEntry.rank`. `git diff` over `mobile/`, `creation.py`, `server/`: 0 lines.

Note: `DesktopSessions.list` **is** reordered by this change (it ranks via `load_catalog`), so the HTTP listing order shifts with the TUI. Pinned by a new test. Also recorded: `load_catalog` ranks before `[:limit]`, so at the `CATALOG_SCAN_LIMIT` boundary an ancient armed-wake session can enter the window and displace a newer row — measured at 251 sessions, and desirable given the feature's intent.

## Testing

| gate | result |
|---|---|
| `flake8 .` | clean |
| `black --check .` (26.1.0) | `1123 files would be left unchanged` |
| `isort --check .` (5.13.2) | clean |
| `pyright --pythonpath .venv/bin/python .` | `0 errors, 0 warnings, 0 informations` |
| `pytest tests/unit` | **16731 passed, 18 skipped** |
| `pytest tests/e2e -m e2e -n0` | `90 passed, 7 skipped` |

New coverage in `tests/unit/tui/test_session_order.py`: a 16-case band table (including a pending row with empty `live_state`, the case a presence-based guard would miss), plus three parametrized regressions pinning the tier-0/4/5 inversions above so they cannot return. The order-asserting tests were confirmed to **fail** against `46b6dfc7f` before the fix. `test_served_list_order_is_the_catalogs_rank` pins the desktop HTTP order to `rank_entries` from shuffled input.

Review rounds (code, QA, design) are posted in the thread.
