### PR TITLE
fix(harness): keep tool bookkeeping when a viewer rebuilds a tool row

### DIFF
--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -2780,21 +2780,18 @@ class AgentLoop:
             # keep their blocks untouched (never text-flatten).
             if not content:
                 content = [TextContent(text=EMPTY_TOOL_RESULT_TEXT)]
-            message = Message(
-                role="tool",
-                content=content,
-                tool_call_id=result.tool_call_id,
-                tool_name=result.tool_name,
-                is_error=result.is_error,
-            )
-            # Compaction and transcript presenters read tool-only metadata from
-            # here; wire clients deliberately ignore these harness keys.
-            if result.details is not None or result.useless or result.duration_s is not None:
-                message.provider_payload = {
-                    "details": result.details,
-                    "useless": result.useless,
-                    "duration_s": result.duration_s,
-                }
+            # The bookkeeping stamp lives in ``Message.tool_result`` rather
+            # than here. Stamping it at this call site is what let the OTHER
+            # callers of that constructor lose it: the viewer's live row
+            # (``RemoteSession._remember_live``) went through the same
+            # constructor and silently carried no duration, so a resumed card
+            # painted a blank column. One definition, so every producer of a
+            # tool row agrees by construction.
+            #
+            # ``content`` rides in on a copy of the result because the
+            # redaction and empty-result backfill above have already rewritten
+            # it; the ToolResult itself must not be mutated.
+            message = Message.tool_result(result.model_copy(update={"content": content}))
             context.messages.append(message)
             new_messages.append(message)
 

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -221,13 +221,48 @@ class Message(BaseModel):
 
     @staticmethod
     def tool_result(result: ToolResult) -> "Message":
