### PR TITLE
fix(imaging): bound screen frames and mobile images at the one existing bound

### DIFF
--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
@@ -417,6 +417,11 @@ class OSWorldV2Adapter:
         # a pure plan (when the task is already known), mints the deterministic
         # cleanup refs, and returns the plan the parent persists BEFORE any
         # side effect exists.
+        # Cheapest possible refusal for an environment that cannot produce a
+        # frame at all: no env var can fix a missing decoder, so asking here
+        # (before any allocation) is the difference between a free failure and
+        # one that lands on the first observation of a paid VM.
+        requirements_mod.require_imaging_decoder()
         provisioning.resolve_proxy_policy(params.infra_values)
         # A SUPPLIED proxy config is validated here, at the earliest point that
         # exists. This deliberately does NOT cover the absent-but-needed case:

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/observation.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/observation.py
@@ -2,11 +2,25 @@
 
 Coordinate space is stated exactly: ``native`` is ALWAYS the VM's real screen
 (1920x1080 on the V2 AMI), never inferred from the PNG header. We assert the
-PNG dimensions agree with that native size and raise if they do not, because
-a mismatch means the guest resized and every pointer coordinate afterwards is
-silently wrong. ``model_visible == native`` for PR 1 — no resize — which
-removes a whole class of off-by-one from the first paid run; the protocol
-supports adding a resize later without a contract change.
+RAW guest PNG's dimensions agree with that native size and raise if they do
+not, because a mismatch means the guest resized and every pointer coordinate
+afterwards is silently wrong. That check runs on the bytes the guest handed
+us, before any bounding of our own, so it keeps guarding the guest rather than
+our resizer.
+
+The frame is then bounded to the model's screen-driving edge and
+``model_visible`` is the size of THOSE bytes. Two consequences worth stating
+plainly:
+
+* The published artifact IS what the model saw. The evidence bundle holds the
+  model-visible frame, not the native capture, because a bundle is judged
+  against what the model was actually looking at; ``native`` is the adapter's
+  private fact and reaches nobody but the coordinate converter.
+* Every coordinate the model emits is in ``model_visible`` space, and
+  ``actions.py`` (``_native_point`` -> ``FrameGeometry.model_to_native``) is
+  the single converter back to guest pixels. Nothing else in the harness
+  rescales a frame or a coordinate; the host verifier enforces that by
+  checking decoded pixels against ``model_visible``.
 
 The a11y tree is deliberately NOT shipped as a frame. ``FrameRef.geometry`` is
 mandatory and a geometry for an XML document is a fiction, and
@@ -28,10 +42,15 @@ from __future__ import annotations
 import hashlib
 import struct
 import zlib
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any
 
