### PR TITLE
chore(release): bump version to 0.51.30

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.29"
+version = "0.51.30"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

Release bump for the window opened after `v0.51.29`. One-file, one-line change to `pyproject.toml`.

## Window contents

| PR | Merge SHA | Impact |
|---|---|---|
| #820 | `5bcd0319e` | `fix(agents)`: an empty legacy `agents/agents/` directory permanently bricked profile launch and `/team` attach |

`v0.51.29` was tagged at 17:18:14Z; #820 merged at 17:24:50Z, six minutes later, so it missed that window and is the only unreleased commit on `main`.

## Bump class

**Patch.** A single bug fix, no new surface, no behaviour change for an unaffected registry. Does not clear the step-function bar for a minor.

## Why this matters

The operator hit this live, twice: a profile follow-up and `/team lopdev` both failed with *"The agent registry could not be read completely. Repair unreadable or invalid agent definitions, then retry."* — with all 20 agent definitions valid and no path named, so there was nothing to repair. The state was permanent and unrecoverable by the user. Affected machines self-heal on first start after upgrade.

## Review rounds on the shipped change

#820 carried two full agent-review rounds and two independent QA rounds, all clean and fresh on head `c64e1ad9b`. Round 1 raised a blocker (a substitution hole where an operator's edited role could be silently replaced by a same-named packaged seed); round 2 adjudicated the remediation empirically, with the reviewer reversing its own proposed one-liner after measuring that it would have opened a new hole of the same shape.

## Scope check

`git diff` touches `pyproject.toml` only, `version` line only. No code, no dependency changes.