### PR TITLE
chore(release): bump version to 0.52.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.30"
+version = "0.52.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window for **v0.52.0**. Owner session pid: 5095.

One line in one file: `pyproject.toml` `version = "0.51.30"` → `"0.52.0"`.

Window (both merged before this bump; re-derived from `git log v0.51.30..origin/main`):
- [x] #806 (`1fe816629`) — inline `/credential` capture in the composer
- [x] #811 (`163cecb2a`) — encrypted secret store + `lop secret` CLI (1 of 4)

**Why minor:** #811 clears the step-function bar on its own — a new encrypted store plus a new `lop secret` CLI surface is a new capability, not a fix to an existing one. Per AGENTS.md, one bump for the whole window.

`git diff v0.51.30..origin/main -- pyproject.toml` shows no `version =` change from either window PR (#811 edits the dependency list only), so 0.52.0 has not been consumed.

Release: minor — the encrypted `lop secret` store and inline `/credential` capture.