### PR TITLE
chore(release): bump version to 0.52.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.52.8"
+version = "0.52.9"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release lock for the post-v0.52.8 window. `pyproject.toml` only, one line.

## Window

Derived from `origin/main` immediately before opening this PR:

- Last tag: **v0.52.8** (target `1f8e5b03e`)
- `git log v0.52.8..origin/main` → exactly one commit

| PR | Merge SHA | Impact |
|---|---|---|
| [#823](https://github.com/damianvtran/local-operator/pull/823) | `4790838ce` | Resumed and reconnected sessions restore real tool-call durations instead of a blank column |

## Bump class: PATCH

A bug fix on an existing surface. No API addition, no schema or config migration, and no behaviour change beyond a value that was always persisted and simply never read back on replay. Nothing in the window clears the step-function bar that a minor would need.

## Ownership

The v0.52.8 owner explicitly yielded this window and had nothing merged-but-unreleased. Ownership was announced to every live lop-dev peer; all who replied (pids 8045, 21144, 7265, 38752, 32842, 35253) confirmed no conflict and nothing to fold in — their work is pre-merge and rides a later window. No competing `chore(release)` PR was open at derivation time.

## Scope check

The diff is one line in `pyproject.toml` (`0.52.8` → `0.52.9`). No source, test, or workflow file is touched, so the C0 one-file scope check is the appropriate gate.