### PR TITLE
fix(tui): stop reporting a newer runtime as a downgrade

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2903,6 +2903,13 @@ class OperatorApp(App[None]):
         #: session id for the owner notices and empty for disk drift — see
         #: :meth:`_check_build_skew` for why the two differ.
         self._skew_notice_shown: set[tuple[str, str, str, str]] = set()
+        #: The build a self-refreshing runtime was on when it retired, plus how
+        #: to name its session, set by :meth:`_on_runtime_refreshed` and
+        #: consumed once by :meth:`_announce_refresh_completed` after the
+        #: successor binds. Held across that gap because the retiring stamp
+        #: only exists BEFORE the re-bind overwrites it, and the comparison it
+        #: is needed for can only be made after.
+        self._refreshed_from: tuple[Any, str] | None = None
         #: True while a runtime is being started for a cold viewer; the band
         #: says "starting…" for exactly this interval.
         self._starting_runtime = False
@@ -11807,16 +11814,78 @@ class OperatorApp(App[None]):
         The latch is reset because it was set by the engage that bound the
         runtime that just left — without the reset the first keystroke after
         ``lop-update`` would pay, in the foreground, a cold start this could
-        have paid in the background. No notice is painted: the operator's bar
-        is "never see this message", the band's ``starting…`` state covers
-        the ~1 s the re-engage takes, and a line of prose for a background
-        housekeeping event is noise. After the bind ``_check_build_skew``
-        runs again and, with a fresh runtime, the owner stamp equals the disk
-        stamp and stays silent.
+        have paid in the background. The band's ``starting…`` state covers the
+        ~1 s the re-engage takes, so nothing here interrupts the user; the one
+        line that IS painted comes after the successor binds and names what
+        changed (:meth:`_announce_refresh_completed`).
+
+        The retiring build is captured HERE because this is the last moment it
+        exists: the facade still carries the stamp it read at dial, and the
+        bind that follows overwrites it with the successor's. Held on the app
+        rather than passed down because the re-engage is a background worker
+        whose completion is where the comparison can first be made.
         """
         logger.debug("runtime retired for a newer build; re-engaging")
+        session = self._session
+        version = str(getattr(session, "owner_version", "") or "")
+        if version:
+            from local_operator.update import BuildStamp
+
+            self._refreshed_from = (
+                BuildStamp(
+                    version=version,
+                    source_ref=str(getattr(session, "owner_source_ref", "") or ""),
+                ),
+                _session_subject(session),
+            )
+        else:
+            # A runtime too old to say what it ran. There is no "from" side to
+            # name, and a half-stated change ("updated to X") reads as an
+            # update that came from nowhere, so this one stays silent.
+            self._refreshed_from = None
         self._warm_engage_started = False
         self._start_runtime_engage(reason="refresh")
+
+    def _announce_refresh_completed(self) -> None:
+        """One line naming the version change a self-refresh just made.
+
+        The operator asked for this explicitly: an update that happens on its
+        own should still SAY it happened, in the idle window, once. Everything
+        else about the refresh stays invisible — this fires only after the
+        successor is bound, so the line describes a completed fact rather than
+        an intention.
+
+        Gated on the build ACTUALLY moving. The re-engage tail runs for every
+        engage reason, and a runtime that retired and came back on the same
+        build (a restart that was not an update, a successor that resolved the
+        same install) changed nothing the user could act on; announcing it
+        would turn ordinary re-engagement into a stream of notices.
+
+        ``note`` ink, matching the skew notice one screen away: nothing is
+        wrong and nothing is asked of the user, but this answers a question
+        they would otherwise ask ("why did my session restart?"), which is not
+        what the dim ``info`` receipt is for.
+        """
+        pending, self._refreshed_from = self._refreshed_from, None
+        if pending is None:
+            return
+        before, subject = pending
+        session = self._session
+        version = str(getattr(session, "owner_version", "") or "")
+        if not version:
+            return
+        from local_operator.update import BuildStamp
+
+        after = BuildStamp(
+            version=version,
+            source_ref=str(getattr(session, "owner_source_ref", "") or ""),
+        )
+        if after == before:
+            return
+        self._system_notice(
+            f"{subject} updated to a newer version ({_build_change(before, after)}).",
+            "note",
+        )
 
     def _start_runtime_engage(self, *, reason: str) -> None:
         """Engage a runtime for a cold viewer, at most once per binding."""
@@ -11825,6 +11894,9 @@ class OperatorApp(App[None]):
         session = self._session
         ensure = getattr(session, "_ensure_bound", None)
         if not callable(ensure) or not getattr(session, "is_cold", False):
+            # Nothing will bind, so drop any pending refresh announcement for
+            # the same reason as the two skips below: it has no "to" side.
+            self._refreshed_from = None
             return
         # BEFORE the spawn, which is the moment the disk build matters: the
         # runtime is started from ``sys.executable``, resolved fresh, so a
@@ -11843,6 +11915,10 @@ class OperatorApp(App[None]):
             # `/model` rebuild the session, which adopts and engages again
             # with a real provider in place.
             logger.debug("%s engage skipped: no provider/model configured", reason)
+            # No successor is coming, so a pending refresh announcement has no
+            # "to" side and must not survive to be answered by some later,
+            # unrelated engage against a different session.
+            self._refreshed_from = None
             return
         self._warm_engage_started = True
         self._set_starting(True)
@@ -11864,6 +11940,9 @@ class OperatorApp(App[None]):
                 # to retry.
                 logger.debug("runtime engage failed (%s)", reason, exc_info=True)
                 self._warm_engage_started = False
+                # Same reason as the skip above: nothing bound, so there is no
+                # change to name and the pending stamp must not outlive it.
+                self._refreshed_from = None
                 return
             finally:
                 self._set_starting(False)
@@ -11876,6 +11955,13 @@ class OperatorApp(App[None]):
             # binding to it without spawning, i.e. an ordinary first prompt
             # against a stale runtime (review round 1, R1-4).
             self._check_build_skew(reason=f"{reason}-bound")
+            # A pending self-refresh resolves HERE and nowhere else: this is
+            # the first moment the successor's stamp is readable, which is
+            # what makes the announcement a statement of fact rather than of
+            # intent. Unconditional because the pending slot is only ever set
+            # by the refresh path and is cleared on read, so an ordinary
+            # engage finds nothing and says nothing.
+            self._announce_refresh_completed()
 
         self.run_worker(run(), group="warm-engage", exclusive=False)
 
@@ -20100,7 +20186,14 @@ class OperatorApp(App[None]):
         * **owner skew** \u2014 the runtime this session is bound to reports a
           different build than this window, or reports none at all (which
           means it predates the field, and is therefore older by
-          construction). The remedy is the RUNTIME's, never the user's: an
+          construction). A difference does not by itself say which side is
+          behind, and getting that backwards is what made this branch report
+          an upgrade as a downgrade: the owner is compared with the build ON
+          DISK (:func:`_owner_matches_disk`), and an owner that MATCHES disk
+          is the current one — the window is the stale side, disk drift above
+          has already said so, and this branch stays completely silent. Only a
+          runtime that differs from disk as well is genuinely stale, and its
+          remedy is the RUNTIME's, never the user's: an
           idle stale runtime is asked to retire now (``request_refresh``, the
           belt for the reaper's own self-refresh) and this viewer re-engages
           a fresh one on its ``retiring`` frame with no notice at all. Every
@@ -20203,12 +20296,34 @@ class OperatorApp(App[None]):
         # fixed, and leaves ``/stop`` ambiguous about which session it acts on
         # (design review round 1, D1). The title is what the user named and can
         # see; "this session" survives only as the fallback for an unnamed one.
-        title = str(getattr(session, "conversation_name", "") or "").strip()
-        subject = f"\u201c{title}\u201d" if title else "this session"
+        subject = _session_subject(session)
         from local_operator.update import BuildStamp
 
         owner = BuildStamp(version=owner_version, source_ref=owner_ref) if owner_version else None
         if owner is not None and owner == loaded:
+            return
+        # WHICH SIDE IS STALE? A difference alone does not say, and this branch
+        # used to assume the runtime always was. On this host the opposite is
+        # the routine shape: a window keeps the build it imported at launch
+        # forever, ``lop-update`` runs several times a day, and a runtime
+        # spawned AFTER it resolves ``sys.executable`` fresh — so the runtime
+        # is the NEWER side. Assuming otherwise asked a perfectly current
+        # runtime to retire (it answered ``kept:``, because ITS comparison is
+        # against disk and found no change), read that as "staying on the old
+        # build", and painted ``newer → older`` promising a switch to a
+        # version it was already running.
+        if owner is not None and _owner_matches_disk(owner, loaded, on_disk):
+            # The RUNTIME is current and the WINDOW is the stale side. Say
+            # nothing and ask for nothing: notice A above has already reported
+            # that the install moved and named ``/reload`` as the remedy, so a
+            # second line about the same fact pointing the other way is the
+            # defect, not the diagnosis.
+            logger.debug(
+                "build skew (owner) at %s: %s is current, this window (%s) is behind",
+                reason,
+                owner.label(),
+                loaded.label(),
+            )
             return
         # Stale owner, and what the user is told depends on what the RUNTIME
         # does about it, not on what this viewer guessed.
@@ -31107,6 +31222,57 @@ def _build_change(before: Any, after: Any) -> str:
     if same_version and before.source_ref and after.source_ref:
         return f"{before.version}, {before.source_ref[:7]} \u2192 {after.source_ref[:7]}"
     return f"{before.label()} \u2192 {after.label()}"
+
+
+def _session_subject(session: Any) -> str:
+    """How a build notice NAMES the session it is about.
+
+    The title the user chose and can see, quoted; ``this session`` only when
+    there is none. Shared by every build notice so two of them on one screen
+    cannot name the same conversation two different ways: with a deictic
+    subject in both, two stale sessions in one terminal render as two
+    byte-identical paragraphs, which reads as the app printing one line twice
+    (design review round 1, D1).
+    """
+    title = str(getattr(session, "conversation_name", "") or "").strip()
+    return f"\u201c{title}\u201d" if title else "this session"
+
+
+def _owner_matches_disk(owner: Any, loaded: Any, on_disk: Any) -> bool:
+    """Whether the bound runtime is the CURRENT build and this window is behind.
+
+    The discriminator for build skew, and the reason it compares against DISK
+    rather than ordering version numbers. The build on disk is what a process
+    started right now would run, so it is the only fixed reference the two
+    long-lived populations here — a window frozen at the build it imported,
+    and a runtime spawned at some later moment — can both be measured against.
+    An owner equal to it is by definition not stale, whatever its version
+    string reads next to the window's.
+
+    **Do not "simplify" this into a version comparison.** This host's headline
+    drift is a same-version rebuild: ``lop-update`` builds from ``main`` while
+    ``pyproject.toml`` still names the last released version, so the two builds
+    are ``0.51.30@aaaaaaa`` and ``0.51.30@bbbbbbb`` and NO ordering of version
+    numbers can say which is which. ``BuildStamp`` equality resolves it exactly,
+    because the recorded ref is part of the token.
+
+    ``on_disk`` is ``None`` only when ``installed_build()`` raised, i.e. when
+    check A was skipped too and the reference does not exist. Version ordering
+    is the fallback there and strictly worse: it answers only when the versions
+    differ AND both parse, so an inconclusive comparison (a shared version, an
+    unparseable side) deliberately returns False and leaves the pre-existing
+    advisory line in place — an undiagnosable skew is still worth one line, and
+    silencing it would regress review round 1 finding R1-1.
+    """
+    if on_disk is not None:
+        return owner == on_disk
+    from local_operator.update import parse_version
+
+    owner_parsed = parse_version(owner.version)
+    loaded_parsed = parse_version(loaded.version)
+    if owner_parsed is None or loaded_parsed is None:
+        return False
+    return owner_parsed > loaded_parsed
 
 
 def _model_spec(session) -> Any | None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -11865,6 +11865,16 @@ class OperatorApp(App[None]):
         wrong and nothing is asked of the user, but this answers a question
         they would otherwise ask ("why did my session restart?"), which is not
         what the dim ``info`` receipt is for.
+
+        THE ARROW IS SOUND HERE BY CONSTRUCTION, which is why this does not
+        need the directional predicate ``_check_build_skew`` uses. A runtime
+        retires for a refresh only when its own comparison finds the build on
+        disk has moved, and the successor is spawned from that same disk
+        install \u2014 so ``after`` is the disk build and ``before`` is one the disk
+        has already replaced. The one route that could pair unrelated stamps
+        was a refresh slot surviving a cancelled engage, which is closed at its
+        source in :meth:`_cancel_runtime_engage` rather than papered over with
+        a second check here (review round 1, R1-2).
         """
         pending, self._refreshed_from = self._refreshed_from, None
         if pending is None:
