### PR TITLE
fix(session): bound owner recovery for a live-but-silent runtime

### DIFF
--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -158,10 +158,21 @@ COLD_FALLBACK_S = 8.0
 #: A bare literal would silently stop tracking that contract if the heartbeat
 #: moved.
 #:
+#: SCOPED TO A RECORD HAVING BEEN SEEN. This bound answers "an owner is there
+#: and will not answer", never "no owner is there": the latter is the DEAD
+#: shape, whose contract is to keep chasing a successor through the takeover
+#: arm, and it keeps that contract unchanged. ``_recover_owner`` tracks the
+#: sighting across passes (``record_seen``) because the deadline is necessarily
+#: evaluated before the pass reads a record.
+#:
 #: The terminal state is COLD AND REBINDABLE, not failed: the exit sets
 #: ``_can_go_cold`` before ``_go_cold`` (see ``_recover_owner``), so the
 #: transcript stays on screen, ``_owner_ready`` is set, and the next prompt
 #: re-engages through ``_ensure_bound`` against this very same live record.
+#: That rebind is the whole repair, and it is why no user-facing copy was added
+#: for this state: a typed ``/model p/id`` on the resulting facade is diverted
+#: by ``OperatorApp._needs_runtime_first`` into ``_bind_then_dispatch``, which
+#: performs exactly that retry and reports its outcome.
 RECOVERY_GIVE_UP_S = 2 * HEARTBEAT_TIMEOUT_S
 
 #: Backoff ceiling for ``_recover_owner``'s DIAL-FAILURE arm specifically.
@@ -657,15 +668,6 @@ class RemoteSession:
         self._gate_key: tuple[str, str, int] | None = None
         self._disposed = False
         self._recovering = False
-        #: Recovery ran to ``RECOVERY_GIVE_UP_S`` without ever getting usable
-        #: state out of an owner that stayed DISCOVERABLE the whole time. It
-        #: is the difference between the two ways a viewer can be cold, which
-        #: the user has to be told apart: ordinarily cold means no runtime is
-        #: running and "send a message to start one" is the lever, but here a
-        #: runtime IS running and merely never answered — so that sentence is
-        #: false in its premise. Read through ``exhausted_recovery`` rather
-        #: than directly; see it for why this is public at all.
-        self._recovery_exhausted = False
         self._recovery_task: asyncio.Task[None] | None = None
         #: Generation of the turn that was live when the socket dropped, or
         #: ``None`` when nothing was streaming. Recovery uses this to decide
@@ -1439,28 +1441,6 @@ class RemoteSession:
         """No fully synchronized runtime is attached to this viewer."""
         return self._client is None or not self._client.connected or not self._ready_for_events
 
