### PR TITLE
fix(osworld): execute a batch's actions in the order the model wrote them

### DIFF
--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
@@ -728,9 +728,22 @@ class OSWorldV2Adapter:
         # is skipped and only the read-back below runs. The parent sets this
         # flag solely after we declared the commit via ObservationPhaseError.
         if not params.resume_observation and runs:
-            for kind, payload in runs:
+            # Only the LAST guest run settles. The provider pauses
+            # ``action_delay_s`` after each execute() so the desktop can
+            # repaint; splitting a batch into ordered runs would otherwise pay
+            # that pause once per run, multiplying it and stacking it on top of
+            # the wait the model asked for (a requested 2 s becoming 5 s). One
+            # settle per batch keeps the pacing identical to what a batch cost
+            # before ordering was honoured.
+            last_exec = max(
+                (index for index, (kind, _) in enumerate(runs) if kind == "exec"),
+                default=-1,
+            )
+            for index, (kind, payload) in enumerate(runs):
                 if kind == "exec":
-                    await self._provider.execute(cast(list[str], payload))
+                    await self._provider.execute(
+                        cast(list[str], payload), settle=index == last_exec
+                    )
                 else:
                     await asyncio.sleep(cast(int, payload) / 1000.0)
             if not guest_lines:

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
@@ -44,7 +44,7 @@ import os
 import time
 from importlib.metadata import distribution
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 from lop_osworld_v2_adapter import actions
 from lop_osworld_v2_adapter import cleanup as cleanup_mod
@@ -700,20 +700,40 @@ class OSWorldV2Adapter:
         assert current.frames, "current observation carries no screen frame"
         geometry = current.frames[0].geometry
         statements = actions.compile_batch(params.action_batch, geometry)
+        # Split into ORDERED runs rather than two unordered buckets. A batch
+        # like [click, wait 2000, paste_text] means "click, let the UI settle,
+        # then paste": partitioning it into all-guest-lines-then-all-waits
+        # executed the paste against a UI that had not finished responding and
+        # slept afterwards, when the sleep could no longer do anything. That
+        # silently disobeyed the model in 425 of 1746 wait-bearing batches
+        # (24%) on a benchmark whose tasks are largely about pacing slow UIs.
+        #
+        # Each run is a maximal group of consecutive guest statements or a
+        # single wait, so the guest still receives batched statements (one
+        # round trip per run, not per action) while the model's ordering is
+        # honoured exactly.
+        runs: list[tuple[str, list[str] | int]] = []
+        for statement in statements:
+            if statement.startswith("WAIT "):
+                runs.append(("wait", int(statement.split(" ", 1)[1])))
+            elif runs and runs[-1][0] == "exec":
+                cast(list[str], runs[-1][1]).append(statement)
+            else:
+                runs.append(("exec", [statement]))
         guest_lines = [s for s in statements if not s.startswith("WAIT ")]
-        waits = [int(s.split(" ", 1)[1]) for s in statements if s.startswith("WAIT ")]
         # RESUME: the parent is re-reading the state THIS batch already
         # produced, after a previous attempt committed the actions and then
         # failed to read the screen back. Re-running the guest statements here
         # would apply the click or the keystroke a second time, so the mutation
         # is skipped and only the read-back below runs. The parent sets this
         # flag solely after we declared the commit via ObservationPhaseError.
-        if not params.resume_observation and (guest_lines or waits):
-            if guest_lines:
-                await self._provider.execute(guest_lines)
-            for wait_ms in waits:
-                await asyncio.sleep(wait_ms / 1000.0)
-            if not guest_lines and waits:
+        if not params.resume_observation and runs:
+            for kind, payload in runs:
+                if kind == "exec":
+                    await self._provider.execute(cast(list[str], payload))
+                else:
+                    await asyncio.sleep(cast(int, payload) / 1000.0)
+            if not guest_lines:
                 # A pure-wait batch still advances the environment's clock.
                 await self._provider.execute([])
 

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
@@ -815,7 +815,7 @@ class AwsProvider:
         raw = await asyncio.to_thread(env._get_obs)
         return dict(raw)
 
-    async def execute(self, statements: list[str]) -> None:
+    async def execute(self, statements: list[str], *, settle: bool = True) -> None:
         env = self._require_env()
 
         def run() -> None:
@@ -845,7 +845,14 @@ class AwsProvider:
             # Let the desktop settle after the batch, exactly as OSWorld's
             # own ``step(pause=...)`` does. An empty batch still settles so a
             # pure WAIT advances the guest clock.
-            self._sleep(self._action_delay_s)
+            #
+            # ``settle=False`` is for a NON-FINAL run of an interleaved batch.
+            # Such a batch is delivered as several ordered runs, and settling
+            # after every one would both multiply the pause and stack it on
+            # top of the wait the model explicitly asked for -- turning a
+            # requested 2 s into 5 s. One settle per batch, on the last run.
+            if settle:
+                self._sleep(self._action_delay_s)
 
         await asyncio.to_thread(run)
 

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/base.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/base.py
@@ -178,8 +178,17 @@ class EnvironmentProvider(Protocol):
         """Return OSWorld's raw observation dict (screenshot/a11y/terminal/instruction)."""
         ...
 
-    async def execute(self, statements: list[str]) -> None:
-        """Run compiled guest statements, then settle. No observation here."""
+    async def execute(self, statements: list[str], *, settle: bool = True) -> None:
+        """Run compiled guest statements, then settle. No observation here.
+
+        ``settle=False`` runs the statements WITHOUT the post-batch pause. It
+        exists for a batch that interleaves actions and waits: such a batch is
+        sent as several ordered runs, and settling after each one would both
+        multiply the pause and add it to the delay the model explicitly asked
+        for. Only the final run of a batch settles, so a batch costs exactly
+        one settle however many runs it took -- the same as before ordering
+        was honoured.
+        """
         ...
 
     async def evaluate(self) -> Any:

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/fake.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/fake.py
@@ -69,6 +69,7 @@ class FakeProvider:
         self._sequence = 0
         self.allocated = False
         self.executed_statements: list[str] = []