@@ -11882,8 +11892,16 @@ class OperatorApp(App[None]):
         )
         if after == before:
             return
+        # BARE ARROW, not a parenthetical. The parenthetical form splits the
+        # version pair across rows at 6 of 19 name lengths at both 80 and 100
+        # columns \u2014 including length 0, the unnamed-session default \u2014 which is
+        # the same wrap the sibling notice's docstring above already records
+        # fixing. "updated" plus a forward arrow carries the direction, so the
+        # clause it replaced was filler beside the pair it introduced, and
+        # actively misleading on a same-version rebuild where both stamps read
+        # alike (design review round 1, D1/D2/D3).
         self._system_notice(
-            f"{subject} updated to a newer version ({_build_change(before, after)}).",
+            f"{subject} updated {_build_change(before, after)}.",
             "note",
         )
 
@@ -12218,6 +12236,15 @@ class OperatorApp(App[None]):
         """
         self.workers.cancel_group(self, "warm-engage")
         self._set_starting(False)
+        # THE FOURTH EXIT. Cancelling the group kills the worker before its
+        # tail, so neither the `except` clear nor `_announce_refresh_completed`
+        # runs and a pending refresh stamp would survive the swap \u2014 to be
+        # answered by the NEXT session's ordinary engage, naming the session the
+        # user just left against an unrelated runtime's build, with the pair
+        # running backwards under the word "updated" (review round 1 R1-2 /
+        # QA Q-2). The three clears inside `_start_runtime_engage` enumerate the
+        # exits it can see; this is the one that happens from outside it.
+        self._refreshed_from = None
 
     async def _retire_unused_runtime(self, session: Any) -> None:
         """Hand back a runtime this viewer started but never used.
@@ -20188,11 +20215,15 @@ class OperatorApp(App[None]):
           means it predates the field, and is therefore older by
           construction). A difference does not by itself say which side is
           behind, and getting that backwards is what made this branch report
-          an upgrade as a downgrade: the owner is compared with the build ON
-          DISK (:func:`_owner_matches_disk`), and an owner that MATCHES disk
-          is the current one — the window is the stale side, disk drift above
-          has already said so, and this branch stays completely silent. Only a
-          runtime that differs from disk as well is genuinely stale, and its
+          an upgrade as a downgrade. :func:`_owner_is_not_behind_this_window`
+          decides it on two terms — the owner IS the build on disk, or its
+          version parses strictly newer than this window's — and either one
+          means the WINDOW is the stale side, disk drift above has already
+          said so, and this branch stays completely silent. Both terms are
+          load-bearing: equality alone described only a two-build host and
+          left the reversed sentence intact whenever window, runtime and disk
+          were three different builds (review round 1 R1-1 / QA Q-1).
+          Only a runtime that neither term clears is genuinely stale, and its
           remedy is the RUNTIME's, never the user's: an
           idle stale runtime is asked to retire now (``request_refresh``, the
           belt for the reaper's own self-refresh) and this viewer re-engages
@@ -20312,7 +20343,7 @@ class OperatorApp(App[None]):
         # against disk and found no change), read that as "staying on the old
         # build", and painted ``newer → older`` promising a switch to a
         # version it was already running.
-        if owner is not None and _owner_matches_disk(owner, loaded, on_disk):
+        if owner is not None and _owner_is_not_behind_this_window(owner, loaded, on_disk):
             # The RUNTIME is current and the WINDOW is the stale side. Say
             # nothing and ask for nothing: notice A above has already reported
             # that the install moved and named ``/reload`` as the remedy, so a
@@ -20394,6 +20425,26 @@ class OperatorApp(App[None]):
                     loaded.label(),
                     f"{subject} is running an older version than this window \u2014 it "
                     "will switch to the new version when it is next idle.",
+                    scope,
+                    notice_kind="note",
+                )
+                return
+            if not _skew_direction_is_knowable(owner, loaded, on_disk):
+                # Same version, different refs, and disk is a THIRD ref \u2014 three
+                # rebuilds of one release, which no ordering can rank. The
+                # arrow copy below would assert an order we cannot derive, and
+                # asserting one anyway is exactly how the reversed sentence
+                # shipped. Name both builds without claiming which came first;
+                # the remedy is identical either way, since the runtime's own
+                # reaper compares itself against disk and acts on the answer
+                # (QA round 1, Q-1 all-refs sub-case).
+                announce(
+                    "owner-undirected",
+                    owner.label(),
+                    loaded.label(),
+                    f"{subject} is running {owner.label()}, this window "
+                    f"{loaded.label()} \u2014 it will switch to the version on disk "
+                    "when it is next idle.",
                     scope,
                     notice_kind="note",
                 )
@@ -31234,38 +31285,63 @@ def _session_subject(session: Any) -> str:
     byte-identical paragraphs, which reads as the app printing one line twice
     (design review round 1, D1).
     """
-    title = str(getattr(session, "conversation_name", "") or "").strip()
+    # GUARDED, not merely defaulted. On a real ``RemoteSession`` this property
+    # reads ``frontend_state``, which RAISES ``RuntimeError`` until the first
+    # sync completes (``session/remote.py``) \u2014 and the refresh callback calls
+    # this BEFORE it re-engages, so a raise there costs the eager re-engage
+    # this feature exists to provide and leaves the viewer cold until the next
+    # keystroke. ``_go_cold``'s guard swallows the exception, which makes the
+    # loss silent rather than loud (review round 1, R1-3). A notice's subject
+    # is never worth degrading behaviour for: an unnamed fallback is correct
+    # and complete on its own.
+    try:
+        title = str(getattr(session, "conversation_name", "") or "").strip()
+    except Exception:  # noqa: BLE001 \u2014 see above; a title read must not cost a re-engage
+        return "this session"
     return f"\u201c{title}\u201d" if title else "this session"
 
 
-def _owner_matches_disk(owner: Any, loaded: Any, on_disk: Any) -> bool:
-    """Whether the bound runtime is the CURRENT build and this window is behind.
+def _owner_is_not_behind_this_window(owner: Any, loaded: Any, on_disk: Any) -> bool:
+    """Whether the bound runtime is at least as new as this window.
 
-    The discriminator for build skew, and the reason it compares against DISK
-    rather than ordering version numbers. The build on disk is what a process
-    started right now would run, so it is the only fixed reference the two
-    long-lived populations here — a window frozen at the build it imported,
-    and a runtime spawned at some later moment — can both be measured against.
-    An owner equal to it is by definition not stale, whatever its version
-    string reads next to the window's.
+    The discriminator for build skew: it decides whether the RUNTIME or the
+    WINDOW is the stale side, which a bare ``owner != loaded`` cannot say and
+    which the notice used to guess wrong.
 
-    **Do not "simplify" this into a version comparison.** This host's headline
+    TWO INDEPENDENT TERMS, either of which is sufficient. Neither subsumes the
+    other, and dropping either one reopens a defect that has already shipped:
+
+    1. **The owner is the build on disk.** Disk is what a process started right
+       now would run, so it is the fixed reference the two long-lived
+       populations here — a window frozen at the build it imported, and a
+       runtime spawned at some later moment — can both be measured against. An
+       owner equal to it is by definition not stale.
+    2. **The owner's version parses strictly newer than this window's.** Needed
+       because term 1 is an equality, and equality answers only the two-build
+       host. With three builds alive — window ``0.51.29``, runtime ``0.51.30``,
+       disk ``0.52.0``, all of which existed on the author's machine at once —
+       the runtime is newer than the window yet unequal to disk, so term 1
+       alone falls through and paints the very ``newer → older`` sentence this
+       function exists to prevent (review round 1 R1-1 / QA Q-1). A runtime
+       lives across updates precisely because it refuses to retire while busy,
+       so this is the steady state of a host that updates often, not a corner.
+
+    **Do not collapse the two into a version comparison.** This host's headline
     drift is a same-version rebuild: ``lop-update`` builds from ``main`` while
     ``pyproject.toml`` still names the last released version, so the two builds
     are ``0.51.30@aaaaaaa`` and ``0.51.30@bbbbbbb`` and NO ordering of version
-    numbers can say which is which. ``BuildStamp`` equality resolves it exactly,
-    because the recorded ref is part of the token.
+    numbers can tell them apart. Term 1 resolves that exactly, because the
+    recorded ref is part of the ``BuildStamp``. Term 2 is what covers the case
+    term 1 cannot see; term 1 is what covers the case term 2 cannot see.
 
-    ``on_disk`` is ``None`` only when ``installed_build()`` raised, i.e. when
-    check A was skipped too and the reference does not exist. Version ordering
-    is the fallback there and strictly worse: it answers only when the versions
-    differ AND both parse, so an inconclusive comparison (a shared version, an
-    unparseable side) deliberately returns False and leaves the pre-existing
-    advisory line in place — an undiagnosable skew is still worth one line, and
-    silencing it would regress review round 1 finding R1-1.
+    Returns False — meaning "say something" — when neither term holds. That
+    includes the genuinely stale runtime (the notice is correct and wanted) and
+    the undiagnosable pair: same version, three different refs, no ordering
+    possible. Silence there would regress the predecessor's R1-1, so the caller
+    still speaks, in copy that does not claim a direction it cannot know.
     """