-    @property
-    def exhausted_recovery(self) -> bool:
-        """Cold because the owner never answered — not because none is running.
-
-        PUBLIC because the TUI has to pick a sentence and the two cold states
-        need different ones. The generic cold copy ("no runtime is running for
-        this session; send a message to start one") is true for a fresh viewer
-        and for one whose runtime exited, and FALSE here: recovery gave up
-        against a record that stayed discoverable, so a runtime is alive and
-        simply busy. A predicate rather than another ``getattr(session,
-        "_recovering")`` private read at the call site, because the app already
-        reaches into this facade's privates in several places and each one is a
-        rename away from silently reading ``False`` forever.
-
-        Latches until the facade next binds, which is the honest lifetime: the
-        state it describes is "the last recovery attempt gave up", and any
-        successful bind is the evidence that it no longer holds. Never true on
-        a local ``Session`` — callers use ``getattr(session, ...)`` for the
-        same reason they do for ``is_cold``.
-        """
-        return self._recovery_exhausted
-
     async def attach_existing(self) -> bool:
         """Attach if an owner exists, without turning a history read into work.
 
@@ -2193,11 +2173,6 @@ class RemoteSession:
             self._finish_sync()
             self._deliberate_stop = False
             self._stopped_announced = False
-            # A bind is the evidence that the last give-up no longer describes
-            # this facade. Cleared on the success tail (not at entry) so a
-            # failed retry leaves the flag — and the sentence it selects —
-            # standing, which is the state that is still true.
-            self._recovery_exhausted = False
             self._owner_ready.set()
         except BaseException:
             # A failed/cancelled sync is not an attached viewer. Retrying must
@@ -3865,7 +3840,31 @@ class RemoteSession:
         # The second, longer bound for the surface that cannot take the branch
         # above. See ``RECOVERY_GIVE_UP_S`` for why it is derived from the
         # heartbeat contract rather than calibrated here.
+        #
+        # READ ONCE HERE, DELIBERATELY, and not re-derived per pass. A deadline
+        # recomputed inside the loop is a deadline that resets every pass and
+        # therefore never fires — the exact never-terminates shape this bound
+        # exists to remove. The cost is that monkeypatching the constant after
+        # the loop has started does not reach a running recovery, which is
+        # correct: the constant is static in production, and a live change to a
+        # bound already being waited on has no defined meaning (review round 1,
+        # R4).
         give_up_deadline = time.monotonic() + RECOVERY_GIVE_UP_S
+        # Whether ANY pass of this loop has found a discoverable owner record.
+        #
+        # The give-up exit below is scoped to the live-but-silent shape — an
+        # owner that keeps publishing a record and never answers — and must not
+        # fire for an owner that is genuinely DEAD, whose contract is to keep
+        # chasing a successor through the takeover arm. The check has to sit at
+        # the top of the pass (that is where a deadline can be evaluated before
+        # the pass spends its time on a dial that may block), which is BEFORE
+        # ``find_owner_record`` runs, so the exit cannot consult this pass's
+        # record. It consults the previous passes' instead: one sighting is
+        # enough, because a record seen at all is what distinguishes "an owner
+        # is there and silent" from "nothing is there". Without this the exit
+        # fired for a no-record viewer too, marking a dead runtime as merely
+        # unresponsive (QA round 1 Q849-1, review round 1 R3).
+        record_seen = False
         try:
             while not self._disposed:
                 if time.monotonic() >= cold_deadline:
@@ -3911,6 +3910,15 @@ class RemoteSession:
                     # ``/model`` and every other mutation seam refused forever
                     # and ``prompt`` parked silently on ``_owner_ready``.
                     #
+                    # SCOPED TO ``record_seen``, which is what makes the
+                    # paragraph below true rather than merely intended. The
+                    # condition cannot be "this pass found a record" — the
+                    # deadline is evaluated before ``find_owner_record`` runs —
+                    # so it is "some pass did", which selects the same class:
+                    # an owner that is discoverable at all is the live-but-
+                    # silent shape, and one that never was is the dead shape the
+                    # takeover arm below is written for.
+                    #
                     # Going cold here does not weaken the chase contract, which
                     # is written for a DEAD owner and is vacuous for a live one:
                     # ``acquire_session_lease`` raises ``SessionLeaseHeldError``
@@ -3923,7 +3931,7 @@ class RemoteSession:
                     # armed for a LATER genuine death — a subsequent owner loss
                     # re-enters this loop and, with the record gone by then,
                     # takes the else-branch exactly as it always has.
-                    if time.monotonic() >= give_up_deadline:
+                    if record_seen and time.monotonic() >= give_up_deadline:
                         logger.info(
                             "no usable state from the runtime for %s after %.0fs; "
                             "unbinding — the conversation stays and the next action "
@@ -3958,11 +3966,22 @@ class RemoteSession:
                         # reintroduce it silently. Cleared locally rather than
                         # inside ``_go_cold`` to keep this off the desktop path.
                         self._runtime_pid = None
-                        # Set BEFORE ``_go_cold``: the went-cold callback fires
-                        # inside it, and a notice handler that asks the facade
-                        # why it went cold must not read a flag that is still
-                        # being written.
-                        self._recovery_exhausted = True
+                        # NO "recovery was exhausted" FLAG IS STAMPED HERE, and
+                        # the absence is deliberate. An earlier revision set one
+                        # so the TUI could pick a different sentence for this
+                        # cold state; the sentence turned out to be unreachable
+                        # (see the note in ``OperatorApp._activate_resolved_
+                        # model``), which left the flag with no consumer — and a
+                        # consumerless flag that LATCHES is not inert. It was
+                        # cleared only on ``_bind_to``'s success tail, while
+                        # this loop's own reattach arm below rebinds inline
+                        # without going through ``_bind_to``, so a viewer that
+                        # gave up once and then recovered still reported the
+                        # give-up verdict against every later, genuinely dead
+                        # owner (review round 1, R2). Deleted rather than fixed
+                        # with two more clear-sites: state whose only defence is
+                        # remembering to clear it everywhere is state that will
+                        # latch again the next time an exit is added.
                         self._go_cold()
                         # ``finally`` clears ``_recovering``: the refusals lift
                         # and the parked prompt is released by ``_owner_ready``.
@@ -3985,6 +4004,14 @@ class RemoteSession:
                     and record.protocol >= 5
                     and FRONTEND_CAPABILITY in record.capabilities
                 ):
+                    # Stamped on the SAME condition that selects the reattach
+                    # arm, not on ``record is not None``: a record this viewer
+                    # cannot use (an older protocol, no frontend capability)
+                    # falls through to the takeover ``else`` and belongs to the
+                    # dead-owner contract, so counting it as a sighting would
+                    # let the give-up exit fire for a chase that never had a
+                    # reattach to give up ON.
+                    record_seen = True
                     try:
                         pending_sync = await self._dial(record)
                     except (ConnectionError, OSError, TimeoutError):

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -94,6 +94,7 @@ from local_operator.session.frontend_state import (
 from local_operator.session.history_window import DisplayHistoryWindow
 from local_operator.session.naming import ConversationName
 from local_operator.session.protocol import CompactionOutcome
+from local_operator.session.runtime.types import HEARTBEAT_TIMEOUT_S
 from local_operator.session.transcript import (
     Transcript,
     read_replay_suffix,
@@ -127,6 +128,63 @@ UNIDENTIFIED_STEER_ID = "remote-steer"
 #: that before concluding nothing is coming. Only the viewer path uses it; the
 #: legacy attach path still recovers by taking over (see ``_can_go_cold``).
 COLD_FALLBACK_S = 8.0
+
+#: The SECOND, longer bound on recovery — the one that applies when the viewer
+#: cannot go cold at ``COLD_FALLBACK_S`` (``_can_go_cold`` is False, i.e. every
+#: terminal ``connect()`` viewer, which is what the TUI builds).
+#:
+#: It exists because that path had NO bounded exit at all. ``COLD_FALLBACK_S``
+#: returns only for a viewer that may go cold; the legacy arm beneath it ends
+#: the in-flight turn and keeps looping, and the takeover that arm is written
+#: to reach lives in the no-record ``else`` branch — so an owner that is LIVE
+#: BUT SILENT (a record is found every pass, the socket accepts, the canonical
+#: sync never lands) kept the loop cycling forever with no verdict to offer.
+#: ``_recovering`` is set for the whole of that loop, so what latches is not a
+#: cosmetic flag: it is the state that REFUSES ``/model``, ``/goal``,
+#: ``/rename``, ``/effort``, ``/compact``, ``/fork`` and ``/credential`` with
+#: ``_RECONNECTING_SLASH_NOTICE``, and that PARKS ``prompt`` silently on
+#: ``_owner_ready`` with no message and no spinner resolution. Reported from
+#: the field as a session whose model could not be switched by any number of
+#: retries or ``/resume``s.
+#:
+#: DERIVED from ``HEARTBEAT_TIMEOUT_S`` rather than written as a literal 90.0,
+#: because the question this bounds is the owner's own liveness contract: the
+#: registry classifies a record ``wedged`` rather than ``live`` after one
+#: heartbeat timeout, and a viewer must not conclude an owner is unreachable
+#: FASTER than the registry concludes it is wedged — a turn-boundary stall
+#: inside that window is normal (see ``FRONTEND_SYNC_BACKSTOP_S`` on the
+#: 15-vs-45 s window). Two of them also buys ~6 genuine attempts at the
+#: measured silent-owner cadence of one redial per ``FRONTEND_SYNC_BLOCKED_S``.
+#: A bare literal would silently stop tracking that contract if the heartbeat
+#: moved.
+#:
+#: The terminal state is COLD AND REBINDABLE, not failed: the exit sets
+#: ``_can_go_cold`` before ``_go_cold`` (see ``_recover_owner``), so the
+#: transcript stays on screen, ``_owner_ready`` is set, and the next prompt
+#: re-engages through ``_ensure_bound`` against this very same live record.
+RECOVERY_GIVE_UP_S = 2 * HEARTBEAT_TIMEOUT_S
+
+#: Backoff ceiling for ``_recover_owner``'s DIAL-FAILURE arm specifically.
+#:
+#: That arm ``continue``s, which skips the sleep at the bottom of the loop, so
+#: its own ``sleep(delay)`` is the only pacing on the path — the ceiling has to
+#: move here and nowhere else. It matters for the FAST-FAILURE owner shape (a
+#: socket that accepts and then rejects the welcome), measured at 2.33 accepted
+#: connections/second. Against ``ATTACH_MAX_CLIENTS`` with LRU eviction that is
+#: a real cascade: every slot this loop takes evicts a legitimate client, the
+#: prior art being the 272-eviction burst documented on
+#: ``_discard_rejected_client``. 2.0 s cuts the worst-case slot-take rate ~4x
+#: while keeping the first four retries inside ~1 s, which is the window a
+#: runtime restarting after ``kill -9`` actually republishes in.
+#:
+#: DELIBERATELY DIVERGED from ``_BIND_RETRY_DELAY_CAP_S``, whose comment says
+#: the two backoff shapes were copied from each other on purpose. They are no
+#: longer the same shape and must not be re-unified: ``_bind_under_lock`` is
+#: bounded to ``_BIND_RETRY_ATTEMPTS`` inside a wall-clock budget, so it cannot
+#: storm and a longer cap there would only add latency a user sits through.
+#: This loop is bounded in wall-clock but not in attempts, so its ceiling is
+#: what limits the rate.
+_RECOVERY_DIAL_CAP_S = 2.0
 
 #: Loop turns granted after a sync wall-clock expiry BEFORE the expiry is
 #: believed. This is the load-bearing half of the fix for the false timeout,
@@ -290,9 +348,13 @@ _MODEL_INTENT_PENDING = (
 #: attempt starts from a clean facade and no attach slot leaks against
 #: ``ATTACH_MAX_CLIENTS``. ``find_owner_record`` is re-run per attempt so a
 #: runtime that retired and respawned between attempts is picked up rather
-#: than redialled at its dead pid. Backoff shape copied from
-#: ``_recover_owner`` (``remote.py`` ``delay = min(delay * 1.7, 0.5)``) so the
-#: two redial loops behave the same way.
+#: than redialled at its dead pid. The backoff shape was originally copied from
+#: ``_recover_owner`` so the two redial loops behaved the same way; the CEILINGS
+#: have since deliberately diverged (``_RECOVERY_DIAL_CAP_S`` is 2.0 s) and this
+#: one is deliberately LEFT at 0.5. This loop is bounded to
+#: ``_BIND_RETRY_ATTEMPTS`` inside a wall-clock budget, so it cannot storm attach
+#: slots the way an attempt-unbounded loop can, and a longer cap here would only
+#: add latency to a bind a caller is waiting on. Do not re-unify them.
 _BIND_RETRY_ATTEMPTS = 3
 _BIND_RETRY_INITIAL_S = 0.1
 _BIND_RETRY_FACTOR = 1.7
@@ -595,6 +657,15 @@ class RemoteSession:
         self._gate_key: tuple[str, str, int] | None = None
         self._disposed = False
         self._recovering = False
+        #: Recovery ran to ``RECOVERY_GIVE_UP_S`` without ever getting usable
+        #: state out of an owner that stayed DISCOVERABLE the whole time. It
+        #: is the difference between the two ways a viewer can be cold, which
+        #: the user has to be told apart: ordinarily cold means no runtime is
+        #: running and "send a message to start one" is the lever, but here a
+        #: runtime IS running and merely never answered — so that sentence is
+        #: false in its premise. Read through ``exhausted_recovery`` rather
+        #: than directly; see it for why this is public at all.
+        self._recovery_exhausted = False
         self._recovery_task: asyncio.Task[None] | None = None
         #: Generation of the turn that was live when the socket dropped, or
         #: ``None`` when nothing was streaming. Recovery uses this to decide
@@ -1368,6 +1439,28 @@ class RemoteSession:
         """No fully synchronized runtime is attached to this viewer."""
         return self._client is None or not self._client.connected or not self._ready_for_events
 
+    @property
+    def exhausted_recovery(self) -> bool:
+        """Cold because the owner never answered — not because none is running.
+
+        PUBLIC because the TUI has to pick a sentence and the two cold states
+        need different ones. The generic cold copy ("no runtime is running for
+        this session; send a message to start one") is true for a fresh viewer
+        and for one whose runtime exited, and FALSE here: recovery gave up
+        against a record that stayed discoverable, so a runtime is alive and
+        simply busy. A predicate rather than another ``getattr(session,
+        "_recovering")`` private read at the call site, because the app already
+        reaches into this facade's privates in several places and each one is a
+        rename away from silently reading ``False`` forever.
+
+        Latches until the facade next binds, which is the honest lifetime: the
+        state it describes is "the last recovery attempt gave up", and any
+        successful bind is the evidence that it no longer holds. Never true on
+        a local ``Session`` — callers use ``getattr(session, ...)`` for the
+        same reason they do for ``is_cold``.
+        """
+        return self._recovery_exhausted
+
     async def attach_existing(self) -> bool:
         """Attach if an owner exists, without turning a history read into work.
 
@@ -2100,6 +2193,11 @@ class RemoteSession:
             self._finish_sync()
             self._deliberate_stop = False
             self._stopped_announced = False
+            # A bind is the evidence that the last give-up no longer describes
+            # this facade. Cleared on the success tail (not at entry) so a
+            # failed retry leaves the flag — and the sentence it selects —
+            # standing, which is the state that is still true.
+            self._recovery_exhausted = False
             self._owner_ready.set()
         except BaseException:
             # A failed/cancelled sync is not an attached viewer. Retrying must
@@ -3764,6 +3862,10 @@ class RemoteSession:
         # the next message engages a fresh runtime. Without a bound the loop
         # would redial forever against a session nobody is running.
         cold_deadline = time.monotonic() + COLD_FALLBACK_S
+        # The second, longer bound for the surface that cannot take the branch
+        # above. See ``RECOVERY_GIVE_UP_S`` for why it is derived from the
+        # heartbeat contract rather than calibrated here.
+        give_up_deadline = time.monotonic() + RECOVERY_GIVE_UP_S
         try:
             while not self._disposed:
                 if time.monotonic() >= cold_deadline:
@@ -3775,9 +3877,13 @@ class RemoteSession:
                         )
                         self._go_cold()
                         return
