### PR TITLE
fix(tests): stop pytest temp dirs accumulating without bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -391,6 +391,34 @@ exclude = ["**/node_modules", "**/__pycache__", "**/.*", "docs", "benchmarks/osw
 #   env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0
 addopts = "-n auto --dist worksteal -m \"not e2e\""
 testpaths = ["tests"]
+
+# `tmp_path` directories are deleted for tests that PASS; a failing test keeps
+# its directory, so debugging a failure is unaffected. pytest's default (`all`)
+# keeps everything and prunes only the last 3 NUMBERED run dirs, which has two
+# consequences here. A green full-suite run left 1185 MB under
+# `$TMPDIR/pytest-of-<user>` -- measured, and dominated by 47 copied
+# interpreters (~17.7 MB each) that the real-spawn tests build across the
+# `popen-gw*` workers. And the 3-dir pruning only ever runs at the START of a
+# LATER session, so a run dir left behind by a KILLED session is reclaimed only
+# if enough further sessions complete; interrupted agent sessions are routine
+# on this machine, so the directories accumulated to 36.5 GB across 68
+# abandoned run dirs and filled the disk to 98%.
+#
+# Measured effect of this setting plus the module-scoped interpreter fixture in
+# `tests/unit/evaluation/adapters/osworld/test_spawn.py`: a green full suite
+# now retains 1 MB rather than 1185 MB, with no wall-time cost (809.8s before
+# vs 800.7s after, and an interleaved A/B on the osworld subset measured 84.5s
+# vs 84.3s -- deleting directories costs I/O, but building six fewer venvs
+# saves more than it costs).
+#
+# Exact semantics, from `_pytest/tmpdir.py`: the fixture teardown removes the
+# directory only when the policy is `failed` AND the test passed (decided on
+# the `call` phase), and `pytest_sessionfinish` removes the whole basetemp when
+# the session exit status is 0 and no `--basetemp` was given. xdist workers ARE
+# given one (`workermanage.py` points each worker at a subdirectory of the
+# controller's basetemp), so per-worker cleanup comes from the fixture teardown
+# and the controller reclaims the rest at the end of a green session.
+tmp_path_retention_policy = "failed"
 markers = [
     # Applied by LOCATION in tests/e2e/conftest.py, so a module in that package
     # cannot forget it and silently rejoin the unit run.

--- a/tests/unit/evaluation/adapters/osworld/spawn_helpers.py
+++ b/tests/unit/evaluation/adapters/osworld/spawn_helpers.py
@@ -23,6 +23,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -174,12 +175,59 @@ def write_workspace(
     return workspace_digest(str(workspace))
 
 
+@dataclass(frozen=True)
+class SpawnInterpreter:
+    """A copied interpreter with the real adapter wheel already installed.
+
+    The two fields are everything a selector needs from the interpreter half of
+    the build: the executable to spawn and the digest of the distribution
+    installed into it. Kept together because they must describe the SAME
+    install -- a digest paired with a different executable would pass the
+    selector's model validation and then fail the handshake with an error that
+    names neither.
+    """
+
+    executable: Path
+    package_digest: str
+
+
+def build_spawn_interpreter(root: Path, wheel: Path) -> SpawnInterpreter:
+    """Build the copied interpreter and install the wheel into it, once.
+
+    Split out of ``build_spawnable_adapter`` so a module can pay this cost a
+    single time instead of per test. It is BY FAR the expensive half: a
+    ``venv --copies`` clone is a real ~17.7 MB interpreter copy plus a pip
+    install, whereas the workspace half is a few small files. Six per-test
+    builds in ``test_spawn.py``, multiplied by every xdist worker that drew one
+    of those tests, was the bulk of the ~1.16 GB a full suite run left under
+    ``$TMPDIR/pytest-of-<user>``.
+
+    Sharing the result across tests is SAFE only because nothing writes to it
+    after this returns: the wheel is installed ``--no-compile`` and every
+    spawned worker runs under ``-B`` (see ``_WORKER_FLAGS`` and the
+    supervisor's spawn flags), so no worker drops ``__pycache__`` entries into
+    the shared site-packages -- which would not merely dirty it but ADD
+    unhashed RECORD rows and break ``distribution_digest`` for every later
+    test. A test that deliberately mutates the install must still build its
+    own; see ``test_spawn.test_helper_wheel_record_and_lazy_startup``.
+    """
+
+    # The copied venv has neither local_operator nor pydantic, and the worker
+    # imports both before it can answer a handshake; ``copied_interpreter``
+    # writes the .pth pointing at this interpreter's real roots and proves
+    # the copy can import through it before handing it back.
+    executable = copied_interpreter(root / "venv")
+    site = site_packages_of(executable)
+    return SpawnInterpreter(executable, install_adapter_into_site(site, wheel))
+
+
 def build_spawnable_adapter(
     tmp_path: Path,
     wheel: Path,
     tasks: dict[str, str],
     *,
     provider: dict[str, object] | None = None,
+    interpreter: SpawnInterpreter | None = None,
 ) -> AdapterSelector:
     """Install the real wheel into a real interpreter and pin a real workspace.
 
@@ -187,16 +235,20 @@ def build_spawnable_adapter(
     computed from the artifact actually on disk, so a selector built here fails
     the handshake if the wheel or the workspace differs by one byte — which is
     the property that makes the spawned tests evidence rather than decoration.
+
+    ``interpreter`` reuses an install from ``build_spawn_interpreter`` instead
+    of building a private one. The WORKSPACE is still built under ``tmp_path``
+    either way, because it is what varies per test (task corpus and provider
+    selection both feed ``workspace_digest``) and it is cheap; only the
+    interpreter is shareable. Left optional so callers that want a pristine
+    install -- or simply have no module-scoped fixture -- keep the original
+    one-call behaviour.
     """
 
-    # The copied venv has neither local_operator nor pydantic, and the worker
-    # imports both before it can answer a handshake; ``copied_interpreter``
-    # writes the .pth pointing at this interpreter's real roots and proves
-    # the copy can import through it before handing it back.
-    executable = copied_interpreter(tmp_path / "venv")
-    site = site_packages_of(executable)
-
-    package_digest = install_adapter_into_site(site, wheel)
+    if interpreter is None:
+        interpreter = build_spawn_interpreter(tmp_path, wheel)
+    executable = interpreter.executable
+    package_digest = interpreter.package_digest
     release_digest = release_digest_for(package_digest, tasks)
     workspace = tmp_path / "workspace"
     workspace_digest_value = write_workspace(workspace, tasks, release_digest, provider=provider)

--- a/tests/unit/evaluation/adapters/osworld/test_spawn.py
+++ b/tests/unit/evaluation/adapters/osworld/test_spawn.py
@@ -46,9 +46,34 @@ _TASKS = {"task_plain": fixtures.PLAIN}
 
 @pytest.fixture(scope="module")
 def adapter_wheel(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    """Build the shipped wheel once; each test installs it into its own venv."""
+    """Build the shipped wheel once for every test in this module."""
 
     return spawn_helpers.build_adapter_wheel(tmp_path_factory.mktemp("wheel"))
+
+
+@pytest.fixture(scope="module")
+def spawn_interpreter(
+    tmp_path_factory: pytest.TempPathFactory, adapter_wheel: Path
+) -> spawn_helpers.SpawnInterpreter:
+    """One copied interpreter with the wheel installed, shared by this module.
+
+    Module scope, matching ``test_score_evidence.py`` and
+    ``test_run_episode_script.py``, which already build their interpreter this
+    way. Function scope here meant a real ``venv --copies`` clone (~17.7 MB)
+    per test per xdist worker, and this module has six spawn tests — the single
+    largest contributor to the temp footprint a suite run leaves behind.
+
+    Sharing is sound because the tests below only READ the install: they spawn
+    workers from it and pin its ``package_digest``, and each still gets its own
+    ``tmp_path`` workspace and artifact root, which is where everything a test
+    writes actually goes. ``test_helper_wheel_record_and_lazy_startup`` is the
+    exception and deliberately does not use this fixture — it tampers with the
+    installed bytes, so it needs an install nothing else can observe.
+    """
+
+    return spawn_helpers.build_spawn_interpreter(
+        tmp_path_factory.mktemp("spawn-interpreter"), adapter_wheel
+    )
 
 
 def _spec_for_spawn(episode_id: str) -> Any:
@@ -75,6 +100,12 @@ def _spec_for_spawn(episode_id: str) -> Any:
 def test_helper_wheel_record_and_lazy_startup(tmp_path: Path, adapter_wheel: Path) -> None:
     import subprocess
 
+    # Deliberately NOT the module-scoped ``spawn_interpreter``: this test
+    # rewrites a file inside the installed distribution to prove the digest
+    # refuses it. The bytes are restored in a ``finally``, but a failure
+    # between the two writes would leave a tampered install behind, and every
+    # later test sharing it would fail its handshake for a reason that names
+    # none of this. A private install keeps the blast radius at one test.
     selector = spawn_helpers.build_spawnable_adapter(tmp_path, adapter_wheel, _TASKS)
     result = subprocess.run(
         [
@@ -117,8 +148,12 @@ assert distribution_digest(dist) == digest
 
 
 @pytest.mark.asyncio
-async def test_real_wheel_handshakes_and_reaps(tmp_path: Path, adapter_wheel: Path) -> None:
-    selector = spawn_helpers.build_spawnable_adapter(tmp_path, adapter_wheel, _TASKS)
+async def test_real_wheel_handshakes_and_reaps(
+    tmp_path: Path, adapter_wheel: Path, spawn_interpreter: spawn_helpers.SpawnInterpreter
+) -> None:
+    selector = spawn_helpers.build_spawnable_adapter(
+        tmp_path, adapter_wheel, _TASKS, interpreter=spawn_interpreter
+    )
     supervisor = AdapterSupervisor.launch(selector)
     try:
         handshake = await supervisor.handshake(timeout=60)
@@ -139,7 +174,10 @@ async def test_real_wheel_handshakes_and_reaps(tmp_path: Path, adapter_wheel: Pa
 
 @pytest.mark.asyncio
 async def test_spawned_worker_seals_a_verified_bundle(
-    tmp_path: Path, adapter_wheel: Path, episode_id: str
+    tmp_path: Path,
+    adapter_wheel: Path,
+    episode_id: str,
+    spawn_interpreter: spawn_helpers.SpawnInterpreter,
 ) -> None:
     """THE headline: a real out-of-process episode ends in a verifiable bundle.
 
@@ -158,6 +196,7 @@ async def test_spawned_worker_seals_a_verified_bundle(
         # stripped, so the backend selection has to live in the workspace whose
         # digest the handshake pins.
         provider={"provider": "fake", "scripted_score": 1.0},
+        interpreter=spawn_interpreter,
     )
     config = spawn_helpers.spawn_config(tmp_path)
 
@@ -210,7 +249,10 @@ async def test_spawned_worker_seals_a_verified_bundle(
 
 @pytest.mark.asyncio
 async def test_spawned_worker_reports_a_partial_score(
-    tmp_path: Path, adapter_wheel: Path, episode_id: str
+    tmp_path: Path,
+    adapter_wheel: Path,
+    episode_id: str,
+    spawn_interpreter: spawn_helpers.SpawnInterpreter,
 ) -> None:
     """A fractional evaluator score survives the boundary as exact ppm.
 
@@ -225,6 +267,7 @@ async def test_spawned_worker_reports_a_partial_score(
         adapter_wheel,
         _TASKS,
         provider={"provider": "fake", "scripted_score": 0.5},
+        interpreter=spawn_interpreter,
     )
     runner = EpisodeRunner(
         _spec_for_spawn(episode_id),
@@ -245,7 +288,10 @@ async def test_spawned_worker_reports_a_partial_score(
 
 @pytest.mark.asyncio
 async def test_secrets_cross_the_boundary_and_never_appear_in_the_worker_env(
-    tmp_path: Path, adapter_wheel: Path, episode_id: str
+    tmp_path: Path,
+    adapter_wheel: Path,
+    episode_id: str,
+    spawn_interpreter: spawn_helpers.SpawnInterpreter,
 ) -> None:
     """Schema 1.2's ``ResetStartParams.secrets`` reaches a REAL spawned worker.
 
@@ -268,7 +314,11 @@ async def test_secrets_cross_the_boundary_and_never_appear_in_the_worker_env(
     )
 
     selector = spawn_helpers.build_spawnable_adapter(
-        tmp_path, adapter_wheel, _TASKS, provider={"provider": "fake"}
+        tmp_path,
+        adapter_wheel,
+        _TASKS,
+        provider={"provider": "fake"},
+        interpreter=spawn_interpreter,
     )
     spec = _spec_for_spawn(episode_id)
     artifact_root = tmp_path / "artifacts"
@@ -353,7 +403,10 @@ def test_a_1_1_selector_cannot_even_be_built_against_a_1_2_parent(tmp_path: Path
 
 @pytest.mark.asyncio
 async def test_real_wheel_simulator_answer_enters_public_artifact_and_next_request(
-    tmp_path: Path, episode_id: str, adapter_wheel: Path
+    tmp_path: Path,
+    episode_id: str,
+    adapter_wheel: Path,
+    spawn_interpreter: spawn_helpers.SpawnInterpreter,
 ) -> None:
     import hashlib
 
@@ -365,6 +418,7 @@ async def test_real_wheel_simulator_answer_enters_public_artifact_and_next_reque
         adapter_wheel,
         {"task_plain": fixtures.SCRIPTED_SIMULATOR},
         provider={"provider": "fake", "has_user_simulator": True},
+        interpreter=spawn_interpreter,
     )
     config = spawn_helpers.spawn_config(tmp_path)
     model, stream = _offline_ask_client(config.artifact_root)

--- a/tests/unit/wakes/test_display.py
+++ b/tests/unit/wakes/test_display.py
@@ -30,13 +30,20 @@ def local_clock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
             monkeypatch.delenv(key)
     monkeypatch.setenv("TZ", "America/Los_Angeles")
     time.tzset()
-    # Drop any watcher registered against a PREVIOUS test's config dir. The
-    # registry in ``config_watch`` is a process-global keyed by path, and the
-    # settings cache is filled from whichever watcher answers for the current
-    # ``config_dir()``. Without this reset a watcher built by an earlier
-    # parametrization keeps answering after its ``tmp_path`` is gone, so this
-    # test reads the previous case's persisted ``display.time_format`` and the
-    # 12h/24h assertion fails depending on execution order.
+    # Drop the watcher this test's config dir may already have registered.
+    # Both parametrizations of ``test_settings_choice_persists_and_refreshes_panel``
+    # receive the SAME ``tmp_path``: pytest's ``_mk_tmp`` sanitises the node name
+    # and truncates it at 30 chars, so ``...panel[100]`` and ``...panel[60]`` share
+    # a stem, and under ``tmp_path_retention_policy = "failed"`` the passing case's
+    # directory is deleted so the numbered-dir allocator reuses index 0.
+    #
+    # The watcher registry in ``config_watch`` is a process-global keyed by that
+    # path, and ``settings_get`` fills its cache from whichever watcher answers
+    # for the current ``config_dir()``. Without this reset the second case reads
+    # the first case's ``display.time_format`` SNAPSHOT from a watcher whose
+    # directory no longer exists, and the 12h/24h assertion fails depending on
+    # execution order. Isolation here therefore rests on this reset rather than
+    # on the two cases having distinct directories.
     _reset_for_tests()
     settings_reload()
     yield

--- a/tests/unit/wakes/test_display.py
+++ b/tests/unit/wakes/test_display.py
@@ -19,6 +19,8 @@ from local_operator.wakes.display import format_wake_time
 
 @pytest.fixture(autouse=True)
 def local_clock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from local_operator.config_watch import _reset_for_tests
+
     if not hasattr(time, "tzset"):
         pytest.skip("Changing the process timezone requires tzset")
     monkeypatch.setenv("HOME", str(tmp_path))
@@ -28,10 +30,19 @@ def local_clock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
             monkeypatch.delenv(key)
     monkeypatch.setenv("TZ", "America/Los_Angeles")
     time.tzset()
+    # Drop any watcher registered against a PREVIOUS test's config dir. The
+    # registry in ``config_watch`` is a process-global keyed by path, and the
+    # settings cache is filled from whichever watcher answers for the current
+    # ``config_dir()``. Without this reset a watcher built by an earlier
+    # parametrization keeps answering after its ``tmp_path`` is gone, so this
+    # test reads the previous case's persisted ``display.time_format`` and the
+    # 12h/24h assertion fails depending on execution order.
+    _reset_for_tests()
     settings_reload()
     yield
     monkeypatch.undo()
     time.tzset()
+    _reset_for_tests()
     settings_reload()
 
 


### PR DESCRIPTION
Stops `$TMPDIR/pytest-of-<user>` growing without bound. A green full suite retained **1185 MB**; it now retains **1 MB**, with no wall-time cost.

**Change class: C1 (standard, pre-authorized).** Test-infrastructure and pytest configuration only. No runtime code, no API, no schema, no user-facing surface.

## The problem

This machine hit **100% disk (119 MB free)** tonight, which killed unrelated agent sessions mid-write with `[Errno 28]`. `$TMPDIR/pytest-of-damian` had reached **36.5 GB across 68 abandoned run dirs**.

**What this PR does and does not fix (corrected after review F1).** Both mechanisms below are real, but they are fixed by different halves of this change. `tmp_path_retention_policy` runs in fixture teardown and `pytest_sessionfinish`, and **neither fires under SIGKILL** — so the config line does *not* reclaim anything from a killed session. The reduction for killed sessions comes entirely from **mechanism 1** (fewer, shared venvs): measured by killing a run mid-flight, base left 108 MB / 6 orphaned venvs, this branch leaves 54 MB / 3. Reclaiming dirs from sessions that were killed outright remains the job of the separate hourly launchd reaper, not of this PR.

Two mechanisms combine:

1. **Cost per run.** `tests/unit/evaluation/adapters/osworld/test_spawn.py` built a real copied interpreter (~17.7 MB, `venv --copies` + pip install) at **6 call sites with function-scoped `tmp_path`** — so once per test, multiplied by every xdist worker that drew one of those tests. A green run dir held **1185 MB across 47 venv copies** in `popen-gw*`.
2. **Nothing reclaims it.** pytest's default `tmp_path_retention_policy = "all"` prunes only the last 3 *numbered* run dirs, and that pruning runs at the **start of a later session**. A run dir left by a killed session is reclaimed only if enough further sessions complete. Interrupted agent sessions are routine here, so they accumulated.

## The change

1. **`tmp_path_retention_policy = "failed"`** in `[tool.pytest.ini_options]`. A **failing test keeps its directory**, so debugging is unaffected; passing tests' dirs are removed at teardown, and `pytest_sessionfinish` reclaims the basetemp on a green session.
2. **`spawn_helpers.py`** — split the expensive half into `build_spawn_interpreter()` returning a frozen `SpawnInterpreter(executable, package_digest)`. `build_spawnable_adapter` takes an optional `interpreter=`; the **workspace stays per-test** because the task corpus and provider feed `workspace_digest` and must vary. The default path is unchanged, so `test_run_episode_script.py` and `test_score_evidence.py` are untouched.
3. **`test_spawn.py`** — module-scoped `spawn_interpreter` fixture, shared by 5 of the 6 call sites that build one.

### Why sharing the interpreter is safe

Nothing writes to the install after it is built: the wheel is installed `--no-compile`, and every spawned worker runs under `-B` (verified at `supervisor.py:310`, whose own comment states "must leave no bytecode there either"). A stray `__pycache__` would add an **unhashed RECORD row** and break `distribution_digest` for every later test.

**One of the seven collected tests is deliberately left function-scoped.** `test_helper_wheel_record_and_lazy_startup` rewrites a file *inside* the installed distribution to prove `distribution_digest` rejects tampering. Restore is in a `finally`, but a failure between the two writes would leave a tampered install poisoning every sharer with a handshake error naming none of this. A private install caps the blast radius at one test.

## Evidence

### Performance: no regression (the explicit gate)

Sequential A/B was meaningless — the machine was at **load average 167** with 12 sibling pytest processes. Switched to **interleaved A/B** (this repo's documented methodology), osworld subset, `-u AWS_DEFAULT_PROFILE`:

| pair | BEFORE wall / retained | AFTER wall / retained |
|---|---|---|
| 1 | 98.7s / 164 MB | 97.7s / 0 MB |
| 2 | 96.6s / 164 MB | 88.3s / 2 MB |
| 3 | 86.9s / 164 MB | 103.2s / 0 MB |
| 4 | 55.6s / 146 MB | 47.9s / 0 MB |
| **mean** | **84.5s / 159.5 MB** | **84.3s / 0.5 MB** |

**Full suite, both legs fully green, 17220 passed:** BEFORE **813.8s** → AFTER **821.6s** (+1.0%, within noise on a contended machine). Deleting directories costs I/O; building fewer venvs pays for it.

**Independent QA measurement** (private worktrees, isolated per-run `TMPDIR`, interleaved at loadavg 10.6–16.0) — head was faster on every paired run:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| base | 130 MB | 257 MB | 386 MB |
| head | **0 MB** | **0 MB** | **0 MB** |

Base grows linearly across repeat runs; head stays flat at equal-or-better wall time.

**Caveat (review F2):** the `1185 MB → 1 MB` headline is the *green-session* case, because `pytest_sessionfinish` reclaims the basetemp only on `exitstatus == 0`. On a red session you get the per-test reclaim instead — still most of the win, but not the headline number.

**Repeat runs** (the specific concern): steady state **0 / 23 / 1 MB** across 3 consecutive runs, no run N+1 slower than baseline N+1. Mechanical proof: instrumenting `copied_interpreter` counts **6 venv builds → 2**.

### Retention semantics verified empirically

Inside the repo rootdir, a probe with one passing and one failing test:

```
1 failed, 1 passed
pytest-30949/test_fails0/f.txt      <- failing test's dir RETAINED
                                    <- passing test's dir removed
```

Independent re-verification of `test_spawn.py` on the pushed head: `7 passed`, **0 MB retained**.

### Isolation

`pytest-randomly` is **not installed** in this venv, so `-p no:randomly` is inert and an earlier "randomized order" claim proved nothing — replaced with explicit node-ID reordering:

- reverse declaration order — 6 passed
- tamper-test first, then sharers — 3 passed
- sharers only, tamper deselected — 6 passed
- module serial `-n0` — 7 passed
- each of the 6 tests individually — all passed

### Gates

`flake8` rc=0 · `black --check` 1165 files unchanged · `isort --check-only` rc=0 · `pyright` 0 errors.

## Pre-existing failures, not from this change

All reproduced on the unmodified parent commit:

- `test_procname::test_unreadable_libpython_parent_does_not_raise` — fails identically on the parent commit.
- ~~`wakes/test_display[60]`~~ — **this one was NOT a pre-existing flake, and is now fixed in `0947743f9`.** See below.
- `osworld/test_dependencies::test_presence_never_imports_parent` — xdist-only flake; line 72 sets `sys.path` to *only* `tmp_path`, so any later first-time import fails. Names a different module each run (`hmac` on the parent, `cryptography` here) — same defect, worker-dependent. Clean under `-n0`.

## `wakes/test_display[60]`: a real defect this change exposed

CI came back red on one shard with `assert '7:52 PM PDT' in '19:52 PDT'`, which looked like an ambient-locale flake. It was not, and the initial "no effect" reading of it was wrong. Toggling **only** the retention setting on one commit decides it:

```
$ pytest tests/unit/wakes/test_display.py -q -n0                                   # as committed
1 failed, 14 passed
$ pytest tests/unit/wakes/test_display.py -q -n0 -o tmp_path_retention_policy=all
15 passed
```

Root cause: `config_watch._watchers` is a **process-global keyed by config-dir path**, and `settings_get` fills its cache from whichever watcher answers for the current `config_dir()`. The fixture pointed `LOCAL_OPERATOR_CONFIG_DIR` at a fresh `tmp_path` per case but never dropped the watcher registered against the previous one, so a stale watcher kept answering and `[60]` read `[100]`'s persisted `display.time_format`.

**It is a pre-existing defect, not one this PR introduced** — forcing `tmp_path_retention_policy=failed` on the parent commit reproduces it with no other change. Each case also passes alone; only the pair fails. Deleting the passing case's directory is simply what made the latent order-dependence observable.

Fixed in `0947743f9` by resetting the registry in fixture setup and teardown, matching the existing `_reset_for_tests()` pattern in `tests/unit/tui/test_app_pilot.py`. Verified under `retention=failed`, under `retention=all`, in reverse parametrization order, and under xdist.

## Rollback

Revert the commit. The setting is pytest configuration with no runtime effect; the fixture split leaves the default `build_spawnable_adapter` path unchanged.
