### PR TITLE
feat(secrets): agent surfaces — `secret` tool, eval library, redaction wiring (3 of 4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1773,6 +1773,59 @@ feel like wiring up. Using it to silence the failure defeats the guard: the
 whole point is that a registry default disagreeing with the code's default is a
 painted lie that nothing else reports.
 
+## Credentials and the encrypted secret store
+
+Full agent-facing guidance is `guide://credentials` (packaged at
+`local_operator/guides/credentials/GUIDE.md`); the design is
+`docs/design/secret-store.md`. This section is what someone CHANGING this code
+needs to know.
+
+**Four things are called credentials and they must stay distinct.** Provider API
+keys (`credentials.py`, plaintext, read by the model layer at boot); session
+credentials (`VariableStore._credentials`, memory-only, injected into `bash`,
+never readable by the agent); ordinary variables (denylist-filtered, not
+secret); and the encrypted long-term store (`local_operator/secrets/`, on disk,
+reachable by the agent through `lop secret get` and the eval library). A change
+that blurs two of them is a defect even when every test passes.
+
+**The agent uses a secret it cannot read — preserve that inversion.** No surface
+returns a value to the model. The `secret` tool's `retrieve` verb returns a
+receipt naming the secret and stating how to reach it; the eval library hands
+real bytes to the WORKER process, not to the transcript. Any new surface that
+returns a value into a tool result is writing it into a transcript that is
+persisted and replayed to the provider on every later turn.
+
+**Redaction has three sinks and they are not interchangeable.** `redact_tool_
+result` (the loop's choke point) covers finished tool results;
+`_redact_tool_text` covers UIs that read output before a result exists;
+`_PipeRedactor` covers live stream bytes and holds back a possible secret suffix
+so a value split across two reads cannot leak. A value must be registered with
+`VariableStore` before the output carrying it can be read — which is why the
+broker writes its session notification and waits for the ack BEFORE answering
+the retrieving child.
+
+**Build a stream filter from `_stream_redaction_values`, never from
+`credential_env()` alone.** That was a real hole: `credential_env()` holds only
+the values this process INJECTED, so a value a child fetched with
+`$(lop secret get X)` was scrubbed from the finished result and painted live in
+the streaming card and in `jobs(op='peek')`. The helper unions the injected map
+with the store's registered values, and **its failure path fails closed** — a
+redaction sink that cannot be read withholds the live output rather than
+publishing bytes it cannot vouch for, while still draining the pipe so the child
+does not block forever on a full buffer.
+
+**The eval worker scrubs through `sys.modules`, deliberately.**
+`eval_worker._scrub_secrets` checks whether `local_operator.secrets.runtime` is
+already imported instead of importing it. A kernel that never touched a secret
+must not pay for SQLite and the AES binding, and the check is exactly correct:
+if nothing imported the module, nothing obtained a value through it.
+
+**Do not describe this store as a vault, in code comments, docs, or to the
+user.** §9 of the design is explicit and the guide repeats it: it defeats the
+"scan the disk for credential files" malware that a bad link drops, and anything
+running as the operator that is willing to run `lop` can still read every
+secret. A comment or a docstring that promises more than that is wrong.
+
 ## Usage analytics (`local_operator/analytics/`)
 
 Every provider call across every session contributes to one shared, on-disk

--- a/local_operator/guides/credentials/GUIDE.md
+++ b/local_operator/guides/credentials/GUIDE.md
@@ -1,6 +1,6 @@
 ---
 name: credentials
-description: How to reach a stored secret from bash and from eval, when to store one and when not to, and what an agent must never do with a credential (echo it, write it to a file, commit it, paste it into a PR).
+description: How to use a stored secret from bash and eval without reading it, when to store one and when not to, and what to never do with a credential (echo, save, commit, paste it).
 ---
 
 # Working with credentials and secrets

--- a/local_operator/guides/credentials/GUIDE.md
+++ b/local_operator/guides/credentials/GUIDE.md
@@ -96,6 +96,25 @@ session).
 To promote a credential the user already handed to this session, they run
 `/credential --persist NAME`.
 
+**Storing a multi-line secret: use `--from-file`, not stdin.** `lop secret set`
+and `lop secret update` read stdin and strip ONE trailing newline, because
+`echo` and every heredoc add one and `echo hunter2` means five characters, not
+six. That is right for a token on a single line and silently wrong for anything
+that legitimately ends in a newline — a PEM private key, a service-account
+JSON, an SSH key. Piping one in costs it its final byte, and the value comes
+back one byte short with no error at any point; you find out when the key fails
+to verify, far from the cause.
+
+```bash
+lop secret set DEPLOY_KEY --from-file ./deploy_key.pem   # exact bytes, newline kept
+printf %s "$TOKEN" | lop secret set API_TOKEN            # single-line: stdin is fine
+```
+
+`--from-file` reads the file's exact bytes and strips nothing. It does not
+remove the file, so delete the plaintext afterwards. Verify a round trip with
+`lop secret get NAME | shasum -a 256` against the original when the value has
+to be byte-exact.
+
 ## What you must never do
 
 - **Never echo, print, or log a secret**, in any surface — bash output, an eval

--- a/local_operator/guides/credentials/GUIDE.md
+++ b/local_operator/guides/credentials/GUIDE.md
@@ -1,0 +1,140 @@
+---
+name: credentials
+description: How to reach a stored secret from bash and from eval, when to store one and when not to, and what an agent must never do with a credential (echo it, write it to a file, commit it, paste it into a PR).
+---
+
+# Working with credentials and secrets
+
+This is for an agent in the middle of a task that has just been handed a
+credential, or needs one that is already stored. It says how to use a secret
+without ever reading it, and what the store does and does not protect against.
+
+## The three places a secret can live
+
+| Where | Lifetime | You can read the value | Reach it with |
+|---|---|---|---|
+| **Session credential** — `/credential`, `ask secret=true` | this session | no, never | `$NAME` in `bash` |
+| **Long-term store** — `lop secret`, the `secret` tool | forever, encrypted | only through the paths below | `$(lop secret get NAME)`, `secrets["NAME"]` |
+| Provider API keys | forever, plaintext | not yours to touch | the harness reads them itself |
+
+A session credential is injected into every `bash` child's environment, so it
+is already `$NAME` there and needs nothing from you. Everything below is about
+the long-term store.
+
+## From bash
+
+Interpolate it **directly into the command that needs it**:
+
+```bash
+curl -H "Authorization: Bearer $(lop secret get GITHUB_TOKEN)" https://api.github.com/user
+```
+
+The value crosses a pipe into the child's argv. You never see it, and it never
+enters the transcript.
+
+Do **not** do any of these — each one puts the secret somewhere it outlives the
+command:
+
+```bash
+echo "$(lop secret get GITHUB_TOKEN)"          # prints it
+TOKEN=$(lop secret get GITHUB_TOKEN); echo $TOKEN   # same, one step later
+lop secret get GITHUB_TOKEN > /tmp/token       # writes it to disk, unencrypted
+```
+
+`lop secret get` writes the value to stdout with no trailing newline and exits
+non-zero with empty stdout on any failure, which is what makes `$( )` safe: a
+missing secret gives you an empty string and a failed command, never a partial
+or a diagnostic in place of a value.
+
+For a secret that is a FILE (a service-account JSON, a PEM), use the form that
+materialises it for one command and removes it afterwards:
+
+```bash
+lop secret file GCP_SA_JSON -- gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
+```
+
+To hand several secrets to one command as environment variables:
+
+```bash
+lop secret run --secret GITHUB_TOKEN --secret NPM_TOKEN=NODE_AUTH_TOKEN -- npm publish
+```
+
+## From eval
+
+```python
+token = secrets["GITHUB_TOKEN"]
+requests.get(url, headers={"Authorization": f"Bearer {token}"})
+```
+
+`secrets` is already bound in the kernel namespace — no import needed. Each
+lookup is one round trip and one audit entry. `"NAME" in secrets` checks
+existence without retrieving. `import secrets` still gets the stdlib module, as
+usual.
+
+The value is a real `str`, so f-strings, concatenation and `.encode()` all work.
+Its `repr` shows `[redacted]`, and anything it does reach — stdout, stderr,
+`display`, the cell's result — is scrubbed before the model sees it. **Do not
+rely on that as permission to print it.** It is a safety net for accidents, not
+a channel: a value you deliberately write to a file or post to a service has
+left the harness entirely.
+
+## When to store a secret
+
+`secret` tool, `op="store"` — or `lop secret set NAME` from bash. Storing is
+your decision to make.
+
+**Store it when:** you have just minted a token that will be needed after this
+session; the user pasted a credential they will clearly need again; a setup step
+produced a key. Prefer this store over writing to a plaintext `.env`.
+
+**Do not store:** anything the user said not to keep; a value needed for exactly
+one command; provider API keys the harness already manages; anything you are not
+sure the user wants persisted — ask instead, with `ask` and `secret=true`
+(add `persist=true` and the answer is saved long-term as well as for the
+session).
+
+To promote a credential the user already handed to this session, they run
+`/credential --persist NAME`.
+
+## What you must never do
+
+- **Never echo, print, or log a secret**, in any surface — bash output, an eval
+  cell, a notice, a commit message.
+- **Never write one to a file** you do not immediately delete, and never into
+  the repository. Not `.env`, not a config file, not a scratch note.
+- **Never put one in a commit, a PR body, an issue, or a message** to anyone.
+  If you think you have, say so immediately — a leaked credential must be
+  rotated, and only the user can do that.
+- **Never paste one into a tool argument** that is echoed back, including your
+  own reasoning text.
+- **Never move a secret between stores** without being asked. Reading one out of
+  the long-term store to put it somewhere more convenient defeats the store.
+
+## What is recorded
+
+Every store, retrieval, update, delete and failed authorization is appended to a
+hash-chained audit trail with a timestamp, the secret's id (never its value),
+the session id, and the calling process's pid and executable path.
+`lop secret audit --verify` checks the chain. So "I just read one to check" is
+visible to the user afterwards.
+
+## What this actually protects against — do not overstate it
+
+Be accurate if the user asks, because the honest answer is the useful one.
+
+The store is AES-256-GCM encrypted with blind-indexed names, so **the "scan the
+disk for credential files" malware that a bad link actually drops finds
+nothing** — no readable `.env`, no greppable `API_KEY=`, not even the names. In
+the default mode the master key is a file beside the store, so an attacker who
+knows to look for it reads both and decrypts; the opt-in passphrase mode holds
+the key only in a running broker's memory, where reading it needs a macOS
+authorization prompt the user would see.
+
+**But anything running as the user that is willing to run `lop` can read these
+secrets**, exactly as you do — `lop` is on `PATH` and a script that spawns a
+session is a legitimate caller. Ancestry proves lineage, not intent. That is the
+fundamental limit and no design confined to one user account removes it.
+
+So: **a large and worthwhile increase in the cost of stealing these credentials,
+not a vault.** Never tell the user their secrets are "safe" or "protected"
+without that qualification.

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -763,6 +763,14 @@ class AskQuestion(BaseModel):
             "session memory under this question's id and only the key name is returned."
         ),
     )
+    persist: bool = Field(
+        default=False,
+        description=(
+            "With secret=true, ALSO save the answer to the operator's encrypted "
+            "long-term store so it outlives this session. Set it when the credential "
+            "will be needed again later; leave it off for a one-off."
+        ),
+    )
 
     @model_validator(mode="after")
     def _shape(self) -> "AskQuestion":
@@ -785,6 +793,11 @@ class AskQuestion(BaseModel):
                     "(letters, digits, underscores)"
                 )
             return self
+        if self.persist:
+            # `persist` is meaningless without a secret to persist, and a model
+            # that set it on an ordinary question has misunderstood something
+            # worth correcting rather than ignoring silently.
+            raise ValueError("persist only applies to a secret question")
         if len(self.options) < 2:
             raise ValueError("at least two answers to pick from")
         if self.recommended is not None and not 0 <= self.recommended < len(self.options):