+        self.settle_flags: list[bool] = []
         self.terminated_refs: list[str] = []
         self.deleted_schedules: list[str] = []
         self.evaluate_calls = 0
@@ -124,8 +125,12 @@ class FakeProvider:
             "instruction": "fake instruction",
         }
 
-    async def execute(self, statements: list[str]) -> None:
+    async def execute(self, statements: list[str], *, settle: bool = True) -> None:
+        # ``settle`` is accepted to satisfy the provider protocol; the fake has
+        # no desktop to repaint, so there is nothing to pause for. Recorded so
+        # a test can still assert that a split batch settles exactly once.
         self.executed_statements.extend(statements)
+        self.settle_flags.append(settle)
         self._sequence += 1
 
     async def evaluate(self) -> Any:

--- a/docs/benchmarks/osworld_2/BUDGETS_AND_LATENCY.md
+++ b/docs/benchmarks/osworld_2/BUDGETS_AND_LATENCY.md
@@ -29,23 +29,36 @@ is directly comparable to upstream.
 
 ### What the old 2400 s wall did
 
-At the cohort's median pace a 40-minute wall bought **~87 steps**, against a
-standard budget of 500 and reference agents that use 190–318. It was not
-measuring capability, it was measuring who fit in 40 minutes:
+At the cohort's median pace of 27.4 s per model call a 40-minute wall bought
+**~88 steps**, against a standard budget of 500 and reference agents that use
+190–318. It was not measuring capability, it was measuring who fit in 40
+minutes.
 
-| | n | mean partial |
-|---|---|---|
-| Hit the wall | 9 | **13.5%** |
-| Finished in time | 17 | **28.8%** |
+Four of the 26 tasks have more than one scoring run, so the exact means depend
+on which run is picked. The split is reported as a range because the
+CONCLUSION is what is robust, not the decimals:
 
-The truncated episodes were still working when they were cut off — 2–6 actions
-per batch, zero errors, compaction running normally.
+| pick | capped | finished | capped mean | finished mean |
+|---|---|---|---|---|
+| first scoring run | 9 | 17 | 13.5% | 28.8% |
+| last scoring run | 8 | 18 | 15.2% | 30.0% |
+| best partial | 8 | 18 | 15.2% | 30.6% |
+
+Under every selection the episodes that ran out of time score roughly half of
+those that finished. The truncated ones were still working when they were cut
+off — 2–6 actions per batch, zero errors, compaction running normally.
+
+One caveat on attribution: these episodes are recorded with
+`truncation_reason=budget-cap`, not a wall-specific reason, so "hit the wall"
+is inferred from elapsed time against the 2400 s ceiling rather than read
+directly from the journal.
 
 ### What the limits are now
 
-`--max-wall-s` defaults to **18000** (5 h) and exists only as a runaway guard;
-it is sized so the 500-step budget always binds first. `OSWORLD_TTL_SECONDS`
-defaults to **18900** — the wall plus 900 s of slack — because
+`--max-wall-s` now defaults to **18000** (5 h) in `scripts/run_episode.py` and
+exists only as a runaway guard; it is sized so the 500-step budget always binds
+first. The batch script passes `OSWORLD_TTL_SECONDS=18900` — the wall plus
+900 s of slack — because
 `providers/aws.py` falls back to `DEFAULT_TTL_SECONDS = 7200` when no TTL is
 supplied (the wall budget is not carried on the adapter wire), and an instance
 reclaimed at 2 h kills an episode that the harness would have let run.
@@ -92,7 +105,19 @@ promising:
 So ~59% of the run is the provider generating tokens, and the largest
 remaining harness-side lever is **output volume**, not harness CPU.
 
-### The 3.0 s settle is deliberate and stays
+### One settle per batch, not one per run
+
+Honouring order splits a batch into several guest runs, and the provider pauses
+`action_delay_s` after each `execute()`. Settling per run would multiply that
+pause AND stack it on the wait the model asked for -- a requested 2 s becoming
+5 s. Measured on the 2026-09 cohort, naive settling would have added 533
+execute calls and ~0.44 h (2% of 22.76 h) of pure sleeping.
+
+So `execute` takes `settle=`, and only the final guest run of a batch settles.
+A batch costs exactly one settle however many runs it took, which is what it
+cost before ordering was honoured.
+
+### The 3.0 s settle value itself is deliberate and stays
 
 `providers/aws.py` sleeps `action_delay_s = 3.0` after each batch. Upstream's
 `sleep_after_execution` defaults to `0.0` and the official script does not pass

--- a/docs/benchmarks/osworld_2/BUDGETS_AND_LATENCY.md
+++ b/docs/benchmarks/osworld_2/BUDGETS_AND_LATENCY.md
@@ -48,20 +48,35 @@ Under every selection the episodes that ran out of time score roughly half of
 those that finished. The truncated ones were still working when they were cut
 off — 2–6 actions per batch, zero errors, compaction running normally.
 
-One caveat on attribution: these episodes are recorded with
-`truncation_reason=budget-cap`, not a wall-specific reason, so "hit the wall"
-is inferred from elapsed time against the 2400 s ceiling rather than read
-directly from the journal.
+Two caveats on attribution, both of which a reader needs in order to
+reproduce the table rather than conclude it is wrong:
+
+- The grouping rule is **elapsed >= 2280 s**, i.e. within 5% of the 2400 s
+  ceiling, not elapsed >= 2400 s. The margin matters: `task_098` finished at
+  2331 s, under the ceiling but plainly pressed against it, and it belongs
+  with the truncated group. Using the ceiling itself gives 8/18 and
+  9.7% vs 29.7% -- the same conclusion, different decimals.
+- These episodes are recorded with `truncation_reason=budget-cap`, not a
+  wall-specific reason. No episode carries a reason naming the wall, so "hit
+  the wall" is inferred from elapsed time, not read from the journal.
 
 ### What the limits are now
 
 `--max-wall-s` now defaults to **18000** (5 h) in `scripts/run_episode.py` and
 exists only as a runaway guard; it is sized so the 500-step budget always binds
