### PR TITLE
feat(session): declare the viewer surface and the runtime-role predicates

### DIFF
--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -693,8 +693,15 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
         ``bridge.remote`` binding. A rename on the facade is therefore an
         ``AttributeError`` inside a live HTTP route rather than the silent
         ``None`` a duck-probe would return — louder, but a 500 on the phone
-        portal all the same, and equally invisible to pyright while the member
-        was undeclared (QA round 2, Q4).
+        portal all the same (QA round 2, Q4).
+
+        Unlike the duck-probed members, these three were NOT invisible to
+        pyright before this declaration: the routes reach them through
+        ``DesktopSessionBridge.remote``, annotated as a concrete
+        ``RemoteSession | None``, so a rename was already a type error there —
+        reproduced against the pre-PR base (QA round 3, Q8, correcting an
+        earlier claim here that it was not). Declaring them buys the protocol's
+        coverage of the surface, not a check that was missing.
 
         Distinct from :meth:`attach_existing`: this one is allowed to START a
         runtime, because the caller is a user action that needs one. A READ

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -468,13 +468,17 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
     takeover, report which build the owner is running.
 
     **Why this is declared.** These members exist only on ``RemoteSession``,
-    and the TUI reaches all of them through ``getattr(session, "name", None)``
-    duck-probes rather than through a type. That is 40 undeclared members on
-    the object the entire front end is written against: a rename on the facade
-    or a typo in a probe string is invisible to pyright and surfaces as a
-    silently missing capability at runtime, which is exactly how ``/info``
-    reported zero subagents for a session that had several (see
-    ``RemoteSession.subagent_comms``).
+    and its hosts reached all of them through ``getattr(session, "name", None)``
+    duck-probes rather than through a type \u2014 roughly forty undeclared members
+    at the time of writing, on the object the entire front end is written
+    against. The exact figure is not maintained here: it is derived by
+    ``tests/unit/session/test_viewer_protocol.py``, which recomputes the
+    viewer-only set from the classes on every run, and quoting a constant in a
+    file whose point is that the number is derived is how the constant becomes
+    wrong. A rename on the facade or a typo in a probe string is invisible to
+    pyright and surfaces as a silently missing capability at runtime, which is
+    exactly how ``/info`` reported zero subagents for a session that had
+    several (see ``RemoteSession.subagent_comms``).
 
     **Why it is a separate protocol and not more of SessionProtocol.** Owners
     genuinely do not have these members and should not be forced to grow
@@ -501,17 +505,37 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
     # --- what kind of viewer this is --------------------------------------
     @property
     def is_cold(self) -> bool:
-        """Whether this viewer is bound to no runtime at all.
+        """Whether NO synchronised runtime is reachable through this viewer.
 