-    if on_disk is not None:
-        return owner == on_disk
+    if on_disk is not None and owner == on_disk:
+        return True
     from local_operator.update import parse_version
 
     owner_parsed = parse_version(owner.version)
@@ -31273,6 +31349,32 @@ def _owner_matches_disk(owner: Any, loaded: Any, on_disk: Any) -> bool:
     if owner_parsed is None or loaded_parsed is None:
         return False
     return owner_parsed > loaded_parsed
+
+
+def _skew_direction_is_knowable(owner: Any, loaded: Any, on_disk: Any) -> bool:
+    """Whether we can say WHICH of two differing builds is older.
+
+    Three ways to know, mirroring the discriminator above:
+
+    * the versions differ, so ordering ranks them;
+    * the refs are equal, so there is only one build to talk about;
+    * disk is readable and IS one of the two — whichever side equals the build
+      on disk is the newer one, which is the whole reason the same-version
+      rebuild is resolvable at all.
+
+    False leaves only the shape where nothing can rank them: one version, three
+    distinct refs — window, runtime and disk each on a different ``main`` build
+    of ``0.51.30`` — or that same pair with disk unreadable. The caller still
+    paints there, because an undiagnosable skew is worth one advisory line, but
+    it must not use the arrow: an arrow asserts an order, and asserting one we
+    have not derived is precisely how the reversed sentence shipped (QA round
+    1, Q-1 all-refs sub-case).
+    """
+    if owner.version != loaded.version:
+        return True
+    if owner.source_ref == loaded.source_ref:
+        return True
+    return on_disk is not None and on_disk in (owner, loaded)
 
 
 def _model_spec(session) -> Any | None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2909,7 +2909,7 @@ class OperatorApp(App[None]):
         #: successor binds. Held across that gap because the retiring stamp
         #: only exists BEFORE the re-bind overwrites it, and the comparison it
         #: is needed for can only be made after.
-        self._refreshed_from: tuple[Any, str] | None = None
+        self._refreshed_from: tuple[Any, str, str] | None = None
         #: True while a runtime is being started for a cold viewer; the band
         #: says "starting…" for exactly this interval.
         self._starting_runtime = False
@@ -11837,6 +11837,13 @@ class OperatorApp(App[None]):
                     source_ref=str(getattr(session, "owner_source_ref", "") or ""),
                 ),
                 _session_subject(session),
+                # WHICH session retired. The subject alone cannot answer this:
+                # two sessions share a title, and the title of one says nothing
+                # about the id of another. This id is the predicate
+                # ``_announce_refresh_completed`` gates the paint on, because a
+                # stamp captured for one session must never be named against
+                # another's runtime (review round 2, R2-1).
+                str(getattr(session, "session_id", "") or ""),
             )
         else:
             # A runtime too old to say what it ran. There is no "from" side to
@@ -11866,21 +11873,43 @@ class OperatorApp(App[None]):
         they would otherwise ask ("why did my session restart?"), which is not
         what the dim ``info`` receipt is for.
 
-        THE ARROW IS SOUND HERE BY CONSTRUCTION, which is why this does not
-        need the directional predicate ``_check_build_skew`` uses. A runtime
-        retires for a refresh only when its own comparison finds the build on
-        disk has moved, and the successor is spawned from that same disk
-        install \u2014 so ``after`` is the disk build and ``before`` is one the disk
-        has already replaced. The one route that could pair unrelated stamps
-        was a refresh slot surviving a cancelled engage, which is closed at its
-        source in :meth:`_cancel_runtime_engage` rather than papered over with
-        a second check here (review round 1, R1-2).
+        THE ARROW IS SOUND HERE ONLY WITH THE GUARD ABOVE. I argued the stamp
+        pair could never be mismatched once the cancel route cleared the slot
+        (round 1); round 2 falsified that with the sidebar-switch route, which
+        swaps the session through a different worker group the cancel never
+        touches. The construction claim is restored by the session-id
+        comparison, not by enumerating swap routes: a runtime retires only when
+        disk has moved and the successor is spawned from that install, so WITHIN
+        one session ``after`` is the disk build and ``before`` is one disk has
+        already replaced; the guard is what makes "within one session" true
+        rather than assumed (R2-1).
         """
         pending, self._refreshed_from = self._refreshed_from, None
         if pending is None:
             return
-        before, subject = pending
+        before, subject, refreshed_id = pending
         session = self._session
+        # THE BELT, added after source-closing proved insufficient. The slot is
+        # cleared on every engage exit found, but the sidebar switch swaps
+        # ``self._session`` through the ``"session"`` worker group — NOT the
+        # ``"warm-engage"`` group the cancel clears — and neither
+        # ``_commit_sidebar_session`` nor ``_adopt_session`` touches this slot,
+        # so the in-flight worker's tail reached this paint against a DIFFERENT
+        # session. Auditing every present and future swap route is the fragile
+        # per-callsite reasoning this file warns against elsewhere; one
+        # comparison here closes the class. A pending stamp belongs to the
+        # session that retired — if what is bound now is not that session, this
+        # line would name one conversation against another's runtime, with the
+        # pair running backwards under the word "updated" (R2-1). An empty
+        # captured id cannot corroborate the pair, so it is silent too: the
+        # alternative is one wrong-named line per unidentifiable swap.
+        if refreshed_id != str(getattr(session, "session_id", "") or ""):
+            logger.debug(
+                "refresh announcement dropped: pending belongs to %s, %s is bound",
+                refreshed_id or "<unstamped>",
+                getattr(session, "session_id", "") or "<none>",
+            )
+            return
         version = str(getattr(session, "owner_version", "") or "")
         if not version:
             return
@@ -20434,17 +20463,52 @@ class OperatorApp(App[None]):
                 # rebuilds of one release, which no ordering can rank. The
                 # arrow copy below would assert an order we cannot derive, and
                 # asserting one anyway is exactly how the reversed sentence
-                # shipped. Name both builds without claiming which came first;
-                # the remedy is identical either way, since the runtime's own
+                # shipped. The copy therefore drops the arrow but keeps every
+                # other rule of the family:
+                #  - ONE debounce kind as the directed branch. The pair is ONE
+                #    fact in one session; two kinds meant a disk move between
+                #    two checks painted the directed C\u2032 and then the undirected
+                #    variant withdrawing the direction the first had asserted
+                #    (review round 2, R2-2).
+                #  - The COLLAPSED pair. ``_skew_direction_is_knowable`` can only
+                #    return False after its versions-differ term has failed, so
+                #    this line is reachable only when the versions are EQUAL
+                #    \u2014 full labels would restate the version twice and bury the
+                #    seven characters that actually differ, the exact defect D3
+                #    removed from the refresh note (design round 2, D2-2).
+                #  - A visible pivot. The comma form read as apposition and the
+                #    eye had to re-parse which stamp belonged to which side;
+                #    "vs" restores the assignment the sibling's arrow supplies
+                #    (design round 2, D2-3). It asserts opposition, not order.
+                # The remedy is identical either way, since the runtime's own
                 # reaper compares itself against disk and acts on the answer
                 # (QA round 1, Q-1 all-refs sub-case).
                 announce(
-                    "owner-undirected",
+                    "owner",
                     owner.label(),
                     loaded.label(),
-                    f"{subject} is running {owner.label()}, this window "
-                    f"{loaded.label()} \u2014 it will switch to the version on disk "
-                    "when it is next idle.",
+                    # Collapsed by hand when the versions are EQUAL (the
+                    # dominant route here, since equal-and-parsing fails
+                    # term 1 of the predicate by definition) \u2014
+                    # ``0.51.30, bbbbbbb vs this window\u2019s aaaaaaa``. An
+                    # UNPARSEABLE pair (``0.51.31rc1``) has no collapse and no
+                    # short ref, so it keeps the full labels; ``label()`` never
+                    # raises on either shape. The "vs" pivot replaces the arrow
+                    # (a claim of order) with opposition, which is all this
+                    # line can support (design round 2, D2-2/D2-3).
+                    (
+                        f"{subject} is running {owner.version}, "
+                        f"{owner.source_ref[:7]} vs this window\u2019s "
+                        f"{loaded.source_ref[:7]} \u2014 it will "
+                        "switch to the version on disk when it is next idle."
+                        if owner.version
+                        and owner.version == loaded.version
+                        and owner.source_ref
+                        and loaded.source_ref
+                        else f"{subject} is running {owner.label()} vs this window "
+                        f"{loaded.label()} \u2014 it will switch to the version on "
+                        "disk when it is next idle."
+                    ),
                     scope,
                     notice_kind="note",
                 )
@@ -31356,21 +31420,43 @@ def _skew_direction_is_knowable(owner: Any, loaded: Any, on_disk: Any) -> bool:
 
     Three ways to know, mirroring the discriminator above:
 
-    * the versions differ, so ordering ranks them;
+    * the versions differ AND both parse, so ordering ranks them;
     * the refs are equal, so there is only one build to talk about;
     * disk is readable and IS one of the two — whichever side equals the build
       on disk is the newer one, which is the whole reason the same-version
       rebuild is resolvable at all.
 
-    False leaves only the shape where nothing can rank them: one version, three
-    distinct refs — window, runtime and disk each on a different ``main`` build
-    of ``0.51.30`` — or that same pair with disk unreadable. The caller still
-    paints there, because an undiagnosable skew is worth one advisory line, but
-    it must not use the arrow: an arrow asserts an order, and asserting one we
-    have not derived is precisely how the reversed sentence shipped (QA round
-    1, Q-1 all-refs sub-case).
+    False leaves only the shapes where nothing can rank them: one version,
+    three distinct refs — window, runtime and disk each on a different
+    ``main`` build of ``0.51.30`` — that same pair with disk unreadable, and a
+    version string that does not parse. The caller still paints there, because
+    an undiagnosable skew is worth one advisory line, but it must not use the
+    arrow: an arrow asserts an order, and asserting one we have not derived is
+    precisely how the reversed sentence shipped (QA round 1, Q-1 all-refs
+    sub-case).
+
+    The first term gates on PARSE, not on string inequality. ``0.51.31rc1`` !=
+    ``0.51.30`` as a string, but ``parse_version`` returns None for the rc
+    form, so the sibling predicate refuses to rank the pair while this one
+    would have claimed it could — the two must agree on what "rankable"
+    means, or an unparseable pair takes the arrow branch asserting an order
+    neither term derived (review round 2, R2-3).
     """