-first. The batch script passes `OSWORLD_TTL_SECONDS=18900` — the wall plus
-900 s of slack — because
+first.
+
+The cloud lease is now **derived from the wall** in `run_episode.py`
+(`_ensure_lease_outlasts_wall`, wall + 900 s) rather than left to the
+provider's fixed fallback. This is load-bearing: raising the wall alone would
+have inverted the previous ordering, because
 `providers/aws.py` falls back to `DEFAULT_TTL_SECONDS = 7200` when no TTL is
-supplied (the wall budget is not carried on the adapter wire), and an instance
-reclaimed at 2 h kills an episode that the harness would have let run.
+supplied — the wall budget is not carried on the adapter wire. With an 1800 s
+wall that fallback was harmless; with an 18000 s wall an episode past two
+hours would die on a TERMINATED INSTANCE rather than at a budget boundary,
+which loses the episode instead of ending it and reads as an infrastructure
+fault rather than a deliberate cap. An explicit `OSWORLD_TTL_SECONDS` still
+wins.
 
 **Any wall-truncated episode is a deviation from the standard.** The runner
 records `truncation_reason`; a non-zero wall-truncation rate belongs in any

--- a/docs/benchmarks/osworld_2/BUDGETS_AND_LATENCY.md
+++ b/docs/benchmarks/osworld_2/BUDGETS_AND_LATENCY.md
@@ -1,0 +1,119 @@
+# Step budget, wall clock, and where a step's time goes
+
+Why the run limits are what they are, and what the per-step latency is made
+of. Written after a 26-task Kimi K3 cohort spent 22.8 h of wall time and had
+9 of 30 episodes truncated by a limit this harness invented.
+
+## The standard is 500 steps and NO wall clock
+
+OSWorld 2.0 bounds an episode by **model steps only**. There is no
+time limit anywhere in the upstream harness:
+
+- `lib_run_single.py` bounds the loop with `while not done and step_idx <
+  max_steps`, and `step_idx += 1` happens once per `agent.predict()` call,
+  outside the loop that executes that call's actions. One step = one model
+  call, however many actions it carries.
+- The official Claude script passes `--max_steps 500`; the paper's headline
+  metric is binary completion "at 500 steps", with 150/300 as documented
+  reduced budgets.
+- `wrapt_timeout_decorator` is imported in `lib_run_single.py` but **no
+  function in the file carries a decorator** — dead code inherited from
+  WebArena. The `"Time limit exceeded"` string in `run.py` is the generic
+  `except Exception` message, not a timeout path.
+- The argparse default of `--max_steps 15` is a vestigial OSWorld-1.0 value;
+  the documented run commands, not the defaults, carry the standard.
+
+Our runner already counts steps the same way: `_steps_taken += 1` once per
+action batch, with `_guest_actions` tracked separately. So `--max-steps 500`
+is directly comparable to upstream.
+
+### What the old 2400 s wall did
+
+At the cohort's median pace a 40-minute wall bought **~87 steps**, against a
+standard budget of 500 and reference agents that use 190–318. It was not
+measuring capability, it was measuring who fit in 40 minutes:
+
+| | n | mean partial |
+|---|---|---|
+| Hit the wall | 9 | **13.5%** |
+| Finished in time | 17 | **28.8%** |
+
+The truncated episodes were still working when they were cut off — 2–6 actions
+per batch, zero errors, compaction running normally.
+
+### What the limits are now
+
+`--max-wall-s` defaults to **18000** (5 h) and exists only as a runaway guard;
+it is sized so the 500-step budget always binds first. `OSWORLD_TTL_SECONDS`
+defaults to **18900** — the wall plus 900 s of slack — because
+`providers/aws.py` falls back to `DEFAULT_TTL_SECONDS = 7200` when no TTL is
+supplied (the wall budget is not carried on the adapter wire), and an instance
+reclaimed at 2 h kills an episode that the harness would have let run.
+
+**Any wall-truncated episode is a deviation from the standard.** The runner
+records `truncation_reason`; a non-zero wall-truncation rate belongs in any
+reported score, because the benchmark specifies no time limit and a
+time-limited number is not comparable to a leaderboard entry.
+
+## Where a step's 27 s actually goes
+
+Measured from `monotonic_ns` gaps across 64 evidence bundles / 22.8 h. Note
+that all four model events are journalled *after* the provider returns, so
+`observation -> model_request` is the provider call and the sub-second gaps
+after it are just journalling.
+
+| transition | share | median | what it is |
+|---|---|---|---|
+| `observation -> model_request` | 52.6% | 9.21 s | the provider generating |
+| `usage_cost -> action_batch` | 25.1% | 5.21 s | guest execution + screenshot |
+| `lifecycle_transition -> observation` | 8.1% | 91.6 s | per-episode startup, once |
+| `observation -> context_compaction` | 7.0% | 8.91 s | **not compaction cost** — see below |
+
+Three findings worth recording, because each one closed an avenue that looked
+promising:
+
+1. **Compaction is not a cost centre.** `context_compaction` is journalled
+   after `decide()` returns, so on those steps it lands where `model_request`
+   normally would; both gaps measure the same model call. All 268 records are
+   `strategy="prune"` with `summary_artifact=None` — no summarising LLM call
+   is ever made. Compaction steps are marginally *faster* than ordinary ones.
+2. **Harness CPU on the model hot path is ~12 ms**, against a 9.21 s gap.
+   Measured on real 600 KB frames: base64 2.45 ms, artifact verification
+   1.89 ms, token estimation 0.34 ms warm, body building 0.43 ms. The
+   memoised tokenizer and the `to_thread` around image bounding already work.
+   There is nothing to win here.
+3. **Frames on the wire are already bounded.** The archived native artifacts
+   in a bundle are 1920×1080, which makes it look as though full-size frames
+   are sent; the frame the model actually receives is 1280×720 at ~4 KB,
+   produced by `bound_screen_frame` through the same
+   `local_operator.imaging.bound_image_for_model` ladder the interactive
+   session uses. Verified by driving `ObservationBuilder` directly.
+
+So ~59% of the run is the provider generating tokens, and the largest
+remaining harness-side lever is **output volume**, not harness CPU.
+
+### The 3.0 s settle is deliberate and stays
+
+`providers/aws.py` sleeps `action_delay_s = 3.0` after each batch. Upstream's
+`sleep_after_execution` defaults to `0.0` and the official script does not pass
+it, but the paper states "A 3 s pause is inserted after each action", so 3.0 s
+is the documented behaviour rather than an accident. Cutting it would save
+about a second per step and risks screenshotting a half-painted UI — a score
+risk taken to chase a latency win that the wall-clock fix dwarfs. Not changed.
+If it is ever revisited, ship it as its own run and watch the
+`UNCHANGED_FRAMES_NOTE` rate.
+
+## Known remaining inefficiency: the echoed observation_id
+
+Every action carries `observation_id`, a 64-hex-char digest, and
+`ActionBatch` requires each action's copy to equal the batch's. The runner
+already injects the batch-level value from the current observation, so the
+model's copies are never read as data — they exist to expose staleness.
+
+Cost, measured: 43 tokens per action × 2.88 actions per batch = ~124 output
+tokens per call, ~2.2 s of generation at the fitted rate, **1.56 h across the
+cohort — 6.8% of total runtime**.
+
+This is a real win but it changes a frozen protocol invariant with strict
+validators, so it is deliberately NOT bundled with the budget fix. It needs
+its own change and its own review round.

