### PR TITLE
fix(session): stop a local default save from reporting a torn model pair

### DIFF
--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -3526,9 +3526,8 @@ class Session:
         if explicit:
             # The user chose: from here a ``hosting``/``model_name`` edit on
             # disk keeps its hands off this session (see
-            # ``_apply_config_change``). ``_adopt_configured_model`` passes
-            # ``explicit=True`` too — for the fallback-pin withdrawal below —
-            # and resets this flag itself afterwards.
+            # ``_apply_config_change``, which now never selects a model off a
+            # default reload — only reports one).
             self._explicit_model_choice = True
         # The measured byte cap belonged to the provider that demonstrated it,
         # and that provider is gone. Keeping it would pin a session to a
@@ -11096,6 +11095,10 @@ class Session:
         values = getattr(change, "values", None)
         if not isinstance(values, Mapping):
             return
+        # ``disk`` for anything this session did not write, which is the
+        # conservative default: only the model branch below consults it, and
+        # only to stay quiet about a write this process already reported.
+        source = getattr(change, "source", "disk")
         if any(key.startswith("compaction.") for key in changed):
             # Same outcome as the factory's ``coerce_compaction_settings`` at
             # build (dict -> validated, invalid -> defaults, absent -> None,
@@ -11155,7 +11158,7 @@ class Session:
             if self._job_id is None:
                 self._web_tools_dirty = True
         if "hosting" in changed or "model_name" in changed:
-            self._on_configured_model_changed(values)
+            self._on_configured_model_changed(values, local=source == "local")
 
     def _rebuild_effort_tier_tools(self) -> None:
         """Re-render the tools whose schema advertises the configured effort tiers.
@@ -11187,15 +11190,49 @@ class Session:
             return
         self.refresh_tools([rebuilt.get(tool.name, tool) for tool in self._tools])
 
-    def _on_configured_model_changed(self, values: Mapping[str, Any]) -> None:
+    def _on_configured_model_changed(self, values: Mapping[str, Any], *, local: bool) -> None:
         """Defaults seed NEW conversations; reloading them never selects a model.
 
         A watcher cannot identify which pane authored an edit. Local commands
         that promise a switch call set_model explicitly on their own session.
         Treating a config-sourced birth as a subscription moved every sibling
         at the next provider call, invalidating its cache and conversation.
