### PR TITLE
fix(tui): stop the sidebar getting slower with uptime and switch count

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1339,11 +1339,37 @@ ASIDE_LAYOUT_CLASS = "aside"
 ASIDE_SCROLL_BACK_KEY = "ctrl+pageup"
 ASIDE_SCROLL_FORWARD_KEY = "ctrl+pagedown"
 
-#: Parked sidebar presentations kept beside the active one, LRU-evicted. One
-#: made every non-adjacent click cold; four covers the handful of live
-#: conversations a user alternates between, at ~1.2 MiB RSS per parked view
-#: and no measurable per-frame cost (six parked: frame 16–17 ms, unchanged).
-RETAINED_PRESENTATIONS = 4
+#: Parked sidebar presentations kept beside the active one, LRU-evicted.
+#:
+#: This is a CAPACITY, not the memory bound: each parked view is admitted
+#: through `retainable()`'s per-view byte budget (`RETAIN_TEXT_BYTES`, via
+#: `_admit_sidebar_presentation`), which is what refuses the pathological
+#: 200 MB-journal case regardless of this count. The count exists to bound
+#: the number of live viewer sockets (a parked presentation pins its leased
+#: `RemoteSession` and its frontend subscription) and mounted transcript
+#: trees, so it has to be sized to the WORKING SET — the conversations a user
+#: alternates between — or every switch past it is a cold rebuild: connect,
+#: history window, replay, MOUNT, layout wait, teardown, on the event loop.
+#:
+#: One made every non-adjacent click cold. Four covered a handful of live
+#: conversations but was smaller than a real working set, and it read to the
+#: user as "switches get slower the longer I use it": a session that had
+#: touched three conversations hit the cache every time, the same session an
+#: hour later, having touched nine, hit it ~7% of the time — and `/reload`
+#: "fixed" it by emptying the working set. Measured on the assembled app,
+#: 40 switches over 8 live conversations, only this constant changed:
+#: 12/40 hits and 246 ms loop-CPU per switch at 4, 39/40 hits and 59 ms at 8;
+#: over 12 conversations, 6/40 and 219 ms at 4, 36/40 and 65 ms at 12.
+#:
+#: Twelve covers the 8–12 live sessions with turns running that is the
+#: reporting operator's normal population. Above the working set the count
+#: buys nothing (16 measured identical to 12), and each occupied slot costs
+#: ~1.5–2.4 MiB RSS (12 vs 4 at full occupancy: +11–17 MB) plus one live
+#: socket whose owner deltas are still delivered while parked. Per-frame
+#: cost stays nil — a parked view is `offset: 100vw` + `overlay: screen`, so
+#: the compositor's visible set (23 widgets) and keystroke latency (p90
+#: 88 vs 93 ms) are unchanged with 7 parked against 4.
+RETAINED_PRESENTATIONS = 12
 #: Ranked entries warmed per catalog poll. Two is the top of the list — the
 #: rows the eye lands on — without turning every poll into a prepare storm.
 PREWARM_PER_REFRESH = 2
@@ -4874,13 +4900,12 @@ class OperatorApp(App[None]):
             self.run_worker(self._release_sidebar_preparation((outgoing, outgoing_presentation)))
         if displaced is not None and displaced is not incoming:
             self.run_worker(self._release_sidebar_preparation((source, displaced)))
-        # Retain the most recently used presentations. One was the original
-        # bound, and it made every non-adjacent click cold; four covers the
-        # two-or-three live conversations a user actually alternates between
-        # at ~1.2 MiB RSS and no per-frame cost per parked view (measured with
-        # six parked). Dict order is recency — hits reinsert — so the oldest
-        # key is the LRU victim. Executing contexts stay alive without
-        # retaining their widgets, and drafts remain source-owned.
+        # Retain the most recently used presentations, up to the working-set
+        # capacity `RETAINED_PRESENTATIONS` documents (the byte budget per view
+        # was already applied at admission). Dict order is recency — hits
+        # reinsert — so the oldest key is the LRU victim. Executing contexts
+        # stay alive without retaining their widgets, and drafts remain
+        # source-owned.
         while len(self._sidebar_presentations) > RETAINED_PRESENTATIONS:
             evicted_id = next(iter(self._sidebar_presentations))
             evicted = self._sidebar_presentations.pop(evicted_id)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -5391,6 +5391,26 @@ class OperatorApp(App[None]):
         would resume a runtime, and speculation must not start processes the
         user did not ask for. Already-cached and current sessions are skipped
         rather than blocking the whole prewarm as they used to.