-from local_operator.evaluation.adapters.api import observation_content_id
+from local_operator.evaluation.adapters.api import (
+    BoundFrame,
+    bound_screen_frame,
+    observation_content_id,
+)
 from local_operator.evaluation.protocol import (
     ArtifactRef,
     FrameGeometry,
@@ -44,6 +63,19 @@ from local_operator.evaluation.protocol import (
 # asserted against the decoded PNG header; a guest that resized mid-episode
 # must fail loudly rather than hand the model a miscalibrated frame.
 NATIVE_SCREEN = FrameSize(width=1920, height=1080)
+
+#: How many distinct native frames keep their bounded form in the builder.
+#:
+#: A ``wait`` or a no-op click returns a byte-identical screenshot, and
+#: re-encoding it would cost ~70ms and — far worse — risk a different artifact
+#: sha for the same screen, which is what ``_frames_identical`` reads to tell
+#: the model "the screen did not change". Memoising on the native sha makes
+#: identical native bytes yield an identical artifact by construction.
+#:
+#: Small because the value is only ever hit by an immediate repeat: an episode
+#: revisiting a screen from twenty steps ago is not the case this serves, and
+#: each entry holds a frame's worth of bytes.
+_BOUND_CACHE_SIZE = 8
 
 
 class ObservationError(ValueError):
@@ -98,6 +130,24 @@ class ObservationBuilder:
 
     def __init__(self, artifact_root: Path) -> None:
         self._artifact_root = artifact_root
+        self._bound_cache: OrderedDict[str, BoundFrame] = OrderedDict()
+
+    def _bound_for(self, native_sha: str, png: bytes) -> BoundFrame:
+        """The bounded form of ``png``, reusing the last few results.
+
+        Keyed on the NATIVE sha so identical guest bytes always produce the
+        identical artifact address — see ``_BOUND_CACHE_SIZE``.
+        """
+
+        cached = self._bound_cache.get(native_sha)
+        if cached is not None:
+            self._bound_cache.move_to_end(native_sha)
+            return cached
+        bound = bound_screen_frame(png)
+        self._bound_cache[native_sha] = bound
+        while len(self._bound_cache) > _BOUND_CACHE_SIZE:
+            self._bound_cache.popitem(last=False)
+        return bound
 
     def build(
         self,
@@ -127,23 +177,39 @@ class ObservationBuilder:
                 "resized, and every pointer coordinate would be wrong"
             )
 
-        sha = hashlib.sha256(png).hexdigest()
+        # Bound to the model's screen edge BEFORE addressing the artifact: the
+        # published frame is the one the model sees, so the content address,
+        # the byte count and the media type all describe those bytes. A
+        # ValueError from the bound (undecodable frame, or an adapter
+        # environment with no decoder) becomes an ObservationError, which is
+        # the failure the episode already knows how to report.
+        native_sha = hashlib.sha256(png).hexdigest()
+        try:
+            bound = self._bound_for(native_sha, png)
+        except ValueError as error:
+            raise ObservationError(f"screenshot could not be bounded for the model: {error}")
+
+        sha = hashlib.sha256(bound.payload).hexdigest()
         # The parent reads the artifact back by opening <root>/<sha256> with
         # O_NOFOLLOW and re-hashing, so the file name IS the content address
         # and there is no extension to disagree over.
         artifact_path = self._artifact_root / sha
         if not artifact_path.exists():
-            artifact_path.write_bytes(png)
+            artifact_path.write_bytes(bound.payload)
 
         frame = FrameRef(
             frame_id="screen",
-            artifact=ArtifactRef(sha256=sha, media_type="image/png", byte_count=len(png)),
+            artifact=ArtifactRef(
+                sha256=sha,
+                media_type=bound.media_type,
+                byte_count=len(bound.payload),
+            ),
             geometry=FrameGeometry(
                 native=NATIVE_SCREEN,
-                # PR 1 ships model_visible == native: the frame goes to the
-                # model unresized, so the conversion is the identity and there
-                # is no off-by-one to debug on the first paid run.
-                model_visible=NATIVE_SCREEN,
+                # Sniffed from the bounded bytes, never computed from the edge:
+                # the host verifier checks decoded pixels against this field,
+                # so it has to be what the file actually is.
+                model_visible=bound.model_visible,
             ),
         )
 

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/requirements.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/requirements.py
@@ -158,6 +158,39 @@ def is_judged(descriptor: TaskDescriptor) -> bool:
     return False
 
 
+class MissingImagingDecoder(RuntimeError):
+    """The worker has no image decoder, so it cannot publish a frame.
+
+    Every observation is bounded to the model's screen geometry before it is
+    published (``observation.bound_screen_frame``), and that resize needs a
+    real decoder. Without one the adapter cannot honour the dimensions
+    invariant the host verifier enforces, so an episode would die on its FIRST
+    observation — after the VM is allocated and paid for.
+    """
+
+
+def require_imaging_decoder() -> None:
+    """Refuse an adapter environment that cannot resize a frame.
+
+    An ENVIRONMENT precondition rather than a task-derived requirement, which
+    is why it is a check and not a :class:`Requirement`: the ``Requirement``
+    table names values the HOST resolves and injects, and no env var can
+    conjure a missing wheel. It lives in this module anyway because this is
+    where the adapter's preflight refusals are collected, and it is called from
+    ``prepare`` — the last boundary that allocates nothing — so a venv built
+    without the imaging extra fails for free instead of mid-episode.
+    """
+
+    from local_operator.helpers import pillow_image_module
+
+    if pillow_image_module() is None:
+        raise MissingImagingDecoder(
+            "this adapter environment has no image decoder (Pillow), so guest "
+            "screenshots cannot be bounded to the model's screen geometry; "
+            "install the harness 'images' extra in the adapter venv"
+        )
+
+
 def _requirement(name: str, *, kind: str, required: bool) -> Requirement:
     # requirement_id is the name itself: it is unique within an episode and
     # self-describing, which is what rescue-from-descriptor needs.

--- a/local_operator/compaction/thresholds.py
+++ b/local_operator/compaction/thresholds.py
@@ -458,8 +458,15 @@ def should_compact(
 ) -> bool:
     """Whether the current context exceeds the compaction threshold.
 
-    Strictly greater-than so a context exactly on the threshold is stable;
-    ``window_tokens <= 0`` (unknown window) never triggers.
+    Strictly greater-than so a context exactly on the threshold is stable.
+
+    ``window_tokens <= 0`` (unknown window) disables the TOKEN term only. It is
+    not a short-circuit for the whole function, because the byte term does not
+    depend on knowing the window: a request over the provider's size cap is
+    refused whether or not the harness could resolve a context length for the
+    route. Guarding both was how an image-heavy session on a model with no
+    published window kept 413-ing with the byte trigger configured and inert —
+    the one configuration where the backstop is the ONLY trigger there is.
 
     ``advisory_ok`` is the compaction advisor's ONLY entry point into the
     trigger, and it is deliberately a parameter of THIS function rather than a
@@ -504,13 +511,14 @@ def should_compact(
     every caller but the plan gate passes) the function is byte-identical to
     its previous form.
     """
-    if not settings.enabled or settings.strategy == "off" or window_tokens <= 0:
+    if not settings.enabled or settings.strategy == "off":
         return False
-    threshold = resolve_threshold_tokens(window_tokens, settings)
-    if advisory_ok and getattr(settings, "advisor_enabled", False):
-        threshold = min(threshold, resolve_advisor_floor_tokens(window_tokens, settings))
-    if context_tokens > threshold:
-        return True
+    if window_tokens > 0:
+        threshold = resolve_threshold_tokens(window_tokens, settings)
+        if advisory_ok and getattr(settings, "advisor_enabled", False):
+            threshold = min(threshold, resolve_advisor_floor_tokens(window_tokens, settings))
+        if context_tokens > threshold:
+            return True
     byte_trigger = resolve_wire_bytes_trigger(settings)
     return byte_trigger > 0 and wire_bytes > byte_trigger
 

--- a/local_operator/evaluation/adapters/api.py
+++ b/local_operator/evaluation/adapters/api.py
@@ -12,14 +12,27 @@ import platform
 import sys
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Annotated, Any, Literal, NamedTuple, Protocol, TypeAlias, runtime_checkable
+from typing import (
+    Annotated,
+    Any,
+    Literal,
+    NamedTuple,
+    Protocol,
+    TypeAlias,
+    runtime_checkable,
+)
 
 from pydantic import AfterValidator, Field, field_validator, model_validator
 
 from local_operator.evaluation.action_surface import ActionSurface
 from local_operator.evaluation.evidence.models import ScoreArtifact, canonical_digest
 from local_operator.evaluation.lifecycle import CleanupPlan
-from local_operator.evaluation.protocol import ActionBatch, FrameSize, Observation, ProtocolModel
+from local_operator.evaluation.protocol import (
+    ActionBatch,
+    FrameSize,
+    Observation,
+    ProtocolModel,
+)
 from local_operator.evaluation.receipts import (
     ZERO_DIGEST,
     Digest,

--- a/local_operator/evaluation/adapters/api.py
+++ b/local_operator/evaluation/adapters/api.py
@@ -12,14 +12,14 @@ import platform
 import sys
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Annotated, Any, Literal, Protocol, TypeAlias, runtime_checkable
+from typing import Annotated, Any, Literal, NamedTuple, Protocol, TypeAlias, runtime_checkable
 
 from pydantic import AfterValidator, Field, field_validator, model_validator
 
 from local_operator.evaluation.action_surface import ActionSurface
 from local_operator.evaluation.evidence.models import ScoreArtifact, canonical_digest
 from local_operator.evaluation.lifecycle import CleanupPlan
-from local_operator.evaluation.protocol import ActionBatch, Observation, ProtocolModel
+from local_operator.evaluation.protocol import ActionBatch, FrameSize, Observation, ProtocolModel
 from local_operator.evaluation.receipts import (
     ZERO_DIGEST,
     Digest,
@@ -863,6 +863,66 @@ class RescuableAdapter(Protocol):
     """
 
     async def begin_rescue(self, params: BeginRescueParams) -> AckResult: ...
+
+
+class BoundFrame(NamedTuple):
+    """A screen frame as the model will actually receive it.
+
+    ``model_visible`` is sniffed back out of ``payload`` rather than computed
+    from the requested edge, so it is the size of the BYTES being shipped and
+    not an arithmetic prediction about them. That distinction is the whole
+    point: the host verifier compares decoded pixels against the geometry an
+    adapter publishes, and a predicted size would let a rounding disagreement
+    inside the resizer surface as a supervision failure mid-episode.
+    """
+
+    payload: bytes
+    media_type: str
+    model_visible: FrameSize
+
+
+def bound_screen_frame(native_bytes: bytes) -> BoundFrame:
+    """Bound a native screenshot to the screen-driving edge for the model.
+
+    The one place an evaluation adapter turns guest pixels into model pixels,
+    so no adapter re-implements the ladder or re-decides the edge. Wraps
+    :func:`~local_operator.imaging.bound_image_for_model` at
+    :data:`~local_operator.imaging.IMAGE_SCREEN_MAX_EDGE` and reports the
+    result's honest size.
+
+    Raises ``ValueError`` when the bytes will not decode OR when no imaging
+    decoder is installed. The second case is the notable one: the ladder's
+    normal answer to a missing decoder is to forward the bytes untouched, and
+    that is exactly what a screen frame must NOT do. Forwarding leaves the
+    model looking at native pixels while the geometry claims the bounded size,
+    which is the coordinate miscalibration this whole seam exists to prevent —
+    so an adapter environment without Pillow fails here rather than shipping a
+    frame whose dimensions invariant cannot hold.
+    """
+
+    from local_operator.helpers import pillow_image_module
+    from local_operator.imaging import IMAGE_SCREEN_MAX_EDGE, bound_image_for_model
+    from local_operator.media import sniff_image
+
+    info = sniff_image(native_bytes)
+    if info is None:
+        raise ValueError("screen frame is not a recognised image format")
+    if pillow_image_module() is None:
+        raise ValueError(
+            "screen frames require an imaging decoder (Pillow) so the frame can be "
+            "resized to the model-visible geometry; install the 'images' extra"
+        )
+    payload, media_type, _summary = bound_image_for_model(
+        native_bytes, info, max_edge=IMAGE_SCREEN_MAX_EDGE
+    )
+    bound_info = sniff_image(payload)
+    if bound_info is None or bound_info.width is None or bound_info.height is None:
+        raise ValueError("bounded screen frame did not report readable dimensions")
+    return BoundFrame(
+        payload=payload,
+        media_type=media_type,
+        model_visible=FrameSize(width=bound_info.width, height=bound_info.height),
+    )
 
 
 def observation_content_id(observation: Observation) -> Digest:

--- a/local_operator/evaluation/adapters/supervisor.py
+++ b/local_operator/evaluation/adapters/supervisor.py
@@ -515,7 +515,8 @@ class HostVerifier:
             raise SupervisionError("adapter observation belongs to another task or episode")
         validate_observation(observation)
         for frame in observation.frames:
-            verify_artifact(self.artifact_root, frame.artifact)
+            data = verify_artifact(self.artifact_root, frame.artifact)
+            _verify_frame_geometry(data, frame)
 
     def validate_execution_result(self, params: ExecuteParams, result: ExecuteResult) -> None:
         if self.current_observation is None:
@@ -994,6 +995,41 @@ def verify_artifact(root: Path, reference: ArtifactRef) -> bytes:
     except MediaValidationError as error:
         raise SupervisionError("artifact media differs") from error
     return raw
+
+
+def _verify_frame_geometry(data: bytes, frame: Any) -> None:
+    """Refuse a frame whose pixels disagree with the geometry it publishes.
+
+    The model is TOLD ``model_visible`` (the runner's frames line), validates
+    its coordinates against it, and the adapter converts them back through the
+    same field. Nothing so far checks that the IMAGE is that size, so an
+    adapter that resized without updating its geometry — or a runner-side
+    rewrite of frame pixels, which is the drift this makes impossible — would
+    silently miscalibrate every click for the rest of the episode.
+
+    Header-only (``sniff_image`` reads dimensions without decoding), so it is
+    cheap enough to run on every observation, which is where it has to run:
+    the invariant is worth nothing if it is sampled.
+
+    A format whose header does not carry dimensions is accepted rather than
+    refused. ``validate_media`` has already agreed the bytes are the declared
+    media type; failing here on an unreadable header would refuse honest
+    frames to catch nothing, since a dishonest adapter would simply pick such
+    a format.
+    """
+
+    from local_operator.media import sniff_image
+
+    info = sniff_image(data)
+    if info is None or info.width is None or info.height is None:
+        return
+    expected = frame.geometry.model_visible
+    if (info.width, info.height) != (expected.width, expected.height):
+        raise SupervisionError(
+            f"frame {frame.frame_id!r} is {info.width}x{info.height} but declares a "
+            f"model-visible geometry of {expected.width}x{expected.height}: every "
+            "coordinate the model emits would be miscalibrated"
+        )
 
 
 def persist_rescue(root: Path, descriptor: RescueDescriptor) -> Path:

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -1221,12 +1221,24 @@ class ProviderModelClient:
         )
         window = int(getattr(self._model_spec, "context_window", 0) or 0)
         wire_before = estimate_wire_bytes(messages)
-        threshold_due = should_compact(
+        # Two questions, asked of the ONE resolver (its docstring forbids a
+        # second predicate): "does the context fit the window?" and "will the
+        # request be accepted?". They are asked separately here because their
+        # answers are consumed separately below. ``token_due`` alone decides
+        # whether the pass must FIT a token band afterwards; the byte answer
+        # only fires the pass and is fitted by ``_enforce_wire_fit``. Folding
+        # both into one flag made a byte-only trigger shed stale turns to a
+        # token band it never crossed, and with an unknown window (``window ==
+        # 0``) resolved that band to 0 and raised ``ContextUnrecoverableError``
+        # on the first byte pass -- the exact case the byte term exists to
+        # save (review round 1, F1).
+        token_due = should_compact(tokens_before, window, self._compaction)
+        threshold_due = token_due or should_compact(
             tokens_before, window, self._compaction, wire_bytes=wire_before
         )
         if not (frame_due or threshold_due):
             return None, None, 0
-        threshold = resolve_threshold_tokens(window, self._compaction) if threshold_due else None
+        threshold = resolve_threshold_tokens(window, self._compaction) if token_due else None
 
         summary_usage: ModelUsage | None = None
         summary_cost = 0

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -1319,12 +1319,7 @@ class ProviderModelClient:
         # request, and a ``context_compaction`` event is the only honest trace
         # of that (review round 4, m8). Returning nothing here would hide it
         # behind a bare ``message_count`` drop.
-        if (
-            shed == 0
-            and frames_dropped == 0
-            and not result.ran
-            and not result.pruned
-        ):
+        if shed == 0 and frames_dropped == 0 and not result.ran and not result.pruned:
             return None, None, 0
         record = CompactionRecord(
             strategy=result.strategy or "prune",
@@ -1399,7 +1394,7 @@ class ProviderModelClient:
         return self._shed_stale_turns(band)
 
     def _enforce_wire_fit(self, budget: int) -> int:
-        """After a pass, shed the oldest FRAMES until the request fits ``budget`` bytes.
+        """After a pass, shed the oldest FRAMES until the request fits the byte band.
 
         The byte counterpart of :meth:`_enforce_threshold_fit`, and deliberately
         a different mechanism: that one sheds whole stale TURNS to recover
@@ -1409,27 +1404,39 @@ class ProviderModelClient:
         and tokens are separate rulers in this package and each gets the shed
         that answers its own question.
 
-        Returns the number of frames dropped, 0 when already under budget or
+        Sheds to a BAND BELOW THE TRIGGER, not merely under ``budget``, and
+        that is the same lesson the token side already carries: the trigger is
+        clamped to at most the budget, so a prefix shed to exactly the budget
+        can still be over the trigger and fire the pass again on the very next
+        turn — measured as a rebuild every turn, which destroys the prefix
+        cache for no headroom. The band buys the episode room to append.
+
+        Returns the number of frames dropped, 0 when already inside the band or
         when no byte ceiling is configured. Raises
         :class:`ContextUnrecoverableError` when even dropping every frame
-        leaves the request over the wire budget — a text-only prefix too large
-        to send is not something this client can repair, and sending it earns
-        a provider rejection that ends the episode anyway, less legibly.
+        leaves the request over ``budget`` — a text-only prefix too large to
+        send is not something this client can repair, and sending it earns a
+        provider rejection that ends the episode anyway, less legibly. Note the
+        asymmetry: the shed AIMS at the band, but only the hard ``budget`` is
+        worth refusing over.
 
-        The rebuild-once property is preserved: in the normal case this shed
-        finds the prefix already under budget and replaces nothing, so the pass
+        The rebuild-once property is preserved: in the normal case this finds
+        the prefix already inside the band and replaces nothing, so the pass
         above remains the single rewrite.
         """
         from local_operator.compaction.pruning import shed_frames_to_wire_budget
+        from local_operator.compaction.thresholds import resolve_wire_bytes_trigger
         from local_operator.compaction.tokens import estimate_wire_bytes
 
         if budget <= 0:
             return 0
+        trigger = resolve_wire_bytes_trigger(self._compaction)
+        band = min(budget, int(0.8 * trigger)) if trigger > 0 else budget
         messages = self._context.messages
         wire = estimate_wire_bytes(messages)
-        if wire <= budget:
+        if wire <= band:
             return 0
-        shed_messages, dropped = shed_frames_to_wire_budget(messages, budget=budget)
+        shed_messages, dropped = shed_frames_to_wire_budget(messages, budget=band)
         if dropped:
             self._context.replace(shed_messages)
         remaining = estimate_wire_bytes(self._context.messages)
@@ -1441,10 +1448,13 @@ class ProviderModelClient:
                 "than send a request the provider will reject"
             )
         logger.info(
-            "evaluation context shed %d frame(s) to fit the wire budget (%d -> %d bytes)",
+            "evaluation context shed %d frame(s) to fit the wire band (%d -> %d bytes, "
+            "band %d, budget %d)",
             dropped,
             wire,
             remaining,
+            band,
+            budget,
         )
         return dropped
 

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -1276,11 +1276,15 @@ class ProviderModelClient:
             # A frame-budget rebuild lets the pass judge its own gate (on a small
             # context it prunes its frames and refuses the summary as
             # below-threshold, the common and correct outcome). A
-            # threshold-triggered pass was ALREADY judged over the line by the
-            # same resolver, so the gate is not re-asked after the prune:
-            # re-asking let the prune alone slip just under the line, refuse
-            # the summary, and re-fire the pass on the very next turn (review
-            # round 1, m2).
+            # threshold-triggered pass -- by tokens OR by bytes -- was ALREADY
+            # judged over the line by the same resolver, so the gate is not
+            # re-asked after the prune: re-asking let the prune alone slip
+            # just under the line, refuse the summary, and re-fire the pass on
+            # the very next turn (review round 1, m2). The pass's own gate
+            # takes ``wire_bytes`` too, so a byte-only pass is admitted by it
+            # either way; ``threshold_due`` (not ``token_due``) is used here
+            # deliberately, and the split above is only about which BAND the
+            # rebuilt prefix must then fit.
             respect_threshold=not threshold_due,
         )
         # The pass returns the pruned list even when it refused to summarize; either

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -803,6 +803,15 @@ class _ContextBuilder:
                 self._closed_turns.add(index)
 
     def _render_observation(self, turn: EpisodeTurn, previous: EpisodeTurn | None) -> Message:
+        # FRAME PIXELS ARE THE ADAPTER'S, AND THIS METHOD MUST NOT TOUCH THEM.
+        # In particular it must never call ``rebound_oversize_image``, however
+        # fat a frame looks: the adapter published ``geometry.model_visible``,
+        # compiles the model's coordinates back through it, and the host
+        # verifier refuses any frame whose decoded pixels disagree with it. A
+        # rewrite here would therefore not silently miscalibrate clicks — it
+        # would fail the next observation loudly, which is the design. Frames
+        # that are too large are a TRANSPORT problem and are handled by
+        # dropping whole frames (``_enforce_wire_fit``), never by resizing one.
         from local_operator.harness.types import ImageContent, Message, TextContent
 
         observation = turn.observation
@@ -1157,14 +1166,21 @@ class ProviderModelClient:
             ) from error
 
     async def _maybe_compact(self) -> tuple[CompactionRecord | None, ModelUsage | None, int]:
-        """Run one compaction pass when the frame budget or the token threshold says so.
+        """Run one compaction pass when the frame budget or the resolved trigger says so.
 
-        Two triggers, one pass. The frame budget (``rebuild_due``) is the usual
-        one for a screen-driving episode; the token threshold is the ordinary
-        session's trigger and applies here too because a long text-heavy episode can
-        fill the window without ever tripping the frame budget. Either way the pass
-        rebuilds the whole prefix ONCE, which is the only rewrite this client
-        ever makes to sent messages.
+        Two inputs, one pass. The frame budget (``rebuild_due``) is the usual
+        one for a screen-driving episode; the resolved trigger
+        (``should_compact``) is the ordinary session's and applies here too,
+        judging TOKENS against the window and BYTES against the wire cap in a
+        single answer. Either way the pass rebuilds the whole prefix ONCE,
+        which is the only rewrite this client ever makes to sent messages.
+
+        The byte input matters here specifically because this client's history
+        is mostly screenshots: their token charge is flat by design, so a
+        request can sit far under every token threshold and still be too large
+        for the provider to accept. Passing ``wire_bytes`` is what makes the
+        byte trigger — and, after a pass, the byte-fit shed below — reachable
+        at all; without it both were configured, tested, and dead in this path.
 
         The token trigger is a SAFETY BOUND and is never silenced (review round
         2, M2): the only way to avoid a rebuild every turn is to make the pass
@@ -1182,8 +1198,10 @@ class ProviderModelClient:
         from local_operator.compaction.thresholds import (
             compaction_context_tokens,
             resolve_threshold_tokens,
+            resolve_wire_bytes_budget,
             should_compact,
         )
+        from local_operator.compaction.tokens import estimate_wire_bytes
 
         messages = self._context.messages
         if not messages:
@@ -1202,7 +1220,10 @@ class ProviderModelClient:
             self._last_provider_context_tokens, self._priced_estimate(messages)
         )
         window = int(getattr(self._model_spec, "context_window", 0) or 0)
-        threshold_due = should_compact(tokens_before, window, self._compaction)
+        wire_before = estimate_wire_bytes(messages)
+        threshold_due = should_compact(
+            tokens_before, window, self._compaction, wire_bytes=wire_before
+        )
         if not (frame_due or threshold_due):
             return None, None, 0
         threshold = resolve_threshold_tokens(window, self._compaction) if threshold_due else None
@@ -1285,13 +1306,25 @@ class ProviderModelClient:
                     "observation turn(s) that shedding could not fit under it; the "
                     "episode ends as a harness error rather than send a rejected request"
                 )
+        # The byte mirror of the fit above, and needed for the same reason: a
+        # pass that RAN is not a pass that FITS. The token side judges the
+        # window, this side judges the transport, and a screenshot-heavy prefix
+        # routinely satisfies one while violating the other — which is the
+        # whole reason bytes are a separate ruler in this package.
+        byte_shed = self._enforce_wire_fit(resolve_wire_bytes_budget(self._compaction))
+        frames_dropped = result.frames_dropped + byte_shed
         # A shed-only rebuild is still a rebuild: when the pass itself refused
         # (``nothing-to-summarize`` — the kept window was the whole tail) but
         # the shed removed turns, previously sent messages vanish from the next
         # request, and a ``context_compaction`` event is the only honest trace
         # of that (review round 4, m8). Returning nothing here would hide it
         # behind a bare ``message_count`` drop.
