### PR TITLE
chore(release): bump version to 0.52.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.52.10"
+version = "0.52.11"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release bump for the v0.52.11 window. **pyproject.toml only**, one line.

## Window

`v0.52.10..main` — exactly one commit:

- #850 (8d1846963) `perf(read): bound internal-URL reads with a head + section outline`

## Bump class: PATCH

A bug fix on an existing surface: one read path was missing the bound every other read path already had. No API addition, no new config key, no migration, no schema change. It does change what a `read skill://` result *looks like*, which is the only argument for a minor; that does not clear the step-function bar.

## What ships

`execute_read`'s internal-URL branch (`skill://`, `guide://`, `mcp://`) returned resolver content with **no size bound**, unlike every other read outcome (8 KiB). Because `_is_prunable` deliberately exempts skill reads from pruning, an oversized result then stayed resident for the life of the session and was re-billed on every subsequent provider call.

Measured before the fix:

| | |
|---|---|
| One `read skill://minerva-software-development` | 78,468 chars (~26,932 billed tokens) |
| Share of one real session's 951,162 billed input tokens | **34%** |
| Fleet-wide (1,722 stored sessions) | 1,849 oversized internal reads, ~49.7M chars above cap |

After: a top banner + a 6 KiB head cut at a heading boundary + a **complete** heading index with line ranges + a `spill://` handle — **78,468 → 7,120 chars (90.9%)**. Documents under 16 KiB are returned byte-identical (8 of 10 bundled guides).

Replay over the 425 affected real trajectories projects **~86%** reduction in re-billed cost (89% short / 90% medium / 86% long).

## Why the index is complete, and not a head truncation

The operative rules in these documents sit deep in the body — in that skill, `## Mandatory Agent Review Gate` is at char 30,343 and the human-reviewer decision tree at 60,012, while a frontmatter phrase survives any head cap. A head-only truncation would *read* complete while every binding rule had been deleted, and an agent acting on it would merge without a review round. All seven safety-critical rules were verified reachable through an advertised range, independently, by the implementer, the reviewer and QA.

## Gate on the released commit

Agent review rounds 1-3 and QA rounds 1-3, all clean and fresh on head `c8701e4e3`, 17/17 CI green. Two reviewer findings (a CRLF symptom and a suggested one-line fix) were reproduced, disproved, and **publicly withdrawn** rather than quietly dropped.

## Scope check

C0 — one file, one line. No source, test, or doc changes ride along.