### PR TITLE
fix(tui): release parked sidebar viewers after five idle minutes

### DIFF
--- a/docs/design-idle-reap.md
+++ b/docs/design-idle-reap.md
@@ -1,0 +1,476 @@
+# Reaping idle runtimes: parked sidebar sources and the 5-minute clock
+
+Status: **superseded in part by the Decision below.** Branch
+`fix/reap-idle-runtimes`. The analysis in §§1–2 is what was implemented; the
+headline recommendation in §3.1 was **not**.
+
+Every file:line below was read on this branch (base `0cd3a9434`).
+
+---
+
+## Decision (recorded at implementation time)
+
+**Option A — delete the LRU clause and evict the presentation with the source
+— was REJECTED. A timed viewer-side release was built instead.**
+
+Option A is one line and cannot be wrong, and §3.1 argues it well. It was
+rejected for a reason that sits outside this note's frame: it pays its cost in
+exactly the interaction `RETAINED_PRESENTATIONS` was raised from 4 to 12 to
+fix, and that raise was made against measurements (`app.py`: 246 ms loop-CPU
+per cold switch versus 59–65 ms on a hit; 12/40 cache hits at capacity 4
+against 39/40 at 8). Under option A *every* parked conversation becomes a cold
+rebuild on switch-back, which reintroduces precisely the switch-back jitter
+that constant exists to prevent. §3.1 acknowledges this as "the strongest
+objection to the viewer-side fix" and proposes measuring afterwards; the
+measurement that motivated the constant already exists, so the regression was
+taken as known rather than as hypothetical.
+
+**What was built.** A parked source keeps its socket *and* its presentation for
+`SIDEBAR_IDLE_RELEASE_S` (5 minutes). Past that, with no attention in the
+interval, the source is released — socket closed, frontend unsubscribed,
+controller disposed, session disposed — and its presentation is evicted at the
+same time. The runtime then sees `attach_clients()` fall to 0 and reaps itself
+through the existing 3-second residency drain. No wire op, no new frame, no
+protocol change.
+
+This keeps both properties the note treats as mutually exclusive: the
+alternating working set is completely unaffected (a user returning inside the
+window never released anything, so there is zero perf regression on the common
+path), while a conversation genuinely abandoned stops pinning a ~283 MB child.
+The presentation is evicted *with* the source for the reason §3.1 already
+identifies — a released source mints a new `SessionInteraction` and therefore a
+new `token`, so a retained presentation could never hit again.
+
+**What this note got right and was kept verbatim:** the viewer is the only safe
+initiator (§2 — the `retiring` churn loop and the EOF redial storm are both
+real, and both were re-verified in the code before implementing); the clock
+must not reset on socket presence, the band poll or the sidebar refresh (§3.4);
+`is_busy()`/`_should_exit` must not be duplicated viewer-side (§3.4); and the
+`retire_if_unused` offer on the sidebar-leave path (§5) was implemented as
+specified.
+
+**The empty conversation, and an idea that was tried and reverted.** The
+`retire_if_unused` offer on the sidebar-leave path (§5) makes a pristine
+runtime go *immediately* when its viewer lets go, rather than waiting for the
+residency drain. The judgment stays the runtime's (`retire_if_unused` →
+`is_pristine`), never a viewer-side guess at emptiness: only the runtime can
+see an armed wake, a just-arrived peer message, or a second attached viewer.
+
+An earlier revision of this change went further and released an
+apparently-empty source at *park* time, on the reasoning that retaining it buys
+no switch-back because there is no transcript to rebuild. **That was wrong and
+was reverted.** A parked empty conversation is still reachable — `/new`, click
+a session with history, click back is a shipped flow — so disposing it at park
+destroys a source the user can still return to. It was caught by
+`test_sidebar_swap_reset.py::test_returning_to_an_empty_conversation_shows_the_splash_under_a_notice`
+and is now pinned directly in
+`test_sidebar_idle_reap.py::test_an_empty_parked_source_still_waits_out_the_clock`.
+Emptiness changes what the runtime does when the clock expires; it is not a
+licence for the viewer to let go early.
+
+**Consequence for the committed repro tests.** They were written during
+diagnosis and encode "release immediately", so they are not compatible with a
+5-minute clock as literally written. The compressed timeout they now use
+patches `SIDEBAR_IDLE_RELEASE_S`; every assertion is unchanged. See the header
+of `tests/e2e/test_sidebar_runtime_reap_e2e.py`.
+
+---
+
+## 1. The problem as I found it
+
+One TUI process held 15 established attach sockets and 15 runtime children
+(~1.9 GB RSS) while idle for ~30 minutes. Two independent defects produce
+that, and only one of them is the leak.
+
+### Defect 1 — the presentation LRU gates process release
+
+`_sidebar_source_releasable` (`app.py:4618-4646`) ends with:
+
+```python
+and source.session.session_id not in self._sidebar_presentations
+```
+
+`_sidebar_presentations` is the retained-widget LRU, capacity
+`RETAINED_PRESENTATIONS = 12` (`app.py:1372`). Its documented purpose is
+fast switch-back of *prepared Textual widgets* (`app.py:1342-1362`), and the
+constant's own comment prices a parked slot at "~1.5-2.4 MiB RSS ... plus one
+live socket whose owner deltas are still delivered while parked"
+(`app.py:1367-1368`).
+
+**That price is wrong, and the omission is the defect.** A parked
+presentation pins its leased `RemoteSession`, whose attach socket makes the
+runtime's `attach_clients()` return 1 (`server.py:1536-1551`), which is
+term 3 of `process._should_exit` (`process.py:282-283`). So a widget cache
+sized for a *rendering* working set silently became a **process** working
+set: 12 parked conversations pin up to 12 runtime children at ~283 MB each
+(the figure `process.py:75` uses), not 12 × 2 MiB of widgets.
+
+The measured probe in the task confirms nothing else was holding them:
+`retained_for_local_work=False`, `retained_for_auto_work=False`,
+`preparations=0`, no pending gate — the predicate's other five clauses
+(`app.py:4633-4644`) all permitted release. Only LRU membership refused.
+
+Note the asymmetry that proves the LRU clause is not load-bearing for
+correctness: the sidebar-*close* path already drops every source
+unconditionally, LRU membership and all (`app.py:5423` clears
+`_sidebar_presentations` wholesale, then `app.py:5452` releases every
+remaining source with `reason="closed"`). Mass viewer-side release of parked
+sources is therefore an **established, shipped path**, not a new mechanism.
+
+### Defect 2 — no signal distinguishes "attached" from "in use"
+
+`_viewer_attached` (`process.py:230-250`) is a pure presence check on
+`attach_clients()`. `_ClientConn.last_seen` (`server.py:426`) is stamped only
+in `_handle_client`'s request loop (`server.py:1345`, immediately before
+`_on_request`), so for a viewer that sends nothing it is the attach time and
+never moves. The task's 12-second spy on `_on_request` measuring zero ops is
+consistent with the code: I found no periodic op from an attach client —
+`remote.py` has no `set_interval`/keepalive, and the only recurring wire op
+in the tree is the desktop host's `desktop_watch` lease
+(`desktop_sessions.py:354-376`), which is not a terminal TUI.
+
+So today an attached viewer pins its runtime forever, by design
+(`process.py:261-275` argues term 3 as a READINESS signal), and there is no
+existing evidence that could time it out.
+
+---
+
+## 2. The constraint that decides the whole design
+
+**A runtime must not idle-reap itself while a TUI is displaying it.**
+
+`_adopt_session` installs `set_refresh_callback(self._on_runtime_refreshed)`
+on the adopted session (`app.py:6039-6041`). `_on_runtime_refreshed`
+(`app.py:12455-12502`) ends in `self._start_runtime_engage(reason="refresh")`
+— eager and unconditional, by explicit design (`app.py:12458-12461`: "the
+band would show the cold state until the user typed"). The `retiring` frame
+(`server.py:849-880`) lands as `RETIRING_REASON`
+(`attach_client.py:398-404`), which `_on_disconnected` routes to
+`_go_cold(refresh=True)` (`remote.py:3375-3384`), which fires that callback
+(`remote.py:3651`).
+
+Therefore a runtime that idle-reaps itself and announces `retiring` to the
+current TUI gets a **brand-new runtime spawned within ~1 s**: exit → spawn →
+idle → exit, forever. That is strictly worse than the leak — it converts a
+static 1.9 GB into 1.9 GB plus a permanent respawn treadmill.
+
+The frame choice is not a way out. The two available frames are the only
+two, and both are wrong for an idle reap of a displayed session:
+
+| frame | viewer behaviour | verdict for idle-reap |
+|---|---|---|
+| `retiring` | `_go_cold(refresh=True)` → eager re-engage (`remote.py:3383`) | **churn loop** |
+| bare EOF | `_on_disconnected` → `_recovering = True` → `_recover_owner` (`remote.py:3400-3407`) | **worse** — see below |
+| `stopping` | parks in the stopped state, tells the user `/resume` (`server.py:854-857`) | lies; the session did not end |
+
+Bare EOF is worse than it looks for exactly the sources we care about.
+`_can_go_cold` is set from `surface == "desktop"` (`remote.py:485`), and
+`_lease_sidebar_source` calls `RemoteSession.connect` (`app.py:4056-4062`)
+without a `surface` argument, so it defaults to `"terminal"`
+(`remote.py:782`) and `_can_go_cold` is **False**. A parked source that sees
+EOF therefore enters owner-death recovery and, per
+`remote.py:3768-3798`, chases a record for `COLD_FALLBACK_S = 8.0`
+(`remote.py:129`) and then — because it cannot go cold — keeps retrying
+forever while the legacy contract tries to **take over** the session
+(`no_takeover` raises by construction, `app.py:4040-4043`, so it loops).
+A runtime-initiated EOF against a parked sidebar source is a redial storm.
+
+### Confirmed: parked sources install neither callback
+
+I verified the parent's suspicion. `_lease_sidebar_source`
+(`app.py:4027-4085`) installs the event controller (4077-4079) and the
+frontend watch (4080) and **nothing else**. The three lifecycle callbacks —
+`set_takeover_callback`, `set_stopped_callback`, `set_refresh_callback` — are
+installed only in `_adopt_session` (`app.py:6025-6041`), for the CURRENT
+session. `set_went_cold_callback` is defined (`remote.py:3711`) but has no
+caller anywhere in `local_operator/`.
+
+So a parked source has no refresh path (no churn loop) but also no cold path
+(no graceful recovery) — it falls into the redial storm above. Both defects
+point the same way: **the viewer must initiate, because only the viewer knows
+what it is showing.**
+
+---
+
+## 3. Recommendation
+
+### 3.1 Fix defect 1 by deleting the LRU clause and decoupling the two caches
+
+Drop `and source.session.session_id not in self._sidebar_presentations` from
+`_sidebar_source_releasable` (`app.py:4645`). Releasing the *source* (socket,
+subscription, runtime pin) while retaining the *presentation* (widgets) is
+what the two caches were always supposed to mean.
+
+Teardown is already correct for this. `_release_sidebar_source`
+(`app.py:4648-4679`) saves the draft, unsubscribes the frontend, disposes the
+controller and calls `session.dispose()` — which closes the client socket
+(`remote.py:4978-4983`, inside `dispose` at 4964) and nothing else. The runtime
+then sees a client disappear, `attach_clients()` drops to 0, and **the
+existing 3-second drain reaps it** (`process.py:341-359`). No new wire op, no
+new frame, no protocol change, and the runtime keeps full authority over its
+own exit via the unchanged `_should_exit`.
+
+**One consequence must be handled, and it is the real cost of this fix.**
+`SessionPresentation.source_token` is compared in
+`_sidebar_presentation_current` (`app.py:3920-3921`), and `token` is a
+per-`SessionInteraction` UUID (`session_interaction.py:115`) whose docstring
+says it "identifies this exact owner-facing incarnation"
+(`session_interaction.py:3-6`). Releasing a source and re-leasing it mints a
+**new** `SessionInteraction` and therefore a new token, so the retained
+presentation can never hit again — it is dead weight that will be rebuilt
+anyway.
+
+That is not a reason to keep the pin; it is the measurement that tells us
+which of two designs to pick:
+
+- **(A) Release the source and evict its presentation together.** Honest, one
+  line of extra bookkeeping, and it makes the cache mean what its comment
+  says. Cost: every parked conversation becomes a cold rebuild on
+  switch-back. The constant's own measured data says what that costs —
+  246 ms loop-CPU per switch at capacity 4 versus 59-65 ms on a hit
+  (`app.py:1360-1362`). That is a real, user-visible regression in exactly
+  the interaction `RETAINED_PRESENTATIONS` was raised from 4 to 12 to fix,
+  and it is the strongest objection to the viewer-side fix.
+
+- **(B) Release the source, keep the presentation, and let it re-validate.**
+  Requires the retained presentation to survive a source swap — i.e. the
+  currency check keys on something that survives re-leasing rather than on
+  the incarnation token.
+
+**I recommend (A) for the first PR, and (B) only if measurement shows the
+regression matters.** Reasons: (A) is strictly smaller and cannot be wrong —
+it removes a pin and takes a known, bounded latency cost on a path that was
+*already* cold for any conversation past the LRU capacity. (B) changes a
+correctness-critical cache-validity predicate whose docstring
+(`app.py:3898-3917`) enumerates four distinct staleness classes that must
+still miss; getting that wrong paints a stale or wrong transcript, which is
+far worse than a 250 ms switch.
+
+The evidence that would settle (A)-vs-(B): instrument switch-back loop-CPU
+across a realistic 8-12 conversation working set with the clause removed,
+using the same method that produced the `app.py:1360-1362` numbers. If the
+p90 lands near the 246 ms cold figure on conversations the user actually
+alternates between, do (B) as a follow-up. My prior is that it will matter
+less than the raw number suggests, because a released source's rebuild no
+longer competes with 11 sibling sockets delivering owner deltas — but that
+is a prior, not a measurement, and I would not ship (B) on it.
+
+A cheaper middle path worth pricing during implementation: keep a **small**
+presentation retention for the 2-3 most recent conversations and release
+sources beyond that. That preserves the alternating-pair case (the common
+one) while capping pinned runtimes at a number a laptop can hold. It is a
+constant change plus the clause removal, not a new mechanism.
+
+### 3.2 Defect 2: do NOT build the 5-minute runtime-side clock
+
+Answering question 1 directly — of the three options:
+
+- **(a) Viewer sends periodic activity heartbeats.** Reject. It is a wire
+  change (`ControlOp` in `mobile/types.py:258-313`, and the additive-op
+  comments at 234-238 and 296-299 show the bar), and the task's own framing
+  names the fatal flaw: a viewer that periodically says "I am alive" is
+  precisely what defeats an inactivity reaper. To be correct it would have to
+  send only on *human* activity, which means the viewer already knows the
+  answer — at which point it should act on it locally rather than telling a
+  remote process to act for it. Worse, whatever the runtime concludes, it can
+  only act via `retiring` (churn loop, §2) or EOF (redial storm, §2).
+
+- **(b) Runtime-side, derived from existing evidence.** Reject — there is no
+  such evidence. `last_seen` (`server.py:426`) does not move for an idle
+  viewer, and per §1 nothing else periodic exists on a terminal attach. This
+  option is not available without (a).
+
+- **(c) Viewer-side release.** **Recommend.** The viewer is the only party
+  that knows a conversation is parked behind a `100vw` offset
+  (`app.py:4196`) rather than being read. Releasing drops the socket; the
+  runtime's own unchanged predicate then decides its fate. Fail-closed is
+  free: the five surviving clauses of `_sidebar_source_releasable` all keep
+  the source on any doubt.
+
+**So: fixing defect 1 subsumes the leak, and the 5-minute runtime-side clock
+is not needed for it.** Question 3 asked me to say this plainly, so: the two
+mechanisms are not complementary for the reported symptom. The 1.9 GB was
+caused entirely by defect 1. A 5-minute clock would not have fixed it any
+faster than the 3-second drain does once the socket drops, and building both
+means maintaining two answers to one question.
+
+### 3.3 The residual case, and my recommendation on it
+
+Question 3 also asks what a runtime-side clock still covers if the viewer
+releases properly. Honestly enumerated, the residual is:
+
+1. **A wedged or `SIGKILL`ed viewer.** Its socket dies with the process, so
+   the OS closes it and `attach_clients()` drops — the 3 s drain handles it.
+   **Not residual.** A viewer wedged but *alive* (event loop frozen, socket
+   still open) is genuinely residual.
+2. **A viewer on another machine.** No such client exists today; the listener
+   is loopback-only (`server.py:1190-1195`). Not residual until it does.
+3. **The desktop lease.** Already time-bounded — `DESKTOP_WATCH_LEASE_S =
+   45.0` (`runtime/types.py:60`), enforced in `_desktop_lease_live`
+   (`server.py:1553-1557`) and renewed by the host
+   (`desktop_sessions.py:354-360`). An abandoned desktop surface stops
+   counting after 45 s. **Not residual — this case is already solved, and it
+   is the precedent that a lease, not a heartbeat, is how this codebase
+   answers "is anyone still there".**
+4. **The phone.** `phone_watchers` is deliberately outside the predicate
+   (`process.py:272-275`) and `watch`/`unwatch` already mark the 0↔N
+   transition (`types.py:284-291`, `server.py:1693-1697`).
+
+That leaves **one** genuinely residual case: a live-but-wedged terminal
+viewer holding an open socket. **I recommend not building a wire protocol
+change for it**, because the only actions a runtime could take on that
+conclusion are the two broken ones from §2 — and a wedged viewer is exactly
+the client least able to handle a `retiring` re-engage or an EOF recovery
+correctly.
+
+If the operator still wants a runtime-side backstop after §3.1 ships, the
+smallest honest version is a **lease, not a heartbeat**, reusing the desktop
+pattern verbatim: an attach client's pin expires unless renewed, and the TUI
+renews only for the session it is actually displaying. That is still a wire
+addition, but it reuses an existing shape, it is fail-closed in the right
+direction (a viewer that cannot renew was not usable anyway), and it needs no
+`PROTOCOL_VERSION` bump under the additive rule (`types.py:234-238`) — an old
+runtime ignores the op and behaves exactly as today. I would build it only
+after §3.1 is deployed and measured, because I expect the residual to be
+approximately zero occurrences per week, and shipping it first is how the
+churn loop in §2 gets discovered in production instead of in this note.
+
+### 3.4 What resets the clock, if one is ever built
+
+Recorded for completeness (question 2), and stated in the existing
+vocabulary rather than a new one. `is_busy()` (`owned.py:688-740`) already
+covers turns, compaction, subagents, jobs, queued prompts and parked gates,
+and is checked first and alone (`process.py:277-279`).
+
+**Must reset** (human intent, none of which `is_busy` sees):
+a keystroke into the composer for that session; the session becoming the
+displayed one; a routed slash command; an answered gate; a scroll or
+navigation action in its transcript.
+
+**Must NOT reset** (presence, not attention): mere socket establishment; the
+1 Hz band repaint poll (`app.py:3424`) and the 2 s sidebar refresh
+(`app.py:5772`); any `daemon`-class client (`process.py:234-240` and
+`server.py:1588-1596` both already argue this); the phone SSE watcher
+(`process.py:272-275`).
+
+The critical observation: **every entry in the "must reset" column is a TUI
+event, and none of them is on the wire today.** That is the same fact that
+makes (a) and (b) unavailable in §3.2, restated. It is also why the clock, if
+built, belongs on the viewer side of the seam — which is §3.1.
+
+---
+
+## 4. Interactions
+
+**`WARM_WINDOW_S = 90` wakes** (`process.py:78`). Untouched. Term 2
+(`process.py:280-281`) is checked before term 3, so a released socket cannot
+reap a runtime with a wake due inside 90 s. Question 6's "wake fires while
+nobody is attached" case is exactly what this constant exists for.
+
+**Build refresh / `retiring`.** Untouched, and this is important: `retiring`
+keeps its single current meaning ("a newer build is on disk; engage a
+successor"), which is what makes `_on_runtime_refreshed`'s unconditional
+re-engage (`app.py:12502`) correct. Overloading it with "you were idle" is
+what creates the churn loop. **An idle reap must use no frame at all** — the
+viewer closes its socket and the runtime exits quietly through the existing
+`_clean_exit` (`process.py:287-301`). That is the answer to question 4: not
+`retiring`, not EOF-from-the-runtime, but *viewer-initiated socket close*,
+which is neither.
+
+**`retire_if_pristine`.** Untouched. Already correct and already re-checks
+under itself (`server.py:1698-1747`, `_retire_if_pristine` at 1881+, with the
+post-broadcast re-check at 1930-1948).
+
+**Desktop lease.** Untouched; already handled inside `attach_clients`
+(`server.py:1547-1551`).
+
+---
+
+## 5. The pristine / "Untitled conversation" case
+
+Question 5: **yes, it needs one thing beyond calling the existing op — but
+the op itself needs no change.**
+
+`retire_if_unused` (`remote.py:4927-4962`) is called from exactly three
+places, all of which ABANDON the *current* session: `/resume` onto a saved
+session (`app.py:8291`), `/resume` onto a live one (`app.py:9496`), and
+unmount/quit (`app.py:17642`). **No sidebar-leave path calls it.** So a user
+who clicks onto an empty "Untitled conversation" from the sidebar and clicks
+away leaves a pristine runtime that only the 3 s drain can collect — and
+today it cannot, because defect 1 keeps the socket open, which is precisely
+what the second committed repro
+(`test_an_empty_conversation_visited_and_left_retires_its_runtime`) asserts.
+
+The fix is to offer the runtime back on the sidebar-leave path too, before
+`session.dispose()` in `_release_sidebar_source` (`app.py:4679`), guarded by
+the same `getattr` probe the existing caller uses (`app.py:12949-12951`).
+Nothing else is required: the op already refuses when another viewer is
+attached (`server.py:1743-1745`) or anything durable exists
+(`is_pristine`, `owned.py:809-894`, every probe failing closed), and its
+failure mode is "the runtime stays up and the drain gets it"
+(`remote.py:4941-4944`).
+
+Strictly speaking §3.1 alone makes the empty case work — the socket drops and
+the drain reaps in 3 s. Adding the offer makes it *immediate* rather than
+3 seconds later, which is the same rationale the op already carries
+(`server.py:1739-1742`). Worth doing in the same PR; not worth doing alone.
+
+---
+
+## 6. Risks
+
+| scenario | what keeps it alive |
+|---|---|
+| Reading a long conversation for 6 min, then typing | It is the CURRENT session. `_sidebar_source_releasable` refuses on `source is not self._interaction` (`app.py:4638`), which is checked before any other clause and is not time-based. Nothing in this design can reap the displayed session — that is the entire reason I reject the runtime-side clock. |
+| Session parked on an approval | Three independent guards: `is_busy()` counts a parked gate as a running turn (`owned.py:692-695`, `724-727`), so `_should_exit` refuses; `has_pending_gate_reply` refuses release (`app.py:4642`); `gate_draft` makes it `retained_for_local_work` (`session_interaction.py:170`). |
+| Detached background job | `is_busy()` counts running jobs (`owned.py:728-737`, uncertainty failing closed at 736-737) and background tasks (738-739). The runtime refuses to exit regardless of viewer state. Note this is genuinely *stronger* than the viewer's own `retained_for_auto_work`, which is gated on `approve_all` (`session_interaction.py:186`) — but that only means the viewer may release a socket, never that the runtime dies. |
+| Phone attached | An interactive phone attach dials as `"attach"` (`process.py:272-275`) and counts in `attach_clients()`; the SSE watcher registers through `watch` (`server.py:1598-1608`). A TUI releasing its own socket does not touch either. |
+
+**The risks I would actually watch during rollout**, none of which the table
+above covers:
+
+1. **Switch-back latency regression.** The known cost of §3.1(A). Watch p90
+   switch loop-CPU against the `app.py:1360-1362` baseline. Mitigation is the
+   small-retention middle path in §3.1.
+2. **Release/re-lease races.** `_release_sidebar_source` already yields at
+   its draft save and re-checks the predicate afterwards
+   (`app.py:4664-4667`), and `_start_sidebar_connection`'s done-callback
+   re-checks after the connection task settles (`app.py:5161-5162`). Removing
+   the LRU clause widens the window in which a source can be released while a
+   prepare is in flight. `preparations` (`app.py:4641`) is the guard;
+   verify it is incremented before any await on every entry path
+   (`app.py:4036`, `4073`).
+3. **Sidebar prewarm churn.** `PREWARM_PER_REFRESH = 2` (`app.py:1375`) warms
+   two entries per 2 s poll (`app.py:5772`). With sources releasing eagerly,
+   confirm prewarm does not immediately re-lease what release just dropped —
+   that would trade a static leak for a spawn treadmill, the same failure
+   mode as §2 by a different route. `_sidebar_unretainable`
+   (`app.py:4754-4767`) is the existing damper, and it has a wrinkle that
+   matters here: its docstring notes "a source that has been released has no
+   readable stamp; the refusal is then trusted until the sidebar closes"
+   (`app.py:4750-4752`). Releasing sources eagerly therefore makes refusals
+   stickier than they are today. Benign by that docstring's own argument (it
+   suppresses only speculation, never an explicit click), but verify.
+4. **Runtime spawn cost on the alternating pair.** If a user ping-pongs
+   between two conversations faster than the 3 s drain, each switch may pay a
+   cold start. The drain's own 3 s window absorbs a fast return; a slow
+   alternation (>3 s, <1 min) is the worst case. Measure before assuming it
+   is fine.
+
+---
+
+## 7. Summary of the recommendation
+
+1. Remove the `_sidebar_presentations` clause from
+   `_sidebar_source_releasable` (`app.py:4645`); evict the presentation with
+   the source (option A). This alone fixes the 1.9 GB leak, via the existing
+   3-second drain and with no wire change.
+2. Call `retire_if_unused` on the sidebar-leave path in
+   `_release_sidebar_source` (`app.py:4648`), probed, best-effort — the
+   "Untitled conversation" case, made immediate instead of 3 s later.
+3. **Do not build the 5-minute runtime-side reaper now.** It does not address
+   the reported leak, its only residual case is a live-but-wedged local
+   viewer, and both frames it could act through are broken for a displayed
+   session (churn loop / redial storm). If a backstop is wanted later, build
+   a *lease* in the shape of `DESKTOP_WATCH_LEASE_S`, not a heartbeat, and
+   only after (1) is measured in production.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1411,6 +1411,18 @@ SIDEBAR_IDLE_RELEASE_S = 300.0
 #: minutes, so a tick that lands up to 15 s late is invisible, and this walks a
 #: dict bounded by the presentation LRU plus prewarm on the event loop.
 SIDEBAR_IDLE_SWEEP_S = 15.0
+#: How long the viewer waits for a runtime to answer the "you are unused, take
+#: yourself down" offer before giving up and disposing the socket anyway.
+#:
+#: The offer is a socket round trip whose caller cannot proceed until it
+#: returns, because `dispose()` closes the socket the ask travels over. The
+#: `AttachClient` default (`ACK_TIMEOUT_S = 15`) is sized for a healthy peer; a
+#: WEDGED runtime would hold every closing source's socket for that long, which
+#: is the case where letting go promptly matters most. A timeout is simply
+#: another "kept" — the runtime's own residency drain collects it seconds later
+#: — so the short bound costs nothing but an occasional deferred collection.
+#: `mobile/daemon.py` bounds the identical call at the same 3 s.
+RETIRE_OFFER_TIMEOUT_S = 3.0
 
 #: The chord that lifts the aside's full text to the clipboard.
 #:
@@ -4737,38 +4749,79 @@ class OperatorApp(App[None]):
         failing closed keeps the source, matching the rest of this module — a
         wrong keep costs one idle runtime for one more window, a wrong release
         costs a cold rebuild the user can see.
+
+        FAIL-CLOSED IS PER SOURCE, NOT PER TICK, and the distinction is the
+        whole value of the guard. `_sidebar_sources` iterates in insertion
+        order, so a single raising probe wrapped at loop scope abandons the
+        same suffix of the map on every subsequent tick — the sweep is the only
+        reaper, so those sources leak permanently, which is precisely the bug
+        this method exists to fix. The per-source `try` below bounds a bad
+        probe to its own source; the outer one only still exists because the
+        timer contract above is absolute (see its comment).
+
+        Instrumenting this? `set_interval` at `on_mount` captures the BOUND
+        method, so patching `OperatorApp._sweep_idle_sidebar_sources` after
+        startup silently measures nothing while the real sweep keeps running.
+        Observe the effect (a parked source released) rather than the call.
         """
         try:
+            # Both constants are re-read per tick on purpose: tests inject a
+            # compressed window by patching the module attribute, and hoisting
+            # either into a local or binding it at `on_mount` would make those
+            # tests pass against a five-minute wait they never reach.
             deadline = SIDEBAR_IDLE_RELEASE_S
             now = time.monotonic()
             for source in list(self._sidebar_sources.values()):
-                parked_at = source.parked_at
-                if parked_at is None or now - parked_at < deadline:
-                    continue
-                if not self._sidebar_source_releasable(source, reason="expired"):
-                    continue
-                session_id = str(getattr(source.session, "session_id", ""))
-                # Evict the presentation WITH the source rather than leaving it
-                # to age out. A released source mints a fresh
-                # `SessionInteraction` on re-lease and therefore a fresh
-                # `token`, which `_sidebar_presentation_current` compares — so
-                # a presentation kept past its source can never hit again. It
-                # is dead weight that would be rebuilt anyway, and holding it
-                # would also keep this source in the prewarm-ineligible set.
-                presentation = self._sidebar_presentations.pop(session_id, None)
-                # Suppress speculative re-preparation of what we just dropped.
-                # `_sidebar_prewarm_refused` reads this map, and prewarm's
-                # candidate filter otherwise selects exactly the sessions with
-                # no retained presentation — i.e. the ones the sweep just
-                # released — turning a 5-minute reap into a 2-second respawn
-                # treadmill. The stamp is the same content pair a `retainable()`
-                # refusal uses, so an explicit click still prepares normally and
-                # any real content change reopens speculation on its own.
-                self._sidebar_unretainable[session_id] = self._sidebar_refusal_stamp(source)
-                self.run_worker(
-                    self._retire_idle_sidebar_source(source, presentation),
-                    group="sidebar-idle-release",
-                )
+                # Per source, so one bad probe costs only itself. Anything that
+                # raises here is a keep for THIS source on THIS tick; the next
+                # tick retries it, and its neighbours are never touched.
+                try:
+                    parked_at = source.parked_at
+                    if parked_at is None or now - parked_at < deadline:
+                        continue
+                    if not self._sidebar_source_releasable(source, reason="expired"):
+                        continue
+                    session_id = str(getattr(source.session, "session_id", ""))
+                    # Evict the presentation WITH the source rather than leaving
+                    # it to age out. A released source mints a fresh
+                    # `SessionInteraction` on re-lease and therefore a fresh
+                    # `token`, which `_sidebar_presentation_current` compares —
+                    # so a presentation kept past its source can never hit
+                    # again. It is dead weight that would be rebuilt anyway, and
+                    # holding it would also keep this source in the
+                    # prewarm-ineligible set.
+                    presentation = self._sidebar_presentations.pop(session_id, None)
+                    # Suppress speculative re-preparation of what we just
+                    # dropped. `_sidebar_prewarm_refused` reads this map, and
+                    # prewarm's candidate filter otherwise selects exactly the
+                    # sessions with no retained presentation — i.e. the ones the
+                    # sweep just released — turning a 5-minute reap into a
+                    # 2-second respawn treadmill.
+                    #
+                    # THIS STAMP IS SPECULATIVE-SUPPRESSION, NOT A `retainable()`
+                    # REFUSAL, even though it reuses that stamp's shape. It is
+                    # written before the release worker runs and stands whatever
+                    # the release returns, so a release the predicate later
+                    # refuses (a click landing in the window bumps
+                    # `preparations`) leaves a source suppressed that was never
+                    # refused. That is deliberate and it must stay synchronous:
+                    # the release path awaits — the draft spill, then the retire
+                    # offer — while the source is still in `_sidebar_sources`
+                    # with its presentation already popped, which is exactly the
+                    # prewarm candidate shape, so stamping after the release
+                    # returns would open a multi-second window for the 2 s poll
+                    # to re-lease what this tick just dropped. The cost is
+                    # bounded and self-healing: only speculation is suppressed,
+                    # the next tick retries the release, `_admit_sidebar_
+                    # presentation` clears the stamp on admission, and closing
+                    # the sidebar clears the whole map.
+                    self._sidebar_unretainable[session_id] = self._sidebar_refusal_stamp(source)
+                    self.run_worker(
+                        self._retire_idle_sidebar_source(source, presentation),
+                        group="sidebar-idle-release",
+                    )
+                except Exception:  # noqa: BLE001 — a bad source costs only itself
+                    logger.debug("idle sidebar sweep skipped a source", exc_info=True)
         except Exception:  # noqa: BLE001 — a throwing interval stops repeating
             logger.debug("idle sidebar sweep failed", exc_info=True)
 
@@ -13121,6 +13174,15 @@ class OperatorApp(App[None]):
         mid-swap, where an exception would be noise the user cannot act on and
         a notice would land on a surface that is going away. A failure leaves
         the runtime up, which the residency drain resolves seconds later.
+
+        BOUNDED AT 3 s because the offer crosses the socket, and the caller
+        cannot let go until it returns — `dispose()` closes the very socket the
+        ask travels over, so the wait is unavoidable in ordering. The
+        `AttachClient` default is `ACK_TIMEOUT_S = 15`, which against a WEDGED
+        runtime would hold each source's socket open for fifteen seconds in
+        exactly the case where letting go promptly matters most. A timeout is
+        just another "kept", and the residency drain collects it seconds later;
+        `mobile/daemon.py` bounds the identical call the same way.
         """
         if session is None:
             return
@@ -13128,7 +13190,10 @@ class OperatorApp(App[None]):
         if not callable(retire):
             return
         try:
-            detail = await cast(Callable[[], Awaitable[str]], retire)()
+            detail = await asyncio.wait_for(
+                cast(Callable[[], Awaitable[str]], retire)(),
+                timeout=RETIRE_OFFER_TIMEOUT_S,
+            )
             logger.debug("unused runtime offer: %s", detail)
         except Exception:  # noqa: BLE001 — teardown must not fail over this
             logger.debug("could not offer the unused runtime back", exc_info=True)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1374,6 +1374,44 @@ RETAINED_PRESENTATIONS = 12
 #: rows the eye lands on — without turning every poll into a prepare storm.
 PREWARM_PER_REFRESH = 2
 
+#: How long a parked sidebar source may keep its runtime attachment.
+#:
+#: THE TWO SIDEBAR CACHES ARE DIFFERENT RESOURCES, and conflating them is the
+#: defect this constant exists to close. `RETAINED_PRESENTATIONS` bounds parked
+#: WIDGETS (~1.5–2.4 MiB each); a parked source additionally pins a whole
+#: runtime CHILD PROCESS, because its attach socket makes the runtime's
+#: `attach_clients()` return 1, which is term 3 of `process._should_exit`. So a
+#: widget LRU sized for a rendering working set silently became a process
+#: working set: one reporting host held 15 attach sockets and 15 runtime
+#: children (~1.9 GB RSS) after merely CLICKING THROUGH conversations, idle for
+#: half an hour, with every genuine retention term false.
+#:
+#: Deleting the LRU clause from `_sidebar_source_releasable` would fix the leak
+#: in one line and was the design note's recommendation, but it reintroduces
+#: exactly the switch-back jitter `RETAINED_PRESENTATIONS` was raised 4→12 to
+#: remove (measured at that constant: 246 ms loop-CPU per cold switch against
+#: 59–65 ms on a hit). A TIME BOUND keeps both properties: the alternating
+#: working set the constant was tuned for is untouched, because a source the
+#: user returns to within the window never released anything, and only a
+#: conversation genuinely abandoned pays a cold rebuild it was going to pay
+#: anyway.
+#:
+#: Five minutes is a human-attention figure, not a tuned one: long enough that
+#: reading a long transcript, taking a call, or stepping away briefly and
+#: coming back is still a cache hit, short enough that a glance costs at most
+#: one idle runtime for one window rather than for the life of the process.
+#:
+#: NOT env-tunable. It trades memory against one switch's latency, both of
+#: which this code can already observe, so a knob would only let a user turn
+#: the leak back on while making every bug report ask "what did you set it
+#: to". Tests inject their own value by patching this module attribute; the
+#: sweep reads it per tick for exactly that reason.
+SIDEBAR_IDLE_RELEASE_S = 300.0
+#: How often the idle sweep runs. Coarse on purpose: the deadline is five
+#: minutes, so a tick that lands up to 15 s late is invisible, and this walks a
+#: dict bounded by the presentation LRU plus prewarm on the event loop.
+SIDEBAR_IDLE_SWEEP_S = 15.0
+
 #: The chord that lifts the aside's full text to the clipboard.
 #:
 #: `omp`, the reference implementation this surface is modelled on, ships copy
@@ -4071,6 +4109,15 @@ class OperatorApp(App[None]):
             if source.draft.approve_all is None:
                 source.draft.approve_all = self._approvals_default_auto
             source.preparations = 1
+            # A newly leased source starts its clock at birth. Prewarm leases
+            # sources the user never visits, and those are parked by
+            # construction — they are never the displayed session, so the swap
+            # path that normally stamps `parked_at` never runs for them. Left
+            # unstamped they would have no deadline at all and would pin a
+            # runtime for the life of the process, which is the original leak
+            # wearing a different hat. The commit path clears this the moment
+            # one does become current.
+            source.parked_at = time.monotonic()
             remote.suspend_viewer_gates()
             self._interactions[id(remote)] = source
             self._sidebar_sources[session_id] = source
@@ -4627,6 +4674,20 @@ class OperatorApp(App[None]):
         remote fact about a read-only projection, it is unbounded, and each
         one costs a deep state copy per owner delta forever. Local retention
         — our own workers, an unsent gate answer — still wins in both.
+        ``reason="expired"`` is the idle sweep, for which see
+        :meth:`_sweep_idle_sidebar_sources`; it is `"idle"` plus permission to
+        release a source the presentation LRU is still holding.
+
+        RELEASING A SOURCE CANNOT KILL LIVE WORK, and that is why this
+        predicate does not try to enumerate what "live" means. It disposes a
+        VIEWER — a socket and a subscription — never a session. The runtime
+        alone decides its own exit, and its `_should_exit`/`is_busy()` already
+        refuse while a turn, compaction, subagent, background job, queued
+        prompt or parked gate is live, and keep a runtime whose wake is due
+        inside `WARM_WINDOW_S`. Duplicating any of that here would be a second,
+        staler answer to a question the runtime already answers correctly. The
+        clauses below exist for the opposite concern: not "is the RUNTIME
+        busy", but "is this VIEWER still doing something for the user".
         """
         from local_operator.session.remote import RemoteSession
 
@@ -4642,8 +4703,91 @@ class OperatorApp(App[None]):
             and not getattr(source.session, "has_pending_gate_reply", False)
             and source.session is not None
             and source.session is not self._fork_source_session
-            and source.session.session_id not in self._sidebar_presentations
+            # The presentation LRU pins the SOURCE only while the parked
+            # presentation could still be revealed cheaply — see
+            # SIDEBAR_IDLE_RELEASE_S for why a widget cache must not own a
+            # process indefinitely. The sweep and the close drain have both
+            # already decided the widgets are forfeit, so they pass a reason
+            # that lifts this clause; every other caller keeps it.
+            and (
+                reason in {"closed", "expired"}
+                or source.session.session_id not in self._sidebar_presentations
+            )
         )
+
+    def _sweep_idle_sidebar_sources(self) -> None:
+        """Release parked viewers nobody has looked at for a while.
+
+        WHY THE CLOCK IS ON THIS SIDE OF THE SEAM. The runtime cannot time its
+        own viewers out: an attached-but-idle TUI sends no periodic op, so
+        `_ClientConn.last_seen` never moves for it and there is no evidence to
+        age. Worse, both actions a runtime could take on such a conclusion are
+        wrong. Announcing `retiring` reaches `_on_runtime_refreshed`, which
+        re-engages eagerly and unconditionally — an exit→spawn→idle→exit
+        treadmill strictly worse than the leak it fixes. A bare EOF is worse
+        still: a sidebar source connects without a `surface`, so it cannot go
+        cold, and owner-death recovery redials forever against a takeover that
+        raises by construction. The viewer closing its OWN socket is the only
+        initiator with no such failure mode — it needs no frame, no wire op and
+        no protocol change, and the runtime keeps full authority over its exit
+        through the existing residency drain.
+
+        Never raises: a Textual interval that throws stops repeating, which
+        would silently disable reaping for the life of the process. Every probe
+        failing closed keeps the source, matching the rest of this module — a
+        wrong keep costs one idle runtime for one more window, a wrong release
+        costs a cold rebuild the user can see.
+        """
+        try:
+            deadline = SIDEBAR_IDLE_RELEASE_S
+            now = time.monotonic()
+            for source in list(self._sidebar_sources.values()):
+                parked_at = source.parked_at
+                if parked_at is None or now - parked_at < deadline:
+                    continue
+                if not self._sidebar_source_releasable(source, reason="expired"):
+                    continue
+                session_id = str(getattr(source.session, "session_id", ""))
+                # Evict the presentation WITH the source rather than leaving it
+                # to age out. A released source mints a fresh
+                # `SessionInteraction` on re-lease and therefore a fresh
+                # `token`, which `_sidebar_presentation_current` compares — so
+                # a presentation kept past its source can never hit again. It
+                # is dead weight that would be rebuilt anyway, and holding it
+                # would also keep this source in the prewarm-ineligible set.
+                presentation = self._sidebar_presentations.pop(session_id, None)
+                # Suppress speculative re-preparation of what we just dropped.
+                # `_sidebar_prewarm_refused` reads this map, and prewarm's
+                # candidate filter otherwise selects exactly the sessions with
+                # no retained presentation — i.e. the ones the sweep just
+                # released — turning a 5-minute reap into a 2-second respawn
+                # treadmill. The stamp is the same content pair a `retainable()`
+                # refusal uses, so an explicit click still prepares normally and
+                # any real content change reopens speculation on its own.
+                self._sidebar_unretainable[session_id] = self._sidebar_refusal_stamp(source)
+                self.run_worker(
+                    self._retire_idle_sidebar_source(source, presentation),
+                    group="sidebar-idle-release",
+                )
+        except Exception:  # noqa: BLE001 — a throwing interval stops repeating
+            logger.debug("idle sidebar sweep failed", exc_info=True)
+
+    async def _retire_idle_sidebar_source(
+        self, source: SessionInteraction, presentation: SessionPresentation | None
+    ) -> None:
+        """Unmount an expired source's widgets, then drop its viewer.
+
+        Split from the sweep because removal and disposal both await, and the
+        sweep runs on a timer that must not block the loop. The predicate is
+        re-checked inside `_release_sidebar_source`, which is what makes this
+        safe against a click that lands while the worker is queued.
+        """
+        try:
+            if presentation is not None and presentation.replay.view.is_mounted:
+                await asyncio.shield(presentation.replay.view.remove())
+            await self._release_sidebar_source(source, reason="expired")
+        except Exception:  # noqa: BLE001 — reaping is best-effort, never fatal
+            logger.debug("idle sidebar release failed", exc_info=True)
 
     async def _release_sidebar_source(
         self, source: SessionInteraction, *, reason: str = "idle"
@@ -4676,6 +4820,20 @@ class OperatorApp(App[None]):
             self._sidebar_sources.pop(session.session_id, None)
         if self._interactions.get(id(session)) is source:
             self._interactions.pop(id(session), None)
+        # Offer an untouched runtime back before dropping the socket. The three
+        # existing callers of this op all abandon the CURRENT session
+        # (`/resume` twice, unmount); no sidebar path did, so a user who
+        # clicked onto an empty "Untitled conversation" and clicked away left a
+        # pristine runtime that only the residency drain could collect.
+        #
+        # WHETHER IT IS REALLY EMPTY STAYS THE RUNTIME'S ANSWER, never a
+        # viewer-side guess at emptiness: only the runtime can see an armed
+        # wake, a peer message that just arrived, or a second viewer attached.
+        # The op already refuses on all three and on any probe failure, and its
+        # failure mode is "the runtime stays up and the drain gets it seconds
+        # later" — so this only makes the empty case immediate, and can never
+        # end a session someone still wants.
+        await self._retire_unused_runtime(session)
         await session.dispose()
 
     @staticmethod
@@ -4884,6 +5042,15 @@ class OperatorApp(App[None]):
             ):
                 self._sidebar_presentations[previous.session_id] = outgoing_presentation
                 outgoing_presentation = None
+        # Start the outgoing source's idle clock, and stop the incoming one's.
+        # This is the single place the two transitions happen together, and
+        # attention is the only thing either stamp records: `outgoing` has just
+        # stopped being on screen, `source` has just become the session the
+        # user is looking at. A source that is current has no deadline at all,
+        # which is what makes "the displayed conversation is never reaped" a
+        # structural property rather than a clause someone must remember.
+        outgoing.parked_at = time.monotonic()
+        source.parked_at = None
         self._park_sidebar_aside(outgoing)
         if isinstance(previous, RemoteSession):
             self._suspend_sidebar_gates(outgoing)
@@ -5848,6 +6015,12 @@ class OperatorApp(App[None]):
         # Keep the active provider's quota warm in the shared cache so `/usage`
         # answers from disk (see USAGE_WARM_INTERVAL_S).
         self.set_interval(USAGE_WARM_INTERVAL_S, self._warm_usage_background)
+        # ALWAYS ON, deliberately not on `_sidebar_timer`. That timer is
+        # registered with `pause=True` and is paused whenever the sidebar is
+        # closed, so hanging the reap off it would mean a user who closes the
+        # sidebar — the state the leak was reported from — stops reaping
+        # entirely and keeps every runtime they ever clicked.
+        self.set_interval(SIDEBAR_IDLE_SWEEP_S, self._sweep_idle_sidebar_sources)
 
         # Await the session in a worker so the app paints first.
         self.run_worker(self._boot_session(), thread=False, group="session")
@@ -5926,6 +6099,11 @@ class OperatorApp(App[None]):
                 else self._approvals_default_auto
             )
         self._interaction = source
+        # Adoption is the other way a source becomes current (boot, `/resume`,
+        # takeover), and the displayed session must never carry a deadline —
+        # a source leased by prewarm and later adopted would otherwise keep the
+        # stamp it was born with and be swept while on screen.
+        source.parked_at = None
         self._watch_source_frontend(source)
         self._set_approve_all(self._approve_all)
         if getattr(session, "session_id", ""):

--- a/local_operator/tui/session_interaction.py
+++ b/local_operator/tui/session_interaction.py
@@ -141,6 +141,15 @@ class SessionInteraction:
     gate_draft: tuple[tuple[Any, ...], Any] | None = field(default=None, repr=False)
     gate_view_generation: int = 0
     unsubscribe_frontend: Any = field(default=None, repr=False)
+    #: `time.monotonic()` when this source stopped being the displayed session,
+    #: or ``None`` while it is current (or has never been shown).
+    #:
+    #: Starts the idle clock the sidebar sweep reads — parking is what begins
+    #: an absence, and becoming current again is the only thing that ends one.
+    #: Deliberately NOT stamped by socket traffic, the band poll or the sidebar
+    #: refresh: those are the app talking to itself, and a clock they reset
+    #: never fires. See `app.SIDEBAR_IDLE_RELEASE_S`.
+    parked_at: float | None = field(default=None, repr=False)
 
     @property
     def unsent(self) -> list[SessionDraft]:

--- a/tests/e2e/test_sidebar_runtime_reap_e2e.py
+++ b/tests/e2e/test_sidebar_runtime_reap_e2e.py
@@ -1,0 +1,216 @@
+"""Switching through the sidebar must not strand one runtime per conversation.
+
+The operator's report: clicking conversations in the sidebar to "check" them
+left every one of those runtimes resident, and an empty ``Untitled
+conversation`` sat there too. Measured on the reporting host: ONE TUI process
+held 15 established attach sockets, one per session ever clicked, and 15
+runtime children (~1.9 GB RSS) that had been idle for half an hour.
+
+These tests drive the REAL app against REAL runtime servers and assert on
+process-level facts (is the viewer's socket still connected, did the runtime
+retire) rather than on widget state, because the leak is invisible on screen —
+the conversation the user is looking at is correct either way.
+
+THE COMPRESSED TIMEOUT BELOW IS DELIBERATE — do not "restore" a real-time
+budget. These tests were written during diagnosis, before the fix was designed,
+so they originally expected release to be IMMEDIATE. The shipped fix releases a
+parked viewer after ``SIDEBAR_IDLE_RELEASE_S`` (5 minutes in production) so that
+switching back to a recent conversation stays a warm cache hit; waiting that out
+here would make the stage take five minutes per test.
+
+What is asserted is unchanged and is the whole acceptance criterion: after the
+clock expires, a conversation the user merely visited holds NO attach client, so
+its runtime can reap. Only the wall-clock is compressed, by patching the module
+constant the sweep re-reads every tick. Loosening or deleting those assertions
+would defeat the purpose of the file.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from local_operator.session.remote import RemoteSession
+from local_operator.session.runtime.owned import OwnedSessionHandle
+from local_operator.session.runtime.server import RuntimeServer
+from local_operator.tui import app as app_module
+from local_operator.tui.app import OperatorApp
+from tests.e2e.harness import (
+    ScriptedStream,
+    assistant_message,
+    build_session,
+    seed_transcript,
+    user_message,
+    wait_for_adoption,
+)
+
+
+def _compress_idle_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run the production reap path on a sub-second clock.
+
+    The sweep re-reads both constants on every tick, so patching the module
+    attributes exercises the real timer, the real predicate and the real
+    release worker — nothing about the mechanism is stubbed, only the wait.
+    """
+    monkeypatch.setattr(app_module, "SIDEBAR_IDLE_RELEASE_S", 0.2)
+    monkeypatch.setattr(app_module, "SIDEBAR_IDLE_SWEEP_S", 0.05)
+
+
+async def _stand_up(config: Path, ids: list[str]) -> dict[str, RuntimeServer]:
+    """One real runtime server per conversation, each with durable history."""
+    servers: dict[str, RuntimeServer] = {}
+    for sid in ids:
+        directory = config / "sessions" / sid
+        await seed_transcript(
+            directory,
+            [user_message(f"{sid} question"), assistant_message(f"{sid} saved answer")],
+        )
+        owner = build_session(directory, ScriptedStream([]), cwd=config)
+        handle = OwnedSessionHandle(owner, asyncio.get_running_loop(), cwd=str(config))
+        server = RuntimeServer(handle, kind="daemon")
+        await server.start_in_process()
+        servers[sid] = server
+    return servers
+
+
+@pytest.mark.asyncio
+async def test_visited_conversations_do_not_hold_their_runtimes_open(
+    headless_tui_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Click through five conversations; only the current one may stay attached.
+
+    ``attach_clients()`` is the runtime's own count of interactive viewers and
+    is exactly the term ``process._should_exit`` reads as "somebody is looking
+    at this" — so a runtime a user merely glanced at reporting 1 here is the
+    leak itself, in the units the reaper cares about.
+    """
+    config = headless_tui_env
+    ids = ["origin", "alpha", "beta", "gamma", "delta"]
+    servers = await _stand_up(config, ids)
+    _compress_idle_clock(monkeypatch)
+
+    def find(_directory, sid):
+        server = servers.get(sid)
+        return (server._record, server._record.pid) if server else (None, None)
+
+    async def never():
+        raise AssertionError("a sidebar viewer never takes over a session")
+
+    async def resume(sid):
+        return await RemoteSession.connect(
+            servers[sid]._record,
+            sid,
+            config_dir=config,
+            takeover_factory=never,
+            display_window=True,
+        )
+
+    app = OperatorApp(lambda: resume("origin"), resume_factory=resume)
+    try:
+        with (
+            patch("local_operator.mobile.attach_client.find_owner_record", find),
+            patch.object(OperatorApp, "_check_for_update", lambda self: None),
+        ):
+            async with app.run_test(size=(120, 36)) as pilot:
+                await wait_for_adoption(app, pilot)
+                for sid in ids[1:]:
+                    await asyncio.wait_for(app._sidebar_navigation.select(sid), 15)
+                    await pilot.pause()
+                # Let every release worker the switches queued run to
+                # completion; the app releases sources from workers, not
+                # inline, so an immediate assertion would race them.
+                for _ in range(40):
+                    await pilot.pause()
+                    await asyncio.sleep(0.05)
+
+                current = str(getattr(app._session, "session_id", ""))
+                assert current == "delta", "the last click is the visible conversation"
+
+                # `attach_clients()` unconditionally: the runtime has no
+                # `_handle_attach_count`, so the defensive branch this replaced
+                # was dead code that only cost a type error.
+                held = {sid: server.attach_clients() for sid, server in servers.items()}
+                stranded = {sid: count for sid, count in held.items() if count and sid != current}
+                assert not stranded, (
+                    "conversations the user merely visited still hold an attached "
+                    f"viewer, so their runtimes can never reap: {stranded} "
+                    f"(all counts: {held})"
+                )
+    finally:
+        for server in servers.values():
+            await server.aclose()
+
+
+@pytest.mark.asyncio
+async def test_an_empty_conversation_visited_and_left_retires_its_runtime(
+    headless_tui_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The ``Untitled conversation`` case: nothing durable, so nothing to keep.
+
+    An empty conversation is still REACHABLE while parked — the user can click
+    back onto the ``/new`` they just left — so it waits out the same clock as
+    any other source rather than being disposed at park time. What makes it
+    special is the offer made when that clock expires: the release path asks
+    the runtime to retire, and a runtime with nothing durable accepts, so it
+    goes immediately instead of waiting for the residency drain.
+
+    The judgment stays the RUNTIME's (``retire_if_unused`` -> ``is_pristine``):
+    only it can see an armed wake, a peer message that just landed, or a second
+    attached viewer.
+    """
+    config = headless_tui_env
+    servers = await _stand_up(config, ["origin"])
+    _compress_idle_clock(monkeypatch)
+
+    # The empty one: a real runtime whose session has no durable row at all.
+    empty_dir = config / "sessions" / "untitled"
+    empty_dir.mkdir(parents=True, exist_ok=True)
+    owner = build_session(empty_dir, ScriptedStream([]), cwd=config)
+    handle = OwnedSessionHandle(owner, asyncio.get_running_loop(), cwd=str(config))
+    empty = RuntimeServer(handle, kind="daemon")
+    await empty.start_in_process()
+    servers["untitled"] = empty
+
+    assert handle.is_pristine(), "the fixture must actually be an empty session"
+
+    def find(_directory, sid):
+        server = servers.get(sid)
+        return (server._record, server._record.pid) if server else (None, None)
+
+    async def never():
+        raise AssertionError("a sidebar viewer never takes over a session")
+
+    async def resume(sid):
+        return await RemoteSession.connect(
+            servers[sid]._record,
+            sid,
+            config_dir=config,
+            takeover_factory=never,
+            display_window=True,
+        )
+
+    app = OperatorApp(lambda: resume("origin"), resume_factory=resume)
+    try:
+        with (
+            patch("local_operator.mobile.attach_client.find_owner_record", find),
+            patch.object(OperatorApp, "_check_for_update", lambda self: None),
+        ):
+            async with app.run_test(size=(120, 36)) as pilot:
+                await wait_for_adoption(app, pilot)
+                await asyncio.wait_for(app._sidebar_navigation.select("untitled"), 15)
+                await pilot.pause()
+                await asyncio.wait_for(app._sidebar_navigation.select("origin"), 15)
+                for _ in range(40):
+                    await pilot.pause()
+                    await asyncio.sleep(0.05)
+
+                assert empty.attach_clients() == 0, (
+                    "an empty conversation the user looked at and left still holds "
+                    "a viewer, so its runtime never retires"
+                )
+    finally:
+        for server in servers.values():
+            await server.aclose()

--- a/tests/unit/session/test_no_session_deletion.py
+++ b/tests/unit/session/test_no_session_deletion.py
@@ -111,6 +111,11 @@ _ALLOWED_ROWS: tuple[tuple[str | int, ...], ...] = (
         "Textual TranscriptView.remove unmounts a widget; no filesystem path",
     ),
     (
+        "local_operator/tui/app.py::OperatorApp._retire_idle_sidebar_source",
+        "<path>.remove",
+        "Textual TranscriptView.remove unmounts a widget; no filesystem path",
+    ),
+    (
         "local_operator/tui/app.py::OperatorApp._prepare_sidebar_session",
         "<path>.remove",
         "Textual TranscriptView.remove unmounts failed preparation; no filesystem path",

--- a/tests/unit/tui/test_sidebar_idle_reap.py
+++ b/tests/unit/tui/test_sidebar_idle_reap.py
@@ -1,0 +1,273 @@
+"""A parked viewer releases its runtime on a clock, but only when truly idle.
+
+The defect these tests pin: ``_sidebar_source_releasable`` refused to release
+any source the presentation LRU was holding, so a widget cache sized for
+rendering (``RETAINED_PRESENTATIONS = 12``) became a *process* working set. One
+reporting host held 15 attach sockets and 15 runtime children (~1.9 GB RSS)
+after merely clicking through conversations, every genuine retention term
+false.
+
+The fix is a time bound rather than deleting that clause, because deleting it
+reintroduces the cold-switch cost ``RETAINED_PRESENTATIONS`` was raised 4->12 to
+remove. So there are two properties here and they pull in opposite directions:
+
+* a source parked LONGER than the window is released (the leak);
+* a source parked SHORTER than the window keeps its socket AND its presentation
+  (the performance property that made the timed design worth building).
+
+The second is a regression guard in the strict sense: an implementation that
+simply drops the LRU clause passes every leak test in this file and fails that
+one.
+
+Assertions are STRUCTURAL — releasable booleans, map membership, dispose call
+counts — and the clock is injected, never slept on, per AGENTS.md
+Section "Timing, flakes".
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import Mock
+
+import pytest
+
+from local_operator.tui import app as app_module
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.session_interaction import SessionInteraction
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+@pytest.fixture(autouse=True)
+def isolate(tmp_path, monkeypatch):
+    # An inherited CMUX_* variable lets a headless app rename the operator's
+    # real workspaces; HOME is redirected too because the cache root is derived
+    # from it independently of LOCAL_OPERATOR_CONFIG_DIR.
+    for key in tuple(os.environ):
+        if key.startswith("CMUX_"):
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setattr(OperatorApp, "_start_update_check", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_terminal_title", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_multiplexer_broadcast", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_herdr_reporter", lambda _self: None)
+
+
+class _Clock:
+    """A monotonic clock the test advances explicitly.
+
+    The sweep's whole contract is "how long has this been parked", so a real
+    sleep would be both slow and the only flaky thing in the file.
+    """
+
+    def __init__(self) -> None:
+        self.now = 1_000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.fixture
+def app_with_clock(monkeypatch):
+    clock = _Clock()
+    monkeypatch.setattr(app_module.time, "monotonic", clock)
+    current = FakeSession()
+    app = OperatorApp(lambda: _factory(current))
+    app._session = current
+    app._interaction = SessionInteraction(current)
+    app._interactions[id(current)] = app._interaction
+    return app, clock
+
+
+def _make_remote(app, session_id, clock, parked_for, *, history=4):
+    """Build a parked source whose session passes the RemoteSession check.
+
+    A real subclass rather than a mock: the predicate's first clause is an
+    ``isinstance(..., RemoteSession)`` test, so a duck-typed stand-in would make
+    every assertion here vacuously true.
+    """
+    from local_operator.session.remote import RemoteSession
+
+    class _ParkedRemote(RemoteSession):
+        def __init__(self) -> None:  # deliberately not RemoteSession.__init__
+            self._session_id = session_id
+            self.disposed = 0
+
+        @property
+        def session_id(self) -> str:
+            return self._session_id
+
+        @property
+        def has_pending_gate_reply(self) -> bool:
+            return False
+
+        @property
+        def history_message_count(self) -> int:
+            return history
+
+        async def dispose(self) -> None:
+            self.disposed += 1
+
+    session = _ParkedRemote()
+    source = SessionInteraction(session)
+    source.parked_at = clock.now - parked_for
+    app._sidebar_sources[session_id] = source
+    app._interactions[id(session)] = source
+    return source
+
+
+def test_source_parked_past_the_window_is_releasable(app_with_clock):
+    """The leak itself, in the units the predicate speaks."""
+    app, clock = app_with_clock
+    source = _make_remote(app, "aged", clock, app_module.SIDEBAR_IDLE_RELEASE_S + 1)
+    # PRECONDITION: it is the LRU clause alone that would refuse, so the test
+    # cannot pass vacuously against an unrelated retention.
+    assert not source.retained_for_local_work
+    assert not source.retained_for_auto_work
+    assert not source.preparations
+    app._sidebar_presentations["aged"] = object()
+
+    assert not app._sidebar_source_releasable(source, reason="idle")
+    assert app._sidebar_source_releasable(source, reason="expired")
+
+
+def test_a_recently_parked_source_keeps_its_socket_and_presentation(app_with_clock):
+    """REGRESSION GUARD: the performance property the timed design protects.
+
+    An implementation that just deletes the LRU clause passes every other test
+    in this file and fails this one, which is the entire point of it.
+    """
+    app, clock = app_with_clock
+    presentation = object()
+    source = _make_remote(app, "fresh", clock, 1.0)
+    app._sidebar_presentations["fresh"] = presentation
+    released = []
+    app.run_worker = lambda coro, **kw: released.append(coro) or coro.close()
+
+    clock.advance(app_module.SIDEBAR_IDLE_RELEASE_S / 2)
+    app._sweep_idle_sidebar_sources()
+
+    assert not released, "a source parked under the window must not be released"
+    assert app._sidebar_sources.get("fresh") is source, "its viewer must survive"
+    assert app._sidebar_presentations.get("fresh") is presentation, (
+        "its presentation must survive, or the switch-back is a cold rebuild "
+        "and RETAINED_PRESENTATIONS bought nothing"
+    )
+
+
+def test_the_sweep_releases_an_expired_source_and_evicts_its_presentation(app_with_clock):
+    """A released source mints a new token, so its presentation can never hit."""
+    app, clock = app_with_clock
+    _make_remote(app, "aged", clock, 0.0)
+    app._sidebar_presentations["aged"] = object()
+    released = []
+    app.run_worker = lambda coro, **kw: released.append(coro) or coro.close()
+
+    clock.advance(app_module.SIDEBAR_IDLE_RELEASE_S + 1)
+    app._sweep_idle_sidebar_sources()
+
+    assert released, "an expired source must be handed to a release worker"
+    assert "aged" not in app._sidebar_presentations, (
+        "the presentation must be evicted with the source: re-leasing mints a "
+        "fresh token, so a retained presentation is dead weight"
+    )
+
+
+def test_the_current_session_is_never_swept(app_with_clock):
+    """No deadline exists for the displayed conversation, by construction."""
+    app, clock = app_with_clock
+    released = []
+    app.run_worker = lambda coro, **kw: released.append(coro) or coro.close()
+    # The current source carries no park stamp at all; that absence, not a
+    # clause someone must remember, is what makes this structural.
+    assert app._interaction.parked_at is None
+
+    clock.advance(app_module.SIDEBAR_IDLE_RELEASE_S * 10)
+    app._sweep_idle_sidebar_sources()
+
+    assert not released
+
+
+@pytest.mark.parametrize(
+    "attribute, value",
+    [
+        ("preparations", 1),
+        ("retired", True),
+    ],
+)
+def test_the_sweep_fails_closed_on_viewer_retention(app_with_clock, attribute, value):
+    """Doubt keeps the source: a wrong keep costs one window, a wrong release
+    costs the user a cold rebuild — and `preparations` is what stops a source
+    being disposed while a prepare is in flight for it."""
+    app, clock = app_with_clock
+    source = _make_remote(app, "busy", clock, 0.0)
+    setattr(source, attribute, value)
+    released = []
+    app.run_worker = lambda coro, **kw: released.append(coro) or coro.close()
+
+    clock.advance(app_module.SIDEBAR_IDLE_RELEASE_S + 1)
+    app._sweep_idle_sidebar_sources()
+
+    assert not released
+
+
+def test_the_sweep_suppresses_prewarm_for_what_it_just_released(app_with_clock):
+    """Otherwise the 2 s prewarm poll re-leases it: a spawn treadmill.
+
+    Prewarm's candidate filter selects entries with no retained presentation —
+    exactly what the sweep produces — so without this damper a 5-minute reap
+    becomes a 2-second respawn.
+    """
+    app, clock = app_with_clock
+    _make_remote(app, "aged", clock, 0.0)
+    app._sidebar_presentations["aged"] = object()
+    app.run_worker = lambda coro, **kw: coro.close()
+
+    clock.advance(app_module.SIDEBAR_IDLE_RELEASE_S + 1)
+    app._sweep_idle_sidebar_sources()
+
+    assert app._sidebar_prewarm_refused(
+        "aged"
+    ), "a swept source must not be immediately re-prepared by prewarm"
+
+
+def test_an_empty_parked_source_still_waits_out_the_clock(app_with_clock):
+    """A parked `/new` is REACHABLE, so emptiness is not a licence to dispose.
+
+    An earlier revision of this fix released an apparently-empty source at park
+    time, reasoning that there is no transcript to rebuild. That broke a shipped
+    flow — `/new`, click a session with history, click back — because the user
+    can still return to the empty conversation, and disposing it at park killed
+    the source behind it (caught by
+    ``test_sidebar_swap_reset.py::test_returning_to_an_empty_conversation_...``).
+    Emptiness changes what the RUNTIME does when the clock finally expires (it
+    accepts the retire offer instead of waiting for the drain), never when the
+    viewer lets go.
+    """
+    app, clock = app_with_clock
+    source = _make_remote(app, "untitled", clock, 0.0, history=0)
+    # PRECONDITION: genuinely empty, so the claim is about emptiness rather
+    # than about some other term happening to keep it.
+    assert getattr(source.session, "history_message_count", None) == 0
+    released = []
+    app.run_worker = lambda coro, **kw: released.append(coro) or coro.close()
+
+    app._sweep_idle_sidebar_sources()
+
+    assert not released, "an empty conversation is still clickable while parked"
+    assert app._sidebar_sources.get("untitled") is source
+
+
+def test_the_sweep_never_raises_into_the_timer(app_with_clock, monkeypatch):
+    """A Textual interval that throws stops repeating, disabling reaping."""
+    app, clock = app_with_clock
+    _make_remote(app, "aged", clock, 0.0)
+    monkeypatch.setattr(
+        app, "_sidebar_source_releasable", Mock(side_effect=RuntimeError("probe exploded"))
+    )
+
+    clock.advance(app_module.SIDEBAR_IDLE_RELEASE_S + 1)
+    app._sweep_idle_sidebar_sources()  # must not raise

--- a/tests/unit/tui/test_sidebar_idle_reap.py
+++ b/tests/unit/tui/test_sidebar_idle_reap.py
@@ -15,9 +15,19 @@ remove. So there are two properties here and they pull in opposite directions:
 * a source parked SHORTER than the window keeps its socket AND its presentation
   (the performance property that made the timed design worth building).
 
-The second is a regression guard in the strict sense: an implementation that
-simply drops the LRU clause passes every leak test in this file and fails that
-one.
+WHICH TEST CATCHES THE "just delete the LRU clause" MUTATION:
+``test_source_parked_past_the_window_is_releasable``, and only it. Running that
+mutation (replacing the clause at ``_sidebar_source_releasable`` with ``True``)
+fails exactly that test and leaves the other eight green — measured, review
+round 1 MINOR-3, not assumed. It is the one that asserts the ``"idle"`` refusal
+AND the ``"expired"`` release on the same source, so deleting the clause breaks
+the refusal half.
+
+``test_a_recently_parked_source_keeps_its_socket_and_presentation`` pins the
+TIME BOUND instead, and cannot catch that mutation: it parks 150 s into a 300 s
+window, so the sweep hits ``now - parked_at < deadline`` and skips the source
+before the predicate is consulted at all. Do not delete the first test on the
+belief that the second covers it — that trade loses the only guard there is.
 
 Assertions are STRUCTURAL — releasable booleans, map membership, dispose call
 counts — and the clock is injected, never slept on, per AGENTS.md
@@ -82,12 +92,18 @@ def app_with_clock(monkeypatch):
     return app, clock
 
 
-def _make_remote(app, session_id, clock, parked_for, *, history=4):
+def _make_remote(app, session_id, clock, parked_for, *, history=4, poison=False):
     """Build a parked source whose session passes the RemoteSession check.
 
     A real subclass rather than a mock: the predicate's first clause is an
     ``isinstance(..., RemoteSession)`` test, so a duck-typed stand-in would make
     every assertion here vacuously true.
+
+    ``poison`` makes ``frontend_state`` raise the way the real property does
+    before its store syncs (``remote.py``), which is the reachable way a probe
+    can throw — the predicate reads it through ``retained_for_auto_work``.
+    Declared on the class rather than assigned afterwards so the raise is part
+    of the type, as it is in production.
     """
     from local_operator.session.remote import RemoteSession
 
@@ -107,6 +123,12 @@ def _make_remote(app, session_id, clock, parked_for, *, history=4):
         @property
         def history_message_count(self) -> int:
             return history
+
+        @property
+        def frontend_state(self):
+            if poison:
+                raise RuntimeError("frontend state has not synchronized")
+            return super().frontend_state
 
         async def dispose(self) -> None:
             self.disposed += 1
@@ -137,8 +159,16 @@ def test_source_parked_past_the_window_is_releasable(app_with_clock):
 def test_a_recently_parked_source_keeps_its_socket_and_presentation(app_with_clock):
     """REGRESSION GUARD: the performance property the timed design protects.
 
-    An implementation that just deletes the LRU clause passes every other test
-    in this file and fails this one, which is the entire point of it.
+    This pins THE TIME BOUND ITSELF — that a sub-window source is skipped on
+    the clock, keeping both its socket and its presentation, which is the whole
+    reason the fix is a deadline rather than a deletion of the LRU clause.
+
+    It does NOT catch the "just delete the LRU clause" mutation, and an earlier
+    version of this docstring wrongly claimed it did (review round 1 MINOR-3).
+    It cannot: parking at half the window means the sweep returns on
+    ``now - parked_at < deadline`` before the predicate is ever consulted.
+    ``test_source_parked_past_the_window_is_releasable`` is the test that fails
+    under that mutation.
     """
     app, clock = app_with_clock
     presentation = object()
@@ -271,3 +301,122 @@ def test_the_sweep_never_raises_into_the_timer(app_with_clock, monkeypatch):
 
     clock.advance(app_module.SIDEBAR_IDLE_RELEASE_S + 1)
     app._sweep_idle_sidebar_sources()  # must not raise
+
+
+def test_one_raising_source_does_not_starve_the_healthy_ones_behind_it(app_with_clock):
+    """PER-SOURCE fail-closed, not per-tick — the difference is permanent leak.
+
+    `_sidebar_sources` iterates in insertion order, so a `try` at loop scope
+    abandons the same suffix of the map on EVERY tick, not just this one. The
+    sweep is the only reaper, so a single bad probe ordered first would restore
+    the original leak for every source behind it, forever (review round 1
+    MINOR-1: 21 consecutive ticks released 0 of 3 healthy sources).
+
+    The raise is planted on `frontend_state`, which is the reachable shape:
+    `retained_for_auto_work` reads it via `getattr` BEFORE the predicate's
+    `isinstance(..., RemoteSession)` guard, and `getattr` does not swallow an
+    exception raised by a property — only a missing attribute.
+    """
+    app, clock = app_with_clock
+    bad = _make_remote(app, "poisoned", clock, 0.0, poison=True)
+    # PRECONDITION: the probe really does raise, so the test cannot pass
+    # because nothing ever threw.
+    with pytest.raises(RuntimeError):
+        _ = bad.retained_for_auto_work
+    healthy = [_make_remote(app, f"healthy{index}", clock, 0.0) for index in range(3)]
+    # PRECONDITION: the bad source really is first, so a pass cannot come from
+    # the raiser happening to sort last.
+    assert list(app._sidebar_sources) == ["poisoned", "healthy0", "healthy1", "healthy2"]
+    released = []
+    app.run_worker = lambda coro, **kw: released.append(coro) or coro.close()
+
+    clock.advance(app_module.SIDEBAR_IDLE_RELEASE_S + 1)
+    app._sweep_idle_sidebar_sources()  # must not raise
+
+    assert len(released) == len(healthy), (
+        "a source whose probe raises must cost only itself; every healthy "
+        "source ordered after it still has to be released"
+    )
+    assert app._sidebar_sources.get("poisoned") is bad, "a failed probe is a KEEP"
+
+
+def test_the_runtime_retire_offer_is_bounded(monkeypatch):
+    """A wedged runtime must not hold the closing socket for `ACK_TIMEOUT_S`.
+
+    The offer crosses the socket and `dispose()` closes that socket, so the
+    caller cannot proceed until it answers. Unbounded, a sidebar close would
+    wait 15 s per source against a runtime that never replies. A timeout is
+    just another "kept": the runtime's residency drain collects it.
+
+    Deliberately NOT on the `app_with_clock` fixture: that fixture freezes
+    `time.monotonic`, which is the clock the asyncio event loop schedules
+    timeouts on, so a real `wait_for` inside it can never fire. This one needs
+    a real loop, so it takes a bare instance instead of the injected clock.
+    """
+    import asyncio
+
+    # PRECONDITION: 3 s is the number, matching `mobile/daemon.py`'s bound on
+    # the identical call. Compressed below only so the test costs milliseconds
+    # instead of the production bound.
+    assert app_module.RETIRE_OFFER_TIMEOUT_S == 3.0
+    monkeypatch.setattr(app_module, "RETIRE_OFFER_TIMEOUT_S", 0.05)
+
+    # No Textual app is booted: the method touches nothing but its argument,
+    # and booting one would drag the whole harness into a timing assertion.
+    app = OperatorApp.__new__(OperatorApp)
+    started: list[bool] = []
+
+    async def _wedged() -> str:
+        started.append(True)
+        await asyncio.sleep(300)  # a runtime that never answers
+        raise AssertionError("unreachable: the bound must fire first")
+
+    session = Mock()
+    session.retire_if_unused = _wedged
+
+    async def _drive() -> float:
+        loop = asyncio.get_running_loop()
+        begin = loop.time()
+        # The OUTER bound is the test's own failure mode, not the assertion:
+        # without the bound under test this await never returns, and a hang is
+        # a far worse test failure than a raise. `CancelledError` is a
+        # `BaseException`, so the method's `except Exception` cannot eat it.
+        await asyncio.wait_for(OperatorApp._retire_unused_runtime(app, session), timeout=2.0)
+        return loop.time() - begin
+
+    # Must RETURN (a timeout is a "kept"), never raise into teardown.
+    elapsed = asyncio.run(_drive())
+
+    assert started, "the offer must actually have been made"
+    assert elapsed < 1.0, (
+        "an unanswered offer must be abandoned on the bound, not held for the "
+        f"AttachClient default of 15 s (took {elapsed:.2f}s)"
+    )
+
+
+def test_the_sweep_re_reads_the_window_constant_every_tick(app_with_clock, monkeypatch):
+    """The only way to reach this path in a test is patching the constant.
+
+    `SIDEBAR_IDLE_RELEASE_S` is deliberately not an env knob (see its
+    docstring), so every test here — and the two e2e repros — compress the
+    window by setting the module attribute and relying on the sweep reading it
+    per tick. Hoisting it into a local or binding it at `on_mount` would leave
+    all of them green against a five-minute wait they never reach, and the
+    coverage would evaporate silently. QA round 1, Q1: this pins it.
+    """
+    app, clock = app_with_clock
+    _make_remote(app, "aged", clock, 0.0)
+    released = []
+    app.run_worker = lambda coro, **kw: released.append(coro) or coro.close()
+
+    clock.advance(10.0)
+    monkeypatch.setattr(app_module, "SIDEBAR_IDLE_RELEASE_S", 1_000_000.0)
+    app._sweep_idle_sidebar_sources()
+    assert not released, "a window widened after startup must be honoured"
+
+    monkeypatch.setattr(app_module, "SIDEBAR_IDLE_RELEASE_S", 1.0)
+    app._sweep_idle_sidebar_sources()
+    assert released, (
+        "a window narrowed after startup must be honoured too: the sweep reads "
+        "the module attribute per tick, which is what makes the e2e repros real"
+    )


### PR DESCRIPTION
Clicking through conversations in the sidebar to check them stranded one runtime child process per conversation. Measured on the reporting host: **one TUI process (pid 63990) held 15 established attach sockets and 15 runtime children, ~1.9 GB RSS, idle for half an hour** — with an empty `Untitled conversation` among them.

**Change class: C1 (standard, pre-authorized).** One predicate correction plus a periodic sweep. No schema, no wire change, no protocol bump, no new dependency.

## Root cause: two caches that are different resources

`_sidebar_source_releasable` refused to release any source whose session id was in `_sidebar_presentations` — the `RETAINED_PRESENTATIONS = 12` **widget** LRU. But a parked presentation also pins its leased `RemoteSession`, whose attach socket makes the runtime's `attach_clients()` return 1, which is **term 3 of `process._should_exit`**. So a widget cache sized for a *rendering* working set silently became a **process** working set, and the runtime could never reap.

Probed on the assembled app after visiting three conversations — every genuine retention term was false, and only LRU membership refused:

```
current: beta
presentations: ['origin', 'alpha']
origin: releasable=False local=False auto=False preps=0 workers=0 in_presentations=True attach=1
alpha:  releasable=False local=False auto=False preps=0 workers=0 in_presentations=True attach=1
```

The live process table on the reporting host, one TUI parenting fifteen children:

```
63990 63964  36:20 418864 Local Operator /Users/damian/.local/bin/lop
63996 63990  36:19  56576 Local Operator [session] id=fa5c2a5d ... runtime.process
64056 63990  35:26 222368 Local Operator [session] id=dea45f5b ... runtime.process
   (13 more)
```

## Why the clock is on the viewer side

The obvious fix — have the runtime time its own viewers out — is wrong three ways, and each was verified rather than assumed:

1. **There is no signal to age.** A spy on `RuntimeServer._on_request` measured an idle attached viewer sending **zero ops over 12 seconds**. `_ClientConn.last_seen` is stamped only in the request loop, so for an idle viewer it is the attach time and never moves.
2. **`retiring` causes a treadmill.** `_adopt_session` installs `set_refresh_callback(_on_runtime_refreshed)`, which calls `_start_runtime_engage` eagerly and unconditionally. A runtime that idle-reaps itself and announces `retiring` to a displaying TUI is replaced within ~1 s: exit → spawn → idle → exit, strictly worse than the leak.
3. **A bare EOF is worse still.** `_lease_sidebar_source` connects without a `surface`, so `_can_go_cold` is False, and `no_takeover` raises by construction — a parked source that sees EOF redials forever.

So the viewer closes its **own** socket, and the runtime's existing 3-second residency drain does the rest. No frame, no wire op, no protocol change; the runtime keeps full authority over its own exit.

## The change

**`SIDEBAR_IDLE_RELEASE_S = 300.0`** — a parked source keeps its socket and its presentation for five minutes, then is released: socket closed, frontend unsubscribed, controller disposed, session disposed, presentation evicted with it.

Deleting the LRU clause outright (the design note's first recommendation, `docs/design-idle-reap.md`) would fix the leak in one line, but it reintroduces exactly the switch-back jitter `RETAINED_PRESENTATIONS` was raised 4→12 to remove — measured at that constant as 246 ms loop-CPU per cold switch against 59–65 ms on a hit. **A time bound keeps both properties**: the alternating working set is untouched because a conversation returned to inside the window never released anything, and only a genuinely abandoned one pays a rebuild it was going to pay anyway. The rejection is recorded in the design note's Decision section.

`parked_at` is stamped in the one place both transitions already happen together — the outgoing source starts its clock, the incoming one clears it. **A current source has no deadline at all**, which makes "the displayed conversation is never reaped" structural rather than a clause someone must remember. `_adopt_session` clears it too, so a prewarmed source that is later adopted cannot be swept while on screen.

The sweep is registered as an **always-on** interval, deliberately *not* on `_sidebar_timer`: that timer is `pause=True` and is paused whenever the sidebar is closed — the very state the leak was reported from.

**The empty `Untitled conversation`.** `retire_if_unused` had three callers, all abandoning the *current* session (`/resume` ×2, unmount); no sidebar path called it. It is now offered on the sidebar-leave path before `dispose()`. **Whether the session is really empty stays the runtime's answer** — only it can see an armed wake, a peer message that just arrived, or a second viewer — and its failure mode is "the runtime stays up and the drain gets it", so this only makes the empty case immediate. A pristine source waits out the same clock as any other; emptiness changes only what the **runtime** does when the offer reaches it at release time, never when the viewer lets go. An earlier revision released apparently-empty sources at *park* time and was reverted: a parked `/new` is still reachable (`/new` → click a session with history → click back), so disposing it at park destroys a source the user can return to. `docs/design-idle-reap.md` records the revert and `test_an_empty_parked_source_still_waits_out_the_clock` pins it.

**Prewarm treadmill damped.** Prewarm's candidate filter selects exactly the sessions with no retained presentation — i.e. the ones the sweep just released — which would turn a 5-minute reap into a 2-second respawn loop. Released sources are recorded in `_sidebar_unretainable` with the same content stamp a `retainable()` refusal uses, so an explicit click still prepares normally and any real content change reopens speculation.

Live work is never at risk: releasing a socket cannot end a turn. The runtime's own `is_busy()` already refuses to exit while a turn, compaction, subagent, background job, queued prompt or parked gate is live, and term 2 keeps a runtime whose wake is due inside `WARM_WINDOW_S`. That logic is **not** duplicated viewer-side.

## Testing evidence

**The failing repro came first.** `tests/e2e/test_sidebar_runtime_reap_e2e.py` drives the real `OperatorApp` against real `RuntimeServer`s over real sockets and asserts on process-level facts, because the leak is invisible on screen. Against the tree before the fix:

```
FAILED test_visited_conversations_do_not_hold_their_runtimes_open -
  conversations the user merely visited still hold an attached viewer, so their
  runtimes can never reap: {'origin': 1, 'alpha': 1, 'beta': 1, 'gamma': 1}
FAILED test_an_empty_conversation_visited_and_left_retires_its_runtime -
  assert 1 == 0  where 1 = attach_clients()
2 failed
```

After, on `b0239dd66`:

```
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
    tests/e2e/test_sidebar_runtime_reap_e2e.py -m e2e -n0 -q
2 passed, 2 warnings in 11.52s
```

The e2e tests compress `SIDEBAR_IDLE_RELEASE_S` by patching the module attribute; the **assertion is unchanged** — only the clock is compressed, which is why the sweep re-reads the constant per tick.

**Regression guard for the perf property** (`tests/unit/tui/test_sidebar_idle_reap.py`): a source parked for *less* than the timeout keeps both its socket and its presentation. That is the property this design exists to protect, so it is pinned rather than assumed.

**Full gates, run over the whole tree exactly as CI:**

```
flake8   OK
black    1170 files would be left unchanged
isort    OK (skipped 2)
pyright  0 errors, 0 warnings, 0 informations
pytest   17400 passed, 18 skipped in 1781.66s (0:29:41)
```

## Not addressed

`app.py` contains ~40 lines of unreachable duplicated timer registrations sitting after a `return` inside the `_turn_notified` property getter. Found while placing the sweep's interval; proven dead by AST rather than by eye. Deliberately **not** fixed here — it would put unrelated deletions into this diff — and carried as a separate follow-up PR.