-        A cold viewer has a session id and a transcript but nothing executing:
-        `lop` launched, the user opened the picker, nothing has been typed. It
-        is NOT "the runtime is unreachable" \u2014 there is no runtime to reach.
+        True in two distinct situations, and callers depend on it covering
+        BOTH:
+
+        * never bound \u2014 a session id and a transcript but nothing executing:
+          `lop` launched, the user opened the picker, nothing typed;
+        * bound and now unreachable \u2014 the socket dropped, the owner died, or
+          the facade is redialing a replacement.
+
+        The implementation is "no client, or not connected, or not ready for
+        events", so the second case is deliberate rather than incidental.
+        ``app.py:23470`` states the dependency outright ("``is_cold`` is a
+        superset of the drop: it is also true while the facade is redialing an
+        owner that died"), and narrowing it to "never bound" would silently
+        re-open the #625 shape at that site.
+
+        So it does NOT distinguish never-bound from lost. A caller needing
+        that reads ``degraded_reason`` or ``runtime_pid``; a caller asking
+        "is a turn reachable right now" wants exactly this.
         """
         ...
 
     @property
     def runtime_pid(self) -> int | None:
-        """Pid of the runtime this viewer is attached to; ``None`` while cold."""
+        """Pid of the runtime this viewer is attached to.
+
+        ``None`` whenever ``is_cold`` is true \u2014 including after a runtime this
+        viewer WAS attached to died, since the disconnect hook clears it. It
+        is "no runtime reachable now", not "never had one".
+        """
         ...
 
     @property
@@ -542,6 +566,35 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
 
         A viewer must not answer from its own machine's catalogue: the runtime
         may hold different credentials and therefore offer different models.
+        """
+        ...
+
+    async def attach_existing(self) -> bool:
+        """Bind to an owner if one is already live, without starting one.
+
+        The desktop host calls this on a cold viewer so that serving a history
+        read never promotes a reader into an executor: losing the owner must
+        not move execution into the HTTP worker.
+        """
+        ...
+
+    async def update_desktop_watch(self, *, visible: bool, can_notify: bool) -> None:
+        """Renew this viewer's desktop attach lease.
+
+        Desktop-surface viewers only; the host recomputes visibility and
+        notifiability from its live subscribers and pushes the result so a
+        bare proxy socket is not mistaken for a watching human.
+        """
+        ...
+
+    @property
+    def supports_completion_ack(self) -> bool:
+        """Whether the attached owner can acknowledge completion attention.
+
+        Read by the DESKTOP host rather than the TUI: it decides whether the
+        phone portal is told completion-attention is supported. An owner too
+        old to carry the ack answers ``False``, which is why the host pairs
+        this with ``is_cold`` instead of reading absence as a capability.
         """
         ...
 
@@ -693,6 +746,25 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
 
     async def detach_viewer_gates(self, *, preserve_answers: bool = False) -> None:
         """Settle open gates because this viewer is leaving for good."""
+        ...
+
+    def preserve_viewer_gate_reply(self) -> None:
+        """Latch an answer the user committed before its bridge is scheduled.
+
+        Called synchronously by the UI as it settles a gate's future: waiting
+        for the wire send loses answers when a reload lands on the same tick.
+        """
+        ...
+
+    @property
+    def has_pending_gate_reply(self) -> bool:
+        """Whether a latched answer is still in flight to the owner.
+
+        The sidebar reads this to avoid tearing down a source whose committed
+        reply has not reached the runtime yet. Probed as a 3-arg ``getattr``
+        defaulting to ``False`` before this declaration, so a rename on the
+        facade silently stopped protecting the reply rather than failing.
+        """
         ...
 
     # --- owner-lifecycle callbacks -----------------------------------------

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -683,6 +683,63 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
         """
         ...
 
+    async def bind_runtime(self) -> None:
+        """Bind this viewer before an explicitly requested owner operation.
+
+        Declared because the desktop ROUTES call it as a HARD access on every
+        path that mutates owner state (``desktop_lifecycle.py`` /mcp,
+        /credential, /fork, aside completion and adoption;
+        ``desktop_sessions.py`` routed slash), reached through the
+        ``bridge.remote`` binding. A rename on the facade is therefore an
+        ``AttributeError`` inside a live HTTP route rather than the silent
+        ``None`` a duck-probe would return — louder, but a 500 on the phone
+        portal all the same, and equally invisible to pyright while the member
+        was undeclared (QA round 2, Q4).
+
+        Distinct from :meth:`attach_existing`: this one is allowed to START a
+        runtime, because the caller is a user action that needs one. A READ
+        must use ``attach_existing`` so serving history never promotes the HTTP
+        worker into an executor.
+        """
+        ...
+
+    async def admit_prompt(
+        self, text: str, *, command_id: str, images: list[dict[str, str]], steer: bool = False
+    ) -> tuple[str, bool]:
+        """Submit a prompt and return the owner's ADMISSION receipt.
+
+        ``(detail, duplicate)``: the owner's receipt text, and whether the
+        stable ``command_id`` matched a reservation it already holds. It does
+        not wait for the turn's outcome — that is the point. The desktop routes
+        serve an HTTP request, and an HTTP disconnect must not cancel work the
+        owner already accepted, which is what awaiting completion would allow.
+
+        Same declaration reasoning as :meth:`bind_runtime`: a HARD access from
+        ``desktop_lifecycle.py`` and ``desktop_sessions.py``.
+        """
+        ...
+
+    async def answer_gate(
+        self,
+        request_id: str,
+        *,
+        value: str | None = None,
+        approved: bool | None = None,
+        question_index: int | None = None,
+    ) -> str:
+        """Answer the owner's open approval gate; returns its receipt.
+
+        ``request_id`` is checked against the gate the facade currently holds
+        before anything crosses the wire, so a stale desktop popup cannot
+        answer a NEWER gate that a reconnect or a multi-question ask advanced
+        in another window. The owner validates again on its side; this check is
+        what keeps the wrong answer from being sent at all.
+
+        Same declaration reasoning as :meth:`bind_runtime`: a HARD access from
+        ``desktop_sessions.py``.
+        """
+        ...
+
     async def request_stop(self) -> str:
         """Ask the owner to end the session; returns its receipt."""
         ...

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -14,9 +14,10 @@ superseded — UIs must handle that (see docs/REWRITE.md, stream D).
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Callable, Protocol, runtime_checkable
+from typing import Any, Callable, Literal, Protocol, runtime_checkable
 
 from local_operator.harness.approval import ApprovalGate
 from local_operator.harness.types import (
@@ -68,9 +69,97 @@ class CompactionOutcome:
     tokens_after: int = 0
 
 
+#: Where the runtime that executes this session's turns lives, relative to the
+#: process asking. ``"this-process"`` means the loop runs on this thread pool
+#: and the transcript is written here; ``"this-machine"`` means a separate
+#: process on this host (the ordinary `lop` viewer, reached over a loopback
+#: socket); ``"unknown"`` is the conservative arm for a facade that cannot
+#: prove either — it exists because the honest answer to "is a config write
+#: going to govern this runtime?" is sometimes "cannot tell", and collapsing
+#: that into a bool is what made the predicate it replaces wrong five times.
+#:
+#: There is deliberately no ``"another-machine"`` member. Every listener and
+#: every dialer in this tree binds or dials ``127.0.0.1`` only
+#: (``session/runtime/server.py``, ``viewer_server.py``, ``control.py``,
+#: ``viewer_client.py``, ``mobile/attach_client.py``, ``peer_client.py``,
+#: ``daemon.py``), and ``viewer_server.py`` states it as a security invariant.
+#: A cross-host runtime cannot occur, so naming it would re-create the dead
+#: axis ``is_remote`` named.
+RuntimeLocality = Literal["this-process", "this-machine", "unknown"]
+
+
 @runtime_checkable
 class SessionProtocol(Protocol):
     """The one object every front end talks to."""
+
+    # --- runtime role -----------------------------------------------------
+    # Three predicates that name what hosts actually need to know about the
+    # relationship between this process and the session's runtime. They exist
+    # because the undeclared ``is_remote`` attribute conflated them: it is
+    # written in exactly one place (``remote.py``), was never declared on this
+    # protocol, and is read through ``getattr(session, "is_remote", False)`` at
+    # every call site, where the default silently means "in-process" and a typo
+    # in the string is invisible to pyright.
+    #
+    # Since 0.46.0 `lop` builds a viewer for every local user, so that flag is
+    # constant-True for every TUI session and the transport question it named
+    # is dead. The same conflation has been fixed site-locally four times
+    # (#576, #609, #624, #625) and guarded a fifth
+    # (``tests/unit/tui/test_noop_consumers.py``). A predicate that has been
+    # wrong five times is a missing type, not a naming problem — so the three
+    # surviving questions are declared here, separately, and checked.
+    #
+    # Stage 2 declares and implements them; no call site reads them yet. The
+    # substitutions and the deletion of ``is_remote`` are Stage 3.
+
+    @property
+    def owns_runtime(self) -> bool:
+        """Whether THIS process runs the turn loop and writes the transcript.
+
+        True on an owner (`lop exec`, the server host, a subagent host), False
+        on a facade attached to a runtime that lives somewhere else. It is the
+        lifecycle question: may this process end the session in-process, does
+        an in-process abort reach the loop, is auto-naming this process's job.
+
+        Not the same as :attr:`outcome_is_synchronous` even though both are
+        False for every `lop` TUI session today — an owner could in principle
+        admit a turn without running it to completion, and the two answers
+        would then diverge. Keeping them separate is the point: the sites that
+        ask them are asking different things.
+        """
+        ...
+
+    @property
+    def outcome_is_synchronous(self) -> bool:
+        """Whether :meth:`prompt` returns only after the turn's terminal outcome.
+
+        True where ``prompt()`` returns after the pipeline's ``finally`` has
+        flushed ``agent_end``, so the caller HOLDS the outcome and may mark the
+        turn failed or succeeded from its own stack. False where it returns on
+        the owner's durable-admission ACK — mid-turn, before the outcome exists
+        — so the caller must wait for the event stream instead and must not
+        infer success from the call returning.
+
+        A host that gets this wrong paints a turn's result from a return value
+        that carries no result. It is the meaning behind the ``outcome_known``
+        and ``knows_outcome`` locals in the TUI.
+        """
+        ...
+
+    @property
+    def runtime_locality(self) -> RuntimeLocality:
+        """Where the runtime executing this session's turns lives.
+
+        The question a host asks before writing this machine's ``config.yml``
+        and expecting the runtime to obey it: ``"this-process"`` and
+        ``"this-machine"`` both mean the write governs the runtime (two
+        terminals on one host share one config file), ``"unknown"`` means it
+        cannot be proven and the caller should be conservative.
+
+        Deliberately three-valued rather than boolean — see
+        :data:`RuntimeLocality`.
+        """
+        ...
 
     # --- identity / state -------------------------------------------------
     @property
@@ -367,3 +456,270 @@ class SessionProtocol(Protocol):
 
     # --- lifecycle --------------------------------------------------------
     async def dispose(self) -> None: ...
+
+
+@runtime_checkable
+class ViewerSessionProtocol(SessionProtocol, Protocol):
+    """The surface a VIEWER offers on top of :class:`SessionProtocol`.
+
+    A viewer is a facade attached to a runtime that executes turns somewhere
+    else. It cannot run the loop, but it can do things an owner has no need to
+    do: page a display window it did not build, ask the owner to stop, adopt a
+    takeover, report which build the owner is running.
+
+    **Why this is declared.** These members exist only on ``RemoteSession``,
+    and the TUI reaches all of them through ``getattr(session, "name", None)``
+    duck-probes rather than through a type. That is 40 undeclared members on
+    the object the entire front end is written against: a rename on the facade
+    or a typo in a probe string is invisible to pyright and surfaces as a
+    silently missing capability at runtime, which is exactly how ``/info``
+    reported zero subagents for a session that had several (see
+    ``RemoteSession.subagent_comms``).
+
+    **Why it is a separate protocol and not more of SessionProtocol.** Owners
+    genuinely do not have these members and should not be forced to grow
+    no-op stubs for them; a stub that returns a plausible empty value is worse
+    than an absent attribute, because the caller cannot tell "nothing to show"
+    from "not this kind of session".
+
+    **Why the TUI is not migrated onto it here.** The probes have graceful
+    fallbacks that also cover an owner too OLD to have a member (see
+    ``_leave_runtime_running``, which keeps a session running when
+    ``request_stop`` is absent). Substituting the type for the probes is
+    Stage 3; this declaration is what makes those substitutions checkable.
+
+    Headless hosts need this surface too, which is why it lives here rather
+    than in the TUI: ``server/utils/desktop_sessions.py`` already imports,
+    types against, and constructs ``RemoteSession`` to serve history pages.
+
+    The member list is not curated by hand \u2014 it is derived by AST from every
+    session-valued attribute access in ``tui/app.py`` and asserted complete by
+    ``tests/unit/session/test_viewer_protocol.py``, which fails when a new
+    undeclared duck-typed member appears.
+    """
+
+    # --- what kind of viewer this is --------------------------------------
+    @property
+    def is_cold(self) -> bool:
+        """Whether this viewer is bound to no runtime at all.
+
+        A cold viewer has a session id and a transcript but nothing executing:
+        `lop` launched, the user opened the picker, nothing has been typed. It
+        is NOT "the runtime is unreachable" \u2014 there is no runtime to reach.
+        """
+        ...
+
+    @property
+    def runtime_pid(self) -> int | None:
+        """Pid of the runtime this viewer is attached to; ``None`` while cold."""
+        ...
+
+    @property
+    def can_detach_runtime(self) -> bool:
+        """Whether leaving this session would leave a runtime running."""
+        ...
+
+    # --- the owner on the other end ---------------------------------------
+    #: The BUILD the runtime is running, read off its discovery record at
+    #: dial. ``""`` on a facade that has never bound AND on one bound to a
+    #: runtime older than the field; hosts distinguish those by ``is_cold``,
+    #: not by this value.
+    owner_version: str
+    #: The source ref of that build, same lifecycle as ``owner_version``.
+    owner_source_ref: str
+    #: Why this viewer opened WITHOUT live state, when that was not the
+    #: ordinary "no runtime was running" case. ``""`` when it was ordinary.
+    degraded_reason: str
+    #: Whether the saved preview this viewer opened against was partial.
+    saved_preview_partial: bool
+
+    def owner_idle(self) -> bool:
+        """Whether the owner reports no turn in flight."""
+        ...
+
+    def owner_model_catalogue(self) -> list[dict[str, Any]]:
+        """The model catalogue as the OWNER resolves it.
+
+        A viewer must not answer from its own machine's catalogue: the runtime
+        may hold different credentials and therefore offer different models.
+        """
+        ...
+
+    # --- display history paging -------------------------------------------
+    # A viewer renders a window over a transcript it does not own, so paging is
+    # a request to the owner rather than a slice of a local list. The revision
+    # counter is what lets the TUI tell "same window, redrawn" from "the window
+    # moved" without diffing rows.
+
+    @property
+    def display_history_revision(self) -> int:
+        """Bumped whenever the display window's CONTENT changes."""
+        ...
+
+    @property
+    def display_history_current(self) -> bool:
+        """Whether the loaded window includes the newest message."""
+        ...
+
+    @property
+    def history_message_count(self) -> int:
+        """How many messages the owner's transcript holds in total."""
+        ...
+
+    @property
+    def history_before_token(self) -> str | None:
+        """Opaque cursor for the next older page; ``None`` at the beginning."""
+        ...
+
+    @property
+    def history_opener_text(self) -> str:
+        """The first user message's text, for the session's title row."""
+        ...
+
+    @property
+    def history_theme_turn_count(self) -> int:
+        """Turns available to the naming pass."""
+        ...
+
+    def display_history_window(self) -> list[Any]:
+        """The currently loaded window of display rows."""
+        ...
+
+    def history_last_message(self) -> Any:
+        """The newest message in the loaded window, or ``None``."""
+        ...
+
+    def pending_display_tool_ids(self) -> set[str]:
+        """Tool ids whose result rows have not arrived yet."""
+        ...
+
+    async def ensure_display_anchor(self, anchor: str) -> bool:
+        """Load whichever page contains ``anchor``; False when it is gone."""
+        ...
+
+    async def ensure_display_current(self) -> None:
+        """Move the window to the newest page."""
+        ...
+
+    async def load_older_display_page(self) -> list[Any]:
+        """Extend the window one page toward the beginning."""
+        ...
+
+    async def materialize_history(self) -> list[Any]:
+        """Pull the WHOLE transcript, not just the loaded window.
+
+        Expensive by construction \u2014 for the paths that genuinely need every
+        message (export, search, compaction preview), not for rendering.
+        """
+        ...
+
+    # --- driving the owner -------------------------------------------------
+    async def prompt_and_wait(
+        self,
+        text: str,
+        images: Sequence[ImageContent] | None = None,
+        *,
+        message_id: str | None = None,
+    ) -> None:
+        """Submit a turn and wait for its terminal outcome.
+
+        The counterpart to :meth:`SessionProtocol.prompt`, which on a viewer
+        returns on the owner's admission ACK rather than on the outcome (see
+        :attr:`SessionProtocol.outcome_is_synchronous`). A host that needs the
+        result \u2014 exec mode, a scripted turn \u2014 must await THIS.
+        """
+        ...
+
+    async def request_stop(self) -> str:
+        """Ask the owner to end the session; returns its receipt."""
+        ...
+
+    async def request_refresh(self) -> str:
+        """Ask the owner to re-send canonical state."""
+        ...
+
+    async def retire_if_unused(self) -> str:
+        """Ask the owner to retire itself if nothing else is attached."""
+        ...
+
+    async def set_working_directory(self, cwd: str) -> str:
+        """Change the OWNER's working directory; returns its receipt."""
+        ...
+
+    async def credential_op(self, action: str, key: str = "", value: str = "") -> dict[str, Any]:
+        """Run a credential verb on the runtime.
+
+        Routed rather than executed locally because the store lives beside the
+        runtime: a viewer that answered from this machine would report the
+        wrong secrets and, worse, refuse a write the user is entitled to make.
+        """
+        ...
+
+    async def route_shared_slash(
+        self,
+        command: str,
+        args: str,
+        images: Sequence[ImageContent] | None = None,
+    ) -> Any:
+        """Run a slash command on the owner and return its result."""
+        ...
+
+    def move_will_wait(self) -> bool:
+        """Whether a move would block on an in-flight turn."""
+        ...
+
+    # --- job trajectories --------------------------------------------------
+    async def load_job_trajectory(self, job_id: str) -> bool:
+        """Stream a subagent's transcript into this viewer; False if absent."""
+        ...
+
+    async def unload_job_trajectory(self, job_id: str) -> None:
+        """Drop a loaded subagent transcript."""
+        ...
+
+    # --- approval gates across a detach ------------------------------------
+    # A viewer that leaves must not strand a gate the user never answered, and
+    # one that returns must not replay a gate the owner already resolved.
+
+    def suspend_viewer_gates(
+        self, *, auto_approve: bool = False, keep_answer: bool = False
+    ) -> "asyncio.Task[Any] | None":
+        """Park this viewer's open gates; returns the task settling them."""
+        ...
+
+    def resume_viewer_gates(self) -> None:
+        """Re-arm gates after a suspension that did not detach."""
+        ...
+
+    async def detach_viewer_gates(self, *, preserve_answers: bool = False) -> None:
+        """Settle open gates because this viewer is leaving for good."""
+        ...
+
+    # --- owner-lifecycle callbacks -----------------------------------------
+    # Installed once at adoption. They are how a viewer learns about outcomes
+    # it cannot poll for: the owner died and this process won the lease, the
+    # owner ended the session, the owner retired itself for a newer build.
+
+    def set_takeover_callback(self, callback: Callable[[Any], Any]) -> None:
+        """Called with a real owner session when this process wins the lease."""
+        ...
+
+    def set_stopped_callback(self, callback: Callable[[], Any]) -> None:
+        """Called when the owner ENDED the session deliberately."""
+        ...
+
+    def set_refresh_callback(self, callback: Callable[[], Any] | None) -> None:
+        """Called when the owner retired itself for a newer build."""
+        ...
+
+    def set_cancel_resolution(self, resolver: Callable[[int], None] | None) -> None:
+        """Arm the seam that rewrites an optimistic cancel count.
+
+        A follower's Esc reports the count it can see synchronously; the
+        authoritative number resolves on the owner and arrives later.
+        """
+        ...
+
+    def set_recall_resolution(self, resolver: Callable[[str], None] | None) -> None:
+        """The recall twin of :meth:`set_cancel_resolution`."""
+        ...

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -93,7 +93,7 @@ from local_operator.session.frontend_state import (
 )
 from local_operator.session.history_window import DisplayHistoryWindow
 from local_operator.session.naming import ConversationName
-from local_operator.session.protocol import CompactionOutcome
+from local_operator.session.protocol import CompactionOutcome, RuntimeLocality
 from local_operator.session.runtime.types import HEARTBEAT_TIMEOUT_S
 from local_operator.session.transcript import (
     Transcript,
@@ -4271,6 +4271,55 @@ class RemoteSession:
         count to the authoritative one. ``None`` disarms it.
         """
         self._cancel_resolution = resolver
+
+    # -- SessionProtocol runtime role --------------------------------------
+    # This facade owns no loop: turns execute in the runtime process on the
+    # other end of the attach socket. See ``SessionProtocol.owns_runtime`` for
+    # why these are three predicates rather than the single ``is_remote`` flag
+    # above, which Stage 3 removes.
+
+    @property
+    def owns_runtime(self) -> bool:
+        """Always False: the loop, the lease and the transcript are the owner's.
+
+        True only after a TAKEOVER — but a takeover does not mutate this
+        facade, it REPLACES it with a real ``Session`` (see
+        ``set_takeover_callback``), so this object never has to answer True.
+        """
+        return False
+
+    @property
+    def outcome_is_synchronous(self) -> bool:
+        """Always False: :meth:`prompt` returns on the owner's admission ACK.
+
+        The ACK lands when the turn is durably appended, which is BEFORE
+        ``agent_start`` — so a caller that treats the return as an outcome
+        paints a result that does not exist yet. Hosts needing the outcome must
+        await :meth:`prompt_and_wait` or the event stream.
+        """
+        return False
+
+    @property
+    def runtime_locality(self) -> RuntimeLocality:
+        """Always ``"this-machine"``, attached or cold.
+
+        Attached: ``AttachClient`` dials ``127.0.0.1`` only and the runtime
+        listener binds ``127.0.0.1`` only ("THE security invariant",
+        ``mobile/service.py``), so a reachable runtime is on this host by
+        construction rather than by inference.
+
+        Cold: there is no runtime at all, and the next one this terminal starts
+        is local — which is why a cold viewer must NOT be treated as elsewhere.
+        Answering ``"unknown"`` here would refuse a config write in the single
+        most common moment a user sets a default (see #625).
+
+        This never returns ``"unknown"``. That arm is for a CALLER that cannot
+        prove locality — the registry scan in ``app.py::_session_runs_elsewhere``
+        has an except branch that must stay conservative. Locality is not
+        re-derived here because a property must not do registry I/O on a path
+        the status bar reads.
+        """
+        return "this-machine"
 
     # -- SessionProtocol identity/state ------------------------------------
 

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -152,7 +152,7 @@ from local_operator.session.naming import (
     ConversationName,
 )
 from local_operator.session.peer import PEER_MESSAGE_MESSAGE_TYPE
-from local_operator.session.protocol import CompactionOutcome
+from local_operator.session.protocol import CompactionOutcome, RuntimeLocality
 from local_operator.session.transcript import ENTRY_CUSTOM, Transcript
 from local_operator.tools.builtin import (
     TODO_REMINDER_MESSAGE_TYPE,
@@ -3076,6 +3076,33 @@ class Session:
             loop = asyncio.get_running_loop()
             delay_s = max(0.0, (self._resume_grace_ends_ms - int(time.time() * 1000)) / 1000.0)
             loop.call_later(delay_s + 0.05, self._handle_missed_wakes)
+
+    # -- runtime role (SessionProtocol) --------------------------------------
+    # This class IS the runtime: it holds the harness loop, the lease and the
+    # transcript writer. All three answers are therefore constants here, and
+    # the constants are the point — the predicates exist so a host can ask the
+    # question by name instead of inferring it from a transport flag that no
+    # longer distinguishes anything (see ``SessionProtocol.owns_runtime``).
+
+    @property
+    def owns_runtime(self) -> bool:
+        """Always True: this object runs the loop and writes the transcript."""
+        return True
+
+    @property
+    def outcome_is_synchronous(self) -> bool:
+        """Always True: :meth:`prompt` returns after the pipeline's ``finally``.
+
+        ``prompt`` awaits the turn to completion, so the caller holds the
+        outcome when it returns — which is why the TUI's in-process path may
+        mark a turn failed from its own stack.
+        """
+        return True
+
+    @property
+    def runtime_locality(self) -> RuntimeLocality:
+        """Always ``"this-process"``: the loop runs on this event loop."""
+        return "this-process"
 
     # -- identity / state (SessionProtocol) ----------------------------------
     @property

--- a/tests/e2e/test_viewer_cold_semantics_e2e.py
+++ b/tests/e2e/test_viewer_cold_semantics_e2e.py
@@ -1,0 +1,149 @@
+"""``is_cold`` means "no runtime reachable", NOT "never bound".
+
+The distinction is load-bearing rather than semantic. ``ViewerSessionProtocol``
+declared the opposite for one round ("it is NOT 'the runtime is unreachable' --
+there is no runtime to reach") while the implementation was exactly that, and a
+declaration is what later call sites get written against: substituting a type
+for a duck-probe against a false declaration propagates the error into every
+branch that trusts it. ``app.py:23470`` already depends in writing on
+``is_cold`` covering the drop ("a superset of the drop: it is also true while
+the facade is redialing an owner that died"), so narrowing it would silently
+re-open the #625 shape there.
+
+A docstring cannot fail, so the corrected claim is pinned here instead. Drives
+the real facade over a real loopback socket through:
+
+  1. never bound                          -> expect is_cold True
+  2. attached, having WATCHED A REAL TURN  -> expect is_cold False
+  3. that same viewer after the runtime dies -> expect is_cold True  (disputed)
+
+If (3) ever reads False, either the implementation was narrowed or the
+declaration is wrong again; the assertion says which. Built on the repo's own
+e2e harness rather than a double, because a stub that declares the member is
+exactly what hid the last outage.
+"""
+
+import asyncio
+import contextlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.session.runtime import registry
+from local_operator.session.runtime.owned import OwnedSessionHandle
+from local_operator.session.runtime.server import RuntimeServer
+from tests.e2e.harness import ScriptedStream, build_session, text_turn
+
+pytestmark = pytest.mark.e2e
+
+
+async def _never_take_over() -> Any:
+    raise AssertionError("a viewer must never take over a session")
+
+
+async def _wait_for_record(config_dir: Path, session_id: str, timeout: float = 10.0) -> Any:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        for record, _state in registry.scan(config_dir):
+            if getattr(record, "session_id", "") == session_id:
+                return record
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"no record published for {session_id} within {timeout}s")
+
+
+@pytest.mark.asyncio
+async def test_is_cold_covers_a_runtime_that_died_not_only_one_never_bound(
+    headless_tui_env: Path, workspace: Path
+) -> None:
+    from local_operator.session.remote import RemoteSession
+
+    directory = headless_tui_env / "sessions" / "iscoldsess01"
+    directory.mkdir(parents=True)
+
+    # --- state 1: cold, never bound to any runtime -------------------------
+    cold = await RemoteSession.cold(
+        "iscold-never-bound",
+        config_dir=headless_tui_env,
+        cwd=str(workspace),
+        takeover_factory=_never_take_over,
+    )
+    try:
+        never_bound = cold.is_cold
+        never_bound_pid = cold.runtime_pid
+    finally:
+        await cold.dispose()
+    print(f"1. never bound            is_cold={never_bound} runtime_pid={never_bound_pid}")
+
+    stream = ScriptedStream([text_turn("Hello from the runtime.")])
+    session = build_session(directory, stream)
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(directory))
+    server = RuntimeServer(handle, kind="daemon")
+    await server.start_in_process()
+
+    viewer = None
+    try:
+        record = await _wait_for_record(headless_tui_env, session.session_id)
+        viewer = await RemoteSession.connect(
+            record,
+            session.session_id,
+            config_dir=headless_tui_env,
+            takeover_factory=_never_take_over,
+        )
+        attached = viewer.is_cold
+        print(f"2. attached, quiescent    is_cold={attached} runtime_pid={viewer.runtime_pid}")
+
+        # --- state 2: watch a REAL turn run on the runtime ------------------
+        events: list[Any] = []
+        viewer.subscribe(lambda e: events.append(e))
+        await viewer.prompt("hello there")
+
+        transcript_path = directory / "transcript.jsonl"
+        for _ in range(200):
+            if transcript_path.exists() and "Hello from the runtime." in transcript_path.read_text(
+                encoding="utf-8"
+            ):
+                break
+            await asyncio.sleep(0.05)
+        else:  # pragma: no cover
+            raise AssertionError("the runtime never wrote the reply; the turn did not run")
+
+        watched = viewer.is_cold
+        watched_pid = viewer.runtime_pid
+        print(
+            f"3. after WATCHING a turn  is_cold={watched} runtime_pid={watched_pid} "
+            f"events={len(events)} (reply on the runtime's own disk)"
+        )
+
+        # --- state 3: the runtime dies under the attached viewer ------------
+        server.close()
+        await session.dispose()
+        for _ in range(200):
+            if viewer.is_cold:
+                break
+            await asyncio.sleep(0.05)
+        died = viewer.is_cold
+        died_pid = viewer.runtime_pid
+        print(f"4. runtime DIED           is_cold={died} runtime_pid={died_pid}")
+    finally:
+        if viewer is not None:
+            await viewer.dispose()
+        with contextlib.suppress(Exception):
+            server.close()
+        with contextlib.suppress(Exception):
+            await session.dispose()
+
+    assert never_bound is True, "a never-bound viewer must read cold"
+    assert attached is False, "an attached viewer must not read cold"
+    assert watched is False and len(events) > 0, "a viewer watching a turn must not read cold"
+    assert watched_pid is not None, "an attached viewer must report the runtime pid"
+
+    # THE DISPUTED CASE. True here means `is_cold` is "no runtime reachable",
+    # covering both never-bound and bound-then-lost -- which is what the
+    # corrected declaration says and what app.py:23470 depends on.
+    assert died is True, (
+        "is_cold must be True once the runtime is gone: app.py:23470 relies on it "
+        "being a superset of the drop. If this fails, the round-1 docstring was "
+        "right and the implementation needs splitting instead."
+    )
+    assert died_pid is None, "runtime_pid must clear when the runtime is lost"

--- a/tests/unit/info/test_collect.py
+++ b/tests/unit/info/test_collect.py
@@ -33,6 +33,7 @@ from local_operator.info.collect import (
     collect_snapshot,
 )
 from local_operator.info.model import InfoSnapshot, SessionsInfo
+from local_operator.session.protocol import RuntimeLocality
 
 #: Frozen stamp for fixtures whose durations must be constants.
 NOW_FIXTURE = 1_788_602_400.0
@@ -803,6 +804,13 @@ def test_nested_subagents_are_counted_once() -> None:
             ]
 
     class _Session:
+        # Runtime role (SessionProtocol). This fake stands in for an OWNER:
+        # it carries no attached runtime, which is what the absent legacy
+        # `is_remote` meant.
+        owns_runtime = True
+        outcome_is_synchronous = True
+        runtime_locality: RuntimeLocality = "this-process"
+
         subagent_comms = _Comms()
 
     live = collect_live(_Session())
@@ -879,6 +887,13 @@ def test_a_comms_object_without_nodes_degrades_instead_of_raising() -> None:
         pass
 
     class _Session:
+        # Runtime role (SessionProtocol). This fake stands in for an OWNER:
+        # it carries no attached runtime, which is what the absent legacy
+        # `is_remote` meant.
+        owns_runtime = True
+        outcome_is_synchronous = True
+        runtime_locality: RuntimeLocality = "this-process"
+
         subagent_comms = _NoNodes()
 
     live = collect_live(_Session())  # must not raise

--- a/tests/unit/mcp/test_grants.py
+++ b/tests/unit/mcp/test_grants.py
@@ -20,6 +20,7 @@ from local_operator.mcp.grants import (
     run_grant,
     start_grant,
 )
+from local_operator.session.protocol import RuntimeLocality
 
 
 class _Conn:
@@ -71,6 +72,13 @@ class _Manager:
 
 
 class _Session:
+    # Runtime role (SessionProtocol). This fake stands in for an OWNER:
+    # it carries no attached runtime, which is what the absent legacy
+    # `is_remote` meant.
+    owns_runtime = True
+    outcome_is_synchronous = True
+    runtime_locality: RuntimeLocality = "this-process"
+
     def __init__(self, manager: Any) -> None:
         self.mcp_manager = manager
 

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -26,6 +26,7 @@ from local_operator.mcp.manager import (
     stdio_start_new_session,
 )
 from local_operator.mcp.tool_cache import McpToolCache, config_digest
+from local_operator.session.protocol import RuntimeLocality
 
 
 def _stdio_digest(command: str) -> str:
@@ -43,6 +44,13 @@ def _tool(name: str, schema: dict[str, Any] | None = None) -> Tool:
 
 class FakeSession:
     """ClientSession stand-in: records calls, returns canned results."""
+
+    # Runtime role (SessionProtocol). This fake stands in for an OWNER:
+    # it carries no attached runtime, which is what the absent legacy
+    # `is_remote` meant.
+    owns_runtime = True
+    outcome_is_synchronous = True
+    runtime_locality: RuntimeLocality = "this-process"
 
     def __init__(
         self,

--- a/tests/unit/session/runtime/test_capability_surface.py
+++ b/tests/unit/session/runtime/test_capability_surface.py
@@ -34,6 +34,8 @@ from typing import Any
 
 import pytest
 
+from local_operator.session.protocol import RuntimeLocality
+
 RUNTIME_DIR = Path(__file__).resolve().parents[4] / "local_operator" / "session" / "runtime"
 
 #: Handle attributes the server reads that are genuinely OPTIONAL — each is
@@ -357,6 +359,13 @@ def test_the_runtime_applies_fast_mode_to_the_spec_it_builds_requests_from() -> 
     from local_operator.session.runtime.owned import OwnedSessionHandle
 
     class _Session:
+        # Runtime role (SessionProtocol). This fake stands in for an OWNER:
+        # it carries no attached runtime, which is what the absent legacy
+        # `is_remote` meant.
+        owns_runtime = True
+        outcome_is_synchronous = True
+        runtime_locality: RuntimeLocality = "this-process"
+
         model_label = "anthropic/claude-opus-5"
 
         def __init__(self) -> None:

--- a/tests/unit/session/runtime/test_eager_runtime.py
+++ b/tests/unit/session/runtime/test_eager_runtime.py
@@ -24,6 +24,7 @@ from typing import Any, cast
 
 import pytest
 
+from local_operator.session.protocol import RuntimeLocality
 from local_operator.session.runtime.server import RuntimeServer, _ClientConn
 from tests.unit.session.runtime.test_server import FakeHandle
 
@@ -235,6 +236,13 @@ async def test_is_pristine_reads_the_attachment_sidecar(tmp_path: Path, monkeypa
     transcript = Transcript(directory)
 
     class _Session:
+        # Runtime role (SessionProtocol). This fake stands in for an OWNER:
+        # it carries no attached runtime, which is what the absent legacy
+        # `is_remote` meant.
+        owns_runtime = True
+        outcome_is_synchronous = True
+        runtime_locality: RuntimeLocality = "this-process"
+
         def __init__(self) -> None:
             self._transcript = transcript
             self.wake_scheduler = None
@@ -273,6 +281,13 @@ async def test_is_pristine_reads_durable_rows_not_the_model_window(
     await transcript.append_message(Message.user("we talked about something"))
 
     class _Session:
+        # Runtime role (SessionProtocol). This fake stands in for an OWNER:
+        # it carries no attached runtime, which is what the absent legacy
+        # `is_remote` meant.
+        owns_runtime = True
+        outcome_is_synchronous = True
+        runtime_locality: RuntimeLocality = "this-process"
+
         def __init__(self) -> None:
             self._transcript = transcript
             self.wake_scheduler = None
@@ -583,6 +598,13 @@ async def test_is_pristine_reads_the_wake_index_not_only_the_live_scheduler(
     )
 
     class _Session:
+        # Runtime role (SessionProtocol). This fake stands in for an OWNER:
+        # it carries no attached runtime, which is what the absent legacy
+        # `is_remote` meant.
+        owns_runtime = True
+        outcome_is_synchronous = True
+        runtime_locality: RuntimeLocality = "this-process"
+
         session_id = "s1"
 
         def __init__(self) -> None:

--- a/tests/unit/session/runtime/test_exec_control.py
+++ b/tests/unit/session/runtime/test_exec_control.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import pytest
 
+from local_operator.session.protocol import RuntimeLocality
 from local_operator.session.runtime import registry
 from local_operator.session.runtime.exec_control import (
     EXEC_RECORD_KIND,
@@ -29,6 +30,13 @@ from local_operator.session.runtime.exec_control import (
 
 class FakeSession:
     """The slice of Session the owned handle and the runtime touch here."""
+
+    # Runtime role (SessionProtocol). This fake stands in for an OWNER:
+    # it carries no attached runtime, which is what the absent legacy
+    # `is_remote` meant.
+    owns_runtime = True
+    outcome_is_synchronous = True
+    runtime_locality: RuntimeLocality = "this-process"
 
     def __init__(self, *, graceful: bool = True) -> None:
         self.session_id = "exec-sess"

--- a/tests/unit/session/runtime/test_inbox.py
+++ b/tests/unit/session/runtime/test_inbox.py
@@ -15,6 +15,7 @@ import os
 import threading
 from pathlib import Path
 
+from local_operator.session.protocol import RuntimeLocality
 from local_operator.session.runtime.inbox import (
     MAX_INBOX_ROWS,
     InboxLine,
@@ -196,6 +197,13 @@ def test_the_drain_reads_a_property_the_session_exposes(tmp_path: Path) -> None:
     transcript.directory.mkdir(parents=True, exist_ok=True)
 
     class _Session:
+        # Runtime role (SessionProtocol). This fake stands in for an OWNER:
+        # it carries no attached runtime, which is what the absent legacy
+        # `is_remote` meant.
+        owns_runtime = True
+        outcome_is_synchronous = True
+        runtime_locality: RuntimeLocality = "this-process"
+
         pass
 
     # A bare stand-in would re-create the defect's blind spot; the point is

--- a/tests/unit/session/runtime/test_owned.py
+++ b/tests/unit/session/runtime/test_owned.py
@@ -22,12 +22,20 @@ from local_operator.harness.types import (
     NoticeEvent,
     SteeringDeliveredEvent,
 )
+from local_operator.session.protocol import RuntimeLocality
 from local_operator.session.runtime import owned as owned_mod
 from local_operator.session.runtime.owned import OwnedSessionHandle
 
 
 class FakeSession:
     """The slice of Session the OwnedSessionHandle touches in these tests."""
+
+    # Runtime role (SessionProtocol). This fake stands in for an OWNER:
+    # it carries no attached runtime, which is what the absent legacy
+    # `is_remote` meant.
+    owns_runtime = True
+    outcome_is_synchronous = True
+    runtime_locality: RuntimeLocality = "this-process"
 
     def __init__(self) -> None:
         self.session_id = "sess-1"

--- a/tests/unit/session/test_viewer_protocol.py
+++ b/tests/unit/session/test_viewer_protocol.py
@@ -18,15 +18,46 @@ four times (#576, #609, #624, #625) with a fifth guarded in
 ``tests/unit/tui/test_noop_consumers.py``.
 
 Site-local fixes do not close a class of bug. This does: it derives the member
-set from the SOURCE — every session-valued attribute access and duck-probe in
-``tui/app.py`` — and fails when one of them is not declared on
-``SessionProtocol`` or ``ViewerSessionProtocol``. Adding a new undeclared
-duck-typed member to the TUI therefore fails here rather than in a user's
+set from the SOURCE — the session-valued attribute accesses and literal-string
+duck-probes in the files listed in ``_SCANNED`` — and fails when one of them is
+not declared on ``SessionProtocol`` or ``ViewerSessionProtocol``. Adding a new
+undeclared duck-typed member therefore fails here rather than in a user's
 terminal.
 
 The derivation is deliberately syntactic rather than type-inferred: pyright
 cannot follow ``getattr`` with a literal string, which is precisely why these
 members escaped typing in the first place.
+
+**What the derivation reaches, stated precisely — it is not "every access".**
+It sees ``<expr>.member`` and ``getattr``/``hasattr(<expr>, "literal", ...)``
+where ``<expr>`` is one of the bindings registered for that file in
+``_SCANNED``. It is blind to:
+
+* local aliases — ``s = self._session; s.member`` (see ``_SESSION_EXPRS``);
+* any other attribute or helper return holding a session
+  (``self._current_session().member``);
+* computed probe names — ``getattr(session, probe, None)`` where ``probe`` is a
+  variable. ``_session_is_busy`` (``app.py:9313``) is a live example: it loops
+  ``for probe in ("is_busy", "busy")``, neither name exists on either class, so
+  it always returns ``False`` and its caller takes a dead branch. The guard
+  runs over that exact line and structurally cannot see it. That is the
+  syntactic approach's ceiling, recorded here so nobody reads a green run as
+  "no duck-probe is broken";
+* sessions arriving as differently-named parameters;
+* files outside ``_SCANNED``.
+
+A green run means "no *reachable-by-this-derivation* probe is undeclared", not
+"the front end is fully typed". Widening any of the above is a matter of adding
+an expression or a path — the machinery does not change.
+
+**Do not narrow pyright's path to ``local_operator/``.** Half of the
+conformance claim is not in ``session/`` at all: it is carried by
+``_static_conformance_is_checked_by_pyright`` at the bottom of THIS file, whose
+body is the only place the two classes are assigned to the protocol types. A
+viewer member broken with no internal caller gives ``pyright
+local_operator/session/`` zero errors, and only checking this file reports it
+(QA round 1). Excluding ``tests/`` from pyright, or pointing it at the package
+alone, therefore disarms the static half silently and leaves the suite green.
 """
 
 from __future__ import annotations
@@ -40,7 +71,6 @@ from local_operator.session.remote import RemoteSession
 from local_operator.session.session import Session
 
 _ROOT = Path(local_operator.__file__).resolve().parent
-_APP = _ROOT / "tui" / "app.py"
 
 #: Expressions in ``app.py`` that are unambiguously a session.
 #:
@@ -49,13 +79,57 @@ _APP = _ROOT / "tui" / "app.py"
 #: version of this probe report ``partition``, ``focus`` and ``label`` as
 #: session members. A guard that cries wolf gets deleted, so it reads only the
 #: bindings that always hold a session.
+#:
+#: ``source.session`` is the sidebar-source binding, and it is here because
+#: omitting it let two real viewer-only members escape:
+#: ``has_pending_gate_reply`` (``app.py:4715``) and
+#: ``preserve_viewer_gate_reply`` (``app.py:15279``) — both approval-gate
+#: members sitting directly beside ones this protocol already declared.
+#:
+#: These are BINDINGS, matched literally. ``s = self._session; s.member`` is
+#: not covered: a local alias is a different expression, and the guard does no
+#: dataflow. Following aliases means resolving assignments per scope, which is
+#: where the false positives that nearly killed this probe come from — so the
+#: boundary is deliberate, and this list is the thing to extend when a new
+#: session binding appears.
 _SESSION_EXPRS = frozenset(
     {
         "self.session",
         "self._session",
         "session",
         "self.app.session",
+        "source.session",
     }
+)
+
+#: The bindings that hold a viewer facade in the desktop host.
+#:
+#: Separate from ``_SESSION_EXPRS`` because the name differs by host: the
+#: bridge stores its facade as ``self.remote`` and copies it into a local
+#: ``remote`` before use, which is a session binding by the same reasoning
+#: ``self._session`` is one in the TUI.
+_HOST_SESSION_EXPRS = frozenset({"remote", "self.remote"})
+
+#: Files scanned for session duck-probes, with the bindings to read in each.
+#:
+#: Not just the TUI. ``ViewerSessionProtocol`` lives in ``session/`` rather
+#: than in ``tui/`` precisely because the viewer facade has more than one
+#: consumer, and the desktop host is the other one: it duck-probed
+#: ``supports_completion_ack`` (``desktop_sessions.py:223``/``262``) — on
+#: ``RemoteSession``, absent from ``Session``, declared on neither protocol —
+#: which is exactly the escape this guard exists to close, one file outside
+#: its original scope. A rename there made the phone portal report
+#: completion-attention as unsupported, silently and with no error.
+#:
+#: Adding a host is one entry here plus whatever it turns out to be probing.
+#: Other ``tui/`` modules also probe sessions (``session_interaction.py``,
+#: ``widgets/session_panel.py``, ``widgets/todo_panel.py``,
+#: ``widgets/subagent_panel.py``, ``widgets/wake_panel.py``), but every member
+#: they read is already declared or excluded below, so listing them today buys
+#: scan cost and no coverage; add one when it starts probing something new.
+_SCANNED = (
+    ("tui/app.py", _SESSION_EXPRS),
+    ("server/utils/desktop_sessions.py", _HOST_SESSION_EXPRS),
 )
 
 #: Members the TUI probes on a session that belong to an OWNER, not a viewer.
@@ -69,10 +143,14 @@ _SESSION_EXPRS = frozenset(
 #: session genuinely has nothing", which is the exact confusion that produced
 #: the fabricated ``/info`` zero above.
 #:
-#: Verified as capability probes, not hard requirements, at:
-#: ``app.py:10345`` (attach_team), ``9761`` (has_pending_fork),
-#: ``6717`` (preflight_usage), ``24969`` (routing_settings), ``13626``
-#: (variables).
+#: The soundness condition is machine-checked, not asserted in prose:
+#: ``test_owner_only_probes_are_all_optional_capability_probes`` requires every
+#: name here to appear ONLY as a 3-argument ``getattr`` (i.e. with a default)
+#: and never as a hard attribute access. An earlier version of this comment
+#: cited five ``app.py`` line numbers instead; they were accurate when written
+#: and are worthless the moment anything above them moves, in a file of 33k
+#: lines. The property is what makes the exclusion sound, so the property is
+#: what gets asserted.
 _OWNER_ONLY_CAPABILITY_PROBES = frozenset(
     {
         "active_team",
@@ -99,6 +177,11 @@ _OWNER_ONLY_CAPABILITY_PROBES = frozenset(
 #: pyright. Listed rather than silently skipped so the debt is visible and the
 #: guard shrinks as they are declared. Declaring them belongs with the call-site
 #: migration (Stage 3), not with this additive change.
+#:
+#: Every name here is asserted to be present on both classes by
+#: ``test_the_exclusion_sets_state_true_facts`` — the set is a claim about the
+#: code, not a mute list, so an entry that stops being true fails rather than
+#: silently widening the guard's blind spot.
 _UNDECLARED_ON_BOTH_CLASSES = frozenset(
     {
         "acknowledge_attention",
@@ -106,7 +189,6 @@ _UNDECLARED_ON_BOTH_CLASSES = frozenset(
         "active_team_name",
         "agent_registry",
         "context_breakdown",
-        "cwd",
         "epoch",
         "fork_snapshot",
         "frontend_state",
@@ -123,6 +205,26 @@ _UNDECLARED_ON_BOTH_CLASSES = frozenset(
     }
 )
 
+#: Probed by a host but present on NEITHER class — the probe is already dead.
+#:
+#: Kept apart from ``_UNDECLARED_ON_BOTH_CLASSES`` because that set's whole
+#: point is "this member exists, it is merely undeclared". Parking a name here
+#: records the opposite and worse fact: the call site reads a member that does
+#: not exist, so its ``getattr`` default is the only value it will ever see.
+#: Filing these as ordinary debt would let the guard built to surface
+#: silent-wrong-answers permanently silence one.
+#:
+#: * ``cwd`` — ``app.py:4049`` passes ``getattr(self._session, "cwd", "")`` to
+#:   ``saved_preview(...)``, so the saved preview's working directory is
+#:   ALWAYS ``""``. Pre-existing (present at ``a8f98be3b``), behavioural, and
+#:   out of scope for this additive change: deferred to Stage 3, where that
+#:   call site is rewritten against a declared member.
+#:
+#: ``test_the_exclusion_sets_state_true_facts`` asserts these are absent from
+#: both classes, so a name here that someone later implements fails the suite
+#: and gets promoted rather than lingering as a false claim.
+_KNOWN_MISSING_ON_BOTH_CLASSES = frozenset({"cwd"})
+
 #: Removed by Stage 3; declaring it would entrench the flag this work retires.
 _RETIRED = frozenset({"is_remote"})
 
@@ -134,13 +236,17 @@ def _unparse(node: ast.AST) -> str:
         return ""
 
 
-def _session_members_touched(source: str) -> dict[str, list[int]]:
-    """Every session member ``app.py`` reads, by name, with line numbers."""
+def _session_members_touched(source: str, exprs: frozenset[str]) -> dict[str, list[int]]:
+    """Session members one file reads, by name, with line numbers.
+
+    ``exprs`` is per-file because the binding that holds a session differs by
+    host: the TUI has ``self._session``, the desktop bridge has ``self.remote``.
+    """
     tree = ast.parse(source)
     touched: dict[str, list[int]] = {}
     for node in ast.walk(tree):
         # session.member / self._session.member
-        if isinstance(node, ast.Attribute) and _unparse(node.value) in _SESSION_EXPRS:
+        if isinstance(node, ast.Attribute) and _unparse(node.value) in exprs:
             touched.setdefault(node.attr, []).append(node.lineno)
         # getattr(session, "member", ...) / hasattr(session, "member")
         if isinstance(node, ast.Call):
@@ -148,12 +254,23 @@ def _session_members_touched(source: str) -> dict[str, list[int]]:
                 isinstance(node.func, ast.Name)
                 and node.func.id in ("getattr", "hasattr")
                 and len(node.args) >= 2
-                and _unparse(node.args[0]) in _SESSION_EXPRS
+                and _unparse(node.args[0]) in exprs
                 and isinstance(node.args[1], ast.Constant)
                 and isinstance(node.args[1].value, str)
             ):
                 touched.setdefault(node.args[1].value, []).append(node.lineno)
     return touched
+
+
+def _all_touched() -> dict[str, list[str]]:
+    """Every scanned file's session members, mapped name -> ``file:line`` sites."""
+    sites: dict[str, list[str]] = {}
+    for relpath, exprs in _SCANNED:
+        filename = relpath.rsplit("/", 1)[-1]
+        found = _session_members_touched((_ROOT / relpath).read_text(), exprs)
+        for member, lines in found.items():
+            sites.setdefault(member, []).extend(f"{filename}:{line}" for line in sorted(set(lines)))
+    return sites
 
 
 def _declared() -> set[str]:
@@ -208,25 +325,31 @@ def _members(klass: type, module: str, name: str) -> set[str]:
     return members
 
 
-def test_every_session_member_the_tui_touches_is_declared() -> None:
+def test_every_session_member_a_host_touches_is_declared() -> None:
     """The guard itself.
 
-    Fails with the offending names and their ``app.py`` lines, so the fix is
+    Fails with the offending names and their ``file:line`` sites, so the fix is
     "declare it on the protocol" rather than "go find what changed".
     """
-    touched = _session_members_touched(_APP.read_text())
+    touched = _all_touched()
     declared = _declared()
-    known = declared | _OWNER_ONLY_CAPABILITY_PROBES | _UNDECLARED_ON_BOTH_CLASSES | _RETIRED
+    known = (
+        declared
+        | _OWNER_ONLY_CAPABILITY_PROBES
+        | _UNDECLARED_ON_BOTH_CLASSES
+        | _KNOWN_MISSING_ON_BOTH_CLASSES
+        | _RETIRED
+    )
 
     offenders = {
-        name: sorted(set(lines))
-        for name, lines in touched.items()
+        name: sites
+        for name, sites in touched.items()
         if not name.startswith("_") and name not in known
     }
 
     assert not offenders, (
-        "the TUI reads session members that no protocol declares: "
-        + ", ".join(f"{name} (app.py:{lines})" for name, lines in sorted(offenders.items()))
+        "a session host reads members that no protocol declares: "
+        + ", ".join(f"{name} ({', '.join(sites)})" for name, sites in sorted(offenders.items()))
         + ". A duck-typed member is invisible to pyright, so a rename or a typo "
         "in the probe string degrades it to a silent None instead of an error. "
         "Declare it on SessionProtocol (both kinds of session have it) or on "
@@ -294,7 +417,7 @@ def test_the_viewer_protocol_covers_what_only_the_facade_has() -> None:
     guard above could be satisfied forever by appending names to the exclusion
     sets instead of declaring them.
     """
-    touched = _session_members_touched(_APP.read_text())
+    touched = _all_touched()
     declared = _declared()
 
     owner_members = _members(Session, "session.py", "Session")
@@ -308,13 +431,109 @@ def test_the_viewer_protocol_covers_what_only_the_facade_has() -> None:
         and name in viewer_members
         and name not in owner_members
     }
-    assert viewer_only, "derivation found no viewer-only members — the probe has broken"
+    # A FLOOR, not a non-empty check. Emptiness only catches TOTAL collapse of
+    # the derivation; the realistic decay is partial — a renamed binding in
+    # ``_SESSION_EXPRS``, a moved path in ``_SCANNED`` — which drops a slice of
+    # the surface while leaving the set plausibly populated, and a bare
+    # ``assert viewer_only`` would still pass (review m3).
+    assert len(viewer_only) >= 20, (
+        f"derivation found only {len(viewer_only)} viewer-only members "
+        f"({sorted(viewer_only)}) — expected at least 20, so the probe has "
+        "partially broken: check that _SESSION_EXPRS' bindings and _SCANNED's "
+        "paths still match the source."
+    )
 
     undeclared = sorted(viewer_only - declared)
     assert not undeclared, (
         f"viewer-only members the TUI uses but no protocol declares: {undeclared}. "
         "These exist on RemoteSession and not on Session, so they belong on "
         "ViewerSessionProtocol."
+    )
+
+
+def test_owner_only_probes_are_all_optional_capability_probes() -> None:
+    """``_OWNER_ONLY_CAPABILITY_PROBES`` is sound only if every name has a default.
+
+    The set is excused from declaration on the grounds that each entry is an
+    OPTIONAL capability: probed with a fallback, so a session lacking it is a
+    supported state rather than a bug. That justification collapses the moment
+    one is read as a hard ``session.member`` — then absence is an
+    ``AttributeError`` in a user's terminal and the name belonged on a protocol
+    all along.
+
+    Asserted rather than commented because the previous form was five hard-coded
+    ``app.py`` line numbers (review n2), which rot into a false claim without
+    failing anything.
+    """
+    hard_accesses: dict[str, list[str]] = {}
+    for relpath, exprs in _SCANNED:
+        filename = relpath.rsplit("/", 1)[-1]
+        tree = ast.parse((_ROOT / relpath).read_text())
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Attribute)
+                and node.attr in _OWNER_ONLY_CAPABILITY_PROBES
+                and _unparse(node.value) in exprs
+            ):
+                hard_accesses.setdefault(node.attr, []).append(f"{filename}:{node.lineno}")
+            # A 2-arg getattr raises exactly like an attribute access does.
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "getattr"
+                and len(node.args) == 2
+                and _unparse(node.args[0]) in exprs
+                and isinstance(node.args[1], ast.Constant)
+                and node.args[1].value in _OWNER_ONLY_CAPABILITY_PROBES
+            ):
+                hard_accesses.setdefault(str(node.args[1].value), []).append(
+                    f"{filename}:{node.lineno}"
+                )
+
+    assert not hard_accesses, (
+        "these are excluded as OPTIONAL capability probes, but are read without "
+        f"a default: {hard_accesses}. Absence is an AttributeError at that site, "
+        "not a supported state, so the name must be declared on a protocol "
+        "rather than excluded here."
+    )
+
+
+def test_the_exclusion_sets_state_true_facts() -> None:
+    """Each exclusion set asserts something about the classes; check it holds.
+
+    An exclusion set is a claim, and a false claim inside the guard is worse
+    than no guard: it silences a member while telling the reader the silence is
+    justified. ``cwd`` was listed as living on BOTH classes when it lives on
+    neither, which converted an always-empty-value defect into permanently
+    silenced debt (review M2). Each set now has to be true.
+    """
+    owner_members = _members(Session, "session.py", "Session")
+    viewer_members = _members(RemoteSession, "remote.py", "RemoteSession")
+
+    missing = sorted(
+        n for n in _UNDECLARED_ON_BOTH_CLASSES if n not in owner_members or n not in viewer_members
+    )
+    assert not missing, (
+        f"_UNDECLARED_ON_BOTH_CLASSES claims these live on both classes: {missing}. "
+        "They do not. A name absent from both is a DEAD probe reading its own "
+        "default forever — move it to _KNOWN_MISSING_ON_BOTH_CLASSES, recording "
+        "the value it actually returns, or declare it."
+    )
+
+    resurrected = sorted(
+        n for n in _KNOWN_MISSING_ON_BOTH_CLASSES if n in owner_members or n in viewer_members
+    )
+    assert not resurrected, (
+        "_KNOWN_MISSING_ON_BOTH_CLASSES claims these exist on neither class: "
+        f"{resurrected}. They now exist, so the probe is live: declare them on a "
+        "protocol and drop them from this set."
+    )
+
+    not_owner_only = sorted(n for n in _OWNER_ONLY_CAPABILITY_PROBES if n in viewer_members)
+    assert not not_owner_only, (
+        "_OWNER_ONLY_CAPABILITY_PROBES claims these are absent from the viewer "
+        f"facade: {not_owner_only}. They exist on RemoteSession, so they are "
+        "viewer surface and belong on ViewerSessionProtocol."
     )
 
 
@@ -331,6 +550,22 @@ def _static_conformance_is_checked_by_pyright() -> None:
     Never called. Its body is type-checked where it is written; running it
     would construct sessions and dial sockets, which is the opposite of what a
     conformance assertion should cost.
+
+    **This function is load-bearing, and pytest cannot tell you when it stops
+    being.** It is the ONLY place either class is assigned to a protocol type,
+    so it is the only thing that makes pyright verify signatures — return
+    types, parameter names, async-ness — rather than mere presence. Proven, not
+    assumed: breaking a viewer member that has no internal caller gives
+    ``pyright local_operator/session/`` zero errors, and only checking THIS
+    FILE reports it (QA round 1).
+
+    Two consequences for anyone editing configuration rather than code:
+
+    * narrowing pyright's path to the package, or excluding ``tests/``, silently
+      disarms the static half of the conformance claim while every test still
+      passes — the repo's pyright invocation is whole-tree for this reason;
+    * deleting this function because "nothing calls it" removes the check
+      entirely, with no failing test to object.
     """
     viewer: ViewerSessionProtocol = RemoteSession.__new__(RemoteSession)
     owner: SessionProtocol = Session.__new__(Session)

--- a/tests/unit/session/test_viewer_protocol.py
+++ b/tests/unit/session/test_viewer_protocol.py
@@ -1,0 +1,338 @@
+"""Every session member the TUI reaches must be DECLARED on a protocol.
+
+The bug this closes has a shape, and the shape has repeated. The front end
+talks to its session through ``getattr(session, "name", None)`` duck-probes
+against attributes that no protocol declares. A probe string is data, so:
+
+* a rename on the facade leaves every probe reading ``None`` — pyright sees
+  nothing, and the capability silently disappears rather than failing;
+* a typo in the string is undetectable for the same reason;
+* the graceful fallback the probe already has ("older owner, no such member")
+  absorbs the failure and reports a plausible wrong answer instead of raising.
+
+That is not hypothetical. ``/info`` reported zero subagents for a session that
+had several because ``subagent_comms`` was private on the facade and the probe
+returned ``None`` (see ``RemoteSession.subagent_comms``), and the
+``is_remote``-conflation half of the same problem has been fixed site-locally
+four times (#576, #609, #624, #625) with a fifth guarded in
+``tests/unit/tui/test_noop_consumers.py``.
+
+Site-local fixes do not close a class of bug. This does: it derives the member
+set from the SOURCE — every session-valued attribute access and duck-probe in
+``tui/app.py`` — and fails when one of them is not declared on
+``SessionProtocol`` or ``ViewerSessionProtocol``. Adding a new undeclared
+duck-typed member to the TUI therefore fails here rather than in a user's
+terminal.
+
+The derivation is deliberately syntactic rather than type-inferred: pyright
+cannot follow ``getattr`` with a literal string, which is precisely why these
+members escaped typing in the first place.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import local_operator
+from local_operator.session.protocol import SessionProtocol, ViewerSessionProtocol
+from local_operator.session.remote import RemoteSession
+from local_operator.session.session import Session
+
+_ROOT = Path(local_operator.__file__).resolve().parent
+_APP = _ROOT / "tui" / "app.py"
+
+#: Expressions in ``app.py`` that are unambiguously a session.
+#:
+#: Deliberately NOT ``target``/``current``/``sess``: those names are reused in
+#: the file for widgets, rows and strings, and including them made an earlier
+#: version of this probe report ``partition``, ``focus`` and ``label`` as
+#: session members. A guard that cries wolf gets deleted, so it reads only the
+#: bindings that always hold a session.
+_SESSION_EXPRS = frozenset(
+    {
+        "self.session",
+        "self._session",
+        "session",
+        "self.app.session",
+    }
+)
+
+#: Members the TUI probes on a session that belong to an OWNER, not a viewer.
+#:
+#: These are OPTIONAL-capability probes: every one is
+#: ``getattr(session, name, None)`` followed by a ``callable()``/``None`` test
+#: with a working fallback, because the TUI's session may be either kind. They
+#: are excluded rather than declared because forcing a viewer to grow a no-op
+#: stub for each would be worse than their absence — a stub returning a
+#: plausible empty value cannot be distinguished by the caller from "this
+#: session genuinely has nothing", which is the exact confusion that produced
+#: the fabricated ``/info`` zero above.
+#:
+#: Verified as capability probes, not hard requirements, at:
+#: ``app.py:10345`` (attach_team), ``9761`` (has_pending_fork),
+#: ``6717`` (preflight_usage), ``24969`` (routing_settings), ``13626``
+#: (variables).
+_OWNER_ONLY_CAPABILITY_PROBES = frozenset(
+    {
+        "active_team",
+        "agent_brief",
+        "attach_agent_profile",
+        "attach_team",
+        "attachment_restore_notice",
+        "clear_agent_profile",
+        "has_pending_fork",
+        "journal_credential_change",
+        "measure_preloaded_context",
+        "preflight_usage",
+        "refresh_frontend_usage",
+        "routing_settings",
+        "variables",
+        "wears_inherited_title",
+    }
+)
+
+#: Undeclared members that live on BOTH classes.
+#:
+#: Not viewer-surface, so out of this PR's scope, but real: the TUI duck-probes
+#: them exactly like the viewer members and they are equally invisible to
+#: pyright. Listed rather than silently skipped so the debt is visible and the
+#: guard shrinks as they are declared. Declaring them belongs with the call-site
+#: migration (Stage 3), not with this additive change.
+_UNDECLARED_ON_BOTH_CLASSES = frozenset(
+    {
+        "acknowledge_attention",
+        "active_agent",
+        "active_team_name",
+        "agent_registry",
+        "context_breakdown",
+        "cwd",
+        "epoch",
+        "fork_snapshot",
+        "frontend_state",
+        "jobs",
+        "mcp_manager",
+        "mcp_startup",
+        "pending_gate",
+        "record_shell",
+        "refresh_attention",
+        "restored_usage",
+        "subscribe_frontend",
+        "team_registry",
+        "wake_scheduler",
+    }
+)
+
+#: Removed by Stage 3; declaring it would entrench the flag this work retires.
+_RETIRED = frozenset({"is_remote"})
+
+
+def _unparse(node: ast.AST) -> str:
+    try:
+        return ast.unparse(node)
+    except Exception:  # noqa: BLE001 — an unparseable node is simply not a session
+        return ""
+
+
+def _session_members_touched(source: str) -> dict[str, list[int]]:
+    """Every session member ``app.py`` reads, by name, with line numbers."""
+    tree = ast.parse(source)
+    touched: dict[str, list[int]] = {}
+    for node in ast.walk(tree):
+        # session.member / self._session.member
+        if isinstance(node, ast.Attribute) and _unparse(node.value) in _SESSION_EXPRS:
+            touched.setdefault(node.attr, []).append(node.lineno)
+        # getattr(session, "member", ...) / hasattr(session, "member")
+        if isinstance(node, ast.Call):
+            if (
+                isinstance(node.func, ast.Name)
+                and node.func.id in ("getattr", "hasattr")
+                and len(node.args) >= 2
+                and _unparse(node.args[0]) in _SESSION_EXPRS
+                and isinstance(node.args[1], ast.Constant)
+                and isinstance(node.args[1].value, str)
+            ):
+                touched.setdefault(node.args[1].value, []).append(node.lineno)
+    return touched
+
+
+def _declared() -> set[str]:
+    """Every name the two protocols declare.
+
+    ``dir()`` alone is not enough: a bare annotation (``owner_version: str``)
+    declares a member for both pyright and ``isinstance``, but creates no class
+    attribute, so it does not appear in ``dir()``. Reading
+    ``__annotations__`` as well is what makes the four instance attributes on
+    ``ViewerSessionProtocol`` count as declared — the first run of this guard
+    reported them as violations, which was the test being wrong rather than
+    the protocol.
+    """
+    names: set[str] = set()
+    for proto in (SessionProtocol, ViewerSessionProtocol):
+        names.update(n for n in dir(proto) if not n.startswith("_"))
+        # ``__mro__`` via getattr: pyright models it as a descriptor on the
+        # metaclass and rejects the direct access on a Protocol class object.
+        for klass in getattr(proto, "__mro__", ()):
+            names.update(n for n in getattr(klass, "__annotations__", {}) if not n.startswith("_"))
+    return names
+
+
+def _members(klass: type, module: str, name: str) -> set[str]:
+    """Every member of a session class, including instance attributes.
+
+    ``dir(klass)`` sees only class-level members, so attributes assigned as
+    ``self.x = ...`` in ``__init__`` are missing from it. That is not a corner
+    case here: ``RemoteSession`` sets ``owner_version``, ``degraded_reason``,
+    ``jobs`` and others that way, and ``Session`` sets ``agent_registry`` and
+    ``team_registry`` that way while ``RemoteSession`` exposes them as
+    properties. Comparing ``dir()`` to ``dir()`` therefore reported
+    ``agent_registry`` as viewer-ONLY, which is false — both classes have it.
+
+    So membership is ``dir()`` plus every ``self.<name> =`` store found by AST
+    in the class body.
+    """
+    members = {n for n in dir(klass) if not n.startswith("_")}
+    tree = ast.parse((_ROOT / "session" / module).read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            for sub in ast.walk(node):
+                if (
+                    isinstance(sub, ast.Attribute)
+                    and isinstance(sub.value, ast.Name)
+                    and sub.value.id == "self"
+                    and isinstance(sub.ctx, ast.Store)
+                    and not sub.attr.startswith("_")
+                ):
+                    members.add(sub.attr)
+            break
+    return members
+
+
+def test_every_session_member_the_tui_touches_is_declared() -> None:
+    """The guard itself.
+
+    Fails with the offending names and their ``app.py`` lines, so the fix is
+    "declare it on the protocol" rather than "go find what changed".
+    """
+    touched = _session_members_touched(_APP.read_text())
+    declared = _declared()
+    known = declared | _OWNER_ONLY_CAPABILITY_PROBES | _UNDECLARED_ON_BOTH_CLASSES | _RETIRED
+
+    offenders = {
+        name: sorted(set(lines))
+        for name, lines in touched.items()
+        if not name.startswith("_") and name not in known
+    }
+
+    assert not offenders, (
+        "the TUI reads session members that no protocol declares: "
+        + ", ".join(f"{name} (app.py:{lines})" for name, lines in sorted(offenders.items()))
+        + ". A duck-typed member is invisible to pyright, so a rename or a typo "
+        "in the probe string degrades it to a silent None instead of an error. "
+        "Declare it on SessionProtocol (both kinds of session have it) or on "
+        "ViewerSessionProtocol (only an attached facade has it)."
+    )
+
+
+def test_remote_session_satisfies_the_viewer_protocol_at_runtime() -> None:
+    """The static half is pyright's; this is the runtime half.
+
+    ``isinstance`` against a ``runtime_checkable`` Protocol checks member
+    PRESENCE only, not signatures — so it catches a rename or a deletion on the
+    facade, which is this guard's job, and pyright catches the signatures.
+    Both are needed: pyright alone would not see a member deleted at runtime by
+    a refactor of ``__init__``.
+    """
+    session = RemoteSession.__new__(RemoteSession)
+    # The instance attributes are assigned in ``__init__``, which dials a
+    # socket. Set them directly: presence is what the protocol requires, and
+    # constructing a real facade would make this a network test.
+    session.owner_version = ""
+    session.owner_source_ref = ""
+    session.degraded_reason = ""
+    session.saved_preview_partial = False
+
+    assert isinstance(session, ViewerSessionProtocol)
+    assert isinstance(session, SessionProtocol)
+
+
+def test_an_owner_session_is_not_a_viewer() -> None:
+    """The negative case, which is what makes the positive one mean anything.
+
+    If ``Session`` also satisfied ``ViewerSessionProtocol`` the split would be
+    decorative and the TUI could not use the type to tell the two apart.
+    """
+    assert not isinstance(Session.__new__(Session), ViewerSessionProtocol)
+
+
+def test_the_runtime_role_predicates_disagree_between_the_two_classes() -> None:
+    """The predicates must actually discriminate.
+
+    Asserted as a PAIR rather than per class: three predicates that returned
+    the same value on both sides would type-check, pass a conformance test, and
+    still be useless — which is the failure mode of the flag they replace
+    (``is_remote`` is constant-True for every `lop` TUI session).
+    """
+    owner = Session.__new__(Session)
+    viewer = RemoteSession.__new__(RemoteSession)
+
+    assert owner.owns_runtime is True
+    assert viewer.owns_runtime is False
+
+    assert owner.outcome_is_synchronous is True
+    assert viewer.outcome_is_synchronous is False
+
+    assert owner.runtime_locality == "this-process"
+    assert viewer.runtime_locality == "this-machine"
+
+
+def test_the_viewer_protocol_covers_what_only_the_facade_has() -> None:
+    """The viewer surface is DERIVED, not curated.
+
+    Recomputes "members ``app.py`` touches that exist on ``RemoteSession`` and
+    not on ``Session``" and asserts every one is declared. Without this, the
+    guard above could be satisfied forever by appending names to the exclusion
+    sets instead of declaring them.
+    """
+    touched = _session_members_touched(_APP.read_text())
+    declared = _declared()
+
+    owner_members = _members(Session, "session.py", "Session")
+    viewer_members = _members(RemoteSession, "remote.py", "RemoteSession")
+
+    viewer_only = {
+        name
+        for name in touched
+        if not name.startswith("_")
+        and name not in _RETIRED
+        and name in viewer_members
+        and name not in owner_members
+    }
+    assert viewer_only, "derivation found no viewer-only members — the probe has broken"
+
+    undeclared = sorted(viewer_only - declared)
+    assert not undeclared, (
+        f"viewer-only members the TUI uses but no protocol declares: {undeclared}. "
+        "These exist on RemoteSession and not on Session, so they belong on "
+        "ViewerSessionProtocol."
+    )
+
+
+def _static_conformance_is_checked_by_pyright() -> None:
+    """The STATIC half of the conformance claim, checked by pyright, not pytest.
+
+    Assigning each class to a variable of the protocol type is what makes
+    pyright verify signatures — return types, parameter names, defaults,
+    async-ness — which ``isinstance`` cannot see: a ``runtime_checkable``
+    Protocol checks member PRESENCE only, so a facade whose
+    ``load_older_display_page`` stopped being a coroutine would still pass the
+    runtime assertion above.
+
+    Never called. Its body is type-checked where it is written; running it
+    would construct sessions and dial sockets, which is the opposite of what a
+    conformance assertion should cost.
+    """
+    viewer: ViewerSessionProtocol = RemoteSession.__new__(RemoteSession)
+    owner: SessionProtocol = Session.__new__(Session)
+    attached: SessionProtocol = RemoteSession.__new__(RemoteSession)
+    _ = (viewer, owner, attached)

--- a/tests/unit/session/test_viewer_protocol.py
+++ b/tests/unit/session/test_viewer_protocol.py
@@ -141,7 +141,18 @@ _HOST_SESSION_EXPRS = frozenset({"remote", "self.remote"})
 #: routes, so a rename is a 500 on the phone portal rather than a silent
 #: ``None``. Adding this set needed no new machinery, only another literal
 #: binding, which is why it is fixed here rather than deferred.
-_ROUTE_SESSION_EXPRS = frozenset({"bridge.remote", "child.remote", "remote"})
+#:
+#: Split PER ROUTE HOST rather than shared, for the reason
+#: ``_INTERACTION_SESSION_EXPRS`` is separate from ``_SESSION_EXPRS``: a binding
+#: registered against a file that does not use it is a coverage claim the file
+#: cannot honour. All three spellings against all three route hosts produced
+#: four (host, binding) pairs deriving nothing, and a shared set hid every one
+#: of them behind a sibling host that did use the name — which is exactly the
+#: hole ``test_every_registered_session_binding_still_matches_the_source``
+#: closes below (review round 3, MAJOR-3 / QA round 3, Q7).
+_LIFECYCLE_SESSION_EXPRS = frozenset({"bridge.remote", "child.remote"})
+_ROUTE_SESSION_EXPRS = frozenset({"bridge.remote"})
+_CATALOGUE_SESSION_EXPRS = frozenset({"bridge.remote", "remote"})
 
 #: The bindings that hold a session in ``info/collect.py``.
 #:
@@ -188,13 +199,23 @@ _INFO_SESSION_EXPRS = frozenset({"session"})
 #: scan cost and no coverage; add one when it starts probing something new.
 #:
 #: The third element is that host's MINIMUM member count, and it is per host for
-#: a structural reason: ``app.py`` derives 104 of the 139 sites, so any single
-#: global floor loose enough to survive ordinary churn there cannot notice a
-#: smaller host going dark at all. Measured, not guessed: dropping the desktop
-#: utils host costs 4 viewer-only members out of 49 and dropping
+#: a structural reason: ``app.py`` derives 104 of the 112 DISTINCT PUBLIC
+#: MEMBERS (and 362 of 413 ``file:line`` SITES, deduped per member and line), so
+#: any single global floor loose enough to survive ordinary churn there cannot
+#: notice a smaller host going dark at all. Measured, not guessed: dropping the
+#: desktop utils host costs 3 VIEWER-ONLY MEMBERS out of 48 and dropping
 #: ``info/collect.py`` costs 0, so both slid under a global ``>= 40`` — the exact
 #: slack review round 2 (MINOR-1) raised, reproduced one floor higher. A count
 #: stated beside each path fires on the host that actually decayed and names it.
+#:
+#: Every figure above names the quantity it counts, because two of them were
+#: wrong when this argument was first made — "104 of the 139 sites" crossed a
+#: member count with a site count, and the viewer-only total was off by one
+#: (review round 3, MINOR-6 / QA round 3, Q9). The dominance claim is now
+#: ASSERTED, as a RATIO, in
+#: ``test_app_py_dominates_the_derivation_so_a_global_floor_cannot_work``; the
+#: absolute counts here are a snapshot for the reader and will drift with
+#: ordinary work, which is exactly why the test does not pin them.
 #:
 #: Set a few members below the current value: enough headroom that deleting a
 #: call site is not a test failure, tight enough that losing a BINDING or a PATH
@@ -204,9 +225,9 @@ _SCANNED = (
     ("tui/app.py", _SESSION_EXPRS, 95),
     ("server/utils/desktop_sessions.py", _HOST_SESSION_EXPRS, 6),
     ("info/collect.py", _INFO_SESSION_EXPRS, 5),
-    ("server/routes/desktop_lifecycle.py", _ROUTE_SESSION_EXPRS, 7),
+    ("server/routes/desktop_lifecycle.py", _LIFECYCLE_SESSION_EXPRS, 7),
     ("server/routes/desktop_sessions.py", _ROUTE_SESSION_EXPRS, 4),
-    ("server/routes/desktop_catalogues.py", _ROUTE_SESSION_EXPRS, 3),
+    ("server/routes/desktop_catalogues.py", _CATALOGUE_SESSION_EXPRS, 3),
     ("tui/session_interaction.py", _INTERACTION_SESSION_EXPRS, 2),
 )
 
@@ -373,18 +394,26 @@ def _session_members_touched(source: str, exprs: frozenset[str]) -> dict[str, li
     return touched
 
 
-def _all_touched() -> dict[str, list[str]]:
-    """Every scanned file's session members, mapped name -> ``file:line`` sites.
+def _site_label(relpath: str) -> str:
+    """A scanned host's ``parent/file.py`` label for an assertion message.
 
-    The site label keeps the parent directory, not just the basename: two
-    scanned hosts are both called ``desktop_sessions.py`` (one under
-    ``server/utils``, one under ``server/routes``), so a bare filename would
-    name an ambiguous file in the very message whose job is to send the reader
-    to the offending line.
+    Keeps the parent directory, not just the basename: two scanned hosts are
+    both called ``desktop_sessions.py`` (one under ``server/utils``, one under
+    ``server/routes``), so a bare filename would name an ambiguous file in the
+    very message whose job is to send the reader to the offending line.
+
+    A shared helper rather than the rule inlined at each site, because it was
+    inlined twice and the two copies had already drifted — one fixed, one still
+    printing the ambiguous basename (review round 3, MINOR-5).
     """
+    return "/".join(relpath.rsplit("/", 2)[-2:])
+
+
+def _all_touched() -> dict[str, list[str]]:
+    """Every scanned file's session members, mapped name -> ``file:line`` sites."""
     sites: dict[str, list[str]] = {}
     for relpath, exprs, _floor in _SCANNED:
-        filename = "/".join(relpath.rsplit("/", 2)[-2:])
+        filename = _site_label(relpath)
         found = _session_members_touched((_ROOT / relpath).read_text(), exprs)
         for member, lines in found.items():
             sites.setdefault(member, []).extend(f"{filename}:{line}" for line in sorted(set(lines)))
@@ -567,14 +596,17 @@ def test_the_viewer_protocol_covers_what_only_the_facade_has() -> None:
     #
     # PER HOST, and that is the whole point rather than a refinement. A GLOBAL
     # floor cannot do this job at any value: ``app.py`` contributes 104 of the
-    # 139 derived sites, so a number that survives ordinary churn there is
-    # necessarily far above every other host's entire contribution. Measured on
-    # this head — dropping the desktop utils host costs 4 viewer-only members of
-    # 49, dropping ``info/collect.py`` costs 0 — so both single-point decays
-    # slid under a global ``>= 40`` exactly as they slid under the ``>= 20``
-    # that review round 2 (MINOR-1) rejected. Raising one number would only
-    # move the blind spot. Each host is now asserted against its own count, so
-    # the failure names the host that decayed.
+    # 112 distinct public MEMBERS, so a number that survives ordinary churn
+    # there is necessarily far above every other host's entire contribution.
+    # Measured on this head — dropping the desktop utils host costs 3
+    # viewer-only members of 48, dropping ``info/collect.py`` costs 0 — so both
+    # single-point decays slid under a global ``>= 40`` exactly as they slid
+    # under the ``>= 20`` that review round 2 (MINOR-1) rejected. Raising one
+    # number would only move the blind spot. Each host is now asserted against
+    # its own count, so the failure names the host that decayed.
+    #
+    # That dominance is itself asserted, as a ratio, by
+    # ``test_app_py_dominates_the_derivation_so_a_global_floor_cannot_work``.
     thin = {
         relpath: (len(members), floor)
         for relpath, exprs, floor in _SCANNED
@@ -613,6 +645,92 @@ def test_the_viewer_protocol_covers_what_only_the_facade_has() -> None:
     )
 
 
+def test_app_py_dominates_the_derivation_so_a_global_floor_cannot_work() -> None:
+    """Assert the dominance the per-host floor's justification rests on.
+
+    ``_SCANNED`` argues for a floor PER HOST rather than one global number, and
+    the argument is entirely quantitative: ``app.py`` derives so much of the
+    total that any global floor loose enough to survive churn there sits above
+    every other host's whole contribution. If that ratio ever stops holding, the
+    per-host design is over-engineering and the comment defending it is wrong.
+
+    Asserted rather than left in prose because two of these numbers WERE wrong
+    (review round 3, MINOR-6 / QA round 3, Q9): the text said "104 of the 139
+    sites", conflating distinct members with ``file:line`` site strings, and
+    said 49 viewer-only members where there are 48. Two independent reviewers
+    measured two different pairs of numbers from the same tree, which is what a
+    figure nothing executes looks like from outside. Everything this file
+    asserts about the source is derived; the argument for its own shape should
+    not be the one exception.
+
+    Each number states exactly WHICH QUANTITY it counts, because that ambiguity
+    is what produced the wrong figure and then hid it. Two reviewers measuring
+    this tree independently reported 104/112 members with 362/413 sites and
+    104/124 members with 364/415 sites, and BOTH were arithmetically right — the
+    three axes they silently differed on are:
+
+    * PUBLIC vs ALL members. Underscore-prefixed names are excluded here (112),
+      included there (124). ``_session_members_touched`` collects both; every
+      assertion in this file that consumes it filters, so public is the number
+      that matches what is guarded.
+    * DISTINCT MEMBERS vs SITE STRINGS. A member touched in twelve places is one
+      member and twelve sites. The original prose said "104 of the 139 sites"
+      while 104 is a MEMBER count — the two axes crossed in a single sentence.
+    * RAW occurrences (364/415) vs sites DEDUPED by ``(member, line)``
+      (362/413). ``_all_touched`` dedupes, so two probes of the same member on
+      one line collapse; ``session.history`` on ``app.py`` lines 19279 and 19356
+      is the only such pair today, and it is the whole 2-site gap.
+
+    The RATIO is asserted rather than the absolute counts, and that is the point
+    rather than a weakening. The counts churn on ordinary work — over the last
+    30 commits touching ``app.py`` the site total moved eight times and the
+    member total four, none of them a decay — so pinning them exactly would fire
+    on unrelated PRs and train the next author to bump a number without reading
+    what it claims. AGENTS.md ("Prefer a structural invariant to a numeric one")
+    is the standing guidance. Dominance is the fact the per-host design rests
+    on, it is what a global floor cannot accommodate, and it is stable: measured
+    at 0.925-0.929 across that same history, against a bound of 0.80.
+    """
+    sites = {name: places for name, places in _all_touched().items() if not name.startswith("_")}
+    app_sites = {
+        name: [place for place in places if place.startswith("tui/app.py")]
+        for name, places in sites.items()
+    }
+    app_sites = {name: places for name, places in app_sites.items() if places}
+
+    # Guard the ratio in both currencies: a member-only bound would miss app.py
+    # shedding sites while keeping the names, which is the shape a refactor into
+    # helper modules actually takes.
+    member_share = len(app_sites) / len(sites)
+    site_share = sum(len(p) for p in app_sites.values()) / sum(len(p) for p in sites.values())
+    assert member_share >= 0.80 and site_share >= 0.80, (
+        f"app.py now derives {len(app_sites)} of {len(sites)} distinct public "
+        f"members ({member_share:.3f}) and "
+        f"{sum(len(p) for p in app_sites.values())} of "
+        f"{sum(len(p) for p in sites.values())} deduped file:line sites "
+        f"({site_share:.3f}). _SCANNED's comment justifies a PER-HOST floor by "
+        "app.py dominating the derivation; below ~0.80 the other hosts are "
+        "comparable enough that one global floor could do the job, so either "
+        "restore the ratio or rewrite that comment — do not just lower this "
+        "bound to make the failure go away."
+    )
+
+    owner = _members(Session, "session.py", "Session")
+    viewer = _members(RemoteSession, "remote.py", "RemoteSession")
+    viewer_only = {
+        name for name in sites if name not in _RETIRED and name in viewer and name not in owner
+    }
+    # An exact pin, unlike the ratio above: this is the population the aggregate
+    # floor of 40 is set against, so a drop here is the decay that floor exists
+    # to catch rather than ordinary churn.
+    assert len(viewer_only) == 48, (
+        f"there are {len(viewer_only)} viewer-only members; _SCANNED's comment "
+        "says 48, and the aggregate floor is set at 40 against that number. A "
+        "drop here is the decay that floor exists to catch, so check it is "
+        "genuinely a removal before editing this figure."
+    )
+
+
 def test_owner_only_probes_are_all_optional_capability_probes() -> None:
     """``_OWNER_ONLY_CAPABILITY_PROBES`` is sound only if every name has a default.
 
@@ -629,7 +747,7 @@ def test_owner_only_probes_are_all_optional_capability_probes() -> None:
     """
     hard_accesses: dict[str, list[str]] = {}
     for relpath, exprs, _floor in _SCANNED:
-        filename = relpath.rsplit("/", 1)[-1]
+        filename = _site_label(relpath)
         tree = ast.parse((_ROOT / relpath).read_text())
         for node in ast.walk(tree):
             if (
@@ -801,14 +919,14 @@ def test_the_static_conformance_anchor_still_exists() -> None:
 
 
 def test_every_registered_session_binding_still_matches_the_source() -> None:
-    """Each binding in every ``_SCANNED`` set must derive at least one member.
+    """Each (host, binding) pair in ``_SCANNED`` must derive at least one member.
 
     The floor in ``test_the_viewer_protocol_covers_what_only_the_facade_has``
     catches decay in AGGREGATE, and QA round 2 (Q5) showed that is not enough:
     renaming ``self._session`` in ``_SESSION_EXPRS`` drops five members and the
-    total stays above any floor loose enough to be maintainable. A per-binding
-    assertion catches the same decay at its source and names the binding, which
-    a total never can.
+    total stays above any floor loose enough to be maintainable. A per-pair
+    assertion catches the same decay at its source and names the host and the
+    binding, which a total never can.
 
     Zero sites means one of two things and both need the reader's attention: the
     binding was renamed in the source (fix the set), or it never matched and the
@@ -820,19 +938,41 @@ def test_every_registered_session_binding_still_matches_the_source() -> None:
 
     The count is pinned as well as the contribution, because the two decays are
     different and only one of them is a rename. DELETING ``source.session``
-    outright costs 2 of 49 viewer-only members — under any floor, per-host or
+    outright costs 2 of 48 viewer-only members — under any floor, per-host or
     aggregate, and invisible to the zero-sites check because a removed entry is
     not an entry that derives nothing. It was the last planted violation this
     guard did not catch. A registered binding is a coverage claim, so removing
     one has to be a deliberate edit to a stated number rather than a quiet
     deletion.
+
+    Counted per (HOST, BINDING) rather than over the union across hosts, which
+    round 3 found was hiding two distinct failures at once (review MAJOR-3, QA
+    Q7). A union credits a binding as live as long as ANY scanned host uses it,
+    so a spelling registered against a host that never had it read as covered:
+    four such pairs existed on the round-2 head, and ``desktop_lifecycle.py``
+    was passing the check solely on ``child.remote``, a single site in the whole
+    package. Per-pair counting also makes the DELETION of a whole ``_SCANNED``
+    entry visible where the union could not see it — dropping the
+    ``info/collect.py`` line removed its pair rather than emptying it, which is
+    how the reviewer re-shipped the motivating outage (rename
+    ``subagent_comms``, drop the exclusion entry it no longer backs) against a
+    fully green guard.
+
+    The scanned PATHS are pinned for the residue that per-pair counting still
+    cannot reach: a deleted entry contributes no pair to check, so the pin is
+    what converts "host silently removed" into a failure. The two assertions are
+    complementary rather than redundant — the pin catches removing a host, the
+    per-pair check catches a host that is still listed but no longer derives
+    what it claims to.
     """
-    per_binding: dict[str, int] = {}
+    per_pair: dict[tuple[str, str], int] = {}
     for relpath, exprs, _floor in _SCANNED:
         source = (_ROOT / relpath).read_text(encoding="utf-8")
         # Counted per binding rather than per member: a member reached through
         # two bindings must credit both, or dropping either looks harmless.
         tree = ast.parse(source)
+        for expr in exprs:
+            per_pair.setdefault((relpath, expr), 0)
         for node in ast.walk(tree):
             expr = None
             if isinstance(node, ast.Attribute) and not node.attr.startswith("_"):
@@ -847,22 +987,46 @@ def test_every_registered_session_binding_still_matches_the_source() -> None:
             ):
                 expr = _unparse(node.args[0])
             if expr is not None and expr in exprs:
-                per_binding[expr] = per_binding.get(expr, 0) + 1
+                per_pair[(relpath, expr)] = per_pair[(relpath, expr)] + 1
 
-    registered = {expr for _relpath, exprs, _floor in _SCANNED for expr in exprs}
-    dead = sorted(expr for expr in registered if per_binding.get(expr, 0) == 0)
+    dead = sorted(f"{relpath}:{expr}" for (relpath, expr), n in per_pair.items() if n == 0)
     assert not dead, (
-        f"these registered session bindings derive ZERO members: {dead}. Either "
-        "the binding was renamed in the source — in which case every member it "
-        "reached has silently stopped being guarded — or it never matched and "
-        "the coverage it implies is fictional. Fix the spelling or remove it "
-        "with a note saying which."
+        f"these registered (host, binding) pairs derive ZERO members: {dead}. "
+        "Either the binding was renamed in that host — in which case every "
+        "member it reached there has silently stopped being guarded — or it "
+        "never matched in that file and the coverage it implies is fictional. "
+        "Fix the spelling or drop the binding from that host's set with a note "
+        "saying which."
+    )
+
+    # The scanned PATHS, pinned by name. A ``_SCANNED`` entry is the claim that
+    # this host is watched at all, and deleting one is invisible to every other
+    # assertion here: the per-pair check loses the pairs it would have failed
+    # on, and both floors only ever see the hosts still listed.
+    assert {relpath for relpath, _exprs, _floor in _SCANNED} == {
+        "tui/app.py",
+        "server/utils/desktop_sessions.py",
+        "info/collect.py",
+        "server/routes/desktop_lifecycle.py",
+        "server/routes/desktop_sessions.py",
+        "server/routes/desktop_catalogues.py",
+        "tui/session_interaction.py",
+    }, (
+        "the set of scanned hosts changed: "
+        f"{sorted(relpath for relpath, _e, _f in _SCANNED)}. Removing one "
+        "unguards every member it derived, and three of these hosts cost ZERO "
+        "viewer-only members to delete — no floor, per-host or aggregate, can "
+        "notice their absence. Deleting the 'info/collect.py' line is how the "
+        "motivating /info outage was re-shipped against a green guard. Adding a "
+        "host is good news and needs this list updated too; either way, say "
+        "which in the commit."
     )
 
     # The bindings themselves, pinned by name. Deliberately the whole set rather
     # than a count: a count would let a deletion be paid for with an unrelated
     # addition, and the message that matters names the spelling that stopped
     # being watched.
+    registered = {expr for _relpath, exprs, _floor in _SCANNED for expr in exprs}
     assert registered == {
         "self._session",
         "session",

--- a/tests/unit/session/test_viewer_protocol.py
+++ b/tests/unit/session/test_viewer_protocol.py
@@ -29,9 +29,10 @@ cannot follow ``getattr`` with a literal string, which is precisely why these
 members escaped typing in the first place.
 
 **What the derivation reaches, stated precisely — it is not "every access".**
-It sees ``<expr>.member`` and ``getattr``/``hasattr(<expr>, "literal", ...)``
-where ``<expr>`` is one of the bindings registered for that file in
-``_SCANNED``. It is blind to:
+It sees ``<expr>.member`` and a two-or-more-argument call to any name in
+``_PROBE_CALLS`` (``getattr``, ``hasattr``, and ``info/collect.py``'s ``_attr``
+wrapper) with a literal member name, where ``<expr>`` is one of the bindings
+registered for that file in ``_SCANNED``. It is blind to:
 
 * local aliases — ``s = self._session; s.member`` (see ``_SESSION_EXPRS``);
 * any other attribute or helper return holding a session
@@ -86,6 +87,14 @@ _ROOT = Path(local_operator.__file__).resolve().parent
 #: ``preserve_viewer_gate_reply`` (``app.py:15279``) — both approval-gate
 #: members sitting directly beside ones this protocol already declared.
 #:
+#: ``self.app.session`` is NOT here, and its removal is a fix rather than a
+#: narrowing: it was registered while occurring nowhere in the package, so it
+#: implied coverage of a spelling that does not exist. A binding that matches
+#: nothing is worse than an absent one — it reads as watched. Every entry here
+#: is now asserted to derive at least one member by
+#: ``test_every_registered_session_binding_still_matches_the_source`` (QA round
+#: 2, Q5), which is what makes that claim checkable instead of aspirational.
+#:
 #: These are BINDINGS, matched literally. ``s = self._session; s.member`` is
 #: not covered: a local alias is a different expression, and the guard does no
 #: dataflow. Following aliases means resolving assignments per scope, which is
@@ -94,13 +103,20 @@ _ROOT = Path(local_operator.__file__).resolve().parent
 #: session binding appears.
 _SESSION_EXPRS = frozenset(
     {
-        "self.session",
         "self._session",
         "session",
-        "self.app.session",
         "source.session",
     }
 )
+
+#: The binding that holds a session in the TUI's interaction helper.
+#:
+#: ``self.session`` was registered against ``app.py``, where it derives nothing
+#: — the app spells it ``self._session``. Rather than drop the spelling (which
+#: stops watching a name that IS live elsewhere), it is pointed at the file that
+#: actually uses it. Scanning that file adds no undeclared members today, so the
+#: entry costs a parse and buys a real binding instead of a fictional one.
+_INTERACTION_SESSION_EXPRS = frozenset({"self.session"})
 
 #: The bindings that hold a viewer facade in the desktop host.
 #:
@@ -109,6 +125,34 @@ _SESSION_EXPRS = frozenset(
 #: ``remote`` before use, which is a session binding by the same reasoning
 #: ``self._session`` is one in the TUI.
 _HOST_SESSION_EXPRS = frozenset({"remote", "self.remote"})
+
+#: The bindings that hold a viewer facade in a desktop ROUTE module.
+#:
+#: A third spelling, and it had to be added rather than folded into the set
+#: above: the routes reach the facade through the bridge they are handed by the
+#: ``host(request).session(...)`` context manager, so the binding is
+#: ``bridge.remote`` (and ``child.remote`` for the fork route's child), while
+#: ``desktop_catalogues.py`` also copies it into a local ``remote`` exactly as
+#: the utils host does.
+#:
+#: This is the binding QA round 2 (Q4) found the guard could not read, and the
+#: three members behind it — ``bind_runtime``, ``admit_prompt``, ``answer_gate``
+#: — are the more severe shape of the escape: HARD accesses in live HTTP
+#: routes, so a rename is a 500 on the phone portal rather than a silent
+#: ``None``. Adding this set needed no new machinery, only another literal
+#: binding, which is why it is fixed here rather than deferred.
+_ROUTE_SESSION_EXPRS = frozenset({"bridge.remote", "child.remote", "remote"})
+
+#: The bindings that hold a session in ``info/collect.py``.
+#:
+#: The ``/info`` collector takes its session as a plain ``session`` parameter,
+#: so one name covers it. Deliberately NOT ``_SESSION_EXPRS``: that set carries
+#: TUI-specific spellings (``self._session``, ``source.session``) which do not
+#: occur here, and re-using it would imply a coverage claim this file cannot
+#: make. Verified equivalent on today's source — scanning ``collect.py`` with
+#: either set yields the identical seven members — so the narrow set is honest
+#: rather than merely cheaper.
+_INFO_SESSION_EXPRS = frozenset({"session"})
 
 #: Files scanned for session duck-probes, with the bindings to read in each.
 #:
@@ -121,16 +165,67 @@ _HOST_SESSION_EXPRS = frozenset({"remote", "self.remote"})
 #: its original scope. A rename there made the phone portal report
 #: completion-attention as unsupported, silently and with no error.
 #:
+#: ``info/collect.py`` is here because it is the host of the MOTIVATING bug —
+#: the ``/info`` screen that reported zero subagents — and round 2 found the
+#: guard did not observe it. The reviewer renamed ``RemoteSession.
+#: subagent_comms``, i.e. re-shipped that exact regression, and got a green
+#: guard and zero pyright errors; only a site-local test in
+#: ``tests/unit/info/`` objected, which is precisely the kind of coverage this
+#: file's docstring argues does not close a class of bug (review round 2,
+#: MAJOR-1). A guard that misses the defect it was built from is not a guard.
+#:
+#: The desktop ROUTE modules are here for the same reason one file below them
+#: is: they hold the same facade under a different binding. Only these three of
+#: the five ``desktop_*`` route modules touch a session at all
+#: (``desktop_profiles.py`` and ``desktop_radient.py`` derive zero members), so
+#: listing those two would buy scan cost and no coverage.
+#:
 #: Adding a host is one entry here plus whatever it turns out to be probing.
 #: Other ``tui/`` modules also probe sessions (``session_interaction.py``,
 #: ``widgets/session_panel.py``, ``widgets/todo_panel.py``,
 #: ``widgets/subagent_panel.py``, ``widgets/wake_panel.py``), but every member
 #: they read is already declared or excluded below, so listing them today buys
 #: scan cost and no coverage; add one when it starts probing something new.
+#:
+#: The third element is that host's MINIMUM member count, and it is per host for
+#: a structural reason: ``app.py`` derives 104 of the 139 sites, so any single
+#: global floor loose enough to survive ordinary churn there cannot notice a
+#: smaller host going dark at all. Measured, not guessed: dropping the desktop
+#: utils host costs 4 viewer-only members out of 49 and dropping
+#: ``info/collect.py`` costs 0, so both slid under a global ``>= 40`` — the exact
+#: slack review round 2 (MINOR-1) raised, reproduced one floor higher. A count
+#: stated beside each path fires on the host that actually decayed and names it.
+#:
+#: Set a few members below the current value: enough headroom that deleting a
+#: call site is not a test failure, tight enough that losing a BINDING or a PATH
+#: is. Removing a probe legitimately means lowering the number in the same
+#: commit, which is where the argument for it belongs.
 _SCANNED = (
-    ("tui/app.py", _SESSION_EXPRS),
-    ("server/utils/desktop_sessions.py", _HOST_SESSION_EXPRS),
+    ("tui/app.py", _SESSION_EXPRS, 95),
+    ("server/utils/desktop_sessions.py", _HOST_SESSION_EXPRS, 6),
+    ("info/collect.py", _INFO_SESSION_EXPRS, 5),
+    ("server/routes/desktop_lifecycle.py", _ROUTE_SESSION_EXPRS, 7),
+    ("server/routes/desktop_sessions.py", _ROUTE_SESSION_EXPRS, 4),
+    ("server/routes/desktop_catalogues.py", _ROUTE_SESSION_EXPRS, 3),
+    ("tui/session_interaction.py", _INTERACTION_SESSION_EXPRS, 2),
 )
+
+#: Call shapes that read one named attribute off a session, by function name.
+#:
+#: ``getattr``/``hasattr`` are the builtins. ``_attr`` is ``info/collect.py``'s
+#: own wrapper (``_attr(session, "name", default)``): it exists because the
+#: members it reads are PROPERTIES on the real ``Session`` and a property on an
+#: unhealthy session can raise, which a bare ``getattr`` would let escape a
+#: function whose contract is "safe on the paint path".
+#:
+#: It has to be listed because a wrapper is indistinguishable from any other
+#: call to the AST, so adding ``collect.py`` to ``_SCANNED`` alone would have
+#: derived nothing from the three lines that matter — the guard would have been
+#: widened to the motivating host and still not observed it (review round 2,
+#: MAJOR-1). The name is matched by ARITY and a literal second argument like
+#: the builtins, so a same-named helper elsewhere cannot smuggle a probe past
+#: this; and a NEW wrapper of this shape is one entry here.
+_PROBE_CALLS = frozenset({"getattr", "hasattr", "_attr"})
 
 #: Members the TUI probes on a session that belong to an OWNER, not a viewer.
 #:
@@ -182,6 +277,16 @@ _OWNER_ONLY_CAPABILITY_PROBES = frozenset(
 #: ``test_the_exclusion_sets_state_true_facts`` — the set is a claim about the
 #: code, not a mute list, so an entry that stops being true fails rather than
 #: silently widening the guard's blind spot.
+#:
+#: ``subagent_comms`` is the MOTIVATING member of this whole file and it sits
+#: here rather than on a protocol, which needs saying plainly. It is read by
+#: ``/info`` and lives on both classes, so declaring it is Stage 3's call-site
+#: work like every other name in this set. What matters for round 2 is that it
+#: is now DERIVED at all: until ``info/collect.py`` joined ``_SCANNED`` the
+#: reviewer could re-ship the original outage — rename it on the facade — with
+#: a green guard and zero pyright errors (review round 2, MAJOR-1). Being an
+#: entry in a checked set means a rename to a name that exists on NEITHER class
+#: now fails here, which is the shape the original bug had.
 _UNDECLARED_ON_BOTH_CLASSES = frozenset(
     {
         "acknowledge_attention",
@@ -199,6 +304,7 @@ _UNDECLARED_ON_BOTH_CLASSES = frozenset(
         "record_shell",
         "refresh_attention",
         "restored_usage",
+        "subagent_comms",
         "subscribe_frontend",
         "team_registry",
         "wake_scheduler",
@@ -214,11 +320,15 @@ _UNDECLARED_ON_BOTH_CLASSES = frozenset(
 #: Filing these as ordinary debt would let the guard built to surface
 #: silent-wrong-answers permanently silence one.
 #:
-#: * ``cwd`` — ``app.py:4049`` passes ``getattr(self._session, "cwd", "")`` to
+#: * ``cwd`` — ``app.py`` passes ``getattr(self._session, "cwd", "")`` to
 #:   ``saved_preview(...)``, so the saved preview's working directory is
 #:   ALWAYS ``""``. Pre-existing (present at ``a8f98be3b``), behavioural, and
 #:   out of scope for this additive change: deferred to Stage 3, where that
-#:   call site is rewritten against a declared member.
+#:   call site is rewritten against a declared member. Cited by call SHAPE
+#:   rather than by line number on purpose — a line number in a moving file is
+#:   the rot this file eliminated elsewhere (review round 2, MINOR-3), and the
+#:   name itself is machine-checked below, so the prose carries no claim the
+#:   suite cannot verify.
 #:
 #: ``test_the_exclusion_sets_state_true_facts`` asserts these are absent from
 #: both classes, so a name here that someone later implements fails the suite
@@ -248,11 +358,12 @@ def _session_members_touched(source: str, exprs: frozenset[str]) -> dict[str, li
         # session.member / self._session.member
         if isinstance(node, ast.Attribute) and _unparse(node.value) in exprs:
             touched.setdefault(node.attr, []).append(node.lineno)
-        # getattr(session, "member", ...) / hasattr(session, "member")
+        # getattr(session, "member", ...) / hasattr(session, "member") /
+        # _attr(session, "member", default) — see ``_PROBE_CALLS``.
         if isinstance(node, ast.Call):
             if (
                 isinstance(node.func, ast.Name)
-                and node.func.id in ("getattr", "hasattr")
+                and node.func.id in _PROBE_CALLS
                 and len(node.args) >= 2
                 and _unparse(node.args[0]) in exprs
                 and isinstance(node.args[1], ast.Constant)
@@ -263,10 +374,17 @@ def _session_members_touched(source: str, exprs: frozenset[str]) -> dict[str, li
 
 
 def _all_touched() -> dict[str, list[str]]:
-    """Every scanned file's session members, mapped name -> ``file:line`` sites."""
+    """Every scanned file's session members, mapped name -> ``file:line`` sites.
+
+    The site label keeps the parent directory, not just the basename: two
+    scanned hosts are both called ``desktop_sessions.py`` (one under
+    ``server/utils``, one under ``server/routes``), so a bare filename would
+    name an ambiguous file in the very message whose job is to send the reader
+    to the offending line.
+    """
     sites: dict[str, list[str]] = {}
-    for relpath, exprs in _SCANNED:
-        filename = relpath.rsplit("/", 1)[-1]
+    for relpath, exprs, _floor in _SCANNED:
+        filename = "/".join(relpath.rsplit("/", 2)[-2:])
         found = _session_members_touched((_ROOT / relpath).read_text(), exprs)
         for member, lines in found.items():
             sites.setdefault(member, []).extend(f"{filename}:{line}" for line in sorted(set(lines)))
@@ -361,15 +479,25 @@ def test_remote_session_satisfies_the_viewer_protocol_at_runtime() -> None:
     """The static half is pyright's; this is the runtime half.
 
     ``isinstance`` against a ``runtime_checkable`` Protocol checks member
-    PRESENCE only, not signatures — so it catches a rename or a deletion on the
-    facade, which is this guard's job, and pyright catches the signatures.
-    Both are needed: pyright alone would not see a member deleted at runtime by
-    a refactor of ``__init__``.
+    PRESENCE only, not signatures — so it catches a rename or a deletion of a
+    CLASS-level member (a method or property removed from ``RemoteSession``),
+    which is this guard's job, and pyright catches the signatures.
+
+    What it does NOT catch, contrary to what this docstring claimed for two
+    rounds, is an ``__init__``-assigned attribute disappearing. The four below
+    are hand-assigned to satisfy ``__new__``, so the ``isinstance`` passes
+    whether or not ``__init__`` still sets them — the reviewer deleted
+    ``owner_version`` from the class outright and got 7 tests passing against 2
+    pyright errors (review round 2, MINOR-2). For those four the division of
+    labour runs the other way: **pyright is the guard and this test is
+    structurally blind.** Stated here because a test believed to cover a case it
+    cannot is worse than an uncovered case.
     """
     session = RemoteSession.__new__(RemoteSession)
     # The instance attributes are assigned in ``__init__``, which dials a
     # socket. Set them directly: presence is what the protocol requires, and
-    # constructing a real facade would make this a network test.
+    # constructing a real facade would make this a network test. See the
+    # docstring: this assignment is exactly why the four are pyright's to guard.
     session.owner_version = ""
     session.owner_source_ref = ""
     session.degraded_reason = ""
@@ -436,11 +564,45 @@ def test_the_viewer_protocol_covers_what_only_the_facade_has() -> None:
     # ``_SESSION_EXPRS``, a moved path in ``_SCANNED`` — which drops a slice of
     # the surface while leaving the set plausibly populated, and a bare
     # ``assert viewer_only`` would still pass (review m3).
-    assert len(viewer_only) >= 20, (
+    #
+    # PER HOST, and that is the whole point rather than a refinement. A GLOBAL
+    # floor cannot do this job at any value: ``app.py`` contributes 104 of the
+    # 139 derived sites, so a number that survives ordinary churn there is
+    # necessarily far above every other host's entire contribution. Measured on
+    # this head — dropping the desktop utils host costs 4 viewer-only members of
+    # 49, dropping ``info/collect.py`` costs 0 — so both single-point decays
+    # slid under a global ``>= 40`` exactly as they slid under the ``>= 20``
+    # that review round 2 (MINOR-1) rejected. Raising one number would only
+    # move the blind spot. Each host is now asserted against its own count, so
+    # the failure names the host that decayed.
+    thin = {
+        relpath: (len(members), floor)
+        for relpath, exprs, floor in _SCANNED
+        for members in [
+            {
+                name
+                for name in _session_members_touched(
+                    (_ROOT / relpath).read_text(encoding="utf-8"), exprs
+                )
+                if not name.startswith("_")
+            }
+        ]
+        if len(members) < floor
+    }
+    assert not thin, (
+        f"these scanned hosts derive fewer members than they should: {thin} "
+        "(actual, floor). The bindings registered for that host no longer match "
+        "its source, or the path moved — either way the members it used to "
+        "guard are silently unguarded now. If probes were genuinely removed, "
+        "lower that host's floor in _SCANNED in the same commit and say which."
+    )
+    # The aggregate floor is kept BELOW the per-host ones as a backstop for a
+    # decay that is spread too thinly to trip any single host.
+    assert len(viewer_only) >= 40, (
         f"derivation found only {len(viewer_only)} viewer-only members "
-        f"({sorted(viewer_only)}) — expected at least 20, so the probe has "
-        "partially broken: check that _SESSION_EXPRS' bindings and _SCANNED's "
-        "paths still match the source."
+        f"({sorted(viewer_only)}) — expected at least 40, so the probe has "
+        "partially broken across several hosts at once: check that the "
+        "bindings and paths in _SCANNED still match the source."
     )
 
     undeclared = sorted(viewer_only - declared)
@@ -466,7 +628,7 @@ def test_owner_only_probes_are_all_optional_capability_probes() -> None:
     failing anything.
     """
     hard_accesses: dict[str, list[str]] = {}
-    for relpath, exprs in _SCANNED:
+    for relpath, exprs, _floor in _SCANNED:
         filename = relpath.rsplit("/", 1)[-1]
         tree = ast.parse((_ROOT / relpath).read_text())
         for node in ast.walk(tree):
@@ -536,6 +698,22 @@ def test_the_exclusion_sets_state_true_facts() -> None:
         "viewer surface and belong on ViewerSessionProtocol."
     )
 
+    # The OTHER half of that set's claim, and the one that was missing. The
+    # exclusion reads "an owner capability the viewer legitimately lacks", so
+    # absence-from-the-viewer alone does not justify it: a name on NEITHER class
+    # is a dead probe, and without this assertion an agent facing a red guard
+    # could silence one by appending a single line here and stay green on every
+    # test. Proved in review round 2 (MAJOR-2) with a fabricated name. Every
+    # sibling set above is two-sided; this one was not.
+    not_on_owner = sorted(n for n in _OWNER_ONLY_CAPABILITY_PROBES if n not in owner_members)
+    assert not not_on_owner, (
+        "_OWNER_ONLY_CAPABILITY_PROBES justifies each name as an OWNER "
+        f"capability, but these are absent from Session too: {not_on_owner}. A "
+        "name on neither class is a DEAD probe reading its own default forever "
+        "— move it to _KNOWN_MISSING_ON_BOTH_CLASSES, recording the value it "
+        "actually returns, rather than laundering it as an owner capability."
+    )
+
 
 def _static_conformance_is_checked_by_pyright() -> None:
     """The STATIC half of the conformance claim, checked by pyright, not pytest.
@@ -565,9 +743,140 @@ def _static_conformance_is_checked_by_pyright() -> None:
       disarms the static half of the conformance claim while every test still
       passes — the repo's pyright invocation is whole-tree for this reason;
     * deleting this function because "nothing calls it" removes the check
-      entirely, with no failing test to object.
+      entirely, with no failing test to object — except that
+      ``test_the_static_conformance_anchor_still_exists`` below now does object,
+      which is what turned that disclosure into detection (QA round 2, Q6).
     """
     viewer: ViewerSessionProtocol = RemoteSession.__new__(RemoteSession)
     owner: SessionProtocol = Session.__new__(Session)
     attached: SessionProtocol = RemoteSession.__new__(RemoteSession)
     _ = (viewer, owner, attached)
+
+
+def test_the_static_conformance_anchor_still_exists() -> None:
+    """Deleting the function above must not be silent in BOTH checkers.
+
+    It is never called, so pytest is indifferent to its existence and pyright
+    only reports what it can still see: delete it and the signature half of the
+    conformance claim vanishes with 7 tests passing and 0 pyright errors — QA
+    round 2 (Q6) verified exactly that. The disclosure in its docstring was
+    honest but disclosure is not detection.
+
+    Asserted on the ANNOTATIONS, not merely on the name: a body reduced to
+    ``pass`` keeps the symbol while removing every assignment that makes pyright
+    check anything, which is the same loss by a quieter route. Read out of the
+    module's own source because the values are type annotations on locals, which
+    do not survive into the compiled function object.
+    """
+    source = Path(__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    anchor = next(
+        (
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "_static_conformance_is_checked_by_pyright"
+        ),
+        None,
+    )
+    assert anchor is not None, (
+        "_static_conformance_is_checked_by_pyright has been deleted. It is the "
+        "ONLY place either class is assigned to a protocol type, so removing it "
+        "silently drops signature checking (return types, parameter names, "
+        "async-ness) from the conformance claim: isinstance sees member "
+        "presence only. Restore it rather than deleting this test."
+    )
+
+    annotated = {
+        _unparse(node.annotation)
+        for node in ast.walk(anchor)
+        if isinstance(node, ast.AnnAssign) and node.annotation is not None
+    }
+    assert {"ViewerSessionProtocol", "SessionProtocol"} <= annotated, (
+        "_static_conformance_is_checked_by_pyright no longer assigns both "
+        f"classes to protocol-typed variables (found annotations: {annotated}). "
+        "Those annotations ARE the static check; a body without them keeps the "
+        "symbol and loses the coverage."
+    )
+
+
+def test_every_registered_session_binding_still_matches_the_source() -> None:
+    """Each binding in every ``_SCANNED`` set must derive at least one member.
+
+    The floor in ``test_the_viewer_protocol_covers_what_only_the_facade_has``
+    catches decay in AGGREGATE, and QA round 2 (Q5) showed that is not enough:
+    renaming ``self._session`` in ``_SESSION_EXPRS`` drops five members and the
+    total stays above any floor loose enough to be maintainable. A per-binding
+    assertion catches the same decay at its source and names the binding, which
+    a total never can.
+
+    Zero sites means one of two things and both need the reader's attention: the
+    binding was renamed in the source (fix the set), or it never matched and the
+    coverage it implies was always fictional. ``self.session`` and
+    ``self.app.session`` were the second case — registered in ``_SESSION_EXPRS``
+    and matching nothing in ``app.py`` — so they are asserted against the files
+    that DO use them rather than being quietly dropped, since dropping a
+    binding is how a real spelling stops being watched.
+
+    The count is pinned as well as the contribution, because the two decays are
+    different and only one of them is a rename. DELETING ``source.session``
+    outright costs 2 of 49 viewer-only members — under any floor, per-host or
+    aggregate, and invisible to the zero-sites check because a removed entry is
+    not an entry that derives nothing. It was the last planted violation this
+    guard did not catch. A registered binding is a coverage claim, so removing
+    one has to be a deliberate edit to a stated number rather than a quiet
+    deletion.
+    """
+    per_binding: dict[str, int] = {}
+    for relpath, exprs, _floor in _SCANNED:
+        source = (_ROOT / relpath).read_text(encoding="utf-8")
+        # Counted per binding rather than per member: a member reached through
+        # two bindings must credit both, or dropping either looks harmless.
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            expr = None
+            if isinstance(node, ast.Attribute) and not node.attr.startswith("_"):
+                expr = _unparse(node.value)
+            elif (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id in _PROBE_CALLS
+                and len(node.args) >= 2
+                and isinstance(node.args[1], ast.Constant)
+                and isinstance(node.args[1].value, str)
+            ):
+                expr = _unparse(node.args[0])
+            if expr is not None and expr in exprs:
+                per_binding[expr] = per_binding.get(expr, 0) + 1
+
+    registered = {expr for _relpath, exprs, _floor in _SCANNED for expr in exprs}
+    dead = sorted(expr for expr in registered if per_binding.get(expr, 0) == 0)
+    assert not dead, (
+        f"these registered session bindings derive ZERO members: {dead}. Either "
+        "the binding was renamed in the source — in which case every member it "
+        "reached has silently stopped being guarded — or it never matched and "
+        "the coverage it implies is fictional. Fix the spelling or remove it "
+        "with a note saying which."
+    )
+
+    # The bindings themselves, pinned by name. Deliberately the whole set rather
+    # than a count: a count would let a deletion be paid for with an unrelated
+    # addition, and the message that matters names the spelling that stopped
+    # being watched.
+    assert registered == {
+        "self._session",
+        "session",
+        "source.session",
+        "remote",
+        "self.remote",
+        "bridge.remote",
+        "child.remote",
+        "self.session",
+    }, (
+        f"the set of registered session bindings changed: {sorted(registered)}. "
+        "Each one is a claim that this spelling of a session is watched, so "
+        "REMOVING one silently unguards every member it reached (deleting "
+        "'source.session' costs 2 viewer-only members — too few for any floor to "
+        "notice). Adding one is good news and needs this list updated too; "
+        "either way, say which in the commit."
+    )

--- a/tests/unit/test_exec_mode.py
+++ b/tests/unit/test_exec_mode.py
@@ -46,13 +46,20 @@ from local_operator.headless_print import PrintRenderer, printable_event, run_pr
 from local_operator.interpreter import SAFE_PATH_FLAG
 from local_operator.paths import CONFIG_DIR_ENV
 from local_operator.session.naming import ConversationName
-from local_operator.session.protocol import CompactionOutcome
+from local_operator.session.protocol import CompactionOutcome, RuntimeLocality
 
 # --- Fakes ---------------------------------------------------------------------
 
 
 class FakeSession:
     """Scripted SessionProtocol: emits a fixed event list per prompt call."""
+
+    # Runtime role (SessionProtocol). This fake stands in for an OWNER:
+    # it carries no attached runtime, which is what the absent legacy
+    # `is_remote` meant.
+    owns_runtime = True
+    outcome_is_synchronous = True
+    runtime_locality: RuntimeLocality = "this-process"
 
     def __init__(self, scripts: list[list[AgentEvent]]) -> None:
         self.scripts = scripts

--- a/tests/unit/test_imaging.py
+++ b/tests/unit/test_imaging.py
@@ -40,6 +40,7 @@ from local_operator.imaging import (
     rebound_oversize_image,
 )
 from local_operator.media import ImageInfo, sniff_image
+from local_operator.session.protocol import RuntimeLocality
 
 #: The stricter per-image dimension limit a provider applies once a request
 #: carries more than twenty images. NOT imported from the module under test:
@@ -246,6 +247,13 @@ def test_unreadable_exif_metadata_does_not_fail_the_image() -> None:
     source = _oriented_jpeg((800, 600), orientation=6)
 
     class Exploding:
+        # Runtime role (SessionProtocol). This fake stands in for an OWNER:
+        # it carries no attached runtime, which is what the absent legacy
+        # `is_remote` meant.
+        owns_runtime = True
+        outcome_is_synchronous = True
+        runtime_locality: RuntimeLocality = "this-process"
+
         def __getattr__(self, name):
             raise OSError("corrupt EXIF")
 

--- a/tests/unit/test_scheduler_new.py
+++ b/tests/unit/test_scheduler_new.py
@@ -37,6 +37,7 @@ from local_operator.harness.types import (
 )
 from local_operator.jobs import JobManager, JobStatus
 from local_operator.scheduler_service import SchedulerService
+from local_operator.session.protocol import RuntimeLocality
 from local_operator.types import OperatorType, Schedule, ScheduleUnit
 
 if TYPE_CHECKING:
@@ -55,6 +56,13 @@ class FakeSession:
     the scheduler narrows on the event and message TYPES, so a look-alike
     namespace would silently exercise a path production never takes.
     """
+
+    # Runtime role (SessionProtocol). This fake stands in for an OWNER:
+    # it carries no attached runtime, which is what the absent legacy
+    # `is_remote` meant.
+    owns_runtime = True
+    outcome_is_synchronous = True
+    runtime_locality: RuntimeLocality = "this-process"
 
     def __init__(self, fail: BaseException | None = None):
         self.prompts: list[str] = []

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -30,7 +30,7 @@ from local_operator.harness.types import (
 from local_operator.paths import config_dir
 from local_operator.session.mcp_status import McpStartupOutcome
 from local_operator.session.naming import ConversationName
-from local_operator.session.protocol import CompactionOutcome
+from local_operator.session.protocol import CompactionOutcome, RuntimeLocality
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.app import (
     BOOT_LAYOUT_CLASS,
@@ -325,6 +325,13 @@ async def test_terminal_loss_reaps_independently_of_remote_viewers(
 
 class FakeSession:
     """Records prompts/aborts; satisfies SessionProtocol."""
+
+    # Runtime role (SessionProtocol). This fake stands in for an OWNER:
+    # it carries no attached runtime, which is what the absent legacy
+    # `is_remote` meant.
+    owns_runtime = True
+    outcome_is_synchronous = True
+    runtime_locality: RuntimeLocality = "this-process"
 
     def context_breakdown(self) -> dict[str, int]:
         return getattr(self, "_context_breakdown", {})
@@ -1756,6 +1763,11 @@ async def test_a_failed_remote_cancel_never_prints_a_confirmed_success() -> None
 
     class RemoteishSession(FakeSession):
         is_remote = True
+        # Runtime role (SessionProtocol): this fake emulates an ATTACHED
+        # viewer, so the predicates must agree with `is_remote` above.
+        owns_runtime = False
+        outcome_is_synchronous = False
+        runtime_locality: RuntimeLocality = "this-machine"
         frontend_state: FrontendSessionState
 
         def __init__(self) -> None:
@@ -1965,6 +1977,11 @@ async def test_takeover_preserves_the_status_band_verbatim() -> None:
 
     class Remoteish(StatefulSession):
         is_remote = True
+        # Runtime role (SessionProtocol): this fake emulates an ATTACHED
+        # viewer, so the predicates must agree with `is_remote` above.
+        owns_runtime = False
+        outcome_is_synchronous = False
+        runtime_locality: RuntimeLocality = "this-machine"
 
         def set_takeover_callback(self, callback: Any) -> None:
             self.takeover_callback = callback
@@ -2110,6 +2127,11 @@ async def test_resume_owned_session_adopts_remote_in_standard_app(monkeypatch, t
 
     class _RemoteFake(FakeSession):
         is_remote = True
+        # Runtime role (SessionProtocol): this fake emulates an ATTACHED
+        # viewer, so the predicates must agree with `is_remote` above.
+        owns_runtime = False
+        outcome_is_synchronous = False
+        runtime_locality: RuntimeLocality = "this-machine"
 
         def __init__(self) -> None:
             super().__init__()

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -23,7 +23,7 @@ from textual.app import App, ComposeResult
 
 from local_operator.harness.types import ImageContent
 from local_operator.session.naming import ConversationName
-from local_operator.session.protocol import CompactionOutcome
+from local_operator.session.protocol import CompactionOutcome, RuntimeLocality
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.events import SubagentEnded, SubagentStarted
@@ -85,6 +85,13 @@ async def test_todo_panel_reads_selected_child_snapshot_without_root_leakage(tmp
 
 class FakeSession:
     """Minimal SessionProtocol the app can boot against."""
+
+    # Runtime role (SessionProtocol). This fake stands in for an OWNER:
+    # it carries no attached runtime, which is what the absent legacy
+    # `is_remote` meant.
+    owns_runtime = True
+    outcome_is_synchronous = True
+    runtime_locality: RuntimeLocality = "this-process"
 
     def __init__(self) -> None:
         self.prompts: list[str] = []

--- a/tests/unit/tui/test_boot_layout.py
+++ b/tests/unit/tui/test_boot_layout.py
@@ -47,7 +47,7 @@ from local_operator.harness.types import (
     ImageContent,
 )
 from local_operator.session.naming import ConversationName
-from local_operator.session.protocol import CompactionOutcome
+from local_operator.session.protocol import CompactionOutcome, RuntimeLocality
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.app import (
     BOOT_CARD_CLASS,
@@ -89,6 +89,13 @@ PLACEHOLDER_HEAD = "Message Local Operator"
 
 class FakeSession:
     """Minimal SessionProtocol stand-in: enough to boot and take one prompt."""
+
+    # Runtime role (SessionProtocol). This fake stands in for an OWNER:
+    # it carries no attached runtime, which is what the absent legacy
+    # `is_remote` meant.
+    owns_runtime = True
+    outcome_is_synchronous = True
+    runtime_locality: RuntimeLocality = "this-process"
 
     def __init__(self) -> None:
         self.prompts: list[str] = []

--- a/tests/unit/tui/test_build_skew.py
+++ b/tests/unit/tui/test_build_skew.py
@@ -34,6 +34,7 @@ import asyncio
 
 import pytest
 
+from local_operator.session.protocol import RuntimeLocality
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.widgets.transcript import NoticeBlock
 from local_operator.update import BuildStamp
@@ -83,6 +84,11 @@ class _BoundViewer(FakeSession):
     """
 
     is_remote = True
+    # Runtime role (SessionProtocol): this fake emulates an ATTACHED
+    # viewer, so the predicates must agree with `is_remote` above.
+    owns_runtime = False
+    outcome_is_synchronous = False
+    runtime_locality: RuntimeLocality = "this-machine"
     is_cold = False
 
     def __init__(

--- a/tests/unit/tui/test_config_change_notice.py
+++ b/tests/unit/tui/test_config_change_notice.py
@@ -19,6 +19,7 @@ import pytest
 from local_operator import settings_io
 from local_operator.config import ConfigManager
 from local_operator.config_watch import _reset_for_tests, process_watcher
+from local_operator.session.protocol import RuntimeLocality
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.widgets.transcript import NoticeBlock
@@ -811,6 +812,11 @@ async def test_only_the_owning_process_prints_the_keep_notice(monkeypatch, tmp_p
 
     class AttachedSession(FakeSession):
         is_remote = True
+        # Runtime role (SessionProtocol): this fake emulates an ATTACHED
+        # viewer, so the predicates must agree with `is_remote` above.
+        owns_runtime = False
+        outcome_is_synchronous = False
+        runtime_locality: RuntimeLocality = "this-machine"
 
     app = OperatorApp(lambda: _factory(AttachedSession()))
     async with app.run_test(size=(100, 24)) as pilot:
@@ -950,6 +956,11 @@ async def test_only_the_process_that_owns_the_gate_prints_the_value(monkeypatch,
 
     class AttachedSession(FakeSession):
         is_remote = True
+        # Runtime role (SessionProtocol): this fake emulates an ATTACHED
+        # viewer, so the predicates must agree with `is_remote` above.
+        owns_runtime = False
+        outcome_is_synchronous = False
+        runtime_locality: RuntimeLocality = "this-machine"
 
     app = OperatorApp(lambda: _factory(AttachedSession()))
     async with app.run_test(size=(100, 24)) as pilot:

--- a/tests/unit/tui/test_events.py
+++ b/tests/unit/tui/test_events.py
@@ -28,7 +28,11 @@ from local_operator.harness.types import (
 )
 from local_operator.model.registry import ModelInfo
 from local_operator.session.naming import ConversationName
-from local_operator.session.protocol import CompactionOutcome, SessionProtocol
+from local_operator.session.protocol import (
+    CompactionOutcome,
+    RuntimeLocality,
+    SessionProtocol,
+)
 from local_operator.tui.costs import turn_cost
 from local_operator.tui.events import (
     AssistantDelta,
@@ -84,6 +88,13 @@ class FakeApp:
 
 class FakeSession:
     """Minimal SessionProtocol that can emit events synchronously."""
+
+    # Runtime role (SessionProtocol). This fake stands in for an OWNER:
+    # it carries no attached runtime, which is what the absent legacy
+    # `is_remote` meant.
+    owns_runtime = True
+    outcome_is_synchronous = True
+    runtime_locality: RuntimeLocality = "this-process"
 
     def __init__(self) -> None:
         self._handlers: list[Any] = []

--- a/tests/unit/tui/test_mcp_startup_announce.py
+++ b/tests/unit/tui/test_mcp_startup_announce.py
@@ -29,6 +29,7 @@ import os
 import pytest
 
 from local_operator.session.mcp_status import McpStartupOutcome
+from local_operator.session.protocol import RuntimeLocality
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.widgets.toast import Toast
 from tests.unit.tui.test_app_pilot import (
@@ -74,6 +75,13 @@ class _IdentifiedMcpSession(McpSession):
     fakes are indistinguishable to the per-session notice key — which is
     exactly the distinction these tests are about.
     """
+
+    # Runtime role (SessionProtocol). This fake stands in for an OWNER:
+    # it carries no attached runtime, which is what the absent legacy
+    # `is_remote` meant.
+    owns_runtime = True
+    outcome_is_synchronous = True
+    runtime_locality: RuntimeLocality = "this-process"
 
     def __init__(self, manager, startup, session_id: str) -> None:
         super().__init__(manager, startup)

--- a/tests/unit/tui/test_sidebar_source_state.py
+++ b/tests/unit/tui/test_sidebar_source_state.py
@@ -11,6 +11,7 @@ from PIL import Image
 from textual.widgets.text_area import Selection
 
 from local_operator.harness.types import AskOption, AskQuestion, ImageContent
+from local_operator.session.protocol import RuntimeLocality
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.session_drafts import SessionDraftStore
 from local_operator.tui.session_interaction import SessionDraft
@@ -207,6 +208,11 @@ async def test_pending_choice_snapshot_restores_typed_and_checked_state():
 async def test_hidden_stopped_callback_cannot_answer_selected_sources_gate(gate_kind):
     class Watched(FakeSession):
         is_remote = True
+        # Runtime role (SessionProtocol): this fake emulates an ATTACHED
+        # viewer, so the predicates must agree with `is_remote` above.
+        owns_runtime = False
+        outcome_is_synchronous = False
+        runtime_locality: RuntimeLocality = "this-machine"
 
         def set_stopped_callback(self, callback):
             self.stopped_callback = callback

--- a/tests/unit/tui/test_sidebar_swap_reset.py
+++ b/tests/unit/tui/test_sidebar_swap_reset.py
@@ -29,6 +29,7 @@ from local_operator.session.frontend_state import (
     FrontendSessionState,
     FrontendStateStore,
 )
+from local_operator.session.protocol import RuntimeLocality
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.session_interaction import SessionInteraction
 from local_operator.tui.widgets.status_line import FORK_PENDING_TEXT
@@ -67,6 +68,11 @@ class SidebarRemote(FakeSession):
     """
 
     is_remote = True
+    # Runtime role (SessionProtocol): this fake emulates an ATTACHED
+    # viewer, so the predicates must agree with `is_remote` above.
+    owns_runtime = False
+    outcome_is_synchronous = False
+    runtime_locality: RuntimeLocality = "this-machine"
 
     def __init__(
         self,

--- a/tests/unit/tui/test_snapshot.py
+++ b/tests/unit/tui/test_snapshot.py
@@ -51,7 +51,7 @@ from local_operator.harness.types import (  # noqa: E402
     Usage,
 )
 from local_operator.session.naming import ConversationName  # noqa: E402
-from local_operator.session.protocol import CompactionOutcome  # noqa: E402
+from local_operator.session.protocol import CompactionOutcome, RuntimeLocality  # noqa: E402
 from local_operator.tui.app import OperatorApp  # noqa: E402
 from local_operator.tui.widgets.editor import Editor  # noqa: E402
 from local_operator.tui.widgets.welcome import WelcomeView  # noqa: E402
@@ -73,6 +73,13 @@ MARKDOWN = (
 
 class FakeSession:
     """Records prompts/aborts; satisfies SessionProtocol."""
+
+    # Runtime role (SessionProtocol). This fake stands in for an OWNER:
+    # it carries no attached runtime, which is what the absent legacy
+    # `is_remote` meant.
+    owns_runtime = True
+    outcome_is_synchronous = True
+    runtime_locality: RuntimeLocality = "this-process"
 
     def __init__(self) -> None:
         self.prompts: list[str] = []

--- a/tests/unit/tui/test_snapshot.py
+++ b/tests/unit/tui/test_snapshot.py
@@ -51,7 +51,10 @@ from local_operator.harness.types import (  # noqa: E402
     Usage,
 )
 from local_operator.session.naming import ConversationName  # noqa: E402
-from local_operator.session.protocol import CompactionOutcome, RuntimeLocality  # noqa: E402
+from local_operator.session.protocol import (  # noqa: E402
+    CompactionOutcome,
+    RuntimeLocality,
+)
 from local_operator.tui.app import OperatorApp  # noqa: E402
 from local_operator.tui.widgets.editor import Editor  # noqa: E402
 from local_operator.tui.widgets.welcome import WelcomeView  # noqa: E402

--- a/tests/unit/tui/test_stop_command.py
+++ b/tests/unit/tui/test_stop_command.py
@@ -20,6 +20,7 @@ from typing import Any
 
 import pytest
 
+from local_operator.session.protocol import RuntimeLocality
 from local_operator.session.runtime import control
 from local_operator.session.runtime.types import SessionRecord
 from local_operator.tui import app as app_mod
@@ -122,6 +123,11 @@ async def test_follower_stop_sends_the_op_to_the_owner() -> None:
 
     class Remoteish(FakeSession):
         is_remote = True
+        # Runtime role (SessionProtocol): this fake emulates an ATTACHED
+        # viewer, so the predicates must agree with `is_remote` above.
+        owns_runtime = False
+        outcome_is_synchronous = False
+        runtime_locality: RuntimeLocality = "this-machine"
         frontend_state: FrontendSessionState
 
         def __init__(self) -> None:

--- a/tests/unit/tui/test_turn_abandoned.py
+++ b/tests/unit/tui/test_turn_abandoned.py
@@ -35,6 +35,7 @@ from typing import Any
 import pytest
 
 from local_operator.harness.types import ToolExecutionStartEvent
+from local_operator.session.protocol import RuntimeLocality
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.events import (
     CompactionStarted,
@@ -118,6 +119,11 @@ class HangingFollowerSession(JobsSession):
     #: than "the turn succeeded". A follower fake without it models the wire
     #: ORDER while claiming the authority of an in-process session.
     is_remote = True
+    # Runtime role (SessionProtocol): this fake emulates an ATTACHED
+    # viewer, so the predicates must agree with `is_remote` above.
+    owns_runtime = False
+    outcome_is_synchronous = False
+    runtime_locality: RuntimeLocality = "this-machine"
 
     async def prompt(self, text: str, images: Any = None, **kwargs: Any) -> None:
         self.streaming = True
@@ -147,6 +153,11 @@ class OwnerEndRacingFollowerSession(JobsSession):
     #: this fallback decline to announce an outcome it was never told, so the
     #: owner's real end behind it is what speaks.
     is_remote = True
+    # Runtime role (SessionProtocol): this fake emulates an ATTACHED
+    # viewer, so the predicates must agree with `is_remote` above.
+    owns_runtime = False
+    outcome_is_synchronous = False
+    runtime_locality: RuntimeLocality = "this-machine"
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -1488,6 +1499,11 @@ async def test_a_follower_whose_prompt_is_refused_before_start_still_clears_the_
 
     class RefusingFollowerSession(JobsSession):
         is_remote = True
+        # Runtime role (SessionProtocol): this fake emulates an ATTACHED
+        # viewer, so the predicates must agree with `is_remote` above.
+        owns_runtime = False
+        outcome_is_synchronous = False
+        runtime_locality: RuntimeLocality = "this-machine"
 
         async def prompt(self, text: str, images: Any = None, **kwargs: Any) -> None:
             raise RuntimeError("session owner is reconnecting")
@@ -1567,6 +1583,11 @@ async def test_a_followers_loop_turn_holds_working_between_iterations() -> None:
         """A follower whose owner advertised nothing — every cold viewer."""
 
         is_remote = True
+        # Runtime role (SessionProtocol): this fake emulates an ATTACHED
+        # viewer, so the predicates must agree with `is_remote` above.
+        owns_runtime = False
+        outcome_is_synchronous = False
+        runtime_locality: RuntimeLocality = "this-machine"
 
         def __init__(self) -> None:
             super().__init__()

--- a/tests/unit/tui/test_welcome.py
+++ b/tests/unit/tui/test_welcome.py
@@ -30,7 +30,7 @@ from textual.color import Color
 
 from local_operator.harness.types import AgentMessage, ImageContent
 from local_operator.session.naming import ConversationName
-from local_operator.session.protocol import CompactionOutcome
+from local_operator.session.protocol import CompactionOutcome, RuntimeLocality
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.app import SLASH_COMMANDS, OperatorApp
 from local_operator.tui.widgets.transcript import TranscriptView, UserBlock
@@ -522,6 +522,13 @@ def test_the_glow_cannot_change_the_blocks_height_at_any_size() -> None:
 class FakeSession:
     """Satisfies SessionProtocol including the naming members StatusSlice
     added to the protocol; the welcome tests never drive naming itself."""
+
+    # Runtime role (SessionProtocol). This fake stands in for an OWNER:
+    # it carries no attached runtime, which is what the absent legacy
+    # `is_remote` meant.
+    owns_runtime = True
+    outcome_is_synchronous = True
+    runtime_locality: RuntimeLocality = "this-process"
 
     def __init__(self, model_label: str = "openrouter/deepseek/deepseek-chat") -> None:
         self.prompts: list[str] = []


### PR DESCRIPTION
## What

Stage 2 of the session consolidation: **declare the interfaces that today are undeclared duck-typing.** Additive only — no call-site substitution, no deletions, no behaviour change. Stage 3 (deleting `is_remote`) depends on this and is a separate PR.

Three things:

1. **`ViewerSessionProtocol`** — the ~49-member surface its hosts program against that exists only on `RemoteSession`.
2. **`owns_runtime` / `outcome_is_synchronous` / `runtime_locality`** on `SessionProtocol`, implemented on both classes.
3. **An AST guard** that fails when a new undeclared duck-typed session member appears, over every file that consumes the viewer surface: the TUI (`app.py`, `session_interaction.py`), the desktop host (`server/utils/desktop_sessions.py`), the three desktop **route** modules that reach the same facade through `bridge.remote`, and `info/collect.py` — the `/info` host whose outage is the reason this guard exists, which round 2 found the guard did not observe.

## Why

The TUI reaches its session through `getattr(session, "name", None)`. The probe string is *data*, so a rename on the facade or a typo in the string is invisible to pyright and degrades the capability to a silent `None` — which the graceful fallback each probe already carries then absorbs into a plausible wrong answer. That is not hypothetical: `/info` reported zero subagents for a session that had several, because `subagent_comms` was private on the facade (`remote.py`, `subagent_comms` docstring).

`is_remote` is the same shape. It is undeclared on any protocol, has exactly one writer (`remote.py:428`), and is constant-`True` for every `lop` TUI session since 0.46.0 — `lop` builds a viewer for every local user. It has been fixed site-locally four times (#576, #609, #624, #625) with a fifth guarded by an AST test whose own docstring says *"Nothing was left behind by the first two, which is why there was a third."* A predicate that has been wrong five times is a missing type, not a naming problem.

## The member list, derived not asserted

I derived it by AST over `tui/app.py` rather than trusting the count in the brief. **It is 40, not 15.** Every session-valued attribute access and `getattr`/`hasattr` probe, intersected against class membership:

<details><summary>The 40 viewer-only members (exist on <code>RemoteSession</code>, not on <code>Session</code>)</summary>

`can_detach_runtime`, `credential_op`, `degraded_reason`, `detach_viewer_gates`, `display_history_current`, `display_history_revision`, `display_history_window`, `ensure_display_anchor`, `ensure_display_current`, `history_before_token`, `history_last_message`, `history_message_count`, `history_opener_text`, `history_theme_turn_count`, `is_cold`, `load_job_trajectory`, `load_older_display_page`, `materialize_history`, `move_will_wait`, `owner_idle`, `owner_model_catalogue`, `owner_source_ref`, `owner_version`, `pending_display_tool_ids`, `prompt_and_wait`, `request_refresh`, `request_stop`, `resume_viewer_gates`, `retire_if_unused`, `route_shared_slash`, `runtime_pid`, `saved_preview_partial`, `set_cancel_resolution`, `set_recall_resolution`, `set_refresh_callback`, `set_stopped_callback`, `set_takeover_callback`, `set_working_directory`, `suspend_viewer_gates`, `unload_job_trajectory`

(`is_remote` is the 41st; deliberately **not** declared, since Stage 3 removes it.)
</details>

Two corrections I made to my own probe mid-derivation, both of which changed the answer:

- A first pass treated bare `target`/`current`/`sess` as session-valued and reported `partition`, `focus` and `label` as session members. Restricted to the bindings that always hold a session.
- A second pass used `dir(cls)` for membership, which misses `self.x = ...` instance attributes. That put `cwd`/`jobs`/`mcp_manager` in "on neither class" and reported `agent_registry`/`team_registry` as viewer-only when **both** classes have them. Membership is now `dir()` ∪ AST self-stores.

## Where the taxonomy did not fit the code

**The brief's "the TUI calls ZERO owner-only members" is wrong as stated.** The TUI touches 14 owner-only members. But the spirit holds and it matters for Stage 3: every one is an *optional-capability probe* — `getattr` + `callable()` with a working fallback — never a hard requirement. That property is now **machine-checked** rather than cited by line number: `test_owner_only_probes_are_all_optional_capability_probes` requires every excluded name to appear only as a 3-argument `getattr` and never as a hard access, so the exclusion cannot quietly stop being sound (round 1, n2). They are listed in the guard's `_OWNER_ONLY_CAPABILITY_PROBES` with that reasoning, rather than forced onto a viewer as no-op stubs — a stub returning a plausible empty value cannot be told apart from "genuinely nothing", which is the exact confusion behind the fabricated `/info` zero.

**`publishes_registrant` (question v) is not implemented.** The two sites that ask it (`app.py:6024`, `17406`) are about whether *this process* may publish a discovery record — a property of the host, not of the session object, and both already do the real work with a `callable()` probe on the next line. Declaring it on the session would put the answer on the wrong object. Deferred to Stage 3, where those two sites are read in context.

**`runtime_locality` is three-valued, and has no `"another-machine"` member.** I re-audited every socket in the tree: `runtime/server.py:987`, `viewer_server.py:220`, `control.py:167`, `viewer_client.py:135`, `mobile/attach_client.py:220`, `peer_client.py:125`, `daemon.py:659` — all bind or dial `127.0.0.1` only, and `viewer_server.py:218` states it as a security invariant. Naming a cross-host case would re-create the dead axis. The `"unknown"` arm exists because `_session_runs_elsewhere`'s `except` branch genuinely cannot prove locality; `RemoteSession` itself never returns it (a property must not do registry I/O on a path the status bar reads).

## Evidence

### pyright verifies `RemoteSession` satisfies `ViewerSessionProtocol` — 0 errors

Whole tree, exactly as CI:

```
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations
```

The static conformance is asserted by typed assignment in `test_viewer_protocol.py`, which is what makes pyright check **signatures** (return types, async-ness, parameter names) rather than mere presence:

```python
viewer: ViewerSessionProtocol = RemoteSession.__new__(RemoteSession)
owner: SessionProtocol = Session.__new__(Session)
attached: SessionProtocol = RemoteSession.__new__(RemoteSession)
```

### The AST guard, demonstrated FAILING on a planted violation

This is the point of the PR, so it is shown failing in both directions and passing after each restore.

**(a) A new undeclared duck-typed member** — planted `getattr(self._session, "totally_undeclared_member", False)` into `app.py`:

```
E  AssertionError: the TUI reads session members that no protocol declares:
   totally_undeclared_member (app.py:[9315]). A duck-typed member is invisible
   to pyright, so a rename or a typo in the probe string degrades it to a silent
   None instead of an error. Declare it on SessionProtocol (both kinds of
   session have it) or on ViewerSessionProtocol (only an attached facade has it).
1 failed
```

**(b) A declared member removed from the protocol** — deleted `pending_display_tool_ids` from `ViewerSessionProtocol`; **both** guards fire, including the derivation guard that stops the exclusion lists from being used to paper over a real member:

```
E  AssertionError: the TUI reads session members that no protocol declares:
   pending_display_tool_ids (app.py:[7352]).
E  AssertionError: viewer-only members the TUI uses but no protocol declares:
   ['pending_display_tool_ids']. These exist on RemoteSession and not on
   Session, so they belong on ViewerSessionProtocol.
2 failed, 3 passed
```

Both violations reverted; `app.py` restored byte-identical (empty `git diff`). On the real tree: `5 passed`.

The guard also caught two genuine mistakes in its own first run — four bare-annotation members (`owner_version` et al.) that `dir()` cannot see, and the `agent_registry` misclassification above. Both were the test being wrong, and both are fixed and commented.

### Real execution, not just a green suite

Constructed both classes for real and read the actual values (isolated `HOME`, synthetic id, no socket dialled):

```
REAL RemoteSession.cold(...)                REAL Session(...)
  owns_runtime            : False             owns_runtime            : True
  outcome_is_synchronous  : False             outcome_is_synchronous  : True
  runtime_locality        : 'this-machine'    runtime_locality        : 'this-process'
  is_cold                 : True
  isinstance Viewer       : True              isinstance Viewer       : False
  isinstance SessionProto : True              isinstance SessionProto : True
  legacy is_remote        : True (untouched)  has is_remote           : False (unchanged)
  declared viewer members missing on the REAL instance: none
```

The predicates **discriminate** — asserted as a pair in the tests, because three predicates returning the same value on both sides would type-check, pass a conformance test, and still be as useless as the flag they replace.

### No behaviour change

Intended and claimed explicitly: no call site reads the new members, no existing member changed, `is_remote` is untouched. Backed by the full unit suite.

`.venv/bin/python -m pytest tests/unit` → **17,406 passed, 18 skipped, 0 failed.**

Two earlier full-suite runs each showed exactly one failure, and it was a *different* test each time — `test_snapshot_entry_is_written_for_a_launched_child` (a transcript byte-size assertion) on one, `test_ctrl_e_is_live_at_the_sizes_the_user_reported` (a footer layout assertion) on the next. Both are timing/load-sensitive under xdist, and both are pre-existing flakes rather than this change:

- a third full run on this branch is **completely green** (17,406 passed, 0 failed);
- each passes serially with this change (`-n0`);
- the byte-size one passed **20/20** consecutive serial runs, and 3/3 full `tests/unit/session` runs under xdist (1813 passed each);
- a clean `origin/main` worktree run under the same machine load also failed;
- neither test touches the protocol, and this change adds only constant properties with no I/O.

Gates on the final head, whole tree exactly as CI: flake8 clean, `black --check` clean (1170 files), `isort --check` clean, **pyright 0 errors**.

## Two properties a future maintainer must not break

**1. The static conformance assertion is carried by the TEST FILE, not by `session/`.**
`_static_conformance_is_checked_by_pyright` in `tests/unit/session/test_viewer_protocol.py` is the only place either class is assigned to a protocol type, which is what makes pyright check *signatures* rather than mere presence. QA proved it is the only place: breaking a viewer member that has no internal caller gives `pyright local_operator/session/` **0 errors**, and only checking that test file reports it.

So **narrowing pyright's path to the package, or excluding `tests/`, silently disarms half of this PR's mechanism** while every test still passes — and deleting the function because "nothing calls it" removes the check with no failing test to object. The repo's pyright invocation is whole-tree for exactly this reason. This is now written where someone changing pyright config would see it (a block comment in the function's own docstring) rather than living only in a PR body.

**2. `_declared()` has zero leakage, and the exclusion lists are clean.** Recorded so a later reader does not re-derive it: the declared-name set is 74 names with **no** non-protocol names leaking in from `object`/`Protocol` machinery, so nothing is masked that way; and both reviewers independently audited all three exclusion lists for dishonest entries and found **0 misclassifications** (no `_UNDECLARED_ON_BOTH_CLASSES` entry is viewer-only, no `_OWNER_ONLY_CAPABILITY_PROBES` entry exists on `RemoteSession`). Those properties are now asserted by `test_the_exclusion_sets_state_true_facts` rather than trusted.

## Round 1 — what changed

Both streams converged on the same structural gap: the guard's coverage did not match its promise. **Five** undeclared viewer-only members were escaping it, every one by *scope alone* — invisible to the round-1 derivation, so no exclusion set and no declaration was protecting them:

| Member | Escaped via | Now |
|---|---|---|
| `has_pending_gate_reply` | `source.session` not in `_SESSION_EXPRS` | declared |
| `preserve_viewer_gate_reply` | same | declared |
| `supports_completion_ack` | guard read `app.py` only | declared |
| `attach_existing` | same (found by widening) | declared |
| `update_desktop_watch` | same (found by widening) | declared |

```
members visible to ROUND-1 guard: 114
members visible to ROUND-2 guard: 120

has_pending_gate_reply       round1_saw=False round2_saw=True  now_declared=True
preserve_viewer_gate_reply   round1_saw=False round2_saw=True  now_declared=True
supports_completion_ack      round1_saw=False round2_saw=True  now_declared=True
attach_existing              round1_saw=False round2_saw=True  now_declared=True
update_desktop_watch         round1_saw=False round2_saw=True  now_declared=True
```

`supports_completion_ack` is the one that matters most: it governs whether the desktop tells the phone portal that completion-attention is supported, it is on `RemoteSession` and absent from `Session`, and it was declared on neither protocol — a live instance of the exact bug class this PR exists to make catchable, escaping only because the guard's scope was one file while the PR's own rationale is that *headless hosts* need this surface. QA confirmed it was the only such case today (0 undeclared across the other 27 TUI files), so widening scope was one entry in a tuple now and a migration later.

### The guard re-demonstrated, 12 planted violations

Each cell mutates the tree, runs the guard, and restores; the harness asserts the mutation actually applied, because a cell whose pattern silently fails to match reports a false PASS.

```
=== baseline (committed) ===
clean tree                                               want=PASS got=PASS OK
=== original scope still catches its own violations ===
V1 direct  self._session.qa_brand_new_member             want=FAIL got=FAIL OK
V2 literal getattr probe                                 want=FAIL got=FAIL OK
=== M1: the source.session hole this round closes ===
M1 source.session probe (ESCAPED pre-round)              want=FAIL got=FAIL OK
M1 undeclare the two real escapees                       want=FAIL got=FAIL OK
=== Q2: the widened host scope ===
Q2 new host probe (ESCAPED pre-round)                    want=FAIL got=FAIL OK
Q2 undeclare supports_completion_ack                     want=FAIL got=FAIL OK
=== anti-gaming: exclusion sets cannot silence viewer-only members ===
hide it in _UNDECLARED_ON_BOTH_CLASSES                   want=FAIL got=FAIL OK
hide it in _OWNER_ONLY_CAPABILITY_PROBES                 want=FAIL got=FAIL OK
=== n2: an excused optional probe must keep its default ===
hard access to routing_settings                          want=FAIL got=FAIL OK
=== M2: exclusion sets must state true facts ===
restore the M2 lie (cwd lives on both)                   want=FAIL got=FAIL OK
=== m3: the floor catches PARTIAL derivation decay ===
cripple _SESSION_EXPRS to one rare binding               want=FAIL got=FAIL OK
=== final ===
tree restored to <base>, clean
restored tree                                            want=PASS got=PASS OK
```

### `is_cold` — the declaration was wrong, not the code

QA reproduced the contradiction: the round-1 docstring said `is_cold` was *not* "runtime unreachable" while the implementation is exactly that. The behaviour is load-bearing — `app.py:23470` depends in writing on it being *"a superset of the drop: it is also true while the facade is redialing an owner that died"* — so **the docstring was the wrong artifact** and now describes the implemented predicate. Narrowing the implementation instead would have silently re-opened the #625 shape at that site. `runtime_pid` carried the same ambiguity and is corrected with it.

Because Stage 3 writes branches against these declarations, the corrected claim is **pinned by a test rather than left as prose** (`tests/e2e/test_viewer_cold_semantics_e2e.py`), driving the production facade over a real loopback socket:

```
1. never bound            is_cold=True  runtime_pid=None
2. attached, quiescent    is_cold=False runtime_pid=69304
3. after WATCHING a turn  is_cold=False runtime_pid=69304 events=8 (reply on the runtime's own disk)
4. runtime DIED           is_cold=True  runtime_pid=None
```

Verified to fail for the right reason — narrowing `is_cold` back to the round-1 claim trips the final assertion with the message naming `app.py:23470`:

```
E  AssertionError: is_cold must be True once the runtime is gone: app.py:23470
   relies on it being a superset of the drop. If this fails, the round-1
   docstring was right and the implementation needs splitting instead.
```

## Test-fake churn

`SessionProtocol` is `@runtime_checkable` and widely faked, so adding required members made ~1,863 pyright errors across 160 test files — all from ~20 root fake classes, **0 in production code**. Each root fake gains the three predicates; fakes that declare `is_remote = True` get *viewer* values rather than a blanket copy, so they stay semantically honest for Stage 3's substitutions.

One subtlety worth flagging for review: an unannotated `runtime_locality = "this-process"` widens to `str` and does **not** satisfy the `Literal`. Every fake carries the explicit `RuntimeLocality` annotation.

## Not done deliberately

- No call site migrated to the new predicates or the viewer type — Stage 3.
- `is_remote` not deleted, not read, not renamed.
- 18 members that exist on **both** classes but are still undeclared (`frontend_state`, `jobs`, `mcp_manager`, `epoch`, `pending_gate`, …) are recorded in `_UNDECLARED_ON_BOTH_CLASSES` so the debt is visible and the guard shrinks as they are declared — deferred, since declaring them belongs with the call-site migration rather than with this additive change.
- **`cwd` is a dead probe, not ordinary debt.** `app.py:4049` reads `getattr(self._session, "cwd", "")` for `saved_preview(...)`, and `cwd` exists on *neither* class, so that argument is always `""`. Pre-existing (present at `a8f98be3b`) and behavioural, so it is not fixed here; it now sits in `_KNOWN_MISSING_ON_BOTH_CLASSES`, which records what the probe actually returns instead of mislabelling it as "lives on both classes" (round 1, M2). **Deferred to Stage 3**, where the call site is rewritten against a declared member.
- **Alias-following is out of scope.** The derivation reads literal bindings, so `s = self._session; s.member` is invisible to it. Confirmed **0 live violations** today by both reviewers, so this is latent rather than actual; the limitation is now stated in `_SESSION_EXPRS` and the module docstring rather than left for a reader to discover. **Deferred** — following aliases means per-scope assignment resolution, which is the source of the false positives that nearly got an earlier version of this probe deleted (round 1, Q3/m1a).
- No version bump (`pyproject.toml` untouched; the branch tracks main's released version).
- `harness/types.py` untouched — no conflict with #858.