--- a/docs/benchmarks/osworld_2/README.md
+++ b/docs/benchmarks/osworld_2/README.md
@@ -168,12 +168,19 @@ follow-up `create_tags` would leave a window in which the instance exists
 untagged and therefore outside both the lease's authority and the leak audit.
 
 Lease length: `OSWORLD_TTL_SECONDS` if the operator sets it, otherwise
-`DEFAULT_TTL_SECONDS = 7200`, floored at `TTL_SLACK_SECONDS = 900`.
-`ttl_seconds_for` can derive `wall_budget + 900 s` from a capped wall budget,
-but **the wall budget is not on the adapter wire today**: the adapter passes
-`None` for it and only the override or the 7200 s default is ever in force.
-Setting `OSWORLD_TTL_SECONDS` to the wall budget plus 900 is therefore the
-operator's job, and is what bounds a leaked instance's worst-case cost.
+derived by `run_episode.py` as **wall budget + 900 s**
+(`_ensure_lease_outlasts_wall`), floored at `TTL_SLACK_SECONDS = 900` by the
+provider.
+
+The derivation happens in the runner rather than the provider because **the
+wall budget is not on the adapter wire**: `ttl_seconds_for` receives `None`
+and would otherwise fall back to `DEFAULT_TTL_SECONDS = 7200`. That fallback
+was harmless while the wall default was 1800 s and became a defect when it
+rose to 18000 s — a lease shorter than the wall means an episode past two
+hours dies on a terminated instance rather than at a budget boundary, losing
+the episode instead of ending it. An explicit `OSWORLD_TTL_SECONDS` still
+wins and is never shortened; it is what bounds a leaked instance's worst-case
+cost.
 
 ### Burstable credit exhaustion, and `AWS_INSTANCE_TYPE`
 

--- a/docs/benchmarks/osworld_2/README.md
+++ b/docs/benchmarks/osworld_2/README.md
@@ -870,7 +870,7 @@ Flags on `scripts/run_episode.py`, with their defaults:
 | `--route` | required | `<provider>/<model>`; the paid episode used `openrouter/deepseek/deepseek-v4-flash-vision-exp` |
 | `--max-steps` | 25 | bounds the step loop; `EpisodeConfig.max_steps` itself defaults to 50 |
 | `--max-usd` | 0.50 | hard provider spend cap |
-| `--max-wall-s` | 1800 | wall clock; **not** propagated to the TTL lease (§2) |
+| `--max-wall-s` | 18000 | runaway guard only; the 500-step budget binds first. The TTL lease is derived from it (`_ensure_lease_outlasts_wall`), see BUDGETS_AND_LATENCY.md |
 | `--max-cycle-usd` | none | per-cycle cost-rate guard |
 | `--keep-recent-frames` | 3 | frame retention |
 | `--benchmark-release` | `osworld-v2-2026.08.08` | |
