### PR TITLE
fix(tui): keep a still-running tool card live across a sidebar switch

### DIFF
--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -2195,6 +2195,11 @@ class AgentLoop:
         # tell an abort apart from a steering interrupt and label their
         # synthetic results correctly.
         aborting = False
+        # WHEN the abort landed, on the same monotonic clock the runners stamp
+        # their spans from. The post-abort backfill needs an END instant for a
+        # tool it will never see finish, and every other candidate is a property
+        # of the harness rather than of the tool: see the stamp below.
+        aborted_at: float | None = None
 
         def park(
             slot: int,
@@ -2355,9 +2360,13 @@ class AgentLoop:
             fully paired — cancelling here changes WHEN the turn ends, never
             whether the wire stays legal.
             """
-            nonlocal aborting
+            nonlocal aborting, aborted_at
             assert signal is not None
             await signal.wait()
+            # Stamped BEFORE the cancellations, so the instant recorded is when
+            # the tools were told to stop rather than when the last of them
+            # acknowledged it.
+            aborted_at = time.monotonic()
             aborting = True
             for task in tasks:
                 if not task.done():
@@ -2587,7 +2596,45 @@ class AgentLoop:
                         # that argument does not stop applying because the call
                         # ended by abort: the tool really did run for this long
                         # before it was cut off.
-                        result.duration_s = max(0.0, time.monotonic() - started_at_by_slot[slot])
+                        #
+                        # MEASURED TO THE ABORT, NOT TO NOW, and the difference
+                        # is the whole finding of review round 3 (MAJOR-4).
+                        # `now` here is not a property of the tool: this code
+                        # runs only after the drain loop has waited out
+                        # ABORT_DRAIN_TIMEOUT_S, and a call reaches the backfill
+                        # only BECAUSE its unwind outran that budget — so
+                        # `now - started_at` always contains the whole drain
+                        # wait. Held the tool's real work at 0.10s and swept the
+                        # cleanup length, `now` reported 2.103 / 2.104 / 2.103s
+                        # for cleanups of 2.5 / 4 / 8s: pinned to the budget,
+                        # 21x the span, and constant regardless of the tool. It
+                        # was measuring the deadline.
+                        #
+                        # The abort instant is the honest end because it is when
+                        # the tool was cut off; what happens after is the
+                        # harness waiting, not the tool working.
+                        #
+                        # It does NOT make this identical to `park`, and the
+                        # difference is stated rather than papered over: a
+                        # runner that unwinds INSIDE the budget stamps in its
+                        # own `CancelledError` handler, after its cleanup has
+                        # run, so it reports start->cleanup-end (measured 0.603s
+                        # for the same 0.101s of work with a 0.50s cleanup).
+                        # That number is defensible there because the task was
+                        # genuinely unwinding for the whole of it and the
+                        # executor watched it happen. It is not available here:
+                        # this emitter fires precisely because the tool has NOT
+                        # finished unwinding and never will be observed doing
+                        # so, so the only instants in scope are the start, the
+                        # abort, and the deadline. Of those the abort is the
+                        # only one that is a property of the tool.
+                        #
+                        # `max(0.0, ...)` is a live guard, not decoration: the
+                        # watcher cancels tasks after stamping, so a runner that
+                        # reaches its first line in that window starts AFTER the
+                        # abort and would otherwise report a negative span.
+                        ended_at = aborted_at if aborted_at is not None else time.monotonic()
+                        result.duration_s = max(0.0, ended_at - started_at_by_slot[slot])
                         pending_ends.append(
                             ToolExecutionEndEvent(
                                 tool_call_id=item.call.id,

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -2172,7 +2172,14 @@ class AgentLoop:
         queue: asyncio.Queue[AgentEvent | _ToolDone | _BatchDone] = asyncio.Queue()
         results_by_slot: list[ToolResult | None] = [None] * len(batch)
         tasks: list[asyncio.Task[None]] = []
-        started_slots: set[int] = set()
+        # Slot -> the monotonic instant its runner announced the start. A SET of
+        # started slots was enough while every end event came from `park`, which
+        # closes over its runner's own `started_at`; the post-abort backfill has
+        # no such closure and was therefore the one emitter that could not
+        # measure what it was reporting (review round 2, MAJOR-3). Membership is
+        # unchanged — `slot in started_at_by_slot` reads the same as before — so
+        # this widens what the batch remembers rather than how it decides.
+        started_at_by_slot: dict[int, float] = {}
         peek = (
             config.has_urgent_steering_messages
             if config.has_urgent_steering_messages is not None
@@ -2216,7 +2223,7 @@ class AgentLoop:
             # one alone leaves the other emitting it (R4-1 fixed the flush, R5-1
             # was the drain doing the same thing a moment earlier). The result
             # still parks, so the WIRE stays paired; only the event is withheld.
-            started = slot in started_slots
+            started = slot in started_at_by_slot
             if started:
                 queue.put_nowait(
                     ToolExecutionEndEvent(
@@ -2239,7 +2246,7 @@ class AgentLoop:
         async def runner(slot: int, item: _PlannedCall) -> None:
             tool_name = item.tool.name if item.tool is not None else item.call.name
             started_at = time.monotonic()
-            started_slots.add(slot)
+            started_at_by_slot[slot] = started_at
             await queue.put(
                 # `item.args`, not `item.call.arguments`: the event must show
                 # what the tool is actually being run with, and those two now
@@ -2274,7 +2281,7 @@ class AgentLoop:
         async def interruptible_runner(slot: int, item: _PlannedCall) -> None:
             tool_name = item.tool.name if item.tool is not None else item.call.name
             started_at = time.monotonic()
-            started_slots.add(slot)
+            started_at_by_slot[slot] = started_at
             await queue.put(
                 ToolExecutionStartEvent(
                     tool_call_id=item.call.id,
@@ -2563,17 +2570,36 @@ class AgentLoop:
                 if results_by_slot[slot] is None:
                     result = self._synthetic_result(item.call, ABORTED_RESULT_TEXT)
                     results_by_slot[slot] = result
-                    if slot in started_slots and item.tool is not None:
+                    if slot in started_at_by_slot and item.tool is not None:
                         # Only for calls that actually STARTED. A planning
                         # failure parked its result up front and never emitted a
                         # start event, so an end event for it would be the
                         # mirror image of this bug.
                         claimed[item.call.id] += 1
+                        # STAMPED like every other emitter. This was the one
+                        # end event in the loop carrying no interval, because it
+                        # is built here rather than inside the runner that owns
+                        # `started_at` — so an aborted call reported an active
+                        # span it had genuinely measured as blank, and the
+                        # receipt a viewer saw depended on whether it had
+                        # watched the start (review round 2, MAJOR-3). The
+                        # executor owns the start/end boundary (see `park`), and
+                        # that argument does not stop applying because the call
+                        # ended by abort: the tool really did run for this long
+                        # before it was cut off.
+                        result.duration_s = max(0.0, time.monotonic() - started_at_by_slot[slot])
                         pending_ends.append(
                             ToolExecutionEndEvent(
                                 tool_call_id=item.call.id,
                                 tool_name=item.tool.name,
                                 result=result,
+                                # Both halves, like the three sibling emitters.
+                                # `duration_s` has no validator ORing it with
+                                # `result.duration_s` the way `_sync_error_flag`
+                                # does for the error bit, so an emitter that
+                                # sets only one ships an event whose live
+                                # consumer and whose replay disagree.
+                                duration_s=result.duration_s,
                                 is_error=result.is_error,
                             )
                         )

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -646,6 +646,18 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
         """Tool ids whose result rows have not arrived yet."""
         ...
 
+    def executing_display_tool_ids(self) -> set[str]:
+        """Tool ids of a STILL-RUNNING turn, so a replayed row is not settled.
+
+        The gate's counterpart: a long tool parks the turn inside execution
+        with no gate open, so ``pending_display_tool_ids`` is empty while the
+        call is alive and a replay would paint ``⊘ interrupted`` over it.
+        Viewer-side for the same reason as its sibling above — it answers a
+        display question off ``is_streaming`` plus the latest call group, and
+        has no meaning on a runtime nobody is viewing.
+        """
+        ...
+
     async def ensure_display_anchor(self, anchor: str) -> bool:
         """Load whichever page contains ``anchor``; False when it is gone."""
         ...

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -2623,13 +2623,18 @@ class RemoteSession:
         two outcomes for that: settled, or ``⊘ interrupted``. The call had not
         stopped; nobody had asked whether it was still going.
 
-        Gated on ``is_streaming`` and on the LATEST group only, so the answer
+        Gated on :attr:`is_streaming` and on the LATEST group only, so the answer
         is "this turn, right now" and never "some turn once left a call
         dangling". A turn that has ended reports nothing here and its
         unanswered rows stay interrupted, which for a turn that really died
         mid-flight is the truth.
         """
-        if not self._streaming:
+        # Through the PROPERTY the docstring names, not the private attribute.
+        # Same value today, and the rest of this file reads `_streaming`
+        # directly — but this predicate's contract is the documented gate, so a
+        # future `is_streaming` that stops being a bare passthrough must move
+        # this answer with it rather than silently leaving it behind.
+        if not self.is_streaming:
             return set()
         return self._unanswered_tail_call_ids()
 

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -2572,15 +2572,16 @@ class RemoteSession:
             raise RuntimeError("this session uses full-history replay")
         return await self._fetch_history_page(before, window.owner_epoch, window.through_id, anchor)
 
-    def pending_display_tool_ids(self) -> set[str]:
-        """Unanswered calls in the pending gate's current serialized user turn.
+    def _unanswered_tail_call_ids(self) -> set[str]:
+        """Calls in the CURRENT turn's latest group that have no result yet.
 
-        A gate can precede tool_execution_start, so no invented start event is
-        needed. The latest call group after the latest user boundary is the
-        only eligible group; old interrupted turns must remain interrupted.
+        Shared by the two "this row is not finished" questions below, which
+        differ only in what makes the call unfinished — a gate parked in front
+        of it, or the tool still executing. The scan itself is one rule and
+        belongs in one place: the latest call group after the latest user
+        boundary is the only eligible group, so old interrupted turns keep
+        their ``⊘`` and are never revived by a later turn's liveness.
         """
-        if self.pending_gate is None:
-            return set()
         answered: set[str] = set()
         for message in reversed(self.display_history_window()):
             role = getattr(message, "role", "")
@@ -2592,6 +2593,45 @@ class RemoteSession:
             if role == "assistant" and calls:
                 return {call.id for call in calls} - answered
         return set()
+
+    def pending_display_tool_ids(self) -> set[str]:
+        """Unanswered calls in the pending gate's current serialized user turn.
+
+        A gate can precede tool_execution_start, so no invented start event is
+        needed.
+        """
+        if self.pending_gate is None:
+            return set()
+        return self._unanswered_tail_call_ids()
+
+    def executing_display_tool_ids(self) -> set[str]:
+        """Unanswered calls of a turn that is STILL RUNNING right now.
+
+        The gate's counterpart, and the reason it cannot answer for both. A
+        long tool — ``wait(wait_ms=1800000)``, a background ``bash``, a
+        ``task`` — parks the turn inside execution with NO gate open, so
+        ``pending_display_tool_ids`` returns nothing for it while the call is
+        very much alive.
+
+        That matters because of where the row comes from. The viewer files
+        each completed live row into ``_live_history`` (see
+        :meth:`_remember_live`), and ``display_history_window`` hands those
+        rows to the next prepared replay. So a viewer that was watching when
+        the model issued the call — the ordinary case for a conversation
+        sitting in the sidebar — replays an assistant message whose
+        ``tool_calls`` have no answer, and ``replay_tool_call`` has exactly
+        two outcomes for that: settled, or ``⊘ interrupted``. The call had not
+        stopped; nobody had asked whether it was still going.
+
+        Gated on ``is_streaming`` and on the LATEST group only, so the answer
+        is "this turn, right now" and never "some turn once left a call
+        dangling". A turn that has ended reports nothing here and its
+        unanswered rows stay interrupted, which for a turn that really died
+        mid-flight is the truth.
+        """
+        if not self._streaming:
+            return set()
+        return self._unanswered_tail_call_ids()
 
     @property
     def display_history_revision(self) -> int:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -8011,12 +8011,53 @@ class OperatorApp(App[None]):
 
     @staticmethod
     def _mark_pending_tool_rows(blocks: list[Any], session: Any) -> None:
+        """Repaint replayed rows whose calls have NOT finished.
+
+        A replayed call row carries no result for two quite different reasons,
+        and ``replay_tool_call`` cannot tell them apart — it sees an absent
+        result and paints ``⊘ interrupted``, which is right only for a call
+        that genuinely stopped mid-flight. The session knows which it is, so
+        the correction is applied here, against the canonical state, rather
+        than by weakening that default:
+
+        * ``waiting`` — a gate is parked in front of the call;
+        * ``running`` — the tool is EXECUTING right now.
+
+        The second is why this method exists in this shape. A long tool
+        (``wait``, a background ``bash``, a ``task``) parks the turn inside
+        execution with no gate open, so the pending scan is empty while the
+        call is alive; switching to that conversation through the sidebar
+        painted ``⊘ interrupted`` on a tool that was still running, under a
+        band that said "working". Neither set is a guess: both are derived
+        from the session's own tail scan, so a call that really did stop keeps
+        its ``⊘``.
+        """
         pending = getattr(session, "pending_display_tool_ids", None)
+        call_ids: set[str] = set()
         if callable(pending):
             call_ids = cast(set[str], pending())
             for block in blocks:
                 if isinstance(block, ToolCard) and block.tool_call_id in call_ids:
                     block.mark_waiting()
+        executing = getattr(session, "executing_display_tool_ids", None)
+        if callable(executing):
+            # A gated turn is also a streaming one, so the two scans overlap on
+            # exactly the call the gate is holding. `waiting` WINS: it is the
+            # more specific fact (the turn is parked on the user, not on a
+            # tool), and letting `running` land on top would repaint the
+            # approval row as though the call the user has not authorised were
+            # already executing.
+            live_ids = cast(set[str], executing()) - call_ids
+            for block in blocks:
+                if isinstance(block, ToolCard) and block.tool_call_id in live_ids:
+                    # `restore`, not `mark_running`: the row was mounted by
+                    # replay, so its `_started` is when this view painted it,
+                    # not when the tool began. `restore(state="running")`
+                    # clears that stamp, which is what keeps the card live
+                    # while refusing to invent an elapsed time it cannot know
+                    # — the same reason `subagent_view` restores a child's
+                    # in-flight row this way.
+                    block.restore(state="running")
 
     def _project_settled_rows(self, history: list[Any], *, bound: int | None = None) -> bool:
         from local_operator.tui.session_presentation import project_settled_rows

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -4295,7 +4295,14 @@ class OperatorApp(App[None]):
                         "Saved preview unavailable. Connect to load the conversation.", "note"
                     )
                 )
-            self._mark_pending_tool_rows(replay.blocks, session)
+            # Into the PRESENTATION's own registry, never `self._tool_cards`:
+            # this conversation is being painted offscreen and is not the
+            # visible one, and `_current_activity` derives the working line's
+            # label from the app's dictionary. `_apply_sidebar_presentation`
+            # promotes this dict to `self._tool_cards` when the switch commits,
+            # which is the moment these cards become the app's to retire.
+            prepared_live_cards: dict[str, ToolCard] = {}
+            self._mark_pending_tool_rows(replay.blocks, session, prepared_live_cards)
             replay.view.styles.layer = "session-cache"
             # visibility:hidden removes the compositor map and makes size=0.
             # A screen overlay is excluded from flow/virtual bounds; parking it
@@ -4364,6 +4371,7 @@ class OperatorApp(App[None]):
                 source_token=source.token,
                 history_size=session.history_message_count,
                 working_fallback=DEFAULT_ACTIVITY,
+                tool_cards=prepared_live_cards,
                 welcome=welcome,
                 welcome_visible=welcome is not None,
             )
@@ -5351,7 +5359,11 @@ class OperatorApp(App[None]):
             # `_sync_fork_pending` reads `self._session`, which the line above
             # has just swapped.
             self._sync_fork_pending()
-            self._mark_pending_tool_rows(incoming.replay.view.blocks(), session)
+            # `self._tool_cards` IS the incoming presentation's dictionary by
+            # now (`_apply_sidebar_presentation` swapped it above), so this is
+            # the same registry the prepare path seeded — repainting after the
+            # commit tops it up rather than filling a second one.
+            self._mark_pending_tool_rows(incoming.replay.view.blocks(), session, self._tool_cards)
             history = session.display_history_window()
             total = session.history_message_count
             if total > incoming.history_size:
@@ -8010,7 +8022,9 @@ class OperatorApp(App[None]):
             notice.set_interactive(text != RESUME_START_NOTICE)
 
     @staticmethod
-    def _mark_pending_tool_rows(blocks: list[Any], session: Any) -> None:
+    def _mark_pending_tool_rows(
+        blocks: list[Any], session: Any, live_cards: dict[str, ToolCard] | None = None
+    ) -> None:
         """Repaint replayed rows whose calls have NOT finished.
 
         A replayed call row carries no result for two quite different reasons,
@@ -8031,6 +8045,34 @@ class OperatorApp(App[None]):
         band that said "working". Neither set is a guess: both are derived
         from the session's own tail scan, so a call that really did stop keeps
         its ``⊘``.
+
+        **``live_cards`` is what OWNS the row's terminal state, and passing it
+        is not optional for the ``running`` arm.** The rows here were mounted by
+        REPLAY, so they are in neither ``_tool_cards`` nor ``_composing_cards``
+        — and every turn-death path in this app settles cards by iterating
+        exactly those two dictionaries. A row repainted live and left out of
+        both is therefore unreachable by all of them: when the owner dies after
+        the switch rather than returning a result, the card stays ``running``
+        forever beside a transcript notice that says ``interrupted``. The
+        liveness predicate is only ever asked HERE, at switch time; nothing
+        re-asks it when the answer changes. So a card this method makes live is
+        entered into the caller's live registry, which puts it back under
+        ``_retire_live_tool_cards`` — the same dictionary
+        ``on_tool_ended``/``_painted_tool_card`` already settle it through on
+        the happy path, so registration adds an owner rather than a second
+        mechanism.
+
+        The registry is passed rather than read off ``self`` because the two
+        prepare-time callers are painting a presentation that is not yet the
+        app's: registering into ``self._tool_cards`` there would attribute
+        another conversation's live call to the visible one, and
+        ``_current_activity`` reads that dictionary for the band. Each caller
+        hands in the dictionary that travels with the transcript it is
+        painting.
+
+        A caller that passes nothing still gets the repaint (the state is
+        honest at the moment it is painted) but keeps the old exposure, which is
+        why the only caller that omits it is the test seam.
         """
         pending = getattr(session, "pending_display_tool_ids", None)
         call_ids: set[str] = set()
@@ -8058,13 +8100,22 @@ class OperatorApp(App[None]):
                     # — the same reason `subagent_view` restores a child's
                     # in-flight row this way.
                     block.restore(state="running")
+                    if live_cards is not None:
+                        # See the docstring: this is the row's ONLY settle path
+                        # when the turn dies instead of returning a result.
+                        live_cards[block.tool_call_id] = block
 
     def _project_settled_rows(self, history: list[Any], *, bound: int | None = None) -> bool:
         from local_operator.tui.session_presentation import project_settled_rows
 
         try:
             projected = project_settled_rows(self, history, bound=bound)
-            self._mark_pending_tool_rows(self._transcript_view().blocks(), self._session)
+            # The visible transcript, so the app's own registry is the right
+            # owner: a row this repaints live is one `_retire_live_tool_cards`
+            # must be able to settle when the turn dies.
+            self._mark_pending_tool_rows(
+                self._transcript_view().blocks(), self._session, self._tool_cards
+            )
             return projected
         finally:
             self._projection_message_id = ""
@@ -32346,6 +32397,15 @@ class OperatorApp(App[None]):
         those cards, so the NEXT turn opened by announcing ``running bash`` for
         a bash call that had died with the previous session.
 
+        The registry is the WHOLE of "still live", which is a claim the app has
+        to keep true at the other end too. A row repainted live by
+        :meth:`_mark_pending_tool_rows` was mounted by replay and so is in
+        neither dictionary by default; left out, it is invisible to this method
+        and to every other turn-death path, and the card stays ``running``
+        forever when the owner dies instead of returning a result. That is why
+        the repaint registers what it makes live — the invariant is stated at
+        both ends because neither site can enforce it alone.
+
         Deliberately UNCONDITIONAL: whatever is still live here has, by
         definition, no outcome on this surface, so there is nothing to be
         conditional on. What keeps that honest is upstream — the reconnect seed
@@ -32749,10 +32809,20 @@ class OperatorApp(App[None]):
         # the headline, so both features stay dark.
         result_text = event.result.text
         details = event.result.details
+        # The executor's MEASURED interval, handed to the card as a fallback for
+        # the row that cannot time itself. A card adopted mid-execution by
+        # `_mark_pending_tool_rows` has no `_started` — deliberately, because
+        # the page painted it after the tool began — so before this it settled
+        # to a blank column while a REPLAY of the same call read the interval
+        # off the persisted payload (#858) and printed `✓ 4.2s`. Same call, two
+        # different receipts, decided only by whether the viewer was watching.
+        # Not a second stamp: this is #858's own number, read where it already
+        # arrives, and a card with its own clock ignores it.
+        measured_s = getattr(event, "duration_s", None)
         if event.is_error:
-            card.mark_failed(_first_line(result_text), result_text, details)
+            card.mark_failed(_first_line(result_text), result_text, details, measured_s=measured_s)
         else:
-            card.mark_done(result_text, details)
+            card.mark_done(result_text, details, measured_s=measured_s)
         # A result that carries image blocks (a `read` of a PNG, a browser
         # screenshot) shows them under the card, so the user watches the same
         # pixels the model is about to reason over. After the card settles, so

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -17792,7 +17792,7 @@ class OperatorApp(App[None]):
         Asks the SAME deriver the working line and the title use, so the three
         cannot disagree about whether a turn is parked.
         """
-        _, phase = self._current_activity()
+        _, phase, _ = self._current_activity()
         if phase != ACTIVITY_APPROVAL:
             return
         asking = self._ask_pending is not None and not self._ask_pending.done()
@@ -32085,7 +32085,8 @@ class OperatorApp(App[None]):
         """
         if self._working_block is not None:
             return
-        self._working_block = WorkingBlock(*self._current_activity())
+        label, phase, clock = self._current_activity()
+        self._working_block = WorkingBlock(label, phase, clock=clock)
         self._append_block(self._working_block, ends_empty_state=ends_empty_state, pin_tail=True)
 
     def _dismiss_working_block(self) -> None:
@@ -32114,9 +32115,9 @@ class OperatorApp(App[None]):
         a stop reaches this hook without either of those paths knowing a title
         exists.
         """
-        label, phase = self._current_activity()
+        label, phase, clock = self._current_activity()
         if self._working_block is not None:
-            self._working_block.set_activity(label, phase)
+            self._working_block.set_activity(label, phase, clock=clock)
         waiting = phase == ACTIVITY_APPROVAL
         if self._status is not None:
             self._status.set_attention(waiting)
@@ -32151,8 +32152,17 @@ class OperatorApp(App[None]):
         elif not waiting:
             self._waiting_kind = None
 
-    def _current_activity(self) -> tuple[str, str]:
-        """What the agent is doing right now: ``(label, phase)``.
+    def _current_activity(self) -> tuple[str, str, bool]:
+        """What the agent is doing right now: ``(label, phase, clock)``.
+
+        ``clock`` is whether the phase's zero is the WORK's zero, i.e. whether
+        the elapsed number the band draws would be true. It is False only for a
+        ``running`` phase every one of whose cards was adopted mid-execution by
+        a sidebar switch: the phase changes when the viewer arrives, not when
+        the tool started, so the clock would count from the switch while naming
+        a tool that may be half an hour old (design round 2, D6). Derived here
+        rather than latched at the switch for the same reason the label is — one
+        deriver, so the band cannot disagree with the ledger under it.
 
         DERIVED from the same state the transcript is drawn from rather than
         latched by each handler, so the line cannot disagree with the ledger
@@ -32177,14 +32187,23 @@ class OperatorApp(App[None]):
             # FIRST, above the approval prompt: the picker is a modal drawn over
             # everything, so it is what the user is looking at even if a card
             # underneath is also waiting.
-            return ("waiting for your answer", ACTIVITY_APPROVAL)
+            return ("waiting for your answer", ACTIVITY_APPROVAL, True)
         if self._approval is not None and not self._approval.answered:
             # Nothing is running: the turn is parked on the question on screen,
             # and "thinking" under an unanswered prompt blames the model for a
             # wait that belongs to the user.
-            return ("waiting for approval", ACTIVITY_APPROVAL)
+            return ("waiting for approval", ACTIVITY_APPROVAL, True)
         if self._tool_cards:
-            return (self._batch_phrase(list(self._tool_cards.values())), "running")
+            cards = list(self._tool_cards.values())
+            # ANY card that dates itself is enough. The clock measures the phase,
+            # and the phase began when the first of these calls started, so one
+            # card this viewer watched start puts a true floor under the number;
+            # it is only when EVERY card was adopted that the zero is unknown.
+            return (
+                self._batch_phrase(cards),
+                "running",
+                any(card.dates_itself for card in cards),
+            )
         if self._composing_cards:
             # The tool's NAME is deliberately absent. It arrives in fragments —
             # `wr` then `write` — and the ledger row above follows those because
@@ -32192,10 +32211,10 @@ class OperatorApp(App[None]):
             # and `composing wr` reads as a typo rather than as a state.
             count = len(self._composing_cards)
             noun = "a call" if count == 1 else f"{count} calls"
-            return (f"composing {noun}", "composing")
+            return (f"composing {noun}", "composing", True)
         if self._streaming_block is not None:
-            return (ACTIVITY_RESPONDING, ACTIVITY_RESPONDING)
-        return (self._working_fallback, self._working_fallback)
+            return (ACTIVITY_RESPONDING, ACTIVITY_RESPONDING, True)
+        return (self._working_fallback, self._working_fallback, True)
 
     @staticmethod
     def _batch_phrase(cards: list[ToolCard]) -> str:
@@ -32818,7 +32837,18 @@ class OperatorApp(App[None]):
         # different receipts, decided only by whether the viewer was watching.
         # Not a second stamp: this is #858's own number, read where it already
         # arrives, and a card with its own clock ignores it.
+        # Read BOTH halves. `ToolExecutionEndEvent` syncs `is_error` with
+        # `result.is_error` through a validator, but has no equivalent for
+        # `duration_s`, so the two can drift and an emitter that fills only the
+        # nested one ships an event whose live consumer reads `None` while a
+        # replay of the same call reads the number off the persisted payload —
+        # the two-receipts asymmetry this whole path exists to close. The
+        # sibling consumer of this wire shape (`subagent_view`, which folds a
+        # child's trajectory) already falls back the same way; this is the
+        # second reader of the same field and is no more entitled to assume.
         measured_s = getattr(event, "duration_s", None)
+        if measured_s is None:
+            measured_s = getattr(getattr(event, "result", None), "duration_s", None)
         if event.is_error:
             card.mark_failed(_first_line(result_text), result_text, details, measured_s=measured_s)
         else:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -17792,7 +17792,7 @@ class OperatorApp(App[None]):
         Asks the SAME deriver the working line and the title use, so the three
         cannot disagree about whether a turn is parked.
         """
-        _, phase, _ = self._current_activity()
+        _, phase, _, _ = self._current_activity()
         if phase != ACTIVITY_APPROVAL:
             return
         asking = self._ask_pending is not None and not self._ask_pending.done()
@@ -32085,8 +32085,8 @@ class OperatorApp(App[None]):
         """
         if self._working_block is not None:
             return
-        label, phase, clock = self._current_activity()
-        self._working_block = WorkingBlock(label, phase, clock=clock)
+        label, phase, clock, clock_from = self._current_activity()
+        self._working_block = WorkingBlock(label, phase, clock=clock, clock_from=clock_from)
         self._append_block(self._working_block, ends_empty_state=ends_empty_state, pin_tail=True)
 
     def _dismiss_working_block(self) -> None:
@@ -32115,9 +32115,9 @@ class OperatorApp(App[None]):
         a stop reaches this hook without either of those paths knowing a title
         exists.
         """
-        label, phase, clock = self._current_activity()
+        label, phase, clock, clock_from = self._current_activity()
         if self._working_block is not None:
-            self._working_block.set_activity(label, phase, clock=clock)
+            self._working_block.set_activity(label, phase, clock=clock, clock_from=clock_from)
         waiting = phase == ACTIVITY_APPROVAL
         if self._status is not None:
             self._status.set_attention(waiting)
@@ -32152,17 +32152,45 @@ class OperatorApp(App[None]):
         elif not waiting:
             self._waiting_kind = None
 
-    def _current_activity(self) -> tuple[str, str, bool]:
-        """What the agent is doing right now: ``(label, phase, clock)``.
+    def _current_activity(self) -> tuple[str, str, bool, float | None]:
+        """What the turn is doing: ``(label, phase, clock, clock_from)``.
 
-        ``clock`` is whether the phase's zero is the WORK's zero, i.e. whether
-        the elapsed number the band draws would be true. It is False only for a
-        ``running`` phase every one of whose cards was adopted mid-execution by
-        a sidebar switch: the phase changes when the viewer arrives, not when
-        the tool started, so the clock would count from the switch while naming
-        a tool that may be half an hour old (design round 2, D6). Derived here
-        rather than latched at the switch for the same reason the label is — one
-        deriver, so the band cannot disagree with the ledger under it.
+        ``clock`` is whether the elapsed number the band draws would be TRUE at
+        all. ``clock_from`` is the instant it should count from when it is:
+        ``None`` means the phase's own zero is correct, which it is for every
+        state but a running tool batch.
+
+        Two fields because the two design findings against this row are
+        different questions, and one bit cannot answer both:
+
+        * ``clock=False`` for a ``running`` phase ANY of whose cards was adopted
+          mid-execution by a sidebar switch. The phase changes when the viewer
+          arrives, not when the tool started, so the number would count from the
+          switch while naming a tool that may be half an hour old (design round
+          2, D6). Round 2 wrote ``any``, arguing one watched card puts a true
+          floor under the number — but a floor is not a measurement, and an
+          adopted sibling may be arbitrarily older than the oldest start the
+          band can see, so the reading is an understatement of unbounded size
+          (design round 3, D9). Withheld is the honest rendering.
+        * ``clock_from`` is the OLDEST of the cards' own starts, because the
+          phase's zero decays even when every card dates itself. A batch that
+          sheds calls keeps the phase at ``running``, so the zero stayed at the
+          switch while the label narrowed to the one survivor: a ``read``
+          printing ``0s`` on its own receipt, one line above a band reading
+          ``running read  14s`` (design round 3, D9). ``all`` alone does not
+          close that — the survivor there dates itself perfectly well; it is
+          the ANCHOR that is wrong. Counting from the cards' own starts makes
+          the number describe the work the label names in every batch shape.
+
+        Shedding a call still does not restart the clock, which is what round 1
+        pinned: a surviving card's start does not move when a sibling settles,
+        so the minimum only ever rises to a survivor that is genuinely younger
+        than the batch it came from — which is the case where holding the old
+        zero was the lie.
+
+        Derived here rather than latched at the switch for the same reason the
+        label is — one deriver, so the band cannot disagree with the ledger
+        under it.
 
         DERIVED from the same state the transcript is drawn from rather than
         latched by each handler, so the line cannot disagree with the ledger
@@ -32187,22 +32215,26 @@ class OperatorApp(App[None]):
             # FIRST, above the approval prompt: the picker is a modal drawn over
             # everything, so it is what the user is looking at even if a card
             # underneath is also waiting.
-            return ("waiting for your answer", ACTIVITY_APPROVAL, True)
+            return ("waiting for your answer", ACTIVITY_APPROVAL, True, None)
         if self._approval is not None and not self._approval.answered:
             # Nothing is running: the turn is parked on the question on screen,
             # and "thinking" under an unanswered prompt blames the model for a
             # wait that belongs to the user.
-            return ("waiting for approval", ACTIVITY_APPROVAL, True)
+            return ("waiting for approval", ACTIVITY_APPROVAL, True, None)
         if self._tool_cards:
             cards = list(self._tool_cards.values())
-            # ANY card that dates itself is enough. The clock measures the phase,
-            # and the phase began when the first of these calls started, so one
-            # card this viewer watched start puts a true floor under the number;
-            # it is only when EVERY card was adopted that the zero is unknown.
+            starts = [card.started_at for card in cards]
+            # EVERY card must date itself, and the zero is then the OLDEST of
+            # their own starts rather than the phase change. One unknown start
+            # poisons the batch's zero, because the call a clock claims to
+            # measure is exactly the oldest one. See the docstring.
+            known = [s for s in starts if s is not None]
+            dateable = len(known) == len(starts)
             return (
                 self._batch_phrase(cards),
                 "running",
-                any(card.dates_itself for card in cards),
+                dateable,
+                min(known) if dateable else None,
             )
         if self._composing_cards:
             # The tool's NAME is deliberately absent. It arrives in fragments —
@@ -32211,10 +32243,10 @@ class OperatorApp(App[None]):
             # and `composing wr` reads as a typo rather than as a state.
             count = len(self._composing_cards)
             noun = "a call" if count == 1 else f"{count} calls"
-            return (f"composing {noun}", "composing", True)
+            return (f"composing {noun}", "composing", True, None)
         if self._streaming_block is not None:
-            return (ACTIVITY_RESPONDING, ACTIVITY_RESPONDING, True)
-        return (self._working_fallback, self._working_fallback, True)
+            return (ACTIVITY_RESPONDING, ACTIVITY_RESPONDING, True, None)
+        return (self._working_fallback, self._working_fallback, True, None)
 
     @staticmethod
     def _batch_phrase(cards: list[ToolCard]) -> str:

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -1110,7 +1110,23 @@ class ToolCard(ExpandableActionBlock):
         self.finalize()
 
     def mark_interrupted(self) -> None:
-        """Turn ended before this tool completed: dim 'interrupted' state."""
+        """Turn ended before this tool completed: dim 'interrupted' state.
+
+        Takes NO ``measured_s``, unlike :meth:`mark_done` and
+        :meth:`mark_failed`, and the asymmetry is a property of the path rather
+        than an omission (design round 2, D7). Those two settle a card because
+        an END EVENT arrived, and that event carries the executor's measured
+        interval; this one settles a card because the turn died with no end
+        event for it at all. ``_retire_live_tool_cards`` reaches exactly the
+        cards still in the live registry, and ``on_tool_ended`` removes a card
+        from that registry the instant its result lands \u2014 so a card arriving
+        here has by construction never been told how long its call ran, and
+        there is no number available to fall back to. A blank duration on a row
+        adopted mid-execution is therefore the honest reading rather than a lost
+        one: nothing on this surface ever knew that call's zero. A row that
+        watched its own start still prints its own elapsed below, which is the
+        one clock here that is true.
+        """
         was_composing = self._state == "composing"
         self._settle_live()
         if was_composing:
@@ -1173,6 +1189,19 @@ class ToolCard(ExpandableActionBlock):
         number that says the tool returned instantly.
         """
         return None if self._started is None else time.monotonic() - self._started
+
+    @property
+    def dates_itself(self) -> bool:
+        """Whether this card knows when its call actually began.
+
+        False for a row this viewer ADOPTED mid-execution: the page painted it
+        after the tool started, so it has no zero and deliberately blanks its
+        own duration (see :meth:`restore`). Exposed because the band above the
+        transcript keys its clock to the phase these cards decide, and a phase
+        derived from a card that cannot date itself must not print a number
+        counted from the moment the phase changed (design round 2, D6).
+        """
+        return self._started is not None
 
     def restore(
         self,

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -231,6 +231,14 @@ NAME_GROWTH_MIN_ROW = 70
 #: of it lands in the same column whether the tool took 0.4s or 12.3s. Five
 #: cells covers every duration the format produces up to ``9999s``.
 DURATION_COL = 5
+#: What a live row with no clock puts in the status column (see
+#: ``_status_runs``). Its LENGTH is load-bearing, not just its wording: it is
+#: sized to the settled spine — ``<glyph> `` plus :data:`DURATION_COL` — so the
+#: status column reserves the same cells before and after the tool returns and
+#: the summary beside it is budgeted identically at both ends. A label of any
+#: other width makes the row reflow on settling at narrow widths. Any
+#: replacement must keep that equality; assert it rather than eyeballing it.
+RUNNING_LABEL = "running"
 #: Minimum summary budget before we drop the expand hint (D8 floor).
 _SUMMARY_FLOOR = 16
 #: Indent of the expanded output block, aligned under the tool name column.
@@ -1018,10 +1026,33 @@ class ToolCard(ExpandableActionBlock):
         self._refresh_row()
 
     # -- lifecycle ----------------------------------------------------------
-    def mark_done(self, result_text: str = "", details: dict[str, Any] | None = None) -> None:
-        """Record success with elapsed duration; the row goes quiet."""
+    def mark_done(
+        self,
+        result_text: str = "",
+        details: dict[str, Any] | None = None,
+        *,
+        measured_s: float | None = None,
+    ) -> None:
+        """Record success with elapsed duration; the row goes quiet.
+
+        ``measured_s`` is the executor's own interval, carried by
+        ``ToolExecutionEndEvent.duration_s``. It is a FALLBACK, not an
+        override: a card that timed its own execution keeps its own reading, so
+        the ordinary live row is unchanged. It exists for the row that CANNOT
+        time itself — one this viewer adopted mid-execution, whose ``_started``
+        is deliberately unset because the page painted it after the tool began
+        (see :meth:`restore`). Without it that row settled to a blank column
+        while a replay of the very same call read ``✓ 4.2s`` off the persisted
+        payload: the same call, two different receipts, decided by whether the
+        viewer happened to be watching.
+        """
         self._settle_live()
         self._duration = self._elapsed()
+        if self._duration is None:
+            # Through the same validator every externally-produced interval
+            # passes: the value crossed a socket, so a NaN or a negative must
+            # degrade to the blank column rather than print nonsense.
+            self._duration = parse_duration(measured_s)
         self._state = "success"
         self._absorb_result(result_text, details)
         self.remove_class("tool-running")
@@ -1031,13 +1062,24 @@ class ToolCard(ExpandableActionBlock):
         self.finalize()
 
     def mark_failed(
-        self, error: str, result_text: str = "", details: dict[str, Any] | None = None
+        self,
+        error: str,
+        result_text: str = "",
+        details: dict[str, Any] | None = None,
+        *,
+        measured_s: float | None = None,
     ) -> None:
         """Record failure with a ONE-line error message.
 
         ``result_text`` defaults to the error itself: a failed tool's full
         message is frequently a stack trace or a multi-line diagnostic, and
         that is exactly what the expansion exists to show.
+
+        ``measured_s`` is the same fallback :meth:`mark_done` documents, and is
+        accepted here for the same reason: a failing tool that this viewer
+        adopted mid-execution is as entitled to its measured interval as a
+        succeeding one, and the two settle paths must not disagree about which
+        rows can show a duration.
         """
         # `_settle_live`, not just a duration: `mark_failed` was the ONE settle
         # path that never stopped the clock. Harmless while only a composing
@@ -1046,6 +1088,8 @@ class ToolCard(ExpandableActionBlock):
         # tool would have left a 1 Hz timer repainting a finalized card.
         self._settle_live()
         self._duration = self._elapsed()
+        if self._duration is None:
+            self._duration = parse_duration(measured_s)
         self._state = "error"
         self._error = _strip_control_sequences(" ".join(error.split())) or "error"
         self._absorb_result(result_text or error, details)
@@ -1177,8 +1221,28 @@ class ToolCard(ExpandableActionBlock):
         # show the exact same receipt as the live card did.
         self._duration = max(0.0, duration_s) if duration_s is not None else None
         if state == "running":
-            # Still live: it keeps `tool-running`, it is not finalized, and the
-            # expansion still offers the command. Only the clock is withheld.
+            # Back to LIVE from wherever the card was, and asserted rather than
+            # assumed. This arm used to say "it keeps `tool-running`", which was
+            # true only of `subagent_view`'s caller — it restores a card it has
+            # just built. `OperatorApp._mark_pending_tool_rows` restores a
+            # REPLAYED row that `replay_tool_call` already put through
+            # `restore(state="interrupted")`, so "keeps" left the one row on
+            # screen actually executing wearing `tool-interrupted` and NOT
+            # `tool-running`: the only live row with no raised background, and
+            # the stale class then survived into the settled row, because
+            # `mark_done` removes `tool-running` and nothing else.
+            self.remove_class("tool-interrupted", "tool-error", "tool-success")
+            self.add_class("tool-running")
+            # Un-finalized for the same reason: a replayed row arrives frozen
+            # under the FINALIZED-BLOCK protocol, and a card claiming to execute
+            # must not also answer `settled_rows() == 1` — the transcript's
+            # spacing and scroll accounting read that number. `_refresh_row`
+            # bypassing finalization for its own repaint hid the disagreement
+            # rather than resolving it. Every settle path finalizes again, so
+            # the freeze comes back with the outcome.
+            self._finalized = False
+            # Only the clock stays withheld; the expansion still offers the
+            # command.
             self._refresh_row()
             return
         self.remove_class("tool-running")
@@ -2346,17 +2410,38 @@ class ToolCard(ExpandableActionBlock):
             # the column the ✓ beside it will use when it settles. The spine
             # holds and the row does not jump on settling.
             #
-            # A REPLAYED live row reports nothing at all. `subagent_view`
-            # rebuilds a child's trajectory into cards and leaves the
-            # outcome-less ones running, where `_started` is when the PAGE
-            # painted the row — so this counted up from zero and reset to zero
-            # every time an earlier entry changed. A clock started from the
-            # wrong zero is worse than no clock, and the settled rows on that
-            # same page already blank the column for exactly this reason.
+            dim = bindings.style("tool.status.running_duration")
+            # A REPLAYED live row has no CLOCK. `subagent_view` rebuilds a
+            # child's trajectory into cards and leaves the outcome-less ones
+            # running, and `_mark_pending_tool_rows` repaints a row the owner is
+            # still executing; in both, `_started` is when the PAGE painted the
+            # row — so a clock here counted up from zero and reset to zero every
+            # time an earlier entry changed. A clock started from the wrong zero
+            # is worse than no clock.
+            #
+            # "No clock" is NOT "no state", though, and returning `[]` made this
+            # the only row in the ladder with an empty status column — silent in
+            # the exact cell a reader checks to answer "is this thing alive?",
+            # which is the frame the paragraph above exists to prevent (a silent
+            # row and a stuck row are the same frame). It is sharpest here: a
+            # 30-minute `wait` is reached by a deliberate sidebar switch made to
+            # ask that very question. So say the state in words, the way
+            # `waiting` does one arm up — the honest, number-free statement the
+            # expansion already shows as `⋯ running`.
+            #
+            # Sized to the settled spine deliberately: "running" is exactly
+            # `<glyph> ` + DURATION_COL cells, so the row occupies the same
+            # cells before and after settling and the summary is budgeted
+            # identically at every width. A shorter label would let the summary
+            # grow while running and then LOSE characters at the instant the
+            # tool returned — the row rewriting itself under the reader's eye at
+            # narrow widths. Shed whole below the width that holds it, never
+            # truncated: a clipped `runn…` is noise, and an outcome glyph here
+            # would falsely claim the tool completed.
             elapsed = self._elapsed()
             if elapsed is None:
-                return []
-            dim = bindings.style("tool.status.running_duration")
+                text = RUNNING_LABEL if not cap or cap >= len(RUNNING_LABEL) else ""
+                return [(text, dim)]
             text = format_duration(max(0, int(elapsed)))
             return [("  ", dim), (text.rjust(DURATION_COL), dim)]
         core = self._outcome_runs(cap, terse=terse)

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -1191,17 +1191,22 @@ class ToolCard(ExpandableActionBlock):
         return None if self._started is None else time.monotonic() - self._started
 
     @property
-    def dates_itself(self) -> bool:
-        """Whether this card knows when its call actually began.
+    def started_at(self) -> float | None:
+        """When this call began on the monotonic clock, or ``None`` if unknown.
 
-        False for a row this viewer ADOPTED mid-execution: the page painted it
-        after the tool started, so it has no zero and deliberately blanks its
-        own duration (see :meth:`restore`). Exposed because the band above the
-        transcript keys its clock to the phase these cards decide, and a phase
-        derived from a card that cannot date itself must not print a number
-        counted from the moment the phase changed (design round 2, D6).
+        ``None`` for a row this viewer ADOPTED mid-execution: the page painted
+        it after the tool started, so it has no zero and deliberately blanks its
+        own duration (see :meth:`restore`).
+
+        Exposed as the INSTANT rather than as a "does it date itself" boolean
+        because the band above the transcript needs both halves of the answer.
+        It withholds its clock when any card cannot date itself (design round 2,
+        D6) — that is the boolean — but when every card can, it must also count
+        from the oldest of these starts rather than from the moment the phase
+        changed, or a shrinking batch leaves the band naming one tool and
+        reporting an age belonging to another (design round 3, D9).
         """
-        return self._started is not None
+        return self._started
 
     def restore(
         self,

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -2487,7 +2487,13 @@ class WorkingBlock(TranscriptBlock):
     #: Pinned by ``test_the_line_holds_one_row_whatever_the_clock_says``.
     _CLOCK_COL = 8
 
-    def __init__(self, activity: str = DEFAULT_ACTIVITY, phase: str = DEFAULT_ACTIVITY) -> None:
+    def __init__(
+        self,
+        activity: str = DEFAULT_ACTIVITY,
+        phase: str = DEFAULT_ACTIVITY,
+        *,
+        clock: bool = True,
+    ) -> None:
         super().__init__()
         self.add_class("working-block")
         self._frame_ms: float = 0.0
@@ -2496,6 +2502,8 @@ class WorkingBlock(TranscriptBlock):
         self._timer = None
         self._activity = activity or DEFAULT_ACTIVITY
         self._phase = phase
+        # Whether this phase's zero is the WORK's zero. See :meth:`set_activity`.
+        self._clock_known = clock
         # The clock times the CURRENT PHASE, not the turn and not the label: how
         # long the agent has been busy altogether is the status band's
         # `duration` segment, and the question this line answers is the other
@@ -2509,8 +2517,23 @@ class WorkingBlock(TranscriptBlock):
         """The label currently on the line (what the turn is doing)."""
         return self._activity
 
-    def set_activity(self, activity: str, phase: str | None = None) -> None:
+    def set_activity(self, activity: str, phase: str | None = None, *, clock: bool = True) -> None:
         """Name what the turn is doing now.
+
+        ``clock=False`` says the caller knows the LABEL but not when the work it
+        names began, and the number is then withheld rather than counted from
+        this moment. The case that forced it: a sidebar switch adopts a tool the
+        owner has been executing for half an hour, so the phase becomes
+        ``running <tool>`` here — at the instant of the switch. The clock is
+        phase-keyed, so it restarted, and the band read ``running await_job 2s``
+        beside a card that had deliberately blanked its own duration for exactly
+        this reason (design review round 2, D6). Naming the tool is what makes
+        the adjacent number read as a claim ABOUT that tool, so the label is
+        kept and the clock is dropped: this row's whole contract is that every
+        number on it was derived from an event the app received, and a clock
+        started from the wrong zero is worse than no clock. There is no honest
+        alternative reading available — the start event carries no timestamp, so
+        the true age is not recoverable on this surface at any price.
 
         The clock restarts only when the PHASE changes, not whenever the label
         does. Keying it to the rendered string made the row refute itself: one
@@ -2526,9 +2549,10 @@ class WorkingBlock(TranscriptBlock):
         if phase != self._phase:
             self._phase = phase
             self._phase_started = time.monotonic()
-        elif activity == self._activity:
+        elif activity == self._activity and clock == self._clock_known:
             return
         self._activity = activity
+        self._clock_known = clock
         self._paint()
 
     def on_mount(self) -> None:
@@ -2605,8 +2629,9 @@ class WorkingBlock(TranscriptBlock):
             return
         # With shimmer off the spinner is frozen too (D26 pins a still frame),
         # so the clock is the only thing that can change and a repaint landing
-        # on the same second is one nobody can see.
-        if self._clock_text() != self._clock:
+        # on the same second is one nobody can see. A phase with no clock has
+        # nothing left that can change at all, so it repaints never.
+        if self._clock_known and self._clock_text() != self._clock:
             self._paint()
 
     def _clock_text(self) -> str:
@@ -2627,11 +2652,15 @@ class WorkingBlock(TranscriptBlock):
         # the band stuttering. Focused, `motion_enabled()` is exactly
         # `shimmer_enabled()`, so nothing about the looked-at frame changes.
         animated = motion_enabled()
-        # ALWAYS shown, from the first frame. It is the one fact this row has
-        # that nothing else on screen does — a running tool's own card carries
-        # no duration until it settles, and the band's clock is the session's
-        # cumulative active time, not this phase's age.
-        self._clock = self._clock_text()
+        # Shown from the first frame WHENEVER the phase's zero is the work's
+        # zero. It is the one fact this row has that nothing else on screen does
+        # — a running tool's own card carries no duration until it settles, and
+        # the band's clock is the session's cumulative active time, not this
+        # phase's age. Withheld only where the caller says the zero is unknown
+        # (`set_activity(clock=False)`), because the alternative is a number
+        # counted from the wrong instant beside the name of the work it appears
+        # to describe.
+        self._clock = self._clock_text() if self._clock_known else ""
         # A frozen frame rather than no glyph when shimmer is off: the braille
         # head is unique to this row either way, which is what a still terminal
         # needs to tell it from an info notice.
@@ -2665,7 +2694,12 @@ class WorkingBlock(TranscriptBlock):
         # from `100h4m` and `100h45m`, and this number matters most exactly when
         # it is largest. That is why the fix for the overflow review round 15
         # found is a days branch in the formatter, not a clip here.
-        line.append(f"  {truncate_cells(self._clock, self._CLOCK_COL - 2)}", style=dim)
+        # The clock's cells stay RESERVED above even when the number is
+        # withheld, so a phase that cannot date itself clips its label at the
+        # same column as one that can — dropping the number must not reflow the
+        # text beside it.
+        if self._clock:
+            line.append(f"  {truncate_cells(self._clock, self._CLOCK_COL - 2)}", style=dim)
         # `layout=False`: this row is ONE row by construction (see above — the
         # label is clipped, never wrapped), so its footprint cannot move and the
         # update is a repaint. The default laid the whole screen out again on

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -2445,6 +2445,15 @@ class WorkingBlock(TranscriptBlock):
     #: a stale age for a gap that is still growing, which is the one number
     #: this line exists to report. One repaint a second is what the clock's own
     #: resolution needs and no more.
+    #:
+    #: It is also, and not by accident, exactly
+    #: :data:`~local_operator.tui.animation.BLURRED_SPINNER_INTERVAL_S` — the
+    #: rate the band, the sidebar and both subagent surfaces turn their heads
+    #: at on a blurred terminal. This row reaches the same cadence from the
+    #: clock's side, so one timer serves both and a blurred row advances its
+    #: glyph in step with every other spinner on screen. Asserted in
+    #: ``test_render_throttling`` rather than left as a coincidence for
+    #: someone to "tidy" apart.
     _STATIC_FRAME_MS = 1000
 
     #: The head glyph, cycled off the same timer as the shimmer. The braille
@@ -2493,12 +2502,19 @@ class WorkingBlock(TranscriptBlock):
         phase: str = DEFAULT_ACTIVITY,
         *,
         clock: bool = True,
+        clock_from: float | None = None,
     ) -> None:
         super().__init__()
         self.add_class("working-block")
         self._frame_ms: float = 0.0
         self._tick_ms: float = self._FRAME_MS
         self._animated = True
+        # The head's position on the STILL path, advanced once per tick while
+        # the terminal is blurred. Separate from ``_frame_ms`` (the shimmer's
+        # phase) because the two run at different rates, and pinned at 0 while
+        # the shimmer kill switch is on so a silenced frame stays byte-identical
+        # and reproducible for the snapshot harness. See :meth:`_tick`.
+        self._still_head = 0
         self._timer = None
         self._activity = activity or DEFAULT_ACTIVITY
         self._phase = phase
@@ -2509,6 +2525,9 @@ class WorkingBlock(TranscriptBlock):
         # `duration` segment, and the question this line answers is the other
         # one — how long the thing on screen has been the thing on screen.
         self._phase_started = time.monotonic()
+        # A zero supplied by the CALLER, overriding the phase's own. See
+        # :meth:`set_activity`; ``None`` means the phase's zero is correct.
+        self._clock_from = clock_from
         self._clock = ""
         self._paint()
 
@@ -2517,8 +2536,26 @@ class WorkingBlock(TranscriptBlock):
         """The label currently on the line (what the turn is doing)."""
         return self._activity
 
-    def set_activity(self, activity: str, phase: str | None = None, *, clock: bool = True) -> None:
+    def set_activity(
+        self,
+        activity: str,
+        phase: str | None = None,
+        *,
+        clock: bool = True,
+        clock_from: float | None = None,
+    ) -> None:
         """Name what the turn is doing now.
+
+        ``clock_from`` overrides the phase's zero with one the caller measured,
+        for the case where the phase outlives the work it names. A running batch
+        keeps the phase at ``running`` as it sheds calls, so a batch that
+        narrowed to its youngest call went on counting from the batch's start
+        while naming only the survivor — a ``read`` printing ``0s`` on its own
+        receipt one line above a band reading ``running read  14s`` (design
+        round 3, D9). The caller passes the oldest start among the cards the
+        label covers, so the number describes the work named rather than the
+        phase containing it. ``None`` keeps the phase's own zero, which is right
+        for every state whose label and phase begin together.
 
         ``clock=False`` says the caller knows the LABEL but not when the work it
         names began, and the number is then withheld rather than counted from
@@ -2549,10 +2586,15 @@ class WorkingBlock(TranscriptBlock):
         if phase != self._phase:
             self._phase = phase
             self._phase_started = time.monotonic()
-        elif activity == self._activity and clock == self._clock_known:
+        elif (
+            activity == self._activity
+            and clock == self._clock_known
+            and clock_from == self._clock_from
+        ):
             return
         self._activity = activity
         self._clock_known = clock
+        self._clock_from = clock_from
         self._paint()
 
     def on_mount(self) -> None:
@@ -2623,22 +2665,48 @@ class WorkingBlock(TranscriptBlock):
         self._paint()
 
     def _tick(self) -> None:
+        from local_operator.tui.shimmer import shimmer_enabled
+
         self._frame_ms += self._tick_ms
         if self._animated:
             self._paint()
             return
-        # With shimmer off the spinner is frozen too (D26 pins a still frame),
-        # so the clock is the only thing that can change and a repaint landing
-        # on the same second is one nobody can see. A phase with no clock has
-        # nothing left that can change at all, so it repaints never.
+        # BLURRED, NOT SILENCED. Reaching here with the shimmer still enabled
+        # means the only gate that fired was focus — and focus is allowed to
+        # drop the RATE of animation, never its content (`animation.py`'s stated
+        # invariant). So the head advances one glyph per tick, which is already
+        # the app's blurred cadence (see `_STATIC_FRAME_MS`), exactly as the
+        # status band and both subagent surfaces do.
+        #
+        # Without this the row froze completely whenever it had no clock to
+        # draw: D26 pins the glyph on the still path, so the clock was the last
+        # moving thing on the row, and a phase that cannot date itself has none
+        # — measured at ZERO repaints over 4s, a static `running await_job` with
+        # a dead head (design round 3, D8). A stopped spinner and a finished job
+        # look identical, and this app uses motion as its word for alive; that a
+        # tool this viewer adopted is the one case where the row can say nothing
+        # else makes it the worst row to freeze, not an acceptable one.
+        if shimmer_enabled():
+            self._still_head = (self._still_head + 1) % len(self._SPINNER)
+            self._paint()
+            return
+        # Shimmer OFF is a deliberate still frame (D26), so the clock is the
+        # only thing that can change and a repaint landing on the same second is
+        # one nobody can see. A phase with no clock repaints never — correct
+        # here, because nothing on the row is meant to be moving.
         if self._clock_known and self._clock_text() != self._clock:
             self._paint()
 
     def _clock_text(self) -> str:
-        """How long the current PHASE has run, in the ledger's own grammar."""
+        """How long the work on the line has run, in the ledger's own grammar.
+
+        The phase's own zero unless the caller supplied a truer one — see
+        ``clock_from`` in :meth:`set_activity`.
+        """
         from local_operator.tui.widgets.tool_card import format_duration
 
-        return format_duration(time.monotonic() - self._phase_started)
+        zero = self._phase_started if self._clock_from is None else self._clock_from
+        return format_duration(time.monotonic() - zero)
 
     def _paint(self) -> None:
         from local_operator.tui.animation import motion_enabled
@@ -2664,8 +2732,17 @@ class WorkingBlock(TranscriptBlock):
         # A frozen frame rather than no glyph when shimmer is off: the braille
         # head is unique to this row either way, which is what a still terminal
         # needs to tell it from an info notice.
-        head = self._SPINNER[int(self._frame_ms // self._SPIN_MS) % len(self._SPINNER)]
-        head = f"{head} " if animated else f"{self._SPINNER[0]} "
+        #
+        # Two clocks drive it, because the still path is not always still. The
+        # shimmer's own phase (`_frame_ms`) at full rate; `_still_head` when the
+        # terminal is merely blurred, where `_tick` turns it once a second. With
+        # the shimmer kill switch on, `_tick` never advances `_still_head`, so
+        # this stays pinned at frame 0 and a silenced frame is reproducible.
+        if animated:
+            head = self._SPINNER[int(self._frame_ms // self._SPIN_MS) % len(self._SPINNER)]
+        else:
+            head = self._SPINNER[self._still_head]
+        head = f"{head} "
         # ONE row, always. The block is SPACING_TRANSIENT, so nothing below it
         # re-measures against its height; a label that wrapped would take rows
         # it had told the transcript it would not, and the intents it shows are

--- a/scripts/wait_card_clock_shot.py
+++ b/scripts/wait_card_clock_shot.py
@@ -1,0 +1,205 @@
+"""Capture the two states design round 3 raised against the band's clock.
+
+The switch shot beside this one captures the ADOPTED row; this one captures the
+two edges that suppression opened, because neither is visible in that frame:
+
+``blurred.svg``/``blurred-next.svg``
+    A row whose phase cannot date itself, on a BLURRED terminal — the state
+    where D26 pins the head glyph and the withheld clock leaves nothing else
+    that can move (design round 3, D8). Captured as a consecutive PAIR, since
+    the finding is that the row does not change: one still cannot show motion,
+    and two identical stills are the defect itself.
+
+``shrinking.svg``
+    A batch that has shed the calls it was named for, leaving one young
+    survivor (design round 3, D9). The frame carries the card's own receipt and
+    the band together, which is what makes the number checkable by eye: the
+    band must not claim an age the card above it contradicts.
+
+Run from the worktree root:
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/wait_card_clock_shot.py OUTDIR [COLSxROWS]
+
+Both states are aged on a REAL wall clock. ``pilot.pause()`` yields without
+advancing time, so a batch aged with it alone is milliseconds old and a clock
+counted from the wrong zero looks correct — which is how D6 survived round 1.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.visual_capture import isolate_capture, save_capture  # noqa: E402
+
+isolate_capture()
+
+from textual.pilot import Pilot  # noqa: E402
+
+from local_operator.harness.types import (  # noqa: E402
+    ToolExecutionEndEvent,
+    ToolExecutionStartEvent,
+    ToolResult,
+)
+from local_operator.tui import animation  # noqa: E402
+from local_operator.tui.app import OperatorApp, ToolCard  # noqa: E402
+from local_operator.tui.events import ToolEnded, ToolStarted, TurnStarted  # noqa: E402
+from local_operator.tui.widgets.editor import Editor  # noqa: E402
+from local_operator.tui.widgets.transcript import WorkingBlock  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+#: Seconds to age the batch before the frame. Large enough that a clock counted
+#: from the wrong zero differs VISIBLY from the right one at the row's own
+#: resolution — the number is what the frame is for.
+AGE_S = 14.0
+
+
+def _started(call_id: str, name: str, **args: object) -> ToolStarted:
+    return ToolStarted(ToolExecutionStartEvent(tool_call_id=call_id, tool_name=name, args=args))
+
+
+def _ended(call_id: str, name: str) -> ToolEnded:
+    return ToolEnded(
+        ToolExecutionEndEvent(
+            tool_call_id=call_id,
+            tool_name=name,
+            result=ToolResult(tool_call_id=call_id, tool_name=name, content=[]),
+        )
+    )
+
+
+async def _age(pilot: Pilot[None], seconds: float) -> None:
+    """Advance REAL time while the app keeps painting."""
+    until = time.monotonic() + seconds
+    while time.monotonic() < until:
+        await pilot.pause()
+        await asyncio.sleep(0.05)
+
+
+def _band(app: OperatorApp) -> WorkingBlock:
+    band = app._working_block
+    # Asserted rather than assumed: a missing band prints `None` for the clock,
+    # which reads as "no wrong number shown", i.e. as the fix working.
+    assert band is not None, "no working line is mounted"
+    return band
+
+
+async def main() -> None:
+    outdir = Path(sys.argv[1])
+    outdir.mkdir(parents=True, exist_ok=True)
+    size = (120, 24)
+    if len(sys.argv) > 2:
+        cols, rows = sys.argv[2].split("x")
+        size = (int(cols), int(rows))
+
+    # ---- D8: a clockless row on a blurred terminal ------------------------
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        app.query_one(Editor).cursor_blink = False
+        # THE SHIMMER PIN MUST COME OFF for this capture, and only for this
+        # one. `isolate_capture()` sets LOCAL_OPERATOR_NO_SHIMMER=1 so exported
+        # frames are reproducible — but that is the OTHER still path, the one
+        # D26 deliberately freezes. Leaving it on captures a silenced row whose
+        # pinned head is correct, and would read as the D8 defect reproducing
+        # after it was fixed. The gate under test is FOCUS.
+        os.environ.pop("LOCAL_OPERATOR_NO_SHIMMER", None)
+        app.post_message(TurnStarted())
+        app.post_message(_started("c0", "await_job", job_id="7a73c97ffc54"))
+        await pilot.pause()
+        card = [b for b in app._transcript_view().blocks() if isinstance(b, ToolCard)][0]
+        # ADOPTED: exactly what a sidebar switch leaves behind. The card clears
+        # its own zero, so the phase cannot be dated and the band withholds.
+        card.restore(state="running")
+        app._refresh_working_activity()
+        await _age(pilot, 2.0)
+
+        app._set_animation_focused(False)
+        await pilot.pause()
+        band = _band(app)
+        print("== D8: blurred, clockless row ==")
+        print(f"motion_enabled()  : {animation.motion_enabled()}")
+        print(f"band label        : {band._activity!r}")
+        print(f"band clock        : {band._clock!r}")
+
+        heads: list[str] = []
+        save_capture(app, outdir / "blurred.svg")
+        heads.append(band._SPINNER[band._still_head])
+        # A CONSECUTIVE frame one blurred tick later. The pair is the evidence:
+        # the finding is a row that does not change, which one still cannot show.
+        await _age(pilot, 1.2)
+        save_capture(app, outdir / "blurred-next.svg")
+        heads.append(band._SPINNER[band._still_head])
+        await _age(pilot, 1.2)
+        save_capture(app, outdir / "blurred-next2.svg")
+        heads.append(band._SPINNER[band._still_head])
+        print(f"heads across 3 frames: {heads}  distinct={len(set(heads))}")
+        print(f"clock still withheld : {band._clock!r}")
+        app._set_animation_focused(True)
+        # Restore the pin for the D9 capture below, which wants the ordinary
+        # reproducible frame.
+        os.environ["LOCAL_OPERATOR_NO_SHIMMER"] = "1"
+
+    # ---- D9: the band beside a batch that shrank --------------------------
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        app.query_one(Editor).cursor_blink = False
+        app.post_message(TurnStarted())
+        app.post_message(_started("old", "await_job", job_id="7a73c97ffc54"))
+        await pilot.pause()
+        # AGE the first call for real, so the batch's zero is genuinely old.
+        await _age(pilot, AGE_S)
+
+        # The owner refills a slot: `max_parallel_tools` is 8 and the worker
+        # refills as slots free, so a batch over eight calls starts its tail
+        # after the viewer arrived. This is that tail.
+        app.post_message(_started("new", "read", path="local_operator/tui/app.py"))
+        await pilot.pause()
+        app._refresh_working_activity()
+        band = _band(app)
+        print()
+        print("== D9: batch shrinking to a young survivor ==")
+        print(f"2 running   : {band._activity!r}  clock={band._clock!r}")
+
+        # The old call settles. The phase never leaves `running`, so the zero is
+        # not re-derived by the phase machinery — the label narrows to `read`.
+        app.post_message(_ended("old", "await_job"))
+        await pilot.pause()
+        app._refresh_working_activity()
+        # Let the survivor age WELL past the row's one-second resolution before
+        # the frame. At a sub-second age the band and the card can legitimately
+        # round to different integers, and a frame whose two numbers differ by
+        # one is unreadable as evidence either way \u2014 the finding was a gap of
+        # fourteen seconds, so the capture has to make the agreement obvious.
+        shed_age = 4.0
+        await _age(pilot, shed_age)
+        app._refresh_working_activity()
+        band = _band(app)
+        cards = [b for b in app._transcript_view().blocks() if isinstance(b, ToolCard)]
+        survivor = [c for c in cards if c.tool_name == "read"][0]
+        real = time.monotonic() - (survivor.started_at or time.monotonic())
+        # Paint both rows at the SAME instant before exporting. The card and the
+        # band run independent one-second tickers, so a frame sampled between
+        # their ticks can show two integers a second apart for one underlying
+        # value \u2014 a paint-cadence artifact that is present on base too, and that
+        # would muddy a frame whose whole subject is whether the two numbers
+        # agree. This forces the state the next tick reaches anyway; it does not
+        # change either clock's zero.
+        band._paint()
+        survivor._refresh_row()
+        await pilot.pause()
+        save_capture(app, outdir / "shrinking.svg")
+        print(f"1 survivor  : {band._activity!r}  clock={band._clock!r}")
+        print(f"survivor real age    : {real:.1f}s")
+        print(f"batch age (old zero) : {AGE_S + shed_age:.1f}s   <- what the band used to say")
+        print(f"overstatement        : {AGE_S + shed_age - real:.1f}s")
+
+
+asyncio.run(main())

--- a/scripts/wait_card_ladder_shot.py
+++ b/scripts/wait_card_ladder_shot.py
@@ -1,0 +1,111 @@
+"""Capture the tool-card state ladder, including the restored-live row.
+
+The row this PR newly reaches — a replayed card the owner is still executing —
+has no clock, so the question the frames answer is whether it still says it is
+alive, and whether saying so keeps the row STILL when the tool returns.
+
+Run from the worktree root:
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/wait_card_ladder_shot.py OUT.svg [COLSxROWS] [settled]
+
+``settled`` captures the same ladder with the restored row settled to success,
+which is the pair that shows whether the summary beside it moved.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.visual_capture import isolate_capture, save_capture  # noqa: E402
+
+isolate_capture()
+
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.editor import Editor  # noqa: E402
+from local_operator.tui.widgets.tool_card import ToolCard  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+#: One call shape across the whole ladder, so a difference between rows is a
+#: difference of STATE and never of content.
+ARGS = {"job_id": "7a73c97ffc54", "wait_ms": 1800000}
+TOOL = "await_job"
+
+
+def _card(call_id: str) -> ToolCard:
+    return ToolCard(call_id, TOOL, dict(ARGS))
+
+
+async def main() -> None:
+    out = sys.argv[1]
+    size = (120, 24)
+    if len(sys.argv) > 2:
+        cols, rows = sys.argv[2].split("x")
+        size = (int(cols), int(rows))
+    settled = len(sys.argv) > 3 and sys.argv[3] == "settled"
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        app.query_one(Editor).cursor_blink = False
+
+        # 1: natively live — the only row with a real start time, so the only
+        # one entitled to a clock.
+        native = _card("call-native")
+        app._append_block(native)
+        native._started = time.monotonic() - 34.0
+
+        # 2: the state this PR newly reaches. Built the way the app builds it:
+        # replay paints `interrupted`, then `_mark_pending_tool_rows` repaints.
+        restored = _card("call-restored")
+        app._append_block(restored)
+        restored.restore(state="interrupted")
+        restored.restore(state="running")
+
+        waiting = _card("call-waiting")
+        app._append_block(waiting)
+        waiting.mark_waiting()
+
+        success = _card("call-success")
+        app._append_block(success)
+        success._started = time.monotonic() - 0.4
+        success.mark_done("job 7a73c97ffc54 finished")
+
+        error = _card("call-error")
+        app._append_block(error)
+        error._started = time.monotonic() - 12.0
+        error.mark_failed("exit status 1", "exit status 1")
+
+        interrupted = _card("call-interrupted")
+        app._append_block(interrupted)
+        interrupted._started = time.monotonic() - 5.0
+        interrupted.mark_interrupted()
+
+        await pilot.pause()
+        if settled:
+            # The settle leg of the SAME row: this is the pair that shows
+            # whether the summary moved when the outcome arrived.
+            restored._started = time.monotonic() - 1800.0
+            restored.mark_done("job 7a73c97ffc54 still running after 1800000ms")
+            await pilot.pause()
+        await pilot.pause()
+        save_capture(app, out)
+        print(f"wrote {out}")
+        for label, card in (
+            ("native   ", native),
+            ("restored ", restored),
+            ("waiting  ", waiting),
+            ("success  ", success),
+            ("error    ", error),
+            ("interrupt", interrupted),
+        ):
+            runs = [text for text, _style in card._status_runs()]
+            print(f"{label} state={card._state:<12} status_runs={runs}")
+
+
+asyncio.run(main())

--- a/scripts/wait_card_switch_shot.py
+++ b/scripts/wait_card_switch_shot.py
@@ -13,6 +13,12 @@ Run from the worktree root:
 Writes ``<outdir>/switch.svg`` (the moment after the switch, tool still
 parked) and ``<outdir>/settled.svg`` (the same row once the tool returns) —
 the pair that shows whether the row moved when its outcome arrived.
+
+The tool is deliberately AGED on a real wall clock before the switch (see
+``AGE_S``), because the band under the row keys its elapsed clock to the phase
+and the phase changes at the moment the viewer arrives. Without a visible age
+the band's number and the tool's true age are indistinguishable in the frame,
+which is exactly how D6 survived round 1.
 """
 
 from __future__ import annotations
@@ -20,6 +26,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import sys
+import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -43,6 +50,11 @@ from tests.unit.tui.test_sidebar_live_tool_card import (  # noqa: E402
     _switch,
     live_owners,
 )
+
+#: Seconds to let the tool genuinely execute before the viewer switches in.
+#: Large enough that a clock restarted at the switch reads visibly differently
+#: from the tool's real age — the whole point of the capture.
+AGE_S = 12.0
 
 
 async def main() -> None:
@@ -85,15 +97,33 @@ async def main() -> None:
                         e.get("type") == "tool_execution_start" for e in state.live_events
                     ):
                         break
-                for _ in range(40):
+                # AGE the call on a real clock while the viewer is elsewhere.
+                # `pilot.pause()` alone yields without advancing wall time, so
+                # the tool would be milliseconds old at the switch and a band
+                # clock counting from the wrong zero would look correct.
+                aged_from = time.monotonic()
+                while time.monotonic() - aged_from < AGE_S:
                     await pilot.pause()
+                    await asyncio.sleep(0.05)
 
                 await _switch(app, "busy01", pilot)
                 app._set_sidebar_open(False)
                 await pilot.pause()
+                real_age = time.monotonic() - aged_from
                 save_capture(app, outdir / "switch.svg")
                 cards = [b for b in app._transcript_view().blocks() if isinstance(b, ToolCard)]
                 print("switch  :", cards[0]._state, [t for t, _s in cards[0]._status_runs()])
+                # The D6 evidence: the tool's REAL age beside what the band says
+                # about it. A number here that is not `real_age` is the finding.
+                band = app._working_block
+                # Asserted, not assumed: a switch that left no band mounted
+                # would otherwise print `None` and read as "no clock shown",
+                # i.e. as the fix working.
+                assert band is not None, "no working line is mounted after the switch"
+                print(f"tool real age    : {real_age:.1f}s")
+                print(f"band label       : {band._activity!r} (phase {band._phase!r})")
+                print(f"band clock shown : {band._clock!r}")
+                print(f"card dates itself: {cards[0].dates_itself}")
 
                 released.set()
                 for _ in range(MAX_PUMP_TURNS):

--- a/scripts/wait_card_switch_shot.py
+++ b/scripts/wait_card_switch_shot.py
@@ -123,7 +123,7 @@ async def main() -> None:
                 print(f"tool real age    : {real_age:.1f}s")
                 print(f"band label       : {band._activity!r} (phase {band._phase!r})")
                 print(f"band clock shown : {band._clock!r}")
-                print(f"card dates itself: {cards[0].dates_itself}")
+                print(f"card dates itself: {cards[0].started_at is not None}")
 
                 released.set()
                 for _ in range(MAX_PUMP_TURNS):

--- a/scripts/wait_card_switch_shot.py
+++ b/scripts/wait_card_switch_shot.py
@@ -1,0 +1,116 @@
+"""Capture the reported frame itself: a sidebar switch into a parked tool.
+
+The ladder shot next to this one compares STATES; this one captures the actual
+reported surface, through real owners over real sockets and the production
+sidebar path, so the evidence is the frame the operator sees rather than a
+reconstruction of it.
+
+Run from the worktree root:
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/wait_card_switch_shot.py OUTDIR [COLSxROWS]
+
+Writes ``<outdir>/switch.svg`` (the moment after the switch, tool still
+parked) and ``<outdir>/settled.svg`` (the same row once the tool returns) —
+the pair that shows whether the row moved when its outcome arrived.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.visual_capture import isolate_capture, save_capture  # noqa: E402
+
+isolate_capture()
+
+# pytest's own fixture implementation, usable outside a test: `live_owners`
+# patches through it, and borrowing the real class rather than a hand-rolled
+# double means this script exercises the same patching (and the same undo) the
+# test suite does.
+from _pytest.monkeypatch import MonkeyPatch  # noqa: E402
+
+from local_operator.tui.app import OperatorApp, ToolCard  # noqa: E402
+from local_operator.tui.widgets.editor import Editor  # noqa: E402
+from tests.e2e.harness import wait_for_adoption  # noqa: E402
+from tests.unit.harness.test_comms import DEADLOCK_GUARD_S, MAX_PUMP_TURNS  # noqa: E402
+from tests.unit.tui.test_sidebar_live_tool_card import (  # noqa: E402
+    _parking_tool,
+    _switch,
+    live_owners,
+)
+
+
+async def main() -> None:
+    outdir = Path(sys.argv[1])
+    outdir.mkdir(parents=True, exist_ok=True)
+    size = (120, 24)
+    if len(sys.argv) > 2:
+        cols, rows = sys.argv[2].split("x")
+        size = (int(cols), int(rows))
+
+    import os
+    import tempfile
+
+    config = Path(tempfile.mkdtemp(prefix="wait-card-shot-")) / "config"
+    os.environ["LOCAL_OPERATOR_CONFIG_DIR"] = str(config)
+    released = asyncio.Event()
+    monkey = MonkeyPatch()
+    try:
+        async with live_owners(config, ["home00", "busy01"], _parking_tool(released), monkey) as r:
+            app = OperatorApp(lambda: r("home00"), resume_factory=r)
+            async with app.run_test(size=size) as pilot:
+                await wait_for_adoption(app, pilot)
+                app.query_one(Editor).cursor_blink = False
+                app._set_sidebar_open(True)
+                if app._sidebar_timer is not None:
+                    app._sidebar_timer.pause()
+
+                # Visit while idle, leave: what files the unanswered call into
+                # the hidden viewer's live history, which is the replay this
+                # whole surface is about.
+                await _switch(app, "busy01", pilot)
+                await _switch(app, "home00", pilot)
+
+                owner = r.servers["busy01"]._handle._session  # type: ignore[attr-defined]
+                turn = asyncio.create_task(owner.prompt("await the fix"))
+                for _ in range(MAX_PUMP_TURNS):
+                    await pilot.pause()
+                    state = owner.frontend_state
+                    if state.streaming and any(
+                        e.get("type") == "tool_execution_start" for e in state.live_events
+                    ):
+                        break
+                for _ in range(40):
+                    await pilot.pause()
+
+                await _switch(app, "busy01", pilot)
+                app._set_sidebar_open(False)
+                await pilot.pause()
+                save_capture(app, outdir / "switch.svg")
+                cards = [b for b in app._transcript_view().blocks() if isinstance(b, ToolCard)]
+                print("switch  :", cards[0]._state, [t for t, _s in cards[0]._status_runs()])
+
+                released.set()
+                for _ in range(MAX_PUMP_TURNS):
+                    await pilot.pause()
+                    if cards[0]._state not in ("running", "waiting"):
+                        break
+                for _ in range(20):
+                    await pilot.pause()
+                save_capture(app, outdir / "settled.svg")
+                print("settled :", cards[0]._state, [t for t, _s in cards[0]._status_runs()])
+                with contextlib.suppress(Exception):
+                    await asyncio.wait_for(turn, DEADLOCK_GUARD_S)
+    finally:
+        released.set()
+        # Same discipline the fixture keeps: this script patches module globals,
+        # so it puts them back rather than leaving a mutated interpreter.
+        monkey.undo()
+
+
+asyncio.run(main())

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -2062,6 +2062,103 @@ async def test_the_post_abort_backfill_reports_how_long_the_tool_actually_RAN():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("cleanup_s", [ABORT_DRAIN_TIMEOUT_S + 0.5, ABORT_DRAIN_TIMEOUT_S + 4.0])
+async def test_the_backfill_measures_the_abort_not_the_drain_deadline(cleanup_s: float):
+    """Review round 3, MAJOR-4. The stamp must be a property of the TOOL.
+
+    Round 2 gave this emitter a duration; it stamped ``now``, and ``now`` here
+    is not a fact about the tool. The backfill runs only after the drain loop
+    has waited out ``ABORT_DRAIN_TIMEOUT_S``, and a call is routed here only
+    BECAUSE its unwind outran that budget — so ``now - started_at`` always
+    contains the whole drain wait. A tool that did 0.1s of work reported 2.1s,
+    and reported it for cleanups of 2.5s, 4s and 8s alike: the number was the
+    deadline, constant for every call that reaches this emitter.
+
+    That is the failure this PR exists to remove, arriving through the fix for
+    it — a plausible wrong number on the ONE surface that can print only what
+    the executor measured (a viewer that adopted the row has no zero of its
+    own), and it persists into ``provider_payload`` for every later replay.
+
+    Parametrised over two cleanup lengths straddling nothing in particular but
+    differing by 3.5s, because the tell is not the absolute value: it is that
+    the reading does NOT move when only the cleanup moves. A stamp taken at the
+    deadline would be ~equal across both AND ~equal to the budget; a stamp taken
+    at the abort is ~equal across both AND ~equal to the work. Asserting against
+    the work is what distinguishes them.
+    """
+    started = asyncio.Event()
+    # The tool's REAL work, held constant while the cleanup varies. Generous
+    # enough to sit well clear of scheduling noise and far below the budget, so
+    # "measured the tool" and "measured the deadline" cannot be confused.
+    ran_for = 0.3
+
+    async def execute(tool_call_id, args, signal, on_update, context) -> ToolResult:
+        started.set()
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            # Outruns the drain budget, which is what routes this call through
+            # the BACKFILL rather than through `park`'s own stamped emitter.
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.sleep(cleanup_s)
+            raise
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="stubborn", content=[TextContent(text="late")]
+        )
+
+    tool = AgentTool(
+        name="stubborn", parameters={"type": "object", "properties": {}}, execute=execute
+    )
+    stream = ScriptedStream(
+        [
+            [
+                tool_call_delta(0, id="c1", name="stubborn", args="{}"),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext(tools=[tool])
+    config = make_config(stream, interrupt_mode="immediate", has_steering_messages=lambda: False)
+    signal = AbortSignal()
+    loop = AgentLoop()
+
+    events: list[Any] = []
+
+    async def run() -> None:
+        async for event in loop.run([Message.user("go")], context, config, signal):
+            events.append(event)
+
+    task = asyncio.ensure_future(run())
+    await asyncio.wait_for(started.wait(), timeout=5)
+    await asyncio.sleep(ran_for)
+    signal.abort("interrupted")
+    await asyncio.wait_for(task, timeout=ABORT_DRAIN_TIMEOUT_S + cleanup_s + 15)
+
+    ends = [e for e in events if isinstance(e, ToolExecutionEndEvent)]
+    assert len(ends) == 1
+    measured = ends[0].duration_s
+    assert measured is not None
+
+    # THE ASSERTION THAT FAILS ON THE OLD CODE. The stamp must not contain the
+    # drain wait: anything at or past the budget is the deadline leaking in.
+    # Bounded well under it rather than at it, so the test states "measured the
+    # tool" rather than merely "not quite the whole budget".
+    assert measured < ABORT_DRAIN_TIMEOUT_S / 2, (
+        f"reported {measured:.3f}s for {ran_for}s of work with a {cleanup_s}s cleanup: "
+        "the stamp is measuring the drain budget, not the tool"
+    )
+    # And it IS the span, not merely a small number: a floor, because the sleep
+    # bounds the work from below and nothing measures it exactly.
+    assert measured >= ran_for
+    # Both halves and the persisted receipt carry the corrected number.
+    assert ends[0].result.duration_s == measured
+    payload = Message.tool_result(ends[0].result).provider_payload
+    assert payload is not None
+    assert payload["duration_s"] == measured
+
+
+@pytest.mark.asyncio
 async def test_a_late_parking_tool_is_not_robbed_of_its_end_event_mid_backfill(monkeypatch):
     """The final flush must emit an end parked after the drain has expired.
 

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -1970,6 +1970,98 @@ async def test_a_slow_unwind_still_reports_the_tool_as_ENDED():
 
 
 @pytest.mark.asyncio
+async def test_the_post_abort_backfill_reports_how_long_the_tool_actually_RAN():
+    """Review round 2, MAJOR-3. The backfill was the one emitter with no clock.
+
+    Three of the four ``ToolExecutionEndEvent`` emitters are built inside the
+    runner that owns ``started_at`` and stamp ``duration_s`` from it. The
+    post-abort backfill is built in the batch body instead, and so reported a
+    call it had genuinely measured \u2014 the tool really did execute for a span
+    before the abort cut it off \u2014 as having no duration at all.
+
+    That mattered beyond tidiness because ``duration_s`` has no validator ORing
+    it with ``result.duration_s`` the way ``_sync_error_flag`` does for the
+    error bit. The number is the ONLY record of the interval: a viewer that
+    watched the call start times it locally, but one that adopted the row
+    mid-execution (a sidebar switch) has no zero of its own and can print only
+    what the executor measured. So the same aborted call showed a duration to
+    the viewer who happened to be watching and a blank to the one who was not,
+    and a replay off the persisted payload agreed with neither.
+
+    Both halves are asserted, because filling one alone is what produced the
+    split: the live consumer reads the top-level field and a replay reads the
+    nested one.
+    """
+    started = asyncio.Event()
+    # Long enough that a stamp of 0.0 (or a missing one) is unambiguous, short
+    # enough not to pad the suite. Asserted as a floor, never as an equality:
+    # the sleep is a lower bound on the span, not a measurement of it.
+    ran_for = 0.4
+
+    async def execute(tool_call_id, args, signal, on_update, context) -> ToolResult:
+        started.set()
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            # Outrun the drain budget, which is what routes this call through
+            # the BACKFILL rather than through `park`'s own stamped emitter.
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.sleep(ABORT_DRAIN_TIMEOUT_S + 2)
+            raise
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="stubborn", content=[TextContent(text="late")]
+        )
+
+    tool = AgentTool(
+        name="stubborn", parameters={"type": "object", "properties": {}}, execute=execute
+    )
+    stream = ScriptedStream(
+        [
+            [
+                tool_call_delta(0, id="c1", name="stubborn", args="{}"),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext(tools=[tool])
+    config = make_config(stream, interrupt_mode="immediate", has_steering_messages=lambda: False)
+    signal = AbortSignal()
+    loop = AgentLoop()
+
+    events: list[Any] = []
+
+    async def run() -> None:
+        async for event in loop.run([Message.user("go")], context, config, signal):
+            events.append(event)
+
+    task = asyncio.ensure_future(run())
+    await asyncio.wait_for(started.wait(), timeout=5)
+    # Let the tool genuinely execute before the abort, so "did it measure?" and
+    # "did it stamp a zero?" are distinguishable in the assertion below.
+    await asyncio.sleep(ran_for)
+    signal.abort("interrupted")
+    await asyncio.wait_for(task, timeout=ABORT_DRAIN_TIMEOUT_S + 10)
+
+    ends = [e for e in events if isinstance(e, ToolExecutionEndEvent)]
+    assert len(ends) == 1
+    end = ends[0]
+    assert end.duration_s is not None, (
+        "the backfill emitted an end event with no interval, so a viewer that "
+        "adopted this row mid-execution can never learn how long it ran"
+    )
+    assert end.duration_s >= ran_for, "the stamp must be the measured span, not a zero"
+    assert end.result.duration_s == end.duration_s, (
+        "the two halves must agree: the live consumer reads the top-level "
+        "field and a replay reads the nested one, and nothing syncs them"
+    )
+    # The receipt a REPLAY reads is the same number, which is the whole point.
+    payload = Message.tool_result(end.result).provider_payload
+    assert payload is not None, "the measured interval must survive into the persisted row"
+    assert payload["duration_s"] == end.duration_s
+
+
+@pytest.mark.asyncio
 async def test_a_late_parking_tool_is_not_robbed_of_its_end_event_mid_backfill(monkeypatch):
     """The final flush must emit an end parked after the drain has expired.
 

--- a/tests/unit/session/test_viewer_protocol.py
+++ b/tests/unit/session/test_viewer_protocol.py
@@ -199,11 +199,11 @@ _INFO_SESSION_EXPRS = frozenset({"session"})
 #: scan cost and no coverage; add one when it starts probing something new.
 #:
 #: The third element is that host's MINIMUM member count, and it is per host for
-#: a structural reason: ``app.py`` derives 104 of the 112 DISTINCT PUBLIC
-#: MEMBERS (and 362 of 413 ``file:line`` SITES, deduped per member and line), so
+#: a structural reason: ``app.py`` derives 105 of the 113 DISTINCT PUBLIC
+#: MEMBERS (and 363 of 414 ``file:line`` SITES, deduped per member and line), so
 #: any single global floor loose enough to survive ordinary churn there cannot
 #: notice a smaller host going dark at all. Measured, not guessed: dropping the
-#: desktop utils host costs 3 VIEWER-ONLY MEMBERS out of 48 and dropping
+#: desktop utils host costs 3 VIEWER-ONLY MEMBERS out of 49 and dropping
 #: ``info/collect.py`` costs 0, so both slid under a global ``>= 40`` — the exact
 #: slack review round 2 (MINOR-1) raised, reproduced one floor higher. A count
 #: stated beside each path fires on the host that actually decayed and names it.
@@ -595,11 +595,11 @@ def test_the_viewer_protocol_covers_what_only_the_facade_has() -> None:
     # ``assert viewer_only`` would still pass (review m3).
     #
     # PER HOST, and that is the whole point rather than a refinement. A GLOBAL
-    # floor cannot do this job at any value: ``app.py`` contributes 104 of the
-    # 112 distinct public MEMBERS, so a number that survives ordinary churn
+    # floor cannot do this job at any value: ``app.py`` contributes 105 of the
+    # 113 distinct public MEMBERS, so a number that survives ordinary churn
     # there is necessarily far above every other host's entire contribution.
     # Measured on this head — dropping the desktop utils host costs 3
-    # viewer-only members of 48, dropping ``info/collect.py`` costs 0 — so both
+    # viewer-only members of 49, dropping ``info/collect.py`` costs 0 — so both
     # single-point decays slid under a global ``>= 40`` exactly as they slid
     # under the ``>= 20`` that review round 2 (MINOR-1) rejected. Raising one
     # number would only move the blind spot. Each host is now asserted against
@@ -723,9 +723,9 @@ def test_app_py_dominates_the_derivation_so_a_global_floor_cannot_work() -> None
     # An exact pin, unlike the ratio above: this is the population the aggregate
     # floor of 40 is set against, so a drop here is the decay that floor exists
     # to catch rather than ordinary churn.
-    assert len(viewer_only) == 48, (
+    assert len(viewer_only) == 49, (
         f"there are {len(viewer_only)} viewer-only members; _SCANNED's comment "
-        "says 48, and the aggregate floor is set at 40 against that number. A "
+        "says 49, and the aggregate floor is set at 40 against that number. A "
         "drop here is the decay that floor exists to catch, so check it is "
         "genuinely a removal before editing this figure."
     )
@@ -938,7 +938,7 @@ def test_every_registered_session_binding_still_matches_the_source() -> None:
 
     The count is pinned as well as the contribution, because the two decays are
     different and only one of them is a rename. DELETING ``source.session``
-    outright costs 2 of 48 viewer-only members — under any floor, per-host or
+    outright costs 2 of 49 viewer-only members — under any floor, per-host or
     aggregate, and invisible to the zero-sites check because a removed entry is
     not an entry that derives nothing. It was the last planted violation this
     guard did not catch. A registered binding is a coverage claim, so removing

--- a/tests/unit/tui/test_render_throttling.py
+++ b/tests/unit/tui/test_render_throttling.py
@@ -524,6 +524,90 @@ async def test_working_block_falls_to_the_static_cadence_on_blur(
 
 
 @pytest.mark.asyncio
+async def test_a_blurred_working_line_still_advances_its_head(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Design round 3, D8. Blur drops the RATE; it may not stop the row.
+
+    Round 2 added a ``_tick`` gate that repainted only when the clock's second
+    changed. Focused that is unreachable (the animated branch returns first),
+    but blur takes the same still path as the shimmer kill switch — and D26
+    pins the head glyph there, so the clock was the last moving thing on the
+    row. A phase that cannot date itself has no clock, so the two together
+    produced a completely static row: measured at ZERO repaints over four
+    seconds, reading ``running await_job`` with a dead head.
+
+    That is precisely the state a sidebar switch leaves behind, which makes it
+    the worst row to freeze rather than an acceptable one — a stopped spinner
+    and a finished job look identical, and this app uses motion as its word for
+    alive. The status band keeps spinning in that state, but it says the
+    SESSION is busy, not that this tool is.
+
+    Asserted as a count of distinct glyphs off the ticker rather than over wall
+    time, per this file's opening note: a timing assertion here proves nothing
+    under load.
+    """
+    app = _running_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(80):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        # The shimmer pin must come OFF, or `motion_enabled()` is False for the
+        # kill-switch reason and the FOCUS gate under test is never isolated.
+        monkeypatch.delenv("LOCAL_OPERATOR_NO_SHIMMER", raising=False)
+        # A phase with no clock: the adopted-tool state from D6. This is the row
+        # that had nothing left to move.
+        working = WorkingBlock("running await_job", "running", clock=False)
+        app._append_block(working)
+        app._working_block = working
+        await pilot.pause()
+
+        app._set_animation_focused(False)
+        await pilot.pause()
+        assert not animation.motion_enabled(), "the still path is the one under test"
+        assert working._tick_ms == WorkingBlock._STATIC_FRAME_MS
+        assert working._timer is not None, "throttled, not stopped"
+
+        painted: list[str] = []
+        original = working.set_content
+
+        def spy(content: Any, **kw: Any) -> None:
+            painted.append(content.plain)
+            original(content, **kw)
+
+        working.set_content = spy  # type: ignore[method-assign]
+        # Ticked directly rather than slept: the cadence is already asserted
+        # above, and this file measures invalidation, never duration.
+        for _ in range(4):
+            working._tick()
+
+        assert len(painted) == 4, (
+            f"a blurred row repainted {len(painted)} times in 4 ticks: with no clock "
+            "and a pinned glyph, nothing on this row says the tool is still alive"
+        )
+        heads = {row.strip()[:1] for row in painted}
+        assert len(heads) == 4, f"the head did not advance: {heads}"
+        assert heads <= set(WorkingBlock._SPINNER)
+        # CONTENT is unchanged by the blur — only the rate dropped. The clock is
+        # still withheld (D6) and the label still names the tool.
+        assert all("running await_job" in row for row in painted)
+        assert not any(ch.isdigit() for row in painted for ch in row.split("await_job")[-1])
+
+        # The shimmer kill switch is NOT focus and must still pin a still frame:
+        # the snapshot harness depends on a silenced frame being reproducible.
+        monkeypatch.setenv("LOCAL_OPERATOR_NO_SHIMMER", "1")
+        painted.clear()
+        frozen = working._still_head
+        for _ in range(4):
+            working._tick()
+        assert working._still_head == frozen, "a silenced frame must not animate"
+        assert painted == [], "shimmer-off with no clock repaints never"
+
+        working.set_content = original  # type: ignore[method-assign]
+
+
+@pytest.mark.asyncio
 async def test_blur_never_drops_content(monkeypatch: pytest.MonkeyPatch) -> None:
     """A blurred session still paints everything it is told.
 

--- a/tests/unit/tui/test_sidebar_live_tool_card.py
+++ b/tests/unit/tui/test_sidebar_live_tool_card.py
@@ -1,0 +1,383 @@
+"""A sidebar switch must not paint a still-running tool call as interrupted.
+
+The operator resumed a session from the sidebar while a long ``wait``
+(``wait_ms=1800000``) was parked. The row read ``⊘ interrupted`` immediately,
+every time, while the band beside it said "working" — and the wait was not
+interrupted at all: it ran to its deadline and returned
+``job … still running after 1800000ms`` through ``_wait``'s clean DEADLINE
+branch, with no ``interrupted_by`` anywhere in the transcript.
+
+So the tool was fine and the PRESENTATION was wrong, and the mechanism is
+structural rather than a race:
+
+* the viewer files each completed live row into ``RemoteSession._live_history``
+  (``_remember_live``), and ``display_history_window()`` hands those rows to
+  the next prepared replay;
+* a conversation sitting in the sidebar therefore replays an assistant message
+  whose ``tool_calls`` have NO answer, because the result does not exist yet;
+* ``session_presentation.replay_tool_call`` has exactly two outcomes for a call
+  with no result — settled, or ``interrupted`` — so it painted ``⊘``;
+* ``_mark_pending_tool_rows`` repainted only rows held by a pending GATE, and a
+  tool that is executing has no gate open.
+
+Nothing retired the card: ``_retire_live_tool_cards`` never runs on this path
+(asserted below, because "a retirement fired" is the other plausible cause and
+ruling it out is what makes this test name the right mechanism).
+
+The guard is a PAIR, and both halves matter equally:
+
+* a call the owner is still executing paints live, never ``⊘``;
+* a call from a turn that really did die mid-flight still paints ``⊘`` — the
+  round-1 Q2 regression referenced throughout ``frontend_state.py`` is exactly
+  the opposite mistake, and a fix that simply stopped painting ``interrupted``
+  would pass the first assertion and reintroduce that one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import tempfile
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from local_operator.harness.types import AgentTool, TextContent, ToolResult
+from local_operator.session.remote import RemoteSession
+from local_operator.session.runtime.owned import OwnedSessionHandle
+from local_operator.session.runtime.server import RuntimeServer
+from local_operator.tui.app import OperatorApp, ToolCard
+from tests.e2e.harness import (
+    ScriptedStream,
+    assistant_message,
+    build_session,
+    seed_transcript,
+    text_turn,
+    tool_call_turn,
+    user_message,
+    wait_for_adoption,
+)
+from tests.unit.harness.test_comms import DEADLOCK_GUARD_S, MAX_PUMP_TURNS
+
+#: Not ``wait``. ``Session._merge_capability_tools`` merges the real ``wait``
+#: builtin into every session it builds, and a same-named double is SHADOWED by
+#: it — the turn then answers ``unknown job …`` and the test passes vacuously
+#: against a settled error row. The bug is about any long-running tool, so a
+#: distinct name is both honest and the only shape that actually exercises it.
+PARKING_TOOL = "await_job"
+
+
+@pytest.fixture(autouse=True)
+def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Headless apps must never rename the caller's real multiplexer workspace.
+    for key in tuple(os.environ):
+        if key.startswith("CMUX_"):
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_NOTIFICATIONS", "1")
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_TERMINAL_TITLE", "1")
+    monkeypatch.setattr(OperatorApp, "_check_for_update", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_terminal_title", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_multiplexer_broadcast", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_herdr_reporter", lambda _self: None)
+
+
+def _parking_tool(released: asyncio.Event) -> AgentTool:
+    """A tool that parks until the test releases it — a `wait` in miniature.
+
+    Real parking rather than a stub returning instantly: the whole question is
+    what the screen shows WHILE a call is outstanding, so the call has to be
+    genuinely outstanding for the duration of the switch.
+    """
+
+    async def execute(
+        call_id: str, _args: Any, _signal: Any, _on_update: Any, _context: Any
+    ) -> ToolResult:
+        await released.wait()
+        return ToolResult(
+            tool_call_id=call_id,
+            tool_name=PARKING_TOOL,
+            content=[TextContent(text="the job finished")],
+        )
+
+    return AgentTool(
+        name=PARKING_TOOL,
+        label="Await",
+        description="Awaits a background job.",
+        parameters={
+            "type": "object",
+            "properties": {"job_id": {"type": "string"}, "wait_ms": {"type": "integer"}},
+            "required": ["job_id"],
+        },
+        execute=execute,
+    )
+
+
+@asynccontextmanager
+async def live_owners(
+    config: Path, ids: list[str], tool: AgentTool, monkeypatch: pytest.MonkeyPatch
+) -> AsyncIterator[Callable[[str | None], Awaitable[RemoteSession]]]:
+    """Real ``RuntimeServer`` owners behind one sidebar, one per id.
+
+    Re-keyed discovery records, for the reason ``test_sidebar_longrun`` states
+    at length: ``registry.publish`` keys by PID and every owner here shares this
+    test's PID, so without this N servers overwrite ONE file and the catalog
+    reports a single live row.
+    """
+    from local_operator.session.runtime import registry
+
+    def publish(record: Any, root: Path | None = None) -> Path:
+        directory = registry.run_dir(root)
+        record.heartbeat_at = time.time()
+        handle, path = tempfile.mkstemp(dir=directory, prefix=".x.", suffix=".tmp")
+        with os.fdopen(handle, "w") as stream:
+            json.dump(record.to_json(), stream)
+        target = directory / f"{record.pid}-{record.session_id}.json"
+        os.replace(path, target)
+        return target
+
+    monkeypatch.setattr(registry, "publish", publish)
+    monkeypatch.setattr(registry, "unpublish", lambda pid, root=None: None)
+
+    servers: dict[str, RuntimeServer] = {}
+    handles: list[OwnedSessionHandle] = []
+    try:
+        for session_id in ids:
+            directory = config / "sessions" / session_id
+            await seed_transcript(
+                directory,
+                [
+                    user_message(f"{session_id} question"),
+                    assistant_message(f"{session_id} saved answer"),
+                ],
+            )
+            stream = ScriptedStream(
+                [
+                    tool_call_turn(
+                        text="Waiting for the subagent to finish.",
+                        tool_name=PARKING_TOOL,
+                        tool_call_id=f"call-{session_id}",
+                        arguments={"job_id": "7a73c97ffc54", "wait_ms": 1800000},
+                    ),
+                    text_turn("the child finished"),
+                ]
+            )
+            owner = build_session(directory, stream, tools=[tool], cwd=config)
+            handle = OwnedSessionHandle(owner, asyncio.get_running_loop(), cwd=str(config))
+            handles.append(handle)
+            server = RuntimeServer(handle, kind="daemon")
+            await server.start_in_process()
+            servers[session_id] = server
+
+        def find(_directory: Path, session_id: str) -> tuple[Any, Any]:
+            server = servers.get(session_id)
+            return (server._record, server._record.pid) if server else (None, None)
+
+        async def never() -> Any:
+            raise AssertionError("view navigation must never take execution ownership")
+
+        async def resume(session_id: str | None) -> RemoteSession:
+            assert session_id is not None
+            return await RemoteSession.connect(
+                servers[session_id]._record,
+                session_id,
+                config_dir=config,
+                takeover_factory=never,
+                display_window=True,
+            )
+
+        monkeypatch.setattr("local_operator.mobile.attach_client.find_owner_record", find)
+        # Exposed on the callable so a test can reach the OWNER session (to run
+        # its turn) without the fixture returning a second value every caller
+        # would have to unpack.
+        resume.servers = servers  # type: ignore[attr-defined]
+        yield resume
+    finally:
+        for server in servers.values():
+            await server.aclose()
+        for handle in handles:
+            await handle.dispose()
+
+
+async def _switch(app: OperatorApp, session_id: str, pilot: Any) -> None:
+    """The production sidebar path: select, then await the connection it opens."""
+    await asyncio.wait_for(app._sidebar_navigation.select(session_id), DEADLOCK_GUARD_S)
+    connection = app._interaction.connection_task
+    if connection is not None:
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(asyncio.shield(connection), DEADLOCK_GUARD_S)
+    for _ in range(40):
+        await pilot.pause()
+
+
+def _cards(app: OperatorApp) -> list[ToolCard]:
+    return [block for block in app._transcript_view().blocks() if isinstance(block, ToolCard)]
+
+
+@pytest.mark.asyncio
+async def test_switching_to_a_session_parked_in_a_tool_paints_a_live_row(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The reported frame, end to end, against real owners over real sockets.
+
+    The sequence is the operator's: visit the conversation while it is idle
+    (which is what leaves a CONNECTED hidden source — the state that files the
+    unanswered call into ``_live_history``), leave it, let its turn park inside
+    a long tool, then click its sidebar row.
+
+    Both ends of the call's life are asserted, because "never paints
+    ``interrupted``" is satisfiable by a card that is stranded live forever:
+    the row must be live during the wait AND settle to its real result when the
+    tool returns.
+    """
+    config = tmp_path / "config"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config))
+    released = asyncio.Event()
+    ids = ["home00", "busy01"]
+    try:
+        async with live_owners(config, ids, _parking_tool(released), monkeypatch) as resume:
+            retirements: list[int] = []
+            original_retire = OperatorApp._retire_live_tool_cards
+
+            def counted_retire(self: OperatorApp) -> int:
+                retirements.append(len(self._tool_cards) + len(self._composing_cards))
+                return original_retire(self)
+
+            monkeypatch.setattr(OperatorApp, "_retire_live_tool_cards", counted_retire)
+
+            app = OperatorApp(lambda: resume("home00"), resume_factory=resume)
+            async with app.run_test(size=(120, 36)) as pilot:
+                await wait_for_adoption(app, pilot)
+                app._set_sidebar_open(True)
+                if app._sidebar_timer is not None:
+                    app._sidebar_timer.pause()  # no background prewarm races
+
+                await _switch(app, "busy01", pilot)
+                await _switch(app, "home00", pilot)
+
+                owner = resume.servers["busy01"]._handle._session  # type: ignore[attr-defined]
+                turn = asyncio.create_task(owner.prompt("await the fix"))
+                for _ in range(MAX_PUMP_TURNS):
+                    await pilot.pause()
+                    state = owner.frontend_state
+                    if state.streaming and any(
+                        event.get("type") == "tool_execution_start" for event in state.live_events
+                    ):
+                        break
+                else:
+                    raise AssertionError("the owner never entered the parking tool")
+                for _ in range(40):
+                    await pilot.pause()
+
+                # PRECONDITION: the call really is unanswered in the rows the
+                # switch is about to replay. Without this the assertion below
+                # could pass because there was nothing to get wrong.
+                # `cast`, because the protocol the app types its sources and
+                # `_session` against does not declare the viewer-only display
+                # surface these preconditions read. The object IS a
+                # `RemoteSession`, which is exactly why the bug reaches here.
+                viewer = cast(Any, app._sidebar_sources["busy01"].session)
+                rows = viewer.display_history_window()
+                unanswered = {
+                    call.id for row in rows for call in (getattr(row, "tool_calls", None) or [])
+                } - {
+                    str(getattr(row, "tool_call_id", ""))
+                    for row in rows
+                    if getattr(row, "role", "") == "tool"
+                }
+                assert unanswered == {"call-busy01"}, (
+                    "the hidden viewer's display window does not carry the in-flight call, "
+                    f"so this test is not exercising the replay path: {unanswered}"
+                )
+
+                retirements.clear()
+                await _switch(app, "busy01", pilot)
+
+                cards = _cards(app)
+                assert [card.tool_call_id for card in cards] == ["call-busy01"]
+                assert cards[0]._state != "interrupted", (
+                    "the sidebar switch painted ⊘ interrupted on a tool the owner is still "
+                    "executing; the session reports streaming="
+                    f"{cast(Any, app._session).frontend_state.streaming}"
+                )
+                assert cards[0]._state in ("running", "waiting"), cards[0]._state
+                # Mechanism B, ruled out rather than assumed: no retirement runs
+                # on this path, so a future change that DOES retire here (and
+                # would reintroduce the ⊘ by another route) fails loudly instead
+                # of silently relying on the repaint above to undo it.
+                assert not retirements, f"a retirement ran during the switch: {retirements}"
+
+                # The other end of the call's life: released, the live row must
+                # take its real outcome rather than stay a spinner forever.
+                released.set()
+                for _ in range(MAX_PUMP_TURNS):
+                    await pilot.pause()
+                    if _cards(app)[0]._state not in ("running", "waiting"):
+                        break
+                else:
+                    raise AssertionError("the live row never settled after the tool returned")
+                assert _cards(app)[0]._state == "success", _cards(app)[0]._state
+                with contextlib.suppress(Exception):
+                    await asyncio.wait_for(turn, DEADLOCK_GUARD_S)
+    finally:
+        released.set()
+
+
+@pytest.mark.asyncio
+async def test_a_call_from_a_turn_that_really_stopped_still_paints_interrupted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The over-fix guard, and the reason the repaint is gated on liveness.
+
+    Same replay path, same unanswered call — but the turn has ENDED. A session
+    killed mid-batch leaves exactly this on disk, and ``⊘ interrupted`` is the
+    honest reading of it: the tool stopped and never reported. A fix that
+    stopped painting ``interrupted`` for an absent result, rather than asking
+    whether the call is still executing, passes the test above and silently
+    reopens the round-1 Q2 defect this one pins shut.
+
+    Driven through ``_mark_pending_tool_rows`` against a session double whose
+    two scans answer for a settled turn, because that is the seam the liveness
+    question is asked at; the pilot test above already covers the assembled
+    path.
+    """
+    from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await wait_for_adoption(app, pilot)
+        await pilot.pause()
+
+        card = ToolCard("dead-call", PARKING_TOOL, {"job_id": "7a73c97ffc54"})
+        card.restore(state="interrupted")
+        assert card._state == "interrupted"
+
+        class Settled:
+            """A session whose turn is over: nothing is pending, nothing runs."""
+
+            def pending_display_tool_ids(self) -> set[str]:
+                return set()
+
+            def executing_display_tool_ids(self) -> set[str]:
+                return set()
+
+        app._mark_pending_tool_rows([card], Settled())
+        assert card._state == "interrupted", (
+            "a call whose turn already ended was repainted live; interrupted must remain "
+            "the outcome for a tool that genuinely stopped mid-flight"
+        )
+
+        # And the positive control on the same seam, so the guard above cannot
+        # pass merely because the repaint is broken for everyone.
+        class Running(Settled):
+            def executing_display_tool_ids(self) -> set[str]:
+                return {"dead-call"}
+
+        app._mark_pending_tool_rows([card], Running())
+        assert card._state == "running"

--- a/tests/unit/tui/test_sidebar_live_tool_card.py
+++ b/tests/unit/tui/test_sidebar_live_tool_card.py
@@ -381,3 +381,160 @@ async def test_a_call_from_a_turn_that_really_stopped_still_paints_interrupted(
 
         app._mark_pending_tool_rows([card], Running())
         assert card._state == "running"
+
+
+@pytest.mark.asyncio
+async def test_a_repainted_row_is_owned_and_settles_when_the_turn_dies(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The third case: the repaint happens, and THEN liveness ends.
+
+    The pair above covers the two endings the call itself can have — the tool
+    returns, or the turn was already over before the switch. Neither covers the
+    ending that arrives from outside: the owner dies with the call outstanding,
+    *after* the row has been repainted live.
+
+    That case is the exact inverse of the bug this file exists for, and it is
+    reachable from ordinary causes rather than only from a killed runtime — a
+    dropped socket deliberately leaves ``_streaming`` True, so a switch during
+    recovery paints ``running`` correctly, and a recovery that then fails ends
+    the turn with the row already painted. The liveness predicate is only ever
+    asked at switch time; nothing re-asks it when the answer changes.
+
+    So the row's settle path cannot be the predicate. It is OWNERSHIP: a card
+    made live must be in the registry every turn-death path iterates, which is
+    what this pins. Asserted at the seam because that is where the invariant
+    lives — the pilot test above already proves the assembled path reaches it.
+    """
+    from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await wait_for_adoption(app, pilot)
+        await pilot.pause()
+
+        card = ToolCard("live-call", PARKING_TOOL, {"job_id": "7a73c97ffc54"})
+        card.restore(state="interrupted")
+
+        class Running:
+            """A session whose turn is executing this call right now."""
+
+            def pending_display_tool_ids(self) -> set[str]:
+                return set()
+
+            def executing_display_tool_ids(self) -> set[str]:
+                return {"live-call"}
+
+        registry: dict[str, ToolCard] = {}
+        app._mark_pending_tool_rows([card], Running(), registry)
+        assert card._state == "running"
+        # The ownership claim itself, stated separately from its consequence:
+        # a repaint that stopped registering would fail HERE, naming the cause,
+        # rather than only at the stranded-row assertion below.
+        assert registry == {"live-call": card}, (
+            "the repainted row was not entered into the live registry, so no "
+            "turn-death path can reach it"
+        )
+
+        # MAJOR-2, on the same row: it must actually WEAR the live styling it
+        # claims, and must not still wear the replay's interrupted class — which
+        # `mark_done` does not remove, so it would otherwise survive into the
+        # settled row.
+        assert "tool-running" in card.classes
+        assert "tool-interrupted" not in card.classes
+        # MINOR-1: a row claiming to execute is not a settled row.
+        assert card.settled_rows() == 0
+
+        # And the consequence: the turn dies with the call outstanding. The
+        # app's own retirement is the path every turn-death site takes.
+        app._tool_cards = registry
+        retired = app._retire_live_tool_cards()
+        assert retired == 1, "the death path could not see the repainted row"
+        assert card._state == "interrupted", (
+            "a row repainted live is stranded ⋯ running after its owner died; "
+            "the frame shows a call executing beside a notice that says it stopped"
+        )
+        assert "tool-running" not in card.classes
+        assert card.settled_rows() == 1
+
+
+def test_a_row_adopted_mid_execution_settles_with_the_measured_interval() -> None:
+    """The settle leg of a clockless row, against #858's measured interval.
+
+    A row repainted live by ``_mark_pending_tool_rows`` has no ``_started`` —
+    deliberately, because the page painted it after the tool began — so it
+    cannot time itself. #858 (``77f1cc75f``) made the executor's own
+    ``duration_s`` survive into the persisted payload, which means a REPLAY of
+    such a call renders ``✓ 4.2s``. Before this, the same call settled LIVE to a
+    blank column: one call, two different receipts, decided only by whether the
+    viewer happened to be watching.
+
+    Pinned as the agreement between the two paths rather than as a literal, and
+    pinned as a FALLBACK: a card that timed its own execution must keep its own
+    reading, or this would silently replace every native row's clock with the
+    executor's.
+    """
+    measured = 4.25
+
+    adopted = ToolCard("adopted", PARKING_TOOL, {"job_id": "7a73c97ffc54"})
+    adopted.restore(state="interrupted")
+    adopted.restore(state="running")
+    assert adopted._started is None, "the adopted row must not invent a start time"
+    adopted.mark_done("done", None, measured_s=measured)
+    assert adopted._duration == measured
+
+    # The replay of the same call, through the path #858 fixed: same receipt.
+    replayed = ToolCard("replayed", PARKING_TOOL, {"job_id": "7a73c97ffc54"})
+    replayed.restore(state="success", result_text="done", duration_s=measured)
+    assert replayed._duration == adopted._duration
+
+    # A row with its OWN clock ignores the fallback — no double stamp.
+    native = ToolCard("native", PARKING_TOOL, {"job_id": "7a73c97ffc54"})
+    native._started = time.monotonic() - 30.0
+    native.mark_done("done", None, measured_s=measured)
+    assert native._duration is not None and native._duration > 29.0
+
+    # And a malformed interval off the wire degrades to the blank column
+    # instead of printing nonsense, the way every external duration must.
+    for bad in (float("nan"), -1.0, "4.2", True, None):
+        card = ToolCard(f"bad-{bad!r}", PARKING_TOOL, {})
+        card.restore(state="interrupted")
+        card.restore(state="running")
+        card.mark_done("done", None, measured_s=bad)  # type: ignore[arg-type]
+        assert card._duration is None, bad
+
+
+def test_a_clockless_running_row_reserves_the_settled_spine() -> None:
+    """D1/D3: the live row says it is alive, in the cells the outcome will use.
+
+    Two facts, and they are one fact: a replayed live row has no ``_started``
+    and must not invent one, so it has no clock — but "no clock" must not
+    become "no state", because this is the one row on screen actually consuming
+    time and the operator switched to it to ask exactly that. And the label's
+    WIDTH is what keeps the row still: the status column competes with the
+    summary for the same budget, so a label narrower than the settled spine
+    lets the summary grow while running and lose characters the instant the
+    tool returns — the text moving under the reader at narrow widths.
+
+    Pinned as an equality against the spine rather than against the literal
+    ``"running"``, so a future relabel that breaks the geometry fails here
+    instead of on a screenshot nobody re-captures.
+    """
+    from local_operator.tui.widgets.tool_card import (
+        DURATION_COL,
+        ICON_SUCCESS,
+        RUNNING_LABEL,
+        cell_len,
+    )
+
+    card = ToolCard("clockless", PARKING_TOOL, {"job_id": "7a73c97ffc54"})
+    card.restore(state="running")
+    assert card._started is None
+    assert [text for text, _style in card._status_runs()] == [RUNNING_LABEL]
+    assert cell_len(RUNNING_LABEL) == cell_len(f"{ICON_SUCCESS} ") + DURATION_COL
+
+    # Shed whole below the width that holds it, never truncated and never
+    # replaced by an outcome glyph that would claim the tool completed — the
+    # same ladder `waiting` uses one arm up.
+    assert [text for text, _style in card._status_runs(cap=len(RUNNING_LABEL))] == [RUNNING_LABEL]
+    assert [text for text, _style in card._status_runs(cap=len(RUNNING_LABEL) - 1)] == [""]

--- a/tests/unit/tui/test_working_line.py
+++ b/tests/unit/tui/test_working_line.py
@@ -429,12 +429,15 @@ async def test_the_band_shows_no_clock_for_a_tool_it_cannot_date() -> None:
 
         line.set_content = spy  # type: ignore[method-assign]
 
-        # A tool this viewer WATCHED start: the phase's zero is the work's zero,
-        # so the clock is true and must still be shown. Wound back rather than
-        # slept, the way the sibling clock tests do it.
+        # A tool this viewer WATCHED start: its own zero is knowable, so the
+        # clock is true and must still be shown. Wound back rather than slept,
+        # the way the sibling clock tests do it — and wound back on the CARD,
+        # because a running batch's clock counts from the oldest call's own
+        # start rather than from the phase change (design round 3, D9).
         card = app._tool_cards["c0"]
-        assert card.dates_itself
-        line._phase_started = time.monotonic() - 30.0
+        assert card.started_at is not None
+        card._started = time.monotonic() - 30.0
+        app._refresh_working_activity()
         line._paint()
         assert composed[-1].rstrip().endswith(format_duration(30)), composed[-1]
 
@@ -442,7 +445,7 @@ async def test_the_band_shows_no_clock_for_a_tool_it_cannot_date() -> None:
         # knows when it began — which is precisely the state a sidebar switch
         # leaves behind (`restore(state="running")` clears `_started`).
         card.restore(state="running")
-        assert not card.dates_itself
+        assert card.started_at is None
         app._refresh_working_activity()
         line._phase_started = time.monotonic() - 30.0
         line._paint()
@@ -455,6 +458,83 @@ async def test_the_band_shows_no_clock_for_a_tool_it_cannot_date() -> None:
         assert format_duration(30) not in painted, painted
 
         line.set_content = original  # type: ignore[method-assign]
+
+
+@pytest.mark.asyncio
+async def test_the_bands_clock_stays_truthful_as_a_batch_sheds_calls() -> None:
+    """Design round 3, D9. The phase outlives the work its label names.
+
+    Round 2 keyed the number to the PHASE and suppressed it only when EVERY
+    card was adopted, arguing that one card this viewer watched start puts a
+    true floor under it. The floor holds at the instant the second card
+    arrives and decays immediately afterwards, because the phase stays
+    ``running`` as the batch sheds calls while the LABEL narrows to whatever
+    survives. A batch adopted at a switch, joined by a fresh call, then reduced
+    to that fresh call, left the band naming the young survivor and reporting
+    the age of the batch it came from — a ``read`` printing ``0s`` on its own
+    receipt one line above a band reading ``running read  14s``.
+
+    Reachable in ordinary use rather than by construction: ``max_parallel_tools``
+    is 8 and the worker refills slots as they free, so any batch of more than
+    eight calls starts its tail after the viewer arrived.
+
+    Two properties are asserted together because either alone is satisfiable by
+    a wrong fix. The number must not exceed the survivor's own age (dropping
+    ``any`` for ``all`` does NOT achieve this — the survivor here dates itself
+    perfectly well; it is the anchor that is wrong), and shedding a call must
+    still not restart the clock, which is what round 1 pinned.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.post_message(TurnStarted())
+        app.post_message(_started("old", "await_job", job_id="7a73c97ffc54"))
+        await pilot.pause()
+        line = _working(app)
+        assert line is not None
+
+        # AGE the first call, then start a second — the shape a batch has when
+        # the viewer arrives mid-execution and the owner refills a slot. Wound
+        # back rather than slept, as the sibling clock tests do it.
+        aged = 14.0
+        app._tool_cards["old"]._started = time.monotonic() - aged
+        app.post_message(_started("new", "read", path="a.py"))
+        await pilot.pause()
+        app._refresh_working_activity()
+        # The batch's clock is the OLDEST call's age: both cards date
+        # themselves, so the number is true of the batch the label describes.
+        assert line._clock_text() == format_duration(aged), line._clock_text()
+
+        # Now the batch sheds the old call and the label narrows to the young
+        # survivor. This is the frame the finding was raised on.
+        app.post_message(_ended("old", "await_job"))
+        await pilot.pause()
+        assert _activity(app) == "running read"
+
+        survivor = app._tool_cards["new"]
+        survivor_started = survivor.started_at
+        assert survivor_started is not None, "the survivor watched its own start"
+        survivor_age = time.monotonic() - survivor_started
+        shown = line._clock_text()
+        # THE ASSERTION THAT FAILS ON THE OLD CODE, which showed ~14s here.
+        # A small tolerance because the survivor ages between the two reads;
+        # the defect was an overstatement of 14s, not of milliseconds.
+        assert shown == format_duration(survivor_age), (
+            f"the band says {shown!r} for a call {survivor_age:.1f}s old: the clock is "
+            "still anchored to the batch the label no longer describes"
+        )
+
+        # Round 1's property still holds: shedding a call does not RESTART the
+        # clock. The survivor's own zero is unchanged by its sibling settling,
+        # so a batch losing a call every twenty seconds still shows a number
+        # past twenty — the "has this been stuck" question the clock answers.
+        app.post_message(_started("third", "bash", command="ls"))
+        await pilot.pause()
+        app._refresh_working_activity()
+        assert line._clock_text() == format_duration(time.monotonic() - survivor_started), (
+            "a call JOINING the batch must not move the zero either: the oldest "
+            "running call is still the one the clock measures"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_working_line.py
+++ b/tests/unit/tui/test_working_line.py
@@ -385,6 +385,79 @@ async def test_the_line_holds_one_row_whatever_the_clock_says() -> None:
 
 
 @pytest.mark.asyncio
+async def test_the_band_shows_no_clock_for_a_tool_it_cannot_date() -> None:
+    """Design round 2, D6. A phase whose zero is not the work's zero says no number.
+
+    The clock is keyed to the PHASE, and a sidebar switch into a session with a
+    tool already executing changes the phase at the moment the viewer arrives —
+    not at the moment the tool started. So the band counted from the switch
+    while NAMING the tool: an operator switching into a thirty-minute ``wait``
+    at minute twenty-eight read ``running await_job  2s``, the one number on
+    screen, attached to the tool's name, understating its age by half an hour.
+
+    That is the same wrong-zero the row itself refuses one line above — an
+    adopted card clears ``_started`` and shows the word ``running`` with no
+    duration, because "a clock started from the wrong zero is worse than no
+    clock". Naming the tool is exactly what turns an adjacent generic clock
+    into a claim about it, so the label is kept and the number is dropped.
+
+    The number is not recoverable by trying harder: ``ToolExecutionStartEvent``
+    carries no timestamp, so the true age of an adopted call does not exist on
+    this surface at any price. Withholding it is the only honest rendering.
+
+    Asserted on the text ``_paint`` COMPOSES rather than on the rendered strip,
+    for the reason the width test above documents: Textual clips a strip to the
+    widget box before it is cached, so a strip assertion cannot tell a withheld
+    clock from a clipped one.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.post_message(TurnStarted())
+        app.post_message(_started("c0", "await_job", job_id="7a73c97ffc54"))
+        await pilot.pause()
+        line = _working(app)
+        assert line is not None
+
+        composed: list[str] = []
+        original = line.set_content
+
+        def spy(content: RenderableType, **kw: Any) -> None:
+            assert isinstance(content, Text), type(content)
+            composed.append(content.plain)
+            original(content, **kw)
+
+        line.set_content = spy  # type: ignore[method-assign]
+
+        # A tool this viewer WATCHED start: the phase's zero is the work's zero,
+        # so the clock is true and must still be shown. Wound back rather than
+        # slept, the way the sibling clock tests do it.
+        card = app._tool_cards["c0"]
+        assert card.dates_itself
+        line._phase_started = time.monotonic() - 30.0
+        line._paint()
+        assert composed[-1].rstrip().endswith(format_duration(30)), composed[-1]
+
+        # Now the adopted row: same call, same label, but the card no longer
+        # knows when it began — which is precisely the state a sidebar switch
+        # leaves behind (`restore(state="running")` clears `_started`).
+        card.restore(state="running")
+        assert not card.dates_itself
+        app._refresh_working_activity()
+        line._phase_started = time.monotonic() - 30.0
+        line._paint()
+        painted = composed[-1]
+
+        assert "await_job" in painted, "the label is the part worth keeping"
+        # No number at all, rather than a different number: the failure this
+        # pins is a plausible-looking clock, so any digits are the defect.
+        assert not any(ch.isdigit() for ch in painted.rsplit("await_job", 1)[-1]), painted
+        assert format_duration(30) not in painted, painted
+
+        line.set_content = original  # type: ignore[method-assign]
+
+
+@pytest.mark.asyncio
 async def test_a_dictated_call_is_reported_before_it_runs() -> None:
     """The longest silence in a turn is a large call streaming its arguments."""
     app = OperatorApp(lambda: _factory(FakeSession()))


### PR DESCRIPTION
Switching to a session through the sidebar while a long `wait` was parked painted its row `⊘ interrupted` immediately, every time — while the band beside it said `working`. The tool was never interrupted.

**Change class: C1 (standard, pre-authorized).** One presentational correction plus its canonical-state query. No schema, no wire change, no new dependency.

## The symptom, and the proof it was not a real interruption

The operator resumed a session from the sidebar with `wait(job_id='7a73c97ffc54', wait_ms=1800000)` outstanding. The row read `⊘ interrupted` at once; the wait kept running and later returned normally.

In `~/.local-operator/sessions/3395b40b8f18/transcript.jsonl` that call returns `job 7a73c97ffc54 still running after 1800000ms` — the clean DEADLINE branch of `tools/builtin.py::_wait` — with **no `interrupted_by` in `details`**. A scan of the 80 most recently-modified transcripts found zero dangling `wait` calls and no `interrupted_by` attributable to a session resume. So the tool was fine and the **presentation** was wrong.

## Which mechanism, established by repro

Two candidates were live going in. The repro settles it: **mechanism A only. Mechanism B is not implicated, and that is asserted rather than assumed.**

**A — durable replay has no result for an in-flight call. CONFIRMED.**

1. `RemoteSession._remember_live` files each completed live row into `_live_history`, and `display_history_window()` returns those rows alongside the durable ones.
2. A conversation sitting in the sidebar is a **connected hidden source**, so it receives the assistant `message_end` carrying the `tool_calls` over the live relay — and files it.
3. The next prepared replay therefore renders an assistant message whose calls have **no answer**, because the result does not exist yet.
4. `session_presentation.replay_tool_call` has exactly two outcomes for a call with no result: settled, or `interrupted`. It paints `⊘`.
5. `_mark_pending_tool_rows` repaints only rows held by a pending **gate**. A tool that is *executing* has no gate open, so nothing ever asked whether the call was still running.

Observed directly, on the real assembled app over real sockets (`display_history_window` shows the unanswered call, and the switch paints it interrupted while the session reports `streaming=True`):

```
hidden viewer connected: RemoteSession
viewer display window: [('user', [], None), ('assistant', [], None),
                        ('user', [], None), ('assistant', ['call-busy01'], None)]
CARDS AFTER SWITCH: [('call-busy01', 'interrupted')]
session streaming: True
```

**B — a retirement runs on the switch. RULED OUT.** `_retire_live_tool_cards` was wrapped with a counting probe for the whole switch. It ran **zero times**:

```
RETIREMENTS: none
```

Consistent with the ledger: the card is not in `_tool_cards` at all on this path (`app._tool_cards: {}`), because it was mounted by *replay*, not by a live `tool_execution_start`. Retirement can only mark cards it holds. Its docstring's unconditionality contract is therefore unchanged and is left as written — the assertion is now pinned by a test so a future change that *does* retire here fails loudly instead of quietly re-opening the `⊘` by another route.

## The change

Fixed at the source, not per tool — `wait`, a background `bash` and `task` all park a turn inside execution the same way.

**`local_operator/session/remote.py`** — the tail scan shared by `pending_display_tool_ids` is lifted into `_unanswered_tail_call_ids()`, and gains a counterpart:

```python
def executing_display_tool_ids(self) -> set[str]:
    """Unanswered calls of a turn that is STILL RUNNING right now."""
    if not self._streaming:
        return set()
    return self._unanswered_tail_call_ids()
```

Gated on `is_streaming` **and** on the latest call group only, so the answer is "this turn, right now" and never "some turn once left a call dangling".

**`local_operator/tui/app.py`** — `_mark_pending_tool_rows` restores those rows to `running`. `restore(state="running")` rather than a live mark, because a replayed row's `_started` is when *this view* painted it, not when the tool began; `restore` clears that stamp, so the card stays live without inventing an elapsed time (the same reason `subagent_view` restores a child's in-flight row this way).

Where the two sets overlap — a gated turn is also a streaming one — **`waiting` wins**: the turn is parked on the user, not on a tool, and letting `running` land on top would paint a call the user has not authorised as though it were already executing.

### `interrupted` is deliberately not weakened

A turn that has **ended** reports nothing from the new query, so a call that really did stop mid-flight keeps its `⊘`. That is the round-1 Q2 regression referenced throughout `frontend_state.py` — the exact opposite mistake — and a fix that simply stopped painting `interrupted` for an absent result would pass the primary test and silently reopen it. It has its own guard test, below.

## Visual evidence

Real `OperatorApp` under `run_test` (so `local_operator.tcss` applies), against two in-process `RuntimeServer` owners over real sockets, driven through the production sidebar `select` → prepare → commit path. Captured with `scripts.visual_capture.save_capture`.

### Before — the reported frame

![before](https://gist.githubusercontent.com/damianvtran/64bb254adacfce9193cd6bdfb74b80a0/raw/618ce99adb754d9098440d507c36cb0be0a9e6f3/pr859-switch-before.svg)

The row reads `interrupted ⊘` while the working line under it says `thinking 2s` and the band says `working`. The frame contradicts itself, which is exactly what the report describes.

### After — the row stays live

![after](https://gist.githubusercontent.com/damianvtran/64bb254adacfce9193cd6bdfb74b80a0/raw/cf2b764cbd7cf8929da5c94430cc227dde6ca5dc/pr859-switch-after.svg)

The `⊘` is gone, the tool name is painted live (`tool-running`), and the row now agrees with the band beside it.

### Consecutive frame — stable, not a paint that settles back

![after settled](https://gist.githubusercontent.com/damianvtran/64bb254adacfce9193cd6bdfb74b80a0/raw/3302025d18c0d8959d7f24c9be389a52f8ac06ce/pr859-switch-settled.svg)

Three consecutive captures were taken; only the working line's clock advances (`1s` → `4s`). Nothing reflows.

### The numbers behind the frames

Geometry sidecars are **byte-identical** across before / after / settled, so this is purely a state-and-colour change with no layout movement:

| frame | TranscriptView size / virtual | ToolCard region | scrollbar |
|---|---|---|---|
| before | `[107, 21]` / `[106, 21]` | `[2, 10, 106, 1]` | `False, False` |
| after | `[107, 21]` / `[106, 21]` | `[2, 10, 106, 1]` | `False, False` |
| after (settled) | `[107, 21]` / `[106, 21]` | `[2, 10, 106, 1]` | `False, False` |

## Behavioural evidence: the whole life of the call

"Never paints `interrupted`" is satisfiable by a card stranded live forever, so **both ends** were exercised on the assembled app.

**Released normally** — the live row takes its real outcome:

```
CARDS AFTER SWITCH:  [('call-busy01', 'running')]
session streaming: True
CARDS AFTER RELEASE: [('call-busy01', 'success')]
streaming after release: False
```

**Aborted instead of released** — the turn dies with the call outstanding, and the row settles rather than stranding. Identical on both trees, so this path is unchanged:

| | on `origin/main` | on this branch |
|---|---|---|
| after switch | `interrupted` ← the bug | `running` |
| after abort | `error` | `error` |

## Regression test

`tests/unit/tui/test_sidebar_live_tool_card.py`, two tests, both driving `run_test()`:

1. **the reported path**, end to end — two real owners, a real parking tool, the real sidebar `select`. Asserts a precondition (the hidden viewer's display window really does carry the unanswered call, so the test cannot pass vacuously), that the card is not `interrupted`, that **no retirement ran**, and that the row settles to `success` once the tool returns.
2. **the over-fix guard** — a call whose turn already ended must still paint `⊘`, with a positive control on the same seam so it cannot pass merely because the repaint is broken for everyone.

**Failing on `origin/main`, passing on this branch.** Same commit, the fix stashed out and back:

```
$ git stash push local_operator/session/remote.py local_operator/tui/app.py
$ .venv/bin/python -m pytest tests/unit/tui/test_sidebar_live_tool_card.py -q -n0
FAILED ...::test_switching_to_a_session_parked_in_a_tool_paints_a_live_row
  AssertionError: the sidebar switch painted ⊘ interrupted on a tool the owner
  is still executing; the session reports streaming=True
FAILED ...::test_a_call_from_a_turn_that_really_stopped_still_paints_interrupted
  AssertionError: assert 'interrupted' == 'running'
2 failed, 2 warnings in 6.64s

$ git stash pop
$ .venv/bin/python -m pytest tests/unit/tui/test_sidebar_live_tool_card.py -q -n0
2 passed, 2 warnings in 7.29s
```

One implementation note worth keeping: the test's parking tool is named `await_job`, **not** `wait`. `Session._merge_capability_tools` merges the real `wait` builtin into every session it builds, so a same-named double is shadowed — the turn answers `unknown job …` and the test passes vacuously against a settled error row. That was caught while building the repro.

## Review round 1 remediation, and the rebase onto #858

Rebased onto `origin/main` at `77f1cc75f` (**#858**, `fix(harness): keep tool bookkeeping when a viewer rebuilds a tool row`). `git range-diff` reports `=` for the original commit — the rebase carried no content change — and the remediation is the commit on top of it.

All eight round-1 findings are answered in ONE commit; the per-finding replies are in the [remediation comment](#issuecomment). The three that change what the code does:

- **the repainted row now has an OWNER.** It was mounted by replay, so it lived in neither live-card registry — and every turn-death path settles cards by iterating exactly those. When the owner died after the switch instead of returning a result, nothing settled it. It is now registered, which is also why the working line names the tool instead of saying `thinking`.
- **it now wears the live styling it claims,** instead of keeping the replay's `tool-interrupted` class (and leaking it into the settled row).
- **it now says it is alive.** It was the only state in the ladder with an empty status column.

### The status column, before and after the remediation

Before — the restored-live row (2nd) is blank in the one cell that answers "is this alive?":

![before](https://gist.githubusercontent.com/damianvtran/64bb254adacfce9193cd6bdfb74b80a0/raw/0bea33f98693702cb97b9a35d8e92449fdc73f44/prehead-ladder-120.svg)

After — it says `running`, sized to the settled spine:

![after](https://gist.githubusercontent.com/damianvtran/64bb254adacfce9193cd6bdfb74b80a0/raw/66a560ae69a5c57183078125c4f8b25270c84b5c/pr859-ladder-120.svg)

No clock is invented. `ToolExecutionStartEvent` carries **no timestamp field** — verified against the owner's own wire events, not just the viewer's — so no restored row can honestly know when its tool began, on either the watched-start or the replayed-from-history path. The row says the state in words, the way `waiting` one row down already does.

The label's WIDTH is load-bearing, not cosmetic: it is sized to `<glyph> ` + `DURATION_COL`, so the status column reserves the same cells before and after settling. That is what fixes D3 — at ≤40 columns the row previously showed the full `1800000` while running and then shrank its own summary to `18…` the instant the tool returned. Measured stable at **120 / 46 / 40 / 34 / 30 / 22**, and pinned by a test asserting the spine equality against the constant rather than against the literal `"running"`.

### Composition with #858 — and a gap it opens on this row

#858 makes a settled row replay with the executor's real `duration_s`. That lands on this surface, and the two did not compose: a row adopted mid-execution has no `_started` (deliberately), so it settled to a **blank** duration while a replay of the *same call* read the interval off the now-persisted payload. Measured, same call, same run:

```
settled LIVE-painted   _duration=None                runs=['✓ ', '     ']
settled REPLAYED       _duration=4.236971707898192   runs=['✓ ', ' 4.2s']
```

One call, two receipts, decided only by whether the viewer happened to be watching. `on_tool_ended` now hands the card the measured interval the `tool_execution_end` event already carries, as a **fallback** — a card that timed its own execution keeps its own reading, so no native row changes — validated through the existing `parse_duration`. This is #858's own number consumed where it already arrives, not a second stamp. After:

```
settled LIVE-painted   _duration=4.20228270906955    runs=['✓ ', ' 4.2s']
settled REPLAYED       _duration=4.20228270906955    runs=['✓ ', ' 4.2s']   AGREE: True
```

## Gates

Re-run in full on the rebased head, in a dedicated worktree with its own venv (`import local_operator` resolves to `/private/tmp/lo-wait-card/...`), exactly as CI runs them:

```
flake8 .                                     rc=0
black --check .                              1172 files unchanged
isort --check-only .                         rc=0
pyright --pythonpath .venv/bin/python .      0 errors, 0 warnings, 0 informations

env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
  17410 passed, 18 skipped, 715 warnings in 1014.45s (0:16:54)

env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
  93 passed, 7 skipped, 5 warnings in 113.94s (0:01:53)
```

No version bump: `pyproject.toml` is untouched at `0.52.11`.

## Rollback

Revert the commit. `executing_display_tool_ids` is additive and read through `getattr`, so a session object without it degrades to exactly today's behaviour.

