### PR TITLE
feat(notify): carry the finished session's last reply in the banner body

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -15279,8 +15279,15 @@ class OperatorApp(App[None]):
             stored = ""
         return sanitize_text(stored) or BACKGROUND_FALLBACK_TITLE
 
-    def _background_completion_body(self, entry: CatalogEntry) -> str:
-        """The banner body: what the finished session last SAID, or the neutral line.
+    def _background_completion_body(self, entry: CatalogEntry, kind: str) -> str:
+        """The banner body for one finished session, chosen by what it says truthfully.
+
+        ALL THREE KINDS, EXPLICITLY. ``complete`` carries the session's last
+        assistant line. ``error`` and ``interrupted`` carry the house sentence
+        for that state (``BODIES[kind]`` — "Stopped with an error" / "Stopped
+        before finishing"). Any kind outside :data:`CONTEXTS`, and every case
+        where no snippet may be shown or none exists, degrades to
+        ``BODY_BACKGROUND``.
 
         WHAT THIS REPLACED AND WHY. The body was the fixed sentence
         ``BODY_BACKGROUND`` — "You were in another session" — which states a
@@ -15323,21 +15330,62 @@ class OperatorApp(App[None]):
         is not. Never returns ``""`` — an empty body would render as a banner
         with a title and a blank line where the content is.
 
-        ``sanitize_text`` because the snippet reaches an OSC escape and an argv,
-        exactly like the title (D16): the text is model-written, and both BEL
-        and ESC terminate an OSC string. It also enforces
-        :data:`BACKGROUND_SNIPPET_MAX_CHARS`, whose reasoning is on the
-        constant.
+        ``sanitize_text`` because the snippet is model-written text reaching an
+        argv (``cmux notify``, the signed bundle, ``notify-send``) and an
+        AppleScript string literal on the ``osascript`` leg. It does NOT reach
+        an OSC escape: the only OSC emitter is ``notification_writes``, whose
+        sole caller passes the fixed ``BODIES`` constant, never this text. The
+        scrub is still required — control characters in argv and in the
+        AppleScript literal, plus the one-line collapse a banner body needs —
+        and it also enforces :data:`BACKGROUND_SNIPPET_MAX_CHARS`, whose
+        reasoning is on the constant. (Review round 1, m2: the earlier wording
+        here named a wire this body does not travel.)
         """
         from local_operator.paths import config_dir
         from local_operator.resume import session_preview
         from local_operator.tui.notify import (
             BACKGROUND_SNIPPET_MAX_CHARS,
+            BODIES,
             BODY_BACKGROUND,
             sanitize_text,
             session_names_in_notifications,
         )
 
+        if kind != "complete":
+            # THE SNIPPET IS ONLY TRUE OF A SESSION THAT COMPLETED. `error` and
+            # `interrupted` are published from `outcome.error`/`outcome.aborted`
+            # — runtime facts that are never an assistant message — and
+            # `session_preview` filters to `role == "assistant"`, so on those
+            # kinds it can only return the last thing the model said BEFORE the
+            # thing that went wrong: typically a success sentence under a
+            # `Needs attention` subtitle, the two content lines of the frame
+            # asserting opposite things (review round 1 M1, design round 1 D1).
+            # `session.py`'s attention anchor already refuses exactly this — it
+            # resolves to `completion-{token}` rather than `messages[-1].id` for
+            # the non-complete kinds because "failure may precede the first
+            # assistant message" — and a body must not assert what the anchor
+            # declines to point at.
+            #
+            # WHY `interrupted` IS GATED TOO, though its snippet reads
+            # coherently. Design round 1 accepted restricting the gate to
+            # `error` alone: an aborted session really was mid-work, so a
+            # mid-work last line is honest there. It is gated anyway because the
+            # honesty is a property of the TEXT, not of the state — an
+            # interrupted session whose last assistant turn happened to close a
+            # sub-task ("All 412 tests pass. The migration is complete.") lands
+            # in exactly M1's frame, and nothing in the kind tells the two
+            # apart. Splitting the rule would make correctness depend on a
+            # judgement no code here can make, on a lock screen where prose is
+            # read once with nothing beside it to check it against. "Snippet iff
+            # complete" is decidable from the kind alone, and what it costs is a
+            # sentence for 14 of 332 completions in the maintainer's real store.
+            #
+            # `BODIES[kind]` rather than `BODY_BACKGROUND`: the house vocabulary
+            # already says the true thing for these states and says more than
+            # the routing sentence does. Unknown kinds keep the neutral fallback
+            # — the same default-to-quiet discipline `digest_subtitle` follows,
+            # so a future kind cannot inherit a claim written for another one.
+            return BODIES.get(kind, BODY_BACKGROUND)
         if not session_names_in_notifications():
             return BODY_BACKGROUND
         try:
@@ -15413,28 +15461,41 @@ class OperatorApp(App[None]):
         store = AttentionStore(config_dir() / "attention.db")
         if not store.claim_delivery(identity, entry.completion_token, backend):
             return False
-        title = self._background_completion_title(entry)
-        # The body carries what the finished session last SAID, falling back to
-        # the neutral routing sentence when no snippet may be shown or none
-        # exists. See `_background_completion_body` for the privacy gate, the
-        # length budget and why the routing cue is not repeated here (D5).
-        body = self._background_completion_body(entry)
         try:
+            # INSIDE THE GUARD, because the claim above is already taken. A
+            # raise between `claim_delivery` and here escapes to the caller's
+            # per-row handler, which sets `released = True` but never calls
+            # `release_delivery` for this row — leaving a claim that asserts a
+            # toast nobody received, the exact hole `release_delivery` exists to
+            # close. Both helpers are internally guarded so nothing reachable
+            # today raises here; the placement is what keeps that true of a
+            # helper someone adds later (review round 1, m3).
+            title = self._background_completion_title(entry)
+            # The body says what the finished session last SAID when it
+            # COMPLETED, and the house sentence for its state otherwise; it
+            # falls back to the neutral routing sentence when no snippet may be
+            # shown or none exists. See `_background_completion_body` for the
+            # kind gate, the privacy gate, the length budget and why the routing
+            # cue is not repeated here (D5).
+            body = self._background_completion_body(entry, kind)
             if surface is not None:
                 delivered = bool(
                     spawn_detached(cmux_command(surface, title, CONTEXTS.get(kind, ""), body))
                 )
             else:
                 delivered = detached_notify(
-                    # `argv_safe` for parity with the cmux branch above, which
-                    # applies it inside `cmux_command`. A model-written name can
-                    # begin with `-`; this title lands in argv slot 1 of the
-                    # signed bundle, where it is positional and so not misparsed
-                    # today — the wrap exists so the two branches cannot drift
-                    # into disagreeing about whether a title is shape-safe
-                    # (review round 1, m2).
+                    # `argv_safe` on BOTH values for parity with the cmux branch
+                    # above, which applies it inside `cmux_command`. Model-
+                    # written text can begin with `-`; title and body land in
+                    # argv slots 1 and 2 of the signed bundle, where they are
+                    # positional and so not misparsed today — the wrap exists so
+                    # the two branches cannot drift into disagreeing about
+                    # whether this text is shape-safe (review round 1, m2). The
+                    # body needs it at least as much as the title now that it
+                    # carries a model-written sentence rather than a constant
+                    # (review round 1 remediation, m1).
                     argv_safe(title),
-                    body,
+                    argv_safe(body),
                     session_id=entry.id,
                     subtitle=CONTEXTS.get(kind, ""),
                 )

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -15279,6 +15279,84 @@ class OperatorApp(App[None]):
             stored = ""
         return sanitize_text(stored) or BACKGROUND_FALLBACK_TITLE
 
+    def _background_completion_body(self, entry: CatalogEntry) -> str:
+        """The banner body: what the finished session last SAID, or the neutral line.
+
+        WHAT THIS REPLACED AND WHY. The body was the fixed sentence
+        ``BODY_BACKGROUND`` — "You were in another session" — which states a
+        routing fact the user is already the authority on. They know which
+        session they were looking at; what they cannot know without opening the
+        session is what the other one concluded. So the banner's only content
+        line was spent restating the reader's own situation, and eleven
+        completions in a window produced eleven identical bodies distinguished
+        only by their titles.
+
+        The last assistant line answers the question the banner actually raises
+        ("finished — with what?") and is the same fact the sidebar row already
+        shows, so the two surfaces now agree rather than the banner being the
+        poorer one.
+
+        THE ROUTING CUE IS NOT LOST, it moved to where it was already carried.
+        The title is the OTHER session's name, which is what says this is not
+        the session on screen, and the subtitle carries the state
+        (``CONTEXTS``). Re-adding a routing sentence beside the snippet would
+        reintroduce design round 1's D5 in a new place — the frame would again
+        spend a line on something another line already says — so it is
+        deliberately not re-added.
+
+        GATED ON ``session_names_in_notifications``. That flag exists to keep
+        MODEL-WRITTEN session text off a screen other people can see, and a
+        transcript snippet is strictly more session-derived than the name the
+        flag was written for: a name is a topic, a snippet is content. A user
+        who opted out of the name has necessarily opted out of this, so the
+        opt-out returns the neutral sentence, which asserts nothing about the
+        conversation. Reading the flag here and not only in
+        :meth:`_background_completion_title` is what keeps that promise true of
+        the whole frame rather than of its top line.
+
+        BEST-EFFORT, like every call on this path. ``session_preview`` already
+        returns ``""`` for a missing, unreadable or assistant-text-free
+        transcript and swallows ``OSError`` itself; the broad guard is for
+        everything above that contract (a config dir that cannot be resolved, a
+        transcript whose bytes decode into something unexpected) because this
+        runs inside the 1 s completion poll and a body is chrome while delivery
+        is not. Never returns ``""`` — an empty body would render as a banner
+        with a title and a blank line where the content is.
+
+        ``sanitize_text`` because the snippet reaches an OSC escape and an argv,
+        exactly like the title (D16): the text is model-written, and both BEL
+        and ESC terminate an OSC string. It also enforces
+        :data:`BACKGROUND_SNIPPET_MAX_CHARS`, whose reasoning is on the
+        constant.
+        """
+        from local_operator.paths import config_dir
+        from local_operator.resume import session_preview
+        from local_operator.tui.notify import (
+            BACKGROUND_SNIPPET_MAX_CHARS,
+            BODY_BACKGROUND,
+            sanitize_text,
+            session_names_in_notifications,
+        )
+
+        if not session_names_in_notifications():
+            return BODY_BACKGROUND
+        try:
+            # `max_chars` passed rather than trimming afterwards, so the
+            # word-boundary ellipsis `_condense` applies is computed against the
+            # budget the banner actually has — a cut applied later would land
+            # mid-word after the ellipsis had already been placed elsewhere.
+            preview = session_preview(
+                config_dir() / "sessions" / entry.id,
+                max_chars=BACKGROUND_SNIPPET_MAX_CHARS,
+            )
+        except Exception:  # noqa: BLE001 — a body is chrome; delivery is not
+            logger.debug("background completion preview unavailable", exc_info=True)
+            preview = ""
+        # `sanitize_text` re-applies the budget as its `limit`; that is
+        # deliberate belt-and-braces, since stripping control characters can
+        # only shorten the string and the two bounds therefore agree.
+        return sanitize_text(preview, BACKGROUND_SNIPPET_MAX_CHARS) or BODY_BACKGROUND
+
     def _deliver_background_completion(self, entry: CatalogEntry, identity: str) -> bool:
         """Announce one finished background session; report whether a toast went out.
 
@@ -15312,7 +15390,6 @@ class OperatorApp(App[None]):
         from local_operator.proc import spawn_detached
         from local_operator.session.attention import AttentionStore
         from local_operator.tui.notify import (
-            BODY_BACKGROUND,
             CONTEXTS,
             argv_safe,
             cmux_command,
@@ -15337,10 +15414,11 @@ class OperatorApp(App[None]):
         if not store.claim_delivery(identity, entry.completion_token, backend):
             return False
         title = self._background_completion_title(entry)
-        # The body says why this banner exists — the session that finished is
-        # not the one on screen — because the subtitle already carries the
-        # state and repeating it there spent both lines on one word (D5).
-        body = BODY_BACKGROUND
+        # The body carries what the finished session last SAID, falling back to
+        # the neutral routing sentence when no snippet may be shown or none
+        # exists. See `_background_completion_body` for the privacy gate, the
+        # length budget and why the routing cue is not repeated here (D5).
+        body = self._background_completion_body(entry)
         try:
             if surface is not None:
                 delivered = bool(

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -15285,9 +15285,14 @@ class OperatorApp(App[None]):
         ALL THREE KINDS, EXPLICITLY. ``complete`` carries the session's last
         assistant line. ``error`` and ``interrupted`` carry the house sentence
         for that state (``BODIES[kind]`` — "Stopped with an error" / "Stopped
-        before finishing"). Any kind outside :data:`CONTEXTS`, and every case
-        where no snippet may be shown or none exists, degrades to
-        ``BODY_BACKGROUND``.
+        before finishing"). Every case where no snippet may be shown or none
+        exists degrades to ``BODY_BACKGROUND``.
+
+        THREE IS ALL THIS EVER SEES. The caller coerces any kind outside
+        :data:`CONTEXTS` to ``complete``, so a fourth kind does not arrive here
+        as itself — it arrives as ``complete`` and takes the snippet path. See
+        the non-complete branch for why that makes the coercion, not this
+        helper, the first thing to change when a kind is added.
 
         WHAT THIS REPLACED AND WHY. The body was the fixed sentence
         ``BODY_BACKGROUND`` — "You were in another session" — which states a
@@ -15382,9 +15387,25 @@ class OperatorApp(App[None]):
             #
             # `BODIES[kind]` rather than `BODY_BACKGROUND`: the house vocabulary
             # already says the true thing for these states and says more than
-            # the routing sentence does. Unknown kinds keep the neutral fallback
-            # — the same default-to-quiet discipline `digest_subtitle` follows,
-            # so a future kind cannot inherit a claim written for another one.
+            # the routing sentence does.
+            #
+            # THE DEFAULT IS DEFENSIVE, NOT REACHABLE — and a future kind does
+            # NOT land on it. The caller coerces any kind outside `CONTEXTS` to
+            # `complete` before this runs, so every kind arriving here is a
+            # `CONTEXTS` key, and `CONTEXTS` and `BODIES` are declared over the
+            # same key set; the `.get` therefore always hits. What happens to a
+            # genuinely new kind is the opposite of quiet: it is coerced to
+            # `complete` upstream and takes the SNIPPET path under the
+            # `Complete` subtitle, never reaching this branch at all.
+            #
+            # So ADDING A FOURTH KIND STARTS AT THE COERCION, not here. Teach it
+            # the new kind first — otherwise the snippet gate above announces
+            # the new state as a completion and shows a last assistant line for
+            # it, which is review round 1's M1 in a new place. The fallback is
+            # kept anyway because unreachable-but-correct costs nothing and a
+            # `KeyError` inside the 1 s completion poll is not a trade worth
+            # making (review round 2 MINOR-1 ≡ QA Q-3: the earlier wording here
+            # claimed a default-to-quiet safety property this code lacks).
             return BODIES.get(kind, BODY_BACKGROUND)
         if not session_names_in_notifications():
             return BODY_BACKGROUND

--- a/local_operator/tui/notify.py
+++ b/local_operator/tui/notify.py
@@ -294,10 +294,13 @@ BODY_BACKGROUND_DIGEST = "Open the session sidebar (Ctrl+B) to see them"
 #: the session that finished is not the one on screen. One string for all three
 #: kinds, because it describes the ROUTING decision, not the outcome.
 #:
-#: NO LONGER THE DEFAULT. It states a routing fact the user already knows —
-#: they know which session they were in — so it spent the banner's only content
-#: line telling them nothing about the session that finished. The default is
-#: now that session's last assistant line (see
+#: NO LONGER THE DEFAULT ON A COMPLETED SESSION. It states a routing fact the
+#: user already knows — they know which session they were in — so it spent the
+#: banner's only content line telling them nothing about the session that
+#: finished. For ``complete`` the body is now that session's last assistant
+#: line; for ``error`` and ``interrupted`` it is the matching :data:`BODIES`
+#: sentence, because a snippet on those kinds is pre-failure text that asserts
+#: an outcome the session did not have (see
 #: ``OperatorApp._background_completion_body``). This stays as the sentence for
 #: every case where no snippet may be shown or none exists, because it reveals
 #: nothing about the conversation: it is exactly what a user who opted OUT of

--- a/local_operator/tui/notify.py
+++ b/local_operator/tui/notify.py
@@ -282,8 +282,10 @@ def background_digest_title(total: int) -> str:
 #: and the rendered captures confirm it lands whole.
 BODY_BACKGROUND_DIGEST = "Open the session sidebar (Ctrl+B) to see them"
 
-#: The observer path's body line, keyed by ROUTE rather than by state — which
-#: is why it is a single constant and not another entry in :data:`BODIES`.
+#: The observer path's body line when nothing better can be said, and the
+#: FALLBACK the snippet path below degrades to. Keyed by ROUTE rather than by
+#: state — which is why it is a single constant and not another entry in
+#: :data:`BODIES`.
 #:
 #: The state already owns the subtitle (:data:`CONTEXTS`), so repeating it in
 #: the body spent the two most valuable lines under the title saying the same
@@ -291,7 +293,43 @@ BODY_BACKGROUND_DIGEST = "Open the session sidebar (Ctrl+B) to see them"
 #: the body can say that the subtitle cannot is why this banner exists at all:
 #: the session that finished is not the one on screen. One string for all three
 #: kinds, because it describes the ROUTING decision, not the outcome.
+#:
+#: NO LONGER THE DEFAULT. It states a routing fact the user already knows —
+#: they know which session they were in — so it spent the banner's only content
+#: line telling them nothing about the session that finished. The default is
+#: now that session's last assistant line (see
+#: ``OperatorApp._background_completion_body``). This stays as the sentence for
+#: every case where no snippet may be shown or none exists, because it reveals
+#: nothing about the conversation: it is exactly what a user who opted OUT of
+#: session text in banners is entitled to see, and it is still true.
 BODY_BACKGROUND = "You were in another session"
+
+#: How much of a finished session's last reply a banner may carry.
+#:
+#: Bodies WRAP rather than clip in macOS Notification Centre — unlike the
+#: ~43-char title clip ``background_digest_title`` is written against — so no
+#: backend forces a number here and an unbounded paragraph would simply render
+#: as an unbounded paragraph. That is the defect this bound exists for rather
+#: than a wire limit: a banner is on screen for a few seconds and is read in
+#: about one, so anything past a glance is text the user never reads while the
+#: words that identify the session scroll further from the top of the frame.
+#:
+#: 120 characters is roughly a sentence — enough to say what the model
+#: concluded, short enough to take in at a glance. MEASURED, not assumed: a
+#: 116-char body posted through the real signed bundle renders as exactly three
+#: wrapped lines of ~40 characters beneath the two-line title/subtitle block,
+#: which is the tallest frame that still reads as a banner rather than as a
+#: paragraph. The other two legs agree that shorter
+#: is safer: ``cmux notify --body`` and ``notify-send`` both take the body as
+#: ONE argv element (so length is bounded only by ``ARG_MAX``, which no
+#: sentence approaches), while several libnotify servers silently ellipsise a
+#: long body themselves — a budget we choose renders identically everywhere,
+#: one we leave to the server does not.
+#:
+#: Applies BEFORE the ``osascript`` leg appends its "— reopen with: lop
+#: --resume <id>" tail (~40 chars) and prefixes the subtitle, which is the
+#: cold-machine route only and already accepted as the longest frame here.
+BACKGROUND_SNIPPET_MAX_CHARS = 120
 
 #: BEL. Every terminal ever made honours it; it carries no text, but it is what
 #: raises tmux's ``monitor-bell``, Zellij's ``[!]`` flag and X11 urgency hints,

--- a/tests/unit/tui/test_background_completion_notify.py
+++ b/tests/unit/tui/test_background_completion_notify.py
@@ -1491,12 +1491,13 @@ async def test_an_unreadable_transcript_still_delivers_the_banner(
 async def test_a_reply_carrying_escape_sequences_is_sanitised(
     store_root: Path, spawned: list[list[str]]
 ) -> None:
-    """The snippet crosses the same wire as the title, so it gets the same scrub.
+    """The snippet crosses the same wires as the title, so it gets the same scrub.
 
-    The text is MODEL-WRITTEN and reaches an OSC string and an argv. Both BEL
-    and ESC terminate an OSC sequence, so a reply containing either would close
-    it early and leave the remainder to the terminal (D16) — the security
-    boundary ``sanitize_text`` exists for.
+    The text is MODEL-WRITTEN and reaches an argv (cmux, the signed bundle,
+    ``notify-send``) and, on the ``osascript`` leg, an AppleScript string
+    literal — the wires ``sanitize_text`` exists for on this path (D16). It
+    does NOT reach an OSC escape: the only OSC emitter passes a fixed
+    ``BODIES`` constant, never this text (review round 1, m2).
     """
     _make_session(store_root, "current", "Current conversation")
     background = _make_session(store_root, "bg0000000001", "Escape session")
@@ -1558,3 +1559,169 @@ async def test_a_long_reply_is_cut_to_the_banner_budget(
         # rather than as the model having stopped mid-word.
         assert body.endswith("…")
         assert not body[:-1].endswith(" ")
+
+
+#: A last assistant line that SOUNDS like success, which is what the snippet
+#: path returns for a session that failed after it: `session_preview` filters to
+#: `role == "assistant"`, and a runtime failure is never an assistant message.
+#: Deliberately a sentence a reader would act on, so a regression that reopens
+#: M1/D1 fails here as the contradiction a user would actually see rather than
+#: as an abstract string mismatch.
+_SUCCESS_SOUNDING_REPLY = "All 412 tests pass. The migration is complete."
+
+
+@pytest.mark.parametrize(
+    ("kind", "expected_body"),
+    [
+        ("error", "Stopped with an error"),
+        ("interrupted", "Stopped before finishing"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_a_non_complete_session_says_its_state_rather_than_its_last_reply(
+    store_root: Path, spawned: list[list[str]], kind: str, expected_body: str
+) -> None:
+    """The snippet is only true of a session that COMPLETED (review M1, design D1).
+
+    The failure that produced `error`, and the abort that produced
+    `interrupted`, are runtime facts that write no assistant message — so the
+    last assistant line is always PRE-failure text, and a session whose previous
+    turn went well hands the banner a success sentence to print under a
+    "Needs attention" subtitle. The two content lines of the frame would assert
+    opposite things.
+
+    `interrupted` is gated alongside `error` even though design round 1 would
+    have accepted restricting it to `error`: whether a mid-work last line reads
+    honestly is a property of the TEXT, and the fixture below is an interrupted
+    session whose last line closes a sub-task. Nothing in the kind separates
+    that from the coherent case, so the rule is decided by the kind alone.
+
+    Asserts the COMPOSED body, not that some substring is absent: what shipped
+    without this coverage was a body nobody had looked at for these kinds.
+    """
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Nightly index rebuild")
+    _with_assistant_reply(background, _SUCCESS_SOUNDING_REPLY)
+    store = AttentionStore(store_root / "attention.db")
+    store.publish(conversation_identity(background), str(uuid.uuid4()), "fresh", kind)
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot)
+        assert len(spawned) == 1, spawned
+        title, body, _session_id, subtitle = spawned[0]
+        assert body == expected_body
+        # The transcript is not merely absent from the body — no word of it
+        # reaches ANY field, so the assertion cannot be satisfied by the snippet
+        # having moved to the subtitle or the title.
+        assert "migration" not in " ".join(spawned[0]).lower()
+        # The state vocabulary agrees across the frame: the subtitle is this
+        # kind's category and the body is this kind's sentence, which is what
+        # "no line contradicts another" means here.
+        from local_operator.tui.notify import CONTEXTS
+
+        assert subtitle == CONTEXTS[kind]
+        # The title still identifies WHICH session; gating the body does not
+        # cost the routing cue (D2/D5).
+        assert title == "Nightly index rebuild"
+
+
+@pytest.mark.asyncio
+async def test_a_completed_session_still_carries_its_last_reply(
+    store_root: Path, spawned: list[list[str]]
+) -> None:
+    """The other side of the gate: `complete` is unaffected by it.
+
+    Same transcript as the non-complete cases above, so the pair isolates the
+    KIND as the only variable — the snippet reaching the body on `complete` and
+    not on the others is then a property of the gate rather than of the fixture.
+    """
+    from local_operator.tui.notify import BODIES, CONTEXT_COMPLETE
+
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Nightly index rebuild")
+    _with_assistant_reply(background, _SUCCESS_SOUNDING_REPLY)
+    store = AttentionStore(store_root / "attention.db")
+    store.publish(conversation_identity(background), str(uuid.uuid4()), "fresh", "complete")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot)
+        assert len(spawned) == 1, spawned
+        _title, body, _session_id, subtitle = spawned[0]
+        assert body == _SUCCESS_SOUNDING_REPLY
+        assert subtitle == CONTEXT_COMPLETE
+        # `complete` takes the snippet, never the house sentence — that constant
+        # is what the OTHER kinds say, and swapping them would make every
+        # completed banner say "Task complete" again (D5's tautology).
+        assert body != BODIES["complete"]
+
+
+@pytest.mark.asyncio
+async def test_a_failed_session_with_no_transcript_still_says_it_failed(
+    store_root: Path, spawned: list[list[str]]
+) -> None:
+    """The state sentence does not depend on a readable transcript.
+
+    `error` is the kind most likely to have nothing to read — a session that
+    died early may never have written an assistant turn at all — so the gate
+    must resolve before the tail read rather than after it. If the body were
+    computed first and corrected afterwards, this case would degrade to the
+    neutral routing sentence and lose the one fact worth stating.
+    """
+    from local_operator.tui.notify import BODY_BACKGROUND, BODY_ERROR
+
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Died on startup")
+    # No assistant turn was ever written: only the seeded user message.
+    store = AttentionStore(store_root / "attention.db")
+    store.publish(conversation_identity(background), str(uuid.uuid4()), "fresh", "error")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot)
+        assert len(spawned) == 1, spawned
+        body = spawned[0][1]
+        assert body == BODY_ERROR
+        assert body != BODY_BACKGROUND
+
+
+@pytest.mark.asyncio
+async def test_the_privacy_opt_out_covers_every_completion_kind(
+    store_root: Path, spawned: list[list[str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The state sentence is house prose, so the opt-out neither adds nor removes it.
+
+    `BODIES[kind]` is a fixed constant carrying nothing session-derived, so a
+    user who opted out of session text is entitled to see it — the flag's
+    promise is about MODEL-WRITTEN text, and gating the state sentence too would
+    make the opt-out a strictly worse banner for no privacy gain. The completed
+    case in the same run is what shows the flag is still doing its job.
+    """
+    from local_operator.tui.notify import APP_NAME, BODY_BACKGROUND, BODY_INTERRUPTED
+
+    monkeypatch.setattr("local_operator.tui.notify.session_names_in_notifications", lambda: False)
+    _make_session(store_root, "current", "Current conversation")
+    halted = _make_session(store_root, "bg0000000001", "Halted rebuild")
+    _with_assistant_reply(halted, _SUCCESS_SOUNDING_REPLY)
+    finished = _make_session(store_root, "bg0000000002", "Finished rebuild")
+    _with_assistant_reply(finished, _SUCCESS_SOUNDING_REPLY)
+    store = AttentionStore(store_root / "attention.db")
+    store.publish(conversation_identity(halted), str(uuid.uuid4()), "fresh", "interrupted")
+    store.publish(conversation_identity(finished), str(uuid.uuid4()), "fresh", "complete")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot)
+        assert len(spawned) == 2, spawned
+        bodies = {call[3]: call[1] for call in spawned}
+        assert bodies["Interrupted"] == BODY_INTERRUPTED
+        # The completed one loses its snippet to the flag, which is the gate
+        # still working: no word of the transcript survives in any field.
+        assert bodies["Complete"] == BODY_BACKGROUND
+        assert all(call[0] == APP_NAME for call in spawned), spawned
+        assert "migration" not in " ".join(" ".join(call) for call in spawned).lower()

--- a/tests/unit/tui/test_background_completion_notify.py
+++ b/tests/unit/tui/test_background_completion_notify.py
@@ -19,6 +19,7 @@ to find unread work would be cleared by the toast telling them about it.
 
 from __future__ import annotations
 
+import json
 import uuid
 from pathlib import Path
 from typing import Any
@@ -1296,3 +1297,264 @@ async def test_the_digest_title_and_subtitle_describe_the_same_sessions(
     # shrinking the title's scope fails here rather than silently reopening D11.
     assert str(len(whole_tick)) in title, (title, whole_tick)
     assert str(len(remainder)) not in title.split()[0], (title, remainder)
+
+
+def _with_assistant_reply(directory: Path, text: str) -> None:
+    """Append one assistant turn, so the session has something it last SAID.
+
+    Written through the same one-line-per-entry shape ``_make_session`` uses
+    rather than through a writer helper, because what is under test is exactly
+    the tail read ``session_preview`` performs over the bytes on disk.
+    """
+    entry = json.dumps(
+        {
+            "id": "a1",
+            "ts": 2,
+            "type": "message",
+            "payload": {"kind": "message", "role": "assistant", "content": [{"text": text}]},
+        }
+    )
+    with (directory / "transcript.jsonl").open("a", encoding="utf-8") as handle:
+        handle.write(entry + "\n")
+
+
+@pytest.mark.asyncio
+async def test_the_banner_body_carries_the_final_assistant_line(
+    store_root: Path, spawned: list[list[str]]
+) -> None:
+    """The operator's request: say WHAT the session concluded, not where they were.
+
+    The body was the fixed sentence ``BODY_BACKGROUND`` — a routing fact the
+    reader is already the authority on — so eleven completions in one window
+    produced eleven identical bodies. The session's last assistant line answers
+    the question the banner actually raises, and it is the same fact the
+    sidebar row already shows.
+    """
+    from local_operator.tui.notify import BODY_BACKGROUND
+
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Article-search-svc schema review")
+    _with_assistant_reply(background, "The schema review is done: two indexes are redundant.")
+    store = AttentionStore(store_root / "attention.db")
+    store.publish(conversation_identity(background), str(uuid.uuid4()), "fresh", "complete")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot)
+        assert len(spawned) == 1, spawned
+        title, body, session_id, _subtitle = spawned[0]
+        assert body == "The schema review is done: two indexes are redundant."
+        # The routing sentence is GONE from the default frame, not merely
+        # joined: it is the fallback now, and a body carrying both would spend
+        # the content line on the thing that made this uninformative.
+        assert BODY_BACKGROUND not in body
+        # The title still identifies WHICH session, which is what carries the
+        # routing fact now that the body carries content (D5 is not reopened by
+        # restating it beside the snippet).
+        assert title == "Article-search-svc schema review"
+        assert session_id == "bg0000000001"
+
+
+@pytest.mark.asyncio
+async def test_the_last_reply_wins_over_earlier_ones(
+    store_root: Path, spawned: list[list[str]]
+) -> None:
+    """A snippet of the FINAL message, not the first — the preview reads the tail."""
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Long conversation")
+    _with_assistant_reply(background, "First pass: I am still investigating.")
+    _with_assistant_reply(background, "Final answer: the leak was the unclosed cursor.")
+    store = AttentionStore(store_root / "attention.db")
+    store.publish(conversation_identity(background), str(uuid.uuid4()), "fresh", "complete")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot)
+        assert len(spawned) == 1, spawned
+        body = spawned[0][1]
+        assert body == "Final answer: the leak was the unclosed cursor."
+        assert "still investigating" not in body
+
+
+@pytest.mark.asyncio
+async def test_the_snippet_is_kept_off_the_banner_by_the_privacy_flag(
+    store_root: Path, spawned: list[list[str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`display.notification_session_name` off means NO session text at all.
+
+    The flag exists to keep model-written session text off a screen other
+    people can see, and a transcript snippet is strictly more session-derived
+    than the name it was written for: a name is a topic, a snippet is content.
+    A gate that covered only the title would leak the conversation itself into
+    the frame directly beneath the brand the opt-out substitutes — the same
+    review round 1 M2 shape, where a flag governing only some banners makes its
+    own settings copy false.
+    """
+    from local_operator.tui.notify import APP_NAME, BODY_BACKGROUND
+
+    monkeypatch.setattr("local_operator.tui.notify.session_names_in_notifications", lambda: False)
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Secret client migration")
+    _with_assistant_reply(background, "Merged the acquisition due-diligence data room export.")
+    store = AttentionStore(store_root / "attention.db")
+    store.publish(conversation_identity(background), str(uuid.uuid4()), "fresh", "complete")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot)
+        assert len(spawned) == 1, spawned
+        title, body, _session_id, _subtitle = spawned[0]
+        assert body == BODY_BACKGROUND
+        assert title == APP_NAME
+        # Not one word of the conversation reaches the frame.
+        argv = " ".join(spawned[0])
+        assert "acquisition" not in argv
+        assert "due-diligence" not in argv
+        assert "Secret client migration" not in argv
+
+
+@pytest.mark.asyncio
+async def test_a_tool_only_final_turn_falls_back_to_the_neutral_sentence(
+    store_root: Path, spawned: list[list[str]]
+) -> None:
+    """A turn that only made tool calls SAID nothing, so there is nothing to quote.
+
+    ``session_preview`` skips a text-free assistant entry by contract; what is
+    pinned here is that the observer path renders the neutral sentence for it
+    rather than a banner with an empty content line.
+    """
+    from local_operator.tui.notify import BODY_BACKGROUND
+
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Tool only run")
+    with (background / "transcript.jsonl").open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "id": "a1",
+                    "ts": 2,
+                    "type": "message",
+                    "payload": {"kind": "message", "role": "assistant", "content": []},
+                }
+            )
+            + "\n"
+        )
+    store = AttentionStore(store_root / "attention.db")
+    store.publish(conversation_identity(background), str(uuid.uuid4()), "fresh", "complete")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot)
+        assert len(spawned) == 1, spawned
+        assert spawned[0][1] == BODY_BACKGROUND
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_transcript_still_delivers_the_banner(
+    store_root: Path, spawned: list[list[str]]
+) -> None:
+    """A snippet read must never cost the notification (it runs in the 1 s poll).
+
+    The body is chrome; delivery is not. An unreadable transcript degrades to
+    the neutral sentence and the toast still goes out with its title, subtitle
+    and click-through intact.
+    """
+    from local_operator.tui.notify import BODY_BACKGROUND
+
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Unreadable session")
+    _with_assistant_reply(background, "should never be read")
+    (background / "transcript.jsonl").chmod(0o000)
+    store = AttentionStore(store_root / "attention.db")
+    store.publish(conversation_identity(background), str(uuid.uuid4()), "fresh", "complete")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    try:
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _booted(app, pilot)
+            await _settle(app, pilot)
+            assert len(spawned) == 1, spawned
+            title, body, session_id, _subtitle = spawned[0]
+            assert body == BODY_BACKGROUND
+            assert title == "Unreadable session"
+            assert session_id == "bg0000000001"
+    finally:
+        # Restored so the tmp tree can be cleaned up on every platform.
+        (background / "transcript.jsonl").chmod(0o644)
+
+
+@pytest.mark.asyncio
+async def test_a_reply_carrying_escape_sequences_is_sanitised(
+    store_root: Path, spawned: list[list[str]]
+) -> None:
+    """The snippet crosses the same wire as the title, so it gets the same scrub.
+
+    The text is MODEL-WRITTEN and reaches an OSC string and an argv. Both BEL
+    and ESC terminate an OSC sequence, so a reply containing either would close
+    it early and leave the remainder to the terminal (D16) — the security
+    boundary ``sanitize_text`` exists for.
+    """
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Escape session")
+    _with_assistant_reply(background, "done\x1b]0;pwned\x07 and\nwrapped\ttoo")
+    store = AttentionStore(store_root / "attention.db")
+    store.publish(conversation_identity(background), str(uuid.uuid4()), "fresh", "complete")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot)
+        assert len(spawned) == 1, spawned
+        body = spawned[0][1]
+        assert "\x1b" not in body
+        assert "\x07" not in body
+        # Collapsed to one line as well: a banner body is a line, not a block.
+        assert "\n" not in body and "\t" not in body
+        assert body == "done ]0;pwned and wrapped too"
+
+
+@pytest.mark.asyncio
+async def test_a_long_reply_is_cut_to_the_banner_budget(
+    store_root: Path, spawned: list[list[str]]
+) -> None:
+    """A banner is read in about a second; an unbounded paragraph is its own defect.
+
+    Nothing on the wire forces this — Notification Centre WRAPS a body rather
+    than clipping it, and both argv legs take it as one element — so the bound
+    is chosen for the reader and has to be asserted, or it silently stops
+    applying the day someone passes the text through unbudgeted.
+    """
+    from local_operator.tui.notify import BACKGROUND_SNIPPET_MAX_CHARS
+
+    reply = (
+        "I finished the migration audit across all seventeen tenant schemas and found "
+        "three tables still carrying the legacy tenant_id column, which the backfill "
+        "job skipped because their names do not match the prefix filter it uses."
+    )
+    # Comfortably past the budget, so the case cannot go vacuous if the number
+    # is nudged: a reply that only just exceeds it would pass against a bound
+    # that had been quietly raised.
+    assert len(reply) > BACKGROUND_SNIPPET_MAX_CHARS + 80, "the case must exceed the budget"
+
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Long reply session")
+    _with_assistant_reply(background, reply)
+    store = AttentionStore(store_root / "attention.db")
+    store.publish(conversation_identity(background), str(uuid.uuid4()), "fresh", "complete")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot)
+        assert len(spawned) == 1, spawned
+        body = spawned[0][1]
+        assert len(body) <= BACKGROUND_SNIPPET_MAX_CHARS
+        assert body.startswith("I finished the migration audit")
+        # Ellipsised on a word boundary, so the cut reads as a truncation
+        # rather than as the model having stopped mid-word.
+        assert body.endswith("…")
+        assert not body[:-1].endswith(" ")

--- a/tests/unit/tui/test_notify.py
+++ b/tests/unit/tui/test_notify.py
@@ -29,6 +29,7 @@ import pytest
 from local_operator.tui.notify import (
     APP_NAME,
     BACKGROUND_FALLBACK_TITLE,
+    BACKGROUND_SNIPPET_MAX_CHARS,
     BEL,
     BODIES,
     BODY_BACKGROUND,
@@ -812,3 +813,43 @@ def test_the_digest_body_says_where_to_go_since_it_cannot_take_you() -> None:
         context.lower() in BODY_BACKGROUND_DIGEST.lower() for context in CONTEXTS.values()
     )
     assert BODY_BACKGROUND_DIGEST != BODY_BACKGROUND
+
+
+def test_the_snippet_budget_fits_a_banner_and_survives_sanitisation() -> None:
+    """The body budget is a READING bound, and `sanitize_text` must honour it.
+
+    No backend clips a body — Notification Centre wraps, and both argv legs are
+    bounded only by ``ARG_MAX`` — so this number is chosen for the reader, not
+    forced by a wire. It has to stay in the range where a banner is still a
+    glance: comfortably under the title cap's order of magnitude and well under
+    a paragraph. Pinned because a later edit that "just raises it a bit" is the
+    way this becomes a wall of text nobody reads.
+
+    ``sanitize_text`` is the enforcement point (it is what the observer path
+    calls), so the budget is asserted THROUGH it rather than as a bare integer.
+    """
+    assert MAX_TITLE_CHARS < BACKGROUND_SNIPPET_MAX_CHARS <= 200
+    long_reply = "word " * 100
+    assert len(sanitize_text(long_reply, BACKGROUND_SNIPPET_MAX_CHARS)) <= (
+        BACKGROUND_SNIPPET_MAX_CHARS
+    )
+    # The security boundary the snippet shares with the title: a model-written
+    # reply reaches an OSC string and an argv, and both BEL and ESC terminate
+    # an OSC sequence early (D16).
+    assert sanitize_text("done\x1b]0;x\x07 ok", BACKGROUND_SNIPPET_MAX_CHARS) == "done ]0;x ok"
+
+
+def test_the_neutral_body_reveals_nothing_about_the_session() -> None:
+    """`BODY_BACKGROUND` is now the OPT-OUT and failure sentence, not the default.
+
+    The observer body carries a transcript snippet by default; this constant is
+    what a user who turned `display.notification_session_name` off receives,
+    and what every unreadable/absent transcript degrades to. Its whole value is
+    that it asserts nothing about the conversation, so it must stay free of
+    anything session-derived — and non-empty, since an empty body renders as a
+    banner with a blank content line.
+    """
+    assert BODY_BACKGROUND
+    # Still routing rather than outcome: repeating a state category here is the
+    # tautology design round 1 removed (D5).
+    assert not any(context.lower() in BODY_BACKGROUND.lower() for context in CONTEXTS.values())

--- a/tests/unit/tui/test_notify.py
+++ b/tests/unit/tui/test_notify.py
@@ -834,8 +834,10 @@ def test_the_snippet_budget_fits_a_banner_and_survives_sanitisation() -> None:
         BACKGROUND_SNIPPET_MAX_CHARS
     )
     # The security boundary the snippet shares with the title: a model-written
-    # reply reaches an OSC string and an argv, and both BEL and ESC terminate
-    # an OSC sequence early (D16).
+    # reply reaches an argv and an AppleScript string literal, so control
+    # characters are stripped there for the same reason they are on a title
+    # (D16). It does NOT reach an OSC string — the only OSC emitter sends a
+    # fixed `BODIES` constant (review round 1, m2).
     assert sanitize_text("done\x1b]0;x\x07 ok", BACKGROUND_SNIPPET_MAX_CHARS) == "done ]0;x ok"
 
 


### PR DESCRIPTION
## What

The **background-completion banner** — the toast you get when a session finishes while you are attached to a *different* one — now carries a snippet of that session's **last assistant message** as its body, instead of the fixed sentence `You were in another session`.

```
BEFORE                                    AFTER
┌────────────────────────────────────┐    ┌────────────────────────────────────┐
│ Article-search-svc schema review   │    │ Article-search-svc schema review   │
│ Complete                           │    │ Complete                           │
│ You were in another session        │    │ The schema review is done: two     │
└────────────────────────────────────┘    │ indexes are redundant.             │
                                          └────────────────────────────────────┘
```

`OperatorApp._background_completion_body` is the new seam, alongside the existing `_background_completion_title`. It reads through **`resume.session_preview`** — the same tail-read the sidebar and `/resume` picker already use — passing the banner's own `max_chars` so `_condense` computes its word-boundary ellipsis against the real budget rather than having a cut applied afterwards.

The snippet is taken **only for `complete`**. `error` and `interrupted` take the existing `BODIES[kind]` sentence (`Stopped with an error` / `Stopped before finishing`), because `session_preview` filters to `role == "assistant"` and a runtime failure is never an assistant message — so on those kinds the snippet is always *pre-failure* text asserting an outcome the session did not have. See the round-1 remediation comment (**M1**/**D1**).

`BODY_BACKGROUND` is kept, demoted from default to **fallback**.

## Why

The old body stated a routing fact **the reader is already the authority on**. They know which session they were looking at; what they cannot know without opening the other one is what it *concluded*. So the banner's only content line was spent restating the reader's own situation — and with eleven sessions open in a window, eleven completions produced eleven identical bodies distinguished only by their titles.

The last assistant line answers the question the banner actually raises ("finished — with what?"), and it is the same fact the sidebar row beside it already shows, so the two surfaces now agree rather than the banner being the poorer one.

**The routing cue is not lost; it moved to where it was already carried.** The title is the *other* session's name — that is what says this is not the session on screen — and the subtitle carries the state (`CONTEXTS`). Re-adding a routing sentence beside the snippet would reintroduce design round 1's **D5** in a new place: the frame would again spend a line saying what another line already says. It is deliberately not re-added, and the docstring records that decision so the next agent does not "restore" it.

### Gated on `display.notification_session_name`

The flag exists to keep **model-written session text off a screen other people can see**, and a transcript snippet is *strictly more* session-derived than the name the flag was written for: **a name is a topic, a snippet is content.** A user who opted out of the name has necessarily opted out of this.

Reading the flag in the body helper and not only in the title helper is what keeps that promise true of the **whole frame** rather than of its top line — a gate covering only the title would leak the conversation itself into the line directly beneath the brand the opt-out substitutes. That is review round 1's **M2** shape, where a flag governing only some banners makes its own settings copy false.

### Budget: 120 characters, chosen for the reader

No backend forces a number. Notification Centre **wraps** a body rather than clipping it (unlike the ~43-char title clip `background_digest_title` is written against), and both argv legs take the body as one element — `cmux notify --body` and `notify-send` are bounded only by `ARG_MAX`, which no sentence approaches. An unbounded paragraph would simply render as an unbounded paragraph.

So the bound exists for a reader who has about a second. **Measured, not assumed:** a 116-char body posted through the real signed bundle renders as exactly three wrapped lines of ~40 characters beneath the two-line title/subtitle block — the tallest frame that still reads as a banner rather than a paragraph.

### Best-effort, and it cannot cost the notification

This runs inside the **1 s completion poll**. A body is chrome; delivery is not. `session_preview` already returns `""` for an unreadable or assistant-text-free transcript and swallows `OSError` itself; the broad guard covers everything above that contract. The helper **never returns `""`** — an empty body would render as a title over a blank content line.

> **The fallback is for a row that EXISTS.** A session whose `transcript.jsonl` is entirely **absent** never reaches this helper at all: `session_activity` uses the transcript as its clock, so the row does not enter the catalog and no banner is raised to fall back. That is pre-existing on `main` and out of scope here (QA round 1, Q-1) — noted because an earlier draft of this description listed "missing transcript" as a fallback case, which read as though a banner were delivered with the neutral body. It is not.

`sanitize_text` before the wire, because the snippet is model-written text reaching an **argv** (`cmux notify`, the signed bundle, `notify-send`) and, on the `osascript` leg, an **AppleScript string literal**. It does *not* reach an OSC escape — the only OSC emitter passes a fixed `BODIES` constant, never this text (corrected in review round 1, **m2**). The scrub is still required for both wires it does travel, plus the one-line collapse a banner body needs.

## Evidence

> A green suite is not the evidence. Everything below is the **real** `OperatorApp`, booted with `run_test`, against real session directories with real `transcript.jsonl` files, with a real completion published into a real `AttentionStore` — the app's own poll decides what to send, and the capture intercepts only at the process boundary. The triples and argv are what the OS would receive.

### The composed frames — every case, both legs

| case | title | subtitle | body | len |
|---|---|---|---|---|
| **snippet** (headline) | `Article-search-svc schema review` | `Complete` | `The schema review is done: two indexes are redundant.` | 53 |
| **privacy flag OFF** | `Local Operator` | `Complete` | `You were in another session` | 27 |
| **tool-only final turn** | `Tool only run` | `Complete` | `You were in another session` | 27 |
| **unreadable transcript** (chmod 000) | `Unreadable` | `Complete` | `You were in another session` | 27 |
| **control chars** | `Escape injection` | `Complete` | `done ]0;pwned and safe too` | 26 |
| **over budget** (307-char reply) | `Long reply` | `Complete` | `I finished the migration audit across all seventeen tenant schemas and found three tables still carrying the legacy…` | 116 |
| **errored session** (round 1 remediation) | `Nightly index rebuild` | `Needs attention` | `Stopped with an error` | 21 |
| **interrupted session** (round 1 remediation) | `Nightly index rebuild` | `Interrupted` | `Stopped before finishing` | 24 |
| **errored, no assistant turn at all** | `Died on startup` | `Needs attention` | `Stopped with an error` | 21 |

The sanitization row's model-written input was `"done\x1b]0;pwned\x07 and\nsafe\ttoo"` — ESC and BEL stripped, newline and tab collapsed to spaces.

**No transcript at all** is not deliverable through the app (the catalog does not list a session without one), so the helper was exercised directly:

```
bg0000000004             BODY: 'You were in another session'   <- dir exists, no transcript.jsonl
does_not_exist_at_all    BODY: 'You were in another session'   <- dir does not exist
```

### Exact argv, both delivery legs

**cmux leg** (`cmux notify`), snippet case:

```
['cmux', 'notify', '--surface', '1d0f4a3e-2b6c-4d51-9a77-8e0f1c2b3d4e',
 '--title', 'Article-search-svc schema review',
 '--subtitle', 'Complete',
 '--body', 'The schema review is done: two indexes are redundant.']
```

**cmux leg**, privacy flag off — not one word of the conversation reaches the wire:

```
['cmux', 'notify', '--surface', '1d0f4a3e-2b6c-4d51-9a77-8e0f1c2b3d4e',
 '--title', 'Local Operator', '--subtitle', 'Complete',
 '--body', 'You were in another session']
```

**detached leg** (macOS signed bundle), snippet case — the argv `detached_notify` actually resolved on this host:

```
['/Users/…/.local-operator/notifier/LocalOperator.app/Contents/MacOS/notifier',
 'Article-search-svc schema review',
 'The schema review is done: two indexes are redundant.',
 '…/lop resume-click bg0000000001',
 'Complete']
```

A body beginning with `-` is shape-safe on both legs — `cmux_command` applies `argv_safe` to it, and `desktop_notify_command` places it after `--`. Verified:

```
cmux  :  -- rm -rf / was NOT run; the audit only listed candidates.   <- leading space, argv_safe
notify: ['--', 'T', '-- rm -rf / was NOT run; the audit only listed candidates.']
```

### Real delivered banners

Posted through the **real signed bundle** (`LocalOperator.app`, the production darwin route) and captured with `screencapture` from the live Notification Centre — four frames, cropped to the banner:

| frame | what it shows |
|---|---|
| **before** | title + `Complete` + `You were in another session` — the reported defect, one line, no content |
| **after** | same title/subtitle + `The schema review is done: two indexes are redundant.` wrapping to **two** lines |
| **opt-out** | `Local Operator` + `Complete` + `You were in another session` — no session text anywhere in the frame |
| **sanitized** | `done ]0;pwned and safe too` renders as inert text; the escape did not terminate anything |
| **at budget** | the 116-char body wraps to exactly **three** lines of ~40 chars — the measurement the constant cites |

**On the cmux leg specifically:** cmux is **not currently running on this host** (`cmux.sock` refuses with errno 61, no process), so the cmux banner could not be *delivered* live — its exact argv is pinned above and by `tui/test_notify.py`'s pure-function tests, but I did not render it and am not claiming I did. The detached leg *is* this host's live route and is what the five captures above went through.

PNGs are on the build host at `/tmp/crop_banner_{before,after,optout,sanitized,max}.png` for the design round; per AGENTS.md §7 evidence artifacts are not committed to the tree.

### The tests fail against the pre-fix behaviour

Confirmed by reverting `body = self._background_completion_body(entry)` to `body = BODY_BACKGROUND` on the branch tree — **4 failed, 32 passed**:

```
FAILED test_the_banner_body_carries_the_final_assistant_line
  assert 'You were in another session' == 'The schema r...re redundant.'
FAILED test_a_long_reply_is_cut_to_the_banner_budget
  'You were in another session'.startswith('I finished the migration audit') is False
```

## Testing

| gate | result |
|---|---|
| `flake8 .` | clean |
| `black --check .` (26.1.0) | `1123 files would be left unchanged` |
| `isort --check-only .` (5.13.2) | clean |
| `pyright --pythonpath .venv/bin/python .` | `0 errors, 0 warnings, 0 informations` |
| `pytest tests/unit/tui/test_notify.py tests/unit/tui/test_background_completion_notify.py -n0` | **91 passed** in 64s |
| `pytest tests/unit` (whole tree) | running at time of writing — see note |

> **Host contention note.** This host was under load average **107–141** with ~15 sibling pytest processes from other worktrees while these gates ran, which is the exact condition AGENTS.md's xdist auto-worker cap exists for. The four static gates and the 91-test focused run above are **read results**, not assumptions. The whole-tree run was restarted at an explicit `-n 2` rather than the auto cap and its result is posted as a follow-up comment rather than asserted here — no gate is reported green in this table that I did not read the output of.

New coverage:

- `tests/unit/tui/test_background_completion_notify.py` — twelve app-level tests driving the real app: the snippet reaches the body; the **last** reply wins over earlier ones; the privacy flag suppresses all session text (asserting the individual conversation words are absent from the argv, not merely that the title changed); tool-only turn → fallback; unreadable transcript → fallback **and the banner still delivers** with its title, subtitle and click-through intact; control chars stripped; long reply cut on a word boundary with the ellipsis. Round-1 remediation added five more covering **every completion kind** and asserting the *composed* body: `error` and `interrupted` say their state rather than a success-sounding pre-failure snippet (parametrised, with the same transcript as the `complete` case so the kind is the only variable); `complete` still carries its snippet; an errored session that never wrote an assistant turn still says it errored; and the privacy opt-out is checked across kinds. Four of the five fail against the pre-fix helper.
- `tests/unit/tui/test_notify.py` — the budget asserted *through* `sanitize_text` (the actual enforcement point) rather than as a bare integer, and `BODY_BACKGROUND` pinned as non-empty and free of any state category so the D5 tautology cannot creep back into the fallback.

## Not addressed (reported, not fixed)

`SessionRuntime._announce_pending` in `local_operator/session/runtime/owned.py` was checked as a possible second instance of this defect. **It is not the same defect and is deliberately untouched:** it already names the action (`write: /path`, or the `BODIES` vocabulary when a tool gives no description) rather than a routing sentence, it announces a session that is *waiting for a person* rather than one that finished, and it already gates its session name on `session_names_in_notifications` for the same M2 reason. Nothing in it says "You were in another session".

The digest banner (`_announce_background_digest`) is also untouched — it stands for several sessions, so there is no single transcript to quote, and its docstring requires it to stay name-free.

Release: patch — background-completion notifications now carry a snippet of the
finished session's last reply instead of the fixed "You were in another session",
with the state sentence for error/interrupted and the existing privacy flag governing it.

No version bump on this branch; released in `v0.52.1`.

Review rounds (code, QA, design) to follow in the thread.


