### PR TITLE
chore(release): bump version to 0.52.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.52.12"
+version = "0.52.13"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Version bump only — `pyproject.toml`, one line, `0.52.12` → `0.52.13`.

**Change class: C0.** No source, test, or documentation change; nothing to review beyond the scope check.

## Window

`v0.52.12..origin/main` at the time of cutting, one commit:

- **#860** (`9a8fb2c02`) `fix(tui): release parked sidebar viewers after five idle minutes`

**Bump class: PATCH.** One bug fix on an existing surface. No API addition, no wire or protocol change, no schema, no migration.

## Latecomers not waited for

- **#825** (`fix(analytics): classify malformed tool arguments as a model fault`) — owner (pid 82425) confirmed it is not merge-ready: review/QA round 3 in flight after a rebase moved the head, ETA beyond this window. Owner explicitly asked not to be waited for; it rides the next window at PATCH.

Ownership was claimed and announced to the active lop-dev peers before opening this PR; the previous window's owner (pid 88791) had already closed v0.52.12 and declared the next window unowned.
