### PR TITLE
chore(release): bump version to 0.52.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.52.7"
+version = "0.52.8"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release-window lock (see AGENTS.md "One release owner per window": the lock on a window is the open bump PR, not a message).

**Owner session:** pid 79836 ("Investigating unexpected runtime downgrade on idle", lopdev manager, anthropic/claude-opus-5 → provider fallbacks disclosed in-thread).

**Window (merged since tag v0.52.7, re-derived at claim time):**
- [ ] #815 — b3ec0abe9bcc4d3225992af253411c9491606739 — feat(secrets): broker daemon with ancestry-based peer authentication — handed over by pid 5095 (merger): adds the secret store's hardened (passphrase) tier; `lop secret harden` / `unlock` now work, backed by a broker daemon that authenticates peers by process ancestry. CLI/operator capability only — agents still cannot reach stored secrets (that is PR #838, unmerged).
- [ ] #833 — a298bd6f570a22bdd8c75c40c4ef1aa6a2680b30 — fix(tui): stop reporting a newer runtime as a downgrade — a wrong-direction build notice stops painting on idle sessions; a self-refresh now says what it updated to.

**Bump decision (owner):** patch → 0.52.8. #815 argues minor through its merger; the owner weighs it patch — the step-function surface of the secrets series (agents reaching secrets) ships with #838, and the bar is "if in doubt, patch". Recorded here so the argument is visible, per AGENTS.md.

Ownership was offered to every live lop-dev session via `send` before this lock; all replied NO/yield (pids 21144, 23991, 24350, 31709, 32234, 32842, 33614, 38752, 5095, 7265, 8045, 86140). This commit is amended into the version bump and retitled once the window closes; the PR number, and so the lock, never changes.