### PR TITLE
chore(release): bump version to 0.52.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.52.6"
+version = "0.52.7"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Patch release window carrying one PR: #821 (fe385af1f) — fix(tui): announce the MCP startup toast once per process, per outcome. The toast fired on every session attach including every sidebar click; it now announces on session creation / first loadup only, with per-session records and generation-scoped eviction release. Bump class: PATCH (single user-visible toast-dedupe fix, no API/config/behaviour step-function). pyproject.toml only change, one line. CI on #821 all 16 green at merge.