### PR TITLE
chore(release): bump version to 0.52.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.52.0"
+version = "0.52.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release bump for the window after `v0.52.0`. Owner session pid: 91700.

## Window

- #830 — 4d9f07db9 — `feat(notify): carry the finished session's last reply in the banner body`

The only PR merged to `main` since `v0.52.0` was tagged (19:17Z); #830 merged at 19:56Z.

## Bump class: PATCH

A single user-facing copy/content improvement to one notification surface. It does not add a capability or change an interface, so it does not clear the step-function bar for a minor. Both peer lop-dev sessions still running (pids 29011, 83697) were asked and independently argued PATCH; neither claimed the window.

## Scope

One line in one file (`pyproject.toml`). No code rides this commit. No other PR in the window touched `pyproject.toml`.