### PR TITLE
chore(release): bump version to 0.52.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.52.4"
+version = "0.52.5"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window claimed. Owner session pid: 82544.

Window (tick as each merges):
- [x] #836 — Release: patch — evaluation and mobile image requests can no longer exceed a provider payload wall (HTTP 413): every screen frame and mobile image is bounded at 1280px through the one existing imaging bound, and the eval runner byte-compaction trigger is live
- [x] #841 — Release: patch — the session sidebar no longer degrades with uptime or switch count: idle polling opens no sockets, the parked-view cache covers a real working set, and the startup-cleanup recheck chain no longer accumulates per switch

Bump class: patch → v0.52.5 (no single PR clears the minor bar). Prior window owner (pid 86514, v0.52.4) closed and handed this window on; its session has ended.