### PR TITLE
fix(mobile): stop the phone dropping refusals, failures and gate timeouts

### DIFF
--- a/.github/workflows/mobile-web.yml
+++ b/.github/workflows/mobile-web.yml
@@ -1,0 +1,76 @@
+name: Mobile web
+
+# The phone UI's TypeScript had NO pre-release gate. `pnpm build` (which is
+# `tsc -b && vite build`, so it is also the only typecheck) ran in exactly one
+# place: publish.yml, at release time, after the tag exists. ci.yml has no
+# mobile-web job at all.
+#
+# That is a trap rather than a gap. Vitest does not typecheck, so a PR adding
+# type-invalid tests goes green on every check GitHub shows — 16/16 — and the
+# TS2322 detonates on whoever cuts the next tag, who is not the author and has
+# no context. Observed on PR #864: five `pid={1}` props against `pid: string`
+# passed the vitest suite in 24 ms while `pnpm build` was red.
+#
+# Paths-gated as a separate workflow, matching extension.yml, because that is
+# how this repo already gates a pnpm subproject: ci.yml gates nothing by path
+# and would make every Python-only PR pay a Node toolchain install for a bundle
+# it cannot affect. The gate keys on the web sources only — the TS build does
+# not read Python, so widening it to projection.py would spend a job for no
+# signal.
+
+on:
+  push:
+    branches:
+      # `main` only, matching ci.yml and extension.yml: a `dev-*` branch with an
+      # open PR would otherwise fire a push run and a pull_request run for one
+      # identical result.
+      - main
+    paths:
+      - 'local_operator/mobile/web/**'
+      - '.github/workflows/mobile-web.yml'
+  pull_request:
+    paths:
+      - 'local_operator/mobile/web/**'
+      - '.github/workflows/mobile-web.yml'
+  workflow_dispatch:
+
+# Matches ci.yml, including the per-SHA group for `main` so a merge commit's run
+# can never be evicted by the next merge. See the long note in ci.yml.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || 'shared' }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # Bounded so a wedged step cannot hold a concurrency slot for GitHub's
+    # 360-minute default; the real run is well under a minute.
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: local_operator/mobile/web
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.22.0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: pnpm
+          cache-dependency-path: local_operator/mobile/web/pnpm-lock.yaml
+
+      - name: Install mobile web dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Build FIRST and separately from the tests. `pnpm build` is `tsc -b &&
+      # vite build`, so this step is the typecheck the vitest suite does not
+      # perform — the failure this workflow exists to catch surfaces here, with
+      # a job name that says which surface broke.
+      - name: Build the phone bundle (typechecks)
+        run: pnpm build
+
+      - name: Run mobile web tests
+        run: pnpm test

--- a/local_operator/harness/rows.py
+++ b/local_operator/harness/rows.py
@@ -127,6 +127,28 @@ def user_row_text(text: str) -> str:
     return typed_line_of(stripped) or stripped
 
 
+def assistant_row_text(text: str) -> str:
+    """What a surface paints for a ``role="assistant"`` message, or ``""``.
+
+    The counterpart to :func:`user_row_text`, and it exists for the same
+    reason: THE HOSTS DO NOT AGREE on what they hand in. The TUI strips a
+    message's text at the top of its replay loop and tests the stripped
+    value, so a whitespace-only turn produces NO block there. The phone
+    tested ``message.text`` verbatim, and ``"   "`` is truthy — so the same
+    history produced an extra EMPTY assistant row on the phone, ~8px of
+    blank space and, more importantly, a row SEQUENCE the TUI never emits.
+
+    That is the weaker version of this module's whole claim. "The two folds
+    produce the same rows" is worth something; "the same rows plus one blank
+    one" is a divergence with a smaller pixel budget, not an agreement.
+
+    Returning the stripped text rather than a bare truthiness verdict also
+    settles the content half: both surfaces paint the same bytes, so a
+    padded message cannot render one row indented and the other not.
+    """
+    return text.strip()
+
+
 def gate_timeout_notice(details: dict[str, Any]) -> str:
     """Say what expired, what it wanted, and that nobody chose it.
 
@@ -201,8 +223,17 @@ def wake_receipt_headline(text: str) -> str:
     head, _, _ = text.partition("\n\n")
     head = " ".join(head.split())  # collapse any envelope whitespace
     head = head.split(" — cancel with wake(", 1)[0]
-    if head.startswith("(alarm) "):
-        head = head[len("(alarm) ") :]
+    # Strip EVERY leading marker, not one. A single strip leaves a doubled
+    # prefix ("(alarm) (alarm) …") leaking model-facing markup onto a human
+    # surface — the exact defect this function exists to prevent, surviving
+    # in the function that prevents it. No producer emits a doubled prefix
+    # today, so this is closing the shape rather than a live bug; a partial
+    # strip is the same "handles the case it happens to have seen" reasoning
+    # that produced the incomplete chrome-prompt copy in this module's
+    # docstring.
+    alarm = "(alarm) "
+    while head.startswith(alarm):
+        head = head[len(alarm) :]
     # The surface's own wake affordance already says "wake"; repeating
     # "Scheduled wake" in the headline is a caption where a label belongs.
     prefix = "Scheduled wake "

--- a/local_operator/harness/rows.py
+++ b/local_operator/harness/rows.py
@@ -1,0 +1,226 @@
+"""Row semantics shared by every human-facing surface.
+
+WHY THIS MODULE EXISTS
+----------------------
+The TUI (``tui/session_presentation.py``) and the phone
+(``mobile/projection.py``) each fold the same ``AgentMessage`` history into
+rows. They are two *renderers* of one *contract*, and for a long time that
+contract was asserted only by comments on each side — comments which were
+wrong. An architecture review (``docs/design/history-fold-convergence.md``,
+§3) enumerated twelve divergences that accumulated under that regime; eight
+were user-visible, and five of them were rows the phone silently DROPPED
+because its ``if/elif`` chain ended with no ``else``.
+
+The decisions below are the ones both surfaces must make identically:
+whether a message is harness chrome that no surface may attribute to the
+user, what a timed-out gate says, what ink a refused compaction gets, and
+which assistant turns produce a notice instead of prose. Each is a pure
+function of a message, with **no host dependency** — no Textual, no wire
+type, no session import at module scope — so both hosts can call it and
+neither can own it.
+
+CONSTRAINT — this module must stay host-free. It sits below both renderers
+the same way ``compaction/marker.py`` sits below the hosts that must not
+import the session. The three chrome prompts live in modules that would be
+the wrong import direction from here (``session.goal_loop``,
+``session.session``), so they are gathered behind a function that imports
+them lazily. That keeps ONE list rather than a copy per host — the partial
+copy is precisely the drift signature the review named: the phone had
+suppressed one of the three prompts and rendered the other two as the
+user's own words.
+
+Adding a new row decision belongs HERE, not in a host. A decision made in
+one renderer is a decision the other will not make.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+#: The severity vocabulary shared by the surfaces. A superset is deliberately
+#: NOT used: these are the tiers a *replayed* row can carry, and the TUI's
+#: wider ``NoticeKind`` (which adds ``note``/``success`` for live receipts)
+#: accepts every one of them, so a value produced here is always renderable
+#: on both sides.
+NoticeSeverity = Literal["info", "warning", "error"]
+
+
+def harness_chrome_prompts() -> tuple[str, ...]:
+    """Every prompt the harness injects as a user turn that NO surface paints.
+
+    Each of these is persisted as a ``role="user"`` message because the
+    TRANSCRIPT must record why the conversation continued — but the user did
+    not type any of them, and painting one attributes the harness's words to
+    them. The live path never shows them, so replay must not either.
+
+    The three, and why each is persisted:
+
+    - ``LOOP_PROMPT`` — the goal loop's self-continuation.
+    - ``_CONTINUATION_PROMPT`` — the session's auto-continuation after a
+      turn hit its step budget.
+    - ``CONNECTIVITY_CONTINUATION_PROMPT`` — records why ONE answer arrived
+      in two pieces across a network interruption; the live run showed a
+      notice instead.
+
+    Imported lazily and gathered here rather than listed per host: this list
+    having been copied INCOMPLETELY into the phone fold (it suppressed the
+    third and rendered the first two) is the drift this function exists to
+    make impossible. A fourth prompt is added in one place.
+    """
+    from local_operator.harness.loop import CONNECTIVITY_CONTINUATION_PROMPT
+    from local_operator.session.goal_loop import LOOP_PROMPT
+    from local_operator.session.session import _CONTINUATION_PROMPT
+
+    return (LOOP_PROMPT, _CONTINUATION_PROMPT, CONNECTIVITY_CONTINUATION_PROMPT)
+
+
+def is_harness_chrome(text: str) -> bool:
+    """Whether this user-role text is harness chrome rather than the user's words."""
+    return text in harness_chrome_prompts()
+
+
+def typed_line_of(text: str) -> str | None:
+    """The ``$skill`` line behind a persisted payload, or ``None``.
+
+    A ``$skill`` invocation persists as its EXPANDED payload, because the
+    payload is what the model was sent. Painting it verbatim shows the whole
+    SKILL.md body as the user's row — and, because a session is titled from
+    its first user turn, titles the thread after the skill body too.
+
+    Lazy-imported and failure-swallowing by contract: a broken or absent
+    skills package must never stop a transcript replaying, on either surface.
+    Every failure degrades to "not an invocation", so the caller falls
+    through to painting the text verbatim.
+    """
+    try:
+        from local_operator.skills.invoke import typed_line_of as _typed_line_of
+
+        return _typed_line_of(text)
+    except Exception:  # noqa: BLE001 — replay must never fail on this
+        return None
+
+
+def user_row_text(text: str) -> str:
+    """What a surface paints for a ``role="user"`` message.
+
+    Collapses a skill payload to the line the user actually typed and leaves
+    every other message alone. Kept beside :func:`is_harness_chrome` because
+    the two are the whole of the "what did the user really say" decision, and
+    splitting them across hosts is how one surface got the skill rule and the
+    other did not.
+    """
+    return typed_line_of(text) or text
+
+
+def gate_timeout_notice(details: dict[str, Any]) -> str:
+    """Say what expired, what it wanted, and that nobody chose it.
+
+    The distinction this line has to carry is denial-by-expiry versus
+    denial-by-decision: the user did not say no, they were not there. Naming
+    the tool matters for the same reason the picker's parked row wants it —
+    "a tool was denied" and "`bash rm -rf build/` was denied" are different
+    amounts of help when you are reconstructing what happened overnight.
+
+    An unattended gate timeout is the most expensive event in the detached
+    feature (up to a day of held residency ends here), which is why it is
+    worth one shared implementation rather than a per-surface paraphrase.
+    """
+    tool = str(details.get("tool") or "a tool").strip()
+    description = str(details.get("description") or "").strip()
+    waited = details.get("waited_s")
+    # REPORT THE WAIT THAT HAPPENED. This used to floor at one hour
+    # (`max(1, waited // 3600)`), so a 30-second expiry — a live, reachable
+    # path when there is no registrant, or notifications are off and nothing
+    # is watching — rendered as "waited 1h" (round 3, D12). This row exists
+    # to preserve the difference between denied-by-decision and
+    # denied-by-absence, and a fabricated duration undermines the one number
+    # that has to be trustworthy. An absent or unreadable value says so
+    # rather than rounding up to an hour.
+    try:
+        seconds = float(waited) if waited is not None else 0.0
+    except (TypeError, ValueError):
+        seconds = 0.0
+    if seconds <= 0:
+        waited_text = "a while"
+    elif seconds < 60:
+        waited_text = f"{int(seconds)}s"
+    elif seconds < 3600:
+        waited_text = f"{int(seconds // 60)}m"
+    elif seconds < 86400:
+        waited_text = f"{int(seconds // 3600)}h"
+    else:
+        waited_text = f"{int(seconds // 86400)}d"
+    # An `ask` is a QUESTION, and an unanswered question was not "denied":
+    # describing it in the approval gate's vocabulary told the user something
+    # that did not happen (D12's copy note).
+    kind = str(details.get("kind") or "approval").strip().lower()
+    subject = f"{tool} · {description}" if description else tool
+    if kind == "ask":
+        return (
+            f"waited {waited_text} for an answer with nobody attached, "
+            f"then moved on — {subject}"
+        )
+    return f"waited {waited_text} for approval with nobody attached, then denied it — {subject}"
+
+
+def compaction_refused_notice(details: dict[str, Any]) -> tuple[str, NoticeSeverity]:
+    """A compaction that did NOT run, and the ink it deserves.
+
+    This row exists to CORRECT the optimistic "compacting context…" receipt
+    the routed command already showed (round 5, U17). ``warning`` ink because
+    the context the user asked to reclaim is still there; ``error`` when the
+    attempt actually FAILED rather than being declined, because those are
+    different things to the person deciding what to do next — a refusal is
+    the system saying "not worth it", a failure is the system saying "I
+    could not".
+
+    The severity is derived here rather than at each call site so the phone
+    cannot flatten a failure into the same ink as a decline.
+    """
+    text = str(details.get("detail") or "compaction did not run").strip()
+    severity: NoticeSeverity = "error" if text.startswith("compaction failed") else "warning"
+    return text, severity
+
+
+def assistant_stop_notice(
+    *,
+    text: str,
+    has_tool_calls: bool,
+    stop_reason: str | None,
+    provider_payload: dict[str, Any] | None,
+) -> tuple[str, NoticeSeverity] | None:
+    """The notice an assistant turn's ``stop_reason`` demands, or ``None``.
+
+    Three turns end in a way the prose alone does not explain, and a surface
+    that omits the notice tells the user something false:
+
+    - **refusal** — the provider cut the answer off. Fires EVEN WHEN the
+      model streamed prose first (Gemini safety stops often cut a partial
+      answer): the prose alone reads as a complete, oddly short reply, and
+      the user re-reading the session needs to know why it ends there.
+    - **error** with nothing produced — the turn FAILED. Without the notice
+      the user sees their prompt followed by silence and reads it as the
+      agent having ignored them.
+    - **aborted** with nothing produced — the turn was interrupted.
+
+    The error/aborted arms are guarded on there being neither prose nor a
+    call because a turn that produced either already shows the user what
+    happened; the notice exists for the turn that shows nothing at all.
+
+    Returning ``None`` means "this turn needs no notice", which is the
+    ordinary case. Every surface must call this — the phone had no
+    ``stop_reason`` branch whatsoever, so refusals, failed turns and
+    interrupted turns were invisible on it.
+    """
+    if stop_reason == "refusal":
+        payload = provider_payload or {}
+        # The fallback keeps the marker grammar (D3): every other refusal
+        # line ends in a parenthetical, and a user who has learned that shape
+        # would read its absence as meaningful.
+        refusal = str(payload.get("refusal") or "") or (
+            "model refused the request (no details recorded)"
+        )
+        return refusal, "error"
+    if not text and not has_tool_calls and stop_reason in ("error", "aborted"):
+        return ("turn failed" if stop_reason == "error" else "interrupted"), "error"
+    return None

