### PR TITLE
perf(read): bound internal-URL reads with a head + section outline

### DIFF
--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -2271,7 +2271,12 @@ def _clamp_file_body(body: str, path: Path, start: int, total: int) -> str:
 #: Markdown ATX headings, depth 1-3, at line start. Depth 4+ is deliberately
 #: out: a document deep enough to need them has more headings than an outline
 #: budget can carry, and the depth fallback would drop them first anyway.
-_HEADING_RE = re.compile(r"(?m)^(#{1,3}) +(\S.*?)\s*$")
+_HEADING_RE = re.compile(r"^(#{1,3}) +(\S.*?)\s*$")
+
+#: A fenced-code delimiter. Both markdown fence styles, and only ever tested
+#: against an already-lstripped line, so an indented fence inside a list item
+#: still toggles.
+_FENCE_PREFIXES = ("```", "~~~")
 
 
 def _internal_read_limit() -> int:
@@ -2304,18 +2309,45 @@ class _Heading(NamedTuple):
     end: int
 
 
-def _collect_headings(content: str) -> list[_Heading]:
-    """Every depth-1..3 heading with the line span of its section."""
-    lines = content.splitlines()
+def _collect_headings(lines: list[str]) -> list[_Heading]:
+    """Every depth-1..3 heading OUTSIDE a fenced code block, with its span.
+
+    Scans line by line rather than running the pattern over the whole document,
+    and takes the caller's already-``splitlines()`` list so the line numbers
+    here are the SAME basis the spill store serves ranges on. That shared basis
+    is the invariant the advertised ``[lines N-M]`` spans depend on; a parallel
+    offset counter is how those numbers silently drift apart (notably on CRLF,
+    where a ``len(line) + 1`` accounting under-counts by one char per line).
+
+    Fenced blocks are skipped, and that is a correctness fix rather than
+    tidiness. These documents are full of shell examples, so a ``# comment``
+    inside a fence used to parse as a heading — 19 phantoms across 6 bundled
+    guides. The cosmetic harm is a junk index entry; the harm that matters is
+    that a section's ``end`` is the next heading's start minus one, so a phantom
+    INSIDE a real section silently truncates that section's advertised range.
+    ``guide://browser``'s "0. Make sure the paired browser is actually open"
+    advertised lines 151-157 against a true 151-191, so an agent following the
+    footer's own instruction got a fragment with no signal that 34 lines were
+    missing — the exact "expansion returns the wrong text" failure this whole
+    shape exists to prevent.
+    """
     total = len(lines)
     found: list[tuple[int, str, int]] = []
