### PR TITLE
chore(release): bump version to 0.52.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.52.5"
+version = "0.52.6"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Change class
**C0 — trivial mechanical release version bump.** Pre-authorized; the PR is the system of record.

## What this is
Releases the current window since tag `v0.52.5`. One commit, `pyproject.toml` only: `version 0.52.5 → 0.52.6`.

## Window contents
Exactly one PR merged since v0.52.5, verified by `git log v0.52.5..origin/main`:

- **#839** — `fix(wakes): prime the login-shell PATH in the wake supervisor` (squash `8c03e4d6d5febc2d7ca54e19ceaa98a528f9056d`). Makes wake-spawned session runtimes inherit a usable PATH instead of launchd's bare default; covered by a mutation-tested regression test. Bump class: **patch** (a bug fix; no PR in the window clears the minor step-function bar).

Confirmed via `git merge-base --is-ancestor` that #841 and #843 are already inside v0.52.5 (shipped), so they are NOT in this window. Full-coverage check across `v0.52.0..origin/main` confirms every other fix/feat PR belongs to an existing tag; #839 is the only untagged one.

## Notes
- No runtime, test, or doc change. The full diff is the two-line version hunk.
- After merge: tag `v0.52.6` on the bump SHA, watch publish.yml + PyPI, `update-ref main`, `lop-update`, smoke outside any checkout.

Scope: C0 one-file scope-check review round applies.