--- a/local_operator/harness/rows.py
+++ b/local_operator/harness/rows.py
@@ -75,8 +75,16 @@ def harness_chrome_prompts() -> tuple[str, ...]:
 
 
 def is_harness_chrome(text: str) -> bool:
-    """Whether this user-role text is harness chrome rather than the user's words."""
-    return text in harness_chrome_prompts()
+    """Whether this user-role text is harness chrome rather than the user's words.
+
+    Normalises before comparing because THE HOSTS DO NOT AGREE on what they
+    hand in: the TUI strips a message's text at the top of its replay loop,
+    the phone fold passes ``message.text`` verbatim. Leaving the strip to the
+    callers is the exact substrate this module exists to remove — one surface
+    would suppress a chrome prompt that the other painted as the user's own
+    words the moment a persisted prompt gained a trailing newline.
+    """
+    return text.strip() in harness_chrome_prompts()
 
 
 def typed_line_of(text: str) -> str | None:
@@ -108,8 +116,15 @@ def user_row_text(text: str) -> str:
     the two are the whole of the "what did the user really say" decision, and
     splitting them across hosts is how one surface got the skill rule and the
     other did not.
+
+    Strips for the same reason :func:`is_harness_chrome` does: the two hosts
+    normalise differently, so an envelope with surrounding whitespace would
+    resolve to a typed line on the TUI and to the whole SKILL.md body on the
+    phone. The fallback returns the stripped text so both surfaces paint one
+    row, not one padded and one not.
     """
-    return typed_line_of(text) or text
+    stripped = text.strip()
+    return typed_line_of(stripped) or stripped
 
 
 def gate_timeout_notice(details: dict[str, Any]) -> str:
@@ -163,6 +178,39 @@ def gate_timeout_notice(details: dict[str, Any]) -> str:
     return f"waited {waited_text} for approval with nobody attached, then denied it — {subject}"
 
 
+def wake_receipt_headline(text: str) -> str:
+    """The human-readable headline of a wake delivery.
+
+    A wake's persisted text is ``<envelope>\\n\\n<message>``, and the envelope
+    is MODEL-FACING markup: ``(alarm) Scheduled wake w-9 (1, every 6h) —
+    cancel with wake({op:"cancel",id:"w-9"})``. The cancel how-to is an
+    instruction for the model, and the ``(alarm)``/``Scheduled wake`` prefixes
+    restate what the row's own affordance already says — so what the user
+    wants from this line is WHICH wake fired, not how to stop it.
+
+    Extracted from ``WakeBlock._summary`` (which owned the only copy) because
+    the phone renders the same receipt: while this logic lived in a TUI widget
+    the phone had no way to reach it and showed the raw envelope verbatim —
+    model-facing markup on a human surface, the same class of defect as the
+    leaked ``<parent-message>`` rows this module exists to close.
+
+    Catch-up deliveries are deliberately NOT handled here: the phone fold
+    skips them entirely (they are user-attributed), so the folding summary
+    stays in the TUI widget where it has the block's ``catchup`` flag.
+    """
+    head, _, _ = text.partition("\n\n")
+    head = " ".join(head.split())  # collapse any envelope whitespace
+    head = head.split(" — cancel with wake(", 1)[0]
+    if head.startswith("(alarm) "):
+        head = head[len("(alarm) ") :]
+    # The surface's own wake affordance already says "wake"; repeating
+    # "Scheduled wake" in the headline is a caption where a label belongs.
+    prefix = "Scheduled wake "
+    if head.startswith(prefix):
+        head = head[len(prefix) :]
+    return head.strip()
+
+
 def compaction_refused_notice(details: dict[str, Any]) -> tuple[str, NoticeSeverity]:
     """A compaction that did NOT run, and the ink it deserves.
 
