### PR TITLE
fix(info): count subagents across the fleet and stop faking a zero

### DIFF
--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -774,11 +774,24 @@ class SubagentComms:
             launch_prompts=launch_prompts,
             attempt_aliases=tuple(record.attempt_aliases),
             live=record.child is not None,
-            status=(
-                "paused"
-                if record.paused
-                else record.outcome or ("cancelled" if record.settled else "gone")
-            ),
+            # Derived through ``_describe`` — the SAME collapse ``roster()``
+            # uses — rather than re-deriving it here. The local derivation this
+            # replaces read only the durable record (``paused``, ``outcome``,
+            # ``settled``) and never the job row, so it could not name a state
+            # that only the row knows: a live child got ``"gone"``, and a
+            # queued one got ``"gone"`` as well. That is outside the range this
+            # field's own docstring documents, and every consumer that filters
+            # on ``running``/``queued`` — ``/info``'s fleet tally, its tree
+            # sort, the glyph table — silently matched nothing and reported a
+            # confident zero over a roster full of live children.
+            #
+            # ``_describe`` is one dict lookup on the job manager plus the same
+            # branch ladder, so the cost is a `jobs.get` per node; the
+            # precedence it encodes (paused > recorded outcome > job row) is
+            # exactly the precedence this field wants, and having one
+            # derivation means the roster and the node can no longer disagree
+            # about the same child.
+            status=self._describe(record, time.time()).status,
             result_text=record.result_text or "",
             error_text=record.error_text or "",
         )

--- a/local_operator/info/collect.py
+++ b/local_operator/info/collect.py
@@ -255,6 +255,15 @@ def collect_process(
     )
 
 
+#: Above this, a published count is treated as corrupt rather than as a
+#: measurement. Deliberately far above anything this codebase can produce —
+#: ``DEFAULT_MAX_RUNNING_JOBS`` is 15 and the count is a ``len()`` over a
+#: bounded roster — so it can only reject a foreign or damaged record, never a
+#: real fleet. It is a RENDERING ceiling, not a belief about how many subagents
+#: can exist: six digits still fit the narrow rung.
+_ABSURD_COUNT = 999_999
+
+
 def _reported_count(value: Any) -> int | None:
     """A published subagent count, or ``None`` when the record did not report one.
 
@@ -281,8 +290,17 @@ def _reported_count(value: Any) -> int | None:
     calling it ``None`` folds it into the lower-bound caveat, which already
     exists to say the total is missing terms. ``bool`` is excluded explicitly —
     it is an ``int`` subclass, so ``True`` would otherwise count as one subagent.
+
+    A count above ``_ABSURD_COUNT`` is refused the same way. It is not that the
+    number is wrong — it is that a 31-digit figure renders 81 cells wide and
+    overflows every frame, including the abbreviated rung that exists to serve
+    narrow ones, because the shed compresses the LABELS and not the FIGURE.
+    Treating it as unreported keeps a corrupt record from breaking the layout
+    of the screen you open when something is already broken.
     """
     if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    if value > _ABSURD_COUNT:
         return None
     return value
 