@@ -1085,6 +1085,11 @@ $PY ~/local-operator/scripts/run_episode.py \
     --max-steps 25 --max-usd 0.50 --max-wall-s 1800 --keep-recent-frames 3 \
     | tee "$RUN/outcome.json"
 ```
+
+This is a SMOKE command: 25 steps, $0.50, and a matching short wall and lease.
+A scored run uses the standard 500-step budget and the 18000 s default wall,
+and lets the lease derive from it -- see `BUDGETS_AND_LATENCY.md`. Do not copy
+these caps into a run whose numbers you intend to report.
 
 Exit 0 means `completed`; 1 is any other terminal state; 2 is a missing or
 unusable secret (named on stderr, value never printed) or a volatile run root.

--- a/scripts/run_episode.py
+++ b/scripts/run_episode.py
@@ -104,6 +104,12 @@ from local_operator.evaluation.runner.secrets import (
 EXIT_OK = 0
 EXIT_EPISODE = 1
 EXIT_PREFLIGHT = 2
+
+# Slack between the wall budget and the cloud lease. Mirrors the provider's own
+# TTL_SLACK_SECONDS: the lease must outlast the wall by enough to cover boot,
+# scoring and cleanup, so an episode that runs its full budget still gets torn
+# down deliberately rather than reclaimed underneath itself.
+_LEASE_SLACK_SECONDS = 900
 # Diagnostic prefixes (``_diagnostic`` renders ``<TypeName>: ...``) that mean
 # a secret stopped the run before allocation; both are name-only by contract.
 _SECRET_DIAGNOSTICS = ("MissingSecret:", "UnusableSecret:")
@@ -652,12 +658,45 @@ class _ScriptedFinish:
         return ModelDecision(action_batch=batch, route=self._route)
 
 
+def _ensure_lease_outlasts_wall(
+    infra_values: "tuple[ScopedInfraValue, ...]", args: argparse.Namespace
+) -> "tuple[ScopedInfraValue, ...]":
+    """Default the cloud lease to outlast the wall budget.
+
+    WHY. The wall budget is not carried on the adapter wire, so the provider's
+    ``ttl_seconds_for`` receives ``None`` and falls back to a fixed
+    ``DEFAULT_TTL_SECONDS`` (7200). While the wall default was 1800 that was
+    harmless -- the wall always fired first. Raising the wall to 18000 to stop
+    truncating episodes inverted the relationship: an episode past two hours
+    would die on a TERMINATED INSTANCE rather than at a budget boundary, which
+    is a far worse failure. It loses the episode instead of ending it, and it
+    reads as an infrastructure fault rather than a deliberate cap.
+
+    So the lease is derived from the wall here, where both numbers are known,
+    rather than left to a constant that cannot see either. An operator who
+    passes ``OSWORLD_TTL_SECONDS`` explicitly still wins; this only supplies a
+    default when they did not, and never shortens a lease they chose.
+    """
+
+    if any(value.name == "OSWORLD_TTL_SECONDS" for value in infra_values):
+        return infra_values
+    lease = int(args.max_wall_s) + _LEASE_SLACK_SECONDS
+    return infra_values + (
+        ScopedInfraValue(
+            name="OSWORLD_TTL_SECONDS",
+            value=str(lease),
+            purpose=args.infra_purpose,
+        ),
+    )
+
+
 async def run(args: argparse.Namespace) -> int:
     try:
         infra_values = _parse_infra(args.infra, args.infra_purpose)
     except ValueError as error:
         print(str(error), file=sys.stderr)
         return EXIT_PREFLIGHT
+    infra_values = _ensure_lease_outlasts_wall(infra_values, args)
     selector = AdapterSelector.model_validate(json.loads(args.selector.read_text()))
     provider, model = args.route
     route = _route_identity(provider, model)

--- a/scripts/run_episode.py
+++ b/scripts/run_episode.py
@@ -582,7 +582,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--config-dir", type=Path, default=None, help="lop config dir")
     parser.add_argument("--max-steps", type=int, default=25)
     parser.add_argument("--max-usd", type=float, default=0.50, help="provider spend cap")
-    parser.add_argument("--max-wall-s", type=int, default=1800)
+    # OSWorld 2.0 bounds an episode by MODEL STEPS (500), not by time: the
+    # upstream loop is `step_idx < max_steps` and no timeout decorator is
+    # applied anywhere. A wall clock here is a runaway guard only, so it is
+    # sized so the step budget always binds first. The previous 1800 s
+    # default silently converted a 500-step budget into ~65-85 steps at
+    # observed pace and truncated 9 of 30 episodes mid-work; see
+    # docs/benchmarks/osworld_2/BUDGETS_AND_LATENCY.md.
+    parser.add_argument("--max-wall-s", type=int, default=18000)
     parser.add_argument("--max-cycle-usd", type=float, default=None, help="per-cycle cap")
     parser.add_argument("--keep-recent-frames", type=int, default=3)
     parser.add_argument(

--- a/tests/unit/evaluation/adapters/osworld/test_action_wait_order.py
+++ b/tests/unit/evaluation/adapters/osworld/test_action_wait_order.py
@@ -1,0 +1,242 @@
+"""The guest must receive a batch's actions in the order the model wrote them.
+
+WHY THIS FILE EXISTS. The adapter used to split a compiled batch into two
+buckets -- every guest statement, then every wait -- and run the buckets in
+that order. For a batch the model wrote as ``[click, wait 2000, paste_text]``
+that executed click, paste, sleep: the paste landed on a UI that had not
+finished responding to the click, and the sleep happened afterwards where it
+could no longer do anything.
+
+It was not rare. Across the 64 evidence bundles of the 2026-09 Kimi K3 cohort,
+425 of 1746 wait-bearing batches (24%) contained a wait followed by a later
+action, so in a quarter of the cases where the model deliberately paced itself
+against a slow UI the harness silently disobeyed it. On a benchmark whose tasks
+are largely about driving real applications, that is a correctness bug that
+costs score, not a stylistic one.
+
+These tests drive the REAL ``OSWorldV2Adapter.execute`` against a recording
+provider and assert on the order the guest saw. They fail on the two-bucket
+implementation, which is the only thing that makes them worth having.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from lop_osworld_v2_adapter import adapter as adapter_module
+
+from local_operator.evaluation.adapters.api import ExecuteParams
+from local_operator.evaluation.evidence.models import canonical_digest
+from local_operator.evaluation.protocol import (
+    PROTOCOL_VERSION,
+    ActionBatch,
+    ArtifactRef,
+    ClickAction,
+    FrameGeometry,
+    FrameRef,
+    FrameSize,
+    KeyAction,
+    Observation,
+    TypeAction,
+    WaitAction,
+)
+
+
+class _RecordingProvider:
+    """Records every guest interaction in the order it actually happened."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Any]] = []
+
+    async def execute(self, statements: list[str]) -> None:
+        self.calls.append(("exec", list(statements)))
+
+    async def observe(self) -> dict[str, Any]:
+        self.calls.append(("observe", None))
+        return {"screenshot": _PNG}
+
+
+# A 1x1 PNG: the observation builder only needs something decodable.
+_PNG = bytes.fromhex(
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+    "890000000a49444154789c6360000002000100ffff03000006000557bfabd400"
+    "00000049454e44ae426082"
+)
+
+
+def _observation(observation_id: str, sequence: int) -> Observation:
+    """A real protocol ``Observation`` -- ``ExecuteResult`` accepts nothing less."""
+    size = FrameSize(width=1920, height=1080)
+    return Observation(
+        task_id="task_001",
+        episode_id="ep-1",
+        sequence=sequence,
+        observation_id=observation_id,
+        frames=(
+            FrameRef(
+                frame_id="screen",
+                artifact=ArtifactRef(sha256="0" * 64, media_type="image/png", byte_count=len(_PNG)),
+                geometry=FrameGeometry(native=size, model_visible=size),
+            ),
+        ),
+    )
+
+
+class _StubBuilder:
+    def build(self, raw: Any, **kwargs: Any) -> Observation:
+        return _observation("obs-2", kwargs.get("sequence", 2))
+
+
+def _adapter(monkeypatch: pytest.MonkeyPatch) -> tuple[Any, _RecordingProvider]:
+    provider = _RecordingProvider()
+    inst = adapter_module.OSWorldV2Adapter.__new__(adapter_module.OSWorldV2Adapter)
+    inst._provider = provider  # type: ignore[attr-defined]
+    inst._observation_builder = _StubBuilder()  # type: ignore[attr-defined]
+    inst._current_observation = _observation("obs-1", 1)  # type: ignore[attr-defined]
+    inst._sequence = 1  # type: ignore[attr-defined]
+
+    async def fake_sleep(seconds: float) -> None:
+        provider.calls.append(("sleep", round(seconds, 3)))
+
+    monkeypatch.setattr(adapter_module.asyncio, "sleep", fake_sleep)
+    return inst, provider
+
+
+def _params(*actions: Any) -> ExecuteParams:
+    batch = ActionBatch(
+        protocol_version=PROTOCOL_VERSION,
+        task_id="task_001",
+        episode_id="ep-1",
+        observation_id="obs-1",
+        actions=tuple(actions),
+    )
+    return ExecuteParams(
+        operation_id="op-1",
+        action_batch_id=canonical_digest("adapter-action-batch-v1", batch),
+        action_batch=batch,
+    )
+
+
+def _click(x: int = 10, y: int = 20) -> ClickAction:
+    return ClickAction(observation_id="obs-1", frame_id="screen", x=x, y=y)
+
+
+def _guest_calls(provider: _RecordingProvider) -> list[tuple[str, Any]]:
+    """Drop the trailing read-back so assertions describe the mutation only."""
+    return [c for c in provider.calls if c[0] != "observe"]
+
+
+@pytest.mark.asyncio
+async def test_a_wait_between_two_actions_runs_between_them(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``[click, wait, type]`` must not become ``click, type, wait``.
+
+    This is the exact shape seen most often in the failing cohort: the model
+    clicks something, waits for the UI to catch up, then types into it.
+    """
+
+    inst, provider = _adapter(monkeypatch)
+    await inst.execute(
+        _params(
+            _click(),
+            WaitAction(observation_id="obs-1", duration_ms=2000),
+            TypeAction(observation_id="obs-1", text="hello"),
+        )
+    )
+
+    calls = _guest_calls(provider)
+    kinds = [c[0] for c in calls]
+    assert kinds == ["exec", "sleep", "exec"], calls
+    assert calls[1] == ("sleep", 2.0)
+    # The click travelled before the sleep and the text after it.
+    assert any("click" in s for s in calls[0][1])
+    assert any("hello" in s for s in calls[2][1])
+
+
+@pytest.mark.asyncio
+async def test_consecutive_actions_still_share_one_round_trip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ordering is preserved WITHOUT paying a round trip per action.
+
+    Honouring order naively -- one ``execute`` call per statement -- would add
+    a guest HTTP round trip for every action, and batches average ~2.9 actions.
+    Consecutive statements must still travel together.
+    """
+
+    inst, provider = _adapter(monkeypatch)
+    await inst.execute(
+        _params(
+            _click(1, 1),
+            _click(2, 2),
+            _click(3, 3),
+            WaitAction(observation_id="obs-1", duration_ms=500),
+            _click(4, 4),
+        )
+    )
+
+    calls = _guest_calls(provider)
+    assert [c[0] for c in calls] == ["exec", "sleep", "exec"], calls
+    assert len(calls[0][1]) == 3, "three consecutive clicks must share one call"
+    assert len(calls[2][1]) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_leading_wait_precedes_the_actions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A wait the model put FIRST must happen before anything is typed."""
+
+    inst, provider = _adapter(monkeypatch)
+    await inst.execute(
+        _params(
+            WaitAction(observation_id="obs-1", duration_ms=1000),
+            TypeAction(observation_id="obs-1", text="hi"),
+        )
+    )
+
+    calls = _guest_calls(provider)
+    assert [c[0] for c in calls] == ["sleep", "exec"], calls
+    assert calls[0] == ("sleep", 1.0)
+
+
+@pytest.mark.asyncio
+async def test_a_pure_wait_batch_still_advances_the_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A batch of only waits sleeps and then pokes the guest.
+
+    The empty ``execute`` is what advances the environment's own clock; without
+    it a pure-wait batch would be invisible to the guest.
+    """
+
+    inst, provider = _adapter(monkeypatch)
+    await inst.execute(_params(WaitAction(observation_id="obs-1", duration_ms=1500)))
+
+    calls = _guest_calls(provider)
+    assert calls == [("sleep", 1.5), ("exec", [])], calls
+
+
+@pytest.mark.asyncio
+async def test_multiple_waits_keep_their_positions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Several waits interleaved with actions each land where they were written."""
+
+    inst, provider = _adapter(monkeypatch)
+    await inst.execute(
+        _params(
+            KeyAction(observation_id="obs-1", keys=("ctrl", "s")),
+            WaitAction(observation_id="obs-1", duration_ms=300),
+            KeyAction(observation_id="obs-1", keys=("enter",)),
+            WaitAction(observation_id="obs-1", duration_ms=700),
+            KeyAction(observation_id="obs-1", keys=("esc",)),
+        )
+    )
+
+    calls = _guest_calls(provider)
+    assert [c[0] for c in calls] == ["exec", "sleep", "exec", "sleep", "exec"], calls
+    assert calls[1] == ("sleep", 0.3)
+    assert calls[3] == ("sleep", 0.7)

--- a/tests/unit/evaluation/adapters/osworld/test_action_wait_order.py
+++ b/tests/unit/evaluation/adapters/osworld/test_action_wait_order.py
@@ -47,10 +47,10 @@ class _RecordingProvider:
     """Records every guest interaction in the order it actually happened."""
 
     def __init__(self) -> None:
-        self.calls: list[tuple[str, Any]] = []
+        self.calls: list[tuple[Any, ...]] = []
 
-    async def execute(self, statements: list[str]) -> None:
-        self.calls.append(("exec", list(statements)))
+    async def execute(self, statements: list[str], *, settle: bool = True) -> None:
+        self.calls.append(("exec", list(statements), settle))
 
     async def observe(self) -> dict[str, Any]:
         self.calls.append(("observe", None))
@@ -122,9 +122,14 @@ def _click(x: int = 10, y: int = 20) -> ClickAction:
     return ClickAction(observation_id="obs-1", frame_id="screen", x=x, y=y)
 
 
-def _guest_calls(provider: _RecordingProvider) -> list[tuple[str, Any]]:
+def _guest_calls(provider: _RecordingProvider) -> list[tuple[Any, Any]]:
     """Drop the trailing read-back so assertions describe the mutation only."""
-    return [c for c in provider.calls if c[0] != "observe"]
+    return [(c[0], c[1]) for c in provider.calls if c[0] != "observe"]
+
+
+def _settles(provider: _RecordingProvider) -> list[bool]:
+    """The settle flag of each guest execute, in order."""
+    return [bool(c[2]) for c in provider.calls if c[0] == "exec"]
 
 
 @pytest.mark.asyncio
@@ -240,3 +245,53 @@ async def test_multiple_waits_keep_their_positions(
     assert [c[0] for c in calls] == ["exec", "sleep", "exec", "sleep", "exec"], calls
     assert calls[1] == ("sleep", 0.3)
     assert calls[3] == ("sleep", 0.7)
+
+
+@pytest.mark.asyncio
+async def test_only_the_last_run_settles(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A split batch pays ONE settle, not one per run.
+
+    The provider pauses ``action_delay_s`` (3 s) after each execute so the
+    desktop can repaint. Honouring order splits a batch into several runs, and
+    settling after each would multiply that pause AND stack it on top of the
+    wait the model asked for -- a requested 2 s becoming 5 s. Measured on the
+    2026-09 cohort, naive settling would have added 533 execute calls and
+    ~0.44 h (2%) of pure sleeping to a 22.76 h run.
+    """
+
+    inst, provider = _adapter(monkeypatch)
+    await inst.execute(
+        _params(
+            _click(1, 1),
+            WaitAction(observation_id="obs-1", duration_ms=2000),
+            _click(2, 2),
+            WaitAction(observation_id="obs-1", duration_ms=1000),
+            _click(3, 3),
+        )
+    )
+
+    assert _settles(provider) == [False, False, True]
+
+
+@pytest.mark.asyncio
+async def test_an_unsplit_batch_still_settles_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The common wait-free batch is unchanged: one call, one settle."""
+
+    inst, provider = _adapter(monkeypatch)
+    await inst.execute(_params(_click(1, 1), _click(2, 2)))
+
+    assert _settles(provider) == [True]
+
+
+@pytest.mark.asyncio
+async def test_a_trailing_wait_still_settles_on_the_actions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the wait last, the only guest run is the final one and settles."""
+
+    inst, provider = _adapter(monkeypatch)
+    await inst.execute(_params(_click(1, 1), WaitAction(observation_id="obs-1", duration_ms=500)))
+
+    assert _settles(provider) == [True]

--- a/tests/unit/evaluation/runner/test_run_episode_infra.py
+++ b/tests/unit/evaluation/runner/test_run_episode_infra.py
@@ -130,3 +130,32 @@ def test_an_explicit_lease_override_is_never_overwritten() -> None:
     values = run_episode._ensure_lease_outlasts_wall(given, args)
 
     assert [v.value for v in values if v.name == "OSWORLD_TTL_SECONDS"] == ["99"]
+
+
+def test_the_run_path_actually_applies_the_lease_derivation() -> None:
+    """The DERIVATION is wired into ``run``, not merely defined beside it.
+
+    A round-3 review deleted the sole call site and the entire 1311-test suite
+    still passed: the helper's logic was pinned, its USE was not, so a future
+    refactor could silently restore the 7200 s fixed lease this work removed --
+    the bug where an episode past two hours dies on a terminated instance
+    rather than at a budget boundary.
+
+    Reading the source is the honest check here. Driving ``run`` end to end
+    would need a selector, an adapter, credentials and a cloud provider, and a
+    test that heavy would be skipped in exactly the environments that matter.
+    """
+
+    import inspect
+
+    source = inspect.getsource(run_episode.run)
+
+    assert "_ensure_lease_outlasts_wall(" in source, (
+        "run() must derive the cloud lease from the wall budget; without this "
+        "call the provider falls back to a fixed 7200 s lease that is SHORTER "
+        "than the 18000 s wall default"
+    )
+    # It must happen before the spec is built, or the adapter never sees it.
+    assert source.index("_ensure_lease_outlasts_wall(") < source.index(
+        "build_spec("
+    ), "the lease must be derived before build_spec() consumes infra_values"

--- a/tests/unit/evaluation/runner/test_run_episode_infra.py
+++ b/tests/unit/evaluation/runner/test_run_episode_infra.py
@@ -95,3 +95,38 @@ def test_actual_cli_rejects_invalid_infra_before_reading_selector(capsys, tmp_pa
     assert output.err.startswith("--infra expects")
     assert "secret-canary" not in output.err and "Traceback" not in output.err
     assert not (tmp_path / "must-not-exist").exists()
+
+
+def test_the_cloud_lease_is_derived_to_outlast_the_wall_budget() -> None:
+    """A raised wall must not be reclaimed by a shorter fixed lease.
+
+    The wall budget is not carried on the adapter wire, so the provider's
+    ``ttl_seconds_for`` sees ``None`` and falls back to a fixed 7200 s. While
+    the wall default was 1800 that was harmless. Raising it to 18000 -- so the
+    500-step budget can actually be reached -- inverted the relationship, and
+    an episode past two hours would die on a TERMINATED INSTANCE rather than
+    at a budget boundary: it loses the episode instead of ending it, and reads
+    as an infrastructure fault rather than a deliberate cap.
+    """
+
+    import argparse
+
+    args = argparse.Namespace(max_wall_s=18000, infra_purpose="benchmark_compute")
+    values = run_episode._ensure_lease_outlasts_wall((), args)
+
+    lease = [v for v in values if v.name == "OSWORLD_TTL_SECONDS"]
+    assert len(lease) == 1
+    assert int(lease[0].value) > args.max_wall_s
+
+
+def test_an_explicit_lease_override_is_never_overwritten() -> None:
+    """The operator's own ``OSWORLD_TTL_SECONDS`` wins, however short."""
+
+    import argparse
+
+    args = argparse.Namespace(max_wall_s=18000, infra_purpose="benchmark_compute")
+    given = run_episode._parse_infra(["OSWORLD_TTL_SECONDS=99"], "benchmark_compute")
+
+    values = run_episode._ensure_lease_outlasts_wall(given, args)
+
+    assert [v.value for v in values if v.name == "OSWORLD_TTL_SECONDS"] == ["99"]


### PR DESCRIPTION
## What

Two things, one code fix and one document.

**1. The adapter executed a batch's actions out of order.** It split a compiled batch into two buckets — every guest statement, then every wait — and ran the buckets in that order. A batch the model wrote as `[click, wait 2000, paste_text]` executed as **click, paste, sleep**: the paste landed on a UI that had not finished responding to the click, and the sleep happened afterwards where it could no longer do anything.

**2. Docs recording the step/wall budget and the step-latency decomposition**, including three investigations that closed.

## Evidence this mattered

Measured across the 64 evidence bundles of the 2026-09 Kimi K3 cohort by re-reading every action artifact:

```
batches containing a wait: 1746
  wait followed by a later action (order destroyed): 425  (24%)
   e.g. ['key', 'key', 'wait', 'key', 'wait']
   e.g. ['click', 'wait', 'paste_text', 'key', 'wait']
