### PR TITLE
chore(release): bump version to 0.52.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.52.2"
+version = "0.52.3"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Change authorization

**C0 — release mechanics, standard/pre-authorized.** Version bump only. This PR is the change record.

## Scope

One line in `pyproject.toml`: `0.52.2` → `0.52.3`. No source, dependency, script, or entry-point change.

```
$ git diff origin/main..HEAD
-version = "0.52.2"
+version = "0.52.3"
```

## Release window

Window re-derived immediately before claiming with `git log v0.52.2..origin/main` rather than from a collected list:

| PR | Merge SHA | Impact |
|---|---|---|
| #831 | `dec8600e39e5575b729a365ac5ccb927432bb644` | `/model default` no longer prints a `keeping …` notice contradicting its own save receipt |

Owner: session 29011. Peers 5095, 91700, 1428 and 83697 were polled; 83697 confirmed nothing merged-but-unreleased on its side and that #821 rides a later window.

**Bump class: PATCH.** A bug fix on an existing seam. No new surface, no migration, no config key, no contract change.

## Why the fix matters

Saving the boot default writes two registry keys through the `settings_io` facade, and each write notifies the config watcher synchronously. The first notification carried a torn pair — the new provider beside the old model name, a combination never on disk and never asked for — which differed from the session's model, so `_on_configured_model_changed` emitted `keeping <model>; default changed for new sessions` directly beneath the `boot default saved:` receipt that said the opposite. Subagent sessions received two such notices with no receipt of their own to explain them.

#831 gates the notice on `ConfigChange.source == "local"`, which `config_watch.py` already set but `session.py` never consulted. Genuine external default changes still notify exactly once.

## Verification

#831 carried code review rounds 1 and 2 (round 2 TERMINAL on the merged head), QA round 1 (PASS, TERMINAL, 19-row matrix against the real app), and design round 1 (TERMINAL, rendered frames at 100/60/40 columns). All 17 CI checks green on `89e3c461a` before merge.

## Not in this release

#815 (secret-store broker) and the agent-facing `secret` tool are still in review, so v0.52.0's statement that agents cannot reach secrets yet remains accurate.