@@ -471,6 +489,11 @@ def build_subagent_tree(
     question being asked, mirroring ``sort_needs_you_first``'s urgency-first
     principle.
     """
+    # Function-local like every other cross-package import here (see the module
+    # docstring). ``runtime.types`` is stdlib-only by contract, but the
+    # convention is what keeps that true.
+    from local_operator.session.runtime.types import RUNNING_SUBAGENT_STATUSES
+
     children: dict[str | None, list[Any]] = defaultdict(list)
     known = {getattr(node, "job_id", "") for node in nodes}
     for node in nodes:
@@ -480,8 +503,13 @@ def build_subagent_tree(
         children[parent if parent in known else None].append(node)
 
     def rank(node: Any) -> tuple[int, str]:
+        # The SHARED predicate, not a local literal: the header counts
+        # ``pausing`` as a running trajectory, so a local tuple that omitted it
+        # sorted a counted-as-running child below the settled rows — the tree
+        # disagreeing with the tally directly above it, which is the one error
+        # this section must never make.
         status = str(getattr(node, "status", "") or "")
-        order = 0 if status in ("running", "starting") else 1 if status == "queued" else 2
+        order = 0 if status in RUNNING_SUBAGENT_STATUSES else 1 if status == "queued" else 2
         return order, str(getattr(node, "label", "") or "")
 
     rows: list[SubagentLine] = []

--- a/local_operator/info/collect.py
+++ b/local_operator/info/collect.py
@@ -255,6 +255,38 @@ def collect_process(
     )
 
 
+def _reported_count(value: Any) -> int | None:
+    """A published subagent count, or ``None`` when the record did not report one.
+
+    ``SessionRecord.from_json`` filters keys and calls the constructor — it does
+    no type validation — so every field on a record is whatever the writer put
+    in the file. That is fine for the strings and bools already read here, which
+    only ever get formatted, but these two are the first record fields this
+    module does ARITHMETIC on, and arithmetic is where a foreign value stops
+    being cosmetic:
+
+    * a ``str`` or ``list`` raises ``TypeError`` inside the roll-up. ``_safe``
+      guards whole SECTIONS, so one bad record cost the entire sessions block —
+      no table, no runtimes row, and no lower-bound caveat — on a screen whose
+      whole purpose is describing a host that is already broken. Before these
+      fields existed there was no arithmetic here and the same record listed
+      normally, so that was a regression rather than a new limitation.
+    * a merely-numeric wrong value does not raise at all, which is worse: a
+      float printed ``4.5 total — 1 sessions + 3.5 subagents`` and a negative
+      printed ``-1 subagents``, both as measured fact.
+
+    Anything that is not a non-negative ``int`` is therefore treated as NOT
+    REPORTED rather than sanitised into a number. That is this screen's own
+    contract applied one layer out: an unusable value is not a measurement, and
+    calling it ``None`` folds it into the lower-bound caveat, which already
+    exists to say the total is missing terms. ``bool`` is excluded explicitly —
+    it is an ``int`` subclass, so ``True`` would otherwise count as one subagent.
+    """
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
 def collect_sessions(
     root: Path | None = None,
     *,
@@ -319,13 +351,13 @@ def collect_sessions(
                 # Same getattr defaulting as the live-state fields above.
                 version=getattr(rec, "version", "") or "",
                 source_ref=getattr(rec, "source_ref", "") or "",
-                # NOT coerced to 0. Same getattr defaulting as the fields
-                # above, but the default is ``None`` and stays ``None``: a
-                # runtime predating these fields has not told us it has no
-                # subagents, and ``or 0`` here would silently turn every
-                # older peer into a confident zero in the fleet total.
-                subagents_running=getattr(rec, "subagents_running", None),
-                subagents_queued=getattr(rec, "subagents_queued", None),
+                # NOT coerced to 0 — see ``_reported_count``. The default is
+                # ``None`` and stays ``None``: a runtime predating these fields
+                # has not told us it has no subagents, and ``or 0`` here would
+                # silently turn every older peer into a confident zero in the
+                # fleet total.
+                subagents_running=_reported_count(getattr(rec, "subagents_running", None)),
+                subagents_queued=_reported_count(getattr(rec, "subagents_queued", None)),
                 is_self=self_pid is not None and rec.pid == self_pid,
             )
         )

--- a/local_operator/info/collect.py
+++ b/local_operator/info/collect.py
@@ -319,12 +319,36 @@ def collect_sessions(
                 # Same getattr defaulting as the live-state fields above.
                 version=getattr(rec, "version", "") or "",
                 source_ref=getattr(rec, "source_ref", "") or "",
+                # NOT coerced to 0. Same getattr defaulting as the fields
+                # above, but the default is ``None`` and stays ``None``: a
+                # runtime predating these fields has not told us it has no
+                # subagents, and ``or 0`` here would silently turn every
+                # older peer into a confident zero in the fleet total.
+                subagents_running=getattr(rec, "subagents_running", None),
+                subagents_queued=getattr(rec, "subagents_queued", None),
                 is_self=self_pid is not None and rec.pid == self_pid,
             )
         )
 
     builds = {(line.version, line.source_ref) for line in lines if line.state == "live"}
     builds.discard(("", ""))
+
+    # The population is every RUNNING PROCESS: ``live`` and ``wedged`` both
+    # name a pid that exists, and a runtime that has merely gone quiet for 45 s
+    # can still have children burning tokens — dropping it would under-report
+    # exactly the fleet somebody opens this screen to understand. It serves its
+    # last published counts and the renderer's caveat says they are as of its
+    # last heartbeat. A ``stale`` record is excluded outright: the scan above
+    # just DELETED its file because the pid is gone, so it is not a runtime.
+    live_lines = [line for line in lines if line.state in ("live", "wedged")]
+    reporting = [line for line in live_lines if line.subagents_running is not None]
+    fleet_running = sum(line.subagents_running or 0 for line in reporting)
+    # Session trajectories and subagent trajectories are DISJOINT by
+    # construction, which is what makes adding them legal: a subagent never
+    # publishes a SessionRecord of its own (``harness.subagent`` builds a bare
+    # Session with no registrant), so nothing is counted both as a runtime's
+    # own turn and as somebody's child.
+    session_trajectories = sum(1 for line in live_lines if line.busy)
     return SessionsInfo(
         lines=tuple(lines),
         total=len(lines),
@@ -339,6 +363,12 @@ def collect_sessions(
         # not be measured", and only the first should suppress the column.
         usage_available=not live_pids
         or any(line.rss_bytes is not None or line.footprint_bytes is not None for line in lines),
+        subagents_reporting=len(reporting),
+        subagents_unreported=len(live_lines) - len(reporting),
+        fleet_subagents_running=fleet_running,
+        fleet_subagents_queued=sum(line.subagents_queued or 0 for line in reporting),
+        fleet_session_trajectories=session_trajectories,
+        fleet_trajectories=session_trajectories + fleet_running,
     )
 
 
@@ -370,6 +400,15 @@ def session_rows(root: Path | None = None) -> list[dict[str, Any]]:
             "detached": line.detached,
             "version": line.version,
             "source_ref": line.source_ref,
+            # Added deliberately, not incidentally: ``--json`` is a published
+            # surface whose key list is pinned against a pre-extraction
+            # snapshot, so adding keys breaks that test BY DESIGN and the
+            # expectation is updated in the same change. A fleet consumer
+            # counting trajectories across a host wants these, and ``null``
+            # (not 0) is what an older runtime contributes — the same
+            # unreported-vs-zero distinction the screen makes.
+            "subagents_running": line.subagents_running,
+            "subagents_queued": line.subagents_queued,
         }
         for line in info.lines
     ]
@@ -490,12 +529,21 @@ def _require_root(root: Path) -> Path:
     return root
 
 
-def collect_agents(live: "LiveState", errors: list[tuple[str, str]]) -> AgentsInfo:
+def collect_agents(
+    live: "LiveState",
+    errors: list[tuple[str, str]],
+    sessions: SessionsInfo | None = None,
+) -> AgentsInfo:
     """Profile and team counts (filesystem walks) over the live tree.
 
     The TREE itself is not read here — it was captured on the event loop by
     :func:`collect_live`, deliberately, so a ``/new`` during this ~900 ms
     snapshot cannot swap the session under an already-painted header.
+
+    ``sessions`` is the already-completed scan, threaded in only to answer
+    whether anyone ELSE reported subagent counts. It is optional so this stays
+    callable on its own, and its absence means "no fleet knowledge", which is
+    the honest reading of not having looked.
     """
     from local_operator.agents import AgentRegistry
     from local_operator.paths import config_dir
@@ -533,11 +581,24 @@ def collect_agents(live: "LiveState", errors: list[tuple[str, str]]) -> AgentsIn
         at_capacity=live.at_capacity,
         max_depth=live.max_depth,
         deeper=live.deeper,
-        # Always False today: nothing about another session's subagents is
-        # observable without a new control-socket op and a PROTOCOL_VERSION
-        # bump. The field is the seam that lets the screen become truthful
-        # later without a copy edit.
-        cross_session_known=False,
+        roster_unread=bool(getattr(live, "roster_unread", False)),
+        # Whether at least one OTHER live runtime reported its counts — not
+        # whether the feature exists. The note this gates claims knowledge of
+        # other windows, so on a single-session host, or one where every peer
+        # runs an older build, it must stay False and the screen must keep
+        # saying only this session is visible.
+        cross_session_known=(
+            sessions is not None
+            and any(
+                # The same population the roll-ups use: a running pid, whether
+                # or not it has gone quiet. A ``stale`` record's process is
+                # gone, so its counts describe nothing.
+                line.state in ("live", "wedged")
+                and not line.is_self
+                and line.subagents_running is not None
+                for line in sessions.lines
+            )
+        ),
     )
 
 
@@ -691,6 +752,8 @@ class LiveState:
         "at_capacity",
         "max_depth",
         "deeper",
+        "roster_unread",
+        "errors",
         "mcp_configured",
         "mcp_connected",
         "mcp_failed",
@@ -724,6 +787,15 @@ _LIVE_DEFAULTS: dict[str, Any] = {
     "at_capacity": False,
     "max_depth": 0,
     "deeper": 0,
+    #: The roster could not be READ, which is not the same fact as an empty
+    #: roster. Held on the live capture because the tree is drawn from it on
+    #: the first frame, before the worker's snapshot exists.
+    "roster_unread": False,
+    #: Probe failures from the live pass, forwarded into the snapshot's
+    #: ``degraded`` block. They used to be collected and DROPPED — the list was
+    #: local to ``collect_live`` and had nowhere to go — so a live probe that
+    #: failed left the screen with a default and no disclosure anywhere.
+    "errors": (),
     "mcp_configured": 0,
     "mcp_connected": 0,
     "mcp_failed": 0,
@@ -751,6 +823,11 @@ def collect_live(
     on the event loop, and what the caller relies on when it pushes the screen
     before starting the worker.
     """
+    # Function-local like every other cross-package import here (see the
+    # module docstring). ``runtime.types`` is stdlib-only by contract, but the
+    # convention is what keeps that true.
+    from local_operator.session.runtime.types import RUNNING_SUBAGENT_STATUSES
+
     errors: list[tuple[str, str]] = []
     tree: tuple[SubagentLine, ...] = ()
     deepest = 0
@@ -765,12 +842,37 @@ def collect_live(
     # is "safe on the paint path", turning a wedged session into a crash on the
     # one screen that exists to describe it.
     comms = _attr(session, "subagent_comms", None) if session is not None else None
-    if comms is not None:
-        nodes = _safe("live.subagents", comms.nodes, [], errors)
+    roster_unread = False
+    if session is not None and comms is None:
+        # A session object that cannot answer for its own roster. This was
+        # silent: the branch below was skipped, the counts stayed 0 and NOTHING
+        # was recorded, so the screen stated "no subagents have been launched"
+        # about a session it had never asked. That is the one failure mode
+        # ``_safe`` does not catch, because nothing raised — the default was
+        # simply returned and believed. Named here so it renders as UNKNOWN and
+        # appears in the degraded block, like every probe that fails loudly.
+        roster_unread = True
+        errors.append(("live.subagents", "session exposes no subagent_comms"))
+    elif comms is not None:
+        # ``lambda: comms.nodes()`` and not ``comms.nodes``: the bare attribute
+        # is resolved as an ARGUMENT, before ``_safe`` enters its try, so a
+        # comms object lacking the method raised straight out of a function
+        # whose whole contract is "safe on the paint path".
+        nodes = _safe("live.subagents", lambda: list(comms.nodes()), None, errors)
+        if nodes is None:
+            # The read was attempted and failed. ``_safe`` already named it in
+            # ``errors``; the flag is what stops the renderer printing a
+            # confident zero over a roster nobody managed to read.
+            roster_unread = True
+            nodes = []
         tree, deepest, deeper = build_subagent_tree(nodes)
         for node in nodes:
             status = str(getattr(node, "status", "") or "")
-            if status in ("running", "starting", "pausing"):
+            # The shared predicate, not a local literal: the runtime publishes
+            # ``subagents_running`` from the same set, and a divergence would
+            # put a fleet total on the header that disagrees with the tree
+            # drawn directly beneath it.
+            if status in RUNNING_SUBAGENT_STATUSES:
                 running += 1
             elif status == "queued":
                 queued += 1
@@ -798,6 +900,8 @@ def collect_live(
         at_capacity=at_capacity,
         max_depth=deepest,
         deeper=deeper,
+        roster_unread=roster_unread,
+        errors=tuple(errors),
         mcp_configured=len(getattr(startup, "configured", ()) or ()),
         mcp_connected=len(getattr(startup, "connected", ()) or ()),
         mcp_failed=len(failures),
@@ -838,7 +942,11 @@ def collect_snapshot(live: LiveState, *, root: Path | None = None) -> InfoSnapsh
     documented in ``mobile/resources.py``). Each block is guarded independently
     so one wedged filesystem costs its own section and nothing else.
     """
-    errors: list[tuple[str, str]] = []
+    # Seeded with the LIVE pass's failures rather than starting empty: those
+    # probes ran on the event loop where this function cannot reach them, and
+    # dropping them meant a failure with a named reason vanished before the
+    # degraded block that exists to print it.
+    errors: list[tuple[str, str]] = list(getattr(live, "errors", ()) or ())
     self_pid = os.getpid()
     sessions = _safe(
         "sessions",
@@ -865,7 +973,9 @@ def collect_snapshot(live: LiveState, *, root: Path | None = None) -> InfoSnapsh
             errors,
         ),
         sessions=sessions,
-        agents=_safe("agents", lambda: collect_agents(live, errors), AgentsInfo(), errors),
+        agents=_safe(
+            "agents", lambda: collect_agents(live, errors, sessions), AgentsInfo(), errors
+        ),
         env=_safe("env", lambda: collect_env(live, errors), EnvInfo(), errors),
         degraded=tuple(errors),
         captured_at=time.time(),

--- a/local_operator/info/model.py
+++ b/local_operator/info/model.py
@@ -157,6 +157,12 @@ class SessionLine:
     #: fields (the ``getattr`` defaulting for mid-upgrade records) long before
     #: it drifted on this one.
     is_self: bool = False
+    #: Subagent trajectories this runtime published on its record. ``None``
+    #: means the runtime did not report — an older build, or a handle that
+    #: cannot answer the probe — which is NOT the same fact as zero and must
+    #: never be summed as one. See :attr:`SessionsInfo.subagents_unreported`.
+    subagents_running: int | None = None
+    subagents_queued: int | None = None
 
 
 @dataclass(frozen=True)
@@ -183,6 +189,34 @@ class SessionsInfo:
     #: header rather than annotating it.
     available: bool = True
 
+    # -- fleet trajectories -------------------------------------------------
+    # The operator's question: how many agent trajectories are running on this
+    # machine right now. Summed over LIVE runtimes only, and split into what
+    # was measured against what could not be, because a total with silently
+    # missing terms is the failure this screen writes essays about.
+
+    #: Live runtimes whose build reports subagent counts.
+    subagents_reporting: int = 0
+    #: Live runtimes that do NOT report them. The denominator of the honesty
+    #: caveat: 3 non-reporting sessions is a different fact from 3 sessions
+    #: with no subagents, and only this field can tell the reader which they
+    #: are looking at.
+    subagents_unreported: int = 0
+    #: Summed across REPORTING live runtimes only. Each term is already a flat
+    #: count over one session's complete roster (nested descendants included),
+    #: so this is an addition over disjoint sets: a subagent never publishes a
+    #: record of its own, so it can never also be counted as a runtime.
+    fleet_subagents_running: int = 0
+    fleet_subagents_queued: int = 0
+    #: Session trajectories — live runtimes publishing ``busy``. The same
+    #: number as :attr:`busy`, named separately so the header does not have to
+    #: explain that the spinner field is also a trajectory count.
+    fleet_session_trajectories: int = 0
+    #: :attr:`fleet_session_trajectories` + :attr:`fleet_subagents_running`. A
+    #: LOWER BOUND whenever :attr:`subagents_unreported` is non-zero, and the
+    #: renderer must say so rather than presenting it as a total.
+    fleet_trajectories: int = 0
+
 
 @dataclass(frozen=True)
 class SubagentLine:
@@ -205,12 +239,22 @@ class SubagentLine:
 class AgentsInfo:
     """Agent profiles, teams, and the subagent tree of THIS session.
 
-    The tree is this session's only. ``SubagentComms`` is a live in-memory
-    object on one ``Session`` and ``SessionRecord`` carries no subagent field,
-    so nothing about another session's children is observable without a new
-    control-socket op and a ``PROTOCOL_VERSION`` bump. The screen says so rather
-    than implying a fleet-wide view; :attr:`cross_session_known` is the seam a
-    later change would flip, and is always ``False`` today.
+    The TREE is still this session's only, and always will be: ``SubagentComms``
+    is a live in-memory object on one ``Session``, so another session's lineage
+    cannot be drawn without putting a socket fan-out on a diagnostic screen that
+    is opened precisely when peers are wedged.
+
+    The COUNTS are another matter, and this docstring used to be wrong about
+    them. It claimed a fleet view needed a new control-socket op and a
+    ``PROTOCOL_VERSION`` bump; in fact each runtime now publishes its own
+    ``subagents_running``/``subagents_queued`` on its ``SessionRecord`` — the
+    same purely additive contract the ``busy`` and build-stamp fields use — and
+    the protocol deliberately did NOT move for it. It must not: peers read
+    ``record.protocol`` as a pre-dial promise about which FRAMES a runtime
+    speaks (``attach_client``, ``session_factory``, ``remote``), and a JSON
+    field that touches no frame changes nothing they are asking about. The
+    fleet roll-ups live on :class:`SessionsInfo`, beside the scan that
+    produces them.
     """
 
     profiles: int = 0
@@ -229,7 +273,20 @@ class AgentsInfo:
     #: Number of nodes below the render depth cap, folded into one summary row
     #: rather than indented off the card.
     deeper: int = 0
+    #: True when at least one live runtime OTHER THAN THIS ONE reported its
+    #: subagent counts — i.e. when the fleet numbers describe more than the
+    #: session being looked at. ``False`` on a single-session host or an
+    #: all-older fleet, where the screen must keep saying that only this
+    #: session is visible. Deliberately "someone else reported", not "the
+    #: feature is compiled in": the note it gates claims knowledge of other
+    #: windows, and on a host where nobody else answered that claim is false.
     cross_session_known: bool = False
+    #: This session's roster could not be READ (a session exposing no comms
+    #: facade, or a roster read that raised). Renders as ``UNKNOWN`` with the
+    #: reason in the degraded block, never as "no subagents have been
+    #: launched" — the screen must not state as fact something it failed to
+    #: measure.
+    roster_unread: bool = False
 
 
 @dataclass(frozen=True)

--- a/local_operator/info/render.py
+++ b/local_operator/info/render.py
@@ -290,11 +290,22 @@ def build_export(snapshot: InfoSnapshot) -> str:
             f"  runtimes          {sessions.live + sessions.wedged} total — "
             f"{sessions.live} live · {sessions.wedged} wedged"
         )
-        lines.append(
-            f"  trajectories      {sessions.fleet_trajectories} total — "
-            f"{sessions.fleet_session_trajectories} sessions + "
-            f"{sessions.fleet_subagents_running} subagents"
-        )
+        # Same rule as the screen: the sum runs over runtimes that REPORTED, so
+        # when some did not the total is a floor, and when none did there is no
+        # total at all. This text is what lands in a bug report, where a
+        # fabricated zero is hardest to challenge after the fact.
+        if not sessions.subagents_reporting and sessions.subagents_unreported:
+            lines.append(
+                f"  trajectories      — ({sessions.subagents_unreported} of "
+                f"{sessions.live + sessions.wedged} runtimes did not report)"
+            )
+        else:
+            bound = ">=" if sessions.subagents_unreported else ""
+            lines.append(
+                f"  trajectories      {bound}{sessions.fleet_trajectories} total — "
+                f"{sessions.fleet_session_trajectories} sessions + "
+                f"{sessions.fleet_subagents_running} subagents"
+            )
     lines.append(f"  profiles          {agents.profiles}")
     lines.append(f"  teams             {agents.teams}")
     if agents.roster_unread:
@@ -328,9 +339,29 @@ def build_export(snapshot: InfoSnapshot) -> str:
     if sessions.available and sessions.subagents_unreported:
         # "lower bound", not a total: the sum above excluded every session that
         # did not report, and a bug report must not present it as complete.
+        #
+        # Inflected, like the panel's copy: this text is pasted into an issue
+        # verbatim, and "1 sessions run ... and do not report" reads as a
+        # template nobody finished rather than as a measurement.
+        one = sessions.subagents_unreported == 1
         lines.append(
-            f"  ({sessions.subagents_unreported} sessions run an older build and do not "
-            "report subagents — lower bound)"
+            f"  ({sessions.subagents_unreported} session{'' if one else 's'} "
+            f"{'runs' if one else 'run'} an older build and "
+            f"{'does' if one else 'do'} not report subagents — lower bound)"
+        )
+    if sessions.available and sessions.wedged:
+        # PARITY with the panel, which has said this since the counts landed.
+        # The totals above deliberately include wedged runtimes — a quiet pid
+        # can still have children working — so their contribution is as of
+        # their last heartbeat, and an export that omitted the disclosure would
+        # present stale counts as current in the one artifact that outlives the
+        # screen.
+        one = sessions.wedged == 1
+        lines.append(
+            f"  ({sessions.wedged} session{'' if one else 's'} "
+            f"{'is' if one else 'are'} wedged; "
+            f"{'its' if one else 'their'} counts are as of "
+            f"{'its' if one else 'their'} last heartbeat)"
         )
 
     lines += [

--- a/local_operator/info/render.py
+++ b/local_operator/info/render.py
@@ -281,12 +281,32 @@ def build_export(snapshot: InfoSnapshot) -> str:
             lines.append(f"      {relativise_home(line.cwd)} · {line.model_label or '—'}")
 
     lines += ["", "## Agents and subagents"]
+    if sessions.available:
+        # The fleet answer FIRST: it is the question the section is opened
+        # with, and the per-session detail below it is the breakdown.
+        # ``live + wedged``: both name a running pid and both contribute to the
+        # sum below, so the denominator printed here has to match it.
+        lines.append(
+            f"  runtimes          {sessions.live + sessions.wedged} total — "
+            f"{sessions.live} live · {sessions.wedged} wedged"
+        )
+        lines.append(
+            f"  trajectories      {sessions.fleet_trajectories} total — "
+            f"{sessions.fleet_session_trajectories} sessions + "
+            f"{sessions.fleet_subagents_running} subagents"
+        )
     lines.append(f"  profiles          {agents.profiles}")
     lines.append(f"  teams             {agents.teams}")
-    lines.append(
-        f"  subagents         {agents.running} running · {agents.queued} queued · "
-        f"{agents.settled} settled (retained)"
-    )
+    if agents.roster_unread:
+        # An unreadable roster is not a roster of zero, in the export exactly
+        # as on screen — this text is what lands in a bug report, where a
+        # fabricated zero is hardest to challenge.
+        lines.append("  this session      — (could not read the roster)")
+    else:
+        lines.append(
+            f"  this session      {agents.running} running · {agents.queued} queued · "
+            f"{agents.settled} settled (retained)"
+        )
     if agents.max_running is not None:
         lines.append(
             f"  capacity          {agents.max_running} concurrent"
@@ -295,11 +315,23 @@ def build_export(snapshot: InfoSnapshot) -> str:
     if agents.tree:
         lines.append(f"  tree (this session only, depth {agents.max_depth}):")
         lines += _tree_lines(agents.tree, agents.deeper)
+    elif agents.roster_unread:
+        lines.append("  roster unreadable — no tree")
     else:
         lines.append("  no subagents launched in this session")
-    # Stated, not implied: only this session's tree is observable, so a report
-    # that showed one tree could otherwise be read as a fleet-wide total.
-    lines.append("  (other sessions report busy/pending and memory only)")
+    # Stated, not implied: the COUNTS above are fleet-wide and the TREE is not,
+    # so a report showing one tree could otherwise be read as the whole story.
+    if agents.cross_session_known:
+        lines.append("  (only this session's tree is drawn; other sessions report counts)")
+    else:
+        lines.append("  (other sessions report busy/pending and memory only)")
+    if sessions.available and sessions.subagents_unreported:
+        # "lower bound", not a total: the sum above excluded every session that
+        # did not report, and a bug report must not present it as complete.
+        lines.append(
+            f"  ({sessions.subagents_unreported} sessions run an older build and do not "
+            "report subagents — lower bound)"
+        )
 
     lines += [
         "",

--- a/local_operator/info/render.py
+++ b/local_operator/info/render.py
@@ -175,6 +175,25 @@ def _latest_line(snapshot: InfoSnapshot) -> str:
     return f"{install.latest_known} · checked {format_duration(age)} ago{stale}"
 
 
+#: Nouns whose plural is not ``+ "s"``. A map rather than a second helper so
+#: the next irregular noun is a data change.
+_IRREGULAR_PLURALS = {"trajectory": "trajectories"}
+
+
+def plural(count: int, noun: str) -> str:
+    """``"1 runtime"`` / ``"5 runtimes"`` / ``"5 trajectories"``.
+
+    Lives HERE, one layer below the panel, because the panel imports this
+    module and not the other way round — and because the export and the screen
+    stating the same fact in different grammar is precisely the drift that put
+    ``1 sessions + 1 subagents`` into pasted bug reports while the screen read
+    correctly. One implementation, used by both.
+    """
+    if count == 1:
+        return f"{count} {noun}"
+    return f"{count} {_IRREGULAR_PLURALS.get(noun, noun + 's')}"
+
+
 def _tree_lines(tree: tuple[SubagentLine, ...], deeper: int) -> list[str]:
     out: list[str] = []
     for node in tree:
@@ -294,17 +313,36 @@ def build_export(snapshot: InfoSnapshot) -> str:
         # when some did not the total is a floor, and when none did there is no
         # total at all. This text is what lands in a bug report, where a
         # fabricated zero is hardest to challenge after the fact.
-        if not sessions.subagents_reporting and sessions.subagents_unreported:
+        # The SAME predicate as the panel's, deliberately: these two guards
+        # drifted apart once (the export asserted ``>=0 total — 0 sessions + 0
+        # subagents`` in a cell where the screen correctly refused to name a
+        # number), and the export is the copy that outlives the screen inside
+        # a bug report. Refuse the total whenever nothing was measured — not
+        # merely when nobody reported.
+        if sessions.subagents_unreported and not sessions.fleet_trajectories:
             lines.append(
                 f"  trajectories      — ({sessions.subagents_unreported} of "
                 f"{sessions.live + sessions.wedged} runtimes did not report)"
             )
         else:
             bound = ">=" if sessions.subagents_unreported else ""
+            # Inflected through the shared helper, like the panel: this line is
+            # pasted verbatim into issues, and ``1 sessions + 1 subagents`` —
+            # the state every fresh install passes through — reads as a
+            # template nobody finished rather than as a measurement.
+            addends = (
+                f"{plural(sessions.fleet_session_trajectories, 'session')} + "
+                f"{plural(sessions.fleet_subagents_running, 'subagent')}"
+            )
+            # Named beside the total, never added to it — see the panel's copy
+            # of this rule. A queued child spends nothing, so it is not a
+            # trajectory; but ``0 total`` alone, printed above a tree of
+            # ``queued`` rows, is the export repeating a contradiction the
+            # screen no longer makes.
+            if sessions.fleet_subagents_queued:
+                addends += f" · {sessions.fleet_subagents_queued} queued"
             lines.append(
-                f"  trajectories      {bound}{sessions.fleet_trajectories} total — "
-                f"{sessions.fleet_session_trajectories} sessions + "
-                f"{sessions.fleet_subagents_running} subagents"
+                f"  trajectories      {bound}{sessions.fleet_trajectories} total — {addends}"
             )
     lines.append(f"  profiles          {agents.profiles}")
     lines.append(f"  teams             {agents.teams}")
@@ -336,6 +374,12 @@ def build_export(snapshot: InfoSnapshot) -> str:
         lines.append("  (only this session's tree is drawn; other sessions report counts)")
     else:
         lines.append("  (other sessions report busy/pending and memory only)")
+    # Both caveats qualify the SAME total, so they are collected and emitted as
+    # one parenthetical rather than as two stacked ones: a host that is both
+    # mid-upgrade and holding a wedged pid printed two bracketed apologies in a
+    # row, which reads as boilerplate in a pasted report and invites skipping
+    # the second. The clause wording is unchanged — only the packaging.
+    caveats: list[str] = []
     if sessions.available and sessions.subagents_unreported:
         # "lower bound", not a total: the sum above excluded every session that
         # did not report, and a bug report must not present it as complete.
@@ -344,10 +388,10 @@ def build_export(snapshot: InfoSnapshot) -> str:
         # verbatim, and "1 sessions run ... and do not report" reads as a
         # template nobody finished rather than as a measurement.
         one = sessions.subagents_unreported == 1
-        lines.append(
-            f"  ({sessions.subagents_unreported} session{'' if one else 's'} "
+        caveats.append(
+            f"{sessions.subagents_unreported} session{'' if one else 's'} "
             f"{'runs' if one else 'run'} an older build and "
-            f"{'does' if one else 'do'} not report subagents — lower bound)"
+            f"{'does' if one else 'do'} not report subagents — lower bound"
         )
     if sessions.available and sessions.wedged:
         # PARITY with the panel, which has said this since the counts landed.
@@ -357,12 +401,18 @@ def build_export(snapshot: InfoSnapshot) -> str:
         # present stale counts as current in the one artifact that outlives the
         # screen.
         one = sessions.wedged == 1
-        lines.append(
-            f"  ({sessions.wedged} session{'' if one else 's'} "
+        caveats.append(
+            f"{sessions.wedged} session{'' if one else 's'} "
             f"{'is' if one else 'are'} wedged; "
             f"{'its' if one else 'their'} counts are as of "
-            f"{'its' if one else 'their'} last heartbeat)"
+            f"{'its' if one else 'their'} last heartbeat"
         )
+    if caveats:
+        # ``·`` and not ``;``: the wedged clause already contains a semicolon
+        # of its own, so a semicolon joiner produced two different grammatical
+        # levels sharing one punctuation mark. The interpunct is this screen's
+        # established separator, and it cannot collide with clause punctuation.
+        lines.append(f"  ({' · '.join(caveats)})")
 
     lines += [
         "",

--- a/local_operator/mobile/tui_handle.py
+++ b/local_operator/mobile/tui_handle.py
@@ -53,6 +53,7 @@ from local_operator.session.runtime.server import (
     image_blocks,
     image_blocks_in_thread,
 )
+from local_operator.session.runtime.types import RUNNING_SUBAGENT_STATUSES
 
 if TYPE_CHECKING:
     from local_operator.tui.app import OperatorApp
@@ -153,6 +154,39 @@ class TuiSessionHandle(SessionHandle):
         if session is None:
             raise RuntimeError("session is still starting")
         return session
+
+    def subagent_counts(self) -> tuple[int | None, int | None]:
+        """``(running, queued)`` subagent trajectories for the record.
+
+        The ``kind="tui"`` twin of ``OwnedSessionHandle.subagent_counts``, so a
+        full TUI runtime contributes to ``/info``'s fleet tally instead of being
+        counted as a session that does not report. Implemented rather than left
+        out because this handle already reaches the roster (see
+        ``_warm_subagent_details``), and an unimplemented probe would publish
+        ``None`` for the most common kind of window on this host.
+
+        Reads the same ``RUNNING_SUBAGENT_STATUSES`` predicate the owned handle
+        and ``/info`` use — a private set here would let the record and the tree
+        drawn beneath it disagree. ``(None, None)`` on any failure, never
+        ``(0, 0)``: this runs before the session finishes starting, and a
+        not-yet-readable roster is not a measurement of zero.
+        """
+        try:
+            comms = getattr(self._session(), "subagent_comms", None)
+            if comms is None:
+                return (None, None)
+            nodes = comms.nodes()
+        except Exception:  # noqa: BLE001 — a stale count never breaks the app
+            logger.debug("could not read the subagent roster", exc_info=True)
+            return (None, None)
+        running = queued = 0
+        for node in nodes:
+            status = str(getattr(node, "status", "") or "")
+            if status in RUNNING_SUBAGENT_STATUSES:
+                running += 1
+            elif status == "queued":
+                queued += 1
+        return (running, queued)
 
     def rebind(self) -> None:
         """Re-point the bridge at the app's NEW session after /new, /resume

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -54,6 +54,7 @@ from local_operator.harness.types import (
 )
 from local_operator.mcp.grants import GRANT_SUBCOMMANDS as _GRANT_SUBCOMMANDS
 from local_operator.session.history_window import DisplayHistoryWindow
+from local_operator.session.runtime.types import RUNNING_SUBAGENT_STATUSES
 from local_operator.tui.costs import cost_summary, job_cost, turn_cost
 
 FRONTEND_STATE_VERSION = 1
@@ -2307,6 +2308,17 @@ class SnapshotSubagentComms:
             prompt=job.prompt or "",
             agent_role=job.agent_role or "",
             effort=job.effort or "",
+            # The LIFECYCLE fields, not merely the graph ones. Every consumer
+            # that asks "what is running" reads these off the node through a
+            # defaulted ``getattr`` — ``info.collect``'s tally and
+            # ``build_subagent_tree``'s status column both do — so omitting
+            # them does not raise, it silently answers "0 running" over a
+            # roster of live children and renders every row as ``unknown``.
+            # That is a wrong number that passes a "the tree appears now"
+            # check, which is why the projection carries them even though the
+            # hierarchy navigation this facade was built for never asked.
+            status=job.status,
+            live=job.status in RUNNING_SUBAGENT_STATUSES,
             # Launch-row reconciliation, read off the node by
             # ``_refresh_subagent_view`` exactly as it is on an owner. Defaulted
             # rather than conditional: an older owner sends neither field, and
@@ -2342,6 +2354,24 @@ class SnapshotSubagentComms:
             # placeholder tier 2 would have sent.
             launch_prompts=_restore_elided_launch_prompts(job),
         )
+
+    def nodes(self) -> list[Any]:
+        """The complete roster, matching ``SubagentComms.nodes()``.
+
+        The facade's docstring claims it answers the SAME methods the app calls
+        on ``_subagent_comms``, and this one was missing — the hierarchy view it
+        was built for always starts from a known job id, so nothing needed a
+        roster until ``/info`` asked one for its tally. Its absence was not a
+        crash but a fabricated zero: ``collect_live`` skipped the whole branch
+        and a follower window reported "no subagents" for a session that had
+        several, with nothing named as degraded.
+
+        One flat list including nested descendants, like the owner's: the
+        canonical jobs stream carries every depth tagged with its true
+        ``parent_job_id``, so consumers count with ``len()`` over a filter and
+        never a recursive walk.
+        """
+        return list(self._nodes.values())
 
     def node(self, job_id: str) -> Any | None:
         return self._nodes.get(self._aliases.get(job_id, job_id))

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -2317,8 +2317,24 @@ class SnapshotSubagentComms:
             # That is a wrong number that passes a "the tree appears now"
             # check, which is why the projection carries them even though the
             # hierarchy navigation this facade was built for never asked.
-            status=job.status,
-            live=job.status in RUNNING_SUBAGENT_STATUSES,
+            #
+            # ``queued`` has to be folded IN rather than read alongside: a
+            # queued child's ``JobState.status`` is still ``"running"`` and the
+            # distinction lives in the separate ``queued`` flag, so projecting
+            # the raw status counts a child that has not started as one that is
+            # spending tokens. The owner reconstructs the same split in
+            # ``SubagentComms._describe``; this is that derivation, on the
+            # follower's side of the wire, so a follower and an owner looking
+            # at the same child agree on its word.
+            status=_snapshot_status(job),
+            # Derived from the RESULTING status, not from the raw one, so a
+            # queued child is never stamped live. Note this ``live`` means
+            # "counts as a running trajectory", which on the owner is
+            # ``record.child is not None`` (child attached) — the two coincide
+            # for every state either side can report, but they are not the same
+            # question, and a future divergence belongs in one of these two
+            # comments rather than being discovered from a wrong total.
+            live=_snapshot_status(job) in RUNNING_SUBAGENT_STATUSES,
             # Launch-row reconciliation, read off the node by
             # ``_refresh_subagent_view`` exactly as it is on an owner. Defaulted
             # rather than conditional: an older owner sends neither field, and
@@ -2551,6 +2567,25 @@ def _derived_dir_belongs_to(directory: Path, label: str, agent_role: str) -> boo
         _DERIVED_OWNERSHIP.pop(next(iter(_DERIVED_OWNERSHIP)))
     _DERIVED_OWNERSHIP[key] = verdict
     return verdict
+
+
+def _snapshot_status(job: JobState) -> str:
+    """The projected job's status in the ROSTER vocabulary a follower renders.
+
+    ``JobState.status`` is the job manager's word, and it does not distinguish a
+    child parked behind the capacity gate from one that is spending tokens:
+    both carry ``"running"``, with the difference held in the separate
+    ``queued`` flag. Every "what is running" surface wants them apart — a queued
+    child is delegated, not working — so the split is reconstructed here exactly
+    as the owner reconstructs it in ``SubagentComms._describe``.
+
+    Kept as a named function rather than an inline expression because it is the
+    follower's half of a derivation whose two halves must agree; a reader
+    changing one needs to be able to find the other.
+    """
+    if job.queued and job.status == "running":
+        return "queued"
+    return job.status
 
 
 def _snapshot_session_dir(job: JobState) -> Path | None:

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -4084,6 +4084,23 @@ class RemoteSession:
         return "main"
 
     @property
+    def subagent_comms(self) -> Any:
+        """This follower's read-only view of the owner's subagent graph.
+
+        The PUBLIC name the real ``Session`` exposes, added because callers
+        duck-type on it and the private attribute alone did not satisfy that.
+        ``/info`` read ``session.subagent_comms`` and got ``None`` here, so a
+        follower window reported zero subagents for a session that had
+        several — a fabricated zero rather than a raise, so nothing was even
+        named as degraded. Every attached window is on this path.
+
+        Never ``None``: the facade is built in ``__init__`` and refilled from
+        canonical state on every sync, so a caller gets an empty roster before
+        the first sync rather than an attribute that is sometimes missing.
+        """
+        return self._subagent_comms
+
+    @property
     def is_streaming(self) -> bool:
         return self._streaming
 

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -53,7 +53,10 @@ from local_operator.session.runtime.server import SessionHandle
 from local_operator.session.runtime.server import (
     image_blocks_in_thread as _image_blocks_async,
 )
-from local_operator.session.runtime.types import runtime_must_complete
+from local_operator.session.runtime.types import (
+    RUNNING_SUBAGENT_STATUSES,
+    runtime_must_complete,
+)
 from local_operator.session.transcript import TRANSCRIPT_FILENAME
 
 logger = logging.getLogger(__name__)
@@ -3741,6 +3744,65 @@ class OwnedSessionHandle(SessionHandle):
             setter(self.is_conversationally_active())
         except Exception:  # noqa: BLE001 — a stale marker is not worth a turn
             logger.debug("could not publish the busy state", exc_info=True)
+        self._publish_subagents()
+
+    def subagent_counts(self) -> tuple[int | None, int | None]:
+        """``(running, queued)`` subagent trajectories, or ``(None, None)``.
+
+        Deliberately NOT folded into :meth:`is_conversationally_active`, which
+        drops subagents on purpose (a session whose children are working is not
+        itself mid-reply). This is the orthogonal fact ``/info`` needs to answer
+        "how many agent trajectories are running across this machine", and it is
+        published on the record because a subagent graph is in-process state no
+        other session can observe.
+
+        The roster is ONE flat read: ``SubagentComms.nodes()`` already contains
+        every nested descendant, so counting is a filter over that list and must
+        never have a recursive walk added on top — that would double count every
+        node below depth 0. The statuses counted as running mirror the ones
+        ``info.collect`` uses, so the record and this session's own tree cannot
+        disagree.
+
+        ``(None, None)`` on an unreadable roster rather than ``(0, 0)``: an
+        unanswerable probe is not a measurement of zero, and the reader's
+        lower-bound caveat depends on being able to tell the two apart.
+        """
+        session = self._session
+        try:
+            comms = getattr(session, "subagent_comms", None)
+            if comms is None:
+                return (None, None)
+            nodes = comms.nodes()
+        except Exception:  # noqa: BLE001 — an unhealthy session still publishes
+            logger.debug("could not read the subagent roster", exc_info=True)
+            return (None, None)
+        running = queued = 0
+        for node in nodes:
+            status = str(getattr(node, "status", "") or "")
+            if status in RUNNING_SUBAGENT_STATUSES:
+                running += 1
+            elif status == "queued":
+                queued += 1
+        return (running, queued)
+
+    def _publish_subagents(self) -> None:
+        """Keep the record's subagent counts in step with the roster.
+
+        Driven from ``_publish_busy`` — i.e. from ``_notify`` — because a
+        subagent launching or settling IS a session event, so the transition
+        publish is sub-second under any real workload while the 15 s heartbeat
+        floor bounds a missed publish. ``set_subagents`` de-duplicates, so the
+        steady-state cost is one dict walk plus two comparisons per event.
+        """
+        server = self._registrant
+        setter = getattr(server, "set_subagents", None)
+        if not callable(setter):
+            return
+        try:
+            running, queued = self.subagent_counts()
+            setter(running, queued)
+        except Exception:  # noqa: BLE001 — a stale count is not worth a turn
+            logger.debug("could not publish the subagent counts", exc_info=True)
 
     def _check_loop_thread(self) -> None:
         """The registrant calls handle methods on its own loop; owned sessions

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -573,6 +573,13 @@ class RuntimeServer:
         #: fields have a defined value before the record exists.
         self._pending: str | None = None
         self._busy = False
+        #: Subagent trajectory counts, ``None`` until the handle answers the
+        #: probe at least once. Starting at ``None`` rather than 0 is what
+        #: makes a runtime whose handle cannot report indistinguishable from
+        #: one that predates the fields — both are honestly "unreported", and
+        #: neither is a measured zero.
+        self._subagents_running: int | None = None
+        self._subagents_queued: int | None = None
         #: True until a terminal attaches. A freshly spawned runtime genuinely
         #: has no viewer, so this starts True rather than False — the old
         #: default had every new runtime claiming a terminal it had never had.
@@ -1110,6 +1117,26 @@ class RuntimeServer:
                     probe = getattr(self._handle, "is_busy", None)
                 if callable(probe):
                     self.set_busy(bool(probe()))
+                # The FLOOR for the subagent counts, for the same reason and
+                # with the same hazard as ``busy`` directly above: this loop
+                # runs forever, so it MUST read the same predicate the
+                # transition publisher does (``subagent_counts`` on the
+                # handle, which ``_publish_busy`` also calls) or it would
+                # overwrite a correct value within one heartbeat instead of
+                # merely bounding staleness. A handle that does not implement
+                # the probe leaves the counts at ``None`` — unreported, which
+                # is the honest answer and not a zero.
+                counts = getattr(self._handle, "subagent_counts", None)
+                if callable(counts):
+                    # Shape-checked rather than unpacked blind: the probe is
+                    # duck-typed off the handle, so a handle that answers with
+                    # something else must leave the counts unreported instead
+                    # of raising inside the loop that also refreshes the
+                    # heartbeat — a heartbeat that stops is a runtime the whole
+                    # fleet reads as wedged.
+                    reported = counts()
+                    if isinstance(reported, tuple) and len(reported) == 2:
+                        self.set_subagents(reported[0], reported[1])
                 # A dead renderer can leave its main-process socket alive.
                 # Expiring the lease must reroute a parked gate even when no
                 # TCP disconnect arrives to trigger the ordinary detach path.
@@ -1461,6 +1488,25 @@ class RuntimeServer:
         self._busy = busy
         self._republish()
 
+    def set_subagents(self, running: int | None, queued: int | None) -> None:
+        """Record this runtime's subagent trajectory counts.
+
+        Deduped exactly like :meth:`set_busy`, and for the same reason: the
+        driver is ``_publish_busy`` on every session event, so the steady-state
+        cost has to be one comparison rather than a staged write.
+
+        ``None`` is accepted and republished as ``None`` on purpose — a handle
+        that cannot answer the probe (a ``kind="tui"`` runtime whose handle
+        does not implement it) must publish "I do not report" rather than a
+        fabricated zero, which is the distinction ``/info``'s lower-bound
+        caveat is built on.
+        """
+        if self._subagents_running == running and self._subagents_queued == queued:
+            return
+        self._subagents_running = running
+        self._subagents_queued = queued
+        self._republish()
+
     def _republish(self) -> None:
         """Refresh the discovery record with the current live state.
 
@@ -1481,6 +1527,8 @@ class RuntimeServer:
                 pending=self._pending,
                 busy=self._busy,
                 detached=not bool(self._visible_attach_surfaces()),
+                subagents_running=self._subagents_running,
+                subagents_queued=self._subagents_queued,
             )
         except Exception:  # noqa: BLE001 — a stale marker is not worth an exception
             logger.debug("could not republish the session record", exc_info=True)