-        if shed == 0 and result.frames_dropped == 0 and not result.ran and not result.pruned:
+        if (
+            shed == 0
+            and frames_dropped == 0
+            and not result.ran
+            and not result.pruned
+        ):
             return None, None, 0
         record = CompactionRecord(
             strategy=result.strategy or "prune",
@@ -1302,9 +1335,11 @@ class ProviderModelClient:
             # After a shed the pass's own figure describes a prefix that no
             # longer exists; measure what is actually being sent.
             tokens_after=(
-                _estimate_context(self._context.messages) if shed else result.tokens_after
+                _estimate_context(self._context.messages)
+                if (shed or byte_shed)
+                else result.tokens_after
             ),
-            frames_dropped=result.frames_dropped,
+            frames_dropped=frames_dropped,
             messages_before=before,
             messages_after=len(self._context.messages),
             summary_text=result.summary_text,
@@ -1362,6 +1397,56 @@ class ProviderModelClient:
         if self._priced_estimate(self._context.messages) <= band:
             return True, 0
         return self._shed_stale_turns(band)
+
+    def _enforce_wire_fit(self, budget: int) -> int:
+        """After a pass, shed the oldest FRAMES until the request fits ``budget`` bytes.
+
+        The byte counterpart of :meth:`_enforce_threshold_fit`, and deliberately
+        a different mechanism: that one sheds whole stale TURNS to recover
+        window, this one replaces the oldest frames with notices to recover
+        transport size (``shed_frames_to_wire_budget``), which removes no
+        message at all and so cannot disturb user/assistant alternation. Bytes
+        and tokens are separate rulers in this package and each gets the shed
+        that answers its own question.
+
+        Returns the number of frames dropped, 0 when already under budget or
+        when no byte ceiling is configured. Raises
+        :class:`ContextUnrecoverableError` when even dropping every frame
+        leaves the request over the wire budget — a text-only prefix too large
+        to send is not something this client can repair, and sending it earns
+        a provider rejection that ends the episode anyway, less legibly.
+
+        The rebuild-once property is preserved: in the normal case this shed
+        finds the prefix already under budget and replaces nothing, so the pass
+        above remains the single rewrite.
+        """
+        from local_operator.compaction.pruning import shed_frames_to_wire_budget
+        from local_operator.compaction.tokens import estimate_wire_bytes
+
+        if budget <= 0:
+            return 0
+        messages = self._context.messages
+        wire = estimate_wire_bytes(messages)
+        if wire <= budget:
+            return 0
+        shed_messages, dropped = shed_frames_to_wire_budget(messages, budget=budget)
+        if dropped:
+            self._context.replace(shed_messages)
+        remaining = estimate_wire_bytes(self._context.messages)
+        if remaining > budget:
+            raise ContextUnrecoverableError(
+                "context cannot fit the wire budget: the rebuilt prefix is "
+                f"{remaining} bytes against a budget of {budget} after dropping "
+                f"{dropped} frame(s); the episode ends as a harness error rather "
+                "than send a request the provider will reject"
+            )
+        logger.info(
+            "evaluation context shed %d frame(s) to fit the wire budget (%d -> %d bytes)",
+            dropped,
+            wire,
+            remaining,
+        )
+        return dropped
 
     def _shed_stale_turns(self, band: int) -> tuple[bool, int]:
         """Shed the oldest stale turns, one at a time, until the priced prefix

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -1276,16 +1276,23 @@ class ProviderModelClient:
             # A frame-budget rebuild lets the pass judge its own gate (on a small
             # context it prunes its frames and refuses the summary as
             # below-threshold, the common and correct outcome). A
-            # threshold-triggered pass -- by tokens OR by bytes -- was ALREADY
-            # judged over the line by the same resolver, so the gate is not
-            # re-asked after the prune: re-asking let the prune alone slip
-            # just under the line, refuse the summary, and re-fire the pass on
-            # the very next turn (review round 1, m2). The pass's own gate
-            # takes ``wire_bytes`` too, so a byte-only pass is admitted by it
-            # either way; ``threshold_due`` (not ``token_due``) is used here
-            # deliberately, and the split above is only about which BAND the
-            # rebuilt prefix must then fit.
-            respect_threshold=not threshold_due,
+            # TOKEN-triggered pass was ALREADY judged over the line by the
+            # same resolver, so the gate is not re-asked after the prune:
+            # re-asking let the prune alone slip just under the line, refuse
+            # the summary, and re-fire the pass on the very next turn (review
+            # round 1, m2).
+            #
+            # ``token_due``, NOT ``threshold_due``. The m2 argument is about
+            # tokens: a frame prices at a flat 1,200 so pruning frames barely
+            # moves the token count, and a re-asked gate slips under by a hair
+            # for no headroom. Bytes are the opposite. The pass's own frame
+            # prune (``keep_recent_frames``) removes megabytes, so on a
+            # BYTE-only trigger the re-asked gate refusing is the CORRECT
+            # outcome -- "a context the prune alone brought under the line
+            # never buys a summary" (pass_.py step 1). Skipping the gate here
+            # bought two summaries and folded observations 0-2 into a marker
+            # on a prefix the prune had already fixed (#836 round 2, F5).
+            respect_threshold=not token_due,
         )
         # The pass returns the pruned list even when it refused to summarize; either
         # way it is the prefix to send from now on.

--- a/local_operator/imaging.py
+++ b/local_operator/imaging.py
@@ -152,6 +152,29 @@ IMAGE_MAX_EDGE = 1568
 #: review round 1, F1; QA round 1). The exemption uses the same
 #: ``_is_line_art`` predicate the repair path does.
 IMAGE_INGEST_MAX_EDGE = 1024
+#: Long-edge ceiling for SCREEN-DRIVING frames: desktop and browser screenshots
+#: the model will emit CLICK COORDINATES against. A third bound rather than a
+#: reuse of either neighbour, because it answers a question neither of them
+#: does — not "can the model read this?" but "can it hit a 24x24 button?".
+#:
+#: Measured on real 1920x1080 OSWorld frames. At 1280 the 10-11px UI text of a
+#: browser tab strip and URL bar stays clearly legible, and one model pixel is
+#: 1.5 native pixels, so a coordinate the model emits lands within a pointer
+#: width of what it aimed at. Token cost is ~44% of native (1,228 against
+#: 2,764 at w*h/750). Anthropic's computer-use guidance names 1280x720 as the
+#: accuracy baseline and prescribes it directly when accuracy is poor.
+#:
+#: The two neighbours were measured and rejected FOR THIS USE, so nobody
+#: re-runs the comparison: :data:`IMAGE_INGEST_MAX_EDGE` (1024) saves a further
+#: 36% of tokens but sits at the legibility floor this module records for 6-7pt
+#: body text AND halves click precision to 1.875 native px per model px; 1568
+#: costs 50% more tokens than 1280 for no measured legibility gain on UI
+#: chrome, whose strokes are already anti-aliased at both sizes.
+#:
+#: Format is left to the ladder (PNG while it fits :data:`IMAGE_MAX_BYTES`,
+#: else JPEG): forcing JPEG would spend quality on the light frames that PNG
+#: already carries under the cap.
+IMAGE_SCREEN_MAX_EDGE = 1280
 #: The provider ceiling a REPAIR is measured against, which is deliberately not
 #: :data:`IMAGE_MAX_EDGE`. Anything this module CREATES is bounded to 1568 for
 #: the cost reasons above; but a block that already exists is only worth
@@ -489,6 +512,12 @@ def bound_image_for_model(
     did not choose, and for line art the smallest possible reduction is worth
     real money. See :func:`rebound_oversize_image`, which passes the refusal
     ceiling for bilevel sources so a pixel font is shrunk by 2% instead of 23%.
+
+    The third documented ``max_edge`` caller is SCREEN DRIVING: an evaluation
+    adapter publishing a frame the model will click on passes
+    :data:`IMAGE_SCREEN_MAX_EDGE` (see
+    :func:`~local_operator.evaluation.adapters.api.bound_screen_frame`), which
+    trades legibility against click precision rather than against cost alone.
 
     With no decoder available the whole ladder collapses to
     :func:`_forward_undecoded`.

--- a/local_operator/mobile/tui_handle.py
+++ b/local_operator/mobile/tui_handle.py
@@ -48,7 +48,11 @@ from local_operator.mobile.types import (
     SessionProjection,
     ask_pending_request,
 )
-from local_operator.session.runtime.server import SessionHandle, image_blocks
+from local_operator.session.runtime.server import (
+    SessionHandle,
+    image_blocks,
+    image_blocks_in_thread,
+)
 
 if TYPE_CHECKING:
     from local_operator.tui.app import OperatorApp
@@ -62,8 +66,12 @@ async def _await_future(future: asyncio.Future[Any]) -> Any:
 
 
 # Decode wire images via the shared mobile-contract helper (registrant.py);
-# kept as a module alias so existing call sites stay short.
+# kept as module aliases so existing call sites stay short. The helper BOUNDS
+# each image, which is CPU-bound, so async callers take the ``_async`` form and
+# the one sync caller (``_decode_attachments``, reached from a Textual callback)
+# keeps the direct call — see its docstring for why that stall is bounded.
 _image_blocks = image_blocks
+_image_blocks_async = image_blocks_in_thread
 
 
 def _decode_attachments(images: list[dict[str, str]] | None) -> dict[int, Any]:
@@ -72,6 +80,12 @@ def _decode_attachments(images: list[dict[str, str]] | None) -> dict[int, Any]:
     Shared by ``slash_images`` and the routed-slash path so both hand the
     dispatch the same ``{1: Attachment, …}`` shape the composer would have
     produced had the images been attached locally.
+
+    Synchronous even though the bound it now performs is CPU-bound, because it
+    runs inside a Textual callback that cannot await. The stall is bounded by
+    the control socket's 1 MB line cap (``_MAX_LINE_BYTES``): a payload that
+    large decodes to at most a few images of a few hundred KB, ~50-100 ms of
+    work, not the ~315 ms a 20 MP paste would cost.
     """
     from local_operator.tui.widgets.editor import Attachment
 
@@ -287,7 +301,7 @@ class TuiSessionHandle(SessionHandle):
     ) -> str:
         if not command_id:
             raise ValueError("command_id is required")
-        image_blocks = _image_blocks(images)
+        image_blocks = await _image_blocks_async(images)
 
         def begin_prompt() -> tuple[asyncio.AbstractEventLoop, asyncio.Future[None], Any] | None:
             session = self._session()
@@ -338,7 +352,7 @@ class TuiSessionHandle(SessionHandle):
     ) -> str:
         if not command_id:
             raise ValueError("command_id is required")
-        image_blocks = _image_blocks(images)
+        image_blocks = await _image_blocks_async(images)
 
         def do_steer() -> bool:
             session = self._session()

--- a/local_operator/server/routes/desktop_sessions.py
+++ b/local_operator/server/routes/desktop_sessions.py
@@ -338,7 +338,7 @@ async def command(session_id: str, body: Command, request: Request):
             outcome = await bridge.remote.route_shared_slash(
                 spec.name,
                 body.args,
-                images=decode_images(body.images),
+                images=await decode_images(body.images),
             )
             if outcome is None or outcome.get("kind") == "noop":
                 return {"command": spec.name, "result": native_action(spec, session_id, body.args)}
@@ -376,10 +376,15 @@ async def command(session_id: str, body: Command, request: Request):
         )
 
 