+
+        ``local`` writes print NOTHING, and that is a correctness fix rather
+        than a volume one (#785). The model default is TWO registry keys, and
+        ``settings_io`` notifies once per FACADE call — so ``/model default
+        p/m``, which loops over ``("hosting", provider)`` and ``("model_name",
+        model_id)``, delivers two synchronous changes to this listener. The
+        first carries a TORN pair: the new provider beside the OLD model name,
+        a combination the user never asked for and that was never on disk as a
+        unit. It differs from the session's model, so the check below fired and
+        printed ``keeping <model>; default changed for new sessions`` — for a
+        save whose whole point was to make that model the default. The receipt
+        the command had already written said the opposite one line above.
+
+        Suppressing on ``source`` rather than coalescing the notices is what
+        matches the watcher's own contract: ``ConfigChange.source`` exists to
+        say "this process wrote it, and the surface that wrote it already told
+        the user" (see :class:`~local_operator.config_watch.ConfigChange` and
+        the TUI's ``_on_config_change``, which has honoured it since it was
+        added). Nothing was lost by staying quiet here — every in-process
+        writer of these two keys is a ``/model`` form that prints its own
+        receipt naming the pair it saved.
+
+        Torn pairs are exclusive to that fast path, which is why the fix is
+        scoped to it and not to the notice. An edit from ANOTHER process
+        arrives through the poll, and a config write is one atomic
+        ``os.replace`` of the whole file, so a single tick sees both keys move
+        together and delivers one change carrying the matched pair. Verified
+        rather than assumed: a two-key external save followed by one
+        ``poll_now()`` produces exactly one delivery, ``changed_keys ==
+        {hosting, model_name}``. So the notice a user actually needs — someone
+        else changed the default under me — still prints, once, with a pair
+        that is real.
         """
         if self._job_id is not None:
+            return
+        if local:
             return
         if (values.get("hosting"), values.get("model_name")) == (
             self.model.provider,

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -11215,20 +11215,37 @@ class Session:
         say "this process wrote it, and the surface that wrote it already told
         the user" (see :class:`~local_operator.config_watch.ConfigChange` and
         the TUI's ``_on_config_change``, which has honoured it since it was
-        added). Nothing was lost by staying quiet here — every in-process
-        writer of these two keys is a ``/model`` form that prints its own
-        receipt naming the pair it saved.
+        added). ``local`` covers exactly the writers that go through the
+        ``settings_io`` facade, because only ``settings_io._store`` calls
+        ``notify_local``: the ``/model`` forms, which print their own receipt
+        naming the pair they saved, and the ``/settings`` Model section, which
+        reports scope on its own surface — its rows repaint to the values just
+        typed, under a ``takes effect: new sessions`` label. Each is its own
+        receipt, so staying quiet here loses nothing the user needed.
 
-        Torn pairs are exclusive to that fast path, which is why the fix is
-        scoped to it and not to the notice. An edit from ANOTHER process
-        arrives through the poll, and a config write is one atomic
-        ``os.replace`` of the whole file, so a single tick sees both keys move
-        together and delivers one change carrying the matched pair. Verified
-        rather than assumed: a two-key external save followed by one
-        ``poll_now()`` produces exactly one delivery, ``changed_keys ==
-        {hosting, model_name}``. So the notice a user actually needs — someone
-        else changed the default under me — still prints, once, with a pair
-        that is real.
+        Writers that reach ``ConfigManager.set_config_value`` directly are NOT
+        covered, since that call has no ``notify_local`` hook: ``/login``
+        (``OperatorApp._save_login_defaults``), the missing-model setup
+        recovery and the CLI ``login`` all write this pair and arrive here as
+        ``disk``, so they still print. Pre-existing, and unchanged by #785 —
+        but it means anyone extending this gate has to route the write through
+        the facade rather than add another source check.
+
+        What is verified about the disk path is narrower than "it cannot
+        tear". A config write is one atomic ``os.replace`` of the whole file,
+        so a two-key external save that a SINGLE tick observes delivers one
+        change carrying the matched pair; that is what
+        ``test_another_process_changing_the_default_still_says_so_once`` pins,
+        and it is why the notice a user actually needs — someone else changed
+        the default under me — prints once with a real pair. Two separate
+        replaces are NOT seen as one. External edits that straddle a tick (the
+        poll interval, or a per-write kqueue wake on macOS) arrive as two
+        ``disk`` deliveries, the first carrying a torn pair, and print twice.
+        That is pre-existing on the disk path, is not the contradiction #785
+        describes, and is deliberately not addressed here: closing it needs
+        per-tick coalescing of the notice, which a source flag cannot express.
+        The fix is scoped to ``local`` because ``source`` identifies that
+        writer set exactly, not because tearing is impossible elsewhere.
         """
         if self._job_id is not None:
             return

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -22056,9 +22056,17 @@ class OperatorApp(App[None]):
             # and the user read a second row — `config.yml changed: model_name
             # needs a relaunch` — that is worded for an edit someone ELSE made,
             # names only the key that happened to differ, and says "when" a
-            # second time in a third phrasing. Two facade calls because the
-            # registry holds the pair as two settings; each notifies once and
-            # both arrive as local, so neither prints.
+            # second time in a third phrasing.
+            #
+            # Two facade calls, because the registry holds the pair as two
+            # settings — and each notifies the watcher separately, so this
+            # loop delivers TWO changes and the first carries a torn pair (new
+            # provider, old model name). Both arrive as ``local``, which is
+            # what keeps them silent: ``_on_config_change`` above returns
+            # early, and ``Session._on_configured_model_changed`` now reads
+            # the same flag. Until #785 the session did NOT, and printed a
+            # ``keeping ...`` notice off that torn pair, contradicting the
+            # receipt written below it.
             try:
                 from local_operator import settings_io
                 from local_operator.config import ConfigManager

