### PR TITLE
chore(release): bump version to 0.52.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.52.11"
+version = "0.52.12"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release lock for the post-v0.52.11 window. `pyproject.toml` only, one line.

## Window

Derived from `origin/main` immediately before opening this PR:

- Last tag: **v0.52.11**
- `git log v0.52.11..origin/main` → three commits

| PR | Merge SHA | Impact |
|---|---|---|
| [#851](https://github.com/damianvtran/local-operator/pull/851) | `0cd3a9434` | pytest temp dirs no longer accumulate without bound |
| [#855](https://github.com/damianvtran/local-operator/pull/855) | `a8f98be3b` | osworld executes a batch's actions in the order the model wrote them |
| [#858](https://github.com/damianvtran/local-operator/pull/858) | `77f1cc75f` | tool bookkeeping survives a viewer rebuilding a tool row |

## Bump class: PATCH

Three bug fixes on existing surfaces. No API addition, no schema or config migration.

#858 is the most user-visible of the three — tool durations rendering blank after a sidebar resume, and the mobile projection losing `elapsed_s` and diff badges — but it *restores* fields consumers already expected rather than adding any, so it does not clear the step-function bar a minor would need.

## Ownership

Ownership was announced to every live lop-dev peer before cutting. All eight who replied (pids 17453, 1188, 66376, 64056, 65121, 79261, 78932, plus 33457) confirmed no conflict and nothing merged-but-unreleased; their work is pre-merge and rides a later window. No competing `chore(release)` PR was open at derivation time.

Known latecomers for the **next** window, none waited on here: #856, #857, #859, #860, and an MCP auth propagation fix not yet opened.

## Scope check

The diff is one line in `pyproject.toml` (`0.52.11` → `0.52.12`). No source, test, or workflow file is touched, so the C0 one-file scope check is the appropriate gate.