-    for match in _HEADING_RE.finditer(content):
-        # ``count`` over the prefix is O(n) per heading but n is a few dozen
-        # headings over ~80 KB, which is microseconds — and it cannot drift
-        # from the ``splitlines`` basis the spill store serves ranges on,
-        # which a parallel hand-rolled line counter could.
-        line_no = content.count("\n", 0, match.start()) + 1
-        found.append((len(match.group(1)), match.group(2), line_no))
+    in_fence = False
+    for index, line in enumerate(lines):
+        stripped = line.lstrip()
+        if stripped.startswith(_FENCE_PREFIXES):
+            # An unclosed fence keeps everything after it out of the index,
+            # which is the safe direction: a phantom corrupts a real section's
+            # span, while a missed heading only costs one index entry and the
+            # enclosing section still covers those lines.
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        match = _HEADING_RE.match(line)
+        if match:
+            found.append((len(match.group(1)), match.group(2), index + 1))
     return [
         _Heading(depth, text, start, (found[i + 1][2] - 1) if i + 1 < len(found) else total)
         for i, (depth, text, start) in enumerate(found)
@@ -2362,9 +2394,14 @@ def _heading_outline(headings: list[_Heading], handle: str, budget: int) -> str:
             head_lines.append(line)
             used += len(line) + 1
         dropped = len(lines) - len(head_lines)
+        # Names what the call ACTUALLY returns. Spill search caps at
+        # SPILL_SEARCH_MATCH_LIMIT and its ``range`` pages through MATCHES, not
+        # lines, so a promise to "list every heading" is false past that cap and
+        # a footer that over-promises teaches the model expansion does not work.
         head_lines.append(
             f"[+{dropped} more sections not listed; "
-            f'read(path="{handle}?q=^#") lists every heading]'
+            f'read(path="{handle}?q=^#") lists the first '
+            f"{SPILL_SEARCH_MATCH_LIMIT} headings]"
         )
         return "\n".join(head_lines)
     return ""
@@ -2397,13 +2434,28 @@ def _shape_internal_document(
     if limit == 0 or len(content) <= limit:
         return content, None
 
+    # ONE line basis for the heading scan, the head cut and the spill store
+    # alike. Splitting the document once and passing the list down is what
+    # keeps the advertised ``[lines N-M]`` spans in the same coordinate space
+    # the handle resolves in.
+    lines = content.splitlines()
+
     meta = _spill(content, "read", context)
     if meta is None:
         # Same degradation contract as the rest of the module: losing
-        # expansion is an inconvenience, failing the call is a bug.
-        return truncate_output(content, limit), None
+        # expansion is an inconvenience, failing the call is a bug. The banner
+        # still leads the result: this is the path where the agent has LESS
+        # recourse (no handle to expand), so the statement that it has not read
+        # the whole document matters more here, not less.
+        degraded_banner = (
+            f"[{target} — {len(lines)} lines, {len(content)} chars. This is a PARTIAL "
+            f"view and the full text could not be saved for expansion. You have NOT "
+            f"read the whole document; re-read it to see any section not shown.]"
+        )
+        budget = max(limit - len(degraded_banner) - 2, 0)
+        return f"{degraded_banner}\n\n{truncate_output(content, budget)}", None
 
-    headings = _collect_headings(content)
+    headings = _collect_headings(lines)
     if len(headings) < INTERNAL_READ_MIN_HEADINGS:
         # No addressable structure to index — fall through to the plain uniform
         # head+tail every other oversized output gets.
@@ -2412,9 +2464,9 @@ def _shape_internal_document(
 
     # Cut the head at a heading boundary so it never ends mid-rule: the last
     # heading that starts at or under the budget wins, and everything from it
-    # onward belongs to the outline. Offsets come from one prefix scan rather
-    # than a re-sum per heading, so this stays linear in the document.
-    lines = content.splitlines()
+    # onward belongs to the outline. Offsets come from one prefix scan over the
+    # SAME line list, using the real line lengths, so the accounting does not
+    # under-count a CRLF document by one char per line.
     offsets = [0]
     for line in lines:
         offsets.append(offsets[-1] + len(line) + 1)
@@ -2424,14 +2476,15 @@ def _shape_internal_document(
             break
         head_end_line = heading.start - 1
     if head_end_line == 0:
-        # First heading is already past the budget (a long frontmatter): take a
-        # plain line-boundary cut rather than emitting an empty head.
-        clipped = content[:INTERNAL_READ_HEAD_CHARS]
-        cut = clipped.rfind("\n")
-        head_text = clipped[:cut] if cut > 0 else clipped
-        head_end_line = len(head_text.splitlines())
-    else:
-        head_text = "\n".join(lines[:head_end_line])
+        # First heading is already past the budget (a long frontmatter): cut on
+        # a line boundary rather than emitting an empty head.
+        head_end_line = 0
+        for index in range(len(lines)):
+            if offsets[index + 1] > INTERNAL_READ_HEAD_CHARS:
+                break
+            head_end_line = index + 1
+        head_end_line = max(head_end_line, 1)
+    head_text = "\n".join(lines[:head_end_line])
 
     # Never empty by construction: ``head_end_line`` is the last FITTING
     # heading's start minus one, so that heading always lands here. That is
@@ -2441,6 +2494,22 @@ def _shape_internal_document(
     # rather than dropping it. Pinned by
     # test_the_outline_covers_every_line_past_the_head.
     remaining = [h for h in headings if h.start > head_end_line]
+
+    # A document whose first heading sits far below the head cut (a long
+    # frontmatter) would otherwise leave every line between the two addressable
+    # by NOTHING — measured at 109 orphaned lines on a 200-line frontmatter —
+    # while the banner asserts the index is complete. Cover the gap with an
+    # explicit entry so the completeness claim stays true by construction.
+    if remaining and remaining[0].start > head_end_line + 1:
+        remaining = [
+            _Heading(
+                1,
+                "(unindexed lines before the first section)",
+                head_end_line + 1,
+                remaining[0].start - 1,
+            )
+        ] + remaining
+
     outline = _heading_outline(remaining, meta.handle, INTERNAL_READ_OUTLINE_CHARS)
 
     # The banner goes at the TOP, not only in the footer. The model reads a
@@ -2449,9 +2518,9 @@ def _shape_internal_document(
     # arrive before the content it qualifies.
     banner = (
         f"[{target} — {len(lines)} lines, {len(content)} chars. This is a PARTIAL "
-        f"view: the head below plus a complete index of every remaining section. "
-        f"You have NOT read the whole document. Expand any section you intend to "
-        f"act on before acting on it.]"
+        f"view: the head below plus an index of every remaining section (headings "
+        f"of depth 1-3). You have NOT read the whole document. Expand any section "
+        f"you intend to act on before acting on it.]"
     )
     # A concrete call derived from a REAL outline entry, following the
     # _spill_footer discipline: a footer that describes an expansion instead of

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -61,7 +61,7 @@ from collections import deque
 from collections.abc import Awaitable, Callable, Iterator
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal, NamedTuple, cast
 from urllib.parse import urlsplit
 
 from pydantic import (
@@ -206,6 +206,50 @@ READ_LINE_CAP = 2000
 #: spill handle, because spilling a copy of a file that is already on disk
 #: would double the bytes for nothing.
 READ_OUTPUT_LIMIT_CHARS = TOOL_OUTPUT_LIMIT_CHARS
+
+#: Char budget for an internal-URL read (``skill://``, ``guide://``, ``mcp://``)
+#: before it is shaped into a map. DELIBERATELY 16 KiB rather than
+#: :data:`READ_OUTPUT_LIMIT_CHARS`, and the asymmetry is the point.
+#:
+#: Instructional markdown is not a log tail. A guide the model is REQUIRED to
+#: read (``prompts_md/system.md``) delivered whole in one call beats the same
+#: guide split into an outline it must then expand twice, so the threshold is
+#: set to return mid-sized documents untouched and intervene only on the few
+#: pathological ones. Measured over the 43 skill/guide docs on the authoring
+#: machine: 8 KiB returns 23/43 whole, 16 KiB returns 34/43, 32 KiB returns
+#: 37/43 while halving the saving. 16 KiB is where the intervention lands on
+#: the four 46-80 KB documents that are the entire problem.
+#:
+#: The threshold is not the output size: shaping compresses an 80 KB skill to
+#: ~7 KB either way, so raising it from 8 to 16 KiB costs almost nothing on the
+#: oversized docs and only decides which mid-sized docs stay whole.
+#:
+#: Overridable via :data:`INTERNAL_READ_LIMIT_ENV` for rollout; ``0`` disables
+#: shaping entirely.
+INTERNAL_READ_LIMIT_CHARS = 16 * 1024
+#: Kill switch for the shaping above. Read per call, never cached at import, so
+#: the operator (or a test) can turn it off in one variable without waiting for
+#: a release — the same discipline :func:`_grep_engine` uses.
+INTERNAL_READ_LIMIT_ENV = "LOCAL_OPERATOR_INTERNAL_READ_LIMIT"
+#: Head kept when an internal document is shaped, cut at a heading boundary.
+#: Sized to cover the ROUTING sections rather than an arbitrary prefix: in the
+#: largest skill on the authoring machine the frontmatter, title and the two
+#: "what you must go read next" sections are 70 lines / 4,645 chars, so 6 KiB
+#: keeps them plus slack and stops before the body rules the outline indexes.
+INTERNAL_READ_HEAD_CHARS = 6 * 1024
+#: Ceiling on the heading outline. Bounded separately from the head so a
+#: heading-dense document cannot turn the map back into the dump it replaced;
+#: the depth fallback in :func:`_heading_outline` spends this budget by
+#: dropping DEPTH (### then ##), which keeps every remaining entry complete,
+#: before it resorts to eliding entries and saying how many it dropped.
+INTERNAL_READ_OUTLINE_CHARS = 4 * 1024
+#: Minimum headings for the outline shape to be worth building. Below this a
+#: document has no addressable structure to index, so it degrades to the plain
+#: uniform :func:`spill_truncate` head+tail every other oversized output gets.
+INTERNAL_READ_MIN_HEADINGS = 3
+#: Slack the bound tests allow over :data:`INTERNAL_READ_LIMIT_CHARS` for a
+#: shaped result: head + outline + banner + footer framing.
+INTERNAL_READ_SHAPE_SLACK_CHARS = 4 * 1024
 #: Lines a footer suggests per expansion call. Sized so one page of ordinary
 #: log text lands inside :data:`TOOL_OUTPUT_LIMIT_CHARS` (~55 head + ~55 tail
 #: lines measured at 8 KiB, so 200 lines of typical 40-char output is the
@@ -2224,6 +2268,208 @@ def _clamp_file_body(body: str, path: Path, start: int, total: int) -> str:
     )
 
 
+#: Markdown ATX headings, depth 1-3, at line start. Depth 4+ is deliberately
+#: out: a document deep enough to need them has more headings than an outline
+#: budget can carry, and the depth fallback would drop them first anyway.
+_HEADING_RE = re.compile(r"(?m)^(#{1,3}) +(\S.*?)\s*$")
+
+
+def _internal_read_limit() -> int:
+    """The shaping threshold in force, honouring the kill switch.
+
+    Read per call rather than cached at import so the override can be set
+    after this module is imported — the same reason :func:`_grep_engine` and
+    :func:`spill_dir` resolve late. A malformed or negative value falls back to
+    the default instead of raising: a bad environment variable must not turn
+    every ``read skill://`` into a failed tool call.
+    """
+    raw = os.environ.get(INTERNAL_READ_LIMIT_ENV)
+    if not raw:
+        return INTERNAL_READ_LIMIT_CHARS
+    try:
+        value = int(raw)
+    except ValueError:
+        return INTERNAL_READ_LIMIT_CHARS
+    return value if value >= 0 else INTERNAL_READ_LIMIT_CHARS
+
+
+class _Heading(NamedTuple):
+    """One outline entry: ``depth`` hashes, ``text``, and the 1-based line span
+    it covers in the SPILLED copy (``end`` inclusive, up to the next heading of
+    any depth or EOF)."""
+
+    depth: int
+    text: str
+    start: int
+    end: int
+
+
+def _collect_headings(content: str) -> list[_Heading]:
+    """Every depth-1..3 heading with the line span of its section."""
+    lines = content.splitlines()
+    total = len(lines)
+    found: list[tuple[int, str, int]] = []
+    for match in _HEADING_RE.finditer(content):
+        # ``count`` over the prefix is O(n) per heading but n is a few dozen
+        # headings over ~80 KB, which is microseconds — and it cannot drift
+        # from the ``splitlines`` basis the spill store serves ranges on,
+        # which a parallel hand-rolled line counter could.
+        line_no = content.count("\n", 0, match.start()) + 1
+        found.append((len(match.group(1)), match.group(2), line_no))
+    return [
+        _Heading(depth, text, start, (found[i + 1][2] - 1) if i + 1 < len(found) else total)
+        for i, (depth, text, start) in enumerate(found)
+    ]
+
+
+def _heading_outline(headings: list[_Heading], handle: str, budget: int) -> str:
+    """The section index, complete unless the budget physically forbids it.
+
+    COMPLETENESS IS THE FEATURE, not a nicety, and this is the part a future
+    reader is most likely to "simplify" away. A head-only truncation of an
+    instructional document is a silent behavioural regression: in the largest
+    skill on the authoring machine the binding ``## Mandatory Agent Review
+    Gate`` sits at char offset 30,343 and the human-reviewer decision tree at
+    60,012, while the frontmatter phrase "agent-review round" at offset 420
+    survives any head cap. The result therefore READS complete while every
+    operative rule has been deleted, and an agent acting on it merges without a
+    review round. Cheaper and wrong is worse than expensive and right.
+
+    So no rule may become invisible. Budget pressure is spent on DEPTH first —
+    drop ``###`` entries, then ``##`` — because a shallower outline still names
+    every region of the document and its ranges still cover every line. Only if
+    depth-1 alone overflows does it elide entries, and then it says how many it
+    dropped and how to list them.
+    """
+    for min_depth in (3, 2, 1):
+        kept = [h for h in headings if h.depth <= min_depth]
+        if not kept:
+            continue
+        lines = [f"{'#' * h.depth} {h.text}  [lines {h.start}-{h.end}]" for h in kept]
+        rendered = "\n".join(lines)
+        if len(rendered) <= budget:
+            return rendered
+        if min_depth > 1:
+            continue
+        # Depth-1 alone still overflows: keep the prefix that fits and name the
+        # escape hatch, so the dropped sections are one call away rather than
+        # unknowable.
+        head_lines: list[str] = []
+        used = 0
+        for line in lines:
+            if used + len(line) + 1 > budget - 120:
+                break
+            head_lines.append(line)
+            used += len(line) + 1
+        dropped = len(lines) - len(head_lines)
+        head_lines.append(
+            f"[+{dropped} more sections not listed; "
+            f'read(path="{handle}?q=^#") lists every heading]'
+        )
+        return "\n".join(head_lines)
+    return ""
+
+
+def _shape_internal_document(
+    content: str, target: str, context: ToolContext | None
+) -> tuple[str, dict[str, Any] | None]:
+    """``(display_text, spill_details)`` for one internal-URL document.
+
+    This branch serves the LARGEST documents in the system (skills and guides
+    run to 80 KB) and was the one ``read`` outcome with no bound at all, so a
+    single ``read skill://…`` injected ~27k billed tokens that ``_is_prunable``
+    then pinned for the life of the session.
+
+    Shape is head + COMPLETE heading outline, not head-only — see
+    :func:`_heading_outline` for why that distinction is load-bearing rather
+    than stylistic. Documents under the threshold are returned byte-identical:
+    most guides fit, and the MUST-read guide rule stays untouched for them.
+
+    The caller must keep the ORIGINAL ``skill://`` URL in ``details['url']``.
+    ``_is_prunable`` (compaction/pruning.py) matches on that prefix to exempt
+    skill reads from pruning, and post-shaping the exempted result carries the
+    spill handle the agent needs to expand — rewriting ``url`` to the handle
+    would silently disable the exemption and blank the address of the very
+    expansion the footer just promised.
+    """
+    limit = _internal_read_limit()
+    # ``0`` is the documented kill switch, not a zero-length budget.
+    if limit == 0 or len(content) <= limit:
+        return content, None
+
+    meta = _spill(content, "read", context)
+    if meta is None:
+        # Same degradation contract as the rest of the module: losing
+        # expansion is an inconvenience, failing the call is a bug.
+        return truncate_output(content, limit), None
+
+    headings = _collect_headings(content)
+    if len(headings) < INTERNAL_READ_MIN_HEADINGS:
+        # No addressable structure to index — fall through to the plain uniform
+        # head+tail every other oversized output gets.
+        body, span = _elide_inline(content, limit)
+        return body + _spill_footer(meta, span), {"spill": _spill_detail(meta)}
+
+    # Cut the head at a heading boundary so it never ends mid-rule: the last
+    # heading that starts at or under the budget wins, and everything from it
+    # onward belongs to the outline. Offsets come from one prefix scan rather
+    # than a re-sum per heading, so this stays linear in the document.
+    lines = content.splitlines()
+    offsets = [0]
+    for line in lines:
+        offsets.append(offsets[-1] + len(line) + 1)
+    head_end_line = 0
+    for heading in headings:
+        if offsets[heading.start - 1] > INTERNAL_READ_HEAD_CHARS:
+            break
+        head_end_line = heading.start - 1
+    if head_end_line == 0:
+        # First heading is already past the budget (a long frontmatter): take a
+        # plain line-boundary cut rather than emitting an empty head.
+        clipped = content[:INTERNAL_READ_HEAD_CHARS]
+        cut = clipped.rfind("\n")
+        head_text = clipped[:cut] if cut > 0 else clipped
+        head_end_line = len(head_text.splitlines())
+    else:
+        head_text = "\n".join(lines[:head_end_line])
+
+    # Never empty by construction: ``head_end_line`` is the last FITTING
+    # heading's start minus one, so that heading always lands here. That is
+    # what makes the tail addressable no matter how the headings are
+    # distributed — a document with three headings at the top and 4,000 lines
+    # of prose after them indexes the prose under its last heading's span
+    # rather than dropping it. Pinned by
+    # test_the_outline_covers_every_line_past_the_head.
+    remaining = [h for h in headings if h.start > head_end_line]
+    outline = _heading_outline(remaining, meta.handle, INTERNAL_READ_OUTLINE_CHARS)
+
+    # The banner goes at the TOP, not only in the footer. The model reads a
+    # result top-down and may act on the head before it ever reaches a trailing
+    # footer, so the statement "you have NOT read this whole document" has to
+    # arrive before the content it qualifies.
+    banner = (
+        f"[{target} — {len(lines)} lines, {len(content)} chars. This is a PARTIAL "
+        f"view: the head below plus a complete index of every remaining section. "
+        f"You have NOT read the whole document. Expand any section you intend to "
+        f"act on before acting on it.]"
+    )
+    # A concrete call derived from a REAL outline entry, following the
+    # _spill_footer discipline: a footer that describes an expansion instead of
+    # spelling one out teaches the model that expansion does not work.
+    example = remaining[0]
+    example_end = min(example.end, example.start + SPILL_PAGE_LINES - 1)
+    footer = (
+        f"\n[The FULL document ({meta.lines} lines) is saved at {meta.handle}. "
+        f"The [lines N-M] spans above are coordinates INTO that handle:\n"
+        f'  read(path="{meta.handle}", range="{example.start}-{example_end}")'
+        f"  -> the '{example.text}' section\n"
+        f'  read(path="{meta.handle}?q=<regex>")  -> find a section by name first]'
+    )
+    body = f"{banner}\n\n{head_text}\n\n[... {len(remaining)} further sections not shown; "
+    body += f"indexed below ...]\n\n{outline}\n{footer}"
+    return body, {"spill": _spill_detail(meta)}
+
+
 def _joined_capped_list_body(
     full_items: list[str],
     shown_items: list[str],
@@ -2682,7 +2928,13 @@ async def execute_read(
         # gets re-read in a loop. Declaring a key would be inert for those and
         # would add avoidable risk for the rest, since a resolver result is not
         # always the same content under the same URL.
-        return _text(tool_call_id, "read", content, details={"url": target})
+        #
+        # ``url`` MUST stay the original internal URL. ``_is_prunable`` keys the
+        # skill exemption off ``details['url'].startswith('skill://')``;
+        # substituting the spill handle here would silently disable it and let
+        # compaction blank the result that carries the expansion handle.
+        body, spill_details = _shape_internal_document(content, target, context)
+        return _text(tool_call_id, "read", body, details={"url": target, **(spill_details or {})})
 
     cwd = _safe_cwd(context)
     path, inside, resolvable = _resolve_workspace_path(target, cwd)
@@ -2715,11 +2967,21 @@ async def execute_read(
         # output) is tens of thousands of stat calls, and the loop this
         # coroutine rides is the one rendering the TUI.
         entries = await asyncio.to_thread(_list_dir_entries, path)
+        # Bounded like every other read outcome: a directory with tens of
+        # thousands of entries (a node_modules, a build output) joined raw is
+        # the same unbounded-result defect the internal-URL branch had, and the
+        # entries beyond the cap are what a spill handle is for.
+        listing, spill_details = spill_truncate(
+            f"Directory listing of {path} ({len(entries)} entries):\n" + "\n".join(entries),
+            "read",
+            context,
+            READ_OUTPUT_LIMIT_CHARS,
+        )
         return _text(
             tool_call_id,
             "read",
-            f"Directory listing of {path} ({len(entries)} entries):\n" + "\n".join(entries),
-            details={"path": str(path)},
+            listing,
+            details={"path": str(path), **(spill_details or {})},
         )
 
     # Stat, content sniff and body read are one worker-thread transaction.

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -58,7 +58,7 @@ import time
 import traceback
 import unicodedata
 from collections import deque
-from collections.abc import Awaitable, Callable, Iterator
+from collections.abc import Awaitable, Callable, Iterator, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal, NamedTuple, cast
@@ -2278,6 +2278,13 @@ _HEADING_RE = re.compile(r"^(#{1,3}) +(\S.*?)\s*$")
 #: still toggles.
 _FENCE_PREFIXES = ("```", "~~~")
 
+#: An opening or closing code fence: at least three backticks or tildes,
+#: optionally indented. The run length and the character are both captured
+#: because CommonMark closes a fence only on the SAME character at the SAME
+#: length or longer — a parity toggle that ignores them lets a nested ``` close
+#: an enclosing ````markdown block, and lets ``~~~`` close a ``` block.
+_FENCE_RE = re.compile(r"^(?P<fence>(?P<char>`|~)(?P=char){2,})(?P<info>.*)$")
+
 
 def _internal_read_limit() -> int:
     """The shaping threshold in force, honouring the kill switch.
@@ -2309,7 +2316,7 @@ class _Heading(NamedTuple):
     end: int
 
 
-def _collect_headings(lines: list[str]) -> list[_Heading]:
+def _collect_headings(lines: Sequence[str]) -> list[_Heading]:
     """Every depth-1..3 heading OUTSIDE a fenced code block, with its span.
 
     Scans line by line rather than running the pattern over the whole document,
@@ -2333,21 +2340,42 @@ def _collect_headings(lines: list[str]) -> list[_Heading]:
     """
     total = len(lines)
     found: list[tuple[int, str, int]] = []
-    in_fence = False
+    # The OPEN fence's delimiter, or None outside a fence. Tracking the
+    # character and length rather than a bare parity bit is what makes nesting
+    # safe: these documents embed fenced examples inside ````markdown blocks,
+    # so a toggle would treat the inner ``` as a close, resume indexing inside
+    # the block and reintroduce the phantom-heading defect this scan exists to
+    # prevent — and a phantom does not merely add a junk entry, it truncates
+    # the advertised span of the section containing it. Live example: the msd
+    # skill's ````markdown block at 812-826 wraps a nested ``` at 817-822, and
+    # an unindented `# ...` inside it would cut `### Comment format` from
+    # 763-855 to 763-817, hiding the review-gate comment template.
+    open_fence: str | None = None
     for index, line in enumerate(lines):
-        stripped = line.lstrip()
-        if stripped.startswith(_FENCE_PREFIXES):
+        match = _FENCE_RE.match(line.lstrip())
+        if match:
+            delimiter = match.group("fence")
+            if open_fence is None:
+                # An info string ("```sh", "````markdown") is allowed on an
+                # opener only, so a line carrying one can never be a closer.
+                open_fence = delimiter
+                continue
+            # CommonMark: a closer matches the opener's character and is at
+            # least as long, and carries no info string.
+            if delimiter[0] == open_fence[0] and len(delimiter) >= len(open_fence):
+                if not match.group("info").strip():
+                    open_fence = None
+                    continue
+            # Otherwise it is ordinary content inside the open fence.
+        if open_fence is not None:
             # An unclosed fence keeps everything after it out of the index,
             # which is the safe direction: a phantom corrupts a real section's
             # span, while a missed heading only costs one index entry and the
-            # enclosing section still covers those lines.
-            in_fence = not in_fence
+            # enclosing section still covers those lines (its end is ``total``).
             continue
-        if in_fence:
-            continue
-        match = _HEADING_RE.match(line)
-        if match:
-            found.append((len(match.group(1)), match.group(2), index + 1))
+        heading = _HEADING_RE.match(line)
+        if heading:
+            found.append((len(heading.group(1)), heading.group(2), index + 1))
     return [
         _Heading(depth, text, start, (found[i + 1][2] - 1) if i + 1 < len(found) else total)
         for i, (depth, text, start) in enumerate(found)

--- a/tests/unit/test_ambient_env_isolation.py
+++ b/tests/unit/test_ambient_env_isolation.py
@@ -86,6 +86,7 @@ _HARMLESS: dict[str, str] = {
     "LOCAL_OPERATOR_GREP_ENGINE": "rg vs python grep",
     "LOCAL_OPERATOR_MCP_TIMEOUT_MS": "a timeout",
     "LOCAL_OPERATOR_SPILL_MAX_BYTES": "a size limit",
+    "LOCAL_OPERATOR_INTERNAL_READ_LIMIT": "a size limit; 0 disables internal-URL shaping",
     "LOCAL_OPERATOR_SCHEDULED_TASK_TIMEOUT_SECONDS": "a timeout",
     "LOCAL_OPERATOR_CONTEXT_FILES": "extra context file names, read relative to cwd",
     "LOCAL_OPERATOR_SKILL_EXTRA_ROOTS": "extra skill roots; read-only directories",

--- a/tests/unit/tools/test_internal_read_bound.py
+++ b/tests/unit/tools/test_internal_read_bound.py
@@ -20,8 +20,10 @@ modelled on the real document's structure rather than on a generic large blob.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
+from unittest import mock
 
 import pytest
 
@@ -121,13 +123,23 @@ async def test_review_gate_heading_survives_shaping_and_its_range_resolves(
     assert _GATE_HEADING in shaped, "the review-gate heading vanished from the outline"
     assert _GATE_BODY not in shaped, "fixture is too small to have been shaped"
 
-    # Pull the range the outline printed beside the gate heading and run it.
-    entry = next(line for line in shaped.splitlines() if _GATE_HEADING in line)
-    span = entry.rsplit("[lines ", 1)[1].rstrip("]")
     handle = result.details["spill"]["handle"]  # type: ignore[index]
 
-    expanded = _text_of(await _call(context, {"path": handle, "range": span}))
-    assert _GATE_BODY in expanded, f"range {span} did not resolve to the gate section"
+    # Asserted as REACHABILITY — the rule's text comes back through the
+    # advertised range of SOME outline entry — rather than as "it is its own
+    # top-level entry". A rule that lives inside a fenced template (the round-2
+    # comment template does, in the real skill) is correctly folded under its
+    # enclosing section by the fence fix; demanding its own entry would pin the
+    # phantom-heading bug instead of the property that matters.
+    reached = False
+    for line in shaped.splitlines():
+        if "  [lines " not in line:
+            continue
+        span = line.rsplit("[lines ", 1)[1].rstrip("]")
+        if _GATE_BODY in _text_of(await _call(context, {"path": handle, "range": span})):
+            reached = True
+            break
+    assert reached, "the gate text is not retrievable through any advertised range"
 
 
 @pytest.mark.asyncio
@@ -254,7 +266,13 @@ async def test_the_outline_covers_every_line_past_the_head(tmp_path: Path) -> No
     ]
     assert spans, "the outline indexed nothing"
 
-    head_lines = len(shaped.split("\n\n[... ", 1)[0].splitlines()) - 2  # minus banner+blank
+    # Derive the head's extent by MATCHING its last line back to the source
+    # rather than by counting rendered lines. A count has to subtract the
+    # banner and its blank line, which is exactly the kind of off-by-one that
+    # reports a phantom one-line gap and hides a real one.
+    head_body = shaped.split("\n\n[... ", 1)[0].split("\n\n", 1)[1]
+    head_lines = len(head_body.splitlines())
+    assert doc.splitlines()[:head_lines] == head_body.splitlines()
     assert spans[0][0] <= head_lines + 1, "a gap sits between the head and the first span"
     assert spans[-1][1] == len(doc.splitlines()), "the outline stops short of EOF"
 
@@ -278,6 +296,192 @@ async def test_kill_switch_restores_unbounded_passthrough(tmp_path: Path) -> Non
         assert _text_of(await _call(context, {"path": "skill://fixture-skill"})) == doc
     finally:
         del os.environ[builtin.INTERNAL_READ_LIMIT_ENV]
+
+
+def _true_extent(lines: list[str], start: int) -> int:
+    """The real last line of the section opening at 1-based ``start``.
+
+    Computed independently of the implementation — a fresh fence-aware scan —
+    so this is a cross-check rather than a restatement of the code under test.
+    """
+    in_fence = False
+    for offset in range(start, len(lines)):
+        stripped = lines[offset].lstrip()
+        if stripped.startswith(("```", "~~~")):
+            in_fence = not in_fence
+            continue
+        if not in_fence and re.match(r"^#{1,3} +\S", lines[offset]):
+            return offset
+    return len(lines)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("guide", ["browser", "peer-messaging"])
+async def test_outline_spans_match_the_true_section_extent(tmp_path: Path, guide: str) -> None:
+    """Every advertised ``[lines N-M]`` must be the section's REAL extent.
+
+    The regression: ``_HEADING_RE`` had no fence awareness, so a ``# comment``
+    inside a ```` ``` ```` block parsed as a heading — 19 phantoms across 6
+    bundled guides. Because a section's ``end`` is the next heading's start
+    minus one, a phantom INSIDE a real section silently truncated that
+    section's range: ``guide://browser``'s "0. Make sure the paired browser is
+    actually open" advertised 151-157 against a true 151-191, so an agent
+    obeying the footer got a fragment with no signal 34 lines were missing.
+
+    Pinned against guides that SHIP in the repo, with real fenced bash, so the
+    fixture cannot rot. Note that ``test_the_outline_covers_every_line_past_the
+    _head`` passed throughout the bug — coverage stayed contiguous by
+    construction — which is exactly why extent, not coverage, is the assertion
+    that matters here.
+    """
+    body = (Path(builtin.__file__).parents[1] / "guides" / guide / "GUIDE.md").read_text()
+    lines = body.splitlines()
+
+    # Asserted on the collector as well as on a shaped result, because the two
+    # strongest fenced-bash fixtures straddle the threshold: ``browser``
+    # (29 KB) shapes, ``peer-messaging`` (14 KB) is correctly returned whole.
+    # The span arithmetic the fence bug corrupted must be right for both.
+    for heading in builtin._collect_headings(lines):
+        assert heading.end == _true_extent(lines, heading.start), (
+            f"{guide}: {heading.text!r} spans {heading.start}-{heading.end} but its "
+            f"true extent ends at {_true_extent(lines, heading.start)}"
+        )
+
+    if len(body) > builtin.INTERNAL_READ_LIMIT_CHARS:
+        context = _context(tmp_path, body, url_prefix="guide://")
+        shaped = _text_of(await _call(context, {"path": f"guide://{guide}"}))
+        entries = [line for line in shaped.splitlines() if "  [lines " in line]
+        assert entries, "expected a shaped outline for an oversized guide"
+        for entry in entries:
+            span = entry.rsplit("[lines ", 1)[1].rstrip("]")
+            start, end = (int(part) for part in span.split("-"))
+            assert end == _true_extent(lines, start), (
+                f"{guide}: {entry.rsplit('  [lines ', 1)[0]!r} advertises "
+                f"{start}-{end}, true extent ends at {_true_extent(lines, start)}"
+            )
+
+
+@pytest.mark.asyncio
+async def test_no_heading_is_collected_from_inside_a_fenced_block(tmp_path: Path) -> None:
+    """The phantom source itself, including the wrapped-comment-continuation
+    shape that did the most range damage in ``guide://browser``."""
+    lines = ["# Real Title", "", "## Real Section", "", "```sh", "# macOS", "pgrep -x x"]
+    lines += ["# a long shell comment that wraps onto", "# the next line as a continuation"]
+    lines += ["```", "", "~~~bash", "## not a heading either", "~~~", ""]
+    lines += [f"filler {i} " + "x" * 60 for i in range(400)]
+    lines += ["## Second Real Section", "tail"]
+    body = "\n".join(lines)
+    context = _context(tmp_path, body, url_prefix="guide://")
+
+    shaped = _text_of(await _call(context, {"path": "guide://fenced"}))
+
+    for phantom in ("# macOS", "not a heading either", "the next line as a continuation"):
+        assert not any(
+            phantom in line and "  [lines " in line for line in shaped.splitlines()
+        ), f"{phantom!r} was indexed as a heading"
+
+
+@pytest.mark.asyncio
+async def test_a_crlf_document_indexes_every_heading_with_resolvable_spans(
+    tmp_path: Path,
+) -> None:
+    """CRLF must behave exactly as LF, and the spans must still resolve.
+
+    The invariant at risk is that the heading scan and the spill store share
+    ONE line basis. Normalising line endings into a copy the store never sees,
+    or counting offsets as ``len(line) + 1`` against CRLF content, drifts the
+    two apart and the advertised ranges stop pointing at their sections.
+    """
+    sections = [f"## Section {i}" for i in range(20)]
+    parts: list[str] = ["# Title", ""]
+    for section in sections:
+        parts += [section, ""] + [f"body of {section} line {j} " + "y" * 50 for j in range(20)]
+    lf_body = "\n".join(parts)
+    crlf_body = "\r\n".join(parts)
+    assert len(crlf_body) > builtin.INTERNAL_READ_LIMIT_CHARS
+
+    def entries(text: str) -> list[str]:
+        return [line.strip() for line in text.splitlines() if "  [lines " in line]
+
+    lf_ctx = _context(tmp_path, lf_body, url_prefix="guide://")
+    crlf_ctx = _context(tmp_path, crlf_body, url_prefix="guide://")
+    lf_shaped = _text_of(await _call(lf_ctx, {"path": "guide://lf"}))
+    crlf_result = await _call(crlf_ctx, {"path": "guide://crlf"})
+    crlf_shaped = _text_of(crlf_result)
+
+    # Equality with the LF twin is the assertion that matters: line endings
+    # must not change the index at all. Headings inside the head budget are
+    # legitimately absent from the OUTLINE (they are shown in full above it),
+    # so the comparison is against LF rather than against every section.
+    assert entries(crlf_shaped) == entries(lf_shaped)
+    assert entries(crlf_shaped), "CRLF produced no outline at all"
+    assert len(sections) == 20
+
+    # And a CRLF span still resolves to its own section through the handle.
+    handle = crlf_result.details["spill"]["handle"]  # type: ignore[index]
+    last = entries(crlf_shaped)[-1]
+    span = last.rsplit("[lines ", 1)[1].rstrip("]")
+    expanded = _text_of(await _call(crlf_ctx, {"path": handle, "range": span}))
+    assert "Section 19" in expanded
+
+
+@pytest.mark.asyncio
+async def test_a_long_frontmatter_leaves_no_orphaned_lines(tmp_path: Path) -> None:
+    """When the first heading sits below the head cut, the lines between must
+    still be addressable. Measured at 109 orphaned lines before the fix, while
+    the banner asserted the index was complete."""
+    body = "---\n" + "\n".join(f"meta_{i}: a metadata value " + "p" * 40 for i in range(200))
+    body += "\n---\n\n"
+    body += "\n".join(
+        f"## S{i}\n" + "\n".join(f"body {i}.{j} " + "y" * 60 for j in range(20)) for i in range(20)
+    )
+    context = _context(tmp_path, body, url_prefix="guide://")
+
+    result = await _call(context, {"path": "guide://frontmatter"})
+    shaped = _text_of(result)
+
+    # Same discipline as the coverage test: match the head back to the source
+    # instead of counting rendered lines, so a banner-shape change cannot make
+    # this assertion quietly wrong in either direction.
+    head_body = shaped.split("\n\n[... ", 1)[0].split("\n\n", 1)[1]
+    head_lines = len(head_body.splitlines())
+    assert body.splitlines()[:head_lines] == head_body.splitlines()
+    spans = [
+        int(line.rsplit("[lines ", 1)[1].rstrip("]").split("-")[0])
+        for line in shaped.splitlines()
+        if "  [lines " in line
+    ]
+    assert (
+        spans[0] <= head_lines + 1
+    ), f"{spans[0] - head_lines - 1} lines are addressable by nothing"
+
+    # The covering entry must actually resolve to the skipped frontmatter.
+    handle = result.details["spill"]["handle"]  # type: ignore[index]
+    expanded = _text_of(
+        await _call(context, {"path": handle, "range": f"{head_lines + 1}-{spans[0] + 2}"})
+    )
+    assert "meta_" in expanded
+
+
+@pytest.mark.asyncio
+async def test_the_degraded_path_still_announces_partiality(tmp_path: Path) -> None:
+    """A refused spill is the path where the agent has LESS recourse — no
+    handle to expand — so the top-of-result banner matters more there, not
+    less. It must stay bounded and must not raise."""
+    body = "\n".join(
+        f"## S{i}\n" + "\n".join(f"body {i}.{j} " + "z" * 60 for j in range(20)) for i in range(20)
+    )
+    context = _context(tmp_path, body, url_prefix="guide://")
+
+    with mock.patch.object(builtin, "_spill", return_value=None):
+        result = await _call(context, {"path": "guide://nospill"})
+
+    shaped = _text_of(result)
+    assert not result.is_error
+    assert "PARTIAL" in shaped.splitlines()[0]
+    assert "NOT read the whole document" in shaped
+    assert len(shaped) <= builtin.INTERNAL_READ_LIMIT_CHARS
+    assert "spill" not in (result.details or {})
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tools/test_internal_read_bound.py
+++ b/tests/unit/tools/test_internal_read_bound.py
@@ -1,0 +1,337 @@
+"""Bounds on ``read``'s internal-URL and directory branches.
+
+The defect these pin: ``execute_read``'s internal-URL branch returned the
+resolver's content with no cap at all, while every other read outcome was
+bounded at 8 KiB — and it is the branch that serves the LARGEST documents in
+the system. One ``read skill://minerva-software-development`` injected 78,320
+chars (~27k billed tokens), and because ``_is_prunable`` exempts ``skill://``
+reads from pruning it stayed resident for the whole session.
+
+The tests that matter most here are NOT the size assertions. They are the ones
+that pin the anti-regression properties, because the cheap fix — truncate the
+head and stop — is a silent behavioural regression: in that skill the binding
+``## Mandatory Agent Review Gate`` sits at char offset 30,343 while the
+frontmatter phrase "agent-review round" at offset 420 survives any head cap,
+so a head-truncated result READS complete while every operative rule is gone.
+An agent acting on it merges without a review round. Hence
+``test_review_gate_heading_survives_shaping_and_its_range_resolves``, which is
+modelled on the real document's structure rather than on a generic large blob.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.compaction.pruning import _is_prunable
+from local_operator.harness.types import (
+    AgentTool,
+    Message,
+    TextContent,
+    ToolContext,
+    ToolResult,
+)
+from local_operator.tools import builtin, spill
+from local_operator.tools.registry import create_tools
+
+
+@pytest.fixture(autouse=True)
+def isolated_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep every spill write inside the test's tmp dir, never the real home."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "cfg"))
+    monkeypatch.delenv(spill.SPILL_MAX_BYTES_ENV, raising=False)
+    monkeypatch.delenv(builtin.INTERNAL_READ_LIMIT_ENV, raising=False)
+
+
+def _context(tmp_path: Path, doc: str, url_prefix: str = "skill://") -> ToolContext:
+    """A context whose resolver serves ``doc`` for any URL under ``url_prefix``."""
+    return ToolContext(
+        cwd=str(tmp_path),
+        session_id="internal-read-test",
+        resolve_internal_url=lambda url: doc if url.startswith(url_prefix) else None,
+    )
+
+
+async def _call(context: ToolContext, args: dict[str, Any]) -> ToolResult:
+    tools: dict[str, AgentTool] = {tool.name: tool for tool in create_tools(context)}
+    read = tools["read"]
+    return await read.execute("call-1", args, None, None, context)  # type: ignore[operator]
+
+
+def _text_of(result: ToolResult) -> str:
+    return "".join(b.text for b in result.content if isinstance(b, TextContent))
+
+
+# A fixture modelled on the real skill: the operative rule sits DEEP, far past
+# any plausible head budget, with a decoy near the top that a head-only
+# truncation would leave behind to make the result read complete.
+_GATE_HEADING = "Mandatory Agent Review Gate"
+_GATE_BODY = "Every MR opened by an agent MUST carry a completed agent-review round."
+
+
+def _skill_like_document() -> str:
+    parts = [
+        "---",
+        "name: fixture-skill",
+        "description: mentions an agent-review round in the frontmatter decoy.",
+        "---",
+        "",
+        "# Fixture Skill",
+        "",
+        "## Start Every Task",
+        "",
+    ]
+    parts += [f"Routing line {i}." for i in range(40)]
+    # Filler sections push the gate well past the 6 KiB head budget, the way
+    # the real document's 30 KB offset does.
+    for section in range(12):
+        parts += ["", f"## Filler Section {section}", ""]
+        parts += [f"Filler body line {i} of section {section}." for i in range(40)]
+    parts += ["", f"## {_GATE_HEADING}", "", _GATE_BODY, ""]
+    parts += [f"Gate detail line {i}." for i in range(20)]
+    parts += ["", "### Comment format", "", "Round comments look like this.", ""]
+    parts += ["", "## Cross-Skill Routing", "", "Route elsewhere when needed.", ""]
+    return "\n".join(parts)
+
+
+@pytest.mark.asyncio
+async def test_review_gate_heading_survives_shaping_and_its_range_resolves(
+    tmp_path: Path,
+) -> None:
+    """THE regression test for this defect, not a generic size test.
+
+    Two assertions, and both are needed: the deep operative heading must be
+    VISIBLE in the outline (so the agent knows the rule exists), and the line
+    range printed beside it must actually RESOLVE through the spill store (so
+    knowing is actionable). A heading listed with a range that does not resolve
+    is worse than no outline: it tells the agent expansion works when it does
+    not.
+    """
+    doc = _skill_like_document()
+    assert (
+        doc.index(_GATE_BODY) > builtin.INTERNAL_READ_HEAD_CHARS
+    ), "fixture must place the gate past the head budget, or it proves nothing"
+    context = _context(tmp_path, doc)
+
+    result = await _call(context, {"path": "skill://fixture-skill"})
+    shaped = _text_of(result)
+
+    assert _GATE_HEADING in shaped, "the review-gate heading vanished from the outline"
+    assert _GATE_BODY not in shaped, "fixture is too small to have been shaped"
+
+    # Pull the range the outline printed beside the gate heading and run it.
+    entry = next(line for line in shaped.splitlines() if _GATE_HEADING in line)
+    span = entry.rsplit("[lines ", 1)[1].rstrip("]")
+    handle = result.details["spill"]["handle"]  # type: ignore[index]
+
+    expanded = _text_of(await _call(context, {"path": handle, "range": span}))
+    assert _GATE_BODY in expanded, f"range {span} did not resolve to the gate section"
+
+
+@pytest.mark.asyncio
+async def test_shaped_result_keeps_the_skill_url_so_pruning_stays_exempt(
+    tmp_path: Path,
+) -> None:
+    """``_is_prunable`` keys the skill exemption off
+    ``details['url'].startswith('skill://')``. An implementation that
+    helpfully rewrote ``url`` to the spill handle would silently disable that
+    exemption — and post-shaping the exempted result is what carries the handle
+    the agent needs, so blanking it strands the expansion. Pinned here because
+    the failure is invisible: nothing errors, sessions just start losing skills.
+    """
+    context = _context(tmp_path, _skill_like_document())
+    result = await _call(context, {"path": "skill://fixture-skill"})
+
+    assert result.details is not None
+    assert result.details["url"] == "skill://fixture-skill"
+    assert result.details["spill"]["handle"].startswith("spill://")
+
+    message = Message(
+        role="tool",
+        content=[TextContent(text=_text_of(result))],
+        tool_name="read",
+        tool_call_id="call-1",
+        provider_payload={"details": result.details},
+    )
+    assert _is_prunable(message) is False
+
+
+@pytest.mark.asyncio
+async def test_shaped_result_announces_partiality_at_the_top(tmp_path: Path) -> None:
+    """The banner leads the result, not just trails it: the model reads
+    top-down and may act on the head before ever reaching a footer."""
+    context = _context(tmp_path, _skill_like_document())
+    shaped = _text_of(await _call(context, {"path": "skill://fixture-skill"}))
+
+    first = shaped.splitlines()[0]
+    assert "PARTIAL" in first
+    assert "NOT read the whole document" in first
+    assert "skill://fixture-skill" in first
+
+
+@pytest.mark.asyncio
+async def test_footer_names_an_expansion_call_that_actually_resolves(
+    tmp_path: Path,
+) -> None:
+    """Same discipline as ``_spill_footer``: run the printed call verbatim and
+    require content back. A footer that describes expansion instead of spelling
+    out a working call teaches the model that expansion does not work."""
+    context = _context(tmp_path, _skill_like_document())
+    result = await _call(context, {"path": "skill://fixture-skill"})
+    shaped = _text_of(result)
+
+    printed = next(line for line in shaped.splitlines() if 'range="' in line)
+    handle = printed.split('read(path="', 1)[1].split('"', 1)[0]
+    span = printed.split('range="', 1)[1].split('"', 1)[0]
+
+    expanded = await _call(context, {"path": handle, "range": span})
+    assert not expanded.is_error
+    assert "beyond the end of" not in _text_of(expanded)
+
+
+@pytest.mark.asyncio
+async def test_documents_under_the_threshold_are_returned_byte_identical(
+    tmp_path: Path,
+) -> None:
+    """Most guides fit. The MUST-read guide rule stays untouched for them, and
+    a shaped result for a document that fits would be a pure regression."""
+    doc = "# Small Guide\n\n" + "\n".join(f"line {i}" for i in range(200))
+    assert len(doc) < builtin.INTERNAL_READ_LIMIT_CHARS
+    context = _context(tmp_path, doc, url_prefix="guide://")
+
+    result = await _call(context, {"path": "guide://small"})
+    assert _text_of(result) == doc
+    assert "spill" not in (result.details or {})
+
+
+@pytest.mark.asyncio
+async def test_heading_poor_documents_fall_back_to_plain_head_and_tail(
+    tmp_path: Path,
+) -> None:
+    """Below the heading minimum there is no structure to index, so the
+    document takes the same uniform ``spill_truncate`` every other oversized
+    output gets rather than an outline of two entries."""
+    doc = "# Only Heading\n\n" + "\n".join(f"prose line {i}" for i in range(4000))
+    assert len(doc) > builtin.INTERNAL_READ_LIMIT_CHARS
+    context = _context(tmp_path, doc, url_prefix="guide://")
+
+    shaped = _text_of(await _call(context, {"path": "guide://flat"}))
+    assert builtin.BASH_TRUNCATION_MARKER.strip() in shaped
+    assert "is SAVED at spill://" in shaped
+    assert len(shaped) <= builtin.INTERNAL_READ_LIMIT_CHARS + 1024
+
+
+@pytest.mark.asyncio
+async def test_the_outline_covers_every_line_past_the_head(tmp_path: Path) -> None:
+    """No line may fall in a gap between the head and the outline's spans.
+
+    This is completeness stated as an invariant rather than as a spot check on
+    one heading: whatever the head cut, the outline's first span must resume at
+    the very next line and its last must reach EOF. The awkward case is a
+    document whose headings all cluster at the top followed by bulk prose — if
+    the outline dropped the heading the head stopped at, those 4,000 lines
+    would be addressable by nothing and would vanish unannounced.
+    """
+    doc = "\n".join(
+        ["# One", "text", "## Two", "text", "## Three", "text", ""]
+        + [f"bulk prose line {i}" for i in range(4000)]
+    )
+    assert len(doc) > builtin.INTERNAL_READ_LIMIT_CHARS
+    context = _context(tmp_path, doc, url_prefix="guide://")
+
+    result = await _call(context, {"path": "guide://clustered"})
+    shaped = _text_of(result)
+
+    spans = [
+        (
+            int(line.rsplit("[lines ", 1)[1].rstrip("]").split("-")[0]),
+            int(line.rsplit("[lines ", 1)[1].rstrip("]").split("-")[1]),
+        )
+        for line in shaped.splitlines()
+        if "  [lines " in line
+    ]
+    assert spans, "the outline indexed nothing"
+
+    head_lines = len(shaped.split("\n\n[... ", 1)[0].splitlines()) - 2  # minus banner+blank
+    assert spans[0][0] <= head_lines + 1, "a gap sits between the head and the first span"
+    assert spans[-1][1] == len(doc.splitlines()), "the outline stops short of EOF"
+
+    # And the bulk prose really is reachable through the last span.
+    handle = result.details["spill"]["handle"]  # type: ignore[index]
+    tail = _text_of(await _call(context, {"path": handle, "range": f"{spans[-1][1] - 5}-"}))
+    assert "bulk prose line 3999" in tail
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_restores_unbounded_passthrough(tmp_path: Path) -> None:
+    """Rollout escape hatch: if shaping degrades behaviour in practice the
+    operator turns it off in one variable rather than waiting for a release."""
+    doc = _skill_like_document()
+    context = _context(tmp_path, doc)
+
+    import os
+
+    os.environ[builtin.INTERNAL_READ_LIMIT_ENV] = "0"
+    try:
+        assert _text_of(await _call(context, {"path": "skill://fixture-skill"})) == doc
+    finally:
+        del os.environ[builtin.INTERNAL_READ_LIMIT_ENV]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "guide_md",
+    # Keyed on the GUIDE.md file, not on "is a directory": the package ships a
+    # __pycache__ beside the guides once it has been imported, and collecting
+    # that would fail at read time rather than assert anything.
+    sorted((Path(builtin.__file__).parents[1] / "guides").glob("*/GUIDE.md")),
+    ids=lambda p: p.parent.name,
+)
+@pytest.mark.asyncio
+async def test_every_bundled_guide_read_is_bounded(tmp_path: Path, guide_md: Path) -> None:
+    """Drives the real bundled guides, so this guard cannot rot: the guides
+    ship in the repo, and a future 80 KB guide fails here rather than in a
+    session. This is the test that makes the original defect unrepeatable."""
+    name = guide_md.parent.name
+    context = _context(tmp_path, guide_md.read_text(), url_prefix="guide://")
+
+    shaped = _text_of(await _call(context, {"path": f"guide://{name}"}))
+    ceiling = builtin.INTERNAL_READ_LIMIT_CHARS + builtin.INTERNAL_READ_SHAPE_SLACK_CHARS
+    assert len(shaped) <= ceiling, f"guide://{name} returned {len(shaped)} chars"
+
+
+@pytest.mark.asyncio
+async def test_no_read_branch_returns_an_unbounded_result(tmp_path: Path) -> None:
+    """The test that would have caught the original hole, across all four
+    branches at once — including the directory listing, which had the same
+    defect and is fixed in the same change."""
+    ceiling = builtin.INTERNAL_READ_LIMIT_CHARS + builtin.INTERNAL_READ_SHAPE_SLACK_CHARS
+
+    big = "\n".join(f"filler line {i}" for i in range(6000))
+    (tmp_path / "big.txt").write_text(big)
+    wide = tmp_path / "wide"
+    wide.mkdir()
+    for i in range(4000):
+        (wide / f"entry-with-a-longish-name-{i:05d}.txt").touch()
+
+    context = _context(tmp_path, _skill_like_document())
+
+    file_result = await _call(context, {"path": str(tmp_path / "big.txt")})
+    dir_result = await _call(context, {"path": str(wide)})
+    url_result = await _call(context, {"path": "skill://fixture-skill"})
+    page_result = await _call(
+        context, {"path": url_result.details["spill"]["handle"]}  # type: ignore[index]
+    )
+
+    for name, result in (
+        ("file", file_result),
+        ("directory", dir_result),
+        ("internal-url", url_result),
+        ("spill-page", page_result),
+    ):
+        assert len(_text_of(result)) <= ceiling, f"{name} branch returned an unbounded result"
+
+    # The directory listing must stay expandable, not merely clipped.
+    assert "spill://" in _text_of(dir_result)

--- a/tests/unit/tools/test_internal_read_bound.py
+++ b/tests/unit/tools/test_internal_read_bound.py
@@ -266,13 +266,8 @@ async def test_the_outline_covers_every_line_past_the_head(tmp_path: Path) -> No
     ]
     assert spans, "the outline indexed nothing"
 
-    # Derive the head's extent by MATCHING its last line back to the source
-    # rather than by counting rendered lines. A count has to subtract the
-    # banner and its blank line, which is exactly the kind of off-by-one that
-    # reports a phantom one-line gap and hides a real one.
-    head_body = shaped.split("\n\n[... ", 1)[0].split("\n\n", 1)[1]
-    head_lines = len(head_body.splitlines())
-    assert doc.splitlines()[:head_lines] == head_body.splitlines()
+    head_lines = _head_line_count(shaped, doc)
+    assert head_lines, "the head reproduced none of the source"
     assert spans[0][0] <= head_lines + 1, "a gap sits between the head and the first span"
     assert spans[-1][1] == len(doc.splitlines()), "the outline stops short of EOF"
 
@@ -296,6 +291,27 @@ async def test_kill_switch_restores_unbounded_passthrough(tmp_path: Path) -> Non
         assert _text_of(await _call(context, {"path": "skill://fixture-skill"})) == doc
     finally:
         del os.environ[builtin.INTERNAL_READ_LIMIT_ENV]
+
+
+def _head_line_count(shaped: str, source: str) -> int:
+    """How many leading SOURCE lines the shaped head reproduces.
+
+    Derived by matching the head against the document rather than by parsing
+    the result's framing. Both framing-based derivations are unreliable for the
+    same reason: the head is emitted as ``{banner}\n\n{head_text}\n\n[...``,
+    so when ``head_text`` itself ends in a blank line — the normal markdown case
+    at a heading boundary — the blank and the separator are indistinguishable,
+    and ``splitlines()`` drops the trailing empty string either way. Splitting
+    on ``"]\n\n"`` instead of ``"\n\n"`` does not help; the ambiguity is at the
+    END of the head, not at its start. Counting short makes
+    ``spans[0] <= head_lines + 1`` fail against correct product code.
+    """
+    lines = source.splitlines()
+    head = shaped.split("\n\n[... ", 1)[0]
+    for count in range(len(lines), -1, -1):
+        if head.endswith("\n".join(lines[:count])):
+            return count
+    return 0
 
 
 def _true_extent(lines: list[str], start: int) -> int:
@@ -381,6 +397,55 @@ async def test_no_heading_is_collected_from_inside_a_fenced_block(tmp_path: Path
         ), f"{phantom!r} was indexed as a heading"
 
 
+def test_a_nested_fence_does_not_reopen_indexing_inside_the_outer_block() -> None:
+    """A ``` inside a ````markdown block must not close it.
+
+    Fence tracking used to be a bare parity toggle, so the inner delimiter
+    flipped it, indexing resumed inside the block, and a heading-shaped line
+    there became a phantom — which does not merely add a junk entry but
+    truncates the advertised span of the section containing it, the exact R1
+    failure this scan exists to prevent. Live exposure: the msd skill wraps a
+    nested ``` at 817-822 inside a ````markdown block at 812-826, so an
+    unindented ``# ...`` there cut ``### Comment format`` from 763-855 to
+    763-817 — the section holding the review-gate comment template.
+    """
+    doc = "# A\n\n````markdown\n```\n# phantom?\n```\n````\n\n## B\n\nprose\n"
+
+    headings = builtin._collect_headings(doc.splitlines())
+
+    assert [h.text for h in headings] == ["A", "B"], "a fenced line was indexed"
+    # The span matters as much as the absence: a phantom would have cut A to 1-4.
+    assert (headings[0].start, headings[0].end) == (1, 8)
+
+
+def test_a_fence_closes_only_on_its_own_delimiter_character_and_length() -> None:
+    """CommonMark: a closer matches the opener's character and is at least as
+    long. ``~~~`` must not close a ``` block, and a shorter run must not close
+    a longer opener — both would resume indexing inside the block."""
+    mismatched_char = "# A\n\n```sh\n# hidden\n~~~\n\n## B\n\nprose\n"
+    assert [h.text for h in builtin._collect_headings(mismatched_char.splitlines())] == ["A"]
+
+    shorter_closer = "# A\n\n````\n# hidden\n```\n# also hidden\n````\n\n## B\n"
+    assert [h.text for h in builtin._collect_headings(shorter_closer.splitlines())] == ["A", "B"]
+
+    # A longer run DOES close, and an info string marks an opener, never a closer.
+    longer_closer = "# A\n\n```\n# hidden\n`````\n\n## B\n"
+    assert [h.text for h in builtin._collect_headings(longer_closer.splitlines())] == ["A", "B"]
+
+
+def test_an_unclosed_fence_still_leaves_its_lines_reachable() -> None:
+    """The fail-safe direction, kept deliberately: an unclosed fence drops the
+    rest of the document from the INDEX, but the enclosing section's end is
+    ``total``, so those lines stay reachable through its advertised range.
+    Losing an index entry is recoverable; a truncated span is not."""
+    lines = ["# A", "", "## Real", "", "```sh"] + [f"swallowed {i}" for i in range(20)]
+
+    headings = builtin._collect_headings(lines)
+
+    assert [h.text for h in headings] == ["A", "Real"]
+    assert headings[-1].end == len(lines), "swallowed lines became unreachable"
+
+
 @pytest.mark.asyncio
 async def test_a_crlf_document_indexes_every_heading_with_resolvable_spans(
     tmp_path: Path,
@@ -440,12 +505,8 @@ async def test_a_long_frontmatter_leaves_no_orphaned_lines(tmp_path: Path) -> No
     result = await _call(context, {"path": "guide://frontmatter"})
     shaped = _text_of(result)
 
-    # Same discipline as the coverage test: match the head back to the source
-    # instead of counting rendered lines, so a banner-shape change cannot make
-    # this assertion quietly wrong in either direction.
-    head_body = shaped.split("\n\n[... ", 1)[0].split("\n\n", 1)[1]
-    head_lines = len(head_body.splitlines())
-    assert body.splitlines()[:head_lines] == head_body.splitlines()
+    head_lines = _head_line_count(shaped, body)
+    assert head_lines, "the head reproduced none of the source"
     spans = [
         int(line.rsplit("[lines ", 1)[1].rstrip("]").split("-")[0])
         for line in shaped.splitlines()


### PR DESCRIPTION
## Change authorization

**C1 — standard / pre-authorized fix.** This PR is the change record. No version bump (`pyproject.toml` untouched at `0.52.7`); the release owner for the current window handles the bump.

`Release: patch — a `read` of a large skill or guide now returns a bounded head plus a complete, expandable section index instead of injecting the whole 78 KB document into context.`

## The defect

`execute_read`'s internal-URL branch returned the resolver's content with **no bound at all**:

```python
content = resolver(target)
...
return _text(tool_call_id, "read", content, details={"url": target})
```

Every other `read` outcome is bounded at 8 KiB — filesystem bodies by `_clamp_file_body`, spill pages at the same limit, bash by `spill_truncate`. This was the one hole, and it is the branch that serves the **largest documents in the system**.

It compounds: `_is_prunable` (`compaction/pruning.py:271-292`) deliberately exempts `skill://` reads from pruning, so the unbounded result is also a **permanently resident** one.

Measured, primary sources:

- One `read skill://minerva-software-development` injects **78,320 chars (~27k billed tokens)**.
- In session `0d949b7cd984` that single result was **34% of 951,162 billed input tokens** — re-billed across 12 subsequent calls (~323,180 tokens).
- Fleet-wide across 1,722 stored sessions: **1,849** internal-URL reads exceeded 8 KiB, **64,882,602 chars** injected uncapped, **49,735,594** above the cap.
- Top offenders: `skill://minerva-software-development` ×484 (avg 78,192 ch), `skill://minerva-data-agents` ×124 (avg 46,055), `skill://minerva-platform-deployments` ×83, `guide://agents` ×82, `guide://peer-messaging` ×52, `guide://browser` ×16.

A second instance of the same defect class: the **directory-listing branch** joined every entry with no cap.

## Why head-only truncation was rejected — this is the load-bearing part

The obvious fix (clip the head, append a footer) is a **silent behavioural regression**, not a cheaper version of this one.

The operative rules in these documents sit *deep in the body*. Measured heading offsets in the 78 KB skill:

| offset | heading |
|---|---|
| 30,343 | `## Mandatory Agent Review Gate` — the binding merge gate |
| 49,119 | `### Agent review — round 2` — the comment template agents must emit |
| 56,339 | `### Design review round for visual changes` |
| 60,012 | `### After agent approval: human reviewers, and whether to merge` |
| 64,158 | `### The one exception: C6 emergencies` |

A head cap at 8 KiB — or even 32 KiB — deletes **all** of them, while the frontmatter phrase "agent-review round" at offset 420 survives. So the result *reads* complete. An agent would believe it had read the skill and merge without a review round. That is a far worse outcome than the token cost.

Hence the shape: **head + a COMPLETE heading outline with line ranges**. No rule becomes invisible; at worst it is one call away. The reasoning is recorded in the code (`_heading_outline`'s docstring) so a future agent does not "simplify" it back into the regression.

## The change

`_shape_internal_document()` in `tools/builtin.py`, called at the internal-URL branch:

1. `len(content) <= INTERNAL_READ_LIMIT_CHARS` (**16 KiB**) → returned **unchanged**. 8 of 10 bundled guides are untouched, so the `guide://` MUST-read rule is unaffected for them.
2. Otherwise spill the full text, then emit: **banner → 6 KiB head cut at a heading boundary → truncation marker → outline of every remaining heading with `[lines N-M]` → footer naming a concrete working call.**
3. Fewer than 3 headings → plain uniform `spill_truncate` head+tail.
4. Outline budget 4 KiB; overflow spends **depth** first (`###` then `##`), so a shallower outline still covers every region, before ever eliding entries.
5. Spill store refuses → `truncate_output`, the same degradation contract the rest of the module uses.

**Threshold is 16 KiB, deliberately not `READ_OUTPUT_LIMIT_CHARS`.** Instructional markdown a model is *required* to read is better delivered whole than split into an outline it must expand twice. Shaping compresses the oversized docs to ~7 KB either way, so the higher threshold costs almost nothing on them and only decides which mid-sized docs stay whole (8 KiB → 23/43 whole; 16 KiB → 34/43; 32 KiB → 37/43 while halving the saving).

**`details['url']` keeps the ORIGINAL `skill://` URL.** `_is_prunable` matches on that prefix. An implementation that helpfully rewrote `url` to the spill handle would **silently disable the pruning exemption** — and post-change the exempted result is what carries the handle the agent needs to expand, so blanking it strands the expansion. Pinned by a dedicated test. Also: **no `supersede_key`** — the reasoning already at that call site still holds.

`LOCAL_OPERATOR_INTERNAL_READ_LIMIT` is a rollout kill switch (`0` disables shaping).

## Testing evidence

Real execution through the **real tool path** (`create_tools()` → `read.execute()`), against the actual 78 KB skill on disk — not a synthetic blob, not a green unit suite.

### 1. Before / after

```
BEFORE (kill switch=0, pre-change behaviour):  78,320 chars  ~28,173 tokens
AFTER  (default shaping):                       7,255 chars  ~ 2,610 tokens
REDUCTION: 90.7%  (71,065 chars, ~25,563 billed tokens saved per read)
```

### 2. The banner leads the result (not only the footer)

```
[skill://minerva-software-development — 1248 lines, 78320 chars. This is a PARTIAL
view: the head below plus a complete index of every remaining section. You have NOT
read the whole document. Expand any section you intend to act on before acting on it.]
```

### 3. Every review-gate rule survives in the outline

Grepped out of the **actual returned result**:

```
## Mandatory Agent Review Gate  [lines 508-537]
### Agent review — round 2  [lines 771-795]
### Agent review remediation — round 2  [lines 796-812]
### Agent review re-pin — round 2  [lines 813-855]
### Design review round for visual changes  [lines 913-971]
### After agent approval: human reviewers, and whether to merge  [lines 972-1034]
### The one exception: C6 emergencies  [lines 1035-1049]
```

### 4. The expansion round-trips — the printed range actually resolves

Running the range the outline printed beside the gate, verbatim:

```
$ read(path="spill://f3e2e68a6a0e88067e1a95dd207e1a87", range="508-537")
spill://f3e2e68a6a0e88067e1a95dd207e1a87 — lines 508-537 of 1248
508| ## Mandatory Agent Review Gate
509|
510| **Every MR opened by an agent MUST carry at least one completed agent-review
511| round, recorded as comments on the MR itself, before it is merged.** This is a
512| hard gate, not a suggestion, and it has no triviality exemption for that first
513| round: the depth of the review scales with risk, but its existence does not.
...  [2,117 chars, bounded at 8 KiB]
```

Search expansion works too:

```
$ read(path="spill://f3e2e68a6a0e88067e1a95dd207e1a87?q=Mandatory Agent Review")
3 of 3 match(es) ... 189| ... 355| ... 508| ## Mandatory Agent Review Gate
```

### 5. The `_is_prunable` exemption still fires on a shaped result

```
details['url']   = 'skill://minerva-software-development'   <- original preserved
details['spill'] = {'handle': 'spill://f3e2e...', 'lines': 1249, 'bytes': 78632, 'complete': True}
_is_prunable(shaped result) = False   (False == still exempt)
```

### 6. Mid-sized guides are returned WHOLE

```
guide://agents            11,108 chars  WHOLE
guide://browser           29,380 chars  shaped -> 6,719
guide://configuration     17,352 chars  shaped -> 5,896
guide://extensions         3,360 chars  WHOLE
guide://failover          14,890 chars  WHOLE
guide://mcp                4,709 chars  WHOLE
guide://mobile            12,240 chars  WHOLE
guide://peer-messaging    13,923 chars  WHOLE
guide://teams              6,727 chars  WHOLE
guide://tunnel             3,736 chars  WHOLE
```

### 7. The directory-listing branch is bounded too

```
4,000-entry directory listing -> 8,555 chars (was ~152,000 unbounded)
[Full output (4001 lines) is SAVED at spill://715082f971c814bdb20ade1b2cf41acf — expand it...
  read(path="spill://715082f...", range="111-310")  -> those lines (of 111-3889 elided...)
```

### 8. Context budget — the trap this change had to avoid

`scripts/bench_context_budget.py` passes with only **8 billed tokens of headroom**, so ~22 characters added to the `read` schema would turn CI red. **Zero schema bytes were added** — the affordance lives entirely in the result, paid only when truncation happens rather than on every call in every session (the footprint ladder applied to descriptions).

```
before: start context: 73,648 chars = ~26,492 billed tokens vs budget 26,500  PASS (8 tokens headroom)
after:  start context: 73,648 chars = ~26,492 billed tokens vs budget 26,500  PASS (8 tokens headroom)
```

Identical, to the character.

## Quality gates

```
.venv/bin/python -m flake8 .                                  -> 0
uvx --from black==26.1.0 black --check .                      -> 1167 files unchanged
uvx isort==5.13.2 --check .                                   -> clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .   -> 0 errors, 0 warnings
tests/unit/tools + compaction + ambient_env_isolation (-n0)   -> 1164 passed
tests/unit/tools/test_internal_read_bound.py                  -> 19 passed
```

**Full-suite note, disclosed rather than hidden.** The whole-tree run reported `4 failed, 16274 passed, 987 errors`. The 987 errors and 3 of the 4 failures were **disk exhaustion on the shared host**, not this diff — every one is `OSError: No space left on device` / `could not create numbered dir` / xdist worker crash, from concurrent sibling worktree suites (host was at load avg 45-95 with 15-46 competing pytest processes and 9.6 GB of leaked pytest tmp). Re-running the **entire errored subset serially** once the machine recovered:

```
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest <29 errored files> -n0 -q
1697 passed, 2 warnings in 1375.39s
```

Green serially, red only under contention — the signature of resource starvation, so no code change was made on the strength of it.

**The 4th failure was real and is fixed in this PR.** `test_every_environment_variable_read_is_scrubbed_or_explained` correctly caught that the new `LOCAL_OPERATOR_INTERNAL_READ_LIMIT` was unregistered; it is now declared in `_HARMLESS` beside the other size limits (77 passed).

## Tests added — `tests/unit/tools/test_internal_read_bound.py` (19)

The named regression guards, not generic size checks:

- **`test_review_gate_heading_survives_shaping_and_its_range_resolves`** — THE test for this defect. A fixture modelled on the real document (deep operative rule, decoy phrase near the top) asserts the gate heading is visible in the outline **and** that the range printed beside it actually resolves through the spill store. A heading listed with a range that does not resolve is worse than no outline.
- **`test_shaped_result_keeps_the_skill_url_so_pruning_stays_exempt`** — pins the `_is_prunable` hazard above; the failure is otherwise invisible.
- **`test_the_outline_covers_every_line_past_the_head`** — completeness as an invariant: no line may fall in a gap between head and outline, and the last span must reach EOF.
- **`test_shaped_result_announces_partiality_at_the_top`**, **`test_footer_names_an_expansion_call_that_actually_resolves`** (runs the printed call verbatim), **`test_documents_under_the_threshold_are_returned_byte_identical`**, **`test_heading_poor_documents_fall_back_to_plain_head_and_tail`**, **`test_kill_switch_restores_unbounded_passthrough`**.
- **`test_every_bundled_guide_read_is_bounded`** (parametrized over the 10 real shipped guides, so it cannot rot) and **`test_no_read_branch_returns_an_unbounded_result`** — drives all four branches at once, which is what would have caught the original hole and catches the directory one.

## Not done, deliberately

- No change to the `_is_prunable` exemption, no `supersede_key`, no change to the start-context ratchet — each carries its own risk and none is needed for this defect.
- No wording added to the `read` tool schema (see §8).
- No version bump.

## Adjacent issues found, not fixed here

- `scripts/bench_context_budget.py` at 8 tokens of headroom is a tripwire any prompt/schema edit will hit; it may deserve a deliberate re-baseline as a separate decision.
- ~9.6 GB of leaked `pytest-of-damian` tmp directories on the shared host (the proximate cause of the run above). Left alone since reclaiming another session's tmp is not this PR's business.
