### PR TITLE
fix(guides): correct the false "no AGENTS.md mechanism" claim and surface instruction provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,6 +765,7 @@ lop config create      # scaffold it
 lop config list        # every option, with descriptions
 lop config edit <key> <value>
 lop config open        # open it in your editor
+lop config instructions  # which instruction files a session assembles, in order
 ```
 
 Commonly set values: `hosting` and `model_name` (skip the CLI flags),
@@ -798,6 +799,10 @@ export LOCAL_OPERATOR_ECOSYSTEM_INSTRUCTIONS=~/.config/AGENTS.md:~/team/AGENTS.m
 # or turn the import off entirely
 export LOCAL_OPERATOR_ECOSYSTEM_INSTRUCTIONS=
 ```
+
+`lop config instructions` reports which files a session actually assembles, in
+order, with the size each contributed and whether it was collapsed as a
+duplicate — paths and sizes only, never the contents.
 
 Project-level `AGENTS.md` / `CLAUDE.md` files are discovered separately by
 walking up from your working directory, and can be disabled with

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1493,17 +1493,32 @@ def config_instructions_command(args: argparse.Namespace) -> int:
             )
         if source.truncated:
             print(paint("│    Truncated: hit the size cap; the tail was dropped", WARNING))
-        if source.overlaps:
+        if source.overlaps_index:
             # The superset arrangement, which the digest collapse cannot catch
             # and which two rows of non-zero "Included" cannot distinguish from
             # two genuinely distinct files. WARNING, matching ``Truncated:``:
             # this is a cost the operator is paying on every cached request and
             # can remove. The overlapping TEXT is never printed — the count and
-            # the other source's label are the whole answer.
+            # the other source's row number are the whole answer.
+            #
+            # Kept within 80 columns in every reachable state: 79 for a
+            # two-digit row number at 64,000 characters, and still 80 at three
+            # digits, which a source list bounded by the override paths plus two
+            # cannot reach. The box has no wrapping of its own, so a longer row
+            # soft-wraps in an 80-column terminal and the overflow lands outside
+            # the "│" gutter — the same reason the footer below is two lines
+            # rather than one. The source is named by ROW NUMBER, not label:
+            # several imported files all render as "imported", so a label could
+            # not identify which file to edit.
+            direction = (
+                f"contains source {source.overlaps_index} verbatim"
+                if source.overlap_contains
+                else f"verbatim inside source {source.overlaps_index}"
+            )
             print(
                 paint(
-                    f"│    Overlaps: contains all {source.overlap_chars:,} chars of "
-                    f'"{source.overlaps}" verbatim; both copies are sent',
+                    f"│    Overlaps: {direction} "
+                    f"({source.overlap_chars:,} chars); both copies are sent",
                     WARNING,
                 )
             )

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -271,6 +271,16 @@ def build_cli_parser() -> argparse.ArgumentParser:
         "create", help="Create a new configuration file", parents=[parent_parser]
     )
 
+    # Instructions command. Takes ``--agent`` from ``parent_parser``, which is
+    # what lets it report the profile layer a session with that agent would
+    # actually assemble rather than only the two global sources.
+    config_subparsers.add_parser(
+        "instructions",
+        help="Show which custom-instruction files a session assembles, in order "
+        "(paths and sizes only, never their contents)",
+        parents=[parent_parser],
+    )
+
     # Agents command
     agents_parser = subparsers.add_parser("agents", help="Manage agents", parents=[parent_parser])
     agents_subparsers = agents_parser.add_subparsers(dest="agents_command")
@@ -1338,6 +1348,157 @@ def config_list_command() -> int:
         print(f"\033[1;32m│ {key}: {config.values[key]}\033[0m")
         print("\033[1;32m│   Description: not a recognised key; nothing reads it\033[0m")
     print("\033[1;32m╰──────────────────────────────────────────────\033[0m")
+    return 0
+
+
+def config_instructions_command(args: argparse.Namespace) -> int:
+    """Report which instruction files a session would actually assemble.
+
+    Answers "what instructions am I running", which before this command was
+    only recoverable by importing ``ecosystem_instructions`` by hand or by
+    reading an INFO log line the TUI writes to a rotating file (#822). The
+    imported ``~/.agents/AGENTS.md`` is the case that needs it: it is written
+    by another tool, named in no lop-owned setting, and silently reshapes the
+    system prompt of every session and every subagent.
+
+    Deliberately PROVENANCE and not content. These files are the operator's
+    standing rules and routinely run to thousands of lines; dumping them here
+    would bury the one thing being asked about (which files, in what order, at
+    what cost) and make the command unusable in a pipe. ``config open`` and an
+    editor already show the text.
+
+    Read-only by construction: the whole report is derived from
+    ``resolve_user_instructions``, which is the same call the session factory
+    makes, so this command cannot report a prompt different from the one that
+    ships \u2014 the divergence #822 is about.
+    """
+    # ``paint`` rather than the raw ``\033[1;32m`` literals ``config_list_command``
+    # still carries: this output is routinely piped into an issue or a review
+    # comment, and cli_style is the module that keeps the escapes out of a
+    # non-tty capture and honours NO_COLOR.
+    from local_operator.cli_style import CYAN, ERROR, SUCCESS, WARNING, paint
+    from local_operator.ecosystem_instructions import (
+        ECOSYSTEM_INSTRUCTION_PATHS,
+        ECOSYSTEM_INSTRUCTIONS_ENV,
+    )
+    from local_operator.session_factory import (
+        MAX_USER_INSTRUCTIONS_CHARS,
+        resolve_user_instructions,
+    )
+
+    # The profile prompt is resolved the way a session resolves it, so
+    # ``--agent NAME`` reports what that agent would actually run rather than
+    # the no-profile case. A name with no agent behind it is NOT created here:
+    # this command must never write, and the interactive path's
+    # create-on-missing behaviour would do exactly that.
+    agent_prompt = ""
+    agent_note = ""
+    agent_name = getattr(args, "agent_name", None)
+    if agent_name:
+        from local_operator.agents import AgentRegistry
+
+        registry = AgentRegistry(config_dir())
+        agent = registry.get_agent_by_name(agent_name)
+        if agent is None:
+            print(
+                paint(f"Error: No agent found with name: {agent_name}", ERROR, stream=sys.stderr),
+                file=sys.stderr,
+            )
+            return 1
+        agent_prompt = registry.get_agent_system_prompt(str(agent.id)) or ""
+        agent_note = agent_name
+
+    assembled, sources = resolve_user_instructions(agent_prompt, log_provenance=False)
+
+    override = os.environ.get(ECOSYSTEM_INSTRUCTIONS_ENV)
+    print(paint("\n╭─ Custom instructions, in assembly order ──────", SUCCESS))
+    for index, source in enumerate(sources, start=1):
+        label = source.label
+        if label == "agent profile" and agent_note:
+            label = f"agent profile ({agent_note})"
+        print(paint(f"│ {index}. {label}", SUCCESS))
+        print(paint(f"│    Path: {source.path if source.path else '(agent registry)'}", SUCCESS))
+        # Both numbers, always: "read 6,960 / included 0" is the collapse an
+        # operator is trying to confirm, and a single figure cannot express it.
+        print(
+            paint(
+                f"│    Read: {source.chars:,} chars   Included: {source.included:,} chars",
+                SUCCESS,
+            )
+        )
+        if source.unreadable:
+            # Degraded, not absent: the session started anyway with this file's
+            # rules missing, which is a state the operator has to be told about
+            # rather than left to read as "no such file".
+            print(paint("│    Unreadable: skipped; the session ran without it", WARNING))
+        elif source.chars == 0:
+            # A path with no bytes behind it reads as a file that exists and is
+            # being used. Saying so keeps the default install (no
+            # system_prompt.md) from looking like a configured-but-broken one.
+            print(paint("│    Empty: no file at that path, or nothing in it", SUCCESS))
+        if source.collapsed:
+            print(
+                paint(
+                    "│    Collapsed: identical to instructions already loaded; sent once",
+                    CYAN,
+                )
+            )
+        if source.truncated:
+            print(paint("│    Truncated: hit the size cap; the tail was dropped", WARNING))
+    if not sources:
+        print(paint("│ (none — no instruction sources resolved)", SUCCESS))
+    print(
+        paint(
+            f"│ Total assembled: {len(assembled):,} of {MAX_USER_INSTRUCTIONS_CHARS:,} chars",
+            SUCCESS,
+        )
+    )
+    print(paint("╰──────────────────────────────────────────────", SUCCESS))
+
+    # The imported half gets its own box because its state is the question:
+    # "none" here is a real answer (the default install has no
+    # ~/.agents/AGENTS.md) and must not read as an empty listing, and the
+    # override has three distinct states an operator can be in by accident.
+    print(paint("\n╭─ Imported user-scope instructions ────────────", SUCCESS))
+    if override is None:
+        default_paths = ", ".join(f"~/{relative}" for relative in ECOSYSTEM_INSTRUCTION_PATHS)
+        print(paint(f"│ Source: default ({default_paths})", SUCCESS))
+    elif not override.strip():
+        print(
+            paint(
+                f"│ Source: DISABLED — {ECOSYSTEM_INSTRUCTIONS_ENV} is set and empty",
+                WARNING,
+            )
+        )
+    else:
+        print(paint(f"│ Source: {ECOSYSTEM_INSTRUCTIONS_ENV}={override}", CYAN))
+    imported = [source for source in sources if source.label == "imported"]
+    if not imported:
+        # "Nothing was imported" has two causes with opposite fixes — the
+        # feature is off, or it is on and the file is simply not there — and an
+        # operator who reads the wrong one goes looking in the wrong place.
+        reason = (
+            "the feature is disabled"
+            if override is not None and not override.strip()
+            else "no imported file exists at those paths"
+        )
+        print(paint(f"│ Files read: none — {reason}", SUCCESS))
+    else:
+        for source in imported:
+            if source.unreadable:
+                state = "unreadable; skipped"
+            elif source.collapsed:
+                state = "collapsed"
+            else:
+                state = f"{source.included:,} chars"
+            print(paint(f"│ Files read: {source.path} ({state})", SUCCESS))
+    print(
+        paint(
+            "│ Read-only: system_prompt.md stays the only file lop writes",
+            SUCCESS,
+        )
+    )
+    print(paint("╰──────────────────────────────────────────────", SUCCESS))
     return 0
 
 
@@ -4259,6 +4420,8 @@ def main() -> int:
                 return config_edit_command(args)
             elif args.config_command == "list":
                 return config_list_command()
+            elif args.config_command == "instructions":
+                return config_instructions_command(args)
             else:
                 parser.error(f"Invalid config command: {args.config_command}")
         elif args.subcommand == "search":

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -278,6 +278,13 @@ def build_cli_parser() -> argparse.ArgumentParser:
         "instructions",
         help="Show which custom-instruction files a session assembles, in order "
         "(paths and sizes only, never their contents)",
+        # ``description=`` as well as ``help=``: the latter renders only on the
+        # PARENT ``config --help`` page, so without this the command's own
+        # ``--help`` is blank above the options list.
+        description="Show which custom-instruction files a session assembles, in "
+        "order, with the size each contributed and whether it was collapsed as a "
+        "duplicate, truncated, or overlaps an earlier source. Paths and sizes "
+        "only, never the contents.",
         parents=[parent_parser],
     )
 
@@ -1397,7 +1404,19 @@ def config_instructions_command(args: argparse.Namespace) -> int:
     if agent_name:
         from local_operator.agents import AgentRegistry
 