-                    # The LEGACY attach surface has no cold state to fall into
-                    # (``_can_go_cold`` is desktop-only) and its contract is to
-                    # keep chasing a successor. But the turn must still reach a
+                    # The LEGACY attach surface does not go cold at THIS bound
+                    # (``_can_go_cold`` is desktop-only) because its contract is
+                    # to keep chasing a successor. It does now go cold at a
+                    # second, longer one — see the give-up branch below; this
+                    # comment used to say it had "no cold state to fall into"
+                    # at all, which is how the forever-latch survived review.
+                    # But the turn must still reach a
                     # verdict: with the abort deferred to recovery, a genuine
                     # owner death whose takeover keeps failing (lease held by
                     # another follower, or any raise — both retry forever by
@@ -3796,6 +3902,71 @@ class RemoteSession:
                             COLD_FALLBACK_S,
                         )
                         self._end_turn_locally(direct=True)
+                    # ...and AFTER that verdict, the loop itself must reach one.
+                    # Ending the turn left ``_recovering`` set, and the only
+                    # other exits are the cold branch above (unreachable here)
+                    # and the takeover in the no-record ``else`` — which a
+                    # LIVE BUT SILENT owner never reaches, because a record is
+                    # found on every pass. So the chase had no terminal state:
+                    # ``/model`` and every other mutation seam refused forever
+                    # and ``prompt`` parked silently on ``_owner_ready``.
+                    #
+                    # Going cold here does not weaken the chase contract, which
+                    # is written for a DEAD owner and is vacuous for a live one:
+                    # ``acquire_session_lease`` raises ``SessionLeaseHeldError``
+                    # unless the holder is proven dead, so a live owner cannot
+                    # be taken over even if this arm did reach the factory. Nor
+                    # does it engage a second runtime for a session that has
+                    # one: ``engage_runtime`` short-circuits on a discoverable
+                    # record and, failing that, waits rather than spawning while
+                    # a live pid holds the lease. ``_takeover_factory`` stays
+                    # armed for a LATER genuine death — a subsequent owner loss
+                    # re-enters this loop and, with the record gone by then,
+                    # takes the else-branch exactly as it always has.
+                    if time.monotonic() >= give_up_deadline:
+                        logger.info(
+                            "no usable state from the runtime for %s after %.0fs; "
+                            "unbinding — the conversation stays and the next action "
+                            "reconnects",
+                            self._session_id,
+                            RECOVERY_GIVE_UP_S,
+                        )
+                        # LOAD-BEARING, and it must precede ``_go_cold``.
+                        # ``_ensure_bound`` returns immediately when this flag
+                        # is False, so clearing ``_recovering`` while leaving it
+                        # unset would produce a viewer that reports ``is_cold``
+                        # and can NEVER bind again — a silent no-op in place of
+                        # today's honest refusal, which is the worse bug.
+                        # Mirrors the refresh arm of ``_go_cold``, which flips
+                        # the same flag with the same reasoning: from here on
+                        # this facade is a viewer.
+                        self._can_go_cold = True
+                        # BELT, not a live repair: verified unreachable with a
+                        # stamped pid today, because this check runs at the TOP
+                        # of a pass and every way the previous pass could fail
+                        # (failed dial, refused sync, timeout) routes through
+                        # ``_discard_rejected_client``, which clears it. It is
+                        # kept because the invariant it upholds is not local:
+                        # ``_go_cold`` does NOT clear the identity ``_dial``
+                        # stamps on entry, while ``runtime_pid`` promises None
+                        # while cold, and ``take_unannounced_cleanup`` reads
+                        # that pid to decide notice ownership — a stale match
+                        # claims another runtime's notice and blanks the
+                        # terminal that should have shown it (the F3 hazard the
+                        # dial-failure arm below documents). Any future exit
+                        # added between a successful dial and this check would
+                        # reintroduce it silently. Cleared locally rather than
+                        # inside ``_go_cold`` to keep this off the desktop path.
+                        self._runtime_pid = None
+                        # Set BEFORE ``_go_cold``: the went-cold callback fires
+                        # inside it, and a notice handler that asks the facade
+                        # why it went cold must not read a flag that is still
+                        # being written.
+                        self._recovery_exhausted = True
+                        self._go_cold()
+                        # ``finally`` clears ``_recovering``: the refusals lift
+                        # and the parked prompt is released by ``_owner_ready``.
+                        return
                 # A stop by someone else while we watched: the transcript's
                 # ``stopped_at`` marker plus no live owner is the deliberate
                 # shape. Read it once at the top of each pass — cheap (one
@@ -3836,7 +4007,13 @@ class RemoteSession:
                         # the runtime it tried.
                         self._discard_rejected_client()
                         await asyncio.sleep(delay)
-                        delay = min(delay * 1.7, 0.5)
+                        # ``_RECOVERY_DIAL_CAP_S``, not the 0.5 this loop shared
+                        # with ``_bind_under_lock``: the ``continue`` below
+                        # skips the sleep at the bottom of the loop, so this is
+                        # the only pacing on the dial-failure path and it is the
+                        # one that can storm attach slots. The two shapes have
+                        # deliberately diverged; see the constant.
+                        delay = min(delay * 1.7, _RECOVERY_DIAL_CAP_S)
                         continue
                     try:
                         # BLOCKED envelope, NOT the generous backstop — a

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -23479,29 +23479,22 @@ class OperatorApp(App[None]):
                     "try /model again in a moment",
                     "warning",
                 )
-            elif bool(getattr(session, "exhausted_recovery", False)):
-                # Cold, but NOT because no runtime is running: recovery gave up
-                # against an owner that stayed discoverable the whole time and
-                # simply never answered. The generic sentence below asserts
-                # something false there — "send a message to start one" tells
-                # the user to start a runtime that is already alive, which is
-                # exactly the dead end the operator reported when no number of
-                # /model retries or /resumes would switch the model.
-                #
-                # Says what is true and ends in the next step, the pattern
-                # `_MODEL_INTENT_PENDING` and `_SYNC_UNRESPONSIVE_REASON` both
-                # follow: the retry itself is the reconnect, because the facade
-                # is rebindable again (`_can_go_cold` was flipped at that exit)
-                # and `_ensure_bound` rediscovers the same live record.
-                # Deliberately avoids runtime vocabulary the user cannot act on
-                # — "owner", "viewer", "cold" — and names the transcript,
-                # because the screen is about to look like a fresh session.
-                self._system_notice(
-                    "this session's runtime is busy and stopped responding — "
-                    "the conversation is intact; try /model again to reconnect",
-                    "warning",
-                )
             else:
+                # NO give-up-specific arm here, and that is deliberate — see
+                # `RECOVERY_GIVE_UP_S` in `session/remote.py`. A viewer that
+                # gave up on a
+                # live-but-silent owner is cold with a callable `_ensure_bound`,
+                # which is exactly the shape `_needs_runtime_first` diverts into
+                # `_bind_then_dispatch`, so a typed `/model p/id` never reaches
+                # this ladder from that state at all. An arm added here would be
+                # unreachable code carrying user-facing copy — and worse than
+                # unreachable, because `_bind_then_dispatch` does not merely
+                # print a better sentence, it RETRIES THE BIND against the same
+                # live record and reports the outcome ("could not reach this
+                # session's runtime in time — it is still running; try that
+                # again in a moment"). Diverting a give-up facade away from that
+                # path to print a nicer string would trade the repair for copy
+                # (review round 1 R1, design round 1 D1).
                 self._system_notice(
                     "no runtime is running for this session; "
                     "send a message to start one, then run /model again",

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -23479,6 +23479,28 @@ class OperatorApp(App[None]):
                     "try /model again in a moment",
                     "warning",
                 )
