### PR TITLE
chore(release): bump version to 0.51.29

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.28"
+version = "0.51.29"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## What

Claims the current release window and bumps the version to **0.51.29**. One file, one line.

**Window owner:** the "Sort Sessions With Wakes" lop session (pid 52326). This PR *is* the claim — an open `chore(release)` PR is the observable lock, since two sessions can both ask "does anyone own the window?" in the same minute and both hear no.

## Why

Window contents — every PR reachable from this tag but not from `v0.51.28`, re-derived with `git log v0.51.28..origin/main`:

| PR | Merge SHA | Impact |
|---|---|---|
| #824 | `5993c4c45` | TUI sidebar: sessions with an armed wake now sort to the top of Previous Sessions, so a session that will act on its own is visible without scrolling. A dormant wake ranks just beneath the armed ones rather than floating. |
| #817 | `46b6dfc7f` | Docs: records three eval-venv construction traps for the OSWorld benchmark adapter (symlinked interpreter shims, a copied interpreter missing its runtime library, and editable installs stamping the wrong version into evidence). Also touches `benchmarks/osworld_v2_adapter/pyproject.toml`. |

**Bump class: PATCH.** A user-visible sidebar ordering fix plus a docs change; neither clears the step-function bar for a minor. Both polled peers independently agreed on patch.

## Coordination

Ownership confirmed with the two other active lop-dev sessions before claiming; neither owns the window nor has anything merged-but-unreleased:

- pid 83697 — PR #821 (MCP startup toast) still open, mid-remediation with 2 MAJOR UX findings outstanding. Rides the next window; explicitly asked not to be waited for.
- pid 86514 — issue #822 (AGENTS.md configuration-guide fix) still in implementation, PR not open. Rides the next window, which that session will own.

The window will be **re-derived once more from `git log v0.51.28..origin/main` immediately before tagging** — anything that merges while this PR is open is reachable from the tag and would otherwise ship unlisted, which is the failure that bit v0.51.4.

## Testing

Version-only change; no code, no tests apply. The release content it carries merged with full CI green — for #824: 5 test shards, both `tui-e2e` legs (ubuntu + macos), lint, type-check, `pip-audit`, `cli-sanity`, `server-sanity` — after two clean agent review rounds, two QA rounds and two design rounds. `version-bump-guard` gates this PR itself.