--- a/local_operator/session/runtime/types.py
+++ b/local_operator/session/runtime/types.py
@@ -157,6 +157,21 @@ RUN_DIRNAME = "run/mobile"
 HEARTBEAT_INTERVAL_S = 15.0
 HEARTBEAT_TIMEOUT_S = 45.0
 
+#: Subagent roster statuses that count as a RUNNING trajectory — one agent loop
+#: that can independently make model calls right now.
+#:
+#: Lives here, beside the record fields it defines the meaning of, because two
+#: modules must agree on it and a divergence is invisible: the runtime publishes
+#: ``subagents_running`` from this set (``owned.OwnedSessionHandle``) and
+#: ``/info`` tallies this session's own tree from it (``info.collect``). If they
+#: drifted, the fleet total and the tree drawn directly beneath it on the same
+#: card would disagree, which is the one error that section must never make.
+#:
+#: ``queued`` is excluded and counted separately: a delegated child waiting for
+#: a capacity slot is not spending anything. This module stays stdlib-only, so
+#: the constant costs nothing to import on the CLI startup path.
+RUNNING_SUBAGENT_STATUSES = frozenset({"running", "starting", "pausing"})
+
 
 @dataclass
 class SessionRecord:
@@ -226,6 +241,39 @@ class SessionRecord:
     #: for PyPI/pipx/editable installs. Needed because same-version rebuilds
     #: are this host's common drift — see ``update.BuildStamp``.
     source_ref: str = ""
+
+    # -- agent trajectories -------------------------------------------------
+    # Same additive contract as the live-state and build-stamp blocks above,
+    # and for the same reason: PROTOCOL_VERSION deliberately does NOT move.
+    # It gates SOCKET FRAME compatibility and is read as a pre-dial CAPABILITY
+    # ASSERTION by peers already running — ``attach_client`` refuses below 2,
+    # ``session_factory`` and the TUI's takeover path below 4, ``remote``'s
+    # canonical attach below 5. Those readers take a HIGHER number as a promise
+    # that every frame through v5 is understood. Two JSON integers that touch
+    # no frame do not make that promise different, so bumping would spend the
+    # one number that carries it on a field nobody has to read, and would leave
+    # nothing to distinguish a build that genuinely changed the frames. A
+    # future reader that must REQUIRE these fields negotiates through
+    # ``capabilities``, which is the seam for exactly that (see
+    # ``FRONTEND_CAPABILITY``, gated alongside the version rather than by it).
+    #
+    # ``None`` (not 0) is the "this build does not report" signal, and the
+    # distinction is load-bearing: a runtime predating these fields has not
+    # told us it has no subagents, and a reader that collapsed the two would
+    # publish a confident total that is silently missing terms. See
+    # ``SessionsInfo.subagents_unreported``.
+
+    #: Subagent trajectories spending tokens right now: roster entries whose
+    #: status is running/starting/pausing. ``SubagentComms.nodes()`` returns
+    #: the COMPLETE roster including nested descendants (nested launches land
+    #: in the root session's single records map tagged with their true
+    #: parent), so this is a flat count over one read and must never be summed
+    #: with a recursive child walk.
+    subagents_running: int | None = None
+    #: Delegated but still waiting for a capacity slot. Kept separate from
+    #: ``subagents_running`` because a queued child is not spending anything,
+    #: and folding it in would inflate "what is running right now".
+    subagents_queued: int | None = None
 
     def to_json(self) -> dict[str, Any]:
         return asdict(self)

--- a/local_operator/tui/widgets/info_panel.py
+++ b/local_operator/tui/widgets/info_panel.py
@@ -220,6 +220,7 @@ class _Body:
         value: str,
         note: str = "",
         *,
+        values: Sequence[str] = (),
         notes: Sequence[str] = (),
         value_style: str = "fg",
     ) -> None:
@@ -228,6 +229,13 @@ class _Body:
         Values are left-aligned because they are IDENTIFIERS, not magnitudes:
         nothing is being compared down this column, and one column edge reads
         more calmly than two.
+
+        ``values`` is the same ladder for the VALUE itself, and exists because
+        the value column has no shed of its own: it is padded to
+        ``_VALUE_MIN`` and then hard-cropped by the final ``truncate``, so a
+        value that outgrows a narrow frame loses characters mid-word. Pass it
+        whenever a value carries an optional trailing clause; the last rung is
+        what the row degrades to and must be the irreducible fact.
 
         ``notes`` is a ladder of progressively shorter spellings of the SAME
         qualifier, widest first, first-that-fits wins. It exists because the
@@ -245,6 +253,16 @@ class _Body:
         """
         row = Text()
         row.append(f"  {name:<{_LABEL_CELL}}", style=semantic_style("dim"))
+        if values:
+            # A ladder for the VALUE, mirroring ``notes`` below, and needed for
+            # the same reason: without one the value is hard-cropped by the
+            # final ``truncate``, which cuts mid-word and can leave a label
+            # promising a number that is not there ("... · depth" with no
+            # digit). That reads as a broken field rather than a narrow one.
+            # Widest-first, first-that-fits, and the last rung must always fit
+            # by construction — it is the caller's irreducible fact.
+            budget = self.width - row.cell_len - 2
+            value = next((rung for rung in values if len(rung) <= budget), values[-1])
         row.append(f"{value:<{_VALUE_MIN}}", style=semantic_style(value_style))
         if notes:
             # Budget measured from the row as actually BUILT, not from a
@@ -715,6 +733,24 @@ def _counted(value: int, probe: str, snapshot: "InfoSnapshot | None") -> str:
     return str(value)
 
 
+#: Nouns whose plural is not formed by appending ``s``. One entry today; the
+#: map exists so the next irregular noun is a data change rather than a second
+#: pluralisation helper beside this one.
+_IRREGULAR_PLURALS = {"trajectory": "trajectories"}
+
+
+def _plural(count: int, noun: str) -> str:
+    """``"1 runtime"`` / ``"5 runtimes"`` / ``"5 trajectories"``.
+
+    ``/info`` pluralises everywhere else (``3 keys``, ``1 session is wedged``),
+    so an unpluralised count reads as unfinished rather than as house style,
+    and a single-window host is the state every fresh install starts in.
+    """
+    if count == 1:
+        return f"{count} {noun}"
+    return f"{count} {_IRREGULAR_PLURALS.get(noun, noun + 's')}"
+
+
 def _runtimes(sessions: SessionsInfo) -> int:
     """Processes publishing a record: ``live`` plus ``wedged``.
 
@@ -744,17 +780,24 @@ def _fleet_caveats(body: _Body, sessions: SessionsInfo | None) -> None:
         return
     if sessions.subagents_unreported:
         count = sessions.subagents_unreported
-        plural = "s" if count != 1 else ""
-        verb = "run" if count != 1 else "runs"
+        # Both verbs inflect together. Inflecting only the first produced
+        # "1 session runs an older build and do not report" — reachable as soon
+        # as the fleet is one restart from updated, i.e. the tail of the very
+        # rollout this caveat exists for.
+        one = count == 1
         body.note(
-            f"{count} session{plural} {verb} an older build and do not report subagents — "
+            f"{_plural(count, 'session')} {'runs' if one else 'run'} an older build and "
+            f"{'does' if one else 'do'} not report subagents — "
             "the fleet total is a lower bound."
         )
     if sessions.wedged:
-        plural = "s are" if sessions.wedged != 1 else " is"
+        one = sessions.wedged == 1
+        # The possessive inflects with the subject too: "1 session is wedged;
+        # their counts" switched number mid-sentence.
         body.note(
-            f"{sessions.wedged} session{plural} wedged; "
-            "their counts are as of their last heartbeat."
+            f"{_plural(sessions.wedged, 'session')} {'is' if one else 'are'} wedged; "
+            f"{'its' if one else 'their'} counts are as of "
+            f"{'its' if one else 'their'} last heartbeat."
         )
 
 
@@ -785,14 +828,47 @@ def _agents_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState)
     if sessions is None or not sessions.available:
         meta = f"this session: {own} running · fleet checking…"
         short = f"{own} running"
-    elif sessions.fleet_trajectories:
-        meta = f"{_runtimes(sessions)} runtimes · {sessions.fleet_trajectories} trajectories"
-        short = f"{sessions.fleet_trajectories} trajectories"
     else:
-        # ``none running`` rather than ``0 running``: a zero in a count column
-        # reads as a failed probe, a word does not.
-        meta = f"{_runtimes(sessions)} runtimes · none running"
-        short = "none running"
+        runtimes = _runtimes(sessions)
+        # ``≥`` — and the reason it is not simply the total — is the whole of
+        # D1/D2. ``fleet_trajectories`` sums only over runtimes that REPORTED,
+        # so when some did not, every term of the sum is a floor rather than a
+        # measurement. Rendering that through the measured branch printed
+        # ``none running`` — a word chosen precisely because it asserts more
+        # confidently than a bare ``0`` — on a frame that was simultaneously
+        # drawing this session's running children four rows below. The record
+        # layer honours "None is not 0" and the header dropped it.
+        #
+        # The hedge rides the FIGURE rather than waiting for the caveat line
+        # because at the real 100x30 viewport the caveat is a page-turn away
+        # from the header, and a qualifier the reader must scroll to is not a
+        # qualifier. The caveat still says how many terms are missing; this
+        # says, where the number is, that it is a floor.
+        bound = "≥" if sessions.subagents_unreported else ""
+        total = sessions.fleet_trajectories
+        if total:
+            meta = f"{_plural(runtimes, 'runtime')} · {bound}{_plural(total, 'trajectory')}"
+            # BOTH halves survive the shed. The operator's question is
+            # explicitly two-part ("how many runtimes and how many
+            # trajectories"), so dropping the denominator leaves the count
+            # unanchored — N trajectories across how many processes? The
+            # abbreviation is what makes keeping both affordable.
+            short = f"{runtimes}rt · {bound}{total}tj"
+        elif bound:
+            # Nothing measured AND nothing known: ``0`` here would be pure
+            # fabrication, so the count is refused outright rather than hedged.
+            # ``—`` is the screen's existing "we looked and could not tell",
+            # not a fourth vocabulary.
+            meta = f"{_plural(runtimes, 'runtime')} · trajectories {UNKNOWN}"
+            short = f"{runtimes}rt · tj {UNKNOWN}"
+        else:
+            # Every runtime reported, and every one of them reported zero. This
+            # is the one state in which the word is earned: it is a
+            # measurement, and ``none running`` reads better than ``0``.
+            meta = f"{_plural(runtimes, 'runtime')} · none running"
+            # ``none`` and not ``0tj``: the bare-zero rule does not relax on a
+            # narrow frame, and the word costs one cell more than the digit.
+            short = f"{runtimes}rt · none"
     body.header("Agents and subagents", meta, short)
     if sessions is not None and sessions.available:
         # The header's runtime count broken down. Both numbers name a live
@@ -802,15 +878,42 @@ def _agents_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState)
             "Runtimes",
             f"{sessions.live} live" + (f" · {sessions.wedged} wedged" if sessions.wedged else ""),
         )
-        body.kv(
-            "Trajectories",
-            f"{sessions.fleet_trajectories} total",
-            notes=(
-                f"{sessions.fleet_session_trajectories} sessions + "
-                f"{sessions.fleet_subagents_running} subagents",
-                f"{sessions.fleet_session_trajectories}+{sessions.fleet_subagents_running}",
-            ),
-        )
+        # Same rule as the header, one row down. Three zeros in a row
+        # (``0 total — 0 sessions + 0 subagents``) under a visible running tree
+        # is the "a bare zero reads as a failed probe" rule firing three times,
+        # and here it would be firing over terms nobody measured. When nothing
+        # reported, the addends are not shown at all rather than shown as
+        # zeros: the note column names WHY the value is a floor, which is the
+        # only fact the row actually has.
+        if sessions.subagents_unreported and not sessions.fleet_trajectories:
+            body.kv(
+                "Trajectories",
+                UNKNOWN,
+                notes=(
+                    f"{sessions.subagents_unreported} of "
+                    f"{_runtimes(sessions)} runtimes did not report",
+                    f"{sessions.subagents_unreported} did not report",
+                    "not reported",
+                ),
+            )
+        else:
+            bound = "≥" if sessions.subagents_unreported else ""
+            body.kv(
+                "Trajectories",
+                f"{bound}{sessions.fleet_trajectories} total",
+                notes=(
+                    f"{_plural(sessions.fleet_session_trajectories, 'session')} + "
+                    f"{_plural(sessions.fleet_subagents_running, 'subagent')}"
+                    + (
+                        f" · {sessions.subagents_unreported} did not report"
+                        if sessions.subagents_unreported
+                        else ""
+                    ),
+                    f"{_plural(sessions.fleet_session_trajectories, 'session')} + "
+                    f"{_plural(sessions.fleet_subagents_running, 'subagent')}",
+                    f"{sessions.fleet_session_trajectories}+{sessions.fleet_subagents_running}",
+                ),
+            )
     if agents is not None:
         body.kv("Agent profiles", _counted(agents.profiles, "agents.profiles", snapshot))
         body.kv("Teams", _counted(agents.teams, "agents.teams", snapshot))
@@ -834,6 +937,16 @@ def _agents_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState)
             # the two numbers it belongs to.
             "This session",
             f"{running} running · {queued} queued" + (f" · depth {depth}" if depth else ""),
