### PR TITLE
chore(release): bump version to 0.52.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.52.13"
+version = "0.52.14"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window bump. Owner session pid: 66376.

**C0 — release bump only.** One file, one line: `pyproject.toml` `0.52.13` → `0.52.14`. No code.

## Window

Exactly one PR merged since `v0.52.13`:

- [x] #857 — `Release: patch — compaction's verbatim-user-turn block no longer fills with harness injections or grows without bound, and an already-poisoned session heals when it resumes.` (merge `45487cd66d0993c2596e6d94504d28091eeaeb33`)

## Bump rationale

**Patch.** A bug fix on an existing surface: no new API, no config key, no migration, no behaviour a user has to opt into. Materiality does not clear the minor step-function bar.

## Pre-tag checks

- `git diff v0.52.13..origin/main -- pyproject.toml` — empty, so no merged PR consumed `0.52.14`.
- `git log --oneline v0.52.13..origin/main` — one commit, matching the window above.
- No other open `chore(release)` PR held the lock.

## Review

C0 scope-check round only, per the standing gate: an independent reviewer confirms the diff is one file and one version string. Not self-reviewed.