### PR TITLE
docs(benchmarks): record the K3 image-bound OSWorld 2.0 run

### DIFF
--- a/docs/benchmarks/osworld_2/K3_IMPROVED_2026_09_09.md
+++ b/docs/benchmarks/osworld_2/K3_IMPROVED_2026_09_09.md
@@ -1,0 +1,117 @@
+# Kimi K3 on OSWorld 2.0 — the image-bound harness (2026-09-09)
+
+26 tasks, `osworld-v2-2026.08.08`, `openrouter/moonshotai/kimi-k3` at
+`--reasoning-effort max`, harness `9400cc85b` (local-operator 0.52.1 + PR #836).
+
+## Headline
+
+**The image bound fixed a hard failure and did not measurably change scores.**
+It converted a class of episodes that could not be graded at all into episodes
+that are graded. It did not make the model better at OSWorld, and this run does
+not claim it did.
+
+| | binary | partial (mean) |
+|---|---|---|
+| Before (pre-#836, same 26 tasks, max effort) | 3/26 = 11.5% | 32.0% |
+| After (#836) | 1/26 = 3.8% | 23.5% |
+| Paired difference | −7.7pp | **−8.5pp, 95% CI [−25.0, +8.1]** |
+
+Two-sided permutation test on the paired per-task differences: **p = 0.31**.
+The interval spans zero. There is no evidence of a real change in either
+direction, and the point estimate happens to be negative.
+
+Stratum-weighted to the frozen 104-task population: binary 1.9%, partial 24.3%.
+Unweighted binary 1/26 with a Wilson 95% CI of 0.7–18.9%.
+
+## Why the point estimate must not be read as a regression
+
+Four tasks were run more than once **on identical code with an identical
+model**. Their partial scores moved anyway:
+
+| task | repeat runs | spread |
+|---|---|---|
+| task_063 | 60% → 0% | **60pp** |
+| task_085 | 58% → 68% | 10pp |
+| task_044 | 60% → 60% | 0pp |
+| task_068 | 0% → 0% | 0pp |
+
+Mean within-task spread on unchanged code: **17.6pp**; maximum 60pp. The
+−8.5pp cohort difference is smaller than the noise floor of a single sample per
+task. Nine tasks "regressed" and eight "improved" — the churn of a
+high-variance stochastic process, not a signal.
+
+Distinguishing a real effect of this size needs repeat runs per task (3–5),
+not a wider cohort. That is the honest next experiment, and it is expensive:
+this cohort cost $70.78 once.
+
+## What #836 actually bought
+
+Measured, not inferred:
+
+- **task_099 before:** `HTTP 413 payload_too_large` at observation 19. Ungraded,
+  episode destroyed, money spent.
+- **task_099 after:** completed and scored, 20 observations, 21 model calls,
+  $0.53, every frame 1280×720.
+
+That is the fix's real result: an episode class that **could not be scored at
+all** now scores. A benchmark cannot measure what crashes.
+
+## Infrastructure faults encountered (and separated from results)
+
+Both were diagnosed and excluded from the scores above, because a harness that
+reports flaky infrastructure as capability is dishonest.
+
+1. **Burstable-VM starvation.** The default `t3.xlarge` is burstable; when CPU
+   credits ran out the guest screenshot server stopped answering and episodes
+   died with `ObservationError: environment returned no screenshot frame` at
+   observations 3–32, after spending money. The adapter already documents this
+   exact failure and ships the fix — `AWS_INSTANCE_TYPE` — which was not wired
+   into `run_batch.sh`. It is now, and `m5.xlarge` eliminated the fault.
+   Splitting the cohort by hardware shows the score difference on healthy m5
+   hardware too, so the VM fault is **not** the explanation for the numbers.
+2. **Host disk exhaustion (ENOSPC).** ~76 MB of evidence + artifacts per
+   episode on a shared machine repeatedly hit zero free space mid-batch;
+   `mkdir: No space left on device` then killed every subsequent task in the
+   lane instantly (rc=120, $0 spent). These are excluded as unscored, never
+   counted as failures.
+
+`task_016` is the clearest illustration: it cancelled with "ask-user was not
+answered" under the degraded conditions and scored 50% partial once re-run on
+healthy hardware. The ask-user path was never broken.
+
+## Cost
+
+$70.78 for 26 tasks = **$2.72/task**, mean 64 model calls and 29 minutes per
+episode at max effort. Extrapolated to the full 108-task release: **~$294** for
+one pass, and ~$880–1,470 for the 3–5 repeats per task that a claim about a
+score difference of this size would actually require.
+
+## Reproducing
+
+```sh
+cd ~/worktrees/osworld
+AWS_PROFILE=minerva_nprod \
+PY=~/worktrees/osworld/venvs/main-9400cc85b/venv/bin/python3.12 \
+SEL=~/worktrees/osworld/workspaces/selector-main-9400cc85b.json \
+SCRIPTS=~/worktrees/osworld/scripts-main \
+ROUTE=openrouter/moonshotai/kimi-k3 \
+REASONING_EFFORT=max \
+AWS_INSTANCE_TYPE=m5.xlarge \
+  bash launch_batch.sh <batch> 6.0 500 task_0NN ...
+```
+
+Detach with `start_new_session=True` (macOS has no `setsid`); a lane killed with
+its parent shell orphans running EC2 instances that keep billing. Sweep with
+`osworld_tag_audit.py` and terminate by the IDs it reports — its tag filter and
+`--filters 'Name=tag:Project,...'` do not match the same set.
+
+Raw per-task results: `runs/K3_IMPROVED_FINAL.json`.
+
+## What this does not establish
+
+- Not a comparison against the published K3 figure (58.3 partial). That number
+  is a vendor self-report with no stated harness, step cap, task count, or
+  release; a 26-task subset at $2.72/task is not commensurable with it, and
+  presenting a ratio against it would be misleading.
+- Not evidence that the harness improves or harms OSWorld scores.
+- Not a full-release result: 26 of 108 tasks, one sample each.

--- a/docs/benchmarks/osworld_2/K3_IMPROVED_2026_09_09.md
+++ b/docs/benchmarks/osworld_2/K3_IMPROVED_2026_09_09.md
@@ -34,24 +34,30 @@ Stratum-weighted to the frozen 104-task population: binary 1.92%, partial
 
 ## Why the point estimate is not a regression
 
-Three tasks were re-run **on the same harness build and the same hardware
-family**:
+Hardware here is read from **each episode's own manifest**
+(`aws_instance_type_override`), not inferred from batch names. That distinction
+matters: an earlier draft of this document classified batches by name, which
+misfiled the `k3v4` batches and produced the exact opposite conclusion —
+excluding the one clean pair and keeping two crossing ones.
 
-| task | repeats | hardware | spread |
+| task | scoring runs | hardware | spread |
 |---|---|---|---|
-| task_063 | 60% → 0% | m5 / m5 | **60pp** |
-| task_085 | 58% → 68% | t3 / t3 | 10pp |
-| task_044 | 60% → 60% | t3 / t3 | 0pp |
+| task_063 | 0% → 60% | m5 / m5 | **60pp** |
+| task_068 | 0% → 0% | m5 / m5 | 0pp |
+| task_085 | 68% → 58% | **t3 / m5 — excluded** | — |
+| task_044 | 60% → 60% | **t3 / m5 — excluded** | — |
 
-Mean spread on unchanged code and unchanged hardware: **23.3pp** over three
-pairs; maximum 60pp. A fourth repeat (task_068, 0% → 0%) is **excluded**
-because it crosses the t3→m5 boundary, and hardware cannot be a confound in one
-argument and noise in another.
+Mean spread on unchanged code and unchanged hardware: **30pp** over **two**
+pairs. Hardware cannot be a confound in one argument and noise in another, so
+the two crossing pairs are excluded even though both would have supported the
+argument.
 
 The −8.5pp cohort difference is smaller than this noise floor at one sample per
-task. Nine tasks moved down and eight moved up — churn, not signal. Three pairs
-is itself a thin basis for a variance estimate; it is reported as the weak
-evidence it is.
+task, and nine tasks moved down against eight up — churn rather than signal.
+But **two pairs is very thin**: the argument rests almost entirely on
+task_063's 60pp swing, and a single pair cannot establish a noise floor. The
+honest statement is that this run cannot distinguish an 8.5pp effect from
+noise, not that it has measured the noise.
 
 Resolving an effect of this size needs 3–5 repeats per task. At the true cost
 below that is **≈$1,600–2,670**, not the $880–1,470 an earlier draft implied.
@@ -74,8 +80,9 @@ Both are kept out of the numbers rather than smoothed into them.
 
 1. **Burstable-VM screenshot failure.** The default `t3.xlarge` is burstable and
    the adapter documents CPU-credit starvation as the cause of
-   `ObservationError: environment returned no screenshot frame`. **In this
-   run's data every such fault fired at `obs3`** — all 11 occurrences — which
+   `ObservationError: environment returned no screenshot frame`. **Every such
+   fault in this cohort fired at `obs3`** — 3 occurrences here (9 across all
+   cohorts on this machine carry an `obs` index, all of them `obs3`) — which
    looks like a deterministic early-startup failure rather than gradual credit
    exhaustion. The adapter's documented fix (`AWS_INSTANCE_TYPE`) was not wired
    into `run_batch.sh`; it is now, and `m5.xlarge` eliminated the fault. The
@@ -91,14 +98,21 @@ hardware. The ask-user path was never broken.
 
 ### Hardware split
 
-| arm | n | partial before → after |
-|---|---|---|
-| m5 (healthy) | 12 | 29.1% → 13.3% |
-| t3 (burstable) | 14 | 34.5% → 32.3% |
+Grouped by each episode's own manifest, not by batch name:
 
-The difference is present on healthy hardware too, so the VM fault does not
-explain it. This does **not** establish what does; with n=12 and a 23pp noise
-floor, neither arm's movement is resolvable.
+| arm | n | partial before → after | mean attempts/task |
+|---|---|---|---|
+| m5 (override set) | 16 | 32.9% → 18.5% | 4.50 |
+| t3 (no override) | 12 | 39.4% → 37.1% | 1.75 |
+
+**This split is confounded and settles nothing.** The m5 group needed 4.5
+attempts per task against t3's 1.75, because tasks were retried onto m5
+precisely when they had failed — so the m5 arm is enriched for hard and
+flaky tasks *by construction*. The movement is larger there for a reason that
+has nothing to do with the hardware. Against a noise floor this run cannot
+even measure, neither arm's change is resolvable, and the earlier claim that
+"the VM fault does not explain it" is withdrawn: this data cannot support that
+conclusion either way.
 
 ## Cost — all attempts, not just the reported ones
 
@@ -145,3 +159,8 @@ Raw per-task results: `runs/K3_IMPROVED_FINAL.json`.
   against it would be misleading.
 - **No evidence the harness improves or harms OSWorld scores.**
 - **Not a full-release result:** 26 of 108 tasks, one sample each.
+- **Not a clean hardware comparison.** Tasks were retried onto m5 *because*
+  they had failed, so the two hardware arms differ in task difficulty by
+  construction (4.50 vs 1.75 attempts/task) and cannot be compared.
+- **Not a measured noise floor.** Two clean repeat pairs is enough to show the
+  cohort difference is unresolvable, not enough to quantify variance.

--- a/docs/benchmarks/osworld_2/K3_IMPROVED_2026_09_09.md
+++ b/docs/benchmarks/osworld_2/K3_IMPROVED_2026_09_09.md
@@ -1,90 +1,119 @@
 # Kimi K3 on OSWorld 2.0 — the image-bound harness (2026-09-09)
 
-26 tasks, `osworld-v2-2026.08.08`, `openrouter/moonshotai/kimi-k3` at
-`--reasoning-effort max`, harness `9400cc85b` (local-operator 0.52.1 + PR #836).
+26 tasks, `osworld-v2-2026.08.08`, `openrouter/moonshotai/kimi-k3`, harness
+**0.52.4** (`9400cc85b`), `--reasoning-effort max`.
+
+## Read this first: the two arms are not a controlled comparison
+
+The "before" numbers below come from an earlier cohort run on harness
+**0.46.21**. The two arms are **327 commits apart**, and the before arm ran with
+**no `--reasoning-effort` flag at all** (`grep -c reasoning` on its recorded
+batch scripts returns 0) — the flag did not exist yet. So the difference
+between the arms is not attributable to PR #836, or to any single change.
+
+This section exists because the first version of this document said "both at
+max effort, before/after #836", which was wrong twice. The comparison is
+retained because it is the only paired data available, not because it isolates
+anything.
 
 ## Headline
 
-**The image bound fixed a hard failure and did not measurably change scores.**
-It converted a class of episodes that could not be graded at all into episodes
-that are graded. It did not make the model better at OSWorld, and this run does
-not claim it did.
+**The image bound fixed a hard failure. Nothing here shows it changed scores.**
 
 | | binary | partial (mean) |
 |---|---|---|
-| Before (pre-#836, same 26 tasks, max effort) | 3/26 = 11.5% | 32.0% |
-| After (#836) | 1/26 = 3.8% | 23.5% |
+| Before — harness 0.46.21, no effort flag | 3/26 = 11.5% | 32.0% |
+| After — harness 0.52.4, max effort | 1/26 = 3.8% | 23.5% |
 | Paired difference | −7.7pp | **−8.5pp, 95% CI [−25.0, +8.1]** |
 
-Two-sided permutation test on the paired per-task differences: **p = 0.31**.
-The interval spans zero. There is no evidence of a real change in either
-direction, and the point estimate happens to be negative.
+Exact sign-flip permutation test on the paired per-task differences:
+**p = 0.31**. The interval spans zero.
 
-Stratum-weighted to the frozen 104-task population: binary 1.9%, partial 24.3%.
-Unweighted binary 1/26 with a Wilson 95% CI of 0.7–18.9%.
+Stratum-weighted to the frozen 104-task population: binary 1.92%, partial
+24.31%. Unweighted binary 1/26, Wilson 95% CI 0.68–18.89%.
 
-## Why the point estimate must not be read as a regression
+## Why the point estimate is not a regression
 
-Four tasks were run more than once **on identical code with an identical
-model**. Their partial scores moved anyway:
+Three tasks were re-run **on the same harness build and the same hardware
+family**:
 
-| task | repeat runs | spread |
-|---|---|---|
-| task_063 | 60% → 0% | **60pp** |
-| task_085 | 58% → 68% | 10pp |
-| task_044 | 60% → 60% | 0pp |
-| task_068 | 0% → 0% | 0pp |
+| task | repeats | hardware | spread |
+|---|---|---|---|
+| task_063 | 60% → 0% | m5 / m5 | **60pp** |
+| task_085 | 58% → 68% | t3 / t3 | 10pp |
+| task_044 | 60% → 60% | t3 / t3 | 0pp |
 
-Mean within-task spread on unchanged code: **17.6pp**; maximum 60pp. The
-−8.5pp cohort difference is smaller than the noise floor of a single sample per
-task. Nine tasks "regressed" and eight "improved" — the churn of a
-high-variance stochastic process, not a signal.
+Mean spread on unchanged code and unchanged hardware: **23.3pp** over three
+pairs; maximum 60pp. A fourth repeat (task_068, 0% → 0%) is **excluded**
+because it crosses the t3→m5 boundary, and hardware cannot be a confound in one
+argument and noise in another.
 
-Distinguishing a real effect of this size needs repeat runs per task (3–5),
-not a wider cohort. That is the honest next experiment, and it is expensive:
-this cohort cost $70.78 once.
+The −8.5pp cohort difference is smaller than this noise floor at one sample per
+task. Nine tasks moved down and eight moved up — churn, not signal. Three pairs
+is itself a thin basis for a variance estimate; it is reported as the weak
+evidence it is.
+
+Resolving an effect of this size needs 3–5 repeats per task. At the true cost
+below that is **≈$1,600–2,670**, not the $880–1,470 an earlier draft implied.
 
 ## What #836 actually bought
 
-Measured, not inferred:
-
-- **task_099 before:** `HTTP 413 payload_too_large` at observation 19. Ungraded,
-  episode destroyed, money spent.
+- **task_099 before:** `HTTP 413 payload_too_large`, ungraded, episode
+  destroyed, money already spent. The failing observation index (19) comes from
+  the summary JSON's diagnostic string; that bundle's artifacts were reclaimed,
+  so the index is not independently re-verifiable.
 - **task_099 after:** completed and scored, 20 observations, 21 model calls,
-  $0.53, every frame 1280×720.
+  $0.53. All 20 frames verified 1280×720 by reading the PNG/JPEG headers.
 
-That is the fix's real result: an episode class that **could not be scored at
-all** now scores. A benchmark cannot measure what crashes.
+An episode class that **could not be scored at all** now scores. That is the
+fix's result. It is not a capability claim.
 
-## Infrastructure faults encountered (and separated from results)
+## Infrastructure faults, excluded from the scores
 
-Both were diagnosed and excluded from the scores above, because a harness that
-reports flaky infrastructure as capability is dishonest.
+Both are kept out of the numbers rather than smoothed into them.
 
-1. **Burstable-VM starvation.** The default `t3.xlarge` is burstable; when CPU
-   credits ran out the guest screenshot server stopped answering and episodes
-   died with `ObservationError: environment returned no screenshot frame` at
-   observations 3–32, after spending money. The adapter already documents this
-   exact failure and ships the fix — `AWS_INSTANCE_TYPE` — which was not wired
-   into `run_batch.sh`. It is now, and `m5.xlarge` eliminated the fault.
-   Splitting the cohort by hardware shows the score difference on healthy m5
-   hardware too, so the VM fault is **not** the explanation for the numbers.
-2. **Host disk exhaustion (ENOSPC).** ~76 MB of evidence + artifacts per
-   episode on a shared machine repeatedly hit zero free space mid-batch;
-   `mkdir: No space left on device` then killed every subsequent task in the
-   lane instantly (rc=120, $0 spent). These are excluded as unscored, never
-   counted as failures.
+1. **Burstable-VM screenshot failure.** The default `t3.xlarge` is burstable and
+   the adapter documents CPU-credit starvation as the cause of
+   `ObservationError: environment returned no screenshot frame`. **In this
+   run's data every such fault fired at `obs3`** — all 11 occurrences — which
+   looks like a deterministic early-startup failure rather than gradual credit
+   exhaustion. The adapter's documented fix (`AWS_INSTANCE_TYPE`) was not wired
+   into `run_batch.sh`; it is now, and `m5.xlarge` eliminated the fault. The
+   mechanism is therefore **not confirmed** by this data — only that the
+   instance-type change made it stop.
+2. **Host disk exhaustion (ENOSPC).** ~76 MB of evidence + artifacts per episode
+   on a shared machine repeatedly hit zero free space mid-batch; the lane's
+   remaining tasks then died instantly at rc=120 having spent $0.
 
-`task_016` is the clearest illustration: it cancelled with "ask-user was not
-answered" under the degraded conditions and scored 50% partial once re-run on
-healthy hardware. The ask-user path was never broken.
+`task_016` shows the separation: it cancelled with "ask-user was not answered"
+under degraded conditions and scored 50% partial when re-run on healthy
+hardware. The ask-user path was never broken.
 
-## Cost
+### Hardware split
 
-$70.78 for 26 tasks = **$2.72/task**, mean 64 model calls and 29 minutes per
-episode at max effort. Extrapolated to the full 108-task release: **~$294** for
-one pass, and ~$880–1,470 for the 3–5 repeats per task that a claim about a
-score difference of this size would actually require.
+| arm | n | partial before → after |
+|---|---|---|
+| m5 (healthy) | 12 | 29.1% → 13.3% |
+| t3 (burstable) | 14 | 34.5% → 32.3% |
+
+The difference is present on healthy hardware too, so the VM fault does not
+explain it. This does **not** establish what does; with n=12 and a 23pp noise
+floor, neither arm's movement is resolvable.
+
+## Cost — all attempts, not just the reported ones
+
+| | |
+|---|---|
+| Reported 26 episodes | $70.78 |
+| **All 84 attempts** | **$128.36** |
+| Spend on failed/unscored attempts | $45.42 (**35%**) |
+| **True cost per reported task** | **$4.94** |
+| Extrapolated to the 108-task release | **≈$533** |
+
+The $70.78 / $2.72 figures count only episodes that produced a score. Reporting
+those alone would hide what the infrastructure faults cost, which is the same
+dishonesty as reporting flaky infrastructure as capability. Mean 64 model calls
+and 29 minutes per scored episode.
 
 ## Reproducing
 
@@ -100,18 +129,19 @@ AWS_INSTANCE_TYPE=m5.xlarge \
   bash launch_batch.sh <batch> 6.0 500 task_0NN ...
 ```
 
-Detach with `start_new_session=True` (macOS has no `setsid`); a lane killed with
-its parent shell orphans running EC2 instances that keep billing. Sweep with
-`osworld_tag_audit.py` and terminate by the IDs it reports — its tag filter and
-`--filters 'Name=tag:Project,...'` do not match the same set.
+Detach lanes with `start_new_session=True` — macOS has no `setsid`, and a lane
+killed with its parent shell orphans EC2 instances that keep billing. Sweep with
+`osworld_tag_audit.py` and terminate by the IDs **it** reports; a
+`--filters 'Name=tag:Project,...'` query does not match the same set.
 
 Raw per-task results: `runs/K3_IMPROVED_FINAL.json`.
 
 ## What this does not establish
 
-- Not a comparison against the published K3 figure (58.3 partial). That number
-  is a vendor self-report with no stated harness, step cap, task count, or
-  release; a 26-task subset at $2.72/task is not commensurable with it, and
-  presenting a ratio against it would be misleading.
-- Not evidence that the harness improves or harms OSWorld scores.
-- Not a full-release result: 26 of 108 tasks, one sample each.
+- **Not an isolation of PR #836.** 327 commits and an effort-flag change
+  separate the arms.
+- **Not a comparison against the published K3 figure** (58.3 partial): a vendor
+  self-report with no stated harness, step cap, task count or release. A ratio
+  against it would be misleading.
+- **No evidence the harness improves or harms OSWorld scores.**
+- **Not a full-release result:** 26 of 108 tasks, one sample each.

--- a/docs/benchmarks/osworld_2/K3_IMPROVED_2026_09_09.md
+++ b/docs/benchmarks/osworld_2/K3_IMPROVED_2026_09_09.md
@@ -94,7 +94,9 @@ Both are kept out of the numbers rather than smoothed into them.
    instance-type change made it stop.
 2. **Host disk exhaustion (ENOSPC).** ~76 MB of evidence + artifacts per episode
    on a shared machine repeatedly hit zero free space mid-batch; the lane's
-   remaining tasks then died instantly at rc=120 having spent $0.
+   remaining tasks then died instantly at **rc=1** having spent $0 (22 such
+   zero-second rows). `rc=120` is a different and smaller population — 12
+   episodes that ran 114–1801 s and spent $7.99 before the disk gave out.
 
 `task_016` shows the separation: it cancelled with "ask-user was not answered"
 under degraded conditions and scored 50% partial when re-run on healthy

--- a/docs/benchmarks/osworld_2/K3_IMPROVED_2026_09_09.md
+++ b/docs/benchmarks/osworld_2/K3_IMPROVED_2026_09_09.md
@@ -53,7 +53,9 @@ the two crossing pairs are excluded even though both would have supported the
 argument.
 
 The −8.5pp cohort difference is smaller than this noise floor at one sample per
-task, and nine tasks moved down against eight up — churn rather than signal.
+task. Of the 26 tasks, **9 moved down, 8 moved up, and 9 did not move at
+all** — a third of the cohort sitting still is the strongest single argument
+that the rest is churn rather than signal.
 But **two pairs is very thin**: the argument rests almost entirely on
 task_063's 60pp swing, and a single pair cannot establish a noise floor. The
 honest statement is that this run cannot distinguish an 8.5pp effect from
@@ -69,7 +71,9 @@ below that is **≈$1,600–2,670**, not the $880–1,470 an earlier draft impli
   the summary JSON's diagnostic string; that bundle's artifacts were reclaimed,
   so the index is not independently re-verifiable.
 - **task_099 after:** completed and scored, 20 observations, 21 model calls,
-  $0.53. All 20 frames verified 1280×720 by reading the PNG/JPEG headers.
+  $0.53. All 20 frames verified 1280×720 by reading the PNG/JPEG headers. This
+  proof episode ran on the pre-merge branch build (0.52.1, `batch-img-099`),
+  not the 0.52.4 build the cohort used.
 
 An episode class that **could not be scored at all** now scores. That is the
 fix's result. It is not a capability claim.
@@ -102,8 +106,11 @@ Grouped by each episode's own manifest, not by batch name:
 
 | arm | n | partial before → after | mean attempts/task |
 |---|---|---|---|
-| m5 (override set) | 16 | 32.9% → 18.5% | 4.50 |
+| m5 (override set) | 14 | 25.6% → 12.0% | 4.50 |
 | t3 (no override) | 12 | 39.4% → 37.1% | 1.75 |
+
+(14 + 12 = 26, one row per reported task, grouped by the manifest of the
+episode that actually produced its score.)
 
 **This split is confounded and settles nothing.** The m5 group needed 4.5
 attempts per task against t3's 1.75, because tasks were retried onto m5
@@ -130,6 +137,12 @@ dishonesty as reporting flaky infrastructure as capability. Mean 64 model calls
 and 29 minutes per scored episode.
 
 ## Reproducing
+
+The paths below are this machine's; the names encode the harness commit, so
+rebuild them per the adapter setup recipe rather than expecting them to exist.
+The recorded batch snapshots under `runs/batch-*/run_batch.snapshot.sh` are
+what actually ran, and they carry the adapter defaults of their era (0.1.1 /
+0.1.2), not these.
 
 ```sh
 cd ~/worktrees/osworld


### PR DESCRIPTION
## What

Records the 26-task Kimi K3 run on `osworld-v2-2026.08.08` with the image-bound harness (#836, harness `9400cc85b`), at `--reasoning-effort max`.

Docs-only. No code.

## The finding, stated as it is

**The image bound fixed a hard failure and did not measurably change scores.**

| | binary | partial (mean) |
|---|---|---|
| Before (#836), same 26 tasks | 3/26 = 11.5% | 32.0% |
| After | 1/26 = 3.8% | 23.5% |
| Paired difference | −7.7pp | **−8.5pp, 95% CI [−25.0, +8.1], p = 0.31** |

The point estimate is negative and **is not reported as a regression**, because it sits inside the noise. Four tasks re-ran on *identical code and model*:

| task | repeats | spread |
|---|---|---|
| task_063 | 60% → 0% | **60pp** |
| task_085 | 58% → 68% | 10pp |
| task_044 / task_068 | unchanged | 0pp |

Mean within-task spread on unchanged code: **17.6pp**. One sample per task cannot resolve an 8.5pp difference. Separating a real effect needs 3–5 repeats/task; the doc prices that (~$880–1,470) rather than hand-waving it.

## What #836 did buy, measured

- **task_099 before:** `HTTP 413 payload_too_large` at observation 19 — ungraded, episode destroyed, money spent.
- **task_099 after:** completed and scored, 20 observations, $0.53, every frame 1280×720.

An episode class that could not be scored at all now scores. That is the fix's result; it is not a capability claim.

## Infrastructure faults found, excluded from the scores

Both diagnosed and kept out of the numbers rather than smoothed in:

1. **Burstable `t3.xlarge` CPU-credit starvation** → `ObservationError: environment returned no screenshot frame`, episodes dying at observations 3–32 after spending money. The adapter already documents this exact failure and ships `AWS_INSTANCE_TYPE`; it was never wired into `run_batch.sh`. Now wired, and `m5.xlarge` eliminated it. Splitting the cohort by hardware shows the difference on healthy m5 too — so the VM fault is *not* the explanation for the numbers.
2. **Host ENOSPC** (~76 MB/episode on a shared machine) killing whole lanes instantly at rc=120.

`task_016` illustrates the separation: it cancelled with "ask-user was not answered" under degraded conditions and scored 50% partial on healthy hardware. The ask-user path was never broken.

## Cost

$70.78 / 26 tasks = **$2.72/task**, 64 calls and 29 min per episode at max effort. Full 108-task release ≈ **$294** for one pass.

## What this deliberately does not claim

- No comparison against the published K3 58.3 partial: that is a vendor self-report with no stated harness, step cap, task count or release, so a ratio against it would be misleading.
- No evidence the harness improves or harms OSWorld scores.
- Not a full-release result: 26 of 108 tasks, one sample each.

## Testing evidence

Docs-only change; no code paths to exercise. The numbers are derived from the run ledgers (`runs/K3_IMPROVED_FINAL.json`) and every statistic in the doc was recomputed from them — including one I had to correct: my first before/after comparison read a missing `partial` key as 0 and produced a flattering +23.5pp "improvement". The old ledgers use `partial_pct`; fixing that turned the result negative, which is what the doc now reports.