-    if owner.version != loaded.version:
+    from local_operator.update import parse_version
+
+    owner_parsed = parse_version(owner.version)
+    loaded_parsed = parse_version(loaded.version)
+    # An unparseable side whose string DIFFERS from the other is unrankable
+    # outright: ``0.51.31rc1`` vs ``0.51.30`` can be compared only by ordering,
+    # and ordering is unavailable, so neither the arrow's order nor an
+    # implicit "they differ" is derivable. (An unparseable side with the SAME
+    # string is either one build — equal refs, the next term — or a
+    # same-version ref drift, which disk can rank below.) Without this early
+    # exit the equal-ref term promoted an unparseable rc to rankable (R2-3,
+    # second shape).
+    if owner.version != loaded.version and (owner_parsed is None or loaded_parsed is None):
+        return False
+    if owner_parsed is not None and loaded_parsed is not None and owner_parsed != loaded_parsed:
         return True
     if owner.source_ref == loaded.source_ref:
         return True

--- a/scripts/build_skew_direction_repro.py
+++ b/scripts/build_skew_direction_repro.py
@@ -1,0 +1,79 @@
+"""The reversed-direction build-skew notice, reproduced against the real app.
+
+The defect this pins: a window sitting IDLE at the end of a session painted
+
+    "<name>" is running 0.51.30@d7f12d3 -> 0.51.29@2412b1d - it will switch to
+    the new version when it is next idle.
+
+which is backwards. The RUNTIME is the newer side, and there was nothing to
+say at all. The shape is routine on a host that runs ``lop-update`` several
+times a day: a window keeps the build it imported at launch forever, and a
+runtime spawned after the update resolves ``sys.executable`` fresh, so an old
+window driving a new runtime is the steady state, not the edge.
+
+Kept as a script rather than only as a unit cell because the evidence that
+matters is the rendered SENTENCE - the unit test asserts on a fragment, while
+this prints what the user actually read and can be diffed across builds.
+
+Usage:
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/build_skew_direction_repro.py
+
+Expected on a fixed tree: ``refresh requests sent to the NEWER runtime: 0``
+and only the disk-drift notice, which names ``/reload``. On d7f12d3a7 it
+prints 1 request and the reversed second line above.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import scripts.probe_isolation  # noqa: F401,E402  -- must precede app imports
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.transcript import NoticeBlock  # noqa: E402
+from local_operator.update import BuildStamp  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+from tests.unit.tui.test_build_skew import _BoundViewer  # noqa: E402
+
+
+async def main() -> None:
+    import local_operator.update as update_mod
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 24)) as pilot:
+        await pilot.pause()
+        # This window imported 0.51.29 at launch and can never change.
+        app._loaded_build = BuildStamp(version="0.51.29", source_ref="2412b1daf")
+        app._skew_notice_shown.clear()
+        # Disk now carries 0.51.30: `lop-update` ran after the window opened.
+        on_disk = BuildStamp(version="0.51.30", source_ref="d7f12d3a7")
+        update_mod.installed_build = lambda *_a, **_k: on_disk
+        # The bound runtime was spawned AFTER that update, so it is 0.51.30 --
+        # NEWER than this window -- and it is idle. Its own refresh check
+        # compares itself against disk, finds a match, and answers "kept".
+        viewer = _BoundViewer(
+            owner_version="0.51.30",
+            owner_source_ref="d7f12d3a7",
+            session_id="s1",
+            conversation_name="Investigating suspicious pwned notification source",
+            idle=True,
+            refresh_answer="kept: build on disk matches (or has not settled)",
+        )
+        app._session = viewer
+        app._check_build_skew(reason="bind")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        notices = [block._text for block in app.query(NoticeBlock)]
+        requests = viewer.refresh_requests
+
+    print(f"refresh requests sent to the NEWER runtime: {requests}")
+    for notice in notices:
+        print("NOTICE:", notice)
+
+
+asyncio.run(main())

--- a/tests/unit/tui/test_build_skew.py
+++ b/tests/unit/tui/test_build_skew.py
@@ -1097,3 +1097,338 @@ def test_the_notices_carry_no_internal_vocabulary() -> None:
     body = " ".join(literals[1:]) if literals else ""
     for word in ("routed", "predates build reporting", "this terminal", "resend"):
         assert word not in body, f"internal vocabulary reached the notice copy: {word!r}"
+
+
+# --- Which side is stale: the direction the notice must not get backwards ----
+#
+# The defect these pin was reported from a live session sitting IDLE, which
+# painted `"<name>" is running 0.51.30@d7f12d3 -> 0.51.29@2412b1d - it will
+# switch to the new version when it is next idle.` Both halves are wrong: the
+# arrow reads as a downgrade when the runtime is the NEWER side, and there was
+# nothing to say at all. `scripts/build_skew_direction_repro.py` prints the
+# sentence itself; these cells pin the behaviour behind it.
+#
+# The shape is routine here rather than exotic. A window keeps the build it
+# imported at launch forever; `lop-update` runs several times a day; a runtime
+# spawned after it resolves `sys.executable` fresh. An OLD window driving a NEW
+# runtime is therefore the steady state, and the old code, seeing only
+# `owner != loaded`, assumed the runtime was always the stale one.
+
+
+@pytest.mark.asyncio
+async def test_a_runtime_newer_than_this_window_is_completely_silent(monkeypatch, tmp_path) -> None:
+    """The reported case: window behind disk, runtime ON disk, idle.
+
+    Nothing may be asked of the runtime (it is already current, and its own
+    check answers ``kept`` because it compares against the same disk), and no
+    owner notice may be painted. Disk drift has ALREADY told the user the
+    install moved and named ``/reload``; a second line about the same fact
+    pointing the other way is the bug.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._loaded_build = BuildStamp(version="0.51.29", source_ref="2412b1daf")
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        on_disk = BuildStamp(version="0.51.30", source_ref="d7f12d3a7")
+        monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: on_disk)
+        viewer = _BoundViewer(
+            owner_version="0.51.30",
+            owner_source_ref="d7f12d3a7",
+            idle=True,
+            refresh_answer="kept: build on disk matches (or has not settled)",
+        )
+        app._session = viewer
+        app._check_build_skew(reason="bind")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        notices = _notices(app)
+
+    assert viewer.refresh_requests == 0, "a runtime that matches disk is already current"
+    assert not [n for n in notices if OWNER_SKEW in n or MOVES_OVER in n], notices
+    # The window IS behind, and that fact keeps its notice - with the arrow the
+    # right way round and the remedy that actually applies to a window.
+    drift = [n for n in notices if DRIFT in n]
+    assert len(drift) == 1, notices
+    assert "0.51.29@2412b1d \u2192 0.51.30@d7f12d3" in drift[0], drift[0]
+    assert "/reload" in drift[0]
+
+
+@pytest.mark.asyncio
+async def test_a_runtime_newer_than_this_window_is_silent_while_busy(monkeypatch, tmp_path) -> None:
+    """Same shape, BUSY runtime: still nothing to say.
+
+    The busy branch paints C\u2032 without asking anything, so it is a second,
+    independent way into the reversed notice - and the complaint is not limited
+    to idle sessions. Whether the runtime is working says nothing about which
+    side is stale.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._loaded_build = BuildStamp(version="0.51.29", source_ref="2412b1daf")
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        on_disk = BuildStamp(version="0.51.30", source_ref="d7f12d3a7")
+        monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: on_disk)
+        viewer = _BoundViewer(owner_version="0.51.30", owner_source_ref="d7f12d3a7", idle=False)
+        app._session = viewer
+        app._check_build_skew(reason="bind")
+        await pilot.pause()
+        notices = _notices(app)
+
+    assert not [n for n in notices if OWNER_SKEW in n or MOVES_OVER in n], notices
+    assert viewer.refresh_requests == 0
+
+
+@pytest.mark.asyncio
+async def test_a_same_version_rebuild_is_directional_both_ways(monkeypatch, tmp_path) -> None:
+    """Ref-only drift, in both directions - the case that forces the disk compare.
+
+    Both builds say ``0.51.30`` and differ only in the recorded commit, so NO
+    ordering of version numbers can say which is newer. Matching disk is the
+    only fact that does, and it resolves both directions exactly.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    import local_operator.update as update_mod
+
+    on_disk = BuildStamp(version="0.51.30", source_ref="bbbbbbb2222")
+
+    # (a) runtime is the rebuild that is on disk: silent.
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._loaded_build = BuildStamp(version="0.51.30", source_ref="aaaaaaa1111")
+        app._skew_notice_shown.clear()
+        monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: on_disk)
+        viewer = _BoundViewer(owner_version="0.51.30", owner_source_ref="bbbbbbb2222", idle=False)
+        app._session = viewer
+        app._check_build_skew(reason="bind")
+        await pilot.pause()
+        current_side = _notices(app)
+
+    assert not [n for n in current_side if OWNER_SKEW in n or MOVES_OVER in n], current_side
+
+    # (b) the window is the one on disk and the runtime is the older rebuild:
+    #     genuinely stale, and it earns the notice.
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._loaded_build = on_disk
+        app._skew_notice_shown.clear()
+        monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: on_disk)
+        viewer = _BoundViewer(owner_version="0.51.30", owner_source_ref="aaaaaaa1111", idle=False)
+        app._session = viewer
+        app._check_build_skew(reason="bind")
+        await pilot.pause()
+        stale_side = _notices(app)
+
+    skew = [n for n in stale_side if MOVES_OVER in n]
+    assert len(skew) == 1, stale_side
+    assert "aaaaaaa \u2192 bbbbbbb" in skew[0], skew[0]
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_disk_falls_back_to_version_order(monkeypatch, tmp_path) -> None:
+    """No disk reference: a strictly newer runtime is still recognised.
+
+    ``installed_build()`` raising skips check A too, so the discriminator has
+    nothing to compare against. Version ordering is the fallback - weaker (it
+    cannot see a ref-only rebuild) but decisive when the versions differ.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._loaded_build = BuildStamp(version="0.51.29")
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        def _boom(*_a, **_k):
+            raise OSError("no install metadata")
+
+        monkeypatch.setattr(update_mod, "installed_build", _boom)
+        viewer = _BoundViewer(owner_version="0.51.30", idle=True)
+        app._session = viewer
+        app._check_build_skew(reason="bind")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        notices = _notices(app)
+
+    assert notices == [], notices
+    assert viewer.refresh_requests == 0
+
+
+@pytest.mark.asyncio
+async def test_an_inconclusive_order_keeps_todays_notice(monkeypatch, tmp_path) -> None:
+    """Unreadable disk AND an undecidable pair: keep the advisory line.
+
+    Same version, differing refs, with no disk to appeal to - nothing here can
+    say which side is behind. Silence would regress R1-1 (a resume onto a
+    pre-refresh runtime explained by nothing, with no later seam to repair it),
+    so an undiagnosable skew is still worth exactly one line.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._loaded_build = BuildStamp(version="0.51.30", source_ref="aaaaaaa1111")
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        def _boom(*_a, **_k):
+            raise OSError("no install metadata")
+
+        monkeypatch.setattr(update_mod, "installed_build", _boom)
+        viewer = _BoundViewer(owner_version="0.51.30", owner_source_ref="bbbbbbb2222", idle=False)
+        app._session = viewer
+        app._check_build_skew(reason="bind")
+        await pilot.pause()
+        notices = _notices(app)
+
+    assert len([n for n in notices if MOVES_OVER in n]) == 1, notices
+
+
+@pytest.mark.asyncio
+async def test_an_unparseable_version_is_not_guessed_at(monkeypatch, tmp_path) -> None:
+    """Fallback ordering answers only when BOTH sides parse.
+
+    A local ``0.51.30rc1`` is not evidence of anything; treating it as newer
+    would silence a skew on a guess. ``parse_version`` returns ``None`` and the
+    advisory line stands.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._loaded_build = BuildStamp(version="0.51.29")
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        def _boom(*_a, **_k):
+            raise OSError("no install metadata")
+
+        monkeypatch.setattr(update_mod, "installed_build", _boom)
+        app._session = _BoundViewer(owner_version="0.51.30rc1", idle=False)
+        app._check_build_skew(reason="bind")
+        await pilot.pause()
+        notices = _notices(app)
+
+    assert len([n for n in notices if MOVES_OVER in n]) == 1, notices
+
+
+# --- The completed self-refresh, said once ----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_completed_refresh_names_the_version_it_moved_to(monkeypatch, tmp_path) -> None:
+    """The operator asked for this: an update that happens on its own says so.
+
+    The line is painted only after the successor BINDS, so it reports a
+    completed fact. The pair is captured across the re-engage: the retiring
+    stamp exists only before the re-bind overwrites it.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._skew_notice_shown.clear()
+        monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: None)
+        # The runtime that is leaving.
+        app._session = _BoundViewer(
+            owner_version="0.51.29",
+            owner_source_ref="2412b1daf",
+            conversation_name="Investigating suspicious pwned notification source",
+        )
+        app._on_runtime_refreshed()
+        # The successor, resolved from the build now on disk.
+        app._session = _BoundViewer(owner_version="0.51.30", owner_source_ref="d7f12d3a7")
+        app._announce_refresh_completed()
+        await pilot.pause()
+        notices = _notices(app)
+        tokens = [block._token for block in app.query(NoticeBlock)]
+
+        # Consumed once: a second engage tail must not repeat it.
+        app._announce_refresh_completed()
+        await pilot.pause()
+        again = _notices(app)
+
+    assert len(notices) == 1, notices
+    assert "0.51.29@2412b1d \u2192 0.51.30@d7f12d3" in notices[0], notices[0]
+    assert "Investigating suspicious pwned" in notices[0], "the line names its session"
+    assert tokens == ["muted"], "a note: nothing is wrong and nothing is asked"
+    assert again == notices, "the pending stamp is cleared on read"
+
+
+@pytest.mark.asyncio
+async def test_an_unchanged_build_after_a_refresh_says_nothing(monkeypatch, tmp_path) -> None:
+    """A re-engage that did not change the build is not an update.
+
+    A runtime that came back on the same build (a restart that was not an
+    update, a successor resolving the same install) changed nothing the user
+    could act on, and announcing it would turn ordinary re-engagement into a
+    stream of notices.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._skew_notice_shown.clear()
+        monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: None)
+        app._session = _BoundViewer(owner_version="0.51.30", owner_source_ref="d7f12d3a7")
+        app._on_runtime_refreshed()
+        app._session = _BoundViewer(owner_version="0.51.30", owner_source_ref="d7f12d3a7")
+        app._announce_refresh_completed()
+        await pilot.pause()
+        notices = _notices(app)
+
+    assert notices == [], notices
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_engage_never_announces_a_refresh(monkeypatch, tmp_path) -> None:
+    """No pending stamp, no line. The engage tail calls this unconditionally."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._skew_notice_shown.clear()
+        app._session = _BoundViewer(owner_version="0.51.30", owner_source_ref="d7f12d3a7")
+        app._announce_refresh_completed()
+        await pilot.pause()
+        notices = _notices(app)
+
+    assert notices == [], notices
+
+
+@pytest.mark.asyncio
+async def test_a_runtime_too_old_to_name_its_build_is_not_half_announced(
+    monkeypatch, tmp_path
+) -> None:
+    """No "from" side means no sentence.
+
+    "updated to X" with nothing it came from reads as an update out of
+    nowhere, which is less informative than saying nothing.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._skew_notice_shown.clear()
+        monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: None)
+        app._session = _BoundViewer(owner_version="")
+        app._on_runtime_refreshed()
+        assert app._refreshed_from is None
+        app._session = _BoundViewer(owner_version="0.51.30", owner_source_ref="d7f12d3a7")
+        app._announce_refresh_completed()
+        await pilot.pause()
+        notices = _notices(app)
+
+    assert notices == [], notices

--- a/tests/unit/tui/test_build_skew.py
+++ b/tests/unit/tui/test_build_skew.py
@@ -1301,6 +1301,9 @@ async def test_an_inconclusive_order_keeps_todays_notice(monkeypatch, tmp_path) 
     owner = [n for n in notices if "is running" in n]
     assert len(owner) == 1, notices
     assert "\u2192" not in owner[0], f"nothing here can rank the pair: {owner[0]}"
+    # The remedy is the reason the line is worth painting at all; a mutation
+    # that strips it must not stay green (QA round 2, Q2-1).
+    assert "switch" in owner[0], owner[0]
 
 
 @pytest.mark.asyncio
@@ -1328,7 +1331,13 @@ async def test_an_unparseable_version_is_not_guessed_at(monkeypatch, tmp_path) -
         await pilot.pause()
         notices = _notices(app)
 
-    assert len([n for n in notices if MOVES_OVER in n]) == 1, notices
+    # parse_version cannot rank the pair, so neither predicate claims a
+    # direction and the notice is the undirected one — a full-label, arrow-free
+    # line. Non-silence is the claim this cell has always made.
+    owner = [n for n in notices if "is running" in n]
+    assert len(owner) == 1, notices
+    assert "\u2192" not in owner[0], owner[0]
+    assert "switch" in owner[0], owner[0]
 
 
 # --- The completed self-refresh, said once ----------------------------------
@@ -1352,11 +1361,16 @@ async def test_a_completed_refresh_names_the_version_it_moved_to(monkeypatch, tm
         app._session = _BoundViewer(
             owner_version="0.51.29",
             owner_source_ref="2412b1daf",
+            session_id="s1",
             conversation_name="Investigating suspicious pwned notification source",
         )
         app._on_runtime_refreshed()
-        # The successor, resolved from the build now on disk.
-        app._session = _BoundViewer(owner_version="0.51.30", owner_source_ref="d7f12d3a7")
+        # The successor, resolved from the build now on disk, is the SAME
+        # session rebound — the refresh keeps the id, which is exactly what the
+        # belt keys on.
+        app._session = _BoundViewer(
+            owner_version="0.51.30", owner_source_ref="d7f12d3a7", session_id="s1"
+        )
         app._announce_refresh_completed()
         await pilot.pause()
         notices = _notices(app)
@@ -1389,9 +1403,13 @@ async def test_an_unchanged_build_after_a_refresh_says_nothing(monkeypatch, tmp_
         await pilot.pause()
         app._skew_notice_shown.clear()
         monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: None)
-        app._session = _BoundViewer(owner_version="0.51.30", owner_source_ref="d7f12d3a7")
+        app._session = _BoundViewer(
+            owner_version="0.51.30", owner_source_ref="d7f12d3a7", session_id="s1"
+        )
         app._on_runtime_refreshed()
-        app._session = _BoundViewer(owner_version="0.51.30", owner_source_ref="d7f12d3a7")
+        app._session = _BoundViewer(
+            owner_version="0.51.30", owner_source_ref="d7f12d3a7", session_id="s1"
+        )
         app._announce_refresh_completed()
         await pilot.pause()
         notices = _notices(app)
@@ -1430,10 +1448,12 @@ async def test_a_runtime_too_old_to_name_its_build_is_not_half_announced(
         await pilot.pause()
         app._skew_notice_shown.clear()
         monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: None)
-        app._session = _BoundViewer(owner_version="")
+        app._session = _BoundViewer(owner_version="", session_id="s1")
         app._on_runtime_refreshed()
         assert app._refreshed_from is None
-        app._session = _BoundViewer(owner_version="0.51.30", owner_source_ref="d7f12d3a7")
+        app._session = _BoundViewer(
+            owner_version="0.51.30", owner_source_ref="d7f12d3a7", session_id="s1"
+        )
         app._announce_refresh_completed()
         await pilot.pause()
         notices = _notices(app)
@@ -1641,7 +1661,12 @@ async def test_three_refs_at_one_version_claim_no_direction(monkeypatch, tmp_pat
     owner = [n for n in notices if "is running" in n]
     assert len(owner) == 1, notices
     assert "\u2192" not in owner[0], f"no arrow may claim a direction here: {owner[0]}"
-    assert "0.51.30@bbbbbbb" in owner[0] and "0.51.30@aaaaaaa" in owner[0], owner[0]
+    # Collapsed: the versions are equal by construction here, so the pair must
+    # be stated once and the "vs" pivot must show which stamp is whose (design
+    # round 2, D2-2/D2-3).
+    assert "0.51.30, bbbbbbb vs this window\u2019s aaaaaaa" in owner[0], owner[0]
+    assert "0.51.30@bbbbbbb" not in owner[0], "the shared version must not be stated twice"
+    assert "switch" in owner[0], owner[0]
 
 
 @pytest.mark.asyncio
@@ -1700,6 +1725,7 @@ async def test_a_cancelled_engage_cannot_announce_the_previous_session(
         app._session = _BoundViewer(
             owner_version="0.51.29",
             owner_source_ref="2412b1daf",
+            session_id="sess-a",
             conversation_name="Session A",
         )
         app._on_runtime_refreshed()
@@ -1713,6 +1739,7 @@ async def test_a_cancelled_engage_cannot_announce_the_previous_session(
         app._session = _BoundViewer(
             owner_version="0.51.19",
             owner_source_ref="dc6bec0aa",
+            session_id="sess-b",
             conversation_name="Session B",
         )
         app._announce_refresh_completed()
@@ -1720,6 +1747,129 @@ async def test_a_cancelled_engage_cannot_announce_the_previous_session(
         notices = _notices(app)
 
     assert notices == [], notices
+
+
+@pytest.mark.asyncio
+async def test_a_sidebar_switch_cannot_announce_the_previous_session(monkeypatch, tmp_path) -> None:
+    """The belt, not the route. The sidebar switch swaps ``self._session``
+    through the ``"session"`` worker group — NOT ``"warm-engage"`` — so the
+    round-1 fix in ``_cancel_runtime_engage`` never ran for it, and the
+    in-flight engage worker's own tail fired the announcement against the
+    session switched TO. The guard is a comparison at the paint point, which
+    closes the CLASS rather than enumerating swap routes (review round 2,
+    R2-1). Driven through the real methods, not a hand-run sequence.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._skew_notice_shown.clear()
+        monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: None)
+        app._session = _BoundViewer(
+            owner_version="0.51.29",
+            owner_source_ref="2412b1daf",
+            session_id="sess-a",
+            conversation_name="Session A",
+        )
+        app._on_runtime_refreshed()
+        assert app._refreshed_from is not None
+
+        # The sidebar swap: the pending slot SURVIVES this, which is the
+        # route round 1 missed. Session B then binds and its engage tail runs.
+        app._session = _BoundViewer(
+            owner_version="0.51.19",
+            owner_source_ref="dc6bec0aa",
+            session_id="sess-b",
+            conversation_name="Session B",
+        )
+        app._announce_refresh_completed()
+        await pilot.pause()
+        notices = _notices(app)
+
+    assert notices == [], f"session A's stamp answered against session B: {notices}"
+
+
+@pytest.mark.asyncio
+async def test_a_refresh_rebind_to_the_same_session_still_announces(monkeypatch, tmp_path) -> None:
+    """The belt must not over-fire: a refresh keeps the session id, so the
+    successor binding the SAME session paints the note. Without this the
+    R2-1 guard could be `return` and every silent cell would still pass.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._skew_notice_shown.clear()
+        monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: None)
+        app._session = _BoundViewer(
+            owner_version="0.51.29",
+            owner_source_ref="2412b1daf",
+            session_id="s1",
+            conversation_name="Session A",
+        )
+        app._on_runtime_refreshed()
+        app._session = _BoundViewer(
+            owner_version="0.51.30", owner_source_ref="d7f12d3a7", session_id="s1"
+        )
+        app._announce_refresh_completed()
+        await pilot.pause()
+        notices = _notices(app)
+
+    assert len(notices) == 1, notices
+    assert "0.51.29@2412b1d \u2192 0.51.30@d7f12d3" in notices[0], notices[0]
+
+
+@pytest.mark.asyncio
+async def test_one_build_pair_is_announced_once_across_a_disk_move(monkeypatch, tmp_path) -> None:
+    """R2-2: the two skew wordings share ONE debounce key.
+
+    A same-version pair can paint directed C\u2032 at adopt (disk == the window)
+    and, after `lop-update` moves disk to a third ref, qualify as undirected
+    on the next check. Two kinds meant ONE unchanged build pair painted BOTH —
+    the second apparently withdrawing the direction the first asserted. The
+    pair is one fact in one session and is announced once, whichever wording
+    won the race.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._loaded_build = BuildStamp(version="0.51.30", source_ref="aaaaaaa11")
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        # First check: disk == the window, so the pair is rankable and the
+        # directed copy paints.
+        monkeypatch.setattr(
+            update_mod,
+            "installed_build",
+            lambda *_a, **_k: BuildStamp(version="0.51.30", source_ref="aaaaaaa11"),
+        )
+        app._session = _BoundViewer(
+            owner_version="0.51.30", owner_source_ref="bbbbbbb22", session_id="s1", idle=False
+        )
+        app._check_build_skew(reason="adopt")
+        await pilot.pause()
+        first = _notices(app)
+        # Disk moves to a third ref; the SAME pair now qualifies as undirected.
+        monkeypatch.setattr(
+            update_mod,
+            "installed_build",
+            lambda *_a, **_k: BuildStamp(version="0.51.30", source_ref="ccccccc33"),
+        )
+        app._check_build_skew(reason="engage")
+        await pilot.pause()
+        second = _notices(app)
+
+    owner = [n for n in second if "is running" in n]
+    assert len(owner) == 1, f"one pair must paint once: {second}"
+    # The DRIFT notice re-paints on the disk move — that is its own fact, not
+    # the pair being repeated. The claim under test is narrower than
+    # `second == first`: the owner notice that already painted at adopt does
+    # not fire again, in EITHER wording, when the direction becomes unknowable.
+    owner_first = [n for n in first if "is running" in n]
+    assert owner == owner_first, (owner_first, owner)
+    assert "\u2192" in owner[0], "the directed form won the race and is the one shown"
 
 
 @pytest.mark.asyncio