--- a/tests/unit/session/test_config_live.py
+++ b/tests/unit/session/test_config_live.py
@@ -976,6 +976,99 @@ async def test_the_writing_pane_is_a_no_op(tmp_path, monkeypatch) -> None:
         await session.dispose()
 
 
+@pytest.mark.asyncio
+async def test_saving_the_default_here_never_reports_the_torn_pair(tmp_path, monkeypatch) -> None:
+    """A local two-key save prints NOTHING, torn intermediate included (#785).
+
+    ``/model default p/id`` writes ``hosting`` and ``model_name`` as two
+    separate facade calls, and each notifies the watcher synchronously — so a
+    listener sees the new provider beside the OLD model name before it sees
+    the pair the user asked for. That torn pair matches nothing, so the
+    divergence check fired and printed ``keeping ...`` for a save whose
+    receipt one line above said the opposite.
+
+    The session under test is pinned to a THIRD model, so the final pair
+    diverges too: without the source gate this emits twice, and a fix that
+    only coalesced to the last delivery would still emit once. Both must be
+    silent, because the writing surface printed its own receipt.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    manager = ConfigManager(config_dir)
+    manager.set_config_value("hosting", MODEL.provider)
+    manager.set_config_value("model_name", MODEL.model_id)
+    session = make_session(tmp_path, RebindableStream({}), compaction_settings=CompactionSettings())
+    _capture_events(session)
+    watcher = process_watcher(config_dir)
+    subscribe(session, watcher)
+    try:
+        session.set_model(MODEL.model_copy(update={"model_id": "chosen"}), explicit=True)
+        await _settle(session)
+        _EVENTS[id(session)].clear()
+
+        # Exactly the loop in ``OperatorApp._activate_resolved_model``: the
+        # facade, one call per key, each notifying this process's watcher.
+        for key, value in (("hosting", "openai"), ("model_name", "gpt-x")):
+            setting = settings_io.resolve_key(key)
+            assert setting is not None, key
+            settings_io.write_setting(manager, setting, value)
+        await _settle(session)
+
+        assert _notices(session) == [], _notices(session)
+        # Silence is not inertness: the save landed and the pin held.
+        assert session.model.model_id == "chosen"
+        saved = ConfigManager(config_dir)
+        assert saved.get_config_value("hosting") == "openai"
+        assert saved.get_config_value("model_name") == "gpt-x"
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_another_process_changing_the_default_still_says_so_once(
+    tmp_path, monkeypatch
+) -> None:
+    """The other half of #785: suppression is scoped to LOCAL writes only.
+
+    An external edit is one atomic ``os.replace`` of the whole file, so a
+    single tick carries both keys and cannot tear — the notice a user needs
+    ("someone changed the default under me") survives, exactly once, naming a
+    pair that really is on disk. This is what proves the source gate did not
+    buy quiet by going deaf.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    manager = ConfigManager(config_dir)
+    manager.set_config_value("hosting", MODEL.provider)
+    manager.set_config_value("model_name", MODEL.model_id)
+    session = make_session(tmp_path, RebindableStream({}), compaction_settings=CompactionSettings())
+    _capture_events(session)
+    watcher = process_watcher(config_dir)
+    subscribe(session, watcher)
+    try:
+        session.set_model(MODEL.model_copy(update={"model_id": "chosen"}), explicit=True)
+        await _settle(session)
+        _EVENTS[id(session)].clear()
+
+        for key, value in (("hosting", "openai"), ("model_name", "gpt-x")):
+            write_from_another_process(config_dir, key, value)
+        change = watcher.poll_now()
+        assert change is not None and change.source == "disk"
+        # One delivery carrying BOTH keys is why the disk path needs no
+        # coalescing; if this ever splits, the notice below would double.
+        assert change.changed_keys == frozenset({"hosting", "model_name"})
+        await _settle(session)
+
+        keep = _notices(session)
+        assert len(keep) == 1, keep
+        assert "keeping test/chosen" in keep[0] and "new sessions" in keep[0]
+        assert session.model.model_id == "chosen"
+    finally:
+        await session.dispose()
+
+
 # ---------------------------------------------------------------------------
 # 10. Web tools: inventory at the turn boundary, never mid-turn
 # ---------------------------------------------------------------------------