+            # ``depth`` sheds FIRST, before ``queued``: it is context about the
+            # tree's shape, while the two counts are the answer. Without a rung
+            # of its own the suffix was cropped mid-word at 60-64 columns,
+            # ending the row on the bare label "depth" — a regression against
+            # the pre-fleet row, which was shorter but always complete.
+            values=(
+                f"{running} running · {queued} queued" + (f" · depth {depth}" if depth else ""),
+                f"{running} running · {queued} queued",
+                f"{running}r · {queued}q",
+            ),
             # "settled (retained)" and not "settled": ``_evict_overflow`` drops
             # settled records past a cap, so this under-reports by design, and a
             # count that silently under-reports inside a bug report is worse

--- a/local_operator/tui/widgets/info_panel.py
+++ b/local_operator/tui/widgets/info_panel.py
@@ -43,6 +43,7 @@ from local_operator.info.collect import LiveState
 from local_operator.info.model import (
     UNKNOWN,
     InfoSnapshot,
+    SessionsInfo,
     format_bytes,
     format_duration,
     is_shadowed_install,
@@ -714,6 +715,49 @@ def _counted(value: int, probe: str, snapshot: "InfoSnapshot | None") -> str:
     return str(value)
 
 
+def _runtimes(sessions: SessionsInfo) -> int:
+    """Processes publishing a record: ``live`` plus ``wedged``.
+
+    The denominator the trajectory tally is summed over, so it is computed in
+    ONE place. A wedged runtime is a pid that still exists and whose children
+    may still be working; only ``stale`` — whose record file the scan just
+    deleted because the process is gone — is not a runtime. A header that
+    counted a narrower set than the sum beneath it would be a screen
+    disagreeing with itself.
+    """
+    return sessions.live + sessions.wedged
+
+
+def _fleet_caveats(body: _Body, sessions: SessionsInfo | None) -> None:
+    """Name the terms the fleet total is MISSING, only when there are any.
+
+    Emitted conditionally rather than as a standing disclaimer: a line that is
+    always there is wallpaper and gets read as boilerplate, so the one time it
+    matters it is not read either.
+
+    ``lower bound`` is the load-bearing phrase. It is the honest description of
+    a sum whose unknown terms were excluded, and it is what distinguishes "3
+    sessions could not report" from "3 sessions have no subagents" without
+    making the reader cross-reference the degraded block.
+    """
+    if sessions is None or not sessions.available:
+        return
+    if sessions.subagents_unreported:
+        count = sessions.subagents_unreported
+        plural = "s" if count != 1 else ""
+        verb = "run" if count != 1 else "runs"
+        body.note(
+            f"{count} session{plural} {verb} an older build and do not report subagents — "
+            "the fleet total is a lower bound."
+        )
+    if sessions.wedged:
+        plural = "s are" if sessions.wedged != 1 else " is"
+        body.note(
+            f"{sessions.wedged} session{plural} wedged; "
+            "their counts are as of their last heartbeat."
+        )
+
+
 def _agents_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState) -> None:
     """Profiles, teams, and this session's subagent tree.
 
@@ -723,27 +767,73 @@ def _agents_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState)
     """
     agents = snapshot.agents if snapshot else None
     running = agents.running if agents else live.running
+    # Depth moved OFF the header, which now carries the fleet answer. It is kept
+    # on this session's own row rather than dropped: the tree's indentation
+    # shows shape but not how much of it the render cap folded away.
     depth = agents.max_depth if agents else live.max_depth
     tree = agents.tree if agents else live.tree
     deeper = agents.deeper if agents else live.deeper
-    # ``none running`` rather than ``0 running``: a zero in a count column reads
-    # as a failed probe, a word does not.
-    meta = f"{running} running · depth {depth}" if running else "none running"
-    body.header("Agents and subagents", meta, f"{running} running" if running else "none running")
+    unread = agents.roster_unread if agents else live.roster_unread
+    sessions = snapshot.sessions if snapshot else None
+    # The fleet half comes from the WORKER snapshot (~900 ms) while the tree
+    # comes from the live capture, so the two arrive on different frames. The
+    # header shows this session's number immediately and says ``checking…`` for
+    # the fleet half rather than printing a zero it will revise upward — the
+    # screen's one loading word, reused rather than joined by a fourth
+    # vocabulary (see ``_env_section``).
+    own = UNKNOWN if unread else str(running)
+    if sessions is None or not sessions.available:
+        meta = f"this session: {own} running · fleet checking…"
+        short = f"{own} running"
+    elif sessions.fleet_trajectories:
+        meta = f"{_runtimes(sessions)} runtimes · {sessions.fleet_trajectories} trajectories"
+        short = f"{sessions.fleet_trajectories} trajectories"
+    else:
+        # ``none running`` rather than ``0 running``: a zero in a count column
+        # reads as a failed probe, a word does not.
+        meta = f"{_runtimes(sessions)} runtimes · none running"
+        short = "none running"
+    body.header("Agents and subagents", meta, short)
+    if sessions is not None and sessions.available:
+        # The header's runtime count broken down. Both numbers name a live
+        # pid — that is why the header adds them — and the split is what tells
+        # the reader how much of the tally is coming from quiet processes.
+        body.kv(
+            "Runtimes",
+            f"{sessions.live} live" + (f" · {sessions.wedged} wedged" if sessions.wedged else ""),
+        )
+        body.kv(
+            "Trajectories",
+            f"{sessions.fleet_trajectories} total",
+            notes=(
+                f"{sessions.fleet_session_trajectories} sessions + "
+                f"{sessions.fleet_subagents_running} subagents",
+                f"{sessions.fleet_session_trajectories}+{sessions.fleet_subagents_running}",
+            ),
+        )
     if agents is not None:
         body.kv("Agent profiles", _counted(agents.profiles, "agents.profiles", snapshot))
         body.kv("Teams", _counted(agents.teams, "agents.teams", snapshot))
     queued = agents.queued if agents else live.queued
     settled = agents.settled if agents else live.settled
-    if running or queued or settled:
+    if unread:
+        # The roster was never read, so every count derived from it is absent
+        # rather than zero. ``UNKNOWN`` and a named reason, the same treatment
+        # ``_counted`` gives a failed probe — the alternative is the screen
+        # asserting "no subagents" about a session it could not ask.
+        body.kv("This session", UNKNOWN, notes=("could not read the roster",))
+    elif running or queued or settled:
         # Only when there is something to count. On a fresh session a
         # ``0 running · 0 queued`` row directly above "No subagents have been
         # launched" says the same thing twice, and a row of zeros reads as a
         # failed probe rather than as an idle session — the same reason the
         # header meta says ``none running`` instead of ``0 running``.
         body.kv(
-            "Subagents",
-            f"{running} running · {queued} queued",
+            # ``This session`` and not ``Subagents``: with a fleet total two
+            # rows above it, an unqualified label is ambiguous about which of
+            # the two numbers it belongs to.
+            "This session",
+            f"{running} running · {queued} queued" + (f" · depth {depth}" if depth else ""),
             # "settled (retained)" and not "settled": ``_evict_overflow`` drops
             # settled records past a cap, so this under-reports by design, and a
             # count that silently under-reports inside a bug report is worse
@@ -760,11 +850,19 @@ def _agents_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState)
             value_style="warning" if at_capacity else "fg",
         )
     if not tree:
-        # The empty state pairs a statement of FACT with a statement of why it
-        # is fine, matching ``/analytics``' own empty shape. The section header
-        # above is the evidence that the screen looked.
-        body.note("No subagents have been launched in this session.")
-        body.note("Subagents appear here while a task is running.")
+        if unread:
+            # NOT "none have been launched": that is a statement of fact about
+            # a roster nobody managed to read. The empty tree here is the
+            # absence of an answer, and saying otherwise is the exact lie the
+            # UNKNOWN row above exists to prevent.
+            body.note("This session's subagent roster could not be read.")
+        else:
+            # The empty state pairs a statement of FACT with a statement of why
+            # it is fine, matching ``/analytics``' own empty shape. The section
+            # header above is the evidence that the screen looked.
+            body.note("No subagents have been launched in this session.")
+            body.note("Subagents appear here while a task is running.")
+        _fleet_caveats(body, sessions)
         return
     body.blank()
     for node in tree:
@@ -812,14 +910,22 @@ def _agents_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState)
         body.lines.append(row)
     body.blank()
     # The honesty boundary, stated rather than implied: a tree on screen would
-    # otherwise read as a fleet-wide view. Nothing about another session's
-    # subagents is observable — ``SessionRecord`` carries no subagent field —
-    # and reaching for one would need a new control-socket op and a protocol
-    # bump.
-    body.note(
-        "Subagent trees are in-process state, so only this session's is visible. "
-        "Other sessions report busy, pending and memory."
-    )
+    # otherwise read as a fleet-wide view. The COUNTS above are fleet-wide, the
+    # TREE is not, and which is which has to be said in words.
+    if agents is not None and agents.cross_session_known:
+        body.note(
+            "Subagent trees are in-process state, so only this session's is drawn. "
+            "Other sessions report counts."
+        )
+    else:
+        # Nobody else reported, so the older text is still exactly right: this
+        # screen genuinely knows nothing about other windows' children, and
+        # promising counts it does not have would be the worse error.
+        body.note(
+            "Subagent trees are in-process state, so only this session's is visible. "
+            "Other sessions report busy, pending and memory."
+        )
+    _fleet_caveats(body, sessions)
 
 
 def _env_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState) -> None:

--- a/local_operator/tui/widgets/info_panel.py
+++ b/local_operator/tui/widgets/info_panel.py
@@ -361,8 +361,16 @@ class _Body:
             row.append(f"  {line}", style=semantic_style("dim"))
             self.lines.append(row)
 
-    def header(self, title: str, meta: str = "", short: str = "") -> None:
+    def header(
+        self, title: str, meta: str = "", short: str = "", *, shorts: Sequence[str] = ()
+    ) -> None:
         """A section header, shedding its meta to ``short`` on a narrow frame.
+
+        ``shorts`` is the same widest-first, first-that-fits ladder ``kv`` uses
+        for ``notes`` and ``values``, and exists for a header whose short form
+        grows with its DIGITS rather than being fixed at authoring time. Pass it
+        instead of ``short`` when a narrower spelling is available; the last
+        rung is what the header degrades to and must be the irreducible fact.
 
         The threshold is a WIDTH FLOOR plus a fit check, not the floor alone:
         ``_NOTE_MIN`` was calibrated against the metas that existed when it was
@@ -370,10 +378,28 @@ class _Body:
         overflowed by a cell at exactly 60 columns while passing the floor.
         Measuring the string that will actually be drawn is what keeps a new
         meta from having to rediscover this by overflowing a frame.
+
+        The final ``truncate`` is the same backstop ``kv`` and ``marked``
+        already end with, and ``header`` was the only row builder without one.
+        The fit check picks BETWEEN ``meta`` and ``short`` but cannot make
+        ``short`` fit, so a short form that outgrows the ``_MIN_CARD_WIDTH``
+        floor had nothing to stop it: the container FOLDS rather than crops, so
+        it rendered as a second line starting at column 0 — the "one record
+        reads as two" fault these screens exist to remove. Cropping a header's
+        trailing meta is survivable; breaking the card's left margin is not.
         """
-        if meta and (self.width < _NOTE_MIN or cell_len(f"{title}   {meta}") + 2 > self.width):
-            meta = short
-        self.lines.append(section_header(title, meta))
+
+        def _fits(candidate: str) -> bool:
+            # ``+ 2`` for the ``▌ `` accent bar the header always carries; the
+            # same measurement the meta fit check above uses.
+            return cell_len(f"{title}   {candidate}") + 2 <= self.width
+
+        if meta and (self.width < _NOTE_MIN or not _fits(meta)):
+            rungs = tuple(shorts) or ((short,) if short else ())
+            meta = next((rung for rung in rungs if _fits(rung)), rungs[-1] if rungs else "")
+        row = section_header(title, meta)
+        row.truncate(self.width, overflow="crop")
+        self.lines.append(row)
 
     def to_text(self) -> Text:
         out = Text(style=semantic_style("fg"), overflow="fold")
@@ -827,9 +853,21 @@ def _agents_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState)
     # screen's one loading word, reused rather than joined by a fourth
     # vocabulary (see ``_env_section``).
     own = UNKNOWN if unread else str(running)
+    # Widest-first rungs for the header's short form, empty unless a state has
+    # a narrower spelling to offer. Only the queued state needs one today: it
+    # is the only short form whose width grows with its digits.
+    shorts: tuple[str, ...] = ()
     if sessions is None or not sessions.available:
         meta = f"this session: {own} running · fleet checking…"
+        # The hedge sheds LAST, not first. The bare ``{own} running`` short
+        # form dropped ``fleet checking…`` entirely, so for the ~900 ms before
+        # the worker returns a narrow frame showed a number that is about to be
+        # revised upward as though it were settled — the same "unmeasured
+        # rendered as measured" fault the rest of this section exists to
+        # prevent. ``fleet …`` keeps the fact that a second half is still
+        # coming; only its wording is compressed.
         short = f"{own} running"
+        shorts = (short + " · fleet checking…", f"{own}r · fleet …", short)
     else:
         runtimes = _runtimes(sessions)
         # ``≥`` — and the reason it is not simply the total — is the whole of
@@ -875,7 +913,16 @@ def _agents_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState)
             # through an unmeasured term.
             queued = sessions.fleet_subagents_queued
             meta = f"{_plural(runtimes, 'runtime')} · none running · {queued} queued"
+            # Two rungs, because this short form is the first whose width grows
+            # with its DIGITS: a fleet-wide queued sum is not bounded by
+            # ``max_running``, so two digits are ordinary on a busy host and
+            # they pushed the one-rung form past the ``_MIN_CARD_WIDTH`` floor.
+            # ``0r`` is what sheds — it restates the ``0 running`` the reader
+            # can already infer from a queued-only header, whereas dropping a
+            # count would lose a measured fact. The ``truncate`` in ``header``
+            # is the backstop beneath both.
             short = f"{runtimes}rt · 0r · {queued}q"
+            shorts = (short, f"{runtimes}rt · {queued}q")
         else:
             # Every runtime reported, every one reported zero, and nothing is
             # waiting either. This is the one state in which the bare word is
@@ -885,7 +932,7 @@ def _agents_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState)
             # ``none`` and not ``0tj``: the bare-zero rule does not relax on a
             # narrow frame, and the word costs one cell more than the digit.
             short = f"{runtimes}rt · none"
-    body.header("Agents and subagents", meta, short)
+    body.header("Agents and subagents", meta, short, shorts=shorts)
     if sessions is not None and sessions.available:
         # The header's runtime count broken down. Both numbers name a live
         # pid — that is why the header adds them — and the split is what tells

--- a/local_operator/tui/widgets/info_panel.py
+++ b/local_operator/tui/widgets/info_panel.py
@@ -48,7 +48,7 @@ from local_operator.info.model import (
     format_duration,
     is_shadowed_install,
 )
-from local_operator.info.render import build_export
+from local_operator.info.render import build_export, plural
 from local_operator.tui.widgets.analytics_panel import (
     _row_prefix,
     section_header,
@@ -362,8 +362,16 @@ class _Body:
             self.lines.append(row)
 
     def header(self, title: str, meta: str = "", short: str = "") -> None:
-        """A section header, shedding its meta to ``short`` on a narrow frame."""
-        if meta and self.width < _NOTE_MIN:
+        """A section header, shedding its meta to ``short`` on a narrow frame.
+
+        The threshold is a WIDTH FLOOR plus a fit check, not the floor alone:
+        ``_NOTE_MIN`` was calibrated against the metas that existed when it was
+        written, so a longer one (``5 runtimes · none running · 3 queued``)
+        overflowed by a cell at exactly 60 columns while passing the floor.
+        Measuring the string that will actually be drawn is what keeps a new
+        meta from having to rediscover this by overflowing a frame.
+        """
+        if meta and (self.width < _NOTE_MIN or cell_len(f"{title}   {meta}") + 2 > self.width):
             meta = short
         self.lines.append(section_header(title, meta))
 
@@ -736,19 +744,13 @@ def _counted(value: int, probe: str, snapshot: "InfoSnapshot | None") -> str:
 #: Nouns whose plural is not formed by appending ``s``. One entry today; the
 #: map exists so the next irregular noun is a data change rather than a second
 #: pluralisation helper beside this one.
-_IRREGULAR_PLURALS = {"trajectory": "trajectories"}
-
-
-def _plural(count: int, noun: str) -> str:
-    """``"1 runtime"`` / ``"5 runtimes"`` / ``"5 trajectories"``.
-
-    ``/info`` pluralises everywhere else (``3 keys``, ``1 session is wedged``),
-    so an unpluralised count reads as unfinished rather than as house style,
-    and a single-window host is the state every fresh install starts in.
-    """
-    if count == 1:
-        return f"{count} {noun}"
-    return f"{count} {_IRREGULAR_PLURALS.get(noun, noun + 's')}"
+#: The ONE implementation, imported rather than reimplemented: the screen and
+#: the export must not inflect the same fact differently, and they did until
+#: the export's addends were found reading ``1 sessions + 1 subagents``.
+#: ``/info`` pluralises everywhere else (``3 keys``, ``1 session is wedged``),
+#: so an unpluralised count reads as unfinished rather than as house style, and
+#: a single-window host is the state every fresh install starts in.
+_plural = plural
 
 
 def _runtimes(sessions: SessionsInfo) -> int:
@@ -861,10 +863,24 @@ def _agents_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState)
             # not a fourth vocabulary.
             meta = f"{_plural(runtimes, 'runtime')} · trajectories {UNKNOWN}"
             short = f"{runtimes}rt · tj {UNKNOWN}"
+        elif sessions is not None and sessions.fleet_subagents_queued:
+            # Measured, and measured as zero RUNNING — but not as nothing.
+            # ``fleet_trajectories`` deliberately excludes queued children
+            # (a child waiting on a capacity slot spends no tokens, which is
+            # what a trajectory count is for), so the total is honestly 0 while
+            # the tree below draws ``⏳ queued`` rows. Saying only ``none
+            # running`` there is the header contradicting a picture the same
+            # frame is showing — the exact failure the three states above
+            # exist to prevent, reached through arithmetic rather than
+            # through an unmeasured term.
+            queued = sessions.fleet_subagents_queued
+            meta = f"{_plural(runtimes, 'runtime')} · none running · {queued} queued"
+            short = f"{runtimes}rt · 0r · {queued}q"
         else:
-            # Every runtime reported, and every one of them reported zero. This
-            # is the one state in which the word is earned: it is a
-            # measurement, and ``none running`` reads better than ``0``.
+            # Every runtime reported, every one reported zero, and nothing is
+            # waiting either. This is the one state in which the bare word is
+            # earned: it is a measurement, and ``none running`` reads better
+            # than ``0``.
             meta = f"{_plural(runtimes, 'runtime')} · none running"
             # ``none`` and not ``0tj``: the bare-zero rule does not relax on a
             # narrow frame, and the word costs one cell more than the digit.
@@ -898,20 +914,53 @@ def _agents_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState)
             )
         else:
             bound = "≥" if sessions.subagents_unreported else ""
+            addends = (
+                f"{_plural(sessions.fleet_session_trajectories, 'session')} + "
+                f"{_plural(sessions.fleet_subagents_running, 'subagent')}"
+            )
+            # Queued rides the ADDENDS, not the total: it is not a trajectory
+            # (nothing is being spent yet), so adding it to the sum would
+            # inflate the very number the section exists to state precisely.
+            # But a row reading ``0 total — 0 sessions + 0 subagents`` above a
+            # visible queued tree is the three-zeros failure again, so the
+            # waiting work is named beside the total rather than folded into
+            # it.
+            waiting = (
+                f" · {sessions.fleet_subagents_queued} queued"
+                if sessions.fleet_subagents_queued
+                else ""
+            )
+            # The waiting clause sheds LAST, after the addends it sits beside.
+            # Ordering matters because the state that needs it most is the one
+            # where the addends carry no information: at ``0 total`` they are
+            # ``0 sessions + 0 subagents``, three zeros whose only honest
+            # companion is the queued count. A ladder that dropped ``queued``
+            # first restored the contradiction at every narrow width while the
+            # wide frame looked fixed.
+            # Two extra rungs when work is waiting, because the note column is
+            # only ~2 cells wide at 50 columns: ``3 queued`` alone would shed
+            # wholesale there and leave ``0 total`` asserting nothing-in-flight
+            # over a queued tree. ``3q`` fits that budget and is decoded by the
+            # ``queued`` rows directly beneath it, the same bargain ``5rt·9tj``
+            # makes in the header.
+            terse: tuple[str, ...] = (
+                (f"{sessions.fleet_subagents_queued} queued", f"{sessions.fleet_subagents_queued}q")
+                if sessions.fleet_subagents_queued
+                else (f"{sessions.fleet_session_trajectories}+{sessions.fleet_subagents_running}",)
+            )
             body.kv(
                 "Trajectories",
                 f"{bound}{sessions.fleet_trajectories} total",
                 notes=(
-                    f"{_plural(sessions.fleet_session_trajectories, 'session')} + "
-                    f"{_plural(sessions.fleet_subagents_running, 'subagent')}"
+                    addends
+                    + waiting
                     + (
                         f" · {sessions.subagents_unreported} did not report"
                         if sessions.subagents_unreported
                         else ""
                     ),
-                    f"{_plural(sessions.fleet_session_trajectories, 'session')} + "
-                    f"{_plural(sessions.fleet_subagents_running, 'subagent')}",
-                    f"{sessions.fleet_session_trajectories}+{sessions.fleet_subagents_running}",
+                    addends + waiting,
+                    *terse,
                 ),
             )
     if agents is not None:

