### PR TITLE
fix(wakes): prime the login-shell PATH in the wake supervisor

### DIFF
--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -4159,10 +4159,21 @@ def main() -> int:
         # run shell commands whose PATH must match a login terminal's, but
         # `config list`, `credential`, `login`, `agents` and the like never
         # spawn a tool — yet every one of them used to pay a full login-shell
-        # round-trip (`$SHELL -l -c 'echo $PATH'`) on startup. The helper keeps
-        # a per-process cache, so a session that later needs it still primes at
-        # most once. ``None`` is the bare interactive launch.
-        _SUBPROCESS_SUBCOMMANDS = frozenset({"exec", "serve", "mobile", "browser", "tunnel"})
+        # round-trip (`$SHELL -l -c 'echo $PATH'`) on startup. The helper is
+        # NOT cached, so this membership test is the only thing keeping that
+        # round-trip off the cheap subcommands — adding a name here costs
+        # every invocation of it one login shell. ``None`` is the bare
+        # interactive launch.
+        #
+        # `wake` is here for `lop wake serve`, the documented foreground form
+        # of the LaunchAgent for anyone running the supervisor under their own
+        # supervisor. It reaches the same `serve()` and therefore spawns
+        # runtimes through `session/runtime/launch.py`, which propagates
+        # `dict(os.environ)` — so without the bootstrap it hands every
+        # wake-driven turn whatever PATH its own supervisor happened to have.
+        _SUBPROCESS_SUBCOMMANDS = frozenset(
+            {"exec", "serve", "mobile", "browser", "tunnel", "wake"}
+        )
         if args.subcommand in _SUBPROCESS_SUBCOMMANDS or args.subcommand is None:
             setup_cross_platform_environment()
 

--- a/local_operator/helpers.py
+++ b/local_operator/helpers.py
@@ -935,6 +935,16 @@ def get_posix_shell_path() -> str | None:
 
         # Run the command. shell=True is necessary here for the '-l' flag to work correctly
         # by invoking the shell itself to interpret the command string.
+        #
+        # The timeout is load-bearing rather than defensive. A login shell runs
+        # the user's rc files, and an rc that blocks — a slow network mount, an
+        # nvm/conda init, anything that reads from a terminal that is not there
+        # — parks this call forever. In an interactive launch that is merely a
+        # hang the user can see and Ctrl-C. In the wake supervisor's KeepAlive
+        # LaunchAgent it is invisible and unrecoverable: the process wedges
+        # BEFORE `serve()`, so it is alive, fires no wakes, and launchd never
+        # restarts it because nothing exited. Ten seconds is far above a
+        # healthy shell's cost and far below a user noticing a missed wake.
         result = subprocess.run(
             command,
             capture_output=True,
@@ -942,6 +952,7 @@ def get_posix_shell_path() -> str | None:
             check=True,
             shell=True,
             executable=shell_path,
+            timeout=10,
         )
 
         full_path = result.stdout.strip()
@@ -974,6 +985,18 @@ def get_posix_shell_path() -> str | None:
         logger.error(
             "Shell executable not found at '%s'. Cannot get PATH from login shell.",
             shell_path if shell_path is not None else "<unknown>",
+        )
+        return None
+    except subprocess.TimeoutExpired:
+        # A wedged rc file. Degrading to `None` costs nothing that was not
+        # already lost — `setup_cross_platform_environment` falls back to the
+        # inherited `os.environ` PATH — and it is strictly better than the
+        # alternative, which is a supervised process that never reaches its
+        # own main loop.
+        logger.error(
+            "Timed out getting PATH from login shell. Command "
+            f"'{command if command is not None else '<unknown>'}' "
+            "did not finish within 10s; falling back to the inherited PATH."
         )
         return None
     except subprocess.CalledProcessError as e:

--- a/local_operator/wakes/supervisor.py
+++ b/local_operator/wakes/supervisor.py
@@ -225,6 +225,29 @@ def main(argv: list[str] | None = None) -> int:
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
+
+    # launchd hands this process a bare ``PATH=/usr/bin:/bin:/usr/sbin:/sbin``
+    # — the LaunchAgent sets ``LOCAL_OPERATOR_CONFIG_DIR`` and nothing else,
+    # deliberately (a PATH baked into the plist render would vary per calling
+    # session and turn ``ensure_supervisor_installed``'s content comparison
+    # into a restart loop). That bare PATH does not stop here: every runtime
+    # this supervisor engages is spawned with ``dict(os.environ)``
+    # (``session/runtime/launch.py``), so a wake-driven turn inherits it and
+    # loses kubectl, Homebrew, nvm, cargo, pyenv and Nix. Interactive launches
+    # never showed it because a terminal already supplies a login PATH, which
+    # is exactly why this was the one process entry point that skipped the
+    # bootstrap every other entry (``cli.main``, ``server.app``) performs.
+    #
+    # Imported function-locally on purpose: importing ``helpers`` pulls in 53
+    # further modules and ~11.5-12.2 ms (measured on this commit, three runs),
+    # which a process whose whole justification is staying light must not pay
+    # at import time, and ``wakes/`` keeps a deliberately thin import graph
+    # (``tests/unit/test_import_graph.py`` pins ``wakes.store`` to stdlib-only;
+    # it does not constrain this module, but the intent covers it).
+    from local_operator.helpers import setup_cross_platform_environment
+
+    setup_cross_platform_environment()
+
     from local_operator.paths import config_dir
 
     try:

--- a/tests/unit/wakes/test_supervisor.py
+++ b/tests/unit/wakes/test_supervisor.py
@@ -9,6 +9,9 @@ also deliver would double-fire every wake it touched.
 
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -199,3 +202,116 @@ async def test_a_malformed_entry_costs_one_session_not_the_sweep(
 
     assert fired == 1
     assert [call["session_id"] for call in engagements] == ["sessiongood2"]
+
+
+# --- The login-shell PATH bootstrap ------------------------------------------
+#
+# These two run the entry point in a CHILD INTERPRETER, not in-process, and
+# that is the whole point. The property under test is a mutation of the
+# process's own `os.environ`, so an in-process test would have to monkeypatch
+# `os.environ` and then assert its own mutation — passing whether or not the
+# entry point does anything. Only a real process started with a bare PATH can
+# observe the bootstrap actually running.
+#
+# `SHELL` pointed at a two-line script is the seam that makes them hermetic:
+# the bootstrap shells out to `$SHELL -l -c 'echo "$PATH"'`, so a fake shell
+# echoing a known marker directory gives an identical result on CI and on a
+# laptop, with no dependence on the developer's rc files or on Homebrew being
+# installed.
+
+_PATH_DRIVERS = {
+    "supervisor": (
+        "import os\n"
+        "from local_operator.wakes.supervisor import main\n"
+        "main(['--once'])\n"
+        "print('OBSERVED_PATH=' + os.environ['PATH'])\n"
+    ),
+    "cli": (
+        "import os, sys\n"
+        "sys.argv = ['lop', 'wake', 'serve', '--once']\n"
+        "from local_operator.cli import main\n"
+        "main()\n"
+        "print('OBSERVED_PATH=' + os.environ['PATH'])\n"
+    ),
+}
+
+
+def _observe_entry_point_path(driver: str, tmp_path: Path) -> str:
+    """Run one wake entry point under a bare PATH; return the PATH it ended with.
+
+    The config dir handed to the child is EMPTY, so ``serve()`` reads an empty
+    index and retires 0 on its first pass: no runtime is spawned, no launchd
+    domain is addressed, and no real session is touched. ``HOME`` is redirected
+    alongside ``LOCAL_OPERATOR_CONFIG_DIR`` because the config variable alone
+    does not redirect the cache root.
+    """
+    marker = tmp_path / "marker-bin"
+    marker.mkdir()
+    shell = tmp_path / "fake-login-shell"
+    shell.write_text(f'#!/bin/sh\necho "{marker}:/usr/bin:/bin"\n', encoding="utf-8")
+    shell.chmod(0o755)
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    repo_root = Path(__file__).resolve().parents[3]
+    result = subprocess.run(
+        [sys.executable, "-c", _PATH_DRIVERS[driver]],
+        env={
+            # launchd's bare default, reproduced exactly.
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "HOME": str(tmp_path),
+            "SHELL": str(shell),
+            "LOCAL_OPERATOR_CONFIG_DIR": str(config_dir),
+            "PYTHONPATH": str(repo_root),
+        },
+        capture_output=True,
+        text=True,
+        # A HANG BACKSTOP ONLY — never an assertion. Nothing on the success
+        # path compares elapsed time (AGENTS.md, "Timing, flakes, and how to
+        # assert that something is fast"); this exists so a wedged child fails
+        # the run instead of holding a CI slot.
+        timeout=180,
+    )
+    assert result.returncode == 0, f"child failed:\n{result.stdout}\n{result.stderr}"
+    observed = [
+        line.removeprefix("OBSERVED_PATH=")
+        for line in result.stdout.splitlines()
+        if line.startswith("OBSERVED_PATH=")
+    ]
+    assert observed, f"driver printed no PATH:\n{result.stdout}\n{result.stderr}"
+    return observed[-1]
+
+
+@pytest.mark.skipif(os.name != "posix", reason="the login-shell seam is POSIX-only")
+def test_the_launchagent_entry_primes_the_login_shell_path(tmp_path: Path) -> None:
+    """Detects the removal of ``setup_cross_platform_environment`` from ``main``.
+
+    launchd gives the supervisor ``/usr/bin:/bin:/usr/sbin:/sbin`` and nothing
+    else, and every runtime it engages is spawned with ``dict(os.environ)``
+    (``session/runtime/launch.py``) — so without this call each wake-driven
+    turn runs without kubectl, Homebrew, nvm, cargo, pyenv or Nix. Mutating
+    the call away leaves the child reporting launchd's bare PATH verbatim.
+    """
+    observed = _observe_entry_point_path("supervisor", tmp_path)
+
+    marker = str(tmp_path / "marker-bin")
+    # Membership, never equality and never index 0: the bootstrap PREPENDS the
+    # Electron ``Local Operator/bin`` directory when one exists, so the marker
+    # is not reliably first and the string is not reliably ours alone.
+    assert marker in observed.split(os.pathsep), observed
+
+
+@pytest.mark.skipif(os.name != "posix", reason="the login-shell seam is POSIX-only")
+def test_wake_serve_primes_the_login_shell_path(tmp_path: Path) -> None:
+    """Detects ``"wake"`` being dropped from ``cli._SUBPROCESS_SUBCOMMANDS``.
+
+    ``lop wake serve`` is a second, documented entry into the same ``serve()``
+    for anyone running the supervisor under their own supervisor, so it spawns
+    runtimes on the identical path. ``cli.main`` primes the PATH only for
+    subcommands on that frozenset; removing the name leaves this child with
+    whatever PATH it inherited.
+    """
+    observed = _observe_entry_point_path("cli", tmp_path)
+
+    marker = str(tmp_path / "marker-bin")
+    assert marker in observed.split(os.pathsep), observed


### PR DESCRIPTION
## Change class

**C2 — standard.** A behavioural fix to a supervised background process plus a bounded
subprocess call. No schema, no interface, no version bump (`pyproject.toml` stays at
`0.52.0`).

## Root cause

`wakes/install.py::render_plist()` gives launchd exactly one environment key —
`LOCAL_OPERATOR_CONFIG_DIR` — so the supervisor starts with launchd's bare default
`PATH=/usr/bin:/bin:/usr/sbin:/sbin`. Verified against the live process:

```
$ pgrep -f wakes.supervisor
68370
$ ps eww -p 68370 | tr ' ' '\n' | grep '^PATH='
PATH=/usr/bin:/bin:/usr/sbin:/sbin
```

**The bare PATH does not stop at the supervisor.** `session/runtime/launch.py:277` builds
the child environment as `env = dict(os.environ)`, so every runtime the supervisor engages
inherits it, and therefore so does every wake-driven turn. `kubectl`, Homebrew, `nvm`,
`cargo`, `pyenv` and Nix binaries are all off the path. Observed impact: a production watch
logged a PATH-repair NOTE on **56 consecutive wake cycles**.

`helpers.setup_cross_platform_environment()` is the existing cross-platform bootstrap
(login shell on Darwin/Linux, registry on Windows, plus `~/.local/bin` and Electron bin
dirs, falling back to `os.environ` on failure). `cli.main()` and `server/app.py` both call
it. The wake supervisor was **the one process entry point that did not** — and interactive
sessions always carry a login-shell PATH, which is precisely why this hid.

## Changes

1. **`wakes/supervisor.py`** — call `setup_cross_platform_environment()` in `main()`,
   after `logging.basicConfig` and before `asyncio.run(serve(...))`. Imported
   **function-locally**: importing `helpers` pulls in 53 further modules and ~11.5–12.2 ms
   (measured on this commit, three runs), which a process whose whole justification is
   staying light must not pay at import. `tests/unit/test_import_graph.py` pins
   `wakes.store` to stdlib-only; it does not constrain `supervisor`, but the intent covers
   it and the function-local import respects it either way.

2. **`cli.py`** — add `"wake"` to `_SUBPROCESS_SUBCOMMANDS`. `lop wake serve` (cli.py:2593)
   is a second, documented entry into the same `serve()` for anyone running the supervisor
   under their own supervisor; it spawns runtimes on the identical path and so had the
   identical bug.

   This also **corrects a false comment** next to that frozenset. It claimed "The helper
   keeps a per-process cache, so a session that later needs it still primes at most once."
   There is no cache — the only `functools.lru_cache` decorators in `helpers.py` are on
   `pillow_image_module` and `heif_image_module`; neither
   `setup_cross_platform_environment` nor `get_posix_shell_path` is cached. The membership
   test is therefore the *only* thing keeping the login-shell round-trip off the cheap
   subcommands, and the comment now says so.

3. **`helpers.py`** — `get_posix_shell_path()` ran `'{shell}' -l -c 'echo "$PATH"'` with
   `shell=True, check=True` and **no timeout**. Added `timeout=10` and a
   `subprocess.TimeoutExpired` handler returning `None`. This matters now because of change
   1: in a `KeepAlive` LaunchAgent a wedged rc file (slow network mount, `nvm`/`conda`
   init, an rc that blocks on a terminal read) parks the process **before** `serve()` — the
   supervisor is alive, fires no wakes, and launchd never restarts it because nothing
   exited. Returning `None` degrades to exactly today's behaviour, since
   `setup_cross_platform_environment` already falls back to `os.environ`.

## Why the plist was deliberately NOT given a PATH key

This was considered and **overruled — please do not "fix" it later.**
`ensure_supervisor_installed()` compares the rendered plist to the on-disk one and, on
mismatch, rewrites it and runs `bootout` + `bootstrap` (`install.py:212`). It runs after
every non-empty wake persist, from whatever session happens to be running. A PATH baked
into `render_plist()` would vary with the calling session's own environment, so the
rendered content would differ from disk on most persists — turning an idempotent installer
into a **supervisor restart loop**.

There is also no pre-Python window to defend: `procname.launchd_program()` returns an
absolute interpreter path with no shell and no wrapper, so nothing is resolved from PATH
before Python starts. Fixing it inside `main()` is both sufficient and the only stable
place. `wakes/install.py` is unchanged in this PR.

## What the regression tests assert

`tests/unit/wakes/test_supervisor.py` gains two tests, both POSIX-skipped.

Each runs an entry point in a **child interpreter** via `subprocess.run([sys.executable,
"-c", driver], env=hermetic)` and prints `os.environ["PATH"]` at the end. Out-of-process is
the crux: the property under test is a mutation of the process's own `os.environ`, so an
in-process test would have to monkeypatch `os.environ` and then assert its own mutation —
passing whether or not the entry point does anything, while *looking* like coverage.

The hermetic environment is `PATH=/usr/bin:/bin:/usr/sbin:/sbin` (launchd's default,
reproduced exactly), `HOME=<tmp>`, `SHELL=<tmp script>`, `LOCAL_OPERATOR_CONFIG_DIR=<empty
tmp dir>`, `PYTHONPATH=<repo root>`.

- **`SHELL` pointed at a two-line script** echoing a marker directory is the seam that
  makes this hermetic — the bootstrap shells out to `$SHELL -l -c 'echo "$PATH"'`, so the
  result is identical on CI and on a laptop with no dependence on anyone's rc files or on
  Homebrew existing.
- **The config dir is empty**, so `serve()` reads an empty index and retires 0 on its first
  pass: no runtime is spawned, no launchd domain is addressed, no real session touched.
- The assertion is `marker in observed.split(os.pathsep)` — **membership, never equality
  and never index 0**, because the Electron `Local Operator/bin` directory is prepended
  when present.
- The `subprocess.run` timeout is a **hang backstop only**. Nothing on the success path
  compares elapsed time (AGENTS.md, "Timing, flakes, and how to assert that something is
  fast").

`test_the_launchagent_entry_primes_the_login_shell_path` covers change 1;
`test_wake_serve_primes_the_login_shell_path` drives `cli.main()` with
`argv = ["lop","wake","serve","--once"]` and covers change 2.

## Mutation-test evidence

Both tests were **watched failing** with their fix mutated away, then restored.

**(a) `setup_cross_platform_environment()` deleted from `supervisor.main()`:**

```
>       assert marker in observed.split(os.pathsep), observed
E       AssertionError: /usr/bin:/bin:/usr/sbin:/sbin
E       assert '/private/var/.../test_the_launchagent_entry_pri0/marker-bin' in ['/usr/bin', '/bin', '/usr/sbin', '/sbin']

FAILED tests/unit/wakes/test_supervisor.py::test_the_launchagent_entry_primes_the_login_shell_path
1 failed, 10 passed in 0.78s
```

**(b) `"wake"` removed from `_SUBPROCESS_SUBCOMMANDS`:**

```
>       assert marker in observed.split(os.pathsep), observed
E       AssertionError: /usr/bin:/bin:/usr/sbin:/sbin
E       assert '/private/var/.../test_wake_serve_primes_the_log0/marker-bin' in ['/usr/bin', '/bin', '/usr/sbin', '/sbin']

FAILED tests/unit/wakes/test_supervisor.py::test_wake_serve_primes_the_login_shell_path
1 failed, 10 passed in 0.71s
```

Note each mutation reddens **only its own** test — the two entry points prime
independently, which is why both needed covering. After restoring: `11 passed in 0.97s`,
and `git diff --stat` confirmed the mutations were gone before committing.

## End-to-end evidence

Both entry points run under a bare launchd PATH in an **isolated config dir** (empty, plus
a redirected `HOME`), with `SHELL` pointed at a fake login shell echoing a marker dir. Same
probe, before and after the fix.

**Before (`origin/main` code):**

```
### BEFORE — supervisor entry
exit: 0
RC=0
OBSERVED_PATH=/usr/bin:/bin:/usr/sbin:/sbin

### BEFORE — lop wake serve entry
exit: 0
RC=0
OBSERVED_PATH=/usr/bin:/bin:/usr/sbin:/sbin
```

**After (this branch):**

```
### AFTER — supervisor entry
exit: 0
RC=0
OBSERVED_PATH=/var/folders/.../lo-wake-evi-x71nxmll/marker-bin:/usr/bin:/bin

### AFTER — lop wake serve entry
exit: 0
RC=0
OBSERVED_PATH=/var/folders/.../lo-wake-evi-06781rmd/marker-bin:/usr/bin:/bin
```

The marker directory that only the fake login shell knows about is now on the PATH of both
entry points, and `RC=0` confirms the supervisor still retires cleanly on an empty index.
No live wake was touched: the live supervisor (pid 68370) was never booted out, the real
`~/.local-operator/wakes/` was never written, and every run used a throwaway
`LOCAL_OPERATOR_CONFIG_DIR` and `HOME`.

## Gates — whole tree, exactly as CI

| gate | result |
| --- | --- |
| `.venv/bin/python -m flake8 .` | clean, rc=0 |
| `uvx --from black==26.1.0 black --check .` | `1147 files would be left unchanged.` |
| `uvx isort==5.13.2 --check .` | clean (`Skipped 2 files`) |
| `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | `0 errors, 0 warnings, 0 informations` |
| `.venv/bin/python -m pytest tests/unit -q` | **`17023 passed, 18 skipped`** in 1837.80s, rc=0 |
| `pytest tests/e2e -m e2e -n0 -q` | **`93 passed, 7 skipped`** in 175.45s, rc=0 |

The unit run reports a full summary line with a real count, so it did not stop early. Run
through `python -m` throughout, never the console scripts (baked shebangs, rc=126 swallowed
by pipelines).

## ⚠️ A LOCAL STOPGAP EXISTS ON THE OPERATOR'S MACHINE ONLY — NOT PART OF THIS FIX

`~/Library/LaunchAgents/com.local-operator.wakes.plist`, backup
`.bak-20260908-154827`. It was applied to hardcode `/opt/homebrew/bin` into the
supervisor's environment as an interim unblock. **It is not the upstream fix and nothing in
this PR depends on it.**

**Correction to what was believed about its current state, verified while preparing this
PR:** the stopgap is **already gone**. Both the live plist and its backup are byte-identical
and neither contains a PATH key or any mention of `/opt/homebrew`:

```
$ diff ~/Library/LaunchAgents/com.local-operator.wakes.plist \
       ~/Library/LaunchAgents/com.local-operator.wakes.plist.bak-20260908-154827
$ grep -c opt/homebrew <both files>
0
0
$ plutil -p ~/Library/LaunchAgents/com.local-operator.wakes.plist | grep -A2 EnvironmentVariables
  "EnvironmentVariables" => {
    "LOCAL_OPERATOR_CONFIG_DIR" => "/Users/damian/.local-operator"
  }
```

A wake persist has already rewritten it from `render_plist()` and dropped the PATH key —
exactly the mechanism described above, and exactly why baking PATH into the render would
loop. The live process (pid 68370, started 16:10) is consequently running on the bare
launchd PATH right now, which is the defect this PR fixes. **No manual revert is needed;
no further action on the plist is required after this merges.**

## Adjacent findings, deliberately not fixed here

- **`tunnels/install.py`** has a related but **non-identical** omission, deferred to a
  sibling PR. Its reachable failure is narrower: an absolute `cloudflared_path` is normally
  persisted, and the gap is a reconnect that drops the key and falls through to
  `shutil.which`. Its evidence needs a real cloudflared connector, so it does not belong in
  this diff.
- **`browser_bridge/install.py`** sets no `EnvironmentVariables` at all, but resolves
  nothing from PATH, so it is deliberately untouched.
