### PR TITLE
perf(session): read per-frame state fields without the whole-state clone

### DIFF
--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -2679,7 +2679,25 @@ class FrontendStateStore:
                 f"{name!r} is not a copy-free derived label; read it through `state` "
                 "so the caller cannot reach the store's own instance"
             )
-        return str(getattr(self._state, name))
+        # ENFORCED, not coerced, per the finding on review round 1: a `str()`
+        # here would silently stringify a label property whose return type
+        # drifted — a tuple-shaped label would render "(a, b)" and pass —
+        # masking the contract instead of upholding it. `str()` always builds
+        # a fresh string so it can never share state; the failure it hides is
+        # the CONTRACT one (a non-str is exactly the shape the allow-list's
+        # closure test exists to catch, and this is the boundary where a drift
+        # it missed must stop). `TypeError` at the boundary is the label
+        # sibling of `read_field`'s `KeyError` on a non-allowlisted name: the
+        # gate raises rather than papering over the input.
+        value = getattr(self._state, name)
+        if not isinstance(value, str):
+            raise TypeError(
+                f"{name!r} is not a copy-free derived label: expected a freshly built "
+                f"str, got {type(value).__name__!r}. The value may be one of the "
+                "store's own objects rather than a derived label, so it must not "
+                "leave the store through this path."
+            )
+        return value
 
     @property
     def pending_gate(self) -> "PendingGateState | None":

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -184,6 +184,29 @@ JOB_TEXT_FLOOR_CHARS = 200
 #: `test_shareable_state_fields_are_real_and_immutable` asserts both properties
 #: against `model_fields`, so neither a renamed field nor a newly mutable type
 #: can silently re-enter this set.