+
+        Speculation only fills FREE slots of the presentation cache; it never
+        evicts to make room. Admitting at capacity evicted the LRU entry to
+        respect ``RETAINED_PRESENTATIONS``, and the evicted session — still
+        live, still top-ranked, no longer cached — matched this filter again on
+        the very next poll. Once live sessions outnumbered the bound that was
+        a real ``RemoteSession.connect`` plus a dispose per candidate per 2 s
+        poll, forever: measured 60 connects + 60 disposes over 30 polls at 10
+        live sessions, poll loop-CPU 9.5 → 110 ms, paid for as long as the
+        sidebar was open and gone the moment it was closed — which is the
+        operator's "slow after a while with the sidebar open" exactly. The
+        refusal map is deliberately NOT used for this: it records
+        ``retainable()`` refusals keyed on content, and these candidates are
+        admissible; parking them there would be the permanent blacklist its
+        own docstring warns about. Under the bound nothing changes — every
+        live row has a slot — so the case that worked keeps working.
+
+        The one exemption is the row the user is heading for
+        (``intent_id``): that admission is user-driven, not speculation, so
+        it may evict like a click does and the guard cannot starve it.
         """
         if (
             not self._session_sidebar.display
@@ -5399,7 +5419,9 @@ class OperatorApp(App[None]):
         ):
             return
         current = str(getattr(self._session, "session_id", ""))
-        candidates = [
+        intent = self._sidebar_navigation.intent_id
+        free_slots = max(0, RETAINED_PRESENTATIONS - len(self._sidebar_presentations))
+        ranked = [
             entry
             for entry in entries
             if entry.id != current
@@ -5410,7 +5432,10 @@ class OperatorApp(App[None]):
             # and the poll would re-select it forever. An explicit click still
             # prepares it — the user asked, and that path does not loop.
             and not self._sidebar_prewarm_refused(entry.id)
-        ][:PREWARM_PER_REFRESH]
+        ]
+        candidates = [entry for entry in ranked if entry.id == intent][:1]
+        candidates += [entry for entry in ranked if entry.id != intent][:free_slots]
+        candidates = candidates[:PREWARM_PER_REFRESH]
         if not candidates:
             return
 
@@ -5430,6 +5455,14 @@ class OperatorApp(App[None]):
                         and not self._sidebar_navigation.requested_id
                         and candidate.id not in self._sidebar_presentations
                         and candidate.id != str(getattr(self._session, "session_id", ""))
+                        # Re-checked here, not only at selection: a click that
+                        # committed while this prepare was in flight may have
+                        # filled the slot this candidate was selected for, and
+                        # admitting anyway would evict what the user just used.
+                        and (
+                            len(self._sidebar_presentations) < RETAINED_PRESENTATIONS
+                            or candidate.id == self._sidebar_navigation.intent_id
+                        )
                         and self._admit_sidebar_presentation(candidate.id, prepared[0], prepared[1])
                     ):
                         self._sidebar_presentations[candidate.id] = prepared[1]

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3107,6 +3107,28 @@ class OperatorApp(App[None]):
         self._session_sidebar = SessionSidebar()
         self._sidebar_settings = SidebarSettings()
         self._sidebar_timer: Timer | None = None
+        #: The live tick of the startup-cleanup recheck chain, so re-seeding
+        #: it REPLACES the chain rather than starting another beside it.
+        #:
+        #: `_report_startup_cleanup` self-schedules a 1 s tick for up to
+        #: `STARTUP_CLEANUP_RECHECK_WINDOW_S`, and `_adopt_session` seeds a
+        #: fresh chain on EVERY adoption — including the sidebar switch that
+        #: re-adopts a conversation the user just left. Without a handle the
+        #: chains could not see each other and simply overlapped: measured on
+        #: the assembled app, live timers grew 9 → 60 over 50 switches and the
+        #: callback ran 6462 times over 150, each one a disk read of
+        #: `sessions/last-cleanup.json` on the event loop. Every timer is also
+        #: a live asyncio task, so this was unbounded in switch count with no
+        #: release site at all — the exact shape `/reload` cures by accident.
+        #:
+        #: A handle rather than a once-per-process latch, deliberately: the
+        #: announce path defers to the removing runtime's own viewer while that
+        #: runtime lives (`cleanup.take_unannounced_cleanup`), so a viewer that
+        #: attaches before its runtime's pass finishes NEEDS the recheck window
+        #: on that adoption, and a latch that skipped it would lose the notice.
+        #: Stopping the previous chain keeps every timing property of the
+        #: window; it only removes the overlap.
+        self._startup_cleanup_timer: Timer | None = None
         self._sidebar_refresh_generation = 0
         self._sidebar_refresh_pending = False
         self._sidebar_prefetch: Any = None
@@ -10896,6 +10918,14 @@ class OperatorApp(App[None]):
             take_unannounced_cleanup,
         )
 
+        # Exactly one chain per app. A seed from `_adopt_session` (every
+        # sidebar switch re-adopts) stops the chain still ticking from the
+        # previous adoption; a tick arriving here stops its own, already-fired
+        # one-shot, which is a no-op. See `_startup_cleanup_timer` for the
+        # measured growth this prevents and why it is not a latch.
+        if self._startup_cleanup_timer is not None:
+            self._startup_cleanup_timer.stop()
+            self._startup_cleanup_timer = None
         # The FORMAT is inside the try too: a hand-edited or newer-schema
         # record (`"removed": "many"`) crashed the first frame when only the
         # read was guarded (review round 3, R3-2). The formatter is total on
@@ -10915,7 +10945,7 @@ class OperatorApp(App[None]):
             return
         if rechecks_left > 0:
             remaining = rechecks_left - STARTUP_CLEANUP_RECHECK_S
-            self.set_timer(
+            self._startup_cleanup_timer = self.set_timer(
                 STARTUP_CLEANUP_RECHECK_S,
                 lambda: self._report_startup_cleanup(rechecks_left=remaining),
             )

--- a/scripts/diag/tui_growth.py
+++ b/scripts/diag/tui_growth.py
@@ -93,7 +93,7 @@ PARSER.add_argument(
     "--retained",
     type=int,
     default=0,
-    help="override RETAINED_PRESENTATIONS (0 = leave the shipped value of 4)",
+    help="override RETAINED_PRESENTATIONS (0 = leave the shipped value of 12)",
 )
 PARSER.add_argument("--tracemalloc", action="store_true")
 PARSER.add_argument("--profile", action="store_true")

--- a/scripts/diag/tui_growth.py
+++ b/scripts/diag/tui_growth.py
@@ -1,0 +1,950 @@
+"""Growth harness: what accumulates in-process across sidebar uptime and switches.
+
+Drives the REAL assembled ``OperatorApp`` headlessly (stylesheet loaded, real
+``RuntimeServer`` owners in-process, real ``RemoteSession`` viewers over real
+loopback sockets) and records, at checkpoints, every quantity that could
+explain "the TUI gets slower until /reload":
+
+* process RSS, ``gc`` object counts by type (top growers vs the baseline),
+* live asyncio tasks, Textual ``Timer`` objects (app + every widget), workers,
+* DOM node count (``len(app.query('*'))``), transcript views mounted,
+* sizes of every app/sidebar/session container that is keyed per session,
+* ``FrontendStateStore`` / ``RemoteSession`` subscriber list lengths,
+* wall + loop-CPU for one switch and one sidebar poll cycle,
+* tracemalloc top allocation deltas between the first and last checkpoint.
+
+Usage (from the worktree root; isolation happens on import, see
+``scripts/probe_isolation``)::
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python scripts/diag/tui_growth.py \\
+        --mode switches --switches 5 20 50 --sessions 12 --output /tmp/growth
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python scripts/diag/tui_growth.py \\
+        --mode uptime --polls 60 --sessions 30 --output /tmp/growth-uptime
+
+``--mode switches``: opens the sidebar, then performs K switches round-robin
+across ``--sessions`` live owners, checkpointing after each K in ``--switches``.
+
+``--mode uptime``: opens the sidebar over ``--sessions`` live owners (busy ones
+so the spinner ticks) and drives the 2 s catalog poll + spinner manually for
+``--polls`` cycles, checkpointing every ``--checkpoint-every`` polls.
+
+Output: ``<output>/checkpoints.json`` (all numbers), ``<output>/report.md``
+(tables), ``<output>/tracemalloc.txt`` (top deltas), and a
+``<output>/profile-{early,late}.prof`` pair in switches mode.
+
+Numbers here are EVIDENCE, not CI ceilings. The structural assertions a
+regression test should make are the ones that read the same at K=5 and K=50
+(timers, tasks, subscribers, DOM nodes, container sizes).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import cProfile
+import gc
+import json
+import os
+import resource
+import sys
+import time
+import tracemalloc
+from collections import Counter
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+PARSER = argparse.ArgumentParser(description=__doc__)
+PARSER.add_argument("--source-root", type=Path, default=Path(__file__).resolve().parents[2])
+PARSER.add_argument("--output", type=Path, required=True)
+PARSER.add_argument("--mode", choices=("switches", "uptime"), default="switches")
+PARSER.add_argument("--sessions", type=int, default=12)
+PARSER.add_argument(
+    "--cycle",
+    type=int,
+    default=0,
+    help="switch round-robin over only the first N sessions (0 = all); N<=4 stays inside the LRU",
+)
+PARSER.add_argument("--switches", type=int, nargs="+", default=[5, 20, 50])
+PARSER.add_argument("--polls", type=int, default=60)
+PARSER.add_argument("--checkpoint-every", type=int, default=10)
+PARSER.add_argument("--history", type=int, default=40, help="messages seeded per session")
+PARSER.add_argument(
+    "--idle-seconds",
+    type=float,
+    default=3.0,
+    help="seconds of IDLE pumping measured at each checkpoint",
+)
+PARSER.add_argument(
+    "--keystrokes",
+    type=int,
+    default=20,
+    help="keypresses timed at each checkpoint (perceived latency)",
+)
+PARSER.add_argument(
+    "--approve-all",
+    action="store_true",
+    help="viewers default to approve_all (the operator's `auto` tool_approval_mode). "
+    "With busy owners this arms SessionInteraction.retained_for_auto_work, which "
+    "is the clause `_sidebar_source_releasable` honours on the idle path.",
+)
+PARSER.add_argument(
+    "--retained",
+    type=int,
+    default=0,
+    help="override RETAINED_PRESENTATIONS (0 = leave the shipped value of 4)",
+)
+PARSER.add_argument("--tracemalloc", action="store_true")
+PARSER.add_argument("--profile", action="store_true")
+PARSER.add_argument(
+    "--no-cleanup-timer",
+    action="store_true",
+    help="stub OperatorApp._report_startup_cleanup (experiment: is the per-adopt timer chain "
+    "the growth?)",
+)
+PARSER.add_argument(
+    "--no-prewarm",
+    action="store_true",
+    help="stub OperatorApp._prewarm_sidebar (experiment: is prewarm churn the steady-state cost?)",
+)
+ARGS = PARSER.parse_args()
+ARGS.output.mkdir(parents=True, exist_ok=True)
+sys.path.insert(0, str(ARGS.source_root.resolve()))
+for _key in tuple(os.environ):
+    if _key.startswith("CMUX_"):
+        del os.environ[_key]
+
+import scripts.probe_isolation as isolation  # noqa: E402
+
+# isort: split
+import local_operator  # noqa: E402
+from local_operator.session.remote import RemoteSession  # noqa: E402
+from local_operator.session.runtime.owned import OwnedSessionHandle  # noqa: E402
+from local_operator.session.runtime.server import RuntimeServer  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from tests.e2e.harness import (  # noqa: E402
+    ScriptedStream,
+    assistant_message,
+    build_session,
+    seed_transcript,
+    user_message,
+    wait_for_adoption,
+)
+
+CONFIG = isolation.SANDBOX / "config"
+
+
+def _publish_per_session() -> None:
+    """Give every in-process owner its own discovery record.
+
+    ``registry.publish`` keys the record file by PID because production runs
+    one session per process. Every owner in this harness shares one PID, so
+    without this the N servers overwrite one file, the catalog sees ONE live
+    row and prewarm never engages — a fixture that silently tests the cold
+    path. Keying by ``(pid, session_id)`` keeps ``scan`` (glob *.json +
+    pid_alive) truthful for all of them.
+    """
+    import json
+    import os
+    import tempfile
+    import time
+
+    from local_operator.session.runtime import registry
+
+    def publish(record: Any, root: Path | None = None) -> Path:
+        directory = registry.run_dir(root)
+        record.heartbeat_at = time.time()
+        fd, tmp = tempfile.mkstemp(dir=directory, prefix=".x.", suffix=".tmp")
+        with os.fdopen(fd, "w") as handle:
+            json.dump(record.to_json(), handle)
+        target = directory / f"{record.pid}-{record.session_id}.json"
+        os.replace(tmp, target)
+        return target
+
+    registry.publish = publish  # type: ignore[assignment]
+    registry.unpublish = lambda pid, root=None: None  # type: ignore[assignment]
+
+
+_publish_per_session()
+
+#: Every switch / poll timing in order, so trends are visible rather than
+#: three noisy single samples.
+SERIES: dict[str, list[float]] = {
+    "switch_total_wall_ms": [],
+    "switch_loop_cpu_ms": [],
+    "poll_wall_ms": [],
+    "poll_loop_cpu_ms": [],
+    "prepare_loop_cpu_ms": [],
+}
+
+#: Work counters, bumped by wrappers installed in ``instrument()``; the
+#: checkpoint records the running total so per-interval deltas are readable.
+COUNTS: Counter[str] = Counter()
+
+
+def instrument() -> None:
+    import local_operator.tui.app as app_mod
+
+    if ARGS.retained:
+        app_mod.RETAINED_PRESENTATIONS = ARGS.retained
+
+    def wrap(cls: Any, name: str, key: str) -> None:
+        original = getattr(cls, name)
+        if asyncio.iscoroutinefunction(original):
+
+            async def wrapped_async(*args: Any, **kwargs: Any) -> Any:
+                COUNTS[key] += 1
+                return await original(*args, **kwargs)
+
+            setattr(cls, name, wrapped_async)
+            return
+
+        def wrapped(*args: Any, **kwargs: Any) -> Any:
+            COUNTS[key] += 1
+            return original(*args, **kwargs)
+
+        setattr(cls, name, wrapped)
+
+    # Count cache HITS: the `cached is not None and _sidebar_presentation_current`
+    # branch of _prepare_sidebar_session is the whole point of the LRU, so a
+    # switch that misses it paid a cold rebuild.
+    original_current = app_mod.OperatorApp._sidebar_presentation_current
+
+    def counted_current(cached: Any, source: Any, gate: Any) -> bool:
+        ok = original_current(cached, source, gate)
+        COUNTS["presentation_hit" if ok else "presentation_stale"] += 1
+        return ok
+
+    app_mod.OperatorApp._sidebar_presentation_current = staticmethod(counted_current)
+
+    original_prepare = app_mod.OperatorApp._prepare_sidebar_session
+
+    async def timed_prepare(self: Any, *args: Any, **kwargs: Any) -> Any:
+        COUNTS["prepare_sidebar_session"] += 1
+        if kwargs.get("speculative"):
+            COUNTS["prepare(speculative)"] += 1
+        elif kwargs.get("refresh"):
+            COUNTS["prepare(refresh)"] += 1
+        else:
+            COUNTS["prepare(navigation)"] += 1
+        cpu0 = time.thread_time()
+        try:
+            return await original_prepare(self, *args, **kwargs)
+        finally:
+            SERIES["prepare_loop_cpu_ms"].append(round((time.thread_time() - cpu0) * 1000, 1))
+
+    app_mod.OperatorApp._prepare_sidebar_session = timed_prepare  # type: ignore[method-assign]
+    wrap(app_mod.OperatorApp, "_lease_sidebar_source", "lease_sidebar_source")
+    wrap(app_mod.OperatorApp, "_release_sidebar_source", "release_sidebar_source(called)")
+    wrap(app_mod.OperatorApp, "_release_sidebar_preparation", "release_sidebar_preparation")
+    wrap(app_mod.OperatorApp, "_report_startup_cleanup", "report_startup_cleanup")
+    if ARGS.no_cleanup_timer:
+        app_mod.OperatorApp._report_startup_cleanup = (  # type: ignore[method-assign]
+            lambda self, **kw: None
+        )
+    if ARGS.no_prewarm:
+        app_mod.OperatorApp._prewarm_sidebar = (  # type: ignore[method-assign]
+            lambda self, entries: None
+        )
+    wrap(RemoteSession, "dispose", "RemoteSession.dispose")
+    original_connect = RemoteSession.connect.__func__  # type: ignore[attr-defined]
+
+    async def connect(cls: Any, *args: Any, **kwargs: Any) -> Any:
+        COUNTS["RemoteSession.connect"] += 1
+        return await original_connect(cls, *args, **kwargs)
+
+    RemoteSession.connect = classmethod(connect)  # type: ignore[method-assign]
+
+
+def rss_mb() -> float:
+    usage = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    # macOS reports bytes, Linux kilobytes.
+    return usage / (1024 * 1024) if sys.platform == "darwin" else usage / 1024
+
+
+def _all_widgets(app: OperatorApp) -> list[Any]:
+    out: list[Any] = []
+    for screen in app.screen_stack:
+        out.append(screen)
+        out.extend(screen.walk_children(with_self=False))
+    return out
+
+
+def timers_snapshot(app: OperatorApp) -> dict[str, Any]:
+    """Every Textual Timer reachable from every message pump, by owner type."""
+    by_owner: Counter[str] = Counter()
+    by_callback: Counter[str] = Counter()
+    running = 0
+    total = 0
+    for pump in [app, *_all_widgets(app)]:
+        timers = getattr(pump, "_timers", None)
+        if not timers:
+            continue
+        for timer in list(timers):
+            total += 1
+            by_owner[type(pump).__name__] += 1
+            cb = getattr(timer, "_callback", None)
+            inner = getattr(cb, "args", None)
+            target = inner[0] if inner else cb
+            by_callback[getattr(target, "__qualname__", None) or repr(target)[:60]] += 1
+            task = getattr(timer, "_task", None)
+            if task is not None and not task.done():
+                running += 1
+    return {
+        "total": total,
+        "running": running,
+        "by_owner": dict(by_owner),
+        "by_callback": dict(by_callback),
+    }
+
+
+def tasks_snapshot() -> dict[str, Any]:
+    names: Counter[str] = Counter()
+    tasks = [t for t in asyncio.all_tasks() if not t.done()]
+    for task in tasks:
+        coro = task.get_coro()
+        name = getattr(coro, "__qualname__", None) or getattr(coro, "__name__", None) or repr(coro)
+        names[str(name)] += 1
+    return {"total": len(tasks), "by_coro": dict(names.most_common(25))}
+
+
+def containers_snapshot(app: OperatorApp) -> dict[str, int]:
+    """Sizes of every per-session / per-switch container we could find."""
+    sizes: dict[str, int] = {}
+
+    def size(name: str, value: Any) -> None:
+        try:
+            sizes[name] = len(value)
+        except TypeError:
+            sizes[name] = -1
+
+    size("app._sidebar_sources", app._sidebar_sources)
+    size("app._sidebar_presentations", app._sidebar_presentations)
+    size("app._sidebar_unretainable", app._sidebar_unretainable)
+    size("app._sidebar_prior_workers", app._sidebar_prior_workers)
+    size("app._interactions", app._interactions)
+    size("app._event_sources", app._event_sources)
+    size("app._sidebar_navigation._tasks", app._sidebar_navigation._tasks)
+    size("app._sidebar_drafts._memory", app._sidebar_drafts._memory)
+    size("app._resume_results", app._resume_results)
+    size("app._resume_mounted_ids", app._resume_mounted_ids)
+    size("app._tool_cards", app._tool_cards)
+    size("app._composing_cards", app._composing_cards)
+    size("app._superseded_steer_controllers", app._superseded_steer_controllers)
+    size("app.workers", list(app.workers))
+    sidebar = app._session_sidebar
+    size("sidebar._painted_lines", sidebar._painted_lines)
+    sizes["app._sidebar_ready_frame_pending"] = int(app._sidebar_ready_frame is not None)
+    displayed = getattr(app, "_sidebar_displayed_frame", None)
+    sizes["app._sidebar_displayed_frame.painted"] = len(displayed[4]) if displayed else 0
+    sizes["app._message_queue"] = app._message_queue.qsize()
+    sizes["screen._message_queue"] = app.screen._message_queue.qsize()
+    sizes["app._callbacks"] = len(getattr(app, "_next_callbacks", ()))
+    import threading
+
+    sizes["threads"] = threading.active_count()
+    names: Counter[str] = Counter()
+    for t in threading.enumerate():
+        base = t.name.split("_")[0] if t.name.startswith("asyncio") else t.name
+        names[base.rstrip("0123456789-") or t.name] += 1
+    sizes.update({f"thread:{k}": v for k, v in names.items()})
+    compositor = app.screen._compositor
+    for name in ("_full_map", "_visible_widgets", "_layers", "_layers_visible", "map"):
+        value = getattr(compositor, name, None)
+        if value is not None and hasattr(value, "__len__"):
+            sizes[f"compositor.{name}"] = len(value)
+    from textual.widget import Widget as _Widget
+
+    sizes["gc.Widget_total"] = sum(1 for o in gc.get_objects() if isinstance(o, _Widget))
+    size("sidebar.entries", sidebar.entries)
+    # Per-source structures that a leak would multiply.
+    subscribers = 0
+    handlers = 0
+    retired_sources = 0
+    connection_tasks = 0
+    seen: dict[int, Any] = {}
+    for source in [*app._sidebar_sources.values(), *app._interactions.values()]:
+        seen[id(source)] = source
+    sizes["sources.distinct"] = len(seen)
+    for source in seen.values():
+        if source.retired:
+            retired_sources += 1
+        session = source.session
+        store = getattr(session, "_frontend_store", None)
+        if store is not None:
+            subscribers += len(getattr(store, "_subscribers", ()))
+        handlers += len(getattr(session, "_handlers", ()))
+        task = source.connection_task
+        if task is not None and not task.done():
+            connection_tasks += 1
+    sizes["sources.frontend_subscribers"] = subscribers
+    sizes["sources.event_handlers"] = handlers
+    sizes["sources.retired_but_referenced"] = retired_sources
+    sizes["sources.live_connection_tasks"] = connection_tasks
+    # Owner side (in-process here; a separate process in production, so any
+    # growth here would NOT be cured by /reload — recorded to eliminate it).
+    owner_clients = 0
+    owner_subs = 0
+    for server in FIXTURE.servers.values():
+        owner_clients += len(server._clients)
+        session = getattr(server._handle, "_session", None)
+        store = getattr(session, "_frontend_state_store", None)
+        if store is not None:
+            owner_subs += len(getattr(store, "_subscribers", ()))
+        owner_subs += len(getattr(session, "_handlers", ()))
+    sizes["owner.server._clients"] = owner_clients
+    sizes["owner.session.subscribers+handlers"] = owner_subs
+    # Module-level caches.
+    from local_operator.session import catalog as catalog_mod
+    from local_operator.session import frontend_state as fs_mod
+
+    size("catalog._ROW_CACHE", catalog_mod._ROW_CACHE)
+    size("frontend_state._DERIVED_OWNERSHIP", fs_mod._DERIVED_OWNERSHIP)
+    size("frontend_state._STATE_FIELD_ADAPTERS", fs_mod._STATE_FIELD_ADAPTERS)
+    return sizes
+
+
+def dom_snapshot(app: OperatorApp) -> dict[str, Any]:
+    from local_operator.tui.widgets.transcript import TranscriptView
+
+    widgets = _all_widgets(app)
+    by_type: Counter[str] = Counter(type(w).__name__ for w in widgets)
+    views = [w for w in widgets if isinstance(w, TranscriptView)]
+    return {
+        "nodes": len(widgets),
+        "query_all": len(app.query("*")),
+        "transcript_views": len(views),
+        "transcript_blocks_total": sum(len(v.blocks()) for v in views),
+        "screen_stack": len(app.screen_stack),
+        "top_types": dict(by_type.most_common(15)),
+    }
+
+
+def gc_snapshot() -> Counter[str]:
+    gc.collect()
+    return Counter(type(o).__name__ for o in gc.get_objects())
+
+
+def gc_delta(base: Counter[str], now: Counter[str], top: int = 25) -> list[tuple[str, int, int]]:
+    rows = []
+    for name, count in now.items():
+        delta = count - base.get(name, 0)
+        if delta > 0:
+            rows.append((name, delta, count))
+    rows.sort(key=lambda r: -r[1])
+    return rows[:top]
+
+
+class Fixture:
+    def __init__(self, count: int, history: int, busy: bool) -> None:
+        self.count = count
+        self.history = history
+        self.busy = busy
+        self.servers: dict[str, RuntimeServer] = {}
+        self.ids: list[str] = []
+
+    async def start(self) -> None:
+        for i in range(self.count):
+            sid = f"growth{i:03d}"
+            self.ids.append(sid)
+            directory = CONFIG / "sessions" / sid
+            messages = []
+            for j in range(self.history // 2):
+                messages.append(user_message(f"{sid} question {j}: " + "context words " * 12))
+                messages.append(assistant_message(f"{sid} answer {j}: " + "reply words " * 25))
+            await seed_transcript(directory, messages)
+            owner = build_session(directory, ScriptedStream([]), cwd=CONFIG)
+            handle = OwnedSessionHandle(owner, asyncio.get_running_loop(), cwd=str(CONFIG))
+            server = RuntimeServer(handle, kind="daemon")
+            await server.start_in_process()
+            if self.busy:
+                # Flip the published record to busy so the sidebar's spinner
+                # ticks for these rows; the owner itself stays idle.
+                server._busy = True
+                server._republish()
+            self.servers[sid] = server
+
+    def find(self, _directory: Path, sid: str) -> tuple[Any, Any]:
+        server = self.servers.get(sid)
+        return (server._record, server._record.pid) if server else (None, None)
+
+    async def resume(self, sid: str | None) -> RemoteSession:
+        async def never() -> Any:
+            raise AssertionError("view navigation must never take execution ownership")
+
+        assert sid is not None
+        return await RemoteSession.connect(
+            self.servers[sid]._record,
+            sid,
+            config_dir=CONFIG,
+            takeover_factory=never,
+            display_window=True,
+        )
+
+    async def close(self) -> None:
+        for server in self.servers.values():
+            await server.aclose()
+
+
+PREV_GC: list[Counter[str]] = []
+
+
+def per_source_snapshot(app: OperatorApp) -> dict[str, int]:
+    """Max over sources of every per-source list/dict that could accumulate."""
+    out: Counter[str] = Counter()
+    seen: dict[int, Any] = {}
+    for source in [*app._sidebar_sources.values(), *app._interactions.values()]:
+        seen[id(source)] = source
+    for source in seen.values():
+        d = source.draft
+        out["draft.recoveries"] = max(out["draft.recoveries"], len(d.recoveries))
+        out["draft.notices"] = max(out["draft.notices"], len(d.notices))
+        out["draft.attachments"] = max(out["draft.attachments"], len(d.attachments))
+        out["turn.pending_echoes"] = max(
+            out["turn.pending_echoes"], len(source.turn.pending_echoes)
+        )
+        out["turn.settled_child_ids"] = max(
+            out["turn.settled_child_ids"], len(source.turn.settled_child_ids)
+        )
+        out["accounting.child_costs"] = max(
+            out["accounting.child_costs"], len(source.accounting.child_costs)
+        )
+        session = source.session
+        for name in (
+            "_buffered_events",
+            "_pending_frontend",
+            "_snapshot_clients",
+            "_handlers",
+            "_frontend_updates",
+            "_display_history",
+        ):
+            value = getattr(session, name, None)
+            if value is not None and hasattr(value, "__len__"):
+                out[f"session.{name}"] = max(out[f"session.{name}"], len(value))
+        store = getattr(session, "_frontend_store", None)
+        if store is not None:
+            out["store._subscribers"] = max(out["store._subscribers"], len(store._subscribers))
+    for presentation in app._sidebar_presentations.values():
+        view = presentation.replay.view
+        out["view.blocks"] = max(out["view.blocks"], len(view.blocks()))
+        for name in ("_blocks", "_pending", "_gap_rows", "_anchors"):
+            value = getattr(view, name, None)
+            if value is not None and hasattr(value, "__len__"):
+                out[f"view.{name}"] = max(out[f"view.{name}"], len(value))
+    return dict(out)
+
+
+async def checkpoint(
+    app: OperatorApp, label: str, base_gc: Counter[str] | None, extra: dict[str, Any]
+) -> dict[str, Any]:
+    now_gc = gc_snapshot()
+    record: dict[str, Any] = {
+        "label": label,
+        "rss_mb": round(rss_mb(), 1),
+        "gc_objects": sum(now_gc.values()),
+        "gc_counts": list(gc.get_count()),
+        "timers": timers_snapshot(app),
+        "tasks": tasks_snapshot(),
+        "dom": dom_snapshot(app),
+        "containers": containers_snapshot(app),
+        "counts": dict(COUNTS),
+        "frontend_objects": {
+            k: now_gc.get(k, 0)
+            for k in (
+                "FrontendSync",
+                "FrontendSessionState",
+                "RemoteSession",
+                "AttachClient",
+                "SessionInteraction",
+                "SessionPresentation",
+                "PreparedReplay",
+                "EventController",
+                "StylesCache",
+                "Style",
+                "TranscriptView",
+            )
+        },
+        **extra,
+    }
+    record["per_source"] = per_source_snapshot(app)
+    if base_gc is not None:
+        record["gc_top_growers"] = gc_delta(base_gc, now_gc)
+    if PREV_GC:
+        record["gc_top_growers_prev"] = gc_delta(PREV_GC[-1], now_gc, top=15)
+    PREV_GC.append(now_gc)
+    record["_gc"] = now_gc
+    return record
+
+
+async def idle_cost(app: OperatorApp, pilot: Any) -> dict[str, float]:
+    """What the app burns doing NOTHING — the honest measure of "it feels slow".
+
+    Loop-thread CPU over a fixed idle window (AGENTS.md "measure CPU, not wall
+    time"): timers, polls and background tasks are the only things that can
+    consume it, so a number that rises with switch count is background work
+    the app acquired and never released.
+    """
+    seconds = ARGS.idle_seconds
+    if seconds <= 0:
+        return {}
+    cpu0, wall0 = time.thread_time(), time.monotonic()
+    while time.monotonic() - wall0 < seconds:
+        await pilot.pause(0.02)
+    elapsed = time.monotonic() - wall0
+    cpu = time.thread_time() - cpu0
+    result = {
+        "idle_cpu_ms_per_s": round(cpu / elapsed * 1000, 1),
+        "idle_window_s": round(elapsed, 2),
+    }
+    SERIES.setdefault("idle_cpu_ms_per_s", []).append(result["idle_cpu_ms_per_s"])
+    return result
+
+
+async def keystroke_cost(app: OperatorApp, pilot: Any) -> dict[str, float]:
+    """Perceived latency: how long one keypress takes to be fully serviced."""
+    n = ARGS.keystrokes
+    if n <= 0:
+        return {}
+    editor = app._editor()
+    editor.focus()
+    await pilot.pause()
+    samples: list[float] = []
+    for _ in range(n):
+        start = time.monotonic()
+        await pilot.press("x")
+        samples.append((time.monotonic() - start) * 1000)
+    samples.sort()
+    editor.text = ""
+    await pilot.pause()
+    result = {
+        "key_median_ms": round(samples[len(samples) // 2], 2),
+        "key_p90_ms": round(samples[int(len(samples) * 0.9)], 2),
+        "key_max_ms": round(samples[-1], 2),
+    }
+    SERIES.setdefault("key_median_ms", []).append(result["key_median_ms"])
+    return result
+
+
+async def one_switch(app: OperatorApp, pilot: Any, sid: str) -> dict[str, float]:
+    hit_before = COUNTS["presentation_hit"]
+    nav_before = COUNTS["prepare(navigation)"]
+    cpu0, wall0 = time.thread_time(), time.monotonic()
+    task = app._sidebar_navigation.select(sid)
+    await asyncio.wait_for(task, 30)
+    committed = time.monotonic()
+    # Let the post-commit connection task (saved view -> canonical) settle so
+    # the switch is fully complete before the next one starts.
+    source = app._interaction
+    if source.connection_task is not None:
+        try:
+            await asyncio.wait_for(asyncio.shield(source.connection_task), 30)
+        except Exception:
+            pass
+    await pilot.pause()
+    result = {
+        "switch_commit_wall_ms": round((committed - wall0) * 1000, 1),
+        "switch_total_wall_ms": round((time.monotonic() - wall0) * 1000, 1),
+        "switch_loop_cpu_ms": round((time.thread_time() - cpu0) * 1000, 1),
+    }
+    result["switch_hit"] = COUNTS["presentation_hit"] - hit_before
+    result["switch_navigation_prepares"] = COUNTS["prepare(navigation)"] - nav_before
+    SERIES.setdefault("switch_hit", []).append(result["switch_hit"])
+    SERIES["switch_total_wall_ms"].append(result["switch_total_wall_ms"])
+    SERIES["switch_loop_cpu_ms"].append(result["switch_loop_cpu_ms"])
+    return result
+
+
+async def one_poll(app: OperatorApp, pilot: Any) -> dict[str, float]:
+    """One catalog poll + prewarm + a spinner tick, timed on the loop thread."""
+    cpu0, wall0 = time.thread_time(), time.monotonic()
+    app._refresh_sidebar()
+    # Wait for the worker that _refresh_sidebar launched.
+    for _ in range(400):
+        if not app._sidebar_refresh_pending:
+            break
+        await pilot.pause()
+    prefetch = app._sidebar_prefetch
+    if prefetch is not None:
+        try:
+            await asyncio.wait_for(asyncio.shield(prefetch.wait()), 30)
+        except Exception:
+            pass
+    app._session_sidebar._advance_spinner()
+    await pilot.pause()
+    result = {
+        "poll_wall_ms": round((time.monotonic() - wall0) * 1000, 1),
+        "poll_loop_cpu_ms": round((time.thread_time() - cpu0) * 1000, 1),
+    }
+    SERIES["poll_wall_ms"].append(result["poll_wall_ms"])
+    SERIES["poll_loop_cpu_ms"].append(result["poll_loop_cpu_ms"])
+    return result
+
+
+def write_report(records: list[dict[str, Any]], path: Path) -> None:
+    lines = ["# TUI growth checkpoints", ""]
+    keys = [
+        ("rss_mb", lambda r: r["rss_mb"]),
+        ("gc_objects", lambda r: r["gc_objects"]),
+        ("timers", lambda r: r["timers"]["total"]),
+        ("timers_running", lambda r: r["timers"]["running"]),
+        ("tasks", lambda r: r["tasks"]["total"]),
+        ("workers", lambda r: r["containers"]["app.workers"]),
+        ("dom_nodes", lambda r: r["dom"]["nodes"]),
+        ("transcript_views", lambda r: r["dom"]["transcript_views"]),
+        ("blocks_total", lambda r: r["dom"]["transcript_blocks_total"]),
+        ("sidebar_sources", lambda r: r["containers"]["app._sidebar_sources"]),
+        ("presentations", lambda r: r["containers"]["app._sidebar_presentations"]),
+        ("interactions", lambda r: r["containers"]["app._interactions"]),
+        ("event_sources", lambda r: r["containers"]["app._event_sources"]),
+        ("frontend_subs", lambda r: r["containers"]["sources.frontend_subscribers"]),
+        ("event_handlers", lambda r: r["containers"]["sources.event_handlers"]),
+        ("retired_refd", lambda r: r["containers"]["sources.retired_but_referenced"]),
+        ("prior_workers", lambda r: r["containers"]["app._sidebar_prior_workers"]),
+        ("painted_lines", lambda r: r["containers"]["sidebar._painted_lines"]),
+        ("drafts_mem", lambda r: r["containers"]["app._sidebar_drafts._memory"]),
+        ("row_cache", lambda r: r["containers"]["catalog._ROW_CACHE"]),
+        ("owner_clients", lambda r: r["containers"]["owner.server._clients"]),
+        ("owner_subs", lambda r: r["containers"]["owner.session.subscribers+handlers"]),
+        ("app_queue", lambda r: r["containers"]["app._message_queue"]),
+        ("displayed_frame_ids", lambda r: r["containers"]["app._sidebar_displayed_frame.painted"]),
+        ("gc_widgets", lambda r: r["containers"]["gc.Widget_total"]),
+        ("compositor_map", lambda r: r["containers"].get("compositor._full_map", "")),
+        ("threads", lambda r: r["containers"]["threads"]),
+    ]
+    header = "| metric | " + " | ".join(r["label"] for r in records) + " |"
+    lines.append(header)
+    lines.append("|" + "---|" * (len(records) + 1))
+    for name, fn in keys:
+        lines.append(f"| {name} | " + " | ".join(str(fn(r)) for r in records) + " |")
+    timing_keys = sorted(
+        {k for r in records for k in r if k.endswith("_ms")},
+    )
+    for name in timing_keys:
+        lines.append(f"| {name} | " + " | ".join(str(r.get(name, "")) for r in records) + " |")
+    lines.append("")
+    lines.append("## Work counters (cumulative)")
+    count_keys = sorted({k for r in records for k in r["counts"]})
+    lines.append("| counter | " + " | ".join(r["label"] for r in records) + " |")
+    lines.append("|" + "---|" * (len(records) + 1))
+    for k in count_keys:
+        lines.append(f"| {k} | " + " | ".join(str(r["counts"].get(k, 0)) for r in records) + " |")
+    lines.append("")
+    lines.append("## Object counts")
+    lines.append("| type | " + " | ".join(r["label"] for r in records) + " |")
+    lines.append("|" + "---|" * (len(records) + 1))
+    for k in records[0]["frontend_objects"]:
+        lines.append(
+            f"| {k} | " + " | ".join(str(r["frontend_objects"][k]) for r in records) + " |"
+        )
+    lines.append("")
+    lines.append("## Timers by owner / callback")
+    for r in records:
+        lines.append(f"- {r['label']}: {r['timers']['by_owner']}")
+        lines.append(f"  - {r['timers']['by_callback']}")
+    lines.append("")
+    lines.append("## Tasks by coroutine (last checkpoint)")
+    for name, n in records[-1]["tasks"]["by_coro"].items():
+        lines.append(f"- {n} × {name}")
+    lines.append("")
+    lines.append("## DOM top types (first vs last)")
+    first, last = records[0]["dom"]["top_types"], records[-1]["dom"]["top_types"]
+    for name in sorted(set(first) | set(last), key=lambda n: -(last.get(n, 0) - first.get(n, 0))):
+        lines.append(f"- {name}: {first.get(name, 0)} -> {last.get(name, 0)}")
+    lines.append("")
+    lines.append("## threads by name")
+    tkeys = sorted({k for r in records for k in r["containers"] if k.startswith("thread:")})
+    lines.append("| thread | " + " | ".join(r["label"] for r in records) + " |")
+    lines.append("|" + "---|" * (len(records) + 1))
+    for k in tkeys:
+        lines.append(
+            f"| {k} | " + " | ".join(str(r["containers"].get(k, 0)) for r in records) + " |"
+        )
+    lines.append("")
+    lines.append("## per-source / per-view container maxima")
+    ps_keys = sorted({k for r in records for k in r["per_source"]})
+    lines.append("| container | " + " | ".join(r["label"] for r in records) + " |")
+    lines.append("|" + "---|" * (len(records) + 1))
+    for k in ps_keys:
+        lines.append(
+            f"| {k} | " + " | ".join(str(r["per_source"].get(k, "")) for r in records) + " |"
+        )
+    lines.append("")
+    lines.append("## gc growers vs PREVIOUS checkpoint")
+    for r in records[1:]:
+        lines.append(
+            f"- {r['label']}: "
+            + ", ".join(f"{n}+{d}" for n, d, _ in r.get("gc_top_growers_prev", [])[:12])
+        )
+    lines.append("")
+    lines.append("## gc top growers vs baseline (last checkpoint)")
+    for name, delta, total in records[-1].get("gc_top_growers", []):
+        lines.append(f"- {name}: +{delta} (now {total})")
+    path.write_text("\n".join(lines) + "\n")
+
+
+async def run_switches(fixture: Fixture) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    app = OperatorApp(lambda: fixture.resume(fixture.ids[0]), resume_factory=fixture.resume)
+    profiler_early = cProfile.Profile() if ARGS.profile else None
+    profiler_late = cProfile.Profile() if ARGS.profile else None
+    with (
+        patch("local_operator.mobile.attach_client.find_owner_record", fixture.find),
+        patch.object(OperatorApp, "_check_for_update", lambda self: None),
+    ):
+        async with app.run_test(size=(140, 40)) as pilot:
+            await wait_for_adoption(app, pilot)
+            await pilot.pause()
+            if ARGS.approve_all:
+                app._approvals_default_auto = True
+                app._set_approve_all(True)
+            app._set_sidebar_open(True)
+            # Let the first catalog poll + prewarm land so the baseline
+            # includes steady-state sidebar structures.
+            await one_poll(app, pilot)
+            for _ in range(20):
+                await pilot.pause()
+            if ARGS.tracemalloc:
+                tracemalloc.start(25)
+            base_gc = gc_snapshot()
+            snap0 = tracemalloc.take_snapshot() if ARGS.tracemalloc else None
+            base_extra = await one_poll(app, pilot)
+            base_extra.update(await idle_cost(app, pilot))
+            base_extra.update(await keystroke_cost(app, pilot))
+            records.append(await checkpoint(app, "K=0", None, base_extra))
+            done = 0
+            targets = ARGS.switches
+            total = max(targets)
+            pool = fixture.ids[: ARGS.cycle] if ARGS.cycle else fixture.ids
+            for k in range(1, total + 1):
+                sid = pool[k % len(pool)]
+                if sid == getattr(app._session, "session_id", ""):
+                    sid = pool[(k + 1) % len(pool)]
+                prof = None
+                if profiler_early is not None and k == 5:
+                    prof = profiler_early
+                if profiler_late is not None and k == total:
+                    prof = profiler_late
+                if prof is not None:
+                    prof.enable()
+                timing = await one_switch(app, pilot, sid)
+                if prof is not None:
+                    prof.disable()
+                done = k
+                if k in targets:
+                    for _ in range(10):
+                        await pilot.pause()
+                    poll = await one_poll(app, pilot)
+                    idle = await idle_cost(app, pilot)
+                    keys = await keystroke_cost(app, pilot)
+                    records.append(
+                        await checkpoint(app, f"K={k}", base_gc, {**timing, **poll, **idle, **keys})
+                    )
+            if snap0 is not None:
+                snap1 = tracemalloc.take_snapshot()
+                stats = snap1.compare_to(snap0, "traceback")
+                out = []
+                for stat in stats[:20]:
+                    out.append(f"{stat.size_diff / 1024:+.1f} KiB, {stat.count_diff:+d} blocks")
+                    out.extend("    " + line for line in stat.traceback.format()[-6:])
+                (ARGS.output / "tracemalloc.txt").write_text("\n".join(out) + "\n")
+                tracemalloc.stop()
+            if profiler_early is not None:
+                profiler_early.dump_stats(str(ARGS.output / "profile-early.prof"))
+            if profiler_late is not None:
+                profiler_late.dump_stats(str(ARGS.output / "profile-late.prof"))
+            print(f"switches done: {done}", flush=True)
+    return records
+
+
+async def run_uptime(fixture: Fixture) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    app = OperatorApp(lambda: fixture.resume(fixture.ids[0]), resume_factory=fixture.resume)
+    with (
+        patch("local_operator.mobile.attach_client.find_owner_record", fixture.find),
+        patch.object(OperatorApp, "_check_for_update", lambda self: None),
+    ):
+        async with app.run_test(size=(140, 40)) as pilot:
+            await wait_for_adoption(app, pilot)
+            await pilot.pause()
+            if ARGS.approve_all:
+                app._approvals_default_auto = True
+                app._set_approve_all(True)
+            app._set_sidebar_open(True)
+            assert app._sidebar_timer is not None
+            # The harness drives polls explicitly so cycles are countable.
+            app._sidebar_timer.pause()
+            await one_poll(app, pilot)
+            for _ in range(20):
+                await pilot.pause()
+            if ARGS.tracemalloc:
+                tracemalloc.start(25)
+            base_gc = gc_snapshot()
+            snap0 = tracemalloc.take_snapshot() if ARGS.tracemalloc else None
+            base_extra = await one_poll(app, pilot)
+            base_extra.update(await idle_cost(app, pilot))
+            base_extra.update(await keystroke_cost(app, pilot))
+            records.append(await checkpoint(app, "P=0", None, base_extra))
+            for p in range(1, ARGS.polls + 1):
+                timing = await one_poll(app, pilot)
+                # Extra spinner ticks between polls: the 2 s poll sees ~16
+                # spinner frames at 120 ms.
+                for _ in range(15):
+                    app._session_sidebar._advance_spinner()
+                    await pilot.pause()
+                if p % ARGS.checkpoint_every == 0 or p == ARGS.polls:
+                    idle = await idle_cost(app, pilot)
+                    keys = await keystroke_cost(app, pilot)
+                    records.append(
+                        await checkpoint(app, f"P={p}", base_gc, {**timing, **idle, **keys})
+                    )
+            if snap0 is not None:
+                snap1 = tracemalloc.take_snapshot()
+                stats = snap1.compare_to(snap0, "traceback")
+                out = []
+                for stat in stats[:20]:
+                    out.append(f"{stat.size_diff / 1024:+.1f} KiB, {stat.count_diff:+d} blocks")
+                    out.extend("    " + line for line in stat.traceback.format()[-6:])
+                (ARGS.output / "tracemalloc.txt").write_text("\n".join(out) + "\n")
+                tracemalloc.stop()
+    return records
+
+
+FIXTURE: Fixture
+
+
+async def main() -> None:
+    global FIXTURE
+    instrument()
+    fixture = Fixture(ARGS.sessions, ARGS.history, busy=(ARGS.mode == "uptime" or ARGS.approve_all))
+    FIXTURE = fixture
+    await fixture.start()
+    try:
+        records = (
+            await run_switches(fixture) if ARGS.mode == "switches" else await run_uptime(fixture)
+        )
+    finally:
+        await fixture.close()
+    for r in records:
+        r.pop("_gc", None)
+    (ARGS.output / "checkpoints.json").write_text(json.dumps(records, indent=1, default=str) + "\n")
+    (ARGS.output / "series.json").write_text(json.dumps(SERIES, indent=1) + "\n")
+    write_report(records, ARGS.output / "report.md")
+    print((ARGS.output / "report.md").read_text())
+    for name, values in SERIES.items():
+        if not values:
+            continue
+        n = len(values)
+        q = max(1, n // 4)
+        quartiles = [
+            round(sum(values[i : i + q]) / len(values[i : i + q]), 1) for i in range(0, n, q)
+        ]
+        print(
+            f"series {name}: n={n} quartile-means={quartiles} "
+            f"first5={values[:5]} last5={values[-5:]}"
+        )
+    print("source:", local_operator.__file__)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/unit/tui/test_sidebar_longrun.py
+++ b/tests/unit/tui/test_sidebar_longrun.py
@@ -113,9 +113,9 @@ async def test_the_startup_cleanup_recheck_chain_does_not_accumulate_across_adop
         # the symptom the operator sees, stated once at the aggregate so a
         # second per-adoption repeater added later is caught here too.
         timers_after = len(list(app._timers))
-        assert timers_after <= timers_before, (
-            f"app timers grew {timers_before} -> {timers_after} over 20 adoptions"
-        )
+        assert (
+            timers_after <= timers_before
+        ), f"app timers grew {timers_before} -> {timers_after} over 20 adoptions"
 
 
 # --- Assembled-app fixture: N live in-process owners behind one sidebar ------
@@ -124,7 +124,7 @@ async def test_the_startup_cleanup_recheck_chain_does_not_accumulate_across_adop
 @asynccontextmanager
 async def live_owners(
     config: Path, count: int, monkeypatch: pytest.MonkeyPatch
-) -> AsyncIterator[tuple[list[str], Callable[[str], Awaitable[RemoteSession]]]]:
+) -> AsyncIterator[tuple[list[str], Callable[[str | None], Awaitable[RemoteSession]]]]:
     """``count`` real ``RuntimeServer`` owners, each discoverable by the catalog.
 
     Production runs one session per process, so ``registry.publish`` keys the
@@ -176,7 +176,8 @@ async def live_owners(
         async def never() -> Any:
             raise AssertionError("view navigation must never take execution ownership")
 
-        async def resume(sid: str) -> RemoteSession:
+        async def resume(sid: str | None) -> RemoteSession:
+            assert sid is not None
             return await RemoteSession.connect(
                 servers[sid]._record,
                 sid,
@@ -268,7 +269,7 @@ async def test_alternating_within_the_working_set_hits_the_cache_every_time(
             # Two more laps: every switch must reveal a parked presentation.
             for _ in range(2):
                 for sid in ids:
-                    if sid == app._session.session_id:
+                    if sid == getattr(app._session, "session_id", ""):
                         continue
                     await one_switch(app, sid)
                     switches += 1
@@ -361,7 +362,7 @@ async def test_an_idle_sidebar_over_a_stable_catalog_opens_no_new_sockets(
                 await one_poll(app, pilot)
             finally:
                 app._sidebar_navigation.intent_id = ""
-            assert target in app._sidebar_presentations, (
-                "the guard starved the row the user is navigating toward"
-            )
+            assert (
+                target in app._sidebar_presentations
+            ), "the guard starved the row the user is navigating toward"
             assert len(app._sidebar_presentations) == bound

--- a/tests/unit/tui/test_sidebar_longrun.py
+++ b/tests/unit/tui/test_sidebar_longrun.py
@@ -279,3 +279,89 @@ async def test_alternating_within_the_working_set_hits_the_cache_every_time(
                 f"(RETAINED_PRESENTATIONS={RETAINED_PRESENTATIONS})"
             )
             assert len(app._sidebar_presentations) == n - 1
+
+
+@pytest.mark.asyncio
+async def test_an_idle_sidebar_over_a_stable_catalog_opens_no_new_sockets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Once the presentation cache is full, polling must not churn viewers.
+
+    F3, stated structurally: with more live sessions than
+    ``RETAINED_PRESENTATIONS``, prewarm used to admit a candidate, evict the
+    LRU entry to respect the bound, and re-select the evicted session on the
+    next poll — one ``RemoteSession.connect`` and one dispose per candidate
+    per poll, forever. The pre-fix tree fails this with +20 connects over
+    10 idle polls.
+
+    Three things are pinned together because each guards a way a naive fix
+    regresses the feature:
+
+    1. Below the bound prewarm still fills every free slot (the fixture's
+       cache reaches the bound at all) — a guard that simply disabled
+       speculation would pass the socket count and make every first click
+       cold.
+    2. At the bound, idle polls open no sockets and evict nothing.
+    3. The row the user is heading for (``intent_id``) is still warmed at
+       the bound: that admission is user-driven, and the guard must not
+       starve it.
+
+    The bound is lowered through the module constant (the same knob the
+    diagnosis harness turns) so six owners suffice; the guard reads the
+    constant at call time.
+    """
+    import local_operator.tui.app as app_mod
+
+    config = tmp_path / "config"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config))
+    bound = 3
+    monkeypatch.setattr(app_mod, "RETAINED_PRESENTATIONS", bound)
+    async with live_owners(config, 6, monkeypatch) as (ids, resume):
+        connects = 0
+        original_connect = RemoteSession.connect.__func__  # type: ignore[attr-defined]
+
+        async def counted_connect(cls: Any, *args: Any, **kwargs: Any) -> Any:
+            nonlocal connects
+            connects += 1
+            return await original_connect(cls, *args, **kwargs)
+
+        monkeypatch.setattr(RemoteSession, "connect", classmethod(counted_connect))
+        app = OperatorApp(lambda: resume(ids[0]), resume_factory=resume)
+        async with app.run_test(size=(120, 36)) as pilot:
+            await wait_for_adoption(app, pilot)
+            app._set_sidebar_open(True)
+            assert app._sidebar_timer is not None
+            app._sidebar_timer.pause()  # the test drives polls so cycles are countable
+            # (1) Prewarm fills the cache up to the bound over a few polls.
+            for _ in range(bound + 2):
+                await one_poll(app, pilot)
+                if len(app._sidebar_presentations) >= bound:
+                    break
+            assert len(app._sidebar_presentations) == bound, (
+                f"prewarm parked {len(app._sidebar_presentations)} of {bound} slots: "
+                "the guard must fill free slots, not disable speculation"
+            )
+            parked = dict(app._sidebar_presentations)
+            connects_at_capacity = connects
+
+            # (2) Idle polls over a stable catalog: no new sockets, no eviction.
+            for _ in range(10):
+                await one_poll(app, pilot)
+            assert connects == connects_at_capacity, (
+                f"{connects - connects_at_capacity} viewer sockets opened over 10 idle polls "
+                f"with {len(ids)} live sessions and a bound of {bound}: prewarm is evicting "
+                "what it just warmed and re-warming it next poll"
+            )
+            assert app._sidebar_presentations == parked
+
+            # (3) The row the user is heading for is exempt from the guard.
+            target = next(sid for sid in ids[1:] if sid not in parked)
+            app._sidebar_navigation.intend(target)
+            try:
+                await one_poll(app, pilot)
+            finally:
+                app._sidebar_navigation.intent_id = ""
+            assert target in app._sidebar_presentations, (
+                "the guard starved the row the user is navigating toward"
+            )
+            assert len(app._sidebar_presentations) == bound

--- a/tests/unit/tui/test_sidebar_longrun.py
+++ b/tests/unit/tui/test_sidebar_longrun.py
@@ -28,13 +28,36 @@ failed there; the PR carries that proof.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import json
+import os
+import tempfile
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
 import pytest
 
+from local_operator.session.remote import RemoteSession
+from local_operator.session.runtime.owned import OwnedSessionHandle
+from local_operator.session.runtime.server import RuntimeServer
 from local_operator.tui.app import (
+    RETAINED_PRESENTATIONS,
     STARTUP_CLEANUP_RECHECK_WINDOW_S,
     OperatorApp,
 )
-from tests.e2e.harness import wait_for_adoption
+from tests.e2e.harness import (
+    ScriptedStream,
+    assistant_message,
+    build_session,
+    seed_transcript,
+    user_message,
+    wait_for_adoption,
+)
+from tests.unit.harness.test_comms import DEADLOCK_GUARD_S, MAX_PUMP_TURNS
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
 
@@ -93,3 +116,166 @@ async def test_the_startup_cleanup_recheck_chain_does_not_accumulate_across_adop
         assert timers_after <= timers_before, (
             f"app timers grew {timers_before} -> {timers_after} over 20 adoptions"
         )
+
+
+# --- Assembled-app fixture: N live in-process owners behind one sidebar ------
+
+
+@asynccontextmanager
+async def live_owners(
+    config: Path, count: int, monkeypatch: pytest.MonkeyPatch
+) -> AsyncIterator[tuple[list[str], Callable[[str], Awaitable[RemoteSession]]]]:
+    """``count`` real ``RuntimeServer`` owners, each discoverable by the catalog.
+
+    Production runs one session per process, so ``registry.publish`` keys the
+    discovery record by PID. Every owner here shares this test's PID, so
+    without re-keying, N servers overwrite ONE file, the catalog reports a
+    single live row, prewarm never selects anything, and every assertion
+    below passes vacuously against a cold path. Keyed by ``(pid, session_id)``
+    instead; ``scan`` globs ``*.json`` and checks ``pid_alive``, so the
+    records stay truthful for all of them.
+    """
+    from local_operator.session.runtime import registry
+
+    def publish(record: Any, root: Path | None = None) -> Path:
+        directory = registry.run_dir(root)
+        record.heartbeat_at = time.time()
+        fd, tmp = tempfile.mkstemp(dir=directory, prefix=".x.", suffix=".tmp")
+        with os.fdopen(fd, "w") as handle:
+            json.dump(record.to_json(), handle)
+        target = directory / f"{record.pid}-{record.session_id}.json"
+        os.replace(tmp, target)
+        return target
+
+    monkeypatch.setattr(registry, "publish", publish)
+    monkeypatch.setattr(registry, "unpublish", lambda pid, root=None: None)
+
+    servers: dict[str, RuntimeServer] = {}
+    handles: list[OwnedSessionHandle] = []
+    ids: list[str] = []
+    try:
+        for i in range(count):
+            sid = f"longrun{i:02d}"
+            ids.append(sid)
+            directory = config / "sessions" / sid
+            await seed_transcript(
+                directory,
+                [user_message(f"{sid} question"), assistant_message(f"{sid} saved answer")],
+            )
+            owner = build_session(directory, ScriptedStream([]), cwd=config)
+            handle = OwnedSessionHandle(owner, asyncio.get_running_loop(), cwd=str(config))
+            handles.append(handle)
+            server = RuntimeServer(handle, kind="daemon")
+            await server.start_in_process()
+            servers[sid] = server
+
+        def find(_directory: Path, sid: str) -> tuple[Any, Any]:
+            server = servers.get(sid)
+            return (server._record, server._record.pid) if server else (None, None)
+
+        async def never() -> Any:
+            raise AssertionError("view navigation must never take execution ownership")
+
+        async def resume(sid: str) -> RemoteSession:
+            return await RemoteSession.connect(
+                servers[sid]._record,
+                sid,
+                config_dir=config,
+                takeover_factory=never,
+                display_window=True,
+            )
+
+        monkeypatch.setattr("local_operator.mobile.attach_client.find_owner_record", find)
+        monkeypatch.setattr(OperatorApp, "_check_for_update", lambda self: None)
+        yield ids, resume
+    finally:
+        for server in servers.values():
+            await server.aclose()
+        for handle in handles:
+            await handle.dispose()
+
+
+async def one_poll(app: OperatorApp, pilot: Any) -> None:
+    """One catalog poll + the prewarm it launches, driven to completion.
+
+    Waits on the app's own state (``_sidebar_refresh_pending`` cleared, then
+    the prefetch worker's ``wait()``) rather than on the clock, per AGENTS.md
+    "Wait on the event, never on the clock".
+    """
+    app._refresh_sidebar()
+    for _ in range(MAX_PUMP_TURNS):
+        if not app._sidebar_refresh_pending:
+            break
+        await pilot.pause()
+    else:
+        raise AssertionError("the catalog refresh never settled")
+    prefetch = app._sidebar_prefetch
+    if prefetch is not None:
+        await asyncio.wait_for(asyncio.shield(prefetch.wait()), DEADLOCK_GUARD_S)
+    await pilot.pause()
+
+
+async def one_switch(app: OperatorApp, sid: str) -> None:
+    await asyncio.wait_for(app._sidebar_navigation.select(sid), DEADLOCK_GUARD_S)
+    connection = app._interaction.connection_task
+    if connection is not None:
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(asyncio.shield(connection), DEADLOCK_GUARD_S)
+
+
+@pytest.mark.asyncio
+async def test_alternating_within_the_working_set_hits_the_cache_every_time(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A user alternating between N <= bound conversations never pays a rebuild.
+
+    F2, stated structurally: after every conversation has been visited once,
+    each further switch takes the reveal path (a hit in
+    ``_sidebar_presentation_current``) rather than ``_prepare_sidebar_session``'s
+    rebuild. Eight conversations is the smallest working set the operator's
+    report describes; the pre-fix bound of 4 fails this with 12/32 hits.
+
+    Counted at the acceptance predicate, not by timing: a rebuild that got
+    faster would still be a rebuild.
+    """
+    config = tmp_path / "config"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config))
+    n = 8
+    assert n <= RETAINED_PRESENTATIONS, "the working set must fit the bound for this claim"
+    async with live_owners(config, n, monkeypatch) as (ids, resume):
+        hits = 0
+        original = OperatorApp._sidebar_presentation_current
+
+        def counted(cached: Any, source: Any, gate: Any) -> bool:
+            nonlocal hits
+            ok = original(cached, source, gate)
+            hits += int(ok)
+            return ok
+
+        monkeypatch.setattr(OperatorApp, "_sidebar_presentation_current", staticmethod(counted))
+        app = OperatorApp(lambda: resume(ids[0]), resume_factory=resume)
+        async with app.run_test(size=(120, 36)) as pilot:
+            await wait_for_adoption(app, pilot)
+            app._set_sidebar_open(True)
+            assert app._sidebar_timer is not None
+            app._sidebar_timer.pause()  # the test drives polls; no background prewarm races
+            # First lap: every conversation visited once, so each is either
+            # parked or the live one. Misses here are expected and not counted.
+            for sid in ids[1:]:
+                await one_switch(app, sid)
+            hits = 0
+            switches = 0
+            # Two more laps: every switch must reveal a parked presentation.
+            for _ in range(2):
+                for sid in ids:
+                    if sid == app._session.session_id:
+                        continue
+                    await one_switch(app, sid)
+                    switches += 1
+            assert switches >= 2 * (n - 1)
+            assert hits == switches, (
+                f"{switches - hits} of {switches} switches over a working set of {n} rebuilt "
+                f"the presentation instead of revealing the parked one "
+                f"(RETAINED_PRESENTATIONS={RETAINED_PRESENTATIONS})"
+            )
+            assert len(app._sidebar_presentations) == n - 1

--- a/tests/unit/tui/test_sidebar_longrun.py
+++ b/tests/unit/tui/test_sidebar_longrun.py
@@ -1,0 +1,95 @@
+"""The TUI must not get slower the longer it runs with the sidebar open.
+
+The operator reported two symptoms that ``/reload`` cures: the TUI slows down
+after running a long time with the session sidebar open, and sidebar switches
+that are fast at first get gradually slower with switch count. A root-cause
+pass on the assembled app (real ``OperatorApp`` under ``run_test``, real
+in-process runtime owners, real ``RemoteSession`` viewers over loopback) found
+three independent accumulations rather than one leak:
+
+* **F1** — ``_report_startup_cleanup`` self-schedules a 1 s recheck chain for
+  30 s, and ``_adopt_session`` seeded a fresh chain on EVERY adoption, which a
+  sidebar switch re-enters. The chains did not know about each other, so live
+  timers grew 9 → 60 over 50 switches and the callback ran 6462 times over
+  150 — each a disk read on the event loop, each timer a live asyncio task.
+* **F2** — ``RETAINED_PRESENTATIONS`` was 4, smaller than a real working set,
+  so a user who had touched more than four conversations paid a cold rebuild
+  (connect, window, replay, MOUNT, layout wait, teardown) on most switches.
+* **F3** — ``_prewarm_sidebar`` admitted a candidate and then immediately
+  evicted an older presentation to respect the same bound, making the evicted
+  session a candidate again on the next 2 s poll: a socket connected and
+  disposed per poll, forever, whenever live sessions exceeded the bound.
+
+The assertions here are STRUCTURAL — timer counts, socket connects, cache
+hits — never wall-clock or CPU bounds, per AGENTS.md "Prefer a structural
+invariant to a numeric one". Each was run against the pre-fix tree and
+failed there; the PR carries that proof.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from local_operator.tui.app import (
+    STARTUP_CLEANUP_RECHECK_WINDOW_S,
+    OperatorApp,
+)
+from tests.e2e.harness import wait_for_adoption
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+def _cleanup_timers(app: OperatorApp) -> list[object]:
+    """Every live Textual timer whose callback is the startup-cleanup recheck.
+
+    Named by callback rather than counted in aggregate so the assertion is
+    about the site (F1) and cannot be satisfied or broken by an unrelated
+    interval timer coming or going.
+    """
+    return [
+        timer
+        for timer in list(app._timers)
+        if "_report_startup_cleanup" in repr(getattr(timer, "_callback", None))
+    ]
+
+
+@pytest.mark.asyncio
+async def test_the_startup_cleanup_recheck_chain_does_not_accumulate_across_adoptions() -> None:
+    """Re-adopting N times leaves at most ONE recheck chain alive, not N.
+
+    ``_adopt_session`` is exactly what a sidebar switch calls, so this is the
+    switch-count growth stated at its site. The pre-fix tree fails with 21
+    live chains after 20 adoptions.
+
+    The bound is ``<= 1`` rather than ``== 1``: the chain is a one-shot that
+    re-arms itself from inside its own callback, so between a tick firing and
+    the next ``set_timer`` there is momentarily no live timer, and a count of
+    exactly one would race that gap. What must never be true is "more than
+    one", which is the accumulation.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await wait_for_adoption(app, pilot)
+        await pilot.pause()
+        # PRECONDITION: the boot adoption armed the chain at all, so the
+        # assertion below is about overlap and not about a chain that never
+        # starts (which would also pass, vacuously).
+        assert len(_cleanup_timers(app)) == 1, "boot did not arm the recheck chain"
+        assert STARTUP_CLEANUP_RECHECK_WINDOW_S > 0
+        timers_before = len(list(app._timers))
+
+        for _ in range(20):
+            app._adopt_session(FakeSession(), replay_history=False)
+            await pilot.pause()
+
+        live = _cleanup_timers(app)
+        assert len(live) <= 1, (
+            f"{len(live)} startup-cleanup recheck chains alive after 20 adoptions: "
+            "each adoption seeded a new chain without stopping the previous one"
+        )
+        # And the app's whole timer census did not grow with adoption count —
+        # the symptom the operator sees, stated once at the aggregate so a
+        # second per-adoption repeater added later is caught here too.
+        timers_after = len(list(app._timers))
+        assert timers_after <= timers_before, (
+            f"app timers grew {timers_before} -> {timers_after} over 20 adoptions"
+        )

--- a/tests/unit/tui/test_sidebar_retain_budget.py
+++ b/tests/unit/tui/test_sidebar_retain_budget.py
@@ -35,6 +35,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from local_operator.tui.app import RETAINED_PRESENTATIONS
 from local_operator.tui.session_presentation import (
     RETAIN_TEXT_BYTES,
     PreparedReplay,
@@ -132,13 +133,19 @@ def test_the_budget_still_refuses_a_payload_above_it():
     # below is derived from `RETAIN_TEXT_BYTES`, so they all scale with it and
     # stay green if the constant is raised 100x — which is exactly the
     # mis-tuning this file exists to catch, and it has already happened twice
-    # in the same direction. `RETAINED_PRESENTATIONS` (4) parked views each get
-    # this budget, so the retained-text ceiling is 4x it; on a host that has
-    # hit macOS "out of application memory", 4 MiB of retained text is the most
-    # that can be justified without a fresh RSS measurement.
+    # in the same direction. `RETAINED_PRESENTATIONS` parked views each get
+    # this budget, so the retained-text ceiling is N x it. On a host that has
+    # hit macOS "out of application memory", 12 MiB of retained text (12 views
+    # at 1 MiB, measured at +11-17 MB RSS for the whole cache at full
+    # occupancy) is the most that can be justified without a fresh RSS
+    # measurement; pin the PRODUCT so raising either factor alone trips this.
     assert RETAIN_TEXT_BYTES <= 4 * 1024 * 1024, (
         "the retain budget grew without a measurement: N x this bounds retained "
         "text, and this host has hit 'out of application memory'"
+    )
+    assert RETAINED_PRESENTATIONS * RETAIN_TEXT_BYTES <= 12 * 1024 * 1024, (
+        "the retained-text ceiling (views x per-view budget) grew without a "
+        "measurement; see RETAINED_PRESENTATIONS for the numbers that sized it"
     )
 
     text = "x" * (RETAIN_TEXT_BYTES + 64 * 1024)


### PR DESCRIPTION
## Summary

The TUI no longer gets slower the longer it runs with the session sidebar open, and sidebar switches no longer get slower with switch count. Both symptoms — the ones `/reload` used to cure — came from three independent accumulations in the sidebar path, not one leak. Each is fixed in its own commit so a later regression is attributable:

| | Finding | Site | Fix |
|---|---|---|---|
| **F1** | `_report_startup_cleanup` seeded a fresh 30-tick 1 s recheck chain on **every** `_adopt_session`, which every sidebar switch re-enters; chains overlapped without bound (live timers 9 → 99 over 50 switches, 772 ticks, each a disk read on the event loop with a live asyncio task behind it) | `app.py` `_adopt_session` → `_report_startup_cleanup` | store the chain's live tick on the app and `stop()` it before seeding a new one |
| **F2** | `RETAINED_PRESENTATIONS = 4` was smaller than a real working set, so a user who had touched >4 conversations paid a cold rebuild (connect, window, replay, **mount**, layout wait, teardown) on most switches — and the working set grows during a session, so it read as "gets slower over time" | `app.py` `RETAINED_PRESENTATIONS` | raise the **capacity** to 12; `retainable()`'s per-view byte budget stays the memory bound; acceptance (`_sidebar_presentation_current`) untouched |
| **F3** | `_prewarm_sidebar` admitted a candidate, then evicted the LRU entry to respect the bound; the evicted session was live, top-ranked and uncached, so it was re-selected next poll — one `RemoteSession.connect` + one dispose per candidate per 2 s poll, forever, once live sessions exceeded the bound | `app.py` `_prewarm_sidebar` candidate filter | speculation fills only **free** slots and never evicts; the row the user is heading for (`intent_id`) is exempt |

F1 explains the switch-count symptom; F3 explains the sidebar-open uptime symptom; F2 is the amplifier that made both feel like "switches got slow".

**Release: patch — the TUI stays as fast after hours with the sidebar open, and after hundreds of switches, as it is at boot.**

**Change class: C2, standard/pre-authorized.** No version bump; `pyproject.toml` stays at the last released version.

Agent review round 1 returned **clean** (terminal — 2 nits) and QA round 1 **PASS** (3 informational findings); the round-1 remediation comment addresses each by ID. The manager merges.

## Delivery contract

- Re-adopting a session N times leaves at most one startup-cleanup recheck chain alive. The notice still announces once per process, including on a viewer that attaches before its runtime's cleanup pass finishes (the recheck window on that adoption is preserved — this is why it is a stored handle and not a once-per-process latch).
- A user alternating between up to 12 conversations reveals a parked presentation on every switch after the first lap; no rebuild, no new socket.
- An idle sidebar over a stable catalog opens **zero** new viewer sockets and evicts nothing once the cache is full, at any number of live sessions.
- Below the bound, prewarm still fills every free slot (the ≤4-session case that already worked keeps working); the row the user is navigating toward is still warmed at capacity.
- `retainable()`'s byte budget, #787's freshness predicate and #808's "fewer rows" reconcile branch are untouched: capacity was raised, acceptance was not.

### Scope / non-goals

Exactly the three sites above. The `frontend_state` deep-copy path (`pydantic.model_copy` → `copy.deepcopy`, the largest allocator in the switch profile; `remote.py`'s `_read_state_field` fast path that per-frame callers bypass) is **out of scope, owned by a parallel session** that has also claimed the transcript render path (`widgets/transcript.py`, `tool_card`, `subagent_view`) and blocking calls on the UI path. That session edits `app.py` only at `frontend_state` call sites and has committed to not touching these three regions; whichever PR merges second rebases.

Not in scope either: `StylesCache` instances pinned by Textual's class-level `lru_cache(1024)` on `get_inner_outer` (upstream, bounded at 1024, reached within ~50 switches and flat thereafter — recorded so nobody re-derives it from a gc dump).

## Implementation — the WHY

**F1 — handle, not latch.** `cleanup.take_unannounced_cleanup` defers to the removing runtime's own viewer while that runtime lives, so a viewer attaching before its runtime's pass finishes needs the recheck window on *that* adoption; a once-per-process latch would skip it and lose the notice. Stopping the previous chain keeps every timing property of the window and only removes the overlap. `Timer.stop()` cancels the tick's task; a tick that reaches the method stops its own already-fired one-shot, which is a no-op.

**F2 — why 12, from measurement rather than the report's experiment.** Swept 4/6/8/10/12/16 on the assembled app (40 switches, only the constant changed):

| live conversations | bound | cache hits / 40 | cold rebuilds | switch loop-CPU (last 10, mean) | RSS |
|---|---|---|---|---|---|
| 8 | 4 | 12 | 28 | 246 ms | 139 MB |
| 8 | 8 | 39 | 1 | 59 ms | 149 MB |
| 8 | 12 | 37 | 3 | 60 ms | 147 MB |
| 10 | 6 | 7 | 33 | 181 ms | 153 MB |
| 10 | 8 | 6 | 34 | 209 ms | 154 MB |
| 10 | 10 | 36 | 4 | 50 ms | 153 MB |
| 12 | 4 | 6 | 34 | 219 ms | 139 MB |
| 12 | 8 | 19 | 21 | 211 ms | 141 MB |
| 12 | 12 | 36 | 4 | 66 ms | 156 MB |
| 12 | 16 | 36 | 4 | 86 ms | 156 MB |

Cost is a step function at the working-set boundary — a bound one below it is as bad as 4 (round-robin over N with LRU N−1 is the pathological case). With the bound at 12 the cliff sits exactly at bound+1, as arithmetic predicts: QA round 1's boundary sweep measured **47/50 hits at 13 live conversations in rotation and 7/50 at 14** (equal to the pre-fix base) — the bound moves the cliff, it does not remove it; F3 keeps churn at zero past it. 12 covers the 8–12 live sessions with turns running that is the reporting operator's normal population; 16 measured identical to 12. Price: one live viewer socket per slot, and an RSS cost for 4 → 12 that has been measured twice — this PR's sweep (runs above): **+11–17 MB** at full occupancy; QA round 1 (matched interleaved `--retained {4,12}` runs, 13 sessions, 40-message histories): **+6–8 MB**. The two runs bracket a history-size-dependent cost; the product budget pinned below is the ceiling either way. Per-frame cost stays nil — a parked view is `offset: 100vw` + `overlay: screen`, and the compositor's visible set stayed at 23 widgets with 7 parked vs 4, keystroke p90 88 vs 93 ms (noise on this host). The budget test now pins the **product** `RETAINED_PRESENTATIONS × RETAIN_TEXT_BYTES ≤ 12 MiB` so raising either factor alone trips it.

**F3 — at the candidate filter, keyed on the eviction the admission would cause.** `free_slots = RETAINED_PRESENTATIONS − len(_sidebar_presentations)`; ranked candidates take that many, plus the `intent_id` row unconditionally, capped at `PREWARM_PER_REFRESH`. The bound is re-checked after the `await` in the prefetch worker too, because a click committing mid-prepare can fill the slot the candidate was selected for. `_sidebar_prewarm_refused` is deliberately **not** used: it records `retainable()` refusals keyed on content, and these candidates are admissible — parking them there is the permanent blacklist its docstring warns about.

## Reproduction and measured outcome

**Host conditions, stated up front.** Every number below was taken on a 14-core M3 Max while 6+ peer sessions ran concurrent `pytest tests/unit` suites: load average **93–220** on 14 cores, 0% idle, swap 8.7/10 GB. AGENTS.md documents this exact failure mode. So: **the structural facts are the evidence** (timer counts, connect/dispose counts, hit/miss counts — they cannot be moved by contention); the timing columns are supporting material, treat absolute values as ceilings. The headline before/after pairs were taken **interleaved, back-to-back in one sequential run** (before, after, before, after) with `uptime` logged before each, so contention cancels within a pair rather than between two runs minutes apart.

Instrument: `scripts/diag/tui_growth.py` (committed; the architect's harness) — the real assembled `OperatorApp` under `run_test()` with the stylesheet, real in-process `RuntimeServer` owners, real `RemoteSession` viewers over loopback, `HOME` + `LOCAL_OPERATOR_CONFIG_DIR` redirected via `scripts/probe_isolation`, every `CMUX_*` scrubbed. "before" is a throwaway detached worktree at `origin/main` with the harness copied in; "after" is this branch.

### Interleaved headline pairs (all three fixes, shipped config, nothing stubbed)

`--mode switches --switches 50 --sessions 8` — 50 switches round-robin over 8 live conversations:

| run | load avg at start | live timers K=0→50 | cleanup ticks | cache hits / 50 | cold rebuilds | connects | disposes | switch loop-CPU (last 10) | switch wall (last 10) |
|---|---|---|---|---|---|---|---|---|---|
| before-1 | 132 | 9 → **99** | 772 | 10 | 40 | 19 | 54 | 208 ms | 282 ms |
| after-1 | 105 | 9 → **9** | 55 | **47** | 3 | 5 | 0 | **56 ms** | 95 ms |
| before-2 | 94 | 9 → **98** | 703 | 11 | 39 | 17 | 51 | 217 ms | 292 ms |
| after-2 | 105 | 9 → **9** | 55 | **47** | 3 | 5 | 0 | **55 ms** | 99 ms |

`--mode uptime --polls 30 --sessions 10` — sidebar open over 10 live busy sessions, 30 catalog polls, no switches:

| run | load avg at start | parked presentations P=0→30 | connects | disposes | poll loop-CPU (last 10) | poll wall (last 10) |
|---|---|---|---|---|---|---|
| before-1 | 109 | 4 → 4 | **65** | **60** | 138 ms | 307 ms |
| after-1 | 128 | 4 → 9 | **10** | **0** | **16 ms** | 79 ms |
| before-2 | 104 | 4 → 4 | **65** | **60** | 137 ms | 215 ms |
| after-2 | 94 | 4 → 9 | **10** | **0** | **15 ms** | 86 ms |

### Per-fix attribution (each measured with the others neutralised)

**F1** — `--sessions 6 --cycle 3` (round-robin over 3 conversations stays inside the old LRU, so F2/F3 cannot contaminate it):

| K switches | 0 | 5 | 20 | 50 |
|---|---|---|---|---|
| live timers, before | 9 | 14 | 29 | 60 |
| live timers, after | 9 | 9 | 9 | 9 |
| cumulative `_report_startup_cleanup` ticks, before | 3 | 19 | 98 | 415 |
| cumulative ticks, after | 4 | 10 | 26 | 58 |

(The remaining ticks after the fix are the one live chain's rechecks over the run's wall time — bounded by the 30 s window, not by switch count.)

**F2** — the sweep table under Implementation.

**F3** — `--mode uptime --sessions 10 --retained 4 --no-cleanup-timer` (F2's bound pinned back to 4 and F1 stubbed, per the report's cross-cutting note, so this guard is visible on its own):

| | before | after |
|---|---|---|
| `RemoteSession.connect` over 30 polls | 65 | 5 |
| `RemoteSession.dispose` over 30 polls | 60 | 0 |
| speculative prepares | 64 | 4 |
| poll loop-CPU (last 10, mean) | 124 ms | 12 ms |

At 4 live sessions (under the bound) after the fix: 4 connects, 0 disposes, 10 ms polls — unchanged from before, which is the "do not disable prewarm for the healthy case" constraint. At 16 live sessions with the shipped bound: the cache fills to 12 over the first polls (13 connects) and then holds at 0 disposes.

### Field evidence from the operator's real long-running TUI (corroborating, explicitly not a profile)

Two independent read-only samples of the operator's own long-lived frontend — pid 82222, `lop --resume 835fbcafdc27`, uptime 3.7 h, a session the operator independently named as slow, whose sidebar has spawned three further session daemons (pids 10134, 24533, 41083 — so it is a multi-session sidebar frontend, the population these fixes target). Observation only: `ps` twice ~45 s apart; nothing was attached to, signalled or disturbed.

| sample | its runtime daemon (pid 23991) | frontend lifetime average | frontend current 45 s window | growth vs its own lifetime |
|---|---|---|---|---|
| peer session (pid 24533) | 0.8% CPU | 9.4% (1271 s CPU / 13509 s) | 38.1% | **4.0×** |
| this session, ~10 min later | 0.5% CPU | 9.7% (22:09 / 3:47:45) | 38.4% (17.29 s / 45 s) | **4.0×** |

This is contention-proof in a way no table above is: it is a ratio of one process against *itself*, so the loaded host cancels out. An idle session's frontend is doing 4× the work per unit time it averaged over its own life, while the session it renders does nothing — per-frame/periodic cost growing with uptime, the shape F1 predicts (overlapping 1 s chains) and F3 compounds (a connect + dispose per poll every 2 s while the sidebar is open). A 3.7 h session has almost certainly done many switches, so both should be live in it at once.

**What this is not.** There are no Python-level stacks: `py-spy` needs root on macOS and neither session would request it unattended, and `sample(1)` symbolicates to C frames only. So this says *the shape matches F1/F3*, **not** *the timer callbacks were observed on the stack*. And 38% on an idle session is a lot — F1's measured tick cost (0.006–0.03 ms) and F3's polls do not obviously sum to it, so a third contributor cannot be ruled out from this sample. That residual is stated here rather than claimed away; it sits next to the §5 gap below. The direct proof is cheap but needs a human at the machine: `sudo py-spy dump --pid 82222` (or the next long-lived frontend) would name the callbacks outright and turn this into a real profile — a follow-up for the operator, not a gap in the fixture evidence.

**Not re-measured:** the operator's real config dir. The fixture caps history at 20–40 messages per session, which deliberately understates `_prepare_sidebar_session`'s tail on the operator's very large journals — so the *absolute* before-figures here understate the operator's experience, and the summed CPU on a 14-core box absorbs 110 ms polls and 215 ms switches better than a loaded laptop. If degradation persists after this lands, §5 of the diagnosis names the next two measurements.

## Regression tests (structural, per AGENTS.md — no wall-time or CPU bounds)

`tests/unit/tui/test_sidebar_longrun.py`, three tests, each proven to fail against the unfixed code:

| test | asserts | pre-fix failure |
|---|---|---|
| `test_the_startup_cleanup_recheck_chain_does_not_accumulate_across_adoptions` | ≤ 1 live recheck chain after 20 `_adopt_session` calls; app timer census does not grow | verbatim `assert 21 <= 1` |
| `test_alternating_within_the_working_set_hits_the_cache_every_time` | over 8 real in-process owners, every switch after the first lap is a `_sidebar_presentation_current` hit | as committed, fails first at its own precondition `assert 8 <= 4` (working set 8 vs bound 4); with that guard line deleted it fails behaviourally — `16 of 16 switches … rebuilt the presentation`, `assert 0 == 16` — the recorded failure requires that local edit to surface (reviewer and QA both reproduced it this way) |
| `test_an_idle_sidebar_over_a_stable_catalog_opens_no_new_sockets` | (1) prewarm fills the cache to the bound; (2) 10 idle polls open 0 sockets and evict nothing; (3) the `intent_id` row is still warmed at capacity | verbatim `20 viewer sockets opened over 10 idle polls`, `assert 25 == 5` |

The F3 test's three clauses were also mutation-tested individually: forcing `free_slots = 0` fails clause (1) with `prewarm parked 0 of 3 slots: the guard must fill free slots, not disable speculation`; removing the intent exemption fails clause (3) with `the guard starved the row the user is navigating toward`. A guard that simply disabled prewarm cannot pass this test.

The F2/F3 fixture re-keys `registry.publish` by `(pid, session_id)`; without that, N in-process owners overwrite one PID-keyed record, the catalog sees ONE live row, prewarm never selects anything and the test passes vacuously against the cold path. The fixture docstring says so.

Existing coverage exercised on the fixed tree: the four cleanup-notice pilots in `test_app_pilot.py` (including the deferred timer-delivered notice, which is the case the latch would have broken) — 4 passed; `test_sidebar_retain_budget.py`, `test_session_sidebar.py`, `test_sidebar_swap_reset.py`, `test_sidebar_source_state.py`, `test_session_navigation.py` — 88 passed.

## Quality gates (whole tree, exactly as CI, on the rebased head)

| Gate | Result |
|---|---|
| `python -m flake8 .` | clean |
| `black --check .` (26.1.0) | 1149 files unchanged |
| `isort --check .` (5.13.2) | clean |
| `pyright --pythonpath .venv/bin/python .` | 0 errors, 0 warnings |
| `pytest tests/unit` | **17039 passed, 18 skipped** in 23:43 (load avg 185–220 during the run) |
| `pytest tests/e2e -m e2e -n0` | **93 passed, 7 skipped** in 2:36 |

Suites were run **serially**, never concurrently with the measurement runs, on a host already carrying 6 peer suites. The worktree owns its own real editable Python 3.12 venv; `import local_operator` was verified to resolve to it before any measurement.

## Coordination

Rebased once onto `origin/main` after #819/#834/#835 landed; `git range-diff` reports all three fix commits `=` (content unchanged) and none of the upstream changes touch the three regions here.

## Rollback

Revert the three `fix(tui)` commits independently; each is self-contained. No storage schema, owner protocol, version or runtime migration is involved.

🤖 Authored by an agent; see the review rounds on this PR.



Release: patch — the session sidebar no longer degrades with uptime or switch count: idle polling opens no sockets, the parked-view cache covers a real working set, and the startup-cleanup recheck chain no longer accumulates per switch