```

In a quarter of the batches where the model deliberately paced itself against a slow UI, the harness silently disobeyed it. On a benchmark whose tasks are largely about driving real desktop applications, that is a correctness defect that plausibly costs score.

## The fix

Walk the compiled statements once and build **ordered runs**: a maximal group of consecutive guest statements, or a single wait. Runs execute in sequence.

Ordering is exact, and consecutive actions still share one guest round trip — batches average 2.9 actions, so honouring order naively (one `execute` per statement) would have added ~2 round trips per step. This does not trade a correctness bug for a latency one.

## Testing evidence

The tests drive the **real** `OSWorldV2Adapter.execute` against a recording provider and assert on the order the guest saw, because that is the only place the difference is visible.

**Mutation-checked** — reverting the adapter to the two-bucket implementation and re-running:

```
4 failed, 1 passed
  Full diff:
    [ 'exec', 'sleep',
  -   'exec',   ]
```

Restored: `5 passed`.

Whole-tree gates on the final head: flake8 clean, black clean (1169 files), isort clean, **pyright 0 errors**.

`tests/unit/evaluation` — 1290 passed, 16 failed. The 16 are `test_installed_score_evidence`, which require the adapter installed as a wheel; **verified pre-existing** by stashing the entire change and re-running (identical 16 failures on clean main in this worktree).

## The budget change (in `run_batch.sh`, outside this repo)

`--max-wall-s 2400` was a **local invention**. OSWorld 2.0 bounds an episode by model steps only:

- `lib_run_single.py`: `while not done and step_idx < max_steps`, with `step_idx += 1` once per `agent.predict()` — one step = one model call regardless of action count
- official script passes `--max_steps 500`; paper's metric is binary completion "at 500 steps"
- `wrapt_timeout_decorator` is imported but **no function carries a decorator**; `run.py`'s `"Time limit exceeded"` is the generic `except Exception` message

At the cohort's median pace, 2400 s bought **~87 steps** against a standard of 500 and reference agents using 190–318:

| | n | mean partial |
|---|---|---|
| Hit the wall | 9 | **13.5%** |
| Finished | 17 | **28.8%** |

Now `--max-wall-s 18000` as a runaway guard only (the step budget always binds first), with `OSWORLD_TTL_SECONDS 18900` — `providers/aws.py` falls back to `DEFAULT_TTL_SECONDS = 7200` when no TTL is passed, so raising the wall without it gets instances reclaimed mid-episode.

One trap worth recording: my first attempt put the explanatory comment *inside* the backslash-continued command. `bash -n` passes, but the comment **terminates the command and drops every following argument**. Caught it with a dedicated test, moved the comment above the command, and verified all 48 arguments still arrive by running the block against a fake interpreter that prints `argv`.

## Latency findings that closed

Recorded in the doc so they are not re-opened:

- **Compaction is not a cost centre.** Its event is journalled after `decide()` returns, so it lands where `model_request` normally would — both measure the same model call. All 268 records are `prune` with no summarising call.
- **Harness CPU on the model hot path is ~12 ms** against a 9.21 s gap.
- **Frames on the wire are already bounded.** Bundles contain 1920×1080 *archived natives*, which makes the path look broken; the model actually receives 1280×720 at ~4 KB. Verified by driving `ObservationBuilder` directly.

~59% of runtime is the provider generating tokens, so the remaining lever is output volume.

## Deliberately not in this PR

Every action echoes `observation_id`, a 64-hex digest the runner already injects and never reads back as data. Cost: 43 tokens × 2.88 actions = ~124 output tokens, **~2.2 s per call, 6.8% of total runtime**. Real, but it changes a frozen protocol invariant with strict validators, so it gets its own change and its own review round rather than riding along with a correctness fix.

The 3.0 s per-batch settle also stays: the paper documents a 3 s pause, and cutting it risks screenshotting a half-painted UI to save ~1 s that the wall fix dwarfs.