+#: Derived properties :meth:`FrontendStateStore.read_label` may serve.
+#:
+#: SEPARATE FROM :data:`_SHAREABLE_STATE_FIELDS` because the safety argument is
+#: a different one, and conflating them would weaken both. That set admits
+#: FIELDS whose stored value is handed out directly, so its bar is deep
+#: immutability of the store's own object. These are PROPERTIES that build a
+#: new ``str`` on every read, so nothing of the store's is shared at all — the
+#: models they read (``selected_model``, ``effective_model``) stay inside and
+#: remain excluded from the field allow-list, which is what keeps review round
+#: 2's Q6/F4 invariant intact.
+#:
+#: Every entry must therefore return a FRESHLY CONSTRUCTED immutable value. A
+#: property that returned one of the state's own mutable objects would share it
+#: exactly as a field read would, with none of the field allow-list's scrutiny;
+#: ``test_derived_state_labels_are_real_and_immutable`` asserts the shape
+#: against the model so such a property cannot join this set unnoticed.
+_DERIVED_STATE_LABELS = frozenset(
+    {
+        "model_label",
+        "effective_model_label",
+    }
+)
+
 _SHAREABLE_STATE_FIELDS = frozenset(
     {
         "streaming",
@@ -2621,6 +2644,42 @@ class FrontendStateStore:
                 "so the caller cannot mutate the store's own instance"
             )
         return getattr(self._state, name)
+
+    def read_label(self, name: str) -> str:
+        """One DERIVED label of the state, WITHOUT cloning the whole state.
+
+        The sibling of :meth:`read_field` for values that are COMPUTED rather
+        than stored, and it exists because the allow-list cannot reach them.
+        ``model_label`` and ``effective_model_label`` are formatted from
+        ``selected_model``/``effective_model``, which are non-frozen models
+        deliberately kept OFF :data:`_SHAREABLE_STATE_FIELDS` (review round 2,
+        Q6/F4: sharing the store's spec let a caller rewrite canonical state).
+        So no widening of that set can serve these two, and widening it to try
+        would reintroduce exactly the invariant that was restored.
+
+        The safety argument is different from ``read_field``'s and stronger.
+        ``read_field`` shares the store's own object and relies on the value
+        being deeply immutable; this returns a str the property JUST BUILT, so
+        the model it was derived from never leaves the store at all. A caller
+        cannot reach the spec through the label under any mutation.
+
+        Restricted to :data:`_DERIVED_STATE_LABELS` for the same reason
+        ``read_field`` is restricted: an enforced membership test rather than a
+        documented convention, so a later property that happens to return a
+        mutable object cannot be served here by accident.
+
+        Measured, at a 120-job roster on a loaded host: the band's per-paint
+        label reads cost ~1.8 ms each through ``state`` (4,214 deepcopy calls
+        for a representative frame) against ~0.0003 ms here, and the cost grows
+        with everything the session accumulates — which is the mechanism behind
+        a TUI that degrades over a long session.
+        """
+        if name not in _DERIVED_STATE_LABELS:
+            raise KeyError(
+                f"{name!r} is not a copy-free derived label; read it through `state` "
+                "so the caller cannot reach the store's own instance"
+            )
+        return str(getattr(self._state, name))
 
     @property
     def pending_gate(self) -> "PendingGateState | None":

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -1442,7 +1442,7 @@ class RemoteSession:
         prevents a stale desktop popup from accidentally answering a newer gate
         while a reconnect or a multi-question ask advances in another window.
         """
-        pending = self.frontend_state.pending_gate
+        pending = self.pending_gate
         client = self._client
         if (
             pending is None
@@ -2576,14 +2576,15 @@ class RemoteSession:
                         self._client is not client
                         or self._disposed
                         or frontend.snapshot.session_id != self._session_id
-                        or frontend.epoch != self.frontend_state.epoch
+                        or frontend.epoch != self.epoch
                     ):
                         raise ConnectionError("history binding changed during refresh")
                     self._frontend_refresh_cut = (frontend.epoch, frontend.sequence)
                     self._install_frontend(frontend.snapshot, publish=True)
                     await self._load_frontend_history(frontend)
                     self._display_invalidated = (
-                        self.frontend_state.history_generation != self._loaded_history_generation
+                        self._read_state_field("history_generation")
+                        != self._loaded_history_generation
                     )
                     self._finish_sync()
                 except BaseException:
@@ -2853,7 +2854,11 @@ class RemoteSession:
         # snapshot, so nothing needs re-stamping. Deviation from the
         # design's "seed as today", proven by the reviewer's counterfactual.
         same_live_turn, self._same_live_turn = self._same_live_turn, False
-        if self.frontend_state.streaming and not same_live_turn:
+        # `streaming` is allow-listed; `generation` is NOT (only
+        # `history_generation` and `sequence` are), so it keeps the clone. The
+        # pair is not a torn read: nothing awaits between them, so both resolve
+        # against the same installed snapshot.
+        if self._read_state_field("streaming") and not same_live_turn:
             seeded.insert(0, AgentStartEvent(generation=self.frontend_state.generation))
         # Durable-before-live is the transcript's paint invariant. On
         # reconnect the buffer's head can hold the gap's HistoryDeltaEvent
@@ -4125,9 +4130,36 @@ class RemoteSession:
             raise RuntimeError("frontend state has not synchronized")
         return self._frontend_store.read_field(name)
 
+    def _read_state_label(self, name: str) -> str:
+        """One DERIVED label without the whole-state clone.
+
+        Separate from :meth:`_read_state_field` because the two answer
+        different questions. That one serves FIELDS, gated by an allow-list of
+        deeply immutable values. A label is not a field: it is computed from
+        `selected_model`/`effective_model`, which are non-frozen models the
+        allow-list deliberately excludes, so no widening of that set could
+        serve it — and none should be attempted, since sharing a spec is the
+        invariant loss review round 2 (Q6/F4) rejected.
+
+        What makes this safe is that the derived value is a freshly built
+        `str`: the spec never leaves the store, and a caller holding the label
+        cannot reach the object it was formatted from.
+        """
+        if self._frontend_store is None:
+            raise RuntimeError("frontend state has not synchronized")
+        return self._frontend_store.read_label(name)
+
     @property
     def model_label(self) -> str:
-        return self.frontend_state.model_label
+        # THE SPEC STAYS INSIDE THE STORE; ONLY ITS LABEL LEAVES.
+        # Not `_read_state_field`: `model_label` is a DERIVED property, not a
+        # field, and the field behind it (`selected_model`) is deliberately off
+        # `_SHAREABLE_STATE_FIELDS` because a `FrontendModelSpec` is a
+        # non-frozen model whose shared instance a caller could rewrite (review
+        # round 2, Q6/F4). The store formats the label from its own instance
+        # and hands back a fresh `str`, so the invariant `state`'s clone exists
+        # to protect is kept while the whole-state copy is not paid.
+        return self._read_state_label("model_label")
 
     @property
     def model(self) -> ModelSpec:
@@ -4151,7 +4183,18 @@ class RemoteSession:
 
     @property
     def effective_model_label(self) -> str:
-        return self.frontend_state.effective_model_label
+        # Per `model_label`: derived string out, spec object in. This one is on
+        # the hottest path of the two — `_effective_label` reads it on EVERY
+        # band paint and falls back to `model_label`, so the band was paying
+        # two whole-state clones per repaint.
+        #
+        # No torn read despite the fallback: the store's property resolves
+        # `effective_model or selected_model` against ONE `self._state`
+        # binding, exactly as `RemoteSession.effective_model` takes one
+        # snapshot for the same reason. That consistency is why the fallback
+        # lives on the state model rather than being reassembled from two reads
+        # here.
+        return self._read_state_label("effective_model_label")
 
     def set_model(self, model: ModelSpec, *, explicit: bool = False) -> None:
         old = self.model
@@ -4167,7 +4210,8 @@ class RemoteSession:
 
     @property
     def goal(self) -> str:
-        return self.frontend_state.goal
+        # Allow-listed immutable scalar (`str`), read per frame by the band.
+        return self._read_state_field("goal")
 
     def set_goal(self, text: str) -> str:
         client = self._client
@@ -4182,7 +4226,10 @@ class RemoteSession:
 
     @property
     def conversation_name(self) -> str:
-        return self.frontend_state.conversation_title
+        # Allow-listed immutable scalar. Read on every band paint AND by the
+        # sidebar row for each session, so a clone here was multiplied by the
+        # roster rather than paid once.
+        return self._read_state_field("conversation_title")
 
     @property
     def conversation_name_state(self) -> ConversationName:
@@ -4516,7 +4563,9 @@ class RemoteSession:
             if message_id
             else ContinuationCommand.create(self._session_id, text, images_wire)
         )
-        epoch = self.frontend_state.epoch
+        # `self.epoch` is the copy-free read of the same field; this is the
+        # captured baseline the observer below compares each event against.
+        epoch = self.epoch
         admitted = False
         generation: int | None = None
         completed: asyncio.Future[AgentEndEvent] = asyncio.get_running_loop().create_future()
@@ -4526,7 +4575,9 @@ class RemoteSession:
             nonlocal admitted, generation
             if completed.done():
                 return
-            if self.frontend_state.epoch != epoch:
+            # Per EVENT, not per frame, and an active turn is the highest-rate
+            # path there is — this was a whole-state clone for one string.
+            if self.epoch != epoch:
                 completed.set_exception(ConnectionError("owner changed during loop iteration"))
                 return
             message = getattr(event, "message", None)
@@ -4806,11 +4857,15 @@ class RemoteSession:
 
     @property
     def active_agent(self) -> str:
-        return self.frontend_state.active_agent
+        # Allow-listed immutable scalar, read per frame by the band's
+        # active-profile segment and by `_poll_subagents` at 1 Hz.
+        return self._read_state_field("active_agent")
 
     @property
     def active_team_name(self) -> str:
-        return self.frontend_state.active_team
+        # Allow-listed immutable scalar; same per-frame band path as
+        # `active_agent`.
+        return self._read_state_field("active_team")
 
     def restored_usage(self) -> Usage | None:
         # Copying path: `Usage` is accumulated in place elsewhere in the

--- a/scripts/bench_state_field_reads.py
+++ b/scripts/bench_state_field_reads.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Cost of a single-field frontend-state read: whole-state clone vs `read_field`.
+
+WHY THIS EXISTS. ``FrontendStateStore.state`` deep-copies the ENTIRE session
+state on every read so a caller cannot mutate the store's own instance. That
+protection is correct and must stay, but its cost scales with how much the
+session has accumulated — jobs, usage components, live events, catalogue rows —
+so the per-frame accessors in ``RemoteSession`` that need ONE immutable scalar
+got slower the longer a session ran. That is the mechanism behind "the TUI
+degrades on long sessions": the band repaints at the same rate, but each paint's
+state reads cost more every hour.
+
+``FrontendStateStore.read_field`` is the existing fast path for exactly this,
+restricted by ``_SHAREABLE_STATE_FIELDS`` to deeply immutable scalars. This
+script measures the gap the conversion closes, in two ways:
+
+  1. WALL TIME per read, at several roster sizes (0/5/20/60/120 jobs), reported
+     as MEDIANS of many reps. Wall time on a shared developer box is
+     contaminated by whatever else is running, so the load average is printed
+     with every table and the numbers are CEILINGS, not claims.
+  2. ``copy.deepcopy`` CALL COUNTS for a representative status-band frame. A
+     call count is contention-proof — it is identical on an idle box and a
+     box at load 200 — which makes it the honest headline number.
+
+INTERLEAVED BY CONSTRUCTION. Both arms are measured in one process, alternating
+rep by rep at each size, so a scheduling burst that inflates one arm inflates
+the other equally instead of manufacturing a win. There is no "before tree" to
+check out: the two paths coexist in the same build, which is what makes the
+comparison reproducible by anyone at any commit.
+
+Run:
+    PYTHONPATH=. .venv/bin/python scripts/bench_state_field_reads.py
+    PYTHONPATH=. .venv/bin/python scripts/bench_state_field_reads.py --json out.json
+
+``PYTHONPATH=.`` matters for the reason ``bench/README.md`` gives: the script
+must import THIS checkout rather than whatever an editable install resolves to.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import statistics
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Callable
+from unittest.mock import patch
+
+from local_operator.session.frontend_state import (
+    FrontendModelSpec,
+    FrontendSessionState,
+    FrontendStateStore,
+    FrontendUsage,
+    JobState,
+)
+from local_operator.session.remote import RemoteSession
+
+#: Roster sizes to sweep. The point of the sweep is the SHAPE, not any single
+#: cell: a cost that is flat in roster size would mean long sessions do not
+#: degrade and this change is pointless, so the growth is the finding.
+ROSTER_SIZES = (0, 5, 20, 60, 120)
+
+#: The fields the per-frame accessors read. Every one is on
+#: ``_SHAREABLE_STATE_FIELDS``; a name that is not raises from ``read_field``,
+#: which is the guard working rather than a bench failure.
+FRAME_FIELDS = (
+    "conversation_title",
+    "goal",
+    "active_agent",
+    "active_team",
+    "epoch",
+    "history_generation",
+    "streaming",
+)
+
+#: The ``RemoteSession`` accessors one status-band paint calls, in the order
+#: ``app.py`` calls them (``_effective_label`` first, then the profile/team
+#: segments and the conversation title). This is the frame the user actually
+#: pays for, as opposed to the store-level microbenchmark above.
+BAND_ACCESSORS = (
+    "effective_model_label",
+    "model_label",
+    "active_agent",
+    "active_team_name",
+    "conversation_name",
+    "goal",
+    "epoch",
+)
+
+
+def build_state(n_jobs: int) -> FrontendSessionState:
+    """A state shaped like a long-running session, not an empty one.
+
+    Deliberately populated on every field the clone has to walk — trajectories,
+    per-job usage, usage components, live events, a catalogue — because a state
+    carrying only its scalars measures the clone's floor and would understate
+    the cost the accessors actually pay in a real session.
+    """
+    jobs = [
+        JobState(
+            id=f"job-{i}",
+            type="task",
+            status="running" if i % 3 else "completed",
+            label=f"child agent {i}",
+            agent="coder",
+            intent="implementing a bounded slice",
+            result_text="x" * 400,
+            trajectory=[{"kind": "tool", "text": "y" * 80} for _ in range(6)],
+            usage=FrontendUsage(input_tokens=1000 + i, output_tokens=500 + i),
+        )
+        for i in range(n_jobs)
+    ]
+    return FrontendSessionState(
+        session_id="bench-session",
+        epoch="epoch-1",
+        conversation_title="a long-running conversation",
+        goal="ship the measured change",
+        active_agent="coder",
+        active_team="lopdev",
+        streaming=False,
+        history_generation=7,
+        jobs=jobs,
+        usage_components=[FrontendUsage(input_tokens=100, output_tokens=50) for _ in range(n_jobs)],
+        live_events=[
+            {"type": "tool_execution_end", "text": "z" * 200} for _ in range(min(n_jobs, 40))
+        ],
+        selected_model=FrontendModelSpec(provider="anthropic", model_id="claude-opus-4"),
+        effective_model=FrontendModelSpec(provider="anthropic", model_id="claude-sonnet-4"),
+        last_usage=FrontendUsage(input_tokens=120_000, output_tokens=8_000),
+        model_catalogue=[
+            {"provider": "anthropic", "model_id": f"model-{i}", "name": f"Model {i}"}
+            for i in range(60)
+        ],
+    )
+
+
+def median_ms(fn: Callable[[], Any], reps: int) -> float:
+    """Median wall time of ``reps`` calls, in milliseconds.
+
+    Median rather than mean: on a loaded host the distribution has a long right
+    tail from descheduling, and a mean reports the tail rather than the work.
+    """
+    samples = []
+    for _ in range(reps):
+        started = time.perf_counter()
+        fn()
+        samples.append((time.perf_counter() - started) * 1000.0)
+    return statistics.median(samples)
+
+
+def deepcopy_calls(fn: Callable[[], Any]) -> int:
+    """How many ``deepcopy`` invocations one operation makes, recursion included.
+
+    The contention-proof metric: identical on an idle box and on one at load
+    200, which is why it and not wall time is the headline.
+
+    BOTH entry points are patched, and missing the second one silently
+    undercounts to near zero. ``copy.deepcopy`` covers the recursive descent,
+    because ``copy.py``'s internal ``_deepcopy_dict``/``_deepcopy_list`` resolve
+    ``deepcopy`` as a module global on every element. But a pydantic model
+    defines ``__deepcopy__``, and ``pydantic.main`` bound ``deepcopy`` into its
+    own namespace with ``from copy import deepcopy`` at import time — so the
+    per-model hop that walks each job and usage row never reads
+    ``copy.deepcopy`` at all. Patching only the first reported 0 calls for a
+    clone that in fact makes thousands.
+
+    The real implementation is still called, so the measured operation does
+    exactly what it does in production.
+    """
+    import pydantic.main
+
+    real = copy.deepcopy
+    count = 0
+
+    def counting(*args: Any, **kwargs: Any) -> Any:
+        nonlocal count
+        count += 1
+        return real(*args, **kwargs)
+
+    with patch("copy.deepcopy", counting), patch.object(pydantic.main, "deepcopy", counting):
+        fn()
+    return count
+
+
+def build_remote(state: FrontendSessionState) -> RemoteSession:
+    """A viewer bound to a real store and nothing else.
+
+    The accessors under measurement read only the store, so a socket would add
+    setup without changing a single number. ``find_owner_record`` is patched to
+    find nothing so construction does no disk work.
+    """
+
+    async def _never() -> Any:
+        raise AssertionError("the benchmark never takes a session over")
+
+    with (
+        patch("local_operator.session.remote.find_owner_record", lambda *a, **k: (None, None)),
+        tempfile.TemporaryDirectory() as config_dir,
+    ):
+        remote = RemoteSession(
+            config_dir=Path(config_dir),
+            session_id=state.session_id,
+            takeover_factory=_never,
+        )
+    remote._frontend_store = FrontendStateStore(state)
+    return remote
+
+
+def band_frame_after(remote: RemoteSession) -> None:
+    """One band paint through the accessors AS THEY ARE NOW."""
+    for name in BAND_ACCESSORS:
+        getattr(remote, name)
+
+
+def band_frame_before(remote: RemoteSession) -> None:
+    """One band paint through the WHOLE-STATE CLONE each accessor used to take.
+
+    Hand-rolled rather than checked out from the parent commit deliberately:
+    running both arms in ONE process is what makes the comparison interleaved,
+    and a separate `git checkout` arm would measure two different processes on
+    a machine whose load moves between them. Each line here is the exact body
+    the corresponding accessor had before the conversion, so the arm is the old
+    code rather than an approximation of it.
+    """
+    state = remote.frontend_state
+    state.effective_model_label
+    remote.frontend_state.model_label
+    remote.frontend_state.active_agent
+    remote.frontend_state.active_team
+    remote.frontend_state.conversation_title
+    remote.frontend_state.goal
+    remote.frontend_state.epoch
+
+
+def load_average() -> str:
+    try:
+        one, five, fifteen = os.getloadavg()
+    except OSError:  # pragma: no cover - not available on every platform
+        return "unavailable"
+    return f"{one:.2f} {five:.2f} {fifteen:.2f}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--reps", type=int, default=200, help="reps per arm per size")
+    parser.add_argument("--json", dest="json_path", default="", help="write results as JSON")
+    args = parser.parse_args()
+
+    print(f"load average (start): {load_average()}")
+    print()
+    print(
+        f"Per-read wall time, medians of {args.reps} interleaved reps " "(CEILINGS: host is shared)"
+    )
+    print()
+    header = f"{'jobs':>5}  {'state clone':>14}  {'read_field':>14}  {'ratio':>10}"
+    print(header)
+    print("-" * len(header))
+
+    rows: list[dict[str, Any]] = []
+    for size in ROSTER_SIZES:
+        store = FrontendStateStore(build_state(size))
+        # Interleaved: alternate the two arms rep by rep so a scheduling burst
+        # lands on both arms rather than on whichever is measured second.
+        clone_samples: list[float] = []
+        fast_samples: list[float] = []
+        for _ in range(args.reps):
+            clone_samples.append(median_ms(lambda: store.state.conversation_title, 1))
+            fast_samples.append(median_ms(lambda: store.read_field("conversation_title"), 1))
+        clone_ms = statistics.median(clone_samples)
+        fast_ms = statistics.median(fast_samples)
+        ratio = clone_ms / fast_ms if fast_ms else float("inf")
+        print(f"{size:>5}  {clone_ms:>11.4f} ms  {fast_ms:>11.6f} ms  {ratio:>9.0f}x")
+        rows.append(
+            {
+                "jobs": size,
+                "state_clone_ms": clone_ms,
+                "read_field_ms": fast_ms,
+                "ratio": ratio,
+            }
+        )
+
+    print()
+    print(f"load average (after wall-time sweep): {load_average()}")
+    print()
+    print(
+        "deepcopy calls for one status-band frame "
+        f"({len(FRAME_FIELDS)} single-field reads), contention-proof:"
+    )
+    print()
+    frame_header = f"{'jobs':>5}  {'via state':>12}  {'via read_field':>15}  {'removed':>10}"
+    print(frame_header)
+    print("-" * len(frame_header))
+
+    frames: list[dict[str, Any]] = []
+    for size in ROSTER_SIZES:
+        store = FrontendStateStore(build_state(size))
+
+        def via_state() -> None:
+            for name in FRAME_FIELDS:
+                getattr(store.state, name)
+
+        def via_read_field() -> None:
+            for name in FRAME_FIELDS:
+                store.read_field(name)
+
+        before = deepcopy_calls(via_state)
+        after = deepcopy_calls(via_read_field)
+        print(f"{size:>5}  {before:>12,}  {after:>15,}  {before - after:>10,}")
+        frames.append({"jobs": size, "via_state": before, "via_read_field": after})
+
+    print()
+    print(f"load average (before band-frame sweep): {load_average()}")
+    print()
+    print("REAL status-band frame on a RemoteSession — the accessors the band calls:")
+    print(f"  {', '.join(BAND_ACCESSORS)}")
+    print()
+    band_header = (
+        f"{'jobs':>5}  {'before (clone)':>16}  {'after':>14}  "
+        f"{'deepcopy before':>16}  {'after':>7}"
+    )
+    print(band_header)
+    print("-" * len(band_header))
+
+    bands: list[dict[str, Any]] = []
+    for size in ROSTER_SIZES:
+        remote = build_remote(build_state(size))
+        before_ms_samples: list[float] = []
+        after_ms_samples: list[float] = []
+        for _ in range(args.reps):
+            before_ms_samples.append(median_ms(lambda: band_frame_before(remote), 1))
+            after_ms_samples.append(median_ms(lambda: band_frame_after(remote), 1))
+        before_ms = statistics.median(before_ms_samples)
+        after_ms = statistics.median(after_ms_samples)
+        before_calls = deepcopy_calls(lambda: band_frame_before(remote))
+        after_calls = deepcopy_calls(lambda: band_frame_after(remote))
+        print(
+            f"{size:>5}  {before_ms:>13.4f} ms  {after_ms:>11.4f} ms  "
+            f"{before_calls:>16,}  {after_calls:>7,}"
+        )
+        bands.append(
+            {
+                "jobs": size,
+                "before_ms": before_ms,
+                "after_ms": after_ms,
+                "deepcopy_before": before_calls,
+                "deepcopy_after": after_calls,
+            }
+        )
+
+    print()
+    print(f"load average (end): {load_average()}")
+
+    if args.json_path:
+        with open(args.json_path, "w", encoding="utf-8") as handle:
+            json.dump(
+                {
+                    "reps": args.reps,
+                    "load_average": load_average(),
+                    "wall_time": rows,
+                    "deepcopy_frame": frames,
+                    "frame_fields": list(FRAME_FIELDS),
+                    "band_frame": bands,
+                    "band_accessors": list(BAND_ACCESSORS),
+                },
+                handle,
+                indent=2,
+            )
+        print(f"\nwrote {args.json_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -1983,6 +1983,37 @@ def test_read_label_refuses_a_name_that_is_not_a_derived_label() -> None:
         store.read_label("not_a_property_at_all")
 
 
+def test_read_label_refuses_a_label_that_is_not_a_str() -> None:
+    """An allow-listed name whose value is not a `str` must FAIL, not stringify.
+
+    Review round 1 (MINOR): the boundary used to read
+    ``return str(getattr(...))``, so a label property whose return type drifted
+    — a tuple-shaped label rendering ``(a, b)`` — passed silently. The
+    coercion could never share state (``str()`` always builds fresh); what it
+    hid was the CONTRACT: a non-str is exactly the shape the allow-list's
+    closure test exists to catch, and the boundary is where a drift it missed
+    has to stop. Now a `TypeError`, the label sibling of ``read_field``'s
+    ``KeyError`` on a non-allowlisted name.
+
+    Reached by swapping the store's state for one whose label is not a str,
+    which exercises the boundary directly without mutating the pydantic model
+    class behind it.
+    """
+    store = FrontendStateStore(FrontendSessionState(session_id="s1", epoch="e1"))
+    store._state = SimpleNamespace(model_label=("openai", "gpt-4o"))  # type: ignore[assignment]
+
+    with pytest.raises(TypeError):
+        store.read_label("model_label")
+
+    # The boundary still serves a genuine str from a genuine state.
+    store._state = FrontendSessionState(
+        session_id="s1",
+        epoch="e1",
+        selected_model=FrontendModelSpec(provider="openai", model_id="gpt-4o"),
+    )
+    assert store.read_label("model_label") == "openai/gpt-4o"
+
+
 def _spec_state() -> FrontendSessionState:
     """A state carrying both specs, a roster and a usage row."""
     return FrontendSessionState(

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -28,6 +28,7 @@ from local_operator.harness.types import ModelSpec, ToolResult, Usage
 from local_operator.mobile.attach_client import _READ_LIMIT_BYTES
 from local_operator.session.attention import AttentionStore
 from local_operator.session.frontend_state import (
+    _DERIVED_STATE_LABELS,
     _MODEL_CATALOGUE_LINE_LIMIT,
     _SHAREABLE_STATE_FIELDS,
     LIVE_EVENT_BLOCK_ELIDED_PLACEHOLDER,
@@ -36,6 +37,7 @@ from local_operator.session.frontend_state import (
     LIVE_EVENT_TEXT_FRAME_BUDGET_CHARS,
     MODEL_CATALOGUE_FLOOR_ROWS,
     USAGE_COMPONENT_CAP,
+    FrontendModelSpec,
     FrontendSessionState,
     FrontendStateStore,
     FrontendSync,
@@ -1915,3 +1917,191 @@ def test_a_lone_elided_marker_does_not_open_with_a_blank_line() -> None:
 
     assert rendered == LIVE_EVENT_BLOCK_ELIDED_PLACEHOLDER
     assert not rendered.startswith("\n")
+
+
+def test_derived_state_labels_are_real_and_immutable() -> None:
+    """The copy-free LABEL list must name real properties returning fresh strings.
+
+    The sibling of ``test_shareable_state_fields_are_real_and_immutable`` for
+    ``read_label``, and it exists because that guard cannot see these: it is
+    driven off ``model_fields``, and a derived label is a PROPERTY, so a label
+    added to ``_DERIVED_STATE_LABELS`` is invisible to every assertion above.
+
+    Two properties are checked, and both are the safety argument rather than
+    tidiness. A name that is not a real property would pass the membership gate
+    and then raise ``AttributeError`` on a per-frame path — the exact shape
+    round 2 caught in the field allow-list (``conversation_name`` for
+    ``conversation_title``). And a property returning one of the state's OWN
+    objects would share it with none of the field allow-list's scrutiny, which
+    is precisely what keeping the specs off that list exists to prevent.
+    """
+    unknown = [
+        name for name in sorted(_DERIVED_STATE_LABELS) if not hasattr(FrontendSessionState, name)
+    ]
+    assert not unknown, (
+        f"copy-free label(s) that are not properties of FrontendSessionState: {unknown}. "
+        "`read_label` checks membership BEFORE `getattr`, so a name that is not real "
+        "passes the guard and then raises AttributeError on a per-frame path."
+    )
+
+    for name in sorted(_DERIVED_STATE_LABELS):
+        attribute = getattr(FrontendSessionState, name)
+        assert isinstance(attribute, property), (
+            f"{name!r} is not a derived property. `read_label` exists for values COMPUTED "
+            "per read; a stored field belongs in _SHAREABLE_STATE_FIELDS, where the "
+            "immutability guard can see it."
+        )
+
+    # A fresh value per read is what makes sharing safe here: the caller holds
+    # a string the property just built, never the spec it was built from.
+    state = FrontendSessionState(
+        session_id="s1",
+        epoch="e1",
+        selected_model=FrontendModelSpec(provider="openai", model_id="gpt-4o"),
+        effective_model=FrontendModelSpec(provider="anthropic", model_id="claude"),
+    )
+    store = FrontendStateStore(state)
+    for name in sorted(_DERIVED_STATE_LABELS):
+        value = store.read_label(name)
+        assert isinstance(value, str), f"{name!r} must return a str, got {type(value)!r}"
+
+
+def test_read_label_refuses_a_name_that_is_not_a_derived_label() -> None:
+    """The gate is enforced, not documented — including against real properties.
+
+    ``FrontendSessionState`` has other properties, and a future one could
+    return a mutable object. Membership rather than "is it a property" is what
+    keeps such a value off this path by default.
+    """
+    store = FrontendStateStore(FrontendSessionState(session_id="s1", epoch="e1"))
+
+    with pytest.raises(KeyError):
+        store.read_label("jobs")
+    with pytest.raises(KeyError):
+        store.read_label("selected_model")
+    with pytest.raises(KeyError):
+        store.read_label("not_a_property_at_all")
+
+
+def _spec_state() -> FrontendSessionState:
+    """A state carrying both specs, a roster and a usage row."""
+    return FrontendSessionState(
+        session_id="s1",
+        epoch="e1",
+        conversation_title="a named conversation",
+        goal="ship it",
+        active_agent="coder",
+        active_team="lopdev",
+        history_generation=4,
+        selected_model=FrontendModelSpec(provider="openai", model_id="gpt-4o"),
+        effective_model=FrontendModelSpec(provider="anthropic", model_id="claude"),
+        last_usage=FrontendUsage(input_tokens=10, output_tokens=5),
+        jobs=[JobState(id="j1", type="task", status="running")],
+    )
+
+
+def _remote_with_state(tmp_path: Path, state: FrontendSessionState) -> RemoteSession:
+    """A viewer bound to a REAL store, with no socket.
+
+    The accessors under test read only the store, so a live connection would
+    add a fixture without adding coverage.
+    """
+    remote = RemoteSession(config_dir=tmp_path, session_id="s1", takeover_factory=_never)
+    remote._frontend_store = FrontendStateStore(state)
+    return remote
+
+
+def test_copy_free_accessors_return_what_the_clone_returned(tmp_path: Path) -> None:
+    """Converting an accessor to the copy-free path must not change its answer.
+
+    The whole value of the conversion is that it is invisible to callers: the
+    band paints the same string, the refresh compares the same epoch. Asserted
+    against ``frontend_state`` — the clone the accessors used to read — so this
+    is a direct equivalence rather than a restatement of the new code.
+    """
+    state = _spec_state()
+    remote = _remote_with_state(tmp_path, state)
+    snapshot = remote.frontend_state
+
+    assert remote.model_label == snapshot.model_label == "openai/gpt-4o"
+    assert remote.effective_model_label == snapshot.effective_model_label == "anthropic/claude"
+    assert remote.goal == snapshot.goal == "ship it"
+    assert remote.conversation_name == snapshot.conversation_title == "a named conversation"
+    assert remote.active_agent == snapshot.active_agent == "coder"
+    assert remote.active_team_name == snapshot.active_team == "lopdev"
+    assert remote.epoch == snapshot.epoch == "e1"
+    assert remote._read_state_field("history_generation") == snapshot.history_generation == 4
+
+
+def test_copy_free_accessors_cannot_corrupt_the_store(tmp_path: Path) -> None:
+    """A caller mutating a returned value must not reach canonical state.
+
+    This is the invariant the whole-state clone provided and the reason the
+    allow-list is a safety argument rather than a convenience list. Every
+    converted accessor returns either an immutable scalar or a freshly built
+    string, so the mutation a caller CAN perform is rebinding its own local
+    name — which is asserted here by re-reading the store afterwards.
+    """
+    remote = _remote_with_state(tmp_path, _spec_state())
+
+    label = remote.model_label
+    label += "/tampered"
+    effective = remote.effective_model_label
+    effective += "/tampered"
+    goal = remote.goal
+    goal += " and then some"
+
+    assert remote.model_label == "openai/gpt-4o"
+    assert remote.effective_model_label == "anthropic/claude"
+    assert remote.goal == "ship it"
+
+    # The specs themselves must never leave the store through a label read: a
+    # label that handed back the spec's own string would still be safe (str is
+    # immutable), but a label read must not be a route to the OBJECT.
+    store = remote._frontend_store
+    assert store is not None
+    canonical = store._state.selected_model
+    assert canonical is not None
+    assert canonical.model_id == "gpt-4o"
+
+
+def test_model_and_usage_accessors_still_deep_copy(tmp_path: Path) -> None:
+    """The accessors NOT converted must keep the clone that protects them.
+
+    ``model``/``effective_model`` hand out a non-frozen ``ModelSpec`` and
+    ``restored_usage`` a ``Usage`` the harness accumulates in place with ``+=``
+    (``harness/jobs.py``, ``harness/subagent.py``). Sharing either instance is
+    the invariant loss review round 2 (Q6/F4) rejected, so these must remain on
+    the copying path even though their sibling label accessors no longer are.
+
+    Asserted by MUTATING what they return and re-reading the store, which fails
+    on a shared instance and passes on a copy — the property itself rather than
+    the implementation detail that currently provides it.
+    """
+    remote = _remote_with_state(tmp_path, _spec_state())
+    store = remote._frontend_store
+    assert store is not None
+
+    spec = remote.model
+    spec.model_id = "tampered"
+    assert store._state.selected_model is not None
+    assert store._state.selected_model.model_id == "gpt-4o"
+    assert remote.model.model_id == "gpt-4o"
+
+    effective = remote.effective_model
+    effective.model_id = "tampered"
+    assert store._state.effective_model is not None
+    assert store._state.effective_model.model_id == "claude"
+
+    usage = remote.restored_usage()
+    assert usage is not None
+    usage.input_tokens += 1_000_000
+    canonical_usage = store._state.last_usage
+    assert canonical_usage is not None
+    assert canonical_usage.input_tokens == 10
+
+    # And the label accessors keep reporting canonical state after all of that,
+    # which is the pairing that matters: the fast path must not be a way to
+    # observe a corruption the slow path prevented.
+    assert remote.model_label == "openai/gpt-4o"
+    assert remote.effective_model_label == "anthropic/claude"


### PR DESCRIPTION
## Summary

`RemoteSession.frontend_state` deep-copies the **entire** state on every read (every job, usage component, live event, catalogue row) so a caller cannot mutate the store's own instance. That protection is correct and stays. But its cost scales with everything a session accumulates, so the single-field accessors the status band paints with got slower the longer a session ran — the mechanism behind "the TUI degrades on long-running sessions".

The copy-free path already existed (`_read_state_field` → `FrontendStateStore.read_field`, gated by the `_SHAREABLE_STATE_FIELDS` allowlist of deeply immutable scalars). Several accessors simply never used it. This PR converts them.

**12 conversions, all already-allowlisted immutable scalars:**

| Site | Field | Hot path |
| --- | --- | --- |
| `goal` | `goal` (str) | band paint |
| `conversation_name` | `conversation_title` (str) | band paint + every sidebar row |
| `active_agent` | `active_agent` (str) | band paint + `_poll_subagents` @ 1 Hz |
| `active_team_name` | `active_team` (str) | band paint + `_poll_subagents` @ 1 Hz |
| refresh binding check | `epoch` (str) | reconnect |
| `_display_invalidated` | `history_generation` (int) | reconnect |
| `_finish_sync` seed guard | `streaming` (bool) | reconnect |
| continuation capture + per-event observer | `epoch` (str) | **per event** during an active turn — the highest-rate path here |
| gate answer identity check | `pending_gate` (existing fast property, was reached through the clone) | desktop popup answer |

**The model labels needed a separate route.** `model_label` / `effective_model_label` are *derived properties*, not fields, and the fields behind them (`selected_model`, `effective_model`) are deliberately OFF `_SHAREABLE_STATE_FIELDS` — a non-frozen `ModelSpec` shared via `read_field` is the exact invariant review round 2 (Q6/F4) restored. New `FrontendStateStore.read_label` formats the label against the store's own instance and hands back a **freshly built `str`**, so the spec never leaves the store at all. That is a strictly stronger safety argument than `read_field`'s (nothing of the store's is shared), and it gets its own enforced allowlist (`_DERIVED_STATE_LABELS`) plus a closure test in the same shape as the existing field-allowlist guard.

## Measured — `scripts/bench_state_field_reads.py` (committed, reproducible)

Arms are **interleaved rep-by-rep in one process**, so contention cancels. Host was at **load average 197.75 / 199.21 / 170.63** during the recorded run — every wall-time number below is a **ceiling, not a claim**. The deepcopy counts are contention-proof and are the honest headline.

### One real status-band frame on a `RemoteSession` (the accessors `app.py` calls per paint: `effective_model_label`, `model_label`, `active_agent`, `active_team_name`, `conversation_name`, `goal`, `epoch`)

| jobs | before (clone) | after | deepcopy before | deepcopy after |
| ---: | ---: | ---: | ---: | ---: |
| 0 | 0.4415 ms | 0.0021 ms | 56 | 0 |
| 5 | 1.0090 ms | 0.0024 ms | 231 | 0 |
| 20 | 2.6138 ms | 0.0045 ms | 756 | 0 |
| 60 | 6.5775 ms | 0.0074 ms | 2,156 | 0 |
| 120 | **12.8719 ms** | **0.0075 ms** | **4,256** | **0** |

At a 120-job roster the band's state reads cost ~12.9 ms **per paint** before; the cost grows with everything the session accumulates, which is precisely the long-session degradation. After the conversion the frame is flat in roster size.

### Store-level microbench (`state` property vs `read_field`, medians)

| jobs | `state` clone | `read_field` | ratio |
| ---: | ---: | ---: | ---: |
| 0 | 0.0618 ms | 0.00017 ms | 372x |
| 5 | 0.1305 ms | 0.00017 ms | 782x |
| 20 | 0.3545 ms | 0.00017 ms | 2,122x |
| 60 | 0.9485 ms | 0.00021 ms | 4,539x |
| 120 | 1.8193 ms | 0.00029 ms | 6,254x |

(Reproduces the manager's baseline shape independently: ~0.05 ms empty → ~1.8 ms at 120 jobs, versus ~0.0002 ms for the fast path.)

A bench-harness gotcha worth recording: counting `copy.deepcopy` calls by patching `copy.deepcopy` alone reports **zero** for a clone that makes thousands — pydantic's `__deepcopy__` resolves `deepcopy` from `pydantic.main`'s namespace (bound at import). The committed counter patches both entry points; this is documented in the script.

## Deliberately NOT converted

- **`model` / `effective_model`** — non-frozen `ModelSpec`; handing out the store's instance is the invariant review round 2 (Q6/F4) rejected. Additionally `effective_model` reads TWO fields from ONE snapshot so a fallback cannot pair a spec with a newer state's selection — two fast reads would be a torn read. Untouched.
- **`restored_usage`** — `Usage` is accumulated in place with `+=` in `harness/jobs.py` and `harness/subagent.py`; a shared instance is one `+=` from corrupting state. Untouched.
- **Mutable collections** — `jobs` (`running_subagents`), `attention`, `context_breakdown`, `queued_steering`, `model_catalogue`, `live_events`. They already wrap in `dict()`/`list()`, but the underlying read still clones; converting them would require the allowlist to admit a mutable value, which it must not. Left as-is.
- **`generation`** (in the `_finish_sync` seed) — NOT on `_SHAREABLE_STATE_FIELDS` (only `history_generation` and `sequence` are), so it keeps the clone. The `streaming`+`generation` pair is not a torn read: nothing awaits between them, both resolve against the same installed snapshot.
- **`epoch`+`pending_gate` pairing** — both now use their existing copy-free accessors (`self.epoch`, `self.pending_gate`), preserving the single-snapshot identity semantics already documented there.

## Tests

- `test_copy_free_accessors_return_what_the_clone_returned` — every converted accessor equals what the clone path returned.
- `test_copy_free_accessors_cannot_corrupt_the_store` — mutating returned values cannot reach canonical state.
- `test_model_and_usage_accessors_still_deep_copy` — asserts by *mutating* what they return and re-reading the store: fails on a shared instance, passes on a copy.
- `test_derived_state_labels_are_real_and_immutable` + `test_read_label_refuses_a_name_that_is_not_a_derived_label` — the new allowlist is driven off the model (a renamed property or one returning a mutable object fails closed), and the gate is enforced.
- Guard efficacy proven by mutation: reverting `model` to a shared-instance read fails the deep-copy test; wiring `effective_model_label` to the selection fails the equality test.

## Quality gates (run serially, as CI runs them)

- `flake8` — clean
- `black --check` (26.1.0, CI pin) — clean
- `isort --check-only` (5.13.2, CI pin) — clean
- `pyright` — 0 errors, 0 warnings
- `pytest tests/unit` — **17040 passed, 18 skipped, 1 failed**: `tests/unit/test_procname.py::test_unreadable_libpython_parent_does_not_raise`. **Pre-existing on the untouched base commit `ab5f37eab`** (verified by stashing the diff and re-running): this host's user can read a `chmod 0o000` directory, so the `PermissionError` precondition never fires. Unrelated to this change.
- `pytest tests/e2e -m e2e -n0` — **93 passed, 7 skipped** (2:20). No `CMUX_*` variables were inherited (verified `env | grep -c '^CMUX_'` = 0).

## Scope boundary

A peer session (pid 82544, branch `fix/tui-longrun-performance`) owns and this PR does **not** touch: `RETAINED_PRESENTATIONS` / the sidebar presentation LRU, `_prewarm_sidebar` and its candidate filter, and the `_report_startup_cleanup` / `_adopt_session` timer chain. No `app.py` line is modified by this PR. No commits on `origin/main` since this branch's base touch `remote.py`, `frontend_state.py` or the test file, so there is nothing to rebase over for these files.

Host context, for the record: the dominant cause of the slow-TUI report was measured by the manager as machine-wide compute pressure (6 concurrent `pytest` suites, ~29 xdist workers) — transient and self-limiting. This PR is the durable half: the per-frame cost that grows with session age.

## Not addressed

- `running_subagents()` walks the full roster clone at 1 Hz per attached session (`_poll_subagents`). Real, but the roster is a mutable collection — fixing it safely means a store-level copy-free iteration API (e.g. a counter the store maintains), which is new surface on the store rather than a conversion. Recorded here rather than smuggled in.
- The `jobs`/`attention`/`model_catalogue` collection reads still clone the whole state to copy one field. A store method returning an already-copied single field would help, but it changes the allowlist's contract ("never admit a mutable value") and deserves its own review round.
- `local_operator/server/utils/desktop_sessions.py` / `desktop_lifecycle.py` reach for `bridge.remote.frontend_state.<field>` directly for `cwd` and `attention`; those are cold request paths, not per-frame, and `cwd` is not currently allowlisted.
- The pre-existing `test_procname` host-sensitivity noted above.