--- a/scripts/info_shot.py
+++ b/scripts/info_shot.py
@@ -3,6 +3,7 @@
 Usage: python scripts/info_shot.py OUTDIR 100x30 [scenario]
   scenarios: populated | empty | degraded | nested | shadowed | loading
              fleet | fleet-mixed | fleet-unread
+             today-quiet | race | one | one-older
 
 Every scenario feeds a hand-built :class:`InfoSnapshot` rather than the
 operator's real one. That is not convenience — the frames go on a PR, and the
@@ -291,6 +292,87 @@ def snapshot_for(scenario: str) -> InfoSnapshot | None:
                     SubagentLine(job_id="j5", label="designer", status="failed", depth=0),
                     SubagentLine(job_id="j6", label="architect", status="completed", depth=0),
                 ),
+            ),
+            env=_env(),
+            captured_at=CAPTURED_AT,
+        )
+
+    if scenario in ("today-quiet", "race", "one", "one-older"):
+        # The states design round 1 captured. ``today-quiet``/``race`` are this
+        # host's ACTUAL default until the whole fleet restarts: nothing
+        # publishes the new fields, so the fleet half is entirely unmeasured
+        # while this session's own tree may well be running (D1/D2).
+        older = scenario in ("today-quiet", "race", "one-older")
+        single = scenario in ("one", "one-older")
+        count = 1 if scenario == "one" else 2 if scenario == "one-older" else 11
+        rows = []
+        for index in range(count):
+            pid = 4243 + index
+            reports = not older or (scenario == "one-older" and index == 0)
+            rows.append(
+                _session_line(
+                    pid,
+                    "Investigate request latency" if index == 0 else f"Session {index}",
+                    is_self=index == 0,
+                    busy=scenario == "one",
+                    # A runtime that predates the fields publishes NEITHER key,
+                    # which is ``None`` and not ``0`` — the whole distinction
+                    # these frames exist to show.
+                    subagents_running=0 if reports else None,
+                    subagents_queued=0 if reports else None,
+                )
+            )
+        lines = tuple(rows)
+        reporting = [line for line in lines if line.subagents_running is not None]
+        busy = sum(1 for line in lines if line.busy)
+        running = sum(line.subagents_running or 0 for line in reporting)
+        sessions = SessionsInfo(
+            lines=lines,
+            total=len(lines),
+            live=len(lines),
+            busy=busy,
+            subagents_reporting=len(reporting),
+            subagents_unreported=len(lines) - len(reporting),
+            fleet_subagents_running=running,
+            fleet_session_trajectories=busy,
+            fleet_trajectories=busy + running,
+        )
+        # ``race``: the own roster reads fine and shows running children while
+        # the own record has not published busy yet (event publish + 15 s
+        # floor). This is the frame where the old header said "none running"
+        # over a visible running tree.
+        tree = (
+            (
+                SubagentLine(
+                    job_id="j1",
+                    label="reviewer",
+                    status="running",
+                    depth=0,
+                    agent_role="reviewer",
+                ),
+                SubagentLine(
+                    job_id="j2", label="scout", status="running", depth=1, agent_role="scout"
+                ),
+                SubagentLine(job_id="j3", label="coder", status="running", depth=0),
+                SubagentLine(job_id="j4", label="qa-tester", status="queued", depth=0),
+            )
+            if scenario == "race"
+            else ()
+        )
+        return InfoSnapshot(
+            install=_install(),
+            process=_process(),
+            sessions=sessions,
+            agents=AgentsInfo(
+                profiles=20,
+                teams=3,
+                tree=tree,
+                running=3 if scenario == "race" else 0,
+                queued=1 if scenario == "race" else 0,
+                settled=7 if scenario == "race" else 0,
+                max_running=4,
+                max_depth=2 if scenario == "race" else 0,
+                cross_session_known=not older and not single,
             ),
             env=_env(),
             captured_at=CAPTURED_AT,

--- a/scripts/info_shot.py
+++ b/scripts/info_shot.py
@@ -2,6 +2,7 @@
 
 Usage: python scripts/info_shot.py OUTDIR 100x30 [scenario]
   scenarios: populated | empty | degraded | nested | shadowed | loading
+             fleet | fleet-mixed | fleet-unread
 
 Every scenario feeds a hand-built :class:`InfoSnapshot` rather than the
 operator's real one. That is not convenience — the frames go on a PR, and the
@@ -295,6 +296,113 @@ def snapshot_for(scenario: str) -> InfoSnapshot | None:
             captured_at=CAPTURED_AT,
         )
 
+    if scenario in ("fleet", "fleet-mixed", "fleet-unread"):
+        # THE REPORTED CASE: a host running a dozen sessions with children in
+        # several of them, which used to render "none running".
+        #
+        # ``fleet-mixed`` adds runtimes on an OLDER build (``subagents_running``
+        # is None, not 0) plus a wedged one, which is the normal state of this
+        # host mid-upgrade and the state the lower-bound caveat exists for.
+        # ``fleet-unread`` is the follower defect's honest rendering: the
+        # roster could not be READ, so the screen must say so rather than
+        # denying that any subagent was launched.
+        mixed = scenario == "fleet-mixed"
+        unread = scenario == "fleet-unread"
+        lines = (
+            _session_line(
+                4243,
+                "Investigate request latency",
+                is_self=True,
+                busy=True,
+                subagents_running=2,
+                subagents_queued=1,
+            ),
+            _session_line(4244, "Add /move command", busy=True, subagents_running=3),
+            _session_line(4245, "OSWorld benchmark", subagents_running=0),
+            # In ``fleet-mixed`` these two run an OLDER build: they publish no
+            # counts at all, which is ``None`` and NOT zero. That is what the
+            # lower-bound caveat is computed from.
+            _session_line(
+                4246,
+                "Sidebar wakes first",
+                busy=True,
+                subagents_running=None if mixed else 1,
+            ),
+            _session_line(4247, "Credential broker", subagents_running=None if mixed else 0),
+        ) + (
+            (
+                _session_line(
+                    4248,
+                    "Wedged runtime",
+                    state="wedged",
+                    heartbeat_age_s=310.0,
+                    busy=True,
+                    subagents_running=2,
+                ),
+            )
+            if mixed
+            else ()
+        )
+        live_count = sum(1 for line in lines if line.state == "live")
+        reporting = [line for line in lines if line.subagents_running is not None]
+        running = sum(line.subagents_running or 0 for line in reporting)
+        busy = sum(1 for line in lines if line.busy)
+        sessions = SessionsInfo(
+            lines=lines,
+            total=len(lines),
+            live=live_count,
+            wedged=sum(1 for line in lines if line.state == "wedged"),
+            busy=busy,
+            build_skew=mixed,
+            subagents_reporting=len(reporting),
+            subagents_unreported=len(lines) - len(reporting),
+            fleet_subagents_running=running,
+            fleet_subagents_queued=sum(line.subagents_queued or 0 for line in reporting),
+            fleet_session_trajectories=busy,
+            fleet_trajectories=busy + running,
+        )
+        return InfoSnapshot(
+            install=_install(),
+            process=_process(),
+            sessions=sessions,
+            agents=AgentsInfo(
+                profiles=20,
+                teams=3,
+                roster_unread=unread,
+                running=0 if unread else 2,
+                queued=0 if unread else 1,
+                settled=0 if unread else 3,
+                max_running=4,
+                max_depth=0 if unread else 1,
+                cross_session_known=True,
+                tree=(
+                    ()
+                    if unread
+                    else (
+                        SubagentLine(
+                            job_id="j1",
+                            label="reviewer",
+                            status="running",
+                            depth=0,
+                            agent_role="reviewer",
+                        ),
+                        SubagentLine(
+                            job_id="j2",
+                            label="scout",
+                            status="running",
+                            depth=1,
+                            agent_role="scout",
+                        ),
+                        SubagentLine(job_id="j3", label="qa-tester", status="queued", depth=0),
+                        SubagentLine(job_id="j4", label="coder", status="completed", depth=0),
+                    )
+                ),
+            ),
+            env=_env(),
+            degraded=((("live.subagents", "session exposes no subagent_comms"),) if unread else ()),
+            captured_at=CAPTURED_AT,
+        )
+
     # populated: the reference frame.
     return InfoSnapshot(
         install=_install(),
@@ -349,6 +457,7 @@ def live_for(scenario: str) -> LiveState:
         max_running=agents.max_running,
         max_depth=agents.max_depth,
         deeper=agents.deeper,
+        roster_unread=agents.roster_unread,
     )
 
 

--- a/scripts/info_shot.py
+++ b/scripts/info_shot.py
@@ -3,7 +3,7 @@
 Usage: python scripts/info_shot.py OUTDIR 100x30 [scenario]
   scenarios: populated | empty | degraded | nested | shadowed | loading
              fleet | fleet-mixed | fleet-unread
-             today-quiet | race | one | one-older
+             today-quiet | race | one | one-older | queued-only
 
 Every scenario feeds a hand-built :class:`InfoSnapshot` rather than the
 operator's real one. That is not convenience — the frames go on a PR, and the
@@ -375,6 +375,58 @@ def snapshot_for(scenario: str) -> InfoSnapshot | None:
                 cross_session_known=not older and not single,
             ),
             env=_env(),
+            captured_at=CAPTURED_AT,
+        )
+
+    if scenario == "queued-only":
+        # D11: every runtime REPORTS, every one reports zero running, and
+        # children are waiting on the capacity gate. ``fleet_trajectories``
+        # excludes queued by design (a parked child spends nothing), so this is
+        # the one measured state whose total is honestly 0 while the tree below
+        # is not empty — the header said "none running" over three ⏳ rows,
+        # with "Subagent capacity 4 concurrent" two lines above advertising
+        # exactly the state that produces it.
+        lines = tuple(
+            _session_line(
+                4243 + index,
+                "Investigate request latency" if index == 0 else f"Session {index}",
+                is_self=index == 0,
+                subagents_running=0,
+                subagents_queued=3 if index == 0 else 0,
+            )
+            for index in range(5)
+        )
+        sessions = SessionsInfo(
+            lines=lines,
+            total=len(lines),
+            live=len(lines),
+            subagents_reporting=len(lines),
+            subagents_unreported=0,
+            fleet_subagents_running=0,
+            fleet_subagents_queued=3,
+            fleet_session_trajectories=0,
+            fleet_trajectories=0,
+        )
+        return InfoSnapshot(
+            install=_install(),
+            process=_process(),
+            sessions=sessions,
+            agents=AgentsInfo(
+                profiles=20,
+                teams=3,
+                running=0,
+                queued=3,
+                settled=3,
+                max_running=4,
+                at_capacity=True,
+                max_depth=1,
+                cross_session_known=True,
+                tree=(
+                    SubagentLine(job_id="j1", label="reviewer", status="queued", depth=0),
+                    SubagentLine(job_id="j2", label="coder", status="queued", depth=0),
+                    SubagentLine(job_id="j3", label="qa-tester", status="queued", depth=0),
+                ),
+            ),
             captured_at=CAPTURED_AT,
         )
 

--- a/scripts/info_shot.py
+++ b/scripts/info_shot.py
@@ -3,7 +3,7 @@
 Usage: python scripts/info_shot.py OUTDIR 100x30 [scenario]
   scenarios: populated | empty | degraded | nested | shadowed | loading
              fleet | fleet-mixed | fleet-unread
-             today-quiet | race | one | one-older | queued-only
+             today-quiet | race | one | one-older | queued-only | queued-many
 
 Every scenario feeds a hand-built :class:`InfoSnapshot` rather than the
 operator's real one. That is not convenience — the frames go on a PR, and the
@@ -378,7 +378,7 @@ def snapshot_for(scenario: str) -> InfoSnapshot | None:
             captured_at=CAPTURED_AT,
         )
 
-    if scenario == "queued-only":
+    if scenario in ("queued-only", "queued-many"):
         # D11: every runtime REPORTS, every one reports zero running, and
         # children are waiting on the capacity gate. ``fleet_trajectories``
         # excludes queued by design (a parked child spends nothing), so this is
@@ -392,7 +392,7 @@ def snapshot_for(scenario: str) -> InfoSnapshot | None:
                 "Investigate request latency" if index == 0 else f"Session {index}",
                 is_self=index == 0,
                 subagents_running=0,
-                subagents_queued=3 if index == 0 else 0,
+                subagents_queued=(12 if scenario == "queued-many" else 3) if index == 0 else 0,
             )
             for index in range(5)
         )
@@ -403,7 +403,10 @@ def snapshot_for(scenario: str) -> InfoSnapshot | None:
             subagents_reporting=len(lines),
             subagents_unreported=0,
             fleet_subagents_running=0,
-            fleet_subagents_queued=3,
+            # D14: a fleet-wide queued SUM is not bounded by ``max_running``,
+            # so two digits are ordinary on a busy host — and two digits are
+            # what pushed the header's short rung past the card floor.
+            fleet_subagents_queued=12 if scenario == "queued-many" else 3,
             fleet_session_trajectories=0,
             fleet_trajectories=0,
         )
@@ -415,7 +418,7 @@ def snapshot_for(scenario: str) -> InfoSnapshot | None:
                 profiles=20,
                 teams=3,
                 running=0,
-                queued=3,
+                queued=12 if scenario == "queued-many" else 3,
                 settled=3,
                 max_running=4,
                 at_capacity=True,

--- a/tests/unit/info/test_collect.py
+++ b/tests/unit/info/test_collect.py
@@ -892,3 +892,59 @@ def test_no_session_at_all_is_not_reported_as_a_failed_roster() -> None:
     live = collect_live(None)
     assert live.roster_unread is False
     assert live.errors == ()
+
+
+def test_a_wrong_typed_count_is_unreported_not_a_lost_section() -> None:
+    """Q1 — one corrupt record used to blank the ENTIRE sessions block.
+
+    ``SessionRecord.from_json`` filters keys and calls the constructor with no
+    type validation, so these two fields — the first this module does
+    ARITHMETIC on — are whatever the writer put in the file. A ``str`` or
+    ``list`` raised ``TypeError`` inside the roll-up, and ``_safe`` guards whole
+    SECTIONS, so a single bad record cost the session table, both fleet rows and
+    the lower-bound caveat on the screen that exists for an already-broken host.
+    ``main`` listed the same record fine, so it was a regression, not a limit.
+
+    An unusable value is not a measurement: it is reported as ``None``, which
+    the caveat already knows how to describe.
+    """
+    # Deliberately ill-typed: the whole point is a record this process did not
+    # write, so the annotations are bypassed exactly as a bad JSON file does.
+    bad_values: list[Any] = ["2", [2], {"n": 2}, object()]
+    for bad in bad_values:
+        records = [
+            (_Record(pid=1, subagents_running=2, subagents_queued=0), "live"),
+            (_Record(pid=2, subagents_running=bad, subagents_queued=bad), "live"),
+        ]
+        info = collect_sessions(scan=_scan(records), usage=_usage({}), now=0.0)
+        assert info.available is True, f"{bad!r} must not cost the section"
+        assert info.total == 2 and info.live == 2
+        assert info.lines[1].subagents_running is None
+        assert info.subagents_reporting == 1
+        assert info.subagents_unreported == 1, "the bad record folds into the caveat"
+        assert info.fleet_subagents_running == 2, "only the good record contributes"
+
+
+def test_a_numerically_plausible_but_wrong_count_is_also_unreported() -> None:
+    """Q1's quieter half: these never raised, they printed as fact.
+
+    A float rendered ``4.5 total — 1 sessions + 3.5 subagents`` and a negative
+    rendered ``-1 subagents``. Both are worse than the crash, because nothing
+    signals that the number is not a measurement. ``bool`` is checked
+    explicitly: it is an ``int`` subclass, so ``True`` would otherwise be
+    counted as one subagent.
+    """
+    bad_values: list[Any] = [3.5, -1, True, False]
+    for bad in bad_values:
+        records = [(_Record(pid=1, subagents_running=bad, subagents_queued=bad), "live")]
+        info = collect_sessions(scan=_scan(records), usage=_usage({}), now=0.0)
+        assert info.lines[0].subagents_running is None, f"{bad!r} is not a count"
+        assert info.subagents_unreported == 1
+        assert info.fleet_subagents_running == 0
+        assert isinstance(info.fleet_trajectories, int)
+
+    # A genuine zero still reports, which is the distinction being protected.
+    good = [(_Record(pid=1, subagents_running=0, subagents_queued=0), "live")]
+    ok = collect_sessions(scan=_scan(good), usage=_usage({}), now=0.0)
+    assert ok.lines[0].subagents_running == 0
+    assert ok.subagents_reporting == 1 and ok.subagents_unreported == 0

--- a/tests/unit/info/test_collect.py
+++ b/tests/unit/info/test_collect.py
@@ -56,6 +56,8 @@ class _Record:
     detached: bool = False
     version: str = "0.51.6"
     source_ref: str = "abc1234"
+    subagents_running: int | None = None
+    subagents_queued: int | None = None
 
 
 @dataclass
@@ -674,3 +676,219 @@ def test_a_registry_that_returns_zero_on_a_missing_root_is_still_degraded() -> N
     # The value is still the dataclass default; it is the DEGRADED entry that
     # makes the screen render `—` instead of that default.
     assert agents.teams == 0
