### PR TITLE
chore(release): bump version to 0.52.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.52.1"
+version = "0.52.2"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## What

Version bump only: `0.52.1` → `0.52.2`. One line, one file (`pyproject.toml`). No source, test, or workflow changes.

## Window

Re-derived from `git log v0.52.1..origin/main` immediately before opening this PR, rather than from a collected list:

| PR | Merge SHA | Change |
|---|---|---|
| [#819](https://github.com/damianvtran/local-operator/pull/819) | `96e7eb1d4285c8fa22f96ac4b39c69f56b051b32` | `fix(tui): recall queued steers by message id, and state an interrupt once` |

Exactly one PR in the window.

## Bump class: PATCH

#819 is a bug fix on an existing seam — no new surface, no data migration, no security-posture change. It does not clear the step-function bar a minor requires. Both peer sessions holding open lop-dev work (pids 29011, 83697) were asked and independently agreed on PATCH before this was opened; both confirmed they do not own this window.

## Not in this window

- #831 (rescoped from #785) — open, draft, mid-gate. Rides the next window.
- #821 (MCP startup toast) — heading into a round 3 after a per-session redesign. Rides the next window.
- #815 (secret-store broker) — **not** carried here, so v0.52.0's note that agents cannot reach secrets yet remains accurate for this release. Whoever ships the window carrying #815 should correct that statement explicitly.

## Scope check

`git diff` is one insertion and one deletion in `pyproject.toml`. C0 one-file release bump.