--- a/local_operator/secrets/__init__.py
+++ b/local_operator/secrets/__init__.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
     from local_operator.secrets.runtime import secrets as secrets
 
 from local_operator.secrets.errors import (
+    BrokerIncompatible,
     BrokerUnavailable,
     IncompatibleStore,
     InsecurePermissions,
@@ -60,6 +61,7 @@ def __getattr__(name: str) -> object:
 
 
 __all__ = [
+    "BrokerIncompatible",
     "BrokerUnavailable",
     "IncompatibleStore",
     "InsecurePermissions",

--- a/local_operator/secrets/__init__.py
+++ b/local_operator/secrets/__init__.py
@@ -18,9 +18,25 @@ It is not a vault and should not be described as one.
 Nothing heavy is imported here: the CLI's argument registration must stay off
 the crypto stack's import path (``tests/unit/test_import_graph.py``), so
 callers import the submodule they need.
+
+``secrets`` — the lazy mapping an agent uses from ``eval`` (design §5.3, and
+``from local_operator.secrets import secrets`` is the documented spelling) — is
+exported through ``__getattr__`` for exactly that reason. Naming it in the
+import list above would put :mod:`local_operator.secrets.runtime` on the path of
+every importer of this package; behind ``__getattr__`` it is loaded on first
+attribute access and the errors stay stdlib-only.
 """
 
 from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    # Import-time cost is the whole reason for the ``__getattr__`` below, and a
+    # TYPE_CHECKING import costs nothing at runtime while letting a type
+    # checker (and an editor) resolve ``from local_operator.secrets import
+    # secrets`` to the real object.
+    from local_operator.secrets.runtime import secrets as secrets
 
 from local_operator.secrets.errors import (
     BrokerUnavailable,
@@ -33,6 +49,16 @@ from local_operator.secrets.errors import (
     SecretStoreError,
 )
 
+
+def __getattr__(name: str) -> object:
+    """Resolve ``secrets`` on first access; see the module docstring."""
+    if name == "secrets":
+        from local_operator.secrets.runtime import secrets
+
+        return secrets
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 __all__ = [
     "BrokerUnavailable",
     "IncompatibleStore",
@@ -42,4 +68,5 @@ __all__ = [
     "SecretExists",
     "SecretNotFound",
     "SecretStoreError",
+    "secrets",
 ]

--- a/local_operator/secrets/access.py
+++ b/local_operator/secrets/access.py
@@ -211,6 +211,7 @@ def master_key_for(base: Path | None = None, *, create: bool = False) -> bytes:
         ensure_broker,
         fetch_master_key,
     )
+    from local_operator.secrets.errors import BrokerIncompatible
 
     try:
         if ensure_broker(base):
@@ -221,6 +222,18 @@ def master_key_for(base: Path | None = None, *, create: bool = False) -> bytes:
                 "be started, so there is no key to decrypt it with. Start one with "
                 "`lop secret broker start`, then `lop secret unlock`."
             )
+    except BrokerIncompatible:
+        # **A stale broker is fatal for VALUES, not for METADATA (Q4).**
+        # `retrieve_secret` lets this propagate, because serving a value from
+        # the local decrypt while a live broker sits there unable to publish
+        # the §6 notice is the Q3 defect. This function is the other kind of
+        # caller: `__contains__`, `__iter__` and `lop secret list` open the
+        # store to read RECORD METADATA, hand out no bytes, and owe no notice —
+        # so failing them would take the store's read-only surfaces down over a
+        # skew that costs them nothing. In the hardened tier there is no key on
+        # disk to fall back to, so it stays fatal there.
+        if hardened:
+            raise
     except BrokerLocked:
         # A locked store has no unwrapped key ANYWHERE, so there is nothing to
         # fall back to and pretending otherwise would just fail later and less
@@ -318,11 +331,24 @@ def retrieve_secret(name: str, base: Path | None = None) -> bytes:
     ``unredactable`` denial, which is exactly "the owning session never
     acknowledged", without needing a new exception class on the wire.
 
-    The residual cost is named rather than hidden: a broker left running across
-    a runtime update answers with a protocol-version refusal, and this raises
-    instead of quietly reading the key file. That surfaces the daemon's own
-    actionable message (``lop secret broker restart``) rather than silently
-    resuming unnotified retrievals, which is the safer of the two failures.
+    A broker left running across a runtime update answers with a
+    protocol-version refusal, and that raises (:class:`BrokerIncompatible`)
+    instead of quietly reading the key file — it is LIVE, so the reachability
+    rule above puts it on the believed side of the line. Round 4 found this
+    docstring describing behaviour the code did not have: the refusal reached
+    ``is_running`` as a bare ``SecretStoreError``, which reported ``False``,
+    and control fell to the unnotified local decrypt — a full reproduction of
+    Q3, arming itself at the first protocol bump, i.e. exactly at a runtime
+    update. The class exists so the two cases stay distinguishable.
+
+    **How the ``unredactable`` denial is actually covered.** An earlier version
+    of this docstring claimed the ``BrokerDenied`` clause below believed it.
+    The property holds — the reviewer drove all five refusal codes and no
+    ``unredactable`` reply serves a value — but by a different route:
+    ``unredactable`` is raised STRUCTURALLY inside the broker's retrieve
+    handler and never reaches that clause at all, arriving instead as a bare
+    :class:`SecretStoreError` that this function does not catch, so it
+    propagates. Right property, wrong mechanism, now stated as it is.
 
     **``BrokerDenied`` in the keyfile tier is the documented exception.** §8
     concedes the broker is not the boundary there — the master key is on disk
@@ -330,6 +356,14 @@ def retrieve_secret(name: str, base: Path | None = None) -> bytes:
     operator's own terminal has no lop session among its ancestors and is
     denied by construction. Making that fatal would break the store's primary
     surface while buying nothing. In the hardened tier the denial stands.
+
+    **The error taxonomy is identical on both paths (R11/Q5).** A store failure
+    raises the same class whichever side served it — the broker names the class
+    on the wire and :func:`local_operator.secrets.errors.error_for_kind`
+    rebuilds it — so a caller translating :class:`SecretNotFound` into a
+    ``KeyError`` behaves the same with a broker live and with none running.
+    Routing this through the broker while the classes still collapsed to
+    ``SecretStoreError`` is what broke ``secrets.get(name, default)``.
     """
     # Imported inside the function, matching `master_key_for` above: this
     # module is on the path of every `lop secret` verb, and the client drags in
@@ -352,3 +386,8 @@ def retrieve_secret(name: str, base: Path | None = None) -> bytes:
         if hardened:
             raise
     return open_store(base).get(name, session_id=session_id())
+
+
+# `BrokerIncompatible` is deliberately absent from the clauses above: it is a
+# LIVE broker, so the reachability rule believes it and it propagates to the
+# caller carrying the daemon's own restart advice.

--- a/local_operator/secrets/access.py
+++ b/local_operator/secrets/access.py
@@ -281,3 +281,74 @@ def open_store(base: Path | None = None, *, create: bool = False) -> SecretStore
     :func:`load_master_key`.
     """
     return SecretStore(master_key_for(base, create=create), base=base)
+
+
+def retrieve_secret(name: str, base: Path | None = None) -> bytes:
+    """One secret's VALUE, announced to the owning session first (design §6).
+
+    **Why this exists rather than a bare ``open_store().get()`` (QA Q3).** The
+    broker's ``retrieve`` op is what makes the §6 redaction notice fire: it
+    tells the session that owns this peer to scrub the value and WAITS for the
+    ack before answering, so a value taken through ``$(lop secret get NAME)``
+    cannot reach a model-visible channel ahead of the filter that redacts it.
+    Decrypting locally is functionally identical to the caller and silently
+    skips that notification — which is exactly what happened: the documented
+    ``$(lop secret get NAME)`` path painted the credential raw in the live
+    stream, in ``jobs(op='peek')`` and in the tool result, because the notifier
+    and its consumer were never connected. Every value-returning surface routes
+    through HERE so there is ONE announcement path rather than one per caller.
+
+    **The fallback is the same shape, and the same trade, as
+    :func:`master_key_for`'s (see below).** A retrieval must not become
+    impossible because no daemon is running: ``lop secret get`` typed in a
+    plain terminal, from a script, or on the keyfile tier has no session to
+    notify and frequently no broker at all. An availability failure therefore
+    degrades to the local decrypt — UNNOTIFIED, never blocked. That is the
+    round-2 invariant applied to this path: degrade to unnotified, never to a
+    blocked or failed retrieval.
+
+    **The fallback is keyed on REACHABILITY, not on the refusal.** This is the
+    one place the shape deliberately departs from :func:`master_key_for`, and
+    the asymmetry is the whole safety property. Falling back after a *live*
+    broker refused would serve, unnotified, precisely the value that broker had
+    just decided could not be kept out of the operator's transcript — the
+    fail-closed rule (review R3) inverted. So only an UNREACHABLE broker
+    (:class:`BrokerUnavailable`, or one that will not start) drops to the local
+    decrypt; a broker that answered and said no is believed. That covers the
+    ``unredactable`` denial, which is exactly "the owning session never
+    acknowledged", without needing a new exception class on the wire.
+
+    The residual cost is named rather than hidden: a broker left running across
+    a runtime update answers with a protocol-version refusal, and this raises
+    instead of quietly reading the key file. That surfaces the daemon's own
+    actionable message (``lop secret broker restart``) rather than silently
+    resuming unnotified retrievals, which is the safer of the two failures.
+
+    **``BrokerDenied`` in the keyfile tier is the documented exception.** §8
+    concedes the broker is not the boundary there — the master key is on disk
+    beside the store, so a refused caller reads it directly anyway, and the
+    operator's own terminal has no lop session among its ancestors and is
+    denied by construction. Making that fatal would break the store's primary
+    surface while buying nothing. In the hardened tier the denial stands.
+    """
+    # Imported inside the function, matching `master_key_for` above: this
+    # module is on the path of every `lop secret` verb, and the client drags in
+    # socket/fcntl machinery the write verbs never need.
+    from local_operator.secrets.client import BrokerDenied, ensure_broker, retrieve
+
+    hardened = key_mode(base) == "passphrase"
+    try:
+        if ensure_broker(base):
+            return retrieve(name, base)
+        # No broker could be started. In the hardened tier there is no
+        # unwrapped key on disk to fall back to, so let the local path raise
+        # its own accurate message rather than inventing one here.
+    except BrokerUnavailable:
+        # Reached one moment, gone the next. Availability, not policy: §13
+        # keeps the store usable rather than making a daemon a hard dependency.
+        if hardened:
+            raise
+    except BrokerDenied:
+        if hardened:
+            raise
+    return open_store(base).get(name, session_id=session_id())

--- a/local_operator/secrets/broker.py
+++ b/local_operator/secrets/broker.py
@@ -480,11 +480,19 @@ class SecretBroker:
 
         version = request.get("version")
         if version != PROTOCOL_VERSION:
+            # **The pid rides on the refusal, and it is load-bearing (Q4).**
+            # The advice is "restart the broker", and restarting means stopping
+            # THIS daemon — but a version-skewed client cannot ask `status` for
+            # the pid, because `status` fails this very gate first. Without the
+            # pid here the only actionable message the operator can be given is
+            # one they cannot act on, so it is answered as part of the refusal.
             self._reply_error(
                 connection,
                 "version",
                 f"this broker speaks protocol {PROTOCOL_VERSION}, the caller speaks "
                 f"{version!r}. Restart the broker after updating: lop secret broker restart",
+                pid=os.getpid(),
+                protocol=PROTOCOL_VERSION,
             )
             return False
 
@@ -1034,7 +1042,13 @@ class SecretBroker:
                 name, session_id=session.session_id if session else None
             )
         except SecretStoreError as exc:
-            self._reply_error(connection, "store", str(exc))
+            # **The class name rides along (R11/Q5).** `"store"` alone erased
+            # the difference between "no such secret" and "this record is
+            # corrupt", and a caller that must distinguish them — the eval
+            # `Mapping`, which owes a `KeyError` for a miss — could not. The
+            # code stays for wire compatibility; `kind` is what carries the
+            # taxonomy across the seam.
+            self._reply_error(connection, "store", str(exc), kind=type(exc).__name__)
             return
 
         # Notify BEFORE replying, and fail closed when the notice is not
@@ -1142,9 +1156,19 @@ class SecretBroker:
     def _audit_denial(self, identity: ProcessIdentity, operation: Any, reason: str) -> None:
         self._audit(identity, f"deny:{operation}", "deny")
 
-    def _reply_error(self, connection: socket.socket, code: str, message: str) -> None:
+    def _reply_error(
+        self, connection: socket.socket, code: str, message: str, **extra: Any
+    ) -> None:
+        """Refuse one request. ``extra`` carries fields a caller must act on.
+
+        Kept open-ended rather than growing a parameter per code: the two live
+        uses (``kind`` on a store failure, ``pid``/``protocol`` on a version
+        refusal) are both "the caller cannot recover without this", and a
+        reader unaware of a field ignores it, so adding one is backward
+        compatible on the wire.
+        """
         try:
-            send_frame(connection, {"ok": False, "code": code, "error": message})
+            send_frame(connection, {"ok": False, "code": code, "error": message, **extra})
         except (OSError, ProtocolError):  # pragma: no cover - peer already gone
             pass
 

--- a/local_operator/secrets/client.py
+++ b/local_operator/secrets/client.py
@@ -36,7 +36,12 @@ import time
 from pathlib import Path
 from typing import Any
 
-from local_operator.secrets.errors import BrokerUnavailable, SecretStoreError
+from local_operator.secrets.errors import (
+    BrokerIncompatible,
+    BrokerUnavailable,
+    SecretStoreError,
+    error_for_kind,
+)
 from local_operator.secrets.protocol import (
     PROTOCOL_VERSION,
     ProtocolError,
@@ -119,6 +124,19 @@ def request(
             raise BrokerDenied(message)
         if code == "locked":
             raise BrokerLocked(message)
+        if code == "version":
+            # **A live-but-stale broker is not an unreachable one (Q4).**
+            # Falling through to the bare `SecretStoreError` below let
+            # `is_running` swallow this into `False`, which every caller reads
+            # as "no broker" — and `retrieve_secret` then served the value
+            # through the unnotified local decrypt. Its own class keeps that
+            # distinction available to the seam.
+            raise BrokerIncompatible(message, pid=reply.get("pid"), protocol=reply.get("protocol"))
+        if code == "store":
+            # The broker names the class it caught; rebuilding it here is what
+            # makes the broker and local paths present ONE error taxonomy to
+            # callers, so a miss is a miss whichever path served it (R11/Q5).
+            raise error_for_kind(reply.get("kind"), message)
         raise SecretStoreError(message)
     return reply
 
@@ -140,18 +158,43 @@ class BrokerLocked(SecretStoreError):
 
 
 def is_running(base: Path | None = None) -> bool:
-    """Is a broker listening right now? Never raises, never blocks long."""
+    """Is a USABLE broker listening right now? Never raises, never blocks long.
+
+    **A version-incompatible broker propagates rather than reporting False
+    (Q4).** It is listening, so answering ``False`` — the same answer given for
+    an empty socket path — laundered "live but unusable" into "unreachable",
+    and :func:`~local_operator.secrets.access.retrieve_secret` keys its
+    fallback on exactly that distinction: an unreachable broker degrades to the
+    unnotified local decrypt, which is correct for an outage and is the Q3
+    defect for a daemon that is right there and refusing. Callers that only
+    want a liveness bool and genuinely do not care about the reason catch
+    :class:`BrokerIncompatible` themselves, where the choice is visible.
+    """
     try:
         request("ping", base)
+    except BrokerIncompatible:
+        raise
     except SecretStoreError:
         return False
     return True
 
 
 def broker_status(base: Path | None = None) -> dict[str, Any] | None:
-    """The broker's own view of itself, or ``None`` when it is not running."""
+    """The broker's own view of itself, or ``None`` when it is not running.
+
+    A version-mismatched daemon cannot answer ``status`` — the gate runs before
+    the operation — so its pid is synthesised from the refusal instead, which
+    is the whole reason the broker attaches one. Reporting ``None`` here would
+    tell ``lop secret broker stop`` that nothing was running while a daemon
+    held the socket, leaving the operator with no way to clear the skew that
+    the version message tells them to clear.
+    """
     try:
         return request("status", base)
+    except BrokerIncompatible as exc:
+        if not isinstance(exc.pid, int):
+            return None
+        return {"running": True, "pid": exc.pid, "protocol": exc.protocol, "incompatible": True}
     except SecretStoreError:
         return None
 
@@ -167,6 +210,14 @@ def ensure_broker(base: Path | None = None, *, timeout: float = STARTUP_TIMEOUT_
     the winner's socket, bounded by ``timeout``. No caller ever waits on the
     lock itself, so a holder that wedges costs a bounded delay rather than a
     deadlock.
+
+    **A version-incompatible daemon raises out of here rather than returning
+    False (Q4).** Returning False would send this function on to spawn a
+    replacement that cannot bind — the stale daemon holds the socket — and
+    then, after burning the full ``timeout``, report "no broker" to a caller
+    that degrades to an unnotified local read. Propagating is both faster and
+    the only answer that lets the seam tell the operator what is actually
+    wrong.
     """
     if is_running(base):
         return True

--- a/local_operator/secrets/errors.py
+++ b/local_operator/secrets/errors.py
@@ -95,8 +95,85 @@ class InsecurePermissions(SecretStoreError):
 class BrokerUnavailable(SecretStoreError):
     """The key broker could not be reached.
 
-    Defined here, and not raised anywhere yet, because the CLI's ``harden`` and
-    ``unlock`` verbs report it as a not-yet-shipped capability. The broker
-    daemon and peer authentication land in the follow-up PR; that PR raises
-    this from the broker client in ``access.open_store``.
+    Strictly "nothing answered": the socket is absent, refused the connection,
+    or the daemon accepted and then never replied. A broker that ANSWERED and
+    said no is a different condition and must not be collapsed into this one —
+    see :class:`BrokerIncompatible` and the round-4 note on it.
     """
+
+
+class BrokerIncompatible(SecretStoreError):
+    """A broker is listening, but it speaks a different protocol version.
+
+    **Its own class because "live but unusable" is not "unreachable", and
+    conflating them silently disarmed a safety property (round-4 Q4).** The
+    broker refuses a version-mismatched request, and every such refusal used to
+    reach callers as a bare :class:`SecretStoreError` that
+    ``client.is_running`` swallowed into ``False``. Every caller then read that
+    as "no broker", and :func:`local_operator.secrets.access.retrieve_secret`
+    degraded to the UNNOTIFIED local decrypt — serving the value with no §6
+    redaction notice, which is the exact defect (Q3) the broker seam exists to
+    close. Because a stale daemon is most likely precisely at a runtime update,
+    the laundering armed itself at the worst moment.
+
+    ``PROTOCOL_VERSION`` has only ever been 1, so no shipped runtime can reach
+    this yet; it is a latent hole being closed before the first bump makes it
+    live rather than after.
+
+    It carries the daemon's ``pid`` and the ``protocol`` it speaks because the
+    version refusal is the one message that MUST be actionable: the advice is
+    to restart the broker, and stopping it needs a pid that no other request
+    can obtain — ``status`` fails the same version gate.
+    """
+
+    def __init__(self, message: str, *, pid: int | None = None, protocol: object = None) -> None:
+        super().__init__(message)
+        self.pid = pid
+        self.protocol = protocol
+
+
+#: Store-error classes that survive a broker round trip, by class name.
+#:
+#: **Why a name-keyed allowlist and not ``getattr`` on this module.** The class
+#: name arrives from the broker socket, and resolving an arbitrary attribute
+#: name off a module because a peer asked for it is how a wire format turns
+#: into a lookup primitive. An explicit table can only ever yield one of these
+#: classes, and an unknown name degrades to :class:`SecretStoreError` rather
+#: than raising something unexpected.
+#:
+#: **Why the taxonomy has to cross the seam at all (round-4 R11/Q5).** The
+#: broker flattened every store failure into one ``"store"`` reply code, so a
+#: caller could not tell a missing secret from a corrupt record — and
+#: :class:`~local_operator.secrets.runtime.SecretsMapping` translates exactly
+#: one of them (:class:`SecretNotFound`) into the ``KeyError`` its ``Mapping``
+#: contract owes callers. With the class erased, ``secrets.get("ABSENT",
+#: "dflt")`` RAISED instead of returning the default whenever a broker happened
+#: to be live. Preserving the class here fixes it for every consumer at once,
+#: rather than in the one that noticed.
+WIRE_ERROR_KINDS: dict[str, type[SecretStoreError]] = {
+    cls.__name__: cls
+    for cls in (
+        InvalidSecretName,
+        SecretNotFound,
+        SecretExists,
+        SecretCorrupt,
+        IncompatibleStore,
+        StaleKeyEpoch,
+        InsecurePermissions,
+    )
+}
+
+
+def error_for_kind(kind: object, message: str) -> SecretStoreError:
+    """Rebuild a store error the broker named, or the base class.
+
+    An unknown or absent ``kind`` is the OLD-broker case and must not be an
+    error of its own: a daemon from before this field existed passes the
+    version gate (the wire version did not change) and simply says nothing
+    about the class, which is exactly the pre-round-4 behaviour.
+    """
+    if isinstance(kind, str):
+        cls = WIRE_ERROR_KINDS.get(kind)
+        if cls is not None:
+            return cls(message)
+    return SecretStoreError(message)

--- a/local_operator/secrets/handlers.py
+++ b/local_operator/secrets/handlers.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from typing import Any
 
 from local_operator.secrets.access import open_store, retrieve_secret, session_id
-from local_operator.secrets.errors import SecretStoreError
+from local_operator.secrets.errors import BrokerIncompatible, SecretStoreError
 from local_operator.secrets.keys import DIR_MODE, FILE_MODE, key_mode, secrets_dir
 from local_operator.secrets.store import SecretRecord
 
@@ -964,10 +964,21 @@ def _stop_broker(client: Any) -> bool | None:
     except OSError as exc:
         _err(f"Could not stop the secret broker (pid {pid}): {exc}")
         return False
+
+    # `is_running` propagates a version refusal (Q4), but here the only
+    # question is whether the socket still answers AT ALL — a stale daemon that
+    # has not died yet is still running for the purpose of waiting it out, and
+    # it is precisely the daemon this verb was invoked to clear.
+    def still_up() -> bool:
+        try:
+            return client.is_running(None)
+        except SecretStoreError:
+            return True
+
     deadline = time.monotonic() + _BROKER_STOP_TIMEOUT_S
-    while time.monotonic() < deadline and client.is_running(None):
+    while time.monotonic() < deadline and still_up():
         time.sleep(0.05)
-    if client.is_running(None):
+    if still_up():
         _err(f"The secret broker (pid {pid}) did not exit within {_BROKER_STOP_TIMEOUT_S:g}s.")
         return False
     _err(f"stopped secret broker (pid {pid})")
@@ -987,7 +998,15 @@ def _broker(args: argparse.Namespace) -> int:
         return broker_module.run_broker()
 
     if command == "start":
-        if client.ensure_broker(None):
+        # A stale daemon holds the socket, so `ensure_broker` cannot start over
+        # it and now says so instead of timing out (Q4). The refusal already
+        # names the fix, and `restart` is a verb away.
+        try:
+            started = client.ensure_broker(None)
+        except BrokerIncompatible as exc:
+            _err(str(exc))
+            return 2
+        if started:
             status = client.broker_status(None) or {}
             _err(f"secret broker running (pid {status.get('pid', '?')})")
             return 0

--- a/local_operator/secrets/handlers.py
+++ b/local_operator/secrets/handlers.py
@@ -27,7 +27,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from local_operator.secrets.access import open_store, session_id
+from local_operator.secrets.access import open_store, retrieve_secret, session_id
 from local_operator.secrets.errors import SecretStoreError
 from local_operator.secrets.keys import DIR_MODE, FILE_MODE, key_mode, secrets_dir
 from local_operator.secrets.store import SecretRecord
@@ -243,8 +243,15 @@ def _get(args: argparse.Namespace) -> int:
     ``$( )`` stripping the newline we add is luck, not contract, in every other
     consumer (a Python ``subprocess.check_output``, a here-string, a file
     redirect).
+
+    Routed through :func:`~local_operator.secrets.access.retrieve_secret` so
+    the §6 notice fires BEFORE these bytes exist here (QA Q3). This verb is the
+    headline path — ``$(lop secret get NAME)`` is what the credentials guide
+    tells agents to write — so it is the one that most needs the value already
+    registered for redaction by the time it can be printed. Nothing about the
+    stdout contract changes: same bytes, no trailing newline.
     """
-    value = open_store().get(args.name, session_id=session_id())
+    value = retrieve_secret(args.name)
     sys.stdout.buffer.write(value)
     sys.stdout.buffer.flush()
     return 0
@@ -747,7 +754,9 @@ def _file(args: argparse.Namespace) -> int:
         _err("usage: lop secret file NAME [--env-var VAR] -- COMMAND...")
         return 2
 
-    value = open_store().get(args.name, session_id=session_id())
+    # Same announcement seam as `_get`: the plaintext is about to be written
+    # to a path the child reads, so the session must already be scrubbing it.
+    value = retrieve_secret(args.name)
     directory = Path(tempfile.mkdtemp(prefix="lop-secret-"))
     os.chmod(directory, DIR_MODE)
     target = directory / args.name.replace(os.sep, "_")
@@ -790,13 +799,16 @@ def _run(args: argparse.Namespace) -> int:
         _err("lop secret run: name at least one secret with --secret NAME")
         return 2
 
-    store = open_store()
     environment = os.environ.copy()
     for specification in args.secret:
         name, _, variable = specification.partition("=")
-        environment[variable or name] = store.get(name, session_id=session_id()).decode(
-            "utf-8", errors="strict"
-        )
+        # Through the announcement seam, per secret. These values go into a
+        # child's environment, which any same-uid process can read while it
+        # runs, so they need the redaction notice at least as much as `_get`'s
+        # do. One store handle is no longer reused across the loop: each
+        # retrieval is its own broker round trip, which is also what makes the
+        # audit trail record them individually.
+        environment[variable or name] = retrieve_secret(name).decode("utf-8", errors="strict")
     return subprocess.run(command, env=environment, check=False).returncode
 
 

--- a/local_operator/secrets/promote.py
+++ b/local_operator/secrets/promote.py
@@ -107,7 +107,13 @@ def promote_session_credential(
             False,
             key,
             f"{key} already exists in the long-term store; it was NOT replaced. "
-            f"Use `lop secret rm {key}` first, or promote it under another name.",
+            # R8: this message rides a model-visible channel (the ask-persist
+            # path reports it to the model), so it must not coach an
+            # irreversible CLI delete the model could attempt. "Ask the
+            # operator" is the safe wording — `lop secret rm` prompts without
+            # `--yes` and cannot be done silently, so nothing here is a thing
+            # the model can act on.
+            f"Ask the operator to remove or rename it, or promote it under another name.",
             already_present=True,
         )
     except SecretStoreError as exc:
@@ -118,3 +124,33 @@ def promote_session_credential(
         f"Promoted {key} to the encrypted long-term store; it now survives this session. "
         f"Reachable as $(lop secret get {key}).",
     )
+
+
+def promote_session_credential_guarded(
+    store: Any,
+    key: str,
+    *,
+    description: str = "",
+    base: Path | None = None,
+) -> PromotionResult:
+    """``promote_session_credential`` that never raises (R4).
+
+    The ``/credential --persist`` owner path, the viewer route and the ask
+    path all promote the same session credential, but only the ask path used
+    to absorb a non-``SecretStoreError`` from the store stack (an unwrapped
+    ``sqlite3.OperationalError``, an ``OSError`` on the key file). The same
+    promotion must not have two robustness levels, so the guard lives here and
+    every caller takes it. The session copy is already in session memory by
+    the time this runs, so a failure degrades to "session only" rather than
+    losing the secret — and says so, because the operator's (or model's) plan
+    depends on which it was. A traceback carries names only, never the value.
+    """
+    try:
+        return promote_session_credential(store, key, description=description, base=base)
+    except Exception:
+        logger.warning("could not promote %s to the long-term store", key, exc_info=True)
+        return PromotionResult(
+            False,
+            key,
+            "Kept for this session only — saving it to the long-term store failed.",
+        )

--- a/local_operator/secrets/promote.py
+++ b/local_operator/secrets/promote.py
@@ -1,0 +1,120 @@
+"""Promote a session credential into the long-term store (design §5.4).
+
+The session path is unchanged: `/credential` and `ask secret=true` still store
+into `VariableStore` memory, still inject into bash, still cannot be read back.
+What is added is a ROUTE — the operator (or the agent, per §5.2) can decide
+that a secret handed over for this session should outlive it.
+
+**Why this is its own module and not a method on either store.** The two stores
+are deliberately separate types with separate lifetimes (`variables.py` holds
+process memory; `secrets/store.py` holds encrypted disk). Putting the promotion
+on `VariableStore` would give the session store an import of the crypto stack
+that every session pays for and only this route uses; putting it on
+`SecretStore` would give the disk store knowledge of session objects it has no
+other reason to know. A function that takes both is the seam with the smallest
+footprint.
+
+**It reads the session value and writes it; it does not expose it.** The value
+crosses this function in memory and is never returned, logged, or put in a
+result — the callers get a name and an outcome. That is what lets the TUI and
+the `ask` path call it on a value the MODEL must never see.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class PromotionResult:
+    """Outcome of one promotion. Carries a NAME and a reason, never a value."""
+
+    ok: bool
+    name: str
+    #: Operator/model-facing sentence. Safe to display: no secret bytes.
+    message: str
+    #: True when the secret was already in the long-term store under this name
+    #: and was left untouched. Not a failure, and reported distinctly so the
+    #: caller does not tell the operator it stored something it did not.
+    already_present: bool = False
+
+
+def promote_session_credential(
+    store: Any,
+    key: str,
+    *,
+    description: str = "",
+    base: Path | None = None,
+) -> PromotionResult:
+    """Copy session credential ``key`` into the encrypted long-term store.
+
+    ``store`` is the session :class:`~local_operator.variables.VariableStore`,
+    consumed through ``credential_env()`` because that is the only accessor
+    that yields values — deliberately, so a promotion is visibly a read of the
+    injectable set rather than a new private door into it.
+
+    The session copy is KEPT. Promotion is additive: the credential stays
+    injected into this session's bash children (which is what the agent is
+    already using) and additionally survives the session. Removing it would
+    break every command in flight that expects the env var.
+
+    ``base`` is for tests only; production always resolves the real config dir.
+    """
+    from local_operator.secrets.access import open_store, session_id
+    from local_operator.secrets.errors import SecretExists, SecretStoreError
+
+    reader = getattr(store, "credential_env", None)
+    if not callable(reader):
+        return PromotionResult(False, key, "This session cannot hold credentials.")
+    try:
+        values = reader()
+    except Exception:
+        logger.warning("could not read the session credential store", exc_info=True)
+        return PromotionResult(False, key, "This session's credential store could not be read.")
+    # `store` is deliberately typed `Any` (a duck-typed VariableStore, which is
+    # also how `builtin.py` consumes it), so the shape of what came back is
+    # checked rather than assumed: a third-party store returning something
+    # else must not raise out of a promotion.
+    if not isinstance(values, dict):
+        return PromotionResult(False, key, "This session's credential store could not be read.")
+    value = values.get(key)
+    if not value:
+        return PromotionResult(
+            False,
+            key,
+            f"No session credential named {key}. Hand it over with /credential {key} first.",
+        )
+    try:
+        target = open_store(base, create=True)
+        target.set(
+            key,
+            value.encode("utf-8"),
+            description=description.strip(),
+            session_id=session_id(),
+        )
+    except SecretExists:
+        # NOT an overwrite. `set` refuses an existing name on purpose (the
+        # previous value is retained nowhere), and silently calling `update`
+        # here would turn "promote this" into "replace whatever is already
+        # under that name" — destroying a long-term secret because a session
+        # happened to reuse its name. The operator is told and chooses.
+        return PromotionResult(
+            False,
+            key,
+            f"{key} already exists in the long-term store; it was NOT replaced. "
+            f"Use `lop secret rm {key}` first, or promote it under another name.",
+            already_present=True,
+        )
+    except SecretStoreError as exc:
+        return PromotionResult(False, key, str(exc))
+    return PromotionResult(
+        True,
+        key,
+        f"Promoted {key} to the encrypted long-term store; it now survives this session. "
+        f"Reachable as $(lop secret get {key}).",
+    )

--- a/local_operator/secrets/runtime.py
+++ b/local_operator/secrets/runtime.py
@@ -1,0 +1,241 @@
+"""The in-process secret library agents reach from ``eval`` (design §5.3).
+
+    from local_operator.secrets import secrets
+    token = secrets["GITHUB_TOKEN"]
+
+**Why a lazy mapping and not injected globals.** The alternative the design
+rejected was seeding every secret into the eval worker's namespace at spawn.
+That would put every secret in the worker's memory whether or not the cell
+wants one, expose them to ``print(globals())`` and any namespace introspection,
+and force a decision about WHICH secrets to inject before knowing what the cell
+does. A mapping decides nothing up front: each ``__getitem__`` is one store
+round trip and one audit row, so the audit trail records retrievals at the
+granularity they actually happen rather than "the kernel started".
+
+**Why the value never reaches the model.** The bytes live in the worker
+process. They enter the transcript only if the cell prints or returns them, and
+:data:`_LEDGER` is the guard for exactly that: every value handed out here is
+registered, and :mod:`local_operator.tools.eval_worker` scrubs every registered
+value out of stdout, stderr, the trailing-expression result, display output and
+the streaming frames that feed ``jobs(op='peek')``. That is a belt-and-braces
+sink, not the primary mechanism — the primary mechanism is that a cell has no
+reason to print a credential — but the failure it guards is the one that
+matters most on this series, so it is unconditional.
+
+**Why the ledger is consulted through ``sys.modules`` rather than imported.**
+``eval_worker`` is on the spawn path of every eval kernel and this module pulls
+the storage stack behind it. A worker that never touches a secret must not pay
+for SQLite and AES, so the worker checks whether this module is ALREADY
+imported and skips the whole ledger when it is not. That is sound rather than
+merely cheap: if nothing imported this module, nothing obtained a value through
+it, and there is nothing to scrub.
+
+**Residual risk, stated because §9 requires it not be overclaimed.** This is
+not a sandbox. A cell that deliberately writes a retrieved value to a file, or
+posts it somewhere, is doing what the operator asked the agent to be able to
+do; the ledger scrubs the transcript, not the world. And anything running as
+the operator that is willing to run ``lop`` can obtain these values itself.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator, Mapping
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from pathlib import Path
+
+
+class SecretValue(str):
+    """A retrieved secret that does not paint itself in a ``repr``.
+
+    A ``str`` subclass rather than a wrapper, because the whole point is that
+    it drops into the code the agent was going to write anyway:
+    ``requests.get(url, headers={"Authorization": f"Bearer {token}"})``,
+    ``token.encode()``, ``"a" + token`` all behave exactly as a ``str`` does.
+
+    **Only ``__repr__`` lies, and deliberately not ``__str__``.** A bare
+    ``token`` as a cell's trailing expression is rendered with ``repr``, and so
+    is a secret sitting inside a printed list or dict — those are the accidents
+    worth catching, and catching them costs nothing. Overriding ``__str__``
+    would instead break the primary use: ``f"Bearer {token}"`` formats through
+    ``__str__``, so a redacting ``__str__`` would silently send the literal text
+    ``Bearer [redacted]`` to the API and produce an authentication failure that
+    looks like a bad credential rather than a harness bug. The safety net for
+    ``print(token)`` is the worker ledger below, which scrubs the bytes out of
+    the captured stream whatever route they took — strictly stronger than a
+    lying ``__str__``, and it cannot break a working request.
+    """
+
+    #: ``name`` must be declared here: ``str`` defines ``__slots__``, so a
+    #: subclass with an empty ``__slots__`` has no ``__dict__`` and cannot take
+    #: an instance attribute at all.
+    __slots__ = ("name",)
+
+    #: The secret's name in the store. Not secret — it is exactly what the
+    #: model is told — so it rides on the object for a readable ``repr``.
+    name: str
+
+    def __new__(cls, value: str, name: str = "") -> "SecretValue":
+        instance = super().__new__(cls, value)
+        # `object.__setattr__` is not needed (str is not frozen), but the
+        # attribute must be set on the instance rather than the class, or every
+        # SecretValue would report the last-retrieved name.
+        instance.name = name
+        return instance
+
+    def __repr__(self) -> str:
+        label = f" {self.name}" if self.name else ""
+        return f"<secret{label}: [redacted], {len(self)} chars>"
+
+
+class _RedactionLedger:
+    """Every secret value this process has handed out, for output scrubbing.
+
+    Thread-safe because a cell may retrieve from a worker thread while the
+    foreground thread is building the response; a set mutated during iteration
+    would raise inside the response path and turn a successful cell into a
+    crash.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._values: set[str] = set()
+
+    def register(self, value: str) -> None:
+        if not value:
+            # Registering "" would make `str.replace` insert the marker between
+            # every character of every output.
+            return
+        with self._lock:
+            self._values.add(value)
+
+    def values(self) -> list[str]:
+        """Registered values, longest first.
+
+        Longest first so a value that is a prefix of another cannot leave the
+        remainder of the longer one visible — the same ordering rule
+        :func:`local_operator.variables.redact_secret_values` documents.
+        """
+        with self._lock:
+            return sorted(self._values, key=len, reverse=True)
+
+    def scrub(self, text: str) -> str:
+        """Replace every registered value in ``text`` with ``[redacted]``."""
+        for value in self.values():
+            if value in text:
+                text = text.replace(value, "[redacted]")
+        return text
+
+
+#: Process-wide ledger. Module-level because the eval worker's namespace is
+#: rebuilt per cell while the kernel (and its retrievals) outlive one cell: a
+#: secret fetched in cell 3 must still be scrubbed out of cell 9's output.
+_LEDGER = _RedactionLedger()
+
+
+def registered_values() -> list[str]:
+    """Values retrieved through this module, for an output filter to scrub."""
+    return _LEDGER.values()
+
+
+def scrub(text: str) -> str:
+    """``text`` with every retrieved secret replaced by ``[redacted]``."""
+    return _LEDGER.scrub(text)
+
+
+class SecretsMapping(Mapping[str, SecretValue]):
+    """Read-through view of the long-term store, one round trip per lookup.
+
+    A ``Mapping`` rather than a bare function so a cell can write the two forms
+    an agent naturally reaches for — ``secrets["NAME"]`` and
+    ``secrets.get("NAME")`` — and so ``"NAME" in secrets`` answers without
+    retrieving (and therefore without an audit row claiming a read that never
+    happened).
+
+    **Nothing is cached.** A second lookup is a second audit row, which is the
+    point: the audit trail is meant to record what the process actually did.
+    Caching would also keep bytes alive in a kernel that outlives the cell that
+    wanted them.
+    """
+
+    def __init__(self, base: "Path | None" = None) -> None:
+        # Only ever non-None in tests, which must not reach the operator's real
+        # store. Threaded through to `open_store` rather than read from the
+        # environment so a test cannot forget to isolate itself.
+        self._base = base
+
+    def _open(self) -> Any:
+        """Open the store through the broker seam.
+
+        Imported here and not at module scope: this module is imported into
+        every eval worker namespace, and the storage stack behind
+        :mod:`local_operator.secrets.access` (SQLite plus the AES binding) is a
+        cost only a cell that actually wants a secret should pay.
+        """
+        from local_operator.secrets.access import open_store
+
+        return open_store(self._base)
+
+    def __getitem__(self, name: str) -> SecretValue:
+        from local_operator.secrets.access import session_id
+        from local_operator.secrets.errors import SecretNotFound
+
+        key = str(name)
+        try:
+            raw = self._open().get(key, session_id=session_id())
+        except SecretNotFound as exc:
+            # A KeyError, because this is a Mapping and `secrets.get(...)` and
+            # `"X" in secrets` are built on __getitem__ raising it. The store's
+            # own message is kept as the argument so a cell that prints the
+            # exception still gets the actionable sentence.
+            raise KeyError(str(exc)) from exc
+        value = raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else str(raw)
+        # REGISTER BEFORE RETURNING. The cell gets the value only after the
+        # scrubber knows about it, so there is no window in which a cell could
+        # print a value the response filter has not been told about.
+        _LEDGER.register(value)
+        return SecretValue(value, key)
+
+    def __contains__(self, name: object) -> bool:
+        """Whether a secret exists, WITHOUT retrieving it.
+
+        Deliberately routed through ``describe`` rather than ``get``: an
+        existence check is not a read, and recording it as one would fill the
+        audit trail with retrievals that never handed out a byte.
+        """
+        from local_operator.secrets.errors import SecretStoreError
+
+        try:
+            self._open().describe(str(name))
+        except SecretStoreError:
+            return False
+        return True
+
+    def __iter__(self) -> Iterator[str]:
+        from local_operator.secrets.errors import SecretStoreError
+
+        try:
+            records = self._open().list()
+        except SecretStoreError:
+            # An absent or unopenable store iterates empty rather than raising:
+            # `list(secrets)` in a cell that is exploring should report "none
+            # here", and the verbs that actually need the store still raise.
+            return iter([])
+        return iter([record.name for record in records])
+
+    def __len__(self) -> int:
+        return sum(1 for _ in self)
+
+    def __repr__(self) -> str:
+        # Never enumerates: __repr__ runs in incidental places (a traceback, a
+        # debugger, an accidental trailing expression) and neither a store hit
+        # nor an audit row belongs on any of them.
+        return "<local_operator secrets: secrets['NAME'] retrieves one value>"
+
+
+#: The instance agents use. Created eagerly because construction touches
+#: nothing — every store access is inside a method — so importing this module
+#: still costs only the stdlib.
+secrets = SecretsMapping()

--- a/local_operator/secrets/runtime.py
+++ b/local_operator/secrets/runtime.py
@@ -208,7 +208,12 @@ class SecretsMapping(Mapping[str, SecretValue]):
         self._base = base
 
     def _open(self) -> Any:
-        """Open the store through the broker seam.
+        """Open the store for the metadata-only reads.
+
+        Kept for ``__contains__``/``__iter__``/``__len__``, which answer from
+        record metadata and never touch a value — so they need no announcement
+        and must not pay for a broker round trip. Value reads go through
+        :meth:`_retrieve` instead.
 
         Imported here and not at module scope: this module is imported into
         every eval worker namespace, and the storage stack behind
@@ -219,13 +224,26 @@ class SecretsMapping(Mapping[str, SecretValue]):
 
         return open_store(self._base)
 
+    def _retrieve(self, name: str) -> bytes:
+        """Fetch one value through the broker seam.
+
+        Uses the same announcement seam as ``lop secret get`` (QA Q3) so an
+        eval retrieval is announced to the owning session exactly as a bash
+        child's is. The in-process ledger below still registers the value
+        independently — that is what covers this worker's own stdout — but the
+        two are no longer the SAME mechanism, and a value fetched here is now
+        redacted from the session's channels too.
+        """
+        from local_operator.secrets.access import retrieve_secret
+
+        return retrieve_secret(name, self._base)
+
     def __getitem__(self, name: str) -> SecretValue:
-        from local_operator.secrets.access import session_id
         from local_operator.secrets.errors import SecretNotFound
 
         key = str(name)
         try:
-            raw = self._open().get(key, session_id=session_id())
+            raw = self._retrieve(key)
         except SecretNotFound as exc:
             # A KeyError, because this is a Mapping and `secrets.get(...)` and
             # `"X" in secrets` are built on __getitem__ raising it. The store's

--- a/local_operator/secrets/runtime.py
+++ b/local_operator/secrets/runtime.py
@@ -110,6 +110,7 @@ class _RedactionLedger:
             return
         with self._lock:
             self._values.add(value)
+        _publish(value)
 
     def values(self) -> list[str]:
         """Registered values, longest first.
@@ -143,6 +144,35 @@ def registered_values() -> list[str]:
 def scrub(text: str) -> str:
     """``text`` with every retrieved secret replaced by ``[redacted]``."""
     return _LEDGER.scrub(text)
+
+
+#: Optional hook the eval worker installs so the parent process learns the
+#: values it must scrub out of the worker's real-fd crash tail. The worker owns
+#: the transport (a dedicated fd); this module owns the trigger (registration).
+#: ``None`` in every non-worker process, where no such parent exists.
+_PUBLISH_HOOK: Any = None
+
+
+def set_publish_hook(hook: Any) -> None:
+    """Install the per-registration publish hook (worker only; see R1)."""
+    global _PUBLISH_HOOK
+    _PUBLISH_HOOK = hook
+
+
+def _publish(value: str) -> None:
+    """Notify the installed hook of a newly registered value, best-effort.
+
+    A hook failure (the parent's fd closed, an old parent) must never fault
+    the retrieval that triggered it — the value is already safely in this
+    process's ledger, which covers every in-worker channel.
+    """
+    hook = _PUBLISH_HOOK
+    if hook is None:
+        return
+    try:
+        hook(value)
+    except BaseException:  # noqa: BLE001 — publication is advisory, never fatal
+        pass
 
 
 class SecretsMapping(Mapping[str, SecretValue]):

--- a/local_operator/secrets/runtime.py
+++ b/local_operator/secrets/runtime.py
@@ -249,6 +249,18 @@ class SecretsMapping(Mapping[str, SecretValue]):
             # `"X" in secrets` are built on __getitem__ raising it. The store's
             # own message is kept as the argument so a cell that prints the
             # exception still gets the actionable sentence.
+            #
+            # **This clause depends on the SEAM preserving the class, not on
+            # the local path being the one that ran (round-4 R11/Q5).** When
+            # the broker flattened every store failure to a bare
+            # `SecretStoreError`, this `except` stopped matching the moment a
+            # broker was live, and `secrets.get("ABSENT", "dflt")` RAISED
+            # instead of returning the default. It was invisible because the
+            # test pinning this contract runs without a broker, so it exercised
+            # the branch that had not changed. `errors.error_for_kind` is what
+            # makes both paths raise the same class; do not repair a future
+            # instance of this by widening the clause here, which would re-fork
+            # the taxonomy per consumer instead of fixing it once at the seam.
             raise KeyError(str(exc)) from exc
         value = raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else str(raw)
         # REGISTER BEFORE RETURNING. The cell gets the value only after the

--- a/local_operator/secrets/runtime.py
+++ b/local_operator/secrets/runtime.py
@@ -109,6 +109,17 @@ class _RedactionLedger:
             # every character of every output.
             return
         with self._lock:
+            if value in self._values:
+                # R9: publication dedups WITH the set, not beside it. Nothing
+                # caches a retrieval (see the mapping's docstring), so the
+                # ordinary retry loop — `secrets["TOK"]` once per attempt —
+                # re-registers one identical value hundreds of times while the
+                # ledger stays size 1. Publishing each of those spent the
+                # parent's bounded scrub channel on records it already had, at
+                # a few hundred bytes a turn. Returning here makes the channel
+                # cost proportional to DISTINCT secrets, which is what the
+                # parent's scrub set is made of.
+                return
             self._values.add(value)
         _publish(value)
 

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -2354,6 +2354,20 @@ class OwnedSessionHandle(SessionHandle):
             for name in names:
                 self._journal_credential(name, action="forgot")
             return {"ok": True, "count": count, "names": names}
+        if action == "persist":
+            # §5.4's promotion route, executed on the OWNER because both stores
+            # that matter are the owner's: the session memory holding the value
+            # and the config dir holding the encrypted long-term store. Only a
+            # name and an outcome sentence cross back — never the value.
+            from local_operator.secrets.promote import promote_session_credential
+
+            outcome = promote_session_credential(store, key)
+            return {
+                "ok": True,
+                "promoted": outcome.ok,
+                "key": key,
+                "message": outcome.message,
+            }
         if action == "store":
             result = store.store_credential(key, value, "command")
             credential = getattr(result, "credential", None)

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -2359,9 +2359,11 @@ class OwnedSessionHandle(SessionHandle):
             # that matter are the owner's: the session memory holding the value
             # and the config dir holding the encrypted long-term store. Only a
             # name and an outcome sentence cross back — never the value.
-            from local_operator.secrets.promote import promote_session_credential
+            from local_operator.secrets.promote import (
+                promote_session_credential_guarded,
+            )
 
-            outcome = promote_session_credential(store, key)
+            outcome = promote_session_credential_guarded(store, key)
             return {
                 "ok": True,
                 "promoted": outcome.ok,

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -58,7 +58,7 @@ import time
 import traceback
 import unicodedata
 from collections import deque
-from collections.abc import Awaitable, Callable, Iterator, Sequence
+from collections.abc import Awaitable, Callable, Iterable, Iterator, Sequence
 from contextvars import ContextVar
 from datetime import UTC, datetime
 from pathlib import Path
@@ -1473,15 +1473,36 @@ class _PipeRedactor:
     enough undecided text for the longest injected credential, and never cut
     through a complete match. UTF-8 decoding is incremental for the same
     reason. Retained output and live job tails receive the same safe bytes.
+
+    Accepts a credential MAP (the historic caller) or a plain sequence of
+    values. The sequence form is what carries §6 registrations — values a child
+    fetched through ``lop secret get``, which have a name nowhere in this
+    process, so there is no map to put them in.
     """
 
-    def __init__(self, credentials: dict[str, str]) -> None:
-        self.secrets = sorted(
-            {value for value in credentials.values() if value}, key=len, reverse=True
-        )
-        self.lookbehind = max((len(value) for value in self.secrets), default=1) - 1
+    def __init__(self, credentials: dict[str, str] | Sequence[str]) -> None:
+        values = credentials.values() if isinstance(credentials, dict) else list(credentials)
+        self._set(values)
         self.pending = ""
         self.decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+
+    def _set(self, values: Iterable[str]) -> None:
+        self.secrets = sorted({value for value in values if value}, key=len, reverse=True)
+        self.lookbehind = max((len(value) for value in self.secrets), default=1) - 1
+
+    def refresh(self, values: Sequence[str]) -> None:
+        """Adopt a newly-widened value set mid-stream.
+
+        A ``$(lop secret get X)`` value is registered with the session DURING
+        the command, so a redactor built once at spawn would not know about it.
+        Re-read per chunk, which is what makes a value that arrives at the same
+        moment as the bytes it must scrub still get scrubbed.
+
+        The lookbehind can only GROW here, never shrink below what is already
+        held back: ``pending`` is untouched, so a longer new secret straddling
+        this chunk boundary is still resolved on the next feed.
+        """
+        self._set(values)
 
     def feed(self, chunk: bytes, *, final: bool = False) -> bytes:
         text = self.pending + self.decoder.decode(chunk, final=final)
@@ -1522,6 +1543,61 @@ def _bash_progress_line(
     return "running"
 
 
+def _stream_redaction_values(store: Any, credential_env: dict[str, str]) -> list[str]:
+    """Every value the live pipe filter must scrub, not just the injected ones.
+
+    **The hole this closes.** ``_PipeRedactor`` used to be built from the
+    injected credential map alone. That map holds the secrets this process
+    PUT INTO the child's environment — but a child that runs
+    ``$(lop secret get NAME)`` fetches a value this process never injected and
+    never saw. The store learns about it out of band (design §6 case 2: the
+    broker notifies the session and waits for the ack BEFORE answering the
+    child), and ``redact_tool_result`` and ``_redact_tool_text`` both read that
+    registration through ``VariableStore.redact``. The pipe filter did not, so
+    the value was scrubbed from the finished tool result and PAINTED LIVE in
+    the streaming card and in ``jobs(op='peek')`` while the command ran.
+
+    **``redaction_values`` is consumed defensively, and its absence FAILS
+    CLOSED.** The method ships with the broker PR; this code must compose with
+    a tree where it is present and one where it is not, which is why it is read
+    with ``getattr`` — the same convention ``credential_env`` above uses. But
+    "absent" must not degrade to "stream unfiltered": the seam being missing is
+    exactly the condition under which a broker-announced value would be
+    invisible to this filter. So when the store advertises a redaction sink at
+    all and it cannot be read, this returns the sentinel
+    :data:`_REDACTION_SEAM_BROKEN` and the caller refuses to stream rather than
+    publishing bytes it cannot vouch for. A store with no sink whatsoever (a
+    third-party embedder's minimal variable store, or a pre-broker tree) has no
+    long-term retrievals to announce and keeps today's behaviour — the injected
+    credentials, which is the complete set of secrets in play there.
+    """
+    values = [str(value) for value in credential_env.values() if value]
+    reader = getattr(store, "redaction_values", None)
+    if not callable(reader):
+        return values
+    try:
+        registered = reader()
+    except Exception:
+        logger.warning("redaction sink unreadable; refusing to stream", exc_info=True)
+        return _REDACTION_SEAM_BROKEN
+    if not isinstance(registered, (list, tuple, set)):
+        logger.warning("redaction sink returned %s; refusing to stream", type(registered).__name__)
+        return _REDACTION_SEAM_BROKEN
+    values.extend(str(value) for value in registered if value)
+    # `redaction_values` already includes the injected credentials once the
+    # broker seam is present, so the two sources overlap. De-duplicated because
+    # `_PipeRedactor` sizes its held-back lookbehind from this list and scans it
+    # per chunk; duplicates cost work on every read for no added coverage.
+    # Order-preserving so the longest-first sort downstream stays deterministic.
+    return list(dict.fromkeys(values))
+
+
+#: Sentinel meaning "the redaction sink exists but could not be read". Not an
+#: empty list, because an empty list is the legitimate "nothing to scrub yet"
+#: answer and must keep streaming; this one stops it.
+_REDACTION_SEAM_BROKEN: list[str] = ["\x00redaction-seam-broken\x00"]
+
+
 def _redact_tool_text(text: str, context: ToolContext | None) -> str:
     """Strip stored session-credential values out of tool output.
 
@@ -1530,13 +1606,28 @@ def _redact_tool_text(text: str, context: ToolContext | None) -> str:
     (bash stream updates, background-job peek, the abort receipt). A command
     that ``echo``s ``$GITHUB_TOKEN`` would otherwise paint the secret while
     the command is still running.
+
+    Reads ``VariableStore.redact``, which the broker PR widens to cover
+    registered long-term retrievals as well as injected session credentials, so
+    this surface picks up ``$(lop secret get NAME)`` values with no change here.
     """
     store = context.variables if context is not None else None
     redact = getattr(store, "redact", None)
-    if callable(redact):
+    if not callable(redact):
+        return text
+    try:
         redacted = redact(text)
-        return redacted if isinstance(redacted, str) else text
-    return text
+    except Exception:
+        # FAIL CLOSED, and do not propagate. `redact` reads the store's
+        # redaction sink, so a sink that raises means this text cannot be
+        # vouched for — returning it is the leak. Letting the exception escape
+        # is not the answer either: this helper is called from the streaming
+        # emit path and from the background-job mirror, where an exception
+        # turns a redaction fault into a crashed bash tool and loses the
+        # command's result along with its output.
+        logger.warning("redaction failed; withholding this text", exc_info=True)
+        return "[output withheld: this session's secret redaction sink could not be read]"
+    return redacted if isinstance(redacted, str) else text
 
 
 def _bash_output_summary(stdout: str, stderr: str) -> str:
@@ -1789,26 +1880,63 @@ async def execute_bash(
             _redact_tool_text(chunk.decode("utf-8", errors="replace"), context),
         )
 
+    injected = extra if isinstance(extra, dict) else {}
+
     async def _pump(stream: asyncio.StreamReader | None, sink: _BashOutput) -> None:
         # Both pipes were requested at spawn, so neither is ever None here;
         # the guard keeps the reader honest instead of asserting.
         if stream is None:
             return
-        redactor = _PipeRedactor(extra if isinstance(extra, dict) else {})
+        redactor = _PipeRedactor(_stream_redaction_values(store, injected))
+        withheld = False
         try:
             while True:
                 chunk = await stream.read(65536)
                 if not chunk:
                     break
+                if withheld:
+                    # KEEP DRAINING AFTER A FAILURE, discarding. Stopping the
+                    # read instead would fill the pipe buffer and block the
+                    # child forever on its next write — turning a redaction
+                    # fault into a hung command, which is a worse outcome than
+                    # the one being guarded against and is not what failing
+                    # closed means.
+                    continue
+                # RE-READ PER CHUNK. A `$(lop secret get X)` value is
+                # registered with the session while this command runs, so a set
+                # captured once before the loop would miss the very value this
+                # filter exists to catch. Cheap: a list copy of a handful of
+                # strings per 64 KB read.
+                values = _stream_redaction_values(store, injected)
+                if values is _REDACTION_SEAM_BROKEN:
+                    # FAIL CLOSED. The sink that knows about broker-announced
+                    # values cannot be read, so these bytes cannot be vouched
+                    # for. Publishing them is the leak; withholding them costs
+                    # the live view only — the command still runs to completion,
+                    # and its final result goes through `redact_tool_result`,
+                    # which is a separate path reading the store directly.
+                    withheld = True
+                    notice = (
+                        b"[live output withheld: this session's secret redaction "
+                        b"sink could not be read]\n"
+                    )
+                    sink.append(notice)
+                    _mirror(notice)
+                    continue
+                redactor.refresh(values)
                 safe = redactor.feed(chunk)
                 sink.append(safe)
                 _mirror(safe)
         except (ConnectionResetError, BrokenPipeError):
             pass
         finally:
-            safe = redactor.feed(b"", final=True)
-            sink.append(safe)
-            _mirror(safe)
+            # The held-back tail is published only if the stream was never
+            # withheld; flushing it after a fault would emit exactly the bytes
+            # the fault said could not be vouched for.
+            if not withheld:
+                safe = redactor.feed(b"", final=True)
+                sink.append(safe)
+                _mirror(safe)
 
     # Hold the tasks ourselves so the readers are never abandoned mid-run.
     stdout_task = asyncio.create_task(_pump(process.stdout, stdout_chunks))
@@ -10717,6 +10845,16 @@ def _report_secret_answers(
         key = getattr(credential, "key", None)
         if getattr(result, "ok", False) and isinstance(key, str):
             reported[question.id] = [key]
+            if question.persist:
+                # §5.4's persist route, reached from `ask` as well as from
+                # `/credential`, so the two ways a credential arrives share one
+                # promotion path rather than two that drift. Reported into the
+                # SAME answer slot the key name occupies, because the model
+                # needs to know whether the secret it just asked for will still
+                # be there tomorrow — a silent failure here would have it plan
+                # around a durable secret that is actually session-only.
+                promotion = _promote_credential(store, key, question.question)
+                reported[question.id] = [key, promotion]
             # Announce only on a successful store, and only the KEY: the
             # announcement is journaled into the live context and sent to the
             # provider, so the value must never ride it.
@@ -10734,6 +10872,27 @@ def _report_secret_answers(
     for key, value in answers.items():
         reported.setdefault(key, list(value))
     return reported
+
+
+def _promote_credential(store: Any, key: str, description: str) -> str:
+    """Promote a just-stored session credential; return a model-safe sentence.
+
+    Never raises and never returns a value. The credential is already in the
+    session store by the time this runs, so a promotion failure must degrade to
+    "it is session-only" rather than losing the secret the user just pasted —
+    and must SAY so, because the model's plan depends on which it was.
+
+    Imported lazily: the crypto stack stays off the path of every `ask` that
+    does not persist, which is nearly all of them.
+    """
+    try:
+        from local_operator.secrets.promote import promote_session_credential
+
+        result = promote_session_credential(store, key, description=description)
+    except Exception:
+        logger.warning("could not promote %s to the long-term store", key, exc_info=True)
+        return "stored for this session only — saving it long-term failed"
+    return result.message
 
 
 def _ask_report(questions: list[AskQuestion], answers: dict[str, list[str]]) -> str:
@@ -10798,7 +10957,9 @@ def build_ask_tool(context: ToolContext) -> AgentTool | None:
             "answers the questions back to back rather than once per turn. "
             "If you need a credential, password, or API key, set secret=true on that "
             "question (options empty, id is the env-var name). The value is stored in "
-            "session memory and injected into bash; you will only ever see the key name."
+            "session memory and injected into bash; you will only ever see the key name. "
+            "Add persist=true when that credential will be needed again after this "
+            "session, and it is also saved to the operator's encrypted long-term store."
         ),
         parameters=AskParams.model_json_schema(),
         # read tier: asking a question changes nothing. Gating it behind the

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -10883,16 +10883,14 @@ def _promote_credential(store: Any, key: str, description: str) -> str:
     and must SAY so, because the model's plan depends on which it was.
 
     Imported lazily: the crypto stack stays off the path of every `ask` that
-    does not persist, which is nearly all of them.
+    does not persist, which is nearly all of them. The never-raises guard lives
+    in :func:`promote_session_credential_guarded` so the ``/credential
+    --persist`` and viewer paths share the same robustness level (R4) rather
+    than this path carrying a second one.
     """
-    try:
-        from local_operator.secrets.promote import promote_session_credential
+    from local_operator.secrets.promote import promote_session_credential_guarded
 
-        result = promote_session_credential(store, key, description=description)
-    except Exception:
-        logger.warning("could not promote %s to the long-term store", key, exc_info=True)
-        return "stored for this session only — saving it long-term failed"
-    return result.message
+    return promote_session_credential_guarded(store, key, description=description).message
 
 
 def _ask_report(questions: list[AskQuestion], answers: dict[str, list[str]]) -> str:

--- a/local_operator/tools/eval.py
+++ b/local_operator/tools/eval.py
@@ -160,6 +160,18 @@ class _Kernel:
         # platform where the side channel could not be set up — the crash path
         # then scrubs nothing, which is the pre-R1 behaviour and still safe.
         self.scrub_read = scrub_read
+        # R9: the pipe is drained on the NORMAL path (after every exchange),
+        # not only on the crash path. A pipe nothing reads is a fixed 64 KiB
+        # CUMULATIVE budget on everything the worker will ever publish, and
+        # the worker publishes from inside the retrieval; draining routinely
+        # is what keeps that budget per-exchange instead of per-kernel.
+        # Values accumulate here because a drain consumes them from the pipe,
+        # so the crash path can no longer be the only reader of the full set.
+        self.scrub_values: list[str] = []
+        # Bytes of a record split across two reads. A drain can land
+        # mid-record; the remainder is carried to the next one rather than
+        # discarded, which would lose that value's scrub entry entirely.
+        self.scrub_partial: bytes = b""
         self.last_used = time.monotonic()
         self.generation = uuid.uuid4().hex
 
@@ -526,6 +538,11 @@ async def _spawn(cwd: str, session_key: str = "") -> _Kernel:
     try:
         scrub_read, scrub_write = os.pipe()
         os.set_inheritable(scrub_write, True)
+        # Non-blocking once, at setup, rather than per drain: the drain now
+        # runs after every exchange (R9) and a mode change per call is both
+        # wasted syscalls and a window where a failure would leave the parent
+        # reading a blocking fd inside the response path.
+        os.set_blocking(scrub_read, False)
         env = dict(os.environ)
         env["LOCAL_OPERATOR_EVAL_SCRUB_FD"] = str(scrub_write)
         spawn_options["env"] = env
@@ -623,25 +640,28 @@ async def _read_crash_stderr(kernel: _Kernel) -> str:
 
 
 def _drain_scrub_channel(kernel: _Kernel) -> list[str]:
-    """Collect every value the worker published on the kernel's scrub pipe.
+    """Drain the scrub pipe into the kernel's set and return it.
 
     The pipe is framed as ``<len>\x00<bytes>\x00`` per value (see the worker's
     ``_publish_secret_value``). A crashed worker has closed its write end, so
     draining reads whatever it buffered; a kernel that never retrieved a secret
     yields ``[]``. A worker spawned without the channel (``scrub_read is
-    None``) drains to ``[]``, which is the safe pre-R1 behaviour. Any framing
-    damage yields whatever whole values were recovered; a partial trailing
-    record is dropped rather than risk splitting a value into scrub-resistant
-    fragments.
+    None``) drains to ``[]``, which is the safe pre-R1 behaviour.
+
+    R9: this is called after EVERY exchange, not only on the crash path, so it
+    is incremental — each call consumes what is in the pipe now, and values
+    accumulate on the kernel. Draining is what bounds the worker's publication
+    budget: the worker's write is non-blocking and DROPS a record onto a full
+    pipe, so a pipe left unread turns ordinary secret use into an unscrubbed
+    crash tail (and, before the worker's write was made non-blocking, into a
+    wedged retrieval). A partial trailing record is CARRIED to the next drain
+    rather than dropped, because with routine draining a split record is the
+    normal case rather than a sign of damage.
     """
     fd = kernel.scrub_read
     if fd is None:
-        return []
-    try:
-        os.set_blocking(fd, False)
-    except (AttributeError, OSError):
-        return []
-    buf = b""
+        return kernel.scrub_values
+    buf = kernel.scrub_partial
     try:
         while True:
             try:
@@ -653,7 +673,6 @@ def _drain_scrub_channel(kernel: _Kernel) -> list[str]:
             buf += chunk
     except OSError:
         pass
-    values: list[str] = []
     i = 0
     while i < len(buf):
         sep = buf.find(b"\x00", i)
@@ -662,13 +681,19 @@ def _drain_scrub_channel(kernel: _Kernel) -> list[str]:
         try:
             length = int(buf[i:sep])
         except ValueError:
+            # Framing damage: the rest of the buffer cannot be parsed against
+            # a length that is not a number. Drop it rather than resynchronise
+            # onto bytes that could split one value into scrub-resistant
+            # fragments; values already recovered stay valid.
+            i = len(buf)
             break
         end = sep + 1 + length
         if end + 1 > len(buf):
             break
-        values.append(buf[sep + 1 : end].decode("utf-8", errors="replace"))
+        kernel.scrub_values.append(buf[sep + 1 : end].decode("utf-8", errors="replace"))
         i = end + 1  # skip the trailing NUL
-    return values
+    kernel.scrub_partial = buf[i:]
+    return kernel.scrub_values
 
 
 async def _exchange(
@@ -783,10 +808,20 @@ async def _exchange(
         channel = response.get("stream")
         if channel:
             # A progress frame, not the answer: publish it and keep reading.
+            # R9: drain here too. A long-running cell that retrieves inside a
+            # loop while streaming would otherwise fill the pipe without ever
+            # reaching the per-response drain below, which is exactly the
+            # cumulative-budget shape this fix exists to remove.
+            _drain_scrub_channel(kernel)
             if on_stream is not None:
                 with contextlib.suppress(Exception):
                     on_stream(str(channel), str(response.get("text") or ""))
             continue
+        # R9: the pipe is drained on the healthy path, before returning. The
+        # worker publishes from inside `register`, which runs BEFORE the value
+        # reaches the cell, so an undrained pipe costs the crash-tail scrub
+        # (records are dropped) rather than merely delaying it.
+        _drain_scrub_channel(kernel)
         return response
 
 

--- a/local_operator/tools/eval.py
+++ b/local_operator/tools/eval.py
@@ -148,11 +148,18 @@ class _Kernel:
         process: asyncio.subprocess.Process,
         *,
         windows_job: int | None = None,
+        scrub_read: int | None = None,
     ) -> None:
         self.process = process
         # On Windows, closing this Job Object is the process-tree equivalent of
         # POSIX killpg. It is assigned before any user code can run.
         self.windows_job = windows_job
+        # R1: read end of the pipe the worker publishes its retrieved-secret
+        # values on. Held open for the kernel's life so a crash mid-cell still
+        # has the full set; closed when the kernel is retired. ``None`` on a
+        # platform where the side channel could not be set up — the crash path
+        # then scrubs nothing, which is the pre-R1 behaviour and still safe.
+        self.scrub_read = scrub_read
         self.last_used = time.monotonic()
         self.generation = uuid.uuid4().hex
 
@@ -425,6 +432,13 @@ async def _close_kernel(kernel: _Kernel) -> None:
     transport = getattr(process, "_transport", None)
     if transport is not None:
         transport.close()
+    # R1: release the scrub channel's read end with the kernel. The worker is
+    # reaped above, so no more values can arrive; leaving the fd open would
+    # leak one descriptor per retired kernel for the parent's lifetime.
+    if kernel.scrub_read is not None:
+        with contextlib.suppress(OSError):
+            os.close(kernel.scrub_read)
+        kernel.scrub_read = None
 
 
 def _retire(kernel: _Kernel) -> None:
@@ -500,6 +514,35 @@ async def _spawn(cwd: str, session_key: str = "") -> _Kernel:
     # bare interpreter when no branded image could be planted.
     from local_operator import procname
 
+    # R1: a dedicated pipe the worker publishes its retrieved-secret values on,
+    # so the parent can scrub the worker's REAL fd-2 tail on a crash. The
+    # parent owns the read end for the kernel's life; the write end is handed
+    # to the worker through the environment (``LOCAL_OPERATOR_EVAL_SCRUB_FD``)
+    # and is inheritable only for this one spawn. Setup is best-effort: a
+    # platform without ``os.pipe`` semantics leaves the channel absent and the
+    # crash path scrubs nothing — the pre-fix behaviour, still safe.
+    scrub_read: int | None = None
+    scrub_write: int | None = None
+    try:
+        scrub_read, scrub_write = os.pipe()
+        os.set_inheritable(scrub_write, True)
+        env = dict(os.environ)
+        env["LOCAL_OPERATOR_EVAL_SCRUB_FD"] = str(scrub_write)
+        spawn_options["env"] = env
+        # ``close_fds=False`` so the worker inherits the scrub-write fd; every
+        # other fd the parent holds is already non-inheritable (PEP 446), so
+        # this widens inheritance by exactly one fd and no more.
+        spawn_options["close_fds"] = False
+    except (AttributeError, OSError):
+        if scrub_read is not None:
+            with contextlib.suppress(OSError):
+                os.close(scrub_read)
+            scrub_read = None
+        if scrub_write is not None:
+            with contextlib.suppress(OSError):
+                os.close(scrub_write)
+            scrub_write = None
+
     link = procname.ensure_branded_interpreter()
     argv0 = sys.executable
     if link is not None:
@@ -539,11 +582,27 @@ async def _spawn(cwd: str, session_key: str = "") -> _Kernel:
             if transport is not None:
                 transport.close()
             raise
-    return _Kernel(process, windows_job=windows_job)
+    # The write end must not stay open in the parent once the child holds it:
+    # the crash path drains the pipe to collect the values, and an open parent
+    # write end would leave the buffer unbounded rather than drained-once.
+    if scrub_write is not None:
+        with contextlib.suppress(OSError):
+            os.close(scrub_write)
+    return _Kernel(process, windows_job=windows_job, scrub_read=scrub_read)
 
 
 async def _read_crash_stderr(kernel: _Kernel) -> str:
-    """Best-effort stderr tail from a worker that stopped answering."""
+    """Best-effort stderr tail from a worker that stopped answering.
+
+    R1: the tail is the worker's REAL fd 2, which the in-worker ``sys.stderr``
+    redirect never touches — user code (``os.write(2, ...)``, or an inherited
+    -stderr subprocess like the guide's own ``curl -v`` with a token in the
+    Authorization header) writes straight past the ledger, and a later crash
+    surfaces it raw. The values to scrub live in the worker's in-process
+    ledger, so the worker publishes each one to this process on the kernel's
+    scrub pipe at the moment of retrieval; the tail is redacted with exactly
+    that set — the SAME source as every other channel, not a second ledger.
+    """
     stream = kernel.process.stderr
     if stream is None:
         return ""
@@ -551,7 +610,65 @@ async def _read_crash_stderr(kernel: _Kernel) -> str:
         raw = await asyncio.wait_for(stream.read(), timeout=1.0)
     except (TimeoutError, ConnectionResetError):
         return ""
-    return raw.decode("utf-8", errors="replace")
+    text = raw.decode("utf-8", errors="replace")
+    values = _drain_scrub_channel(kernel)
+    if not values:
+        return text
+    # Longest first so a value that is a prefix of another cannot leak the
+    # longer one's remainder (the runtime ledger's own ordering contract).
+    for value in sorted(values, key=len, reverse=True):
+        if value:
+            text = text.replace(value, "[redacted]")
+    return text
+
+
+def _drain_scrub_channel(kernel: _Kernel) -> list[str]:
+    """Collect every value the worker published on the kernel's scrub pipe.
+
+    The pipe is framed as ``<len>\x00<bytes>\x00`` per value (see the worker's
+    ``_publish_secret_value``). A crashed worker has closed its write end, so
+    draining reads whatever it buffered; a kernel that never retrieved a secret
+    yields ``[]``. A worker spawned without the channel (``scrub_read is
+    None``) drains to ``[]``, which is the safe pre-R1 behaviour. Any framing
+    damage yields whatever whole values were recovered; a partial trailing
+    record is dropped rather than risk splitting a value into scrub-resistant
+    fragments.
+    """
+    fd = kernel.scrub_read
+    if fd is None:
+        return []
+    try:
+        os.set_blocking(fd, False)
+    except (AttributeError, OSError):
+        return []
+    buf = b""
+    try:
+        while True:
+            try:
+                chunk = os.read(fd, 65536)
+            except BlockingIOError:
+                break
+            if not chunk:
+                break
+            buf += chunk
+    except OSError:
+        pass
+    values: list[str] = []
+    i = 0
+    while i < len(buf):
+        sep = buf.find(b"\x00", i)
+        if sep < 0:
+            break
+        try:
+            length = int(buf[i:sep])
+        except ValueError:
+            break
+        end = sep + 1 + length
+        if end + 1 > len(buf):
+            break
+        values.append(buf[sep + 1 : end].decode("utf-8", errors="replace"))
+        i = end + 1  # skip the trailing NUL
+    return values
 
 
 async def _exchange(

--- a/local_operator/tools/eval_worker.py
+++ b/local_operator/tools/eval_worker.py
@@ -98,17 +98,42 @@ def _publish_secret_value(value: str) -> None:
     Called from the runtime ledger's ``register`` hook, so it fires on the
     retrieval itself — before the cell that just received the value can write
     it anywhere. Length-prefixed and NUL-terminated so the parent frames one
-    value per record across pipe-read boundaries. Best-effort: a closed or
-    absent fd must never turn a retrieval into a crash, so all failures are
-    swallowed; the parent reads what arrived and treats a short read as "no
-    values".
+    value per record across pipe-read boundaries.
+
+    R9: THE WRITE IS NON-BLOCKING, AND THAT IS THE LOAD-BEARING PROPERTY.
+    ``register`` publishes BEFORE the value reaches the caller, so anything
+    that parks here parks the retrieval itself — and a blocking ``os.write``
+    onto a full pipe does not raise, it parks forever, which no ``except``
+    can rescue. The pipe holds 64 KiB and the parent drains it between
+    exchanges, so a full pipe means one cell out-published a whole drain
+    cycle. The ranking that settles what to do then: a dropped record
+    degrades to an UNSCRUBBED CRASH TAIL for that one value, which is the
+    documented pre-R1 fallback and survivable; a blocked write degrades to a
+    dead kernel and total loss of session state, which is not. Availability
+    of the retrieval outranks completeness of the crash-tail scrub, so a
+    record that does not fit is dropped.
+
+    A record smaller than ``PIPE_BUF`` is written atomically or not at all, so
+    an ordinary token-sized value can only ever be dropped WHOLE. A larger
+    value can be cut short, which would desynchronise the parent's framing and
+    cost every LATER value too — so a short write retires the channel instead,
+    leaving the partial record as the trailing one the parent already drops.
     """
+    global _SCRUB_FD
     fd = _SCRUB_FD
     if fd is None:
         return
     try:
         data = value.encode("utf-8", errors="replace")
-        os.write(fd, str(len(data)).encode("ascii") + b"\x00" + data + b"\x00")
+        record = str(len(data)).encode("ascii") + b"\x00" + data + b"\x00"
+        written = os.write(fd, record)
+        if written != len(record):
+            # Framing is now damaged; every later record would be misparsed.
+            # Stop publishing rather than corrupt values already delivered.
+            _SCRUB_FD = None
+    except BlockingIOError:
+        # The pipe is full. Drop this record — see the ranking above.
+        pass
     except BaseException:  # noqa: BLE001 — publication must never fault a cell
         pass
 
@@ -118,7 +143,10 @@ def _install_scrub_channel() -> None:
 
     Reads ``LOCAL_OPERATOR_EVAL_SCRUB_FD`` once. The fd is inherited from the
     parent; it is made non-inheritable so a grandchild process cannot hold it
-    open and stall the parent's read at the crash path.
+    open and stall the parent's read at the crash path, and NON-BLOCKING so a
+    full pipe can never park a retrieval (R9 — see ``_publish_secret_value``).
+    Both are required: if the non-blocking mode cannot be set, the channel is
+    left absent rather than run in a mode that can wedge the kernel.
     """
     global _SCRUB_FD
     raw = os.environ.pop(_SCRUB_FD_ENV, None)
@@ -130,7 +158,8 @@ def _install_scrub_channel() -> None:
         return
     try:
         os.set_inheritable(fd, False)
-    except OSError:
+        os.set_blocking(fd, False)
+    except (AttributeError, OSError):
         return
     _SCRUB_FD = fd
     # Lazy: the runtime module is only present once the worker has imported it

--- a/local_operator/tools/eval_worker.py
+++ b/local_operator/tools/eval_worker.py
@@ -393,20 +393,70 @@ State SURVIVES across calls: variables, imports and functions defined in one
 call are still present in the next. The kernel runs in the session's working
 directory. Use display(value) to show a value to the USER only — it is never
 added to the model's context.
+
+secrets["NAME"] retrieves a stored secret from the encrypted long-term store
+(`lop secret list` names them). The value stays in this process: it is scrubbed
+out of stdout, stderr, display and the cell's result, so use it directly in the
+call that needs it and never print it. `import secrets` still gets the stdlib
+module, as usual.
 """
 
 
+def _scrub_secrets(text: str) -> str:
+    """Strip values retrieved through ``local_operator.secrets`` out of ``text``.
+
+    The §6 sink for the eval surface. A cell that fetches a secret through the
+    library (design §5.3) holds real bytes in the worker; this is what keeps
+    them from riding stdout, stderr, a trailing expression, a ``display`` item
+    or a streaming frame into the model's transcript.
+
+    **Checked through ``sys.modules`` rather than imported.** This function is
+    on the path of EVERY cell in every kernel, and the secrets runtime pulls
+    SQLite and the AES binding behind it. A worker that never touched a secret
+    must not pay that import. The check is also exactly correct rather than
+    merely cheap: if the module was never imported, nothing obtained a value
+    through it, so there is provably nothing to scrub.
+
+    Failure here is swallowed on purpose — but it FAILS CLOSED. A scrubber that
+    raised would surface as a broken cell, and a scrubber that silently
+    returned the input would publish the secret. So an unexpected failure drops
+    the text entirely and says why, because losing output is recoverable (re-run
+    the cell) and leaking a credential is not.
+    """
+    if not text:
+        return text
+    runtime = sys.modules.get("local_operator.secrets.runtime")
+    if runtime is None:
+        return text
+    try:
+        scrubbed = runtime.scrub(text)
+    except BaseException:  # noqa: BLE001 — see the fail-closed note above
+        return (
+            "[output withheld: the secret redaction filter failed, and this worker "
+            "has retrieved at least one secret value. Re-run the cell.]"
+        )
+    return scrubbed if isinstance(scrubbed, str) else text
+
+
 def _safe_repr(value: Any) -> str:
-    """``repr(value)`` that cannot raise.
+    """``repr(value)`` that cannot raise, with retrieved secrets scrubbed.
 
     A user-defined ``__repr__`` is arbitrary code; one that raises would turn
     a successful computation into a lost result, so the failure is reported
     in-band instead.
+
+    The scrub covers the case :class:`~local_operator.secrets.runtime.\
+SecretValue`'s own ``__repr__`` cannot: a secret nested inside a container,
+    whose repr is built by the CONTAINER (``[token]`` renders through
+    ``list.__repr__``, which calls ``repr`` on the element — that one is
+    covered — but ``"".join`` or an f-string inside a user ``__repr__`` is
+    not). Scrubbing the finished string catches every route at one point.
     """
     try:
-        return _REPR.repr(value)
+        rendered = _REPR.repr(value)
     except BaseException as exc:  # noqa: BLE001 — user code, any failure is data
-        return f"<unrepresentable result: {type(exc).__name__}: {exc}>"
+        rendered = f"<unrepresentable result: {type(exc).__name__}: {exc}>"
+    return _scrub_secrets(rendered)
 
 
 def _make_display(sink: _DisplaySink) -> Callable[..., None]:
@@ -504,11 +554,18 @@ class _StreamingTextIO(_CappedTextIO):
     def write(self, value: str) -> int:
         written = super().write(value)
         if value:
+            # SCRUBBED HERE TOO, not only in the final response. A streaming
+            # frame reaches `jobs(op='peek')` and the live card while the cell
+            # is still running, so a secret printed by a long-running cell
+            # would paint in the live view for as long as the cell ran even
+            # though the final response redacted it. Same hole as the bash
+            # pipe filter, same fix.
+            #
             # A failure to emit must never break the user's code, which is what
             # an exception raised inside ``print`` would do. The frame is
             # advisory; the authoritative copy rides the final response.
             with contextlib.suppress(Exception):
-                self._emit(value)
+                self._emit(_scrub_secrets(value))
         return written
 
 
@@ -563,14 +620,22 @@ def _handle(namespace: dict[str, Any], request: dict[str, Any]) -> dict[str, Any
         # Background threads left behind by arbitrary Python code cannot issue
         # tool calls between cells using an expired turn's authority.
         _ACTIVE_BRIDGE = ("", False)
+    # EVERY model-visible channel of the response passes the secret scrubber,
+    # at the single point where the response is assembled rather than at each
+    # producer. `result` is already scrubbed by `_safe_repr`; it is re-scrubbed
+    # here anyway because this choke point is the invariant ("nothing leaves
+    # the worker unscrubbed") and a second pass over a redacted string is a
+    # no-op. `error` matters as much as `stdout`: a traceback renders the
+    # arguments of the failing frame, so a request that fails WITH a secret in
+    # scope puts it in the error text.
     return {
         "id": request.get("id", ""),
         "ok": ok,
-        "stdout": stdout.getvalue(),
-        "stderr": stderr.getvalue(),
-        "error": error,
-        "result": result,
-        "display": display_sink.finish(),
+        "stdout": _scrub_secrets(stdout.getvalue()),
+        "stderr": _scrub_secrets(stderr.getvalue()),
+        "error": _scrub_secrets(error) if error is not None else None,
+        "result": _scrub_secrets(result) if result is not None else None,
+        "display": [_scrub_secrets(item) for item in display_sink.finish()],
     }
 
 
@@ -597,6 +662,62 @@ def _enable_cwd_imports() -> None:
         sys.path.append(cwd)
 
 
+class _LazySecrets:
+    """``secrets`` in the cell namespace, importing the store on FIRST USE.
+
+    Bound into every kernel's namespace so a cell can write ``secrets["NAME"]``
+    with no import line, while a kernel that never asks for a secret never
+    loads SQLite or the AES binding — the import this proxy exists to defer.
+    That deferral is also what keeps :func:`_scrub_secrets`'s ``sys.modules``
+    check honest: the runtime module appears there exactly when a lookup has
+    been attempted.
+
+    Only the mapping operations are forwarded, and each one re-resolves through
+    the real object rather than caching it, so this stays a thin alias for
+    ``local_operator.secrets.secrets`` instead of a second implementation that
+    could drift from it.
+
+    **It shadows the stdlib ``secrets`` module, and that is survivable rather
+    than accidental.** The name comes from design §5.3. A cell that wants
+    ``secrets.token_hex()`` writes ``import secrets`` first, which REBINDS the
+    name in this namespace to the stdlib module for the rest of the kernel's
+    life — the ordinary Python behaviour, unaffected by the pre-binding. The
+    only case the pre-binding changes is a cell that used ``secrets.token_hex``
+    with no import at all, which raised ``NameError`` before and now raises
+    ``AttributeError``: a different message for code that was already broken.
+    """
+
+    __slots__ = ()
+
+    def _target(self) -> Any:
+        from local_operator.secrets.runtime import secrets as target
+
+        return target
+
+    def __getitem__(self, name: str) -> Any:
+        return self._target()[name]
+
+    def get(self, name: str, default: Any = None) -> Any:
+        return self._target().get(name, default)
+
+    def __contains__(self, name: object) -> bool:
+        return name in self._target()
+
+    def __iter__(self) -> Any:
+        return iter(self._target())
+
+    def __len__(self) -> int:
+        return len(self._target())
+
+    def keys(self) -> Any:
+        return self._target().keys()
+
+    def __repr__(self) -> str:
+        # Does not resolve the target: a repr must not import the crypto stack
+        # (nor touch the store) just because a traceback rendered the namespace.
+        return "<local_operator secrets: secrets['NAME'] retrieves one value>"
+
+
 def main() -> None:
     """Read requests, run them, answer — until stdin closes or the tool kills
     the process. Either ending is normal from this side: the tool owns the
@@ -605,6 +726,9 @@ def main() -> None:
     namespace: dict[str, Any] = {
         "__name__": "__eval__",
         "__doc__": NAMESPACE_DOC,
+        # Pre-bound so the documented form works with no import line; see
+        # _LazySecrets for why this is a proxy rather than the real mapping.
+        "secrets": _LazySecrets(),
     }
     for line in sys.stdin:
         line = line.strip()

--- a/local_operator/tools/eval_worker.py
+++ b/local_operator/tools/eval_worker.py
@@ -79,6 +79,74 @@ TRUNCATED_MARKER = "\n[…worker output truncated before protocol serialization]
 _PROTOCOL_OUT = sys.stdout
 _PROTOCOL_IN = sys.stdin
 
+#: R1. The parent's crash path must scrub the worker's REAL fd-2 tail, but the
+#: values live in this process's ledger, unreachable across the boundary. The
+#: worker publishes each value to the parent on a dedicated fd at the moment of
+#: registration, so the parent's scrub set is byte-identical to the ledger the
+#: other channels use rather than a second, divergent record — the exact shape
+#: of the original pipe bug. ``None`` until the parent spawns us with the fd
+#: (``LOCAL_OPERATOR_EVAL_SCRUB_FD``); a worker started without it publishes
+#: nothing, leaving the parent's crash path with an empty set, which is the
+#: pre-R1 behaviour and still fails safe.
+_SCRUB_FD_ENV = "LOCAL_OPERATOR_EVAL_SCRUB_FD"
+_SCRUB_FD: "int | None" = None
+
+
+def _publish_secret_value(value: str) -> None:
+    """Write one newly retrieved value to the parent's scrub channel.
+
+    Called from the runtime ledger's ``register`` hook, so it fires on the
+    retrieval itself — before the cell that just received the value can write
+    it anywhere. Length-prefixed and NUL-terminated so the parent frames one
+    value per record across pipe-read boundaries. Best-effort: a closed or
+    absent fd must never turn a retrieval into a crash, so all failures are
+    swallowed; the parent reads what arrived and treats a short read as "no
+    values".
+    """
+    fd = _SCRUB_FD
+    if fd is None:
+        return
+    try:
+        data = value.encode("utf-8", errors="replace")
+        os.write(fd, str(len(data)).encode("ascii") + b"\x00" + data + b"\x00")
+    except BaseException:  # noqa: BLE001 — publication must never fault a cell
+        pass
+
+
+def _install_scrub_channel() -> None:
+    """Resolve the side-channel fd and register the publish hook.
+
+    Reads ``LOCAL_OPERATOR_EVAL_SCRUB_FD`` once. The fd is inherited from the
+    parent; it is made non-inheritable so a grandchild process cannot hold it
+    open and stall the parent's read at the crash path.
+    """
+    global _SCRUB_FD
+    raw = os.environ.pop(_SCRUB_FD_ENV, None)
+    if raw is None:
+        return
+    try:
+        fd = int(raw)
+    except ValueError:
+        return
+    try:
+        os.set_inheritable(fd, False)
+    except OSError:
+        return
+    _SCRUB_FD = fd
+    # Lazy: the runtime module is only present once the worker has imported it
+    # (on first secret use). Deferring the import to ``main()`` keeps the crypto
+    # stack off the startup path of a worker that never touches a secret — the
+    # same ``sys.modules`` deferral ``_scrub_secrets`` is built around. The hook
+    # is inert until then because registration is the only thing that triggers
+    # publication.
+    try:
+        import local_operator.secrets.runtime as runtime
+
+        runtime.set_publish_hook(_publish_secret_value)
+    except BaseException:  # noqa: BLE001
+        pass
+
+
 # A worker can ask the parent to execute a harness tool, but cannot grant
 # itself one. The parent resolves only the current session's available or
 # explicitly discovered tools and repeats normal validation/approval. Keeping
@@ -435,7 +503,20 @@ def _scrub_secrets(text: str) -> str:
             "[output withheld: the secret redaction filter failed, and this worker "
             "has retrieved at least one secret value. Re-run the cell.]"
         )
-    return scrubbed if isinstance(scrubbed, str) else text
+    # R6: the scrubber's contract is "return a scrubbed string". Anything else
+    # (a broken store returning a non-str) is an unexpected failure, and the
+    # fail-closed rule above applies to it exactly as it does to a raise —
+    # publishing ``text`` unscrubbed here would be the leak the guard exists
+    # to stop.
+    return (
+        scrubbed
+        if isinstance(scrubbed, str)
+        else (
+            "[output withheld: the secret redaction filter returned an unexpected "
+            "result, and this worker has retrieved at least one secret value. "
+            "Re-run the cell.]"
+        )
+    )
 
 
 def _safe_repr(value: Any) -> str:
@@ -723,6 +804,7 @@ def main() -> None:
     the process. Either ending is normal from this side: the tool owns the
     lifecycle (idle reaping, LRU eviction, timeout kill)."""
     _enable_cwd_imports()
+    _install_scrub_channel()
     namespace: dict[str, Any] = {
         "__name__": "__eval__",
         "__doc__": NAMESPACE_DOC,

--- a/local_operator/tools/registry.py
+++ b/local_operator/tools/registry.py
@@ -19,6 +19,7 @@ from local_operator.tools import builtin
 from local_operator.tools.agent_tool import build_agent_tool
 from local_operator.tools.eval import build_eval_tool
 from local_operator.tools.lsp import build_lsp_tool
+from local_operator.tools.secret_tool import build_secret_tool
 from local_operator.tools.team_tool import build_team_delete_tool, build_team_tool
 from local_operator.web_fetch.tool import build_web_fetch_tool
 from local_operator.web_search.tool import build_web_search_tool
@@ -49,6 +50,9 @@ TOOL_BUILDERS: dict[str, Callable[[ToolContext], AgentTool | None]] = {
     # when no peer happens to be running right now (see build_send_tool).
     "send": lambda context: builtin.build_send_tool(context),
     "ask": lambda context: builtin.build_ask_tool(context),
+    # createIf: returns None where the encrypted secret store is unreachable,
+    # so a session that cannot use it pays no schema for it (design §5.2).
+    "secret": lambda context: build_secret_tool(context),
     "list_variables": lambda _context: builtin.build_list_variables_tool(),
     "read_variable": lambda _context: builtin.build_read_variable_tool(),
     "browser": lambda _context: builtin.build_browser_tool(_context),
@@ -80,6 +84,7 @@ DEFAULT_TOOL_NAMES: list[str] = [
     "hub",
     "send",
     "ask",
+    "secret",
     "list_variables",
     "read_variable",
     "browser",

--- a/local_operator/tools/secret_tool.py
+++ b/local_operator/tools/secret_tool.py
@@ -96,17 +96,15 @@ def build_secret_tool(context: ToolContext) -> AgentTool | None:
     """CreateIf builder: exists only where a secret store is actually reachable.
 
     Gated on REACHABILITY, which is what ``AGENTS.md`` says a ``createIf``
-    factory may ask. Two conditions, and both are about the dependency rather
-    than about which host spawned the session:
-
-    * the storage stack imports (a source checkout without the optional crypto
-      dependency installed must not advertise a tool whose every call errors),
-      and
-    * a store already exists on disk, OR one could be created.
-
-    The second is deliberately permissive: ``store`` is the verb that CREATES
-    the store, so gating on "a store already exists" would make the first
-    secret unstorable through the tool and leave the agent no way in.
+    factory may ask. R5: the gate is IMPORTS ONLY. The storage stack must
+    import (a source checkout without the optional crypto dependency installed
+    must not advertise a tool whose every call errors), and that is the whole
+    check — there is deliberately NO disk condition. ``store`` is the verb that
+    CREATES the store, so gating on "a store already exists" would make the
+    first secret unstorable through the tool and leave the agent no way in.
+    The consequence, worth naming rather than leaving a reader hunting for a
+    check that is not there: on a read-only config dir the tool still appears
+    and every verb errors per-call at the store layer.
     """
     del context  # gating is on the machine's store, not on session state
     try:

--- a/local_operator/tools/secret_tool.py
+++ b/local_operator/tools/secret_tool.py
@@ -61,50 +61,34 @@ class SecretParams(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     op: Literal["store", "retrieve", "list", "describe", "update", "delete"] = Field(
-        description=(
-            "store: persist a new secret; retrieve: make an existing one usable "
-            "(never returns the value); list: names and descriptions; describe: "
-            "metadata for one; update: replace a value; delete: remove permanently."
-        )
+        description="retrieve makes a secret usable without returning its value."
     )
-    name: str | None = Field(
-        default=None,
-        description="Secret name, e.g. GITHUB_TOKEN. Required for every op except list.",
-    )
+    name: str | None = Field(default=None, description="Secret name; required except for list.")
     value: str | None = Field(
-        default=None,
-        description=(
-            "The secret itself (store/update only). Supply this ONLY when you already "
-            "hold the value legitimately — a token you just minted, or one the user "
-            "handed you. Never invent one, and never read a value out of a file just "
-            "to pass it here."
-        ),
+        default=None, description="The secret (store/update). Only a value you already hold."
     )
     description: str | None = Field(
-        default=None,
-        description="What this secret is for; shown in list/describe. Never secret itself.",
+        default=None, description="What it is for; shown in list. Not secret."
     )
 
 
-#: The tool description IS the interface: it is the only guidance the model
-#: reliably reads, so it states WHEN to reach for this, not just what it does.
+#: The tool description IS the interface — the only guidance a model reliably
+#: reads — so it states WHEN to reach for this, not merely what it does. It is
+#: also schema that ships on EVERY request in every session and subagent (the
+#: footprint ladder), so each clause has to earn its tokens: "store it as soon
+#: as you get one" and "retrieve NEVER returns the value" change behaviour and
+#: stay; the rationale behind them lives in `guide://credentials`, which costs
+#: nothing until it is read.
 _DESCRIPTION = (
-    "Persist and use long-term secrets from the operator's encrypted store "
-    "(the same store as `lop secret`). "
-    "Reach for it the moment you obtain a credential that will be needed again "
-    "after this session — an API token you just created, a key the user pasted, "
-    "a password a setup step produced: `store` it here rather than leaving it in "
-    "a plaintext .env, a note, or only in this conversation. Storing is your "
-    "decision to make. "
-    "`retrieve` before using a secret in a command: it confirms the secret exists "
-    "and tells you how to reach it, but NEVER returns the value — you use secrets "
-    'without reading them, via $(lop secret get NAME) in bash or secrets["NAME"] '
-    "in eval. `list` to see what is already stored before asking the user for "
-    "something they have already given you. "
-    "Do NOT store: anything the user asked you not to keep, a value you only need "
-    "for one command, or provider API keys the harness already manages. "
-    "Read guide://credentials before your first store, and never echo a secret, "
-    "write it to a file, or put it in a commit or a PR."
+    "Store and use long-term secrets in the operator's encrypted store (same store as "
+    "`lop secret`). Store a credential as soon as you get one that outlives this session "
+    "— a token you minted, a key the user pasted — rather than a plaintext .env or only "
+    "this conversation; that is your decision to make. retrieve NEVER returns the value: "
+    "use secrets without reading them, via $(lop secret get NAME) in bash or "
+    'secrets["NAME"] in eval. list before asking the user for something they already '
+    "gave you. Do not store a one-off value or provider keys the harness manages. Never "
+    "echo a secret, write it to a file, or put it in a commit or PR. "
+    "See guide://credentials."
 )
 
 

--- a/local_operator/tools/secret_tool.py
+++ b/local_operator/tools/secret_tool.py
@@ -1,0 +1,307 @@
+"""The ``secret`` agent tool — one createIf-gated verb tool (design §5.2).
+
+**Why one tool and not six.** ``AGENTS.md``'s tool-surface footprint ladder is
+explicit: every core tool's schema rides in the same prompt-cache prefix as the
+system prompt, on every request, in every session and every subagent, whether
+or not it is ever called. Six tools (``secret_store``, ``secret_retrieve``, …)
+would be six schemas of permanent tax. One tool with an ``op`` parameter is a
+fraction of that, and this is rung 3 rather than rung 5 because the builder
+returns ``None`` when no store is reachable — a session that cannot use it pays
+nothing at all. The CLI (``lop secret``, rung 2) remains the PRIMARY surface
+and carries the full verb set including rotation and hardening; this tool
+carries only what an agent decides in the middle of a task.
+
+**``retrieve`` does not return the value.** It returns a receipt naming the
+secret and stating how to USE it — ``$(lop secret get NAME)`` in bash,
+``secrets["NAME"]`` in eval. That inversion is the same one the session
+credential path already implements (``variables.py``): the agent uses a secret
+it cannot read. Returning the bytes here would write them straight into the
+transcript, which is persisted and replayed to the provider on every
+subsequent turn — the single worst outcome this whole design exists to prevent.
+
+**``store`` is the verb that makes persistence a decision the agent makes**,
+which is what the operator asked for. Guidance lives in ``guide://credentials``
+and the tool description points at it.
+
+**Residual risk is not overclaimed here or in the description** (design §9):
+this store raises the cost of credential theft a great deal against the
+scan-the-disk malware that a bad link actually drops, and it is not a vault.
+Anything running as the operator that is willing to run ``lop`` can read these
+values.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from local_operator.harness.types import AbortSignal, AgentTool, ToolContext, ToolResult
+
+logger = logging.getLogger(__name__)
+
+#: What the model is told after a successful ``retrieve``. Written as an
+#: instruction rather than a description because it is the only place an agent
+#: learns HOW to use a secret it just proved exists, and a receipt that only
+#: says "ok" invites a retry with a different verb looking for the value.
+_USE_HINT = (
+    "The value is NOT shown here and never will be. Use it without reading it:\n"
+    "  bash:  interpolate it directly into the command that needs it, e.g.\n"
+    '         curl -H "Authorization: Bearer $(lop secret get {name})" ...\n'
+    '  eval:  secrets["{name}"] returns the value inside the worker process.\n'
+    "Never echo it, assign-and-print it, write it to a file, or paste it into "
+    "a commit, a PR or a message."
+)
+
+
+class SecretParams(BaseModel):
+    """Arguments for the ``secret`` tool. One model, ``op`` selects the verb."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    op: Literal["store", "retrieve", "list", "describe", "update", "delete"] = Field(
+        description=(
+            "store: persist a new secret; retrieve: make an existing one usable "
+            "(never returns the value); list: names and descriptions; describe: "
+            "metadata for one; update: replace a value; delete: remove permanently."
+        )
+    )
+    name: str | None = Field(
+        default=None,
+        description="Secret name, e.g. GITHUB_TOKEN. Required for every op except list.",
+    )
+    value: str | None = Field(
+        default=None,
+        description=(
+            "The secret itself (store/update only). Supply this ONLY when you already "
+            "hold the value legitimately — a token you just minted, or one the user "
+            "handed you. Never invent one, and never read a value out of a file just "
+            "to pass it here."
+        ),
+    )
+    description: str | None = Field(
+        default=None,
+        description="What this secret is for; shown in list/describe. Never secret itself.",
+    )
+
+
+#: The tool description IS the interface: it is the only guidance the model
+#: reliably reads, so it states WHEN to reach for this, not just what it does.
+_DESCRIPTION = (
+    "Persist and use long-term secrets from the operator's encrypted store "
+    "(the same store as `lop secret`). "
+    "Reach for it the moment you obtain a credential that will be needed again "
+    "after this session — an API token you just created, a key the user pasted, "
+    "a password a setup step produced: `store` it here rather than leaving it in "
+    "a plaintext .env, a note, or only in this conversation. Storing is your "
+    "decision to make. "
+    "`retrieve` before using a secret in a command: it confirms the secret exists "
+    "and tells you how to reach it, but NEVER returns the value — you use secrets "
+    'without reading them, via $(lop secret get NAME) in bash or secrets["NAME"] '
+    "in eval. `list` to see what is already stored before asking the user for "
+    "something they have already given you. "
+    "Do NOT store: anything the user asked you not to keep, a value you only need "
+    "for one command, or provider API keys the harness already manages. "
+    "Read guide://credentials before your first store, and never echo a secret, "
+    "write it to a file, or put it in a commit or a PR."
+)
+
+
+def build_secret_tool(context: ToolContext) -> AgentTool | None:
+    """CreateIf builder: exists only where a secret store is actually reachable.
+
+    Gated on REACHABILITY, which is what ``AGENTS.md`` says a ``createIf``
+    factory may ask. Two conditions, and both are about the dependency rather
+    than about which host spawned the session:
+
+    * the storage stack imports (a source checkout without the optional crypto
+      dependency installed must not advertise a tool whose every call errors),
+      and
+    * a store already exists on disk, OR one could be created.
+
+    The second is deliberately permissive: ``store`` is the verb that CREATES
+    the store, so gating on "a store already exists" would make the first
+    secret unstorable through the tool and leave the agent no way in.
+    """
+    del context  # gating is on the machine's store, not on session state
+    try:
+        from local_operator.secrets import keys  # noqa: F401
+        from local_operator.secrets.access import open_store  # noqa: F401
+    except Exception:
+        # The crypto stack is an optional-in-practice dependency; a tree where
+        # it will not import must not carry a tool that can only fail.
+        logger.debug("secret tool unavailable: store modules will not import", exc_info=True)
+        return None
+    return AgentTool(
+        name="secret",
+        label="Secret",
+        description=_DESCRIPTION,
+        parameters=SecretParams.model_json_schema(),
+        # write tier: store/update/delete mutate a durable, encrypted store the
+        # operator owns, and `delete` is irreversible — the value is kept
+        # nowhere else. `retrieve` is a read, but the approval tier is per tool
+        # rather than per verb and the safe direction is to prompt.
+        approval_tier="write",
+        # Exclusive: the verbs open the same SQLite store and `rotate` (through
+        # the CLI) re-seals every record. WAL handles concurrent readers, but
+        # two writes racing from one session is a self-inflicted conflict with
+        # no benefit.
+        concurrency="exclusive",
+        interruptible=False,
+        execute=execute_secret,
+    )
+
+
+def _receipt(name: str) -> str:
+    return _USE_HINT.format(name=name)
+
+
+async def execute_secret(
+    tool_call_id: str,
+    args: dict[str, Any],
+    signal: AbortSignal | None = None,
+    on_update: Any = None,
+    context: ToolContext | None = None,
+) -> ToolResult:
+    """Dispatch one ``secret`` verb against the encrypted store."""
+    from local_operator.tools.builtin import _error, _text
+
+    del signal, on_update
+    try:
+        params = SecretParams(**args)
+    except ValidationError as exc:
+        from local_operator.tools.builtin import _validation_error
+
+        return _validation_error(tool_call_id, "secret", exc)
+
+    from local_operator.secrets.access import open_store, session_id
+    from local_operator.secrets.errors import SecretStoreError
+
+    if params.op != "list" and not (params.name or "").strip():
+        return _error(tool_call_id, "secret", f"'{params.op}' requires a secret name.")
+    name = (params.name or "").strip()
+
+    from local_operator.secrets.keys import store_path
+
+    if params.op == "list" and not store_path().exists():
+        # "Nothing stored yet" rather than an error. `list` is the verb an
+        # agent uses to ORIENT — the guidance tells it to check what exists
+        # before asking the user for a credential they already gave — and an
+        # error here reads as "the store is broken" and invites a retry, when
+        # the true and actionable answer is that this machine has no secrets
+        # yet. Every other verb still reports the absent store, because for
+        # them it is genuinely the reason they could not do the job.
+        return _text(
+            tool_call_id,
+            "secret",
+            "No secrets are stored on this machine yet. Use op='store' to add the first.",
+            details={"op": "list", "count": 0},
+        )
+
+    try:
+        # `create=True` only for the verb that legitimately creates a store.
+        # A `retrieve` against a store that does not exist must say so rather
+        # than initialise an empty one and then report the secret missing —
+        # two different problems with two different fixes (the same reasoning
+        # `access.open_store` documents for the CLI).
+        store = open_store(create=params.op == "store")
+        if params.op == "store":
+            if not (params.value or "").strip():
+                return _error(
+                    tool_call_id,
+                    "secret",
+                    "'store' needs the value. If you do not have it, ask the user for it "
+                    "with the ask tool (secret=true) instead of guessing.",
+                )
+            # `set` initializes the store itself, so the first `store` verb on
+            # a machine with no store creates one.
+            store.set(
+                name,
+                (params.value or "").encode("utf-8"),
+                description=(params.description or "").strip(),
+                session_id=session_id(),
+            )
+            return _text(
+                tool_call_id,
+                "secret",
+                f"Stored {name} in the encrypted long-term store.\n{_receipt(name)}",
+                details={"op": "store", "name": name},
+            )
+        if params.op == "update":
+            if not (params.value or "").strip():
+                return _error(tool_call_id, "secret", "'update' needs the replacement value.")
+            store.update(
+                name,
+                (params.value or "").encode("utf-8"),
+                description=params.description,
+                session_id=session_id(),
+            )
+            return _text(
+                tool_call_id,
+                "secret",
+                f"Updated {name}.\n{_receipt(name)}",
+                details={"op": "update", "name": name},
+            )
+        if params.op == "retrieve":
+            # `describe`, NOT `get`. The value is not returned, so fetching it
+            # would move plaintext into this process and write a `get` audit
+            # row for a retrieval that never handed out a byte — misreporting
+            # the one trail the operator relies on. Existence is the whole
+            # question this verb answers.
+            record = store.describe(name)
+            summary = f"{record.name} is stored"
+            if record.description:
+                summary += f" — {record.description}"
+            return _text(
+                tool_call_id,
+                "secret",
+                f"{summary}.\n{_receipt(record.name)}",
+                details={"op": "retrieve", "name": record.name},
+            )
+        if params.op == "describe":
+            record = store.describe(name)
+            lines = [
+                f"name: {record.name}",
+                f"kind: {record.kind}",
+                f"description: {record.description or '(none)'}",
+            ]
+            return _text(
+                tool_call_id,
+                "secret",
+                "\n".join(lines),
+                details={"op": "describe", "name": record.name},
+            )
+        if params.op == "delete":
+            store.delete(name, session_id=session_id())
+            return _text(
+                tool_call_id,
+                "secret",
+                f"Deleted {name}. The value is not recoverable.",
+                details={"op": "delete", "name": name},
+            )
+        records = store.list()
+        if not records:
+            return _text(
+                tool_call_id,
+                "secret",
+                "No secrets are stored yet.",
+                details={"op": "list", "count": 0},
+            )
+        width = max(len(record.name) for record in records)
+        rows = [
+            f"  {record.name.ljust(width)}  {record.description or ''}".rstrip()
+            for record in records
+        ]
+        return _text(
+            tool_call_id,
+            "secret",
+            "\n".join([f"{len(records)} stored secret(s) — names only, never values:", *rows]),
+            details={"op": "list", "count": len(records)},
+        )
+    except SecretStoreError as exc:
+        # Every store failure carries a message written for a human at a
+        # terminal; passing it through verbatim is what lets the model act on
+        # it (missing secret, damaged record, store written by a newer runtime,
+        # broker down) instead of retrying blindly.
+        return _error(tool_call_id, "secret", str(exc))

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -28247,6 +28247,16 @@ class OperatorApp(App[None]):
             self._journal_credential_change(parsed.key, action="forgot")
             notice(format_credential_forget(removed, parsed.key))
             return
+        if parsed.action == "persist":
+            # §5.4's promotion route: the credential STAYS in session memory
+            # (every bash command in flight still reads it) and is additionally
+            # written to the encrypted long-term store. Synchronous because the
+            # write is a few ms of local SQLite and the operator is waiting at
+            # the composer to hear whether their secret is durable now.
+            from local_operator.secrets.promote import promote_session_credential
+
+            notice(promote_session_credential(store, parsed.key).message)
+            return
         if parsed.action == "forget-all":
             # Snapshot the names BEFORE the clear: clear_credentials() empties
             # the store, so iterating credential_names() after it reads an
@@ -28374,6 +28384,17 @@ class OperatorApp(App[None]):
             if _refused(answer):
                 return
             self._notice(format_credential_forget_all(int(answer.get("count") or 0)))
+            return
+        if parsed.action == "persist":
+            # Runs on the OWNER, like every other verb here: the session store
+            # holding the value is the owner's, and so is the config dir the
+            # long-term store lives in. A viewer promoting into its OWN store
+            # would write the secret to the wrong machine's disk.
+            answer = await route("persist", parsed.key)
+            if _refused(answer):
+                return
+            kind: NoticeKind = "info" if answer.get("promoted") else "warning"
+            self._notice(str(answer.get("message") or ""), kind)
             return
         value = await self._request_login_key(
             parsed.key, secret=True, sole_path=True, credential=True

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -28253,9 +28253,11 @@ class OperatorApp(App[None]):
             # written to the encrypted long-term store. Synchronous because the
             # write is a few ms of local SQLite and the operator is waiting at
             # the composer to hear whether their secret is durable now.
-            from local_operator.secrets.promote import promote_session_credential
+            from local_operator.secrets.promote import (
+                promote_session_credential_guarded,
+            )
 
-            notice(promote_session_credential(store, parsed.key).message)
+            notice(promote_session_credential_guarded(store, parsed.key).message)
             return
         if parsed.action == "forget-all":
             # Snapshot the names BEFORE the clear: clear_credentials() empties

--- a/local_operator/variables.py
+++ b/local_operator/variables.py
@@ -117,7 +117,7 @@ def describe_store_failure(reason: CredentialStoreFailure, key: str) -> str:
 class CredentialCommand:
     """What ``/credential <args>`` asked for."""
 
-    action: Literal["list", "store", "forget", "forget-all", "error"]
+    action: Literal["list", "store", "forget", "forget-all", "persist", "error"]
     key: str = ""
     message: str = ""
 
@@ -125,6 +125,7 @@ class CredentialCommand:
 CREDENTIAL_USAGE = (
     "Usage: /credential <KEY>\n"
     "       /credential                # list\n"
+    "       /credential --persist <KEY>  # also save to the encrypted long-term store\n"
     "       /credential --forget <KEY>\n"
     "       /credential --forget-all"
 )
@@ -145,6 +146,17 @@ def parse_credential_command(args: str) -> CredentialCommand:
         if key is None:
             return CredentialCommand("error", message=f"Not a usable credential key: {rest}")
         return CredentialCommand("forget", key=key)
+    if trimmed.startswith("--persist"):
+        # Design §5.4: the session path is unchanged and GAINS a route. The
+        # credential named here stays in session memory and is additionally
+        # written to the encrypted long-term store.
+        rest = trimmed[len("--persist") :].strip()
+        if not rest:
+            return CredentialCommand("error", message=f"Missing key. {CREDENTIAL_USAGE}")
+        key = normalize_credential_key(rest)
+        if key is None:
+            return CredentialCommand("error", message=f"Not a usable credential key: {rest}")
+        return CredentialCommand("persist", key=key)
     if trimmed.startswith("-"):
         option = trimmed.split()[0]
         return CredentialCommand("error", message=f"Unknown option: {option}. {CREDENTIAL_USAGE}")

--- a/scripts/bench_context_budget.py
+++ b/scripts/bench_context_budget.py
@@ -95,7 +95,22 @@ CHARS_PER_BILLED_TOKEN = 2.78
 #:
 #: Measured on the full 24-tool surface (see ``real_tool_surface``); on
 #: ``origin/main`` with this same script the figure was 31,100.
-BUDGET_BILLED_TOKENS = 26_500
+#:
+#: RAISED 26,500 -> 27,250 for the 25th tool, ``secret`` (design §5.2), with the
+#: numbers rather than a wave of the hand: ``origin/main`` measured 26,492 (8
+#: tokens of headroom — the ceiling was already at its limit), and the tool as
+#: first written cost 828 billed tokens. That is what the ladder means by
+#: "measure it": the schema was then cut to **556** by moving the rationale out
+#: of the field descriptions and into ``guide://credentials``, which is read on
+#: demand and costs nothing until it is. Verbs were NOT split into separate
+#: tools for the same reason — six schemas instead of one.
+#:
+#: The remaining 556 is the price of the capability and is paid only where it
+#: is usable: ``build_secret_tool`` is a createIf factory that returns ``None``
+#: when the store modules will not import, so a session that cannot reach a
+#: store carries no schema for it. The new ceiling keeps the same ~2% headroom
+#: the comment below describes, and the next context reduction tightens it.
+BUDGET_BILLED_TOKENS = 27_250
 
 #: How much slack is allowed before the guard demands the ratchet be TIGHTENED.
 #:

--- a/scripts/bench_context_budget.py
+++ b/scripts/bench_context_budget.py
@@ -108,8 +108,12 @@ CHARS_PER_BILLED_TOKEN = 2.78
 #: The remaining 556 is the price of the capability and is paid only where it
 #: is usable: ``build_secret_tool`` is a createIf factory that returns ``None``
 #: when the store modules will not import, so a session that cannot reach a
-#: store carries no schema for it. The new ceiling keeps the same ~2% headroom
-#: the comment below describes, and the next context reduction tightens it.
+#: store carries no schema for it. R7: the branch measures 27,201, which is
+#: main's 26,492 + ~709 — the tool's 556 plus ~150 from the ask ``persist``
+#: schema growth, the registry inventory line and the guide's own row, so the
+#: arithmetic closes without re-measuring. Headroom at 27,250 is 49 tokens
+#: (~0.2% — tighter than the ~2% this comment's sibling describes, in the safe
+#: direction), and the next context reduction tightens it.
 BUDGET_BILLED_TOKENS = 27_250
 
 #: How much slack is allowed before the guard demands the ratchet be TIGHTENED.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,14 @@ _AMBIENT_VARS = (
     "LOP_MOBILE_CHILD_PROVIDER",
     "LOP_MOBILE_CHILD_MODEL",
     "LOP_MODEL_SELECTION_OVERRIDE",
+    # The eval worker's scrub-channel transport (R1). The parent sets it per
+    # spawn, but a worker that inherited a STALE value from the operator's own
+    # runtime would publish retrieved secret values onto whatever that number
+    # names in the test process — an arbitrary fd, not the pipe the parent is
+    # holding. The parent's explicit env override makes that unreachable in
+    # practice; scrubbing it keeps the guarantee at the fixture rather than
+    # resting on one caller always remembering to set it.
+    "LOCAL_OPERATOR_EVAL_SCRUB_FD",
     "LOP_MOBILE_CHILD_CWD",
     "LOP_MOBILE_PASSWORD",
     # The calling cmux workspace/surface. A headless fork e2e test inherited

--- a/tests/unit/guides/test_guides.py
+++ b/tests/unit/guides/test_guides.py
@@ -27,6 +27,7 @@ def test_packaged_catalog_is_small_and_descriptions_are_prompt_sized() -> None:
         "agents",
         "browser",
         "configuration",
+        "credentials",
         "extensions",
         "failover",
         "mcp",

--- a/tests/unit/secrets/test_agent_surfaces.py
+++ b/tests/unit/secrets/test_agent_surfaces.py
@@ -1,0 +1,718 @@
+"""PR 3's agent surfaces: the tool, the eval library, and the §6 stream fix.
+
+The redaction tests here are the load-bearing ones. Each asserts the SAFE
+outcome and is paired with a check that the guard is actually what produces it
+— a redaction test that passes because the value never reached the filter is
+worthless, and this series has produced false-passing harnesses repeatedly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import shlex
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.harness.types import AbortSignal, ToolContext
+from local_operator.secrets.promote import promote_session_credential
+from local_operator.secrets.runtime import SecretsMapping, SecretValue
+from local_operator.tools import builtin
+from local_operator.tools.secret_tool import build_secret_tool, execute_secret
+from local_operator.variables import VariableStore, redact_secret_values
+
+
+class BrokerAwareStore(VariableStore):
+    """A VariableStore carrying the §6 redaction sink.
+
+    The sink (``register_redaction`` / ``redaction_values``) ships on the
+    BROKER branch, not on main, and this PR consumes it defensively so it
+    composes whichever order the two land in. That is exactly why the tests
+    supply it as a subclass: asserting against a locally-defined seam proves
+    the consumer works when the seam is present, while
+    ``test_stream_values_without_the_seam_keep_the_injected_set`` covers the
+    tree as it stands today. A test that called the real method would simply
+    fail to run here and would prove nothing about either arrangement.
+    """
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+        self._registered: set[str] = set()
+
+    def register_redaction(self, value: str) -> bool:
+        trimmed = value.strip()
+        if not trimmed or trimmed in self._registered:
+            return False
+        self._registered.add(trimmed)
+        return True
+
+    def redaction_values(self) -> list[str]:
+        return [*self.credential_env().values(), *self._registered]
+
+    def redact(self, text: str) -> str:
+        return redact_secret_values(text, self.redaction_values())
+
+
+# --------------------------------------------------------------------------
+# The agent tool
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated(config_root: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point every default-base store call inside tmp_path.
+
+    ``config_root`` already redirects HOME and the config-dir override; the
+    surfaces under test call ``open_store()`` with no base, so this asserts the
+    redirect actually reaches them rather than trusting it.
+    """
+    from local_operator.secrets.keys import secrets_dir
+
+    assert secrets_dir().is_relative_to(config_root), "store escaped the sandbox"
+    return config_root
+
+
+async def _call(op: str, **kwargs: object):
+    return await execute_secret("call-1", {"op": op, **kwargs}, AbortSignal(), None, ToolContext())
+
+
+@pytest.mark.asyncio
+async def test_store_then_retrieve_never_returns_the_value(isolated: Path) -> None:
+    """The whole inversion: retrieve confirms and instructs, and does not tell."""
+    secret = "ghp_thisisthevalue_9f3a"
+    stored = await _call("store", name="GH_TOKEN", value=secret, description="github")
+    assert not stored.is_error, stored.text
+    assert secret not in stored.text
+
+    got = await _call("retrieve", name="GH_TOKEN")
+    assert not got.is_error, got.text
+    assert secret not in got.text
+    # The receipt has to be actionable, or the model retries looking for bytes.
+    assert "lop secret get GH_TOKEN" in got.text
+    assert 'secrets["GH_TOKEN"]' in got.text
+
+    listed = await _call("list")
+    assert "GH_TOKEN" in listed.text and secret not in listed.text
+    described = await _call("describe", name="GH_TOKEN")
+    assert "github" in described.text and secret not in described.text
+
+
+@pytest.mark.asyncio
+async def test_retrieve_of_a_missing_secret_is_an_actionable_error(isolated: Path) -> None:
+    await _call("store", name="PRESENT", value="v")
+    missing = await _call("retrieve", name="ABSENT")
+    assert missing.is_error
+    assert "ABSENT" in missing.text
+
+
+@pytest.mark.asyncio
+async def test_retrieve_against_no_store_at_all_says_so(isolated: Path) -> None:
+    """`retrieve` must not create an empty store and then report 'not found'."""
+    result = await _call("retrieve", name="ANY")
+    assert result.is_error
+    assert "No secret store" in result.text
+    from local_operator.secrets.keys import store_path
+
+    assert not store_path().exists(), "retrieve created a store"
+
+
+@pytest.mark.asyncio
+async def test_store_refuses_to_overwrite_and_update_replaces(isolated: Path) -> None:
+    await _call("store", name="K", value="first")
+    clash = await _call("store", name="K", value="second")
+    assert clash.is_error, "set must refuse an existing name"
+
+    updated = await _call("update", name="K", value="second")
+    assert not updated.is_error, updated.text
+    from local_operator.secrets.access import open_store
+
+    assert open_store().get("K") == b"second"
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_and_missing_name_is_rejected(isolated: Path) -> None:
+    await _call("store", name="K", value="v")
+    assert not (await _call("delete", name="K")).is_error
+    assert (await _call("retrieve", name="K")).is_error
+    assert (await _call("retrieve")).is_error, "a name is required"
+
+
+def test_the_tool_is_one_verb_tool_not_six() -> None:
+    """The footprint ladder's whole point; asserted so a split shows up red."""
+    tool = build_secret_tool(ToolContext())
+    assert tool is not None
+    ops = tool.parameters["properties"]["op"]["enum"]
+    assert set(ops) == {"store", "retrieve", "list", "describe", "update", "delete"}
+
+
+def test_the_tool_is_gated_and_the_registry_carries_it() -> None:
+    from local_operator.tools.registry import DEFAULT_TOOL_NAMES, TOOL_BUILDERS
+
+    assert TOOL_BUILDERS["secret"] is not None
+    assert "secret" in DEFAULT_TOOL_NAMES
+
+
+def test_the_builder_returns_none_when_the_store_cannot_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """createIf: a tree where the crypto stack will not import advertises nothing."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def refuse(name: str, *args: Any, **kwargs: Any):
+        if name.startswith("local_operator.secrets"):
+            raise ImportError("no crypto here")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", refuse)
+    assert build_secret_tool(ToolContext()) is None
+
+
+# --------------------------------------------------------------------------
+# The eval runtime library
+# --------------------------------------------------------------------------
+
+
+def test_secret_value_repr_redacts_but_str_does_not(isolated: Path) -> None:
+    """`f"Bearer {token}"` must send the REAL token; only repr may lie."""
+    value = SecretValue("abc123", "K")
+    assert "abc123" not in repr(value)
+    assert "[redacted]" in repr(value)
+    assert str(value) == "abc123"
+    assert f"Bearer {value}" == "Bearer abc123"
+    assert value.encode() == b"abc123"
+
+
+def test_mapping_retrieves_registers_and_reports_existence(isolated: Path) -> None:
+    from local_operator.secrets.access import open_store
+    from local_operator.secrets.runtime import registered_values, scrub
+
+    store = open_store(create=True)
+    store.set("API", b"sk-live-4417", description="d")
+
+    mapping = SecretsMapping()
+    value = mapping["API"]
+    assert value == "sk-live-4417"
+    # Registered BEFORE it was handed out, so the worker filter already knows.
+    assert "sk-live-4417" in registered_values()
+    assert scrub("token=sk-live-4417 end") == "token=[redacted] end"
+
+    assert "API" in mapping
+    assert "NOPE" not in mapping
+    assert list(mapping) == ["API"]
+    with pytest.raises(KeyError):
+        mapping["NOPE"]
+    assert mapping.get("NOPE") is None
+
+
+def test_existence_check_does_not_write_a_retrieval_audit_row(isolated: Path) -> None:
+    """`in` is not a read; recording it as one would corrupt the audit trail."""
+    from local_operator.secrets.access import open_store
+
+    store = open_store(create=True)
+    store.set("API", b"v")
+    before = sum(1 for e in store.audit_entries() if e.event == "get")
+    assert "API" in SecretsMapping()
+    after = sum(1 for e in store.audit_entries() if e.event == "get")
+    assert after == before
+
+
+def test_mapping_repr_does_not_touch_the_store(isolated: Path) -> None:
+    assert "retrieves one value" in repr(SecretsMapping())
+
+
+# --------------------------------------------------------------------------
+# §6 redaction — the correctness-critical piece
+# --------------------------------------------------------------------------
+
+
+def test_pipe_redactor_accepts_bare_values_not_only_a_credential_map() -> None:
+    """§6 values have no name in this process, so there is no map to pass."""
+    redactor = builtin._PipeRedactor(["broker-value"])
+    assert redactor.feed(b"a broker-value b", final=True) == b"a [redacted] b"
+
+
+def test_stream_values_union_injected_and_registered() -> None:
+    """The exact hole: a registered value must reach the STREAM filter."""
+    store = BrokerAwareStore()
+    store.store_credential("SESSION_KEY", "injected-secret")
+    store.register_redaction("broker-fetched-secret")
+    values = builtin._stream_redaction_values(store, store.credential_env())
+    assert "injected-secret" in values
+    assert "broker-fetched-secret" in values
+
+
+def test_stream_values_without_the_seam_keep_the_injected_set() -> None:
+    """A pre-broker / third-party store has no announcements to miss."""
+
+    class Minimal:
+        def credential_env(self) -> dict[str, str]:
+            return {"A": "a-value"}
+
+    values = builtin._stream_redaction_values(Minimal(), {"A": "a-value"})
+    assert values == ["a-value"]
+    assert values is not builtin._REDACTION_SEAM_BROKEN
+
+
+def test_an_unreadable_redaction_sink_fails_closed() -> None:
+    """Present-but-broken must NOT degrade to 'stream everything'."""
+
+    class Broken:
+        def redaction_values(self):
+            raise RuntimeError("sink down")
+
+    assert builtin._stream_redaction_values(Broken(), {}) is builtin._REDACTION_SEAM_BROKEN
+
+    class WrongType:
+        def redaction_values(self):
+            return "not a sequence"
+
+    assert builtin._stream_redaction_values(WrongType(), {}) is builtin._REDACTION_SEAM_BROKEN
+
+
+def test_redactor_refresh_scrubs_a_value_registered_mid_stream() -> None:
+    """A `$(lop secret get X)` value arrives DURING the command."""
+    redactor = builtin._PipeRedactor([])
+    early = redactor.feed(b"starting\n")
+    assert b"starting" in early
+    redactor.refresh(["late-secret"])
+    assert redactor.feed(b"got late-secret ok", final=True) == b"got [redacted] ok"
+
+
+@pytest.mark.asyncio
+async def test_live_bash_stream_scrubs_a_registered_value(tmp_path: Path) -> None:
+    """END TO END: a value registered on the store never paints in the stream.
+
+    Registered BEFORE the command runs (the ordering §6's ack-before-reply
+    invariant guarantees), and the command prints it repeatedly so a
+    single-chunk fluke cannot pass this.
+    """
+    store = BrokerAwareStore()
+    store.register_redaction("brokered-abcdef123456")
+    context = ToolContext(cwd=str(tmp_path), variables=store)
+
+    updates: list[str] = []
+    command = f"{shlex.quote(sys.executable)} -c " + shlex.quote(
+        "import sys,time\n"
+        "for _ in range(40):\n"
+        '    sys.stdout.write("line brokered-abcdef123456\\n"); sys.stdout.flush()\n'
+    )
+    result = await builtin.execute_bash(
+        "bash-live",
+        {"command": command},
+        AbortSignal(),
+        lambda update: updates.append(getattr(update.content[0], "text", "")),
+        context,
+    )
+    assert not result.is_error, result.text
+    # The value appeared 40 times; if the filter is off, it is in the result.
+    assert "brokered-abcdef123456" not in result.text
+    assert "[redacted]" in result.text
+    for painted in updates:
+        assert "brokered-abcdef123456" not in painted
+
+
+@pytest.mark.asyncio
+async def test_the_stream_guard_is_load_bearing(tmp_path: Path, monkeypatch) -> None:
+    """THE RED. Revert the union and the same value paints — proving the fix.
+
+    Without this, the test above could be passing because of
+    `redact_tool_result` or `_redact_tool_text` rather than because of the pipe
+    filter, and the guard would be untested scenery.
+    """
+    store = BrokerAwareStore()
+    store.register_redaction("brokered-abcdef123456")
+    context = ToolContext(cwd=str(tmp_path), variables=store)
+
+    # The pre-fix behaviour exactly: build the stream filter from the INJECTED
+    # credential map alone, ignoring registrations.
+    monkeypatch.setattr(
+        builtin,
+        "_stream_redaction_values",
+        lambda store, injected: [str(v) for v in injected.values() if v],
+    )
+    command = f"{shlex.quote(sys.executable)} -c " + shlex.quote(
+        'import sys\nsys.stdout.write("line brokered-abcdef123456\\n")\n'
+    )
+    painted: list[str] = []
+    await builtin.execute_bash(
+        "bash-red",
+        {"command": command},
+        AbortSignal(),
+        lambda update: painted.append(getattr(update.content[0], "text", "")),
+        context,
+    )
+    # `_redact_tool_text` still cleans the emitted snapshot, so the leak is
+    # asserted where the pipe filter is the ONLY guard: the bytes the sink
+    # actually received.
+    raw = builtin._PipeRedactor({}).feed(b"line brokered-abcdef123456\n", final=True)
+    assert b"brokered-abcdef123456" in raw, "the RED harness itself is broken"
+
+
+@pytest.mark.asyncio
+async def test_a_broken_sink_withholds_live_output_instead_of_leaking(
+    tmp_path: Path,
+) -> None:
+    """Fail-closed, end to end, and the command still completes."""
+
+    class Broken(BrokerAwareStore):
+        def redaction_values(self):
+            raise RuntimeError("sink down")
+
+    store = Broken()
+    context = ToolContext(cwd=str(tmp_path), variables=store)
+    command = f"{shlex.quote(sys.executable)} -c " + shlex.quote(
+        'import sys\nfor _ in range(5): sys.stdout.write("would-be-secret\\n")\n'
+    )
+    result = await builtin.execute_bash(
+        "bash-closed", {"command": command}, AbortSignal(), None, context
+    )
+    assert "would-be-secret" not in result.text
+    assert "withheld" in result.text
+
+
+# --------------------------------------------------------------------------
+# §5.4 — the persist route
+# --------------------------------------------------------------------------
+
+
+def test_promote_copies_the_session_credential_and_keeps_it(isolated: Path) -> None:
+    store = VariableStore()
+    store.store_credential("DEPLOY_KEY", "s3cr3t-value")
+    result = promote_session_credential(store, "DEPLOY_KEY")
+    assert result.ok, result.message
+    assert "s3cr3t-value" not in result.message
+
+    from local_operator.secrets.access import open_store
+
+    assert open_store().get("DEPLOY_KEY") == b"s3cr3t-value"
+    # Additive: the session copy still feeds bash children in flight.
+    assert store.credential_env()["DEPLOY_KEY"] == "s3cr3t-value"
+
+
+def test_promote_refuses_to_clobber_an_existing_long_term_secret(isolated: Path) -> None:
+    from local_operator.secrets.access import open_store
+
+    open_store(create=True).set("SHARED", b"the-original")
+    store = VariableStore()
+    store.store_credential("SHARED", "the-session-one")
+    result = promote_session_credential(store, "SHARED")
+    assert not result.ok and result.already_present
+    assert open_store().get("SHARED") == b"the-original", "promotion overwrote a secret"
+
+
+def test_promote_of_an_unknown_key_says_what_to_do(isolated: Path) -> None:
+    result = promote_session_credential(VariableStore(), "NOPE")
+    assert not result.ok
+    assert "/credential NOPE" in result.message
+
+
+def test_credential_command_parses_the_persist_verb() -> None:
+    from local_operator.variables import parse_credential_command
+
+    parsed = parse_credential_command("--persist github token")
+    assert parsed.action == "persist" and parsed.key == "GITHUB_TOKEN"
+    assert parse_credential_command("--persist").action == "error"
+
+
+def test_ask_question_persist_requires_a_secret_question() -> None:
+    from pydantic import ValidationError
+
+    from local_operator.harness.types import AskQuestion
+
+    ok = AskQuestion(id="API_KEY", question="key?", secret=True, persist=True)
+    assert ok.persist
+    with pytest.raises(ValidationError):
+        AskQuestion(
+            id="q",
+            question="pick",
+            options=[{"label": "a"}, {"label": "b"}],  # type: ignore[list-item]
+            persist=True,
+        )
+
+
+def test_ask_secret_answer_persists_when_asked(isolated: Path) -> None:
+    """The operator's explicit ask: `ask secret=true` reaches the same route."""
+    from local_operator.harness.types import AskQuestion
+
+    store = VariableStore()
+    context = ToolContext(variables=store)
+    question = AskQuestion(id="NPM_TOKEN", question="token?", secret=True, persist=True)
+    reported = builtin._report_secret_answers([question], {"NPM_TOKEN": ["npm-abc-999"]}, context)
+    answer = reported["NPM_TOKEN"]
+    assert answer[0] == "NPM_TOKEN"
+    assert "npm-abc-999" not in " ".join(answer), "the value rode the ask result"
+
+    from local_operator.secrets.access import open_store
+
+    assert open_store().get("NPM_TOKEN") == b"npm-abc-999"
+
+
+def test_ask_secret_without_persist_stays_session_only(isolated: Path) -> None:
+    from local_operator.harness.types import AskQuestion
+
+    store = VariableStore()
+    context = ToolContext(variables=store)
+    question = AskQuestion(id="TMP_TOKEN", question="token?", secret=True)
+    builtin._report_secret_answers([question], {"TMP_TOKEN": ["only-here"]}, context)
+    assert store.credential_env()["TMP_TOKEN"] == "only-here"
+    from local_operator.secrets.keys import store_path
+
+    assert not store_path().exists(), "a non-persist ask created a long-term store"
+
+
+def test_promotion_failure_does_not_lose_the_session_credential(
+    isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The secret the user just pasted must survive a broken long-term store."""
+    from local_operator.harness.types import AskQuestion
+
+    def explode(*args: object, **kwargs: object):
+        raise RuntimeError("disk on fire")
+
+    monkeypatch.setattr("local_operator.secrets.promote.promote_session_credential", explode)
+    store = VariableStore()
+    context = ToolContext(variables=store)
+    question = AskQuestion(id="K", question="k?", secret=True, persist=True)
+    reported = builtin._report_secret_answers([question], {"K": ["kept"]}, context)
+    assert store.credential_env()["K"] == "kept"
+    assert "session only" in " ".join(reported["K"])
+
+
+@pytest.mark.asyncio
+async def test_a_value_registered_MID_command_is_still_scrubbed(tmp_path: Path) -> None:
+    """The real §6 shape: the child fetches the secret while it is running.
+
+    `$(lop secret get X)` resolves inside the child, so the session learns the
+    value from the broker DURING the command — after the pipe filter was
+    built. A filter constructed once at spawn misses exactly this, which is why
+    the pump re-reads the value set on every chunk.
+    """
+    store = BrokerAwareStore()
+    context = ToolContext(cwd=str(tmp_path), variables=store)
+
+    # Print a marker, wait for the registration, then print the secret.
+    flag = tmp_path / "registered"
+    command = f"{shlex.quote(sys.executable)} -c " + shlex.quote(
+        "import sys,time\n"
+        'sys.stdout.write("started\\n"); sys.stdout.flush()\n'
+        "for _ in range(400):\n"
+        f"    if __import__('os').path.exists({str(flag)!r}): break\n"
+        "    time.sleep(0.01)\n"
+        'sys.stdout.write("fetched midstream-9d2f1a\\n"); sys.stdout.flush()\n'
+    )
+
+    async def register_once_running() -> None:
+        await asyncio.sleep(0.05)
+        store.register_redaction("midstream-9d2f1a")
+        flag.write_text("go")
+
+    task = asyncio.create_task(register_once_running())
+    result = await builtin.execute_bash(
+        "bash-mid", {"command": command}, AbortSignal(), None, context
+    )
+    await task
+    assert not result.is_error, result.text
+    assert "started" in result.text, "the harness never ran the command"
+    assert "midstream-9d2f1a" not in result.text
+    assert "[redacted]" in result.text
+
+
+@pytest.mark.asyncio
+async def test_background_job_peek_scrubs_a_registered_value(tmp_path: Path) -> None:
+    """The peek buffer is fed by the PIPE filter, not by the result path.
+
+    `jobs(op='peek')` reads what `_mirror` appended while the command ran, so
+    this is the surface where `_PipeRedactor` is the only guard — the model
+    sees these bytes without a finished ToolResult ever existing. The secret is
+    written one byte at a time so it necessarily straddles pipe reads, which is
+    the exact case the redactor's held-back suffix exists for.
+    """
+    from local_operator.harness.jobs import AsyncJobManager
+
+    manager = AsyncJobManager()
+    store = BrokerAwareStore()
+    store.register_redaction("peeked-7c1e5b")
+    context = ToolContext(cwd=str(tmp_path), variables=store, jobs=manager, session_id="s")
+
+    command = f"{shlex.quote(sys.executable)} -c " + shlex.quote(
+        "import sys,time\n"
+        'for ch in "peeked-7c1e5b":\n'
+        "    sys.stdout.write(ch); sys.stdout.flush(); time.sleep(0.005)\n"
+        'sys.stdout.write("\\n"); sys.stdout.flush()\n'
+        "time.sleep(0.4)\n"
+    )
+    started = await builtin.execute_bash(
+        "bash-bg", {"command": command, "background": True}, AbortSignal(), None, context
+    )
+    job_id = (started.details or {})["job_id"]
+    for _ in range(60):
+        await asyncio.sleep(0.05)
+        probe = manager.read_output(job_id, 0)
+        if probe is not None and probe[0].strip():
+            break
+
+    window = manager.read_output(job_id, 0)
+    assert window is not None
+    mirrored = window[0]
+    assert "peeked-7c1e5b" not in mirrored, "the secret painted in the peek buffer"
+    assert "[redacted]" in mirrored
+    with contextlib.suppress(Exception):
+        await manager.cancel(job_id)
+
+
+@pytest.mark.asyncio
+async def test_peek_scrubs_a_value_registered_AFTER_the_command_started(
+    tmp_path: Path,
+) -> None:
+    """The full §6 shape, on the surface where the pipe filter is the only guard.
+
+    `$(lop secret get X)` resolves INSIDE the child, so the session is told the
+    value while the command is already streaming — after the pipe filter was
+    constructed. Combined with a background job (whose peek buffer never passes
+    through the result path) this is what makes the per-chunk `refresh` load
+    bearing rather than decorative.
+    """
+    from local_operator.harness.jobs import AsyncJobManager
+
+    manager = AsyncJobManager()
+    store = BrokerAwareStore()
+    context = ToolContext(cwd=str(tmp_path), variables=store, jobs=manager, session_id="s")
+
+    flag = tmp_path / "registered"
+    command = f"{shlex.quote(sys.executable)} -c " + shlex.quote(
+        "import os,sys,time\n"
+        'sys.stdout.write("started\\n"); sys.stdout.flush()\n'
+        "for _ in range(400):\n"
+        f"    if os.path.exists({str(flag)!r}): break\n"
+        "    time.sleep(0.01)\n"
+        'for ch in "afterreg-2b8d4f":\n'
+        "    sys.stdout.write(ch); sys.stdout.flush(); time.sleep(0.005)\n"
+        'sys.stdout.write("\\n"); sys.stdout.flush()\n'
+        "time.sleep(0.5)\n"
+    )
+    started = await builtin.execute_bash(
+        "bash-bg2", {"command": command, "background": True}, AbortSignal(), None, context
+    )
+    job_id = (started.details or {})["job_id"]
+
+    # Wait for the command to be streaming, THEN register — the ordering under
+    # test. Waits on the observed output, never on the clock.
+    for _ in range(60):
+        await asyncio.sleep(0.05)
+        probe = manager.read_output(job_id, 0)
+        if probe is not None and "started" in probe[0]:
+            break
+    store.register_redaction("afterreg-2b8d4f")
+    flag.write_text("go")
+
+    for _ in range(80):
+        await asyncio.sleep(0.05)
+        probe = manager.read_output(job_id, 0)
+        if probe is not None and probe[0].count("\n") >= 2:
+            break
+
+    window = manager.read_output(job_id, 0)
+    assert window is not None
+    assert "started" in window[0], "the harness never ran the command"
+    assert "afterreg-2b8d4f" not in window[0], "a mid-command registration painted in peek"
+    with contextlib.suppress(Exception):
+        await manager.cancel(job_id)
+
+
+# --------------------------------------------------------------------------
+# The eval worker's scrubbing of library-retrieved values
+# --------------------------------------------------------------------------
+
+
+def test_worker_scrub_is_free_until_a_secret_is_retrieved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No import, no cost — and provably nothing to scrub in that state."""
+    from local_operator.tools import eval_worker
+
+    monkeypatch.delitem(sys.modules, "local_operator.secrets.runtime", raising=False)
+    assert eval_worker._scrub_secrets("anything at all") == "anything at all"
+
+
+def test_worker_scrub_removes_a_retrieved_value(isolated: Path) -> None:
+    from local_operator.secrets.access import open_store
+    from local_operator.secrets.runtime import SecretsMapping
+    from local_operator.tools import eval_worker
+
+    open_store(create=True).set("K", b"worker-value-8812")
+    assert SecretsMapping()["K"] == "worker-value-8812"
+    assert eval_worker._scrub_secrets("out: worker-value-8812") == "out: [redacted]"
+
+
+def test_worker_scrub_fails_closed_when_the_filter_breaks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broken scrubber must withhold, never publish."""
+    from local_operator.tools import eval_worker
+
+    class Exploding:
+        @staticmethod
+        def scrub(text: str) -> str:
+            raise RuntimeError("filter down")
+
+    monkeypatch.setitem(sys.modules, "local_operator.secrets.runtime", Exploding)
+    out = eval_worker._scrub_secrets("would-be-secret")
+    assert "would-be-secret" not in out
+    assert "withheld" in out
+
+
+def test_worker_response_scrubs_every_model_visible_channel(isolated: Path) -> None:
+    """stdout, stderr, result and display all pass the filter."""
+    from local_operator.secrets.access import open_store
+    from local_operator.secrets.runtime import SecretsMapping
+    from local_operator.tools import eval_worker
+
+    open_store(create=True).set("K", b"chan-value-4417")
+    assert SecretsMapping()["K"] == "chan-value-4417"
+
+    namespace: dict[str, object] = {"__name__": "__eval__"}
+    response = eval_worker._handle(
+        namespace,
+        {
+            "id": "r1",
+            "code": (
+                "import sys\n"
+                "v = 'chan-value-4417'\n"
+                "print(v)\n"
+                "sys.stderr.write(v)\n"
+                "display(v)\n"
+                "v\n"
+            ),
+        },
+    )
+    blob = "".join(
+        [
+            str(response["stdout"]),
+            str(response["stderr"]),
+            str(response["result"]),
+            "".join(response["display"]),  # type: ignore[arg-type]
+        ]
+    )
+    assert "chan-value-4417" not in blob
+    assert "[redacted]" in blob
+
+
+def test_secrets_is_prebound_in_the_worker_namespace_without_importing_crypto() -> None:
+    """The documented `secrets["NAME"]` form works with no import line."""
+    from local_operator.tools import eval_worker
+
+    proxy = eval_worker._LazySecrets()
+    assert "retrieves one value" in repr(proxy)
+
+
+@pytest.mark.asyncio
+async def test_list_on_a_machine_with_no_store_is_not_an_error(isolated: Path) -> None:
+    """`list` is the orienting verb; an error there reads as 'broken'."""
+    result = await _call("list")
+    assert not result.is_error, result.text
+    assert "No secrets are stored" in result.text

--- a/tests/unit/secrets/test_agent_surfaces.py
+++ b/tests/unit/secrets/test_agent_surfaces.py
@@ -792,6 +792,149 @@ async def test_a_crash_with_a_secret_on_real_fd2_is_scrubbed(isolated: Path) -> 
 
 
 @pytest.mark.asyncio
+async def test_a_retry_loop_of_one_secret_does_not_wedge_the_kernel(isolated: Path) -> None:
+    """R9 regression: the ORDINARY retry shape, not a pathological big value.
+
+    The scrub channel is a 64 KiB pipe the worker writes from inside
+    ``register`` — before the value reaches the cell — so anything that parks
+    the write parks the retrieval, and the kernel dies at the timeout taking
+    all session state with it. Nothing caches a retrieval, so a loop that
+    re-fetches ONE token per attempt (a retry, a paginated API walk) publishes
+    once per iteration while the ledger stays size 1: at 200 bytes a record
+    that filled the pipe at ~319 iterations.
+
+    This asserts the CELL COMPLETES. It is the availability half of the
+    invariant the fix is built on: a dropped scrub record degrades to an
+    unscrubbed crash tail (the documented pre-R1 fallback), never to a blocked
+    retrieval. 400 iterations is comfortably past the old wedge point, and the
+    generous timeout means a FAIL here is a park, not a slow machine.
+    """
+    from local_operator.secrets.access import open_store
+    from local_operator.tools import eval as eval_tool
+
+    open_store(create=True).set("RETRY_TOKEN", b"R" * 200)
+    tool = eval_tool.build_eval_tool()
+    context = ToolContext(cwd="/tmp", session_id="retry-loop")
+    code = "n = 0\nfor _ in range(400):\n    t = secrets['RETRY_TOKEN']\n    n += 1\nn\n"
+    result = await tool.execute("c1", {"code": code, "timeout": 60}, AbortSignal(), None, context)
+    assert not result.is_error, f"the retrieval loop wedged: {result.text[:400]}"
+    assert "400" in result.text
+    await eval_tool.close_session_kernel("retry-loop")
+
+
+def test_publication_dedups_with_the_ledger_not_beside_it() -> None:
+    """R9 regression: re-registering one value publishes exactly once.
+
+    ``add()`` on a set dedups for free, which hid that publication sat OUTSIDE
+    it: five registrations of one identical value produced five publishes
+    against a ledger of size 1. That asymmetry is what turned an ordinary
+    retry loop into hundreds of records for a scrub set with one entry in it,
+    and it is the half of the fix that removes the pressure rather than
+    surviving it.
+    """
+    from local_operator.secrets import runtime
+
+    published: list[str] = []
+    ledger = runtime._RedactionLedger()
+    original = runtime._PUBLISH_HOOK
+    runtime.set_publish_hook(published.append)
+    try:
+        for _ in range(5):
+            ledger.register("one-identical-value")
+        ledger.register("a-second-value")
+    finally:
+        runtime.set_publish_hook(original)
+
+    assert published == ["one-identical-value", "a-second-value"]
+    assert sorted(ledger.values()) == ["a-second-value", "one-identical-value"]
+
+
+def test_a_full_scrub_pipe_drops_the_record_instead_of_parking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """R9: past the channel's capacity, publication must return, not block.
+
+    The acceptance criterion stated as an assertion, and it takes the REAL
+    setup path: the fd is handed over the way the parent hands it over, so the
+    non-blocking mode under test is the one ``_install_scrub_channel`` sets
+    rather than one the test quietly supplied for it. That ordering matters —
+    a test that sets the mode itself passes against a worker that never sets
+    it at all.
+
+    The mode assertion is deliberately first. It is the property that makes
+    the park impossible, and checking it fails FAST where the behaviour it
+    protects can only fail by hanging forever (a park is not an exception and
+    no ``except`` or assertion can catch it). With that established, filling
+    the pipe and publishing exercises the drop: the record is lost, which
+    downgrades the crash tail for that one value to the documented pre-R1
+    unscrubbed behaviour, and the retrieval stays free to complete.
+    """
+    import os as _os
+
+    from local_operator.tools import eval_worker
+
+    read_fd, write_fd = _os.pipe()
+    monkeypatch.setattr(eval_worker, "_SCRUB_FD", None)
+    try:
+        monkeypatch.setenv(eval_worker._SCRUB_FD_ENV, str(write_fd))
+        eval_worker._install_scrub_channel()
+        assert eval_worker._SCRUB_FD == write_fd, "the worker ignored the handed-over fd"
+        assert not _os.get_blocking(write_fd), (
+            "the scrub fd is BLOCKING: a full pipe now parks the retrieval that "
+            "published onto it, killing the kernel and all session state"
+        )
+
+        # Fill it. A non-blocking write to a full pipe raises rather than
+        # parking, which is how this loop terminates at all.
+        with contextlib.suppress(BlockingIOError):
+            while True:
+                _os.write(write_fd, b"x" * 4096)
+
+        eval_worker._publish_secret_value("value-that-does-not-fit")
+        # Dropped, not buffered, and the channel stays usable for the next
+        # value once the parent drains: a full pipe is a transient condition.
+        assert eval_worker._SCRUB_FD == write_fd
+    finally:
+        eval_worker._SCRUB_FD = None
+        _os.close(read_fd)
+        _os.close(write_fd)
+
+
+@pytest.mark.asyncio
+async def test_secrets_retrieved_across_cells_still_scrub_a_later_crash(
+    isolated: Path,
+) -> None:
+    """R9 must not cost R1: draining early keeps values, it does not spend them.
+
+    Draining the pipe on the healthy path means the crash path is no longer
+    its only reader, so the values a crash needs are the ones EARLIER
+    exchanges already consumed. This retrieves in one cell and crashes in a
+    later one — if the drain dropped what it read, the fd-2 tail would come
+    back raw.
+    """
+    from local_operator.secrets.access import open_store
+    from local_operator.tools import eval as eval_tool
+
+    open_store(create=True).set("EARLY", b"EARLYLEAK-2b7c-4410")
+    tool = eval_tool.build_eval_tool()
+    context = ToolContext(cwd="/tmp", session_id="cross-cell-crash")
+    first = await tool.execute(
+        "c1", {"code": "token = secrets['EARLY']\nlen(token)\n"}, AbortSignal(), None, context
+    )
+    assert not first.is_error, first.text
+    result = await tool.execute(
+        "c2",
+        {"code": "import os\nos.write(2, f'TAIL {token}'.encode())\nos._exit(3)\n"},
+        AbortSignal(),
+        None,
+        context,
+    )
+    assert result.is_error
+    assert "EARLYLEAK-2b7c-4410" not in result.text, "a drained value stopped scrubbing"
+    assert "TAIL [redacted]" in result.text
+
+
+@pytest.mark.asyncio
 async def test_list_on_a_machine_with_no_store_is_not_an_error(isolated: Path) -> None:
     """`list` is the orienting verb; an error there reads as 'broken'."""
     result = await _call("list")

--- a/tests/unit/secrets/test_agent_surfaces.py
+++ b/tests/unit/secrets/test_agent_surfaces.py
@@ -951,3 +951,105 @@ async def test_list_on_a_machine_with_no_store_is_not_an_error(isolated: Path) -
     result = await _call("list")
     assert not result.is_error, result.text
     assert "No secrets are stored" in result.text
+
+
+# --------------------------------------------------------------------------
+# The production read path, end to end (QA Q3)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    sys.platform not in ("darwin",) and not sys.platform.startswith("linux"),
+    reason="the broker is implemented for macOS and Linux",
+)
+@pytest.mark.asyncio
+async def test_a_real_bash_child_running_lop_secret_get_is_redacted_everywhere(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The whole §6 chain with NOTHING mocked — the seam Q3 found open.
+
+    Every other redaction test here supplies one side of the chain: the store
+    subclass above stands in for the broker's notice, and the broker PR's own
+    tests stand in for this consumer. Each passed while the two were never
+    connected, because each mocked the other's half — so this asserts across
+    the join instead. A real broker, a real registered session answering
+    notices, and a real `bash` child running the documented
+    `$(lop secret get NAME)` from the credentials guide.
+
+    Then it checks the three channels a model can actually read: the live
+    stream the TUI paints, the `jobs(op='peek')` buffer, and the finished tool
+    result. Before the fix the child was served by a LOCAL decrypt that never
+    told the session anything, so `redaction_values()` stayed empty and the
+    credential was painted verbatim in all three.
+    """
+    pytest.importorskip("local_operator.secrets.client")
+
+    from local_operator.secrets.broker import SecretBroker
+    from local_operator.secrets.crypto import generate_master_key
+    from local_operator.secrets.keys import key_path, write_private_file
+    from local_operator.secrets.session import register_session
+    from local_operator.secrets.store import SecretStore
+
+    root = tmp_path / "config"
+    root.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    (tmp_path / "home").mkdir()
+    from local_operator.paths import CONFIG_DIR_ENV
+
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(root))
+
+    secret = "Q3-REAL-BROKER-9f4c1a2e"
+    key = generate_master_key()
+    store_on_disk = SecretStore(key, base=root)
+    store_on_disk.initialize()
+    store_on_disk.set("Q3_TOKEN", secret.encode(), description="q3")
+    write_private_file(key_path(root), key)
+
+    broker = SecretBroker(root, key_provider=lambda: key, idle_shutdown_s=0)
+    broker.start()
+
+    variables = BrokerAwareStore()
+
+    def on_secret(_name: str, value: bytes) -> None:
+        # Returns None: `register_session` types the callback as `-> None`, and
+        # `register_redaction` answers bool, so the result is deliberately
+        # dropped rather than returned.
+        variables.register_redaction(value.decode())
+
+    registration = register_session(on_secret, session_id="q3-e2e", base=root)
+    assert registration is not None, "no session registered; the seam is untestable"
+
+    from local_operator.harness.jobs import AsyncJobManager
+
+    manager = AsyncJobManager()
+    context = ToolContext(cwd=str(tmp_path), variables=variables, jobs=manager, session_id="q3-e2e")
+    # The child must import the tree UNDER TEST, not whatever `lop` happens to
+    # be installed on this machine — without this the subprocess silently
+    # exercises the released runtime and the assertion below reports on the
+    # wrong code. Derived from the package location rather than hardcoded so it
+    # follows the worktree.
+    import local_operator
+
+    tree = str(Path(local_operator.__file__).resolve().parent.parent)
+    cli = f"{shlex.quote(sys.executable)} -m local_operator.cli secret get Q3_TOKEN"
+    # The documented path, verbatim from guide://credentials, in a real shell.
+    command = (
+        f"export PYTHONPATH={shlex.quote(tree)}; "
+        f"{cli} > /dev/null; sleep 0.2; "
+        f'printf %s "$({cli})"'
+    )
+    try:
+        result = await builtin.execute_bash(
+            "q3", {"command": command}, AbortSignal(), None, context
+        )
+    finally:
+        registration.close()
+        broker.stop(timeout=5)
+
+    # The session was actually told — this is the notifier/consumer join.
+    assert secret in variables.redaction_values(), (
+        "the session was never notified of a value its own child retrieved; "
+        "the redaction notifier and its consumer are not wired together"
+    )
+    assert secret not in result.text, "the credential reached the model-visible tool result"
+    assert "[redacted]" in result.text

--- a/tests/unit/secrets/test_agent_surfaces.py
+++ b/tests/unit/secrets/test_agent_surfaces.py
@@ -318,61 +318,110 @@ async def test_live_bash_stream_scrubs_a_registered_value(tmp_path: Path) -> Non
 
 @pytest.mark.asyncio
 async def test_the_stream_guard_is_load_bearing(tmp_path: Path, monkeypatch) -> None:
-    """THE RED. Revert the union and the same value paints — proving the fix.
+    """THE RED. With the union reverted, the same value paints in the peek buffer.
 
-    Without this, the test above could be passing because of
-    `redact_tool_result` or `_redact_tool_text` rather than because of the pipe
-    filter, and the guard would be untested scenery.
+    R2. The previous form was provably inert: it monkeypatched
+    ``_stream_redaction_values``, collected the live updates but never asserted
+    on them, and its only real assertion — an empty ``_PipeRedactor`` passing
+    bytes through — is tautological. The pipe filter's guarantee is genuinely
+    carried by the two peek-buffer tests below, so this RED is pointed at the
+    same surface they guard: a background job's peek buffer, which the model
+    reads with NO finished ToolResult and which the result path's
+    ``redact_tool_result`` never touches. The union is reverted the way the
+    reviewer demonstrated (``_stream_redaction_values`` returns the injected
+    map alone), the command is run as a background job, and the secret is
+    asserted to be PRESENT in the peek buffer — the leak must be shown to
+    exist, not assumed. Mutation-verified: this test reds under the revert.
     """
-    store = BrokerAwareStore()
-    store.register_redaction("brokered-abcdef123456")
-    context = ToolContext(cwd=str(tmp_path), variables=store)
+    from local_operator.harness.jobs import AsyncJobManager
 
-    # The pre-fix behaviour exactly: build the stream filter from the INJECTED
-    # credential map alone, ignoring registrations.
+    manager = AsyncJobManager()
+    store = BrokerAwareStore()
+    store.register_redaction("loadbearing-9f3e1a")
+    context = ToolContext(cwd=str(tmp_path), variables=store, jobs=manager, session_id="s")
+
+    # The pre-fix behaviour exactly: the stream filter sees the INJECTED
+    # credential map alone, ignoring broker registrations.
     monkeypatch.setattr(
         builtin,
         "_stream_redaction_values",
         lambda store, injected: [str(v) for v in injected.values() if v],
     )
     command = f"{shlex.quote(sys.executable)} -c " + shlex.quote(
-        'import sys\nsys.stdout.write("line brokered-abcdef123456\\n")\n'
+        "import sys,time\n"
+        'for ch in "loadbearing-9f3e1a":\n'
+        "    sys.stdout.write(ch); sys.stdout.flush(); time.sleep(0.005)\n"
+        'sys.stdout.write("\\n"); sys.stdout.flush()\n'
+        "time.sleep(0.4)\n"
     )
-    painted: list[str] = []
-    await builtin.execute_bash(
-        "bash-red",
-        {"command": command},
-        AbortSignal(),
-        lambda update: painted.append(getattr(update.content[0], "text", "")),
-        context,
+    started = await builtin.execute_bash(
+        "bash-red", {"command": command, "background": True}, AbortSignal(), None, context
     )
-    # `_redact_tool_text` still cleans the emitted snapshot, so the leak is
-    # asserted where the pipe filter is the ONLY guard: the bytes the sink
-    # actually received.
-    raw = builtin._PipeRedactor({}).feed(b"line brokered-abcdef123456\n", final=True)
-    assert b"brokered-abcdef123456" in raw, "the RED harness itself is broken"
+    job_id = (started.details or {})["job_id"]
+    try:
+        for _ in range(60):
+            await asyncio.sleep(0.05)
+            probe = manager.read_output(job_id, 0)
+            if probe is not None and "loadbearing-9f3e1a" in probe[0]:
+                break
+        window = manager.read_output(job_id, 0)
+        assert window is not None
+        # The union is dead, so the pipe filter does not know the registered
+        # value and the peek buffer carries it raw — the leak, demonstrated on
+        # the channel the filter alone guards.
+        assert "loadbearing-9f3e1a" in window[0], (
+            "with the union reverted the secret must paint in the peek buffer; "
+            "if it does not, the RED harness is broken"
+        )
+    finally:
+        with contextlib.suppress(Exception):
+            await manager.cancel(job_id)
 
 
 @pytest.mark.asyncio
 async def test_a_broken_sink_withholds_live_output_instead_of_leaking(
     tmp_path: Path,
 ) -> None:
-    """Fail-closed, end to end, and the command still completes."""
+    """Fail-closed, end to end, on the channel the stream guard owns.
+
+    R3. The previous form asserted on ``result.text`` — a channel the finished
+    result's ``redact_tool_result`` keeps clean regardless of what the pipe
+    filter published, so it proved nothing about the fail-closed path it names.
+    The live snapshot and the peek buffer are doubly guarded (both also pass
+    ``_redact_tool_text``), so neither can isolate the pipe filter's branch
+    either. The one observable no downstream guard re-cleans is the filter's
+    own sink — exactly what it appended. This captures the sink and asserts
+    the withheld notice — not the secret — is what landed there. Mutation-
+    verified: reds under M3 (the sink failing OPEN, the reviewer-demonstrated
+    revert). The command still completes: failing closed must cost the live
+    view, not the run.
+    """
 
     class Broken(BrokerAwareStore):
         def redaction_values(self):
             raise RuntimeError("sink down")
 
     store = Broken()
-    context = ToolContext(cwd=str(tmp_path), variables=store)
+    context = ToolContext(cwd=str(tmp_path), variables=store, session_id="s")
     command = f"{shlex.quote(sys.executable)} -c " + shlex.quote(
         'import sys\nfor _ in range(5): sys.stdout.write("would-be-secret\\n")\n'
     )
-    result = await builtin.execute_bash(
-        "bash-closed", {"command": command}, AbortSignal(), None, context
-    )
-    assert "would-be-secret" not in result.text
-    assert "withheld" in result.text
+    sinks: list[Any] = []
+    real_sink = builtin._BashOutput
+    builtin._BashOutput = lambda: sinks.append(real_sink()) or sinks[-1]  # type: ignore[assignment]
+    try:
+        result = await builtin.execute_bash(
+            "bash-closed", {"command": command}, AbortSignal(), None, context
+        )
+    finally:
+        builtin._BashOutput = real_sink  # type: ignore[assignment]
+    sink_bytes = b"".join(b"".join(s.chunks()) for s in sinks) if sinks else b""
+    assert (
+        b"would-be-secret" not in sink_bytes
+    ), "the broken sink's bytes reached the pipe filter unfiltered (fail-open)"
+    assert b"withheld" in sink_bytes, "the fail-closed notice must be what the filter emitted"
+    # Failing closed costs the live view only — the command still completed.
+    assert result.is_error is False
 
 
 # --------------------------------------------------------------------------
@@ -708,6 +757,38 @@ def test_secrets_is_prebound_in_the_worker_namespace_without_importing_crypto() 
 
     proxy = eval_worker._LazySecrets()
     assert "retrieves one value" in repr(proxy)
+
+
+@pytest.mark.asyncio
+async def test_a_crash_with_a_secret_on_real_fd2_is_scrubbed(isolated: Path) -> None:
+    """R1 regression: the worker's REAL fd-2 tail is scrubbed with the ledger.
+
+    ``redirect_stderr`` swaps the ``sys.stderr`` OBJECT, not the fd, so
+    ``os.write(2, ...)`` (the deliberate form) and any inherited-stderr
+    subprocess (``curl -v`` with a token in the Authorization header — the
+    accidental form) write straight past the in-worker ledger. The value set
+    lives in the worker, so it is published to the parent on a side channel at
+    the moment of retrieval; this drives a REAL worker crash with a secret on
+    fd 2 and asserts the returned tool result carries the marker, not the
+    bytes.
+    """
+    from local_operator.secrets.access import open_store
+    from local_operator.tools import eval as eval_tool
+
+    open_store(create=True).set("CRASH_DEMO", b"CRASHLEAK-f00dcafe-9517")
+    tool = eval_tool.build_eval_tool()
+    context = ToolContext(cwd="/tmp", session_id="crash-leak")
+    code = (
+        "import os\n"
+        "token = secrets['CRASH_DEMO']\n"
+        "os.write(2, f'BOOM got {token}'.encode())\n"
+        "os._exit(3)\n"
+    )
+    result = await tool.execute("c1", {"code": code}, AbortSignal(), None, context)
+    assert result.is_error, "a hard worker crash must surface as an error"
+    assert "crashed" in result.text
+    assert "CRASHLEAK-f00dcafe-9517" not in result.text, "the fd-2 tail leaked raw"
+    assert "BOOM got [redacted]" in result.text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/secrets/test_agent_surfaces.py
+++ b/tests/unit/secrets/test_agent_surfaces.py
@@ -168,8 +168,19 @@ def test_the_builder_returns_none_when_the_store_cannot_import(
             raise ImportError("no crypto here")
         return real_import(name, *args, **kwargs)
 
+    # The refusal is installed and REMOVED around the one call under test
+    # rather than left to monkeypatch's unwind. The broker (#815) added an
+    # autouse teardown in tests/conftest.py that imports
+    # `local_operator.secrets.client` to sweep stray broker sockets, and
+    # fixture teardown runs BEFORE monkeypatch undoes a setattr made in the
+    # test body — so a still-installed refusal turns this passing test into a
+    # teardown ERROR. Scoping it here keeps the assertion identical while
+    # leaving no global hook alive past the line that needs it.
     monkeypatch.setattr(builtins, "__import__", refuse)
-    assert build_secret_tool(ToolContext()) is None
+    try:
+        assert build_secret_tool(ToolContext()) is None
+    finally:
+        monkeypatch.setattr(builtins, "__import__", real_import)
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit/secrets/test_agent_surfaces.py
+++ b/tests/unit/secrets/test_agent_surfaces.py
@@ -12,6 +12,7 @@ import asyncio
 import contextlib
 import shlex
 import sys
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +20,7 @@ import pytest
 
 from local_operator.harness.types import AbortSignal, ToolContext
 from local_operator.secrets.promote import promote_session_credential
+from local_operator.secrets.protocol import PROTOCOL_VERSION
 from local_operator.secrets.runtime import SecretsMapping, SecretValue
 from local_operator.tools import builtin
 from local_operator.tools.secret_tool import build_secret_tool, execute_secret
@@ -218,6 +220,164 @@ def test_mapping_retrieves_registers_and_reports_existence(isolated: Path) -> No
     with pytest.raises(KeyError):
         mapping["NOPE"]
     assert mapping.get("NOPE") is None
+
+
+def test_mapping_contract_holds_over_the_broker_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The SAME `Mapping` contract, served by a REAL broker (round-4 R11/Q5).
+
+    **Why this exists beside the test directly above it, which asserts the same
+    three things.** That one runs under `isolated`, which never starts a
+    broker, so `retrieve_secret` falls through to the local decrypt — it pins
+    the contract on the branch this PR did NOT change. Routing the mapping
+    through the broker broke it on the branch that has no test: the broker
+    reported every store failure as one flat `"store"` code, the class was
+    erased, `__getitem__`'s `except SecretNotFound` stopped matching, and
+    `secrets.get("ABSENT", "dflt")` RAISED instead of returning the default.
+    The suite stayed green throughout.
+
+    So the assertions are duplicated ON PURPOSE. The contract is one contract
+    and the two paths must be indistinguishable to a caller; a test that only
+    ever exercises one of them cannot notice when they diverge.
+    """
+    pytest.importorskip("local_operator.secrets.client")
+
+    from local_operator.paths import CONFIG_DIR_ENV
+    from local_operator.secrets import client
+    from local_operator.secrets.broker import SecretBroker
+    from local_operator.secrets.crypto import generate_master_key
+    from local_operator.secrets.keys import key_path, write_private_file
+    from local_operator.secrets.store import SecretStore
+
+    root = tmp_path / "config"
+    root.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    (tmp_path / "home").mkdir()
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(root))
+
+    key = generate_master_key()
+    store_on_disk = SecretStore(key, base=root)
+    store_on_disk.initialize()
+    store_on_disk.set("API", b"sk-live-4417", description="d")
+    write_private_file(key_path(root), key)
+
+    broker = SecretBroker(root, key_provider=lambda: key, idle_shutdown_s=0)
+    broker.start()
+    channel = None
+    stop = threading.Event()
+    try:
+        # **A running broker is NOT enough to reach the broker path, and
+        # discovering that is part of this finding.** Without a registered
+        # session the broker denies the retrieval on ancestry, and §8's keyfile
+        # fallback quietly serves it from the local decrypt — so a version of
+        # this test that merely started a broker PASSED against the unfixed
+        # head, reproducing the very "green because it exercised the other
+        # branch" defect it was written to catch. The registration is what puts
+        # the retrieval on the broker path, exactly as the TUI's startup
+        # registration does in production.
+        channel = client.register_session(root, session_id="mapping-contract")
+        assert channel is not None, "registration failed; the broker path is unreachable"
+
+        def drain() -> None:
+            while not stop.is_set():
+                notice = client.read_notification(channel)
+                if notice is None:
+                    return
+                client.acknowledge(channel)
+
+        # A real session answers §6 notifications; an unanswered notice would
+        # make the broker refuse as unredactable and mask the contract.
+        reader = threading.Thread(target=drain, daemon=True)
+        reader.start()
+
+        assert client.is_running(root), "no broker; this test would re-cover the local path"
+        mapping = SecretsMapping(root)
+        assert mapping["API"] == "sk-live-4417"
+
+        assert mapping.get("ABSENT", "dflt") == "dflt"
+        assert mapping.get("ABSENT") is None
+        with pytest.raises(KeyError):
+            mapping["MISSING"]
+        assert "MISSING" not in mapping
+        assert "API" in mapping
+    finally:
+        stop.set()
+        if channel is not None:
+            channel.close()
+        broker.stop(timeout=5)
+
+
+def test_a_stale_broker_refuses_rather_than_serving_unnotified(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A LIVE broker this runtime cannot speak to must not degrade (round-4 Q4).
+
+    **The case is a runtime update under a live daemon**, which `AGENTS.md`
+    calls routine: the new client speaks a protocol the running broker does
+    not. `retrieve_secret`'s docstring named this as the accepted cost and said
+    it raises — but `is_running` caught the version refusal and answered
+    `False`, laundering "live but stale" into "unreachable", so the fallback
+    fired and the value came back through the UNNOTIFIED local decrypt. That is
+    a full reproduction of Q3, and it arms itself at exactly the moment a
+    protocol bump ships.
+
+    `PROTOCOL_VERSION` has only ever been 1, so the skew is produced here by
+    running a real broker whose module constant is bumped — a real daemon, a
+    real socket and a real refusal, rather than a mock that would only restate
+    the assumption being tested.
+    """
+    pytest.importorskip("local_operator.secrets.client")
+
+    from local_operator.paths import CONFIG_DIR_ENV
+    from local_operator.secrets import broker as broker_module
+    from local_operator.secrets import client
+    from local_operator.secrets.access import retrieve_secret
+    from local_operator.secrets.crypto import generate_master_key
+    from local_operator.secrets.errors import BrokerIncompatible
+    from local_operator.secrets.keys import key_path, write_private_file
+    from local_operator.secrets.store import SecretStore
+
+    root = tmp_path / "config"
+    root.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    (tmp_path / "home").mkdir()
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(root))
+
+    secret = b"stale-broker-payload-71c2"
+    key = generate_master_key()
+    store_on_disk = SecretStore(key, base=root)
+    store_on_disk.initialize()
+    store_on_disk.set("STALE_TOKEN", secret, description="q4")
+    write_private_file(key_path(root), key)
+
+    # The daemon speaks a version this client does not. Patched on the broker
+    # module only, so the CLIENT keeps the real constant and the two disagree
+    # exactly as they would across an update.
+    monkeypatch.setattr(broker_module, "PROTOCOL_VERSION", PROTOCOL_VERSION + 1)
+    stale = broker_module.SecretBroker(root, key_provider=lambda: key, idle_shutdown_s=0)
+    stale.start()
+    try:
+        with pytest.raises(BrokerIncompatible) as refusal:
+            retrieve_secret("STALE_TOKEN", root)
+        # Actionable, not merely fatal: the operator is told what to run, and
+        # the pid is present because `status` cannot answer through the same
+        # version gate.
+        assert "lop secret broker restart" in str(refusal.value)
+        assert isinstance(refusal.value.pid, int)
+
+        # The distinction that carries the safety property: an unreachable
+        # broker still degrades, a live one does not.
+        with pytest.raises(BrokerIncompatible):
+            client.is_running(root)
+        status = client.broker_status(root)
+        assert status is not None and status.get("incompatible") is True
+
+        # Metadata is the deliberate exception: it hands out no bytes and owes
+        # no §6 notice, so the read-only surfaces stay up under skew.
+        assert "STALE_TOKEN" in SecretsMapping(root)
+    finally:
+        stale.stop(timeout=5)
 
 
 def test_existence_check_does_not_write_a_retrieval_audit_row(isolated: Path) -> None:


### PR DESCRIPTION
## Summary of Changes

**PR 3 of 4** from `docs/design/secret-store.md`: the surfaces an **agent** uses to reach the encrypted store PR 1 built, and the redaction wiring that keeps a retrieved value out of the transcript.

C2. Additive; the only user-visible surface is a new `/credential --persist` verb and a new tool. No version bump.

Release: minor — agents can now persist and use long-term secrets (`secret` tool, `secrets["NAME"]` in eval), and a `$(lop secret get ...)` value is no longer painted in the live bash view.

Four pieces, and one of them is a **live-output leak fix** that matters independently of the rest.

### 1. The `secret` tool (§5.2) — one gated tool, not six

One `createIf`-gated tool with an `op` parameter (`store|retrieve|list|describe|update|delete`). `AGENTS.md`'s tool-surface footprint ladder is explicit that every core tool's schema rides in the same prompt-cache prefix as the system prompt, **on every request, in every session and every subagent**, whether or not it is ever called. Six tools would be six schemas of permanent tax; the builder returns `None` where the store modules will not import, so a session that cannot use it pays nothing.

**`retrieve` deliberately does not return the value.** It returns a receipt naming the secret and stating how to *use* it. That preserves the inversion the session-credential path already implements: the agent uses a secret it cannot read. Returning bytes there would write them into a transcript that is persisted and replayed to the provider on every later turn — the worst outcome this design exists to prevent.

### 2. The eval runtime (§5.3) — a library, not injected variables

`secrets["NAME"]` is a lazy `Mapping`, pre-bound in the kernel namespace. Injecting every secret into the worker's globals (the rejected alternative) would put every secret in memory whether or not the cell wants one, expose them to `print(globals())`, and force a choice about *which* to inject before knowing what the cell does. Each lookup is one round trip and one audit row; `"X" in secrets` checks existence via `describe` so it does not log a read that handed out no bytes.

The returned `SecretValue` is a real `str` — f-strings, concatenation and `.encode()` all work — and **only `__repr__` redacts**. `__str__` deliberately does not: `f"Bearer {token}"` formats through `__str__`, so a redacting one would send `Bearer [redacted]` to the API as an auth failure that looks like a bad credential rather than a harness bug. The safety net is the worker ledger, which scrubs every model-visible channel instead — strictly stronger, and it cannot break a working request.

### 3. The redaction fix (§6) — the correctness-critical piece

**The hole.** `_PipeRedactor` was constructed from `credential_env()` **alone** — the values this process *injected*. A child running `$(lop secret get X)` fetches a value this process never saw, which the broker announces to the session out of band. So the value was scrubbed from the finished tool result and by `_redact_tool_text`, but **painted live** in the streaming card and in `jobs(op='peek')`.

`_stream_redaction_values` now unions the injected map with the store's registered values, and the pump **re-reads it per chunk** because the registration lands *during* the command.

**Composition with #815, and failing closed.** The sink (`VariableStore.register_redaction` / `redaction_values`) ships on the broker branch. It is consumed via `getattr` — this codebase's existing convention (`builtin.py` `credential_env`, `_redact_tool_text`) — so this composes whichever order the two land in and **adds zero lines to the methods #815 owns**. Its absence does **not** degrade to "no redaction": a sink that is present but unreadable returns a sentinel and the pump **withholds** the live output rather than publishing bytes it cannot vouch for, while still draining the pipe so a redaction fault cannot become a hung child on a full buffer. `_redact_tool_text` was hardened the same way — it is called from the streaming emit and the job mirror, where a raising sink previously **crashed the whole bash tool** and lost the command's result along with its output (found by my own test, not by inspection).

### 4. Persist route (§5.4) and guidance docs (§10)

The session path is unchanged and *gains a route*: `/credential --persist KEY`, `ask secret=true` with `persist=true`, and an owner-side op so a viewer promotes onto the owner where both stores live. Promotion is **additive** (the session copy stays, so bash commands in flight keep working) and **refuses to overwrite** an existing long-term secret rather than silently destroying one because a session reused a name.

Guidance is `guide://credentials` plus an `AGENTS.md` section, written for a model mid-task. **Residual risk is not overclaimed**: per §9 it defeats the "scan the disk for credential files" malware a bad link drops, and anything running as the operator that is willing to run `lop` can still read every secret. A large increase in attacker cost, not a vault — the guide says so in those words.

## Related Issue(s)

None requested. PR 3 of 4 per design §14; PR 4 (inline `/credential` capture) has already landed, PR 2 (broker) is #815.

## Reproduction and actual execution

Real CLI subprocesses, the real `bash` tool, the real `eval` worker, and a real job manager. Scratch config dir with **both** `HOME` and `LOCAL_OPERATOR_CONFIG_DIR` redirected (per `AGENTS.md`: the override alone does not isolate a run). The operator's `~/.local-operator/secrets` and `~/.minerva/credentials/.env` were asserted untouched before and after — `~/.minerva/credentials/.env` aggregate SHA `6719ea77…` identical on both checks, and `~/.local-operator/secrets` absent throughout.

### The CLI contract still holds (PR 1's invariant, not regressed)

```
$ lop secret set DEMO_TOKEN --description 'demo api token'   (value on stdin)
exit=0 stdout='' stderr='stored DEMO_TOKEN (27 bytes, kind=string)'

$ lop secret get DEMO_TOKEN
exit=0 stdout='ghp_REALSECRET_a1b2c3d4e5f6'
byte-exact, no trailing newline? True

$ lop secret get NO_SUCH_SECRET
exit=2  stdout=''  (empty => $() is safe)
stderr: No secret named 'NO_SUCH_SECRET' in this store.
```

### The fix: a real bash tool call resolving `$(lop secret get ...)`

The child fetches the secret; this process never sees the bytes.

```
--- what the MODEL sees (tool result) ---
exit code: 0
--- stdout ---
calling api with [redacted]
calling api with [redacted]
calling api with [redacted]

secret in model-visible result?   False
secret in ANY live stream update? False
```

### Background-job peek — the surface where the pipe filter is the ONLY guard

`jobs(op='peek')` reads what the pipe filter mirrored while the command ran; no `ToolResult` exists yet, so `redact_tool_result` cannot help. The secret is emitted **one character at a time** so it necessarily straddles pipe reads — the case `_PipeRedactor` uniquely exists for.

```
$ jobs(op='peek', job_id=506933bb595c)
peek sees [redacted]
peek sees [redacted]
peek sees [redacted]

secret in peek buffer? False
```

### THE RED — revert the fix and the secret paints

Rebuilding the filter from `credential_env()` alone, exactly what shipped before this PR:

```
--- peek buffer WITHOUT the fix ---
peek sees ghp_REALSECRET_a1b2c3d4e5f6
peek sees ghp_REALSECRET_a1b2c3d4e5f6
peek sees ghp_REALSECRET_a1b2c3d4e5f6

>>> SECRET PAINTED IN THE LIVE VIEW? True
>>> The guard is load-bearing.
```

**A false-passing harness caught on the way to this.** The first fragmenter used `printf "%s" "$TOKEN" | fold -w1 | while read -r c`, which silently **drops the last character** — so the child never printed the whole secret, and the RED could not fire (it reported `False` while showing 26 of 27 characters painting). Found by checking the emitted bytes rather than trusting the pipeline. The harness was fixed to `cut -c$n` in a counted loop and verified to emit the full secret before the RED was believed.

### The eval library, in a real worker subprocess

```
>>> eval cell: token = secrets['EVAL_TOKEN']; len(token)
    result: 23

>>> eval cell: print('printed:', token); token
    result: <secret EVAL_TOKEN: [redacted], 23 chars>
    stdout: printed: [redacted]

>>> eval cell: f'Bearer {token}' == 'Bearer ' + token
    result: True                      # the value is REAL where it is used

>>> eval cell: 'EVAL_TOKEN' in secrets, list(secrets)
    result: (True, ['EVAL_TOKEN'])

>>> eval cell: secrets['MISSING_ONE']
    KeyError: "No secret named 'MISSING_ONE' in this store."

>>> eval cell: import secrets as stdlib_secrets; len(stdlib_secrets.token_hex(8))
    result: 16                        # stdlib shadowing still works

SECRET ANYWHERE IN WHAT THE MODEL SAW? False
```

`grep -c` for the raw secret across the entire captured transcript: **0**.

### The agent tool, called as the model calls it

```
>>> secret({"op": "list"})                       # fresh machine
    No secrets are stored on this machine yet. Use op='store' to add the first.

>>> secret({"op": "store", "name": "STRIPE_KEY", "value": "...", "description": "stripe production key"})
    Stored STRIPE_KEY in the encrypted long-term store.
    The value is NOT shown here and never will be. Use it without reading it:
      bash:  curl -H "Authorization: Bearer $(lop secret get STRIPE_KEY)" ...
      eval:  secrets["STRIPE_KEY"] returns the value inside the worker process.

>>> secret({"op": "list"})
    1 stored secret(s) — names only, never values:
      STRIPE_KEY  stripe production key

--- failure cases ---
>>> secret({"op": "retrieve", "name": "NOT_THERE"})   is_error=True
    No secret named 'NOT_THERE' in this store.
>>> secret({"op": "store", "name": "STRIPE_KEY", ...})  is_error=True
    A secret named 'STRIPE_KEY' already exists. Use `lop secret update` to change its value.
>>> secret({"op": "store", "name": "NO_VALUE"})       is_error=True
    'store' needs the value. If you do not have it, ask the user for it with the ask tool
    (secret=true) instead of guessing.
>>> secret({"op": "retrieve"})                        is_error=True
    'retrieve' requires a secret name.
```

`list` on a machine with no store returns "none yet" rather than an error — it is the verb the guidance tells an agent to use to *orient*, and an error there reads as "the store is broken" and invites a retry.

### The persist route

```
/credential --persist deploy key  ->  action='persist' key='DEPLOY_KEY'
promote -> ok=True   value in message? False
long-term store now has: ['DEPLOY_KEY']   round-trips: True
session copy KEPT (bash still works): True

--- clobber guard ---
promote again -> ok=False already_present=True
  DEPLOY_KEY already exists in the long-term store; it was NOT replaced.
original preserved: True
```

### Audit trail

```
2026-09-08 17:01:56  set     ok    pid=90856   c31c382c-...
2026-09-08 17:01:56  get     ok    pid=90859   c31c382c-...
...
$ lop secret audit --verify -> exit=0
audit chain intact
```

### Failure cases

```
secrets["ABSENT"]  -> KeyError: "No secret named 'ABSENT' in this store."
no store at all    -> SecretStoreError: No secret store found at .../secrets.
                      Create one by storing a secret: lop secret set NAME
broken sink        -> live output withheld, command still completes
```

## Adversarial testing: six mutants, each demonstrated RED

`AGENTS.md` §"Prove the test can still fail". Every guard was reverted and the suite re-run, because a redaction test that passes for the wrong reason is worse than none.

| # | Mutation | Result |
|---|---|---|
| 1 | `_stream_redaction_values` ignores registrations (**the shipped bug**) | 2 failed |
| 2 | pump never `refresh`es mid-stream | 1 failed |
| 3 | `refresh()` is a no-op | 1 failed |
| 4 | `_PipeRedactor` built from injected map only | 1 failed |
| 5 | worker response does not scrub | 1 failed |
| 6 | worker scrub returns input on error (not fail-closed) | 1 failed |

**Mutants 2 and 4 initially SURVIVED**, which is the useful part. The final tool result is re-scrubbed by `_redact_tool_text`, so an assertion on `result.text` passes even with the pipe filter disabled — the tests were passing for the wrong reason. Two tests were added that assert on the **peek buffer** (fed only by the pipe filter, with no `ToolResult` in existence) and register the value **after the command has started streaming**. Both mutants then failed. This is exactly the false-passing-harness pattern the brief warned about, caught by mutation rather than by reading the code.

## Sibling sweep (requested explicitly, reported either way)

Swept every consumer built from `credential_env()` or session credential values:

- **`_PipeRedactor` (builtin.py:1714)** — the bug. Fixed.
- **`_redact_tool_text`** — already reads `VariableStore.redact`, so it picks up registrations for free once #815 lands. Hardened to fail closed on a raising sink (it previously propagated and crashed the bash tool).
- **`_mirror` / `_emit_update` / `_detach_to_job` / background seeding** — all route through `_redact_tool_text`; covered by the same fix, no separate construction.
- **`execute_bash` env injection (builtin.py:1576)** — correctly uses `credential_env()` alone: it is *injecting*, and a registered §6 value must **not** be injected (that would make a scrub-only value readable, the exact confusion §6 warns about). Not a sibling.
- **`server/routes/desktop_radient.py:251`** — has the same *shape* (`value.replace(secret, "[redacted]")`) but its secrets are values it holds locally (a Radient token and a just-minted key), not session credentials, so it has no announced-value blind spot. **Different mechanism, no shared bug.**
- **`evaluation/` `RedactionSet`** — a wholly separate subsystem with its own explicit value set. Not a sibling.

**One real sibling found and fixed** (`_redact_tool_text`'s crash-on-raise); the rest are genuinely not affected.

## Scope boundary with #815

Verified rather than asserted. This branch defines **no** `register_redaction`, `redaction_values`, or `_redactions` on `VariableStore`, adds nothing to `secrets/session.py`, and touches no TUI boot wiring — `grep` confirms zero hits. Its only `variables.py` change is the additive `--persist` verb in the slash parser.

Composition was tested by splicing #815's real `variables.py` seam in and re-running:

```
stream values: ['injected-v', 'broker-v']       # union, de-duplicated
redact():      a [redacted] b [redacted] c
```

Then reverted, so the seam ships with #815 and not here.

## Quality gates

| Gate | Result |
|---|---|
| `flake8 .` | clean |
| `black --check .` | 1151 files unchanged |
| `isort --check .` | clean |
| `pyright` | **0 errors, 0 warnings** |
| `tests/unit/secrets` | 172 passed |
| new suite `test_agent_surfaces.py` | 37 passed |
| import-graph / startup-cost guards | 13 passed — crypto stays off the CLI path |

The eval worker's import path was checked directly: importing `eval_worker` pulls **nothing heavy** (no `cryptography`, no `sqlite3`, no `secrets.runtime`), so a kernel that never touches a secret pays nothing for the lazy proxy.

Whole-tree number is in a follow-up comment: this host is running ~6 concurrent suites at load average 125-145 with `ulimit -n` at 256, which produced 1166 `Errno 24` infrastructure errors unrelated to this change. Re-run serialised at `-n 4` with the fd limit raised, per the machine-wide guidance.
