### PR TITLE
fix(analytics): classify malformed tool arguments as a model fault

### DIFF
--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -44,6 +44,8 @@ from local_operator.harness.intent import (
     scan_streaming_intent,
 )
 from local_operator.harness.types import (
+    FAULT_INVALID_ARGUMENTS,
+    FAULT_KEY,
     AbortSignal,
     AgentEndEvent,
     AgentEvent,
@@ -55,6 +57,7 @@ from local_operator.harness.types import (
     ChatRequest,
     Content,
     CustomMessage,
+    InvalidToolArgumentsError,
     LoopConfig,
     Message,
     MessageEndEvent,
@@ -146,9 +149,13 @@ SKIPPED_RESULT_TEXT = "Tool call skipped: interrupted by steering."
 # are the user's decision, our own bug, or the world failing. Only the first
 # three feed the tool-call validity figure — see ``analytics.model.MODEL_FAULTS``,
 # which owns that classification for the read side.
-FAULT_KEY = "__fault"
+#
+# ``FAULT_KEY`` and ``FAULT_INVALID_ARGUMENTS`` are re-exported from
+# ``harness.types`` rather than declared here: a tool BODY also needs to claim
+# the invalid-arguments class (see ``InvalidToolArgumentsError``), and tool
+# modules import ``harness.types`` while this module imports them indirectly.
+# Importing them keeps one spelling for the value the ledger stores.
 FAULT_UNKNOWN_TOOL = "unknown_tool"  # model named a tool that does not exist
-FAULT_INVALID_ARGUMENTS = "invalid_arguments"  # model violated the tool's schema
 FAULT_DUPLICATE_ID = "duplicate_id"  # model emitted one call id twice
 FAULT_DENIED = "denied"  # the user declined the call
 FAULT_GATE_FAILED = "gate_failed"  # our approval plumbing raised
@@ -2086,6 +2093,31 @@ class AgentLoop:
             return await tool.execute(call.id, item.args, signal, on_update, execution_context)
         except asyncio.CancelledError:
             raise
+        except InvalidToolArgumentsError as exc:
+            # An argument-SHAPE rejection raised from inside a tool body. This
+            # is the one exception class that carries its own fault
+            # classification, and this is the only place it is translated —
+            # the marker is set here, where the reason is known, rather than
+            # inferred later from the message text (``_classify_fault``).
+            #
+            # Why it needs its own branch: schema validation
+            # (``validate_tool_arguments``) can only check a JSON-Schema type,
+            # and a tool's real argument grammar is often finer. ``read``'s
+            # ``range`` is typed ``str | None``, so the literal-quoted
+            # ``'"270-330"'`` the model actually emitted passes validation and
+            # fails in the parser — landing in the generic handler below and
+            # being recorded as ``execution``, i.e. laundered out of the
+            # model-accuracy figure. Logged at DEBUG, not WARNING: unlike the
+            # handler below this is a MODEL mistake, not a harness defect, and
+            # it is already counted where it belongs.
+            logger.debug("tool %s rejected malformed arguments: %s", tool.name, exc)
+            return ToolResult(
+                tool_call_id=call.id,
+                tool_name=tool.name,
+                is_error=True,
+                content=[TextContent(text=f"invalid arguments: {exc}")],
+                details={FAULT_KEY: FAULT_INVALID_ARGUMENTS},
+            )
         except Exception as exc:
             logger.warning("tool %s raised", tool.name, exc_info=True)
             return ToolResult(
@@ -2680,6 +2712,14 @@ class AgentLoop:
         the reason is known where the result is built and nowhere else, and a
         reworded message must not silently reclassify a model fault as an
         execution error (or the reverse, which would inflate the benchmark).
+
+        A TOOL BODY is one such source. The fallback is right only for a call
+        whose arguments were usable, so a tool that rejects a malformed
+        argument its JSON-Schema type was too coarse to catch must say so —
+        by raising ``InvalidToolArgumentsError`` or returning a result already
+        carrying the marker. Without that, an argument-shape rejection is
+        indistinguishable here from a genuine execution failure and is
+        silently laundered into the execution bucket.
         """
         if not result.is_error:
             return ""

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -68,6 +68,60 @@ from local_operator.harness.wake import WakeSchedule
 # ---------------------------------------------------------------------------
 
 
+#: Key under which ``ToolResult.details`` carries WHY a call did not run
+#: cleanly. The vocabulary itself (``FAULT_UNKNOWN_TOOL`` and friends) is
+#: declared in ``harness.loop``, which owns classification; only the key and
+#: the one value a TOOL BODY may claim live here, because tool modules import
+#: this module and must not import the loop.
+FAULT_KEY = "__fault"
+
+#: The single fault class a tool body may assert about itself: the arguments
+#: the model emitted were MALFORMED. Duplicated as a literal rather than
+#: imported from ``harness.loop`` for the layering reason above; a test pins
+#: the two spellings together so they cannot drift.
+FAULT_INVALID_ARGUMENTS = "invalid_arguments"
+
+
+class InvalidToolArgumentsError(ValueError):
+    """The model emitted an argument this tool cannot parse.
+
+    Raise this — never a bare ``ValueError`` — when an argument's SHAPE is
+    wrong, and the executor records the call as ``invalid_arguments`` (a MODEL
+    fault, counted in the tool-call error rate) instead of ``execution``.
+
+    **MALFORMED, NOT MERELY UNSATISFIABLE. Read this before raising it.**
+    The test is whether the argument could ever have been valid, not whether
+    the call succeeded:
+
+    - Malformed — raise this. ``range='"270-330"'`` is not a line range in any
+      world; ``pattern='('`` is not a regex. The model could have known, from
+      the schema alone, that the value was wrong before sending it.
+    - Unsatisfiable — do NOT raise this; return an ordinary error result and
+      let it classify as ``execution``. A path that does not exist, an HTTP
+      500, a refused credential, a file that vanished between planning and
+      execution. The argument was well-formed; the world did not cooperate.
+      A missing file is the canonical case and is explicitly NOT a model fault
+      even though it arrives at the same handler.
+
+    Why the boundary is worth this much prose: ``invalid_arguments`` feeds
+    ``analytics.model.MODEL_FAULTS``, and therefore the published
+    ``validity`` / ``tool_call_error_rate`` benchmark figures. Marking an
+    unsatisfiable call as a model fault INFLATES the error rate, which is the
+    worse failure direction — under-reporting is merely incomplete, while
+    over-reporting corrupts the measurement. When a case is genuinely
+    ambiguous, leave it as ``execution``.
+
+    This exists because a JSON-Schema type is coarser than an argument's real
+    grammar. ``read``'s ``range`` is typed ``str | None``, so ``'"270-330"'``
+    passes ``validate_tool_arguments`` and fails in the tool body — arriving
+    at the generic handler indistinguishable from a genuine execution failure.
+    The class is known where the value is parsed and nowhere else, which is
+    exactly the principle ``AgentLoop._classify_fault`` is built on: the
+    marker is SET at the source, never text-matched out of a message
+    afterwards.
+    """
+
+
 class RenderedStreamError(Exception):
     """A stream failure whose ``str()`` is the whole story for the user.
 

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -69,16 +69,16 @@ from local_operator.harness.wake import WakeSchedule
 
 
 #: Key under which ``ToolResult.details`` carries WHY a call did not run
-#: cleanly. The vocabulary itself (``FAULT_UNKNOWN_TOOL`` and friends) is
-#: declared in ``harness.loop``, which owns classification; only the key and
-#: the one value a TOOL BODY may claim live here, because tool modules import
-#: this module and must not import the loop.
+#: cleanly. Declared HERE, and re-exported by ``harness.loop`` (which owns the
+#: rest of the vocabulary and all classification), because tool modules import
+#: this module and must not import the loop. One definition, two importers —
+#: so the ledger's spelling cannot drift between writer and classifier.
 FAULT_KEY = "__fault"
 
-#: The single fault class a tool body may assert about itself: the arguments
-#: the model emitted were MALFORMED. Duplicated as a literal rather than
-#: imported from ``harness.loop`` for the layering reason above; a test pins
-#: the two spellings together so they cannot drift.
+#: The single fault class a TOOL BODY may assert about itself: the arguments
+#: the model emitted were MALFORMED. Lives here for the same layering reason;
+#: the value must stay a member of ``analytics.model.MODEL_FAULTS``, which is
+#: what a test pins.
 FAULT_INVALID_ARGUMENTS = "invalid_arguments"
 
 
@@ -119,6 +119,35 @@ class InvalidToolArgumentsError(ValueError):
     exactly the principle ``AgentLoop._classify_fault`` is built on: the
     marker is SET at the source, never text-matched out of a message
     afterwards.
+    """
+
+
+class EnvironmentDependentRejectionError(ValueError):
+    """A validator refused a value for a reason OUTSIDE the arguments.
+
+    The escape hatch from :class:`InvalidToolArgumentsError`, for the case a
+    params model rejects a value by consulting live config, the environment,
+    the filesystem or the clock rather than by inspecting the argument's
+    shape. Such a rejection is NOT the model's fault: the value may be exactly
+    what the advertised schema offered, and the world moved underneath it.
+
+    The motivating case is ``effort``. Its enum is rendered into the schema at
+    tool-BUILD time from the configured tiers, but the validator re-checks the
+    tier against config at CALL time. Between the two, an operator can edit a
+    tier away — or ``config.yml`` can simply become unreadable, which
+    ``configured_effort_tiers`` deliberately reports as "no tiers" rather than
+    raising, precisely so a corrupt config costs a tier picker and not a
+    session. Without this class the model emits the one value its own schema
+    contained, gets refused, and is billed a model fault for the operator's
+    config — inflating the published benchmark in the direction
+    :class:`InvalidToolArgumentsError` calls the worse one.
+
+    Raise it from inside a pydantic validator; ``ValidationError.errors()``
+    preserves the original exception under ``ctx['error']``, which is how the
+    tool layer tells this apart from a static shape violation WITHOUT matching
+    on message text. Any rejection that is a pure function of the arguments
+    (``extra="forbid"``, a type error, a constrained int, a cross-field
+    validator) must NOT use this — those are genuine model faults.
     """
 
 

--- a/local_operator/harness/wake.py
+++ b/local_operator/harness/wake.py
@@ -136,9 +136,27 @@ class WakeBuilt(TypedDict):
 
 
 class WakeBuildFailed(TypedDict):
-    """Why the request was rejected, phrased for the model to act on."""
+    """Why the request was rejected, phrased for the model to act on.
+
+    ``malformed`` separates the two reasons a request can be refused, because
+    only one of them is the MODEL's fault (see
+    ``harness.types.InvalidToolArgumentsError``):
+
+    - ``True`` — an argument could never have been valid: ``in='soonish'`` is
+      not a duration in any world. ``in``/``at``/``every``/``until`` are typed
+      as plain strings, so no JSON-Schema check can reject these before the
+      parser sees them.
+    - ``False`` — the request parsed but the world refuses it: the schedule
+      table is full, or the requested time has already passed. Well-formed,
+      merely unsatisfiable, and not a model fault.
+
+    Carried as data rather than raised so ``build_wake_schedule`` keeps its
+    documented "returns the error text, never raises" contract, which the
+    union's exactly-one-key typing depends on.
+    """
 
     error: str
+    malformed: bool
 
 
 #: :func:`build_wake_schedule` returns a mapping rather than raising because
@@ -289,8 +307,11 @@ def build_wake_schedule(
     request: dict[str, Any], existing: list[WakeSchedule], now_ms: int
 ) -> WakeBuildResult:
     """Validate a wake-create request. Returns ``{"schedule": WakeSchedule}``
-    or ``{"error": str}`` — it returns the error text rather than raising, so
-    the tool's failure path is a sentence the model can act on.
+    or ``{"error": str, "malformed": bool}`` — it returns the error text
+    rather than raising, so the tool's failure path is a sentence the model
+    can act on. ``malformed`` tells the caller whether the refusal was the
+    model's fault (see :class:`WakeBuildFailed`); the caller uses it to pick
+    the fault class, so a new error branch must set it deliberately.
 
     Recognized request keys: ``message`` (required), ``in`` or ``at`` (one
     required), plus optional ``every``, ``until``, ``limit``. Ids ``w1``..``w16``
@@ -298,34 +319,49 @@ def build_wake_schedule(
     """
     message = request.get("message")
     if not isinstance(message, str) or not message.strip():
-        return {"error": "wake requires a non-empty 'message'."}
+        return {"error": "wake requires a non-empty 'message'.", "malformed": True}
     message = message.strip()
     if len(message) > MAX_WAKE_MESSAGE_CHARS:
-        return {"error": f"wake message must be at most {MAX_WAKE_MESSAGE_CHARS} characters."}
+        return {
+            "error": f"wake message must be at most {MAX_WAKE_MESSAGE_CHARS} characters.",
+            "malformed": True,
+        }
     if len(existing) >= MAX_WAKE_SCHEDULES:
-        return {"error": f"at most {MAX_WAKE_SCHEDULES} wake schedules are allowed."}
+        return {
+            "error": f"at most {MAX_WAKE_SCHEDULES} wake schedules are allowed.",
+            "malformed": False,
+        }
 
     in_val = request.get("in")
     at_val = request.get("at")
     if in_val is not None:
         duration = parse_wake_duration(str(in_val))
         if duration is None:
-            return {"error": f"invalid duration '{in_val}'; use e.g. 45s, 30m, 2h, 7d, 1w."}
+            return {
+                "error": f"invalid duration '{in_val}'; use e.g. 45s, 30m, 2h, 7d, 1w.",
+                "malformed": True,
+            }
         next_due_at = now_ms + duration
     elif at_val is not None:
         parsed = parse_wake_at(str(at_val), now_ms)
         if parsed is None:
             return {
-                "error": f"invalid time '{at_val}'; use +duration, HH:MM, or an ISO-8601 timestamp."
+                "error": (
+                    f"invalid time '{at_val}'; use +duration, HH:MM, or an " "ISO-8601 timestamp."
+                ),
+                "malformed": True,
             }
         next_due_at = parsed
     else:
-        return {"error": "wake requires 'in' (e.g. '30m') or 'at' (e.g. '09:00')."}
+        return {
+            "error": "wake requires 'in' (e.g. '30m') or 'at' (e.g. '09:00').",
+            "malformed": True,
+        }
 
     # Past-at grace: up to PAST_AT_GRACE_MS in the past is accepted and fires
     # immediately; anything older is a user mistake worth surfacing.
     if next_due_at < now_ms - PAST_AT_GRACE_MS:
-        return {"error": "wake time is in the past."}
+        return {"error": "wake time is in the past.", "malformed": False}
     if next_due_at < now_ms:
         next_due_at = now_ms
 
@@ -334,16 +370,19 @@ def build_wake_schedule(
     if every_val is not None:
         every_ms = parse_wake_duration(str(every_val))
         if every_ms is None:
-            return {"error": f"invalid 'every' duration '{every_val}'."}
+            return {"error": f"invalid 'every' duration '{every_val}'.", "malformed": True}
         if every_ms < MIN_WAKE_INTERVAL_MS:
-            return {"error": f"wake interval must be at least {MIN_WAKE_INTERVAL_MS // 1000}s."}
+            return {
+                "error": f"wake interval must be at least {MIN_WAKE_INTERVAL_MS // 1000}s.",
+                "malformed": True,
+            }
 
     until_at: int | None = None
     until_val = request.get("until")
     if until_val is not None:
         until_at = parse_wake_at(str(until_val), now_ms)
         if until_at is None:
-            return {"error": f"invalid 'until' time '{until_val}'."}
+            return {"error": f"invalid 'until' time '{until_val}'.", "malformed": True}
 
     limit: int | None = None
     limit_val = request.get("limit")
@@ -351,9 +390,9 @@ def build_wake_schedule(
         try:
             limit = int(limit_val)
         except (TypeError, ValueError):
-            return {"error": f"invalid 'limit' '{limit_val}'."}
+            return {"error": f"invalid 'limit' '{limit_val}'.", "malformed": True}
         if limit < 1:
-            return {"error": "'limit' must be a positive integer."}
+            return {"error": "'limit' must be a positive integer.", "malformed": True}
 
     used = {schedule.id for schedule in existing}
     wake_id: str | None = None
@@ -363,7 +402,7 @@ def build_wake_schedule(
             wake_id = candidate
             break
     if wake_id is None:
-        return {"error": "no free wake id."}
+        return {"error": "no free wake id.", "malformed": False}
 
     schedule = WakeSchedule(
         id=wake_id,

--- a/local_operator/tools/agent_tool.py
+++ b/local_operator/tools/agent_tool.py
@@ -55,7 +55,14 @@ import logging
 from pathlib import Path
 from typing import Any, Callable, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    ValidationInfo,
+    field_validator,
+)
 
 from local_operator.agent_profiles import (
     MAX_INSTRUCTIONS_CHARS,
@@ -91,6 +98,8 @@ from local_operator.tools.builtin import (
     _text,
     _validate_effort_tier,
     _validation_error,
+    _with_advertised_effort,
+    effort_validation_context,
     spill_truncate,
 )
 
@@ -167,17 +176,21 @@ class AgentParams(BaseModel):
 
     @field_validator("effort")
     @classmethod
-    def _effort_is_configured(cls, value: str | None) -> str | None:
+    def _effort_is_configured(cls, value: str | None, info: ValidationInfo) -> str | None:
         """A pin must name a tier a launch could honour TODAY.
 
         Before this, any of ``lo|med|hi`` was accepted and stored, and the pin
         then failed at every launch of the role once the strict path refused
         the unconfigured tier. Refusing here keeps a stale pin from ever being
         written; the launch path still catches one that went stale later.
+
+        ``info`` carries what the schema advertised, which is what decides
+        whether a refusal is the model's fault or the operator's — see
+        :func:`_validate_effort_tier`.
         """
         if value == "inherit":
             return value
-        return _validate_effort_tier(value)
+        return _validate_effort_tier(value, info)
 
     delegate: bool | None = Field(
         default=None,
@@ -1176,7 +1189,7 @@ async def execute_agent(
     """
 
     try:
-        params = AgentParams(**args)
+        params = AgentParams.model_validate(args, context=effort_validation_context())
     except ValidationError as exc:
         return _validation_error(tool_call_id, "agent", exc)
 
@@ -1231,6 +1244,11 @@ def build_agent_tool(context: ToolContext) -> AgentTool | None:
 
     if getattr(context, "agent_registry", None) is None:
         return None
+    parameters = _advertise_effort_tiers(
+        AgentParams.model_json_schema(),
+        description=_effort_pin_description(),
+        extra=("inherit",),
+    )
     return AgentTool(
         name="agent",
         label="Agent roles",
@@ -1242,11 +1260,7 @@ def build_agent_tool(context: ToolContext) -> AgentTool | None:
             "specialist is the reusable base a team layers collaboration and "
             "project briefs on top of."
         ),
-        parameters=_advertise_effort_tiers(
-            AgentParams.model_json_schema(),
-            description=_effort_pin_description(),
-            extra=("inherit",),
-        ),
+        parameters=parameters,
         # Writes land in the user's own configuration directory, never in the
         # workspace, and are trivially reversible by editing the profile back.
         # Gating them behind an approval prompt would make an agent improving
@@ -1258,5 +1272,5 @@ def build_agent_tool(context: ToolContext) -> AgentTool | None:
         approval_tier="read",
         concurrency="exclusive",
         interruptible=False,
-        execute=execute_agent,
+        execute=_with_advertised_effort(execute_agent, parameters),
     )

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -91,6 +91,7 @@ from local_operator.harness.types import (
     AskQuestion,
     BrowserSurface,
     BrowserSurfaceProtocol,
+    EnvironmentDependentRejectionError,
     ImageContent,
     InvalidToolArgumentsError,
     TextContent,
@@ -1057,22 +1058,52 @@ def _image(
     )
 
 
+def _rejection_is_environmental(exc: ValidationError) -> bool:
+    """True when ANY sub-error was raised for a reason outside the arguments.
+
+    Reads the original exception pydantic preserves under ``ctx['error']``, so
+    the distinction is made from the raised TYPE and never from message text —
+    the same source-of-truth rule ``_classify_fault`` is built on.
+
+    Conservative on purpose: one environment-dependent rejection anywhere in
+    the error set makes the whole call environmental. A ``ValidationError``
+    reports every failed field at once, so a mixed set (a genuine shape error
+    plus a vanished config tier) cannot be split into two verdicts on one
+    call, and the fail-safe direction is to NOT bill the model. Under-claiming
+    merely leaves the figure incomplete; over-claiming corrupts it.
+    """
+    for err in exc.errors():
+        if isinstance((err.get("ctx") or {}).get("error"), EnvironmentDependentRejectionError):
+            return True
+    return False
+
+
 def _validation_error(tool_call_id: str, tool_name: str, exc: ValidationError) -> ToolResult:
     """One ``invalid arguments:`` line per field — no traceback. The model can
     correct its call from the message; the stack trace could not.
 
-    Marked as a model fault. A pydantic rejection of the params model IS the
-    model violating the tool's contract — the same class the loop's own
-    ``validate_tool_arguments`` records — and it only lands here instead of
-    there because the params model is strictly finer than the advertised
-    JSON-Schema type (extra="forbid", cross-field validators, constrained
-    ints). Leaving it unmarked recorded every one of them as ``execution``.
+    Marked as a model fault ONLY when the rejection is a pure function of the
+    arguments — ``extra="forbid"``, a type error, a constrained int, a
+    cross-field validator. Those are the model violating the tool's contract,
+    the same class the loop's ``validate_tool_arguments`` records, and they
+    land here rather than there because the params model is finer than the
+    advertised JSON-Schema type.
+
+    A validator that consults live config, the environment, the filesystem or
+    the clock is NOT in that set: it can refuse a value the advertised schema
+    itself offered, which is the world changing rather than the model erring.
+    Those raise ``EnvironmentDependentRejectionError`` and stay ``execution``.
+    Marking them would let a corrupt ``config.yml`` inflate a published
+    accuracy figure — see ``_validate_effort_tier``, the case that proved it.
     """
     lines = [
         f"- {'.'.join(str(part) for part in err['loc']) or '<root>'}: {err['msg']}"
         for err in exc.errors()
     ]
-    return _invalid_arguments(tool_call_id, tool_name, "invalid arguments:\n" + "\n".join(lines))
+    body = "invalid arguments:\n" + "\n".join(lines)
+    if _rejection_is_environmental(exc):
+        return _error(tool_call_id, tool_name, body)
+    return _invalid_arguments(tool_call_id, tool_name, body)
 
 
 #: The shape every ``execute_*`` in this module has. It differs from
@@ -2702,7 +2733,11 @@ def _read_spill(tool_call_id: str, target: str, range_spec: str | None) -> ToolR
     """
     ref = parse_handle(target)
     if ref is None:
-        return _error(
+        # Malformed, matching the regex branch in `_search_spill` below: the
+        # handle rides inside `path`, a plain schema string, so a value that
+        # is not a handle at all can only be caught here. A well-formed handle
+        # the store cannot serve is a different case and stays `execution`.
+        return _invalid_arguments(
             tool_call_id,
             "read",
             f"Malformed spill handle '{target}'. Expected "
@@ -5315,6 +5350,12 @@ async def _wake_create(
     }
     outcome = build_wake_schedule(request, existing, now_ms)
     if "error" in outcome:
+        # `in`/`at`/`every`/`until` are plain strings in the schema, so an
+        # unparseable duration only fails here — the coarse-schema case this
+        # classification exists for. A full schedule table or a past time is
+        # well-formed and unsatisfiable, and stays an execution error.
+        if outcome["malformed"]:
+            return _invalid_arguments(tool_call_id, "wake", outcome["error"])
         return _error(tool_call_id, "wake", outcome["error"])
     schedule = outcome["schedule"]
     updated = [s for s in existing if s.id != schedule.id] + [schedule]
@@ -8460,7 +8501,15 @@ def _validate_effort_tier(value: str | None) -> str | None:
         return None
     rejection = effort_tier_rejection(value)
     if rejection is not None:
-        raise ValueError(rejection)
+        # NOT a model fault, however it reads. The enum the model chose from
+        # was rendered into the schema at BUILD time and this check reads
+        # config at CALL time, so a value that was valid when advertised can
+        # be refused because the operator edited a tier away — or because
+        # ``config.yml`` became unreadable, which ``configured_effort_tiers``
+        # reports as "no tiers" by design rather than raising. Billing that to
+        # the model would put an operator config error into a published
+        # accuracy figure.
+        raise EnvironmentDependentRejectionError(rejection)
     return value
 
 

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -59,6 +59,7 @@ import traceback
 import unicodedata
 from collections import deque
 from collections.abc import Awaitable, Callable, Iterator, Sequence
+from contextvars import ContextVar
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal, NamedTuple, cast
@@ -69,6 +70,7 @@ from pydantic import (
     ConfigDict,
     Field,
     ValidationError,
+    ValidationInfo,
     field_validator,
     model_validator,
 )
@@ -1065,12 +1067,29 @@ def _rejection_is_environmental(exc: ValidationError) -> bool:
     the distinction is made from the raised TYPE and never from message text —
     the same source-of-truth rule ``_classify_fault`` is built on.
 
-    Conservative on purpose: one environment-dependent rejection anywhere in
-    the error set makes the whole call environmental. A ``ValidationError``
-    reports every failed field at once, so a mixed set (a genuine shape error
-    plus a vanished config tier) cannot be split into two verdicts on one
-    call, and the fail-safe direction is to NOT bill the model. Under-claiming
-    merely leaves the figure incomplete; over-claiming corrupts it.
+    ANY, not ALL: one environment-dependent rejection anywhere in the error
+    set makes the whole call environmental. A ``ValidationError`` reports
+    every failed field at once, so a mixed set cannot be split into two
+    verdicts on one call, and not billing the model is the better way to be
+    wrong — under-claiming leaves the figure incomplete, over-claiming
+    corrupts it.
+
+    That rule is only safe because the environmental branch is NARROW. While
+    ``_validate_effort_tier`` raised environmentally for every refusal, one
+    invented tier laundered a genuine ``extra="forbid"`` reported in the same
+    call — under-claiming in aggregate but actively erasing faults that were
+    correctly attributed. It now raises environmentally only for a value the
+    schema really advertised, so a laundering pair is not environmental under
+    either rule and ANY is the right choice for what remains.
+
+    **Two failure directions, only one of them safe.** The ANY rule above
+    fails toward ``execution``. The ``ctx`` read below fails the other way: a
+    validator raising a bare ``ValueError``, or a pydantic that stopped
+    populating ``ctx``, reads as a model fault. That is the over-claiming
+    direction, and it is not reachable today — ``exc.errors()`` defaults to
+    ``include_context=True`` and nothing in the tree overrides it — but it is
+    the honest description of the mechanism, so do not read the paragraph
+    above as a guarantee about this one.
     """
     for err in exc.errors():
         if isinstance((err.get("ctx") or {}).get("error"), EnvironmentDependentRejectionError):
@@ -1105,6 +1124,17 @@ def _validation_error(tool_call_id: str, tool_name: str, exc: ValidationError) -
         return _error(tool_call_id, tool_name, body)
     return _invalid_arguments(tool_call_id, tool_name, body)
 
+
+#: Public name for :func:`_validation_error`, for callers OUTSIDE the ``tools``
+#: package. The underscore form is this module's own spelling and is shared
+#: freely within ``tools`` (``eval``, ``lsp``, ``agent_tool``, ``team_tool``),
+#: but ``web_fetch``/``web_search`` are separate packages: importing a private
+#: name across that boundary claims a privacy the tree does not honour and
+#: makes a refactor of this module's internals silently break them. They must
+#: share the helper — a fault class that differs by which tool the model
+#: picked is the defect this whole change exists to remove — so the sharing
+#: gets a supported name rather than being done through the back door.
+validation_error_result = _validation_error
 
 #: The shape every ``execute_*`` in this module has. It differs from
 #: ``ToolExecuteFn`` only in accepting ``context=None``, which the bare-tool
@@ -8487,7 +8517,78 @@ def build_browser_tool(context: ToolContext | None) -> AgentTool | None:
 # never advertise tools that can only error.
 
 
-def _validate_effort_tier(value: str | None) -> str | None:
+#: Key under which the ``effort`` members a BUILD actually advertised are
+#: handed to ``model_validate`` as ``context=``, read back in the validator
+#: through ``ValidationInfo.context``.
+ADVERTISED_EFFORT_KEY = "advertised_effort"
+
+#: The advertised set for the tool currently executing, published by the
+#: builder's wrapper (:func:`_with_advertised_effort`) and read at the
+#: ``model_validate`` call.
+#:
+#: A ContextVar rather than a parameter because the executor signature is the
+#: fixed five-argument ``ToolExecutor`` contract, and rather than a module
+#: global because concurrent calls — a parent and its subagents run on one
+#: loop — must not see each other's snapshot; a ContextVar is copied per task.
+#:
+#: It cannot be recomputed at call time, which is the whole point: reading
+#: ``configured_effort_tiers()`` here would yield the CURRENT tiers, making
+#: "was advertised" collapse into "is valid now" and every refusal a model
+#: fault — losing exactly the operator-config case this PR fixed. Only the
+#: build side knows what the model was shown.
+#:
+#: ``None`` means no build published a snapshot (a direct call to the module
+#: level executor, e.g. from a test). That is treated as environmental, the
+#: under-claiming direction, because a call whose provenance is unknown must
+#: not be billed to the model. Production always publishes: every advertised
+#: ``task``/``agent`` tool is built through its builder.
+_ADVERTISED_EFFORT: ContextVar[frozenset[str] | None] = ContextVar(
+    "advertised_effort", default=None
+)
+
+
+def _with_advertised_effort(executor: ToolExecutor, parameters: dict[str, Any]) -> ToolExecutor:
+    """Publish what this build advertised for the duration of one call.
+
+    Wraps the builder's executor so the validator can tell an operator's
+    vanished tier from a value the model invented. Reset in a ``finally`` so a
+    raising tool cannot leak one tool's snapshot into the next call.
+    """
+    advertised = advertised_effort_members(parameters)
+
+    async def wrapper(
+        tool_call_id: str,
+        args: dict[str, Any],
+        signal: AbortSignal | None = None,
+        on_update: Callable[[AgentToolUpdate], None] | None = None,
+        context: ToolContext | None = None,
+    ) -> ToolResult:
+        token = _ADVERTISED_EFFORT.set(advertised)
+        try:
+            return await executor(tool_call_id, args, signal, on_update, context)
+        finally:
+            _ADVERTISED_EFFORT.reset(token)
+
+    wrapper.__name__ = getattr(executor, "__name__", "execute")
+    wrapper.__qualname__ = wrapper.__name__
+    return wrapper
+
+
+def effort_validation_context() -> dict[str, Any]:
+    """Validation context carrying the advertised ``effort`` members."""
+    return {ADVERTISED_EFFORT_KEY: _ADVERTISED_EFFORT.get()}
+
+
+def _advertised_effort(info: ValidationInfo) -> frozenset[str] | None:
+    """What ``effort`` members the schema offered, or ``None`` if unrecorded."""
+    context = info.context if isinstance(info.context, dict) else None
+    if not context:
+        return None
+    members = context.get(ADVERTISED_EFFORT_KEY)
+    return frozenset(members) if isinstance(members, (set, frozenset, list, tuple)) else None
+
+
+def _validate_effort_tier(value: str | None, info: ValidationInfo) -> str | None:
     """Refuse an ``effort`` the live config cannot honour, naming what can be.
 
     Shared by both ``task`` forms and the ``agent`` tool so the three fields
@@ -8496,21 +8597,44 @@ def _validate_effort_tier(value: str | None) -> str | None:
     agree except across a mid-session edit, and this is the side that must be
     right — an accepted-but-stale tier would reach the strict launch path and
     fail there with less context than the message here carries.
+
+    **The refusal splits into two fault classes, and only the build-time
+    record can tell them apart.** ``effort_tier_rejection`` says only "not
+    usable now"; whether that is the model's mistake depends on what the model
+    was shown:
+
+    - The value WAS in the advertised enum and is gone now — the operator
+      edited a tier away, or ``config.yml`` became unreadable (which
+      ``configured_effort_tiers`` reports as "no tiers" by design rather than
+      raising). The model picked from the menu it was given; billing it would
+      put an operator config error into a published accuracy figure.
+    - The value was NEVER advertised — including the common case where no
+      tiers are configured at all and ``_advertise_effort_tiers`` DELETES the
+      property, so ``effort`` is a field the schema does not contain. The
+      model invented it, which is the same kind of mistake as an
+      ``extra="forbid"`` key, and is a model fault.
+
+    Treating both as environmental also laundered any genuine violation
+    reported in the SAME call: one invented tier made the whole
+    ``ValidationError`` environmental and erased a co-reported
+    ``extra="forbid"``. Narrow branch, no laundering.
     """
     if value is None:
         return None
     rejection = effort_tier_rejection(value)
-    if rejection is not None:
-        # NOT a model fault, however it reads. The enum the model chose from
-        # was rendered into the schema at BUILD time and this check reads
-        # config at CALL time, so a value that was valid when advertised can
-        # be refused because the operator edited a tier away — or because
-        # ``config.yml`` became unreadable, which ``configured_effort_tiers``
-        # reports as "no tiers" by design rather than raising. Billing that to
-        # the model would put an operator config error into a published
-        # accuracy figure.
+    if rejection is None:
+        return value
+    advertised = _advertised_effort(info)
+    if advertised is None or value in advertised:
+        # ``None`` is "no build published a snapshot" — a direct call to the
+        # module-level executor, which production never makes (every
+        # advertised task/agent tool is built through its builder). Unknown
+        # provenance takes the environmental branch deliberately: a call whose
+        # schema cannot be established must not be billed to the model, which
+        # is the same under-claiming preference the rest of this boundary
+        # applies.
         raise EnvironmentDependentRejectionError(rejection)
-    return value
+    raise ValueError(rejection)
 
 
 def _advertise_effort_tiers(
@@ -8581,6 +8705,32 @@ def _advertise_effort_tiers(
             if isinstance(entry, dict):
                 patch(entry.get("properties"))
     return patched
+
+
+def advertised_effort_members(parameters: dict[str, Any] | None) -> frozenset[str]:
+    """The ``effort`` members a BUILT schema offers, read back from the schema.
+
+    The tool's own parameters are the record of what the model was shown, so
+    the advertised set is recovered from them rather than tracked separately —
+    one source of truth, and it cannot fall out of step with what shipped. An
+    empty set is the meaningful answer for a session with no tiers configured:
+    ``_advertise_effort_tiers`` deletes the property outright, so any
+    ``effort`` the model sends is a field its schema does not contain.
+
+    Read at CALL time and handed to ``model_validate`` as validation context;
+    see :func:`_validate_effort_tier` for why the distinction decides a fault
+    class.
+    """
+    properties = (parameters or {}).get("properties")
+    if not isinstance(properties, dict):
+        return frozenset()
+    effort = properties.get("effort")
+    if not isinstance(effort, dict):
+        return frozenset()
+    for variant in effort.get("anyOf") or [effort]:
+        if isinstance(variant, dict) and isinstance(variant.get("enum"), list):
+            return frozenset(str(member) for member in variant["enum"])
+    return frozenset()
 
 
 def _effort_tier_field_description() -> str:
@@ -8662,8 +8812,8 @@ class TaskItem(BaseModel):
 
     @field_validator("effort")
     @classmethod
-    def _effort_is_configured(cls, value: str | None) -> str | None:
-        return _validate_effort_tier(value)
+    def _effort_is_configured(cls, value: str | None, info: ValidationInfo) -> str | None:
+        return _validate_effort_tier(value, info)
 
 
 class TaskParams(BaseModel):
@@ -8694,8 +8844,8 @@ class TaskParams(BaseModel):
 
     @field_validator("effort")
     @classmethod
-    def _effort_is_configured(cls, value: str | None) -> str | None:
-        return _validate_effort_tier(value)
+    def _effort_is_configured(cls, value: str | None, info: ValidationInfo) -> str | None:
+        return _validate_effort_tier(value, info)
 
     context: str = Field(
         default="",
@@ -9145,7 +9295,7 @@ async def execute_task(
     between children.
     """
     try:
-        params = TaskParams(**args)
+        params = TaskParams.model_validate(args, context=effort_validation_context())
     except ValidationError as exc:
         return _validation_error(tool_call_id, "task", exc)
 
@@ -9223,21 +9373,22 @@ async def execute_task(
 def build_task_tool(context: ToolContext) -> AgentTool | None:
     if context.subagent_launcher is None:
         return None
+    parameters = _advertise_effort_tiers(
+        TaskParams.model_json_schema(),
+        description=_effort_tier_field_description(),
+    )
     return AgentTool(
         name="task",
         label="Subagent task",
         describe_approval=_describe_task_approval,
         description=_task_tool_description(),
-        parameters=_advertise_effort_tiers(
-            TaskParams.model_json_schema(),
-            description=_effort_tier_field_description(),
-        ),
+        parameters=parameters,
         # Spawns autonomous child work, so it rides the write gate just like
         # scheduling a wake: the user approves starting the child.
         approval_tier="write",
         concurrency="exclusive",
         interruptible=False,
-        execute=execute_task,
+        execute=_with_advertised_effort(execute_task, parameters),
     )
 
 

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -82,6 +82,8 @@ from local_operator.harness.subagent import (
     effort_tier_rejection,
 )
 from local_operator.harness.types import (
+    FAULT_INVALID_ARGUMENTS,
+    FAULT_KEY,
     AbortSignal,
     AgentTool,
     AgentToolUpdate,
@@ -90,6 +92,7 @@ from local_operator.harness.types import (
     BrowserSurface,
     BrowserSurfaceProtocol,
     ImageContent,
+    InvalidToolArgumentsError,
     TextContent,
     ToolContext,
     ToolResult,
@@ -984,6 +987,26 @@ def _error(tool_call_id: str, tool_name: str, message: str) -> ToolResult:
     )
 
 
+def _invalid_arguments(tool_call_id: str, tool_name: str, message: str) -> ToolResult:
+    """An error result MARKED as the model's fault, not the machine's.
+
+    Same shape as :func:`_error`, plus the ``__fault`` marker that makes the
+    call count as ``invalid_arguments`` in the tool-call error rate. Use it
+    only where an argument is MALFORMED — see
+    :class:`~local_operator.harness.types.InvalidToolArgumentsError` for the
+    malformed-vs-unsatisfiable rule and why guessing wrong in the permissive
+    direction is the worse error. A missing file or a failed request is an
+    ordinary :func:`_error`.
+    """
+    return ToolResult(
+        tool_call_id=tool_call_id,
+        tool_name=tool_name,
+        content=[TextContent(text=message)],
+        details={FAULT_KEY: FAULT_INVALID_ARGUMENTS},
+        is_error=True,
+    )
+
+
 def _text(
     tool_call_id: str,
     tool_name: str,
@@ -1036,12 +1059,20 @@ def _image(
 
 def _validation_error(tool_call_id: str, tool_name: str, exc: ValidationError) -> ToolResult:
     """One ``invalid arguments:`` line per field — no traceback. The model can
-    correct its call from the message; the stack trace could not."""
+    correct its call from the message; the stack trace could not.
+
+    Marked as a model fault. A pydantic rejection of the params model IS the
+    model violating the tool's contract — the same class the loop's own
+    ``validate_tool_arguments`` records — and it only lands here instead of
+    there because the params model is strictly finer than the advertised
+    JSON-Schema type (extra="forbid", cross-field validators, constrained
+    ints). Leaving it unmarked recorded every one of them as ``execution``.
+    """
     lines = [
         f"- {'.'.join(str(part) for part in err['loc']) or '<root>'}: {err['msg']}"
         for err in exc.errors()
     ]
-    return _error(tool_call_id, tool_name, "invalid arguments:\n" + "\n".join(lines))
+    return _invalid_arguments(tool_call_id, tool_name, "invalid arguments:\n" + "\n".join(lines))
 
 
 #: The shape every ``execute_*`` in this module has. It differs from
@@ -1155,6 +1186,19 @@ def _guard(tool_name: str) -> Callable[[ToolExecutor], ToolExecutor]:
         ) -> ToolResult:
             try:
                 return await fn(tool_call_id, args, signal, on_update, context)
+            except InvalidToolArgumentsError as exc:
+                # Handled BEFORE the catch-all, which would otherwise convert a
+                # deliberate argument-shape rejection into an unmarked
+                # "failed unexpectedly" traceback — losing the fault marker and
+                # recording a model fault as an execution error. This guard sits
+                # inside the tool, so the loop's identical branch never sees a
+                # raise from a guarded tool; both exist because unguarded tools
+                # (MCP bridges, hosts) reach the loop directly.
+                #
+                # No traceback: the model can correct a malformed argument from
+                # the message, and a stack trace of our own parser cannot help
+                # it — the same reasoning as ``_validation_error``.
+                return _invalid_arguments(tool_call_id, tool_name, f"invalid arguments: {exc}")
             except Exception:  # noqa: BLE001 — boundary: nothing may escape
                 return _error(
                     tool_call_id,
@@ -2223,15 +2267,33 @@ _LINE_RANGE_RE = re.compile(r"^(\d+)\s*-\s*(\d+)?$")
 
 
 def _parse_line_range(spec: str) -> tuple[int, int | None]:
+    """Parse a ``'start-end'`` / ``'start-'`` range spec.
+
+    Raises :class:`InvalidToolArgumentsError` (a ``ValueError`` subclass, so
+    existing ``except ValueError`` callers are unaffected) because every
+    rejection here is a MALFORMED argument: the schema types ``range`` as a
+    plain string, so a value like ``'"270-330"'`` — the literal-quoted form a
+    model really emitted — passes validation and only fails at this parse.
+    Marking it here is what keeps it out of the execution bucket.
+
+    Callers deliberately catch the SUBCLASS rather than ``ValueError``: an
+    unrelated ``ValueError`` escaping this call is a bug in our own code, not
+    the model's mistake, and catching the broad type would credit it to the
+    model and inflate the benchmark. Narrow is the fail-safe direction — an
+    unexpected error falls through to the execution bucket, which merely
+    under-reports.
+    """
     match = _LINE_RANGE_RE.match(spec.strip())
     if not match:
-        raise ValueError(f"invalid line range '{spec}' (expected 'start-end' or 'start-')")
+        raise InvalidToolArgumentsError(
+            f"invalid line range '{spec}' (expected 'start-end' or 'start-')"
+        )
     start = int(match.group(1))
     if start < 1:
-        raise ValueError(f"invalid line range '{spec}': start must be >= 1")
+        raise InvalidToolArgumentsError(f"invalid line range '{spec}': start must be >= 1")
     end = int(match.group(2)) if match.group(2) else None
     if end is not None and end < start:
-        raise ValueError(f"invalid line range '{spec}': end must be >= start")
+        raise InvalidToolArgumentsError(f"invalid line range '{spec}': end must be >= start")
     return start, end
 
 
@@ -2666,8 +2728,8 @@ def _read_spill(tool_call_id: str, target: str, range_spec: str | None) -> ToolR
     if range_spec:
         try:
             start, end = _parse_line_range(range_spec)
-        except ValueError as exc:
-            return _error(tool_call_id, "read", str(exc))
+        except InvalidToolArgumentsError as exc:
+            return _invalid_arguments(tool_call_id, "read", str(exc))
     result = store.read_lines(ref.handle, start, end)
     if result is None:
         return _error(tool_call_id, "read", f"Spilled output {ref.handle} could not be read.")
@@ -2721,8 +2783,12 @@ def _search_spill(
     try:
         found = store.search(ref.handle, ref.query, SPILL_SEARCH_MATCH_LIMIT)
     except re.error as exc:
-        return _error(tool_call_id, "read", f"invalid regex '{ref.query}': {exc}")
+        # Malformed, same as grep's pattern: the `?q=` fragment rides inside a
+        # URL string, so no schema can reject a bad regex before it parses.
+        return _invalid_arguments(tool_call_id, "read", f"invalid regex '{ref.query}': {exc}")
     if found is None:
+        # Unsatisfiable, not malformed — the handle parsed fine and the store
+        # could not serve it. Stays `execution`.
         return _error(tool_call_id, "read", f"Spilled output {ref.handle} could not be read.")
     matches, total_matches, total_lines = found
     if range_spec:
@@ -2731,8 +2797,8 @@ def _search_spill(
         # whenever the matches fell outside the requested line window.
         try:
             start, end = _parse_line_range(range_spec)
-        except ValueError as exc:
-            return _error(tool_call_id, "read", str(exc))
+        except InvalidToolArgumentsError as exc:
+            return _invalid_arguments(tool_call_id, "read", str(exc))
         matches = matches[start - 1 : end]
     details = {"url": f"{ref.handle}?q={ref.query}"}
     if not matches:
@@ -3143,8 +3209,8 @@ async def execute_read(
     if params.range:
         try:
             start, end = _parse_line_range(params.range)
-        except ValueError as exc:
-            return _error(tool_call_id, "read", str(exc))
+        except InvalidToolArgumentsError as exc:
+            return _invalid_arguments(tool_call_id, "read", str(exc))
         selected = lines[start - 1 : end]
         if not selected:
             return _text(
@@ -4391,11 +4457,16 @@ async def execute_grep(
     try:
         regex = re.compile(params.pattern, 0 if params.case else re.IGNORECASE)
     except re.error as exc:
-        return _error(tool_call_id, "grep", f"invalid regex '{params.pattern}': {exc}")
+        # Malformed: `pattern` is typed `string`, so an unbalanced group passes
+        # schema validation and only fails here. The model could have known.
+        return _invalid_arguments(tool_call_id, "grep", f"invalid regex '{params.pattern}': {exc}")
 
     cwd = _safe_cwd(context)
     target, inside, resolvable = _resolve_workspace_path(params.path, cwd)
     if not target.exists():
+        # Deliberately NOT a model fault: a well-formed path that does not
+        # exist is unsatisfiable, not malformed, and the file may have vanished
+        # after the model planned the call. Stays `execution`.
         return _error(tool_call_id, "grep", f"Path does not exist: {target}")
 
     # Outside-workspace searches escalate to an approval prompt regardless
@@ -10050,8 +10121,8 @@ async def _hub_peek(tool_call_id: str, comms: Any, params: Any, ids: list[str]) 
     if params.range is not None:
         try:
             start, end = _parse_line_range(params.range)
-        except ValueError as exc:
-            return _error(tool_call_id, "hub", str(exc))
+        except InvalidToolArgumentsError as exc:
+            return _invalid_arguments(tool_call_id, "hub", str(exc))
     window = await comms.peek(ids[0], start=start, end=end, steps=params.steps)
     if window.error is not None:
         return _error(tool_call_id, "hub", f"{window.label} ({window.job_id}): {window.error}")

--- a/local_operator/web_fetch/tool.py
+++ b/local_operator/web_fetch/tool.py
@@ -35,7 +35,7 @@ from local_operator.harness.types import (
     ToolResult,
 )
 from local_operator.paths import config_dir
-from local_operator.tools.builtin import _validation_error, spill_truncate
+from local_operator.tools.builtin import spill_truncate, validation_error_result
 from local_operator.tools.spill import get_store
 from local_operator.web_fetch.models import FetchResult
 from local_operator.web_fetch.service import (
@@ -514,7 +514,7 @@ async def execute_web_fetch(
         # classification must not depend on WHICH tool the model picked, or
         # `validity` acquires a hidden dependence on tool identity. Same
         # rejection, same class, same "invalid arguments:" voice.
-        return _validation_error(tool_call_id, "web_fetch", error)
+        return validation_error_result(tool_call_id, "web_fetch", error)
 
     preview, details, is_error = await run_fetch(
         params.url,

--- a/local_operator/web_fetch/tool.py
+++ b/local_operator/web_fetch/tool.py
@@ -35,7 +35,7 @@ from local_operator.harness.types import (
     ToolResult,
 )
 from local_operator.paths import config_dir
-from local_operator.tools.builtin import spill_truncate
+from local_operator.tools.builtin import _validation_error, spill_truncate
 from local_operator.tools.spill import get_store
 from local_operator.web_fetch.models import FetchResult
 from local_operator.web_fetch.service import (
@@ -510,9 +510,11 @@ async def execute_web_fetch(
     try:
         params = WebFetchParams.model_validate(args)
     except ValidationError as error:
-        return _result(
-            tool_call_id, "web_fetch", f"Invalid web_fetch arguments: {error}", error=True
-        )
+        # Shared with the builtins rather than hand-built here: the fault
+        # classification must not depend on WHICH tool the model picked, or
+        # `validity` acquires a hidden dependence on tool identity. Same
+        # rejection, same class, same "invalid arguments:" voice.
+        return _validation_error(tool_call_id, "web_fetch", error)
 
     preview, details, is_error = await run_fetch(
         params.url,

--- a/local_operator/web_search/tool.py
+++ b/local_operator/web_search/tool.py
@@ -22,6 +22,7 @@ from local_operator.harness.types import (
     ToolResult,
 )
 from local_operator.paths import config_dir
+from local_operator.tools.builtin import _validation_error
 from local_operator.web_search.models import SearchProviderId, SearchResponse
 from local_operator.web_search.providers import PROVIDERS, tavily_response_from_payload
 from local_operator.web_search.service import (
@@ -324,7 +325,10 @@ async def execute_web_search(
     try:
         params = WebSearchParams.model_validate(args)
     except ValidationError as error:
-        return _result(tool_call_id, f"Invalid web_search arguments: {error}", error=True)
+        # Shared with the builtins rather than hand-built here: the fault
+        # classification must not depend on WHICH tool the model picked, or
+        # `validity` acquires a hidden dependence on tool identity.
+        return _validation_error(tool_call_id, "web_search", error)
 
     manager = ConfigManager(config_dir())
     settings = load_search_settings(manager)

--- a/local_operator/web_search/tool.py
+++ b/local_operator/web_search/tool.py
@@ -22,7 +22,7 @@ from local_operator.harness.types import (
     ToolResult,
 )
 from local_operator.paths import config_dir
-from local_operator.tools.builtin import _validation_error
+from local_operator.tools.builtin import validation_error_result
 from local_operator.web_search.models import SearchProviderId, SearchResponse
 from local_operator.web_search.providers import PROVIDERS, tavily_response_from_payload
 from local_operator.web_search.service import (
@@ -328,7 +328,7 @@ async def execute_web_search(
         # Shared with the builtins rather than hand-built here: the fault
         # classification must not depend on WHICH tool the model picked, or
         # `validity` acquires a hidden dependence on tool identity.
-        return _validation_error(tool_call_id, "web_search", error)
+        return validation_error_result(tool_call_id, "web_search", error)
 
     manager = ConfigManager(config_dir())
     settings = load_search_settings(manager)

--- a/tests/unit/harness/test_tool_call_analytics.py
+++ b/tests/unit/harness/test_tool_call_analytics.py
@@ -423,3 +423,149 @@ async def test_shipped_eval_nested_exclusion_is_not_a_failed_tool_call(
             assert nested.split("excluded", 1)[1].strip().startswith("1")
     finally:
         store.close()
+
+
+# ---------------------------------------------------------------------------
+# The classification BOUNDARY: malformed argument vs unsatisfiable request.
+#
+# Both arrive at the same generic handler as an is_error result from a tool
+# body, and before the marker existed both recorded as `execution` — which is
+# how a session with four model-caused invalid calls rendered a 0.0% error
+# rate. These pin the boundary in BOTH directions, because the permissive
+# direction (calling an execution error a model fault) inflates a published
+# benchmark and is the worse failure.
+# ---------------------------------------------------------------------------
+
+
+def _shipped_read_tool(tmp_path) -> AgentTool:
+    """The REAL shipped ``read``, not a stand-in: the claim under test is that
+    its own argument parsing is classified correctly."""
+    from local_operator.tools.registry import create_tools
+
+    context = ToolContext(cwd=str(tmp_path), session_id="s1")
+    return next(t for t in create_tools(context) if t.name == "read")
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_range_is_a_model_fault_not_an_execution_error(tmp_path):
+    """The operator's exact repro: ``range='"270-330"'`` — a line range with
+    literal quote characters embedded.
+
+    ``range`` is typed ``str | None``, so this passes the loop's schema check
+    and fails inside the tool body. It is unambiguously the model emitting an
+    argument the tool cannot use, and recording it as ``execution`` is what
+    laundered it out of the accuracy figure.
+    """
+    (tmp_path / "a.txt").write_text("l1\nl2\nl3\n")
+    recorded = await _run(
+        _calls((0, "c1", "read", '{"path":"a.txt","range":"\\"270-330\\""}'))
+        + [StreamEndEvent(stop_reason="toolUse")],
+        [_shipped_read_tool(tmp_path)],
+        cwd=str(tmp_path),
+    )
+    assert _faults(recorded) == {"read": "invalid_arguments"}
+
+
+@pytest.mark.asyncio
+async def test_a_wellformed_range_on_a_missing_file_stays_an_execution_error(tmp_path):
+    """The regression that matters most. A path that does not exist is
+    UNSATISFIABLE, not malformed — the file may have vanished after the model
+    planned the call — so it must NOT be credited to the model."""
+    recorded = await _run(
+        _calls((0, "c1", "read", '{"path":"ghost.txt","range":"1-5"}'))
+        + [StreamEndEvent(stop_reason="toolUse")],
+        [_shipped_read_tool(tmp_path)],
+        cwd=str(tmp_path),
+    )
+    assert _faults(recorded) == {"read": "execution"}
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_regex_is_a_model_fault_but_a_missing_path_is_not(tmp_path):
+    """``grep``'s two rejections sit three lines apart in the same function and
+    fall on opposite sides of the boundary."""
+    from local_operator.tools.registry import create_tools
+
+    context = ToolContext(cwd=str(tmp_path), session_id="s1")
+    grep = next(t for t in create_tools(context) if t.name == "grep")
+
+    bad_regex = await _run(
+        _calls((0, "c1", "grep", '{"pattern":"("}')) + [StreamEndEvent(stop_reason="toolUse")],
+        [grep],
+        cwd=str(tmp_path),
+    )
+    assert _faults(bad_regex) == {"grep": "invalid_arguments"}
+
+    missing_path = await _run(
+        _calls((0, "c1", "grep", '{"pattern":"x","path":"no/such/dir"}'))
+        + [StreamEndEvent(stop_reason="toolUse")],
+        [grep],
+        cwd=str(tmp_path),
+    )
+    assert _faults(missing_path) == {"grep": "execution"}
+
+
+@pytest.mark.asyncio
+async def test_a_tool_body_raising_the_typed_error_is_translated_by_the_executor():
+    """A tool may RAISE rather than hand-build a marked result; the executor
+    performs the translation so every tool gets it for free."""
+    from local_operator.harness.types import InvalidToolArgumentsError
+
+    async def execute(tool_call_id, args, signal, on_update, context):
+        raise InvalidToolArgumentsError("not a duration: 'soonish'")
+
+    tool = AgentTool(
+        name="wake",
+        parameters={"type": "object", "properties": {"in": {"type": "string"}}},
+        execute=execute,
+    )
+    recorded = await _run(
+        _calls((0, "c1", "wake", '{"in":"soonish"}')) + [StreamEndEvent(stop_reason="toolUse")],
+        [tool],
+    )
+    assert _faults(recorded) == {"wake": "invalid_arguments"}
+
+
+def test_the_fault_marker_spellings_agree_across_the_layering_gap():
+    """``harness.types`` duplicates two constants ``harness.loop`` also uses,
+    because tool modules may not import the loop. A drift would not fail — it
+    would silently write an unrecognised fault name into the ledger, dropping
+    those calls out of ``MODEL_FAULTS`` and back to under-reporting."""
+    from local_operator.analytics.model import MODEL_FAULTS
+    from local_operator.harness import loop as loop_module
+    from local_operator.harness import types as types_module
+
+    assert types_module.FAULT_KEY == loop_module.FAULT_KEY == "__fault"
+    assert types_module.FAULT_INVALID_ARGUMENTS == loop_module.FAULT_INVALID_ARGUMENTS
+    assert types_module.FAULT_INVALID_ARGUMENTS in MODEL_FAULTS
+
+
+@pytest.mark.asyncio
+async def test_the_builtin_guard_does_not_swallow_the_typed_error():
+    """``_guard`` wraps every builtin and catches ``Exception`` INSIDE the tool,
+    so the loop's translation branch never sees a raise from one.
+
+    Without its own branch there, the guard's catch-all converted a deliberate
+    argument-shape rejection into an unmarked "failed unexpectedly" traceback —
+    the marker lost, the call recorded as ``execution``, and the raise mechanism
+    silently useless for exactly the tools it was built for. A genuine internal
+    error must still take the traceback path.
+    """
+    from local_operator.harness.types import InvalidToolArgumentsError
+    from local_operator.tools.builtin import _guard
+
+    @_guard("demo")
+    async def malformed(tool_call_id, args, signal=None, on_update=None, context=None):
+        raise InvalidToolArgumentsError("not a duration: 'soonish'")
+
+    @_guard("demo")
+    async def internal(tool_call_id, args, signal=None, on_update=None, context=None):
+        raise RuntimeError("genuine internal failure")
+
+    rejected = await malformed("c", {}, None, None, None)
+    assert rejected.is_error and rejected.details == {"__fault": "invalid_arguments"}
+    assert "Traceback" not in rejected.text
+
+    crashed = await internal("c", {}, None, None, None)
+    assert crashed.is_error
+    assert not (crashed.details or {}).get("__fault"), "an internal error is not a model fault"

--- a/tests/unit/harness/test_tool_call_analytics.py
+++ b/tests/unit/harness/test_tool_call_analytics.py
@@ -12,6 +12,7 @@ for an HTTP 500). Each class is therefore pinned at its own source.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any, Literal
 
@@ -694,10 +695,19 @@ async def test_an_effort_tier_that_vanished_after_build_is_not_the_models_fault(
 
 
 @pytest.mark.asyncio
-async def test_a_malformed_effort_value_is_still_a_model_fault(tmp_path, monkeypatch):
-    """The escape hatch must not blanket-exempt the field: a non-string
-    `effort` fails on declared type, before the config-reading validator, and
-    is decidable from the arguments alone."""
+async def test_a_non_string_effort_fails_on_declared_type_before_the_validator(
+    tmp_path, monkeypatch
+):
+    """The escape hatch must not blanket-exempt the FIELD.
+
+    Named for what it actually covers: ``123`` is rejected on declared type,
+    so it never reaches ``_validate_effort_tier`` at all. That makes it a
+    check on the field not being exempted wholesale — NOT coverage of the
+    validator's own branch, which
+    ``test_an_effort_tier_that_was_never_advertised_is_the_models_fault``
+    exercises. The previous name implied the latter and was the reason a real
+    gap in that branch read as covered.
+    """
     config_dir = tmp_path / "config"
     config_dir.mkdir()
     monkeypatch.setenv("HOME", str(tmp_path))
@@ -792,3 +802,180 @@ async def test_validity_does_not_depend_on_which_tool_the_model_picked(tmp_path)
         faults[name] = _faults(recorded)[name]
     assert set(faults.values()) == {"invalid_arguments"}, faults
     assert "read" in faults and len(faults) > 1, f"web tools were not exercised: {faults}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "configured,sent,why",
+    [
+        ("med", "hi", "tier exists but this one was never offered"),
+        ("med", "turbo", "value is not a tier name at all"),
+        (None, "hi", "no tiers configured, so `effort` is not in the schema"),
+    ],
+)
+async def test_an_effort_tier_that_was_never_advertised_is_the_models_fault(
+    tmp_path, monkeypatch, configured, sent, why
+):
+    """The model invented a value the schema never offered — a model fault.
+
+    This is the branch the round-1 fix over-corrected: it treated EVERY
+    ``effort`` refusal as environmental, so a value the model made up booked
+    as ``execution``. Config is written once here and never touched, so
+    nothing environmental happens at all.
+
+    The third case is this machine's real shape: with no tiers configured,
+    ``_advertise_effort_tiers`` DELETES the property, so sending ``effort`` is
+    sending a field the schema does not contain — the same kind of mistake as
+    a stray key.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    (config_dir / "config.yml").write_text(
+        "values:\n  subagents:\n    models:\n"
+        + (f"      {configured}: anthropic/claude-sonnet-4-5\n" if configured else "      {}\n")
+    )
+
+    from local_operator.tools.builtin import advertised_effort_members
+
+    task = _shipped_task_tool(tmp_path)
+    effort = (task.parameters.get("properties") or {}).get("effort")
+    advertised = advertised_effort_members(task.parameters)
+    if configured is None:
+        assert effort is None, "with no tiers the property must be dropped entirely"
+        assert advertised == frozenset()
+    else:
+        # Against the ENUM, not the rendered JSON: the description names tiers
+        # in prose, so a substring check would pass for the wrong reason.
+        assert sent not in advertised, "the value under test must NOT be advertised"
+
+    recorded = await _run(
+        _calls((0, "c1", "task", json.dumps({"label": "x", "prompt": "y", "effort": sent})))
+        + [StreamEndEvent(stop_reason="toolUse")],
+        [task],
+        cwd=str(tmp_path),
+    )
+    assert _faults(recorded) == {"task": "invalid_arguments"}, why
+
+
+@pytest.mark.asyncio
+async def test_an_invented_tier_cannot_launder_a_genuine_violation(tmp_path, monkeypatch):
+    """The regression the narrow branch removes.
+
+    `_rejection_is_environmental` is ANY-of, so while an invented tier counted
+    as environmental it erased every real violation reported in the same
+    `ValidationError` — `extra="forbid"`, the canonical model fault this
+    change exists to capture. The two co-occur naturally: a model confused
+    enough to invent a tier is the model likely to also pass a stray key.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    (config_dir / "config.yml").write_text(
+        "values:\n  subagents:\n    models:\n      med: anthropic/claude-sonnet-4-5\n"
+    )
+    task = _shipped_task_tool(tmp_path)
+
+    control = await _run(
+        _calls((0, "c1", "task", json.dumps({"label": "x", "prompt": "y", "bogus": 1})))
+        + [StreamEndEvent(stop_reason="toolUse")],
+        [task],
+        cwd=str(tmp_path),
+    )
+    assert _faults(control) == {"task": "invalid_arguments"}, "control: extra=forbid is a fault"
+
+    paired = await _run(
+        _calls(
+            (
+                0,
+                "c1",
+                "task",
+                json.dumps({"label": "x", "prompt": "y", "effort": "hi", "bogus": 1}),
+            )
+        )
+        + [StreamEndEvent(stop_reason="toolUse")],
+        [task],
+        cwd=str(tmp_path),
+    )
+    assert _faults(paired) == {"task": "invalid_arguments"}, "an invented tier must not erase it"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_tools_do_not_see_each_others_advertised_effort():
+    """The advertised set is per-call, not process-wide.
+
+    A parent and its subagents run on one event loop and can hold tools built
+    from different configs; a module global would let one tool's snapshot
+    decide another's fault class. Pins the ContextVar's isolation and that it
+    is reset after the call rather than leaking into the next one.
+    """
+    from local_operator.tools.builtin import _ADVERTISED_EFFORT, _with_advertised_effort
+
+    async def report(tool_call_id, args, signal=None, on_update=None, context=None):
+        await asyncio.sleep(0)  # force interleaving
+        return ToolResult(
+            tool_call_id=tool_call_id,
+            tool_name="probe",
+            content=[TextContent(text=",".join(sorted(_ADVERTISED_EFFORT.get() or [])))],
+        )
+
+    def schema(*members: str) -> dict[str, Any]:
+        return {"properties": {"effort": {"anyOf": [{"type": "string", "enum": list(members)}]}}}
+
+    first = _with_advertised_effort(report, schema("med"))
+    second = _with_advertised_effort(report, schema("hi", "lo"))
+    left, right = await asyncio.gather(
+        first("1", {}, None, None, None), second("2", {}, None, None, None)
+    )
+
+    assert (left.text, right.text) == ("med", "hi,lo")
+    assert _ADVERTISED_EFFORT.get() is None, "the snapshot must not outlive the call"
+
+
+@pytest.mark.asyncio
+async def test_a_static_violation_paired_with_a_vanished_tier_is_not_billed_to_the_model(
+    tmp_path, monkeypatch
+):
+    """The ANY-vs-ALL judgement call, pinned.
+
+    `_rejection_is_environmental` returns True if ANY sub-error is
+    environmental, and this is the only shape where that choice is observable:
+    a genuine `extra="forbid"` reported in the same `ValidationError` as a
+    tier that really was advertised and really did vanish. One call cannot
+    carry two verdicts, so the rule picks `execution` — not billing the model
+    is the better way to be wrong.
+
+    This is safe ONLY because the environmental branch is narrow. The
+    sibling test `test_an_invented_tier_cannot_launder_a_genuine_violation`
+    is its counterpart: an INVENTED tier is not environmental, so the same
+    pairing there stays `invalid_arguments`. Both must hold, or the ANY rule
+    is a laundering channel rather than a conservative default.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    (config_dir / "config.yml").write_text(
+        "values:\n  subagents:\n    models:\n      med: anthropic/claude-sonnet-4-5\n"
+    )
+    task = _shipped_task_tool(tmp_path)
+
+    # The tier really was on offer, then the operator removed it.
+    (config_dir / "config.yml").write_text("values:\n  subagents:\n    models: {}\n")
+
+    recorded = await _run(
+        _calls(
+            (
+                0,
+                "c1",
+                "task",
+                json.dumps({"label": "x", "prompt": "y", "effort": "med", "bogus": 1}),
+            )
+        )
+        + [StreamEndEvent(stop_reason="toolUse")],
+        [task],
+        cwd=str(tmp_path),
+    )
+    assert _faults(recorded) == {"task": "execution"}

--- a/tests/unit/harness/test_tool_call_analytics.py
+++ b/tests/unit/harness/test_tool_call_analytics.py
@@ -12,6 +12,7 @@ for an HTTP 500). Each class is therefore pinned at its own source.
 
 from __future__ import annotations
 
+import json
 from typing import Any, Literal
 
 import pytest
@@ -526,18 +527,26 @@ async def test_a_tool_body_raising_the_typed_error_is_translated_by_the_executor
     assert _faults(recorded) == {"wake": "invalid_arguments"}
 
 
-def test_the_fault_marker_spellings_agree_across_the_layering_gap():
-    """``harness.types`` duplicates two constants ``harness.loop`` also uses,
-    because tool modules may not import the loop. A drift would not fail — it
-    would silently write an unrecognised fault name into the ledger, dropping
-    those calls out of ``MODEL_FAULTS`` and back to under-reporting."""
-    from local_operator.analytics.model import MODEL_FAULTS
-    from local_operator.harness import loop as loop_module
+def test_the_tool_bodys_fault_class_is_one_the_reader_counts():
+    """The value a tool body writes must be one ``MODEL_FAULTS`` recognises.
+
+    ``harness`` carries no analytics dependency (see ``LoopConfig``), so the
+    writer's spelling and the reader's frozenset are pinned only here. A drift
+    would not raise — it would write a fault name no rate counts, silently
+    returning the figure to the under-reporting this PR fixes.
+
+    Deliberately NOT asserting ``loop.FAULT_KEY == types.FAULT_KEY``: the loop
+    now IMPORTS both names, so that compares an object with itself and can
+    never fail. What is worth pinning is the cross-package agreement below.
+    """
+    from local_operator.analytics.model import EXCLUDED_FAULTS, MODEL_FAULTS
     from local_operator.harness import types as types_module
 
-    assert types_module.FAULT_KEY == loop_module.FAULT_KEY == "__fault"
-    assert types_module.FAULT_INVALID_ARGUMENTS == loop_module.FAULT_INVALID_ARGUMENTS
     assert types_module.FAULT_INVALID_ARGUMENTS in MODEL_FAULTS
+    assert types_module.FAULT_INVALID_ARGUMENTS not in EXCLUDED_FAULTS
+    # The key is what the store reads out of ``details``; the store's own
+    # schema comment documents this exact string.
+    assert types_module.FAULT_KEY == "__fault"
 
 
 @pytest.mark.asyncio
@@ -569,3 +578,217 @@ async def test_the_builtin_guard_does_not_swallow_the_typed_error():
     crashed = await internal("c", {}, None, None, None)
     assert crashed.is_error
     assert not (crashed.details or {}).get("__fault"), "an internal error is not a model fault"
+
+
+# ---------------------------------------------------------------------------
+# `_validation_error`: a pydantic rejection is a model fault ONLY when it is a
+# pure function of the arguments.
+#
+# This is the change with the widest blast radius in this area — it reclassifies
+# every params-model rejection across every tool — and it shipped without
+# behavioural coverage, which is exactly how the `effort` case below survived to
+# review. Both directions are pinned here.
+# ---------------------------------------------------------------------------
+
+
+def _shipped_task_tool(tmp_path) -> AgentTool:
+    """The REAL ``task``, whose schema is rendered from live config at BUILD
+    time while its validator re-reads config at CALL time — the gap under test.
+
+    ``task`` is ``createIf``-gated on a launcher, so one is supplied; nothing in
+    these tests launches anything, the call is refused during validation.
+    """
+    from local_operator.tools.registry import create_tools
+
+    def _launcher(
+        label: str, prompt: str, *, agent: str = "task", effort: str | None = None
+    ) -> str:
+        raise AssertionError("validation must refuse the call before any launch")
+
+    context = ToolContext(cwd=str(tmp_path), session_id="s1", subagent_launcher=_launcher)
+    return next(t for t in create_tools(context) if t.name == "task")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "args,why",
+    [
+        ({"path": "a.txt", "bogus": 1}, "extra=forbid"),
+        ({"path": "a.txt", "range": 5}, "declared type"),
+    ],
+)
+async def test_a_static_shape_violation_is_a_model_fault(tmp_path, args, why):
+    """`extra="forbid"` and a wrong declared type are decidable from the
+    arguments alone, so they are the model violating the tool's contract."""
+    (tmp_path / "a.txt").write_text("l1\nl2\n")
+    recorded = await _run(
+        _calls((0, "c1", "read", json.dumps(args))) + [StreamEndEvent(stop_reason="toolUse")],
+        [_shipped_read_tool(tmp_path)],
+        cwd=str(tmp_path),
+    )
+    assert _faults(recorded) == {"read": "invalid_arguments"}, why
+
+
+@pytest.mark.asyncio
+async def test_a_cross_field_validator_is_still_a_model_fault(tmp_path):
+    """A cross-field rule is a pure function of the arguments — the model could
+    have satisfied it — so the environmental escape hatch must not catch it."""
+    from local_operator.tools.registry import create_tools
+
+    context = ToolContext(cwd=str(tmp_path), session_id="s1")
+    edit = next(t for t in create_tools(context) if t.name == "edit")
+    recorded = await _run(
+        _calls((0, "c1", "edit", json.dumps({"path": "a.txt", "old_text": "a"})))
+        + [StreamEndEvent(stop_reason="toolUse")],
+        [edit],
+        cwd=str(tmp_path),
+    )
+    assert _faults(recorded) == {"edit": "invalid_arguments"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "damage,why",
+    [
+        ("values:\n  subagents:\n    models: {}\n", "operator removed the tier"),
+        ("values: [ this is not: valid yaml\n", "config.yml became unreadable"),
+    ],
+)
+async def test_an_effort_tier_that_vanished_after_build_is_not_the_models_fault(
+    tmp_path, monkeypatch, damage, why
+):
+    """The blocker this suite missed: `effort`'s enum is rendered into the
+    schema at BUILD time, but `_validate_effort_tier` re-reads config at CALL
+    time. The model emits the one value its own schema offered and is refused
+    because the world moved.
+
+    The corrupt-config variant is the sharper one: `configured_effort_tiers`
+    swallows a read failure and reports "no tiers" ON PURPOSE, so that a broken
+    config costs the operator a tier picker rather than a session. Billing that
+    to the model would put an operator config error into a published accuracy
+    figure — the over-claiming direction `InvalidToolArgumentsError` names as
+    the worse one.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    (config_dir / "config.yml").write_text(
+        "values:\n  subagents:\n    models:\n      med: anthropic/claude-sonnet-4-5\n"
+    )
+
+    # Build the tool while the tier exists, so the advertised enum contains it.
+    task = _shipped_task_tool(tmp_path)
+    effort = task.parameters["properties"]["effort"]
+    assert "med" in json.dumps(effort), "the schema must have offered the tier"
+
+    (config_dir / "config.yml").write_text(damage)
+
+    recorded = await _run(
+        _calls((0, "c1", "task", json.dumps({"label": "x", "prompt": "y", "effort": "med"})))
+        + [StreamEndEvent(stop_reason="toolUse")],
+        [task],
+        cwd=str(tmp_path),
+    )
+    assert _faults(recorded) == {"task": "execution"}, why
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_effort_value_is_still_a_model_fault(tmp_path, monkeypatch):
+    """The escape hatch must not blanket-exempt the field: a non-string
+    `effort` fails on declared type, before the config-reading validator, and
+    is decidable from the arguments alone."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+
+    recorded = await _run(
+        _calls((0, "c1", "task", json.dumps({"label": "x", "prompt": "y", "effort": 123})))
+        + [StreamEndEvent(stop_reason="toolUse")],
+        [_shipped_task_tool(tmp_path)],
+        cwd=str(tmp_path),
+    )
+    assert _faults(recorded) == {"task": "invalid_arguments"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "args,expected,why",
+    [
+        ({"op": "create", "message": "m", "in": "soonish"}, "invalid_arguments", "duration"),
+        ({"op": "create", "message": "m", "at": "whenever"}, "invalid_arguments", "time"),
+        ({"op": "create", "message": "m", "at": "2001-01-01T00:00:00Z"}, "execution", "past"),
+    ],
+)
+async def test_the_real_wake_tool_separates_malformed_from_unsatisfiable(
+    tmp_path, args, expected, why
+):
+    """Driven through the REAL ``wake``, not a synthetic stand-in.
+
+    Two fixture tests in this module raise the typed error from a tool NAMED
+    ``wake``, which made the suite read as though the shipped tool were covered
+    when it was not. ``'soonish'`` could never be a duration; a timestamp in
+    2001 is perfectly well-formed and merely unsatisfiable.
+    """
+    from local_operator.tools.registry import create_tools
+
+    class _Scheduler:
+        schedules: list[Any] = []
+
+        async def update(self, schedules: list[Any]) -> None:
+            return None
+
+    context = ToolContext(cwd=str(tmp_path), session_id="s1", wake_scheduler=_Scheduler())
+    wake = next(t for t in create_tools(context) if t.name == "wake")
+    recorded = await _run(
+        _calls((0, "c1", "wake", json.dumps(args))) + [StreamEndEvent(stop_reason="toolUse")],
+        [wake],
+        cwd=str(tmp_path),
+        wake_scheduler=_Scheduler(),
+    )
+    assert _faults(recorded) == {"wake": expected}, why
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_spill_handle_is_a_model_fault(tmp_path):
+    """The handle rides inside ``path``, a plain schema string, so a value that
+    is not a handle at all can only be rejected in the tool body — the same
+    argument its sibling regex branch already carries."""
+    recorded = await _run(
+        _calls((0, "c1", "read", json.dumps({"path": "spill://not-a-valid-handle!!"})))
+        + [StreamEndEvent(stop_reason="toolUse")],
+        [_shipped_read_tool(tmp_path)],
+        cwd=str(tmp_path),
+    )
+    assert _faults(recorded) == {"read": "invalid_arguments"}
+
+
+@pytest.mark.asyncio
+async def test_validity_does_not_depend_on_which_tool_the_model_picked(tmp_path):
+    """``web_fetch``/``web_search`` built their own validation results and so
+    classified an identical modelling mistake differently from ``read``.
+
+    A benchmark whose denominator moves with tool identity is the hidden
+    dependence the analytics origin-partition prose exists to prevent.
+    """
+    from local_operator.tools.registry import create_tools
+
+    context = ToolContext(cwd=str(tmp_path), session_id="s1")
+    built = {t.name: t for t in create_tools(context)}
+    faults = {}
+    for name, args in (
+        ("read", {"path": "a.txt", "bogus": 1}),
+        ("web_fetch", {"url": "https://example.com", "bogus": 1}),
+        ("web_search", {"query": "x", "bogus": 1}),
+    ):
+        if name not in built:  # web tools are createIf-gated on configuration
+            continue
+        recorded = await _run(
+            _calls((0, "c1", name, json.dumps(args))) + [StreamEndEvent(stop_reason="toolUse")],
+            [built[name]],
+            cwd=str(tmp_path),
+        )
+        faults[name] = _faults(recorded)[name]
+    assert set(faults.values()) == {"invalid_arguments"}, faults
+    assert "read" in faults and len(faults) > 1, f"web tools were not exercised: {faults}"


### PR DESCRIPTION
## Summary

The `/session` "Tool surface" block reported this on a live session, and the
operator flagged it as inconsistent:

```
Tool calls              41      37 ok · 4 failed
Tool-call error rate    0.0%    0 invalid of 41 emitted
Tool-side errors        4       9.8% of 41 dispatched · not a model-accuracy figure
```

The arithmetic was internally consistent — all four faults were recorded
`execution`, and only `MODEL_FAULTS` feeds the rate. The **classification
boundary was in the wrong place**.

Three of those four calls were the model passing `range='"270-330"'` to `read`
— a line range with literal quote characters embedded. Because `range` is typed
`str | None`, that value *passes* the loop's schema check and is rejected only
by the parser inside the tool body, which raised a bare `ValueError`. The
generic handler built a `ToolResult` with no `details`, and `_classify_fault`
falls back to `execution` for anything unmarked.

So **an argument-shape rejection raised from inside a tool body was
indistinguishable from a genuine execution failure.** Any tool whose argument
grammar is richer than its JSON-Schema type — a range spec, a regex, an
enum-like string, a duration — silently laundered model faults into the
execution bucket.

No version bump: `pyproject.toml` stays at the last released version.

## The metric change, stated plainly

`invalid_arguments` is in `analytics.model.MODEL_FAULTS`, so this **moves a
published benchmarking figure**: `validity` and `tool_call_error_rate` will
report higher than before on identical behaviour.

That is the correct direction — these calls always *were* model faults and the
metric was under-reporting — but it is a semantic change to a published number
and is called out here rather than buried. The codebase names the permissive
direction as the worse failure (over-claiming corrupts the benchmark; under-
claiming is merely incomplete), so the change is deliberately conservative:

- The rule encoded is **malformed vs unsatisfiable**, not "did it fail".
  A value that could never have been valid is the model's fault. A missing
  path, an HTTP 500, a refused credential is not — **a file that vanished
  between planning and execution arrives at the same handler and stays
  `execution`.**
- Catches are narrowed to the typed subclass, so an unexpected `ValueError`
  escaping our own parser falls through to `execution` rather than being
  credited to the model.
- Where a case is genuinely ambiguous, it stays `execution`.

`grep`'s missing-path branch sits three lines from its regex branch and is
deliberately left as `execution`, commented as such.

## What changed

**1. A marker a tool can set at the source.** `InvalidToolArgumentsError`
(`harness/types.py`) is raised where an argument is malformed; the executor
translates it into the existing `__fault` marker. Set at the source, never
text-matched out of a message — `_classify_fault`'s standing contract, whose
docstring now names a tool body as one of the sources it reads.

**2. Both translation points, because there are two.** The loop's generic
handler covers unguarded tools (MCP bridges, hosts). `_guard` — which wraps
every builtin and catches `Exception` *inside* the tool — needed its own
branch, or its catch-all converts a deliberate rejection into an unmarked
"failed unexpectedly" traceback and the raise mechanism is silently useless for
exactly the tools it was built for. That gap was found by exercising the
guarded path, not by reading it; a regression test pins it.

**3. Swept the genuine argument-shape rejections.** `read`'s range parsing (all
four call sites), `grep` and spill-search regex compilation, and
`_validation_error` — every pydantic params rejection is the model violating
the tool's contract, and only lands there instead of in the loop's validator
because the params model is strictly finer than the advertised JSON-Schema type
(`extra="forbid"`, cross-field validators, constrained ints).

**4. The rule is written where a tool author will read it** —
on `InvalidToolArgumentsError`, with the missing-file case named explicitly as
NOT a model fault.

**No schema migration**, confirmed rather than assumed: `fault` is
`TEXT NOT NULL DEFAULT ''` with a documented vocabulary, and `invalid_arguments`
already appears in the live ledger (`8` rows) alongside `execution` and
`unknown_tool`.

## Testing evidence

Isolated `HOME` + `LOCAL_OPERATOR_CONFIG_DIR` per run, all `CMUX_*` scrubbed.
The operator's live `~/.local-operator/analytics.db` was **copied**, never
opened for write.

### The operator's symptom, reproduced before the fix

`/tmp/repro_fault.py` drives the **real `AgentLoop`** with the **real shipped
`read`/`grep` tools** against an isolated ledger, then renders the **real**
session panel. Same script, two trees; only the code under it differs.

Call mix: 3× `read` with `range='"270-330"'` (malformed) · 1× `grep` on a
non-existent path (unsatisfiable) · 2 clean calls.

**Before — `origin/main` @ `46b6dfc7f`:**

```
  grep   model  fault=execution
  read   model  fault=execution
  read   model  fault=execution
  read   model  fault=execution

  model_faults=0 faults={'execution': 4}   tool_call_error_rate=0.0

  Tool calls            6            2 ok · 4 failed
  Tool-call error rate  0.0%         0 invalid of 6 emitted
  Tool-side errors      4            66.7% of 6 dispatched · not a model-accuracy figure
```

The reported symptom exactly: **four failures beside a 0.0% error rate.**

**After — this branch:**

```
  grep   model  fault=execution
  read   model  fault=invalid_arguments
  read   model  fault=invalid_arguments
  read   model  fault=invalid_arguments

  model_faults=3 faults={'execution': 1, 'invalid_arguments': 3}
  tool_call_error_rate=0.5

  Tool calls            6            2 ok · 4 failed
  Tool-call error rate  50.0%        3 invalid of 6 emitted
   └ invalid arguments  3
  Tool-side errors      1            33.3% of 3 dispatched · not a model-accuracy figure
```

The rate stops reading 0.0%, names the fault class, and the execution counter
correctly drops to the one call that genuinely was an execution error.

### The ledger row moved

Read back with `sqlite3` from the isolated db, not from the harness:

| | before | after |
|---|---|---|
| `read` / `invalid_arguments` | — | **3** |
| `read` / `execution` | 3 | — |
| `grep` / `execution` | 1 | **1** (unchanged) |

The operator's real session `daca7bac8267` in the copied ledger shows the same
shape the diagnosis predicted — `read|execution|3`, `grep|execution|1`.

### The regression that matters most

Over-claiming model faults corrupts the benchmark, so the boundary is pinned in
**both** directions, through the real loop and the real tools:

| Case | Classified |
|---|---|
| `read` malformed range `'"270-330"'` | `invalid_arguments` |
| `read` well-formed range, **missing file** | **`execution`** |
| `grep` unparseable regex `(` | `invalid_arguments` |
| `grep` well-formed pattern, **missing path** | **`execution`** |
| tool raising the typed error | `invalid_arguments` |
| tool raising `RuntimeError` (internal failure) | **no marker** → `execution` |

Direct probe of the guarded path, showing the marker survives `_guard` and that
a genuine crash still takes the traceback path unmarked:

```
read malformed range  -> True {'__fault': 'invalid_arguments'}
read missing file     -> True None
read pydantic reject  -> True {'__fault': 'invalid_arguments'}
grep bad regex        -> True {'__fault': 'invalid_arguments'}
grep missing path     -> True None
guarded typed raise   -> True {'__fault': 'invalid_arguments'} | invalid arguments: ...
guarded other raise   -> True None | Tool 'demo2' failed unexpectedly:|Traceb
```

### Quality gates on this head

Whole tree, via the worktree's own `.venv` (verified resolving to this
checkout, not a sibling), exactly as CI:

- flake8 `7.3.0` — **0**
- black `26.1.0` `--check` — **0** (1123 files unchanged)
- isort `5.13.2` `--check` — **0**
- pyright `1.1.411` — **0 errors, 0 warnings**, whole tree
- unit suite — **16712 passed, 18 skipped** in 35m34s, zero failures

New tests live in `tests/unit/harness/test_tool_call_analytics.py`, matching the
module's existing discipline of driving a real turn and asserting what the loop
reported rather than unit-testing a helper (6 added, 20 pass).

## Not done deliberately

- **`grep` on a missing path left as `execution`.** Decided, not overlooked:
  the class docstring names "a missing file" as an execution error, and a path
  can stop existing between planning and execution. Reclassifying it would
  inflate the metric in the direction this codebase calls worse.
- **No sweep of unrelated `ValueError`s.** Only genuine argument-shape
  rejections were routed; `_file_resource_keys`, `EditParams`/`TaskParams`
  cross-field validators (already `_validation_error`, now marked) and browser
  payload decoding were left alone.
- **No follow-up issues filed.**
