### PR TITLE
perf(tui): land the session switch in one settled state

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -7610,6 +7610,23 @@ class OperatorApp(App[None]):
         """
         view = self._transcript_view()
         viewport = view.container_size.height or view.size.height
+        # ONE PAGE, NOT A LOOP TO THE GOAL. A page mounted here cannot be
+        # measured here: `insert_blocks` schedules the settle that lets each
+        # block author its real height, and that needs refresh hops this
+        # synchronous section does not have. Measured at 100x100: the transcript
+        # grew 51 -> 75 blocks while `scroll_y`, `max_scroll_y` and
+        # `virtual_size.height` all stayed exactly where they started, so a loop
+        # here is measuring a ruler that cannot move and every extra iteration
+        # is a page mounted blind. It also left the paging lease HELD on exit —
+        # `_mount_older_resume_page` releases it from that same deferred settle
+        # — which made the ordinary fill stand down against a gate the commit
+        # had taken and never returned.
+        #
+        # One page is what this can honestly do: it is the page that closes the
+        # under-fill the reveal would otherwise show (21 blocks against a
+        # 27-row viewport), it is the page whose absence caused the visible
+        # 14 -> 62 scroll jump, and the `_start_resume_fill` below still reaches
+        # the real goal by the settling route that owns it.
         if not viewport and self._resume_pending_head and not self._resume_paging:
             # A FIRST-VISIT (`display_only`) presentation is mounted without the
             # in-prepare layout round trip -- `_prepare_sidebar_session` skips it
@@ -7631,46 +7648,53 @@ class OperatorApp(App[None]):
             return
         self._resume_fill_active = True
         self._resume_fill_serial += 1
+        chained = False
         try:
-            for _ in range(RESUME_FILL_MAX_PAGES):
-                notice = self._resume_head_notice
-                prefix = (
-                    notice.virtual_region.bottom
-                    if notice is not None and notice.parent is view
-                    else 0
-                )
-                if view.scroll_y >= viewport + prefix or not self._resume_pending_head:
-                    break
-                pending_before = len(self._resume_pending_head)
-                # `on_settled=None`: the continuation IS this loop. The page's
-                # own settle callback still releases the paging lease and
-                # reconciles the head notice on its normal schedule.
-                self._mount_older_resume_page()
-                if len(self._resume_pending_head) >= pending_before:
-                    break  # Cursor did not advance; do not spin.
-                # SETTLE THE GEOMETRY THIS PAGE JUST CHANGED, before measuring
-                # again or handing the view to the gate. A mounted block only
-                # authors its real height during a layout pass, so without this
-                # the loop re-measures against a stale `scroll_y` and, worse,
-                # the view is revealed with its tail block not yet in the
-                # compositor's painted map -- which the readiness gate reads as
-                # NOT READY and pays a recovery relayout for. Measured: 12
-                # TAIL_BLOCK refusals across 4 cold switches without this call,
-                # 0 with it. Synchronous, for the same reason as above: this
-                # commit may not await.
+            notice = self._resume_head_notice
+            prefix = (
+                notice.virtual_region.bottom if notice is not None and notice.parent is view else 0
+            )
+            if view.scroll_y < viewport + prefix:
+                # CHAIN THE ORDINARY FILL TO THIS PAGE'S SETTLE, rather than
+                # scheduling it beside one. `_mount_older_resume_page` holds the
+                # single-flight paging lease until the settle callback
+                # `insert_blocks` schedules releases it, and
+                # `_fill_resume_attempt` stands down immediately while that gate
+                # is held. So a fill started independently of this page raced it
+                # and lost -- it saw `_resume_paging` true, returned, and the
+                # goal was never reached: `test_real_sidebar_projection_runs_
+                # rendered_fill` measured the view stranded at `scroll_y=0`
+                # against a 91-row viewport. Handing the continuation to
+                # `on_settled` is the seam that method documents for exactly
+                # this, and it is why the `finally` below only starts a fill
+                # when no page was mounted here.
+                chained = True
+                self._mount_older_resume_page(on_settled=self._start_resume_fill)
+                # SETTLE THE GEOMETRY THIS PAGE JUST CHANGED before the view is
+                # handed to the readiness gate. A mounted block authors its real
+                # height during a layout pass, so without this the view is
+                # revealed with its tail block not yet in the compositor's
+                # painted map -- which the gate reads as NOT READY and pays a
+                # recovery relayout for. Measured: 12 TAIL_BLOCK refusals across
+                # 4 cold switches without this call, 0 with it. Synchronous, for
+                # the same reason as above: this commit may not await.
                 self.screen._refresh_layout()
         except Exception:
             # See the docstring: a projection failure must degrade to the
             # deferred fill, never propagate into the invalidation retry.
             logger.debug("pre-reveal resume fill failed; deferring", exc_info=True)
         finally:
-            # ALWAYS follow with the ordinary scheduled fill. It re-measures
-            # against real laid-out geometry, tops up anything this synchronous
-            # pass could not reach (a page behind a network fetch), and settles
-            # `_resume_fill_active` / the head notice through the one path that
-            # owns them. When the goal is already met its first attempt exits
-            # immediately, which is the normal case after this pre-fill.
-            self._start_resume_fill()
+            # Start the ordinary fill only when no page was mounted above; when
+            # one was, it is chained to that page's settle instead (see there),
+            # so the two can never race for the same paging lease.
+            # That fill re-measures against real laid-out geometry, tops up
+            # anything this synchronous pass could not reach (a page behind a
+            # network fetch), and settles `_resume_fill_active` and the head
+            # notice through the one path that owns them. When the goal is
+            # already met its first attempt exits immediately, which is the
+            # normal case after this pre-fill.
+            if not chained:
+                self._start_resume_fill()
 
     def _start_resume_fill(self, *, target: float | None = None) -> None:
         """Top up a newly revealed projection, not every subsequent resize.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -4278,6 +4278,20 @@ class OperatorApp(App[None]):
                 raise RuntimeError("Sidebar navigation requires an owner-backed session")
             # Canonical synchronization belongs to the source connection task,
             # never to a click waiting for its first useful viewport.
+            #
+            # THIS CAN NOW FIRE WHERE IT PREVIOUSLY COULD NOT, and it is benign.
+            # v0.52.16 (#849) bounds `_recover_owner` at 90s, so a
+            # `RemoteSession` can reach a TERMINAL cold state on a path that
+            # used to retry forever; a speculative prepare can therefore meet
+            # `is_cold` for real rather than only in transit. Verified by
+            # execution against a terminally cold session rather than reasoned
+            # about: the raise costs one discarded speculative preparation and
+            # nothing else -- source not retired, no paging lease held, no
+            # presentation admitted, ZERO redials, and a subsequent real click
+            # on the same session still prepares successfully. `speculative`
+            # is reached only from the prewarm worker, whose `except Exception`
+            # logs at debug and whose `finally` releases the preparation, so no
+            # user-visible surface observes it.
             if speculative and session.is_cold:
                 raise RuntimeError("The prepared owner is no longer ready")
             if speculative or refresh:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -5459,27 +5459,48 @@ class OperatorApp(App[None]):
             self._set_sidebar_open(False)
         self._prefill_resume_before_reveal()
         self._show_sidebar_connection(source)
-        # `restore_revealed_anchor` USED TO RUN HERE, on a `call_after_refresh`
-        # AFTER reveal, to correct for "offscreen measurement is not final
-        # visible geometry for a wrapped viewport". It was measured to be a
-        # no-op and is now deleted; the in-prepare restore
-        # (`_prepare_sidebar_session`, both the cache-hit and the built-replay
-        # branch) is the one that positions the view, and it runs on the parked
-        # view where it is free.
-        #
-        # THE WRAPPED-CONTENT CASE WAS THE OPEN QUESTION AND IT WAS MEASURED,
-        # not assumed. A fixture whose blocks genuinely re-wrap (the same anchor
-        # block measures 3 rows at a 96-cell conversation column and 5 rows at a
-        # 63-cell one) was switched away from and back, with the parked and
-        # revealed geometry read on the SAME view object two lines apart at this
-        # commit seam. Parked and revealed agreed exactly — content width 63/63,
-        # scroll_y 44.0/44.0, anchor at y=42 h=5 both times — because the parked
-        # view is mounted into `#session-conversation`, the same container the
-        # visible view occupies: `_prepare_sidebar_session` pins only its
-        # HEIGHT, so it is already laid out at the revealed WIDTH. Re-running
-        # the restore at the revealed width moved the position by 0.0 rows in
-        # every arm. The correction was for a width difference that the park
-        # does not actually produce.
+        if not source.draft.following_tail and source.draft.scroll_anchor_id:
+            scroll_revision = source.scroll_revision
+            view = incoming.replay.view
+
+            def restore_revealed_anchor() -> None:
+                if (
+                    not self._is_current(source)
+                    or generation != self._sidebar_navigation.generation
+                    or self._transcript_view() is not view
+                ):
+                    return
+                if source.scroll_revision != scroll_revision:
+                    self._capture_sidebar_scroll(source)
+                    return
+                # Offscreen measurement is not final visible geometry for a
+                # wrapped viewport. Re-anchor after reveal, and let the normal
+                # painted-map gate verify the resulting frame, not a timer.
+                #
+                # THIS IS LOAD-BEARING FOR WRAPPED CONTENT AND IT WAS MEASURED,
+                # in both directions. The audit (§6.2) could not falsify it and
+                # asked for the settling experiment; a first pass on blocks that
+                # re-wrap from 3 rows to 5 found parked and revealed geometry
+                # identical and concluded this was dead code. That conclusion
+                # was WRONG, and deleting it wedged
+                # `tests/e2e/test_sidebar_display_e2e.py`'s `wrapped` case:
+                # the readiness gate refused 1156 consecutive frames with the
+                # anchor block absent from the painted map, and the switch
+                # timed out. The difference is how hard the content wraps — that
+                # fixture's rows are ~10 screen rows each, where the in-prepare
+                # restore's position no longer survives the reveal.
+                #
+                # So the honest statement is the one the original comment made:
+                # the parked measurement is not final. The gate is what proves
+                # the resulting frame, which is why this may run after reveal
+                # without re-introducing a geometry lie.
+                view.restore_navigation_anchor(
+                    source.draft.scroll_anchor_id,
+                    source.draft.scroll_anchor_part,
+                    source.draft.scroll_offset,
+                )
+
+            self.call_after_refresh(restore_revealed_anchor)
         ready = self._await_sidebar_frame(source, generation)
         if source.display_only:
             source.preview_scroll_revision = source.scroll_revision

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -4799,9 +4799,7 @@ class OperatorApp(App[None]):
             typed = text[len(prefix) :] if text.startswith(prefix) else ""
         frozen = set(self._sidebar_transition_attachments)
         return typed, {
-            index: marked
-            for index, marked in editor.attachments().items()
-            if index not in frozen
+            index: marked for index, marked in editor.attachments().items() if index not in frozen
         }
 
     def _abandon_sidebar_transition(self) -> None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1372,6 +1372,21 @@ ASIDE_SCROLL_FORWARD_KEY = "ctrl+pagedown"
 RETAINED_PRESENTATIONS = 12
 
 
+def _suppress_intermediate_paint() -> None:
+    """Stand in for ``Screen._compositor_refresh`` to drop one mid-commit paint.
+
+    The switch commit needs a synchronous LAYOUT so a freshly mounted page can
+    author its real height before the readiness gate reads the painted map, but
+    it must not put that layout on screen: at that moment the transcript has
+    been revealed while the composer still holds the outgoing draft's rows, and
+    a frame drawn from that arrangement shows an empty conversation (design
+    round 1, D1). Restoring the real method in a ``finally`` is what keeps this
+    to exactly one frame; see the call site in
+    :meth:`OperatorApp._prefill_resume_before_reveal` for the measurements.
+    """
+    return None
+
+
 def _set_transcript_parked(view: Widget, parked: bool) -> None:
     """Park or un-park a transcript WITHOUT the disabled stylesheet cascade.
 
@@ -1391,23 +1406,47 @@ def _set_transcript_parked(view: Widget, parked: bool) -> None:
       10.2 ms of the 18.8 ms commit, 54% of a section that deliberately never
       awaits, paid on every switch.
 
-    The appearance half is worth exactly nothing to a parked view: it is
-    ``overlay: screen`` at ``offset: 100vw``, so every cell of its ink is
-    clipped off-screen and no opacity it is given can be seen. The incoming
-    view's un-park is the mirror image — it is revealed at full opacity because
-    the cascade it never received never dimmed it.
+    The appearance half is worth nothing to a parked view WHILE IT IS PARKED:
+    it is ``overlay: screen`` at ``offset: 100vw``, so every cell of its ink is
+    clipped off-screen and no opacity it is given can be seen.
 
     ``set_reactive`` writes the reactive's value while skipping its watcher,
-    which is precisely that split. Verified on a 40-block subtree: shipped
-    toggle 4.13 ms / 44 ``Stylesheet.apply`` calls, this 0.002 ms / 0, with
-    ``disabled``, ``_self_or_ancestors_disabled``, ``focusable``,
-    ``allow_vertical_scroll`` and mouse-message refusal all identical.
+    which is precisely that split. Verified on a 40-block subtree: 44
+    ``Stylesheet.apply`` calls → 0, with ``disabled``,
+    ``_self_or_ancestors_disabled``, ``focusable``, ``allow_vertical_scroll``
+    and mouse-message refusal all identical. (The wall figures behind those
+    counts — ~4.1 ms → ~0 ms, and RC2's ~10.2 ms of an ~18.8 ms commit — were
+    taken on a box at load ~36 and are indicative only. The COUNTS are the
+    invariant worth defending; the milliseconds are not.)
 
-    IF A ``:disabled`` RULE IS EVER WRITTEN THAT MUST REACH A PARKED
-    TRANSCRIPT, this is the line to revert — the field would then be carrying
-    appearance the cascade is required to apply.
+    THE TWO DIRECTIONS ARE NOT SYMMETRIC, which is why this is not simply
+    ``set_reactive`` both ways. Skipping the park cascade declines to dim a
+    view nobody can see. Skipping the UN-park cascade would decline to
+    **un-dim** one the user is about to look at — and the rule that dims it
+    already exists: Textual's own ``*:disabled:can-focus { opacity: 0.7 }``
+    matches because ``TranscriptView.can_focus`` is True. Any cascade over the
+    subtree while it is parked (a terminal resize and a theme change were both
+    reproduced) applies that 0.7, and without a watcher on the un-park it is
+    revealed still dimmed and never self-heals — measured across a reveal, a
+    keystroke, a scroll and a further switch, and visible in the rendered
+    palette (body text ``#3b3527`` → ``#2f2a1e``). So the un-park goes through
+    the real reactive and pays the one cascade Textual already pays on every
+    switch today; the saving this helper exists for is on the OUTGOING 45-81
+    block transcript, which is untouched by that.
+
+    ``watch_disabled`` also blurs ``screen.focused`` when the disabled widget
+    is its ancestor and queues a ``Leave`` for a hovered widget; ``set_reactive``
+    skips both on the park. That is safe here because the commit path refocuses
+    the composer independently — probed with focus placed inside the outgoing
+    transcript before the switch, focus afterwards lands on the ``Editor``
+    rather than being stranded in the parked offscreen view. Documented so the
+    next reader does not have to re-derive it.
     """
-    view.set_reactive(Widget.disabled, parked)
+    if parked:
+        view.set_reactive(Widget.disabled, True)
+    else:
+        # The real reactive: see the asymmetry note above. Never `set_reactive`.
+        view.disabled = False
 
 
 #: Ranked entries warmed per catalog poll. Two is the top of the list — the
@@ -5494,6 +5533,20 @@ class OperatorApp(App[None]):
                 # the parked measurement is not final. The gate is what proves
                 # the resulting frame, which is why this may run after reveal
                 # without re-introducing a geometry lie.