+
+
+# -- the fleet tally ----------------------------------------------------------
+#
+# The operator's question is "how many agent trajectories are running on this
+# machine", and the whole hazard is answering it with a confident number whose
+# terms are silently missing. Every test below is about the difference between
+# "reported zero" and "did not report".
+
+
+def test_a_mixed_fleet_excludes_the_unreported_and_names_how_many() -> None:
+    """An older runtime is UNREPORTED, never a zero.
+
+    The normal state of this host is a mixed fleet — windows are replaced a few
+    at a time — so this is the common case, not a transient. Folding a
+    non-reporting session in as 0 would make the total look complete while
+    silently dropping every subagent those windows are running.
+    """
+    records = [
+        (_Record(pid=1, busy=True, subagents_running=3, subagents_queued=1), "live"),
+        (_Record(pid=2, subagents_running=0, subagents_queued=0), "live"),
+        (_OldRecord(3, "tui", "s", "c", "/tmp", "m", 0.0, 0.0), "live"),
+    ]
+    info = collect_sessions(scan=_scan(records), usage=_usage({}), now=0.0)
+    assert info.subagents_reporting == 2
+    assert info.subagents_unreported == 1
+    assert info.fleet_subagents_running == 3
+    assert info.fleet_subagents_queued == 1
+    # pid 2 REPORTED zero and is counted as reporting; pid 3 did not report at
+    # all. Collapsing the two is the defect this pair exists to catch.
+    assert info.lines[1].subagents_running == 0
+    assert info.lines[2].subagents_running is None
+
+
+def test_an_all_older_fleet_is_not_a_confident_zero() -> None:
+    """Nothing reported, so the total is 0 WITH the caveat's denominator set."""
+    records = [
+        (_OldRecord(1, "tui", "s", "c", "/tmp", "m", 0.0, 0.0), "live"),
+        (_OldRecord(2, "tui", "s", "c", "/tmp", "m", 0.0, 0.0), "live"),
+    ]
+    info = collect_sessions(scan=_scan(records), usage=_usage({}), now=0.0)
+    assert info.subagents_reporting == 0
+    assert info.subagents_unreported == 2
+    assert info.fleet_subagents_running == 0
+    # The screen renders a caveat off this, which is what stops the zero above
+    # reading as a measurement.
+    assert collect_agents(LiveState(), [], info).cross_session_known is False
+
+
+def test_a_wedged_runtime_contributes_its_last_counts_and_a_stale_one_does_not() -> None:
+    """A quiet pid can still have children burning tokens; a dead one cannot.
+
+    ``wedged`` means no heartbeat for 45 s — the process is still there. ``stale``
+    means ``registry.scan`` just DELETED the record because the pid is gone.
+    Dropping the wedged session would under-report exactly the broken fleet this
+    screen is opened to explain.
+    """
+    records = [
+        (_Record(pid=1, subagents_running=1), "live"),
+        (_Record(pid=2, busy=True, subagents_running=2), "wedged"),
+        (_Record(pid=3, subagents_running=9), "stale"),
+    ]
+    info = collect_sessions(scan=_scan(records), usage=_usage({}), now=0.0)
+    assert info.fleet_subagents_running == 3, "wedged in, stale out"
+    assert info.subagents_reporting == 2
+
+
+def test_session_and_subagent_trajectories_are_disjoint_and_added() -> None:
+    """A subagent never publishes a record, so the two sets cannot overlap.
+
+    ``harness.subagent`` builds a bare ``Session`` with no registrant, so a
+    child is never also a runtime. That is the invariant that makes the
+    addition legal rather than a double count.
+    """
+    records = [
+        (_Record(pid=1, busy=True, subagents_running=2), "live"),
+        (_Record(pid=2, busy=True, subagents_running=0), "live"),
+        (_Record(pid=3, busy=False, subagents_running=1), "live"),
+    ]
+    info = collect_sessions(scan=_scan(records), usage=_usage({}), now=0.0)
+    assert info.fleet_session_trajectories == 2
+    assert info.fleet_subagents_running == 3
+    assert info.fleet_trajectories == 5
+
+
+def test_cross_session_known_means_somebody_ELSE_reported() -> None:
+    """Not "the feature is compiled in" — the note it gates claims knowledge of
+    OTHER windows, and on a single-session host that claim is false."""
+    solo = collect_sessions(
+        scan=_scan([(_Record(pid=1, subagents_running=4), "live")]),
+        usage=_usage({}),
+        self_pid=1,
+        now=0.0,
+    )
+    assert collect_agents(LiveState(), [], solo).cross_session_known is False
+
+    pair = collect_sessions(
+        scan=_scan(
+            [
+                (_Record(pid=1, subagents_running=4), "live"),
+                (_Record(pid=2, subagents_running=0), "live"),
+            ]
+        ),
+        usage=_usage({}),
+        self_pid=1,
+        now=0.0,
+    )
+    assert collect_agents(LiveState(), [], pair).cross_session_known is True
+
+
+def test_nested_subagents_are_counted_once() -> None:
+    """``nodes()`` is already the COMPLETE roster including every descendant.
+
+    So the count is a flat ``len()`` over a filter. A recursive child walk added
+    on top would count every node below depth 0 twice, which is the specific
+    trap the roster's own docstring warns about.
+    """
+
+    class _Comms:
+        def nodes(self) -> list[Any]:
+            return [
+                _Node(job_id="a", label="reviewer"),
+                _Node(job_id="b", label="scout", parent_job_id="a"),
+                _Node(job_id="c", label="coder", parent_job_id="b"),
+            ]
+
+    class _Session:
+        subagent_comms = _Comms()
+
+    live = collect_live(_Session())
+    assert live.running == 3, "one per roster entry, not per path through the tree"
+    assert len(live.tree) == 3
+
+
+def test_a_follower_session_reports_its_own_subagents() -> None:
+    """The §1.3 regression: a ``RemoteSession``-backed window showed ZERO.
+
+    ``collect_live`` reads the PUBLIC ``subagent_comms``; ``RemoteSession`` only
+    held ``_subagent_comms``, so the branch was skipped, the counts stayed 0 and
+    nothing was recorded as degraded. Every attached window is on this path, so
+    the screen said "no subagents" on a host full of them.
+
+    Asserts the COUNT, not merely that rows exist: the naive fix (adding
+    ``nodes()`` without projecting ``status``) makes the tree appear while the
+    tally stays 0 and every row renders ``unknown``.
+    """
+    from local_operator.session.frontend_state import JobState, SnapshotSubagentComms
+    from local_operator.session.remote import RemoteSession
+
+    assert hasattr(RemoteSession, "subagent_comms"), "the public name is the contract"
+
+    comms = SnapshotSubagentComms(
+        [
+            JobState(id="j1", type="task", status="running", label="reviewer"),
+            JobState(id="j2", type="task", status="running", label="scout", parent_job_id="j1"),
+            JobState(id="j3", type="task", status="queued", label="qa"),
+            JobState(id="j4", type="task", status="completed", label="coder"),
+        ]
+    )
+    follower = RemoteSession.__new__(RemoteSession)
+    follower._subagent_comms = comms
+
+    live = collect_live(follower)
+    assert live.running == 2, f"the follower must report 2 running, got {live.running}"
+    assert live.queued == 1
+    assert live.settled == 1
+    assert live.roster_unread is False
+    assert [row.status for row in live.tree].count("running") == 2
+    assert all(row.status for row in live.tree), "a node with no status renders as 'unknown'"
+
+
+def test_a_session_with_no_comms_facade_is_degraded_not_zero() -> None:
+    """The silent-default failure: nothing raised, so nothing was named.
+
+    ``_safe`` catches probes that RAISE. This one returned a default and was
+    believed, which is how the screen came to state "no subagents have been
+    launched" about a session it had never actually asked.
+    """
+
+    class _Opaque:
+        pass
+
+    live = collect_live(_Opaque())
+    assert live.roster_unread is True
+    assert "live.subagents" in {name for name, _ in live.errors}
+    # And the flag reaches the snapshot the renderer reads.
+    snapshot = collect_snapshot(live, root=Path("/nonexistent-info-root"))
+    assert snapshot.agents.roster_unread is True
+    assert "live.subagents" in {name for name, _ in snapshot.degraded}
+
+
+def test_a_comms_object_without_nodes_degrades_instead_of_raising() -> None:
+    """``collect_live`` runs on the PAINT PATH and must never raise.
+
+    The guard was ``_safe("live.subagents", comms.nodes, ...)``, which resolves
+    the attribute as an ARGUMENT — before ``_safe`` enters its try — so a comms
+    object lacking the method took the app down rather than degrading.
+    """
+
+    class _NoNodes:
+        pass
+
+    class _Session:
+        subagent_comms = _NoNodes()
+
+    live = collect_live(_Session())  # must not raise
+    assert live.roster_unread is True
+    assert live.running == 0 and live.tree == ()
+    assert "live.subagents" in {name for name, _ in live.errors}
+
+
+def test_no_session_at_all_is_not_reported_as_a_failed_roster() -> None:
+    """The CLI path passes ``session=None``. That is not a failed probe."""
+    live = collect_live(None)
+    assert live.roster_unread is False
+    assert live.errors == ()

--- a/tests/unit/info/test_collect.py
+++ b/tests/unit/info/test_collect.py
@@ -948,3 +948,52 @@ def test_a_numerically_plausible_but_wrong_count_is_also_unreported() -> None:
     ok = collect_sessions(scan=_scan(good), usage=_usage({}), now=0.0)
     assert ok.lines[0].subagents_running == 0
     assert ok.subagents_reporting == 1 and ok.subagents_unreported == 0
+
+
+def test_a_pausing_child_sorts_with_the_running_ones() -> None:
+    """The tree must not contradict the tally directly above it.
+
+    ``pausing`` is in ``RUNNING_SUBAGENT_STATUSES``, so the header counts it as
+    a running trajectory. A local literal in ``rank()`` omitted it and sorted it
+    below the settled rows — the same local-vs-shared divergence this module's
+    own comments say the predicate exists to remove.
+    """
+
+    class _Node:
+        def __init__(self, job_id: str, label: str, status: str) -> None:
+            self.job_id = job_id
+            self.label = label
+            self.status = status
+            self.parent_job_id = None
+            self.agent_role = ""
+            self.effort = ""
+            self.session_id = ""
+
+    rows, _, _ = build_subagent_tree(
+        [
+            _Node("a", "alpha", "completed"),
+            _Node("b", "bravo", "pausing"),
+            _Node("c", "charlie", "running"),
+        ]
+    )
+    assert [row.label for row in rows] == ["bravo", "charlie", "alpha"]
+
+
+def test_an_absurd_count_is_refused_rather_than_breaking_the_layout() -> None:
+    """Q7: a 31-digit count renders 81 cells wide and overflows every frame.
+
+    Not reachable from this codebase's publisher — the count is a ``len()`` over
+    a roster bounded by ``DEFAULT_MAX_RUNNING_JOBS`` — so this only guards a
+    corrupt or foreign record, which is exactly the population ``_reported_count``
+    already exists to reason about. Six digits still pass: the ceiling is about
+    rendering, not about a belief regarding how many subagents can exist.
+    """
+    for value, reported in ((999_999, True), (1_000_000, False), (10**30, False)):
+        records = [
+            (_Record(pid=1, subagents_running=1, subagents_queued=0), "live"),
+            (_Record(pid=2, subagents_running=value, subagents_queued=0), "live"),
+        ]
+        info = collect_sessions(scan=_scan(records), usage=_usage({}), now=0.0)
+        assert info.available is True
+        assert (info.lines[1].subagents_running is not None) is reported, value
+        assert info.subagents_unreported == (0 if reported else 1), value

--- a/tests/unit/info/test_sessions_extraction.py
+++ b/tests/unit/info/test_sessions_extraction.py
@@ -38,6 +38,8 @@ class _Record:
     pending: str | None = None
     busy: bool = False
     detached: bool = False
+    subagents_running: int | None = None
+    subagents_queued: int | None = None
     version: str = ""
     source_ref: str = ""
 
@@ -77,6 +79,8 @@ FIXTURE: list[tuple[Any, str]] = [
             busy=True,
             version="0.51.6",
             source_ref="4311eb653aa9",
+            subagents_running=2,
+            subagents_queued=1,
         ),
         "live",
     ),
@@ -111,7 +115,11 @@ FIXTURE: list[tuple[Any, str]] = [
 ]
 
 #: EXACTLY what ``sessions_command`` produced before the extraction: same keys,
