### PR TITLE
chore(release): bump version to 0.52.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.52.9"
+version = "0.52.10"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

Release bump for the window since `v0.52.9`. **`pyproject.toml` only** — one line, no code.

Window derived from `origin/main` at claim time (`git log v0.52.9..origin/main`), exactly two commits:

- `b5f4001b8` docs(benchmarks): record the K3 image-bound OSWorld 2.0 run (#852)
- `c5ab36944` fix(info): count subagents across the fleet and stop faking a zero (#826)

## Bump class: PATCH

One bug fix on an existing surface plus a docs record. No API addition, no migration, no behaviour change requiring a consumer to act. Nothing here clears the step-function bar a minor is reserved for.

## Ownership

Claimed the window under the combined-release rule: last tag `v0.52.9` (`5981276ab`), no open `chore(release)` PR, so no lock was held. Announced to every live lop peer before opening this PR; no competing claim and nothing offered to fold in.

## Scope check

```
$ git diff --name-only
pyproject.toml
$ git diff --stat
 pyproject.toml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

C0 one-file scope change: the diff is the version string and nothing else.