@@ -1776,10 +1926,13 @@ async def test_the_refresh_note_keeps_its_version_pair_on_one_row(monkeypatch, t
                 app._session = _BoundViewer(
                     owner_version="0.51.29",
                     owner_source_ref="2412b1daf",
+                    session_id="s1",
                     conversation_name=name,
                 )
                 app._on_runtime_refreshed()
-                app._session = _BoundViewer(owner_version="0.51.30", owner_source_ref="d7f12d3a7")
+                app._session = _BoundViewer(
+                    owner_version="0.51.30", owner_source_ref="d7f12d3a7", session_id="s1"
+                )
                 app._announce_refresh_completed()
                 await pilot.pause()
                 blocks = list(app.query(NoticeBlock))
@@ -1804,9 +1957,13 @@ async def test_the_refresh_note_does_not_restate_the_version_twice(monkeypatch, 
         await pilot.pause()
         app._skew_notice_shown.clear()
         monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: None)
-        app._session = _BoundViewer(owner_version="0.51.30", owner_source_ref="aaaaaaa11")
+        app._session = _BoundViewer(
+            owner_version="0.51.30", owner_source_ref="aaaaaaa11", session_id="s1"
+        )
         app._on_runtime_refreshed()
-        app._session = _BoundViewer(owner_version="0.51.30", owner_source_ref="bbbbbbb22")
+        app._session = _BoundViewer(
+            owner_version="0.51.30", owner_source_ref="bbbbbbb22", session_id="s1"
+        )
         app._announce_refresh_completed()
         await pilot.pause()
         notices = _notices(app)

--- a/tests/unit/tui/test_build_skew.py
+++ b/tests/unit/tui/test_build_skew.py
@@ -1274,6 +1274,11 @@ async def test_an_inconclusive_order_keeps_todays_notice(monkeypatch, tmp_path) 
     say which side is behind. Silence would regress R1-1 (a resume onto a
     pre-refresh runtime explained by nothing, with no later seam to repair it),
     so an undiagnosable skew is still worth exactly one line.
+
+    The line it gets is the UNDIRECTED one, since this is exactly the shape
+    where no term can rank the pair (QA round 1, Q-1). The cell's claim has
+    always been non-silence rather than a particular wording, so it asserts a
+    notice paints and that the wording makes no claim it cannot support.
     """
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
     app = OperatorApp(lambda: _factory(FakeSession()))
@@ -1293,7 +1298,9 @@ async def test_an_inconclusive_order_keeps_todays_notice(monkeypatch, tmp_path) 
         await pilot.pause()
         notices = _notices(app)
 
-    assert len([n for n in notices if MOVES_OVER in n]) == 1, notices
+    owner = [n for n in notices if "is running" in n]
+    assert len(owner) == 1, notices
+    assert "\u2192" not in owner[0], f"nothing here can rank the pair: {owner[0]}"
 
 
 @pytest.mark.asyncio
@@ -1432,3 +1439,378 @@ async def test_a_runtime_too_old_to_name_its_build_is_not_half_announced(
         notices = _notices(app)
 
     assert notices == [], notices
+
+
+# --- Three builds alive at once: the quadrant round 1 found still broken -----
+#
+# `_owner_matches_disk` answered only `owner == on_disk`, which is an equality
+# and therefore only ever describes a TWO-build host. With three builds alive
+# the runtime can be newer than the window while being unequal to disk, and the
+# old code fell through and painted the reversed arrow at it. That is not a
+# corner: a runtime lives across updates precisely because it refuses to retire
+# while busy, so on a host that runs `lop-update` several times a day the triple
+# is the steady state (review round 1 R1-1 / QA round 1 Q-1, both reproduced
+# against the previous head using this machine's own live build population).
+
+
+@pytest.mark.asyncio
+async def test_a_newer_runtime_is_silent_when_disk_has_moved_again(monkeypatch, tmp_path) -> None:
+    """Window 0.51.29, runtime 0.51.30, disk 0.52.0 — the live triple.
+
+    The runtime is newer than the window and older than disk. It is not this
+    window's problem to report: the window is the stale side, the drift notice
+    already says so, and asking a runtime that is ahead of us to retire is the
+    original defect wearing a third version number.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._loaded_build = BuildStamp(version="0.51.29", source_ref="2412b1daf")
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(
+            update_mod,
+            "installed_build",
+            lambda *_a, **_k: BuildStamp(version="0.52.0", source_ref="5db5f6d65"),
+        )
+        viewer = _BoundViewer(
+            owner_version="0.51.30",
+            owner_source_ref="d7f12d3a7",
+            idle=True,
+            refresh_answer="kept: build on disk matches (or has not settled)",
+        )
+        app._session = viewer
+        app._check_build_skew(reason="bind")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        notices = _notices(app)
+
+    assert viewer.refresh_requests == 0, "a runtime ahead of this window is never asked to retire"
+    assert not [n for n in notices if OWNER_SKEW in n or MOVES_OVER in n], notices
+    # The window is behind DISK, and that is the fact worth painting.
+    drift = [n for n in notices if DRIFT in n]
+    assert len(drift) == 1, notices
+    assert "0.52.0@5db5f6d" in drift[0] and "/reload" in drift[0]
+
+
+@pytest.mark.asyncio
+async def test_a_newer_runtime_stays_silent_while_busy_in_the_triple(monkeypatch, tmp_path) -> None:
+    """The same triple on the BUSY branch, which paints without asking first."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._loaded_build = BuildStamp(version="0.51.29", source_ref="2412b1daf")
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(
+            update_mod,
+            "installed_build",
+            lambda *_a, **_k: BuildStamp(version="0.52.0", source_ref="5db5f6d65"),
+        )
+        viewer = _BoundViewer(owner_version="0.51.30", owner_source_ref="d7f12d3a7", idle=False)
+        app._session = viewer
+        app._check_build_skew(reason="bind")
+        await pilot.pause()
+        notices = _notices(app)
+
+    assert not [n for n in notices if OWNER_SKEW in n or MOVES_OVER in n], notices
+    assert viewer.refresh_requests == 0
+
+
+@pytest.mark.asyncio
+async def test_a_long_lived_window_does_not_start_speaking_when_disk_moves_again(
+    monkeypatch, tmp_path
+) -> None:
+    """The second route into the triple, which looks like a different bug.
+
+    A window correctly silenced about a runtime at t0 must not start reporting
+    that SAME runtime at t1 merely because `lop-update` ran again. Nothing
+    about the pair changed; only a third build appeared.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._loaded_build = BuildStamp(version="0.51.29", source_ref="2412b1daf")
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        viewer = _BoundViewer(
+            owner_version="0.51.30",
+            owner_source_ref="d7f12d3a7",
+            idle=True,
+            refresh_answer="kept: build on disk matches (or has not settled)",
+        )
+        app._session = viewer
+        # t0: disk == the runtime's build. Silent, and pinned elsewhere too.
+        monkeypatch.setattr(
+            update_mod,
+            "installed_build",
+            lambda *_a, **_k: BuildStamp(version="0.51.30", source_ref="d7f12d3a7"),
+        )
+        app._check_build_skew(reason="t0")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        # t1: a second lop-update. The runtime has not moved.
+        monkeypatch.setattr(
+            update_mod,
+            "installed_build",
+            lambda *_a, **_k: BuildStamp(version="0.52.0", source_ref="5db5f6d65"),
+        )
+        app._check_build_skew(reason="t1")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        notices = _notices(app)
+
+    assert not [n for n in notices if OWNER_SKEW in n or MOVES_OVER in n], notices
+    assert viewer.refresh_requests == 0
+    assert len([n for n in notices if DRIFT in n]) == 2, "each install move is its own fact"
+
+
+@pytest.mark.asyncio
+async def test_an_older_runtime_still_speaks_when_disk_has_moved_again(
+    monkeypatch, tmp_path
+) -> None:
+    """The over-silencing guard: adding the ordering term must not mute a
+    genuinely older runtime just because disk is a third build.
+
+    Without this cell the R1-1 fix could be "return True more often" and every
+    other cell would still pass.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._loaded_build = BuildStamp(version="0.51.29", source_ref="2412b1daf")
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(
+            update_mod,
+            "installed_build",
+            lambda *_a, **_k: BuildStamp(version="0.52.0", source_ref="5db5f6d65"),
+        )
+        viewer = _BoundViewer(owner_version="0.51.28", owner_source_ref="8c2015f11", idle=False)
+        app._session = viewer
+        app._check_build_skew(reason="bind")
+        await pilot.pause()
+        notices = _notices(app)
+
+    skew = [n for n in notices if MOVES_OVER in n]
+    assert len(skew) == 1, notices
+    assert "0.51.28@8c2015f \u2192 0.51.29@2412b1d" in skew[0], skew[0]
+
+
+@pytest.mark.asyncio
+async def test_three_refs_at_one_version_claim_no_direction(monkeypatch, tmp_path) -> None:
+    """Window, runtime and disk are three rebuilds of ONE version.
+
+    Nothing can rank them: the versions are equal so ordering is silent, and
+    all three refs differ so the disk equality cannot fire either. The notice
+    still paints — an undiagnosable skew is worth one line, and silence would
+    regress the predecessor's R1-1 — but it must NOT use the arrow, because an
+    arrow asserts an order that no term here derived (QA round 1, Q-1 all-refs
+    sub-case).
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._loaded_build = BuildStamp(version="0.51.30", source_ref="aaaaaaa11")
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(
+            update_mod,
+            "installed_build",
+            lambda *_a, **_k: BuildStamp(version="0.51.30", source_ref="ccccccc33"),
+        )
+        app._session = _BoundViewer(
+            owner_version="0.51.30", owner_source_ref="bbbbbbb22", idle=False
+        )
+        app._check_build_skew(reason="bind")
+        await pilot.pause()
+        notices = _notices(app)
+
+    owner = [n for n in notices if "is running" in n]
+    assert len(owner) == 1, notices
+    assert "\u2192" not in owner[0], f"no arrow may claim a direction here: {owner[0]}"
+    assert "0.51.30@bbbbbbb" in owner[0] and "0.51.30@aaaaaaa" in owner[0], owner[0]
+
+
+@pytest.mark.asyncio
+async def test_a_ref_only_pair_still_uses_the_arrow_when_disk_ranks_it(
+    monkeypatch, tmp_path
+) -> None:
+    """Direction IS knowable when disk equals one of the two, so the arrow stays.
+
+    Guards the undirected branch from swallowing the same-version case the disk
+    comparison exists to resolve — that reasoning is the docstring's core claim
+    and must not be undone by the fix for the all-refs shape.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        on_disk = BuildStamp(version="0.51.30", source_ref="bbbbbbb22")
+        app._loaded_build = on_disk
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: on_disk)
+        app._session = _BoundViewer(
+            owner_version="0.51.30", owner_source_ref="aaaaaaa11", idle=False
+        )
+        app._check_build_skew(reason="bind")
+        await pilot.pause()
+        notices = _notices(app)
+
+    skew = [n for n in notices if MOVES_OVER in n]
+    assert len(skew) == 1, notices
+    assert "aaaaaaa \u2192 bbbbbbb" in skew[0], skew[0]
+
+
+# --- The fourth exit from an engage, and a title that must not cost one ------
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_engage_cannot_announce_the_previous_session(
+    monkeypatch, tmp_path
+) -> None:
+    """`/resume` and `/new` cancel the engage worker before its tail runs.
+
+    The three clears inside `_start_runtime_engage` enumerate the exits IT can
+    see; cancellation happens from outside it, so the pending stamp survived
+    and the next session's ordinary engage consumed it — naming a session the
+    user had already left, against an unrelated runtime's build, with the pair
+    running backwards under the word "updated" (R1-2 / Q-2).
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._skew_notice_shown.clear()
+        monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: None)
+        app._session = _BoundViewer(
+            owner_version="0.51.29",
+            owner_source_ref="2412b1daf",
+            conversation_name="Session A",
+        )
+        app._on_runtime_refreshed()
+        assert app._refreshed_from is not None, "the retire must arm the announcement"
+
+        # The real teardown `/resume` and `/new` run.
+        app._cancel_runtime_engage()
+        assert app._refreshed_from is None, "the swap must disarm it"
+
+        # Session B binds normally. Nothing about session A may be said.
+        app._session = _BoundViewer(
+            owner_version="0.51.19",
+            owner_source_ref="dc6bec0aa",
+            conversation_name="Session B",
+        )
+        app._announce_refresh_completed()
+        await pilot.pause()
+        notices = _notices(app)
+
+    assert notices == [], notices
+
+
+@pytest.mark.asyncio
+async def test_a_title_that_raises_does_not_cost_the_re_engage(monkeypatch, tmp_path) -> None:
+    """A pre-sync `conversation_name` raises; the eager re-engage must survive.
+
+    `RemoteSession.conversation_name` reads `frontend_state`, which raises
+    until the first sync completes — and the refresh callback reads the title
+    BEFORE re-engaging. `_go_cold` swallows the exception, so the cost was a
+    silently lost re-engage: the viewer stays cold until the next keystroke,
+    which is the guarantee this feature exists to provide (R1-3).
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+
+    class _Raising(_BoundViewer):
+        @property
+        def conversation_name(self) -> str:  # type: ignore[override]
+            raise RuntimeError("frontend state has not synchronized")
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        reasons: list[str] = []
+        monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: reasons.append(reason))
+        app._warm_engage_started = True
+        app._session = _Raising(owner_version="0.51.29", owner_source_ref="2412b1daf")
+        app._on_runtime_refreshed()
+        await pilot.pause()
+
+    assert reasons == ["refresh"], "the re-engage must happen even with no readable title"
+    assert app._warm_engage_started is False
+    assert app._refreshed_from is not None
+    assert app._refreshed_from[1] == "this session", "an unreadable title degrades to the deictic"
+
+
+@pytest.mark.asyncio
+async def test_the_refresh_note_keeps_its_version_pair_on_one_row(monkeypatch, tmp_path) -> None:
+    """D1: the pair must not wrap, INCLUDING for an unnamed session.
+
+    The parenthetical form split it at 6 of 19 name lengths at both 80 and 100
+    columns — length 0, the unnamed default, among them. The reported 51-char
+    name happened to be a non-splitting length, which is why the original still
+    looked clean. Asserted through the real block's wrapped rows rather than
+    the raw string, since the defect is invisible to `_text`.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    for width in (80, 100):
+        for name in ("", "Debugging the reaper", "x" * 72):
+            app = OperatorApp(lambda: _factory(FakeSession()))
+            async with app.run_test(size=(width, 24)) as pilot:
+                await pilot.pause()
+                app._skew_notice_shown.clear()
+                monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: None)
+                app._session = _BoundViewer(
+                    owner_version="0.51.29",
+                    owner_source_ref="2412b1daf",
+                    conversation_name=name,
+                )
+                app._on_runtime_refreshed()
+                app._session = _BoundViewer(owner_version="0.51.30", owner_source_ref="d7f12d3a7")
+                app._announce_refresh_completed()
+                await pilot.pause()
+                blocks = list(app.query(NoticeBlock))
+                assert len(blocks) == 1, (width, name)
+                rows = _wrapped_rows(blocks[0])
+
+            pair_rows = [r for r in rows if "0.51.29@2412b1d" in r or "0.51.30@d7f12d3" in r]
+            assert len(pair_rows) == 1, f"the pair wrapped apart at {width} for {name!r}: {rows}"
+
+
+@pytest.mark.asyncio
+async def test_the_refresh_note_does_not_restate_the_version_twice(monkeypatch, tmp_path) -> None:
+    """D3: on a same-version rebuild the copy must not claim novelty in prose.
+
+    "a newer version" was the only thing asserting a change beside two stamps
+    that read alike; `_build_change`'s collapsed form puts the seven characters
+    that actually differ where the reader looks.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._skew_notice_shown.clear()
+        monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: None)
+        app._session = _BoundViewer(owner_version="0.51.30", owner_source_ref="aaaaaaa11")
+        app._on_runtime_refreshed()
+        app._session = _BoundViewer(owner_version="0.51.30", owner_source_ref="bbbbbbb22")
+        app._announce_refresh_completed()
+        await pilot.pause()
+        notices = _notices(app)
+
+    assert len(notices) == 1, notices
+    assert "0.51.30, aaaaaaa \u2192 bbbbbbb" in notices[0], notices[0]
+    assert "newer version" not in notices[0], notices[0]


### PR DESCRIPTION
## Change authorization

**C1 — standard / pre-authorized bug fix.** This PR is the change record. No version bump (`pyproject.toml` untouched at `0.51.30`).

`Release: patch — a wrong-direction build notice stops painting on idle sessions; a self-refresh now says what it updated to.`

## The defect

Reported from a live session sitting **idle** at the end of a turn, which painted:

> “Investigating suspicious pwned notification source” is running 0.51.30@d7f12d3 → 0.51.29@2412b1d — it will switch to the new version when it is next idle.

Two things are wrong. The arrow reads as a **downgrade** when the runtime is in fact the newer side, and the line **appeared at all** on an idle session where the disk-drift notice one row above had already said the only true thing.

## Root cause

`OperatorApp._check_build_skew` runs two checks. **A (disk drift)** is directional and correct. **C (owner skew)** compared the bound runtime's stamp with `self._loaded_build` using only `owner != loaded` — **it had no notion of which side was newer** — and then unconditionally treated the runtime as the stale one: it asked an idle runtime to `request_refresh()`, and on any answer but `retiring` painted `_build_change(owner, loaded)`, i.e. `runtime → window`.

The routine shape on this host makes that backwards. A TUI keeps the build it imported at launch forever; `lop-update` runs several times a day; a runtime spawned **after** an update resolves `sys.executable` fresh and is therefore **newer** than the window driving it. So check C:

1. asked a perfectly current runtime to retire — it answered `kept: build on disk matches (or has not settled)` from `RuntimeServer._refresh_if_idle`, because **its own** comparison is against disk and found no change;
2. read that `kept` as "the runtime is staying on the old build";
3. printed `newer → older` with copy promising a switch to the version it was already running.

Not hypothetical: the runtime records under `~/.local-operator/run/mobile` currently carry 0.51.19, 0.51.28, 0.51.29 and 0.51.30 simultaneously.

## The fix — discriminate against DISK, not by version ordering

The build **on disk** is what a process started right now would run, so it is the only fixed reference the two long-lived populations here — a window frozen at the build it imported, and a runtime spawned at some later moment — can both be measured against. The viewer already reads `on_disk` for check A, so the discriminator is free.

| | runtime **stale** (`owner != on_disk`) | runtime **current** (`owner == on_disk`) |
|---|---|---|
| **window current** (`loaded == on_disk`) | today's behaviour, unchanged: idle ⇒ ask to retire, silent on `retiring`; `kept:`/failure/busy ⇒ C′ | impossible — both equal disk, so `owner == loaded` and the check returns early |
| **window stale** (`loaded != on_disk`) | both sides behind: still genuinely stale, C′ preserved | **the reported case → completely silent.** No refresh request, no owner notice. Notice A already named the drift and `/reload`, which is the remedy that actually applies to a *window* |

**Why not order the version numbers?** This host's headline drift is a same-version rebuild — `lop-update` builds from `main` while `pyproject.toml` still names the last released version, so the two builds are `0.51.30@aaaaaaa` and `0.51.30@bbbbbbb` and **no ordering of version numbers can say which is which**. `BuildStamp` equality against disk resolves it exactly, because the recorded ref is part of the token. Both directions of that case are pinned by a test, and the reasoning is in the helper's docstring so nobody "simplifies" it back to a version compare.

Version ordering survives only as the **fallback** for when `installed_build()` raised (so check A was skipped and the disk reference does not exist): an owner that parses strictly newer is treated as current, and an **inconclusive** comparison — equal versions differing only by ref, or an unparseable side — deliberately keeps today's notice. Silence there would regress review round 1 finding R1-1; an undiagnosable skew is still worth one advisory line.

## Second change: a self-refresh now says what it updated to

Requested explicitly: *"if an upgrade happens to the runtime it should just happen and maybe emit an info message that the runtime has updated from version to version in the idle window."*

The silent-refresh path (`RemoteSession.set_refresh_callback` → `_on_runtime_refreshed`) painted nothing. It now captures the retiring stamp **before** the re-engage — the last moment it exists, since `_dial` overwrites it in place on the same facade — and, once the successor binds, paints **one** `note` line naming the change. Gated on the build **actually** moving, so an ordinary re-engage on an unchanged stamp stays quiet, and dropped on every path where nothing binds (no provider configured, engage failed, non-engageable facade) so a pending stamp cannot be answered by a later unrelated engage.

Ink is `note` (`muted`), matching the existing C′ choice — not `warning`, not `info`. Copy stays in the existing register; `test_the_notices_carry_no_internal_vocabulary` still passes.

## Reproduction — actual output

Kept in-tree as `scripts/build_skew_direction_repro.py`. Drives the real `OperatorApp` under `run_test`, isolated `HOME` + config dir via `scripts.probe_isolation`, no inherited `CMUX_*`, no provider calls.

```sh
env -u NO_COLOR TERM=xterm-256color .venv/bin/python scripts/build_skew_direction_repro.py
```

**Before** (run against pristine `main` @ `d7f12d3a7` in a separate worktree):
```
refresh requests sent to the NEWER runtime: 1
NOTICE: local-operator was updated after this window opened (0.51.29@2412b1d → 0.51.30@d7f12d3) — this window is still on the old version. /reload updates it and picks this session back up.
NOTICE: “Investigating suspicious pwned notification source” is running 0.51.30@d7f12d3 → 0.51.29@2412b1d — it will switch to the new version when it is next idle.
```
That second line is byte-for-byte the one the operator reported.

**After** (this branch):
```
refresh requests sent to the NEWER runtime: 0
NOTICE: local-operator was updated after this window opened (0.51.29@2412b1d → 0.51.30@d7f12d3) — this window is still on the old version. /reload updates it and picks this session back up.
```

**The new refresh note**, driven through `_on_runtime_refreshed` → `_announce_refresh_completed`:
```
NOTICE: “Investigating suspicious pwned notification source” updated to a newer version (0.51.29@2412b1d → 0.51.30@d7f12d3). | token: muted
```

**Stamp lifecycle probed against the real `RemoteSession`**, since the second half depends on it:
```
stamp visible to the refresh callback: {'version': '0.51.29', 'ref': '2412b1daf'}
PASS: the retiring stamp survives go_cold(refresh=True)
stamp assigned on self inside _dial: True   # so the re-bind replaces it in place
```

## Before / after frames

Rendered with `scripts.visual_capture.save_capture` (real `OperatorApp`, production CSS, native 8×17 cells), rasterized with `rsvg-convert` and **actually viewed** — not inferred from a green test. Geometry JSON is in the [gist](https://gist.github.com/damianvtran/bb6896dd4c13ddaa2c4945be1de86bd1).

| Before (idle window, 120 cols) | After |
|---|---|
| ![before](https://gist.githubusercontent.com/damianvtran/bb6896dd4c13ddaa2c4945be1de86bd1/raw/bb7dfe2b18c5e82916d1489ff5f64f31f66fbc23/before.svg) | ![after](https://gist.githubusercontent.com/damianvtran/bb6896dd4c13ddaa2c4945be1de86bd1/raw/56ec417cb7cd2a7a8637fbeb439a9524f1d8fd4d/after.svg) |

The reversed line is gone; the drift notice that *is* correct is untouched, still naming `/reload`.

The new self-refresh note:

![refresh note](https://gist.githubusercontent.com/damianvtran/bb6896dd4c13ddaa2c4945be1de86bd1/raw/af3612014d71909f4eba87bc0d572c0233e4b4f7/refresh_note.svg)

## Tests

Ten cells added to `tests/unit/tui/test_build_skew.py`, reusing its `_BoundViewer` and `_notices` helpers:

- `test_a_runtime_newer_than_this_window_is_completely_silent` — the reported case: **zero** refresh requests, **no** owner notice, drift notice still present and still naming `/reload`.
- `test_a_runtime_newer_than_this_window_is_silent_while_busy` — the busy branch reaches C′ without asking anything, so it is an independent way into the same reversed line.
- `test_a_same_version_rebuild_is_directional_both_ways` — ref-only drift both ways: silent when the runtime is the on-disk rebuild, C′ when it is the older one. This is the cell that forbids a version-ordering "simplification".
- `test_an_unreadable_disk_falls_back_to_version_order` / `test_an_inconclusive_order_keeps_todays_notice` / `test_an_unparseable_version_is_not_guessed_at` — the fallback and its two refusals to guess.
- Five refresh-note cells: fires once with the right pair on a real change; silent on an unchanged stamp; silent on an ordinary engage; silent when the retiring runtime was too old to name its build; pending stamp cleared on read.

Every pre-existing assertion in the file is unchanged — the genuinely-stale paths were not weakened.

**Proved capable of failing** (AGENTS.md "Prove the test can still fail"). The new file run against pristine `main` @ `d7f12d3a7`:
```
FAILED test_a_runtime_newer_than_this_window_is_completely_silent - AssertionError: a runtime that matches disk is already current
FAILED test_a_runtime_newer_than_this_window_is_silent_while_busy - AssertionError: [... 'this session is running 0.51.30@d7f12d3 → 0.51.29@2412b1d — it will switch to the new version when it is next idle.']
FAILED test_a_same_version_rebuild_is_directional_both_ways - AssertionError: [... 'is running 0.51.30, bbbbbbb → aaaaaaa ...']
FAILED test_an_unreadable_disk_falls_back_to_version_order - assert 1 == 0
FAILED test_a_completed_refresh_names_the_version_it_moved_to - AttributeError: 'OperatorApp' object has no attribute '_announce_refresh_completed'
FAILED test_an_unchanged_build_after_a_refresh_says_nothing - AttributeError: ...
FAILED test_an_ordinary_engage_never_announces_a_refresh - AttributeError: ...
FAILED test_a_runtime_too_old_to_name_its_build_is_not_half_announced - AttributeError: 'OperatorApp' object has no attribute '_refreshed_from'
8 failed, 35 passed
```
Each fails for the reason it exists for, and the three cells that legitimately pass on `main` (the two inconclusive-fallback refusals and the unparseable one) are the ones whose behaviour this PR deliberately preserves.

## Gate results

Whole tree, exactly as CI, via `python -m` / `uvx` (never the venv console scripts):

| Gate | Result |
|---|---|
| `flake8 .` | clean |
| `black --check .` (26.1.0) | `1126 files would be left unchanged` |
| `isort --check .` (5.13.2) | clean |
| `pyright --pythonpath .venv/bin/python .` | `0 errors, 0 warnings, 0 informations` |
| `pytest tests/unit -q` | **16798 passed**, 18 skipped, 0 failed (20:44) |
| `pytest tests/unit/tui -q` (`env -u NO_COLOR TERM=xterm-256color`) | **6291 passed**, 12 skipped, 0 failed (14:49) |

Worktree owns its own venv, verified resolving its own source (`.../lo-skew-direction/local_operator/__init__.py`).

## Deliberately not done

- **No change to the runtime side.** `RuntimeServer._refresh_if_idle` is already correct — it compares itself against disk and answers `kept` truthfully. The defect was entirely in how the viewer interpreted that answer.
- **No `pyproject.toml` bump** — releases are batched per window.
- **No follow-up issues opened**, per standing instructions.