-        return Message(
+        """A tool row carrying the harness bookkeeping beside its content.
+
+        ``details``/``useless``/``duration_s`` are written HERE rather than by
+        each caller because a caller that forgets them destroys information no
+        later surface can rebuild. ``duration_s`` is the executor's MEASURED
+        interval; a viewer repainting the row hours later has no clock that
+        could recover it.
+
+        That is not hypothetical. ``harness/loop.py::_append_results`` stamped
+        the payload onto the message AFTER calling this, so the owner's rows
+        carried it and everyone else's did not — and
+        ``RemoteSession._remember_live`` builds the live row for a relayed
+        ``tool_execution_end`` through exactly this constructor. The interval
+        reached the viewer on the wire (``event.result.duration_s``) and was
+        dropped the moment the row was built, so every tool card on a session
+        the viewer had WATCHED RUN repainted with a bare ``✓`` and no duration
+        (and no diff badge, since ``details`` died on the same line) as soon as
+        history was re-rendered — a sidebar switch, for instance. Only the
+        newest card looked right, because it is the live-painted widget settled
+        by ``_settle_painted_tool_card`` rather than replayed from history.
+
+        Written only when there is something to carry: a bare result keeps
+        ``provider_payload`` at ``None``, so rows that never had bookkeeping
+        serialize exactly as before and no consumer sees a new empty dict.
+        These are harness keys — every provider wire builder constructs its
+        tool entry from ``role``/``tool_call_id``/``content`` explicitly, so
+        they are structurally incapable of reaching a provider.
+        """
+        message = Message(
             role="tool",
             content=list(result.content),
             tool_call_id=result.tool_call_id,
             tool_name=result.tool_name,
             is_error=result.is_error,
         )
+        if result.details is not None or result.useless or result.duration_s is not None:
+            message.provider_payload = {
+                "details": result.details,
+                "useless": result.useless,
+                "duration_s": result.duration_s,
+            }
+        return message
 
 
 class Usage(BaseModel):

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -7061,7 +7061,9 @@ class OperatorApp(App[None]):
         rather than recomputed from when this row was mounted (see
         :func:`session_presentation.replay_tool_call`). A row written before
         durations were persisted has no such key and paints a blank duration
-        column, which is the honest answer when the interval is unknown. A call
+        column, which is the honest answer when the interval is unknown \u2014 as
+        does a bang-mode `! cmd` receipt, which carries the key but never a
+        measured value, because nothing times a command run outside a turn. A call
         whose result is missing from the transcript is shown ``interrupted``
         rather than complete — that is what a session killed mid-turn actually
         left behind, and it is the only arm with no interval to restore.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -7056,10 +7056,15 @@ class OperatorApp(App[None]):
         screen was a list of questions with no answers, which reads as a
         session that never ran rather than one being continued.
 
-        Tool rows are replayed settled, never running, and with no duration:
-        see :meth:`ToolCard.restore`. A call whose result is missing from the
-        transcript is shown ``interrupted`` rather than complete — that is what
-        a session killed mid-turn actually left behind.
+        Tool rows are replayed settled, never running, and carry the interval
+        the executor MEASURED — restored from ``provider_payload.duration_s``
+        rather than recomputed from when this row was mounted (see
+        :func:`session_presentation.replay_tool_call`). A row written before
+        durations were persisted has no such key and paints a blank duration
+        column, which is the honest answer when the interval is unknown. A call
+        whose result is missing from the transcript is shown ``interrupted``
+        rather than complete — that is what a session killed mid-turn actually
+        left behind, and it is the only arm with no interval to restore.
 
         Guarded: a fresh session has an empty history, and a /clear already
         retired the splash — this must not fight either.

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -855,8 +855,9 @@ def replay_tool_call(
         # duration onto fails this guard and takes the plain error arm below.
         #
         # So `duration_s` is passed for faithfulness, not for a population we
-        # can point at today. `_error(...)` sets no `duration_s`, and only
-        # `loop.py::_append_results` writes the `provider_payload` this reads
+        # can point at today. `_error(...)` sets no `duration_s`, and the only
+        # producer that MEASURES one is the agent loop (`loop.py::park`, which
+        # stamps `result.duration_s` from its own `time.monotonic()` span)
         # — review round 2 swept 37 real aborted runs (model-issued bash,
         # parallel-batch races, eval kernel aborts) and produced the
         # `aborted (` + `duration_s` conjunction zero times. The arm is
@@ -870,9 +871,14 @@ def replay_tool_call(
         #
         # Not covered here: a bang-mode `! cmd` the user stopped. That row
         # persists through `session/shell_record.py` →
-        # `Message.tool_result`, which copies content/ids/`is_error` and
-        # never writes `provider_payload` at all — so it replays blank, as a
-        # successful `! echo hi` also does. Pre-existing and out of scope.
+        # `Message.tool_result`, which DOES carry a `provider_payload` when
+        # the result has one (a spilled capture writes `details['spill']`).
+        # It still replays blank, for a different reason: nothing measures a
+        # bang command, so `duration_s` is `None`. The terminal runs it
+        # outside a turn, so the loop's `park()` — the only caller that
+        # stamps an interval — never sees it, and `execute_bash` reports no
+        # duration of its own. A successful `! echo hi` replays blank for the
+        # same reason. The producer gap is upstream and out of scope.
         card.restore(state="interrupted", duration_s=duration_s)
         return
     if getattr(result, "is_error", False):

--- a/tests/unit/session/test_shell_record_pruning.py
+++ b/tests/unit/session/test_shell_record_pruning.py
@@ -1,0 +1,110 @@
+"""A bang-mode receipt must stay inert for compaction's pruning passes.
+
+``shell_record_messages`` builds its tool row through ``Message.tool_result``,
+which carries ``details``/``useless``/``duration_s`` on ``provider_payload``.
+Unlike the viewer's display-only rows, a receipt lands in the owner's
+``Session._context.messages`` and in the durable transcript, so it is a real
+pruning INPUT — the pass reads exactly those keys (``_is_useless`` on
+``useless``, ``_supersede_key`` on ``details['path']``/``details['range']``/
+``details['supersede_key']``).
+
+It is inert today only because ``execute_bash`` sets none of them: its sole
+detail key is ``spill``, which no pruning rule reads. That is a property of
+another module, invisible from here, and a future ``details={"path": ...}``
+there would make two runs of one command supersede each other — silently
+blanking output the operator ran by hand and can no longer see. These tests
+pin the guarantee where it is consumed rather than trusting that property to
+hold, and drive the REAL producer so a fixture cannot pass in its place.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from local_operator.compaction.pruning import (
+    MIN_PRUNE_TOKENS,
+    _is_useless,
+    _supersede_key,
+    prune_tool_outputs,
+)
+from local_operator.compaction.tokens import estimate_tokens
+from local_operator.harness.types import AbortSignal, ToolContext
+from local_operator.session.shell_record import shell_record_messages
+from local_operator.tools import builtin
+
+NOW = 10_000_000
+ACTIVE = NOW  # not idle, so the warm-cache guard is the only one relaxed
+
+
+@pytest.fixture(autouse=True)
+def _no_inherited_cmux(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A test that runs a real tool must not inherit the operator's session."""
+    for key in [k for k in os.environ if k.startswith("CMUX_")]:
+        monkeypatch.delenv(key, raising=False)
+
+
+async def _receipt(call_id: str, command: str, cwd: str):
+    """One real bang-mode receipt: execute_bash, then the synthetic exchange."""
+    result = await builtin.execute_bash(
+        call_id, {"command": command}, AbortSignal(), None, ToolContext(cwd=cwd)
+    )
+    return result, shell_record_messages(command, result)[-1]
+
+
+@pytest.mark.asyncio
+async def test_bang_receipt_carries_no_pruning_key(tmp_path) -> None:
+    """The payload exists, and none of its keys is one the prune pass acts on.
+
+    Asserted against a SPILLING command, because that is the only shape whose
+    ``details`` is non-empty today (``{'spill': ...}``) — a small ``echo``
+    writes no payload at all and would make this vacuous.
+    """
+    result, tool = await _receipt(
+        "spill-1",
+        "for i in $(seq 1 4000); do echo line-$i-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; done",
+        str(tmp_path),
+    )
+    payload = tool.provider_payload or {}
+    assert payload, "a spilling receipt should carry a payload; the probe is otherwise vacuous"
+
+    details = payload.get("details") or {}
+    assert details, "expected the spill detail; without it the supersede assertions are vacuous"
+    # The exact keys pruning reads. `spill` is fine; `path`/`range`/
+    # `supersede_key` are not, because two runs of one command would then
+    # blank each other's output.
+    assert not (set(details) & {"path", "range", "supersede_key", "url", "useless"}), (
+        f"execute_bash grew a detail key the prune pass acts on: {sorted(details)}. "
+        "A bang receipt is the operator's own output and must not be superseded "
+        "or useless-blanked; see this module's docstring."
+    )
+    assert _supersede_key(tool) is None, "a bang receipt became supersede-eligible"
+    assert _is_useless(tool) is False, "a bang receipt became useless-eligible"
+    assert result.useless is False
+
+
+@pytest.mark.asyncio
+async def test_repeated_bang_receipts_are_never_blanked(tmp_path) -> None:
+    """End of the chain: the real pass leaves two identical receipts intact.
+
+    This is the behaviour the keys above protect, asserted on the output the
+    operator would actually lose. Both rows clear ``MIN_PRUNE_TOKENS``, so a
+    pass that wanted to blank them is not merely being stopped by the floor.
+    """
+    command = "for i in $(seq 1 4000); do echo line-$i-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; done"
+    _, first = await _receipt("spill-1", command, str(tmp_path))
+    _, second = await _receipt("spill-2", command, str(tmp_path))
+
+    for row in (first, second):
+        assert estimate_tokens(row) >= MIN_PRUNE_TOKENS, (
+            "receipt is below the prune floor, so this test would pass without "
+            "the guarantee it claims to pin"
+        )
+
+    before = [first.text, second.text]
+    out, changed = prune_tool_outputs([first, second], NOW, ACTIVE)
+    after = [m.text for m in out if m.role == "tool"]
+
+    assert changed is False, "compaction blanked a bang-mode receipt"
+    assert after == before, "a bang receipt's output was rewritten by the prune pass"

--- a/tests/unit/tui/test_reconnect_parity.py
+++ b/tests/unit/tui/test_reconnect_parity.py
@@ -154,11 +154,18 @@ async def _boot(app: OperatorApp, pilot: Any) -> None:
 
 
 def _with_payload(message: Message, payload: dict[str, Any]) -> Message:
-    """Attach the ``provider_payload`` the harness writes beside a tool result.
+    """Force an EXACT ``provider_payload`` onto a fixture row.
 
-    ``Message.tool_result`` does not carry it — ``harness/loop.py`` sets it on
-    the message after construction — so the fixture reproduces that shape here
-    rather than asserting against a row no real transcript holds.
+    ``Message.tool_result`` now carries ``details``/``useless``/``duration_s``
+    itself, so this no longer compensates for a lossy constructor; it pins the
+    payload to a known value so the assertions below read a fixed interval
+    rather than whatever the fixture's ToolResult happened to hold.
+
+    This file's coverage stops at the DURABLE reconnect path, where
+    ``_live_history`` is cleared. The viewer path — a session whose turns this
+    terminal WATCHED RUN, so live rows exist and are what history re-renders
+    from — is covered by ``test_sidebar_duration_replay.py``, which is where
+    the blank-duration regression actually lived.
     """
     message.provider_payload = payload
     return message

--- a/tests/unit/tui/test_sidebar_duration_replay.py
+++ b/tests/unit/tui/test_sidebar_duration_replay.py
@@ -1,0 +1,245 @@
+"""A viewer that WATCHED tool calls run must keep their measured durations.
+
+Regression guard for the defect PR #823 shipped past: durations were blank on
+every already-settled tool card after resuming through the sidebar, while the
+newest card still showed a time.
+
+WHAT IS BEING PROVEN
+--------------------
+A viewer attached over a runtime socket (what the SIDEBAR attaches to) keeps
+each completed tool result in ``RemoteSession._live_history``, built by
+``_remember_live`` via ``Message.tool_result(event.result)``. That constructor
+copies content/ids/is_error and NOT ``provider_payload`` — so the measured
+``duration_s`` that rode the wire on ``event.result.duration_s`` is dropped.
+
+``display_history_window()`` returns those live rows, and every re-render of
+history (a sidebar switch -> ``_adopt_session``, and the keystroke route's
+``PreparedReplay.prepare``) replays them through ``replay_tool_call``, which
+reads ``provider_payload["duration_s"]`` and finds nothing. Result: blank
+column. ``details`` and ``useless`` are dropped on the same line, so the tool
+diff badge (``+1``) disappears from those cards too.
+
+WHY EVERY EARLIER TEST STAYED GREEN
+-----------------------------------
+The state this needs is a viewer that WATCHED TURNS RUN, so ``_live_history``
+is populated. A viewer attached to a QUIESCENT owner renders durations fine
+(nothing shadows the durable rows), and a cold local resume never builds a
+live row at all — those are the paths #823 was verified on. Reaching the bug
+therefore requires a real ``OwnedSessionHandle`` + ``RuntimeServer`` +
+``RemoteSession(display_window=True)`` executing a REAL tool, which is what
+``_live_runtime`` stands up: the duration here is MEASURED by the harness, not
+fixtured, so a test that fakes the payload cannot pass in its place.
+
+And the assertion is the DURATION COLUMN itself. ``test_reconnect_parity.py``
+compared block classes, so it stayed green while the column diverged — the
+``✓``-shaped signature is identical whether or not the interval survives.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.harness.types import Message, TextContent
+from local_operator.session.remote import RemoteSession
+from local_operator.session.runtime.owned import OwnedSessionHandle
+from local_operator.session.runtime.server import RuntimeServer
+from local_operator.tools.builtin import build_write_tool
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.tool_card import ToolCard
+from local_operator.tui.widgets.transcript import TranscriptView
+from tests.e2e.harness import (
+    ScriptedStream,
+    build_session,
+    seed_transcript,
+    text_turn,
+    tool_call_turn,
+)
+from tests.unit.session.test_remote import _never_take_over
+
+
+@pytest.fixture(autouse=True)
+def isolated(tmp_path, monkeypatch):
+    # A headless pilot must never touch the operator's real multiplexer.
+    for key in tuple(os.environ):
+        if key.startswith("CMUX_"):
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_NOTIFICATIONS", "1")
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_TERMINAL_TITLE", "1")
+    monkeypatch.setattr(OperatorApp, "_check_for_update", lambda _s: None)
+    monkeypatch.setattr(OperatorApp, "_start_terminal_title", lambda _s: None)
+    monkeypatch.setattr(OperatorApp, "_start_multiplexer_broadcast", lambda _s: None)
+    monkeypatch.setattr(OperatorApp, "_start_herdr_reporter", lambda _s: None)
+    (tmp_path / "home").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "config").mkdir(parents=True, exist_ok=True)
+
+
+def _cells(app: OperatorApp) -> list[float | None]:
+    view = app.query_one(TranscriptView)
+    return [b._duration for b in view.blocks() if isinstance(b, ToolCard)]
+
+
+async def _boot(app, pilot) -> None:
+    for _ in range(400):
+        await pilot.pause()
+        if app._session is not None and app._transcript_view().blocks():
+            for _ in range(10):
+                await pilot.pause()
+            return
+    raise AssertionError("app never booted")
+
+
+async def _live_runtime(tmp_path: Path, n: int):
+    """A REAL runtime socket serving a session that RUNS n timed tool calls."""
+    config = tmp_path / "config"
+    (config / "config.yml").write_text(
+        "version: 0.0.0\nvalues:\n  hosting: test\n  model_name: mock\n"
+    )
+    directory = config / "sessions" / "synthetic-dur"
+    await seed_transcript(
+        directory, [Message(id="u0", role="user", content=[TextContent(text="start")])]
+    )
+    # The session's first model request is its own internal one (conversation
+    # naming), so the scripted tool turns start at index 1.
+    turns: list[Any] = [text_turn("filler")]
+    for i in range(n):
+        turns.append(
+            tool_call_turn(
+                text=f"step {i}",
+                tool_name="write",
+                tool_call_id=f"c{i}",
+                arguments={"path": str(tmp_path / f"o{i}.txt"), "content": f"{i}\n"},
+            )
+        )
+        turns.append(text_turn(f"ok {i}"))
+    # Spare turns: the session may issue its own extra model requests
+    # (naming/retries); running off the end of the script is a harness
+    # IndexError, not a product failure.
+    turns.extend(text_turn("spare") for _ in range(6))
+
+    session = build_session(
+        directory, ScriptedStream(turns), tools=[build_write_tool()], cwd=tmp_path
+    )
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(tmp_path))
+    server = RuntimeServer(handle, kind="daemon")
+    await server.start_in_process()
+    remote = await RemoteSession.connect(
+        server._record,
+        directory.name,
+        config_dir=config,
+        takeover_factory=_never_take_over,
+        display_window=True,
+    )
+    return session, handle, server, remote, directory
+
+
+async def _run_turns(handle, remote, tmp_path: Path, n: int, pilot=None) -> None:
+    """Drive n real tool turns; wait on the tool's OWN side effect, not a flag."""
+    await handle.prompt("warmup")
+    for _ in range(400):
+        await asyncio.sleep(0.01)
+        if pilot is not None:
+            await pilot.pause()
+        if not remote.frontend_state.streaming:
+            break
+    for i in range(n):
+        await handle.prompt(f"go {i}")
+        target = tmp_path / f"o{i}.txt"
+        for _ in range(800):
+            await asyncio.sleep(0.01)
+            if pilot is not None:
+                await pilot.pause()
+            if target.exists() and not remote.frontend_state.streaming:
+                break
+        assert target.exists(), f"tool call {i} never executed"
+    await asyncio.sleep(0.3)
+
+
+@pytest.mark.asyncio
+async def test_live_tool_row_keeps_its_measured_duration(tmp_path) -> None:
+    """UNIT-LEVEL: the losing boundary itself.
+
+    ``duration_s`` arrives on the wire as ``event.result.duration_s`` and must
+    survive into the live row's ``provider_payload``, because that row is what
+    ``display_history_window()`` serves to every replay.
+    """
+    session, handle, server, remote, _ = await _live_runtime(tmp_path, 2)
+    try:
+        await _run_turns(handle, remote, tmp_path, 2)
+        live_tools = [
+            (k, m) for k, m in remote._live_history.items() if getattr(m, "role", "") == "tool"
+        ]
+        assert live_tools, "no live tool rows were retained"
+        for key, message in live_tools:
+            payload = getattr(message, "provider_payload", None) or {}
+            assert isinstance(payload, dict), f"{key}: provider_payload missing entirely"
+            duration = payload.get("duration_s")
+            assert isinstance(duration, (int, float)) and duration >= 0, (
+                f"{key}: measured duration was dropped building the live row "
+                f"(provider_payload={payload!r})"
+            )
+            # ``details`` rides the SAME construction and was lost with it, so
+            # the tool card's diff badge vanished on this path as well. The
+            # write tool always reports its line counts, so an absent key here
+            # is the same defect rather than a tool that had nothing to say.
+            assert payload.get("details"), (
+                f"{key}: harness details were dropped building the live row "
+                f"(provider_payload={payload!r})"
+            )
+    finally:
+        await remote.dispose()
+        server.close()
+        await handle.dispose()
+
+
+@pytest.mark.asyncio
+async def test_sidebar_resume_renders_durations_on_a_watched_session(tmp_path) -> None:
+    """END TO END: the operator's exact gesture, in the real app.
+
+    Watch tool calls run, then re-render history the way a SIDEBAR switch does
+    (``_adopt_session`` -> ``_render_resumed_history``) and assert the DURATION
+    COLUMN, not the block classes — the assertion ``test_reconnect_parity.py``
+    was missing when this shipped.
+    """
+    session, handle, server, remote, _ = await _live_runtime(tmp_path, 3)
+
+    async def factory():
+        return remote
+
+    app = OperatorApp(factory)
+    try:
+        async with app.run_test(size=(118, 40)) as pilot:
+            await _boot(app, pilot)
+            await _run_turns(handle, remote, tmp_path, 3, pilot=pilot)
+            for _ in range(20):
+                await pilot.pause()
+
+            live_cells = _cells(app)
+            assert live_cells, "no tool cards painted live"
+            assert all(
+                c is not None for c in live_cells
+            ), f"live painting already lost durations: {live_cells}"
+
+            # THE SIDEBAR GESTURE: re-adopt the same session, which is what
+            # SessionSidebar.Selected -> _adopt_session does on a switch.
+            app._adopt_session(remote)
+            for _ in range(25):
+                await pilot.pause()
+
+            resumed = _cells(app)
+            assert resumed, "resume painted no tool cards"
+            blank = [i for i, c in enumerate(resumed) if c is None]
+            assert not blank, (
+                f"{len(blank)}/{len(resumed)} tool cards lost their duration on the "
+                f"sidebar resume path: {resumed} (live frame was {live_cells})"
+            )
+    finally:
+        await remote.dispose()
+        server.close()
+        await handle.dispose()


### PR DESCRIPTION
## What and why

**C1 — regression fix.** The operator reports that after #823 shipped, tool-call durations are **still blank when resuming through the sidebar**: a long run of `bash`/`eval` cards showing `✓` with no duration, except the newest row which shows `1.8s`.

That report is correct, and #823 did not fix this path. #823 fixed the two *renderers*; this is a loss that happens **before any renderer runs**.

### Root cause

`Message.tool_result` (`harness/types.py`) was a **lossy projection**. It copied `content` / `tool_call_id` / `tool_name` / `is_error` and dropped exactly the three fields the loop persists beside a tool result:

```python
# harness/loop.py::_append_results — stamped AFTER the factory returned
if result.details is not None or result.useless or result.duration_s is not None:
    message.provider_payload = {"details": ..., "useless": ..., "duration_s": result.duration_s}
```

Because the stamp lived at that one call site, the owner's rows carried the bookkeeping and **every other producer's did not**. That is why `session/remote.py` contains zero occurrences of `provider_payload`.

`RemoteSession._remember_live` builds the viewer's live row for a relayed `tool_execution_end` through the same factory:

```python
result = Message.tool_result(event.result)      # <-- payload dropped here
result.id = f"live-tool:{event.tool_call_id}"
self._live_history[result.id] = result
```

The measured interval **reaches the viewer intact on the wire** (`event.result.duration_s`) and is discarded the instant the row is built. `display_history_window()` serves those live rows, so every re-render of history — a sidebar switch, `_adopt_session` → `_render_resumed_history`, and the keystroke route's `PreparedReplay.prepare` — replays them through `replay_tool_call`, which reads `provider_payload["duration_s"]` and finds nothing.

Hop-by-hop, by execution on a real harness-timed call:

| hop | `duration_s` |
| --- | --- |
| owner history | present |
| durable transcript | present |
| wire `tool_execution_end` `result.duration_s` | `0.00064924999` — **reaches the viewer** |
| `_live_history['live-tool:c0'].provider_payload` | **`None` — LOST** |

### Why #823 missed it, and why the suite stayed green

The bug needs a viewer that **watched turns run**, so `_live_history` is populated. Neither path #823 was verified on can reach that state:

- A viewer attached to a **quiescent** owner renders durations fine — nothing shadows the durable rows.
- A **cold local resume** never builds a live row at all.

And the newest card looks right in the operator's screenshot for a real reason: it is the live-painted widget settled by `_settle_painted_tool_card`, not a row replayed from history.

`tests/unit/tui/test_reconnect_parity.py` *does* assert duration parity — but only over the durable-reconnect path, where `_live_history` is cleared. Its own helper documented that gap without closing it. Its docstring also asserted that `Message.tool_result` does not carry the payload, which was true and is now false; both are corrected here, since a stale comment is the false-trail class review flagged last round.

### The fix, and why at this layer

Fixed in the **shared projection**, not at the `remote.py` call site. Both are defensible; this one is chosen because:

- It fixes the defect where the information is **lost**, not where it is **observed**. Patching `_remember_live` (or the display-window merge) leaves the next caller of the factory to rediscover the same bug.
- It makes the class **unrepresentable** rather than fixed once: any present or future producer of a tool row now agrees by construction.
- `harness/loop.py::_append_results` now builds its row through the same factory, so there is exactly **one** definition of what a tool row carries. The second local construction there is precisely what let the other callers diverge.

Behavioural equivalence of the loop refactor was verified by execution over five result shapes (bare, duration-only, error+details, useless, `duration_s=0.0`): `model_dump` is byte-identical to the previous hand-built message in every case, and the redaction/empty-backfill rewritten `content` is passed via a copy so the `ToolResult` itself is never mutated.

**All three fields are carried**, not just `duration_s`.

### This is not only the TUI's duration column

`details` and `useless` die on the same line as `duration_s`, so a second consumer was degraded with it: the **mobile/relay projection**, which folds the same rows for the phone surface (`mobile/projection.py:671`, `:826` read `provider_payload["duration_s"]` and `["details"]` off `session.history()`). Measured on a viewer-rebuilt row carrying `duration_s=4.5, details={'lines_added': 3, 'lines_removed': 1}`:

| `fold_messages_to_entries` | `elapsed_s` | diff badge |
| --- | --- | --- |
| base (lossy projection) | **0.0** | **+0/-0** |
| head (this PR) | **4.5** | **+3/-1** |

So the phone showed every watched tool call as instantaneous and with no diff badge, for the same reason the TUI showed a blank column. Independently reproduced by QA and re-run here. The `+1` badge returning in the after-frame below is that same loss, visible in the TUI.

**Correction — no compaction threshold moves.** An earlier revision of this description claimed the loss "degraded compaction inputs". That overstates it and is withdrawn. Review and QA both checked it: `RemoteSession` has no `_context` and no compaction method at all, and pruning runs only over the **owner's** `Session._context.messages` (`session.py:8143` → `_render_for_compaction()`). The viewer-rebuilt rows this PR restores are **display-only**, so they were never a pruning input and no threshold shifts — QA measured `rows_pruned=0` and `prune_changed=false` on **both** base and head. What is true is narrower: the pruning pass can now *see* `useless`/`details` on those rows (`_is_useless` 0/4 → 4/4), which matters only if they ever become a compaction input. The real justification for this fix is the rendered duration column plus the mobile/relay projection above.

### Over-reach check

Every production call site of the factory *wants* the payload — there is no site that deliberately builds a payload-free tool result:

- `harness/loop.py::_append_results` — stamped it by hand; now gets it from the factory.
- `session/remote.py::_remember_live` — the defect; needs it.
- `session/shell_record.py` — bang-mode; see below. This caller now writes a payload where it previously wrote none, and unlike the viewer's rows a bang receipt **does** land in the owner's `Session._context.messages` and the durable transcript. It is inert for pruning (`execute_bash` sets no `useless`, `path` or `supersede_key`; its only detail key is `spill`, which no pruning rule reads) — and that inertness is now pinned by `tests/unit/session/test_shell_record_pruning.py` rather than left to a property of another module.

The payload cannot leak to a provider: all four wire dialects build their tool entry from an explicit dict of `role`/`tool_call_id`/`content` (`providers/clients.py:1650`, `:1733`, `:3144`, `:3497`) and only ever read `provider_payload["native_replay"]`. A bare result still yields `provider_payload = None`, so rows that never had bookkeeping serialize exactly as before.

### Bang-mode `! cmd` — explicitly NOT fixed here, and why

The plumbing is now correct: `shell_record.py` → `Message.tool_result` carries the payload, and stamping a duration onto its `ToolResult` produces `{'details': None, 'useless': False, 'duration_s': 1.23}`. But bang-mode rows still replay blank, because **`execute_bash` never measures one** — its `ToolResult` comes back with `duration_s=None`. That is a separate upstream gap (the loop's `park()` stamps the interval for model-issued calls; the bang-mode path builds its result outside the loop), not a projection loss. Out of scope here rather than fixed silently; it needs a measurement added at the shell worker, not a change to this factory.

## Testing evidence

Landed QA's independent reproduction as `tests/unit/tui/test_sidebar_duration_replay.py`. It stands up a real `OwnedSessionHandle` + `RuntimeServer` + `RemoteSession(display_window=True)` and executes the **real builtin `write` tool**, so the duration is **measured by the harness, not fixtured**, and it asserts the **duration column** rather than block classes — the assertion `test_reconnect_parity.py` was missing. An assertion on `details` was added, since it is lost on the same line.

**Negative control — verified on this branch before fixing:**

```
$ git stash   # revert the fix only
$ pytest tests/unit/tui/test_sidebar_duration_replay.py -q -n0
FAILED test_live_tool_row_keeps_its_measured_duration -
  AssertionError: live-tool:c0: measured duration was dropped building the live row (provider_payload={})
FAILED test_sidebar_resume_renders_durations_on_a_watched_session -
  AssertionError: 6/6 tool cards lost their duration on the sidebar resume path:
  [None, None, None, None, None, None] (live frame was [0.0036, 0.0025, 0.0029])
2 failed
```

With the fix: `4 passed` (both new tests plus the three existing parity tests).

### Before / after, rendered frames from the real app on the sidebar path

Captured with `scripts.visual_capture.save_capture` per AGENTS.md "Visual validation", isolated `HOME` + config dir, all `CMUX_*` unset, synthetic ids. **Geometry held constant** across both — only the duration column changes:

| | before | after |
| --- | --- | --- |
| screen | 118x40 | 118x40 |
| transcript content box | 115x31 | 115x31 |
| transcript virtual size | 114x73 | 114x73 |
| tool cards | 8 | 8 |
| **blank duration cells** | **8 / 8** | **0 / 8** |

The before-frame reproduces the operator's screenshot exactly: a run of `write` cards with `✓` and no duration. The after-frame shows `0.0s` on every card — and the `+1` diff badge is back, which is `details` being restored on the same line.

Frames are attached as a comment on this PR (never committed to the repo).

### Additional verification

- **Keystroke-level route** (the one QA did not drive): `_switch_session_cold` funnels through `_switch_session_from` → `SessionSidebar.Selected` → `_prepare_sidebar_session`, whose renderer is `PreparedReplay.prepare` over `session.display_history_window()`. Driven directly against a live runtime: `2/2` blank before, `0/2` after. Same window, same reader — the keystroke path converges on the same defect and the same fix.
- **Real operator transcript** (a copy in an isolated fixture dir, never attached to a live session): 143 durable tool rows, all carrying `duration_s`. Live twins rebuilt from each: **0/143** preserved the interval before, **143/143** after.

## Gates

Run in a fresh worktree cut from `origin/main` (`0cd3a9434`) with its **own** venv, exactly as CI:

- `flake8 .` — clean
- `black==26.1.0 --check .` — clean (1169 files)
- `isort==5.13.2 --check .` — clean
- `pyright` (1.1.411, `--pythonpath .venv/bin/python`) — **0 errors, 0 warnings**
- `pytest tests/unit -q` — **17392 passed, 18 skipped** in 18:46

Re-run in full on the remediation head (round 1); figures in the remediation comment. That round is **comment-only in production terms** — both touched `.py` files are AST-identical to the reviewed head — plus one new test file.

No version bump: `pyproject.toml` stays at `0.52.11`.