-        registry = AgentRegistry(config_dir())
+        # Guarded because ``AgentRegistry.__init__`` mkdirs both ``config_dir``
+        # and ``config_dir/agents`` — so on a machine with no config root at
+        # all, asking this read-only command about an agent materialised one.
+        # Read-only was a stated deliverable, and there is nothing to report
+        # anyway: a config dir that does not exist holds no agents.
+        root = config_dir()
+        if not root.exists():
+            print(
+                paint(f"Error: No agent found with name: {agent_name}", ERROR, stream=sys.stderr),
+                file=sys.stderr,
+            )
+            return 1
+        registry = AgentRegistry(root)
         agent = registry.get_agent_by_name(agent_name)
         if agent is None:
             print(
@@ -1411,6 +1430,16 @@ def config_instructions_command(args: argparse.Namespace) -> int:
     assembled, sources = resolve_user_instructions(agent_prompt, log_provenance=False)
 
     override = os.environ.get(ECOSYSTEM_INSTRUCTIONS_ENV)
+    # Both counts right-aligned in one field so the ``Included`` column does not
+    # move between rows: comparing ``Read`` against ``Included``, and rows
+    # against each other, is the whole reason both numbers are printed, and a
+    # column that shifts with the digit count defeats scanning down it. Sized
+    # from the data rather than a constant so the common small-number case
+    # stays tight.
+    count_width = max(
+        (len(f"{value:,}") for source in sources for value in (source.chars, source.included)),
+        default=1,
+    )
     print(paint("\n╭─ Custom instructions, in assembly order ──────", SUCCESS))
     for index, source in enumerate(sources, start=1):
         label = source.label
@@ -1422,7 +1451,8 @@ def config_instructions_command(args: argparse.Namespace) -> int:
         # operator is trying to confirm, and a single figure cannot express it.
         print(
             paint(
-                f"│    Read: {source.chars:,} chars   Included: {source.included:,} chars",
+                f"│    Read: {source.chars:>{count_width},} chars"
+                f"   Included: {source.included:>{count_width},} chars",
                 SUCCESS,
             )
         )
@@ -1435,7 +1465,25 @@ def config_instructions_command(args: argparse.Namespace) -> int:
             # A path with no bytes behind it reads as a file that exists and is
             # being used. Saying so keeps the default install (no
             # system_prompt.md) from looking like a configured-but-broken one.
-            print(paint("│    Empty: no file at that path, or nothing in it", SUCCESS))
+            #
+            # Imported rows state the stronger fact: the loader only lists paths
+            # that resolve to a real file, so an imported row with zero
+            # characters is a file that EXISTS and is blank — not a path that
+            # might be empty. Reporting the disjunction there would repeat, one
+            # level down, the "no imported file exists" claim about a path that
+            # has one.
+            #
+            # CYAN, not SUCCESS: every other line in the box — chrome, headers,
+            # counts — is green, so a green annotation carries no signal at all,
+            # and this is the row the DEFAULT install shows. The ladder is green
+            # = normal contribution, cyan = present but contributed nothing,
+            # yellow = degraded.
+            empty_note = (
+                "Empty: the file is there but holds no instructions"
+                if source.label == "imported"
+                else "Empty: no file at that path, or nothing in it"
+            )
+            print(paint(f"│    {empty_note}", CYAN))
         if source.collapsed:
             print(
                 paint(
@@ -1445,11 +1493,34 @@ def config_instructions_command(args: argparse.Namespace) -> int:
             )
         if source.truncated:
             print(paint("│    Truncated: hit the size cap; the tail was dropped", WARNING))
+        if source.overlaps:
+            # The superset arrangement, which the digest collapse cannot catch
+            # and which two rows of non-zero "Included" cannot distinguish from
+            # two genuinely distinct files. WARNING, matching ``Truncated:``:
+            # this is a cost the operator is paying on every cached request and
+            # can remove. The overlapping TEXT is never printed — the count and
+            # the other source's label are the whole answer.
+            print(
+                paint(
+                    f"│    Overlaps: contains all {source.overlap_chars:,} chars of "
+                    f'"{source.overlaps}" verbatim; both copies are sent',
+                    WARNING,
+                )
+            )
     if not sources:
         print(paint("│ (none — no instruction sources resolved)", SUCCESS))
+    # The recurrence, not just the headroom: without it the counts read as file
+    # sizes rather than as a cost paid again on every request, which is the
+    # framing the guide uses and the reason the numbers are worth showing.
     print(
         paint(
             f"│ Total assembled: {len(assembled):,} of {MAX_USER_INSTRUCTIONS_CHARS:,} chars",
+            SUCCESS,
+        )
+    )
+    print(
+        paint(
+            "│ Re-sent with every request, in every session and subagent",
             SUCCESS,
         )
     )
@@ -1484,14 +1555,25 @@ def config_instructions_command(args: argparse.Namespace) -> int:
         )
         print(paint(f"│ Files read: none — {reason}", SUCCESS))
     else:
+        # "Files read" is plural and reads as a heading, so repeating it per row
+        # made a two-file install read as two separate answers to one question.
+        # Printed once with the entries indented beneath, matching the
+        # four-space continuation the first box already uses — but only in the
+        # multi-row case, since a lone "Files read: <path>" is correct as one
+        # line and splitting it would cost a row for nothing.
+        if len(imported) > 1:
+            print(paint("│ Files read:", SUCCESS))
         for source in imported:
             if source.unreadable:
                 state = "unreadable; skipped"
             elif source.collapsed:
                 state = "collapsed"
+            elif source.chars == 0:
+                state = "empty"
             else:
                 state = f"{source.included:,} chars"
-            print(paint(f"│ Files read: {source.path} ({state})", SUCCESS))
+            prefix = "│    " if len(imported) > 1 else "│ Files read: "
+            print(paint(f"{prefix}{source.path} ({state})", SUCCESS))
     print(
         paint(
             "│ Read-only: system_prompt.md stays the only file lop writes",

--- a/local_operator/ecosystem_instructions.py
+++ b/local_operator/ecosystem_instructions.py
@@ -231,6 +231,24 @@ def read_ecosystem_instructions(
             continue
         stripped = text.strip()
         if not stripped:
+            # A record, not a ``continue``: the file EXISTS. Dropping it here made
+            # the report say "no imported file exists at those paths" about a
+            # path that has a file on it, which is the mirror image of the
+            # mistake ``InstructionSource.unreadable`` exists to prevent — an
+            # operator who truncated their shared file while debugging would be
+            # sent looking for a missing file instead of at the empty one they
+            # have. Its digest is deliberately NOT added to ``seen``: nothing
+            # was contributed, so it cannot collapse a later file.
+            records.append(
+                EcosystemFile(
+                    path=path,
+                    text="",
+                    chars=0,
+                    collapsed=False,
+                    truncated=truncated,
+                    unreadable=False,
+                )
+            )
             continue
         digest = content_digest(stripped)
         collapsed = digest in seen

--- a/local_operator/ecosystem_instructions.py
+++ b/local_operator/ecosystem_instructions.py
@@ -66,6 +66,7 @@ import hashlib
 import logging
 import os
 import stat
+from dataclasses import dataclass
 from pathlib import Path
 
 logger = logging.getLogger("local_operator.ecosystem_instructions")
@@ -87,6 +88,32 @@ ECOSYSTEM_INSTRUCTIONS_ENV = "LOCAL_OPERATOR_ECOSYSTEM_INSTRUCTIONS"
 #: budget by the caller; this one exists so a single pathological file is never
 #: read into memory whole just to be discarded a moment later.
 MAX_FILE_BYTES = 64 * 1024
+
+
+@dataclass(frozen=True)
+class EcosystemFile:
+    """What one imported file contributed, or why it contributed nothing.
+
+    Exists because the INFO log below is not an answer an operator can ask a
+    question of: it is emitted once at session construction, lands in the
+    rotating log file under the TUI, and says nothing at all about a file that
+    was collapsed or truncated. ``lop config instructions`` renders these
+    records, so the same read that feeds the prompt is the one reported —
+    a second implementation of "what is lop reading" would be free to drift
+    from the first, which is the exact class of divergence this type exists to
+    close.
+
+    ``text`` is empty for every non-contributing outcome; ``chars`` still
+    reports what was READ, so a collapsed duplicate can be shown with its size
+    rather than as a blank row.
+    """
+
+    path: Path
+    text: str
+    chars: int
+    collapsed: bool
+    truncated: bool
+    unreadable: bool
 
 
 def content_digest(text: str) -> str:
@@ -115,8 +142,14 @@ def ecosystem_instruction_files() -> list[Path]:
     return [candidate for candidate in candidates if candidate.is_file()]
 
 
-def _read_bounded(path: Path) -> str:
+def _read_bounded(path: Path) -> tuple[str, bool]:
     """Read one regular file, following links, without exceeding the cap.
+
+    Returns the text and whether the cap CUT it. The flag is returned rather
+    than left to the warning below because the provenance report has to state
+    truncation as a fact about the file, and re-deriving it from the returned
+    length would be wrong for multi-byte content: a 64 KiB read can decode to
+    fewer than ``MAX_FILE_BYTES`` characters and look untouched.
 
     Symlinks are followed (see the module docstring), but a non-regular target
     is still refused: this runs on the synchronous session-construction path
@@ -145,7 +178,8 @@ def _read_bounded(path: Path) -> str:
             probe = stream.read(MAX_FILE_BYTES + 1)
     finally:
         os.close(descriptor)
-    if len(probe) > MAX_FILE_BYTES:
+    truncated = len(probe) > MAX_FILE_BYTES
+    if truncated:
         logger.warning(
             "ecosystem instructions at %s exceed %d bytes; reading the first %d",
             path,
@@ -154,11 +188,19 @@ def _read_bounded(path: Path) -> str:
         )
     # ``utf-8-sig`` for the same reason the native loader uses it: a BOM from a
     # Windows editor would otherwise survive into the prompt ahead of rule one.
-    return probe[:MAX_FILE_BYTES].decode("utf-8-sig", errors="replace")
+    return probe[:MAX_FILE_BYTES].decode("utf-8-sig", errors="replace"), truncated
 
 
-def load_ecosystem_instructions(skip_digests: frozenset[str] = frozenset()) -> str:
-    """Imported user-scope instructions, joined in order. ``""`` when there are none.
+def read_ecosystem_instructions(
+    skip_digests: frozenset[str] = frozenset(),
+) -> list[EcosystemFile]:
+    """Read every imported file in order, recording what each one contributed.
+
+    The single read that both the prompt and the provenance report are built
+    from. It is deliberately SILENT — :func:`log_ecosystem_provenance` emits the
+    records — so that a caller whose entire output is the provenance (``lop
+    config instructions``) does not print the same fact twice, once as a log
+    line on stderr and once inside its own box.
 
     ``skip_digests`` carries the digests of content the caller has ALREADY
     taken — in practice ``system_prompt.md`` — so an operator who generates the
@@ -166,35 +208,75 @@ def load_ecosystem_instructions(skip_digests: frozenset[str] = frozenset()) -> s
     cached request.
 
     Failures degrade rather than breaking startup, matching
-    ``load_user_instructions``: an unreadable file is skipped and undecodable
-    bytes are replaced, because a bad byte in a shared instructions file should
-    cost one glyph, never a session.
+    ``load_user_instructions``: an unreadable file is recorded and skipped and
+    undecodable bytes are replaced, because a bad byte in a shared instructions
+    file should cost one glyph, never a session.
     """
-    parts: list[str] = []
+    records: list[EcosystemFile] = []
     seen = set(skip_digests)
     for path in ecosystem_instruction_files():
         try:
-            text = _read_bounded(path)
+            text, truncated = _read_bounded(path)
         except OSError:
+            records.append(
+                EcosystemFile(
+                    path=path,
+                    text="",
+                    chars=0,
+                    collapsed=False,
+                    truncated=False,
+                    unreadable=True,
+                )
+            )
             continue
         stripped = text.strip()
         if not stripped:
             continue
         digest = content_digest(stripped)
-        if digest in seen:
-            logger.debug("skipping %s: identical to instructions already loaded", path)
-            continue
+        collapsed = digest in seen
         seen.add(digest)
-        # INFO, not DEBUG: this file is written by another tool and named in no
-        # lop-owned setting, yet it changes the system prompt of every session
-        # and every subagent — the one import whose provenance an operator
-        # cannot otherwise recover. It is not startup chatter: the record is
-        # emitted only when a file actually EXISTS and actually contributed, so
-        # the default install (no ``~/.agents/AGENTS.md``) stays silent, and on
-        # the TUI it lands in the rotating log file rather than on screen
-        # because ``file_logging`` detaches the console handlers. The dedup
-        # skip above stays at DEBUG: nothing reached the prompt, so there is
-        # nothing to account for.
-        logger.info("loaded ecosystem instructions from %s (%d chars)", path, len(stripped))
-        parts.append(stripped)
-    return "\n\n".join(parts)
+        records.append(
+            EcosystemFile(
+                path=path,
+                text="" if collapsed else stripped,
+                chars=len(stripped),
+                collapsed=collapsed,
+                truncated=truncated,
+                unreadable=False,
+            )
+        )
+    return records
+
+
+def log_ecosystem_provenance(records: list[EcosystemFile]) -> None:
+    """Record which imported files reached the prompt.
+
+    INFO, not DEBUG: these files are written by another tool and named in no
+    lop-owned setting, yet they change the system prompt of every session and
+    every subagent — the one import whose provenance an operator cannot
+    otherwise recover. It is not startup chatter: a record is emitted only when
+    a file actually EXISTS and actually contributed, so the default install (no
+    ``~/.agents/AGENTS.md``) stays silent, and on the TUI it lands in the
+    rotating log file rather than on screen because ``file_logging`` detaches
+    the console handlers. The dedup skip stays at DEBUG: nothing reached the
+    prompt, so there is nothing to account for.
+    """
+    for record in records:
+        if record.collapsed:
+            logger.debug("skipping %s: identical to instructions already loaded", record.path)
+        elif record.text:
+            logger.info(
+                "loaded ecosystem instructions from %s (%d chars)", record.path, record.chars
+            )
+
+
+def load_ecosystem_instructions(skip_digests: frozenset[str] = frozenset()) -> str:
+    """Imported user-scope instructions, joined in order. ``""`` when there are none.
+
+    The joining half of :func:`read_ecosystem_instructions`, kept as the plain
+    text-returning entry point for callers that want the content and not the
+    accounting.
+    """
+    records = read_ecosystem_instructions(skip_digests)
+    log_ecosystem_provenance(records)
+    return "\n\n".join(record.text for record in records if record.text)

--- a/local_operator/guides/configuration/GUIDE.md
+++ b/local_operator/guides/configuration/GUIDE.md
@@ -72,7 +72,9 @@ Keep the file free of secrets and of absolute home paths (prefer `~/`) when it m
 
 ### Imported instructions (`~/.agents/AGENTS.md`)
 
-Local Operator also reads `~/.agents/AGENTS.md`, the tool-neutral user-scope file Claude Code, Codex, opencode and droid have converged on, so one set of standing preferences serves every harness without a second copy under a lop-specific name. That directory and no other by default because Local Operator already scans `~/.agents/skills`; `~/.local-operator/AGENTS.md` is deliberately **not** read, since with both it and `system_prompt.md` present there would be no single answer to what `GET /v1/config/system-prompt` returns or where `PATCH` writes.
+Local Operator also reads `~/.agents/AGENTS.md`, so one set of standing preferences can serve several harnesses without a second copy under a lop-specific name. There is no standard for *user-scope* agent instructions — the agents.md spec covers repository files only — but the **filename** has converged, and `~/.agents/` is a tool-neutral directory with more than one independent implementation (Cline, Factory droid). Local Operator chose it because it already scans `~/.agents/skills`, so this needs no new relationship with a path it does not already know. `~/.local-operator/AGENTS.md` is deliberately **not** read, since with both it and `system_prompt.md` present there would be no single answer to what `GET /v1/config/system-prompt` returns or where `PATCH` writes.
+
+Other harnesses keep their user-scope instructions elsewhere — Claude Code in `~/.claude/CLAUDE.md`, Codex in `~/.codex/AGENTS.md` — and Local Operator does **not** read those paths. Point it at one with the redirect below if that is where your rules already live.
 
 - **Read-only.** `system_prompt.md` remains the sole write target of Settings → **Instructions** and `GET`/`PATCH /v1/config/system-prompt`. Local Operator never writes an imported file.
 - **Order and precedence**: imported file first, then `system_prompt.md`, then the selected agent profile's prompt. Later text reads as the more specific instruction, so your own `system_prompt.md` wins over the shared file and the profile outranks both.
@@ -83,7 +85,7 @@ export LOCAL_OPERATOR_ECOSYSTEM_INSTRUCTIONS=~/.config/AGENTS.md:~/team/AGENTS.m
 export LOCAL_OPERATOR_ECOSYSTEM_INSTRUCTIONS=   # off
 ```
 
-Each imported file is capped at 64 KiB at read; the assembled result is then bounded on the same 64,000-character budget described above, where the imported text is a third source with its own 16,000-character floor, so it can neither crowd out nor be crowded out by the other two.
+Each imported file is capped at 64 KiB at read; the assembled result is then bounded on the same 64,000-character budget described above. The imported text and the agent profile each hold a **16,000-character floor**; `system_prompt.md` has none and takes whatever remains. So a large imported file — written by another tool, and one you may not know is there — **can** truncate your own `system_prompt.md`, silently dropping its last rules: with a 40,000-character `~/.agents/AGENTS.md`, a 62,000-character `system_prompt.md` is cut to 47,998. `local-operator config instructions` marks the file that lost text with `Truncated:`, and truncation is logged as a warning.
 
 **Watch the duplicate collapse.** Content byte-identical to `system_prompt.md` (whitespace-stripped) is loaded once instead of twice. The collapse is keyed on a digest of the **whole file**, so a `system_prompt.md` that is a *superset* of the shared file — shared rules plus a lop-only overlay, the natural arrangement when maintaining one rule set across harnesses — does **not** collapse, and you pay for both copies in the cached prefix of every request, in every session and every subagent. Check with:
 
@@ -91,7 +93,16 @@ Each imported file is capped at 64 KiB at read; the assembled result is then bou
 local-operator config instructions
 ```
 
-It prints each source, its resolved path, characters read versus included, and whether it was collapsed or truncated — never the contents. Two rows both reporting non-zero "Included" for the same rules means no collapse: either keep the shared file and the lop-only file **disjoint**, or make them byte-identical.
+It prints each source, its resolved path, characters read versus included, and whether it was collapsed or truncated — never the contents. A superset is named explicitly, so you do not have to infer it from the counts:
+
+```
+│ 2. system_prompt.md
+│    Path: ~/.local-operator/system_prompt.md
+│    Read: 1,124 chars   Included: 1,124 chars
+│    Overlaps: contains all 1,079 chars of "imported" verbatim; both copies are sent
+```
+
+An `Overlaps:` row means you are paying twice for those characters on every request. Fix it by keeping the shared file and the lop-only file **disjoint** — move the overlapping rules out of `system_prompt.md` — or by making them byte-identical, which collapses instead. Two rows with no `Overlaps:` line are two genuinely distinct sources and are nothing to fix.
 
 ## Set the default provider and model
 

--- a/local_operator/guides/configuration/GUIDE.md
+++ b/local_operator/guides/configuration/GUIDE.md
@@ -20,6 +20,7 @@ Use the CLI to avoid guessing:
 local-operator config create
 local-operator config open
 local-operator config list
+local-operator config instructions
 ```
 
 `config create` and `config open` print the resolved backend path. Main files under that root include:
@@ -39,7 +40,7 @@ Standing user preferences — commit conventions, review gates, where projects l
 <config root>/system_prompt.md
 ```
 
-That single file is what the desktop UI's Settings → **Instructions** box edits and what `GET`/`PATCH /v1/config/system-prompt` reads and writes, so the CLI, TUI, server, and desktop app all share one definition of "custom instructions". There is no `AGENTS.md` mechanism and no `custom_instructions` key in `config.yml`; writing either does nothing.
+That single file is what the desktop UI's Settings → **Instructions** box edits and what `GET`/`PATCH /v1/config/system-prompt` reads and writes, so the CLI, TUI, server, and desktop app all share one definition of "custom instructions". There is no `custom_instructions` key in `config.yml`; writing one does nothing. A user-scope `AGENTS.md` **is** read, but from the shared agent-tool directory and read-only — see "Imported instructions" below.
 
 To install or update them, write the file directly, resolving the root by the rule at the top of this guide so the commands stay correct under `LOCAL_OPERATOR_CONFIG_DIR`:
 
@@ -68,6 +69,29 @@ How the content is used:
 The content is capped at 64,000 characters, past which it is truncated with an explicit marker and a logged warning, because it is re-sent as the cached prefix of every request. The global file and an agent profile's prompt are bounded separately so neither can crowd the other out: each is guaranteed at least 16,000 characters and may spend whatever the other leaves, so a file under that share costs the other source nothing.
 
 Keep the file free of secrets and of absolute home paths (prefer `~/`) when it may be shared. For task-specific knowledge that should load only when relevant, prefer a skill (`extensions` guide) over adding bulk here: this file is in context for every single turn.
+
+### Imported instructions (`~/.agents/AGENTS.md`)
+
+Local Operator also reads `~/.agents/AGENTS.md`, the tool-neutral user-scope file Claude Code, Codex, opencode and droid have converged on, so one set of standing preferences serves every harness without a second copy under a lop-specific name. That directory and no other by default because Local Operator already scans `~/.agents/skills`; `~/.local-operator/AGENTS.md` is deliberately **not** read, since with both it and `system_prompt.md` present there would be no single answer to what `GET /v1/config/system-prompt` returns or where `PATCH` writes.
+
+- **Read-only.** `system_prompt.md` remains the sole write target of Settings → **Instructions** and `GET`/`PATCH /v1/config/system-prompt`. Local Operator never writes an imported file.
+- **Order and precedence**: imported file first, then `system_prompt.md`, then the selected agent profile's prompt. Later text reads as the more specific instruction, so your own `system_prompt.md` wins over the shared file and the profile outranks both.
+- **Redirect or disable** with `LOCAL_OPERATOR_ECOSYSTEM_INSTRUCTIONS`: a colon-separated path list that *replaces* the default set, and an **empty value disables the import entirely**.
+
+```bash
+export LOCAL_OPERATOR_ECOSYSTEM_INSTRUCTIONS=~/.config/AGENTS.md:~/team/AGENTS.md
+export LOCAL_OPERATOR_ECOSYSTEM_INSTRUCTIONS=   # off
+```
+
+Each imported file is capped at 64 KiB at read; the assembled result is then bounded on the same 64,000-character budget described above, where the imported text is a third source with its own 16,000-character floor, so it can neither crowd out nor be crowded out by the other two.
+
+**Watch the duplicate collapse.** Content byte-identical to `system_prompt.md` (whitespace-stripped) is loaded once instead of twice. The collapse is keyed on a digest of the **whole file**, so a `system_prompt.md` that is a *superset* of the shared file — shared rules plus a lop-only overlay, the natural arrangement when maintaining one rule set across harnesses — does **not** collapse, and you pay for both copies in the cached prefix of every request, in every session and every subagent. Check with:
+
+```bash
+local-operator config instructions
+```
+
+It prints each source, its resolved path, characters read versus included, and whether it was collapsed or truncated — never the contents. Two rows both reporting non-zero "Included" for the same rules means no collapse: either keep the shared file and the lop-only file **disjoint**, or make them byte-identical.
 
 ## Set the default provider and model
 

--- a/local_operator/guides/configuration/GUIDE.md
+++ b/local_operator/guides/configuration/GUIDE.md
@@ -93,16 +93,25 @@ Each imported file is capped at 64 KiB at read; the assembled result is then bou
 local-operator config instructions
 ```
 
-It prints each source, its resolved path, characters read versus included, and whether it was collapsed or truncated — never the contents. A superset is named explicitly, so you do not have to infer it from the counts:
+It prints each source, its resolved path, characters read versus included, and whether it was collapsed or truncated — never the contents. A duplicated span is named explicitly, so you do not have to infer it from the counts:
 
 ```
 │ 2. system_prompt.md
 │    Path: ~/.local-operator/system_prompt.md
 │    Read: 1,124 chars   Included: 1,124 chars
-│    Overlaps: contains all 1,079 chars of "imported" verbatim; both copies are sent
+│    Overlaps: contains source 1 verbatim (1,079 chars); both copies are sent
 ```
 
-An `Overlaps:` row means you are paying twice for those characters on every request. Fix it by keeping the shared file and the lop-only file **disjoint** — move the overlapping rules out of `system_prompt.md` — or by making them byte-identical, which collapses instead. Two rows with no `Overlaps:` line are two genuinely distinct sources and are nothing to fix.
+The row names the other source by its **row number** in the same box, since several imported paths all print as `imported`. It reads either way round — the migration case, where the rules moved into `~/.agents/AGENTS.md` and grew there while the old `system_prompt.md` was left behind as a subset, prints on the smaller file instead:
+
+```
+│ 2. system_prompt.md
+│    Overlaps: verbatim inside source 1 (1,079 chars); both copies are sent
+```
+
+An `Overlaps:` row means you are paying twice for those characters on every request. Fix it by keeping the shared file and the lop-only file **disjoint** — move the overlapping rules out of whichever file is the copy — or, when one is wholly inside the other, by deleting the subset or making the two byte-identical, which collapses instead.
+
+Two rows with no `Overlaps:` line are not a certificate of no duplication: the check is whole-source containment with a 200-character floor, so it does not catch two files that share a paragraph while each holding rules the other does not, and it does not report spans under 200 characters. It also stays silent for a source the size cap already cut — that row carries `Truncated:` instead, and a claim that both copies are sent whole would be untrue of text the prompt partly dropped.
 
 ## Set the default provider and model
 

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -33,7 +33,7 @@ import logging
 import os
 import sys
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
@@ -776,6 +776,22 @@ class InstructionSource:
     #: the ordinary state of an install that simply has no such file, and
     #: reporting both as "empty" sends the operator to the wrong one.
     unreadable: bool = False
+    #: Label of an EARLIER source whose text this one contains verbatim, and how
+    #: many characters that is. The superset arrangement — shared rules plus a
+    #: lop-only overlay in ``system_prompt.md`` — is the case the digest
+    #: collapse cannot catch, so both copies ride the cached prefix of every
+    #: request. Without this the frame is identical to two genuinely distinct
+    #: files, and "two rows with non-zero Included" is true of every healthy
+    #: multi-source install, so it cannot be the diagnosis.
+    #:
+    #: Containment rather than equality, and it does not double-report the
+    #: collapse: an imported file byte-identical to ``system_prompt.md`` is
+    #: dropped upstream and arrives with empty ``text``, so it is excluded from
+    #: the test. An agent PROFILE equal to an earlier source is a different
+    #: matter — profiles are never collapsed — and is flagged, correctly: both
+    #: copies really are in the prompt.
+    overlaps: str | None = None
+    overlap_chars: int = 0
 
 
 def resolve_user_instructions(
@@ -867,32 +883,57 @@ def resolve_user_instructions(
 
     # The whole-source cap is reported per imported FILE rather than against
     # the joined block: with several override paths the operator needs to know
-    # which file lost text, and the join is what the budget acts on. Attributing
-    # the cut to the last file read is the only accurate answer, since the
-    # earlier ones are what consumed the budget.
-    ecosystem_cut = len(ecosystem_raw) - len(ecosystem_text)
+    # which file lost text, and the join is what the budget acts on. The budget
+    # truncates that joined block from the TAIL, so a cut larger than the last
+    # file also eats the tail of the file before it. Charging the whole cut to
+    # the last contributor therefore credited earlier files with text that never
+    # reached the prompt — rows summing to 107,998 "included" characters inside a
+    # 64,000-character total, with the file that actually lost 44k carrying no
+    # truncation flag. Walking the SURVIVING length forward instead reproduces
+    # how the block was actually cut, so each file is credited only what its own
+    # span contributed.
+    #
+    # ``remaining`` is measured against the ASSEMBLED block rather than the raw
+    # one, which means the truncation marker rides with the file whose tail it
+    # replaced. That is deliberate: it keeps ``sum(included) + separators ==
+    # len(assembled)`` exactly true, and a report whose own rows do not add up to
+    # its own total is the defect class this whole surface exists to close.
+    remaining = len(ecosystem_text)
+    emitted = False
     sources: list[InstructionSource] = []
-    for index, record in enumerate(ecosystem_records):
-        is_last_contributor = index == max(
-            (i for i, r in enumerate(ecosystem_records) if r.text), default=-1
-        )
+    # What each source actually held, positionally parallel to ``sources``, for
+    # the containment test below. Empty for a source that contributed nothing.
+    raw_texts: list[str] = []
+    for record in ecosystem_records:
+        if record.text:
+            if emitted:
+                # The "\n\n" join before this file, charged to neither side.
+                remaining = max(0, remaining - 2)
+            included = min(record.chars, remaining)
+            remaining -= included
+            emitted = emitted or included > 0
+        else:
+            # Collapsed, empty or unreadable: contributed nothing, and consumed
+            # no separator either.
+            included = 0
+        raw_texts.append(record.text)
         sources.append(
             InstructionSource(
                 label="imported",
                 path=record.path,
                 chars=record.chars,
-                included=(
-                    max(0, record.chars - ecosystem_cut)
-                    if is_last_contributor
-                    else (record.chars if record.text else 0)
-                ),
+                included=included,
                 collapsed=record.collapsed,
                 # Truncated by the per-FILE 64 KiB read cap, or by the shared
-                # instructions budget landing on this file.
-                truncated=record.truncated or (is_last_contributor and ecosystem_cut > 0),
+                # instructions budget landing on this file. Guarded on
+                # ``record.text`` so a collapsed file — which also has
+                # ``included`` 0 against a non-zero ``chars`` — is not reported
+                # as truncated on top of being reported as collapsed.
+                truncated=record.truncated or (bool(record.text) and included < record.chars),
                 unreadable=record.unreadable,
             )
         )
+    raw_texts.append(global_raw)
     sources.append(
         InstructionSource(
             label="system_prompt.md",
@@ -904,6 +945,7 @@ def resolve_user_instructions(
         )
     )
     if agent_raw:
+        raw_texts.append(agent_raw)
         sources.append(
             InstructionSource(
                 label="agent profile",
@@ -914,6 +956,34 @@ def resolve_user_instructions(
                 truncated=len(agent_text) < len(agent_raw),
             )
         )
+
+    # Duplicate content the collapse cannot catch. The digest collapse is keyed
+    # on the WHOLE file, so a native file that is a superset of the shared one
+    # ships both copies in every cached request — the expensive arrangement, and
+    # the one the frame could not previously distinguish from two healthy
+    # distinct files. A plain containment test on text already in hand: no new
+    # read, no new arithmetic, and CPython's substring search over a handful of
+    # sources bounded at 64,000 characters is not work worth avoiding.
+    #
+    # Restricted to sources that survived WHOLE (``included == chars``) so the
+    # row can say both copies are sent without qualification: a source the
+    # budget already cut carries a ``Truncated:`` row, and claiming a verbatim
+    # duplicate of text that was itself partly dropped would be the report
+    # asserting something the prompt does not do.
+    whole = [
+        (index, raw)
+        for index, (source, raw) in enumerate(zip(sources, raw_texts))
+        if raw and source.included == source.chars
+    ]
+    for position, (index, raw) in enumerate(whole):
+        for earlier_index, earlier_raw in whole[:position]:
+            if earlier_raw in raw:
+                sources[index] = replace(
+                    sources[index],
+                    overlaps=sources[earlier_index].label,
+                    overlap_chars=len(earlier_raw),
+                )
+                break
 
     # Imported first, native second, profile last: later text is read as the
     # more specific instruction, so lop's own file outranks the shared one and

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -44,7 +44,8 @@ from local_operator.ansi import sanitize_prompt_line
 # startup path that ``test_import_graph`` guards.
 from local_operator.ecosystem_instructions import (
     content_digest,
-    load_ecosystem_instructions,
+    log_ecosystem_provenance,
+    read_ecosystem_instructions,
 )
 from local_operator.harness.types import AgentMessage, Message
 
@@ -745,6 +746,182 @@ def _env_details(cwd: str | None = None) -> str:
     )
 
 
+@dataclass(frozen=True)
+class InstructionSource:
+    """One contributor to the assembled custom instructions, as assembled.
+
+    The accounting half of :func:`resolve_user_instructions`, and the reason
+    that function exists at all. ``lop config instructions`` answers "what
+    instructions am I actually running" from these records rather than from its
+    own reimplementation of the budget arithmetic below — a report derived from
+    a second copy of that arithmetic would drift from the prompt on the first
+    change to either, which is the same class of divergence (documentation
+    disagreeing with the code in the same install) that issue #822 reported.
+
+    ``chars`` is what the source held; ``included`` is what survived the
+    collapse and the cap, so a row can state the difference rather than
+    reporting the smaller number as the whole truth. ``path`` is ``None`` for
+    the agent profile, whose prompt comes from the registry database and has no
+    file an operator could open.
+    """
+
+    label: str
+    path: Path | None
+    chars: int
+    included: int
+    collapsed: bool
+    truncated: bool
+    #: The file exists but could not be read (permissions, a fifo swapped in).
+    #: Distinct from a zero-length file: one is a mistake to fix, the other is
+    #: the ordinary state of an install that simply has no such file, and
+    #: reporting both as "empty" sends the operator to the wrong one.
+    unreadable: bool = False
+
+
+def resolve_user_instructions(
+    agent_prompt: str = "",
+    *,
+    log_provenance: bool = True,
+) -> tuple[str, list[InstructionSource]]:
+    """Assemble the custom instructions AND account for where they came from.
+
+    Split out of :func:`load_user_instructions` — whose docstring carries the
+    behavioural contract — so the provenance surface reads the same assembly
+    the prompt does. See :class:`InstructionSource` for why a second
+    implementation of this arithmetic was not acceptable.
+
+    The returned records are in ASSEMBLY order, which is the fact operators get
+    wrong and the reason the report exists at all.
+
+    ``log_provenance=False`` is for the ONE caller whose entire output already
+    IS the provenance (``lop config instructions``): there the INFO record
+    would print the same file and size to stderr immediately above the box
+    reporting it, so the command would contradict nothing and repeat
+    everything. Every session path leaves it on — the log is the only trace a
+    running session leaves of an import it did not name.
+    """
+    parts: list[str] = []
+    # ``is_file()`` follows symlinks deliberately: pointing the file at a
+    # dotfiles checkout is a normal way to version instructions.
+    path = app_config_dir() / "system_prompt.md"
+    try:
+        if path.is_file():
+            parts.append(path.read_text(encoding="utf-8-sig", errors="replace"))
+    except OSError:
+        pass
+
+    # Each source is bounded on its OWN budget before joining. Capping only
+    # the joined string let a full-size global file consume the whole budget
+    # and silently discard the selected agent's profile prompt entirely,
+    # inverting the documented layering: the machine-wide file would discard
+    # the profile the operator explicitly chose.
+    #
+    # The split is a FLOOR each way, never a flat tax. Subtracting the
+    # reserve unconditionally cut a 64k global file to 48k even with no agent
+    # selected, handing the 16k to nobody; capping the profile at the reserve
+    # unconditionally did the mirror image to a large profile when the global
+    # file was small. So each source may spend whatever the other leaves,
+    # down to its own guaranteed share.
+    global_raw = "\n\n".join(part.strip() for part in parts if part.strip())
+    agent_raw = agent_prompt.strip()
+    # The digest is handed down so a shared file byte-identical to the native
+    # one is dropped rather than duplicated into every cached request.
+    ecosystem_records = read_ecosystem_instructions(
+        skip_digests=frozenset({content_digest(global_raw)} if global_raw else ())
+    )
+    if log_provenance:
+        log_ecosystem_provenance(ecosystem_records)
+    ecosystem_raw = "\n\n".join(record.text for record in ecosystem_records if record.text).strip()
+
+    # The "\n\n" joins are only emitted between sources that SURVIVE, so the
+    # characters are only withheld then. Keyed off the agent text alone, a
+    # profile that fits the documented cap exactly was truncated by two
+    # characters while a global file of the same size passed whole.
+    present = sum(1 for raw in (ecosystem_raw, global_raw, agent_raw) if raw)
+    separator = 2 * max(0, present - 1)
+    # Bounded in ascending order of ownership: the imported file first, then
+    # the profile, and the operator's own file takes the remainder. Each may
+    # spend what the others leave, down to its own floor — so a lone 64k source
+    # is still whole, and no source is taxed for room the others never use.
+    ecosystem_text = _bound_instructions(
+        ecosystem_raw,
+        "imported user-scope instructions",
+        max(
+            _ECOSYSTEM_INSTRUCTIONS_RESERVE,
+            MAX_USER_INSTRUCTIONS_CHARS - len(global_raw) - len(agent_raw) - separator,
+        ),
+    )
+    agent_text = _bound_instructions(
+        agent_raw,
+        "the selected agent's profile",
+        max(
+            _AGENT_INSTRUCTIONS_RESERVE,
+            MAX_USER_INSTRUCTIONS_CHARS - len(ecosystem_text) - len(global_raw) - separator,
+        ),
+    )
+    global_text = _bound_instructions(
+        global_raw,
+        str(path),
+        MAX_USER_INSTRUCTIONS_CHARS - len(ecosystem_text) - len(agent_text) - separator,
+    )
+
+    # The whole-source cap is reported per imported FILE rather than against
+    # the joined block: with several override paths the operator needs to know
+    # which file lost text, and the join is what the budget acts on. Attributing
+    # the cut to the last file read is the only accurate answer, since the
+    # earlier ones are what consumed the budget.
+    ecosystem_cut = len(ecosystem_raw) - len(ecosystem_text)
+    sources: list[InstructionSource] = []
+    for index, record in enumerate(ecosystem_records):
+        is_last_contributor = index == max(
+            (i for i, r in enumerate(ecosystem_records) if r.text), default=-1
+        )
+        sources.append(
+            InstructionSource(
+                label="imported",
+                path=record.path,
+                chars=record.chars,
+                included=(
+                    max(0, record.chars - ecosystem_cut)
+                    if is_last_contributor
+                    else (record.chars if record.text else 0)
+                ),
+                collapsed=record.collapsed,
+                # Truncated by the per-FILE 64 KiB read cap, or by the shared
+                # instructions budget landing on this file.
+                truncated=record.truncated or (is_last_contributor and ecosystem_cut > 0),
+                unreadable=record.unreadable,
+            )
+        )
+    sources.append(
+        InstructionSource(
+            label="system_prompt.md",
+            path=path,
+            chars=len(global_raw),
+            included=len(global_text),
+            collapsed=False,
+            truncated=len(global_text) < len(global_raw),
+        )
+    )
+    if agent_raw:
+        sources.append(
+            InstructionSource(
+                label="agent profile",
+                path=None,
+                chars=len(agent_raw),
+                included=len(agent_text),
+                collapsed=False,
+                truncated=len(agent_text) < len(agent_raw),
+            )
+        )
+
+    # Imported first, native second, profile last: later text is read as the
+    # more specific instruction, so lop's own file outranks the shared one and
+    # the chosen profile outranks both.
+    assembled = "\n\n".join(part for part in (ecosystem_text, global_text, agent_text) if part)
+    return assembled, sources
+
+
 def load_user_instructions(agent_prompt: str = "") -> str:
     """Read the operator's standing custom instructions for the system prompt.
 
@@ -786,71 +963,7 @@ def load_user_instructions(agent_prompt: str = "") -> str:
     ``utf-8-sig`` strips a BOM that a Windows editor writes; without it the
     ``\ufeff`` survives into the prompt ahead of the first rule.
     """
-    parts: list[str] = []
-    # ``is_file()`` follows symlinks deliberately: pointing the file at a
-    # dotfiles checkout is a normal way to version instructions.
-    path = app_config_dir() / "system_prompt.md"
-    try:
-        if path.is_file():
-            parts.append(path.read_text(encoding="utf-8-sig", errors="replace"))
-    except OSError:
-        pass
-
-    # Each source is bounded on its OWN budget before joining. Capping only
-    # the joined string let a full-size global file consume the whole budget
-    # and silently discard the selected agent's profile prompt entirely,
-    # inverting the documented layering: the machine-wide file would discard
-    # the profile the operator explicitly chose.
-    #
-    # The split is a FLOOR each way, never a flat tax. Subtracting the
-    # reserve unconditionally cut a 64k global file to 48k even with no agent
-    # selected, handing the 16k to nobody; capping the profile at the reserve
-    # unconditionally did the mirror image to a large profile when the global
-    # file was small. So each source may spend whatever the other leaves,
-    # down to its own guaranteed share.
-    global_raw = "\n\n".join(part.strip() for part in parts if part.strip())
-    agent_raw = agent_prompt.strip()
-    # The digest is handed down so a shared file byte-identical to the native
-    # one is dropped rather than duplicated into every cached request.
-    ecosystem_raw = load_ecosystem_instructions(
-        skip_digests=frozenset({content_digest(global_raw)} if global_raw else ())
-    ).strip()
-
-    # The "\n\n" joins are only emitted between sources that SURVIVE, so the
-    # characters are only withheld then. Keyed off the agent text alone, a
-    # profile that fits the documented cap exactly was truncated by two
-    # characters while a global file of the same size passed whole.
-    present = sum(1 for raw in (ecosystem_raw, global_raw, agent_raw) if raw)
-    separator = 2 * max(0, present - 1)
-    # Bounded in ascending order of ownership: the imported file first, then
-    # the profile, and the operator's own file takes the remainder. Each may
-    # spend what the others leave, down to its own floor — so a lone 64k source
-    # is still whole, and no source is taxed for room the others never use.
-    ecosystem_text = _bound_instructions(
-        ecosystem_raw,
-        "imported user-scope instructions",
-        max(
-            _ECOSYSTEM_INSTRUCTIONS_RESERVE,
-            MAX_USER_INSTRUCTIONS_CHARS - len(global_raw) - len(agent_raw) - separator,
-        ),
-    )
-    agent_text = _bound_instructions(
-        agent_raw,
-        "the selected agent's profile",
-        max(
-            _AGENT_INSTRUCTIONS_RESERVE,
-            MAX_USER_INSTRUCTIONS_CHARS - len(ecosystem_text) - len(global_raw) - separator,
-        ),
-    )
-    global_text = _bound_instructions(
-        global_raw,
-        str(path),
-        MAX_USER_INSTRUCTIONS_CHARS - len(ecosystem_text) - len(agent_text) - separator,
-    )
-    # Imported first, native second, profile last: later text is read as the
-    # more specific instruction, so lop's own file outranks the shared one and
-    # the chosen profile outranks both.
-    return "\n\n".join(part for part in (ecosystem_text, global_text, agent_text) if part)
+    return resolve_user_instructions(agent_prompt)[0]
 
 
 def _bound_instructions(text: str, source: str, limit: int) -> str:

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -101,6 +101,18 @@ _AGENT_INSTRUCTIONS_RESERVE = 16_000
 #: standing preference of the same kind and the same order of magnitude.
 _ECOSYSTEM_INSTRUCTIONS_RESERVE = 16_000
 
+#: Floor on a shared span before ``Overlaps:`` claims it is worth removing.
+#: The containment test has no natural lower bound — a single ``-`` present in
+#: both files is literal containment — and a WARNING row advertising a one-
+#: character cost is exactly the warning operators learn to ignore, which is
+#: the failure this row was added to avoid. 200 characters is roughly a
+#: paragraph of standing rules: below it the row would cost more attention than
+#: the duplication costs context (200 chars ≈ 50 tokens on the cached prefix,
+#: and 0.3% of the 64,000-character budget), and no realistic shared rule set
+#: is smaller. Deliberately not scaled to file size: the operator is being told
+#: about an absolute cost re-paid on every request, not a ratio.
+_OVERLAP_MIN_CHARS = 200
+
 
 #: Modules whose import dominates :func:`create_session`, measured rather than
 #: guessed: on this machine ``mcp`` costs 443 ms and ``httpx`` 234 ms to import,
@@ -776,13 +788,18 @@ class InstructionSource:
     #: the ordinary state of an install that simply has no such file, and
     #: reporting both as "empty" sends the operator to the wrong one.
     unreadable: bool = False
-    #: Label of an EARLIER source whose text this one contains verbatim, and how
-    #: many characters that is. The superset arrangement — shared rules plus a
-    #: lop-only overlay in ``system_prompt.md`` — is the case the digest
+    #: 1-based ASSEMBLY INDEX of an earlier source this one shares text with,
+    #: and how many characters that is. The superset arrangement — shared rules
+    #: plus a lop-only overlay in ``system_prompt.md`` — is the case the digest
     #: collapse cannot catch, so both copies ride the cached prefix of every
     #: request. Without this the frame is identical to two genuinely distinct
     #: files, and "two rows with non-zero Included" is true of every healthy
     #: multi-source install, so it cannot be the diagnosis.
+    #:
+    #: An index rather than a label because labels are not unique: several
+    #: override paths all render as ``imported``, so a label named a row the
+    #: operator could not pick out of the box, and the remedy (edit one of these
+    #: two files) needs exactly that.
     #:
     #: Containment rather than equality, and it does not double-report the
     #: collapse: an imported file byte-identical to ``system_prompt.md`` is
@@ -790,8 +807,14 @@ class InstructionSource:
     #: the test. An agent PROFILE equal to an earlier source is a different
     #: matter — profiles are never collapsed — and is flagged, correctly: both
     #: copies really are in the prompt.
-    overlaps: str | None = None
+    overlaps_index: int | None = None
     overlap_chars: int = 0
+    #: Which way round the containment runs: ``True`` when THIS source holds all
+    #: of the earlier one, ``False`` when this source sits wholly inside it. The
+    #: two arrangements have different remedies — trim the superset, or delete
+    #: the subset — so the row has to say which one the operator is looking at,
+    #: and a single "these overlap" would send half of them to the wrong file.
+    overlap_contains: bool = True
 
 
 def resolve_user_instructions(
@@ -965,6 +988,15 @@ def resolve_user_instructions(
     # read, no new arithmetic, and CPython's substring search over a handful of
     # sources bounded at 64,000 characters is not work worth avoiding.
     #
+    # SYMMETRIC, because the cost is. An earlier version asked only whether a
+    # LATER source contained an EARLIER one, which is silent on the natural
+    # migration: rules move into ``~/.agents/AGENTS.md`` and grow there while the
+    # old ``system_prompt.md`` is left behind as a subset. Both copies ship in
+    # every request and no row fired — and the guide read that silence as an
+    # all-clear, which is issue #822's own shape (a claim the code does not
+    # make). Measured at 41 µs for 64 KiB-in-64 KiB, so the second direction is
+    # free.
+    #
     # Restricted to sources that survived WHOLE (``included == chars``) so the
     # row can say both copies are sent without qualification: a source the
     # budget already cut carries a ``Truncated:`` row, and claiming a verbatim
@@ -977,13 +1009,24 @@ def resolve_user_instructions(
     ]
     for position, (index, raw) in enumerate(whole):
         for earlier_index, earlier_raw in whole[:position]:
-            if earlier_raw in raw:
-                sources[index] = replace(
-                    sources[index],
-                    overlaps=sources[earlier_index].label,
-                    overlap_chars=len(earlier_raw),
-                )
-                break
+            # Equal-length texts satisfy both directions; "contains" is tried
+            # first so an agent profile identical to an earlier source keeps
+            # reading as the superset case rather than flipping on tie order.
+            if len(earlier_raw) >= _OVERLAP_MIN_CHARS and earlier_raw in raw:
+                contains, shared_chars = True, len(earlier_raw)
+            elif len(raw) >= _OVERLAP_MIN_CHARS and raw in earlier_raw:
+                contains, shared_chars = False, len(raw)
+            else:
+                continue
+            sources[index] = replace(
+                sources[index],
+                # 1-based: the box numbers its rows from 1, and an index the
+                # operator cannot match to a printed row is not an answer.
+                overlaps_index=earlier_index + 1,
+                overlap_chars=shared_chars,
+                overlap_contains=contains,
+            )
+            break
 
     # Imported first, native second, profile last: later text is read as the
     # more specific instruction, so lop's own file outranks the shared one and

--- a/tests/unit/test_cli_config_instructions.py
+++ b/tests/unit/test_cli_config_instructions.py
@@ -1,0 +1,269 @@
+"""``lop config instructions``: provenance for the assembled system prompt.
+
+The command exists because #822 found the packaged guide asserting that lop has
+no ``AGENTS.md`` mechanism while lop was reading the reporter's — a divergence
+between what the install does and what it says about itself. So the property
+these tests pin is not the wording of the box but the CORRESPONDENCE: what the
+command reports is what ``resolve_user_instructions`` actually assembles, for
+every arrangement an operator can be in. A provenance command that lies is
+worse than no provenance command.
+
+The second property is that it never prints the CONTENTS. Those are the
+operator's standing rules, routinely thousands of lines, and pasting a report
+into an issue must not paste their preferences with it.
+
+``HOME`` is redirected by the autouse ``isolate_environment`` fixture, so these
+reach a scratch home rather than the developer's real ``~/.agents`` — which on
+a machine that has one would inject their own preferences into every assertion.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+import pytest
+
+from local_operator import ecosystem_instructions as eco
+from local_operator.cli import config_instructions_command
+from local_operator.session_factory import resolve_user_instructions
+
+
+def _args(**overrides: object) -> argparse.Namespace:
+    base: dict[str, object] = {"agent_name": None}
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A scratch HOME with a redirected config dir, as an isolated run needs.
+
+    Both variables, per AGENTS.md "Isolating a run": ``LOCAL_OPERATOR_CONFIG_DIR``
+    alone leaves anything deriving from the home directory pointed at the real
+    one, and ``~/.agents/AGENTS.md`` is derived from ``Path.home()``.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / ".local-operator"))
+    (tmp_path / ".local-operator").mkdir()
+    return tmp_path
+
+
+def _write_agents_md(home: Path, text: str) -> Path:
+    path = home / ".agents" / "AGENTS.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _write_system_prompt(home: Path, text: str) -> Path:
+    path = home / ".local-operator" / "system_prompt.md"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_no_imported_file_reports_none_rather_than_an_empty_box(home: Path, capsys) -> None:
+    """The DEFAULT install has no ``~/.agents/AGENTS.md``.
+
+    An empty listing there reads as "the command is broken" rather than as the
+    answer it is, which is the whole reason the imported half gets its own box.
+    """
+    _write_system_prompt(home, "- lop only.\n")
+
+    assert config_instructions_command(_args()) == 0
+
+    out = capsys.readouterr().out
+    assert "Files read: none — no imported file exists at those paths" in out
+    assert "Source: default (~/.agents/AGENTS.md)" in out
+
+
+def test_an_imported_file_is_reported_with_its_path_and_size(home: Path, capsys) -> None:
+    _write_agents_md(home, "- Shared rule.\n")
+    _write_system_prompt(home, "- lop only.\n")
+
+    assert config_instructions_command(_args()) == 0
+
+    out = capsys.readouterr().out
+    assert str(home / ".agents" / "AGENTS.md") in out
+    # Assembly ORDER is the fact operators get wrong, so it is pinned as an
+    # order and not merely as membership.
+    assert out.index("1. imported") < out.index("2. system_prompt.md")
+
+
+def test_a_collapsed_duplicate_is_named_as_collapsed(home: Path, capsys) -> None:
+    """The undocumented dedup #822 reports as a silent context cost.
+
+    Reported as read-versus-included rather than as one number: "37 read, 0
+    included" is the confirmation an operator is looking for, and a single
+    figure cannot express it.
+    """
+    shared = "- Shared rule one.\n- Shared rule two.\n"
+    _write_agents_md(home, shared)
+    _write_system_prompt(home, shared)
+
+    assert config_instructions_command(_args()) == 0
+
+    out = capsys.readouterr().out
+    assert "Collapsed: identical to instructions already loaded" in out
+    assert "(collapsed)" in out
+
+
+def test_a_superset_native_file_does_not_collapse(home: Path, capsys) -> None:
+    """The case the issue reporter had to discover by hand.
+
+    The collapse is keyed on the digest of the WHOLE file, so shared rules plus
+    a lop-only overlay pays for both copies. The report must show that as two
+    contributing sources, since it is the only place an operator finds out.
+    """
+    shared = "- Shared rule.\n"
+    _write_agents_md(home, shared)
+    _write_system_prompt(home, shared + "- lop-only extra.\n")
+
+    assert config_instructions_command(_args()) == 0
+
+    out = capsys.readouterr().out
+    assert "Collapsed" not in out
+    assert "Included: 14 chars" in out  # the imported file, paid for in full
+
+
+def test_the_env_override_is_reflected_in_the_report(
+    home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    elsewhere = tmp_path / "elsewhere" / "AGENTS.md"
+    elsewhere.parent.mkdir(parents=True)
+    elsewhere.write_text("- Redirected rule.\n", encoding="utf-8")
+    _write_agents_md(home, "- Default rule that must NOT be read.\n")
+    monkeypatch.setenv(eco.ECOSYSTEM_INSTRUCTIONS_ENV, str(elsewhere))
+
+    assert config_instructions_command(_args()) == 0
+
+    out = capsys.readouterr().out
+    assert f"{eco.ECOSYSTEM_INSTRUCTIONS_ENV}={elsewhere}" in out
+    assert str(elsewhere) in out
+    assert "Default rule" not in out
+
+
+def test_an_empty_override_reports_the_feature_as_disabled(
+    home: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """ "Nothing imported" has two causes with opposite fixes.
+
+    An operator told "no file exists" while the feature is switched off goes
+    looking in the wrong place entirely.
+    """
+    _write_agents_md(home, "- Shared rule.\n")
+    monkeypatch.setenv(eco.ECOSYSTEM_INSTRUCTIONS_ENV, "")
+
+    assert config_instructions_command(_args()) == 0
+
+    out = capsys.readouterr().out
+    assert "DISABLED" in out
+    assert "Files read: none — the feature is disabled" in out
+
+
+def test_a_file_over_the_cap_is_reported_as_truncated(home: Path, capsys) -> None:
+    _write_agents_md(home, "z" * (eco.MAX_FILE_BYTES * 3))
+    _write_system_prompt(home, "- lop only.\n")
+
+    assert config_instructions_command(_args()) == 0
+
+    out = capsys.readouterr().out
+    assert "Truncated: hit the size cap" in out
+
+
+def test_an_unreadable_file_is_named_as_unreadable_not_as_absent(home: Path, capsys) -> None:
+    """A degraded session, not a default one.
+
+    The loader skips an unreadable file so a bad mode never costs a session —
+    which means the operator's rules are silently missing. "Empty" or "none"
+    here sends them to create a file that already exists.
+    """
+    path = _write_agents_md(home, "- Shared rule.\n")
+    path.chmod(0o000)
+    try:
+        if os.access(path, os.R_OK):  # pragma: no cover — root ignores the mode
+            pytest.skip("running as root; the mode is not enforced")
+        assert config_instructions_command(_args()) == 0
+        out = capsys.readouterr().out
+    finally:
+        path.chmod(0o644)
+
+    assert "Unreadable: skipped; the session ran without it" in out
+    assert "unreadable; skipped" in out
+
+
+def test_the_report_never_prints_the_contents(home: Path, capsys) -> None:
+    """Paths and sizes, never the rules themselves."""
+    _write_agents_md(home, "- SHARED-SECRET-MARKER rule.\n")
+    _write_system_prompt(home, "- NATIVE-SECRET-MARKER rule.\n")
+
+    assert config_instructions_command(_args()) == 0
+
+    out = capsys.readouterr().out
+    assert "SHARED-SECRET-MARKER" not in out
+    assert "NATIVE-SECRET-MARKER" not in out
+
+
+def test_the_command_writes_nothing(home: Path, capsys) -> None:
+    """Read-only by contract: ``system_prompt.md`` is lop's only write target,
+    and a provenance command that touched a file would be the one surface able
+    to break that. Asserted against the filesystem, because "we do not call
+    write" is exactly the claim a later refactor invalidates silently."""
+    imported = _write_agents_md(home, "- Shared rule.\n")
+    native = _write_system_prompt(home, "- lop only.\n")
+    before = {path: path.stat().st_mtime_ns for path in (imported, native)}
+
+    assert config_instructions_command(_args()) == 0
+    capsys.readouterr()
+
+    assert {path: path.stat().st_mtime_ns for path in (imported, native)} == before
+    # And no file was created anywhere under the two roots it can see.
+    assert sorted(p.name for p in (home / ".agents").iterdir()) == ["AGENTS.md"]
+
+
+def test_an_unknown_agent_name_is_refused_without_creating_it(home: Path, capsys) -> None:
+    """The interactive path CREATES a missing named agent. This command must
+    not: it is read-only, and reporting on an agent it just invented would
+    describe a session nobody asked for."""
+    _write_system_prompt(home, "- lop only.\n")
+
+    assert config_instructions_command(_args(agent_name="nonexistent-agent")) == 1
+
+    err = capsys.readouterr().err
+    assert "No agent found with name: nonexistent-agent" in err
+
+
+@pytest.mark.parametrize(
+    "shared,native",
+    [
+        (None, "- lop only.\n"),
+        ("- Shared rule.\n", "- lop only.\n"),
+        ("- Same.\n", "- Same.\n"),
+        ("- Shared.\n", "- Shared.\n- Extra.\n"),
+        ("z" * (eco.MAX_FILE_BYTES * 3), "- lop only.\n"),
+    ],
+    ids=["absent", "distinct", "collapsed", "superset", "over-cap"],
+)
+def test_the_reported_total_is_the_prompt_that_is_actually_assembled(
+    home: Path, capsys, shared: str | None, native: str
+) -> None:
+    """The property the command exists for, across every arrangement.
+
+    ``resolve_user_instructions`` is the call ``create_session`` makes, so this
+    compares the report against the real prompt rather than against a second
+    model of it — the divergence being guarded is precisely a report drifting
+    from the thing it reports on.
+    """
+    if shared is not None:
+        _write_agents_md(home, shared)
+    _write_system_prompt(home, native)
+
+    assert config_instructions_command(_args()) == 0
+    out = capsys.readouterr().out
+
+    assembled, _ = resolve_user_instructions()
+    line = next(ln for ln in out.splitlines() if "Total assembled" in ln)
+    reported = int(line.split(":")[1].split("of")[0].strip().replace(",", ""))
+    assert reported == len(assembled)

--- a/tests/unit/test_cli_config_instructions.py
+++ b/tests/unit/test_cli_config_instructions.py
@@ -194,6 +194,80 @@ def test_an_unreadable_file_is_named_as_unreadable_not_as_absent(home: Path, cap
     assert "unreadable; skipped" in out
 
 
+def test_an_existing_but_empty_file_is_reported_as_empty_not_as_absent(home: Path, capsys) -> None:
+    """A zero-byte ``~/.agents/AGENTS.md`` EXISTS.
+
+    Reporting "no imported file exists at those paths" about a path that has a
+    file on it is a statement about the filesystem that is simply false, and it
+    is the mirror image of the distinction ``InstructionSource.unreadable``
+    exists to draw: an operator who truncated their shared file while debugging
+    must be sent to the empty file they have, not to a missing one.
+    """
+    _write_agents_md(home, "")
+    _write_system_prompt(home, "- lop only.\n")
+
+    assert config_instructions_command(_args()) == 0
+
+    out = capsys.readouterr().out
+    assert "no imported file exists at those paths" not in out
+    # The stronger claim for an imported row: the loader lists only paths that
+    # resolve to a real file, so "might not exist" would understate what is known.
+    assert "Empty: the file is there but holds no instructions" in out
+    assert "(empty)" in out
+    assert str(home / ".agents" / "AGENTS.md") in out
+
+
+def test_a_whitespace_only_file_is_reported_as_empty_not_as_absent(home: Path, capsys) -> None:
+    """Same rule as the zero-byte case: the bytes are there, the rules are not."""
+    _write_agents_md(home, "\n\n   \t\n")
+    _write_system_prompt(home, "- lop only.\n")
+
+    assert config_instructions_command(_args()) == 0
+
+    out = capsys.readouterr().out
+    assert "no imported file exists at those paths" not in out
+    assert "Empty: the file is there but holds no instructions" in out
+
+
+def test_a_superset_native_file_names_the_overlap_it_pays_for(home: Path, capsys) -> None:
+    """The one arrangement the digest collapse cannot catch.
+
+    Without this row the frame is byte-identical to two genuinely distinct
+    files, so the guide's "check with ``config instructions``" pointed at a
+    diagnosis the output could not give — the gap #822 reported, one level down.
+    The overlapping TEXT must never appear: the count is the answer.
+    """
+    _write_agents_md(home, "- SHARED-OVERLAP-MARKER rule.\n")
+    _write_system_prompt(home, "- SHARED-OVERLAP-MARKER rule.\n\n- lop only.\n")
+
+    assert config_instructions_command(_args()) == 0
+
+    out = capsys.readouterr().out
+    assert 'Overlaps: contains all 29 chars of "imported" verbatim' in out
+    assert "both copies are sent" in out
+    assert "SHARED-OVERLAP-MARKER" not in out
+
+
+def test_the_overlap_row_stays_silent_on_the_collapsed_and_distinct_cases(
+    home: Path, capsys
+) -> None:
+    """``Overlaps:`` is a cost the operator can remove, so it must not fire on
+    the two arrangements where nothing is being paid twice: identical files are
+    already collapsed and reported as such, and two distinct files are healthy.
+    A warning on a healthy install is a warning operators learn to ignore."""
+    _write_agents_md(home, "- Same.\n")
+    _write_system_prompt(home, "- Same.\n")
+    assert config_instructions_command(_args()) == 0
+    collapsed = capsys.readouterr().out
+    assert "Collapsed:" in collapsed
+    assert "Overlaps:" not in collapsed
+
+    _write_agents_md(home, "- Shared rule.\n")
+    _write_system_prompt(home, "- Entirely different.\n")
+    assert config_instructions_command(_args()) == 0
+    assert "Overlaps:" not in capsys.readouterr().out
+
+
 def test_the_report_never_prints_the_contents(home: Path, capsys) -> None:
     """Paths and sizes, never the rules themselves."""
     _write_agents_md(home, "- SHARED-SECRET-MARKER rule.\n")
@@ -221,6 +295,28 @@ def test_the_command_writes_nothing(home: Path, capsys) -> None:
     assert {path: path.stat().st_mtime_ns for path in (imported, native)} == before
     # And no file was created anywhere under the two roots it can see.
     assert sorted(p.name for p in (home / ".agents").iterdir()) == ["AGENTS.md"]
+
+
+def test_the_command_writes_nothing_under_agent(tmp_path: Path, monkeypatch, capsys) -> None:
+    """``--agent`` is the ONE branch that can write, and the writes-nothing test
+    above cannot see it: it passes no agent, so it never reaches the registry,
+    and it scans only ``~/.agents`` — never the config dir, which is where
+    ``AgentRegistry.__init__``'s ``mkdir`` lands. On a machine with no config
+    root, asking a read-only provenance command about an agent materialised
+    ``<config_dir>/`` and ``<config_dir>/agents/``.
+
+    Deliberately NOT using the ``home`` fixture, which pre-creates the config
+    dir: the defect only shows on a home that has none.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / ".local-operator"))
+
+    assert config_instructions_command(_args(agent_name="ghost")) == 1
+
+    err = capsys.readouterr().err
+    assert "No agent found with name: ghost" in err
+    assert sorted(p.name for p in tmp_path.iterdir()) == []
 
 
 def test_an_unknown_agent_name_is_refused_without_creating_it(home: Path, capsys) -> None:

--- a/tests/unit/test_cli_config_instructions.py
+++ b/tests/unit/test_cli_config_instructions.py
@@ -236,16 +236,64 @@ def test_a_superset_native_file_names_the_overlap_it_pays_for(home: Path, capsys
     files, so the guide's "check with ``config instructions``" pointed at a
     diagnosis the output could not give — the gap #822 reported, one level down.
     The overlapping TEXT must never appear: the count is the answer.
+
+    The other source is named by ROW NUMBER rather than label because labels are
+    not unique — several override paths all render as ``imported`` — and because
+    the label form did not fit 80 columns, wrapping the row out of the box.
     """
-    _write_agents_md(home, "- SHARED-OVERLAP-MARKER rule.\n")
-    _write_system_prompt(home, "- SHARED-OVERLAP-MARKER rule.\n\n- lop only.\n")
+    shared = "- SHARED-OVERLAP-MARKER rule." + "x" * 200
+    _write_agents_md(home, f"{shared}\n")
+    _write_system_prompt(home, f"{shared}\n\n- lop only.\n")
 
     assert config_instructions_command(_args()) == 0
 
     out = capsys.readouterr().out
-    assert 'Overlaps: contains all 29 chars of "imported" verbatim' in out
-    assert "both copies are sent" in out
+    assert "Overlaps: contains source 1 verbatim (229 chars); both copies are sent" in out
     assert "SHARED-OVERLAP-MARKER" not in out
+
+
+def test_the_overlap_row_reports_the_migration_case_on_the_subset(home: Path, capsys) -> None:
+    """Rules moved into the shared file and grew there, leaving the old
+    ``system_prompt.md`` behind as a subset. Both copies still ship, so silence
+    here would be the report asserting an all-clear it has not established — and
+    the direction has to be on the row, because the remedy differs: delete the
+    subset rather than trim the superset."""
+    shared = "- SHARED-OVERLAP-MARKER rule." + "y" * 200
+    _write_agents_md(home, f"{shared}\n\n- Grown since the move.\n")
+    _write_system_prompt(home, f"{shared}\n")
+
+    assert config_instructions_command(_args()) == 0
+
+    out = capsys.readouterr().out
+    assert "Overlaps: verbatim inside source 1 (229 chars); both copies are sent" in out
+    assert "SHARED-OVERLAP-MARKER" not in out
+
+
+def test_every_overlap_row_fits_inside_the_box_at_eighty_columns(home: Path, capsys) -> None:
+    """The box does no wrapping of its own, so a row past 80 characters
+    soft-wraps in a standard terminal and the overflow lands outside the “│”
+    gutter — the failure the two-line footer below already avoids. Asserted on
+    the widest realistic inputs (a 64,000-character span, a two-digit row
+    number) rather than on the default install, because it is the large numbers
+    that push the row over."""
+    shared = "- Shared rule." + "z" * 200
+    _write_agents_md(home, f"{shared}\n")
+    _write_system_prompt(home, f"{shared}\n\n- lop only.\n")
+
+    assert config_instructions_command(_args()) == 0
+    rendered = [line for line in capsys.readouterr().out.splitlines() if "Overlaps:" in line]
+    assert rendered and all(len(line) <= 80 for line in rendered)
+
+    # The widest states the format string can reach, measured directly rather
+    # than by constructing a 64,000-character file per case.
+    for index in (1, 9, 10, 99):
+        for count in (1, 999, 1_000, 63_998, 64_000):
+            for direction in (
+                f"contains source {index} verbatim",
+                f"verbatim inside source {index}",
+            ):
+                row = f"│    Overlaps: {direction} ({count:,} chars); both copies are sent"
+                assert len(row) <= 80, row
 
 
 def test_the_overlap_row_stays_silent_on_the_collapsed_and_distinct_cases(
@@ -263,6 +311,13 @@ def test_the_overlap_row_stays_silent_on_the_collapsed_and_distinct_cases(
     assert "Overlaps:" not in collapsed
 
     _write_agents_md(home, "- Shared rule.\n")
+    _write_system_prompt(home, "- Entirely different.\n")
+    assert config_instructions_command(_args()) == 0
+    assert "Overlaps:" not in capsys.readouterr().out
+
+    # Third silent case: containment too short to be worth an operator's
+    # attention. "- " appears in both files, which is literal containment.
+    _write_agents_md(home, "- \n")
     _write_system_prompt(home, "- Entirely different.\n")
     assert config_instructions_command(_args()) == 0
     assert "Overlaps:" not in capsys.readouterr().out

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -2571,7 +2571,9 @@ def test_the_resolver_names_a_superset_but_not_a_collapsed_duplicate(
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
     monkeypatch.setenv("HOME", str(tmp_path))
     (tmp_path / "config").mkdir()
-    shared = "- Shared rule."
+    # Over the 200-char floor, so the finding is the containment rather than
+    # the threshold (which has its own test below).
+    shared = "- Shared rule." + "x" * 200
     _write_ecosystem_file(tmp_path, shared)
 
     (tmp_path / "config" / "system_prompt.md").write_text(
@@ -2579,7 +2581,8 @@ def test_the_resolver_names_a_superset_but_not_a_collapsed_duplicate(
     )
     assembled, sources = session_factory.resolve_user_instructions()
     native = next(source for source in sources if source.label == "system_prompt.md")
-    assert native.overlaps == "imported"
+    assert native.overlaps_index == 1
+    assert native.overlap_contains is True
     assert native.overlap_chars == len(shared)
     # The cost the row is claiming is real: both copies are in the prompt.
     assert assembled.count(shared) == 2
@@ -2587,14 +2590,84 @@ def test_the_resolver_names_a_superset_but_not_a_collapsed_duplicate(
     # Byte-identical: collapsed, sent once, and NOT flagged as an overlap.
     (tmp_path / "config" / "system_prompt.md").write_text(shared, encoding="utf-8")
     assembled, sources = session_factory.resolve_user_instructions()
-    assert [source.overlaps for source in sources] == [None, None]
+    assert [source.overlaps_index for source in sources] == [None, None]
     assert next(source for source in sources if source.label == "imported").collapsed is True
     assert assembled.count(shared) == 1
 
     # Two distinct files: healthy, and must stay unflagged.
     (tmp_path / "config" / "system_prompt.md").write_text("- Entirely other.", encoding="utf-8")
     _, sources = session_factory.resolve_user_instructions()
-    assert [source.overlaps for source in sources] == [None, None]
+    assert [source.overlaps_index for source in sources] == [None, None]
+
+
+def test_the_resolver_names_the_overlap_when_the_earlier_source_is_the_superset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The migration arrangement, and the reason the test is symmetric.
+
+    An operator moves their rules into ``~/.agents/AGENTS.md``, grows them
+    there, and leaves the old ``system_prompt.md`` behind as a subset. Both
+    copies ship in every request, exactly as in the superset case — but a test
+    that only asks "does a LATER source contain an EARLIER one" is silent here,
+    and the guide reads that silence as an all-clear. That is issue #822's own
+    shape: documentation asserting something the code does not do.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "config").mkdir()
+    shared = "- Rule that moved to the shared file." + "y" * 200
+    _write_ecosystem_file(tmp_path, f"{shared}\n\n- Grown since the move.")
+    (tmp_path / "config" / "system_prompt.md").write_text(shared, encoding="utf-8")
+
+    assembled, sources = session_factory.resolve_user_instructions()
+
+    native = next(source for source in sources if source.label == "system_prompt.md")
+    # Reported on the SUBSET, pointing back at the file that holds it, because
+    # the remedy here is to delete this file rather than to trim the other one.
+    assert native.overlaps_index == 1
+    assert native.overlap_contains is False
+    assert native.overlap_chars == len(shared)
+    assert next(source for source in sources if source.label == "imported").overlaps_index is None
+    # The claim is true of the prompt, not just of the arithmetic.
+    assert assembled.count(shared) == 2
+
+
+def test_the_resolver_ignores_an_overlap_too_small_to_be_worth_removing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Containment has no natural floor — a shared ``-`` is literal containment
+    — and a WARNING row advertising a one-character cost is the warning
+    operators learn to ignore, which is what this row exists to avoid. Pinned at
+    the boundary in both directions so the constant cannot drift silently.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "config").mkdir()
+    floor = session_factory._OVERLAP_MIN_CHARS
+    native = tmp_path / "config" / "system_prompt.md"
+
+    _write_ecosystem_file(tmp_path, "-")
+    native.write_text("- lop only rule.", encoding="utf-8")
+    _, sources = session_factory.resolve_user_instructions()
+    assert [source.overlaps_index for source in sources] == [None, None]
+
+    _write_ecosystem_file(tmp_path, "s" * (floor - 1))
+    native.write_text("s" * (floor - 1) + "\n\n- lop only.", encoding="utf-8")
+    _, sources = session_factory.resolve_user_instructions()
+    assert [source.overlaps_index for source in sources] == [None, None]
+
+    _write_ecosystem_file(tmp_path, "s" * floor)
+    native.write_text("s" * floor + "\n\n- lop only.", encoding="utf-8")
+    _, sources = session_factory.resolve_user_instructions()
+    assert sources[1].overlaps_index == 1
+    assert sources[1].overlap_chars == floor
+
+    # The floor applies to the subset direction too, on the span that is
+    # actually duplicated rather than on the size of the containing file.
+    _write_ecosystem_file(tmp_path, "s" * (floor - 1) + "\n\n- Shared only.")
+    native.write_text("s" * (floor - 1), encoding="utf-8")
+    _, sources = session_factory.resolve_user_instructions()
+    assert [source.overlaps_index for source in sources] == [None, None]
 
 
 def test_the_resolver_flags_a_profile_that_repeats_an_earlier_source(
@@ -2609,13 +2682,17 @@ def test_the_resolver_flags_a_profile_that_repeats_an_earlier_source(
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
     monkeypatch.setenv("HOME", str(tmp_path))
     (tmp_path / "config").mkdir()
-    shared = "- Rule the profile repeats."
+    shared = "- Rule the profile repeats." + "z" * 200
     (tmp_path / "config" / "system_prompt.md").write_text(shared, encoding="utf-8")
 
     assembled, sources = session_factory.resolve_user_instructions(shared)
 
     profile = next(source for source in sources if source.label == "agent profile")
-    assert profile.overlaps == "system_prompt.md"
+    assert profile.overlaps_index == 1
+    # Equal-length texts satisfy containment both ways; "contains" is tried
+    # first, so the tie reads as the superset case rather than flipping with
+    # source order.
+    assert profile.overlap_contains is True
     assert profile.overlap_chars == len(shared)
     assert assembled.count(shared) == 2
 

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -10,6 +10,7 @@ import argparse
 import asyncio
 import inspect
 import json
+import logging
 import os
 import sqlite3
 import time
@@ -2377,6 +2378,135 @@ def test_lop_never_writes_the_imported_file(
 
     assert (path.read_bytes(), path.stat().st_mtime_ns) == before
     assert system_prompt_file() == tmp_path / "config" / "system_prompt.md"
+
+
+# --- The provenance half of the same assembly (`lop config instructions`) ---
+#
+# `resolve_user_instructions` exists so the report and the prompt cannot
+# disagree; these pin that they come from ONE assembly rather than two that
+# happen to agree today. `test_cli_config_instructions.py` covers the rendered
+# command; here the contract is the records themselves.
+
+
+def test_the_resolver_returns_the_same_text_load_user_instructions_does(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The wrapper is a projection of the resolver, not a parallel path.
+
+    If these ever diverge, every caller of ``load_user_instructions`` — the
+    session factory and every subagent — is running a prompt the report does
+    not describe, which is the defect ``lop config instructions`` exists to
+    make impossible.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "system_prompt.md").write_text("- NATIVE", encoding="utf-8")
+    _write_ecosystem_file(tmp_path, "- IMPORTED")
+
+    assembled, sources = session_factory.resolve_user_instructions("- PROFILE")
+
+    assert assembled == session_factory.load_user_instructions("- PROFILE")
+    assert [source.label for source in sources] == [
+        "imported",
+        "system_prompt.md",
+        "agent profile",
+    ]
+
+
+def test_the_resolver_reports_no_imported_source_when_there_is_no_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The default install. ``system_prompt.md`` is still reported, with zero
+    characters, because the path is the answer to "where would it go"."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    _, sources = session_factory.resolve_user_instructions()
+
+    assert [source.label for source in sources] == ["system_prompt.md"]
+    assert sources[0].chars == 0
+
+
+def test_the_resolver_marks_a_byte_identical_import_as_collapsed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Read but not included: the two numbers together are what let an
+    operator confirm the dedup fired rather than infer it from a total."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "config").mkdir()
+    shared = "- Shared rule."
+    (tmp_path / "config" / "system_prompt.md").write_text(shared, encoding="utf-8")
+    _write_ecosystem_file(tmp_path, shared)
+
+    assembled, sources = session_factory.resolve_user_instructions()
+
+    imported = sources[0]
+    assert imported.collapsed is True
+    assert (imported.chars, imported.included) == (len(shared), 0)
+    assert assembled.count(shared) == 1
+
+
+def test_the_resolver_does_not_collapse_a_superset_native_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The context cost #822 reports: the digest covers the WHOLE file, so
+    shared-rules-plus-an-overlay pays for both copies on every cached request.
+    Pinned as behaviour so the guide's warning stays true."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "config").mkdir()
+    shared = "- Shared rule."
+    (tmp_path / "config" / "system_prompt.md").write_text(
+        f"{shared}\n- lop-only extra.", encoding="utf-8"
+    )
+    _write_ecosystem_file(tmp_path, shared)
+
+    assembled, sources = session_factory.resolve_user_instructions()
+
+    assert sources[0].collapsed is False
+    assert sources[0].included == len(shared)
+    assert assembled.count(shared) == 2
+
+
+def test_the_resolver_reports_a_truncated_import(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A file over the per-file 64 KiB read cap. ``chars`` is what was read
+    and ``included`` what survived the instructions budget, so the row states
+    the loss rather than reporting the smaller number as the whole file."""
+    from local_operator.ecosystem_instructions import MAX_FILE_BYTES
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_ecosystem_file(tmp_path, "z" * (MAX_FILE_BYTES * 3))
+
+    _, sources = session_factory.resolve_user_instructions()
+
+    assert sources[0].truncated is True
+    assert sources[0].chars == MAX_FILE_BYTES
+    assert sources[0].included <= session_factory.MAX_USER_INSTRUCTIONS_CHARS
+
+
+def test_the_resolver_can_stay_silent_for_the_provenance_caller(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog
+) -> None:
+    """``lop config instructions`` prints the provenance itself, so the INFO
+    record would land on stderr immediately above the box repeating it. Every
+    session path keeps the log — it is the only trace a running session leaves
+    of an import it never named."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_ecosystem_file(tmp_path, "- Shared rule.")
+
+    with caplog.at_level(logging.INFO, logger="local_operator.ecosystem_instructions"):
+        session_factory.resolve_user_instructions(log_provenance=False)
+    assert not caplog.records
+
+    with caplog.at_level(logging.INFO, logger="local_operator.ecosystem_instructions"):
+        session_factory.load_user_instructions()
+    assert any("loaded ecosystem instructions" in record.message for record in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -2489,6 +2489,137 @@ def test_the_resolver_reports_a_truncated_import(
     assert sources[0].included <= session_factory.MAX_USER_INSTRUCTIONS_CHARS
 
 
+def test_the_resolver_attributes_a_multi_file_cut_to_the_files_that_lost_text(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The budget cuts the JOINED imported block from the tail, so a cut larger
+    than the last file also eats the tail of the one before it.
+
+    Charging the whole cut to the last contributor credited earlier files with
+    text that never reached the prompt: rows summing to 107,998 "included"
+    characters inside a 64,000-character total, and the file that actually lost
+    44k carrying no truncation flag. The sum invariant below is the property
+    that makes the report checkable at all — a report whose own rows do not add
+    up to its own total is the defect this surface exists to close.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "system_prompt.md").write_text("N" * 60_000, encoding="utf-8")
+    first = tmp_path / "a.md"
+    first.write_text("A" * 60_000, encoding="utf-8")
+    second = tmp_path / "b.md"
+    second.write_text("B" * 10_000, encoding="utf-8")
+    monkeypatch.setenv("LOCAL_OPERATOR_ECOSYSTEM_INSTRUCTIONS", f"{first}:{second}")
+
+    assembled, sources = session_factory.resolve_user_instructions()
+
+    imported = [source for source in sources if source.label == "imported"]
+    assert [source.path for source in imported] == [first, second]
+    # Measured against the prompt itself, not against a model of it. ``included``
+    # is the span this file occupies in the assembled text, so it covers the
+    # truncation marker that replaced its own tail — which is what keeps the sum
+    # invariant below exactly true rather than off by the marker.
+    first_span = assembled[: imported[0].included]
+    assert first_span.count("A") == assembled.count("A") < imported[0].included
+    assert "custom instructions truncated at" in first_span
+    # The second file reached the prompt not at all: the budget was already
+    # spent by the first, which the old accounting credited as whole.
+    assert imported[1].included == assembled.count("B") == 0
+    # Both imported files lost text, so both must say so — the earlier file is
+    # the one the old accounting reported as whole.
+    assert imported[0].truncated is True
+    assert imported[1].truncated is True
+
+    separators = 2 * max(0, sum(1 for source in sources if source.included) - 1)
+    assert sum(source.included for source in sources) + separators == len(assembled)
+
+
+def test_the_resolver_reports_an_existing_but_empty_import_rather_than_omitting_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Absent and present-but-empty are different states with different fixes.
+
+    Omitting the record made the report state that no file exists at a path
+    that has one — the mirror image of the distinction
+    ``InstructionSource.unreadable`` is documented to preserve.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    path = _write_ecosystem_file(tmp_path, "")
+
+    _, sources = session_factory.resolve_user_instructions()
+
+    imported = [source for source in sources if source.label == "imported"]
+    assert [source.path for source in imported] == [path]
+    assert imported[0].chars == 0
+    assert imported[0].included == 0
+    # Empty is not degraded and not a duplicate: the other two states must stay
+    # off, or the operator is sent to fix something that is not wrong.
+    assert imported[0].unreadable is False
+    assert imported[0].collapsed is False
+
+
+def test_the_resolver_names_a_superset_but_not_a_collapsed_duplicate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The superset is the arrangement the digest collapse cannot catch, and
+    the only one where the operator pays for the same rules twice on every
+    cached request. The collapsed case already reports itself and costs
+    nothing, so flagging it too would train the operator to ignore the row.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "config").mkdir()
+    shared = "- Shared rule."
+    _write_ecosystem_file(tmp_path, shared)
+
+    (tmp_path / "config" / "system_prompt.md").write_text(
+        f"{shared}\n\n- lop only.", encoding="utf-8"
+    )
+    assembled, sources = session_factory.resolve_user_instructions()
+    native = next(source for source in sources if source.label == "system_prompt.md")
+    assert native.overlaps == "imported"
+    assert native.overlap_chars == len(shared)
+    # The cost the row is claiming is real: both copies are in the prompt.
+    assert assembled.count(shared) == 2
+
+    # Byte-identical: collapsed, sent once, and NOT flagged as an overlap.
+    (tmp_path / "config" / "system_prompt.md").write_text(shared, encoding="utf-8")
+    assembled, sources = session_factory.resolve_user_instructions()
+    assert [source.overlaps for source in sources] == [None, None]
+    assert next(source for source in sources if source.label == "imported").collapsed is True
+    assert assembled.count(shared) == 1
+
+    # Two distinct files: healthy, and must stay unflagged.
+    (tmp_path / "config" / "system_prompt.md").write_text("- Entirely other.", encoding="utf-8")
+    _, sources = session_factory.resolve_user_instructions()
+    assert [source.overlaps for source in sources] == [None, None]
+
+
+def test_the_resolver_flags_a_profile_that_repeats_an_earlier_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The dedup collapses IMPORTED files only, so an agent profile whose prompt
+    repeats ``system_prompt.md`` genuinely ships both copies in every request of
+    every session using that agent. Equality is therefore a real overlap here,
+    unlike the imported case where it is collapsed upstream and reported as
+    such — the row must fire on what the prompt actually carries.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "config").mkdir()
+    shared = "- Rule the profile repeats."
+    (tmp_path / "config" / "system_prompt.md").write_text(shared, encoding="utf-8")
+
+    assembled, sources = session_factory.resolve_user_instructions(shared)
+
+    profile = next(source for source in sources if source.label == "agent profile")
+    assert profile.overlaps == "system_prompt.md"
+    assert profile.overlap_chars == len(shared)
+    assert assembled.count(shared) == 2
+
+
 def test_the_resolver_can_stay_silent_for_the_provenance_caller(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog
 ) -> None:


### PR DESCRIPTION
## Summary

The packaged `configuration` guide told operators — and, more damagingly, told
**agents** — that Local Operator has no `AGENTS.md` mechanism. That has been
false since `ecosystem_instructions.py` shipped (#523): lop reads
`~/.agents/AGENTS.md` at session construction and prepends it ahead of
`system_prompt.md`.

The harness prompt makes reading a matching guide **mandatory** before
answering, so the mandatory source was the wrong one. The reporter hit exactly
that: he told an operator lop could not read their `~/.agents/AGENTS.md` while
lop was, at that moment, reading theirs. Following the rule produced a worse
answer than ignoring it.

```
Release: patch — the configuration guide no longer denies the ~/.agents/AGENTS.md import, and `lop config instructions` reports which instruction files a session actually assembles
```

**Change class: C1 (standard / pre-authorized).** A documentation correction
plus one additive read-only CLI subcommand. No behaviour change to the assembled
prompt — proved below. `pyproject.toml` stays at `0.51.28`; no version bump.

Closes #822.

## What changed

**1. The false sentence** (`guides/configuration/GUIDE.md:42`). The
`custom_instructions` half was correct and stays; the `AGENTS.md` clause is
gone and now points at the new subsection. The guide's own front-matter
`description:` already advertises "AGENTS.md-style defaults" — which is *how*
the guide gets selected for these questions, and another reason the body had to
be right.

**2. The imported file is now documented** (`### Imported instructions`), from
the module docstring and the assembly block rather than from memory: the default
path and why that path (`~/.agents/skills` is already read; `~/.local-operator/
AGENTS.md` is deliberately *not*, to keep the write path unambiguous),
**read-only** status, load order and precedence, `LOCAL_OPERATOR_ECOSYSTEM_
INSTRUCTIONS` for redirect/disable, the 64 KiB cap and separate budget, and the
digest collapse — including the part the reporter had to discover by hand: the
collapse is keyed on the digest of the **whole file**, so a `system_prompt.md`
that is a *superset* of the shared file does **not** collapse, and both copies
are paid for in the cached prefix of every request, session and subagent.

**3. `lop config instructions`** — issue suggestion 3. Read-only provenance:
every source in **assembly order**, resolved path, characters read versus
included, and whether it was collapsed, truncated or unreadable. Paths and sizes
only, **never the contents** — those are the operator's standing rules and run
to thousands of lines.

### One assembly, not two

`resolve_user_instructions` is factored out of `load_user_instructions`, which
is now a projection of it. The report is computed from the same call
`create_session` makes, because a report derived from a **second** copy of the
budget/collapse arithmetic would drift from the prompt on the first change to
either — the same class of divergence (the install disagreeing with itself)
that this PR exists to fix.

## Evidence

All runs in an isolated `HOME` **and** `LOCAL_OPERATOR_CONFIG_DIR`, per
AGENTS.md "Isolating a run" — the operator's real `~/.agents/AGENTS.md` and
`~/.local-operator` were never read or written.

### The doc bug, reproduced and fixed

The issue's own Steps to Reproduce, run against the committed base and this
branch:

```console
$ git show origin/main:local_operator/guides/configuration/GUIDE.md | grep -n "no \`AGENTS.md\` mechanism"
42:That single file is what the desktop UI's Settings → **Instructions** box edits ...
   There is no `AGENTS.md` mechanism and no `custom_instructions` key in `config.yml`;
   writing either does nothing.

$ grep -n "no \`AGENTS.md\` mechanism" local_operator/guides/configuration/GUIDE.md
(no match — fixed)

$ grep -n "Imported instructions\|LOCAL_OPERATOR_ECOSYSTEM_INSTRUCTIONS\|config instructions" \
    local_operator/guides/configuration/GUIDE.md
23:local-operator config instructions
73:### Imported instructions (`~/.agents/AGENTS.md`)
79:- **Redirect or disable** with `LOCAL_OPERATOR_ECOSYSTEM_INSTRUCTIONS`: ...
91:local-operator config instructions
```

`grep -rn "AGENTS.md" local_operator/guides/` was swept for further
contradictions; the only other hits are the front-matter description (correct),
a `cp` example (correct), and the browser guide referring to a *repository*
`AGENTS.md` (unrelated). `docs/` and `README.md` carried no false claim — the
README already described the feature accurately, and now also points at the new
command.

### The command, on every arrangement

**No ecosystem file — the default install.** "None" is a real answer and must
not read as an empty box:

```console
$ env HOME=$ISO LOCAL_OPERATOR_CONFIG_DIR=$ISO/.local-operator lop config instructions

╭─ Custom instructions, in assembly order ──────
│ 1. system_prompt.md
│    Path: $HOME/.local-operator/system_prompt.md
│    Read: 0 chars   Included: 0 chars
│    Empty: no file at that path, or nothing in it
│ Total assembled: 0 of 64,000 chars
│ Re-sent with every request, in every session and subagent
╰──────────────────────────────────────────────

╭─ Imported user-scope instructions ────────────
│ Source: default (~/.agents/AGENTS.md)
│ Files read: none — no imported file exists at those paths
│ Read-only: system_prompt.md stays the only file lop writes
╰──────────────────────────────────────────────
```

**Present and distinct** — order is the thing operators get wrong, so it is what
the box leads with:

```console
╭─ Custom instructions, in assembly order ──────
│ 1. imported
│    Path: /tmp/.../.agents/AGENTS.md
│    Read: 37 chars   Included: 37 chars
│ 2. system_prompt.md
│    Path: /tmp/.../.local-operator/system_prompt.md
│    Read: 16 chars   Included: 16 chars
│ Total assembled: 55 of 64,000 chars
╰──────────────────────────────────────────────
```

**Byte-identical — the collapse.** Read 37, included 0; one number could not
express this:

```console
╭─ Custom instructions, in assembly order ──────
│ 1. imported
│    Path: /tmp/.../.agents/AGENTS.md
│    Read: 37 chars   Included: 0 chars
│    Collapsed: identical to instructions already loaded; sent once
│ 2. system_prompt.md
│    Path: /tmp/.../.local-operator/system_prompt.md
│    Read: 37 chars   Included: 37 chars
│ Total assembled: 37 of 64,000 chars
╰──────────────────────────────────────────────

╭─ Imported user-scope instructions ────────────
│ Source: default (~/.agents/AGENTS.md)
│ Files read: /tmp/.../.agents/AGENTS.md (collapsed)
│ Read-only: system_prompt.md stays the only file lop writes
╰──────────────────────────────────────────────
```

**Superset `system_prompt.md` — the silent cost the issue reports.** Both rows
report non-zero Included, which is the operator's signal that no collapse
happened:

```console
│ 1. imported          Read: 14 chars   Included: 14 chars
│ 2. system_prompt.md  Read: 32 chars   Included: 32 chars
│ Total assembled: 48 of 64,000 chars
```

**Env override redirects** — and the default path is demonstrably not read:

```console
╭─ Imported user-scope instructions ────────────
│ Source: LOCAL_OPERATOR_ECOSYSTEM_INSTRUCTIONS=/tmp/.../elsewhere/AGENTS.md
│ Files read: /tmp/.../elsewhere/AGENTS.md (18 chars)
│ Read-only: system_prompt.md stays the only file lop writes
╰──────────────────────────────────────────────
```

**Empty env value disables the feature.** "Nothing imported" has two causes with
opposite fixes, so they are worded differently:

```console
╭─ Imported user-scope instructions ────────────
│ Source: DISABLED — LOCAL_OPERATOR_ECOSYSTEM_INSTRUCTIONS is set and empty
│ Files read: none — the feature is disabled
│ Read-only: system_prompt.md stays the only file lop writes
╰──────────────────────────────────────────────
```

**Over the 64 KiB per-file cap** — the two warnings are the real loader's, on
the real path:

```console
WARNING - ecosystem instructions at /tmp/.../.agents/AGENTS.md exceed 65536 bytes; reading the first 65536
WARNING - custom instructions from imported user-scope instructions are 65536 chars; truncating to 63982

│ 1. imported
│    Read: 65,536 chars   Included: 63,982 chars
│    Truncated: hit the size cap; the tail was dropped
│ Total assembled: 64,000 of 64,000 chars
```

**Unreadable file** (mode `000`) — a degraded session, not a default one; saying
"empty" would send the operator to create a file that already exists:

```console
│ 1. imported
│    Read: 0 chars   Included: 0 chars
│    Unreadable: skipped; the session ran without it
```

### Proof the report is not lying

A provenance command that lies is worse than none, so the report was checked
against what a session **actually assembles** — via `load_user_instructions`,
the call `create_session` makes at `session_factory.py:1843` — in a separate
process per arrangement:

```console
$ .venv/bin/python /tmp/lo822_correspondence.py
--- no ecosystem file ---
  report total=11  session total=11  MATCH
  report lists imported source=False  imported text present in real prompt=False
--- present and distinct ---
  report total=50  session total=50  MATCH
  report lists imported source=True   imported text present in real prompt=True
--- byte-identical (collapse) ---
  report total=37  session total=37  MATCH
  report lists imported source=True  collapsed=True
  shared text occurs exactly once in the real prompt  MATCH
--- superset system_prompt (NO collapse) ---
  report total=85  session total=85  MATCH
--- env override redirects ---
  report total=26  session total=26  MATCH
--- env empty disables ---
  report total=11  session total=11  MATCH
--- over the 64 KiB cap ---
  report total=64000  session total=64000  MATCH

ALL CORRESPONDENCE ASSERTIONS PASSED
```

This is also the no-behaviour-change proof for the refactor: the assembled
prompt is identical in every arrangement, and the 151 pre-existing
`test_session_factory.py` + `test_ecosystem_instructions.py` tests pass
unchanged against the refactored assembly.

The same property is pinned as a parametrized unit test
(`test_the_reported_total_is_the_prompt_that_is_actually_assembled`, 5 ids), so
it cannot regress silently.

### Rendered output for the design round

Re-captured on `19e42f378` (round-3 remediation) through a real pty with
`TERM=xterm-256color` at **80 columns** (`TIOCSWINSZ`), under an isolated
`LOCAL_OPERATOR_CONFIG_DIR` and a fake `HOME` with `CMUX_*` stripped. Plain text
under `NO_COLOR` and a pipe, since the command uses `cli_style.paint` rather than
the raw escapes `config_list_command` still carries (`STDOUT contains ESC: False`
in both). Line lengths below are **measured**, not eyeballed: the row previously
shipped at 81-93 characters and soft-wrapped out of the `│` gutter (design D7).

**The superset trap**, which the design round found rendered identically to a
healthy two-file install. The `Overlaps:` row is the fix — it names the
duplicated character count and the row number of the source it duplicates, never
the content:

```
 48 |╭─ Custom instructions, in assembly order ──────
 13 |│ 1. imported
 34 |│    Path: $HOME/.agents/AGENTS.md
 42 |│    Read: 343 chars   Included: 343 chars
 21 |│ 2. system_prompt.md
 40 |│    Path: $HOME/config/system_prompt.md
 42 |│    Read: 356 chars   Included: 356 chars
 75 |│    Overlaps: contains source 1 verbatim (343 chars); both copies are sent
 38 |│ Total assembled: 701 of 64,000 chars
 59 |│ Re-sent with every request, in every session and subagent
 47 |╰──────────────────────────────────────────────
    max line = 75, lines over 80 = 0
```

**The migration arrangement** — rules moved into `~/.agents/AGENTS.md` and grown
there, the old `system_prompt.md` left behind as a subset. Both copies ship, and
before round 3 this frame carried **no** `Overlaps:` row at all (QA Q4): the
containment test only asked whether a later source contained an earlier one. It
is now symmetric, and the row states which way round the containment runs,
because the remedy differs — trim the superset, or delete the subset:

```
 13 |│ 1. imported
 42 |│    Read: 368 chars   Included: 368 chars
 21 |│ 2. system_prompt.md
 42 |│    Read: 343 chars   Included: 343 chars
 73 |│    Overlaps: verbatim inside source 1 (343 chars); both copies are sent
    max line = 73, lines over 80 = 0
```

Widest realistic case measured at **79** (a two-digit row number at 64,000
characters); an exhaustive sweep of 260 index × count × direction combinations
gives min 71, max 80, **zero over 80**.

```
╭─ Imported user-scope instructions ────────────
│ Source: default (~/.agents/AGENTS.md)
│ Files read: $HOME/.agents/AGENTS.md (343 chars)
│ Read-only: system_prompt.md stays the only file lop writes
╰──────────────────────────────────────────────
```

**The default install**, the most-seen frame. `Empty:` is CYAN, so the state
ladder reads green = normal contribution, cyan = present but contributed
nothing, yellow = degraded or costing you:

```
╭─ Custom instructions, in assembly order ──────
│ 1. system_prompt.md
│    Path: $HOME/.local-operator/system_prompt.md
│    Read: 0 chars   Included: 0 chars
│    Empty: no file at that path, or nothing in it
│ Total assembled: 0 of 64,000 chars
│ Re-sent with every request, in every session and subagent
╰──────────────────────────────────────────────

╭─ Imported user-scope instructions ────────────
│ Source: default (~/.agents/AGENTS.md)
│ Files read: none — no imported file exists at those paths
│ Read-only: system_prompt.md stays the only file lop writes
╰──────────────────────────────────────────────
```

Colour audit from the raw escape bytes:

```
  ESC[1;32m  │ 1. system_prompt.md
  ESC[1;32m  │    Read: 0 chars   Included: 0 chars
  ESC[1;36m  │    Empty: no file at that path, or nothing in it
  ESC[1;32m  │ Total assembled: 0 of 64,000 chars
```

**A multi-path override**, showing the right-aligned count columns and the
single `Files read:` heading:

```
╭─ Custom instructions, in assembly order ──────
│ 1. imported
│    Path: $HOME/rules-a/AGENTS.md
│    Read:    99 chars   Included:    99 chars
│ 2. imported
│    Path: $HOME/rules-b/AGENTS.md
│    Read: 2,999 chars   Included: 2,999 chars
│ 3. system_prompt.md
│    Path: $HOME/.local-operator/system_prompt.md
│    Read:    34 chars   Included:    34 chars
│ Total assembled: 3,136 of 64,000 chars
│ Re-sent with every request, in every session and subagent
╰──────────────────────────────────────────────

╭─ Imported user-scope instructions ────────────
│ Source: LOCAL_OPERATOR_ECOSYSTEM_INSTRUCTIONS=$HOME/rules-a/AGENTS.md:$HOME/rules-b/AGENTS.md
│ Files read:
│    $HOME/rules-a/AGENTS.md (99 chars)
│    $HOME/rules-b/AGENTS.md (2,999 chars)
│ Read-only: system_prompt.md stays the only file lop writes
╰──────────────────────────────────────────────
```

**Multi-file over budget** — every file that lost text carries `Truncated:`,
and the rows sum to the total (`16,000 + 0 + 47,998 + 2 separators = 64,000`):

```
╭─ Custom instructions, in assembly order ──────
│ 1. imported
│    Path: $HOME/rules-a/AGENTS.md
│    Read: 60,000 chars   Included: 16,000 chars
│    Truncated: hit the size cap; the tail was dropped
│ 2. imported
│    Path: $HOME/rules-b/AGENTS.md
│    Read: 10,000 chars   Included:      0 chars
│    Truncated: hit the size cap; the tail was dropped
│ 3. system_prompt.md
│    Path: $HOME/.local-operator/system_prompt.md
│    Read: 60,000 chars   Included: 47,998 chars
│    Truncated: hit the size cap; the tail was dropped
│ Total assembled: 64,000 of 64,000 chars
│ Re-sent with every request, in every session and subagent
╰──────────────────────────────────────────────

╭─ Imported user-scope instructions ────────────
│ Source: LOCAL_OPERATOR_ECOSYSTEM_INSTRUCTIONS=$HOME/rules-a/AGENTS.md:$HOME/rules-b/AGENTS.md
│ Files read:
│    $HOME/rules-a/AGENTS.md (16,000 chars)
│    $HOME/rules-b/AGENTS.md (0 chars)
│ Read-only: system_prompt.md stays the only file lop writes
╰──────────────────────────────────────────────
```

Box widths match `config list` exactly (48-char top rule, 47-char bottom), so
the two `lop config` surfaces align in a terminal.

## Testing

New: `tests/unit/test_cli_config_instructions.py` (24 tests) — absent, present,
collapsed, superset, the migration subset case, override redirect, empty
override, over-cap, unreadable, never-prints-contents, never-writes (with and
without `--agent`), unknown agent name refused without creating it,
existing-but-empty and whitespace-only files reported as empty rather than
absent, the `Overlaps:` row and its silence on the collapsed, distinct and
sub-threshold cases, that every rendered `Overlaps:` row fits inside the box at
80 columns, plus the 5-way correspondence parametrization. Plus 12 tests for the
shared helper in `test_session_factory.py`, including that the resolver and the
wrapper return identical text, that the INFO log stays on for every session
path, that a multi-file over-budget cut is attributed to the files that actually
lost text (with `sum(included) + separators == len(assembled)` asserted against
the real assembly), that containment is detected in BOTH directions with the
direction recorded, that a shared span under 200 characters is not reported, and
that a profile repeating an earlier source is flagged while a collapsed
duplicate is not.

Gates, whole tree, exactly as CI:

| Gate | Result |
|---|---|
| `.venv/bin/python -m flake8 .` | clean |
| `uvx --from black==26.1.0 black --check .` | 1124 files unchanged |
| `uvx isort==5.13.2 --check .` | clean |
| `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | 0 errors, 0 warnings |
| `.venv/bin/python -m pytest tests/unit -q` | **16,741 passed, 18 skipped** in 1395.92s — no failures |

Re-run on `19e42f378`. The round-2 load flake in
`tests/unit/session/test_frontend_sync_liveness.py` (a wall-clock liveness
assertion in a file this diff does not touch) did not recur; this run is clean
end to end.

## Review rounds

**Round 3** (`19e42f378`) answers the two streams that were not terminal after
round 2: QA's Q4 — the `Overlaps:` containment test was directional, so the
migration arrangement (rules grown in `~/.agents/AGENTS.md`, the old
`system_prompt.md` left as a subset) shipped both copies with no row firing while
the guide read that silence as an all-clear — and design's D7/D8, the row
wrapping out of the box at 80 columns and naming an ambiguous label. The test is
now symmetric with the direction on the row, the row is 71-79 characters across
the reachable range and names the source by row number, the guide states what the
check does and does not cover, and the reviewer's minor M2 (a 200-character floor
before the WARNING fires) is fixed in the same commit. M1 is rejected on merit:
the alternative trades a bounded ≤61-character misattribution for rows that no
longer sum to their own total. The code round was **clean and TERMINAL** on
`3efd79bd7`; the round-3 comment discloses exactly which approved lines this
commit changed and why.

Round 1 of all three streams is answered by a single remediation commit,
`3efd79bd7` — code (R1-R6), design (D1-D6) and QA (Q1-Q3), each with a
per-finding disposition on the PR. Highlights: the report's per-file truncation
accounting now attributes the cut to the files that actually lost text (rows
previously summed to 107,998 "included" characters inside a 64,000-character
total); an existing-but-empty imported file is reported as empty rather than
absent; the superset arrangement is named by an `Overlaps:` row; and two false
claims in the new guide text — that the imported file "can neither crowd out nor
be crowded out by the other two", and that four named tools have converged on
`~/.agents/AGENTS.md` — are corrected against the code and the module docstring
respectively.

## Not addressed

- `config_list_command` still emits raw `\033[1;32m` literals rather than
  `cli_style.paint`, so it ignores `NO_COLOR` and non-tty stdout. Pre-existing
  and out of scope here; the new command uses `paint`.
- No TUI change: no `/` surface enumerates `config` subcommands (checked
  `local_operator/tui/`), so there was nothing to add without inventing one.
- **`system_prompt.md` has no budget floor against the imported file.** The
  imported text and the agent profile each hold a 16,000-character reserve, but
  `system_prompt.md` is bounded last on the remainder, so a large file written by
  another tool silently truncates the operator's own instructions (a 40,000-char
  import cuts a 62,000-char `system_prompt.md` to 47,998). Pre-existing and
  byte-identical on `main`; this PR corrects the guide sentence that denied it
  and makes it visible via `Truncated:`, but a change to the prompt budget sits
  on every session's construction path and belongs in its own reviewed PR.


