### PR TITLE
chore(release): bump version to 0.52.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.52.3"
+version = "0.52.4"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window claimed. Owner session pid: 86514 (conversation "Fixing GitHub Issue 822").

Window (tick as each merges):
- [x] #829 — `Release: patch — the configuration guide no longer denies the AGENTS.md mechanism, and `lop config instructions` reports what a session actually loads`

Base tag: v0.52.3. Bump decided once the window closes; this commit is amended into the version change and the PR retitled, so the PR number (and the lock) never changes.

Contributors: send the owner your PR number and merge SHA AT MERGE TIME if you merge while this is open — a PR that lands during the cut is reachable from the tag and ships unlisted otherwise.