--- a/tests/unit/session/test_config_live.py
+++ b/tests/unit/session/test_config_live.py
@@ -1056,8 +1056,11 @@ async def test_another_process_changing_the_default_still_says_so_once(
             write_from_another_process(config_dir, key, value)
         change = watcher.poll_now()
         assert change is not None and change.source == "disk"
-        # One delivery carrying BOTH keys is why the disk path needs no
-        # coalescing; if this ever splits, the notice below would double.
+        # Narrower than "the disk path cannot tear": what is pinned is that a
+        # two-key save observed by ONE tick arrives as a single matched pair,
+        # so the notice below is single. Two external writes that straddle a
+        # tick do split, and do double it — pre-existing and out of scope for
+        # #785 (see ``Session._on_configured_model_changed``).
         assert change.changed_keys == frozenset({"hosting", "model_name"})
         await _settle(session)
 


### PR DESCRIPTION
## Change authorization

**C1 — standard / pre-authorized bug fix.** This PR is the change record. No version bump (`pyproject.toml` untouched, stays at the last released version).

**Replaces #785**, which is `CONFLICTING` and cannot be rebased mechanically: its design targets machinery `main` has since deleted. See "Why #785 could not be rebased" below.

## Root cause

Saving the boot default writes **two** registry keys, and `settings_io` notifies the config watcher **once per facade call** — so `app.py`'s loop

```python
for key, value in (("hosting", provider), ("model_name", model_id)):
    settings_io.write_setting(manager, setting, value)
```

delivers **two** synchronous changes to every subscribed `Session`. The first carries a **torn pair**: the new provider beside the **old** model name — a combination the user never asked for and that was never on disk as a unit.

`Session._on_configured_model_changed` compared that torn pair against the session's model, found a difference, and emitted `keeping <model>; default changed for new sessions`. So a save whose whole purpose was to make that model the default printed a notice **contradicting the receipt one line above it**.

Measured, not assumed — a watcher subscriber on the real `/model default openrouter/chosen` path:

```
source='local'   changed=['hosting']     pair=(openrouter, old)      <- torn
source='local'   changed=['model_name']  pair=(openrouter, chosen)
```

### An inaccurate comment was part of the bug

`app.py` asserted a suppression the code did not implement: *"each notifies once and both arrive as local, so neither prints."* `Session` never read `.source` at all (0 occurrences in `session.py`) while `config_watch.py` does set `source="local"` vs `"disk"`. The comment described the intended design; the session simply never honoured it. Corrected here.

## The fix, and why this mechanism

Gate the notice on `ConfigChange.source == "local"` — which is precisely what the watcher's own contract says the field is for:

> `source` tells a listener whether THIS process made the write (`"local"`: the page or CLI here already showed its own result, so the TUI stays quiet)

The TUI's `_on_config_change` has honoured this since it was added; the session is now consistent with it. Nothing is lost by staying quiet, because `local` covers exactly the writers that go through the `settings_io` facade — the only caller of `notify_local`. Those are the `/model` forms, which print their own receipt naming the pair they saved, and the `/settings` Model section, which reports scope on its own surface (rows repaint to the value just typed, under a `takes effect: new sessions` label). Writers that call `ConfigManager.set_config_value` directly are *not* covered and still print: `/login`, the missing-model setup recovery, and the CLI `login`. That is pre-existing and unchanged here.

**Why not coalesce on the notice side?** Coalescing to the last delivery would still emit a notice for a save the user just made and already has a receipt for. It also treats the symptom (two events) rather than the fact that one of them is *not a real state*. Suppressing by source removes exactly the deliveries whose reporting is redundant, and leaves the poll path untouched.

**Why this is safely scoped.** The fix targets `local` because `source` identifies that writer set exactly — not because tearing is impossible elsewhere. A config write is one atomic `os.replace` of the whole file, so a two-key external save that a **single tick** observes delivers one change carrying the matched pair:

```
=== external two-key save, then one poll ===
  source='disk'   changed=['hosting', 'model_name'] pair=(openai, gpt-x)
deliveries: 1  -> matched pair
```

That is what the disk-path test pins, and it is why the notice a user genuinely needs — *someone else changed the default under me* — still prints, once, naming a pair that really is on disk.

Two separate `os.replace` calls are **not** seen as one. External edits that straddle a tick (the poll interval, or a per-write kqueue wake on macOS) arrive as two `disk` deliveries, the first carrying a torn pair, and print twice:

```
=== two external writes, a poll between them ===
  ('disk', ['hosting'],    ('openai', 'm'))      <-- torn
  ('disk', ['model_name'], ('openai', 'gpt-x'))
deliveries: 2
```

This is **pre-existing on the disk path**, byte-identical on `origin/main`, and deliberately not addressed here: closing it needs per-tick coalescing of the notice, which a source flag cannot express. It is a different defect from the self-contradicting receipt #785 describes.

**No config-following behaviour is reintroduced.** #797 deliberately removed it ("Defaults seed NEW conversations; reloading them never selects a model"); this PR only changes whether a notice is *emitted*, never whether a model is *selected*.

## Reproduction — actual output

Real `OperatorApp`, real `Session`, real `ConfigManager`, real facade writes, real process watcher. Isolated `HOME`/`LOCAL_OPERATOR_CONFIG_DIR`, every inherited `CMUX_*` stripped. No paid provider calls. [Scripts and raw artifacts](https://gist.github.com/damianvtran/4a922b8e38397f84ea2b02f0260fcda8).

**Before** — `/model default openrouter/chosen`:
```
--- transcript notices: 2 ---
  [1] boot default saved to ~/config/config.yml: hosting openrouter, model_name chosen (used by new sessions) · openrouter logged in
  [2] keeping openrouter/chosen; default changed for new sessions. /model saved adopts it here
```
Note notice [2] is self-contradictory: it says the default changed away from `openrouter/chosen` while the default **is now exactly** `openrouter/chosen`.

**After**:
```
--- transcript notices: 1 ---
  [1] boot default saved to ~/config/config.yml: hosting openrouter, model_name chosen (used by new sessions) · openrouter logged in
'keeping' notices: 0
session model: openrouter/chosen     saved default: openrouter/chosen
```

**Both halves, one probe** (a session pinned to a third model, so the final pair diverges too):
```
A) LOCAL two-key save (this process, /model default):
   notices=0 []
B) EXTERNAL default change (another process + poll):
   notices=1 ['keeping test/chosen; default changed for new sessions. /model saved adopts it here']
   session model unchanged: test/chosen
RESULT: PASS (local silent=True, external speaks once=True)
```

## Before / after frames

Rendered with `scripts.visual_capture.save_capture` (real `OperatorApp`, production CSS), rasterized and **actually viewed**, at two widths.

| | Before | After |
|---|---|---|
| 100 cols | ![before 100](https://gist.githubusercontent.com/damianvtran/4a922b8e38397f84ea2b02f0260fcda8/raw/29c0d8874533574ea6cbed3e39092456dc10c8fb/before-100.svg) | ![after 100](https://gist.githubusercontent.com/damianvtran/4a922b8e38397f84ea2b02f0260fcda8/raw/6accf70a790e35a18afcd920b186ff6088c533de/after-100.svg) |
| 60 cols | ![before 60](https://gist.githubusercontent.com/damianvtran/4a922b8e38397f84ea2b02f0260fcda8/raw/6a3c579d14482e402d6fda89856b0bcadc8a50b4/before-60.svg) | ![after 60](https://gist.githubusercontent.com/damianvtran/4a922b8e38397f84ea2b02f0260fcda8/raw/09c1b959dc64e26b8b9657e7bc3949e9adb986e3/after-60.svg) |

The contradictory second line is gone; the true receipt is untouched at both widths.

## Tests

Two regression tests in `tests/unit/session/test_config_live.py`, beside the existing model-rule table:

- `test_saving_the_default_here_never_reports_the_torn_pair` — drives the **exact** two-key facade loop `app.py` runs, against a session pinned to a **third** model so the final pair diverges too. Without the gate this emits **twice**; a fix that merely coalesced to the last delivery would still emit **once**. Asserts silence *and* that the save landed and the pin held (silence is not inertness).
- `test_another_process_changing_the_default_still_says_so_once` — the other half: asserts the external path delivers `source == "disk"` with `changed_keys == {hosting, model_name}` in **one** change, and that the notice still fires exactly once. This is what proves the gate did not buy quiet by going deaf.

**Both were proved capable of failing** (AGENTS.md "Prove the test can still fail"). Reverting only the `if local: return` guard:

```
Left contains 2 more items, first extra item: 'keeping test/chosen; default changed for new sessions...'
1 failed, 1 passed
```
The torn-pair test fails with exactly the 2 duplicates; the disk test correctly stays green, confirming it is scoped to the other half.

## Gate results

| Gate | Result |
|---|---|
| `flake8 .` | clean |
| `black --check .` (26.1.0) | `1125 files would be left unchanged` |
| `isort --check .` (5.13.2) | clean |
| `pyright --pythonpath .venv/bin/python .` | `0 errors, 0 warnings, 0 informations` |
| `pytest tests/unit -q` | **16781 passed**, 18 skipped, 9 failed — see below |
| `tests/unit/session/test_config_live.py` | 82 passed |

### The 9 failures are pre-existing and environmental — proven, not assumed

All 9 are in `tests/unit/tui/test_ask_picker.py` (ask-picker footer), a surface this diff does not touch. AGENTS.md warns against writing failures off as weather, so I bisected instead:

1. Reverting **both** source files (keeping only the new tests) — **still fails**. Not my code.
2. Pristine `origin/main` @ `5bcd0319e` in a worktree at a *short* path — **122 passed**.
3. Pristine `origin/main` @ **the same commit** in a worktree at a *long* path — **fails identically**.

The assertions look for `answer` / `^e more` in the painted footer and instead find the cwd: `'◆ test/model › ⌂ /Users/damian/workspace/repos/lo-785-rescope'`. The footer is **sensitive to the checkout path length**, which crowds the routed keys out of the painted row. This is a latent test-isolation defect on `main`, reproducible on unmodified `main`, and independent of this change. **Not addressed here** (out of scope; no issue created per standing instructions) — flagging it for a follow-up decision.

## Why #785 could not be rebased

`main` moved 30+ commits, and #797 (`5f3a63ee2`) rewrote the exact subsystem:

- `_adopt_configured_model` — **deleted** from `main`.
- `_configured_model_generation` — **gone** (0 occurrences).
- `_on_configured_model_changed` — rewritten; no longer branches on `_model_source`/`_explicit_model_choice` to choose adopt-vs-keep.

#785's patch branched on `self._model_source != "config" or self._explicit_model_choice` and called `_adopt_configured_model`. Resolving that conflict textually would **reinstate the config-following policy #797 intentionally removed**. This PR is a fresh implementation against main's current design instead.

**Bug 1 of #785 (picker help noise on every `ModelQueryOpened`) is dropped**: verified already fixed independently on `main`, where `on_model_query_opened` dedupes the hint against the ledger's last row. Nothing of that half is carried over.

Of #785's wording changes, **none** are carried over: `main` has since reworded these strings itself, and the current text is already correct once the spurious notice stops firing. Minimal diff by preference.

## Rollout / rollback

No migration, no config rewrite, no schema change. Rollback is reverting this PR.