+            elif bool(getattr(session, "exhausted_recovery", False)):
+                # Cold, but NOT because no runtime is running: recovery gave up
+                # against an owner that stayed discoverable the whole time and
+                # simply never answered. The generic sentence below asserts
+                # something false there — "send a message to start one" tells
+                # the user to start a runtime that is already alive, which is
+                # exactly the dead end the operator reported when no number of
+                # /model retries or /resumes would switch the model.
+                #
+                # Says what is true and ends in the next step, the pattern
+                # `_MODEL_INTENT_PENDING` and `_SYNC_UNRESPONSIVE_REASON` both
+                # follow: the retry itself is the reconnect, because the facade
+                # is rebindable again (`_can_go_cold` was flipped at that exit)
+                # and `_ensure_bound` rediscovers the same live record.
+                # Deliberately avoids runtime vocabulary the user cannot act on
+                # — "owner", "viewer", "cold" — and names the transcript,
+                # because the screen is about to look like a fresh session.
+                self._system_notice(
+                    "this session's runtime is busy and stopped responding — "
+                    "the conversation is intact; try /model again to reconnect",
+                    "warning",
+                )
             else:
                 self._system_notice(
                     "no runtime is running for this session; "

--- a/tests/unit/session/test_remote_disconnect.py
+++ b/tests/unit/session/test_remote_disconnect.py
@@ -433,3 +433,311 @@ async def test_a_recall_with_no_client_declines_instead_of_claiming_success(
     assert remote.recall_steering(message) is False, "no client means no recall"
     assert remote._recall_task is None, "and no op was issued"
     await _cancel_recovery(remote)
+
+
+# --- the live-but-silent owner: recovery must reach a verdict ---------------
+#
+# An owner that is LIVE (a record is found on every pass) but SILENT (the
+# socket accepts, the canonical sync never lands) is the shape that had NO
+# bounded exit: `COLD_FALLBACK_S` returns only for `_can_go_cold`, and the
+# takeover the legacy arm is written to reach lives in the no-record `else`
+# branch a discoverable record never takes. Reported from the field as a
+# session whose model could not be switched by any retry or `/resume`.
+
+
+def _live_record() -> Any:
+    """A record that always reads live, protocol 5, frontend-capable."""
+    import time as _time
+
+    from local_operator.session.frontend_state import FRONTEND_CAPABILITY
+    from local_operator.session.runtime.types import SessionRecord
+
+    return SessionRecord(
+        pid=99999,
+        kind="tui",
+        session_id="s1",
+        conversation_name="probe",
+        cwd="/tmp",
+        model_label="m",
+        control_port=1,
+        control_key="k",
+        protocol=5,
+        capabilities=[FRONTEND_CAPABILITY],
+        heartbeat_at=_time.time(),
+    )
+
+
+def _silent_owner_facade(tmp_path, monkeypatch) -> tuple[RemoteSession, list[float]]:
+    """A terminal viewer whose owner accepts the dial and then never speaks.
+
+    Bounds are compressed so the exits are exercised in milliseconds; every
+    assertion is on the VERDICT, never on elapsed time.
+    """
+    import time as _time
+
+    monkeypatch.setattr(remote_module, "COLD_FALLBACK_S", 0.05)
+    monkeypatch.setattr(remote_module, "FRONTEND_SYNC_BLOCKED_S", 0.05)
+    monkeypatch.setattr(remote_module, "RECOVERY_GIVE_UP_S", 0.3)
+    monkeypatch.setattr(remote_module, "find_owner_record", lambda *a: (_live_record(), None))
+
+    remote = RemoteSession(
+        config_dir=tmp_path,
+        session_id="s1",
+        takeover_factory=lambda: asyncio.sleep(0, result=None),
+    )
+    # The surface the operator actually uses: connect() defaults to "terminal".
+    assert remote._can_go_cold is False
+    remote._streaming = True
+    remote._generation = 7
+    remote._ready_for_events = True
+
+    dials: list[float] = []
+
+    async def silent_dial(record: Any) -> Any:
+        dials.append(_time.monotonic())
+        # The REAL `_dial` stamps the identity on entry, before the sync it
+        # will never get; without this the `_runtime_pid` assertion below is
+        # vacuous, because nothing ever set the pid it checks is cleared.
+        remote._runtime_pid = record.pid
+        return asyncio.get_running_loop().create_future()  # never resolves
+
+    monkeypatch.setattr(remote, "_dial", silent_dial)
+    return remote, dials
+
+
+async def _await_verdict(remote: RemoteSession) -> None:
+    """Wait on the STATE, never on the clock."""
+    for _ in range(600):
+        if not remote._recovering:
+            return
+        await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+async def test_a_live_but_silent_owner_does_not_latch_the_viewer_forever(
+    tmp_path, monkeypatch
+) -> None:
+    """THE regression guard: recovery must not latch `_recovering` forever.
+
+    Fails on the pre-fix tree, where the loop has no reachable return while a
+    record keeps being found. `_recovering` is not a cosmetic flag: it is what
+    refuses `/model`, `/goal`, `/rename`, `/effort`, `/compact`, `/fork` and
+    `/credential` at every request/response seam.
+    """
+    remote, dials = _silent_owner_facade(tmp_path, monkeypatch)
+    remote._on_disconnected("send timeout")
+    assert remote._recovering is True, "the premise: recovery is running"
+    await _await_verdict(remote)
+
+    # SAMPLED BEFORE TEARDOWN. Cancelling the recovery task runs the loop's
+    # `finally`, which clears `_recovering` and makes a broken tree look green
+    # — this test passed against the defect for exactly that reason once.
+    latched = remote._recovering
+    await _cancel_recovery(remote)
+
+    assert latched is False, (
+        "the viewer latched in recovery against a live-but-silent owner: "
+        f"dials={len(dials)} — every /model, /fork, /compact is refused forever"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_give_up_exit_leaves_a_viewer_that_can_bind_again(tmp_path, monkeypatch) -> None:
+    """`_can_go_cold` must be flipped BEFORE `_go_cold`, or the fix is worse.
+
+    `_ensure_bound` returns immediately when `_can_go_cold` is False, so
+    clearing `_recovering` without the flip yields a viewer that is cold,
+    permanently unbindable, and silently no-ops — worse than the honest
+    refusal it replaces. Nothing else covers that variant.
+    """
+    remote, _ = _silent_owner_facade(tmp_path, monkeypatch)
+    remote._on_disconnected("send timeout")
+    await _await_verdict(remote)
+    exhausted = remote.exhausted_recovery
+    can_go_cold = remote._can_go_cold
+    runtime_pid = remote.runtime_pid
+    await _cancel_recovery(remote)
+
+    assert can_go_cold is True, "the viewer can never bind again"
+    assert exhausted is True, "the cold state is not distinguishable from 'no runtime'"
+    # `runtime_pid` promises None while cold. Today `_discard_rejected_client`
+    # already clears it on every failure path, so this pins the INVARIANT at
+    # the exit rather than a defect: a stale live pid would let
+    # `take_unannounced_cleanup` claim another runtime's notice (F3).
+    assert runtime_pid is None, f"a stale owner pid outlived the unbind: {runtime_pid}"
+
+
+@pytest.mark.asyncio
+async def test_the_refusal_is_no_longer_driven_by_the_recovery_flag(tmp_path, monkeypatch) -> None:
+    """The PERMANENT refusal lifts: `_recovering` no longer gates the seams.
+
+    A cold viewer still refuses a routed slash on `client is None` — that is
+    the ordinary, self-correcting cold state every viewer reaches after
+    `/stop`, and it is not what this fix is about. What changed is that the
+    refusal is no longer held open by a flag nothing can clear: the facade is
+    rebindable, so the next action repairs it. Asserted on the CAUSE (the
+    flag, and the dial the repair reaches) rather than on the string, because
+    both causes raise the same sentence.
+    """
+    remote, dials = _silent_owner_facade(tmp_path, monkeypatch)
+    # `_bind_under_lock` imports both of these function-locally, so the
+    # module-level patches the fixture makes do not reach it. The engage is a
+    # no-op because the record below already names a live runtime — which is
+    # exactly what `engage_runtime` short-circuits on in production.
+    import local_operator.mobile.attach_client as attach_client
+    import local_operator.session.runtime.launch as launch
+
+    monkeypatch.setattr(attach_client, "find_owner_record", lambda *a: (_live_record(), None))
+    monkeypatch.setattr(launch, "engage_runtime", lambda *a, **k: asyncio.sleep(0))
+
+    remote._on_disconnected("send timeout")
+    await _await_verdict(remote)
+
+    # Issued BEFORE teardown, for the same reason `latched` is sampled early.
+    recovering = remote._recovering
+    dials_before = len(dials)
+    # The repair path the user actually takes: any action rebinds. It must
+    # reach the DIAL — a viewer left with `_can_go_cold` False returns from
+    # `_ensure_bound` immediately and silently no-ops forever instead.
+    try:
+        await asyncio.wait_for(remote._ensure_bound(), timeout=1.0)
+    except (asyncio.TimeoutError, ConnectionError, OSError):
+        pass  # the owner is still silent; that it TRIED is the assertion
+    dials_after = len(dials)
+    await _cancel_recovery(remote)
+
+    assert recovering is False, "the recovery flag still gates every seam"
+    assert dials_after > dials_before, (
+        "the repair path never reached a dial: this viewer is permanently "
+        f"unbindable (dials {dials_before} -> {dials_after})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_parked_prompt_is_released_by_the_bound(tmp_path, monkeypatch) -> None:
+    """The silent half of the defect: `prompt` waits on `_owner_ready` forever.
+
+    `_on_disconnected` clears `_owner_ready` and the only setters are
+    `_go_cold`, the takeover branch and the deliberate-stop arms — none of
+    which fired on this path. The user saw no message and no spinner
+    resolution, which is worse than the refusal `/model` at least printed.
+    """
+    remote, _ = _silent_owner_facade(tmp_path, monkeypatch)
+    released = asyncio.Event()
+
+    async def parks_on_owner_ready() -> None:
+        await remote._owner_ready.wait()
+        released.set()
+
+    waiter = asyncio.create_task(parks_on_owner_ready())
+    await asyncio.sleep(0)
+    remote._on_disconnected("send timeout")
+    assert released.is_set() is False, "the premise: the prompt path is parked"
+
+    await _await_verdict(remote)
+    for _ in range(100):
+        if released.is_set():
+            break
+        await asyncio.sleep(0.01)
+    was_released = released.is_set()
+    waiter.cancel()
+    await _cancel_recovery(remote)
+
+    assert was_released is True, "the prompt path is still parked on _owner_ready"
+
+
+@pytest.mark.asyncio
+async def test_a_genuinely_dead_owner_still_takes_the_legacy_takeover_path(
+    tmp_path, monkeypatch
+) -> None:
+    """Guard against over-reach: the chase contract survives for a DEAD owner.
+
+    The give-up exit is scoped to the record-present branch. With no record
+    the loop must still reach `_takeover_factory` and keep chasing, exactly as
+    ``test_the_real_recovery_loop_bounds_the_turn_on_a_terminal_viewer`` pins.
+    """
+    monkeypatch.setattr(remote_module, "COLD_FALLBACK_S", 0.05)
+    monkeypatch.setattr(remote_module, "RECOVERY_GIVE_UP_S", 0.3)
+    monkeypatch.setattr(remote_module, "find_owner_record", lambda *a: (None, None))
+    attempts: list[int] = []
+
+    async def failing_takeover() -> Any:
+        attempts.append(1)
+        raise RuntimeError("the lease is held by another follower")
+
+    remote = RemoteSession(
+        config_dir=tmp_path,
+        session_id="s1",
+        takeover_factory=failing_takeover,
+    )
+    remote._streaming = True
+    remote._generation = 7
+    remote._ready_for_events = True
+    went_cold: list[str] = []
+    remote.set_went_cold_callback(lambda: went_cold.append("cold"))
+
+    remote._on_disconnected("owner exited")
+    for _ in range(80):
+        if len(attempts) >= 3:
+            break
+        await asyncio.sleep(0.01)
+    still_chasing = remote._recovering
+    cold_calls = list(went_cold)
+    await _cancel_recovery(remote)
+
+    assert len(attempts) >= 3, f"the loop stopped chasing a successor: {len(attempts)}"
+    assert still_chasing is True, "the no-record branch took the give-up exit"
+    assert cold_calls == [], "a dead owner took the give-up cold exit"
+
+
+@pytest.mark.asyncio
+async def test_the_dial_failure_backoff_reaches_the_recovery_cap(tmp_path, monkeypatch) -> None:
+    """The dial-failure arm paces at `_RECOVERY_DIAL_CAP_S`, not the old 0.5.
+
+    That arm `continue`s, skipping the sleep at the bottom of the loop, so its
+    own sleep is the only pacing on the path — and against `ATTACH_MAX_CLIENTS`
+    with LRU eviction its rate is a real cascade risk. Asserted structurally on
+    the delay sequence handed to `asyncio.sleep`, never as a rate measured
+    against wall time.
+    """
+    monkeypatch.setattr(remote_module, "COLD_FALLBACK_S", 60.0)
+    monkeypatch.setattr(remote_module, "RECOVERY_GIVE_UP_S", 60.0)
+    monkeypatch.setattr(remote_module, "find_owner_record", lambda *a: (_live_record(), None))
+
+    remote = RemoteSession(
+        config_dir=tmp_path,
+        session_id="s1",
+        takeover_factory=lambda: asyncio.sleep(0, result=None),
+    )
+    remote._ready_for_events = True
+
+    async def refusing_dial(record: Any) -> Any:
+        raise ConnectionError("connection refused")
+
+    monkeypatch.setattr(remote, "_dial", refusing_dial)
+
+    delays: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def recording_sleep(delay: float, *args: Any, **kwargs: Any) -> Any:
+        delays.append(delay)
+        return await real_sleep(0, *args, **kwargs)  # run the loop hot
+
+    monkeypatch.setattr(remote_module.asyncio, "sleep", recording_sleep)
+
+    remote._on_disconnected("send timeout")
+    for _ in range(400):
+        if delays and max(delays) >= remote_module._RECOVERY_DIAL_CAP_S:
+            break
+        await real_sleep(0.005)
+    observed = list(delays)
+    await _cancel_recovery(remote)
+
+    assert observed, "the dial-failure arm never paced at all"
+    assert max(observed) == pytest.approx(remote_module._RECOVERY_DIAL_CAP_S), (
+        f"the backoff ceiling is {max(observed)}, not _RECOVERY_DIAL_CAP_S "
+        f"({remote_module._RECOVERY_DIAL_CAP_S}) — sequence={observed[:12]}"
+    )
+    assert (
+        remote_module._RECOVERY_DIAL_CAP_S > remote_module._BIND_RETRY_DELAY_CAP_S
+    ), "the two backoff shapes are meant to have diverged"

--- a/tests/unit/session/test_remote_disconnect.py
+++ b/tests/unit/session/test_remote_disconnect.py
@@ -8,6 +8,7 @@ turn. These pin that ``_on_disconnected`` no longer synthesises an
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import Any
 
 import pytest
@@ -553,13 +554,11 @@ async def test_the_give_up_exit_leaves_a_viewer_that_can_bind_again(tmp_path, mo
     remote, _ = _silent_owner_facade(tmp_path, monkeypatch)
     remote._on_disconnected("send timeout")
     await _await_verdict(remote)
-    exhausted = remote.exhausted_recovery
     can_go_cold = remote._can_go_cold
     runtime_pid = remote.runtime_pid
     await _cancel_recovery(remote)
 
     assert can_go_cold is True, "the viewer can never bind again"
-    assert exhausted is True, "the cold state is not distinguishable from 'no runtime'"
     # `runtime_pid` promises None while cold. Today `_discard_rejected_client`
     # already clears it on every failure path, so this pins the INVARIANT at
     # the exit rather than a defect: a stale live pid would let
@@ -652,9 +651,19 @@ async def test_a_genuinely_dead_owner_still_takes_the_legacy_takeover_path(
 ) -> None:
     """Guard against over-reach: the chase contract survives for a DEAD owner.
 
-    The give-up exit is scoped to the record-present branch. With no record
-    the loop must still reach `_takeover_factory` and keep chasing, exactly as
+    The give-up exit is scoped to a record having been SEEN (`record_seen` in
+    `_recover_owner`). With no record the loop must still reach
+    `_takeover_factory` and keep chasing, exactly as
     ``test_the_real_recovery_loop_bounds_the_turn_on_a_terminal_viewer`` pins.
+
+    WATCHES PAST ITS OWN BOUND, and that is the whole guard. Sampling at an
+    attempt COUNT is what made the first version of this test unable to fail:
+    three takeover attempts arrive at ~0.28 s against a monkeypatched 0.3 s
+    `RECOVERY_GIVE_UP_S`, so it stopped watching ~20 ms before the deadline it
+    exists to prove is never reached, and it stayed green against a tree that
+    took the exit (QA round 1, Q849-2). The wait below is therefore expressed
+    as a multiple of the bound rather than as a number of attempts, and the
+    assertions are read after it has comfortably elapsed.
     """
     monkeypatch.setattr(remote_module, "COLD_FALLBACK_S", 0.05)
     monkeypatch.setattr(remote_module, "RECOVERY_GIVE_UP_S", 0.3)
@@ -677,17 +686,77 @@ async def test_a_genuinely_dead_owner_still_takes_the_legacy_takeover_path(
     remote.set_went_cold_callback(lambda: went_cold.append("cold"))
 
     remote._on_disconnected("owner exited")
-    for _ in range(80):
-        if len(attempts) >= 3:
+    # Watch WELL PAST the bound, never to an attempt count. Three attempts land
+    # before the deadline, so breaking on them samples a loop that has not yet
+    # had the chance to take the exit — the blindness Q849-2 measured. The wait
+    # is a multiple of the monkeypatched bound, so compressing the bound
+    # compresses the test with it and no wall-clock literal is asserted on.
+    deadline = time.monotonic() + remote_module.RECOVERY_GIVE_UP_S * 3
+    while time.monotonic() < deadline:
+        if not remote._recovering:
+            break  # the loop returned: the exit was taken, which is the failure
+        await asyncio.sleep(0.01)
+    still_chasing = remote._recovering
+    cold_calls = list(went_cold)
+    attempt_count = len(attempts)
+    await _cancel_recovery(remote)
+
+    assert attempt_count >= 3, f"the loop stopped chasing a successor: {attempt_count}"
+    assert still_chasing is True, "the no-record branch took the give-up exit"
+    assert cold_calls == [], "a dead owner took the give-up cold exit"
+
+
+@pytest.mark.asyncio
+async def test_an_unusable_record_is_not_a_sighting_for_the_give_up_exit(
+    tmp_path, monkeypatch
+) -> None:
+    """A record this viewer cannot ATTACH to belongs to the dead-owner contract.
+
+    `record_seen` is stamped on the same condition that selects the reattach
+    arm — protocol >= 5 with `FRONTEND_CAPABILITY` — rather than on `record is
+    not None`. A record failing either check falls through to the takeover
+    `else`, so counting it as a sighting would arm the give-up exit for a chase
+    that never had a reattach to give up on: the loop would go cold instead of
+    chasing a successor, which is the over-reach Q849-1 measured wearing a
+    different hat.
+    """
+    monkeypatch.setattr(remote_module, "COLD_FALLBACK_S", 0.05)
+    monkeypatch.setattr(remote_module, "RECOVERY_GIVE_UP_S", 0.3)
+
+    stale = _live_record()
+    stale.protocol = 4  # a pre-frontend owner: discoverable, not attachable
+    monkeypatch.setattr(remote_module, "find_owner_record", lambda *a: (stale, None))
+    attempts: list[int] = []
+
+    async def failing_takeover() -> Any:
+        attempts.append(1)
+        raise RuntimeError("the lease is held by another follower")
+
+    remote = RemoteSession(
+        config_dir=tmp_path,
+        session_id="s1",
+        takeover_factory=failing_takeover,
+    )
+    remote._streaming = True
+    remote._generation = 7
+    remote._ready_for_events = True
+    went_cold: list[str] = []
+    remote.set_went_cold_callback(lambda: went_cold.append("cold"))
+
+    remote._on_disconnected("owner exited")
+    deadline = time.monotonic() + remote_module.RECOVERY_GIVE_UP_S * 3
+    while time.monotonic() < deadline:
+        if not remote._recovering:
             break
         await asyncio.sleep(0.01)
     still_chasing = remote._recovering
     cold_calls = list(went_cold)
+    attempt_count = len(attempts)
     await _cancel_recovery(remote)
 
-    assert len(attempts) >= 3, f"the loop stopped chasing a successor: {len(attempts)}"
-    assert still_chasing is True, "the no-record branch took the give-up exit"
-    assert cold_calls == [], "a dead owner took the give-up cold exit"
+    assert attempt_count >= 3, f"the loop stopped chasing a successor: {attempt_count}"
+    assert still_chasing is True, "an unattachable record armed the give-up exit"
+    assert cold_calls == [], "an unattachable record took the give-up cold exit"
 
 
 @pytest.mark.asyncio
@@ -738,6 +807,17 @@ async def test_the_dial_failure_backoff_reaches_the_recovery_cap(tmp_path, monke
         f"the backoff ceiling is {max(observed)}, not _RECOVERY_DIAL_CAP_S "
         f"({remote_module._RECOVERY_DIAL_CAP_S}) — sequence={observed[:12]}"
     )
-    assert (
-        remote_module._RECOVERY_DIAL_CAP_S > remote_module._BIND_RETRY_DELAY_CAP_S
-    ), "the two backoff shapes are meant to have diverged"
+    # BOTH VALUES, not the ordering. `>` alone stays green if someone raises
+    # `_BIND_RETRY_DELAY_CAP_S` to 1.9 — which is the re-unification the two
+    # constants' comments explicitly forbid, and is the change this assertion
+    # exists to catch (review round 1, R5). Pinning the pair asserts what those
+    # comments promise: 2.0 s of pacing on the storm-capable loop, 0.5 s on the
+    # attempt-bounded one a caller waits through.
+    assert remote_module._RECOVERY_DIAL_CAP_S == 2.0, (
+        "the recovery dial ceiling moved; see _RECOVERY_DIAL_CAP_S for why it "
+        "is 2.0 and must not be re-unified with the bind cap"
+    )
+    assert remote_module._BIND_RETRY_DELAY_CAP_S == 0.5, (
+        "the bind retry ceiling moved; a longer cap here only adds latency to "
+        "a bind a caller is waiting on"
+    )

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -9713,46 +9713,65 @@ async def test_switch_on_a_cold_viewer_says_nothing_switched() -> None:
     assert _unwrapped("(this session)") not in text, text
 
 
-class _ExhaustedRecoveryLabelSession(_ColdAsyncLabelSession):
-    """Cold because recovery GAVE UP on an owner that stayed discoverable.
+class _GaveUpRecoveryLabelSession(_ColdAsyncLabelSession):
+    """The facade shape ``_recover_owner``'s give-up exit actually produces.
 
-    The state ``RemoteSession._recover_owner`` reaches at
-    ``RECOVERY_GIVE_UP_S``: a runtime is alive and simply never answered, so
-    the generic cold sentence is false in its premise.
+    CARRIES ``_ensure_bound``, and that attribute is the entire point of this
+    stub. ``_needs_runtime_first`` routes a cold, non-recovering, non-stopped
+    session on ``callable(getattr(session, "_ensure_bound", None))``, so a fake
+    that omits it takes a route the real ``RemoteSession`` — which always
+    defines it — cannot. An earlier revision of this file pinned a cold-arm
+    notice with such a fake and was green against a branch that never executed
+    in production (review round 1 R1, design round 1 D1).
     """
 
-    @property
-    def exhausted_recovery(self) -> bool:
-        return True
+    def __init__(self) -> None:
+        super().__init__()
+        self.bind_attempts = 0
+
+    async def _ensure_bound(self, *, foreground: bool = True) -> None:
+        # The give-up exit leaves the viewer REBINDABLE against the same live
+        # record, so the repair path really does redial. It raises here because
+        # the owner in this scenario is still silent — the honest outcome, and
+        # the one `_bind_then_dispatch` has a dedicated sentence for.
+        self.bind_attempts += 1
+        error = ConnectionError("the runtime is not responding")
+        setattr(error, "runtime_alive", True)
+        raise error
 
 
 @pytest.mark.asyncio
-async def test_switch_after_recovery_gave_up_does_not_claim_no_runtime_is_running() -> None:
-    """The generic cold copy asserts something FALSE on this path.
+async def test_switch_after_recovery_gave_up_retries_the_bind_and_says_so() -> None:
+    """A give-up facade is REPAIRED by `/model`, not merely described by it.
 
-    A viewer whose owner is live but silent unbinds at ``RECOVERY_GIVE_UP_S``
-    and is then cold — but "no runtime is running for this session; send a
-    message to start one" tells the user to start a runtime that is already
-    running, which is the dead end the operator hit: no number of /model
-    retries or /resumes would switch the model. The honest sentence names the
-    busy runtime, reassures about the transcript (the screen is about to look
-    like a fresh session) and ends in the next step, which really does repair
-    it now that the facade is rebindable.
+    The state ``RemoteSession._recover_owner`` reaches at
+    ``RECOVERY_GIVE_UP_S`` is cold with a callable ``_ensure_bound``, which is
+    exactly what ``_needs_runtime_first`` diverts into ``_bind_then_dispatch``.
+    So the cold ladder in ``_activate_resolved_model`` is never consulted from
+    this state, and the sentence the user reads comes from the bind attempt's
+    own outcome. This pins that route: the command must reach a real rebind
+    (the repair) and report the live-runtime sentence, and must NOT print the
+    generic "no runtime is running" premise, which is false while the owner is
+    discoverable.
     """
-    session = _ExhaustedRecoveryLabelSession()
+    session = _GaveUpRecoveryLabelSession()
     ctrl = _AccessController(stored=("openrouter", "anthropic"))
     app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
     async with app.run_test(size=(110, 24)) as pilot:
         await _await_session(app, pilot)
         app._run_slash_command("/model anthropic/claude-fable-5-1")
         await pilot.pause()
+        await pilot.pause()
         text = _unwrapped(_transcript_text(app))
-    assert _unwrapped("no runtime is running for this session") not in text, (
-        "the false premise is still printed for a live-but-silent owner: " + text
+    assert session.bind_attempts >= 1, (
+        "the typed /model never reached a rebind — the repair, not the copy, "
+        "is what this state needs"
     )
-    assert _unwrapped("this session's runtime is busy and stopped responding") in text, text
-    assert _unwrapped("the conversation is intact") in text, text
-    assert _unwrapped("try /model again to reconnect") in text, text
+    assert _unwrapped("could not reach this session's runtime in time") in text, text
+    assert _unwrapped("it is still running") in text, text
+    assert _unwrapped("no runtime is running for this session") not in text, (
+        "the false premise is printed for a live-but-silent owner: " + text
+    )
     # Still a refusal, not a receipt: nothing was switched.
     assert _unwrapped("(this session)") not in text, text
 

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -9713,6 +9713,50 @@ async def test_switch_on_a_cold_viewer_says_nothing_switched() -> None:
     assert _unwrapped("(this session)") not in text, text
 
 
+class _ExhaustedRecoveryLabelSession(_ColdAsyncLabelSession):
+    """Cold because recovery GAVE UP on an owner that stayed discoverable.
+
+    The state ``RemoteSession._recover_owner`` reaches at
+    ``RECOVERY_GIVE_UP_S``: a runtime is alive and simply never answered, so
+    the generic cold sentence is false in its premise.
+    """
+
+    @property
+    def exhausted_recovery(self) -> bool:
+        return True
+
+
+@pytest.mark.asyncio
+async def test_switch_after_recovery_gave_up_does_not_claim_no_runtime_is_running() -> None:
+    """The generic cold copy asserts something FALSE on this path.
+
+    A viewer whose owner is live but silent unbinds at ``RECOVERY_GIVE_UP_S``
+    and is then cold — but "no runtime is running for this session; send a
+    message to start one" tells the user to start a runtime that is already
+    running, which is the dead end the operator hit: no number of /model
+    retries or /resumes would switch the model. The honest sentence names the
+    busy runtime, reassures about the transcript (the screen is about to look
+    like a fresh session) and ends in the next step, which really does repair
+    it now that the facade is rebindable.
+    """
+    session = _ExhaustedRecoveryLabelSession()
+    ctrl = _AccessController(stored=("openrouter", "anthropic"))
+    app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
+    async with app.run_test(size=(110, 24)) as pilot:
+        await _await_session(app, pilot)
+        app._run_slash_command("/model anthropic/claude-fable-5-1")
+        await pilot.pause()
+        text = _unwrapped(_transcript_text(app))
+    assert _unwrapped("no runtime is running for this session") not in text, (
+        "the false premise is still printed for a live-but-silent owner: " + text
+    )
+    assert _unwrapped("this session's runtime is busy and stopped responding") in text, text
+    assert _unwrapped("the conversation is intact") in text, text
+    assert _unwrapped("try /model again to reconnect") in text, text
+    # Still a refusal, not a receipt: nothing was switched.
+    assert _unwrapped("(this session)") not in text, text
+
+
 class _StoppedFollowerSession(_AsyncLabelSession):
     """The shape a real follower is in after ``/stop``: the socket is closed
     (``is_cold``) but ``frontend_state`` still carries the owner's LAST


### PR DESCRIPTION
## Change authorization

**C1 — standard / pre-authorized bug fix.** This PR is the change record. No version bump (`pyproject.toml` untouched at `0.52.13`; the release owner for the current window bundles it).

`Release: patch — a terminal viewer whose runtime is alive but busy no longer refuses /model, /fork and /compact forever, and no longer parks prompts silently.`

> **Round 1 changed this PR's shape.** Three independent reviewers (code, QA, design) each landed findings; the remediation is commit ``15470f603``. Two claims this description previously made were **disproved in round 1 and have been removed rather than softened**: that the new TUI copy was reachable, and that the give-up exit was scoped to the record-present branch. What survives — and what round 1 independently confirmed — is the session-layer fix. See [Round 1 outcome](#round-1-outcome).

## The defect

Reported from a live session: `/model` would not switch the model, **no matter how many times it was retried or `/resume`d**. Every attempt answered:

> session is reconnecting; try /model again in a moment

It never stopped saying that. The session was permanently unusable and the only way out was to abandon it.

## Root cause

`RemoteSession._recovering` latches forever for a terminal `connect()` viewer whose owner is **live but silent** — a record is discoverable on every pass, the socket accepts and authenticates, but the canonical frontend sync never lands (an owner whose authoritative loop is occupied by a long turn).

`_recovering` is set in `_on_disconnected` and cleared **only** in the `finally` of `_recover_owner`. That loop's only bounded exit is the `cold_deadline` branch, which returns **only when `self._can_go_cold`** — and for a terminal viewer that flag is False (`self._can_go_cold = surface == "desktop"`; `tui/app.py` calls `connect()` without `surface`). The legacy arm beneath it ends the in-flight turn and keeps looping.

The takeover that arm's comment describes as its contract is **unreachable on this path**: `_takeover_factory` is called only in the `else` branch taken when *no usable record exists*. With a record found every pass, the loop takes the `if` branch forever and never reaches it. So there was no `return` reachable at all.

### The blast radius is wider than `/model`

Every request/response seam refuses on `_recovering`: `route_shared_slash`, `set_working_directory`, `acknowledge_attention`, `fork_snapshot`, `compact_now`, `credential_op`, `_consume_model_override`.

**And the prompt path is worse than refused — it parks silently.** `_on_disconnected` clears `_owner_ready`, and its only setters are `_go_cold`, the takeover branch and the deliberate-stop arms, none of which fire here. A prompt waits forever with no message and no spinner resolution.

`/resume` does not help either: it builds a *replacement* `connect()` facade that dials the same silent owner and fails its own foreground bind.

## The fix

**1. A second, longer bound (`RECOVERY_GIVE_UP_S`), scoped to a record having been SEEN.** Checked beside `cold_deadline`, applying only when `not _can_go_cold`. Derived as `2 * HEARTBEAT_TIMEOUT_S` (90 s) rather than written as a literal: the question it bounds is the owner's own liveness contract, and a viewer must not conclude an owner is unreachable *faster* than the registry concludes it is wedged — a turn-boundary stall inside that window is normal.

The exit answers **"an owner is there and will not answer"**, never *"no owner is there"*. The latter is the DEAD shape, whose contract is to keep chasing a successor through the takeover arm, and that contract is unchanged. Because the deadline is necessarily evaluated at the top of the pass — *before* `find_owner_record` runs — the loop tracks the sighting across passes in `record_seen`, stamped on the same condition that selects the reattach arm (protocol >= 5 with `FRONTEND_CAPABILITY`) rather than on `record is not None`.

**2. `_can_go_cold = True` BEFORE `_go_cold()` — load-bearing, not a nicety.** `_ensure_bound` returns immediately when the flag is False, so clearing `_recovering` while leaving it unset produces a viewer that is cold, reports `is_cold` True, and **can never bind again** — a silent no-op replacing today's honest refusal, which is strictly worse than the bug. Measured, and pinned by a test:

```
_can_go_cold=False: is_cold=True  rebinds=[]      <- permanently dead viewer
_can_go_cold=True:  is_cold=False rebinds=[(99999, 15.0)]
```

**3. Dial-failure backoff ceiling → `_RECOVERY_DIAL_CAP_S = 2.0`.** That arm's `continue` skips the loop-bottom sleep, so its own sleep is the only pacing on the path. It matters for the *fast-failure* owner shape (accepts, then rejects the welcome) at a measured 2.33 accepted connections/second — against `ATTACH_MAX_CLIENTS` with LRU eviction that is a real cascade, prior art being the 272-eviction burst on `_discard_rejected_client`. `_bind_under_lock`'s identical-looking ceiling is deliberately **left at 0.5** (it is attempt-bounded inside a budget, so it cannot storm); both comments record that the shapes have diverged and must not be re-unified, and the test now pins **both values** rather than their ordering.

**4. No new TUI copy.** An earlier revision added a fourth arm to `_activate_resolved_model`'s cold ladder, selected by a public `exhausted_recovery` predicate. **Round 1 proved that arm unreachable and it has been deleted** — along with the predicate and the latching flag behind it. See below.

### Why going cold on a LIVE owner is safe

Two hazards were considered and neither materialises:

- **Takeover cannot steal the lease.** `acquire_session_lease` raises `SessionLeaseHeldError` unless the holder is proven dead, so a live owner cannot be robbed even if this arm reached the factory. `_takeover_factory` stays armed for a later genuine death: a subsequent owner loss re-enters the loop and, with the record gone by then, takes the else-branch exactly as it always has.
- **It does not engage a second runtime.** `engage_runtime` short-circuits on a discoverable record (`_deliver` returns `runtime ready` without spawning) and, failing that, waits rather than spawning while a live pid holds the lease.

The terminal state is *unbound viewer, transcript intact, owner still running, next action reconnects* — the same state a desktop viewer already reaches after 8 s.

**Behaviour note for reviewers:** `_can_go_cold` stays True on that facade afterwards, so it takes the viewer contract for any *later* owner death. Intended, and it mirrors what `_go_cold(refresh=True)` already does.

## Round 1 outcome

### The copy was unreachable — the branch is deleted, not relocated

The previous description claimed the new sentence was reachable and that the claim was *"verified, not assumed"*. **It was not, and the evidence behind it was non-probative.** The reviewer (R1) and the designer (D1) established this independently:

`_run_slash_command` consults `_needs_runtime_first` **before** `_cmd_model` → `_activate_resolved_model`. For an argument-bearing `/model` that gate returns True — diverting into `_bind_then_dispatch` — whenever `is_cold and not _recovering and not _deliberate_stop and callable(_ensure_bound)`. That is *exactly* the state the give-up exit produces, and a `RemoteSession` always defines `_ensure_bound`. The old pilot test passed only because its fake omitted that attribute — the very attribute that selects the route.

Measured on a real `RemoteSession` driven to the real give-up exit:

```
=== state at the give-up exit (real RemoteSession) ===
  recovering          = False
  is_cold             = True
  can_go_cold         = True
  deliberate_stop     = False
  ensure_bound        = True
  runtime_pid         = None

  _needs_runtime_first diverts /model p/id = True
```

**Remedy 1 was taken (delete the branch), and the reason is stronger than "unreachable".** The divert is not merely where dispatch lands — it is where the *repair* happens. Driving the diverted path against the still-silent owner:

```
=== _bind_then_dispatch's await: _ensure_bound(foreground=True) ===
  raised RuntimeUnresponsiveError  actionable=False runtime_alive=True
    text    = 'the runtime is not responding'
    elapsed = 0.88s
  dials issued during the attempt = 5

  => USER READS: "could not reach this session's runtime in time — it is
                  still running; try that again in a moment"
```

Five real dials — the rebind the give-up exit exists to make possible. Teaching `_needs_runtime_first` to decline the divert (remedy 2) would have traded that repair for a nicer string. The sentence the user already gets is also **honest on both counts round 1 raised against the proposed copy**: it hedges with *"in a moment"* (D2) and claims nothing about the transcript (D3).

### The latching flag is deleted, not patched

R2 proved `_recovery_exhausted` latches: it was cleared only on `_bind_to`'s success tail, while `_recover_owner`'s own reattach path rebinds inline without going through `_bind_to`. A viewer that gave up once and later lost a **genuinely dead** owner still reported `exhausted_recovery=True`.

With the copy branch gone the flag had no consumer. It was **deleted outright** rather than left as dead state with two more clear-sites added: state whose only defence is remembering to clear it everywhere will latch again the next time an exit is added.

```
RemoteSession defines 'exhausted_recovery': False
occurrences of '_recovery_exhausted' in remote.py: 0
```

### The over-reach is fixed and the guard test can now fail

Q849-1/R3: the exit was not scoped to the record-present branch despite the comment and the guard test docstring both asserting it was (give-up @ +81, `find_owner_record` @ +136). QA reproduced a no-record terminal viewer taking the exit. Now gated on `record_seen`; the comment and the constant's docstring were rewritten to state what the code does.

QA's own repro shape, replayed against the fixed tree:

```
=== Q849-1 REPRO (a genuinely dead owner, no record) ===
  watched_for_s               = 2.0
  give_up_bound_s             = 0.3
  takeover_attempts           = 6
  still_chasing (_recovering) = True   <- contract says True
  went_cold                   = []     <- contract says []
```

Q849-2: `test_a_genuinely_dead_owner_still_takes_the_legacy_takeover_path` could not fail — it broke at 3 takeover attempts (~0.28 s), ~20 ms before its own 0.3 s bound. It now watches to `RECOVERY_GIVE_UP_S * 3`, expressed as a multiple of the bound so compressing the bound compresses the test.

### The original defect is still fixed

```
=== ORIGINAL DEFECT (live but silent owner) ===
  reached_a_verdict = True
  recovering        = False  (was: latched True forever)
  can_go_cold       = True   (rebindable)
  went_cold         = ['cold']
  runtime_pid       = None
```

## Cross-PR interaction with #860

#860 (`9a8fb2c02`, in this base) releases parked sidebar viewers after 5 idle minutes; its author asked to be told rather than worked around, cautioning that a sidebar-leased source is "terminal" so `_can_go_cold` is False, and that #860's design assumed a parked source could never take a cold path.

**Measured, and the premise is narrower than stated.** `_lease_sidebar_source` has two branches:

```
branch 1: NOT speculative (a CLICK) -> RemoteSession.saved_preview(...)
    _can_go_cold at birth = True     <- ALREADY cold-capable, on the base
branch 2: speculative (PREWARM)      -> RemoteSession.connect(...)
    _can_go_cold at birth = False    <- #860's premise holds HERE only
```

So the click path was cold-capable before this PR and is unaffected by it. Only the prewarm path is flipped, and only after a full `RECOVERY_GIVE_UP_S` recovery episode.

**On that path this PR removes the hazard #860 documents rather than adding one.** #860's own docstring says *"a bare EOF sends a parked source — which cannot go cold — into an unbounded redial storm."* On the base that is exactly what happens; here it is bounded.

**The flagged race (retire accepted FIRST, then a rebind rediscovers the record during teardown) does not open.** The give-up exit issues no dial and no `_ensure_bound` — it unbinds and returns — so a rebind needs a separate caller, and `_release_sidebar_source` disposes the facade, which `_ensure_bound`'s first guard (`if not self._can_go_cold or self._disposed`) refuses. Measured across the one real window (between the accepted retire offer and `dispose()`):

```
  [HEAD (bounded)]     dials during the retire->dispose window = 0   total dials = 2
  [BASE (unbounded)]   dials during the retire->dispose window = 1   total dials = 5
```

Neither `_sidebar_source_releasable` nor `_sweep_idle_sidebar_sources` consults coldness at all, so the sweep's decisions are unchanged either way. **Verdict: no defensive change made, and none needed.**

## Tests

`tests/unit/session/test_remote_disconnect.py` plus one TUI pilot test. **Each was proved to fail without the change**, not merely asserted to pass with it.

Removing the `record_seen` gate (the round-1 over-reach, restored as a mutation):

```
FAILED test_a_genuinely_dead_owner_still_takes_the_legacy_takeover_path
  AssertionError: the no-record branch took the give-up exit
FAILED test_an_unusable_record_is_not_a_sighting_for_the_give_up_exit
  AssertionError: an unattachable record armed the give-up exit
2 failed, 19 passed
```

Stamping the sighting on `record is not None` instead of the attachable condition:

```
FAILED test_an_unusable_record_is_not_a_sighting_for_the_give_up_exit
  AssertionError: the loop stopped chasing a successor: 0
```

Removing `_ensure_bound` from the new pilot stub — i.e. reverting it to the shape that made the old test non-probative:

```
FAILED test_switch_after_recovery_gave_up_retries_the_bind_and_says_so
  AssertionError: the typed /model never reached a rebind — the repair, not
  the copy, is what this state needs
```

Reverting the backoff ceiling to `0.5`:

```
FAILED test_the_dial_failure_backoff_reaches_the_recovery_cap
  assert 0.5 == 2.0 ± 2.0e-06
```

The four original latch guards (`..._does_not_latch_the_viewer_forever`, `..._leaves_a_viewer_that_can_bind_again`, `..._no_longer_driven_by_the_recovery_flag`, `..._parked_prompt_is_released_by_the_bound`) are unchanged and still fail when the give-up branch is removed.

## Rendered frames

Captured through the real `OperatorApp` under `run_test` (the app that loads `local_operator.tcss`), via `scripts.visual_capture.save_capture`, rasterised and viewed. Isolated config dir, every inherited `CMUX_*` unset, synthetic session ids.

```
=== generic cold (neighbour, unchanged) ===
    ! no runtime is running for this session; send a message to start one,
      then run /model again

=== give-up facade, on the route it ACTUALLY takes (has _ensure_bound) ===
    · could not reach this session's runtime in time — it is still running;
      try that again in a moment
```

The second frame is what this PR's user-visible half now delivers: not new copy, but the correct existing sentence reached by a path that also retries the bind.

## Gates

Run over the whole tree, exactly as CI:

```
.venv/bin/python -m flake8 .                                  rc=0
uvx --from black==26.1.0 black --check .                      1173 files unchanged
uvx isort==5.13.2 --check .                                   rc=0
.venv/bin/python -m pyright --pythonpath .venv/bin/python .   0 errors, 0 warnings
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
  17426 passed, 18 skipped in 2482.90s (0:41:22)
```

## Not addressed

- **Self-healing recovery** (clear `_recovering` but keep the loop dialling so the viewer rebinds on its own) is deliberately rejected here: `_recover_owner` never takes `_bind_lock`, so the flag is the *only* thing serialising it against `_ensure_bound`. Clearing it while the loop still dials removes that ordering and risks the half-bound state `_discard_rejected_client` exists to prevent. It belongs in a loop that takes the lock — a larger change than this defect justifies.
- **No `/reconnect` command.** It would duplicate the automatic repair (any action after the bound) and the typed one (`/resume`).
- The `_runtime_pid` clear at the new exit is a **belt, not a live repair**: verified unreachable with a stamped pid today because every failure path routes through `_discard_rejected_client` first. Kept because the invariant is not local (`_go_cold` does not clear it while `runtime_pid` promises None while cold), and the comment says exactly that rather than claiming a fix.
- The other two `"no runtime is running for this session"` sites (`/credential`, and the cold-bind seam) are **left alone** — out of scope, and neither is on the path this defect reaches.
- **D4/D5 (nits) declined** — see the remediation comment.