-def decode_images(images: list[Image]):
-    from local_operator.session.runtime.server import image_blocks
+async def decode_images(images: list[Image]):
+    """Wire images to bounded ImageContent blocks, off the event loop.
 
-    return image_blocks([image.model_dump() for image in images])
+    The shared helper resizes and re-encodes each image, which is CPU-bound;
+    this runs inside a request handler, so it takes the threaded form.
+    """
+    from local_operator.session.runtime.server import image_blocks_in_thread
+
+    return await image_blocks_in_thread([image.model_dump() for image in images])
 
 
 @router.post(

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -28,6 +28,7 @@ import time
 import uuid
 from asyncio import InvalidStateError
 from collections import deque
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Coroutine, Iterable, cast
@@ -127,6 +128,22 @@ GATE_TIMEOUT_CUSTOM_TYPE = _GATE_TIMEOUT_CUSTOM_TYPE
 # Socket admission is intentionally bounded: many front ends may produce input,
 # but an abandoned automation loop must not grow one owner's memory forever.
 MAX_QUEUED_PROMPTS = 32
+
+
+def _already_bounded(images: Any) -> bool:
+    """Whether ``images`` are decoded ``ImageContent`` rather than wire dicts.
+
+    The wire carries ``[{"data_b64": ..., "mime_type": ...}]``; in-process
+    callers that have already run the bound pass ``ImageContent`` blocks. Both
+    reach ``prompt``/``steer``, and telling them apart is what lets an
+    already-bounded caller keep the prelude await-free (see ``prompt``).
+
+    An EMPTY list is "already bounded" -- there is nothing to decode, and the
+    hop would only cost a suspension point.
+    """
+    if not images:
+        return True
+    return not isinstance(images[0], Mapping)
 
 
 @dataclass
@@ -1116,7 +1133,7 @@ class OwnedSessionHandle(SessionHandle):
     async def prompt(
         self,
         text: str,
-        images: list[dict[str, str]] | None = None,
+        images: list[dict[str, str]] | list["ImageContent"] | None = None,
         command_id: str | None = None,
         *,
         wait_complete: bool = False,
@@ -1137,7 +1154,24 @@ class OwnedSessionHandle(SessionHandle):
         # span await-free. The cost of bounding an image for a prompt that is
         # then rejected is a duplicate submission's worth of CPU, which is the
         # cheaper side of that trade.
-        blocks = await _image_blocks_async(images)
+        #
+        # ALREADY-DECODED blocks pass straight through, and that is not a
+        # convenience: ``_admit_without_waiting_for_the_turn`` budgets a few
+        # LOOP TURNS for this method's synchronous prelude to raise its
+        # reportable refusals, and a thread hop does not resolve inside that
+        # budget (measured: not done at 2 sleep(0)s, done by 20) no matter how
+        # warm the pool is, because ``to_thread`` always yields at least once.
+        # A caller that has already bounded therefore keeps the prelude
+        # await-free, which is the premise ``_ADMISSION_PRELUDE_TURNS``
+        # documents. Without this, an image-carrying admission reached the
+        # budget with its prelude unrun and its refusals were logged to a
+        # detached callback instead of reaching the user -- the silent drop
+        # that method exists to repair.
+        blocks = (
+            cast(list["ImageContent"], images)
+            if _already_bounded(images)
+            else await _image_blocks_async(cast(list[dict[str, str]] | None, images))
+        )
         if not self._command_reservations.reserve(command_id, kind="prompt"):
             return "already admitted"
         # Restore intentionally keeps missing attachments readable. Admission is
@@ -1494,7 +1528,7 @@ class OwnedSessionHandle(SessionHandle):
     async def steer(
         self,
         text: str,
-        images: list[dict[str, str]] | None = None,
+        images: list[dict[str, str]] | list["ImageContent"] | None = None,
         command_id: str | None = None,
     ) -> str:
         self._check_loop_thread()
@@ -1503,7 +1537,14 @@ class OwnedSessionHandle(SessionHandle):
         # hop, and awaiting between reserving a producer identity and handing
         # the steer to the session would open a suspension point inside that
         # window. Decoding first keeps the reserve-to-mutate span await-free.
-        blocks = await _image_blocks_async(images)
+        # Already-decoded blocks pass through for the reason ``prompt``
+        # documents: an in-process caller that bounded already must not be
+        # made to yield again.
+        blocks = (
+            cast(list["ImageContent"], images)
+            if _already_bounded(images)
+            else await _image_blocks_async(cast(list[dict[str, str]] | None, images))
+        )
         if not self._command_reservations.reserve(
             command_id,
             kind="steer",
@@ -2520,8 +2561,22 @@ class OwnedSessionHandle(SessionHandle):
         its synchronous prelude" is a fact about scheduling that holds under any
         contention (AGENTS.md, "Wait on the event, never on the clock").
         """
+        # Bounded HERE and handed on DECODED, so ``prompt``'s prelude stays
+        # await-free and the loop-turn budget below measures what it claims to.
+        #
+        # The budget gives ``prompt`` a few turns to raise its reportable
+        # refusals, on the documented premise that it raises them before its
+        # first await. Bounding images inside ``prompt`` broke that premise: a
+        # thread hop does not resolve within the budget however warm the pool
+        # is, because ``to_thread`` always yields at least once. An
+        # image-carrying admission then reached the budget with its prelude
+        # unrun, was judged "genuinely queued behind a running turn", and its
+        # refusals went to the detached log instead of the warning receipt --
+        # the silent drop this method exists to repair, back for requests with
+        # attachments.
+        blocks = await _image_blocks_async(images)
         task = asyncio.ensure_future(
-            self.prompt(request, images=images, command_id=str(uuid.uuid4()))
+            self.prompt(request, images=blocks, command_id=str(uuid.uuid4()))
         )
         # One turn is enough today — nothing before ``prompt``'s first suspension
         # point yields — but a couple of extra turns costs nothing and keeps this

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -150,7 +150,12 @@ def _already_bounded(images: Any) -> bool:
 class _PromptCommand:
     command_id: str
     text: str
-    images: list["ImageContent"]
+    # ``None`` at runtime on an image-less prompt: ``_already_bounded`` treats
+    # None as "already bounded" (nothing to decode) and passes it through, so
+    # the cast that feeds this field can legitimately hand over None. Declared
+    # here because pyright trusts the cast and would not catch a consumer
+    # that assumed a list.
+    images: list["ImageContent"] | None
     admitted: asyncio.Future[None]
     completed: asyncio.Future[bool] | None = None
 

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -49,7 +49,7 @@ from local_operator.mobile.types import (
     ask_pending_request,
 )
 from local_operator.session.runtime.server import SessionHandle
-from local_operator.session.runtime.server import image_blocks as _image_blocks
+from local_operator.session.runtime.server import image_blocks_in_thread as _image_blocks_async
 from local_operator.session.runtime.types import runtime_must_complete
 from local_operator.session.transcript import TRANSCRIPT_FILENAME
 
@@ -1128,6 +1128,14 @@ class OwnedSessionHandle(SessionHandle):
         if existing is not None:
             await existing.admitted
             return "already admitted"
+        # Bounded BEFORE the reservation, deliberately: the bound is a thread
+        # hop, and awaiting between reserving a producer identity and queueing
+        # the command would open a suspension point inside that window, where
+        # every path out is a reject. Decoding first keeps the reserve-to-queue
+        # span await-free. The cost of bounding an image for a prompt that is
+        # then rejected is a duplicate submission's worth of CPU, which is the
+        # cheaper side of that trade.
+        blocks = await _image_blocks_async(images)
         if not self._command_reservations.reserve(command_id, kind="prompt"):
             return "already admitted"
         # Restore intentionally keeps missing attachments readable. Admission is
@@ -1174,7 +1182,7 @@ class OwnedSessionHandle(SessionHandle):
         self._maybe_name_conversation(text)
         admitted: asyncio.Future[None] = self._loop.create_future()
         completed = self._loop.create_future() if wait_complete else None
-        command = _PromptCommand(command_id, text, _image_blocks(images), admitted, completed)
+        command = _PromptCommand(command_id, text, blocks, admitted, completed)
         position = len(self._prompt_queue) + 1
         legacy_prompt = "message_id" not in inspect.signature(self._session.prompt).parameters
         # Compatibility-only fake/third-party sessions predate durable
@@ -1489,6 +1497,11 @@ class OwnedSessionHandle(SessionHandle):
     ) -> str:
         self._check_loop_thread()
         command_id = command_id or str(uuid.uuid4())
+        # Bounded BEFORE the reservation, deliberately: the bound is a thread
+        # hop, and awaiting between reserving a producer identity and handing
+        # the steer to the session would open a suspension point inside that
+        # window. Decoding first keeps the reserve-to-mutate span await-free.
+        blocks = await _image_blocks_async(images)
         if not self._command_reservations.reserve(
             command_id,
             kind="steer",
@@ -1504,7 +1517,7 @@ class OwnedSessionHandle(SessionHandle):
         if "producer_command_id" in parameters:
             fields["producer_command_id"] = command_id
         try:
-            self._session.steer(text, _image_blocks(images), **fields)
+            self._session.steer(text, blocks, **fields)
         except Exception:
             # No queue insertion means no durable acceptance exists; the same
             # producer identity must remain retryable after this terminal reject.

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -49,7 +49,9 @@ from local_operator.mobile.types import (
     ask_pending_request,
 )
 from local_operator.session.runtime.server import SessionHandle
-from local_operator.session.runtime.server import image_blocks_in_thread as _image_blocks_async
+from local_operator.session.runtime.server import (
+    image_blocks_in_thread as _image_blocks_async,
+)
 from local_operator.session.runtime.types import runtime_must_complete
 from local_operator.session.transcript import TRANSCRIPT_FILENAME
 

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -37,6 +37,8 @@ from the runtime's loop, serialized by the implementor".
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 import hmac
 import inspect
 import json
@@ -70,16 +72,31 @@ logger = logging.getLogger(__name__)
 
 
 def image_blocks(images: list[dict[str, str]] | None) -> list["ImageContent"]:
-    """Decode the wire's [{data_b64, mime_type}] into ImageContent blocks.
+    """Decode the wire's [{data_b64, mime_type}] into BOUNDED ImageContent blocks.
 
     Bad entries are dropped, not fatal: a paste that half-decoded should cost
     that one image, not the whole prompt. Empty input yields an empty list,
     which ``_submit_prompt`` treats exactly like no images. This is part of
     the mobile contract — both handles use it.
+
+    Every entry is bounded at the INGEST edge here, the same call the composer
+    makes on a paste, because this is the equivalent seam: a phone camera roll
+    produces 4032x3024 photos and a phone screenshot 2206x266, and a provider
+    refuses an image over 2000 pixels on its long edge once a request carries
+    more than twenty of them. Forwarding verbatim was not lossless, it was
+    deferred: the block lands in the HISTORY, so every later request re-sends
+    it. The render seam did repair oversize blocks afterwards, which made this
+    degraded rather than broken — but a repair on every render is work paid
+    repeatedly for a bound that costs nothing once, at entry.
+
+    CPU-bound (~315 ms for a 20 MP image), so an async caller must use
+    :func:`image_blocks_in_thread` instead.
     """
     if not images:
         return []
     from local_operator.harness.types import ImageContent
+    from local_operator.imaging import bound_image_for_model
+    from local_operator.media import sniff_image
 
     out: list[ImageContent] = []
     for item in images:
@@ -91,8 +108,55 @@ def image_blocks(images: list[dict[str, str]] | None) -> list["ImageContent"]:
         if not data:
             logger.debug("mobile image dropped: no data_b64/data")
             continue
-        out.append(ImageContent(data=data, mime_type=mime))
+        try:
+            raw = base64.b64decode(data, validate=True)
+        except (ValueError, binascii.Error):
+            logger.debug("mobile image dropped: data_b64 is not valid base64")
+            continue
+        # Format comes from the CONTENT, never the client's mime_type: a phone
+        # that mislabels a HEIC as image/png would otherwise pick the encoder
+        # for a format the bytes are not.
+        info = sniff_image(raw)
+        if info is None:
+            logger.debug("mobile image dropped: unrecognised image format")
+            continue
+        try:
+            payload, wire_mime, _summary = bound_image_for_model(raw, info)
+        except ValueError as error:
+            # Undecodable, a decompression bomb, or too large to send with no
+            # decoder available. Same contract as every other bad entry here:
+            # this image is dropped, the rest of the prompt proceeds.
+            logger.debug("mobile image dropped: %s", error)
+            continue
+        out.append(
+            ImageContent(
+                data=base64.b64encode(payload).decode("ascii"),
+                mime_type=wire_mime,
+            )
+        )
     return out
+
+
+async def image_blocks_in_thread(images: list[dict[str, str]] | None) -> list["ImageContent"]:
+    """:func:`image_blocks` off the event loop.
+
+    The bound decodes and re-encodes, which is CPU-bound and unbounded in
+    duration by an event loop's standards, so every async caller goes through
+    here — the same discipline the composer's paste path follows.
+
+    Returns WITHOUT suspending when there is nothing to decode, and that is
+    load-bearing rather than an optimisation. ``asyncio.to_thread`` always
+    yields to the loop, so an unconditional hop turns every image-less prompt
+    and steer into a suspension point — and these callers reserve a producer
+    identity and queue in FIFO order right after this call, so a yield here
+    lets concurrently submitted turns interleave and be admitted out of order
+    (three gathered prompts admitted 1,3,2). The overwhelming majority of
+    prompts carry no images and must keep the await-free path they had.
+    """
+
+    if not images:
+        return []
+    return await asyncio.to_thread(image_blocks, images)
 
 
 #: A prompt payload past 1 MB is a bug, not a prompt — the line limit the

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -103,8 +103,11 @@ def image_blocks(images: list[dict[str, str]] | None) -> list["ImageContent"]:
         if not isinstance(item, dict):
             logger.debug("mobile image dropped: not a dict (%r)", type(item).__name__)
             continue
+        # The client's declared ``mime_type`` is deliberately NOT read: the
+        # format is decided by CONTENT below, and the wire mime comes back from
+        # the bound. A phone that mislabels a HEIC as image/png would otherwise
+        # pick an encoder for a format the bytes are not.
         data = item.get("data_b64") or item.get("data") or ""
-        mime = item.get("mime_type") or "image/png"
         if not data:
             logger.debug("mobile image dropped: no data_b64/data")
             continue

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -28661,6 +28661,12 @@ class OperatorApp(App[None]):
         if not request:
             return result
         try:
+            # ``image_blocks`` bounds each image, which is CPU-bound, and this
+            # method is synchronous by contract (it runs on the app loop and
+            # cannot await). The stall is bounded by the control socket's 1 MB
+            # line cap on the payload that carried these images: ~50-100 ms of
+            # decode, not the ~315 ms a 20 MP local paste would cost. The paste
+            # path, which has no such cap, uses the threaded form instead.
             images = image_blocks(wire_images)
             self._submit_prompt(request, images, None, typed=request)
         except Exception as exc:  # noqa: BLE001 — the attach landed; name what did not

--- a/scripts/run_episode.py
+++ b/scripts/run_episode.py
@@ -429,17 +429,39 @@ def _model_client(
     episode_id: str,
     task_id: str,
     keep_recent_frames: int,
+    reasoning_effort: str | None = None,
 ) -> Any:
     from local_operator.evaluation.runner.provider_client import (
         create_provider_model_client,
     )
     from local_operator.model.configure import build_model_spec
 
+    model_spec = build_model_spec(provider, model)
+    if reasoning_effort is not None:
+        # Validated against the model's OWN ladder rather than a fixed list of
+        # level names: the ladder differs per model, and the client silently
+        # DROPS an effort the spec does not list (providers/clients.py
+        # ``_reasoning_effort``). Dropping it is right mid-episode, where the
+        # alternative is losing the turn — but here it would mean a paid run
+        # quietly executing at the default effort while the operator believed
+        # otherwise, and comparing that against published maximum-effort
+        # numbers. Fail before anything is allocated instead.
+        ladder = model_spec.reasoning_efforts
+        if reasoning_effort not in ladder:
+            raise ValueError(
+                f"{provider}/{model} does not accept reasoning effort "
+                f"{reasoning_effort!r}; its ladder is "
+                f"{', '.join(ladder) if ladder else '(none: this model has no effort ladder)'}"
+            )
+        # ModelSpec is mutable at runtime by design — this is the same field
+        # ``/effort`` writes — so setting it here is the supported path.
+        model_spec.reasoning_effort = reasoning_effort
+
     return create_provider_model_client(
         auth_store=auth_store,
         settings=settings,
         route=route,
-        model_spec=build_model_spec(provider, model),
+        model_spec=model_spec,
         artifact_root=artifact_root,
         episode_id=episode_id,
         # The label this run wears in ``/analytics``. The task is what a human
@@ -564,6 +586,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-cycle-usd", type=float, default=None, help="per-cycle cap")
     parser.add_argument("--keep-recent-frames", type=int, default=3)
     parser.add_argument(
+        "--reasoning-effort",
+        default=None,
+        help="reasoning effort level for the decision model (e.g. high, max); "
+        "omit to leave the model spec's own default. Published comparison "
+        "numbers are produced at maximum effort, so a run meant to be read "
+        "against them has to say so explicitly",
+    )
+    parser.add_argument(
         "--no-store",
         action="store_true",
         help="never open the credential store: every secret must be on --secret-env "
@@ -677,6 +707,18 @@ async def run(args: argparse.Namespace) -> int:
             # runner's ``synthetic_model`` label are what keep it from being
             # read as a result.
             "model_client": args.model_client,
+            # The effort the decisions were made at, beside the route they were
+            # made on. A score is not comparable across effort levels, and the
+            # published numbers this run is read against are at maximum effort,
+            # so the bundle has to carry the level rather than leave it to the
+            # operator's memory of which flags were passed. Absent when not
+            # overridden: the effective value is then the model table's
+            # documented default for the route already stamped above.
+            **(
+                {"reasoning_effort": args.reasoning_effort}
+                if args.reasoning_effort is not None
+                else {}
+            ),
             "script": "scripts/run_episode.py",
             # Apparatus disclosure: the infra overrides REQUESTED for this run
             # (instance type, root volume size, system proxy policy). A score on
@@ -705,17 +747,24 @@ async def run(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return EXIT_PREFLIGHT
-        model_client = _model_client(
-            auth_store=auth_store,
-            settings={},
-            provider=provider,
-            model=model,
-            route=route,
-            artifact_root=config.artifact_root,
-            episode_id=episode_id,
-            task_id=args.task_id,
-            keep_recent_frames=args.keep_recent_frames,
-        )
+        try:
+            model_client = _model_client(
+                auth_store=auth_store,
+                settings={},
+                provider=provider,
+                model=model,
+                route=route,
+                artifact_root=config.artifact_root,
+                episode_id=episode_id,
+                task_id=args.task_id,
+                keep_recent_frames=args.keep_recent_frames,
+                reasoning_effort=args.reasoning_effort,
+            )
+        except ValueError as error:
+            # An unusable effort level is the operator's to fix before anything
+            # is allocated, which is exactly what EXIT_PREFLIGHT means here.
+            print(str(error), file=sys.stderr)
+            return EXIT_PREFLIGHT
 
     runner = EpisodeRunner(
         spec,

--- a/tests/unit/compaction/test_thresholds.py
+++ b/tests/unit/compaction/test_thresholds.py
@@ -252,3 +252,24 @@ def test_resolve_strategy_selection():
 def test_resolve_strategy_ignores_missing_attribute():
     """A model without supports_images is treated as non-vision."""
     assert resolve_strategy(CompactionSettings(), object()) == "context-full"
+
+
+def test_wire_bytes_trigger_fires_with_an_unknown_window() -> None:
+    """An unresolved context window must not disarm the transport backstop.
+
+    The window guard answers the TOKEN question ("does this fit the model's
+    context?"), which is unanswerable without a window. The byte question
+    ("will the provider accept a request this large?") is answerable regardless,
+    and on a route whose context length the harness could not resolve the byte
+    trigger is the ONLY trigger there is — precisely the configuration where a
+    session 413s forever with a working guard switched off.
+    """
+    settings = CompactionSettings(wire_bytes_trigger=1_000_000)
+
+    assert should_compact(0, 0, settings, wire_bytes=2_000_000) is True
+    # Still monotone in bytes and still strictly greater-than.
+    assert should_compact(0, 0, settings, wire_bytes=1_000_000) is False
+    assert should_compact(0, 0, settings, wire_bytes=0) is False
+    # The disabled/off short-circuit outranks it, unknown window or not.
+    assert should_compact(0, 0, CompactionSettings(enabled=False), wire_bytes=2_000_000) is False
+    assert should_compact(0, 0, CompactionSettings(strategy="off"), wire_bytes=2_000_000) is False

--- a/tests/unit/compaction/test_wire_bytes.py
+++ b/tests/unit/compaction/test_wire_bytes.py
@@ -124,8 +124,12 @@ def test_byte_trigger_respects_disabled_and_off_exactly_like_the_token_trigger()
     assert (
         should_compact(0, 1_000_000, CompactionSettings(strategy="off"), wire_bytes=10**9) is False
     )
-    # Unknown window still never triggers, byte pressure or not.
-    assert should_compact(0, 0, CompactionSettings(), wire_bytes=10**9) is False
+    # An unknown window disables the TOKEN term only: a request over the wire
+    # cap is too large to send whether or not a context length is known for
+    # the route, and that is the one configuration where the byte trigger is
+    # the only trigger there is.
+    assert should_compact(0, 0, CompactionSettings(), wire_bytes=10**9) is True
+    assert should_compact(0, 0, CompactionSettings(), wire_bytes=0) is False
     # Explicitly disabled byte trigger.
     settings = CompactionSettings(wire_bytes_trigger=0)
     assert should_compact(0, 1_000_000, settings, wire_bytes=10**9) is False

--- a/tests/unit/evaluation/adapters/osworld/test_observation.py
+++ b/tests/unit/evaluation/adapters/osworld/test_observation.py
@@ -46,14 +46,18 @@ def test_observation_id_is_content_derived(tmp_path: Path) -> None:
 
 
 def test_artifact_lands_at_the_content_address(tmp_path: Path) -> None:
+    # The address is that of the BOUNDED frame, not the guest capture: the
+    # artifact is what the model saw, so its digest, size and media type all
+    # describe the bytes that were sent.
     builder = ObservationBuilder(tmp_path)
     observation = builder.build(_raw(shade=7), task_id="t", episode_id="e", sequence=0)
     artifact = observation.frames[0].artifact
-    expected = tmp_path / hashlib.sha256(_frame(shade=7)).hexdigest()
-    assert expected.exists()
-    assert artifact.sha256 == hashlib.sha256(_frame(shade=7)).hexdigest()
-    assert artifact.media_type == "image/png"
-    assert artifact.byte_count == len(_frame(shade=7))
+    payload = (tmp_path / artifact.sha256).read_bytes()
+    assert hashlib.sha256(payload).hexdigest() == artifact.sha256
+    assert artifact.byte_count == len(payload)
+    assert artifact.media_type in {"image/png", "image/jpeg"}
+    # The native capture is no longer a published artifact.
+    assert not (tmp_path / hashlib.sha256(_frame(shade=7)).hexdigest()).exists()
 
 
 def test_the_real_verify_artifact_accepts_the_frame(tmp_path: Path) -> None:
@@ -61,15 +65,17 @@ def test_the_real_verify_artifact_accepts_the_frame(tmp_path: Path) -> None:
     observation = builder.build(_raw(), task_id="t", episode_id="e", sequence=0)
     # This is the same call the parent's HostVerifier makes on every frame.
     data = verify_artifact(tmp_path, observation.frames[0].artifact)
-    assert data == _frame()
+    assert hashlib.sha256(data).hexdigest() == observation.frames[0].artifact.sha256
 
 
-def test_geometry_is_native_and_unresized(tmp_path: Path) -> None:
+def test_geometry_keeps_native_and_publishes_the_bounded_model_size(tmp_path: Path) -> None:
     builder = ObservationBuilder(tmp_path)
     observation = builder.build(_raw(), task_id="t", episode_id="e", sequence=0)
     geometry = observation.frames[0].geometry
+    # Native stays the guest's real screen: it is what coordinates convert BACK
+    # to, and it is never inferred from the image.
     assert geometry.native == FrameSize(width=1920, height=1080)
-    assert geometry.model_visible == FrameSize(width=1920, height=1080)
+    assert geometry.model_visible == FrameSize(width=1280, height=720)
 
 
 def test_sequence_zero_carries_the_instruction(tmp_path: Path) -> None:

--- a/tests/unit/evaluation/adapters/osworld/test_observation.py
+++ b/tests/unit/evaluation/adapters/osworld/test_observation.py
@@ -10,6 +10,7 @@ build raises (a resized guest would silently miscalibrate every coordinate).
 from __future__ import annotations
 
 import hashlib
+import io
 from pathlib import Path
 
 import pytest
@@ -132,3 +133,95 @@ def test_metadata_excludes_floats(tmp_path: Path) -> None:
     observation = builder.build(_raw(), task_id="t", episode_id="e", sequence=0)
     for value in observation.metadata.values():
         assert not isinstance(value, float)
+
+
+def _photographic_frame(size: tuple[int, int]) -> bytes:
+    """A native-sized frame that is NOT line art and NOT flat.
+
+    ``write_png_rgb`` with a constant shade compresses to a few KB and reads as
+    line art, which takes the ladder's bilevel exemption — so it would prove
+    nothing about the screen edge. Real per-pixel content is what makes the
+    resize and the format choice meaningful.
+    """
+    import os
+
+    width, height = size
+    return write_png_rgb(width, height, os.urandom(width * height * 3))
+
+
+def test_frame_artifact_is_the_bounded_image_and_geometry_maps_back_to_native(
+    tmp_path: Path,
+) -> None:
+    """The published frame IS what the model sees, and it still points home.
+
+    Three properties the episode depends on together: the artifact decodes to
+    the model-visible size (not the guest's), a coordinate at the far corner of
+    that space converts back into native pixels, and an identical guest screen
+    yields an identical artifact address — which is what ``_frames_identical``
+    reads to tell the model the screen did not move.
+    """
+    from PIL import Image
+
+    png = _photographic_frame((NATIVE_SCREEN.width, NATIVE_SCREEN.height))
+    builder = ObservationBuilder(tmp_path)
+    observation = builder.build(
+        {"screenshot": png, "accessibility_tree": None, "terminal": None, "instruction": "go"},
+        task_id="t",
+        episode_id="e",
+        sequence=0,
+    )
+
+    frame = observation.frames[0]
+    payload = (tmp_path / frame.artifact.sha256).read_bytes()
+    assert Image.open(io.BytesIO(payload)).size == (1280, 720)
+    assert frame.geometry.model_visible == FrameSize(width=1280, height=720)
+    assert frame.geometry.native == NATIVE_SCREEN
+
+    # Coordinates the model emits in this space land back on the guest's.
+    # The interior scales by 1.5 native px per model px...
+    interior = frame.geometry.model_to_native(640, 360)
+    assert (interior.x, interior.y) == (960, 540)
+    penultimate = frame.geometry.model_to_native(1278, 718)
+    assert (penultimate.x, penultimate.y) == (1917, 1077)
+    # ...and the last row/column is CLAMPED to the last native pixel rather
+    # than scaled (protocol._scale_clamped_axis), so a click on the extreme
+    # edge of the frame cannot land one pixel short of the screen edge.
+    corner = frame.geometry.model_to_native(1279, 719)
+    assert (corner.x, corner.y) == (1919, 1079)
+
+    # Identical native bytes must give an identical artifact address, both
+    # within one builder (memoised) and across a fresh one (deterministic).
+    again = builder.build(
+        {"screenshot": png, "accessibility_tree": None, "terminal": None, "instruction": "go"},
+        task_id="t",
+        episode_id="e",
+        sequence=1,
+    )
+    assert again.frames[0].artifact.sha256 == frame.artifact.sha256
+    fresh = ObservationBuilder(tmp_path).build(
+        {"screenshot": png, "accessibility_tree": None, "terminal": None, "instruction": "go"},
+        task_id="t",
+        episode_id="e",
+        sequence=2,
+    )
+    assert fresh.frames[0].artifact.sha256 == frame.artifact.sha256
+
+
+def test_native_dimension_check_still_runs_on_the_raw_screenshot(tmp_path: Path) -> None:
+    """The guest-resize guard must judge the GUEST's bytes, not our own.
+
+    Bounding happens after this check by construction: if the assertion ever
+    moved onto the bounded frame it would compare our resizer's output against
+    the native screen and either fire on every observation or never fire at
+    all, and the case it exists for — a guest that silently changed resolution,
+    miscalibrating every coordinate — would go unnoticed.
+    """
+    builder = ObservationBuilder(tmp_path)
+    raw = {
+        "screenshot": _photographic_frame((1600, 900)),
+        "accessibility_tree": None,
+        "terminal": None,
+        "instruction": "go",
+    }
+    with pytest.raises(ObservationError, match="guest frame is 1600x900"):
+        builder.build(raw, task_id="t", episode_id="e", sequence=0)

--- a/tests/unit/evaluation/adapters/test_api.py
+++ b/tests/unit/evaluation/adapters/test_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import json
 import subprocess
 import sys
@@ -193,3 +194,45 @@ def test_pre_ownership_wire_is_rejected(version: str, tmp_path: Path) -> None:
     data["schema_version"] = version
     with pytest.raises(ValidationError, match="1.6"):
         AdapterSelector.model_validate(data)
+
+
+def test_bound_screen_frame_reports_the_size_of_the_bytes_it_returns() -> None:
+    """``model_visible`` must describe the payload, not the requested edge.
+
+    This is the contract the host verifier checks on every observation: it
+    sniffs the artifact and compares against the geometry the adapter
+    published. A helper that predicted the size arithmetically instead of
+    reading it back would turn any rounding disagreement inside the resizer
+    into a mid-episode supervision failure.
+    """
+    from PIL import Image
+
+    from local_operator.evaluation.adapters.api import bound_screen_frame
+    from local_operator.media import sniff_image
+
+    buffer = io.BytesIO()
+    Image.new("RGB", (1920, 1080), (24, 36, 48)).save(buffer, format="PNG")
+
+    bound = bound_screen_frame(buffer.getvalue())
+
+    sniffed = sniff_image(bound.payload)
+    assert sniffed is not None
+    assert (sniffed.width, sniffed.height) == (
+        bound.model_visible.width,
+        bound.model_visible.height,
+    )
+    assert sniffed.mime_type == bound.media_type
+    assert (bound.model_visible.width, bound.model_visible.height) == (1280, 720)
+
+
+def test_bound_screen_frame_refuses_bytes_that_are_not_an_image() -> None:
+    """A frame that will not decode fails HERE, not on the wire.
+
+    The adapter turns this into an ObservationError, which the episode already
+    knows how to report; forwarding it would earn an opaque provider 400 with
+    the block already in the history.
+    """
+    from local_operator.evaluation.adapters.api import bound_screen_frame
+
+    with pytest.raises(ValueError):
+        bound_screen_frame(b"not an image at all")

--- a/tests/unit/evaluation/adapters/test_supervisor.py
+++ b/tests/unit/evaluation/adapters/test_supervisor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import io
 import os
 import signal
 import stat
@@ -59,6 +60,9 @@ from local_operator.evaluation.lifecycle import CleanupAction, CleanupPlan
 from local_operator.evaluation.protocol import (
     ActionBatch,
     ArtifactRef,
+    FrameGeometry,
+    FrameRef,
+    FrameSize,
     Observation,
     WaitAction,
 )
@@ -784,3 +788,53 @@ def test_completion_rejects_incompatible_ownership(
     )
     with pytest.raises(SupervisionError, match="answer"):
         verifier.finish_ask(params, result, answer_owner=owner)
+
+
+def _frame_observation(root: Path, payload: bytes, *, declared: FrameSize) -> Observation:
+    """An observation whose one frame declares ``declared`` as model-visible."""
+    digest = hashlib.sha256(payload).hexdigest()
+    (root / digest).write_bytes(payload)
+    provisional = Observation(
+        task_id="task",
+        episode_id="episode",
+        sequence=0,
+        observation_id="provisional",
+        text="state",
+        frames=(
+            FrameRef(
+                frame_id="screen",
+                artifact=ArtifactRef(
+                    sha256=digest, media_type="image/png", byte_count=len(payload)
+                ),
+                geometry=FrameGeometry(
+                    native=FrameSize(width=1920, height=1080), model_visible=declared
+                ),
+            ),
+        ),
+    )
+    return provisional.model_copy(update={"observation_id": observation_content_id(provisional)})
+
+
+def test_host_refuses_a_frame_whose_pixels_disagree_with_model_visible(tmp_path: Path) -> None:
+    """The invariant the whole resize seam rests on, enforced by the host.
+
+    The model is told ``model_visible``, validates its coordinates against it,
+    and the adapter converts them back through it. Nothing else checks that the
+    IMAGE is that size, so an adapter that resized without updating its
+    geometry — or any runner-side rewrite of frame pixels — would miscalibrate
+    every click for the rest of the episode, silently. It must fail loudly on
+    the observation instead.
+    """
+    from PIL import Image
+
+    buffer = io.BytesIO()
+    Image.new("RGB", (1280, 720), (12, 24, 36)).save(buffer, format="PNG")
+    payload = buffer.getvalue()
+
+    verifier = HostVerifier("task", "episode", tmp_path)
+    honest = _frame_observation(tmp_path, payload, declared=FrameSize(width=1280, height=720))
+    verifier.accept_initial(honest)
+
+    lying = _frame_observation(tmp_path, payload, declared=FrameSize(width=1920, height=1080))
+    with pytest.raises(SupervisionError, match="model-visible geometry"):
+        HostVerifier("task", "episode", tmp_path).accept_initial(lying)

--- a/tests/unit/evaluation/runner/test_provider_client.py
+++ b/tests/unit/evaluation/runner/test_provider_client.py
@@ -2521,12 +2521,23 @@ async def test_a_byte_only_pass_whose_prune_fixes_the_bytes_buys_no_summary(tmp_
     )
 
     history: list[EpisodeTurn] = []
+    compactions = []
     for sequence in range(8):
         current = _fat_framed_observation(tmp_path, sequence, pixels=60_000)
         history.append(EpisodeTurn(observation=current))
         decision = await client.decide(current, tuple(history))
+        if decision.compaction is not None:
+            compactions.append(decision.compaction)
         history[-1] = history[-1].model_copy(update={"batch": decision.action_batch})
 
+    # The negative below is vacuous unless the byte trigger actually fired:
+    # pin that a pass RAN, pruned frames, and refused to summarise (round 3,
+    # F6). "prune" is what the record says when the gate refused after the
+    # frame prune stood.
+    assert compactions, "the byte trigger never fired; the assertions below prove nothing"
+    assert all(c.strategy == "prune" and c.frames_dropped > 0 for c in compactions), [
+        (c.strategy, c.frames_dropped) for c in compactions
+    ]
     final = stream.requests[-1].messages
     assert stream.summary_requests == [], (
         f"a byte-only pass bought {len(stream.summary_requests)} summary call(s) "

--- a/tests/unit/evaluation/runner/test_provider_client.py
+++ b/tests/unit/evaluation/runner/test_provider_client.py
@@ -2449,6 +2449,9 @@ async def test_a_byte_only_trigger_never_fits_to_a_token_band(tmp_path: Path, wi
         model_spec=spec,
         artifact_root=tmp_path,
         compaction=CompactionSettings(
+            # Large enough that the pass itself never finds a cut (it refuses
+            # "nothing-to-summarize"), so the ONLY mechanism that could remove
+            # an observation turn here is the token-band shed under test.
             keep_recent_tokens=20_000,
             wire_bytes_trigger=trigger,
             wire_bytes_budget=budget,

--- a/tests/unit/evaluation/runner/test_provider_client.py
+++ b/tests/unit/evaluation/runner/test_provider_client.py
@@ -2420,6 +2420,66 @@ async def test_byte_trigger_rebuilds_once_when_frames_outgrow_the_wire_trigger(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("window", [0, 24_000], ids=["unknown-window", "known-window"])
+async def test_a_byte_only_trigger_never_fits_to_a_token_band(tmp_path: Path, window: int) -> None:
+    """A pass fired by BYTES alone must not be finished as a TOKEN pass.
+
+    Round 1, F1: ``threshold_due`` was token-OR-bytes, and everything after it
+    treated a true answer as "the token threshold was crossed": it resolved a
+    token band and shed stale turns to it. On a byte-only trigger that band was
+    never crossed, so turns were shed for no reason; with an UNKNOWN window
+    (``context_window == 0``, the exact case the byte term exists to cover) the
+    band resolved to 0 and the first byte pass raised
+    ``ContextUnrecoverableError`` -- killing the episode the guard was meant
+    to save. Both windows are pinned: 0 for the raise, and 24k for the phantom
+    shed. 24k is chosen so the token threshold (19,200) sits ABOVE the priced
+    context on the byte-trigger turn (~17,250; the token trigger never fires)
+    while its 0.8 band (15,360) sits BELOW it -- the one arrangement where the
+    OR'd flag sheds turns that no token trigger asked for.
+    """
+    from local_operator.compaction.pruning import count_stale_observations
+    from local_operator.compaction.thresholds import CompactionSettings
+
+    stream = RecordingStream(_wait_reply)
+    spec = ModelSpec(provider="provider", model_id="model", context_window=window)
+    trigger, budget = 350_000, 500_000
+    client = ProviderModelClient(
+        stream,
+        route=ROUTE,
+        model_spec=spec,
+        artifact_root=tmp_path,
+        compaction=CompactionSettings(
+            keep_recent_tokens=20_000,
+            wire_bytes_trigger=trigger,
+            wire_bytes_budget=budget,
+        ),
+        keep_recent_frames=6,
+        rebuild_every_frames=64,
+    )
+
+    history: list[EpisodeTurn] = []
+    for sequence in range(6):
+        current = _fat_framed_observation(tmp_path, sequence, pixels=60_000)
+        history.append(EpisodeTurn(observation=current))
+        # Must not raise on the unknown window.
+        decision = await client.decide(current, tuple(history))
+        history[-1] = history[-1].model_copy(update={"batch": decision.action_batch})
+
+    # The byte pass replaced FRAMES with notices; it did not shed whole turns.
+    # A stale observation turn is one whose frame was pruned -- those are
+    # expected. What must NOT happen is the token-band shed, which REMOVES
+    # observation turns from the prefix: every observation sent still has a
+    # user message in the final request.
+    final = stream.requests[-1].messages
+    user_turns = sum(1 for m in final if m.role == "user")
+    assert user_turns >= 6, (
+        f"a byte-only pass shed observation turns to a token band: "
+        f"{user_turns} user messages for 6 observations "
+        f"(stale={count_stale_observations(final)})"
+    )
+
+
+@pytest.mark.asyncio
 async def test_byte_trigger_does_not_fire_under_the_trigger(tmp_path: Path) -> None:
     """Under the trigger, the prefix is append-only and message identity holds.
 

--- a/tests/unit/evaluation/runner/test_provider_client.py
+++ b/tests/unit/evaluation/runner/test_provider_client.py
@@ -2483,6 +2483,60 @@ async def test_a_byte_only_trigger_never_fits_to_a_token_band(tmp_path: Path, wi
 
 
 @pytest.mark.asyncio
+async def test_a_byte_only_pass_whose_prune_fixes_the_bytes_buys_no_summary(tmp_path: Path) -> None:
+    """A byte-only pass must re-ask the pass's own gate after its frame prune.
+
+    Round 2, F5. ``respect_threshold`` was ``not threshold_due`` -- tokens OR
+    bytes -- so a byte-only pass skipped the gate on the strength of the m2
+    argument, which is about TOKENS (a frame prune barely moves the token
+    count). On bytes the frame prune removes megabytes, so with the gate
+    skipped the pass summarised a prefix its own prune had already brought
+    under the line: two summaries bought and observations 0-2 folded into a
+    marker (reviewer's reproduction, 8 fat frames, keep_recent_frames=3).
+    With the gate re-asked it refuses as below-threshold, the frames are
+    pruned, and every observation turn survives.
+
+    Needs a summarising strategy and a small ``keep_recent_tokens`` so a
+    skipped gate would actually find a cut; ``keep_recent_frames=3`` so the
+    prune actually relieves the byte pressure (at 6 it drops nothing and both
+    settings agree, which is why the F1 test cannot see this).
+    """
+    from local_operator.compaction.thresholds import CompactionSettings
+
+    stream = RecordingStream(_wait_reply)
+    spec = ModelSpec(provider="provider", model_id="model", context_window=24_000)
+    client = ProviderModelClient(
+        stream,
+        route=ROUTE,
+        model_spec=spec,
+        artifact_root=tmp_path,
+        compaction=CompactionSettings(
+            keep_recent_tokens=2_000,
+            wire_bytes_trigger=350_000,
+            wire_bytes_budget=500_000,
+            strategy="context-full",
+        ),
+        keep_recent_frames=3,
+        rebuild_every_frames=64,
+    )
+
+    history: list[EpisodeTurn] = []
+    for sequence in range(8):
+        current = _fat_framed_observation(tmp_path, sequence, pixels=60_000)
+        history.append(EpisodeTurn(observation=current))
+        decision = await client.decide(current, tuple(history))
+        history[-1] = history[-1].model_copy(update={"batch": decision.action_batch})
+
+    final = stream.requests[-1].messages
+    assert stream.summary_requests == [], (
+        f"a byte-only pass bought {len(stream.summary_requests)} summary call(s) "
+        "for a prefix its own frame prune had already brought under the line"
+    )
+    user_turns = sum(1 for message in final if message.role == "user")
+    assert user_turns == 8, f"observation turns were folded into a marker: {user_turns} of 8 remain"
+
+
+@pytest.mark.asyncio
 async def test_byte_trigger_does_not_fire_under_the_trigger(tmp_path: Path) -> None:
     """Under the trigger, the prefix is append-only and message identity holds.
 

--- a/tests/unit/evaluation/runner/test_provider_client.py
+++ b/tests/unit/evaluation/runner/test_provider_client.py
@@ -17,6 +17,7 @@ import base64
 import hashlib
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any, AsyncIterator, Callable
 
@@ -2318,3 +2319,141 @@ def test_an_eval_row_falls_back_to_the_episode_when_there_is_no_task() -> None:
     finally:
         analytics_pkg.get_recorder = original  # type: ignore[assignment]
     assert captured == [("lop-eval-ep-42", f"eval ep-42 · {ROUTE.model_id}")]
+
+
+def _fat_framed_observation(root: Path, sequence: int, *, pixels: int) -> Observation:
+    """A framed observation whose frame is big enough to matter in BYTES.
+
+    The other frame helpers publish a 1x1 PNG, which is right for identity and
+    geometry tests and useless here: the byte trigger measures the base64
+    payload, so a frame has to actually weigh something to move it.
+    """
+    from local_operator.compaction.png import encode_grayscale_png
+    from local_operator.evaluation.protocol import (
+        ArtifactRef,
+        FrameGeometry,
+        FrameRef,
+        FrameSize,
+    )
+
+    # Incompressible, so the encoded size tracks the pixel count instead of
+    # collapsing to a few bytes of run-length.
+    data = encode_grayscale_png(pixels, 1, os.urandom(pixels))
+    digest = _publish_frame(root, data)
+    provisional = Observation(
+        task_id="task-1",
+        episode_id="episode-1",
+        sequence=sequence,
+        observation_id="provisional",
+        text=f"screen {sequence}",
+        frames=(
+            FrameRef(
+                frame_id="screen",
+                artifact=ArtifactRef(sha256=digest, media_type="image/png", byte_count=len(data)),
+                geometry=FrameGeometry(
+                    native=FrameSize(width=pixels, height=1),
+                    model_visible=FrameSize(width=pixels, height=1),
+                ),
+            ),
+        ),
+    )
+    return provisional.model_copy(update={"observation_id": observation_content_id(provisional)})
+
+
+@pytest.mark.asyncio
+async def test_byte_trigger_rebuilds_once_when_frames_outgrow_the_wire_trigger(
+    tmp_path: Path,
+) -> None:
+    """Bytes must be able to fire the pass on their own, and fire it ONCE.
+
+    A screenshot's token charge is flat by design, so an image-heavy prefix can
+    sit far under every token threshold while the serialized request is past
+    the provider's size cap. Before ``wire_bytes`` was passed through, the byte
+    trigger and the wire shed were both configured, both tested in isolation,
+    and both unreachable from this client — the session 413'd with its
+    backstops inert.
+    """
+    from local_operator.compaction.thresholds import CompactionSettings
+    from local_operator.compaction.tokens import estimate_wire_bytes
+
+    stream = RecordingStream(_wait_reply)
+    # A window big enough that the TOKEN trigger cannot fire: whatever compacts
+    # here compacted on bytes.
+    spec = ModelSpec(provider="provider", model_id="model", context_window=10_000_000)
+    # Each fixture frame is ~80 KB on the wire once base64'd. Frames accumulate
+    # (keep_recent_frames covers the whole run), so the payload grows by one
+    # frame per turn and crosses the trigger exactly once during six turns; the
+    # shed then puts it far enough under that the remaining turns stay below.
+    trigger, budget = 350_000, 500_000
+    client = ProviderModelClient(
+        stream,
+        route=ROUTE,
+        model_spec=spec,
+        artifact_root=tmp_path,
+        compaction=CompactionSettings(
+            keep_recent_tokens=20_000,
+            wire_bytes_trigger=trigger,
+            wire_bytes_budget=budget,
+        ),
+        keep_recent_frames=6,
+        rebuild_every_frames=64,  # far out of reach, so only bytes can trigger
+    )
+
+    history: list[EpisodeTurn] = []
+    for sequence in range(6):
+        current = _fat_framed_observation(tmp_path, sequence, pixels=60_000)
+        history.append(EpisodeTurn(observation=current))
+        decision = await client.decide(current, tuple(history))
+        history[-1] = history[-1].model_copy(update={"batch": decision.action_batch})
+
+    rebuilds = [
+        index
+        for index in range(1, len(stream.requests))
+        if not all(
+            a is b
+            for a, b in zip(stream.requests[index - 1].messages, stream.requests[index].messages)
+        )
+    ]
+    assert len(rebuilds) == 1, f"expected exactly one prefix rebuild, got {rebuilds}"
+    final = estimate_wire_bytes(stream.requests[-1].messages)
+    assert final <= budget, f"the request after the rebuild is still {final} bytes over {budget}"
+
+
+@pytest.mark.asyncio
+async def test_byte_trigger_does_not_fire_under_the_trigger(tmp_path: Path) -> None:
+    """Under the trigger, the prefix is append-only and message identity holds.
+
+    The guarantee the byte path owes every ordinary episode: a session below
+    the ceiling must behave byte-identically to one without a byte trigger at
+    all, which means no rebuild and no re-created message objects.
+    """
+    from local_operator.compaction.thresholds import CompactionSettings
+
+    stream = RecordingStream(_wait_reply)
+    spec = ModelSpec(provider="provider", model_id="model", context_window=10_000_000)
+    client = ProviderModelClient(
+        stream,
+        route=ROUTE,
+        model_spec=spec,
+        artifact_root=tmp_path,
+        compaction=CompactionSettings(
+            keep_recent_tokens=20_000,
+            wire_bytes_trigger=50_000_000,
+            wire_bytes_budget=100_000_000,
+        ),
+        keep_recent_frames=3,
+        rebuild_every_frames=64,
+    )
+
+    history: list[EpisodeTurn] = []
+    for sequence in range(6):
+        current = _fat_framed_observation(tmp_path, sequence, pixels=60_000)
+        history.append(EpisodeTurn(observation=current))
+        decision = await client.decide(current, tuple(history))
+        history[-1] = history[-1].model_copy(update={"batch": decision.action_batch})
+
+    # Every earlier message object survives into the next request unchanged:
+    # append-only, so the provider's prefix cache stays warm.
+    for previous, following in zip(stream.requests, stream.requests[1:]):
+        assert len(following.messages) > len(previous.messages)
+        assert all(a is b for a, b in zip(previous.messages, following.messages))

--- a/tests/unit/evaluation/runner/test_run_episode_effort.py
+++ b/tests/unit/evaluation/runner/test_run_episode_effort.py
@@ -1,0 +1,196 @@
+"""``--reasoning-effort`` on the episode script.
+
+The published numbers this harness is compared against are produced at maximum
+effort, so a run meant to be read beside them has to be able to say which level
+it used — and to fail loudly when it cannot use the one it was given.
+
+That second half is the point of the validation. The provider clients DROP an
+effort a model does not list (``providers/clients._reasoning_effort``), which is
+the right call mid-episode where the alternative is losing the turn, but here it
+would mean a paid run quietly executing at the default while the operator
+believed otherwise.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from local_operator.model.configure import build_model_spec
+from scripts import run_episode
+
+# A real route with a real ladder: validating against a fabricated spec would
+# assert our own fixture rather than the model table the script actually reads.
+_PROVIDER, _MODEL = "anthropic", "claude-opus-5"
+
+
+def _client_kwargs(**overrides: Any) -> dict[str, Any]:
+    from pathlib import Path
+
+    base: dict[str, Any] = {
+        "auth_store": object(),
+        "settings": {},
+        "provider": _PROVIDER,
+        "model": _MODEL,
+        "route": run_episode._route_identity(_PROVIDER, _MODEL),
+        "artifact_root": Path("/nonexistent"),
+        "episode_id": "ep-effort",
+        "task_id": "task",
+        "keep_recent_frames": 3,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_an_invalid_effort_fails_before_any_provider_or_adapter_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The refusal must happen before the client is constructed, not inside it.
+
+    A VM is allocated and billed downstream of this call, so an effort the
+    model cannot accept has to be caught while the run is still free.
+    """
+    called = False
+
+    def _never(**_kwargs: Any) -> object:
+        nonlocal called
+        called = True
+        return object()
+
+    monkeypatch.setattr(
+        "local_operator.evaluation.runner.provider_client.create_provider_model_client",
+        _never,
+    )
+
+    with pytest.raises(ValueError) as error:
+        run_episode._model_client(**_client_kwargs(reasoning_effort="turbo"))
+
+    assert called is False, "the model client was built despite an unusable effort"
+    # The message has to name the ladder: "invalid" alone leaves the operator
+    # guessing at a per-model vocabulary.
+    message = str(error.value)
+    assert "turbo" in message
+    for level in build_model_spec(_PROVIDER, _MODEL).reasoning_efforts:
+        assert level in message
+
+
+def test_a_valid_effort_reaches_the_model_spec_the_request_is_built_from(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The level must land on the spec the client bills against.
+
+    ``_reasoning_effort`` re-reads ``request.model.reasoning_effort`` at send
+    time, so this field IS the wire behaviour; a flag that parsed and went
+    nowhere would look identical from the outside.
+    """
+    captured: dict[str, Any] = {}
+
+    def _capture(**kwargs: Any) -> object:
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        "local_operator.evaluation.runner.provider_client.create_provider_model_client",
+        _capture,
+    )
+
+    ladder = build_model_spec(_PROVIDER, _MODEL).reasoning_efforts
+    chosen = ladder[-1]
+    run_episode._model_client(**_client_kwargs(reasoning_effort=chosen))
+
+    spec = captured["model_spec"]
+    assert spec.reasoning_effort == chosen
+    # And the client would actually send it: same membership check the wire
+    # clients apply, rather than a second opinion about the ladder.
+    assert spec.reasoning_effort in spec.reasoning_efforts
+
+
+def test_omitting_the_flag_leaves_the_spec_default_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No flag means no opinion: the model table's default stands."""
+    captured: dict[str, Any] = {}
+
+    def _capture(**kwargs: Any) -> object:
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        "local_operator.evaluation.runner.provider_client.create_provider_model_client",
+        _capture,
+    )
+
+    run_episode._model_client(**_client_kwargs())
+
+    expected = build_model_spec(_PROVIDER, _MODEL).reasoning_effort
+    assert captured["model_spec"].reasoning_effort == expected
+
+
+def test_the_parser_defaults_the_flag_to_none() -> None:
+    """Default None is what "leave the spec alone" is spelled as."""
+    args = run_episode.build_parser().parse_args(
+        ["--selector", "s.json", "--task-id", "t", "--route", "test/model", "--run-root", "r"]
+    )
+    assert args.reasoning_effort is None
+
+    args = run_episode.build_parser().parse_args(
+        [
+            "--selector",
+            "s.json",
+            "--task-id",
+            "t",
+            "--route",
+            "test/model",
+            "--run-root",
+            "r",
+            "--reasoning-effort",
+            "max",
+        ]
+    )
+    assert args.reasoning_effort == "max"
+
+
+def test_the_chosen_effort_lands_in_the_episode_metadata(tmp_path) -> None:
+    """A score is not comparable across effort levels, so the bundle records it.
+
+    Asserted on ``build_spec``'s output rather than a completed run because
+    this is the seam that carries it: the manifest metadata is what a reader
+    has months later, and "which flags did I pass" is not.
+    """
+    # build_spec hashes the task's real bytes for the manifest, so the
+    # workspace has to hold one.
+    (tmp_path / "tasks").mkdir()
+    (tmp_path / "tasks" / "task.py").write_text("TASK = {}\n")
+    spec = run_episode.build_spec(
+        episode_id="ep-effort",
+        selector=run_episode.AdapterSelector.model_validate(
+            {
+                "schema_version": "1.6",
+                "adapter_id": "tiny",
+                "distribution": "tiny-adapter",
+                "version": "1.0",
+                "entry_point": "tiny:create",
+                "package_digest": "a" * 64,
+                "release_digest": "b" * 64,
+                "python_executable": str(tmp_path / "python"),
+                "workspace": str(tmp_path),
+                "workspace_digest": "c" * 64,
+                "route_capability": "computer",
+            }
+        ),
+        task_id="task",
+        route=run_episode._route_identity(_PROVIDER, _MODEL),
+        benchmark_id="bench",
+        benchmark_release="release",
+        secret_refs=(),
+        infra_values=(),
+        max_usd_micros=1,
+        max_wall_ms=1000,
+        max_steps=1,
+        metadata={"route": f"{_PROVIDER}/{_MODEL}", "reasoning_effort": "max"},
+    )
+
+    assert spec.metadata["reasoning_effort"] == "max"
+    # Beside the route, not instead of it: both are needed to read the score.
+    assert spec.metadata["route"] == f"{_PROVIDER}/{_MODEL}"

--- a/tests/unit/session/runtime/test_action_receipt_completion.py
+++ b/tests/unit/session/runtime/test_action_receipt_completion.py
@@ -37,6 +37,7 @@ from typing import Any, AsyncIterator
 
 import pytest
 
+from local_operator.harness.types import ImageContent
 from local_operator.session.runtime.owned import OwnedSessionHandle
 from local_operator.session.runtime.types import SLASH_ACTION_RECEIPTS
 from local_operator.teams import TeamEditFields, TeamMember, TeamRegistry
@@ -133,6 +134,53 @@ async def _settle() -> None:
     """
     for _ in range(20):
         await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_an_image_carrying_admission_still_reports_its_refusals() -> None:
+    """The loop-turn budget must not be spent on the image bound.
+
+    ``_admit_without_waiting_for_the_turn`` gives ``prompt`` a few loop turns
+    to reach its first suspension point, then treats anything still pending as
+    "genuinely queued behind a running turn" and stops watching it. Bounding
+    images is a THREAD HOP, and a cold pool does not resolve one inside that
+    budget (measured: not done at 2 sleep(0)s, done by 20) -- so once ``prompt``
+    bounded its own images, an image-carrying admission reached the budget with
+    its SYNCHRONOUS prelude unrun and its reportable refusals stopped becoming
+    the warning receipt: the silent drop this module exists to repair, back
+    again for requests carrying attachments.
+
+    ``_disposing`` is the refusal used because it is raised in that prelude,
+    AFTER the bound and before any real await -- the same shape as a full queue
+    or a rejected reservation.
+
+    The executor is replaced with a fresh one so the pool is COLD. That is the
+    whole reason the defect reached CI: on a warm pool the hop resolves inside
+    the budget and the bug is invisible, so it passed a full-file run here and
+    failed only in the shard that ran this file first. An order dependency, not
+    a flake.
+    """
+    import concurrent.futures
+
+    handle, _session = make_handle()
+    handle._disposing = True
+    images = [{"data_b64": "aGk=", "mime_type": "image/png"}]
+
+    loop = asyncio.get_running_loop()
+    cold = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    loop.set_default_executor(cold)
+    try:
+        result = await handle._complete_unconsumed_action(_attach_receipt(), images, None)
+    finally:
+        cold.shutdown(wait=False)
+        loop.set_default_executor(concurrent.futures.ThreadPoolExecutor())
+
+    await _settle()
+    assert result.style == "warning", (
+        "an admission refused in prompt's synchronous prelude must reach the "
+        "user as a warning; a budget spent on the image bound loses it"
+    )
+    assert "was not sent" in result.text
 
 
 @pytest.mark.asyncio
@@ -329,6 +377,14 @@ def test_the_declared_set_matches_what_the_producers_emit() -> None:
     assert all(isinstance(item, str) and item for item in SLASH_ACTION_RECEIPTS)
 
 
+#: A 1x1 PNG, so the test images decode. The bound drops anything that does
+#: not, and a fake payload would test the drop rather than the ride.
+_TINY_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk"
+    "+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+
+
 @pytest.mark.asyncio
 async def test_images_ride_the_completed_request() -> None:
     """Wire images survive the completion; only paste BODIES degrade.
@@ -348,12 +404,19 @@ async def test_images_ride_the_completed_request() -> None:
 
     handle.prompt = capture  # type: ignore[method-assign]
 
-    await handle._complete_unconsumed_action(
-        _attach_receipt(), [{"data_b64": "aGk=", "mime_type": "image/png"}], None
-    )
+    # A VALID tiny PNG: "aGk=" (base64 of "hi") used to stand in here, and the
+    # bound now drops it as undecodable -- which was the correct behaviour, but
+    # it made this test assert on the wrong half of the contract. A real image
+    # is what the degradation note promises survives.
+    image = [{"data_b64": _TINY_PNG_B64, "mime_type": "image/png"}]
+
+    await handle._complete_unconsumed_action(_attach_receipt(), image, None)
 
     assert session.prompt_calls == ["do the thing"]
     assert captured and captured[0], "the wire images must reach the admission"
+    assert isinstance(
+        captured[0][0], ImageContent
+    ), "an image reaches the admission DECODED -- the bound runs on the way in"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/runtime/test_image_blocks.py
+++ b/tests/unit/session/runtime/test_image_blocks.py
@@ -1,0 +1,102 @@
+"""The bound every image entering a session over the wire passes through.
+
+The phone portal is the one image seam that used to forward whatever it was
+given. A camera roll produces 4032x3024 photos and a phone screenshot 2206x266,
+and a provider refuses an image over 2000 pixels on its long edge as soon as a
+request carries more than twenty of them — so an unbounded block was not
+"lossless", it was a delayed fault that lands in the HISTORY and re-fires on
+every later request, including the compaction meant to be the escape hatch.
+
+The session render seam did repair oversize blocks afterwards, which is why
+this was degraded rather than broken. What is asserted here is that the repair
+has nothing left to do: the bound happens once, at entry.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+
+from PIL import Image
+
+from local_operator.imaging import IMAGE_INGEST_MAX_EDGE
+from local_operator.media import sniff_image
+from local_operator.session.runtime.server import image_blocks
+
+
+def _wire_image(size: tuple[int, int]) -> dict[str, str]:
+    """A wire entry carrying a real PNG of ``size``, the shape the phone sends."""
+    import os
+
+    # Noise rather than a flat fill: a flat image compresses to a few KB at any
+    # dimension and reads as line art, which takes the ladder's bilevel
+    # exemption and would not exercise the ingest bound at all.
+    buffer = io.BytesIO()
+    Image.frombytes("RGB", size, os.urandom(size[0] * size[1] * 3)).save(buffer, format="PNG")
+    return {
+        "data_b64": base64.b64encode(buffer.getvalue()).decode("ascii"),
+        "mime_type": "image/png",
+    }
+
+
+def test_mobile_images_are_bounded_on_entry() -> None:
+    """A phone screenshot arrives at the ingest edge, not at its native size.
+
+    2206x266 is the real shape that motivated this: comfortably under the 2000
+    px refusal line on its SHORT edge and over it on its long one, so it sat
+    harmlessly in a history for a hundred turns and then wedged the session the
+    moment the twenty-first image arrived.
+    """
+    blocks = image_blocks([_wire_image((2206, 266))])
+
+    assert len(blocks) == 1
+    payload = base64.b64decode(blocks[0].data)
+    info = sniff_image(payload)
+    assert info is not None
+    assert info.width is not None and info.height is not None
+    assert max(info.width, info.height) <= IMAGE_INGEST_MAX_EDGE
+    # The declared mime must describe the bytes: the ladder is free to switch
+    # to JPEG, and a stale "image/png" label would be a 400 at the provider.
+    assert blocks[0].mime_type == info.mime_type
+
+
+def test_a_small_image_keeps_its_bytes() -> None:
+    """Inside the bound means untouched — no gratuitous PNG round-trip.
+
+    Re-encoding an in-bounds image routinely makes it BIGGER, which is why the
+    ladder's first rung is verbatim; asserting it here keeps the mobile seam on
+    that rung rather than quietly paying for every small paste.
+    """
+    entry = _wire_image((320, 200))
+
+    blocks = image_blocks([entry])
+
+    assert len(blocks) == 1
+    assert blocks[0].data == entry["data_b64"]
+
+
+def test_undecodable_mobile_image_is_dropped_not_fatal() -> None:
+    """One bad image costs that image, never the whole prompt.
+
+    The pre-existing contract of this helper ("bad entries are dropped") has to
+    survive the bound, which introduces new ways to fail: bytes that are not
+    base64, and base64 that is not an image.
+    """
+    good = _wire_image((320, 200))
+
+    blocks = image_blocks(
+        [
+            {"data_b64": "not base64 at all!!", "mime_type": "image/png"},
+            {"data_b64": base64.b64encode(b"not an image").decode("ascii")},
+            good,
+        ]
+    )
+
+    assert len(blocks) == 1
+    assert blocks[0].data == good["data_b64"]
+
+
+def test_no_images_is_an_empty_list() -> None:
+    """``None`` and ``[]`` both mean "no images", which _submit_prompt relies on."""
+    assert image_blocks(None) == []
+    assert image_blocks([]) == []

--- a/tests/unit/session/test_no_session_deletion.py
+++ b/tests/unit/session/test_no_session_deletion.py
@@ -492,6 +492,12 @@ _ALLOWED_ROWS: tuple[tuple[str | int, ...], ...] = (
         "<path>.replace",
         "in-memory context .replace()",
     ),
+    (
+        "local_operator/evaluation/runner/provider_client.py"
+        "::ProviderModelClient._enforce_wire_fit",
+        "<path>.replace",
+        "in-memory context .replace()",
+    ),
     # -- unlink/remove of FILES the same function owns (locks, caches, sidecars,
     #    temp files, install artefacts). A session directory is never the arg.
     (

--- a/tests/unit/test_imaging.py
+++ b/tests/unit/test_imaging.py
@@ -34,6 +34,7 @@ from local_operator.imaging import (
     IMAGE_MAX_EDGE,
     IMAGE_MAX_PIXELS,
     IMAGE_REFUSAL_MAX_B64_BYTES,
+    IMAGE_SCREEN_MAX_EDGE,
     _is_line_art,
     bound_image_for_model,
     rebound_oversize_image,
@@ -846,3 +847,85 @@ def test_an_oversized_archive_frame_is_repaired_without_going_lossy() -> None:
     repaired = Image.open(io.BytesIO(base64.b64decode(data)))
     assert repaired.mode == "L", "grayscale was widened, which is what forces the JPEG rung"
     assert max(repaired.size) <= MANY_IMAGE_PIXEL_LIMIT
+
+
+def _ui_frame(size: tuple[int, int]) -> bytes:
+    """A synthetic desktop screenshot: chrome, small labels, and a photo block.
+
+    Deliberately NOT line art. The ladder exempts bilevel sources from the
+    tighter bounds (see ``IMAGE_INGEST_MAX_EDGE``), so a two-tone fixture would
+    take the exemption and prove nothing about the screen edge. A photographic
+    block with per-pixel noise is what keeps ``_is_line_art`` answering "no",
+    and it is also what makes the PNG large enough for the byte cap to mean
+    something.
+    """
+    from PIL import ImageDraw
+
+    width, height = size
+    image = Image.new("RGB", size, (246, 246, 248))
+    draw = ImageDraw.Draw(image)
+    # Window chrome and a tab strip, the 10-11px text this edge is chosen for.
+    draw.rectangle((0, 0, width, 36), fill=(222, 225, 232))
+    draw.rectangle((8, 6, 220, 30), fill=(255, 255, 255))
+    draw.text((14, 12), "Documents — Finder", fill=(40, 42, 48))
+    draw.rectangle((8, 44, width - 8, 68), fill=(255, 255, 255))
+    draw.text((16, 50), "https://example.internal/reports/q3?tab=summary", fill=(60, 62, 70))
+    for row in range(12):
+        y = 90 + row * 22
+        draw.text(
+            (20, y),
+            f"row {row:02d}   2026-03-1{row % 10}   invoice-{row:04d}.pdf",
+            fill=(30, 30, 34),
+        )
+    # The photographic block: per-pixel noise over a third of the frame, which
+    # is what stops the whole thing reading as line art.
+    import os
+
+    noise_size = (width // 3, height // 3)
+    noise = Image.frombytes("RGB", noise_size, os.urandom(noise_size[0] * noise_size[1] * 3))
+    image.paste(noise, (width - noise_size[0] - 20, height - noise_size[1] - 20))
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def test_screen_edge_bounds_a_1080p_frame_to_1280x720_under_the_byte_cap() -> None:
+    """The screen bound is what an eval adapter publishes as ``model_visible``.
+
+    Three properties at once, because the adapter depends on all three: the
+    frame comes back at exactly 1280x720 (the geometry it will advertise), the
+    payload is inside the byte cap (so the request is sendable), and the media
+    type is one the clients serialize (the ladder is free to pick either).
+    """
+    frame = _ui_frame((1920, 1080))
+    assert not _is_line_art(
+        Image.open(io.BytesIO(frame))
+    ), "the fixture took the line-art exemption"
+
+    payload, mime, _summary = bound_image_for_model(
+        frame, _sniffed(frame), max_edge=IMAGE_SCREEN_MAX_EDGE
+    )
+
+    assert Image.open(io.BytesIO(payload)).size == (1280, 720)
+    assert len(payload) <= IMAGE_MAX_BYTES, (
+        f"a bounded screen frame is {len(payload)} bytes, over the "
+        f"{IMAGE_MAX_BYTES}-byte cap the ladder promises"
+    )
+    assert mime in {"image/png", "image/jpeg"}
+
+
+def test_screen_edge_leaves_a_720p_frame_verbatim() -> None:
+    """Already inside the bound means untouched — no re-encode, no resize.
+
+    A guest that already renders at the model's size must not pay a PNG
+    round-trip, which routinely makes screenshots BIGGER (see the ladder's
+    first rung).
+    """
+    frame = _ui_frame((1280, 720))
+
+    payload, mime, _summary = bound_image_for_model(
+        frame, _sniffed(frame), max_edge=IMAGE_SCREEN_MAX_EDGE
+    )
+
+    assert payload == frame, "a frame already at the screen edge was re-encoded"
+    assert mime == "image/png"


### PR DESCRIPTION
## What

Bound every screen frame and every mobile image at the point it becomes an `ImageContent`, through the ONE existing bound (`imaging.bound_image_for_model`), and make the evaluation runner's byte trigger live so a request can never grow past a provider's wall between prefix rebuilds.

Found by a real paid OSWorld 2.0 episode (task_099, Kimi K3 via OpenRouter) that died at observation 19:

```
HTTP 413 payload_too_large: Downloaded image content cannot exceed 30MB
```

## Why it failed

Three separate holes, one root cause — the interactive harness had a centralised image bound and the eval runner and the mobile seam did not use it:

1. `_ContextBuilder._render_observation` base64'd the native 1920x1080 PNG (2.4–3.7 MB each) verbatim. `rebuild_due()` lets `keep_recent(3) + rebuild_every(8) = 11` frames ride one request → **31.6 MB**, over OpenRouter's 30 MB wall. Reproduced exactly by the probe below.
2. `_maybe_compact` called `should_compact(...)` **without** `wire_bytes`, so the byte trigger the interactive session has had since `DEFAULT_WIRE_BYTES_TRIGGER` landed was dead in the runner. And `should_compact`'s `window_tokens <= 0` guard short-circuited the byte term too — a wire cap does not depend on knowing the token window.
3. `session/runtime/server.py::image_blocks` (mobile) forwarded base64 unbounded — the same hole the TUI composer had before it was fixed. A 36.6 MB camera photo reached the render seam and was repaired on every render by `rebound_oversize_image`.

Nothing checked that a frame artifact's pixels equal the `model_visible` geometry the model is told and validated against. They agreed only by adapter convention.

## The fix

**One constant, one bound, one converter, one invariant.**

- `imaging.IMAGE_SCREEN_MAX_EDGE = 1280`. Measured on the real frames: 1280 keeps 10–11 px Chrome/UI text legible (viewed), 1.5 native px per model px, ~44% of native token cost. 1024 sits at the legibility floor and halves click precision; 1568 costs 50% more tokens with no measured UI gain. Anthropic's computer-use docs name 1280x720 as the accuracy baseline. No signature change — `bound_image_for_model(max_edge=)` already existed.
- `evaluation.adapters.api.bound_screen_frame(native_bytes) -> BoundFrame(payload, media_type, model_visible)`: the bound plus a header sniff so `model_visible` is the honest size of the bytes returned, not arithmetic.
- OSWorld adapter publishes the bounded frame with `FrameGeometry(native=1920x1080, model_visible=1280x720)`. The native-size assertion on raw guest bytes is kept (guards guest resize). Memoised by native sha so an identical screenshot ⇒ identical artifact sha (keeps `_frames_identical`). `actions.py::model_to_native` is unchanged and remains the single converter. **The evidence frame is now what the model saw.**
- Host verifier (`supervisor.py`) enforces `sniff(frame bytes).dims == geometry.model_visible`. Header-only. Any future runner-side pixel rewrite now fails loudly instead of silently mis-mapping clicks.
- Runner: `should_compact(..., wire_bytes=estimate_wire_bytes(messages))`; after the pass, `_enforce_wire_fit` sheds to a band below the trigger (not merely under the budget — shedding to the budget re-fired every turn, measured). Still one `replace` per pass; the frame budget remains the primary trigger and the byte trigger is a backstop.
- `should_compact`: the unknown-window guard now applies to the token comparison only. Monotonic in both args, off/disabled short-circuit preserved.
- Mobile `image_blocks` bounds on entry (default ingest edge, same as the composer) with `image_blocks_in_thread` for the async callers; the bound moved ahead of producer-identity reservation so FIFO admission is unchanged (4 existing `test_owned` tests pinned that).
- `scripts/run_episode.py --reasoning-effort`: the published numbers we compare against are at max effort and the runner had no way to set it. Validated against the spec's ladder, recorded in the manifest.

Deviations from the architect's design, each with a reason, are in the commit messages.

## Testing evidence

**Real-path probe** (`~/workspace/imgbound-probe/probe.py`, the 19 real task_099 frames, no provider/AWS):

```
total           46,367,518 -> 9,579,737 bytes (0.21x), every frame 1280x720
request of 11 frames (keep_recent 3 + rebuild_every 8):
  unbounded    31,558,306 bytes  OpenRouter wall 30,000,000  over: True   <- the 413
  bounded       8,793,082 bytes  byte trigger    16,000,000  over: False
```

Real 1920x1080 guest frame → `ObservationBuilder` → `HostVerifier.accept_initial` **accepted**; artifact re-reads at 1280x720; identical screen ⇒ identical sha. Mobile seam: 36.6 MB camera photo → 264 KB; `rebound_oversize_image` returns `None` (nothing left to repair).

**Mutation tests.** Revert the supervisor dims check → `test_host_refuses_a_frame_whose_pixels_disagree_with_model_visible` fails `DID NOT RAISE`. Revert `wire_bytes=` → `test_byte_trigger_rebuilds_once...` fails `expected exactly one prefix rebuild, got []`.

**Suites.** Affected areas (`test_imaging`, `evaluation`, `compaction`, `session/runtime`): 1987 passed, 1 skipped post-rebase. Whole-tree gates: flake8, black 26.1.0, isort 5.13.2, pyright — all clean.

**Paid episode**: the task_099 rerun with this build is the next step after review and is reported on the PR when it lands.

## Note on evidence semantics

Bundles now hold the model-visible frame (1280x720, PNG or JPEG per the ladder), not the native PNG. That is the frame the batch was judged against. Retaining native as an unreferenced artifact is a one-line addition if wanted.


## Update — round 4 scope: a mobile/viewer admission regression CI caught

The first CI run on `7223c1611` failed shard `test (3.12, 4)` on
`test_an_undeclared_receipt_has_its_request_admitted`. That is a real defect I
introduced, and an order-dependent test is why a full local run passed: on a
warm executor the thread hop resolved inside the admission's loop-turn budget
and the bug was invisible; CI's shard ran the file first with a cold pool.

`_admit_without_waiting_for_the_turn` budgets a few loop turns for `prompt`'s
synchronous prelude to raise its refusals. Bounding images inside `prompt`
added a thread hop that never resolves inside that budget (`to_thread` always
yields once), so an image-carrying admission was judged "genuinely queued",
its refusals logged detached — the silent drop the method exists to repair.

Fix (`44308f39d`): `prompt`/`steer` accept already-decoded `ImageContent`
blocks alongside wire dicts; the admission bounds once and forwards blocks, so
the prelude is await-free again. Two new tests pin it against a cold executor,
and both fail on their mutations. See the round-4 review.


Release: patch — evaluation and mobile image requests can no longer exceed a provider payload wall (HTTP 413): every screen frame and mobile image is bounded at 1280px through the one existing imaging bound, and the eval runner's byte-compaction trigger is live