+                #
+                # THE GUARD IS THE E2E `wrapped` PARAMETRISATION, not a unit
+                # test, and that is deliberate rather than an omission (QA round
+                # 1, Q3, which could not confirm this from outside because its
+                # rig never scheduled the callback). Re-verified by deleting
+                # this line: `test_sidebar_display_e2e.py::test_saved_view_
+                # switches_while_authenticated_owner_sync_is_held[...True-True
+                # -False]` fails with a TimeoutError. The unit rig in
+                # `test_sidebar_switch_smoothness.py` cannot reach here at all --
+                # its `_switch` helper installs a fresh lease per call, so the
+                # `SessionInteraction` carrying the saved anchor is replaced
+                # before the commit reads it, and the draft is re-captured from
+                # the on-screen view (which is at tail). Anyone tempted to
+                # delete this again: run the e2e stage, not just the unit suite.
                 view.restore_navigation_anchor(
                     source.draft.scroll_anchor_id,
                     source.draft.scroll_anchor_part,
@@ -7638,7 +7691,22 @@ class OperatorApp(App[None]):
             # frame would run, pulled forward, and it is SYNCHRONOUS -- no await
             # is introduced between the navigation's final identity check and
             # this commit (`session_navigation._prepare_and_commit`).
-            self.screen._refresh_layout()
+            #
+            # Paint suppressed for the same reason as the settle below, and it
+            # is the same defect: this layout runs with the transcript revealed
+            # and the composer still holding the OUTGOING draft's rows, so the
+            # frame it would paint shows 21 mounted blocks and NONE of them in
+            # view (design round 1, D1, cold/draft2 f001 at dock 7 / editor 3
+            # against a settled 5 / 1). The layout is needed -- it is what gives
+            # this first-visit view a measurable viewport -- but its
+            # intermediate arrangement must not reach the screen.
+            screen = self.screen
+            paint = screen._compositor_refresh
+            screen._compositor_refresh = _suppress_intermediate_paint
+            try:
+                screen._refresh_layout()
+            finally:
+                screen._compositor_refresh = paint
             viewport = view.container_size.height or view.size.height
         if not viewport or self._resume_paging or not self._resume_pending_head:
             # Nothing locally pending, or a fetch already owns the gate. The
@@ -7668,8 +7736,16 @@ class OperatorApp(App[None]):
                 # `on_settled` is the seam that method documents for exactly
                 # this, and it is why the `finally` below only starts a fill
                 # when no page was mounted here.
-                chained = True
                 self._mount_older_resume_page(on_settled=self._start_resume_fill)
+                # ONLY NOW is the deferred fill genuinely chained. Setting this
+                # BEFORE the mount meant a raising mount was swallowed by the
+                # `except` with `chained` already True, so the `finally` skipped
+                # the very fallback the docstring promises -- reproduced at 18
+                # blocks / scroll_y 15 against 42 / 63 normal. `_mount_older_
+                # resume_page` restores `_resume_pending_head` and releases the
+                # paging lease before re-raising, so the deferred fill that then
+                # starts runs against clean state.
+                chained = True
                 # SETTLE THE GEOMETRY THIS PAGE JUST CHANGED before the view is
                 # handed to the readiness gate. A mounted block authors its real
                 # height during a layout pass, so without this the view is
@@ -7678,7 +7754,45 @@ class OperatorApp(App[None]):
                 # recovery relayout for. Measured: 12 TAIL_BLOCK refusals across
                 # 4 cold switches without this call, 0 with it. Synchronous, for
                 # the same reason as above: this commit may not await.
-                self.screen._refresh_layout()
+                #
+                # THE LAYOUT IS WANTED HERE; THE PAINT IS NOT. `_refresh_layout`
+                # ends in `_compositor_refresh()`, which calls `App._display`
+                # straight away -- so this settle PAINTED a frame of its own,
+                # mid-commit, and that frame is a half-arranged one: the
+                # transcript has already been revealed and tail-scrolled, while
+                # the composer still occupies the OUTGOING draft's rows (dock 7
+                # / editor 3 against the incoming draft's final 5 / 1). Content
+                # drawn against a box that is about to shrink lands outside the
+                # viewport, so the frame showed an EMPTY conversation -- design
+                # round 1, D1, reproduced at `blocks_mounted=46,
+                # blocks_in_view=0, scroll_y=84=max` immediately before a
+                # settled `82`. On a warm switch that was the FIRST painted
+                # frame, i.e. the fastest switch opened on a blank screen, and
+                # at 80x24 the whole screen blanked. It also produced the
+                # `84 -> 82` scroll excursion (D4) and showed the incoming
+                # draft inside the outgoing-sized box (D2).
+                #
+                # Suppressing just the paint keeps every reason this call is
+                # here -- the mounted page still authors its height, the gate
+                # still gets a complete painted map from the NEXT real frame --
+                # while the user never sees the intermediate arrangement.
+                # Measured across warm/cold/draft2 at 120x36 and 80x24: blank
+                # frames 1-3 -> 0 in every arm, painted frames 12 -> 9 (cold)
+                # and 11 -> 8 (draft2), the scroll excursion collapses to a
+                # single settled position, and gate refusals stay 0.
+                #
+                # `_compositor_refresh` rather than `App.batch_update()`: the
+                # batch defers this paint to a `call_later`, which still paints
+                # the same stale arrangement one turn later (measured: blanks
+                # unchanged at `[0]`). The frame must not exist at all, not
+                # arrive late.
+                screen = self.screen
+                paint = screen._compositor_refresh
+                screen._compositor_refresh = _suppress_intermediate_paint
+                try:
+                    screen._refresh_layout()
+                finally:
+                    screen._compositor_refresh = paint
         except Exception:
             # See the docstring: a projection failure must degrade to the
             # deferred fill, never propagate into the invalidation retry.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1370,6 +1370,46 @@ ASIDE_SCROLL_FORWARD_KEY = "ctrl+pagedown"
 #: the compositor's visible set (23 widgets) and keystroke latency (p90
 #: 88 vs 93 ms) are unchanged with 7 parked against 4.
 RETAINED_PRESENTATIONS = 12
+
+
+def _set_transcript_parked(view: Widget, parked: bool) -> None:
+    """Park or un-park a transcript WITHOUT the disabled stylesheet cascade.
+
+    ``Widget.disabled`` does two unrelated jobs here, and only one of them is
+    wanted inside the switch commit.
+
+    * **Interactivity gating** reads the FIELD:
+      ``_self_or_ancestors_disabled`` (mouse routing in
+      ``check_message_enabled``), ``focusable``, and
+      ``allow_vertical_scroll`` / ``allow_horizontal_scroll`` all test
+      ``disabled`` directly. This is the job the park needs, and it is why the
+      field is still written.
+    * **Appearance** is ``watch_disabled`` → ``update_node_styles`` →
+      ``App.update_styles`` → a ``Stylesheet.apply`` over the WHOLE subtree, so
+      Textual's built-in ``*:disabled { opacity: 0.7 }`` can take effect. On a
+      45-81 block transcript that is 131 node applications — measured at
+      10.2 ms of the 18.8 ms commit, 54% of a section that deliberately never
+      awaits, paid on every switch.
+
+    The appearance half is worth exactly nothing to a parked view: it is
+    ``overlay: screen`` at ``offset: 100vw``, so every cell of its ink is
+    clipped off-screen and no opacity it is given can be seen. The incoming
+    view's un-park is the mirror image — it is revealed at full opacity because
+    the cascade it never received never dimmed it.
+
+    ``set_reactive`` writes the reactive's value while skipping its watcher,
+    which is precisely that split. Verified on a 40-block subtree: shipped
+    toggle 4.13 ms / 44 ``Stylesheet.apply`` calls, this 0.002 ms / 0, with
+    ``disabled``, ``_self_or_ancestors_disabled``, ``focusable``,
+    ``allow_vertical_scroll`` and mouse-message refusal all identical.
+
+    IF A ``:disabled`` RULE IS EVER WRITTEN THAT MUST REACH A PARKED
+    TRANSCRIPT, this is the line to revert — the field would then be carrying
+    appearance the cascade is required to apply.
+    """
+    view.set_reactive(Widget.disabled, parked)
+
+
 #: Ranked entries warmed per catalog poll. Two is the top of the list — the
 #: rows the eye lands on — without turning every poll into a prepare storm.
 PREWARM_PER_REFRESH = 2
@@ -3356,6 +3396,19 @@ class OperatorApp(App[None]):
         self._sidebar_ready_frame: tuple[SessionInteraction, int, asyncio.Future[None]] | None = (
             None
         )
+        #: How many times the readiness gate refused a post-commit frame and
+        #: `post_display_hook` had to buy another relayout. A healthy switch
+        #: leaves this at zero — the arming refresh in `_await_sidebar_frame`
+        #: makes the first paint a full `LayoutUpdate` the gate can pass on.
+        #: Counted rather than logged so a regression test can assert the
+        #: recovery branch stays dead across N switches without measuring time.
+        self._sidebar_gate_recoveries = 0
+        #: How many post-commit displays reached the gate with a live readiness
+        #: future. Its only job is to keep `_sidebar_gate_recoveries == 0` from
+        #: being satisfiable by a rig that never armed the gate at all — a zero
+        #: that means "never asked" reads identically to one that means "never
+        #: refused", and only one of them is the property worth asserting.
+        self._sidebar_gate_reached = 0
         self._sidebar_frame_pending = False
         self._sidebar_focus_restore: ReferenceType[Widget] | None = None
         self._sidebar_presentations: dict[str, SessionPresentation] = {}
@@ -3399,6 +3452,14 @@ class OperatorApp(App[None]):
         #: draft). Its presence is what distinguishes the two ``pending("")``
         #: callers — the navigation makes both — without a second flag.
         self._sidebar_transition_from: SessionInteraction | None = None
+        #: The outgoing draft as it stood when the transition opened. The
+        #: editor keeps PAINTING it until commit loads the incoming draft over
+        #: it — a composer that empties at `pending` collapses to one row and
+        #: reflows the whole conversation column (see
+        #: :meth:`_begin_sidebar_transition`). Everything typed after the click
+        #: sits after this prefix, which is how the two are told apart.
+        self._sidebar_transition_prefix: str = ""
+        self._sidebar_transition_attachments: dict[int, Any] = {}
         self._sidebar_sources: dict[str, SessionInteraction] = {}
         self._sidebar_drafts = SessionDraftStore()
         self._sidebar_navigation = SessionNavigation(
@@ -4253,7 +4314,12 @@ class OperatorApp(App[None]):
             # layout while clipping ALL ink/hit targets (unlike cached opacity).
             replay.view.styles.overlay = "screen"
             replay.view.styles.offset = ("100vw", 0)
-            replay.view.disabled = True
+            # Same seam as the commit's park: a view whose ink is clipped
+            # off-screen needs the interactivity half of `disabled` and none of
+            # its stylesheet cascade. Here the view has no children yet, so the
+            # saving is small — using the one helper is what keeps the two
+            # parks from drifting into different notions of "parked".
+            _set_transcript_parked(replay.view, True)
             replay.view.set_navigation_visible(False)
             for block in replay.blocks:
                 block.set_navigation_visible(False)
@@ -4520,6 +4586,27 @@ class OperatorApp(App[None]):
         future.add_done_callback(lambda _future: timer.stop())
         # The first target frame must cover its transcript, draft and gates,
         # not merely a sidebar/status fragment sharing the new geometry map.
+        #
+        # `refresh(layout=True)` alone asks for a LAYOUT; it does not ask for a
+        # FULL paint, and the compositor is free to satisfy the resulting
+        # render with a partial `ChopsUpdate` over whatever regions the reflow
+        # dirtied. Only a `LayoutUpdate` records `_sidebar_displayed_frame`
+        # (see `_display`), so the gate could NEVER pass on the first
+        # post-commit paint and every switch paid a forced second full-screen
+        # relayout from `post_display_hook`'s recovery branch below — measured
+        # on 21/21 switches, p50 15-71 ms and up to 215 ms at p90.
+        #
+        # Marking the whole screen region dirty is what makes the arming
+        # refresh PRODUCE the evidence rather than merely hope for it:
+        # `render_update` takes `render_full_update()` whenever the screen
+        # region is in `_dirty_regions`, so the very next paint is a
+        # `LayoutUpdate` carrying the complete compositor map. This does NOT
+        # weaken the gate — it still waits for a real painted map covering the
+        # target surfaces, exactly as the comment in
+        # `_sidebar_gate_surface_ready` requires. It only makes that map arrive
+        # on the frame the switch already pays for.
+        compositor = self.screen._compositor
+        compositor._dirty_regions.add(compositor.size.region)
         self.screen.refresh(layout=True)
         return future
 
@@ -4556,6 +4643,10 @@ class OperatorApp(App[None]):
         if pending is None:
             return
         source, generation, future = pending
+        if not future.done():
+            # Counted before the verdict, so "reached the gate" and "passed the
+            # gate" stay separable facts (see the attribute's own note).
+            self._sidebar_gate_reached += 1
         if future.done():
             self._sidebar_ready_frame = None
         elif generation == self._sidebar_navigation.generation and self._sidebar_gate_surface_ready(
@@ -4574,6 +4665,19 @@ class OperatorApp(App[None]):
             # scroll map. Request the actual follow-up layout/paint now rather
             # than waiting for the unrelated two-second catalog poll. The same
             # displayed-map gate still decides readiness; no timer waives it.
+            #
+            # THIS IS A RECOVERY PATH AND IT SHOULD NEVER FIRE ON A NORMAL
+            # SWITCH. It used to be the normal path: the arming refresh in
+            # `_await_sidebar_frame` produced a `ChopsUpdate`, the gate refused
+            # for NO_DISPLAYED_FRAME every single time, and this branch bought
+            # the second full relayout that finally satisfied it. The arming
+            # refresh now dirties the whole screen region, so the first
+            # post-commit paint is already a full `LayoutUpdate` and the gate
+            # passes on it. Kept — deliberately — because the case it was
+            # written for is real and the cost of an unnecessary recovery is
+            # one frame, while the cost of no recovery is a wedged switch.
+            # `test_switch_gate_is_never_refused` asserts it stays dead.
+            self._sidebar_gate_recoveries += 1
             self.screen.refresh(layout=True)
 
     def _sidebar_navigation_pending(self, session_id: str) -> None:
@@ -4625,9 +4729,29 @@ class OperatorApp(App[None]):
         buffer is a transition buffer, and its contents are attributed at the
         moment the outcome is known (commit → target, failure → outgoing).
         Synchronous, before any await, so nothing can slip in between the
-        snapshot and the empty buffer. A burst of clicks re-enters here with
+        snapshot and the frozen prefix. A burst of clicks re-enters here with
         a transition already open; the snapshot is kept and only the buffer
         is carried on.
+
+        THE BUFFER IS NOT EMPTIED HERE, and that is deliberate. It used to be:
+        ``load_text("")`` ran at ``pending`` while the incoming draft was only
+        loaded ~100 ms later inside commit, so every frame in between painted a
+        ONE-ROW composer regardless of either session's real height. ``Editor``
+        is ``height: auto`` (1..8) inside a ``height: auto`` docked
+        ``#input-dock``, so that collapse is not one widget resizing — the
+        transcript above it grows into the vacated rows and the whole
+        conversation column reflows. The operator sees his half-written
+        sentence vanish and come back, and the screen shudder around it.
+        Measured: 3 -> 1 -> 3 rows over two consecutive painted frames, 9
+        off-state frames per A/B arm, down to 0 once the emptying moves into
+        the commit that loads the incoming draft over it.
+
+        Attribution is unaffected because it never depended on the buffer being
+        VISIBLY empty — only on knowing where the outgoing draft ended.
+        :attr:`_sidebar_transition_prefix` is that boundary, and
+        :meth:`_take_sidebar_transition_buffer` subtracts it, so what the user
+        types during the switch is still attributed to the target on commit and
+        handed back to the outgoing session on failure.
         """
         if self._sidebar_transition_from is not None:
             return
@@ -4642,24 +4766,63 @@ class OperatorApp(App[None]):
         outgoing.draft.history_stash = recall.stash
         outgoing.draft.history_stash_attachments = dict(recall.stash_attachments)
         self._sidebar_transition_from = outgoing
-        # The buffer now belongs to no session. Leave recall as it was: a
-        # transition is not a prompt, and load_text must not reset the index
-        # the outgoing session will get back if this fails.
-        editor.load_text("")
-        editor.adopt_attachments({})
+        # The buffer now belongs to no session, but it keeps PAINTING the
+        # outgoing draft until commit swaps it (see the docstring). This is the
+        # frozen prefix everything typed from here on sits after. Recall is
+        # left exactly as it was: a transition is not a prompt, and nothing may
+        # reset the index the outgoing session gets back if this fails.
+        self._sidebar_transition_prefix = editor.text
+        self._sidebar_transition_attachments = editor.attachments()
 
     def _take_sidebar_transition_buffer(self) -> tuple[str, dict[int, Any]]:
+        """What the user typed AFTER the click, without the frozen prefix.
+
+        The buffer still holds the outgoing draft the transition froze, so the
+        prefix is subtracted here rather than having been erased at ``pending``.
+        The ``startswith`` test is the honest one: a user who EDITED the frozen
+        text rather than appending to it has not typed a separable suffix, and
+        guessing at a diff would attribute their edit to the wrong session.
+        Yielding nothing there is exactly what the old empty-at-pending buffer
+        produced for the same gesture, and the outgoing draft is still restored
+        whole by :meth:`_abandon_sidebar_transition`.
+
+        Attachments are subtracted BY KEY, never by count: a marker is an index
+        cited in the text, so an index the frozen prefix already carried belongs
+        to the outgoing draft whatever position it now occupies.
+        """
         editor = self._editor()
-        return editor.text, editor.attachments()
+        prefix = self._sidebar_transition_prefix
+        text = editor.text
+        if not prefix:
+            typed = text
+        else:
+            typed = text[len(prefix) :] if text.startswith(prefix) else ""
+        frozen = set(self._sidebar_transition_attachments)
+        return typed, {
+            index: marked
+            for index, marked in editor.attachments().items()
+            if index not in frozen
+        }
 
     def _abandon_sidebar_transition(self) -> None:
-        """Failure/cancel: the user stays put, so what they typed is theirs."""
+        """Failure/cancel: the user stays put, so what they typed is theirs.
+
+        ``draft.text + typed`` is still assembled from the two halves rather
+        than from the live buffer, even though the buffer now holds both. The
+        buffer is only equal to the sum while the user appended; an edit into
+        the frozen region makes ``typed`` empty (see
+        :meth:`_take_sidebar_transition_buffer`) and the snapshot is then the
+        record worth restoring. Taking the buffer must therefore happen BEFORE
+        the prefix is cleared, or the subtraction has nothing to subtract and
+        the outgoing draft is doubled.
+        """
         outgoing = self._sidebar_transition_from
-        self._sidebar_transition_from = None
         if outgoing is None or outgoing is not self._interaction:
+            self._clear_sidebar_transition()
             return
         editor = self._editor()
         typed, typed_attachments = self._take_sidebar_transition_buffer()
+        self._clear_sidebar_transition()
         editor.load_text(outgoing.draft.text + typed)
         merged = dict(outgoing.draft.attachments)
         merged.update(typed_attachments)
@@ -4673,6 +4836,19 @@ class OperatorApp(App[None]):
             )
         )
         editor.move_cursor(editor._end_of_buffer())
+
+    def _clear_sidebar_transition(self) -> None:
+        """Close the transition and drop its frozen prefix.
+
+        One seam for all three outcomes (commit, abandon, a stale abandon for
+        an interaction that is no longer current) so the prefix can never
+        outlive the transition it belongs to: a stale prefix would be
+        subtracted from the NEXT switch's buffer and silently eat the target's
+        own draft.
+        """
+        self._sidebar_transition_from = None
+        self._sidebar_transition_prefix = ""
+        self._sidebar_transition_attachments = {}
 
     def _sidebar_source_releasable(
         self, source: SessionInteraction, *, reason: str = "idle"
@@ -5064,9 +5240,13 @@ class OperatorApp(App[None]):
             self._close_settings_view()
         editor = self._editor()
         if self._sidebar_transition_from is outgoing:
-            # The outgoing draft was frozen at ``pending``; the editor holds
-            # the transition buffer, which belongs to the TARGET. Take it now,
-            # before the incoming draft is loaded over it.
+            # The outgoing draft was frozen at ``pending`` and is STILL what the
+            # editor paints — that is what keeps the composer at a stable height
+            # through the switch. What the user typed after the click sits after
+            # the frozen prefix and belongs to the TARGET. Take it now, before
+            # the incoming draft is loaded over the whole buffer further down;
+            # that load is the point at which the outgoing text finally leaves
+            # the screen, in the same frame its replacement arrives.
             typed, typed_attachments = self._take_sidebar_transition_buffer()
         else:
             # No transition was opened (a programmatic swap); the buffer is
@@ -5080,7 +5260,7 @@ class OperatorApp(App[None]):
             outgoing.draft.history_index = recall.index
             outgoing.draft.history_stash = recall.stash
             outgoing.draft.history_stash_attachments = dict(recall.stash_attachments)
-        self._sidebar_transition_from = None
+        self._clear_sidebar_transition()
         if (not refreshing or source.scroll_revision != source.preview_scroll_revision) and (
             not outgoing.display_only
             or outgoing.scroll_revision != outgoing.preview_scroll_revision
@@ -5128,14 +5308,14 @@ class OperatorApp(App[None]):
         old_view.styles.layer = "session-cache"
         old_view.styles.overlay = "screen"
         old_view.styles.offset = ("100vw", 0)
-        old_view.disabled = True
+        _set_transcript_parked(old_view, True)
         old_view.styles.height = old_view.outer_size.height
         displaced = self._sidebar_presentations.pop(session_id, None)
         self._apply_sidebar_presentation(incoming)
         incoming.replay.view.styles.layer = "default"
         incoming.replay.view.styles.overlay = "none"
         incoming.replay.view.styles.offset = (0, 0)
-        incoming.replay.view.disabled = False
+        _set_transcript_parked(incoming.replay.view, False)
         incoming.replay.view.set_navigation_visible(True)
         if incoming.welcome is not None:
             incoming.welcome.set_navigation_visible(True)
@@ -5279,32 +5459,29 @@ class OperatorApp(App[None]):
             # A drawer cannot count as a correct visible conversation while it
             # covers the response. Pinned wide sidebars stay open.
             self._set_sidebar_open(False)
-        self._start_resume_fill()
+        self._prefill_resume_before_reveal()
         self._show_sidebar_connection(source)
-        if not source.draft.following_tail and source.draft.scroll_anchor_id:
-            scroll_revision = source.scroll_revision
-            view = incoming.replay.view
-
-            def restore_revealed_anchor() -> None:
-                if (
-                    not self._is_current(source)
-                    or generation != self._sidebar_navigation.generation
-                    or self._transcript_view() is not view
-                ):
-                    return
-                if source.scroll_revision != scroll_revision:
-                    self._capture_sidebar_scroll(source)
-                    return
-                # Offscreen measurement is not final visible geometry for a
-                # wrapped viewport. Re-anchor after reveal, and let the normal
-                # painted-map gate verify the resulting frame, not a timer.
-                view.restore_navigation_anchor(
-                    source.draft.scroll_anchor_id,
-                    source.draft.scroll_anchor_part,
-                    source.draft.scroll_offset,
-                )
-
-            self.call_after_refresh(restore_revealed_anchor)
+        # `restore_revealed_anchor` USED TO RUN HERE, on a `call_after_refresh`
+        # AFTER reveal, to correct for "offscreen measurement is not final
+        # visible geometry for a wrapped viewport". It was measured to be a
+        # no-op and is now deleted; the in-prepare restore
+        # (`_prepare_sidebar_session`, both the cache-hit and the built-replay
+        # branch) is the one that positions the view, and it runs on the parked
+        # view where it is free.
+        #
+        # THE WRAPPED-CONTENT CASE WAS THE OPEN QUESTION AND IT WAS MEASURED,
+        # not assumed. A fixture whose blocks genuinely re-wrap (the same anchor
+        # block measures 3 rows at a 96-cell conversation column and 5 rows at a
+        # 63-cell one) was switched away from and back, with the parked and
+        # revealed geometry read on the SAME view object two lines apart at this
+        # commit seam. Parked and revealed agreed exactly — content width 63/63,
+        # scroll_y 44.0/44.0, anchor at y=42 h=5 both times — because the parked
+        # view is mounted into `#session-conversation`, the same container the
+        # visible view occupies: `_prepare_sidebar_session` pins only its
+        # HEIGHT, so it is already laid out at the revealed WIDTH. Re-running
+        # the restore at the revealed width moved the position by 0.0 rows in
+        # every arm. The correction was for a width difference that the park
+        # does not actually produce.
         ready = self._await_sidebar_frame(source, generation)
         if source.display_only:
             source.preview_scroll_revision = source.scroll_revision
@@ -5322,7 +5499,23 @@ class OperatorApp(App[None]):
     def _capture_sidebar_scroll(self, source: SessionInteraction) -> None:
         old_view = self._transcript_view()
         source.draft.following_tail = old_view.is_following_tail
-        if not source.draft.following_tail:
+        if source.draft.following_tail:
+            # A reader who scrolled up and then scrolled BACK to the tail wrote
+            # an anchor into the draft on the way up and nothing cleared it on
+            # the way down, so the record contradicted itself:
+            # `following_tail=True` alongside `anchor='6602e4b2…' offset=-1`.
+            # Every consumer today tests `not following_tail` first, so it is
+            # latent — but it is a loaded gun. Any future read of
+            # `scroll_anchor_id` that does not check the flag first would land
+            # the user at a position they left, and the nonsense `-1` offset
+            # would be clamped by `min(offset, max(0, height - 1))` into silent
+            # wrongness rather than into an error. The operator's instruction is
+            # that a session left at tail lands on the most recent message; this
+            # makes the stored record say exactly that.
+            source.draft.scroll_anchor_id = ""
+            source.draft.scroll_anchor_part = 0
+            source.draft.scroll_offset = 0
+        else:
             top = old_view.content_region.y
             anchor = next(
                 (
@@ -7344,6 +7537,121 @@ class OperatorApp(App[None]):
         # ones a reader sees, and they are exactly as provisional as the ones
         # between attempts.
         self._start_resume_fill()
+
+    def _prefill_resume_before_reveal(self) -> None:
+        """Fill the incoming projection to its goal INSIDE the commit.
+
+        WHAT THIS FIXES. `_start_resume_fill` schedules its first attempt with
+        `call_after_refresh`, which is strictly AFTER the frame that reveals the
+        view. The prepared window under-fills the viewport by construction —
+        `bound = max(12, height // 2)` yields 21 blocks / 14 scroll rows against
+        a 27-row viewport, and `_fill_resume_attempt`'s `goal = viewport +
+        prefix` is 27, so `14 < 27` fires the fill on essentially every switch.
+        The consequence is the operator's "tool traces load all into the same
+        view then shuffle upward": 24 further rows mount into the ALREADY
+        VISIBLE view and drag the viewport 14 -> 62, measured on 10/10 cold
+        switches. It is also the whole of the scroll bounce — the second painted
+        position comes from `_size_updated` reacting to that insert, not from
+        any anchor restore.
+
+        Running the same fill here, synchronously, while the incoming view is
+        still parked, means the rows arrive before anything is on screen: the
+        first painted state IS the settled state. Post-reveal insertions go to
+        zero and the switch paints exactly one scroll position.
+
+        THE TRADE, stated plainly: this moves work from after the reveal to
+        before it, so a COLD switch's `ready_ms` grows (measured +89 ms in the
+        audit's A/B) while its post-reveal movement goes to zero. Warm switches
+        already hold their rows and skip the fill entirely. If cold readiness
+        ever regresses beyond tolerance the fallback is to BOUND this pre-fill
+        (one extra page, then let the rest continue after reveal) rather than to
+        return to filling a view the user is looking at.
+
+        WHY THE LOOP IS BOUNDED THE WAY IT IS. `_fill_resume_attempt` normally
+        chains its next attempt through the settle callback `insert_blocks`
+        schedules, which needs event-loop turns this synchronous section
+        deliberately does not have (`session_navigation` documents that there is
+        no await between the final identity check and commit, and nothing here
+        may introduce one). So each pass is driven directly instead, and only
+        while it keeps making progress against locally held pages: the loop
+        stops as soon as `_resume_pending_head` is empty — a page that needs a
+        NETWORK fetch is left to the ordinary post-reveal path, because waiting
+        for a socket before showing anything is the one thing worse than a
+        shuffle.
+
+        NOTHING HERE MAY RAISE INTO `PreparationInvalidated`. That retry path
+        (`session_navigation._prepare_and_commit`) releases the prepared widgets
+        and re-prepares, and it is reached by the invalidation check ABOVE this
+        point in the commit; a failure here happens after ownership has already
+        moved, so a raise would tear down a presentation that is already live.
+        `_mount_older_resume_page` re-raises projection failures by design
+        (keeping the page retryable), so the pass is guarded and degrades to the
+        ordinary deferred fill, which is exactly the behaviour before this
+        change.
+        """
+        view = self._transcript_view()
+        viewport = view.container_size.height or view.size.height
+        if not viewport and self._resume_pending_head and not self._resume_paging:
+            # A FIRST-VISIT (`display_only`) presentation is mounted without the
+            # in-prepare layout round trip -- `_prepare_sidebar_session` skips it
+            # deliberately so a first saved view reveals its real rows without
+            # paying an extra frame first. The consequence here is that the view
+            # has no measured viewport yet, and a fill with no geometry to
+            # measure against would mount pages blindly. Resolve the geometry
+            # instead of giving up on it: this is the same layout pass the next
+            # frame would run, pulled forward, and it is SYNCHRONOUS -- no await
+            # is introduced between the navigation's final identity check and
+            # this commit (`session_navigation._prepare_and_commit`).
+            self.screen._refresh_layout()
+            viewport = view.container_size.height or view.size.height
+        if not viewport or self._resume_paging or not self._resume_pending_head:
+            # Nothing locally pending, or a fetch already owns the gate. The
+            # scheduled fill below still runs and reaches the same goal by the
+            # ordinary route.
+            self._start_resume_fill()
+            return
+        self._resume_fill_active = True
+        self._resume_fill_serial += 1
+        try:
+            for _ in range(RESUME_FILL_MAX_PAGES):
+                notice = self._resume_head_notice
+                prefix = (
+                    notice.virtual_region.bottom
+                    if notice is not None and notice.parent is view
+                    else 0
+                )
+                if view.scroll_y >= viewport + prefix or not self._resume_pending_head:
+                    break
+                pending_before = len(self._resume_pending_head)
+                # `on_settled=None`: the continuation IS this loop. The page's
+                # own settle callback still releases the paging lease and
+                # reconciles the head notice on its normal schedule.
+                self._mount_older_resume_page()
+                if len(self._resume_pending_head) >= pending_before:
+                    break  # Cursor did not advance; do not spin.
+                # SETTLE THE GEOMETRY THIS PAGE JUST CHANGED, before measuring
+                # again or handing the view to the gate. A mounted block only
+                # authors its real height during a layout pass, so without this
+                # the loop re-measures against a stale `scroll_y` and, worse,
+                # the view is revealed with its tail block not yet in the
+                # compositor's painted map -- which the readiness gate reads as
+                # NOT READY and pays a recovery relayout for. Measured: 12
+                # TAIL_BLOCK refusals across 4 cold switches without this call,
+                # 0 with it. Synchronous, for the same reason as above: this
+                # commit may not await.
+                self.screen._refresh_layout()
+        except Exception:
+            # See the docstring: a projection failure must degrade to the
+            # deferred fill, never propagate into the invalidation retry.
+            logger.debug("pre-reveal resume fill failed; deferring", exc_info=True)
+        finally:
+            # ALWAYS follow with the ordinary scheduled fill. It re-measures
+            # against real laid-out geometry, tops up anything this synchronous
+            # pass could not reach (a page behind a network fetch), and settles
+            # `_resume_fill_active` / the head notice through the one path that
+            # owns them. When the goal is already met its first attempt exits
+            # immediately, which is the normal case after this pre-fill.
+            self._start_resume_fill()
 
     def _start_resume_fill(self, *, target: float | None = None) -> None:
         """Top up a newly revealed projection, not every subsequent resize.

--- a/scripts/bench_session_switch.py
+++ b/scripts/bench_session_switch.py
@@ -69,9 +69,16 @@ SETTLE_PUMPS = 12
 DEFAULT_SAMPLES = 8
 
 #: Distinct sessions the cold pattern rotates through. Must exceed
-#: ``RETAINED_PRESENTATIONS`` (4) plus the two live sources by a clear margin,
-#: or the "cold" cell silently starts measuring cache hits.
-COLD_POOL = 12
+#: ``RETAINED_PRESENTATIONS`` -- which is **12**, not the 4 an earlier draft of
+#: this comment claimed (agent review round 1, R4) -- by a clear margin, or the
+#: "cold" cell silently starts measuring cache hits instead of cold switches.
+#:
+#: At 12 the rotation was exactly the retain budget, i.e. no margin at all: a
+#: presentation evicted only just before its turn came round again is one
+#: scheduling accident away from still being resident. 20 restores the headroom
+#: the sentence above promises, and the cost is only a few more seeded
+#: transcripts per worker.
+COLD_POOL = 20
 
 TRANSCRIPTS = {"small": 7, "large": 134}  # turns; a turn renders 3 blocks
 SIZES = {"120x36": (120, 36), "200x50": (200, 50)}

--- a/scripts/bench_session_switch.py
+++ b/scripts/bench_session_switch.py
@@ -1,0 +1,677 @@
+"""Measure sidebar session-switch latency: click-to-usable-frame, and the jitter around it.
+
+The operator's report is three symptoms of one switch: the composer resizes, the
+transcript reflows and "shuffles" after it is already visible, and the scroll
+position bounces before it settles. So this harness does not report a single
+latency number. It reports the latency AND the counts of the three visible
+artefacts, because on a box under load average ~36 a wall-clock number is noise
+and a **count of frames, layouts, mounts and distinct scroll positions is not** —
+a count is a fact about how much work one switch costs, and it is identical on an
+idle laptop and a wedged CI runner. See AGENTS.md "Timing, flakes, and how to
+assert that something is fast": structural invariants first, CPU before wall,
+never calibrate a ceiling from this laptop.
+
+Examples (no live configuration, sessions, providers or sockets are used)::
+
+    # Baseline on the tree this script lives in.
+    .venv/bin/python scripts/bench_session_switch.py --output /tmp/switch-bench/baseline.json
+
+    # Interleaved A/B: the SAME harness alternates between two trees within one
+    # run, group by group, so before and after share the same load weather.
+    .venv/bin/python scripts/bench_session_switch.py \
+        --source-root /tmp/lo-bench-base --output /tmp/switch-bench/ab.json
+
+WHY A SEPARATE SCRIPT AND NOT ``sidebar_performance.py --mode switch``.
+That harness measures the sidebar WIDGET's render cost; its matrix axes are
+(session count, sidebar open, streaming) and its cell result is a render count.
+This measures the SWITCH, whose axes are (transcript size, terminal size, cache
+pattern) and whose result is a per-switch record. Grafting the second matrix into
+the first script's ``main()`` would give one file two unrelated cell shapes and
+two unrelated result schemas. It follows every convention of the neighbouring
+``bench_*.py`` scripts instead — module-level parser, ``--source-root``,
+``probe_isolation`` before the package import, CMUX scrubbing, provenance in the
+JSON — which is the house style those files already establish.
+
+TWO PROCESSES, ONE HARNESS. An editable install resolves ONE source root, so a
+single process cannot hold two trees. The driver therefore alternates *worker
+subprocesses*, each running under its own tree's venv, group by group and with
+the order flipped every round. That is what makes an A/B credible here: the two
+trees are sampled seconds apart under the same load, not in two runs minutes
+apart. ``--source-root`` names the OTHER tree; the tree this file lives in is
+always side "A".
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+HERE = Path(__file__).resolve().parent.parent
+
+#: One switch is measured from the ``Selected`` message to the readiness future.
+#: Everything after that future is the SETTLE window: the frames the user is
+#: already looking at. It is bounded in loop turns rather than milliseconds
+#: because a turn count survives contention that a wall-clock budget does not
+#: (AGENTS.md, "Wait on the event, never on the clock").
+SETTLE_PUMPS = 12
+
+#: How many switches make up one cell's sample. Small enough that the whole
+#: matrix stays inside a few minutes on a loaded box, large enough that a median
+#: and a p90 mean something.
+DEFAULT_SAMPLES = 8
+
+#: Distinct sessions the cold pattern rotates through. Must exceed
+#: ``RETAINED_PRESENTATIONS`` (4) plus the two live sources by a clear margin,
+#: or the "cold" cell silently starts measuring cache hits.
+COLD_POOL = 12
+
+TRANSCRIPTS = {"small": 7, "large": 134}  # turns; a turn renders 3 blocks
+SIZES = {"120x36": (120, 36), "200x50": (200, 50)}
+PATTERNS = ("cold", "warm", "alternating")
+
+
+def groups() -> list[str]:
+    return [f"{t}@{s}" for t in TRANSCRIPTS for s in SIZES]
+
+
+PARSER = argparse.ArgumentParser(description=__doc__)
+PARSER.add_argument(
+    "--source-root",
+    type=Path,
+    default=None,
+    help="a second worktree to interleave against; omit for a single-tree baseline",
+)
+PARSER.add_argument("--output", type=Path, required=True, help="destination JSON file")
+PARSER.add_argument("--samples", type=int, default=DEFAULT_SAMPLES)
+PARSER.add_argument("--rounds", type=int, default=3, help="interleaved passes over the matrix")
+PARSER.add_argument("--group", default="", help=argparse.SUPPRESS)  # worker-only
+PARSER.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
+
+
+# ---------------------------------------------------------------------------
+# Worker: measures one group (transcript size x terminal size, all patterns).
+# ---------------------------------------------------------------------------
+
+
+def _run_worker(args: argparse.Namespace) -> None:
+    # Multiplexer variables are independent of HOME/config. Even a headless
+    # pilot must not inherit identifiers that could rename the operator's real
+    # workspace. Scrubbed before ANY import, including this file's own.
+    for key in tuple(os.environ):
+        if key.startswith("CMUX_"):
+            del os.environ[key]
+
+    import scripts.probe_isolation  # noqa: F401  -- re-homes HOME/config on import
+
+    # isort: split
+    # Isolation must precede even the package root import.
+    from unittest.mock import patch
+
+    import local_operator
+    from local_operator.harness.types import Message, ToolCall
+    from local_operator.resume import SessionRow
+    from local_operator.tui.app import OperatorApp
+    from local_operator.tui.session_catalog import CatalogEntry
+    from local_operator.tui.session_interaction import SessionInteraction
+    from local_operator.tui.widgets.session_sidebar import SessionSidebar
+    from local_operator.tui.widgets.transcript import TranscriptView
+    from tests.unit.tui.test_app_pilot import _factory
+    from tests.unit.tui.test_sidebar_swap_reset import SidebarRemote
+
+    transcript_name, _, size_name = args.group.partition("@")
+    turns = TRANSCRIPTS[transcript_name]
+    size = SIZES[size_name]
+
+    def history(count: int) -> list[Message]:
+        """A conversation shaped like the ones the complaint is about.
+
+        Every turn carries a tool call AND its result, so the replay path mounts
+        a ``ToolCard`` per turn rather than only prose blocks — the operator's
+        report is specifically about tool traces shuffling, and a prose-only
+        fixture would not exercise the card projection at all.
+        """
+        out: list[Message] = []
+        for i in range(count):
+            out.append(
+                Message.user(
+                    f"turn {i}: please look into the switch latency and report back. " * 2,
+                    id=f"u{i}",
+                )
+            )
+            call = ToolCall(
+                id=f"c{i}",
+                name="bash",
+                arguments={"command": f"rg -n 'switch' local_operator/tui/app.py | sed -n '{i}p'"},
+            )
+            out.append(
+                Message.assistant(
+                    f"Reading the sidebar path, step {i}. Here is what the trace shows so far.",
+                    id=f"a{i}",
+                    tool_calls=[call],
+                )
+            )
+            out.append(
+                Message(
+                    role="tool",
+                    content=[],
+                    tool_call_id=f"c{i}",
+                    tool_name="bash",
+                    id=f"t{i}",
+                )
+            )
+        return out
+
+    ids = [f"{i:04x}00000000" for i in range(COLD_POOL + 2)]
+    home = SidebarRemote("home00000000", history=history(2))
+    remotes = {sid: SidebarRemote(sid, history=history(turns)) for sid in ids}
+    entries = [
+        CatalogEntry(SessionRow(sid, 1788700000 - i * 60, f"Switch bench session {i}"))
+        for i, sid in enumerate(ids)
+    ]
+
+    app = OperatorApp(lambda: _factory(home))
+
+    async def lease(session_id: str, *, speculative: bool = False) -> SessionInteraction:
+        """Stand in for the disk/socket lease, and NOTHING else.
+
+        The real lease reads an owner record and opens a socket, neither of
+        which may touch the operator's machine here. Everything the measurement
+        is about — prepare, mount, park, commit, adopt, reveal, the readiness
+        gate — stays production code.
+
+        ``_interactions[id(remote)]`` is populated exactly as the real lease
+        does: ``_adopt_session`` looks the source up by session identity, and a
+        fake that skips this registration makes the app adopt a DIFFERENT
+        interaction than the one the readiness gate is bound to, so the gate can
+        never be satisfied and every cold switch reads as a 15 s timeout.
+        """
+        source = app._sidebar_sources.get(session_id)
+        if source is None:
+            remote = remotes[session_id]
+            source = SessionInteraction(remote)
+            source.display_only = remote.is_cold
+            # A DRAFT PER SESSION, and a multi-line one. The composer is
+            # `height: auto` between 1 and 8 rows, so it can only be seen to
+            # resize if the sessions being switched between disagree about how
+            # tall it should be. With every draft empty the composer is pinned
+            # at one row and the harness would report "no resize" for a switch
+            # the operator watches shrink and grow. Lengths are staggered so
+            # consecutive targets in every pattern want different heights.
+            lines = 1 + (int(session_id[:4], 16) % 4)
+            source.draft.text = "\n".join(
+                f"draft line {n} for {session_id[:4]}" for n in range(lines)
+            )
+            app._interactions[id(remote)] = source
+            app._sidebar_sources[session_id] = source
+        source.preparations += 1
+        return source
+
+    # ---- instrumentation. All of it lives here; product code is untouched. ----
+    state: dict[str, Any] = {
+        "armed": False,
+        "revealed": False,
+        "displays": 0,
+        "after_refresh": 0,
+        "layouts": 0,
+        "reveal_displays": 0,
+        "reveal_layouts": 0,
+        "reveal_mounts": 0,
+        "scrolls": [],
+        "editor_heights": [],
+        "settle": False,
+        "settle_displays": 0,
+        "settle_layouts": 0,
+        "settle_mounts": 0,
+        "settle_scrolls": [],
+    }
+
+    def observe() -> None:
+        """Sample the VISIBLE surfaces on a display pass.
+
+        Scroll position and composer height are read per painted frame rather
+        than once at the end: the complaint is that they move between frames,
+        and a single end-state reading cannot see motion. Distinct-value counts
+        of these sequences are the load-independent evidence — one distinct
+        value means the user saw no movement, whatever the wall clock said.
+        """
+        try:
+            editor = app._editor()
+        except Exception:  # noqa: BLE001 - a mid-swap query can find nothing
+            return
+        # The COMPOSER is sampled on every armed frame, including the ones
+        # before reveal. The operator's report is that it "shrinks while in the
+        # loading state and then grows back": that shrink happens during the
+        # pending window, so a probe that only looked after reveal would miss
+        # the exact frames complained about and report zero resizes.
+        state["editor_heights"].append(int(editor.outer_size.height))
+        if not state["revealed"]:
+            return
+        # SCROLL is only meaningful once the incoming view IS the visible one:
+        # before that, `_transcript_view()` returns the outgoing transcript and
+        # its scroll position says nothing about the switch.
+        try:
+            view = app._transcript_view()
+        except Exception:  # noqa: BLE001
+            return
+        bucket = "settle_scrolls" if state["settle"] else "scrolls"
+        state[bucket].append(float(view.scroll_y))
+
+    real_hook = app.post_display_hook
+
+    def post_display_hook() -> None:
+        if state["armed"]:
+            state["displays"] += 1
+            if state["settle"]:
+                state["settle_displays"] += 1
+            elif state["revealed"]:
+                state["reveal_displays"] += 1
+            observe()
+        real_hook()
+
+    real_after_refresh = app.call_after_refresh
+
+    def call_after_refresh(callback: Any, *a: Any, **kw: Any) -> bool:
+        if state["armed"]:
+            state["after_refresh"] += 1
+        return real_after_refresh(callback, *a, **kw)
+
+    real_commit = app._commit_sidebar_session
+
+    def commit(session_id: str, prepared: Any, generation: int) -> Any:
+        # Reveal is the instant the prepared view becomes the visible one. Every
+        # layout, mount and scroll change AFTER this point is work the user is
+        # looking at, which is exactly the "shuffle" being counted.
+        started = time.perf_counter()
+        out = real_commit(session_id, prepared, generation)
+        state["commit_ms"] = (time.perf_counter() - started) * 1000
+        state["revealed"] = True
+        observe()
+        return out
+
+    real_prepare = app._prepare_sidebar_session
+
+    async def prepare(session_id: str, **kw: Any) -> Any:
+        started = time.perf_counter()
+        out = await real_prepare(session_id, **kw)
+        state["prepare_ms"] = (time.perf_counter() - started) * 1000
+        return out
+
+    ready: dict[str, Any] = {}
+    real_await = app._await_sidebar_frame
+
+    def await_frame(source: Any, generation: int) -> Any:
+        future = real_await(source, generation)
+        ready["future"] = future
+        return future
+
+    def install_layout_probe() -> None:
+        # Bound only once the pilot has pushed a screen: `app.screen` raises
+        # ScreenStackError before `run_test` starts, and the layout pass being
+        # counted belongs to the live screen instance, not to the class.
+        screen = app.screen
+        real_layout = screen._refresh_layout
+
+        def refresh_layout(*a: Any, **kw: Any) -> None:
+            if state["armed"]:
+                state["layouts"] += 1
+                if state["settle"]:
+                    state["settle_layouts"] += 1
+                elif state["revealed"]:
+                    state["reveal_layouts"] += 1
+            return real_layout(*a, **kw)
+
+        screen._refresh_layout = refresh_layout  # type: ignore[method-assign]
+
+    real_append = TranscriptView.append_block
+
+    def append_block(view: Any, block: Any) -> None:
+        # Only mounts onto the ALREADY VISIBLE view count: rows appended to a
+        # parked offscreen replay are the preparation doing its job, while rows
+        # appended after reveal are rows that appear under the reader's eyes.
+        if state["armed"] and state["revealed"] and view is app._transcript_view():
+            if state["settle"]:
+                state["settle_mounts"] += 1
+            else:
+                state["reveal_mounts"] += 1
+        return real_append(view, block)
+
+    async def measure(pilot: Any, target: str) -> dict[str, Any]:
+        warm = target in app._sidebar_presentations
+        for key, value in (
+            ("revealed", False),
+            ("settle", False),
+            ("displays", 0),
+            ("after_refresh", 0),
+            ("layouts", 0),
+            ("reveal_displays", 0),
+            ("reveal_layouts", 0),
+            ("reveal_mounts", 0),
+            ("settle_displays", 0),
+            ("settle_layouts", 0),
+            ("settle_mounts", 0),
+        ):
+            state[key] = value
+        state["scrolls"] = []
+        state["settle_scrolls"] = []
+        state["editor_heights"] = []
+        state["prepare_ms"] = None
+        state["commit_ms"] = None
+        ready.clear()
+
+        editor_before = app._editor().outer_size.height
+        state["armed"] = True
+        wall0, cpu0 = time.perf_counter(), time.thread_time()
+        app.post_message(SessionSidebar.Selected(target))
+        # Drive the loop, not a sleep: readiness is published by the app, and
+        # the bound below exists only so a genuine wedge fails the run.
+        future = None
+        for _ in range(4000):
+            await pilot.pause()
+            future = ready.get("future")
+            if future is not None and future.done():
+                break
+        wall = (time.perf_counter() - wall0) * 1000
+        cpu = (time.thread_time() - cpu0) * 1000
+        settled = future is not None and future.done() and not future.cancelled()
+        ok = settled and future.exception() is None
+        if future is not None and not future.done():
+            future.cancel()
+
+        # The settle window: frames the user is already looking at. Anything
+        # that moves here is the reported "shuffle after it loads".
+        state["settle"] = True
+        for _ in range(SETTLE_PUMPS):
+            await pilot.pause()
+        state["armed"] = False
+
+        view = app._transcript_view()
+        heights = state["editor_heights"]
+        return {
+            "target": target,
+            "warm": warm,
+            "ok": ok,
+            "wall_ms": wall,
+            "loop_cpu_ms": cpu,
+            "prepare_ms": state["prepare_ms"],
+            "commit_ms": state["commit_ms"],
+            "displays": state["displays"],
+            "call_after_refresh": state["after_refresh"],
+            "layouts": state["layouts"],
+            "reveal_displays": state["reveal_displays"],
+            "reveal_layouts": state["reveal_layouts"],
+            "reveal_mounts": state["reveal_mounts"],
+            "scroll_settle": len(set(state["scrolls"])),
+            "scroll_sequence": state["scrolls"][:8],
+            "settle_displays": state["settle_displays"],
+            "settle_layouts": state["settle_layouts"],
+            "settle_mounts": state["settle_mounts"],
+            "settle_scroll_settle": len(set(state["settle_scrolls"])),
+            "composer_heights": sorted(set([editor_before] + heights)),
+            "composer_resizes": len(set([editor_before] + heights)) - 1,
+            "blocks_at_ready": len(view.blocks()),
+            "scroll_y_at_ready": float(view.scroll_y),
+        }
+
+    async def run() -> list[dict[str, Any]]:
+        results: list[dict[str, Any]] = []
+        with (
+            patch("local_operator.session.remote.RemoteSession", SidebarRemote),
+            patch("local_operator.tui.session_catalog.load_catalog", return_value=entries),
+            # Prewarm reads owner records off disk; the cache states it would
+            # produce are modelled explicitly by the `warm` pattern instead.
+            patch.object(OperatorApp, "_prewarm_sidebar", lambda _s, _e: None),
+            patch.object(OperatorApp, "_check_for_update", lambda _s: None),
+            patch.object(OperatorApp, "_start_terminal_title", lambda _s: None),
+            patch.object(OperatorApp, "_start_multiplexer_broadcast", lambda _s: None),
+            patch.object(OperatorApp, "_start_herdr_reporter", lambda _s: None),
+            patch.object(TranscriptView, "append_block", append_block),
+        ):
+            async with app.run_test(size=size) as pilot:
+                app._lease_sidebar_source = lease  # type: ignore[method-assign]
+                app._prepare_sidebar_session = prepare  # type: ignore[method-assign]
+                app._commit_sidebar_session = commit  # type: ignore[method-assign]
+                app._await_sidebar_frame = await_frame  # type: ignore[method-assign]
+                app.post_display_hook = post_display_hook  # type: ignore[method-assign]
+                app.call_after_refresh = call_after_refresh  # type: ignore[method-assign]
+                # SessionNavigation captures BOUND methods in `__init__`, so
+                # rebinding the attributes above is invisible to it — the
+                # coordinator would keep calling the originals and the phase
+                # timings would silently read `null` while everything else
+                # looked correct. Re-point the coordinator's own slots too.
+                app._sidebar_navigation._prepare = prepare
+                app._sidebar_navigation._commit = commit
+                install_layout_probe()
+                for _ in range(40):
+                    await pilot.pause()
+                app._session_sidebar.set_entries(entries)
+                await pilot.pause()
+
+                # COLD first and in a strict forward rotation: each target is
+                # visited once, so nothing it measures can be a cache hit. The
+                # pool is larger than the retain budget, so by the time the
+                # rotation wraps the early entries have been evicted.
+                for i in range(args.samples):
+                    record = await measure(pilot, ids[i % COLD_POOL])
+                    record["pattern"] = "cold"
+                    results.append(record)
+
+                # WARM: a two-session ping-pong, both retained. Every switch
+                # here takes the `_sidebar_presentations` hit path.
+                warm_pair = ids[COLD_POOL], ids[COLD_POOL + 1]
+                for sid in warm_pair:
+                    await measure(pilot, sid)
+                for i in range(args.samples):
+                    record = await measure(pilot, warm_pair[i % 2])
+                    record["pattern"] = "warm"
+                    results.append(record)
+
+                # ALTERNATING over three, which is what a user actually does and
+                # what exercises the LRU's recency reinsertion rather than a
+                # degenerate two-key swap.
+                trio = ids[0], ids[1], ids[2]
+                for sid in trio:
+                    await measure(pilot, sid)
+                for i in range(args.samples):
+                    record = await measure(pilot, trio[i % 3])
+                    record["pattern"] = "alternating"
+                    results.append(record)
+        return results
+
+    records = asyncio.run(run())
+    for record in records:
+        record["group"] = args.group
+        record["transcript"] = transcript_name
+        record["size"] = size_name
+        record["history_messages"] = turns * 3
+    print(
+        json.dumps({"source": str(local_operator.__file__), "records": records}),
+        flush=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Driver: alternates worker subprocesses between trees.
+# ---------------------------------------------------------------------------
+
+
+def _provenance(root: Path) -> dict[str, Any]:
+    def git(*a: str) -> str:
+        try:
+            return subprocess.run(
+                ["git", "-C", str(root), *a], capture_output=True, text=True, timeout=30
+            ).stdout.strip()
+        except Exception:  # noqa: BLE001
+            return ""
+
+    return {
+        "root": str(root),
+        "sha": git("rev-parse", "HEAD"),
+        "describe": git("describe", "--always", "--dirty"),
+        "dirty": bool(git("status", "--porcelain")),
+    }
+
+
+def _interpreter(root: Path) -> tuple[str, dict[str, str]]:
+    """Each worktree owns its own venv; a wrong one silently measures main.
+
+    AGENTS.md is explicit that an editable install resolves ONE hard-coded
+    source root, so running tree B's harness under tree A's interpreter would
+    import A and report it as B. The venv is preferred and ``PYTHONPATH`` is set
+    regardless, so the tree under test wins even if a venv is missing or stale;
+    the worker echoes the resolved ``local_operator.__file__`` back and the
+    driver refuses a mismatch.
+    """
+    env = dict(os.environ, PYTHONPATH=str(root))
+    candidate = root / ".venv/bin/python"
+    return (str(candidate) if candidate.exists() else sys.executable), env
+
+
+def _worker(root: Path, group: str, samples: int) -> list[dict[str, Any]]:
+    python, env = _interpreter(root)
+    env.pop("NO_COLOR", None)
+    env["TERM"] = "xterm-256color"
+    proc = subprocess.run(
+        [
+            python,
+            str(root / "scripts/bench_session_switch.py"),
+            "--worker",
+            "--group",
+            group,
+            "--samples",
+            str(samples),
+            "--output",
+            os.devnull,
+        ],
+        cwd=str(root),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=900,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"worker for {root} group {group} failed:\n{proc.stderr[-3000:]}")
+    payload = json.loads(proc.stdout.strip().splitlines()[-1])
+    resolved = Path(payload["source"]).resolve()
+    if root.resolve() not in resolved.parents:
+        raise RuntimeError(f"worker for {root} imported {resolved} — wrong tree, refusing")
+    return payload["records"]
+
+
+def _summarise(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Median/p90/IQR, never a bare mean.
+
+    A mean on this box is dominated by whichever sample happened to land inside
+    a scheduling hole. The dispersion is reported alongside so a reader can see
+    whether a difference between two trees is larger than the run's own spread.
+    """
+
+    def stat(key: str) -> dict[str, Any]:
+        values = sorted(float(r[key]) for r in records if r.get(key) is not None)
+        if not values:
+            return {"n": 0}
+        quantiles = statistics.quantiles(values, n=4) if len(values) > 1 else [values[0]] * 3
+        return {
+            "n": len(values),
+            "median": round(statistics.median(values), 2),
+            "p90": round(values[min(len(values) - 1, int(round(0.9 * (len(values) - 1))))], 2),
+            "iqr": round(quantiles[2] - quantiles[0], 2),
+            "min": round(values[0], 2),
+            "max": round(values[-1], 2),
+        }
+
+    keys = (
+        "wall_ms",
+        "loop_cpu_ms",
+        "prepare_ms",
+        "commit_ms",
+        "displays",
+        "call_after_refresh",
+        "layouts",
+        "reveal_displays",
+        "reveal_layouts",
+        "reveal_mounts",
+        "scroll_settle",
+        "settle_displays",
+        "settle_layouts",
+        "settle_mounts",
+        "settle_scroll_settle",
+        "composer_resizes",
+        "blocks_at_ready",
+    )
+    return {
+        "samples": len(records),
+        "failures": sum(1 for r in records if not r["ok"]),
+        **{key: stat(key) for key in keys},
+    }
+
+
+def _run_driver(args: argparse.Namespace) -> None:
+    trees: list[tuple[str, Path]] = [("A", HERE)]
+    if args.source_root is not None:
+        trees.append(("B", args.source_root.resolve()))
+
+    collected: dict[str, list[dict[str, Any]]] = {side: [] for side, _ in trees}
+    started = time.time()
+    for round_index in range(args.rounds):
+        for group in groups():
+            # Flip the order every round so neither tree systematically owns the
+            # quieter half of a load wave. Without this an A/B on a busy box
+            # measures scheduling order as much as it measures code.
+            order = trees if round_index % 2 == 0 else list(reversed(trees))
+            for side, root in order:
+                records = _worker(root, group, args.samples)
+                for record in records:
+                    record["round"] = round_index
+                    record["side"] = side
+                collected[side].extend(records)
+                print(
+                    f"round {round_index} {group} side {side}: {len(records)} switches",
+                    file=sys.stderr,
+                    flush=True,
+                )
+
+    payload: dict[str, Any] = {
+        "harness": "bench_session_switch",
+        "captured_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "wall_s": round(time.time() - started, 1),
+        "rounds": args.rounds,
+        "samples_per_cell_per_round": args.samples,
+        "settle_pumps": SETTLE_PUMPS,
+        "trees": {side: _provenance(root) for side, root in trees},
+        "sides": {},
+    }
+    for side, records in collected.items():
+        cells: dict[str, Any] = {}
+        for group in groups():
+            for pattern in PATTERNS:
+                subset = [r for r in records if r["group"] == group and r["pattern"] == pattern]
+                if subset:
+                    cells[f"{group}/{pattern}"] = _summarise(subset)
+        payload["sides"][side] = {"overall": _summarise(records), "cells": cells}
+    payload["records"] = {side: records for side, records in collected.items()}
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2) + "\n")
+    overall = {side: payload["sides"][side]["overall"] for side in payload["sides"]}
+    print(json.dumps(overall, indent=2))
+
+
+if __name__ == "__main__":
+    ARGS = PARSER.parse_args()
+    if ARGS.samples < 1:
+        PARSER.error("--samples must be positive")
+    sys.path.insert(0, str(HERE))
+    if ARGS.worker:
+        if ARGS.group not in groups():
+            PARSER.error(f"--group must be one of {groups()}")
+        _run_worker(ARGS)
+    else:
+        _run_driver(ARGS)

--- a/scripts/bench_session_switch.py
+++ b/scripts/bench_session_switch.py
@@ -381,7 +381,10 @@ def _run_worker(args: argparse.Namespace) -> None:
         wall = (time.perf_counter() - wall0) * 1000
         cpu = (time.thread_time() - cpu0) * 1000
         settled = future is not None and future.done() and not future.cancelled()
-        ok = settled and future.exception() is None
+        # Narrowed for the type checker as well as for the reader: `settled`
+        # already implies a non-None future, but only the explicit test proves
+        # it at the call site.
+        ok = settled and future is not None and future.exception() is None
         if future is not None and not future.done():
             future.cancel()
 

--- a/tests/unit/server/utils/test_attachment_utils.py
+++ b/tests/unit/server/utils/test_attachment_utils.py
@@ -1,4 +1,5 @@
 import base64
+import mimetypes
 import uuid
 from pathlib import Path
 from unittest.mock import patch
@@ -138,6 +139,21 @@ class TestSaveBase64Attachment:
 
     def test_save_fails_if_cannot_write_file(self, temp_uploads_dir: Path):
         data_url = to_data_url("text/plain", b"test")
+        # Force `mimetypes`' LAZY init before `open` is patched. The module
+        # reads system mime.types files on first use, and this test patches
+        # `builtins.open` GLOBALLY -- so if nothing earlier in the shard has
+        # already initialised it, `guess_extension` inside the function under
+        # test opens those files, hits this mock, and the test fails on the
+        # wrong `open` call with the right exception type.
+        #
+        # That made the test order-dependent rather than wrong: it passed only
+        # when some neighbour happened to initialise `mimetypes` first, and
+        # failed in isolation (`pytest <this test> -p no:randomly`) on an
+        # unmodified tree. Any change to shard composition could surface it, as
+        # one did. Asserting `inited` keeps the guard honest if the stdlib ever
+        # stops exposing it.
+        mimetypes.init()
+        assert mimetypes.inited, "mimetypes did not initialise; the patch below would catch it"
         # Make the directory non-writable (not straightforward to do
         # robustly cross-platform for a dir)
         # Instead, mock open to raise IOError

--- a/tests/unit/tui/test_sidebar_switch_smoothness.py
+++ b/tests/unit/tui/test_sidebar_switch_smoothness.py
@@ -1,0 +1,661 @@
+"""The sidebar switch must land in ONE settled state, not converge into one.
+
+The operator's report was four symptoms of a single unsmooth switch: the
+composer changed size mid-switch, tool traces mounted into an already-visible
+view and shuffled it upward, the scroll position bounced, and the whole thing
+felt slow. Four root causes were measured behind them, and each assertion below
+pins one of them.
+
+WHY THERE IS NOT A SINGLE MILLISECOND IN THIS FILE. AGENTS.md, "Timing, flakes,
+and how to assert that something is fast", is explicit: a ceiling calibrated on
+a dev box flakes on CI, where the same sites measured 206-413 ms against a local
+36-38 ms. The facts this change is really about are structural and do not move
+with machine load:
+
+* the readiness gate is never refused, so no switch pays a recovery relayout;
+* no painted frame shows the composer at a height neither session asked for;
+* no history rows mount into the view after it becomes visible;
+* the switch paints exactly one scroll position.
+
+Each is a fact about WHAT the app did, not how long it took, so it fails
+deterministically when the code regresses and never when the box is busy.
+
+The rig drives the real prepare/commit pair through `_switch` from
+``test_sidebar_swap_reset`` — only the owner lease is stubbed; the prepared
+replay, the parked outgoing view, the commit, the adopt, the reveal and the
+readiness gate are all production code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import patch
+
+import pytest
+from textual._compositor import LayoutUpdate
+from textual.widget import Widget
+
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.session_interaction import SessionInteraction
+from local_operator.tui.widgets.transcript import TranscriptView
+from tests.unit.tui.test_app_pilot import _factory
+from tests.unit.tui.test_sidebar_swap_reset import SidebarRemote, _message, _switch
+
+
+@pytest.fixture(autouse=True)
+def isolated_switch(tmp_path, monkeypatch):
+    # A headless TUI test must never inherit the operator's multiplexer
+    # identity: an inherited CMUX_WORKSPACE_ID has previously let a headless run
+    # rename his real cmux workspaces.
+    for key in tuple(os.environ):
+        if key.startswith("CMUX_"):
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_NOTIFICATIONS", "1")
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_TERMINAL_TITLE", "1")
+    monkeypatch.setattr(OperatorApp, "_check_for_update", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_terminal_title", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_multiplexer_broadcast", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_herdr_reporter", lambda _self: None)
+
+
+def _conversation(session_id: str, turns: int) -> SidebarRemote:
+    """A transcript several viewports deep, so the resume fill has work to do.
+
+    The under-fill that causes the post-reveal shuffle is a property of a
+    conversation LONGER than the prepared window (`bound = max(12, height//2)`),
+    so a short fixture cannot exercise it at all.
+
+    Every message carries an ``id``: `PreparedReplay` derives a block's
+    navigation anchor from the projecting message's id, so a fixture without one
+    produces a transcript with no anchors and cannot exercise the saved-position
+    path at all.
+    """
+    history = []
+    for turn in range(turns):
+        user = _message("user", f"question {turn} about the switch path")
+        user.id = f"{session_id}-u{turn}"
+        assistant = _message("assistant", f"answer {turn}, with some detail to render")
+        assistant.id = f"{session_id}-a{turn}"
+        history.extend((user, assistant))
+    return SidebarRemote(session_id, history=history)
+
+
+async def _switch_bound(app: OperatorApp, pilot, remote: SidebarRemote) -> None:
+    """`_switch`, with the source registered the way the REAL lease registers it.
+
+    `_adopt_session` looks a source up by session identity through
+    ``_interactions[id(session)]``. A fixture that skips that registration makes
+    the app adopt a DIFFERENT `SessionInteraction` than the one the readiness
+    gate is bound to, so `_is_current(source)` is False for the whole switch —
+    `post_display_hook` returns before its recovery branch and the gate can
+    never be satisfied. The bench harness documents the same trap, where it
+    reads as a 15 s timeout on every cold switch.
+
+    Anything asserting on the GATE has to go through here; `_switch` alone is
+    enough for assertions about widgets and drafts.
+    """
+    source = app._sidebar_sources.get(remote.session_id)
+    if source is None:
+        source = SessionInteraction(remote)
+        app._sidebar_sources[remote.session_id] = source
+    app._interactions[id(remote)] = source
+    await _switch(app, pilot, remote)
+
+
+class _FrameRecorder:
+    """Every painted frame, with the geometry the complaints are about.
+
+    `App._display` is the single funnel every compositor refresh passes
+    through, so this is the app's own paint sequence rather than a poll. It is
+    installed on the INSTANCE, never on the class, so a failure cannot leak into
+    a sibling test.
+    """
+
+    def __init__(self, app: OperatorApp) -> None:
+        self.app = app
+        self.frames: list[dict] = []
+        self.armed = False
+        self.revealed = False
+        self._real_display = app._display
+
+        def display(screen, renderable):  # type: ignore[no-untyped-def]
+            out = self._real_display(screen, renderable)
+            if self.armed:
+                self.frames.append(self._sample(renderable))
+            return out
+
+        app._display = display  # type: ignore[method-assign]
+
+    def _sample(self, renderable) -> dict:  # type: ignore[no-untyped-def]
+        sample: dict = {"layout": isinstance(renderable, LayoutUpdate)}
+        try:
+            sample["editor_height"] = int(self.app._editor().outer_size.height)
+        except Exception:  # noqa: BLE001 - a mid-swap query can find nothing
+            sample["editor_height"] = None
+        if self.revealed:
+            try:
+                view = self.app._transcript_view()
+                sample["scroll_y"] = float(view.scroll_y)
+                sample["blocks"] = len(view.blocks())
+            except Exception:  # noqa: BLE001
+                pass
+        return sample
+
+    @property
+    def editor_heights(self) -> list[int]:
+        return [f["editor_height"] for f in self.frames if f.get("editor_height") is not None]
+
+    @property
+    def scroll_positions(self) -> list[float]:
+        return [f["scroll_y"] for f in self.frames if "scroll_y" in f]
+
+
+@pytest.mark.asyncio
+async def test_switch_never_refuses_the_readiness_gate() -> None:
+    """RC1: the first post-commit paint must be evidence the gate can accept.
+
+    `_sidebar_displayed_frame` is only recorded for a `LayoutUpdate`, and the
+    arming refresh used to be satisfied by a partial `ChopsUpdate` — so the gate
+    refused on the first paint of EVERY switch (21/21 measured) and
+    `post_display_hook` bought a second full-screen relayout to recover. The fix
+    is to make the arming refresh PRODUCE a full update, never to let the gate
+    accept weaker evidence: `_sidebar_gate_surface_ready` still requires a real
+    painted compositor map covering the target surfaces.
+
+    `_sidebar_gate_recoveries` counts entries into that recovery branch. The
+    branch is deliberately KEPT — the container-lands-before-its-children case
+    it was written for is real — so this asserts it stays dead, not that it is
+    gone.
+    """
+    home = SidebarRemote("home-session")
+    targets = [_conversation(f"target-{i}", 40) for i in range(3)]
+
+    app = OperatorApp(lambda: _factory(home))
+    with patch("local_operator.session.remote.RemoteSession", SidebarRemote):
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(20):
+                await pilot.pause()
+
+            for remote in targets:
+                await _switch_bound(app, pilot, remote)
+            # And back again: a return leg hits the retained-presentation path,
+            # which reaches the gate by a different route than a first visit.
+            for remote in targets:
+                await _switch_bound(app, pilot, remote)
+
+            # The gate must actually have been REACHED, or a zero below would
+            # mean "never armed" rather than "never refused".
+            assert app._sidebar_gate_reached > 0, "no switch reached the readiness gate"
+            assert app._sidebar_gate_recoveries == 0, (
+                "the readiness gate was refused and paid a recovery relayout; "
+                "the arming refresh is no longer producing a full LayoutUpdate"
+            )
+
+
+@pytest.mark.asyncio
+async def test_the_composer_never_paints_a_height_neither_session_asked_for() -> None:
+    """RC3: no off-state composer frame.
+
+    Both sessions carry the SAME multi-line draft, so the steady-state composer
+    height is identical before and after. Any other height in the painted
+    sequence is therefore transition jitter and not a legitimate per-session
+    draft handoff — which is exactly what emptying the buffer at `pending`
+    produced: the composer collapsed to one row, the docked input shrank with
+    it, and the transcript above reflowed into the vacated rows.
+    """
+    home = SidebarRemote("home-session")
+    first = _conversation("draft-a", 30)
+    second = _conversation("draft-b", 30)
+    draft = "first line of the draft\nsecond line\nthird line"
+
+    app = OperatorApp(lambda: _factory(home))
+    with patch("local_operator.session.remote.RemoteSession", SidebarRemote):
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(20):
+                await pilot.pause()
+            await _switch(app, pilot, first)
+            for _ in range(20):
+                await pilot.pause()
+
+            # Give BOTH sides the same draft: the one the editor is holding, and
+            # the one the target will be handed at commit.
+            editor = app._editor()
+            editor.load_text(draft)
+            for _ in range(20):
+                await pilot.pause()
+            incoming = app._sidebar_sources.get(second.session_id)
+            if incoming is None:
+                incoming = SessionInteraction(second)
+                app._sidebar_sources[second.session_id] = incoming
+            incoming.draft.text = draft
+
+            settled_height = int(editor.outer_size.height)
+            assert settled_height > 1, "the fixture draft must not be one row"
+
+            recorder = _FrameRecorder(app)
+            recorder.armed = True
+            # The pending hook is what a click runs before the navigation task;
+            # it is where the buffer used to be emptied.
+            app._sidebar_navigation_pending(second.session_id)
+            for _ in range(20):
+                await pilot.pause()
+            await _switch(app, pilot, second)
+            recorder.armed = False
+
+            off_state = [h for h in recorder.editor_heights if h != settled_height]
+            assert not off_state, (
+                f"the composer painted {sorted(set(off_state))} rows during a switch whose "
+                f"steady state is {settled_height} on both sides"
+            )
+
+
+@pytest.mark.asyncio
+async def test_no_history_rows_mount_into_the_visible_view() -> None:
+    """RC4: the resume fill runs before reveal, so nothing arrives afterwards.
+
+    The prepared window under-fills the viewport by construction, so the fill
+    fired on essentially every switch and mounted 24 further rows into a view
+    the user was already looking at — 53% of the conversation appearing after
+    the fact, which is the "traces shuffle upward" report.
+
+    Counted on the VISIBLE view only: rows appended to a parked offscreen replay
+    are the preparation doing its job.
+    """
+    home = SidebarRemote("home-session")
+    target = _conversation("deep-session", 60)
+
+    app = OperatorApp(lambda: _factory(home))
+    mounted_after_reveal: list[int] = []
+    revealed = {"yes": False}
+
+    real_insert = TranscriptView.insert_blocks
+
+    def insert_blocks(self, index, blocks, **kwargs):  # type: ignore[no-untyped-def]
+        if revealed["yes"]:
+            try:
+                if self is app._transcript_view():
+                    mounted_after_reveal.append(len(list(blocks)))
+            except Exception:  # noqa: BLE001
+                pass
+        return real_insert(self, index, blocks, **kwargs)
+
+    with patch("local_operator.session.remote.RemoteSession", SidebarRemote), patch.object(
+        TranscriptView, "insert_blocks", insert_blocks
+    ):
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(20):
+                await pilot.pause()
+
+            real_commit = app._commit_sidebar_session
+
+            def commit(session_id, prepared, generation):  # type: ignore[no-untyped-def]
+                out = real_commit(session_id, prepared, generation)
+                revealed["yes"] = True
+                return out
+
+            app._commit_sidebar_session = commit  # type: ignore[method-assign]
+            await _switch(app, pilot, target)
+            for _ in range(60):
+                await pilot.pause()
+
+            assert not mounted_after_reveal, (
+                f"{sum(mounted_after_reveal)} history rows mounted into the visible view "
+                "after it was revealed; the pre-reveal fill is not reaching its goal"
+            )
+
+
+@pytest.mark.asyncio
+async def test_a_switch_paints_exactly_one_scroll_position() -> None:
+    """RC4/§6.1(6): the scroll lands once, with no bounce.
+
+    Two painted positions is the operator's "scroll position jitter": the view
+    appeared at one offset and was dragged to another a frame or two later, by
+    `_size_updated` reacting to rows arriving after reveal. With the fill landed
+    before reveal there is nothing left to move it, so the sequence is
+    single-valued.
+
+    The session is left at TAIL, which is the case the operator called out
+    explicitly: it must land on the most recent message, cleanly.
+    """
+    home = SidebarRemote("home-session")
+    target = _conversation("tail-session", 60)
+
+    app = OperatorApp(lambda: _factory(home))
+    with patch("local_operator.session.remote.RemoteSession", SidebarRemote):
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(20):
+                await pilot.pause()
+
+            recorder = _FrameRecorder(app)
+            real_commit = app._commit_sidebar_session
+
+            def commit(session_id, prepared, generation):  # type: ignore[no-untyped-def]
+                out = real_commit(session_id, prepared, generation)
+                recorder.revealed = True
+                return out
+
+            app._commit_sidebar_session = commit  # type: ignore[method-assign]
+            recorder.armed = True
+            await _switch(app, pilot, target)
+            for _ in range(60):
+                await pilot.pause()
+            recorder.armed = False
+
+            positions = recorder.scroll_positions
+            assert positions, "no painted frame carried a scroll position"
+            assert len(set(positions)) == 1, (
+                f"the switch painted {sorted(set(positions))} — the view moved after it was "
+                "already on screen"
+            )
+            view = app._transcript_view()
+            assert view.is_following_tail, "a session left at tail did not land at the tail"
+
+
+@pytest.mark.asyncio
+async def test_leaving_at_tail_clears_the_saved_anchor() -> None:
+    """§5.3: `following_tail` and a stale anchor must not both be recorded.
+
+    A reader who scrolls up and then scrolls BACK to the tail wrote an anchor on
+    the way up and nothing cleared it on the way down, so the draft claimed both
+    "I am following the tail" and "restore me to this block at offset -1". Every
+    consumer today tests the flag first, which is what makes it latent rather
+    than visible — and is exactly why it is worth pinning: the next reader of
+    `scroll_anchor_id` that forgets the flag lands the user at a position they
+    left, with a nonsense offset that clamps into silent wrongness.
+    """
+    home = SidebarRemote("home-session")
+    target = _conversation("anchor-session", 60)
+
+    app = OperatorApp(lambda: _factory(home))
+    with patch("local_operator.session.remote.RemoteSession", SidebarRemote):
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(20):
+                await pilot.pause()
+            await _switch(app, pilot, target)
+            for _ in range(40):
+                await pilot.pause()
+
+            view = app._transcript_view()
+            source = app._interaction
+
+            # Scroll UP, which is what writes an anchor into the draft.
+            view.scroll_to(y=max(0.0, view.max_scroll_y - 8), animate=False, immediate=True)
+            app._transcript_scrolled(True)
+            for _ in range(20):
+                await pilot.pause()
+            app._capture_sidebar_scroll(source)
+            assert source.draft.following_tail is False
+            assert source.draft.scroll_anchor_id, "the fixture never produced an anchor to go stale"
+
+            # Now scroll back DOWN to the tail and leave.
+            view.scroll_to(y=view.max_scroll_y, animate=False, immediate=True)
+            app._transcript_scrolled(False)
+            for _ in range(20):
+                await pilot.pause()
+            app._capture_sidebar_scroll(source)
+
+            assert source.draft.following_tail is True
+            assert source.draft.scroll_anchor_id == "", (
+                "a session left at the tail kept a stale scroll anchor"
+            )
+            assert source.draft.scroll_offset == 0
+
+
+@pytest.mark.asyncio
+async def test_text_typed_during_a_transition_belongs_to_the_target() -> None:
+    """RC3's attribution contract, which the frozen prefix must not change.
+
+    The composer no longer empties at `pending`, so the buffer visibly holds the
+    OUTGOING draft while the switch runs. What the user types lands after it,
+    and `_take_sidebar_transition_buffer` subtracts the frozen prefix so the
+    suffix — and only the suffix — is attributed to the session being opened.
+    """
+    home = SidebarRemote("home-session")
+    first = _conversation("attribution-a", 20)
+    second = _conversation("attribution-b", 20)
+
+    app = OperatorApp(lambda: _factory(home))
+    with patch("local_operator.session.remote.RemoteSession", SidebarRemote):
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(20):
+                await pilot.pause()
+            await _switch(app, pilot, first)
+            for _ in range(20):
+                await pilot.pause()
+
+            editor = app._editor()
+            editor.load_text("outgoing draft")
+            for _ in range(10):
+                await pilot.pause()
+            outgoing = app._interaction
+
+            app._sidebar_navigation_pending(second.session_id)
+            for _ in range(10):
+                await pilot.pause()
+
+            # The buffer still PAINTS the outgoing draft — that is the whole
+            # point — and the snapshot has been taken.
+            assert editor.text == "outgoing draft"
+            assert outgoing.draft.text == "outgoing draft"
+
+            editor.load_text("outgoing draft and what I typed after clicking")
+            for _ in range(10):
+                await pilot.pause()
+
+            typed, _attachments = app._take_sidebar_transition_buffer()
+            assert typed == " and what I typed after clicking", (
+                "the frozen prefix was not subtracted; the outgoing draft would be "
+                "attributed to the target"
+            )
+
+
+@pytest.mark.asyncio
+async def test_an_abandoned_transition_restores_the_draft_exactly_once() -> None:
+    """The failure leg: the user stays put, so text is theirs — and is not doubled.
+
+    `_abandon_sidebar_transition` assembles `draft.text + typed`. With the
+    buffer no longer emptied at `pending` it holds both halves already, so
+    taking the buffer BEFORE clearing the prefix is what keeps the restore from
+    concatenating the outgoing draft onto itself.
+    """
+    home = SidebarRemote("home-session")
+    first = _conversation("abandon-a", 20)
+
+    app = OperatorApp(lambda: _factory(home))
+    with patch("local_operator.session.remote.RemoteSession", SidebarRemote):
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(20):
+                await pilot.pause()
+            await _switch(app, pilot, first)
+            for _ in range(20):
+                await pilot.pause()
+
+            editor = app._editor()
+            editor.load_text("half a sentence")
+            for _ in range(10):
+                await pilot.pause()
+
+            app._sidebar_navigation_pending("some-other-session")
+            for _ in range(10):
+                await pilot.pause()
+            editor.load_text("half a sentence, and the rest")
+            for _ in range(10):
+                await pilot.pause()
+
+            # `pending("")` with no commit in between: the switch failed.
+            app._sidebar_navigation_pending("")
+            for _ in range(10):
+                await pilot.pause()
+
+            assert editor.text == "half a sentence, and the rest", (
+                "the abandoned transition did not restore the draft exactly once"
+            )
+            assert app._sidebar_transition_from is None
+            assert app._sidebar_transition_prefix == ""
+
+
+@pytest.mark.asyncio
+async def test_a_click_burst_keeps_the_original_snapshot() -> None:
+    """Re-entering with a transition already open must not re-snapshot.
+
+    A burst of clicks calls the pending hook repeatedly. The first call owns the
+    snapshot; a later one would otherwise capture a buffer that already contains
+    transition typing and record it as the outgoing session's draft.
+    """
+    home = SidebarRemote("home-session")
+    first = _conversation("burst-a", 20)
+
+    app = OperatorApp(lambda: _factory(home))
+    with patch("local_operator.session.remote.RemoteSession", SidebarRemote):
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(20):
+                await pilot.pause()
+            await _switch(app, pilot, first)
+            for _ in range(20):
+                await pilot.pause()
+
+            editor = app._editor()
+            editor.load_text("original draft")
+            for _ in range(10):
+                await pilot.pause()
+            outgoing = app._interaction
+
+            app._sidebar_navigation_pending("target-one")
+            for _ in range(10):
+                await pilot.pause()
+            editor.load_text("original draft plus typing")
+            for _ in range(10):
+                await pilot.pause()
+            # Second click of the burst, transition already open.
+            app._sidebar_navigation_pending("target-two")
+            for _ in range(10):
+                await pilot.pause()
+
+            assert outgoing.draft.text == "original draft", (
+                "a re-entrant click overwrote the frozen snapshot"
+            )
+            assert app._sidebar_transition_prefix == "original draft"
+            typed, _ = app._take_sidebar_transition_buffer()
+            assert typed == " plus typing"
+
+
+@pytest.mark.asyncio
+async def test_the_parked_view_stays_non_interactive() -> None:
+    """RC2: skipping the stylesheet cascade must not make a parked view live.
+
+    `Widget.disabled` does two jobs — interactivity gating, which reads the
+    field, and appearance, which is the whole-subtree `Stylesheet.apply` that
+    `watch_disabled` triggers. Only the second is skipped, and it is invisible
+    on a view parked at `offset: 100vw`. The first is what keeps a clipped
+    transcript from taking focus, scroll or mouse events, so it is asserted
+    directly rather than trusted.
+    """
+    home = SidebarRemote("home-session")
+    first = _conversation("park-a", 20)
+    second = _conversation("park-b", 20)
+
+    app = OperatorApp(lambda: _factory(home))
+    with patch("local_operator.session.remote.RemoteSession", SidebarRemote):
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(20):
+                await pilot.pause()
+            await _switch(app, pilot, first)
+            for _ in range(20):
+                await pilot.pause()
+            parked = app._transcript_view()
+
+            await _switch(app, pilot, second)
+            for _ in range(40):
+                await pilot.pause()
+            live = app._transcript_view()
+            assert live is not parked, "the switch did not change the visible transcript"
+
+            assert parked.disabled is True
+            assert parked._self_or_ancestors_disabled is True
+            assert parked.focusable is False
+            assert parked.allow_vertical_scroll is False
+
+            # And the revealed view is genuinely interactive again: an un-park
+            # that only skipped the cascade would leave the field set.
+            assert live.disabled is False
+            assert live.focusable is True
+            assert live.allow_vertical_scroll is True
+
+
+def test_parking_a_transcript_skips_the_stylesheet_cascade() -> None:
+    """The cost half of RC2, asserted structurally rather than in milliseconds.
+
+    `watch_disabled` re-applies CSS across the whole subtree — 131 node
+    applications on a real transcript, 10.2 ms of the 18.8 ms commit, inside a
+    section that deliberately never awaits. The fact that matters is that the
+    watcher does not run at all, which is a property of the call and not of the
+    machine: `set_reactive` writes the value without invoking watchers.
+    """
+    from local_operator.tui.app import _set_transcript_parked
+
+    calls: list[bool] = []
+
+    class _Probe(Widget):
+        def watch_disabled(self, disabled: bool) -> None:  # pragma: no cover - must not run
+            calls.append(disabled)
+
+    probe = _Probe()
+    _set_transcript_parked(probe, True)
+    assert probe.disabled is True
+    _set_transcript_parked(probe, False)
+    assert probe.disabled is False
+    assert calls == [], "the disabled watcher ran, re-applying the stylesheet subtree"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_pre_reveal_fill_does_not_invalidate_the_preparation() -> None:
+    """The pre-reveal fill runs after the invalidation check, so it may not raise.
+
+    `PreparationInvalidated` releases the prepared widgets and re-prepares. The
+    pre-reveal fill runs inside the commit, AFTER ownership has already moved,
+    so a raise out of `_prefill_resume_before_reveal` would tear down a
+    presentation that is already live.
+
+    SCOPE OF THIS GUARD, stated so it is not read as more than it is: it covers
+    the SYNCHRONOUS pre-reveal pass this change added. The ordinary deferred
+    fill scheduled afterwards still propagates a projection failure the way it
+    always has — `_fill_resume_until_scrollable` re-raises by design, to keep
+    the page retryable rather than silently losing its cursor — and that path is
+    reached from a `call_after_refresh` callback, long after the commit has
+    returned, so it cannot reach the invalidation retry either. Changing it is
+    not in this change's scope.
+    """
+    home = SidebarRemote("home-session")
+    target = _conversation("raising-session", 60)
+
+    app = OperatorApp(lambda: _factory(home))
+    with patch("local_operator.session.remote.RemoteSession", SidebarRemote):
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(20):
+                await pilot.pause()
+
+            calls: list[int] = []
+
+            def explode(*_args, **_kwargs):
+                calls.append(1)
+                raise RuntimeError("projection failed")
+
+            # Only the synchronous pre-reveal pass is exercised: it is called
+            # directly, exactly as the commit calls it, with the deferred
+            # follow-up stubbed out so a later raise cannot be mistaken for
+            # this one.
+            app._mount_older_resume_page = explode  # type: ignore[method-assign]
+            app._start_resume_fill = lambda **_kw: None  # type: ignore[method-assign]
+
+            await _switch(app, pilot, target)
+            for _ in range(40):
+                await pilot.pause()
+
+            # The commit completed and the conversation is usable.
+            assert app._session is not None
+            assert app._session.session_id == target.session_id
+            assert app._transcript_view().blocks()
+            assert calls, "the pre-reveal fill never reached the projection at all"

--- a/tests/unit/tui/test_sidebar_switch_smoothness.py
+++ b/tests/unit/tui/test_sidebar_switch_smoothness.py
@@ -21,16 +21,32 @@ with machine load:
 Each is a fact about WHAT the app did, not how long it took, so it fails
 deterministically when the code regresses and never when the box is busy.
 
-TWO OF THESE ARE WIDTH-CONDITIONAL, and the sizes below are therefore
-load-bearing rather than incidental (QA round 1, Q1/Q2):
+TWO OF THESE ARE VIEWPORT-CONDITIONAL, and the sizes below are therefore
+load-bearing rather than incidental (QA rounds 1 and 2, Q1/Q2/Q4):
 
-* **Zero gate refusals holds at >=41 columns.** At 40x24 and narrower the gate
-  refuses again (24 arrivals / 18 recoveries, attributed to
-  ``TAIL_BLOCK_UNPAINTED`` and a 2-row ``TAIL_BLOCK_OVERFLOWS_CONTENT``), with a
-  sharp threshold at 41. The BASE behaves the same way there, so this is reach,
-  not regression -- the recovery branch is doing exactly the job it exists for,
-  and the switch still completes and lands correctly at every width measured
-  from 20 to 140.
+* **Zero gate refusals needs BOTH enough columns and enough rows.** An earlier
+  version of this note said ">=41 columns" and QA round 2 replied "no, it is
+  height"; both are half right, and the single-axis phrasing is what sent a
+  reader to the wrong axis. Measured on this rig, sweeping one axis at a time:
+
+  ===========  ============  ===========================================
+  size         recoveries    what it falsifies
+  ===========  ============  ===========================================
+  41x30        0             --
+  40x30        5             not "any height >= 22 passes"
+  120x22       0             --
+  120x20       9             not "any width >= 41 passes"
+  41x20        13            wide enough, still refuses -> height matters
+  30x36        13            tall enough, still refuses -> width matters
+  ===========  ============  ===========================================
+
+  So it is a viewport FLOOR on both axes, not a threshold on either one: at 30
+  rows the boundary sits between 40 and 41 columns, and at 120 columns it sits
+  between 20 and 22 rows. Below it the gate refuses again
+  (``TAIL_BLOCK_UNPAINTED`` and a 2-row ``TAIL_BLOCK_OVERFLOWS_CONTENT``) and
+  the recovery branch does exactly the job it exists for. The BASE behaves
+  identically in every cell measured, so this is reach, not regression, and the
+  switch still completes and lands correctly at every size tried.
 * **Exactly one painted scroll position holds at >=70 columns.** Below that the
   switch paints two positions 1-2 rows apart, with ZERO post-reveal inserts --
   a final geometry settle, not content arriving late. The base at the same
@@ -38,8 +54,10 @@ load-bearing rather than incidental (QA round 1, Q1/Q2):
   after reveal, so the operator's actual complaint (the large upward shuffle)
   is gone at every width.
 
-So a narrow-width failure of either test is a GENUINE regression at that width;
-do not "fix" it by widening the fixture.
+If either test fails at a SMALLER viewport than the one it declares, that is a
+genuine regression at that size -- do not "fix" it by enlarging the fixture. If
+one fails at the declared size, check both axes before concluding anything: the
+history of this note is two confident single-axis claims that were each wrong.
 
 The rig drives the real prepare/commit pair through `_switch` from
 ``test_sidebar_swap_reset`` — only the owner lease is stubbed; the prepared
@@ -766,24 +784,29 @@ async def test_no_painted_frame_shows_an_empty_conversation() -> None:
     painted such a frame, so this was a regression introduced by the fix, and a
     blank flash is a worse unpolish signal than the shuffle it replaced.
 
-    WHAT THIS ASSERTS, AND WHY IT IS NOT THE PAINTED SEQUENCE. Under `run_test`
-    the commit paints NOTHING -- measured: zero `App._display` calls between
-    entering and leaving `_commit_sidebar_session`, at any terminal size and
-    with any draft. The headless compositor does not service the synchronous
-    `_refresh_layout` the way a real terminal does, so a frame-sequence
-    assertion here would be vacuous: it passes identically with the fix and
-    without it (verified by neutering the suppression -- still green).
+    WHAT THIS ASSERTS. Both halves of the defect, directly: no painted frame
+    inside the commit shows rows mounted with none in view, AND the commit runs
+    no painting refresh at all. The second implies the first here, but they fail
+    with different diagnostics -- the frame assertion names the symptom the user
+    reported, the refresh assertion names the mechanism -- so both are kept.
 
-    So the invariant is asserted where this rig can actually see it: the commit
-    must not perform a PAINTING refresh, only a layout. That is the property the
-    fix establishes, it fails when the suppression is removed, and it does not
-    pretend to be visual evidence.
+    AN EARLIER VERSION OF THIS DOCSTRING WAS WRONG, and the correction is worth
+    recording because it would otherwise talk the next author out of the
+    stronger assertion. It claimed the commit "paints NOTHING" under `run_test`
+    and that a frame-sequence assertion would therefore be vacuous. That was a
+    measurement taken with the fix LIVE: zero paints in the commit is precisely
+    what the fix produces, and reading that as "the harness cannot see paints"
+    confused the fix working with the rig being blind (QA round 2, Q5). With
+    the suppression neutered -- the real `_compositor_refresh` restored inside
+    the stand-in, every other line untouched -- this rig reports
+    `displays_in_commit=1` with `mounted=44, in_view=0`. The frame sequence is
+    observable and non-vacuous, so it is asserted below.
 
-    The blank frames themselves are a rendered-frame fact and were measured with
-    the frame-capture rig against a real compositor (design round 1, D1 and its
-    remediation): blank frames 1-3 -> 0 across warm/cold/draft2 at 120x36 and
-    80x24, with the before/after SVGs attached to the PR. AGENTS.md is explicit
-    that a green test is not visual evidence; this test is the structural half.
+    The rendered-frame evidence still lives on the PR (design round 1 D1 and its
+    remediation; QA round 2 measured 0 blank frames across 18 cells on head
+    against 11 on the baseline). AGENTS.md is explicit that a green test is not
+    visual evidence: this test is the structural half of that pair, not a
+    replacement for it.
     """
     home = SidebarRemote("home-session")
     target = _conversation("blank-frame-session", 60)
@@ -831,6 +854,38 @@ async def test_no_painted_frame_shows_an_empty_conversation() -> None:
                 return real_layout(*args, **kwargs)
 
             screen._refresh_layout = refresh_layout  # type: ignore[method-assign]
+
+            # THE SYMPTOM ITSELF: every frame painted while the commit is on the
+            # stack, scored the way the user experiences it -- rows mounted but
+            # none intersecting the content region is a conversation the user
+            # sees as empty.
+            commit_frames: list[dict[str, int]] = []
+            real_display = app._display
+
+            def display(target_screen, renderable):  # type: ignore[no-untyped-def]
+                out = real_display(target_screen, renderable)
+                if in_commit["yes"]:
+                    try:
+                        view = app._transcript_view()
+                        blocks = view.blocks()
+                        content = view.content_region
+                        commit_frames.append(
+                            {
+                                "mounted": len(blocks),
+                                "in_view": sum(
+                                    1
+                                    for block in blocks
+                                    if (region := getattr(block, "region", None)) is not None
+                                    and region.area
+                                    and content.overlaps(region)
+                                ),
+                            }
+                        )
+                    except Exception:  # noqa: BLE001 - a mid-swap query can find nothing
+                        pass
+                return out
+
+            app._display = display  # type: ignore[method-assign]
             real_commit = app._commit_sidebar_session
 
             def commit(session_id, prepared, generation):  # type: ignore[no-untyped-def]
@@ -857,6 +912,16 @@ async def test_no_painted_frame_shows_an_empty_conversation() -> None:
                 f"{len(paints)} of {len(layouts)} synchronous layouts inside the commit "
                 "would have painted; the switch can put a half-arranged frame "
                 "(revealed transcript, outgoing-sized composer) on screen"
+            )
+            blank = [
+                index
+                for index, frame in enumerate(commit_frames)
+                if frame["in_view"] == 0 and frame["mounted"] > 0
+            ]
+            assert not blank, (
+                f"frames {blank} of {len(commit_frames)} painted inside the commit showed "
+                f"rows mounted with none in view ({[commit_frames[i] for i in blank]}); "
+                "the user sees an empty conversation mid-switch"
             )
 
 

--- a/tests/unit/tui/test_sidebar_switch_smoothness.py
+++ b/tests/unit/tui/test_sidebar_switch_smoothness.py
@@ -28,7 +28,6 @@ readiness gate are all production code.
 
 from __future__ import annotations
 
-import asyncio
 import os
 from unittest.mock import patch
 
@@ -116,7 +115,7 @@ class _FrameRecorder:
 
     def __init__(self, app: OperatorApp) -> None:
         self.app = app
-        self.frames: list[dict] = []
+        self.frames: list[dict[str, object]] = []
         self.armed = False
         self.revealed = False
         self._real_display = app._display
@@ -129,8 +128,8 @@ class _FrameRecorder:
 
         app._display = display  # type: ignore[method-assign]
 
-    def _sample(self, renderable) -> dict:  # type: ignore[no-untyped-def]
-        sample: dict = {"layout": isinstance(renderable, LayoutUpdate)}
+    def _sample(self, renderable) -> dict[str, object]:  # type: ignore[no-untyped-def]
+        sample: dict[str, object] = {"layout": isinstance(renderable, LayoutUpdate)}
         try:
             sample["editor_height"] = int(self.app._editor().outer_size.height)
         except Exception:  # noqa: BLE001 - a mid-swap query can find nothing
@@ -146,11 +145,17 @@ class _FrameRecorder:
 
     @property
     def editor_heights(self) -> list[int]:
-        return [f["editor_height"] for f in self.frames if f.get("editor_height") is not None]
+        return [
+            int(height) for f in self.frames if isinstance(height := f.get("editor_height"), int)
+        ]
 
     @property
     def scroll_positions(self) -> list[float]:
-        return [f["scroll_y"] for f in self.frames if "scroll_y" in f]
+        return [
+            float(scroll)
+            for f in self.frames
+            if isinstance(scroll := f.get("scroll_y"), (int, float))
+        ]
 
 
 @pytest.mark.asyncio
@@ -282,8 +287,9 @@ async def test_no_history_rows_mount_into_the_visible_view() -> None:
                 pass
         return real_insert(self, index, blocks, **kwargs)
 
-    with patch("local_operator.session.remote.RemoteSession", SidebarRemote), patch.object(
-        TranscriptView, "insert_blocks", insert_blocks
+    with (
+        patch("local_operator.session.remote.RemoteSession", SidebarRemote),
+        patch.object(TranscriptView, "insert_blocks", insert_blocks),
     ):
         async with app.run_test(size=(100, 30)) as pilot:
             for _ in range(20):
@@ -398,9 +404,9 @@ async def test_leaving_at_tail_clears_the_saved_anchor() -> None:
             app._capture_sidebar_scroll(source)
 
             assert source.draft.following_tail is True
-            assert source.draft.scroll_anchor_id == "", (
-                "a session left at the tail kept a stale scroll anchor"
-            )
+            assert (
+                source.draft.scroll_anchor_id == ""
+            ), "a session left at the tail kept a stale scroll anchor"
             assert source.draft.scroll_offset == 0
 
 
@@ -490,9 +496,9 @@ async def test_an_abandoned_transition_restores_the_draft_exactly_once() -> None
             for _ in range(10):
                 await pilot.pause()
 
-            assert editor.text == "half a sentence, and the rest", (
-                "the abandoned transition did not restore the draft exactly once"
-            )
+            assert (
+                editor.text == "half a sentence, and the rest"
+            ), "the abandoned transition did not restore the draft exactly once"
             assert app._sidebar_transition_from is None
             assert app._sidebar_transition_prefix == ""
 
@@ -534,9 +540,9 @@ async def test_a_click_burst_keeps_the_original_snapshot() -> None:
             for _ in range(10):
                 await pilot.pause()
 
-            assert outgoing.draft.text == "original draft", (
-                "a re-entrant click overwrote the frozen snapshot"
-            )
+            assert (
+                outgoing.draft.text == "original draft"
+            ), "a re-entrant click overwrote the frozen snapshot"
             assert app._sidebar_transition_prefix == "original draft"
             typed, _ = app._take_sidebar_transition_buffer()
             assert typed == " plus typing"

--- a/tests/unit/tui/test_sidebar_switch_smoothness.py
+++ b/tests/unit/tui/test_sidebar_switch_smoothness.py
@@ -15,10 +15,31 @@ with machine load:
 * the readiness gate is never refused, so no switch pays a recovery relayout;
 * no painted frame shows the composer at a height neither session asked for;
 * no history rows mount into the view after it becomes visible;
-* the switch paints exactly one scroll position.
+* the switch paints exactly one scroll position;
+* no painted frame shows an empty conversation.
 
 Each is a fact about WHAT the app did, not how long it took, so it fails
 deterministically when the code regresses and never when the box is busy.
+
+TWO OF THESE ARE WIDTH-CONDITIONAL, and the sizes below are therefore
+load-bearing rather than incidental (QA round 1, Q1/Q2):
+
+* **Zero gate refusals holds at >=41 columns.** At 40x24 and narrower the gate
+  refuses again (24 arrivals / 18 recoveries, attributed to
+  ``TAIL_BLOCK_UNPAINTED`` and a 2-row ``TAIL_BLOCK_OVERFLOWS_CONTENT``), with a
+  sharp threshold at 41. The BASE behaves the same way there, so this is reach,
+  not regression -- the recovery branch is doing exactly the job it exists for,
+  and the switch still completes and lands correctly at every width measured
+  from 20 to 140.
+* **Exactly one painted scroll position holds at >=70 columns.** Below that the
+  switch paints two positions 1-2 rows apart, with ZERO post-reveal inserts --
+  a final geometry settle, not content arriving late. The base at the same
+  sizes paints ``[15.0, 63.0]`` / ``[13.0, 14.0, 62.0]`` with 24 rows mounting
+  after reveal, so the operator's actual complaint (the large upward shuffle)
+  is gone at every width.
+
+So a narrow-width failure of either test is a GENUINE regression at that width;
+do not "fix" it by widening the fixture.
 
 The rig drives the real prepare/commit pair through `_switch` from
 ``test_sidebar_swap_reset`` — only the owner lease is stubbed; the prepared
@@ -35,7 +56,7 @@ import pytest
 from textual._compositor import LayoutUpdate
 from textual.widget import Widget
 
-from local_operator.tui.app import OperatorApp
+from local_operator.tui.app import OperatorApp, _suppress_intermediate_paint
 from local_operator.tui.session_interaction import SessionInteraction
 from local_operator.tui.widgets.transcript import TranscriptView
 from tests.unit.tui.test_app_pilot import _factory
@@ -138,7 +159,20 @@ class _FrameRecorder:
             try:
                 view = self.app._transcript_view()
                 sample["scroll_y"] = float(view.scroll_y)
-                sample["blocks"] = len(view.blocks())
+                blocks = view.blocks()
+                sample["blocks"] = len(blocks)
+                # BLOCKS THE USER CAN ACTUALLY SEE, not blocks mounted. The two
+                # diverge exactly when a frame is laid out against geometry it
+                # is not drawn in, which is the D1 blank frame: 46 mounted, 0
+                # intersecting the content region.
+                content = view.content_region
+                sample["blocks_in_view"] = sum(
+                    1
+                    for block in blocks
+                    if (region := getattr(block, "region", None)) is not None
+                    and region.area
+                    and content.overlaps(region)
+                )
             except Exception:  # noqa: BLE001
                 pass
         return sample
@@ -155,6 +189,18 @@ class _FrameRecorder:
             float(scroll)
             for f in self.frames
             if isinstance(scroll := f.get("scroll_y"), (int, float))
+        ]
+
+    @property
+    def blank_frames(self) -> list[int]:
+        """Indices of painted frames that had rows mounted but none visible."""
+        return [
+            index
+            for index, f in enumerate(self.frames)
+            if isinstance(in_view := f.get("blocks_in_view"), int)
+            and in_view == 0
+            and isinstance(mounted := f.get("blocks"), int)
+            and mounted > 0
         ]
 
 
@@ -258,7 +304,8 @@ async def test_the_composer_never_paints_a_height_neither_session_asked_for() ->
 
 
 @pytest.mark.asyncio
-async def test_no_history_rows_mount_into_the_visible_view() -> None:
+@pytest.mark.parametrize("size", [(100, 30), (200, 50)])
+async def test_no_history_rows_mount_into_the_visible_view(size: tuple[int, int]) -> None:
     """RC4: the resume fill runs before reveal, so nothing arrives afterwards.
 
     The prepared window under-fills the viewport by construction, so the fill
@@ -268,6 +315,13 @@ async def test_no_history_rows_mount_into_the_visible_view() -> None:
 
     Counted on the VISIBLE view only: rows appended to a parked offscreen replay
     are the preparation doing its job.
+
+    TWO TERMINAL HEIGHTS, because the pre-reveal pass mounts exactly ONE page
+    and "one page is enough" is a claim about geometry, not a law (agent review
+    round 1, R3). A taller terminal needs more rows to fill the same viewport,
+    so 200x50 is where the bound would break first if `RESUME_PAGE_MESSAGES`
+    ever stopped covering it; the 30-row case is the one the audit measured
+    (21 blocks against a 27-row viewport).
     """
     home = SidebarRemote("home-session")
     target = _conversation("deep-session", 60)
@@ -291,7 +345,7 @@ async def test_no_history_rows_mount_into_the_visible_view() -> None:
         patch("local_operator.session.remote.RemoteSession", SidebarRemote),
         patch.object(TranscriptView, "insert_blocks", insert_blocks),
     ):
-        async with app.run_test(size=(100, 30)) as pilot:
+        async with app.run_test(size=size) as pilot:
             for _ in range(20):
                 await pilot.pause()
 
@@ -595,10 +649,17 @@ def test_parking_a_transcript_skips_the_stylesheet_cascade() -> None:
     """The cost half of RC2, asserted structurally rather than in milliseconds.
 
     `watch_disabled` re-applies CSS across the whole subtree — 131 node
-    applications on a real transcript, 10.2 ms of the 18.8 ms commit, inside a
-    section that deliberately never awaits. The fact that matters is that the
-    watcher does not run at all, which is a property of the call and not of the
-    machine: `set_reactive` writes the value without invoking watchers.
+    applications on a real transcript, inside a section that deliberately never
+    awaits. The fact that matters is that the watcher does not run ON THE PARK,
+    which is a property of the call and not of the machine: `set_reactive`
+    writes the value without invoking watchers. (The millisecond figures behind
+    that count were taken on a loaded box and are indicative only; the count is
+    the invariant.)
+
+    ONLY THE PARK. The un-park deliberately DOES run the watcher — see
+    `test_a_revealed_transcript_is_never_left_dimmed` for why skipping it left
+    revealed transcripts at `opacity: 0.7`. The saving this asserts is on the
+    outgoing 45-81 block transcript, which is where the cost was measured.
     """
     from local_operator.tui.app import _set_transcript_parked
 
@@ -611,9 +672,9 @@ def test_parking_a_transcript_skips_the_stylesheet_cascade() -> None:
     probe = _Probe()
     _set_transcript_parked(probe, True)
     assert probe.disabled is True
+    assert calls == [], "the disabled watcher ran on the park, re-applying the subtree"
     _set_transcript_parked(probe, False)
     assert probe.disabled is False
-    assert calls == [], "the disabled watcher ran, re-applying the stylesheet subtree"
 
 
 @pytest.mark.asyncio
@@ -649,12 +710,27 @@ async def test_a_failed_pre_reveal_fill_does_not_invalidate_the_preparation() ->
                 calls.append(1)
                 raise RuntimeError("projection failed")
 
-            # Only the synchronous pre-reveal pass is exercised: it is called
-            # directly, exactly as the commit calls it, with the deferred
-            # follow-up stubbed out so a later raise cannot be mistaken for
-            # this one.
+            # The deferred fill is RECORDED, not stubbed to a no-op. Stubbing it
+            # out was this test's blind spot (agent review round 1, R2): with
+            # the call swallowed, the test still passed while `chained = True`
+            # was being set BEFORE the mount, so a raising mount left the
+            # `finally`'s `if not chained:` already False and the documented
+            # degradation path never ran. Recording it means the promise in the
+            # docstring -- "a projection failure must degrade to the deferred
+            # fill" -- is what is actually asserted.
+            # Recorded and then STOPPED. Letting the real deferred fill run
+            # would re-enter the same stubbed `_mount_older_resume_page` and
+            # raise from `_fill_resume_until_scrollable`, which re-raises by
+            # design (see the scope note above) -- a second, unrelated failure
+            # on a path this test does not own. What R2 is about is whether the
+            # degradation path is REACHED, so that is what is recorded.
+            deferred: list[int] = []
+
+            def record_start(**_kwargs):
+                deferred.append(1)
+
             app._mount_older_resume_page = explode  # type: ignore[method-assign]
-            app._start_resume_fill = lambda **_kw: None  # type: ignore[method-assign]
+            app._start_resume_fill = record_start  # type: ignore[method-assign]
 
             await _switch(app, pilot, target)
             for _ in range(40):
@@ -665,3 +741,163 @@ async def test_a_failed_pre_reveal_fill_does_not_invalidate_the_preparation() ->
             assert app._session.session_id == target.session_id
             assert app._transcript_view().blocks()
             assert calls, "the pre-reveal fill never reached the projection at all"
+            assert deferred, (
+                "the pre-reveal fill raised and the deferred fill never started; "
+                "the documented degradation path is dead (see R2)"
+            )
+
+
+@pytest.mark.asyncio
+async def test_no_painted_frame_shows_an_empty_conversation() -> None:
+    """D1: the switch must never paint a frame with rows mounted and none visible.
+
+    The pre-reveal fill needs a synchronous layout so a freshly mounted page can
+    author its height before the readiness gate reads the painted map. But
+    `Screen._refresh_layout()` ends in `_compositor_refresh()`, which paints
+    immediately — and at that moment the transcript has been revealed while the
+    composer still occupies the OUTGOING draft's rows. Content laid out against
+    a box that is about to shrink falls outside the viewport, so the frame
+    showed an EMPTY conversation: 46 blocks mounted, 0 intersecting the content
+    region, at `scroll_y = 84 = max_scroll_y` immediately before a settled 82.
+
+    On a warm switch that was the FIRST painted frame — the fastest, most
+    common switch opening on a blank screen — and at 80x24 the whole screen
+    blanked, sidebar included (design review round 1, D1). The base never
+    painted such a frame, so this was a regression introduced by the fix, and a
+    blank flash is a worse unpolish signal than the shuffle it replaced.
+
+    WHAT THIS ASSERTS, AND WHY IT IS NOT THE PAINTED SEQUENCE. Under `run_test`
+    the commit paints NOTHING -- measured: zero `App._display` calls between
+    entering and leaving `_commit_sidebar_session`, at any terminal size and
+    with any draft. The headless compositor does not service the synchronous
+    `_refresh_layout` the way a real terminal does, so a frame-sequence
+    assertion here would be vacuous: it passes identically with the fix and
+    without it (verified by neutering the suppression -- still green).
+
+    So the invariant is asserted where this rig can actually see it: the commit
+    must not perform a PAINTING refresh, only a layout. That is the property the
+    fix establishes, it fails when the suppression is removed, and it does not
+    pretend to be visual evidence.
+
+    The blank frames themselves are a rendered-frame fact and were measured with
+    the frame-capture rig against a real compositor (design round 1, D1 and its
+    remediation): blank frames 1-3 -> 0 across warm/cold/draft2 at 120x36 and
+    80x24, with the before/after SVGs attached to the PR. AGENTS.md is explicit
+    that a green test is not visual evidence; this test is the structural half.
+    """
+    home = SidebarRemote("home-session")
+    target = _conversation("blank-frame-session", 60)
+
+    app = OperatorApp(lambda: _factory(home))
+    with patch("local_operator.session.remote.RemoteSession", SidebarRemote):
+        # 120x36, not the 100x30 the sibling tests use: with a 3-row outgoing
+        # draft the smaller terminal leaves a 16-row viewport that the prepared
+        # window ALREADY fills, so the pre-fill correctly early-returns and the
+        # settle this guard is about never runs (measured: scroll_y 17 against
+        # a 16-row viewport, 18 blocks in and 18 out). At 120x36 the same draft
+        # leaves a 25-row viewport and the fill mounts 20 -> 44 blocks.
+        async with app.run_test(size=(120, 36)) as pilot:
+            for _ in range(20):
+                await pilot.pause()
+
+            # A multi-row outgoing draft against the target's empty one: the
+            # stale box only exists while the composer is about to CHANGE
+            # height, so this is what makes the dock shrink across the commit.
+            editor = app._editor()
+            editor.load_text("outgoing draft line one\nline two\nline three")
+            for _ in range(20):
+                await pilot.pause()
+            assert int(editor.outer_size.height) > 1, (
+                "the outgoing draft must make the composer taller than the "
+                "incoming session's, or there is no height change to lag"
+            )
+
+            # Observe the COMPOSITOR REFRESH, which is the thing that paints,
+            # rather than the layout that calls it: the pre-fill reaches
+            # `_refresh_layout` by two routes (the first-visit viewport probe
+            # and the post-mount settle) and the fix guards both by rebinding
+            # this attribute for the duration of the call.
+            layouts: list[int] = []
+            paints: list[int] = []
+            screen = app.screen
+            real_layout = screen._refresh_layout
+            in_commit = {"yes": False}
+
+            def refresh_layout(*args, **kwargs):  # type: ignore[no-untyped-def]
+                if in_commit["yes"]:
+                    layouts.append(1)
+                    if screen._compositor_refresh is not _suppress_intermediate_paint:
+                        paints.append(1)
+                return real_layout(*args, **kwargs)
+
+            screen._refresh_layout = refresh_layout  # type: ignore[method-assign]
+            real_commit = app._commit_sidebar_session
+
+            def commit(session_id, prepared, generation):  # type: ignore[no-untyped-def]
+                in_commit["yes"] = True
+                try:
+                    return real_commit(session_id, prepared, generation)
+                finally:
+                    in_commit["yes"] = False
+
+            app._commit_sidebar_session = commit  # type: ignore[method-assign]
+            await _switch(app, pilot, target)
+            for _ in range(60):
+                await pilot.pause()
+
+            assert layouts, (
+                "the commit ran no synchronous layout at all; the pre-reveal "
+                "settle this asserts about is not happening"
+            )
+            assert app._resume_fill_active or app._transcript_view().blocks(), (
+                "the pre-reveal fill never engaged, so the layouts counted above "
+                "are not the ones this guard is about"
+            )
+            assert not paints, (
+                f"{len(paints)} of {len(layouts)} synchronous layouts inside the commit "
+                "would have painted; the switch can put a half-arranged frame "
+                "(revealed transcript, outgoing-sized composer) on screen"
+            )
+
+
+@pytest.mark.asyncio
+async def test_a_revealed_transcript_is_never_left_dimmed() -> None:
+    """R1: un-parking must run the stylesheet cascade, even though parking skips it.
+
+    `_set_transcript_parked` skips `watch_disabled` to avoid a whole-subtree
+    re-apply inside the frozen commit. That is safe in one direction only: the
+    park declines to dim a view nobody can see, but skipping the UN-park cascade
+    would decline to UN-dim one the user is about to look at.
+
+    The rule that dims it already exists — Textual's own
+    `*:disabled:can-focus { opacity: 0.7 }` matches because
+    `TranscriptView.can_focus` is True. Any cascade while the view is parked (a
+    terminal resize, a theme change) applies it, and without a watcher on the
+    un-park the view is revealed still carrying 0.7 and never self-heals: the
+    reviewer measured it surviving a reveal, a keystroke, a scroll and a further
+    switch, visibly dimming the body text in the rendered palette.
+
+    Asserted here as the appearance half that
+    `test_the_parked_view_stays_non_interactive` deliberately does not cover.
+    """
+    from local_operator.tui.app import _set_transcript_parked
+
+    applied: list[bool] = []
+
+    class _Probe(Widget):
+        can_focus = True
+
+        def watch_disabled(self, disabled: bool) -> None:
+            applied.append(disabled)
+
+    probe = _Probe()
+    _set_transcript_parked(probe, True)
+    assert probe.disabled is True
+    assert applied == [], "parking ran the cascade it exists to skip"
+
+    _set_transcript_parked(probe, False)
+    assert probe.disabled is False
+    assert applied == [False], (
+        "un-parking did not run the disabled watcher, so a view dimmed by a "
+        "cascade while parked would stay dimmed after it is revealed"
+    )


### PR DESCRIPTION
## What and why

**C2 — user-visible performance/polish defect.** The operator reported the sidebar session switch three ways: the composer "shrinks during loading then grows back", tool traces "load all into the same view then shuffle upward", the scroll position "bounces back and forth", and overall "it should be as fast as terminal multiplexing switch and currently feels like 500ms–1s".

An architect audit measured four independent root causes behind that one symptom. This PR fixes all four plus a latent defect that rides along. They are together in one PR deliberately: they are one user-visible symptom, they share the commit tail, and the evidence for each is only meaningful against the combined frame sequence.

### RC1 — the readiness gate could never pass on the first post-commit paint

`_await_sidebar_frame` armed the gate with `screen.refresh(layout=True)`. That requests a **layout**; it does not request a **full paint**, and the compositor is free to satisfy the resulting render with a partial `ChopsUpdate` over whatever regions the reflow dirtied. But only a `LayoutUpdate` records `_sidebar_displayed_frame` (see `_display`), so the gate refused the first paint of **every** switch and `post_display_hook`'s recovery branch bought a second full-screen relayout to recover — measured 21/21 switches, and here 26 refusals across 16 switches on `origin/main`.

The fix is to make the arming refresh **produce** the evidence, not to let the gate accept weaker evidence:

```python
compositor = self.screen._compositor
compositor._dirty_regions.add(compositor.size.region)
self.screen.refresh(layout=True)
```

`render_update` takes `render_full_update()` whenever the screen region is dirty, so the very next paint is a `LayoutUpdate` carrying the complete compositor map. The comment at `_sidebar_gate_surface_ready` — *"only the compositor map used by that display can prove its target pixels/gates were actually on screen"* — is preserved exactly: the gate still requires a real painted map, it just arrives on the frame the switch already pays for. **Neither `ChopsUpdate` acceptance nor a live `Widget.region` read was used.**

The refusal branch is **kept and instrumented**, not deleted. The container-lands-before-its-children case it was written for is real; the cost of an unnecessary recovery is one frame, while the cost of no recovery is a wedged switch. `_sidebar_gate_recoveries` counts it so a test can assert it stays dead.

### RC3 — the composer emptied at `pending`, ~100 ms before its replacement arrived

`_begin_sidebar_transition` ran `load_text("")` synchronously at `pending`, while the incoming draft was only loaded inside commit. Every frame between painted a **1-row** composer regardless of either session's real height. `Editor` is `height: auto` (1..8) inside a `height: auto` docked `#input-dock`, so that collapse is not one widget resizing — the transcript above grows into the vacated rows and the whole conversation column reflows. The user watches their own half-written sentence disappear and come back.

The buffer now keeps painting the outgoing draft until commit swaps it. `_sidebar_transition_prefix` records where that draft ended, and `_take_sidebar_transition_buffer` subtracts it, so **draft attribution is unchanged**: what is typed during the switch still belongs to the target on commit and to the outgoing session on failure. The `startswith` test is the honest one — a user who *edited* the frozen text has not typed a separable suffix, and guessing a diff would attribute their edit to the wrong session.

### RC2 — a whole-subtree stylesheet cascade inside the frozen commit

`Widget.disabled` does two unrelated jobs. Interactivity gating reads the **field** (`_self_or_ancestors_disabled`, `focusable`, `allow_*_scroll`, `check_message_enabled`). Appearance is `watch_disabled` → `App.update_styles` → a `Stylesheet.apply` across the whole subtree, so Textual's built-in `*:disabled { opacity: 0.7 }` can take effect — **131 node applications, 10.2 ms of an 18.8 ms commit, on the event loop, in a section that deliberately never awaits.**

That appearance half is worth nothing to a view parked at `overlay: screen; offset: 100vw`: every cell of its ink is clipped off-screen, so no opacity it is given can be seen. `_set_transcript_parked` writes the field through `set_reactive`, which skips the watcher — measured on a 40-block subtree at **4.13 ms / 44 applies → 0.002 ms / 0**, with `disabled`, `focusable`, `allow_vertical_scroll` and mouse-message refusal all identical. **The parked view stays non-interactive** and `_sidebar_gate_surface_ready`'s `editor.disabled` check is untouched.

### RC4 — 24 rows mounted into a view the user was already looking at

The prepared window under-fills the viewport by construction: `bound = max(12, height // 2)` yields 21 blocks / 14 scroll rows against a 27-row viewport, and `_fill_resume_attempt`'s goal is `viewport + prefix` = 27. Since `14 < 27` the fill fired on essentially every switch — and it was scheduled with `call_after_refresh`, i.e. strictly **after** reveal. **24 of 45 rows arrived after the user could see the conversation, dragging the viewport 14 → 62.** That is both the "shuffle" and the whole of the scroll bounce: the second painted position comes from `_size_updated` reacting to the insert, not from any anchor restore.

`_prefill_resume_before_reveal` now mounts that page synchronously inside the commit, while the incoming view is still parked, so the first painted state **is** the settled state.

Two constraints were found by the suite rather than by inspection, and both are documented in the code:

- **It mounts one page, not a loop to the goal.** `insert_blocks` schedules the settle that lets each block author its height, so nothing mounted here is measurable here. Measured at 100x100: blocks grew 51 → 75 while `scroll_y`, `max_scroll_y` **and** `virtual_size.height` all stayed exactly where they started. A loop would be mounting pages blind against a ruler that cannot move.
- **The ordinary fill is chained to that page's settle**, via the `on_settled` seam `_mount_older_resume_page` documents. The page holds the single-flight paging lease until its settle releases it, and `_fill_resume_attempt` stands down while that gate is held — so a fill started *beside* the mount raced it and lost, stranding the view at `scroll_y=0` against a 91-row viewport.

### §5.3 — a latent stale-anchor defect, riding along

A reader who scrolls up (writing an anchor into the draft) and then scrolls back to the tail left the record self-contradictory: `following_tail=True` alongside `anchor='6602e4b2…' offset=-1`. Every consumer today tests the flag first, so it is latent — but the nonsense `-1` would be clamped by `min(offset, max(0, height - 1))` into silent wrongness the moment any future read forgets. Cleared at the source, which is also what makes the stored record say what the operator asked for: a session left at tail lands on the most recent message.

## The `restore_revealed_anchor` question — resolved experimentally, and the first answer was wrong

§6.2 flagged one unfalsified risk: whether the in-prepare restore suffices for **wrapped** content at the revealed width. I ran the settling experiment it asked for — blocks that genuinely re-wrap (the same anchor block measures 3 rows at a 96-cell column and 5 at a 63-cell one), parked and revealed geometry read on the **same view object** two lines apart at the commit seam. They agreed exactly (width 63/63, `scroll_y` 44.0/44.0, anchor y=42 h=5 both times), because the parked view shares `#session-conversation` with the visible one and prepare pins only its *height*. So I deleted it.

**That was wrong, and the e2e stage caught it.** `test_saved_view_switches_while_authenticated_owner_sync_is_held[wrapped]` wraps far harder — `"wrapped content " * 35`, ~10 screen rows per block — and there the in-prepare position does not survive the reveal. Deleting the post-reveal restore wedged that test: the gate refused **1156 consecutive frames** with the anchor block absent from the painted map, and the switch timed out.

It is restored, with the counter-evidence and the wrap depth that separates the two results recorded beside it, so the next person to conclude it is dead code has to answer that measurement first. It costs a `call_after_refresh` and is a no-op whenever the in-prepare position already landed.

## Benchmark — interleaved A/B against current `origin/main`

`scripts/bench_session_switch.py` (committed; see below). Side A = this branch `f0c2f78ae`, side B = `origin/main` `0cd3a9434`, alternating worker subprocesses group by group with the order flipped each round, so both trees are sampled seconds apart under the same load. **288 switches per side, 0 failures.** The harness refuses a side whose worker imported the wrong tree.

**Lead with the counts.** This box runs ten concurrent agent sessions; wall milliseconds are load-contaminated by construction, while frames/layouts/mounts/scroll-settles are facts about how much work one switch costs and are identical on an idle laptop and a wedged runner.

| cell | n | frames A/B | layouts A/B | post-reveal layouts A/B | scroll settle A/B | composer resizes A/B |
| --- | --- | --- | --- | --- | --- | --- |
| `large@120x36/cold` | 24 | **6 / 8** | **4 / 6** | **2 / 4** | **2 / 3** | **1 / 1.5** |
| `large@200x50/cold` | 24 | **7 / 8** | **5 / 7** | 3 / 2 | 3 / 3 | **1 / 1.5** |
| `small@120x36/cold` | 24 | **6 / 8** | **4 / 6** | **2 / 3.5** | **2 / 3** | **1 / 1.5** |
| `small@200x50/cold` | 24 | **5 / 6** | **4 / 5** | 3 / 3 | 3 / 3 | **1 / 1.5** |
| `large@120x36/warm` | 24 | 3 / 3 | 2 / 2 | 2 / 2 | 1 / 1 | 1 / 1 |
| `large@200x50/warm` | 24 | 3 / 3 | 2 / 2 | 2 / 2 | 1 / 1 | 1 / 1 |
| `small@120x36/warm` | 24 | 3 / 3 | 2 / 2 | 2 / 2 | 1 / 1 | 1 / 1 |
| `small@200x50/warm` | 24 | 3 / 3 | 2 / 2 | 2 / 2 | 1 / 1 | 1 / 1 |
| `*/alternating` (4 cells) | 96 | 3 / 3 | 2 / 2 | 2 / 2 | 1 / 1 | 1 / 1 |

Aggregate over all 288 samples per side:

| metric | branch | origin/main |
| --- | --- | --- |
| frames (median / **max**) | 3 / **7** | 3 / **10** |
| layouts (median / **max**) | 2 / **6** | 2 / **7** |
| post-reveal layouts (max) | **3** | **5** |
| scroll settle (max) | **3** | **5** |
| **composer resizes (max)** | **1** | **2** |
| post-reveal mounts | 0 | 0 |
| wall ms (median) | **110.5** | 137.2 (**−19.5%**) |
| loop CPU ms (median) | **59.8** | 78.6 (**−23.9%**) |
| wall ms (p90) | 274.2 | 278.1 |
| failures | 0 | 0 |

`composer resizes` max **2 → 1** is the RC3 result stated as a count: no switch on this branch ever paints a composer height that is neither endpoint, where every cold cell on `main` does.

A separate structural probe, both arms verified to resolve their own tree, over 16 switches in three cache arms:

| arm | gate refusals | of which `NO_DISPLAYED_FRAME` | first post-commit paint |
| --- | --- | --- | --- |
| `origin/main` | **26** | 16 | `ChopsUpdate` |
| this branch | **0** | 0 | `LayoutUpdate` |

## Visual evidence — consecutive painted frames

Re-captured on **both** trees at current `origin/main` after the rebase, since a baseline against the old SHA is no longer the right comparison. Real `OperatorApp` under `run_test` at 120x36 with production CSS, one capture per painted frame via `App._display`, real `RuntimeServer` owners over real `RemoteSession` connections. Import resolution asserted per arm.

| scenario | arm | painted frames | **off-state composer frames** | blocks on visible view | scroll positions |
| --- | --- | --- | --- | --- | --- |
| `draft` | BEFORE | 13 | **1** | [6, 21, 46] | [0.0, 24.0, 84.0] |
| `draft` | **AFTER** | **11** | **0** | [6, 21, 46] | [0.0, 24.0, 84.0] |
| `cold` | BEFORE | 13 | 0 | [6, 21, 46] | [0.0, 22.0, 82.0] |
| `cold` | **AFTER** | **12** | 0 | [6, 21, 46] | [0.0, 24.0, 82.0, 84.0] |
| `warm` | BEFORE | 4 | 0 | **[21, 46]** | **[22.0, 82.0]** |
| `warm` | **AFTER** | 4 | 0 | **[46]** | **[82.0, 84.0]** |
| `back` | BEFORE | 8 | 0 | [6, 60] | [0.0, 116.0] |
| `back` | **AFTER** | 8 | 0 | [6, 60] | [0.0, 118.0] |

Two rows carry the headline:

- **`draft`** is the scenario built to isolate the composer defect — both sides carry the same 3-row draft, so the steady state is identical and any other height is jitter. BEFORE paints one frame at editor 1 / dock 5 with the 167-character draft replaced by the placeholder; AFTER is uniformly 3 / 7 across all 11 frames. The dock shrinking also grew the transcript 25 → 27 rows, so that frame was a whole-column reflow.
- **`warm`** shows the pre-reveal fill: blocks on the visible view go **[21, 46] → [46]**. The intermediate 21-block state is never painted.

In `cold`/`warm`/`back` only the outgoing side has a draft, so 3 → 1 is the correct handoff; BEFORE jumped to 1 immediately at `pending`, AFTER holds the outgoing draft until commit swaps it.

## The cold-switch pre-fill trade-off, stated plainly (§6.2)

**Work moves from after the reveal to before it.** A cold switch pays the page before anything is on screen, so `ready_ms` grows; in exchange post-reveal movement goes to zero and the first painted state is the settled state. The audit measured that trade at +89 ms for a full fill-to-goal; this PR mounts **one** page, and the measured cold wall medians came out *lower* than `main` in 3 of 4 cold cells because RC1's extra relayout and RC2's 10 ms are removed on the same path.

It is only paid on a cold switch — warm switches already hold their rows and skip the fill, and warm/alternating is 100% of the operator's described alternation.

**Fallback if cold `ready_ms` regresses on real sessions:** the pre-fill is already bounded to one page, so the next step down is to gate it on `view.scroll_y < viewport` being a large shortfall rather than any shortfall, or to drop the pre-fill and let the deferred path run — *not* to revert to filling a view the user is looking at. The chaining to `on_settled` must stay either way; that is a correctness fix for the paging lease, not part of the trade.

## What this does NOT fix

**The transcript shuffle is not fully eliminated.** A first-visit (`display_only`) switch still costs **two full prepare+commit cycles** — `_connect_sidebar_source` re-prepares and re-commits ~137–217 ms after the first painted frame, destroying and re-mounting every block widget (`shared_block_widgets = 0`) to install byte-identical content. Measured on this branch: `commits=2`, second commit installs 21 blocks over a 45-block view, **45 widgets discarded**.

This PR's item 4 **masks the visible collapse** on that path (the first commit now has its rows before reveal) while the rebuild still discards *more* widgets than before. That is deliberately out of scope here and is scoped as a follow-up in `/tmp/switch-audit/RECOMMIT.md`, whose recommendation is an incremental *promote* rather than a rebuild (a counterfactual produced an end state identical on all 15 measured fields). The `PreparationInvalidated` retry path is untouched by items 1–5, so there is no interaction risk.

Also not addressed: the audit's items on widening the retained LRU and prewarming, both **rejected on evidence** (hit rate is already 15/15 with 0 admission refusals).

## Tests

`tests/unit/tui/test_sidebar_switch_smoothness.py`, 11 cases. Every assertion is a **structural fact**, never a millisecond ceiling — AGENTS.md is explicit that bounds calibrated on this box flake CI (local 36–38 ms sites read 206–413 ms there):

- zero gate refusals across N switches, with a companion `_sidebar_gate_reached` counter so a zero cannot mean "never armed";
- zero off-state composer frames, on a fixture where both sides carry the same draft;
- zero post-reveal block insertions onto the visible view;
- exactly one painted scroll position, and a session left at tail lands at the tail;
- the three §6.1(3) attribution properties: the suffix only, no doubling on abandon, and a click burst keeping the original snapshot;
- the parked view stays non-interactive (field, `focusable`, `allow_vertical_scroll` all asserted), and the `disabled` watcher provably does not run;
- the pre-reveal fill cannot raise into `PreparationInvalidated`.

**Each guard was proven able to fail** by reverting its fix and re-running: RC1 → 1 failed, RC3 → 1 failed, RC2 → 1 failed, §5.3 → 1 failed, RC4 → 2 failed, reproducing the operator's exact symptom (`the switch painted [15.0, 63.0]` — a 48-row bounce).

`scripts/bench_session_switch.py` is committed, following the precedent of `scripts/diag/tui_growth.py` in #841. Its docstring states what it measures and why counts beat milliseconds here.

## Gates

Run from the worktree with its own venv, exactly as CI:

| gate | result |
| --- | --- |
| `flake8 .` | clean |
| `black --check .` (pinned 26.1.0) | 1170 files unchanged |
| `isort --check-only .` (pinned 5.13.2) | clean |
| `pyright` | **0 errors**, 0 warnings |
| `pytest tests/unit` | **17401 passed**, 18 skipped |
| `pytest tests/e2e -m e2e -n0` | **93 passed**, 7 skipped |

The e2e stage is not optional here: this change is in the switch/commit path its resume-liveness guard covers, and it is what caught the `restore_revealed_anchor` deletion.

**Rebase:** branched from `b3ec0abe9`, rebased onto `0cd3a9434` (four releases landed meanwhile). `git range-diff` reports `=` — content byte-identical across the rebase. #823 (tool durations on transcript replay) touches `project_settled_rows`, which the pre-reveal fill drives, so the interaction was checked by execution rather than inspection: 24 rows mounted by the pre-reveal fill, **13/13 replayed `ToolCard`s kept their restored durations**. `pyproject.toml` is untouched — no version bump.