@@ -211,7 +259,16 @@ def assistant_stop_notice(
     ordinary case. Every surface must call this — the phone had no
     ``stop_reason`` branch whatsoever, so refusals, failed turns and
     interrupted turns were invisible on it.
+
+    ``text`` is stripped HERE rather than trusted from the caller. The TUI
+    strips before calling and the phone fold does not, so a whitespace-only
+    assistant turn with ``stop_reason="error"`` produced "turn failed" on the
+    TUI and SILENCE on the phone — D3 reopening inside the module built to
+    close it. The emptiness test below is the whole decision for the
+    error/aborted arms, so whose definition of "empty" wins cannot be a
+    per-host choice.
     """
+    text = text.strip()
     if stop_reason == "refusal":
         payload = provider_payload or {}
         # The fallback keeps the marker grammar (D3): every other refusal

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -38,6 +38,7 @@ from local_operator.harness.comms import HUB_MESSAGE_TYPE, extract_parent_messag
 # the convergence review found was a decision one surface made and the other
 # did not (docs/design/history-fold-convergence.md §3).
 from local_operator.harness.rows import (
+    assistant_row_text,
     assistant_stop_notice,
     compaction_refused_notice,
     gate_timeout_notice,
@@ -785,8 +786,16 @@ def fold_messages_to_entries(history: list[AgentMessage]) -> list[TranscriptEntr
             # the `!` row, so a later unrelated turn must not inherit the flag.
             message_bang = bang_pending
             bang_pending = False
-            if message.text:
-                entries.append(TranscriptEntry(id=message.id, kind="assistant", text=message.text))
+            # Through the shared helper, not `if message.text:` — the latter
+            # is truthy for `"   "`, so a whitespace-only turn painted an
+            # extra EMPTY row here that the TUI (which tests its stripped
+            # text) never emits. Same rows plus one blank one is not the
+            # same rows.
+            assistant_text = assistant_row_text(message.text)
+            if assistant_text:
+                entries.append(
+                    TranscriptEntry(id=message.id, kind="assistant", text=assistant_text)
+                )
             for call in message.tool_calls:
                 # Only the FIRST call of a bang assistant message is the
                 # command's own card; the shape record_shell writes has exactly

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -43,6 +43,7 @@ from local_operator.harness.rows import (
     gate_timeout_notice,
     is_harness_chrome,
     user_row_text,
+    wake_receipt_headline,
 )
 from local_operator.harness.types import (
     AgentEndEvent,
@@ -678,11 +679,27 @@ def fold_messages_to_entries(history: list[AgentMessage]) -> list[TranscriptEntr
                 # transcript as if the user had typed it.
                 details = message.details or {}
                 if not details.get("wake_catchup"):
+                    # Strip the model-facing envelope with the SAME helper the
+                    # TUI's WakeBlock uses. The raw payload is
+                    # '(alarm) Scheduled wake w-9 (1, every 6h) — cancel with
+                    # wake({op:"cancel",id:"w-9"})', which is markup addressed
+                    # to the model; painting it verbatim on a human surface is
+                    # the same defect as the leaked <parent-message> rows.
+                    raw = str(details.get("text", ""))
+                    headline = wake_receipt_headline(raw)
+                    _, _, body = raw.partition("\n\n")
                     entries.append(
                         TranscriptEntry(
                             id=message.id,
                             kind="notice",
-                            text=_compact(str(details.get("text", "")), 400),
+                            # Headline plus the delivered prompt: the phone has
+                            # no expand affordance for a notice row, so the
+                            # prompt rides the same row rather than being
+                            # dropped (the TUI hides it behind an expansion).
+                            text=_compact(
+                                f"{headline} — {body.strip()}" if body.strip() else headline,
+                                400,
+                            ),
                             details={"notice_kind": "wake"},
                         )
                     )

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -29,8 +29,21 @@ import time
 from collections.abc import Mapping
 from typing import Any
 
+from local_operator.compaction.marker import COMPACTION_REFUSED_TYPE
+from local_operator.harness.approval import GATE_TIMEOUT_CUSTOM_TYPE
 from local_operator.harness.comms import HUB_MESSAGE_TYPE, extract_parent_message
-from local_operator.harness.loop import CONNECTIVITY_CONTINUATION_PROMPT
+
+# The row DECISIONS both this fold and the TUI's must make identically. They
+# live outside both hosts precisely so neither can own them: every divergence
+# the convergence review found was a decision one surface made and the other
+# did not (docs/design/history-fold-convergence.md §3).
+from local_operator.harness.rows import (
+    assistant_stop_notice,
+    compaction_refused_notice,
+    gate_timeout_notice,
+    is_harness_chrome,
+    user_row_text,
+)
 from local_operator.harness.types import (
     AgentEndEvent,
     AgentEvent,
@@ -58,6 +71,7 @@ from local_operator.harness.types import (
     ToolExecutionUpdateEvent,
     TurnEndEvent,
 )
+from local_operator.harness.wake import WAKE_PROMPT_MESSAGE_TYPE
 from local_operator.mobile.types import (
     PROJECTION_TRANSCRIPT_LIMIT,
     PendingRequest,
@@ -246,6 +260,30 @@ def _image_refs(message: AgentMessage) -> list[dict[str, Any]]:
             refs.append({"index": image_index, "mime_type": block.mime_type or "image/png"})
             image_index += 1
     return refs
+
+
+def _tool_row_details(
+    args: dict[str, Any], output: str, result_details: dict[str, Any] | None
+) -> dict[str, Any]:
+    """The expand-on-tap payload for a settled tool row.
+
+    Shared by the history fold and :meth:`ProjectionFold._tool_details` so a
+    replayed row expands to exactly what the live one did. The caps are the
+    wire budget's, not a display choice: this payload is re-sent on every
+    projection repaint.
+    """
+    details: dict[str, Any] = {}
+    if args:
+        details["args"] = {k: _compact(str(v), TOOL_ARGS_CHARS) for k, v in args.items()}
+    if output:
+        details["output"] = output[-TOOL_OUTPUT_TAIL_CHARS:]
+    if result_details:
+        # Diff payloads ride through whole — the expanded row renders the
+        # coloured unified diff from them.
+        for key in ("diff", "added", "removed", "lines_added", "lines_removed"):
+            if key in result_details:
+                details[key] = result_details[key]
+    return details
 
 
 def _diff_counts(details: dict[str, Any] | None) -> tuple[int, int]:
@@ -565,14 +603,25 @@ def cap_projection_frame(
 
 
 def fold_messages_to_entries(history: list[AgentMessage]) -> list[TranscriptEntry]:
-    """Fold a full message history into transcript entries, UNCAPPED.
+    """Fold a message history into transcript entries — THE phone's row fold.
 
-    The session-side ``ProjectionFold.fold_history`` caps to the live tail
-    (the phone's realtime view is a window, not the whole log). The daemon's
-    history endpoint needs the SAME render semantics over the FULL history so
-    it can serve the older pages the cap dropped — this is the lazy-load
-    source. Pure (no ProjectionFold state), so the daemon can call it per
-    request without touching the live fold.
+    UNCAPPED and pure. Both phone surfaces come through here: the daemon's
+    history endpoint calls it directly for the older pages a cap dropped, and
+    :meth:`ProjectionFold.fold_history` calls it for the attach seed and then
+    layers its correlation-map maintenance and ``_cap_tail`` on top.
+
+    WHY ONE FUNCTION. This used to be two near-identical folds (this one and
+    a copy inside ``fold_history``), each carrying a comment asserting the
+    other could not disagree with it. They disagreed: a hub steer rendered as
+    a clean ``parent_message`` card here and leaked the raw
+    ``<parent-message>`` XML envelope as a ``notice`` on the attach seed, so
+    the phone contradicted ITSELF one scroll gesture apart. A contract two
+    functions promise to keep is a contract nothing checks — the only fix
+    that holds is that there is one function to change.
+
+    Row semantics that both the phone and the TUI must agree on live in
+    ``harness/rows.py`` and are called from here, so a decision cannot be
+    made on one surface and missed on the other.
 
     Tool-result diffs ride in ``provider_payload["details"]`` (where the
     harness stores them); rehydrated messages carry that payload, so the
@@ -582,9 +631,15 @@ def fold_messages_to_entries(history: list[AgentMessage]) -> list[TranscriptEntr
     # tool_call_id -> its row, local to this fold (a fresh fold re-pairs).
     tool_rows: dict[str, TranscriptEntry] = {}
     tool_args: dict[str, dict[str, Any]] = {}
+    # Message ids whose assistant turn opened a bang-mode (`! cmd`) command,
+    # so the call it issues opens expanded exactly as the TUI's does.
+    bang_pending = False
     for message in history:
         if isinstance(message, CustomMessage):
             if message.custom_type == HUB_MESSAGE_TYPE:
+                # The parent's own words (``body``), never the model-facing
+                # envelope in ``details["text"]``. Reading the envelope here
+                # is what leaked raw XML onto the attach seed.
                 body = str(message.details.get("body") or "").strip()
                 direction = message.details.get("direction")
                 if body:
@@ -613,6 +668,55 @@ def fold_messages_to_entries(history: list[AgentMessage]) -> list[TranscriptEntr
                         )
                     )
                 continue
+            if message.custom_type == WAKE_PROMPT_MESSAGE_TYPE:
+                # A wake delivery is a receipt with its own identity, not a
+                # generic notice: a resumed session that showed the agent
+                # answering a wake with no sign the wake fired is the bug this
+                # row exists to prevent. The CATCH-UP prompt is skipped for the
+                # opposite reason — it is user-attributed, so replaying it
+                # would put a raw '(alarm) The session resumed…' line in the
+                # transcript as if the user had typed it.
+                details = message.details or {}
+                if not details.get("wake_catchup"):
+                    entries.append(
+                        TranscriptEntry(
+                            id=message.id,
+                            kind="notice",
+                            text=_compact(str(details.get("text", "")), 400),
+                            details={"notice_kind": "wake"},
+                        )
+                    )
+                continue
+            if message.custom_type == GATE_TIMEOUT_CUSTOM_TYPE:
+                # A gate that timed out unattended is the most expensive event
+                # in the detached feature — up to a day of held residency ends
+                # here — and it rendered NOWHERE on the phone: the user
+                # returned to a conversation that promised an action and
+                # appeared to simply stop.
+                entries.append(
+                    TranscriptEntry(
+                        id=message.id,
+                        kind="notice",
+                        text=_compact(gate_timeout_notice(message.details or {}), 400),
+                        details={"severity": "warning"},
+                    )
+                )
+                continue
+            if message.custom_type == COMPACTION_REFUSED_TYPE:
+                # A compaction that did NOT run, correcting the optimistic
+                # "compacting context…" receipt the routed command showed.
+                # Severity is derived by the shared helper so the phone cannot
+                # flatten a FAILURE into the same ink as a decline.
+                text, severity = compaction_refused_notice(message.details or {})
+                entries.append(
+                    TranscriptEntry(
+                        id=message.id,
+                        kind="notice",
+                        text=_compact(text, 400),
+                        details={"severity": severity},
+                    )
+                )
+                continue
             text = _message_text(message)
             if text:
                 entries.append(
@@ -624,44 +728,93 @@ def fold_messages_to_entries(history: list[AgentMessage]) -> list[TranscriptEntr
             if parent_message is not None:
                 # A persisted hub steer: model-facing XML around the parent's
                 # own words. The phone shows the body the parent authored,
-                # never the envelope. Unlike the TUI, this fold sees only
-                # LLM-visible messages — the journaled communication fact is a
-                # custom row that never replays — so body extraction is the
-                # phone's only path to a human-facing rendering.
+                # never the envelope.
                 entries.append(
                     TranscriptEntry(id=message.id, kind="parent_message", text=parent_message.body)
                 )
                 continue
-            if message.text == CONNECTIVITY_CONTINUATION_PROMPT:
-                # Harness chrome, not the user's words: the loop persists this
-                # so the TRANSCRIPT records why one answer arrived in two
-                # pieces, but no front end paints it as a user bubble — the
-                # live run showed a notice instead. Same rule as the TUI's
-                # replay suppression; the surfaces must not diverge.
+            if is_harness_chrome(message.text):
+                # Harness chrome, not the user's words. The loop persists these
+                # so the TRANSCRIPT records why the conversation continued, but
+                # no front end paints one as a user bubble. The list is shared
+                # with the TUI (``harness/rows.py``) because this fold used to
+                # carry a PARTIAL copy of it — suppressing the connectivity
+                # prompt while rendering the goal-loop and auto-continuation
+                # prompts as the user's own words.
                 continue
+            # A `$skill` invocation persists as its EXPANDED payload, because
+            # that is what the model was sent. Rendering it verbatim showed the
+            # whole SKILL.md body as the user's bubble and titled the session
+            # after it; the typed line rides the payload's own opening tag.
+            text = user_row_text(message.text)
             # Carry image attachments as references so an image-only prompt
             # (the composer allows "" text + images) renders its thumbnails on
             # replay instead of round-tripping as an empty bubble — the same
             # inline render the live fold produces. The bytes are fetched
             # lazily from the image endpoint; only the reference travels here.
             refs = _image_refs(message)
-            text = message.text
             entries.append(TranscriptEntry(id=message.id, kind="user", text=text, images=refs))
+            # A bang-mode receipt replays as open as it lived: the user row is
+            # `! <command>` and the assistant message that follows carries
+            # exactly one bash call, whose card opens expanded. SET only,
+            # never cleared here — matching the TUI's replay exactly, which
+            # clears the flag on the next ASSISTANT message rather than on an
+            # intervening user row.
+            if text.startswith("! "):
+                bang_pending = True
         elif message.role == "assistant":
+            # Consume the pending bang marker on EVERY assistant message:
+            # record_shell writes the call-bearing assistant immediately after
+            # the `!` row, so a later unrelated turn must not inherit the flag.
+            message_bang = bang_pending
+            bang_pending = False
             if message.text:
                 entries.append(TranscriptEntry(id=message.id, kind="assistant", text=message.text))
             for call in message.tool_calls:
+                # Only the FIRST call of a bang assistant message is the
+                # command's own card; the shape record_shell writes has exactly
+                # one, so consuming here is exact in practice.
+                user_run = bool(
+                    message_bang and message.tool_calls[0] is call and call.name == "bash"
+                )
                 entry = TranscriptEntry(
                     id=f"{message.id}:{call.id}",
                     kind="tool",
                     tool_call_id=call.id,
                     tool_name=call.name,
-                    tool_state="done",
+                    # UNKNOWN until a result pairs, not "done". A call whose
+                    # result never arrived is a call that never returned, and
+                    # painting it ✓ asserts an outcome nobody observed — the
+                    # same "a default that means success" class as the three
+                    # shipped duration bugs. The tool-role branch below settles
+                    # it; anything this fold never pairs stays interrupted.
+                    tool_state="interrupted",
                     summary=_summarize_args(call.name, call.arguments or {}),
+                    details={"user_run": True} if user_run else {},
                 )
                 entries.append(entry)
                 tool_rows[call.id] = entry
                 tool_args[call.id] = call.arguments or {}
+            notice = assistant_stop_notice(
+                text=message.text,
+                has_tool_calls=bool(message.tool_calls),
+                stop_reason=getattr(message, "stop_reason", None),
+                provider_payload=message.provider_payload,
+            )
+            if notice is not None:
+                # A refused, failed or interrupted turn. The phone had no
+                # ``stop_reason`` branch at all, so a truncated answer looked
+                # complete and a failed turn looked like the agent ignoring
+                # the user.
+                text, severity = notice
+                entries.append(
+                    TranscriptEntry(
+                        id=f"{message.id}:stop",
+                        kind="notice",
+                        text=_compact(text, 400),
+                        details={"severity": severity},
+                    )
+                )
         elif message.role == "tool":
             entry = tool_rows.get(message.tool_call_id or "")
             if entry is not None:
@@ -673,19 +826,18 @@ def fold_messages_to_entries(history: list[AgentMessage]) -> list[TranscriptEntr
                 duration = payload.get("duration_s")
                 if isinstance(duration, (int, float)) and not isinstance(duration, bool):
                     entry.elapsed_s = float(duration)
-                entry.diff_added, entry.diff_removed = _diff_counts(result_details)
-                details: dict[str, Any] = {}
-                args = tool_args.get(message.tool_call_id or "", {})
-                if args:
-                    details["args"] = {
-                        k: _compact(str(v), TOOL_ARGS_CHARS) for k, v in args.items()
-                    }
-                if message.text:
-                    details["output"] = message.text[-TOOL_OUTPUT_TAIL_CHARS:]
-                if isinstance(result_details, dict):
-                    for key in ("diff", "added", "removed", "lines_added", "lines_removed"):
-                        if key in result_details:
-                            details[key] = result_details[key]
+                entry.diff_added, entry.diff_removed = _diff_counts(
+                    result_details if isinstance(result_details, dict) else None
+                )
+                details = _tool_row_details(
+                    tool_args.get(message.tool_call_id or "", {}),
+                    message.text,
+                    result_details if isinstance(result_details, dict) else None,
+                )
+                # The expansion flag is set on the CALL and must survive the
+                # result settling the row.
+                if entry.details.get("user_run"):
+                    details["user_run"] = True
                 entry.details = details
     return entries
 
@@ -745,97 +897,47 @@ class ProjectionFold:
 
     def fold_history(self, history: list[AgentMessage]) -> None:
         """Wholesale fold on attach: rebuild the transcript tail from the
-        session's persisted history. Tool calls arrive as assistant messages
-        carrying ``tool_calls`` followed by tool-role messages; we pair them
-        into the same one-line rows live events would have produced."""
-        entries: list[TranscriptEntry] = []
+        session's persisted history.
+
+        Row production is delegated ENTIRELY to
+        :func:`fold_messages_to_entries` — this method owns only what is
+        stateful and therefore cannot live in a pure function: the
+        ``_tool_rows``/``_tool_args`` correlation maps that let a LATER live
+        event settle a row this seed painted, and the ``_cap_tail`` trim to
+        the render window.
+
+        WHY THE DELEGATION. This method used to carry its own copy of the
+        fold, under a comment promising it could not disagree with the
+        original. It did disagree: a hub steer leaked its raw
+        ``<parent-message>`` XML envelope here while rendering as a clean card
+        on a history page, so the phone contradicted itself one scroll gesture
+        apart. Both comments asserted a contract that nothing enforced. Now
+        there is one function to change, and the seed and the page cannot
+        disagree because they are the same code.
+
+        The cap is applied AFTER the fold, so the extra notice rows the fold
+        now produces (refusals, failed turns, gate timeouts) compete for the
+        window like any other row — ``_cap_tail`` still pins the opening user
+        message so a tail full of notices cannot push the conversation's
+        subject out of the seed.
+        """
+        entries = fold_messages_to_entries(history)
+        # Rebuild the correlation maps from the rows just produced. Keyed off
+        # the fold's output rather than maintained during it: the pure fold
+        # cannot own instance state, and its row ids are stable
+        # (``{message.id}:{call.id}``), so this is a total reconstruction
+        # rather than a second pass over the messages.
+        self._tool_rows = {
+            entry.tool_call_id: entry.id
+            for entry in entries
+            if entry.kind == "tool" and entry.tool_call_id
+        }
+        self._tool_args = {}
         for message in history:
-            if isinstance(message, CustomMessage):
-                if message.custom_type == PEER_MESSAGE_MESSAGE_TYPE:
-                    # A cross-session `lop send` delivery renders as its own
-                    # inbound card (never a bare notice), so an attaching phone
-                    # sees the same peer affordance the TUI paints.
-                    body = str(message.details.get("body") or "").strip()
-                    if body:
-                        entries.append(
-                            TranscriptEntry(
-                                id=message.id,
-                                kind="peer_message",
-                                text=body,
-                                details={"sender": message.details.get("sender") or {}},
-                            )
-                        )
-                    continue
-                text = _message_text(message)
-                if text:
-                    entries.append(
-                        TranscriptEntry(id=message.id, kind="notice", text=_compact(text, 400))
-                    )
+            if isinstance(message, CustomMessage) or message.role != "assistant":
                 continue
-            if message.role == "user":
-                if message.text == CONNECTIVITY_CONTINUATION_PROMPT:
-                    # Harness chrome — see ``fold_messages_to_entries``, whose
-                    # rule this mirrors so the attaching phone and the
-                    # lazy-loaded page agree about the same row.
-                    continue
-                parent_message = extract_parent_message(message.text)
-                if parent_message is not None:
-                    # A persisted hub steer renders as the parent's own words,
-                    # never the model-facing envelope — the same rule as
-                    # ``fold_messages_to_entries``; the two folds must not
-                    # diverge or an attaching phone and a lazy-loaded page
-                    # would disagree about the same row.
-                    entries.append(
-                        TranscriptEntry(
-                            id=message.id, kind="parent_message", text=parent_message.body
-                        )
-                    )
-                    continue
-                entries.append(
-                    TranscriptEntry(
-                        id=message.id,
-                        kind="user",
-                        text=message.text,
-                        images=_image_refs(message),
-                    )
-                )
-            elif message.role == "assistant":
-                if message.text:
-                    entries.append(
-                        TranscriptEntry(id=message.id, kind="assistant", text=message.text)
-                    )
-                for call in message.tool_calls:
-                    entry = TranscriptEntry(
-                        id=f"{message.id}:{call.id}",
-                        kind="tool",
-                        tool_call_id=call.id,
-                        tool_name=call.name,
-                        tool_state="done",
-                        summary=_summarize_args(call.name, call.arguments or {}),
-                    )
-                    entries.append(entry)
-                    self._tool_rows[call.id] = entry.id
-                    self._tool_args[call.id] = call.arguments or {}
-            elif message.role == "tool":
-                entry_id = self._tool_rows.get(message.tool_call_id or "")
-                entry = next((e for e in entries if e.id == entry_id), None)
-                if entry is not None:
-                    entry.tool_state = "failed" if message.is_error else "done"
-                    if message.is_error:
-                        entry.error = _compact(message.text, 200)
-                    payload = message.provider_payload or {}
-                    result_details = payload.get("details")
-                    entry.diff_added, entry.diff_removed = _diff_counts(
-                        result_details if isinstance(result_details, dict) else None
-                    )
-                    duration = payload.get("duration_s")
-                    if isinstance(duration, (int, float)) and not isinstance(duration, bool):
-                        entry.elapsed_s = float(duration)
-                    entry.details = self._tool_details(
-                        self._tool_args.get(message.tool_call_id or "", {}),
-                        message.text,
-                        result_details if isinstance(result_details, dict) else None,
-                    )
+            for call in message.tool_calls:
+                self._tool_args[call.id] = call.arguments or {}
         # A resumed fold starts clean: no streaming row, no half-run tools, and
         # no pending echoes — the rows those entries pointed at have just been
         # replaced wholesale, and the persisted history already carries any
@@ -961,6 +1063,13 @@ class ProjectionFold:
             self._tool_args[event.tool_call_id] = event.args
         elif isinstance(event, ToolExecutionUpdateEvent):
             row = self._tool_row(event.tool_call_id, event.tool_name)
+            # Partial output means the call IS running. Normally the start
+            # event already said so, but a relayed stream can deliver an
+            # update whose start was dropped, and such a row would otherwise
+            # keep the factory default — which must never be a state this
+            # path can observe to be false.
+            if row.tool_state not in ("done", "failed"):
+                row.tool_state = "running"
             text = getattr(event.partial_result, "text", "") or ""
             if text:
                 row.details["partial"] = text[-TOOL_OUTPUT_TAIL_CHARS:]
@@ -1594,19 +1703,13 @@ class ProjectionFold:
     def _tool_details(
         self, args: dict[str, Any], output: str, result_details: dict[str, Any] | None
     ) -> dict[str, Any]:
-        details: dict[str, Any] = {}
-        if args:
-            rendered = {k: _compact(str(v), TOOL_ARGS_CHARS) for k, v in args.items()}
-            details["args"] = rendered
-        if output:
-            details["output"] = output[-TOOL_OUTPUT_TAIL_CHARS:]
-        if result_details:
-            # Diff payloads ride through whole — the expanded row renders the
-            # coloured unified diff from them.
-            for key in ("diff", "added", "removed", "lines_added", "lines_removed"):
-                if key in result_details:
-                    details[key] = result_details[key]
-        return details
+        """The live path's expand payload — one implementation with replay's.
+
+        Delegated rather than duplicated so a live row and the replayed row
+        for the same call expand to the same thing; the caps here are the
+        wire budget's and must not drift between the two paths.
+        """
+        return _tool_row_details(args, output, result_details)
 
     def _append(self, entry: TranscriptEntry) -> None:
         self.projection.transcript.append(entry)

--- a/local_operator/mobile/types.py
+++ b/local_operator/mobile/types.py
@@ -367,7 +367,15 @@ class TranscriptEntry:
     # tool rows
     tool_call_id: str = ""
     tool_name: str = ""
-    tool_state: ToolState = "done"
+    # NOT "done". A row whose state nobody set is a call nobody has seen
+    # return, and defaulting to success ASSERTS an outcome that was never
+    # observed — an unanswered call rendered ✓ while the TUI showed it
+    # interrupted. This is the same class as the three shipped duration bugs:
+    # one path silently defaulting where another is explicit. Every path that
+    # knows the real state sets it (composing/running on the live events,
+    # done/failed when a result pairs), so the default is only ever read by a
+    # row that genuinely has no outcome.
+    tool_state: ToolState = "interrupted"
     summary: str = ""  # the one-line args summary (compacted path etc.)
     intent: str = ""  # the model's own narration, when it gave one
     diff_added: int = 0

--- a/local_operator/mobile/web/src/components/tool-row.tsx
+++ b/local_operator/mobile/web/src/components/tool-row.tsx
@@ -75,7 +75,20 @@ function DiffBlock({ diff }: { diff: string | string[] }) {
 const DIFF_FIRST_TOOLS = new Set(["write", "edit", "apply_patch", "patch"]);
 
 export function ToolRow({ entry }: { entry: TranscriptEntry }) {
-	const [open, setOpen] = useState(false);
+	/* Bang-mode (`! cmd`) opens EXPANDED, matching the TUI: the user typed
+	   this command themselves and is waiting to read its output, so making
+	   them tap to see it asks for a gesture to reveal the thing they asked
+	   for. Every other card stays collapsed (§7.4 — one line per action,
+	   details in one tap).
+
+	   Tracked as an OVERRIDE rather than as initial state: a live bang row
+	   is mounted while still running and only learns `user_run` when its
+	   result settles, and a `useState` initializer runs once at mount, so
+	   seeding it there would leave the live card shut. `null` means "the
+	   user has not touched this row", in which case `user_run` decides. */
+	const [override, setOverride] = useState<boolean | null>(null);
+	const open = override ?? entry.details.user_run === true;
+	const setOpen = setOverride;
 	const running =
 		entry.tool_state === "running" || entry.tool_state === "composing";
 	const isDiffFirst =

--- a/local_operator/mobile/web/src/components/transcript.tsx
+++ b/local_operator/mobile/web/src/components/transcript.tsx
@@ -122,14 +122,30 @@ function NoticeRow({ entry }: { entry: TranscriptEntry }) {
 				"text-meta flex gap-1.5 break-words",
 				severity === "error" && "text-danger",
 				severity === "warning" && "text-warning",
-				!severity && "text-ink-dim",
+				/* `info` and absent are ONE case, not two. Written as three
+				   branches this fell through all of them for an explicit
+				   `severity: "info"` and rendered with no ink class at all —
+				   while NOTICE_GLYPHS above does handle `info`, so the table
+				   and the renderer disagreed about the same tier. Latent (no
+				   producer emits it today) and exactly the shape of the
+				   typed-but-unread field this delta exists to remove. */
+				(!severity || severity === "info") && "text-ink-dim",
 			)}
 		>
 			{/* aria-hidden: the glyph is a redundant encoding of the severity
 			    already carried by the text, so announcing "✗" adds noise for a
 			    screen reader rather than information. `shrink-0` keeps the
-			    marker on the first line when the text wraps. */}
-			<span aria-hidden="true" className="shrink-0">
+			    marker on the first line when the text wraps.
+
+			    `w-4 text-center font-mono` is the glyph-column recipe
+			    `tool-row.tsx` already uses, and it is what makes the column a
+			    column: bare `shrink-0` sizes each marker to its own advance
+			    width in the PROPORTIONAL body font, so the text beside it
+			    started anywhere across a 7.6px range (21.6→29.1px) — worst on
+			    the highest-severity rows, which are the ones the eye should
+			    catch fastest. A fixed monospace box makes every notice's text
+			    start on one edge. */}
+			<span aria-hidden="true" className="w-4 shrink-0 text-center font-mono">
 				{glyph}
 			</span>
 			<span className="min-w-0">{entry.text}</span>

--- a/local_operator/mobile/web/src/components/transcript.tsx
+++ b/local_operator/mobile/web/src/components/transcript.tsx
@@ -180,8 +180,21 @@ function Entry({ entry, pid }: { entry: TranscriptEntry; pid: string }) {
 			return <ToolRow entry={entry} />;
 		case "notice":
 		case "compaction":
+			/* Severity ink mirrors the TUI's NoticeBlock kind. A refusal, a
+			   failed turn and a failed compaction are things the user has to
+			   know happened; an unattended gate timeout is something they may
+			   have to act on. Everything else keeps the quiet default — the
+			   loudest ink in the palette is worth nothing once routine
+			   receipts are wearing it. */
 			return (
-				<p className="text-meta text-ink-dim break-words">
+				<p
+					className={cn(
+						"text-meta break-words",
+						entry.details.severity === "error" && "text-danger",
+						entry.details.severity === "warning" && "text-warning",
+						!entry.details.severity && "text-ink-dim",
+					)}
+				>
 					{entry.text}
 				</p>
 			);

--- a/local_operator/mobile/web/src/components/transcript.tsx
+++ b/local_operator/mobile/web/src/components/transcript.tsx
@@ -80,6 +80,63 @@ function AttachmentImage({
 	);
 }
 
+/* Severity glyphs, matching the TUI's NOTICE_GLYPHS exactly (transcript.py).
+   Severity was HUE-ONLY on this surface: measured against the theme tokens,
+   `danger` and `ink-dim` sit at 1.30:1, and across all 31 themes those two are
+   within 1.6:1 on 30 of them (exactly 1.00:1 on six). Desaturated — grayscale,
+   a cheap screen, low vision, bright sun — "turn failed", "compaction failed"
+   and a routine wake receipt collapsed into one indistinguishable grey, while
+   the TUI stayed readable because it fronts every notice with a symbol.
+
+   The glyph is the redundant channel that makes the distinction survive losing
+   colour, and `tool-row.tsx` already leads with a state glyph (✓/✗), so
+   without this the surface was speaking two visual languages for one idea. */
+const NOTICE_GLYPHS = {
+	error: "✗",
+	warning: "!",
+	info: "·",
+} as const;
+
+function NoticeRow({ entry }: { entry: TranscriptEntry }) {
+	const severity = entry.details.severity;
+	const isWake = entry.details.notice_kind === "wake";
+	/* A wake is a DELIVERY RECEIPT, not a failure or a warning, so it takes a
+	   neutral marker rather than a severity one — but it still gets one,
+	   because a row with no glyph in a column of glyphed rows reads as a
+	   rendering bug.
+
+	   `○` is the TUI's own ASCII wake glyph (`glyphs.py`, "a clock face"),
+	   deliberately not the ⏰ emoji: an emoji renders from the colour font, so
+	   it keeps its hue under the grayscale test this glyph exists to pass and
+	   carries far more visual weight than the ✗/!/· it sits beside — two
+	   inks and two weights for one column. */
+	const glyph = isWake ? "○" : severity ? NOTICE_GLYPHS[severity] : NOTICE_GLYPHS.info;
+	return (
+		/* Severity ink mirrors the TUI's NoticeBlock kind. A refusal, a failed
+		   turn and a failed compaction are things the user has to know
+		   happened; an unattended gate timeout is something they may have to
+		   act on. Everything else keeps the quiet default — the loudest ink in
+		   the palette is worth nothing once routine receipts are wearing it. */
+		<p
+			className={cn(
+				"text-meta flex gap-1.5 break-words",
+				severity === "error" && "text-danger",
+				severity === "warning" && "text-warning",
+				!severity && "text-ink-dim",
+			)}
+		>
+			{/* aria-hidden: the glyph is a redundant encoding of the severity
+			    already carried by the text, so announcing "✗" adds noise for a
+			    screen reader rather than information. `shrink-0` keeps the
+			    marker on the first line when the text wraps. */}
+			<span aria-hidden="true" className="shrink-0">
+				{glyph}
+			</span>
+			<span className="min-w-0">{entry.text}</span>
+		</p>
+	);
+}
+
 function Entry({ entry, pid }: { entry: TranscriptEntry; pid: string }) {
 	switch (entry.kind) {
 		case "user": {
@@ -180,24 +237,7 @@ function Entry({ entry, pid }: { entry: TranscriptEntry; pid: string }) {
 			return <ToolRow entry={entry} />;
 		case "notice":
 		case "compaction":
-			/* Severity ink mirrors the TUI's NoticeBlock kind. A refusal, a
-			   failed turn and a failed compaction are things the user has to
-			   know happened; an unattended gate timeout is something they may
-			   have to act on. Everything else keeps the quiet default — the
-			   loudest ink in the palette is worth nothing once routine
-			   receipts are wearing it. */
-			return (
-				<p
-					className={cn(
-						"text-meta break-words",
-						entry.details.severity === "error" && "text-danger",
-						entry.details.severity === "warning" && "text-warning",
-						!entry.details.severity && "text-ink-dim",
-					)}
-				>
-					{entry.text}
-				</p>
-			);
+			return <NoticeRow entry={entry} />;
 		default:
 			return null;
 	}

--- a/local_operator/mobile/web/src/transcript.divergence.test.tsx
+++ b/local_operator/mobile/web/src/transcript.divergence.test.tsx
@@ -49,7 +49,7 @@ describe("rows the phone used to drop entirely", () => {
 	it("shows a refusal, a failed turn and a gate timeout", () => {
 		render(
 			<Transcript
-				pid={1}
+				pid="1"
 				entries={[
 					entry({ id: "a", kind: "assistant", text: "I started to answer but" }),
 					entry({ id: "b", text: "content policy", details: { severity: "error" } }),
@@ -75,7 +75,7 @@ describe("rows the phone used to drop entirely", () => {
 		// deciding what to do next, and one ink for both loses that.
 		render(
 			<Transcript
-				pid={1}
+				pid="1"
 				entries={[
 					entry({ id: "a", text: "compaction failed", details: { severity: "error" } }),
 					entry({ id: "b", text: "compaction skipped", details: { severity: "warning" } }),
@@ -84,11 +84,67 @@ describe("rows the phone used to drop entirely", () => {
 			/>,
 		);
 
-		expect(screen.getByText("compaction failed").className).toContain("text-danger");
-		expect(screen.getByText("compaction skipped").className).toContain("text-warning");
+		/* The tint sits on the notice ROW, not on the text node: the row is
+		   `<p class="…text-danger"><span aria-hidden>✗</span><span>text</span></p>`,
+		   so the severity class lives on the text span's parent. */
+		const row = (text: string) => screen.getByText(text).parentElement;
+
+		expect(row("compaction failed")?.className).toContain("text-danger");
+		expect(row("compaction skipped")?.className).toContain("text-warning");
 		// Negative control: an unmarked notice keeps the quiet default rather
 		// than acquiring the loudest ink in the palette.
-		expect(screen.getByText("an ordinary receipt").className).toContain("text-ink-dim");
+		expect(row("an ordinary receipt")?.className).toContain("text-ink-dim");
+	});
+
+	it("fronts a notice with a glyph so severity survives losing colour", () => {
+		/* Design D2: severity was HUE-ONLY here. danger-vs-ink-dim measures
+		   1.30:1, and across all 31 themes those two sit within 1.6:1 on 30 of
+		   them (1.00:1 on six) — so in grayscale a failure and a routine
+		   receipt were one indistinguishable grey, while the TUI survived
+		   desaturation because it fronts every notice with ✗/!/·. */
+		render(
+			<Transcript
+				pid="1"
+				entries={[
+					entry({ id: "a", text: "compaction failed", details: { severity: "error" } }),
+					entry({ id: "b", text: "compaction skipped", details: { severity: "warning" } }),
+					entry({ id: "c", text: "an ordinary receipt" }),
+				]}
+			/>,
+		);
+
+		const glyphOf = (text: string) =>
+			screen.getByText(text).parentElement?.textContent?.trimStart()[0];
+
+		// The TUI's NOTICE_GLYPHS grammar exactly (transcript.py).
+		expect(glyphOf("compaction failed")).toBe("✗");
+		expect(glyphOf("compaction skipped")).toBe("!");
+		expect(glyphOf("an ordinary receipt")).toBe("·");
+	});
+
+	it("gives a wake receipt its own affordance instead of an anonymous line", () => {
+		/* Design D3 / review MINOR-1: `notice_kind: "wake"` was emitted and
+		   typed but read by NO component, so the row rendered exactly as it
+		   did before the field existed — a typed-but-unread field is worse
+		   than none. A wake is a receipt the user scheduled, so it takes a
+		   neutral clock rather than alarm ink. */
+		render(
+			<Transcript
+				pid="1"
+				entries={[
+					entry({
+						id: "a",
+						text: "w-9 (1, every 6h) — Check the deploy pipeline",
+						details: { notice_kind: "wake" },
+					}),
+				]}
+			/>,
+		);
+
+		const row = screen.getByText("w-9 (1, every 6h) — Check the deploy pipeline");
+		expect(row.parentElement?.textContent?.trimStart()[0]).toBe("○");
+		// Not dressed as a failure: the user asked for this to fire.
+		expect(row.parentElement?.className).not.toContain("text-danger");
 	});
 });
 
@@ -96,7 +152,7 @@ describe("a hub steer never leaks its envelope", () => {
 	it("renders the parent's own words as a parent_message card", () => {
 		render(
 			<Transcript
-				pid={1}
+				pid="1"
 				entries={[entry({ id: "a", kind: "parent_message", text: "focus on the parser" })]}
 			/>,
 		);
@@ -113,7 +169,7 @@ describe("tool rows", () => {
 		// observed.
 		render(
 			<Transcript
-				pid={1}
+				pid="1"
 				entries={[
 					entry({
 						id: "a",
@@ -151,7 +207,7 @@ describe("tool rows", () => {
 				details: { output: "MODEL RAN THIS" },
 			}),
 		];
-		render(<Transcript pid={1} entries={rows} />);
+		render(<Transcript pid="1" entries={rows} />);
 
 		// The user's own command shows its output without a tap...
 		expect(screen.getByText(/drwxr-xr-x/)).toBeTruthy();

--- a/local_operator/mobile/web/src/transcript.divergence.test.tsx
+++ b/local_operator/mobile/web/src/transcript.divergence.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment happy-dom
+//
+// The RENDERED half of the history-fold convergence. The python fold now
+// emits rows the phone never used to receive (refusals, failed turns,
+// unattended gate timeouts, refused compactions) plus two new `details`
+// fields — `severity` on a notice and `user_run` on a tool row. A fold that
+// emits a field no renderer reads is a fix that does not reach the user, so
+// these tests render the REAL Transcript component over the REAL fold's
+// output shape and assert what a person would actually see.
+//
+// The fixtures below are the verbatim JSON the python fold produced for one
+// session containing every restored row (see the PR's before/after evidence);
+// keeping them as literal rows rather than hand-built objects is what makes
+// this a test of the contract between the two halves rather than of a mock.
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Transcript } from "./components/transcript";
+import type { TranscriptEntry } from "./types";
+
+vi.mock("./api", () => ({
+	getHistory: vi.fn(async () => ({ entries: [], has_more: false })),
+	getSubagentHistory: vi.fn(async () => ({ entries: [], has_more: false })),
+	imageUrl: vi.fn(() => ""),
+}));
+
+afterEach(cleanup);
+
+function entry(over: Partial<TranscriptEntry>): TranscriptEntry {
+	return {
+		id: "e1",
+		kind: "notice",
+		text: "",
+		tool_call_id: "",
+		tool_name: "",
+		tool_state: "done",
+		summary: "",
+		intent: "",
+		diff_added: 0,
+		diff_removed: 0,
+		elapsed_s: 0,
+		error: "",
+		details: {},
+		final: true,
+		...over,
+	};
+}
+
+describe("rows the phone used to drop entirely", () => {
+	it("shows a refusal, a failed turn and a gate timeout", () => {
+		render(
+			<Transcript
+				pid={1}
+				entries={[
+					entry({ id: "a", kind: "assistant", text: "I started to answer but" }),
+					entry({ id: "b", text: "content policy", details: { severity: "error" } }),
+					entry({ id: "c", text: "turn failed", details: { severity: "error" } }),
+					entry({
+						id: "d",
+						text: "waited 2h for approval with nobody attached, then denied it — bash · rm -rf /x",
+						details: { severity: "warning" },
+					}),
+				]}
+			/>,
+		);
+
+		// Each was invisible on the phone before this change.
+		expect(screen.getByText("content policy")).toBeTruthy();
+		expect(screen.getByText("turn failed")).toBeTruthy();
+		expect(screen.getByText(/waited 2h for approval/)).toBeTruthy();
+	});
+
+	it("tints a notice by severity rather than flattening every row to grey", () => {
+		// The severity distinction is the POINT of D7: a compaction that was
+		// declined and one that FAILED are different things to the person
+		// deciding what to do next, and one ink for both loses that.
+		render(
+			<Transcript
+				pid={1}
+				entries={[
+					entry({ id: "a", text: "compaction failed", details: { severity: "error" } }),
+					entry({ id: "b", text: "compaction skipped", details: { severity: "warning" } }),
+					entry({ id: "c", text: "an ordinary receipt" }),
+				]}
+			/>,
+		);
+
+		expect(screen.getByText("compaction failed").className).toContain("text-danger");
+		expect(screen.getByText("compaction skipped").className).toContain("text-warning");
+		// Negative control: an unmarked notice keeps the quiet default rather
+		// than acquiring the loudest ink in the palette.
+		expect(screen.getByText("an ordinary receipt").className).toContain("text-ink-dim");
+	});
+});
+
+describe("a hub steer never leaks its envelope", () => {
+	it("renders the parent's own words as a parent_message card", () => {
+		render(
+			<Transcript
+				pid={1}
+				entries={[entry({ id: "a", kind: "parent_message", text: "focus on the parser" })]}
+			/>,
+		);
+
+		expect(screen.getByText("focus on the parser")).toBeTruthy();
+		expect(document.body.textContent).not.toContain("<parent-message>");
+	});
+});
+
+describe("tool rows", () => {
+	it("shows an unanswered call as interrupted, not as succeeded", () => {
+		// D10: `–` is the interrupted glyph, `✓` the success one. A call that
+		// never returned wearing a ✓ is the phone asserting an outcome nobody
+		// observed.
+		render(
+			<Transcript
+				pid={1}
+				entries={[
+					entry({
+						id: "a",
+						kind: "tool",
+						tool_name: "read",
+						tool_call_id: "t9",
+						tool_state: "interrupted",
+						summary: "/var/log/deploy.log",
+					}),
+				]}
+			/>,
+		);
+
+		expect(screen.getByText("–")).toBeTruthy();
+		expect(screen.queryByText("✓")).toBeNull();
+	});
+
+	it("opens a bang-mode card expanded and leaves a model call collapsed", () => {
+		// D11: the user typed `! ls -la` and is waiting to read its output.
+		const rows = [
+			entry({
+				id: "a",
+				kind: "tool",
+				tool_name: "bash",
+				tool_call_id: "sh1",
+				summary: "ls -la",
+				details: { user_run: true, output: "total 0\ndrwxr-xr-x" },
+			}),
+			entry({
+				id: "b",
+				kind: "tool",
+				tool_name: "bash",
+				tool_call_id: "m1",
+				summary: "make deploy",
+				details: { output: "MODEL RAN THIS" },
+			}),
+		];
+		render(<Transcript pid={1} entries={rows} />);
+
+		// The user's own command shows its output without a tap...
+		expect(screen.getByText(/drwxr-xr-x/)).toBeTruthy();
+		// ...while the model's call stays one line until asked.
+		expect(screen.queryByText(/MODEL RAN THIS/)).toBeNull();
+	});
+});

--- a/local_operator/mobile/web/src/transcript.divergence.test.tsx
+++ b/local_operator/mobile/web/src/transcript.divergence.test.tsx
@@ -146,6 +146,64 @@ describe("rows the phone used to drop entirely", () => {
 		// Not dressed as a failure: the user asked for this to fire.
 		expect(row.parentElement?.className).not.toContain("text-danger");
 	});
+
+	it("inks an explicit `info` notice the same as an unmarked one", () => {
+		/* Review round 2 MINOR-2: written as three branches
+		   (error / warning / !severity), an explicit `severity: "info"` fell
+		   through ALL of them and rendered with no ink class at all — while
+		   NOTICE_GLYPHS does handle `info`, so the glyph table and the ink
+		   renderer disagreed about one tier. Latent (nothing emits it today)
+		   and the same shape as the typed-but-unread `notice_kind` above:
+		   a declared case the renderer drops. */
+		render(
+			<Transcript
+				pid="1"
+				entries={[
+					entry({ id: "a", text: "explicitly info", details: { severity: "info" } }),
+					entry({ id: "b", text: "unmarked" }),
+				]}
+			/>,
+		);
+
+		const row = (text: string) => screen.getByText(text).parentElement;
+		// The point is that the two agree — `info` IS the default tier.
+		expect(row("explicitly info")?.className).toContain("text-ink-dim");
+		expect(row("unmarked")?.className).toContain("text-ink-dim");
+		expect(row("explicitly info")?.className).toBe(row("unmarked")?.className);
+	});
+
+	it("gives every notice glyph one fixed column so the text starts on one edge", () => {
+		/* Design D12: the marker span was bare `shrink-0`, so in the
+		   PROPORTIONAL body font each glyph sized to its own advance width and
+		   the text beside it started anywhere across a 7.6px range
+		   (21.6→29.1px) — worst on the highest-severity rows. `w-4 text-center
+		   font-mono` is the column recipe `tool-row.tsx` already uses; asserted
+		   as classes because jsdom has no layout engine, with the measured
+		   spread (7.6px → 0.0px) recorded on the PR. */
+		render(
+			<Transcript
+				pid="1"
+				entries={[
+					entry({ id: "a", text: "compaction failed", details: { severity: "error" } }),
+					entry({ id: "b", text: "compaction skipped", details: { severity: "warning" } }),
+					entry({ id: "c", text: "an ordinary receipt" }),
+					entry({ id: "d", text: "a wake fired", details: { notice_kind: "wake" } }),
+				]}
+			/>,
+		);
+
+		for (const text of [
+			"compaction failed",
+			"compaction skipped",
+			"an ordinary receipt",
+			"a wake fired",
+		]) {
+			const marker = screen.getByText(text).parentElement?.firstElementChild;
+			expect(marker?.className).toContain("w-4");
+			expect(marker?.className).toContain("text-center");
+			expect(marker?.className).toContain("font-mono");
+		}
+	});
 });
 
 describe("a hub steer never leaks its envelope", () => {

--- a/local_operator/mobile/web/src/types.ts
+++ b/local_operator/mobile/web/src/types.ts
@@ -50,6 +50,21 @@ export interface TranscriptEntryDetails {
 	   conversation_name / model_label / session_id / cwd, all advisory. Rides
 	   through the fold's `details` so the card can label who reached in. */
 	sender?: PeerSender;
+	/* Severity ink for a `notice` row, mirroring the TUI's NoticeBlock kind.
+	   A refusal, a failed turn and a failed compaction are `error`; an
+	   unattended gate timeout and a declined compaction are `warning`.
+	   Absent means the quiet default — most notices are receipts nobody has
+	   to read, and tinting those would spend the loudest ink in the palette
+	   on routine chrome. */
+	severity?: "info" | "warning" | "error";
+	/* A wake delivery, which the TUI gives its own affordance. Carried so
+	   the phone can tell a wake receipt from an arbitrary notice rather
+	   than flattening both into the same grey line. */
+	notice_kind?: "wake";
+	/* Bang-mode (`! cmd`): the user ran this command themselves, so its card
+	   opens EXPANDED — they are waiting to read the output, not to be told a
+	   command they typed has finished. Mirrors the TUI's ToolCard user_run. */
+	user_run?: boolean;
 }
 
 export interface PeerSender {

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -762,23 +762,6 @@ def _skill_body_has_content(body: str | None) -> TypeGuard[str]:
     return bool(text.strip())
 
 
-def _typed_line_of(text: str) -> str | None:
-    """The ``$skill`` line behind a persisted payload, or ``None``.
-
-    A thin lazy-import wrapper over
-    :func:`local_operator.skills.invoke.typed_line_of`, matching the contract
-    the rest of this module keeps with the skills subsystem: it is imported at
-    the point of use and every failure degrades to "not an invocation", so a
-    broken or absent skills package can never stop a transcript replaying.
-    """
-    try:
-        from local_operator.skills.invoke import typed_line_of
-
-        return typed_line_of(text)
-    except Exception:  # noqa: BLE001 — replay must never fail on this
-        return None
-
-
 #: Transport wording that means THE RUNTIME IS GONE, as opposed to a refusal
 #: the session itself produced. Matched on the transport's own phrases rather
 #: than on the exception type: `ConnectionError` also carries the graceful
@@ -806,53 +789,6 @@ def _is_runtime_gone(error: BaseException) -> bool:
     if "stopped" in text or "reconnecting" in text:
         return False
     return any(marker in text for marker in _RUNTIME_GONE_MARKERS)
-
-
-def _gate_timeout_notice(details: dict[str, Any]) -> str:
-    """Say what expired, what it wanted, and that nobody chose it.
-
-    The distinction this line has to carry is denial-by-expiry versus
-    denial-by-decision: the user did not say no, they were not there. Naming
-    the tool matters for the same reason the picker's parked row wants it —
-    "a tool was denied" and "`bash rm -rf build/` was denied" are different
-    amounts of help when you are reconstructing what happened overnight.
-    """
-    tool = str(details.get("tool") or "a tool").strip()
-    description = str(details.get("description") or "").strip()
-    waited = details.get("waited_s")
-    # REPORT THE WAIT THAT HAPPENED. This used to floor at one hour
-    # (`max(1, waited // 3600)`), so a 30-second expiry — a live, reachable
-    # path when there is no registrant, or notifications are off and nothing
-    # is watching — rendered as "waited 1h" (round 3, D12). This row exists
-    # to preserve the difference between denied-by-decision and
-    # denied-by-absence, and a fabricated duration undermines the one number
-    # that has to be trustworthy. An absent or unreadable value says so
-    # rather than rounding up to an hour.
-    try:
-        seconds = float(waited) if waited is not None else 0.0
-    except (TypeError, ValueError):
-        seconds = 0.0
-    if seconds <= 0:
-        waited_text = "a while"
-    elif seconds < 60:
-        waited_text = f"{int(seconds)}s"
-    elif seconds < 3600:
-        waited_text = f"{int(seconds // 60)}m"
-    elif seconds < 86400:
-        waited_text = f"{int(seconds // 3600)}h"
-    else:
-        waited_text = f"{int(seconds // 86400)}d"
-    # An `ask` is a QUESTION, and an unanswered question was not "denied":
-    # describing it in the approval gate's vocabulary told the user something
-    # that did not happen (D12's copy note).
-    kind = str(details.get("kind") or "approval").strip().lower()
-    subject = f"{tool} · {description}" if description else tool
-    if kind == "ask":
-        return (
-            f"waited {waited_text} for an answer with nobody attached, "
-            f"then moved on — {subject}"
-        )
-    return f"waited {waited_text} for approval with nobody attached, then denied it — {subject}"
 
 
 #: How often the band re-counts running background jobs. Nothing emits an
@@ -13928,7 +13864,8 @@ class OperatorApp(App[None]):
         # §2.5's `text == sent` rule bought replay consistency for ordinary
         # prompts, and it does not reach this path: `$skill` already has a
         # display/sent split — `sent` is the rendered body, the row is the typed
-        # line, and `_typed_line_of` exists to keep a resumed row from becoming
+        # line, and `harness.rows.typed_line_of` exists to keep a resumed row
+        # from becoming
         # the whole SKILL.md. Expanding the row here made live and REPLAY
         # disagree for the paste case alone, because `render_invocation` records
         # the typed line in the payload's `invocation=` attribute and replay

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -505,6 +505,7 @@ def project_settled_rows(
     # found was a decision one surface made and the other missed
     # (docs/design/history-fold-convergence.md §3).
     from local_operator.harness.rows import (
+        assistant_row_text,
         assistant_stop_notice,
         compaction_refused_notice,
         gate_timeout_notice,
@@ -732,7 +733,12 @@ def project_settled_rows(
             # inherit the open-on-settle flag.
             bang_pending = self._replay_bang_pending
             self._replay_bang_pending = False
-            if text:
+            # Through the shared helper even though this loop already
+            # stripped: the DECISION about what an assistant row shows is the
+            # thing both surfaces must read from one place. Leaving it as a
+            # bare truthiness test here is what let the phone's own bare test
+            # drift — the helper is only load-bearing if both hosts call it.
+            if assistant_row_text(text):
                 block = AssistantBlock()
                 block.completion_anchor_id = str(getattr(message, "id", ""))
                 block.update_text(text)

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -499,8 +499,19 @@ def project_settled_rows(
 
     from local_operator.compaction.marker import COMPACTION_REFUSED_TYPE
     from local_operator.harness.approval import GATE_TIMEOUT_CUSTOM_TYPE
+
+    # The row DECISIONS this fold shares with the phone's. Held outside both
+    # hosts so neither owns them: every divergence the convergence review
+    # found was a decision one surface made and the other missed
+    # (docs/design/history-fold-convergence.md §3).
+    from local_operator.harness.rows import (
+        assistant_stop_notice,
+        compaction_refused_notice,
+        gate_timeout_notice,
+        is_harness_chrome,
+        user_row_text,
+    )
     from local_operator.tui.app import (
-        LOOP_PROMPT,
         PEER_MESSAGE_MESSAGE_TYPE,
         RESUME_OLDER_NOTICE,
         WAKE_PROMPT_MESSAGE_TYPE,
@@ -508,9 +519,7 @@ def project_settled_rows(
         PeerMessageBlock,
         UserBlock,
         WakeBlock,
-        _gate_timeout_notice,
         _resume_tail_start,
-        _typed_line_of,
     )
 
     # Results are keyed by the call they answer, and a tool message can sit
@@ -527,13 +536,6 @@ def project_settled_rows(
     # rendered tail. Empty for every unbounded caller.
     results: dict[str, Any] = dict(self._resume_results)
     settled_results: set[str] = set()
-    # Harness chrome the LIVE path never paints as a user row, so replay
-    # must not either (see the `role == "user"` branch). Deferred once to
-    # the top of this method rather than inside the loop, matching the
-    # file's other lazy session.* imports.
-    from local_operator.harness.loop import CONNECTIVITY_CONTINUATION_PROMPT
-    from local_operator.session.session import _CONTINUATION_PROMPT
-
     for message in history:
         if getattr(message, "role", None) != "tool":
             continue
@@ -651,7 +653,7 @@ def project_settled_rows(
             # distinction the transcript row itself exists to preserve.
             if getattr(message, "custom_type", None) == GATE_TIMEOUT_CUSTOM_TYPE:
                 details = getattr(message, "details", None) or {}
-                self._append_block(NoticeBlock(_gate_timeout_notice(details), kind="warning"))
+                self._append_block(NoticeBlock(gate_timeout_notice(details), kind="warning"))
                 appended = True
                 continue
             # A compaction that did NOT run. Rendered here for the same
@@ -662,8 +664,7 @@ def project_settled_rows(
             # context the user asked to reclaim is still there.
             if getattr(message, "custom_type", None) == COMPACTION_REFUSED_TYPE:
                 details = getattr(message, "details", None) or {}
-                text = str(details.get("detail") or "compaction did not run").strip()
-                kind = "error" if text.startswith("compaction failed") else "warning"
+                text, kind = compaction_refused_notice(details)
                 self._append_block(NoticeBlock(text, kind=kind))
                 appended = True
                 continue
@@ -684,11 +685,12 @@ def project_settled_rows(
                 # reason: it is persisted so the TRANSCRIPT explains why one
                 # answer arrived in two pieces, but the user never typed it
                 # and the live run showed a NoticeEvent instead.
-                if text in (
-                    LOOP_PROMPT,
-                    _CONTINUATION_PROMPT,
-                    CONNECTIVITY_CONTINUATION_PROMPT,
-                ):
+                #
+                # The list itself lives in ``harness/rows.py`` so the phone
+                # fold reads the SAME three. It previously kept its own
+                # partial copy — suppressing the connectivity prompt while
+                # painting the other two as the user's own words.
+                if is_harness_chrome(text):
                     continue
                 # A `$skill` invocation persists as its EXPANDED payload,
                 # because that is what the model was sent. Replaying it
@@ -699,7 +701,7 @@ def project_settled_rows(
                 # rides the payload's own opening tag, so replay repaints
                 # exactly what the live session painted. Same live/replay
                 # parity rule as the two prompts skipped above.
-                text = _typed_line_of(text) or text
+                text = user_row_text(text)
                 # The images ride the persisted message as base64 content
                 # blocks — the same bytes the model saw — so a resumed
                 # prompt replays WITH its pictures, not just the receipt
@@ -748,34 +750,23 @@ def project_settled_rows(
                 )
                 self._replay_tool_call(call, results, user_run=user_run)
                 appended = True
-            stop = getattr(message, "stop_reason", None)
-            if stop == "refusal":
-                # A refused turn replays its refusal even when the model DID
-                # stream some prose first (Gemini safety stops often cut a
-                # partial answer): the prose alone reads as a complete,
-                # oddly short reply, and the user re-reading the session
-                # needs to know the provider cut it off and why. The message
-                # itself was stashed on the assistant message by the loop
-                # precisely so this replay could show it.
-                payload = getattr(message, "provider_payload", None) or {}
-                # The fallback keeps the marker grammar (D3): every other
-                # refusal line ends in a parenthetical, and a user who has
-                # learned that shape would read its absence as meaningful.
-                refusal = str(payload.get("refusal") or "") or (
-                    "model refused the request (no details recorded)"
-                )
-                self._append_block(NoticeBlock(refusal, "error"))
+            # A refused, failed or interrupted turn needs a notice the prose
+            # alone does not carry — a refusal fires even when the model
+            # streamed some prose first, while error/aborted fire only for a
+            # turn that produced nothing at all. The decision is shared with
+            # the phone fold, which had NO stop_reason branch and therefore
+            # showed a truncated answer as complete and a failed turn as
+            # silence (§3, D2-D4).
+            notice = assistant_stop_notice(
+                text=text,
+                has_tool_calls=bool(tool_calls),
+                stop_reason=getattr(message, "stop_reason", None),
+                provider_payload=getattr(message, "provider_payload", None),
+            )
+            if notice is not None:
+                reason, severity = notice
+                self._append_block(NoticeBlock(reason, severity))
                 appended = True
-            elif not text and not tool_calls:
-                # An assistant message with neither prose nor a call is a
-                # turn that FAILED. Skipping it is what left a resumed
-                # session showing a prompt and nothing after it, with no
-                # hint that the answer had errored rather than never been
-                # asked for.
-                if stop in ("error", "aborted"):
-                    reason = "turn failed" if stop == "error" else "interrupted"
-                    self._append_block(NoticeBlock(reason, "error"))
-                    appended = True
     # Every message this pass rendered, by stable id — the dedupe key a
     # later backward page is filtered through.
     self._projection_message_id = ""

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -1678,11 +1678,9 @@ class WakeBlock(ExpandableActionBlock):
         the dim single-line the user could not find. The body is the
         verbatim prompt, shown only once the row is opened.
         """
-        head, _, message = self._text.partition("\n\n")
-        head = " ".join(head.split())  # collapse any envelope whitespace
-        # Drop the cancel how-to — it is instructions for the model, and the
-        # user wants WHICH wake fired, not how to stop it.
-        head = head.split(" — cancel with wake(", 1)[0]
+        from local_operator.harness.rows import wake_receipt_headline
+
+        _, _, message = self._text.partition("\n\n")
         if self._catchup:
             # The catch-up's first line is itself a model-facing preamble
             # ("(alarm) The session resumed after being closed; the following
@@ -1702,15 +1700,10 @@ class WakeBlock(ExpandableActionBlock):
             if ids:
                 headline += f" ({', '.join(ids)})"
             return headline, message
-        if head.startswith("(alarm) "):
-            head = head[len("(alarm) ") :]
-        # The name column already says ``wake``; repeating "Scheduled wake"
-        # in the summary is the same caption-not-card problem at the next
-        # column along.
-        prefix = "Scheduled wake "
-        if head.startswith(prefix):
-            head = head[len(prefix) :]
-        return head, message
+        # The envelope strip is shared with the phone fold
+        # (``harness.rows.wake_receipt_headline``): while it lived only here,
+        # the phone rendered the raw model-facing envelope verbatim.
+        return wake_receipt_headline(self._text), message
 
     def settled_rows(self) -> int:
         """Rows settled now: one collapsed, the whole card when expanded."""

--- a/tests/unit/mobile/test_fold_parity.py
+++ b/tests/unit/mobile/test_fold_parity.py
@@ -1,4 +1,4 @@
-"""The two phone folds and the TUI fold must agree about the same row.
+"""The two phone folds must agree about the same row.
 
 WHY THIS FILE EXISTS
 --------------------
@@ -15,12 +15,30 @@ SEPARATELY and never runs two folds over one input. A contract asserted by
 comment is a contract nothing checks. These tests run the folds over the same
 history and compare, so the next divergence fails here rather than shipping.
 
-The TUI-parity half deliberately compares ROW KINDS and TEXT rather than
-widgets: the two surfaces legitimately differ in how they mount a row (the
-TUI has a dedicated ``WakeBlock`` where the phone has a tagged notice), and a
-divergence has to be NAMED in ``TUI_ALLOWANCES`` to be legal. An entry
-disappearing from that list is a fix; an entry appearing without a reason is
-the failure mode this file exists to prevent.
+WHAT THIS FILE DOES **NOT** DO
+------------------------------
+It does not compare the phone against the TUI. Every assertion here is
+phone-fold vs phone-fold, or pins one fold's output against a literal. The
+cross-SURFACE contract is enforced structurally instead: the row decisions
+both hosts share live in ``harness/rows.py`` and each host calls them, so
+there is no second implementation left to disagree with — which is why the
+convergence work moved those decisions out of the hosts rather than adding a
+test to watch two copies stay in step.
+
+That structural guarantee stops at the module boundary. A host can still
+misuse a shared helper (feed it differently-normalized text, ignore a field
+it emits), and nothing in this file would catch it. Closing THAT gap needs a
+test mounting the real ``OperatorApp`` through ``_project_settled_rows`` over
+this corpus and comparing rendered row kinds and text against the phone's,
+with the legitimate mounting differences (the TUI's dedicated ``WakeBlock``
+against the phone's tagged notice) named in an allowance table.
+
+An earlier version of this docstring claimed that comparison and that table
+already existed. Neither did — no test here ever built a TUI row, and no
+``TUI_ALLOWANCES`` was ever defined. The claim is recorded as absent rather
+than quietly deleted because a docstring promising a guarantee the file does
+not provide is worse than no docstring: it tells the next reader a whole
+class of defect is already covered.
 """
 
 from __future__ import annotations
@@ -39,7 +57,12 @@ from local_operator.harness.comms import (
     PARENT_MESSAGE_TAG,
     TO_CHILD_INSTRUCTIONS,
 )
-from local_operator.harness.rows import harness_chrome_prompts
+from local_operator.harness.rows import (
+    assistant_stop_notice,
+    harness_chrome_prompts,
+    is_harness_chrome,
+    user_row_text,
+)
 from local_operator.harness.types import (
     AgentMessage,
     CustomMessage,
@@ -411,3 +434,61 @@ def test_a_model_issued_call_does_not_open_expanded() -> None:
     ]
 
     assert not _page_rows(history)[-1].details.get("user_run")
+
+
+def test_a_wake_receipt_strips_the_model_facing_envelope() -> None:
+    """D6/design D3: the phone rendered ``wake.py``'s payload VERBATIM.
+
+    The envelope — ``(alarm) Scheduled wake w-9 (1, every 6h) — cancel with
+    wake({op:"cancel",id:"w-9"})`` — is markup addressed to the model. The
+    TUI stripped it inside ``WakeBlock._summary``, so the strip was
+    unreachable from the phone and the raw JSON-ish cancel instruction landed
+    on a human surface: the same defect class as D1's leaked
+    ``<parent-message>`` rows.
+    """
+    history = [
+        CustomMessage(
+            custom_type=WAKE_PROMPT_MESSAGE_TYPE,
+            details={
+                "text": (
+                    "(alarm) Scheduled wake w-9 (1, every 6h) — cancel with "
+                    'wake({op:"cancel",id:"w-9"})\n\nCheck the deploy pipeline'
+                ),
+                "wake_id": "w-9",
+            },
+        )
+    ]
+
+    for rows in (_page_rows(history), _attach_rows(history)):
+        assert [row.kind for row in rows] == ["notice"]
+        row = rows[0]
+        assert row.details["notice_kind"] == "wake"
+        # The cancel how-to and the (alarm) prefix are for the model.
+        assert "cancel with wake(" not in row.text
+        assert "(alarm)" not in row.text
+        # What the user needs: which wake fired, and what it delivered.
+        assert row.text == "w-9 (1, every 6h) — Check the deploy pipeline"
+
+
+def test_the_shared_helpers_normalize_so_the_hosts_cannot_diverge() -> None:
+    """Review round 1: the two hosts fed the shared helpers differently.
+
+    The TUI strips a message's text at the top of its replay loop; the phone
+    fold passed ``message.text`` verbatim. A whitespace-only assistant turn
+    with ``stop_reason="error"`` therefore said "turn failed" on the TUI and
+    NOTHING on the phone — D3 reopening inside the module built to close it.
+    The strip belongs to the helper, so neither host's normalization can
+    decide the answer.
+    """
+    padded = "  \n\t "
+
+    assert assistant_stop_notice(
+        text=padded, has_tool_calls=False, stop_reason="error", provider_payload=None
+    ) == assistant_stop_notice(
+        text=padded.strip(), has_tool_calls=False, stop_reason="error", provider_payload=None
+    )
+
+    # Chrome and skill payloads take the same treatment, for the same reason.
+    chrome = harness_chrome_prompts()[0]
+    assert is_harness_chrome(f"  {chrome}\n")
+    assert user_row_text("  hello  ") == "hello"

--- a/tests/unit/mobile/test_fold_parity.py
+++ b/tests/unit/mobile/test_fold_parity.py
@@ -58,10 +58,12 @@ from local_operator.harness.comms import (
     TO_CHILD_INSTRUCTIONS,
 )
 from local_operator.harness.rows import (
+    assistant_row_text,
     assistant_stop_notice,
     harness_chrome_prompts,
     is_harness_chrome,
     user_row_text,
+    wake_receipt_headline,
 )
 from local_operator.harness.types import (
     AgentMessage,
@@ -492,3 +494,59 @@ def test_the_shared_helpers_normalize_so_the_hosts_cannot_diverge() -> None:
     chrome = harness_chrome_prompts()[0]
     assert is_harness_chrome(f"  {chrome}\n")
     assert user_row_text("  hello  ") == "hello"
+
+
+def test_a_whitespace_only_turn_produces_no_assistant_row_on_either_surface() -> None:
+    """QA round 2 (Q3): the phone emitted an extra EMPTY assistant row.
+
+    ``if message.text:`` is truthy for ``"   "``, so a whitespace-only turn
+    painted a blank row on the phone that the TUI — which tests its stripped
+    text — never produces. The notice beside it rendered correctly on both
+    surfaces, so the visible symptom was only ~8px of blank space; the real
+    defect is that the row SEQUENCES stopped matching, which is the whole
+    claim this delta makes.
+
+    Asserted as sequence equality rather than by looking at a frame: the
+    property is "these two lists are the same", and a screenshot can only
+    show that some blank space went away.
+    """
+    padded = "   \n\t "
+
+    # The helper both hosts read: whitespace is nothing, prose is itself.
+    assert assistant_row_text(padded) == ""
+    assert assistant_row_text("  hello  ") == "hello"
+
+    history = [Message.user("do it"), _assistant(padded, stop="error")]
+
+    # Both phone folds, and the kinds in order.
+    page = [row.kind for row in _page_rows(history)]
+    attach = [row.kind for row in _attach_rows(history)]
+    assert page == attach
+
+    # The notice still renders — this fix removes the blank row, NOT the
+    # row the reviewer's MAJOR was about.
+    assert page == ["user", "notice"]
+    assert "assistant" not in page
+
+    # And the ordinary case is untouched: real prose still gets its row. No
+    # notice here — `assistant_stop_notice` guards its error arm on there
+    # being NOTHING produced, which is the same emptiness question this test
+    # is about, answered by the same strip.
+    real = [Message.user("do it"), _assistant("here is the answer", stop="error")]
+    assert [row.kind for row in _page_rows(real)] == ["user", "assistant"]
+
+
+def test_the_wake_headline_strips_every_model_facing_prefix() -> None:
+    """Review round 2 (MINOR-1): a single strip leaves a doubled prefix.
+
+    ``wake_receipt_headline`` removed one ``(alarm) `` and stopped, so
+    ``(alarm) (alarm) x`` leaked the marker onto a human surface. No producer
+    emits a doubled prefix today; this pins the shape so the function that
+    exists to keep model-facing markup off the screen cannot itself pass some
+    through.
+    """
+    assert wake_receipt_headline("(alarm) build finished") == "build finished"
+    assert wake_receipt_headline("(alarm) (alarm) build finished") == "build finished"
+    assert wake_receipt_headline("(alarm) " * 5 + "build finished") == "build finished"
+    # A message that merely MENTIONS the marker keeps its own words.
+    assert wake_receipt_headline("see (alarm) in the logs") == "see (alarm) in the logs"

--- a/tests/unit/mobile/test_fold_parity.py
+++ b/tests/unit/mobile/test_fold_parity.py
@@ -1,0 +1,413 @@
+"""The two phone folds and the TUI fold must agree about the same row.
+
+WHY THIS FILE EXISTS
+--------------------
+``mobile/projection.py`` used to contain two independent folds over
+``AgentMessage`` — one for lazy-loaded history pages, one for the attach seed
+— each carrying a comment asserting the other could not disagree with it.
+They disagreed twelve ways (``docs/design/history-fold-convergence.md`` §3).
+The worst was a hub steer rendering as a clean ``parent_message`` card on a
+scrolled-up page and leaking the raw ``<parent-message>`` XML envelope as a
+``notice`` on attach: the phone contradicted ITSELF one scroll gesture apart.
+
+Nothing caught that, because ``test_projection.py`` pins each fold
+SEPARATELY and never runs two folds over one input. A contract asserted by
+comment is a contract nothing checks. These tests run the folds over the same
+history and compare, so the next divergence fails here rather than shipping.
+
+The TUI-parity half deliberately compares ROW KINDS and TEXT rather than
+widgets: the two surfaces legitimately differ in how they mount a row (the
+TUI has a dedicated ``WakeBlock`` where the phone has a tagged notice), and a
+divergence has to be NAMED in ``TUI_ALLOWANCES`` to be legal. An entry
+disappearing from that list is a fix; an entry appearing without a reason is
+the failure mode this file exists to prevent.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.compaction.marker import COMPACTION_REFUSED_TYPE
+from local_operator.harness.approval import GATE_TIMEOUT_CUSTOM_TYPE
+from local_operator.harness.comms import (
+    HUB_MESSAGE_TYPE,
+    PARENT_MESSAGE_CLOSE_TAG,
+    PARENT_MESSAGE_TAG,
+    TO_CHILD_INSTRUCTIONS,
+)
+from local_operator.harness.rows import harness_chrome_prompts
+from local_operator.harness.types import (
+    AgentMessage,
+    CustomMessage,
+    Message,
+    TextContent,
+    ToolCall,
+    ToolResult,
+)
+from local_operator.harness.wake import WAKE_PROMPT_MESSAGE_TYPE
+from local_operator.mobile.projection import ProjectionFold, fold_messages_to_entries
+from local_operator.mobile.types import SessionProjection, TranscriptEntry
+from local_operator.session.shell_record import shell_record_messages
+
+
+def _page_rows(history: Sequence[AgentMessage]) -> list[TranscriptEntry]:
+    """The lazy-loaded history page's rows."""
+    return fold_messages_to_entries(list(history))
+
+
+def _attach_rows(history: Sequence[AgentMessage]) -> list[TranscriptEntry]:
+    """The attach seed's rows."""
+    fold = ProjectionFold(SessionProjection(session_id="s", pid=1))
+    fold.fold_history(list(history))
+    return list(fold.projection.transcript)
+
+
+def _shape(rows: list[TranscriptEntry]) -> list[tuple[Any, ...]]:
+    """The comparable shape of a row list: everything a reader would notice."""
+    return [
+        (
+            row.kind,
+            row.text,
+            row.tool_name,
+            row.tool_state,
+            row.details.get("severity", ""),
+            bool(row.details.get("user_run")),
+        )
+        for row in rows
+    ]
+
+
+def _envelope(body: str, kind: str = "steer") -> str:
+    """Exactly what ``SubagentComms._format_to_child`` emits."""
+    return (
+        f"{PARENT_MESSAGE_TAG}\n{TO_CHILD_INSTRUCTIONS[kind]}\n\n{body}\n{PARENT_MESSAGE_CLOSE_TAG}"
+    )
+
+
+def _hub_steer(body: str) -> CustomMessage:
+    """Exactly what ``SubagentComms`` journals for a parent steer."""
+    return CustomMessage(
+        custom_type=HUB_MESSAGE_TYPE,
+        attribution="user",
+        details={
+            "direction": "to_child",
+            "body": body,
+            "expects_reply": False,
+            "steer": True,
+            "text": _envelope(body),
+        },
+    )
+
+
+def _assistant(text: str = "", calls=(), stop=None, payload=None) -> Message:
+    message = Message(
+        role="assistant",
+        content=[TextContent(text=text)] if text else [],
+        stop_reason=stop,
+        provider_payload=payload or {},
+    )
+    message.tool_calls = list(calls)
+    return message
+
+
+#: Every conversation shape the convergence review enumerated, keyed by the
+#: divergence it closes. Built from the REAL producers wherever one exists
+#: (``shell_record_messages``, the comms envelope constants) rather than from
+#: hand-written approximations, because a hand-written shape tests the wrong
+#: path — an envelope missing its exact instruction preamble does not extract.
+CORPUS: dict[str, Sequence[AgentMessage]] = {
+    "D1 hub steer": [Message.user("start"), _hub_steer("focus on the parser")],
+    "D1 persisted envelope": [Message.user(_envelope("focus on the parser"))],
+    "D2 refusal": [
+        Message.user("do it"),
+        _assistant(
+            "I started to answer but", stop="refusal", payload={"refusal": "content policy"}
+        ),
+    ],
+    "D3 failed turn": [Message.user("do it"), _assistant(stop="error")],
+    "D4 interrupted turn": [Message.user("do it"), _assistant(stop="aborted")],
+    "D5 gate timeout": [
+        CustomMessage(
+            custom_type=GATE_TIMEOUT_CUSTOM_TYPE,
+            details={"tool": "bash", "description": "rm -rf /x", "waited_s": 7200},
+        )
+    ],
+    "D6 wake": [
+        CustomMessage(
+            custom_type=WAKE_PROMPT_MESSAGE_TYPE,
+            details={"text": "(alarm) build finished", "wake_id": "w1", "occurrence": 1},
+        )
+    ],
+    "D7 compaction refused": [
+        CustomMessage(
+            custom_type=COMPACTION_REFUSED_TYPE,
+            details={"detail": "compaction skipped: history too short"},
+        )
+    ],
+    "D9 chrome prompts": [Message.user(p) for p in harness_chrome_prompts()],
+    "D10 unanswered call": [
+        _assistant("reading", calls=[ToolCall(id="t9", name="read", arguments={"path": "/a"})])
+    ],
+    "D11 bang mode": shell_record_messages(
+        "ls -la",
+        ToolResult(tool_call_id="sh1", content=[TextContent(text="total 0")], is_error=False),
+    ),
+    "settled conversation": [
+        Message.user("edit it"),
+        _assistant("editing", calls=[ToolCall(id="e1", name="edit", arguments={"path": "/x"})]),
+        Message(
+            role="tool",
+            content=[TextContent(text="done")],
+            tool_call_id="e1",
+            tool_name="edit",
+            provider_payload={"duration_s": 9.75, "details": {"added": 3, "removed": 1}},
+        ),
+    ],
+}
+
+
+@pytest.mark.parametrize("name", sorted(CORPUS))
+def test_the_two_phone_folds_agree_about_every_row(name: str) -> None:
+    """The attach seed and a history page must render one history identically.
+
+    This is the property D1 violated: the phone contradicted itself across
+    one scroll gesture. It holds now because there is only one fold — this
+    test is what keeps it that way if someone reintroduces a second.
+    """
+    history = CORPUS[name]
+
+    assert _shape(_page_rows(history)) == _shape(_attach_rows(history))
+
+
+def test_the_attach_seed_never_leaks_the_model_facing_envelope() -> None:
+    """D1's headline: the raw XML wrapper must never reach a user surface.
+
+    ``extract_parent_message`` exists to hide it, and the attach seed used to
+    render it verbatim inside a notice row.
+    """
+    history = [_hub_steer("focus on the parser"), Message.user(_envelope("and retries"))]
+
+    for rows in (_page_rows(history), _attach_rows(history)):
+        rendered = " ".join(row.text for row in rows)
+        assert PARENT_MESSAGE_TAG not in rendered
+        assert PARENT_MESSAGE_CLOSE_TAG not in rendered
+        assert [row.kind for row in rows] == ["parent_message", "parent_message"]
+        assert [row.text for row in rows] == ["focus on the parser", "and retries"]
+
+
+@pytest.mark.parametrize(
+    ("stop_reason", "payload", "expected"),
+    [
+        ("refusal", {"refusal": "content policy"}, "content policy"),
+        ("refusal", {}, "model refused the request (no details recorded)"),
+        ("error", {}, "turn failed"),
+        ("aborted", {}, "interrupted"),
+    ],
+)
+def test_a_turn_that_did_not_finish_says_so_on_the_phone(
+    stop_reason: str, payload: dict[str, Any], expected: str
+) -> None:
+    """D2-D4: the phone had NO ``stop_reason`` branch, so a refused turn read
+    as a complete (oddly short) answer and a failed turn as the agent
+    ignoring the user."""
+    history = [Message.user("do it"), _assistant(stop=stop_reason, payload=payload)]
+
+    rows = _page_rows(history)
+
+    assert rows[-1].kind == "notice"
+    assert rows[-1].text == expected
+    assert rows[-1].details["severity"] == "error"
+
+
+def test_a_refusal_shows_even_when_the_model_streamed_prose_first() -> None:
+    """A provider safety stop often cuts a PARTIAL answer. The prose alone
+    reads as a complete reply, so the notice fires alongside it rather than
+    instead of it."""
+    history = [
+        _assistant("Here is the first half", stop="refusal", payload={"refusal": "content policy"})
+    ]
+
+    rows = _page_rows(history)
+
+    assert [row.kind for row in rows] == ["assistant", "notice"]
+    assert rows[0].text == "Here is the first half"
+
+
+def test_an_ordinary_turn_gets_no_notice() -> None:
+    """Negative control for the ``stop_reason`` branch: a normal answer and a
+    normal tool call must not acquire a notice row."""
+    history = [
+        Message.user("edit it"),
+        _assistant("editing", calls=[ToolCall(id="e1", name="edit", arguments={"path": "/x"})]),
+    ]
+
+    assert [row.kind for row in _page_rows(history)] == ["user", "assistant", "tool"]
+
+
+def test_an_unattended_gate_timeout_reaches_the_phone() -> None:
+    """D5: the most expensive event in the detached feature — up to a day of
+    held residency — rendered nowhere on the phone."""
+    history = [
+        CustomMessage(
+            custom_type=GATE_TIMEOUT_CUSTOM_TYPE,
+            details={"tool": "bash", "description": "rm -rf /x", "waited_s": 7200},
+        )
+    ]
+
+    row = _page_rows(history)[0]
+
+    assert row.kind == "notice"
+    assert row.text == (
+        "waited 2h for approval with nobody attached, then denied it — bash · rm -rf /x"
+    )
+    assert row.details["severity"] == "warning"
+
+
+def test_an_unanswered_ask_says_it_moved_on_rather_than_denied() -> None:
+    """An ``ask`` is a QUESTION, and an unanswered question was not denied —
+    the severity vocabulary must not be borrowed from the approval gate."""
+    history = [
+        CustomMessage(
+            custom_type=GATE_TIMEOUT_CUSTOM_TYPE,
+            details={"tool": "ask", "description": "which env?", "waited_s": 45, "kind": "ask"},
+        )
+    ]
+
+    assert "moved on" in _page_rows(history)[0].text
+
+
+@pytest.mark.parametrize(
+    ("detail", "severity"),
+    [
+        ("compaction skipped: history too short", "warning"),
+        ("compaction failed: provider error", "error"),
+    ],
+)
+def test_a_refused_compaction_keeps_its_severity_on_the_phone(detail: str, severity: str) -> None:
+    """D7: the phone dropped this row entirely, and flattening the two cases
+    into one ink would lose the difference between "not worth it" and "I
+    could not" — which is what the reader decides their next step on."""
+    history = [CustomMessage(custom_type=COMPACTION_REFUSED_TYPE, details={"detail": detail})]
+
+    row = _page_rows(history)[0]
+
+    assert row.kind == "notice"
+    assert row.details["severity"] == severity
+
+
+def test_an_unanswered_tool_call_is_not_asserted_successful() -> None:
+    """D10: a call whose result never arrived rendered ✓ on the phone while
+    the TUI showed it interrupted. A default that means "success" is how this
+    bug class keeps recurring."""
+    history = [
+        _assistant("reading", calls=[ToolCall(id="t9", name="read", arguments={"path": "/a"})])
+    ]
+
+    assert _page_rows(history)[-1].tool_state == "interrupted"
+
+
+def test_the_bare_transcript_entry_default_is_not_success() -> None:
+    """The root cause of D10, pinned at the type: a row nobody set a state on
+    has no observed outcome, and must not claim one."""
+    assert TranscriptEntry(id="x", kind="tool").tool_state == "interrupted"
+
+
+def test_a_paired_call_still_settles_done() -> None:
+    """Negative control for D10: the interrupted default must not leak into a
+    call that DID return."""
+    history = [
+        _assistant("editing", calls=[ToolCall(id="e1", name="edit", arguments={"path": "/x"})]),
+        Message(
+            role="tool", content=[TextContent(text="done")], tool_call_id="e1", tool_name="edit"
+        ),
+    ]
+
+    assert _page_rows(history)[-1].tool_state == "done"
+
+
+def test_a_skill_invocation_shows_the_typed_line_not_the_payload() -> None:
+    """D8: a ``$skill`` persists as its EXPANDED payload, and painting it
+    verbatim put the whole SKILL.md body in the user's bubble — and titled
+    the session after it."""
+    from local_operator.skills.discovery import Skill
+    from local_operator.skills.invoke import SkillInvocation, render_invocation
+
+    # The REAL Skill type and the REAL renderer: a stub here would test a
+    # payload shape the product never produces, and it is the product's own
+    # ``invocation`` attribute that ``typed_line_of`` reads back.
+    skill = Skill(
+        name="research",
+        description="research things",
+        file_path=Path("/skills/research/SKILL.md"),
+        base_dir=Path("/skills/research"),
+        source="user",
+    )
+    typed = "$research the widget market"
+    payload = render_invocation(
+        SkillInvocation(skill=skill, request="the widget market", token="$research", typed=typed),
+        "# Research\n\n" + "a very long skill body\n" * 50,
+    )
+    assert len(payload) > 500
+
+    rows = _page_rows([Message.user(payload)])
+
+    assert rows[0].kind == "user"
+    assert rows[0].text == typed
+
+
+def test_ordinary_prose_mentioning_a_skill_is_left_alone() -> None:
+    """Negative control for D8: only a rendered payload collapses."""
+    rows = _page_rows([Message.user("what does the $research skill do?")])
+
+    assert rows[0].text == "what does the $research skill do?"
+
+
+def test_no_harness_prompt_is_painted_as_the_users_words() -> None:
+    """D9: the phone suppressed ONE of the three continuation prompts and
+    rendered the other two as the user's own words — a partially copied
+    list, which is the drift signature itself. All three now come from one
+    shared list."""
+    prompts = harness_chrome_prompts()
+    assert len(prompts) == 3
+
+    assert _page_rows([Message.user(p) for p in prompts]) == []
+
+
+def test_a_human_quoting_the_envelope_keeps_their_own_words() -> None:
+    """Negative control for D1/D9 suppression: asking about the wrapper is a
+    realistic thing to do, and must not be rewritten as a parent steer."""
+    quoted = f"{PARENT_MESSAGE_TAG}\nwhy does my log show this?\n{PARENT_MESSAGE_CLOSE_TAG}"
+
+    rows = _page_rows([Message.user(quoted)])
+
+    assert rows[0].kind == "user"
+    assert rows[0].text == quoted
+
+
+def test_a_bang_mode_command_opens_expanded() -> None:
+    """D11: the user typed this command and is waiting to read its output, so
+    the card opens rather than asking for a tap to reveal what they asked
+    for. Built from the real ``shell_record_messages`` shape."""
+    history = shell_record_messages(
+        "ls -la",
+        ToolResult(tool_call_id="sh1", content=[TextContent(text="total 0")], is_error=False),
+    )
+
+    rows = _page_rows(history)
+
+    assert rows[0].text == "! ls -la"
+    assert rows[-1].details["user_run"] is True
+
+
+def test_a_model_issued_call_does_not_open_expanded() -> None:
+    """Negative control for D11: only the user's own command self-opens."""
+    history = [
+        Message.user("list the files"),
+        _assistant(calls=[ToolCall(id="c1", name="bash", arguments={"command": "ls"})]),
+    ]
+
+    assert not _page_rows(history)[-1].details.get("user_run")


### PR DESCRIPTION
## What and why

**C2 — user-visible correctness fix on the phone surface.** The phone's history fold silently **drops five kinds of row the TUI renders**, and **contradicts itself** about a sixth. On one real 8-message transcript replayed through `build_llm_history()`, the TUI renders **9 rows and the phone renders 6**.

Implements Stage 1 + Stage 2 of `docs/design/history-fold-convergence.md` (the architecture report's §3 divergence table). Stage 3 (`RowSpec` + `assert_never`) and Stage 4 (the TUI seam) are **not** in this PR — Stage 4 is explicitly un-prototyped and gated.

### What a user saw before this change

| | The phone showed | It should have shown |
|---|---|---|
| Provider **refused** the turn | a truncated answer, nothing to say it was cut off | `content policy` notice |
| Turn **failed** | prompt followed by silence — reads as the agent ignoring them | `turn failed` |
| Turn **interrupted** | same silence | `interrupted` |
| **Gate timed out unattended** | *nothing at all* | `waited 2h for approval with nobody attached, then denied it — bash · rm -rf /x` |
| **Compaction refused** | *nothing* — the optimistic "compacting context…" receipt was never corrected | the refusal, with `error` vs `warning` ink |
| **Hub/parent steer** | a clean card on a scrolled-up page, **raw `<parent-message>` XML** on the attach seed | the parent's words, both places |
| **`$skill` invocation** | the entire expanded SKILL.md body as the user's own bubble | the line they typed |
| **Harness continuation prompts** | two of three painted as the user's own words | suppressed |
| **Unanswered tool call** | `✓` | `–` interrupted |

The gate timeout is the one worth dwelling on: it is **the most expensive event in the detached feature** — up to a day of held residency ends in it — and the phone is precisely the surface on which nobody was attended.

D8 is not a rounding error. On a real skill (`minerva-design`), the persisted payload is **3,303 characters** and the line the user typed is **43**. That payload was the user's bubble, and it also poisons phone-side session titling.

### Why this kept happening

`mobile/projection.py` contained **two independent folds** over `AgentMessage` — `fold_messages_to_entries` (`:567`, history pages) and `ProjectionFold.fold_history` (`:746`, attach seed) — ~80% identical, **each carrying a comment asserting the other could not disagree with it**:

> *"the two folds must not diverge or an attaching phone and a lazy-loaded page would disagree about the same row"* — `projection.py:777-787`

That comment was **false on `main`**. Verified by execution:

```
BEFORE  PHONE ATTACH SEED:  notice        | '<parent-message> This changes your instructions…'
BEFORE  PHONE HISTORY PAGE: parent_message | 'focus on the parser'
```

A contract two functions promise to keep is a contract nothing checks. No test anywhere ran two folds over one input — `test_projection.py` pins each **separately**, while its header claims to pin "the TUI-parity contract" without ever executing the TUI.

### The fix

**1. One fold.** `fold_history` now delegates row production **entirely** to `fold_messages_to_entries`, keeping only what is genuinely stateful — the `_tool_rows`/`_tool_args` correlation maps and `_cap_tail`. The seed and the page cannot disagree because they are the same code. The false comments are replaced with what is actually true now.

**2. One set of decisions.** The row decisions both the phone and the TUI must make identically move into a new **host-free** `harness/rows.py` — the chrome-prompt list, the gate-timeout line, the compaction severity, the `stop_reason` notice, the skill typed line. Both hosts call it; neither owns it. It imports no Textual, no wire type, and no session at module scope, mirroring how `compaction/marker.py` already sits below its hosts.

**The TUI is the source of truth throughout** (the report measures it as the strict superset), so this converges the phone **onto** the TUI rather than inventing a third answer. D7's `error`-vs-`warning` ink is **preserved, not flattened**.

D9 is fixed by **deriving from one list**, not by adding two more copies — the phone had suppressed `CONNECTIVITY_CONTINUATION_PROMPT` while rendering `LOOP_PROMPT` and `_CONTINUATION_PROMPT`. A *partially copied list* is the drift signature itself.

**3. A default that no longer means success.** `TranscriptEntry.tool_state` defaulted to `"done"`, so an unpaired call was *asserted* successful. It now defaults to `"interrupted"` — unknown, not success. This is the same class as the three shipped duration bugs (#823 and follow-ups): one path silently defaulting where another is explicit.

### Caches: deliberately untouched

`durable.py` and `daemon.py` have a **zero diff**. The report measured the fold at **5.3 ms over 3,000 messages**; the 90–900 ms `durable.py` attributes to itself is **file parse and replay**, and the cache already calls the fold through a four-line seam. Re-measured after this change — no regression:

| messages | fold, before (report) | fold, after |
|---|---:|---:|
| 120 | 0.19 ms | **0.20 ms** |
| 600 | 0.98 ms | **1.01 ms** |
| 3000 | 5.26 ms | **5.22 ms** |

## Testing evidence

### The headline number closing

`probe.py --e2e` builds a **real on-disk `Transcript`** and replays it through `build_llm_history()`, so the input to both folds is literally the replay output:

```
BEFORE   REAL transcript replayed: 8 messages
         === E2E real transcript  [tui=9 page=6 attach=6]
AFTER    === E2E real transcript  [tui=9 page=9 attach=9] OK
```

All nine rows, and `page == attach` on every one.

### Per-divergence, before → after

Each row produced by running **both phone folds and the TUI fold over the same history** and diffing:

| | before (page / attach) | after (both) |
|---|---|---|
| **D1** | `parent_message` / **`notice` with raw XML** | `parent_message` · `parent_message` |
| **D2** | *dropped* | `notice/error 'content policy'` |
| **D3** | *dropped* | `notice/error 'turn failed'` |
| **D4** | *dropped* | `notice/error 'interrupted'` |
| **D5** | *dropped* | `notice/warning 'waited 2h for approval…'` |
| **D5b** (`ask`) | *dropped* | `notice/warning 'waited 45s for an answer… moved on'` |
| **D7** | *dropped* | `notice/warning 'compaction skipped…'` |
| **D7b** | *dropped* | `notice/error 'compaction failed…'` (severity preserved) |
| **D8** | 3,303-char payload | `'$minerva-design review the dashboard header'` |
| **D9** | 2 of 3 prompts painted | all 3 suppressed |
| **D10** | `tool_state=done` | `tool_state=interrupted` |
| **D11** | collapsed | `user_run=True`, opens expanded |

Across the 27-case corpus: **14 flagged before → 2 after**, and the 2 remaining are D1's TUI-renders-nothing case, where the report states the history page's `parent_message` is the correct answer and neither fold's *old* behaviour was right.

### Real records, not synthetic shapes

The report flagged D8/D9/D10/D11 as verified on synthetic messages only and asked for real ones. Both were captured:

- **Real skill invocation** — `discover_skills(default_skill_roots())` found 17 real skills on this machine; `$minerva-design` parsed through the real `parse_invocation`/`render_invocation`. 3,303-char payload → 43-char row, page and attach agreeing.
- **Real bang-mode record** — built by `session/shell_record.py::shell_record_messages` itself rather than hand-approximated. Also caught a real bug in my first attempt: I had matched the TUI's bang flag by *clearing* it on an intervening user row, which the TUI does not do. Fixed to match exactly, with `D11b` (bang → plain user → call) and `D11c` (non-bash call after a bang) pinning the edge cases.
- **Real hub envelope** — built from the shared `TO_CHILD_INSTRUCTIONS` constants, because extraction requires a byte-exact preamble and a hand-typed envelope silently fails to extract, testing the wrong path.

### Rendered evidence

cmux's socket was down for this session, so browser screenshots were unavailable — rather than stand up a second browser stack, the phone surface is exercised through the repo's own component-test stack, which renders **the real `Transcript` component**: `local_operator/mobile/web/src/transcript.divergence.test.tsx` (5 tests) asserts what a person actually sees — the restored notices present, severity tinting `text-danger`/`text-warning` with an unmarked notice keeping `text-ink-dim`, the interrupted glyph `–` rather than `✓`, and a bang card showing its output with a model call still collapsed.

**Negative control on the renderer:** reverting *only* the two `.tsx` files to `origin/main` and re-running → **2 of 5 fail** (severity tinting, bang expansion), then pass again on restore. The fold changes alone would not have reached the user without them.

### Negative control on the fold

The 32 new parity tests, run against **pristine `origin/main`** (with only the new module copied in so the import resolves): **16 fail, 16 pass** — each failure landing exactly on the divergence it pins, including `assert '<parent-message>' not in '<parent-mes... and retries'`. On this branch: **32/32 pass.**

Per-fix negative controls are in the suite: an ordinary turn gains no notice; a paired call still settles `done`; prose mentioning `$research` is left alone; a human **quoting** the `<parent-message>` envelope keeps their own words; a model-issued call does not self-expand; an unmarked notice keeps the quiet ink.

### `_cap_tail` interaction (report risk 2)

Adding rows changes what the attach cap keeps, so this was tested explicitly. With a tail of **120 consecutive gate-timeout notices** (the pathological shape) against `PROJECTION_TRANSCRIPT_LIMIT = 80`:

```
notice-heavy tail: 122 messages -> 122 rows uncapped, 80 rows in seed
  bound respected      : True
  opening row pinned   : 'THE OPENING QUESTION — what is this sess'
  newest row survives  : 'THE NEWEST QUESTION'
```

Plus a mixed session and a short session below the cap. The opener stays pinned and the newest row survives; a notice-saturated tail cannot push the conversation's subject out of the seed.

### Cache correctness (report risk 6)

The incremental `DurableFoldCache` path was exercised against a fresh full fold over the same file, appending the newly-restored row kinds so they land on the **incremental** branch:

```
cold cached render rows: 3
incremental cached render rows: 6 | fresh full fold rows: 6
INCREMENTAL CACHE == FULL FOLD: True
```

> [!IMPORTANT]
> **Validation requires a mobile service restart.** `_DURABLE_FOLD_CACHE` is a process-local singleton (`daemon.py:112`), so a long-running daemon keeps serving **old-fold rows** to the phone while a new TUI renders new-fold ones. Without the restart this will look like it did not land.

### Gate

- `flake8`, `black==26.1.0 --check`, `isort==5.13.2 --check-only` — clean over the whole tree
- `pyright` — **0 errors** (run as `--pythonpath .venv/bin/python`; the bare invocation resolves the wrong interpreter and reports ~1,581 phantom import errors)
- **Unit suite: 17,436 passed, 18 skipped**, one unrelated flake in `test_builtin_tools.py::test_bash_background_cancelled_before_start_kills_the_process_group` (a process-group timing test under parallel load) — passes in isolation on this branch and its whole file passes on pristine `main`; this PR touches no tool-execution code.
- Web: `tsc -b --noEmit` clean, **82 vitest tests pass** (77 existing + 5 new)

## Rebase note

Rebased onto **`main` at v0.53.1 (`2469d39d9`)**. An earlier revision of this note claimed the base was #858 (`77f1cc75f`); that commit is an ancestor, not the base, and a later revision claimed v0.52.18 — the reviewer verified the branch was actually on v0.52.17 (`8e429ffb2`) at that point. Both claims are corrected here rather than quietly dropped: a PR whose thesis is that two surfaces must not assert things that are not true of each other cannot carry a false claim in its own body.

The current base includes **#838** (agent-facing secret store), which adds redaction across tool results and eval channels. Confirmed nothing in the fold path double-redacts or strips a row's content: redaction is applied at tool-execution time before persistence (`tools/builtin.py`), and neither `mobile/projection.py` nor `harness/rows.py` imports `tools` or `secrets` at all. `git merge-tree --write-tree origin/main HEAD` reports **no conflicts** after the rebase, and `git range-diff` reports both pre-existing commits as `=` (content identical across the move).

## Scope

**Not in this PR**, per the report's staging: the `RowSpec` discriminated union + `assert_never` exhaustiveness (Stage 3) and the TUI-side seam (Stage 4, un-prototyped and gated on an experiment). This is semantics convergence within the mobile stack.

**D12 verified benign, deliberately not "fixed".** A `compaction_summary` marker renders as a `notice` on the phone and nothing in the TUI. The report initially wrote it up as a bug and downgraded it after reading the web renderer: `case "notice": case "compaction":` fall through to the same element (`transcript.tsx:181-182`). It is a latent divergence — real the day those two kinds render differently — not a user-visible defect today, and it is not counted as one.

`session/history_window.py` is untouched: it is a **pager**, not a fold (25 of its 52 statements are paging/budget, 4 touch row semantics), and merging it into a row fold would be merging a cursor-signing pager into a renderer.

`Release: patch — the phone stops silently dropping refusals, failed turns, interrupts and unattended gate timeouts, and stops contradicting itself on hub steers.`