-#: same order, same values.
+#: same order, same values — PLUS ``subagents_running``/``subagents_queued``,
+#: added deliberately rather than discovered as a red test. ``--json`` is a
+#: published surface and a fleet consumer counting agent trajectories across a
+#: host wants them; the pin exists to make an addition a DECISION, which this
+#: is, not to forbid one. Everything above them is byte-for-byte unchanged.
 EXPECTED = [
     {
         "state": "live",
@@ -130,6 +138,8 @@ EXPECTED = [
         "detached": False,
         "version": "0.51.6",
         "source_ref": "4311eb653aa9",
+        "subagents_running": 2,
+        "subagents_queued": 1,
     },
     {
         "state": "live",
@@ -148,6 +158,8 @@ EXPECTED = [
         "detached": True,
         "version": "0.51.5",
         "source_ref": "",
+        "subagents_running": None,
+        "subagents_queued": None,
     },
     {
         "state": "stale",
@@ -166,6 +178,11 @@ EXPECTED = [
         "detached": False,
         "version": "",
         "source_ref": "",
+        # ``None``, not 0: ``_OldRecord`` has no such attribute at all, which
+        # is exactly a runtime predating the fields. The distinction is the
+        # whole point of the pair — see ``SessionsInfo.subagents_unreported``.
+        "subagents_running": None,
+        "subagents_queued": None,
     },
 ]
 

--- a/tests/unit/session/runtime/test_registry.py
+++ b/tests/unit/session/runtime/test_registry.py
@@ -185,3 +185,74 @@ def test_the_heartbeat_republishes_the_build_stamp(tmp_path: Path) -> None:
         assert found[0].conversation_name == "renamed", "the rewrite really happened"
     finally:
         publisher.close()
+
+
+def test_the_subagent_counts_round_trip_and_absent_means_none_not_zero() -> None:
+    """``None`` and ``0`` are DIFFERENT FACTS and the record must keep them apart.
+
+    A runtime that predates these fields has not told us it has no subagents.
+    Defaulting the absent case to 0 would let ``/info`` sum a fleet total whose
+    missing terms are invisible — the caveat line ("the total is a lower bound")
+    exists precisely because this distinction survives the wire.
+    """
+    record = make_record()
+    record.subagents_running = 3
+    record.subagents_queued = 1
+    payload = record.to_json()
+    assert SessionRecord.from_json(payload).subagents_running == 3
+    assert SessionRecord.from_json(payload).subagents_queued == 1
+
+    payload.pop("subagents_running")
+    payload.pop("subagents_queued")
+    restored = SessionRecord.from_json(payload)
+    assert restored.subagents_running is None, "absent must not become 0"
+    assert restored.subagents_queued is None
+
+
+def test_the_heartbeat_republishes_the_subagent_counts(tmp_path: Path) -> None:
+    """They ride every rewrite, like the build stamp, for the same reason.
+
+    A field published once at startup and dropped by the first rewrite would be
+    wrong 15 seconds later — and these change far more often than the stamp.
+    """
+    record = make_record()
+    record.subagents_running = 2
+    record.subagents_queued = 1
+    publisher = registry.RecordPublisher(record, root=tmp_path)
+    try:
+        publisher.heartbeat(conversation_name="renamed")
+        found = [rec for rec, _ in registry.scan(root=tmp_path) if rec.pid == record.pid]
+        assert found and found[0].subagents_running == 2
+        assert found[0].subagents_queued == 1
+        assert found[0].conversation_name == "renamed", "the rewrite really happened"
+    finally:
+        registry.unpublish(record.pid, root=tmp_path)
+
+
+def test_the_protocol_version_did_not_move_for_the_subagent_counts() -> None:
+    """Pinned WITH ITS REASON, because the tempting change is to bump it.
+
+    ``subagents_running``/``subagents_queued`` are purely additive: an older
+    reader drops them in ``from_json`` and behaves exactly as before, and a
+    newer reader sees ``None`` for a record an older runtime wrote. Meanwhile
+    peers read ``record.protocol`` as a pre-dial promise about which FRAMES a
+    runtime speaks (``attach_client`` refuses below 2, the TUI takeover path
+    and ``session_factory`` below 4, ``remote``'s canonical attach below 5).
+    Two JSON integers that ride in no frame change nothing those readers ask
+    about, so bumping would spend the one number that carries that promise and
+    leave nothing to mark a build whose frames really did change.
+    """
+    from local_operator.session.runtime.types import PROTOCOL_VERSION
+
+    assert PROTOCOL_VERSION == 5
+
+
+def test_a_record_with_unknown_future_keys_still_parses() -> None:
+    """Forward-compat in the other direction: a NEWER runtime's record.
+
+    The same tolerance the counts rely on, asserted from the far side so a
+    future field cannot be added in a way that breaks this build mid-upgrade.
+    """
+    payload = make_record().to_json()
+    payload["a_field_from_the_future"] = {"nested": True}
+    assert SessionRecord.from_json(payload).pid == make_record().pid

--- a/tests/unit/session/runtime/test_subagent_counts_published.py
+++ b/tests/unit/session/runtime/test_subagent_counts_published.py
@@ -1,0 +1,252 @@
+"""The record carries this runtime's subagent trajectory counts.
+
+**This file exists because ``/info`` could not answer "how many agent
+trajectories are running on this machine".** ``SessionRecord`` published no
+subagent data at all, so the screen could only ever describe the window it was
+opened in — on a host running a dozen sessions with children in most of them,
+the section said "none running".
+
+The counts ride the record rather than a new control-socket op for the reason
+the option was rejected: ``/info`` is opened when something is ALREADY wrong,
+which is exactly when peers are wedged, and a diagnostic screen that fans out
+TCP dials to a broken fleet is a diagnostic screen that hangs. The record is
+already scanned, already 0600, and already carries live state on the same
+purely additive contract.
+
+Two properties are load-bearing and both are asserted here:
+
+* **``None`` is not ``0``.** A handle that cannot answer publishes ``None``, and
+  a reader must be able to tell "did not report" from "reported none". The
+  fleet total's honesty caveat is derived from exactly that difference.
+* **The floor and the transition publisher read the SAME predicate.** This code
+  has had that bug once already, in the ``busy`` bit: a 15 s heartbeat that
+  disagreed with the event-driven publisher does not merely go stale, it
+  OVERWRITES the correct value on its next tick.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.session.runtime.owned import OwnedSessionHandle
+from local_operator.session.runtime.server import RuntimeServer
+from local_operator.session.runtime.types import RUNNING_SUBAGENT_STATUSES
+from tests.e2e.harness import ScriptedStream, build_session, text_turn
+
+
+async def _rig(directory: Path) -> tuple[Any, OwnedSessionHandle, RuntimeServer]:
+    """A real Session under the production handle and server.
+
+    The same rig as ``test_busy_settles`` and ``test_activity_vs_residency``:
+    the seam under test is the one production runs, so only the provider stream
+    is scripted.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    session = build_session(directory, ScriptedStream([text_turn("reply")]))
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(directory))
+    server = RuntimeServer(handle, kind="daemon")
+    handle.subscribe(server._schedule_push)
+    return session, handle, server
+
+
+class _Node:
+    """One roster entry, in the shape ``SubagentComms.nodes()`` returns."""
+
+    def __init__(self, job_id: str, status: str, parent_job_id: str | None = None) -> None:
+        self.job_id = job_id
+        self.status = status
+        self.parent_job_id = parent_job_id
+        self.label = job_id
+        self.agent_role = ""
+        self.effort = ""
+        self.session_id = None
+        self.live = status in RUNNING_SUBAGENT_STATUSES
+
+
+class _Comms:
+    def __init__(self, nodes: list[_Node]) -> None:
+        self._nodes = nodes
+
+    def nodes(self) -> list[_Node]:
+        return list(self._nodes)
+
+
+def _with_roster(session: Any, comms: Any) -> None:
+    """Install a roster the real ``subagent_comms`` property will hand back.
+
+    Assigned to the PRIVATE slot, not the public name: ``subagent_comms`` is a
+    property on the class, which an instance attribute cannot shadow. Writing
+    the public name would silently leave the real (empty) roster in place and
+    the test would pass against nothing.
+    """
+    session._subagent_comms = comms
+
+
+@pytest.mark.asyncio
+async def test_the_probe_counts_running_and_queued_off_one_flat_roster(tmp_path: Path) -> None:
+    """``nodes()`` already contains every nested descendant.
+
+    So the count is a ``len()`` over a filter. Adding a recursive child walk on
+    top — the obvious-looking way to "include nested subagents" — would count
+    every node below depth 0 twice. The roster here is three deep for that
+    reason: a recursive implementation would report more than three.
+    """
+    session, handle, _ = await _rig(tmp_path / "s")
+    _with_roster(
+        session,
+        _Comms(
+            [
+                _Node("a", "running"),
+                _Node("b", "starting", parent_job_id="a"),
+                _Node("c", "pausing", parent_job_id="b"),
+                _Node("d", "queued"),
+                _Node("e", "completed"),
+            ]
+        ),
+    )
+    assert handle.subagent_counts() == (3, 1)
+
+
+@pytest.mark.asyncio
+async def test_a_session_event_publishes_the_counts_onto_the_record(tmp_path: Path) -> None:
+    """The transition path: ``_notify`` → ``_publish_busy`` → ``set_subagents``.
+
+    Driven from the same seam as the busy bit because a subagent launching or
+    settling IS a session event, which is what keeps the number current
+    sub-second rather than up to a heartbeat stale.
+    """
+    session, handle, server = await _rig(tmp_path / "s")
+    _with_roster(session, _Comms([_Node("a", "running"), _Node("b", "queued")]))
+    handle._publish_busy()
+    assert (server._subagents_running, server._subagents_queued) == (1, 1)
+
+
+@pytest.mark.asyncio
+async def test_an_unchanged_count_does_not_rewrite_the_record(tmp_path: Path) -> None:
+    """Deduped like ``set_busy``: this runs on EVERY session event.
+
+    Without the comparison the steady-state cost would be a staged write and
+    rename per event rather than per transition.
+    """
+    _, _, server = await _rig(tmp_path / "s")
+    writes: list[dict[str, Any]] = []
+
+    class _Publisher:
+        def heartbeat(self, **updates: Any) -> None:
+            writes.append(updates)
+
+    server._publisher = _Publisher()  # type: ignore[assignment]
+    server.set_subagents(2, 1)
+    assert len(writes) == 1, "a change publishes"
+    assert writes[0]["subagents_running"] == 2
+    assert writes[0]["subagents_queued"] == 1
+    server.set_subagents(2, 1)
+    assert len(writes) == 1, "an identical count must not rewrite the record"
+    server.set_subagents(2, 0)
+    assert len(writes) == 2, "a change in EITHER count publishes"
+
+
+@pytest.mark.asyncio
+async def test_a_handle_without_the_probe_publishes_none_and_does_not_raise(
+    tmp_path: Path,
+) -> None:
+    """An older or narrower handle must degrade, not explode or fabricate a zero.
+
+    ``TuiSessionHandle`` implements neither ``is_busy`` nor
+    ``is_conversationally_active``, which is the precedent: a handle that cannot
+    answer a probe leaves the field unreported. ``None`` is the honest value —
+    the reader counts it under ``subagents_unreported`` rather than as a session
+    with no children.
+    """
+    _, _, server = await _rig(tmp_path / "s")
+
+    class _Bare:
+        pass
+
+    server._handle = _Bare()  # type: ignore[assignment]
+    counts = getattr(server._handle, "subagent_counts", None)
+    assert counts is None, "the probe is optional by getattr, exactly like is_busy"
+    assert server._subagents_running is None, "unreported, never 0"
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_roster_publishes_none_rather_than_zero(tmp_path: Path) -> None:
+    """A roster that RAISES is not a roster of zero.
+
+    ``_publish_busy`` runs on every session event and must never take a turn
+    down, so the failure is swallowed — but what it publishes afterwards has to
+    be "I could not tell", not a confident zero that quietly drops this
+    runtime's children out of the fleet total.
+    """
+    session, handle, server = await _rig(tmp_path / "s")
+
+    class _Exploding:
+        def nodes(self) -> list[_Node]:
+            raise RuntimeError("roster unavailable")
+
+    _with_roster(session, _Exploding())
+    assert handle.subagent_counts() == (None, None)
+    handle._publish_busy()  # must not raise
+    assert server._subagents_running is None
+
+
+@pytest.mark.asyncio
+async def test_the_heartbeat_floor_agrees_with_the_transition_publisher(
+    tmp_path: Path,
+) -> None:
+    """The §5 failure mode, which this codebase has already shipped once.
+
+    The floor exists to bound how stale a MISSED publish can get. If it read a
+    different predicate from the transition publisher it would not bound
+    anything — it would overwrite the correct value within one heartbeat,
+    forever. Both must call ``subagent_counts``, so driving a divergence and
+    then running the floor's read must restore agreement rather than clobber it.
+    """
+    session, handle, server = await _rig(tmp_path / "s")
+    _with_roster(
+        session, _Comms([_Node("a", "running"), _Node("b", "running"), _Node("c", "queued")])
+    )
+
+    # A wrong value, as a missed publish would leave behind.
+    server.set_subagents(99, 99)
+    assert server._subagents_running == 99
+
+    # Exactly what the heartbeat loop does.
+    probe = getattr(server._handle, "subagent_counts", None)
+    assert callable(probe), "the floor's probe must exist on the production handle"
+    reported = probe()
+    assert isinstance(reported, tuple) and len(reported) == 2
+    server.set_subagents(reported[0], reported[1])
+
+    assert (server._subagents_running, server._subagents_queued) == (2, 1)
+    assert (server._subagents_running, server._subagents_queued) == handle.subagent_counts()
+
+
+@pytest.mark.asyncio
+async def test_the_tui_handle_answers_the_same_probe(tmp_path: Path) -> None:
+    """A ``kind="tui"`` runtime must contribute to the fleet tally too.
+
+    It is the most common kind of window on a developer host, so leaving it
+    unimplemented would report most of the fleet as non-reporting. It reads the
+    shared status predicate rather than a private copy — two spellings of
+    "running" is how the record and the tree beneath it come to disagree.
+    """
+    from local_operator.mobile.tui_handle import TuiSessionHandle
+
+    session, _, _ = await _rig(tmp_path / "s")
+    _with_roster(session, _Comms([_Node("a", "running"), _Node("b", "queued")]))
+
+    handle = TuiSessionHandle.__new__(TuiSessionHandle)
+    handle._session = lambda: session  # type: ignore[method-assign]
+    assert handle.subagent_counts() == (1, 1)
+
+    # And a session that is not ready yet reports UNREPORTED, not zero.
+    def _not_started() -> Any:
+        raise RuntimeError("session is still starting")
+
+    handle._session = _not_started  # type: ignore[method-assign]
+    assert handle.subagent_counts() == (None, None)

--- a/tests/unit/session/runtime/test_subagent_counts_published.py
+++ b/tests/unit/session/runtime/test_subagent_counts_published.py
@@ -54,7 +54,16 @@ async def _rig(directory: Path) -> tuple[Any, OwnedSessionHandle, RuntimeServer]
 
 
 class _Node:
-    """One roster entry, in the shape ``SubagentComms.nodes()`` returns."""
+    """One roster entry, in the shape ``SubagentComms.nodes()`` returns.
+
+    A SHAPE stub for the wiring tests below (dedupe, floor/transition
+    agreement) and nothing more. It cannot prove the FILTER is right, because
+    it sets ``status`` from the same vocabulary the filter tests against — an
+    assertion against itself. Review round 1 (R1) found exactly that: the real
+    ``node()`` derived a status from a disjoint vocabulary and the tally was a
+    hard 0 while every test here stayed green. The real-object test at the
+    bottom of this file is the one that pins the filter.
+    """
 
     def __init__(self, job_id: str, status: str, parent_job_id: str | None = None) -> None:
         self.job_id = job_id
@@ -250,3 +259,89 @@ async def test_the_tui_handle_answers_the_same_probe(tmp_path: Path) -> None:
 
     handle._session = _not_started  # type: ignore[method-assign]
     assert handle.subagent_counts() == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_the_probe_counts_a_REAL_SubagentComms_roster(tmp_path: Path) -> None:
+    """THE R1 REGRESSION. The stub above cannot catch this; only the real object can.
+
+    ``subagent_counts`` filters ``comms.nodes()`` on
+    ``RUNNING_SUBAGENT_STATUSES = {running, starting, pausing}``, but
+    ``SubagentComms.node()`` used to derive status privately as
+    ``paused | <outcome> | cancelled | gone`` — a vocabulary with an EMPTY
+    intersection with the filter. A live running child was reported ``gone``,
+    so every owner runtime published a *measured* ``0``: it landed in
+    ``reporting``, suppressed the lower-bound caveat, and made the header
+    assert "none running" over a roster full of live children. Strictly worse
+    than the bug the feature exists to fix, and invisible to a stub that sets
+    ``status`` from the counting vocabulary itself.
+
+    ``node()`` now derives status through ``_describe`` — the same collapse
+    ``roster()`` uses — so the node and the roster cannot disagree about the
+    same child. This test asserts the COUNT against a real registry, and the
+    node/roster agreement that keeps it true.
+    """
+    from local_operator.harness.comms import SubagentComms
+    from tests.unit.harness.test_comms import FakeChild, FakeJobs, FakeParent
+
+    session, handle, _ = await _rig(tmp_path / "s")
+    jobs = FakeJobs()
+    comms = SubagentComms(FakeParent(jobs))  # type: ignore[arg-type]
+
+    # Distinct session dirs: ``attach`` folds a record whose dir matches a
+    # settled one, which would silently collapse the roster under test.
+    running_dir = tmp_path / "running"
+    running_dir.mkdir()
+    settled_dir = tmp_path / "settled"
+    settled_dir.mkdir()
+
+    jobs.add("j1", status="running")
+    comms.record_launch("j1", "reviewer", prompt="review")
+    comms.attach("j1", FakeChild(), running_dir)  # type: ignore[arg-type]
+
+    # Queued: the job row still says ``running`` and the split lives in the
+    # separate ``queued`` flag, which is exactly the distinction R2 covers.
+    jobs.add("j2", status="running")
+    jobs.jobs["j2"].queued = True
+    comms.record_launch("j2", "qa-tester", prompt="qa")
+
+    jobs.add("j3", status="running")
+    comms.record_launch("j3", "coder", prompt="code")
+    comms.attach("j3", FakeChild(), settled_dir)  # type: ignore[arg-type]
+    comms.record_outcome("j3", "completed")
+
+    _with_roster(session, comms)
+
+    statuses = {node.job_id: node.status for node in comms.nodes()}
+    assert statuses == {"j1": "running", "j2": "queued", "j3": "completed"}, statuses
+    assert statuses == {
+        row.job_id: row.status for row in comms.roster()
+    }, "node() and roster() must agree; two derivations of one fact is how they drift"
+    assert handle.subagent_counts() == (1, 1), "a live child is not 'gone'"
+
+
+@pytest.mark.asyncio
+async def test_a_real_roster_reaches_the_record_as_a_nonzero_count(tmp_path: Path) -> None:
+    """End to end on the owner path: real registry -> probe -> published record.
+
+    R1's damage was not the count in isolation, it was that a fabricated
+    *measured* zero reaches ``SessionRecord`` and is then indistinguishable
+    from a runtime that genuinely has no children — which is precisely the
+    distinction the whole feature is built on.
+    """
+    from local_operator.harness.comms import SubagentComms
+    from tests.unit.harness.test_comms import FakeChild, FakeJobs, FakeParent
+
+    session, handle, server = await _rig(tmp_path / "s")
+    jobs = FakeJobs()
+    comms = SubagentComms(FakeParent(jobs))  # type: ignore[arg-type]
+    child_dir = tmp_path / "child"
+    child_dir.mkdir()
+    jobs.add("j1", status="running")
+    comms.record_launch("j1", "reviewer", prompt="review")
+    comms.attach("j1", FakeChild(), child_dir)  # type: ignore[arg-type]
+    _with_roster(session, comms)
+
+    handle._publish_busy()
+    assert server._subagents_running == 1, "the record must carry the live child"
+    assert server._subagents_queued == 0

--- a/tests/unit/tui/test_info_panel.py
+++ b/tests/unit/tui/test_info_panel.py
@@ -956,3 +956,159 @@ def test_the_depth_fold_row_is_a_section_summary_not_a_child_row() -> None:
     # Base indent — the same two cells every top-level row in the section uses,
     # not the cap's child indent.
     assert len(row) - len(row.lstrip()) == 2, f"fold is not at base indent: {row!r}"
+
+
+# -- the fleet tally ----------------------------------------------------------
+
+
+def _unwrapped(text: str) -> str:
+    """One line, so a phrase assertion is not defeated by ``note``'s wrapping.
+
+    ``_Body.note`` wraps at the body width and re-indents every continuation, so
+    a sentence under test is routinely split mid-phrase at a width the test did
+    not choose.
+    """
+    return " ".join(text.split())
+
+
+def _fleet_sessions(**overrides: Any) -> SessionsInfo:
+    base: dict[str, Any] = dict(
+        lines=(),
+        total=3,
+        live=3,
+        busy=2,
+        subagents_reporting=3,
+        subagents_unreported=0,
+        fleet_subagents_running=5,
+        fleet_subagents_queued=1,
+        fleet_session_trajectories=2,
+        fleet_trajectories=7,
+    )
+    base.update(overrides)
+    return SessionsInfo(**base)
+
+
+def test_the_header_answers_the_fleet_question_not_this_session_only() -> None:
+    """The operator's actual question, on the header line.
+
+    The section used to say "none running" on a host with a dozen busy windows,
+    because the only number it had was this session's tree.
+    """
+    text = _text(_snapshot(sessions=_fleet_sessions(), agents=AgentsInfo(running=1)))
+    assert "3 runtimes · 7 trajectories" in text
+    assert "7 total" in text
+    assert "2 sessions + 5 subagents" in text
+
+
+def test_the_first_frame_shows_this_session_and_says_the_fleet_is_still_checking() -> None:
+    """The tree is live (first frame); the fleet comes from the ~900 ms worker.
+
+    So the header must not print a fleet number it does not have yet. It reuses
+    ``checking…`` — the screen's ONE loading word — rather than a zero it would
+    then revise upward, which is the flash this rule exists to prevent.
+    """
+    text = _text(None, _live(running=2))
+    assert "this session: 2 running · fleet checking…" in text
+    assert "7 trajectories" not in text
+
+
+def test_a_quiet_fleet_says_none_running_rather_than_zero() -> None:
+    """A zero in a count column reads as a failed probe; a word does not."""
+    text = _text(
+        _snapshot(
+            sessions=_fleet_sessions(
+                busy=0,
+                fleet_subagents_running=0,
+                fleet_session_trajectories=0,
+                fleet_trajectories=0,
+            ),
+            agents=AgentsInfo(),
+        )
+    )
+    assert "3 runtimes · none running" in text
+
+
+def test_the_lower_bound_caveat_appears_only_when_a_session_did_not_report() -> None:
+    """A permanent disclaimer is wallpaper; a conditional one is information.
+
+    "lower bound" is the load-bearing phrase: it distinguishes "2 sessions could
+    not report" from "2 sessions have no subagents" without making the reader
+    cross-reference the degraded block.
+    """
+    mixed = _text(
+        _snapshot(sessions=_fleet_sessions(subagents_unreported=2), agents=AgentsInfo(running=1))
+    )
+    assert "2 sessions run an older build" in mixed
+    assert "lower bound" in mixed
+
+    clean = _text(_snapshot(sessions=_fleet_sessions(), agents=AgentsInfo(running=1)))
+    assert "lower bound" not in clean
+
+
+def test_a_wedged_session_is_named_as_possibly_stale() -> None:
+    """Its counts are real but as of its last heartbeat, and the screen says so
+    rather than presenting them as current."""
+    text = _text(_snapshot(sessions=_fleet_sessions(wedged=1), agents=AgentsInfo()))
+    assert "1 session is wedged" in text
+    assert "last heartbeat" in text
+
+
+def test_an_unreadable_roster_renders_unknown_not_a_denial() -> None:
+    """THE REGRESSION, as an assertion.
+
+    "No subagents have been launched in this session" is a statement of FACT. It
+    must not appear when the roster could not be read — that is the fabricated
+    zero a follower window used to show on a host full of subagents.
+    """
+    text = _text(
+        _snapshot(sessions=_fleet_sessions(), agents=AgentsInfo(roster_unread=True)),
+        _live(roster_unread=True),
+    )
+    assert "No subagents have been launched" not in text
+    assert "could not be read" in text
+    assert "could not read the roster" in text
+
+
+def test_a_genuinely_empty_session_still_says_so() -> None:
+    """The honest empty state must survive: a fresh session has no subagents and
+    the screen should say that plainly rather than hedging."""
+    text = _text(_snapshot(sessions=_fleet_sessions(), agents=AgentsInfo()))
+    assert "No subagents have been launched in this session." in text
+
+
+def test_the_closing_note_promises_counts_only_when_someone_else_reported() -> None:
+    """The note claims knowledge of other windows, so it must be true.
+
+    On an all-older fleet nobody reported, and the older wording — other
+    sessions report busy/pending and memory — is still exactly right.
+    """
+    tree = (SubagentLine(job_id="j1", label="reviewer", status="running"),)
+    known = _text(
+        _snapshot(
+            sessions=_fleet_sessions(),
+            agents=AgentsInfo(tree=tree, running=1, cross_session_known=True),
+        )
+    )
+    assert "Other sessions report counts." in _unwrapped(known)
+
+    unknown = _text(
+        _snapshot(
+            sessions=_fleet_sessions(subagents_unreported=3, subagents_reporting=0),
+            agents=AgentsInfo(tree=tree, running=1, cross_session_known=False),
+        )
+    )
+    assert "busy, pending and memory" in _unwrapped(unknown)
+
+
+def test_the_header_meta_sheds_to_the_short_form_on_a_narrow_frame() -> None:
+    """Below ``_NOTE_MIN`` the header keeps the fleet NUMBER and drops the rest.
+
+    The trajectory count is the fact the section exists to report, so it is what
+    survives the shed; the runtime denominator is still on its own row below.
+    """
+    text = _text(
+        _snapshot(sessions=_fleet_sessions(), agents=AgentsInfo(running=1)),
+        width=52,
+    )
+    assert "7 trajectories" in text
+    assert "3 runtimes · 7 trajectories" not in text

--- a/tests/unit/tui/test_info_panel.py
+++ b/tests/unit/tui/test_info_panel.py
@@ -1299,3 +1299,149 @@ def test_the_exports_lower_bound_caveat_inflects_like_the_panels() -> None:
         _snapshot(sessions=_fleet_sessions(subagents_unreported=3), agents=AgentsInfo(running=1))
     )
     assert "3 sessions run an older build and do not report subagents" in plural
+
+
+def test_queued_work_is_never_rendered_as_nothing_in_flight() -> None:
+    """D11: ``fleet_trajectories`` excludes queued, so the total is honestly 0.
+
+    A parked child spends nothing, which is why it is not a trajectory — but a
+    header reading ``none running`` above a tree of ``queued`` rows is the
+    screen contradicting a picture the same frame is drawing. The word is
+    reserved for the state where nothing is running AND nothing is waiting.
+    """
+    sessions = SessionsInfo(
+        available=True,
+        total=5,
+        live=5,
+        subagents_reporting=5,
+        fleet_subagents_running=0,
+        fleet_subagents_queued=3,
+        fleet_trajectories=0,
+    )
+    text = _text(_snapshot(sessions=sessions))
+    assert "none running · 3 queued" in text
+    header = [line for line in text.split("\n") if "Agents and subagents" in line][0]
+    assert not header.rstrip().endswith("none running")
+
+
+def test_the_queued_clause_survives_every_width_it_is_needed_at() -> None:
+    """The narrow rungs matter more than the wide one.
+
+    At ``0 total`` the addends are ``0 sessions + 0 subagents`` — three zeros
+    whose only informative companion is the queued count, so a ladder that shed
+    ``queued`` FIRST restored the contradiction on exactly the frames too small
+    to show anything else.
+    """
+    sessions = SessionsInfo(
+        available=True,
+        total=5,
+        live=5,
+        subagents_reporting=5,
+        fleet_subagents_running=0,
+        fleet_subagents_queued=3,
+        fleet_trajectories=0,
+    )
+    snapshot = _snapshot(sessions=sessions)
+    for width in range(50, 121):
+        row = [line for line in _lines(snapshot, width=width) if "Trajectories" in line][0]
+        assert "3 queued" in row or "3q" in row, (width, row)
+
+    # Below 50 the note column cannot fit even ``3q`` plus its separator, so
+    # the fact has to live in the header's short form instead. A 60-column
+    # terminal renders a 47-cell card, which is exactly this case: a captured
+    # frame at that size is what showed the row alone was not enough.
+    for width in range(38, 50):
+        header = [line for line in _lines(snapshot, width=width) if "Agents and subagents" in line][
+            0
+        ]
+        assert "3q" in header, (width, header)
+
+
+def test_no_line_overflows_at_any_width_with_the_longest_meta() -> None:
+    """The header shed is a fit check, not only a width floor.
+
+    ``_NOTE_MIN`` was calibrated against the metas that existed when it was
+    written; ``5 runtimes · none running · 3 queued`` is one cell longer and
+    overflowed at exactly 60 columns while passing the floor.
+    """
+    from rich.cells import cell_len
+
+    sessions = SessionsInfo(
+        available=True,
+        total=5,
+        live=5,
+        subagents_reporting=5,
+        fleet_subagents_running=0,
+        fleet_subagents_queued=3,
+        fleet_trajectories=0,
+    )
+    snapshot = _snapshot(sessions=sessions)
+    for width in range(38, 161):
+        for line in _lines(snapshot, width=width):
+            assert cell_len(line) <= max(38, width), (width, repr(line))
+
+
+def test_the_export_refuses_a_total_on_the_same_terms_as_the_panel() -> None:
+    """Q5: the two guards drifted, and the export is the copy that gets pasted.
+
+    When some runtimes reported and everything they reported was zero, the
+    panel refused to name a number while the export asserted ``>=0 total — 0
+    sessions + 0 subagents``.
+    """
+    from local_operator.info.render import build_export
+
+    sessions = SessionsInfo(
+        available=True,
+        total=2,
+        live=2,
+        subagents_reporting=1,
+        subagents_unreported=1,
+        fleet_trajectories=0,
+    )
+    export = build_export(_snapshot(sessions=sessions))
+    assert "1 of 2 runtimes did not report" in export
+    assert ">=0 total" not in export
+
+
+def test_the_exports_addends_inflect_like_the_panels() -> None:
+    """Q6/D12: ``1 sessions + 1 subagents`` is the state a fresh install is in."""
+    from local_operator.info.render import build_export
+
+    sessions = SessionsInfo(
+        available=True,
+        total=1,
+        live=1,
+        subagents_reporting=1,
+        fleet_session_trajectories=1,
+        fleet_subagents_running=1,
+        fleet_trajectories=2,
+    )
+    export = build_export(_snapshot(sessions=sessions))
+    assert "1 session + 1 subagent" in export
+    assert "1 sessions + 1 subagents" not in export
+
+
+def test_the_export_states_both_caveats_as_one_parenthetical() -> None:
+    """Reviewer NIT: two stacked apologies read as boilerplate and get skipped.
+
+    Both clauses qualify the same total, and both must still be present — the
+    packaging changes, not the disclosure.
+    """
+    from local_operator.info.render import build_export
+
+    sessions = SessionsInfo(
+        available=True,
+        total=3,
+        live=2,
+        wedged=1,
+        subagents_reporting=1,
+        subagents_unreported=1,
+        fleet_session_trajectories=1,
+        fleet_subagents_running=2,
+        fleet_trajectories=3,
+    )
+    export = build_export(_snapshot(sessions=sessions))
+    caveats = [line for line in export.split("\n") if "lower bound" in line]
+    assert len(caveats) == 1, caveats
+    assert "1 session runs an older build" in caveats[0]
+    assert "1 session is wedged; its counts" in caveats[0]

--- a/tests/unit/tui/test_info_panel.py
+++ b/tests/unit/tui/test_info_panel.py
@@ -1357,28 +1357,81 @@ def test_the_queued_clause_survives_every_width_it_is_needed_at() -> None:
         assert "3q" in header, (width, header)
 
 
-def test_no_line_overflows_at_any_width_with_the_longest_meta() -> None:
+@pytest.mark.parametrize(
+    ("runtimes", "queued"),
+    [
+        (5, 3),
+        # Two- and three-digit counts: this header's short form is the FIRST
+        # whose width grows with its digits, and pinning a single-digit fixture
+        # is exactly why the original guard could not see it overflow. A
+        # fleet-wide queued sum is not bounded by ``max_running``, so a host
+        # with several sessions past capacity reaches double digits normally.
+        (5, 12),
+        (5, 120),
+        (12, 1),
+        (12, 12),
+        (99, 999),
+    ],
+)
+def test_no_line_overflows_at_any_width_with_the_longest_meta(runtimes: int, queued: int) -> None:
     """The header shed is a fit check, not only a width floor.
 
     ``_NOTE_MIN`` was calibrated against the metas that existed when it was
     written; ``5 runtimes · none running · 3 queued`` is one cell longer and
     overflowed at exactly 60 columns while passing the floor.
+
+    The container FOLDS rather than crops, so an overflowing header renders as
+    a second line at column 0 — the card's left margin visibly broken, which is
+    the "one record reads as two" fault these screens exist to remove.
     """
     from rich.cells import cell_len
 
     sessions = SessionsInfo(
         available=True,
-        total=5,
-        live=5,
-        subagents_reporting=5,
+        total=runtimes,
+        live=runtimes,
+        subagents_reporting=runtimes,
         fleet_subagents_running=0,
-        fleet_subagents_queued=3,
+        fleet_subagents_queued=queued,
         fleet_trajectories=0,
     )
     snapshot = _snapshot(sessions=sessions)
     for width in range(38, 161):
         for line in _lines(snapshot, width=width):
             assert cell_len(line) <= max(38, width), (width, repr(line))
+
+
+def test_the_queued_header_keeps_both_counts_when_it_sheds() -> None:
+    """D14's shed must drop a RESTATEMENT, never a measured number.
+
+    ``0r`` is inferable from a queued-only header; the queued count is not
+    inferable from anything. So the narrow rung sheds ``0r`` and keeps both
+    figures rather than truncating one of them away.
+    """
+    sessions = SessionsInfo(
+        available=True,
+        total=12,
+        live=12,
+        subagents_reporting=12,
+        fleet_subagents_running=0,
+        fleet_subagents_queued=12,
+        fleet_trajectories=0,
+    )
+    snapshot = _snapshot(sessions=sessions)
+    header = [line for line in _lines(snapshot, width=38) if "Agents and subagents" in line][0]
+    assert "12rt" in header and "12q" in header, header
+
+
+def test_the_loading_header_keeps_its_hedge_at_every_width() -> None:
+    """D15: a number about to be revised upward must not render as settled.
+
+    The fleet half arrives ~900 ms after the live half, and the bare short form
+    dropped ``fleet checking…`` entirely below 66 cells — showing ``0 running``
+    as though the probe had finished.
+    """
+    for width in range(38, 161):
+        header = [line for line in _lines(None, width=width) if "Agents and subagents" in line][0]
+        assert "checking…" in header or "fleet …" in header, (width, header)
 
 
 def test_the_export_refuses_a_total_on_the_same_terms_as_the_panel() -> None:

--- a/tests/unit/tui/test_info_panel.py
+++ b/tests/unit/tui/test_info_panel.py
@@ -19,6 +19,7 @@ from textual.binding import Binding
 
 from local_operator.info.collect import LiveState, collect_live
 from local_operator.info.model import (
+    UNKNOWN,
     AgentsInfo,
     EnvInfo,
     InfoSnapshot,
@@ -1100,15 +1101,201 @@ def test_the_closing_note_promises_counts_only_when_someone_else_reported() -> N
     assert "busy, pending and memory" in _unwrapped(unknown)
 
 
-def test_the_header_meta_sheds_to_the_short_form_on_a_narrow_frame() -> None:
-    """Below ``_NOTE_MIN`` the header keeps the fleet NUMBER and drops the rest.
+def test_the_header_short_form_keeps_both_halves_of_the_answer() -> None:
+    """Below ``_NOTE_MIN`` the header abbreviates rather than dropping a half.
 
-    The trajectory count is the fact the section exists to report, so it is what
-    survives the shed; the runtime denominator is still on its own row below.
+    The operator's question is explicitly two-part — how many runtimes AND how
+    many trajectories — so shedding the denominator leaves the count
+    unanchored: N trajectories across how many processes? Abbreviating is what
+    makes keeping both affordable at a narrow width (design round 1, D4).
     """
     text = _text(
         _snapshot(sessions=_fleet_sessions(), agents=AgentsInfo(running=1)),
         width=52,
     )
-    assert "7 trajectories" in text
-    assert "3 runtimes · 7 trajectories" not in text
+    assert "3rt · 7tj" in text
+    assert "3 runtimes · 7 trajectories" not in text, "the long form must have shed"
+
+
+def test_an_unmeasured_fleet_never_renders_as_a_measured_zero() -> None:
+    """D1/D2 — the section contradicting itself in this host's default state.
+
+    When NO runtime reported, every term of ``fleet_trajectories`` is unknown,
+    but the falsy total used to render through the measured branch: the header
+    printed ``none running`` and the row ``0 total — 0 sessions + 0 subagents``
+    while the same frame drew this session's running children four rows below.
+    ``none running`` is a word chosen precisely because it asserts more
+    confidently than a bare ``0`` — so it must not be spent on a number nobody
+    measured. The record layer honours "None is not 0"; the header must too.
+    """
+    sessions = _fleet_sessions(
+        live=4,
+        busy=0,
+        subagents_reporting=0,
+        subagents_unreported=4,
+        fleet_subagents_running=0,
+        fleet_session_trajectories=0,
+        fleet_trajectories=0,
+    )
+    text = _text(
+        _snapshot(
+            sessions=sessions,
+            agents=AgentsInfo(
+                running=3,
+                queued=1,
+                tree=(SubagentLine(job_id="j1", label="reviewer", status="running"),),
+            ),
+        )
+    )
+    assert "none running" not in text, "nothing was measured, so nothing may be asserted"
+    assert "0 total" not in text
+    assert "0 sessions + 0 subagents" not in text
+    assert f"4 runtimes · trajectories {UNKNOWN}" in text
+    assert "4 of 4 runtimes did not report" in _unwrapped(text)
+    # And the tree it would have contradicted is still drawn.
+    assert "reviewer" in text
+
+
+def test_a_partially_reported_fleet_hedges_the_figure_itself() -> None:
+    """The caveat is twelve rows and a page-turn from the header at 100x30, so
+    the hedge rides the number rather than waiting for the note (D2)."""
+    text = _text(
+        _snapshot(
+            sessions=_fleet_sessions(subagents_unreported=2),
+            agents=AgentsInfo(running=1),
+        )
+    )
+    assert "≥7 trajectories" in text, "the header figure carries its own floor marker"
+    assert "≥7 total" in text
+    # The caveat still states the denominator; the marker does not replace it.
+    assert "lower bound" in _unwrapped(text)
+
+
+def test_none_running_survives_only_when_every_runtime_reported_zero() -> None:
+    """The one state where the word is earned: it is then a measurement."""
+    text = _text(
+        _snapshot(
+            sessions=_fleet_sessions(
+                busy=0,
+                subagents_reporting=3,
+                subagents_unreported=0,
+                fleet_subagents_running=0,
+                fleet_session_trajectories=0,
+                fleet_trajectories=0,
+            ),
+            agents=AgentsInfo(),
+        )
+    )
+    assert "none running" in text
+    assert UNKNOWN not in text.split("Agents and subagents")[1].split("Environment")[0]
+
+
+@pytest.mark.parametrize("width", list(range(50, 101)))
+def test_no_row_in_the_section_is_clipped_mid_word(width: int) -> None:
+    """D3 — ``· depth N`` arrived with no rung in the shed ladder.
+
+    The value column is padded and then hard-cropped, so a value that outgrows
+    a narrow frame loses characters mid-word: at 64 columns the row ended on
+    the bare label ``depth`` with no number, at 60/62 on ``de``/``dept``. A
+    label promising a value that is not there reads as a broken field, which is
+    a regression against the pre-fleet row — shorter, but always complete.
+    """
+    text = _text(
+        _snapshot(
+            sessions=_fleet_sessions(),
+            agents=AgentsInfo(running=3, queued=1, settled=7, max_depth=2),
+        ),
+        width=width,
+    )
+    section = text.split("Agents and subagents")[1].split("Environment")[0]
+    for line in section.split("\n"):
+        stripped = line.rstrip()
+        assert not stripped.endswith("·"), f"{width}: dangling separator: {stripped!r}"
+        for fragment in ("depth", "de", "dept", "runnin", "queue"):
+            assert not stripped.endswith(fragment), f"{width}: clipped: {stripped!r}"
+
+
+def test_counts_are_pluralised() -> None:
+    """D5 — ``1 runtimes · 1 trajectories`` is what every fresh install saw."""
+    text = _text(
+        _snapshot(
+            sessions=_fleet_sessions(
+                total=1,
+                live=1,
+                busy=1,
+                subagents_reporting=1,
+                fleet_subagents_running=0,
+                fleet_session_trajectories=1,
+                fleet_trajectories=1,
+            ),
+            agents=AgentsInfo(),
+        )
+    )
+    assert "1 runtime · 1 trajectory" in text
+    assert "1 session + 0 subagents" in text
+    assert "1 runtimes" not in text and "1 trajectories" not in text
+
+
+def test_the_caveats_agree_with_themselves_in_the_singular() -> None:
+    """D6/D7 — the singular branches switched number mid-sentence."""
+    older = _unwrapped(
+        _text(
+            _snapshot(
+                sessions=_fleet_sessions(subagents_unreported=1), agents=AgentsInfo(running=1)
+            )
+        )
+    )
+    assert "1 session runs an older build and does not report" in older
+    assert "do not report" not in older
+
+    wedged = _unwrapped(
+        _text(_snapshot(sessions=_fleet_sessions(wedged=1), agents=AgentsInfo(running=1)))
+    )
+    assert "1 session is wedged; its counts are as of its last heartbeat." in wedged
+    assert "their counts" not in wedged
+
+
+def test_the_export_discloses_wedged_staleness_like_the_panel() -> None:
+    """Q2 — the panel has said this since the counts landed; the export did not.
+
+    The fleet totals deliberately include wedged runtimes (a quiet pid can still
+    have children working), so their contribution is as of their last heartbeat.
+    The export is the artifact that outlives the screen and lands in an issue,
+    which makes an undisclosed stale number harder to challenge there than
+    anywhere else.
+    """
+    from local_operator.info.render import build_export
+
+    export = build_export(
+        _snapshot(sessions=_fleet_sessions(live=4, wedged=2), agents=AgentsInfo(running=1))
+    )
+    assert "2 sessions are wedged; their counts are as of their last heartbeat" in export
+
+    single = build_export(
+        _snapshot(sessions=_fleet_sessions(live=5, wedged=1), agents=AgentsInfo(running=1))
+    )
+    assert "1 session is wedged; its counts are as of its last heartbeat" in single
+
+    # Conditional, not standing: with nothing wedged the CAVEAT is absent,
+    # though the runtimes row still reports "· 0 wedged" as a breakdown.
+    quiet = build_export(_snapshot(sessions=_fleet_sessions(), agents=AgentsInfo(running=1)))
+    assert "last heartbeat" not in quiet
+
+
+def test_the_exports_lower_bound_caveat_inflects_like_the_panels() -> None:
+    """Q3 — the export read "1 sessions run ... and do not report".
+
+    Pasted verbatim into an issue, an uninflected count reads as a template
+    nobody finished rather than as a measurement.
+    """
+    from local_operator.info.render import build_export
+
+    single = build_export(
+        _snapshot(sessions=_fleet_sessions(subagents_unreported=1), agents=AgentsInfo(running=1))
+    )
+    assert "1 session runs an older build and does not report subagents" in single
+
+    plural = build_export(
+        _snapshot(sessions=_fleet_sessions(subagents_unreported=3), agents=AgentsInfo(running=1))
+    )
+    assert "3 sessions run an older build and do not report subagents" in plural


### PR DESCRIPTION
## What

`/info`'s "Agents and subagents" section now answers the question it is opened
for: **how many agent trajectories are running on this machine**. Two
independent defects are fixed; either alone would have left the screen wrong.

## Why

The reported symptom: `/info` said `none running` and "No subagents have been
launched in this session" on a host running 12–13 live sessions with active
subagents in several of them.

**1. The follower bug — why even the OWN session's tree was empty.**
`collect_live` reads the public `session.subagent_comms`. `RemoteSession` only
ever set `self._subagent_comms` and exposed no public property, so on an
attached window the branch was skipped, the counts stayed 0, and — the part
that makes it a lie rather than a gap — **nothing was recorded as degraded**,
because nothing raised. `_safe` catches probes that *fail*; this one returned a
default and was believed. All 11 live records on this host are `kind: "daemon"`
followers, so this was not an edge case here, it was the only path.

Fixing the name alone is not enough. `SnapshotSubagentComms` had no `nodes()`,
and its `_node_for` projected **no `status` and no `live`**. Adding the roster
without those makes the tree appear while the running tally stays 0 and every
row renders `unknown` — a fix that looks done and is not. Both are projected
from `JobState`, which already carries them.

**2. No cross-session visibility.** `SessionRecord` published no subagent data,
so the screen could only ever describe its own window. Each runtime now
publishes `subagents_running` / `subagents_queued` on its record, on the same
purely additive contract as the live-state and build-stamp blocks above them.

**`PROTOCOL_VERSION` deliberately does NOT move.** Peers read `record.protocol`
as a pre-dial promise about which *frames* a runtime speaks (`attach_client`
refuses below 2, the TUI takeover path and `session_factory` below 4,
`remote`'s canonical attach below 5). Two JSON integers riding in no frame
change nothing those readers ask about. The `AgentsInfo` docstring claiming a
bump was required was wrong and is corrected; `cross_session_known` is
**redefined** rather than deleted, and now means *somebody else reported* —
which is what the note it gates actually claims.

## `None` is not `0`

A runtime predating these fields has not told us it has no subagents. It is
counted under `subagents_unreported`, excluded from the sum, and the total is
rendered as a **lower bound** with a caveat naming how many terms are missing.
That is why the type is `int | None` rather than `int` defaulting to 0, and it
is exactly what this host shows today — every live session predates the fields,
so the honest render is `11 runtimes · 11 trajectories` **plus the caveat**,
not a confident tally.

Counting is a flat `len()` over one roster read: `SubagentComms.nodes()` already
returns every nested descendant, so a recursive walk on top would double count.
Session and subagent trajectories are disjoint by construction — a subagent
never publishes a `SessionRecord` — which is what makes adding them legal.

**Also fixed:** `_safe("live.subagents", comms.nodes, ...)` resolved the
attribute as an *argument*, before `_safe` entered its `try`, so a comms object
lacking the method raised straight out of the paint path. It is now a lambda.

**Floor/transition agreement:** the event-driven publisher and the 15 s
heartbeat floor read the same predicate, `RUNNING_SUBAGENT_STATUSES`, which
lives beside the record fields it defines the meaning of. This code shipped the
opposite once already in the `busy` bit: a floor that disagrees does not merely
go stale, it *overwrites* the correct value on its next tick.

## Before / after frames

Real `OperatorApp` under `run_test` via the existing `scripts/info_shot.py`
(loads `local_operator.tcss`; the lightweight test hosts do not), isolated
HOME/config, every `CMUX_*` variable cleared, `env -u NO_COLOR
TERM=xterm-256color`, 100×30. Before frames captured from the clean tree
**before any edit**.

| frame | shows |
|---|---|
| [before-nested-agents.svg](https://gist.githubusercontent.com/damianvtran/57f5dfcfe1622da46fa2a43691dab354/raw/before-nested-agents.svg) | old section: `3 running · depth 4`, this session only, no fleet number |
| [before-empty-agents.svg](https://gist.githubusercontent.com/damianvtran/57f5dfcfe1622da46fa2a43691dab354/raw/before-empty-agents.svg) | **the reported bug**: "No subagents have been launched in this session." |
| [after-fleet-header.svg](https://gist.githubusercontent.com/damianvtran/57f5dfcfe1622da46fa2a43691dab354/raw/after-fleet-header.svg) | **`Agents and subagents   5 runtimes · 9 trajectories`** |
| [after-fleet-section.svg](https://gist.githubusercontent.com/damianvtran/57f5dfcfe1622da46fa2a43691dab354/raw/after-fleet-section.svg) | `Trajectories 9 total — 3 sessions + 6 subagents`; `This session` relabelled |
| [after-mixed-section.svg](https://gist.githubusercontent.com/damianvtran/57f5dfcfe1622da46fa2a43691dab354/raw/after-mixed-section.svg) | mixed fleet incl. a wedged runtime: `6 runtimes · 11 trajectories` |
| [after-mixed-caveats.svg](https://gist.githubusercontent.com/damianvtran/57f5dfcfe1622da46fa2a43691dab354/raw/after-mixed-caveats.svg) | **the degradation**: "2 sessions run an older build … the fleet total is a **lower bound**." + the wedged-staleness line |
| [after-unread-roster.svg](https://gist.githubusercontent.com/damianvtran/57f5dfcfe1622da46fa2a43691dab354/raw/after-unread-roster.svg) | **the honesty fix**: `This session  —  could not read the roster`, and the "No subagents have been launched" denial is gone |
| [after-first-frame.svg](https://gist.githubusercontent.com/damianvtran/57f5dfcfe1622da46fa2a43691dab354/raw/after-first-frame.svg) | first frame, live only — this session's tree with **no fabricated fleet number** |

Consecutive settled frames are **byte-identical** in all three scenarios (no
post-paint reflow):

```
$ cmp -s opened.svg settled.svg
fleet: no reflow    fleet-mixed: no reflow    fleet-unread: no reflow
```

First-frame transition, driven through the real screen — the header never
flashes a wrong number, it says `checking…` (the screen's one existing loading
word, not a fourth vocabulary) and then settles:

```
FIRST  : ▌ Agents and subagents   this session: 2 running · fleet checking…
SETTLED: ▌ Agents and subagents   5 runtimes · 9 trajectories
```

## Testing

**The follower path specifically**, against the REAL `RemoteSession` class —
the defect was that the class exposed no public name, so only the real class
proves it. Asserts the **count**, not merely that rows exist, because the naive
fix leaves the tally at 0:

```
$ .venv/bin/python  # real RemoteSession + real SnapshotSubagentComms
class has subagent_comms: True
public property resolves: True
running: 2 settled: 1 unread: False
tree: [('reviewer', 'running'), ('scout', 'starting'), ('coder', 'completed')]
OK: real RemoteSession reports its own tree with correct statuses
```

Statuses are real, not `unknown` — that is the silent-zero trap closed.

**The publish path**, through the production `Session` + `OwnedSessionHandle` +
`RuntimeServer` rig (only the provider stream is scripted):

```
probe on handle: True
after _publish_busy: 0 0
writes after unchanged republish: 0          <- dedupe holds
writes after change: 1 {'pending': None, 'busy': False, 'detached': True,
                        'subagents_running': 2, 'subagents_queued': 1}
writes after identical set (dedupe): 1
```

**The degradation matrix**, against `collect_sessions` with a synthetic scan —
2 reporting + 1 older build + 1 wedged + 1 stale:

```
reporting 3 unreported 1
fleet_running 5 session_traj 3 total 8      <- wedged included, stale excluded
```

**Against the operator's REAL live records** (read-only: `registry.scan(root=)`,
no publish, no unpublish, no writes; session names and cwds not printed):

```
live records on this host: 11
kinds/states: {('daemon', 'live'): 11}       <- every window is a follower
reports counts: 0                            <- all predate the fields

Agents and subagents   11 runtimes · 11 trajectories
  Runtimes            11 live
  Trajectories        11 total                  11 sessions + 0 subagents
  11 sessions run an older build and do not report subagents — the fleet total
  is a lower bound.
```

That is the mixed-build rollout state behaving as designed: a lower bound with
its denominator named, **not** a confident zero.

**`lop sessions --json`** (published surface, keys added deliberately; the
pinned expectation in `test_sessions_extraction.py` is updated in the same
commit with a comment saying why):

```
keys: [..., 'version', 'source_ref', 'subagents_running', 'subagents_queued']
subagents_running: None   (None = older runtime, not zero)
```

### Suites

23 new tests across the record, publish, collect and render layers, including
the two named regressions (follower reports 2 not 0; a comms object without
`nodes` degrades instead of raising out of the paint path) and an explicit
`PROTOCOL_VERSION == 5` pin carrying its reason.

```
tests/unit                     16736 passed, 18 skipped in 1466.09s
.venv/bin/python -m flake8 .                                    clean
uvx --from black==26.1.0 black --check .    1124 files unchanged
uvx isort==5.13.2 --check .                                     clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .
                                0 errors, 0 warnings, 0 informations
```

## Notes for review

- `pyproject.toml` is untouched — no version bump on this branch.
- Does not touch `analytics/model.py`, `harness/loop.py`, `tools/builtin.py` or
  `tui/widgets/session_panel.py` (the in-flight
  `fix/tool-fault-argument-classification` branch).
- One divergence from the design note, and one correction to it, are described
  in the first review comment.
