### PR TITLE
fix(mcp): propagate a peer session's re-auth to servers this session gave up on

### DIFF
--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -547,6 +547,61 @@ class McpTokenStorage:
         creds.pop(GRANT_DEAD_AT_KEY, None)
         self._write(creds)
 
+    def grant_marker(self) -> tuple[float, bool] | None:
+        """``(tokens_obtained_at, grant_is_dead)``, or ``None`` if unreadable.
+
+        The identity of the grant currently stored for this server, read in ONE
+        row fetch. Callers use it to answer "has somebody obtained a different
+        grant since I last looked?" without caring what the grant is.
+
+        ``None`` means the store could not be read, and is deliberately NOT a
+        tuple: a sentinel VALUE would compare unequal to the real marker either
+        side of a transient failure, so an unreadable store would look exactly
+        like a peer's re-auth. For a caller that retries on movement that turns
+        a broken store into a refresh-token retry storm — which, against a
+        provider running reuse detection, revokes the whole token family (see
+        :data:`GRANT_DEAD_AT_KEY`). Unknown has to be representable as unknown.
+
+        Read-only, and the single row read is the point: deriving both fields
+        from one fetch costs a third of what calling ``_read_row`` and
+        :meth:`grant_is_dead` separately does, and it means the two halves
+        describe the SAME instant rather than two reads a write may fall
+        between.
+
+        It reads the store directly rather than through :meth:`_read_row`, which
+        cannot serve this caller: ``_read_row`` deliberately converts a store
+        FAILURE into the same ``None`` it returns for a row that is simply
+        ABSENT, and every other caller wants that (a missing grant and an
+        unreadable one both mean "start a fresh flow"). Here the two must stay
+        distinguishable — absent is the stable, knowable marker ``(0.0, False)``
+        that moves when a peer writes a grant, while unreadable is no
+        information at all. Collapsing them is what turns a broken store into a
+        retry storm.
+        """
+        store = self._store
+        if store is None:
+            # No store configured is a KNOWN state, not a failed read: there is
+            # no grant, and there never will be one until a store appears.
+            return (0.0, False)
+        try:
+            rows = store.list_credentials(MCP_OAUTH_PROVIDER)
+        except Exception:  # noqa: BLE001 — an unreadable store is "unknown", never a value
+            logger.debug("MCP grant marker read failed for %s", self.credential_id, exc_info=True)
+            return None
+        row = next((r for r in rows if r.identity_key == self.server_url), None)
+        data = row.data if row is not None and isinstance(row.data, dict) else {}
+        if not isinstance(data, dict):
+            return (0.0, False)
+        obtained = data.get(TOKENS_OBTAINED_AT_KEY)
+        obtained_at = (
+            float(obtained)
+            if isinstance(obtained, (int, float)) and not isinstance(obtained, bool)
+            else 0.0
+        )
+        dead = data.get(GRANT_DEAD_AT_KEY)
+        is_dead = isinstance(dead, (int, float)) and not isinstance(dead, bool) and dead > 0
+        return (obtained_at, is_dead)
+
     def grant_is_dead(self) -> bool:
         """Whether this row's refresh token is a known-dead grant.
 

--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -117,6 +117,24 @@ RECONNECT_BACKOFF_S = (0.5, 1.0, 2.0, 4.0)
 RECONNECT_BURST_WINDOW_S = 30.0
 RECONNECT_BURST_LIMIT = 5
 
+# How often a session re-reads the SHARED credential store for servers it gave
+# up on over an auth failure (see :meth:`McpManager.revalidate_auth_blocked`).
+#
+# Why a poll at all: ``~/.local-operator/auth.db`` is shared by every running
+# process, but nothing propagated a peer's re-auth INTO a process that had
+# already blocked the server, so completing ``/mcp reauth`` in one session left
+# every other running session dead for its whole lifetime (measured: two
+# sessions booted at 08:52/08:56 still reported ``notion [disconnected]`` at
+# 13:30 against a grant re-authed at 12:31 with 8h of life left).
+#
+# Why 60 s: the thing being waited on is a HUMAN completing a browser login, so
+# a minute of latency is imperceptible against it, and the poll reads only
+# auth-blocked servers — a healthy fleet pays zero SQLite reads. At the
+# operator's real row count one marker read measured 135 us, which puts the
+# worst case (every server blocked, nine processes) at ~0.24 ms/s fleet-wide.
+# Exported so tests can shrink it without patching a private name.
+AUTH_REVALIDATE_INTERVAL_S = 60.0
+
 # Reconnect attempts are accounted in one sliding window per server
 # (``_reconnect_history``); the backoff ladder position is separate state
 # (``_backoff_index``) so a successful reconnect resets the LADDER but never
@@ -1085,6 +1103,30 @@ class McpManager:
         self._notify_tasks: set[asyncio.Task[None]] = set()
         self._reconnect_history: dict[str, deque[float]] = {}
         self._reconnect_suspended: set[str] = set()
+        # Servers auto-reconnect gave up on because their OAUTH GRANT is not
+        # usable, held separately from ``_reconnect_suspended`` because the two
+        # have different RECOVERY CONDITIONS and only ever shared a set by
+        # accident of implementation:
+        #   * the flap breaker recovers on a TIME property — a server stops
+        #     flapping — and its documented manual recovery is a reconnect;
+        #   * an auth block recovers on a STORE property — somebody, possibly
+        #     another PROCESS, obtained a fresh grant into the shared
+        #     ``auth.db`` — and no amount of retrying heals it before that.
+        # Fusing them is why the auth arm had to borrow the breaker's
+        # "permanent" semantics, which is exactly the defect this fixes: the
+        # block outlived the condition that justified it. ``reconnect_suspended()``
+        # keeps reporting the BREAKER only, so its meaning and its tests are
+        # unchanged; the reconnect guards check both sets, so refusal behaviour
+        # is byte-identical to before.
+        self._auth_blocked: set[str] = set()
+        # The grant marker observed at the moment we blocked each server:
+        # ``(tokens_obtained_at, grant_is_dead)``. ``revalidate_auth_blocked``
+        # retries a server only when this pair MOVES, which is what makes the
+        # retry safe — we retry because the grant CHANGED, never because time
+        # passed. A timer-based retry would re-spend a refresh token the server
+        # may have already rejected, across nine processes, which is precisely
+        # the family-revoking storm ``GRANT_DEAD_AT_KEY`` exists to stop.
+        self._auth_grant_marker: dict[str, tuple[float, bool]] = {}
         # Backoff ladder position is separate from the breaker window (MCP-07):
         # a successful reconnect resets the ladder but keeps the window intact,
         # so a flapping server still trips the breaker.
@@ -1212,11 +1254,23 @@ class McpManager:
         return self._connections.get(name)
 
     def get_connection_status(self, name: str) -> str:
-        """``connected`` | ``connecting`` | ``disconnected`` for one server."""
+        """``connected`` | ``connecting`` | ``auth-required`` | ``disconnected``.
+
+        ``auth-required`` distinguishes a server whose OAUTH GRANT is not usable
+        (the fix is ``/mcp reauth <name>``, or a peer session completing one)
+        from one whose process died. Every status surface renders this string
+        directly, so naming the actual fix costs nothing and stops an
+        auth-blocked server from being read as a crashed one.
+
+        The ``connected`` check comes first deliberately: a server that
+        reconnected while still carrying a stale block must report the truth.
+        """
         if name in self._connections:
             return "connected"
         if name in self._connect_futures or name in self._pending_reconnects:
             return "connecting"
+        if name in self._auth_blocked:
+            return "auth-required"
         return "disconnected"
 
     def get_connected_servers(self) -> list[str]:
@@ -1286,6 +1340,9 @@ class McpManager:
         self._reconnect_history.pop(name, None)
         self._reconnect_suspended.discard(name)
         self._backoff_index.pop(name, None)
+        # A completed login is a new grant by definition, so the auth block and
+        # the marker it was taken against are both stale here.
+        self._clear_auth_block(name)
         self._register_connection(conn)
         # A mid-session login adds tools the session booted without; notify
         # subscribers exactly like a successful reconnect does. A no-op when no
@@ -1342,6 +1399,10 @@ class McpManager:
             self._reconnect_history.pop(name, None)
             self._reconnect_suspended.discard(name)
             self._backoff_index.pop(name, None)
+            # A removed server must not carry an auth block (or a marker read
+            # against the OLD entry's URL) across a re-add: the re-added server
+            # may point somewhere else entirely.
+            self._clear_auth_block(name)
             # A server that left the config must not carry its arming across a
             # re-add: the model's incident is about the OLD entry, and a
             # re-added server connecting for the first time would otherwise
@@ -1504,6 +1565,10 @@ class McpManager:
         self._reconnect_history.pop(name, None)
         self._reconnect_suspended.discard(name)
         self._backoff_index.pop(name, None)
+        # A user-initiated reconnect clears the auth block for the same reason
+        # it clears the breaker: the user asked for one more attempt, and the
+        # attempt below either succeeds or re-blocks on a fresh marker.
+        self._clear_auth_block(name)
         pending = self._pending_reconnects.pop(name, None)
         if pending is not None:
             pending.cancel()
@@ -2272,6 +2337,15 @@ class McpManager:
                 # The startup toast has already been dismissed by the time an
                 # after-gate connect fails, so raise a fresh one via the UI hook.
                 self._fire_auth_required(name, auth_exc)
+                # Record the auth block. Before this line an after-gate auth
+                # failure was neither suspended NOR rescheduled — the server was
+                # simply FORGOTTEN, invisible to anything that inspects
+                # ``_reconnect_suspended``, and never retried for the life of
+                # the process. HTTP OAuth servers almost always land here rather
+                # than in ``_reconnect``'s arm, because PRM/ASM discovery and a
+                # token refresh make them miss the 250 ms startup gate, so this
+                # is the arm the operator's dead sessions were actually stuck in.
+                self._block_on_auth(name)
             # Whether this continuation still belongs to the CURRENT round. A
             # reload()/dispose() during the await bumps the epoch, and a stale
             # continuation must not write the new round's startup accounting —
@@ -2703,8 +2777,156 @@ class McpManager:
         self._schedule_reconnect(name)
 
     def reconnect_suspended(self, name: str) -> bool:
-        """Whether the circuit breaker currently suspends auto-reconnect."""
+        """Whether the circuit breaker currently suspends auto-reconnect.
+
+        Reports the FLAP BREAKER only, deliberately: an auth block is a
+        different condition with a different recovery (see ``_auth_blocked``),
+        and widening this predicate would make "the server flapped" and "the
+        grant expired" indistinguishable to every existing caller and test.
+        """
         return name in self._reconnect_suspended
+
+    def auth_blocked(self, name: str) -> bool:
+        """Whether auto-reconnect is held back by an unusable OAuth grant."""
+        return name in self._auth_blocked
+
+    def _grant_marker(self, name: str) -> tuple[float, bool]:
+        """``(tokens_obtained_at, grant_is_dead)`` for a server's stored grant.
+
+        The identity of the grant this session gave up on. Two properties make
+        it safe to retry against:
+
+        * ``tokens_obtained_at`` is written by ``McpTokenStorage.set_tokens``
+          and NOWHERE else — the single funnel every path that obtains a
+          *working* token goes through — so it moves exactly when a new grant
+          exists. The row's ``updated_at`` looks like the same signal and is
+          not: it moves on ANY write to the row, including the
+          ``seed_client_info`` write ``wire_oauth_auth`` performs on every
+          connect for a pinned-client server, so keying on it would make this
+          session retry on its OWN writes, every tick, forever. That is the
+          retry storm ``GRANT_DEAD_AT_KEY`` was built to stop, so this choice
+          is load-bearing rather than stylistic.
+        * ``grant_is_dead`` catches the reverse transition — a peer tombstoning
+          a grant we still believe in. We want to observe it (it changes the
+          marker, so the block is re-taken against current truth); the single
+          attempt that follows is bounded by the marker moving again.
+
+        Degrades to ``(0.0, False)`` on any store failure and never raises:
+        auth state is best-effort throughout this subsystem, and a poller that
+        raises into a dispose hook is worse than one that declines to heal.
+        """
+        try:
+            cfg = self._configs.get(name)
+            url = getattr(cfg, "url", None)
+            if not url:
+                # stdio servers carry no OAuth grant; a stable marker means the
+                # poll never retries them, which is correct.
+                return (0.0, False)
+            from local_operator.mcp.auth import TOKENS_OBTAINED_AT_KEY, McpTokenStorage
+
+            storage = McpTokenStorage(str(url), self._effective_auth_store())
+            row = storage._read_row()
+            data = row.data if row is not None and isinstance(row.data, dict) else {}
+            obtained = data.get(TOKENS_OBTAINED_AT_KEY)
+            obtained_at = (
+                float(obtained)
+                if isinstance(obtained, (int, float)) and not isinstance(obtained, bool)
+                else 0.0
+            )
+            return (obtained_at, storage.grant_is_dead())
+        except Exception:  # noqa: BLE001 — revalidation is best-effort
+            logger.debug("MCP grant marker read failed for %r", name, exc_info=True)
+            return (0.0, False)
+
+    def _block_on_auth(self, name: str) -> None:
+        """Hold ``name`` back from auto-reconnect until its stored grant moves.
+
+        Called from every arm that gives up over authorization. Recording the
+        marker AT BLOCK TIME is what lets ``revalidate_auth_blocked`` tell "the
+        grant we already failed on" from "a grant somebody has since replaced".
+        """
+        self._auth_blocked.add(name)
+        self._auth_grant_marker[name] = self._grant_marker(name)
+
+    def _clear_auth_block(self, name: str) -> None:
+        """Drop the auth block and the marker it was taken against."""
+        self._auth_blocked.discard(name)
+        self._auth_grant_marker.pop(name, None)
+
+    async def revalidate_auth_blocked(self) -> list[str]:
+        """Re-read the SHARED grant store for auth-blocked servers; heal movers.
+
+        The propagation seam. ``~/.local-operator/auth.db`` is shared by every
+        running process and a peer's write is visible to an already-open
+        connection immediately (WAL, plus a fresh ``SELECT`` per read), but
+        nothing ever re-read it after a session gave up on a server — so
+        completing ``/mcp reauth`` in one session left every other running
+        session dead until it exited. This closes that loop from the
+        composition root (``session_factory.attach_mcp_dispose``), so every
+        host benefits, not just the one with a status widget.
+
+        Returns the servers that healed, for tests and callers that log.
+
+        Three properties this must keep:
+
+        * **Zero cost when healthy.** The early return means a fleet with
+          nothing blocked performs no SQLite I/O at all; only blocked servers
+          are read, one marker each.
+        * **One attempt per genuine grant change.** A server whose marker moved
+          but still fails re-blocks on the NEW marker, so a broken grant costs
+          one connect per change rather than one per tick.
+        * **Never interactive.** ``_connect_server`` is called with the default
+          ``interactive=False``: this path runs unattended in nine processes,
+          and opening a browser from it would be a fleet of surprise auth
+          windows. A grant that needs a human still surfaces as
+          ``auth-required`` and waits for ``/mcp reauth``.
+        """
+        # THE COST GATE — keep it first: this runs on a timer in every session.
+        if not self._auth_blocked or self._disposed:
+            return []
+        healed: list[str] = []
+        for name in sorted(self._auth_blocked):
+            marker = self._grant_marker(name)
+            if marker == self._auth_grant_marker.get(name):
+                continue  # same grant we already failed on: stay blocked
+            self._clear_auth_block(name)
+            # A new grant deserves a fresh ladder: the old position describes
+            # attempts against a grant that no longer exists.
+            self._backoff_index.pop(name, None)
+            cfg = self._configs.get(name)
+            if cfg is None or name in self._connections:
+                continue
+            epoch = self._epoch
+            try:
+                conn = await self._connect_server(name, cfg)
+            except Exception as exc:  # noqa: BLE001 — any failure re-blocks
+                logger.info(
+                    "MCP revalidation attempt for %r failed after its grant changed: %s",
+                    name,
+                    exc,
+                )
+                self._block_on_auth(name)
+                continue
+            # Re-check ownership AFTER the await, as every other reconnect path
+            # does: a dispose()/reload() during the connect bumps the epoch, and
+            # registering into a disposing manager resurrects a connection whose
+            # teardown has already run.
+            if self._disposed or epoch != self._epoch:
+                if conn.stack is not None:
+                    with suppress(Exception):
+                        await conn.stack.aclose()
+                continue
+            # Route through _register_connection rather than assigning the
+            # connection directly: it is the choke point that fires
+            # ``on_recovery`` (gated on ``_incident_announced``), settles parked
+            # waiters, and installs the disconnect watcher. A healing that
+            # bypassed it would leave the model still holding a death notice.
+            self._register_connection(conn)
+            self._backoff_index[name] = 0
+            healed.append(name)
+        if healed:
+            self._fire_tools_changed()
+        return healed
 
     def get_tool_meta(self, tool_name: str) -> McpToolMeta | None:
         """MCP origin metadata for a minted tool name (server, tool, deferred)."""
@@ -2737,6 +2959,13 @@ class McpManager:
     def _schedule_reconnect(self, name: str) -> None:
         """Queue a backoff-delayed reconnect unless the breaker is tripped."""
         if self._disposed:
+            return
+        if name in self._auth_blocked:
+            # Held for an unusable grant, not for flapping. Retrying is not just
+            # futile (auto-reconnect is non-interactive) but harmful: it re-spends
+            # a refresh token the server may already have rejected. The recovery
+            # is a new grant, which ``revalidate_auth_blocked`` watches for.
+            self._abandon_reconnect(name, "auto-reconnect suspended (authorization required)")
             return
         if name in self._reconnect_suspended:
             self._abandon_reconnect(name, "auto-reconnect suspended (breaker tripped)")
@@ -2845,9 +3074,14 @@ class McpManager:
                 future.set_exception(exc)
                 future.exception()  # mark retrieved; waiters still see the raise
             self._connect_futures.pop(name, None)
-            # Suspend durably (like the breaker) so a call-site retry also stops
-            # hammering a grant that cannot heal without a login.
-            self._reconnect_suspended.add(name)
+            # Block on the GRANT rather than on the breaker so a call-site retry
+            # also stops hammering a grant that cannot heal without a login. The
+            # block used to be ``_reconnect_suspended.add(name)``, which never
+            # cleared without user action IN THIS PROCESS — so a peer session's
+            # ``/mcp reauth`` healed nothing here. ``_block_on_auth`` records the
+            # grant we failed on, and ``revalidate_auth_blocked`` lifts the block
+            # when that grant is replaced, by this process or any other.
+            self._block_on_auth(name)
             self._abandon_reconnect(name, str(exc))
             return
         except Exception as exc:
@@ -2878,7 +3112,7 @@ class McpManager:
         cfg = self._configs.get(name)
         if cfg is None:
             return None
-        if name in self._reconnect_suspended:
+        if name in self._reconnect_suspended or name in self._auth_blocked:
             return None
         if not self._record_reconnect_attempt(name):
             logger.warning("MCP reconnect breaker tripped for %r (call-site attempt)", name)
@@ -2890,6 +3124,10 @@ class McpManager:
         except (McpAuthRequiredError, McpAuthChallengeError) as exc:
             logger.info("MCP call-site reconnect needs authorization for %r", name)
             self._fire_auth_required(name, exc)
+            # This arm previously recorded NOTHING, so the next tool call tried
+            # the same dead grant again. Blocking here both stops that and makes
+            # the server eligible for revalidation when the grant is replaced.
+            self._block_on_auth(name)
             return None
         except Exception as exc:
             logger.warning("MCP call-site reconnect failed for %r: %s", name, exc)
@@ -2944,6 +3182,7 @@ class McpManager:
 
 # Re-export for callers that serialize cache entries.
 __all__ = [
+    "AUTH_REVALIDATE_INTERVAL_S",
     "CHILD_QUIET_ENV",
     "RECONNECT_BACKOFF_S",
     "RECONNECT_BURST_LIMIT",

--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -129,10 +129,12 @@ RECONNECT_BURST_LIMIT = 5
 #
 # Why 60 s: the thing being waited on is a HUMAN completing a browser login, so
 # a minute of latency is imperceptible against it, and the poll reads only
-# auth-blocked servers — a healthy fleet pays zero SQLite reads. At the
-# operator's real row count one marker read measured 135 us, which puts the
-# worst case (every server blocked, nine processes) at ~0.24 ms/s fleet-wide.
-# Exported so tests can shrink it without patching a private name.
+# auth-blocked servers — a healthy fleet pays zero SQLite reads. Measured at the
+# operator's real row count (16 ``mcp-oauth`` rows, 36 total): 78.8 us per
+# blocked server per tick, over TWO ``list_credentials`` calls — the storage
+# constructor snapshots ``updated_at`` and ``grant_marker`` reads the row once.
+# That puts the worst case (every server blocked, nine processes) at ~0.14 ms/s
+# fleet-wide. Exported so tests can shrink it without patching a private name.
 AUTH_REVALIDATE_INTERVAL_S = 60.0
 
 # Reconnect attempts are accounted in one sliding window per server
@@ -1126,7 +1128,10 @@ class McpManager:
         # passed. A timer-based retry would re-spend a refresh token the server
         # may have already rejected, across nine processes, which is precisely
         # the family-revoking storm ``GRANT_DEAD_AT_KEY`` exists to stop.
-        self._auth_grant_marker: dict[str, tuple[float, bool]] = {}
+        # ``None`` for a server whose store could not be read at block time:
+        # unknown is a state, not the value ``(0.0, False)``. See
+        # :meth:`_grant_marker`.
+        self._auth_grant_marker: dict[str, tuple[float, bool] | None] = {}
         # Backoff ladder position is separate from the breaker window (MCP-07):
         # a successful reconnect resets the ladder but keeps the window intact,
         # so a flapping server still trips the breaker.
@@ -1472,6 +1477,16 @@ class McpManager:
                 message = self._auth_failure_text(name, exc)
                 result.errors[name] = message
                 self._startup_failures[name] = message
+                # Block here too, not only in the AFTER-gate arm: the identical
+                # failure lands in one arm or the other purely by whether it beat
+                # the 250 ms gate, and without this the fast one is neither
+                # ``auth-required`` nor revalidatable. Fast is the COMMON case
+                # after the first failure, not the exotic one — a tombstoned
+                # grant short-circuits before any POST and endpoint discovery is
+                # cached process-wide, so every later ``/mcp reload`` and ``/new``
+                # fails warm (measured ~15 ms), and a stdio server with a missing
+                # command fails in microseconds.
+                self._block_on_auth(name)
                 logger.info("MCP server %r needs authorization: %s", name, exc)
                 waiter = self._connect_futures.pop(name, None)
                 _settle_future_error(waiter, exc)
@@ -2403,6 +2418,23 @@ class McpManager:
         # A successful (re)connect clears the auth-toast latch, so a grant that
         # expires AGAIN later gets its own toast instead of staying silent.
         self._auth_toasted.discard(conn.name)
+        # …and the AUTH BLOCK, for the same reason ``_fire_recovery`` lives
+        # here: this is the single choke point every route to a live connection
+        # passes through, and a server that is connected is by definition not
+        # held back from connecting. Clearing it only at the user-initiated
+        # sites was a defect — ``reload()`` heals a server without touching
+        # them, leaving it ``connected`` while still blocked, so its next
+        # ORDINARY disconnect was abandoned by the ``_schedule_reconnect``
+        # guard and never retried. ``revalidate_auth_blocked`` cannot rescue
+        # that: the grant is valid, so its marker never moves again. That is
+        # the same "state outliving its condition" this whole feature fixes.
+        self._clear_auth_block(conn.name)
+        # A connected server must stop being accused of the failure it
+        # recovered from: the startup accumulator feeds ``McpServerState.error``
+        # in the frontend projection, which no status check filters. The
+        # after-gate success arm pops it for exactly this reason; every other
+        # heal (reload, revalidation, a call-site retry) needs it too.
+        self._startup_failures.pop(conn.name, None)
         self._log_first_connect_security(conn)
         self._register_tools(conn.name, conn.tools)
         self._fire_recovery(conn.name)
@@ -2790,8 +2822,8 @@ class McpManager:
         """Whether auto-reconnect is held back by an unusable OAuth grant."""
         return name in self._auth_blocked
 
-    def _grant_marker(self, name: str) -> tuple[float, bool]:
-        """``(tokens_obtained_at, grant_is_dead)`` for a server's stored grant.
+    def _grant_marker(self, name: str) -> tuple[float, bool] | None:
+        """``(tokens_obtained_at, grant_is_dead)``, or ``None`` if unreadable.
 
         The identity of the grant this session gave up on. Two properties make
         it safe to retry against:
@@ -2811,32 +2843,40 @@ class McpManager:
           marker, so the block is re-taken against current truth); the single
           attempt that follows is bounded by the marker moving again.
 
-        Degrades to ``(0.0, False)`` on any store failure and never raises:
-        auth state is best-effort throughout this subsystem, and a poller that
-        raises into a dispose hook is worse than one that declines to heal.
-        """
-        try:
-            cfg = self._configs.get(name)
-            url = getattr(cfg, "url", None)
-            if not url:
-                # stdio servers carry no OAuth grant; a stable marker means the
-                # poll never retries them, which is correct.
-                return (0.0, False)
-            from local_operator.mcp.auth import TOKENS_OBTAINED_AT_KEY, McpTokenStorage
+        Returns ``None`` — never a sentinel TUPLE — when the store cannot be
+        read, and never raises: auth state is best-effort throughout this
+        subsystem, and a poller that raises into a dispose hook is worse than
+        one that declines to heal.
 
-            storage = McpTokenStorage(str(url), self._effective_auth_store())
-            row = storage._read_row()
-            data = row.data if row is not None and isinstance(row.data, dict) else {}
-            obtained = data.get(TOKENS_OBTAINED_AT_KEY)
-            obtained_at = (
-                float(obtained)
-                if isinstance(obtained, (int, float)) and not isinstance(obtained, bool)
-                else 0.0
-            )
-            return (obtained_at, storage.grant_is_dead())
+        The ``None`` matters as much as the value. A degraded read that returned
+        ``(0.0, False)`` would be a marker like any other, so a store failing on
+        alternating ticks would make the marker appear to oscillate
+        ``real -> (0.0, False) -> real`` and every tick would count as "a peer
+        re-authed" and spend a refresh token. That is §7 risk 1 — the
+        family-revoking storm — reached through the degrade path instead of
+        through a naive ``updated_at``. Unknown must be un-comparable, not a
+        value: :meth:`revalidate_auth_blocked` treats it as "stay blocked,
+        unchanged", and :meth:`_block_on_auth` refuses to overwrite a good
+        marker with it.
+        """
+        cfg = self._configs.get(name)
+        url = getattr(cfg, "url", None)
+        if not url:
+            # stdio servers carry no OAuth grant. A CONSTANT marker (not None)
+            # is right here: the answer is known and it never moves, so the poll
+            # never retries them — whereas None would mean "unreadable".
+            return (0.0, False)
+        try:
+            from local_operator.mcp.auth import McpTokenStorage
+
+            # One row read for both halves, through the storage's own public
+            # accessor rather than its privates: this is a read of what auth.py
+            # already writes, and a marker assembled out of two separate reads
+            # could straddle a write and describe no single instant.
+            return McpTokenStorage(str(url), self._effective_auth_store()).grant_marker()
         except Exception:  # noqa: BLE001 — revalidation is best-effort
             logger.debug("MCP grant marker read failed for %r", name, exc_info=True)
-            return (0.0, False)
+            return None
 
     def _block_on_auth(self, name: str) -> None:
         """Hold ``name`` back from auto-reconnect until its stored grant moves.
@@ -2844,9 +2884,18 @@ class McpManager:
         Called from every arm that gives up over authorization. Recording the
         marker AT BLOCK TIME is what lets ``revalidate_auth_blocked`` tell "the
         grant we already failed on" from "a grant somebody has since replaced".
+
+        An unreadable store (``None``) must not clobber a marker we already
+        hold: overwriting a known grant with "unknown" would make the NEXT
+        successful read compare unequal and buy a retry the grant never earned.
+        Keeping the old value means a transient failure costs nothing, and a
+        first block that cannot read the store simply stays unknown until one
+        can.
         """
         self._auth_blocked.add(name)
-        self._auth_grant_marker[name] = self._grant_marker(name)
+        marker = self._grant_marker(name)
+        if marker is not None or name not in self._auth_grant_marker:
+            self._auth_grant_marker[name] = marker
 
     def _clear_auth_block(self, name: str) -> None:
         """Drop the auth block and the marker it was taken against."""
@@ -2871,10 +2920,12 @@ class McpManager:
 
         * **Zero cost when healthy.** The early return means a fleet with
           nothing blocked performs no SQLite I/O at all; only blocked servers
-          are read, one marker each.
+          are read, one marker each (78.8 us over two ``list_credentials``
+          calls — see :data:`AUTH_REVALIDATE_INTERVAL_S`).
         * **One attempt per genuine grant change.** A server whose marker moved
           but still fails re-blocks on the NEW marker, so a broken grant costs
-          one connect per change rather than one per tick.
+          one connect per change rather than one per tick — and an UNREADABLE
+          marker buys nothing at all, because unknown is not movement.
         * **Never interactive.** ``_connect_server`` is called with the default
           ``interactive=False``: this path runs unattended in nine processes,
           and opening a browser from it would be a fleet of surprise auth
@@ -2887,8 +2938,28 @@ class McpManager:
         healed: list[str] = []
         for name in sorted(self._auth_blocked):
             marker = self._grant_marker(name)
-            if marker == self._auth_grant_marker.get(name):
-                continue  # same grant we already failed on: stay blocked
+            # ``None`` is an UNREADABLE store, not a changed grant, and it must
+            # not count as movement in EITHER direction. Treating a failed read
+            # as movement spends a refresh token on every tick a flaky store
+            # fails on; treating the recovery from one as movement does the same
+            # at half the rate, because an alternating store oscillates
+            # unknown/known forever. Both are the family-revoking storm of §7
+            # risk 1. No EVIDENCE of a new grant means stay blocked.
+            known = self._auth_grant_marker.get(name)
+            if marker is None or marker == known:
+                continue  # same grant we already failed on (or no news): stay blocked
+            if known is None:
+                # We could not read the store when we gave up, so we never knew
+                # which grant we failed on and this read is not evidence that it
+                # changed. Adopt it as the baseline and wait for the NEXT move.
+                # The cost of being wrong is bounded and one-sided: if a peer
+                # re-authed inside that unreadable window we miss this heal and
+                # catch the next one (or a manual ``/mcp reauth``), whereas
+                # guessing the other way spends a token nobody asked us to
+                # spend — and a store we cannot read is a broken machine, not
+                # ordinary contention.
+                self._auth_grant_marker[name] = marker
+                continue
             self._clear_auth_block(name)
             # A new grant deserves a fresh ladder: the old position describes
             # attempts against a grant that no longer exists.
@@ -2897,6 +2968,17 @@ class McpManager:
             if cfg is None or name in self._connections:
                 continue
             epoch = self._epoch
+            # Publish a waiter BEFORE the await, as ``_reconnect`` does: a real
+            # OAuth connect takes seconds, and without one the server reports
+            # ``disconnected`` for that whole window (a visible flicker on the
+            # way to healing) and a deferred execute parked on this server fails
+            # instead of riding the heal. Reuse any waiter already installed by
+            # ``_handle_disconnect`` rather than replacing it, or that parked
+            # execute is stranded on a future nobody settles (MCP-08).
+            future = self._connect_futures.get(name)
+            if future is None or future.done():
+                future = asyncio.get_running_loop().create_future()
+                self._connect_futures[name] = future
             try:
                 conn = await self._connect_server(name, cfg)
             except Exception as exc:  # noqa: BLE001 — any failure re-blocks
@@ -2905,6 +2987,10 @@ class McpManager:
                     name,
                     exc,
                 )
+                if not future.done():
+                    future.set_exception(exc)
+                    future.exception()  # mark retrieved; waiters still see the raise
+                self._connect_futures.pop(name, None)
                 self._block_on_auth(name)
                 continue
             # Re-check ownership AFTER the await, as every other reconnect path
@@ -2915,6 +3001,11 @@ class McpManager:
                 if conn.stack is not None:
                     with suppress(Exception):
                         await conn.stack.aclose()
+                # Settle the waiter published above rather than dropping it: a
+                # deferred execute parked on it must fail, not hang (MCP-08).
+                # ``disconnect_all`` already settles the futures it can see, but
+                # a reload that merely bumped the epoch does not.
+                self._abandon_reconnect(name, "MCP manager reloaded during revalidation")
                 continue
             # Route through _register_connection rather than assigning the
             # connection directly: it is the choke point that fires
@@ -2965,6 +3056,14 @@ class McpManager:
             # futile (auto-reconnect is non-interactive) but harmful: it re-spends
             # a refresh token the server may already have rejected. The recovery
             # is a new grant, which ``revalidate_auth_blocked`` watches for.
+            #
+            # It abandons rather than parking waiters, deliberately matching the
+            # breaker arm below: a revalidatable block invites the assumption
+            # that a deferred execute should WAIT for the heal, but the wait is
+            # unbounded — it ends when a human completes a browser login, which
+            # may be never — and MCP-08 requires a parked execute to get a real
+            # error instead of hanging. The tool call fails now and succeeds on
+            # the next one after the poller heals.
             self._abandon_reconnect(name, "auto-reconnect suspended (authorization required)")
             return
         if name in self._reconnect_suspended:

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -2413,6 +2413,11 @@ def attach_mcp_dispose(session: Session, manager: McpManager) -> None:
     each caller about the manager. The manager is also exposed as
     ``mcp_manager`` for diagnostics.
     """
+    # BEFORE the disconnect hook, deliberately: dispose runs hooks in
+    # REGISTRATION order, and ``disconnect_all`` bumps the manager's epoch, so
+    # the revalidation poller has to be cancelled first or a tick could register
+    # a connection into a manager that is tearing down.
+    _attach_mcp_auth_revalidation(session, manager)
     session.add_dispose_hook(manager.disconnect_all)
     session.mcp_manager = manager
     if hasattr(session, "_frontend_state_store"):
@@ -2429,6 +2434,58 @@ def attach_mcp_dispose(session: Session, manager: McpManager) -> None:
     # the bug. Subagents deliberately do NOT reach this function (they BORROW
     # the parent's manager), so a child never overwrites the parent's sink.
     manager.on_recovery = session._on_mcp_recovery
+
+
+def _attach_mcp_auth_revalidation(session: Session, manager: McpManager) -> None:
+    """Poll the SHARED credential store for servers this session gave up on.
+
+    The credential store is shared by every running process; propagation of a
+    fresh grant was not. A session that hit an auth failure held the server
+    blocked for its entire lifetime, so completing ``/mcp reauth`` in one
+    session left every other running session dead — measured on this machine as
+    sessions booted at 08:52 still reporting ``notion [disconnected]`` at 13:30
+    against a grant re-authed at 12:31 with eight hours of life left.
+
+    It lives HERE, beside ``on_incident``/``on_recovery``, for the reason those
+    do: this is the composition root every host goes through, so the CLI,
+    headless, exec and server hosts heal too. Bolting it onto the TUI would
+    cover one of six routes. Subagents deliberately never reach this function
+    (they BORROW the parent's manager), so a child starts no second poller
+    against its parent's servers — adding the task anywhere else loses that.
+
+    Degrades to "this host does not revalidate" rather than failing the boot
+    when there is no running loop, exactly as ``attach_config_watch`` does: a
+    synchronous embedding is left as it was before this seam existed.
+    """
+    # Imported here rather than at module scope: ``McpManager`` itself is a
+    # TYPE_CHECKING-only import in this module, and the MCP package is an
+    # optional extra, so an install without it must still import the factory.
+    from local_operator.mcp.manager import AUTH_REVALIDATE_INTERVAL_S
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        logger.debug("no running loop: MCP auth revalidation not attached")
+        return
+
+    async def _revalidate_forever() -> None:
+        while True:
+            await asyncio.sleep(AUTH_REVALIDATE_INTERVAL_S)
+            try:
+                healed = await manager.revalidate_auth_blocked()
+            except Exception:  # noqa: BLE001 — a poll must never kill the session
+                logger.debug("MCP auth revalidation tick failed", exc_info=True)
+                continue
+            if healed:
+                logger.info("MCP servers recovered after a peer re-auth: %s", ", ".join(healed))
+
+    task = loop.create_task(_revalidate_forever())
+    # Cancelled through the SAME dispose helper the boot wiring uses, which
+    # AWAITS the task's quietus so a tick already inside a connect finishes its
+    # own cleanup. ``revalidate_auth_blocked`` also re-checks ``_disposed`` and
+    # the epoch after its await, as every other reconnect path does, so the
+    # ordering above is defence in depth rather than the only guard.
+    session.add_dispose_hook(_cancel_task(task))
 
 
 def _cancel_task(task: "asyncio.Task[Any]") -> Callable[[], Awaitable[None] | None]:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -6333,7 +6333,16 @@ class OperatorApp(App[None]):
             mcp=McpStatus(
                 configured=len(mcp_servers),
                 connected=sum(1 for server in mcp_servers if server.status == "connected"),
-                failed=any(server.status == "failed" for server in mcp_servers),
+                # The SAME predicate as the owner's band (``_mcp_status``), and
+                # for the same reason: two surfaces reporting one session must
+                # not disagree. ``== "failed"`` only ever matched the projection's
+                # own placeholder, which ``_mcp_state`` overwrites with the
+                # manager's live status whenever a manager is present — so an
+                # auth-blocked server projected as ``auth-required`` and this
+                # band stayed calm while the owner's went red.
+                failed=any(
+                    server.status not in ("connected", "connecting") for server in mcp_servers
+                ),
             ),
         )
         # Refresh data, not the interaction. The picker may have opened against
@@ -11079,15 +11088,18 @@ class OperatorApp(App[None]):
             return McpStatus(
                 configured=len(configured),
                 connected=len(manager.get_connected_servers()),
-                # Anything not connected is a failure for the band's purposes.
-                # Tested against "connected" rather than "disconnected" because
-                # the status vocabulary grew an ``auth-required`` value: an
-                # equality test on the old string silently stops counting a
-                # server whose grant expired, which is the exact case the band
-                # exists to surface. ``connecting`` is momentary and settles
-                # into one of the terminal values on the next refresh.
+                # Every TERMINAL non-connected state is a failure, named as a
+                # negative rather than as equality with "disconnected": the
+                # status vocabulary grew ``auth-required``, and an equality test
+                # on the old string silently stops counting a server whose grant
+                # expired — exactly the case the band exists to surface.
+                # ``connecting`` is excluded because it is not terminal: the
+                # startup gate leaves slow servers there on every launch, and
+                # tinting it danger would make a red lamp the normal boot (see
+                # this method's docstring, which this predicate must agree with).
                 failed=any(
-                    manager.get_connection_status(name) != "connected" for name in configured
+                    manager.get_connection_status(name) not in ("connected", "connecting")
+                    for name in configured
                 ),
             )
         except Exception:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -11079,8 +11079,15 @@ class OperatorApp(App[None]):
             return McpStatus(
                 configured=len(configured),
                 connected=len(manager.get_connected_servers()),
+                # Anything not connected is a failure for the band's purposes.
+                # Tested against "connected" rather than "disconnected" because
+                # the status vocabulary grew an ``auth-required`` value: an
+                # equality test on the old string silently stops counting a
+                # server whose grant expired, which is the exact case the band
+                # exists to surface. ``connecting`` is momentary and settles
+                # into one of the terminal values on the next refresh.
                 failed=any(
-                    manager.get_connection_status(name) == "disconnected" for name in configured
+                    manager.get_connection_status(name) != "connected" for name in configured
                 ),
             )
         except Exception:

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -3490,3 +3490,167 @@ class TestDeadGrantTombstone:
         assert provider.context.current_tokens is not None
         assert provider.context.current_tokens.refresh_token is None
         assert provider.context.can_refresh_token() is False
+
+
+class TestAPeersReauthReachesABlockedSession:
+    """The defect this whole mechanism exists for, across REAL processes.
+
+    Storage is unified — every ``lop`` process on the machine shares
+    ``auth.db`` — but propagation was not: a session that blocked a server over
+    an auth failure never re-read the store, so completing ``/mcp reauth`` in
+    one session healed nothing anywhere else. Measured on the operator's
+    machine: sessions booted at 08:52 and 08:56 still reported ``notion
+    [disconnected]`` at 13:30, against a grant re-authed at 12:31 with eight
+    hours of life left, and one of them took a turn-ending incident from it.
+
+    A second CONNECTION in this process would not prove it. The claim is about
+    a second PROCESS, so the re-auth below runs in a real ``subprocess`` doing a
+    real ``McpTokenStorage.set_tokens`` against the same file, and the child's
+    return code and stderr are asserted — a child that dies of an import error
+    must fail loudly rather than pass as "no change detected".
+    """
+
+    URL = "https://peer.example/mcp"
+
+    #: What a completed ``/mcp reauth`` writes, run in a genuine second process.
+    _PEER_REAUTH_SRC = """
+import asyncio, sys
+sys.path.insert(0, sys.argv[1])
+from mcp.shared.auth import OAuthToken
+from local_operator.mcp.auth import McpTokenStorage
+from local_operator.providers.auth_store import AuthStore
+
+store = AuthStore(sys.argv[2])
+storage = McpTokenStorage(sys.argv[3], store)
+asyncio.run(
+    storage.set_tokens(
+        OAuthToken(
+            access_token="FRESH-FROM-PEER",
+            refresh_token="R2",
+            token_type="Bearer",
+            expires_in=28800,
+        )
+    )
+)
+store.close()
+print("PEER-REAUTH-OK")
+"""
+
+    @pytest.mark.asyncio
+    async def test_a_peers_reauth_reaches_a_blocked_session(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import subprocess
+        import sys as _sys
+
+        from mcp.types import CallToolResult, ListToolsResult, TextContent, Tool
+
+        from local_operator.mcp.auth import TOKENS_OBTAINED_AT_KEY, McpAuthRequiredError
+        from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+        from local_operator.mcp.manager import McpManager, ServerConnection
+        from local_operator.providers.auth_store import AuthStore
+
+        db_path = tmp_path / "auth.db"
+        store = AuthStore(str(db_path))
+        store.upsert_credential(
+            MCP_OAUTH_PROVIDER,
+            {
+                "project_id": self.URL,
+                "tokens": {
+                    "access_token": "STALE",
+                    "refresh_token": "R1",
+                    "token_type": "Bearer",
+                    "expires_in": 28800,
+                },
+                TOKENS_OBTAINED_AT_KEY: 1000.0,
+            },
+        )
+
+        manager = McpManager(str(tmp_path), auth_store=store)
+        cfg = MCPHttpServerConfig(url=self.URL, auth=MCPAuthConfig(type="oauth"))
+        manager._configs["peer"] = cfg
+        manager._sources["peer"] = "global"
+        incidents: list[tuple[str, str]] = []
+        recoveries: list[tuple[str, int]] = []
+        manager.on_incident = lambda name, reason: incidents.append((name, reason))
+        manager.on_recovery = lambda name, count: recoveries.append((name, count))
+
+        class _Session:
+            """The ``McpSession`` protocol, no further than the heal needs it.
+
+            ``_register_connection`` only stores the session, but satisfying the
+            real protocol is what keeps this test asserting against the
+            manager's actual contract rather than against ``Any``.
+            """
+
+            async def list_tools(self, *, params: Any = None) -> ListToolsResult:
+                return ListToolsResult(tools=[], next_cursor=None)
+
+            async def call_tool(
+                self,
+                name: str,
+                arguments: dict[str, Any] | None = None,
+                read_timeout_seconds: float | None = None,
+            ) -> CallToolResult:
+                return CallToolResult(content=[TextContent(type="text", text="ok")], is_error=False)
+
+        reauthed = {"done": False}
+
+        async def connect(name: str, cfg: Any, **_: Any) -> ServerConnection:
+            if not reauthed["done"]:
+                raise McpAuthRequiredError(self.URL)
+            return ServerConnection(
+                name=name,
+                config=cfg,
+                session=_Session(),
+                tools=[Tool(name="search", description="d", input_schema={"type": "object"})],
+            )
+
+        monkeypatch.setattr(manager, "_connect_server", connect)
+
+        try:
+            # 1. The session gives up through the real auth arm.
+            await manager._reconnect("peer", 0.0, manager._epoch)
+            assert manager.auth_blocked("peer") is True
+            assert manager.get_connection_status("peer") == "auth-required"
+            assert [name for name, _ in incidents] == ["peer"]
+
+            # 2. Ticks while the grant is untouched heal nothing (and must not
+            #    re-spend the refresh token that is already known bad).
+            for _ in range(3):
+                assert await manager.revalidate_auth_blocked() == []
+
+            # 3. A REAL second process completes the re-auth against the same
+            #    file. The manager below is never told; it only re-reads.
+            env = dict(os.environ)
+            env["LOCAL_OPERATOR_CONFIG_DIR"] = str(tmp_path)
+            repo_root = str(Path(__file__).resolve().parents[3])
+            proc = subprocess.run(
+                [
+                    _sys.executable,
+                    "-c",
+                    self._PEER_REAUTH_SRC,
+                    repo_root,
+                    str(db_path),
+                    self.URL,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=120,
+                env=env,
+            )
+            assert proc.returncode == 0, (
+                "the peer re-auth process failed; "
+                f"rc={proc.returncode} stderr={proc.stderr[-2000:]!r}"
+            )
+            assert "PEER-REAUTH-OK" in proc.stdout, f"stdout={proc.stdout!r}"
+
+            # 4. One tick, and the blocked session heals off the peer's write.
+            reauthed["done"] = True
+            assert await manager.revalidate_auth_blocked() == ["peer"]
+            assert manager.get_connection_status("peer") == "connected"
+            # The model was told the server died, so it is told it came back.
+            assert recoveries == [("peer", 1)]
+        finally:
+            await manager.disconnect_all()
+            store.close()

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -1648,7 +1648,15 @@ class TestAuthRequiredHandling:
 
         An expired grant will not heal by retrying, so further attempts would
         only burn the breaker window. The manager abandons auto-reconnect and
-        leaves ``/mcp login`` as the recovery path.
+        leaves ``/mcp login`` — or a peer session's, via
+        ``revalidate_auth_blocked`` — as the recovery path.
+
+        The abandonment is recorded in ``_auth_blocked``, NOT in the flap
+        breaker: the two conditions recover differently (a breaker on time, an
+        auth block on the shared grant changing), and this assertion used to
+        read ``reconnect_suspended`` only because they shared one set. Keeping
+        that predicate breaker-only is what lets the block be lifted by a
+        store change without also resurrecting a flapping server.
         """
         from local_operator.mcp.auth import McpAuthRequiredError
         from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
@@ -1677,8 +1685,11 @@ class TestAuthRequiredHandling:
 
         # The reconnect must NOT have re-scheduled itself (abandoned instead).
         assert scheduled["called"] is False
-        # And the server must be marked as having abandoned auto-reconnect.
-        assert manager.reconnect_suspended("dd") is True
+        # And the server must be marked as having abandoned auto-reconnect over
+        # AUTHORIZATION, which the flap breaker deliberately does not claim.
+        assert manager.auth_blocked("dd") is True
+        assert manager.reconnect_suspended("dd") is False
+        assert manager.get_connection_status("dd") == "auth-required"
 
     @pytest.mark.asyncio
     async def test_an_abandoned_grant_survives_the_real_transport(
@@ -2885,3 +2896,440 @@ class TestMcpRecoveryNotice:
         assert await manager.reconnect_server("fast") is not None
         assert recoveries == [], "a sinkless connect left the server armed to re-announce"
         await manager.disconnect_all()
+
+
+class TestAuthBlockRevalidation:
+    """Propagation of a SHARED grant change into a session that gave up.
+
+    ``~/.local-operator/auth.db`` is shared by every running process, but a
+    session that hit an auth failure never re-read it: the block was cleared
+    only by user action IN THAT PROCESS. So completing ``/mcp reauth`` in one
+    session left every other running session with a dead server for its whole
+    lifetime — observed on the operator's machine as sessions booted at 08:52
+    still reporting ``notion [disconnected]`` at 13:30 against a grant re-authed
+    at 12:31 with eight hours left on it.
+
+    Two properties here are load-bearing rather than stylistic, and each has a
+    test that must not be deleted:
+
+    * the retry is keyed on ``tokens_obtained_at``, NOT on the row's
+      ``updated_at`` — a marker that moves on our own writes turns a 60 s poll
+      in nine processes into a refresh-token retry storm against a provider
+      running reuse detection, which revokes the whole token family
+      (``test_a_client_info_write_is_not_a_new_grant``);
+    * the poll never connects interactively, because it runs unattended
+      (``test_the_poll_never_opens_an_interactive_grant``).
+    """
+
+    URL = "https://srv.example/mcp"
+
+    @staticmethod
+    def _oauth_manager(tmp_path: Path, store: Any = None) -> McpManager:
+        """A manager with one OAuth HTTP server configured, no connections."""
+        from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+
+        manager = McpManager(str(tmp_path), auth_store=store)
+        manager._configs["dd"] = MCPHttpServerConfig(
+            url=TestAuthBlockRevalidation.URL, auth=MCPAuthConfig(type="oauth")
+        )
+        manager._sources["dd"] = "global"
+        return manager
+
+    @staticmethod
+    def _real_store(tmp_path: Path, obtained_at: float) -> Any:
+        """A REAL ``AuthStore`` over a temp file holding one stale grant.
+
+        A real store rather than a fake because the whole mechanism rests on
+        what ``McpTokenStorage`` actually writes: a fake that returns invented
+        markers would pass while the production read looked at the wrong key.
+        """
+        from local_operator.mcp.auth import MCP_OAUTH_PROVIDER, TOKENS_OBTAINED_AT_KEY
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(str(tmp_path / "auth.db"))
+        store.upsert_credential(
+            MCP_OAUTH_PROVIDER,
+            {
+                "project_id": TestAuthBlockRevalidation.URL,
+                "tokens": {
+                    "access_token": "STALE",
+                    "refresh_token": "R1",
+                    "token_type": "Bearer",
+                    "expires_in": 28800,
+                },
+                TOKENS_OBTAINED_AT_KEY: obtained_at,
+            },
+        )
+        return store
+
+    @staticmethod
+    async def _block_via_reconnect(manager: McpManager, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Drive the REAL ``_reconnect`` auth arm so the block is genuine."""
+        from local_operator.mcp.auth import McpAuthRequiredError
+
+        async def failing(name: str, cfg: Any, **_: Any) -> ServerConnection:
+            raise McpAuthRequiredError(TestAuthBlockRevalidation.URL)
+
+        monkeypatch.setattr(manager, "_connect_server", failing)
+        await manager._reconnect("dd", 0.0, manager._epoch)
+
+    @pytest.mark.asyncio
+    async def test_an_auth_block_is_not_the_flap_breaker(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The two conditions recover differently, so they are separate state.
+
+        A breaker recovers when a server stops flapping; an auth block recovers
+        when the shared grant is replaced. Fusing them is what forced the auth
+        arm to borrow "permanent" semantics it could never shed.
+        """
+        manager = self._oauth_manager(tmp_path)
+        await self._block_via_reconnect(manager, monkeypatch)
+
+        assert manager.auth_blocked("dd") is True
+        assert manager.reconnect_suspended("dd") is False
+        assert "dd" not in manager._reconnect_suspended
+
+    @pytest.mark.asyncio
+    async def test_a_blocked_server_refuses_reconnects_exactly_as_before(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Splitting the sets must not weaken the refusal the block exists for.
+
+        Both reconnect entry points still decline, and the parked waiter still
+        gets a real error rather than hanging (MCP-08).
+        """
+        manager = self._oauth_manager(tmp_path)
+        await self._block_via_reconnect(manager, monkeypatch)
+
+        attempts: list[str] = []
+
+        async def counting(name: str, cfg: Any, **_: Any) -> ServerConnection:
+            attempts.append(name)
+            return _make_conn(name, cfg)
+
+        monkeypatch.setattr(manager, "_connect_server", counting)
+        manager._schedule_reconnect("dd")
+        await asyncio.sleep(0)
+        assert await manager._reconnect_for_call("dd") is None
+        assert attempts == [], "a blocked server must not be re-dialled"
+
+        future = manager._connect_futures.get("dd")
+        assert future is None or future.done(), "a waiter was left parked forever"
+
+    @pytest.mark.asyncio
+    async def test_revalidate_retries_only_when_the_grant_marker_moved(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unchanged grant costs zero connects, however many ticks run."""
+        store = self._real_store(tmp_path, obtained_at=1000.0)
+        manager = self._oauth_manager(tmp_path, store)
+        try:
+            await self._block_via_reconnect(manager, monkeypatch)
+
+            attempts: list[str] = []
+
+            async def counting(name: str, cfg: Any, **_: Any) -> ServerConnection:
+                attempts.append(name)
+                return _make_conn(name, cfg)
+
+            monkeypatch.setattr(manager, "_connect_server", counting)
+            for _ in range(5):
+                assert await manager.revalidate_auth_blocked() == []
+            assert attempts == []
+
+            # A peer writes a fresh grant: exactly ONE attempt, and it heals.
+            await self._write_fresh_grant(store)
+            assert await manager.revalidate_auth_blocked() == ["dd"]
+            assert attempts == ["dd"]
+            assert manager.get_connection_status("dd") == "connected"
+
+            # …and a healed server is no longer polled at all.
+            assert await manager.revalidate_auth_blocked() == []
+            assert attempts == ["dd"]
+        finally:
+            await manager.disconnect_all()
+            store.close()
+
+    @staticmethod
+    async def _write_fresh_grant(store: Any) -> None:
+        """What a peer's completed ``/mcp reauth`` writes: a real ``set_tokens``."""
+        from mcp.shared.auth import OAuthToken
+
+        from local_operator.mcp.auth import McpTokenStorage
+
+        storage = McpTokenStorage(TestAuthBlockRevalidation.URL, store)
+        await storage.set_tokens(
+            OAuthToken(
+                access_token="FRESH", refresh_token="R2", token_type="Bearer", expires_in=28800
+            )
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_client_info_write_is_not_a_new_grant(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """THE guard against a fleet-wide retry storm. Do not delete or weaken.
+
+        ``wire_oauth_auth`` calls ``seed_client_info`` on EVERY connect for a
+        pinned-client server, and that write moves the row's ``updated_at``. If
+        the marker were keyed on ``updated_at`` — which looks like the same
+        signal and is not — this session would retry on its own writes, every
+        tick, in every process, re-presenting a refresh token that Notion's
+        reuse detection answers by revoking the entire token family. Keying on
+        ``tokens_obtained_at`` (written only by ``set_tokens``) is what makes
+        the retry mean "somebody obtained a NEW grant".
+        """
+        from local_operator.mcp.auth import McpTokenStorage
+
+        store = self._real_store(tmp_path, obtained_at=1000.0)
+        manager = self._oauth_manager(tmp_path, store)
+        try:
+            await self._block_via_reconnect(manager, monkeypatch)
+
+            attempts: list[str] = []
+
+            async def counting(name: str, cfg: Any, **_: Any) -> ServerConnection:
+                attempts.append(name)
+                return _make_conn(name, cfg)
+
+            monkeypatch.setattr(manager, "_connect_server", counting)
+
+            storage = McpTokenStorage(self.URL, store)
+            row_before = storage._read_row()
+            assert row_before is not None
+            for _ in range(3):
+                storage.seed_client_info("client-abc")
+            row_after = storage._read_row()
+            assert row_after is not None
+            assert row_after.updated_at >= row_before.updated_at
+
+            assert await manager.revalidate_auth_blocked() == []
+            assert attempts == [], "a client-info write was mistaken for a new grant"
+            assert manager.auth_blocked("dd") is True
+        finally:
+            await manager.disconnect_all()
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_revalidate_reblocks_on_the_new_marker(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A grant that changed but is still bad costs ONE attempt, not a loop.
+
+        Re-blocking against the NEW marker is what bounds the cost to one
+        connect per genuine grant change rather than one per tick.
+        """
+        from local_operator.mcp.auth import McpAuthRequiredError
+
+        store = self._real_store(tmp_path, obtained_at=1000.0)
+        manager = self._oauth_manager(tmp_path, store)
+        try:
+            await self._block_via_reconnect(manager, monkeypatch)
+            attempts: list[str] = []
+
+            async def still_failing(name: str, cfg: Any, **_: Any) -> ServerConnection:
+                attempts.append(name)
+                raise McpAuthRequiredError(self.URL)
+
+            monkeypatch.setattr(manager, "_connect_server", still_failing)
+            await self._write_fresh_grant(store)
+
+            assert await manager.revalidate_auth_blocked() == []
+            assert attempts == ["dd"]
+            assert manager.auth_blocked("dd") is True
+
+            for _ in range(3):
+                assert await manager.revalidate_auth_blocked() == []
+            assert attempts == ["dd"], "a still-bad grant was retried on every tick"
+        finally:
+            await manager.disconnect_all()
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_the_poll_never_opens_an_interactive_grant(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """This runs unattended in every session; a browser must never open."""
+        store = self._real_store(tmp_path, obtained_at=1000.0)
+        manager = self._oauth_manager(tmp_path, store)
+        try:
+            await self._block_via_reconnect(manager, monkeypatch)
+            seen: list[bool] = []
+
+            async def recording(
+                name: str, cfg: Any, *, interactive: bool = False
+            ) -> ServerConnection:
+                seen.append(interactive)
+                return _make_conn(name, cfg)
+
+            monkeypatch.setattr(manager, "_connect_server", recording)
+            await self._write_fresh_grant(store)
+            assert await manager.revalidate_auth_blocked() == ["dd"]
+            assert seen == [False]
+        finally:
+            await manager.disconnect_all()
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_a_startup_gate_auth_failure_is_blocked_and_heals(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The second dead state: after-gate auth failures were FORGOTTEN.
+
+        ``_finish_pending``'s auth arm fired the incident and the toast but
+        neither suspended nor rescheduled, so the server was invisible to
+        anything inspecting the breaker and was never retried. HTTP OAuth
+        servers land here rather than in ``_reconnect``'s arm — discovery plus a
+        refresh makes them miss the 250 ms gate — so this is the arm the
+        operator's dead sessions were actually stuck in.
+        """
+        from local_operator.mcp.auth import McpAuthRequiredError
+
+        store = self._real_store(tmp_path, obtained_at=1000.0)
+        manager = self._oauth_manager(tmp_path, store)
+        try:
+            incidents: list[tuple[str, str]] = []
+            recoveries: list[tuple[str, int]] = []
+            manager.on_incident = lambda server, reason: incidents.append((server, reason))
+            manager.on_recovery = lambda server, count: recoveries.append((server, count))
+
+            # A connect that resolves AFTER the gate, exactly as a real OAuth
+            # HTTP server does, so the failure runs through _finish_pending.
+            async def slow_auth_failure(name: str, cfg: Any, **_: Any) -> ServerConnection:
+                await asyncio.sleep(0.05)
+                raise McpAuthRequiredError(self.URL)
+
+            monkeypatch.setattr(manager, "_connect_server", slow_auth_failure)
+            monkeypatch.setattr("local_operator.mcp.manager.STARTUP_GATE_MS", 1)
+            await manager._connect_round({"dd": manager._configs["dd"]}, {"dd": "global"})
+            for _ in range(200):
+                await asyncio.sleep(0.005)
+                if manager.auth_blocked("dd"):
+                    break
+
+            assert manager.auth_blocked("dd") is True
+            assert manager.get_connection_status("dd") == "auth-required"
+            assert [name for name, _ in incidents] == ["dd"]
+
+            async def good(name: str, cfg: Any, **_: Any) -> ServerConnection:
+                return _make_conn(name, cfg)
+
+            monkeypatch.setattr(manager, "_connect_server", good)
+            await self._write_fresh_grant(store)
+            assert await manager.revalidate_auth_blocked() == ["dd"]
+            assert manager.get_connection_status("dd") == "connected"
+            # The model was told it broke, so it must be told it came back.
+            assert recoveries == [("dd", 1)]
+        finally:
+            await manager.disconnect_all()
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_healing_a_server_the_model_never_heard_about_stays_silent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``on_recovery`` stays gated on ``_incident_announced`` through the poll.
+
+        Healing routes through ``_register_connection`` precisely so the
+        existing gate applies: a server blocked on a host with no incident sink
+        must not produce a recovery notice for a failure nobody announced.
+        """
+        store = self._real_store(tmp_path, obtained_at=1000.0)
+        manager = self._oauth_manager(tmp_path, store)
+        try:
+            # No incident sink installed => nothing armed.
+            await self._block_via_reconnect(manager, monkeypatch)
+            assert "dd" not in manager._incident_announced
+
+            recoveries: list[tuple[str, int]] = []
+            manager.on_recovery = lambda server, count: recoveries.append((server, count))
+
+            async def good(name: str, cfg: Any, **_: Any) -> ServerConnection:
+                return _make_conn(name, cfg)
+
+            monkeypatch.setattr(manager, "_connect_server", good)
+            await self._write_fresh_grant(store)
+            assert await manager.revalidate_auth_blocked() == ["dd"]
+            assert recoveries == []
+        finally:
+            await manager.disconnect_all()
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_status_reports_auth_required_only_while_actually_blocked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A connected server never reports ``auth-required``.
+
+        The status surfaces render this string directly, so a stale block must
+        never outrank a live connection.
+        """
+        store = self._real_store(tmp_path, obtained_at=1000.0)
+        manager = self._oauth_manager(tmp_path, store)
+        try:
+            assert manager.get_connection_status("dd") == "disconnected"
+            await self._block_via_reconnect(manager, monkeypatch)
+            assert manager.get_connection_status("dd") == "auth-required"
+
+            async def good(name: str, cfg: Any, **_: Any) -> ServerConnection:
+                return _make_conn(name, cfg)
+
+            monkeypatch.setattr(manager, "_connect_server", good)
+            assert await manager.reconnect_server("dd") is not None
+            assert manager.get_connection_status("dd") == "connected"
+            assert manager.auth_blocked("dd") is False
+        finally:
+            await manager.disconnect_all()
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_a_healthy_fleet_reads_the_store_zero_times(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The cost gate: this runs on a 60 s timer in every session.
+
+        With nothing blocked the tick must not touch SQLite at all, or nine
+        processes pay for a condition none of them are in.
+        """
+        manager = self._oauth_manager(tmp_path)
+        reads: list[str] = []
+        monkeypatch.setattr(
+            manager, "_grant_marker", lambda name: (reads.append(name), (0.0, False))[1]
+        )
+        for _ in range(100):
+            assert await manager.revalidate_auth_blocked() == []
+        assert reads == []
+
+    @pytest.mark.asyncio
+    async def test_a_disposed_manager_never_registers_a_healed_connection(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The poller and dispose race: a tick must not resurrect a connection.
+
+        ``disconnect_all`` bumps the epoch; a connect already in flight when it
+        runs must close its own stack rather than land in a torn-down manager.
+        """
+        store = self._real_store(tmp_path, obtained_at=1000.0)
+        manager = self._oauth_manager(tmp_path, store)
+        try:
+            await self._block_via_reconnect(manager, monkeypatch)
+            await self._write_fresh_grant(store)
+            closed = {"stack": False}
+
+            class _Stack:
+                async def aclose(self) -> None:
+                    closed["stack"] = True
+
+            async def disposing_connect(name: str, cfg: Any, **_: Any) -> ServerConnection:
+                await manager.disconnect_all()
+                conn = _make_conn(name, cfg)
+                conn.stack = cast(Any, _Stack())
+                return conn
+
+            monkeypatch.setattr(manager, "_connect_server", disposing_connect)
+            assert await manager.revalidate_auth_blocked() == []
+            assert manager.get_connection("dd") is None
+            assert closed["stack"] is True
+        finally:
+            store.close()

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -3333,3 +3333,370 @@ class TestAuthBlockRevalidation:
             assert closed["stack"] is True
         finally:
             store.close()
+
+
+class TestAuthBlockClearsWhereverAServerHeals:
+    """Review round 1, blocker-1: an auth block must not outlive its condition.
+
+    The block is durable state, and durable state that survives the condition
+    that justified it is the exact defect this feature exists to fix. Clearing
+    it only at the user-initiated sites (``connect_configured_server``,
+    ``reconnect_server``, ``_drop_removed_servers``) missed the route users
+    actually take — ``/mcp reload`` — leaving a server ``connected`` while still
+    blocked. Its next disconnect for an ORDINARY reason (server process died, a
+    network blip) was then abandoned by the ``_schedule_reconnect`` guard, and
+    ``revalidate_auth_blocked`` could never rescue it: the grant is valid, so
+    its marker never moves again. Permanently dead on a healthy grant.
+
+    ``_register_connection`` is the single choke point every route to a live
+    connection passes through — the same argument ``_fire_recovery``'s docstring
+    makes for living there — so the clear belongs there and nowhere else.
+    """
+
+    URL = "https://reload.example/mcp"
+
+    @staticmethod
+    def _project(tmp_path: Path) -> Path:
+        """A real config file, so ``reload()`` genuinely re-finds the server."""
+        (tmp_path / ".local-operator").mkdir(exist_ok=True)
+        (tmp_path / ".local-operator" / "mcp.json").write_text(
+            '{"mcpServers": {"dd": {"type": "http",'
+            f' "url": "{TestAuthBlockClearsWhereverAServerHeals.URL}",'
+            ' "auth": {"type": "oauth"}}}}',
+            encoding="utf-8",
+        )
+        return tmp_path
+
+    @pytest.mark.asyncio
+    async def test_a_reload_heal_leaves_no_block_and_the_next_drop_reconnects(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The full sequence: auth failure -> /mcp reload -> ordinary drop."""
+        from local_operator.mcp.auth import McpAuthRequiredError
+
+        self._project(tmp_path)
+        manager = McpManager(str(tmp_path))
+        manager.on_incident = lambda server, reason: None
+        healthy = {"v": False}
+
+        async def connect(name: str, cfg: Any, **_: Any) -> ServerConnection:
+            if not healthy["v"]:
+                raise McpAuthRequiredError(self.URL)
+            return _make_conn(name, cfg)
+
+        monkeypatch.setattr(manager, "_connect_server", connect)
+        try:
+            await manager.discover_and_connect()
+            assert manager.auth_blocked("dd") is True
+            assert manager.get_connection_status("dd") == "auth-required"
+
+            # The user re-auths elsewhere and reloads, which is the ordinary way
+            # a running session picks up a new grant.
+            healthy["v"] = True
+            await manager.reload()
+            assert manager.get_connection_status("dd") == "connected"
+            assert manager.auth_blocked("dd") is False, "a connected server is still blocked"
+            # …and the stale startup error stops being reported with it.
+            assert "dd" not in manager.startup_failures()
+
+            # An ORDINARY disconnect, nothing to do with auth: it must reconnect.
+            attempts: list[str] = []
+
+            async def counting(name: str, cfg: Any, **_: Any) -> ServerConnection:
+                attempts.append(name)
+                return _make_conn(name, cfg)
+
+            monkeypatch.setattr(manager, "_connect_server", counting)
+            manager._handle_disconnect("dd", manager.get_connection("dd"))
+            for _ in range(200):
+                await asyncio.sleep(0.01)
+                if manager.get_connection_status("dd") == "connected":
+                    break
+            assert attempts == ["dd"], "an ordinary drop was abandoned, not retried"
+            assert manager.get_connection_status("dd") == "connected"
+        finally:
+            await manager.disconnect_all()
+
+    @pytest.mark.asyncio
+    async def test_an_in_gate_auth_failure_blocks_like_the_after_gate_one(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Review round 1, major-1: the fourth auth arm.
+
+        ``_connect_round``'s own auth arm handles failures that beat the 250 ms
+        gate. It recorded a startup failure and settled the waiter but never
+        blocked, so the IDENTICAL failure was revalidatable or not purely by
+        whether it was fast. Fast is the common case after the first failure,
+        not the exotic one: a tombstoned grant short-circuits before any POST
+        and endpoint discovery is cached process-wide, so every later reload
+        fails warm.
+        """
+        from local_operator.mcp.auth import McpAuthRequiredError
+        from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+
+        manager = McpManager(str(tmp_path))
+        cfg = MCPHttpServerConfig(url=self.URL, auth=MCPAuthConfig(type="oauth"))
+
+        async def fast_auth_failure(name: str, cfg: Any, **_: Any) -> ServerConnection:
+            raise McpAuthRequiredError(self.URL)  # immediate: wins the gate race
+
+        monkeypatch.setattr(manager, "_connect_server", fast_auth_failure)
+        try:
+            result = await manager._connect_round({"dd": cfg}, {"dd": "global"})
+            assert "dd" in result.errors
+            assert manager.auth_blocked("dd") is True
+            assert manager.get_connection_status("dd") == "auth-required"
+        finally:
+            await manager.disconnect_all()
+
+
+class TestAnUnreadableGrantMarkerIsNotAChangedGrant:
+    """Review round 1, blocker-2 (and QA's Q-1): the degrade path must not storm.
+
+    ``_grant_marker`` used to degrade to the VALUE ``(0.0, False)``, which is
+    indistinguishable from a real marker and participates in the equality test.
+    So a store failing on alternating ticks made the marker appear to oscillate
+    ``real -> (0.0, False) -> real``, and EVERY tick counted as "a peer
+    re-authed" and spent a refresh token — across nine processes, against a
+    provider running refresh-token reuse detection, which answers by revoking
+    the entire token family. That is §7 risk 1 reached through the degrade path.
+
+    QA measured the failure as unreachable under ordinary contention (0 degraded
+    reads in 208k reads against 22.6k concurrent writes; WAL plus
+    ``busy_timeout`` absorbs it), so this needs a genuinely broken store. That
+    is a reason to keep the guard cheap, not a reason to omit it: the shape is
+    one widened ``except`` away from being live.
+    """
+
+    URL = "https://flaky.example/mcp"
+
+    @staticmethod
+    def _blocked_manager(tmp_path: Path, store: Any) -> McpManager:
+        from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+
+        manager = McpManager(str(tmp_path), auth_store=store)
+        manager._configs["dd"] = MCPHttpServerConfig(
+            url=TestAnUnreadableGrantMarkerIsNotAChangedGrant.URL,
+            auth=MCPAuthConfig(type="oauth"),
+        )
+        manager._sources["dd"] = "global"
+        return manager
+
+    @staticmethod
+    def _store(tmp_path: Path) -> Any:
+        from local_operator.mcp.auth import MCP_OAUTH_PROVIDER, TOKENS_OBTAINED_AT_KEY
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(str(tmp_path / "auth.db"))
+        store.upsert_credential(
+            MCP_OAUTH_PROVIDER,
+            {
+                "project_id": TestAnUnreadableGrantMarkerIsNotAChangedGrant.URL,
+                "tokens": {
+                    "access_token": "A",
+                    "refresh_token": "R1",
+                    "token_type": "Bearer",
+                    "expires_in": 28800,
+                },
+                TOKENS_OBTAINED_AT_KEY: 1000.0,
+            },
+        )
+        return store
+
+    @pytest.mark.asyncio
+    async def test_a_flapping_store_buys_zero_connect_attempts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The oscillation repro: alternating read failures, grant never changed."""
+        from local_operator.mcp.auth import McpAuthRequiredError
+
+        store = self._store(tmp_path)
+        manager = self._blocked_manager(tmp_path, store)
+        try:
+
+            async def failing(name: str, cfg: Any, **_: Any) -> ServerConnection:
+                raise McpAuthRequiredError(self.URL)
+
+            monkeypatch.setattr(manager, "_connect_server", failing)
+            await manager._reconnect("dd", 0.0, manager._epoch)
+            assert manager.auth_blocked("dd") is True
+
+            attempts: list[str] = []
+
+            async def counting(name: str, cfg: Any, **_: Any) -> ServerConnection:
+                attempts.append(name)
+                raise McpAuthRequiredError(self.URL)
+
+            monkeypatch.setattr(manager, "_connect_server", counting)
+
+            # Every other read raises, as an intermittently broken store does.
+            real = store.list_credentials
+            calls = {"n": 0}
+
+            def flaky(*args: Any, **kwargs: Any) -> Any:
+                calls["n"] += 1
+                if calls["n"] % 2 == 0:
+                    raise RuntimeError("database is locked")
+                return real(*args, **kwargs)
+
+            monkeypatch.setattr(store, "list_credentials", flaky)
+            for _ in range(10):
+                assert await manager.revalidate_auth_blocked() == []
+            assert attempts == [], (
+                "an unreadable store was mistaken for a new grant: "
+                f"{len(attempts)} refresh-token spends over 10 ticks"
+            )
+            assert manager.auth_blocked("dd") is True
+        finally:
+            await manager.disconnect_all()
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_a_totally_dead_store_never_retries_and_still_heals_later(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unknown at block time is not evidence either, but it is not a trap.
+
+        Blocking while the store is unreadable records ``None``. The next
+        successful read is adopted as the BASELINE rather than treated as
+        movement — we never knew which grant we failed on, so it is not evidence
+        of a new one — and a genuine later change still heals.
+        """
+        from mcp.shared.auth import OAuthToken
+
+        from local_operator.mcp.auth import McpAuthRequiredError, McpTokenStorage
+
+        store = self._store(tmp_path)
+        manager = self._blocked_manager(tmp_path, store)
+        try:
+            real = store.list_credentials
+            monkeypatch.setattr(
+                store,
+                "list_credentials",
+                lambda *a, **k: (_ for _ in ()).throw(RuntimeError("no such table")),
+            )
+
+            async def failing(name: str, cfg: Any, **_: Any) -> ServerConnection:
+                raise McpAuthRequiredError(self.URL)
+
+            monkeypatch.setattr(manager, "_connect_server", failing)
+            await manager._reconnect("dd", 0.0, manager._epoch)
+            assert manager._auth_grant_marker["dd"] is None, "a failed read stored a value"
+
+            attempts: list[str] = []
+
+            async def counting(name: str, cfg: Any, **_: Any) -> ServerConnection:
+                attempts.append(name)
+                return _make_conn(name, cfg)
+
+            monkeypatch.setattr(manager, "_connect_server", counting)
+
+            # The store comes back. That is NOT movement — adopt the baseline.
+            monkeypatch.setattr(store, "list_credentials", real)
+            for _ in range(5):
+                assert await manager.revalidate_auth_blocked() == []
+            assert attempts == [], "recovering from an unreadable store counted as a new grant"
+            assert manager._auth_grant_marker["dd"] is not None, "no baseline was adopted"
+
+            # A REAL new grant on top of that baseline still heals, so the
+            # conservative choice costs one poll cycle, never the recovery.
+            storage = McpTokenStorage(self.URL, store)
+            await storage.set_tokens(
+                OAuthToken(
+                    access_token="FRESH",
+                    refresh_token="R2",
+                    token_type="Bearer",
+                    expires_in=28800,
+                )
+            )
+            assert await manager.revalidate_auth_blocked() == ["dd"]
+            assert attempts == ["dd"]
+            assert manager.get_connection_status("dd") == "connected"
+        finally:
+            await manager.disconnect_all()
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_a_missing_row_is_a_known_marker_not_an_unreadable_one(
+        self, tmp_path: Path
+    ) -> None:
+        """Absent and unreadable must not collapse into one answer.
+
+        ``McpTokenStorage._read_row`` deliberately returns ``None`` for both,
+        which is right for its other callers (either way, start a fresh flow)
+        and wrong here: an absent grant is a stable marker that MOVES when a
+        peer writes one — that is how a never-authorized server heals — while an
+        unreadable store is no information at all. This is why ``grant_marker``
+        reads the store itself rather than reusing ``_read_row``.
+        """
+        from local_operator.mcp.auth import McpTokenStorage
+        from local_operator.providers.auth_store import AuthStore
+
+        store = AuthStore(str(tmp_path / "auth.db"))
+        try:
+            assert McpTokenStorage("https://never-authed.example/mcp", store).grant_marker() == (
+                0.0,
+                False,
+            )
+        finally:
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_the_heal_reports_connecting_and_settles_a_parked_execute(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Review round 1, minor-2: publish a waiter before the poller's connect.
+
+        A real OAuth connect takes seconds. Without a waiter the server reports
+        ``disconnected`` for that whole window — a visible flicker on the way to
+        healing, and worse, a deferred execute parked on this server fails
+        instead of riding the heal it is one await away from.
+        """
+        from mcp.shared.auth import OAuthToken
+
+        from local_operator.mcp.auth import McpAuthRequiredError, McpTokenStorage
+
+        store = self._store(tmp_path)
+        manager = self._blocked_manager(tmp_path, store)
+        try:
+
+            async def failing(name: str, cfg: Any, **_: Any) -> ServerConnection:
+                raise McpAuthRequiredError(self.URL)
+
+            monkeypatch.setattr(manager, "_connect_server", failing)
+            await manager._reconnect("dd", 0.0, manager._epoch)
+
+            gate = asyncio.Event()
+            seen: list[str] = []
+
+            async def slow_connect(name: str, cfg: Any, **_: Any) -> ServerConnection:
+                seen.append(manager.get_connection_status(name))
+                await gate.wait()
+                return _make_conn(name, cfg)
+
+            monkeypatch.setattr(manager, "_connect_server", slow_connect)
+            storage = McpTokenStorage(self.URL, store)
+            await storage.set_tokens(
+                OAuthToken(
+                    access_token="F", refresh_token="R2", token_type="Bearer", expires_in=28800
+                )
+            )
+
+            tick = asyncio.create_task(manager.revalidate_auth_blocked())
+            for _ in range(200):
+                await asyncio.sleep(0.005)
+                if seen:
+                    break
+            # A deferred execute arriving mid-heal parks on the waiter…
+            parked = asyncio.create_task(manager.wait_for_connection("dd"))
+            await asyncio.sleep(0)
+            assert (
+                manager.get_connection_status("dd") == "connecting"
+            ), "the server reported a terminal state while its heal was in flight"
+            gate.set()
+            assert await tick == ["dd"]
+            # …and rides the heal instead of failing.
+            assert (await asyncio.wait_for(parked, timeout=5)) is manager.get_connection("dd")
+        finally:
+            await manager.disconnect_all()
+            store.close()

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -879,6 +879,12 @@ class FakeMcpManager:
         # creating attributes the production object also has.
         self.on_incident: Callable[[str, str], None] | None = None
         self.on_recovery: Callable[[str, int], None] | None = None
+        #: Ticks the auth-revalidation poller has performed against this manager.
+        self.revalidations = 0
+
+    async def revalidate_auth_blocked(self) -> list[str]:
+        self.revalidations += 1
+        return []
 
     def set_on_tools_changed(self, cb) -> None:
         self.callback = cb
@@ -3649,4 +3655,69 @@ async def test_attach_mcp_dispose_installs_the_recovery_sink() -> None:
     assert manager.on_recovery is not None
     manager.on_recovery("minerva-qa", 41)
     assert recoveries == [("minerva-qa", 41)]
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_mcp_auth_revalidation_runs_from_the_composition_root(monkeypatch) -> None:
+    """Every host polls the shared credential store, and stops on dispose.
+
+    The poller lives in ``attach_mcp_dispose`` because that is the seam every
+    front end goes through: a CLI, headless, exec or server session must heal
+    from a peer's ``/mcp reauth`` too, and bolting it onto the TUI would cover
+    one of six routes. Subagents deliberately never reach this function (they
+    BORROW the parent's manager), so a child starts no second poller.
+
+    The cancel hook is registered BEFORE ``manager.disconnect_all``: dispose
+    runs hooks in registration order and ``disconnect_all`` bumps the manager's
+    epoch, so a tick must not still be in flight when it does.
+    """
+    session = FakeSessionShell()
+    manager = FakeMcpManager()
+    # A tick per event-loop turn, so the test waits on the EVENT rather than
+    # on the clock (the production interval is 60 s).
+    monkeypatch.setattr("local_operator.mcp.manager.AUTH_REVALIDATE_INTERVAL_S", 0)
+
+    attach_mcp_dispose(session, cast("McpManager", manager))
+    for _ in range(200):
+        await asyncio.sleep(0)
+        if manager.revalidations:
+            break
+    assert manager.revalidations > 0, "the composition root installed no revalidation poller"
+
+    await session.dispose()
+    assert manager.disconnected == 1
+    settled = manager.revalidations
+    for _ in range(50):
+        await asyncio.sleep(0)
+    assert manager.revalidations == settled, "the poller outlived the session that owns it"
+
+
+@pytest.mark.asyncio
+async def test_a_raising_revalidation_never_kills_the_poller(monkeypatch) -> None:
+    """A store read that blows up must cost one tick, not the whole session.
+
+    Auth state is best-effort throughout this subsystem; a poller that dies on
+    a transient store error would silently stop healing for the rest of the
+    session, which is the failure it exists to fix.
+    """
+    session = FakeSessionShell()
+    manager = FakeMcpManager()
+    calls = {"n": 0}
+
+    async def flaky() -> list[str]:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("store unavailable")
+        return []
+
+    manager.revalidate_auth_blocked = flaky  # type: ignore[method-assign]
+    monkeypatch.setattr("local_operator.mcp.manager.AUTH_REVALIDATE_INTERVAL_S", 0)
+
+    attach_mcp_dispose(session, cast("McpManager", manager))
+    for _ in range(200):
+        await asyncio.sleep(0)
+        if calls["n"] >= 3:
+            break
+    assert calls["n"] >= 3, "the poller stopped after a raising tick"
     await session.dispose()

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -6039,6 +6039,9 @@ class FakeMcpManager:
         self._configs: dict[str, Any] = {}
         self.disconnects: list[str] = []
         self.connects: list[tuple[str, Any]] = []
+        #: Servers held back by an unusable OAuth grant, which the real manager
+        #: reports as ``auth-required`` rather than ``disconnected``.
+        self._auth_blocked: set[str] = set()
 
     def get_all_server_names(self) -> list[str]:
         return sorted(self._configured)
@@ -6047,7 +6050,9 @@ class FakeMcpManager:
         return sorted(self._connected)
 
     def get_connection_status(self, name: str) -> str:
-        return "connected" if name in self._connected else "disconnected"
+        if name in self._connected:
+            return "connected"
+        return "auth-required" if name in self._auth_blocked else "disconnected"
 
     def get_server_config(self, name: str) -> Any:
         return self._configs.get(name)
@@ -12194,3 +12199,33 @@ async def test_a_never_active_only_sweep_does_not_announce(
         for _ in range(8):
             await pilot.pause()
         assert not [b for b in app.query(NoticeBlock) if "session cleanup" in (b.text() or "")]
+
+
+@pytest.mark.asyncio
+async def test_the_band_counts_an_auth_blocked_server_as_failed() -> None:
+    """A server whose grant expired must still turn the lamp.
+
+    The band asks "is anything not up", and it used to answer by comparing the
+    status against the literal ``"disconnected"``. When the manager gained
+    ``auth-required`` as a fourth value, that equality silently stopped counting
+    exactly the servers this segment exists to surface — a session would show a
+    calm two-of-two lamp while a server had been unusable for hours. The test is
+    the guard for the ``!= "connected"`` form.
+    """
+    manager = FakeMcpManager(["github", "notion"], ["github", "notion"])
+    session = McpSession(manager=manager, startup=McpStartupOutcome())
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        assert app._mcp_status().failed is False
+
+        # notion's grant expires mid-session: not connected, not dead.
+        manager.drop("notion")
+        manager._auth_blocked.add("notion")
+        for _ in range(4):
+            await pilot.pause()
+        assert manager.get_connection_status("notion") == "auth-required"
+        status = app._mcp_status()
+        assert status.connected == 1
+        assert status.failed is True, "an auth-blocked server was not counted as failed"

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -6042,6 +6042,9 @@ class FakeMcpManager:
         #: Servers held back by an unusable OAuth grant, which the real manager
         #: reports as ``auth-required`` rather than ``disconnected``.
         self._auth_blocked: set[str] = set()
+        #: Servers still connecting past the startup gate — the state a slow
+        #: HTTP MCP server is in on every launch.
+        self._connecting: set[str] = set()
 
     def get_all_server_names(self) -> list[str]:
         return sorted(self._configured)
@@ -6052,6 +6055,8 @@ class FakeMcpManager:
     def get_connection_status(self, name: str) -> str:
         if name in self._connected:
             return "connected"
+        if name in self._connecting:
+            return "connecting"
         return "auth-required" if name in self._auth_blocked else "disconnected"
 
     def get_server_config(self, name: str) -> Any:
@@ -12229,3 +12234,86 @@ async def test_the_band_counts_an_auth_blocked_server_as_failed() -> None:
         status = app._mcp_status()
         assert status.connected == 1
         assert status.failed is True, "an auth-blocked server was not counted as failed"
+
+
+@pytest.mark.asyncio
+async def test_the_band_stays_calm_while_a_slow_server_is_still_connecting() -> None:
+    """Review round 1, major-2: `connecting` is not a failure.
+
+    The startup gate leaves slow HTTP servers `connecting` on EVERY launch, and
+    `mcp_semantic` maps `failed` straight to `danger` — so counting that state
+    would make a red lamp the normal boot, which is exactly the desensitisation
+    the lamp's alarm-or-nothing design argues against. `_mcp_status`'s own
+    docstring says so; the predicate has to agree with it.
+
+    The pairing matters: `auth-required` must count (a terminal state a user has
+    to act on) while `connecting` must not (momentary, settles on its own).
+    """
+    manager = FakeMcpManager(["github", "slow"], ["github"])
+    manager._connecting.add("slow")
+    session = McpSession(manager=manager, startup=McpStartupOutcome())
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        assert manager.get_connection_status("slow") == "connecting"
+        assert app._mcp_status().failed is False, "a normal boot painted the lamp danger"
+
+        # The same server settling into a TERMINAL failure does count.
+        manager._connecting.discard("slow")
+        manager._auth_blocked.add("slow")
+        for _ in range(4):
+            await pilot.pause()
+        assert app._mcp_status().failed is True
+
+
+@pytest.mark.asyncio
+async def test_the_follower_band_agrees_with_the_owner_band_on_auth_required() -> None:
+    """Review round 1, major-3: two surfaces reporting one session must agree.
+
+    The follower/remote band computes from the frontend-state projection, and
+    tested `status == "failed"` — a value `_mcp_state` only ever writes as a
+    PLACEHOLDER, and then overwrites with the manager's live status whenever a
+    manager is present. So an auth-blocked server projected as `auth-required`
+    and the follower's lamp stayed calm while the owner's went red for the same
+    state. Both predicates are now the same one, including the `connecting`
+    exemption, so a slow boot is calm on both surfaces too.
+    """
+    from local_operator.session.frontend_state import (
+        FrontendSessionState,
+        McpServerState,
+    )
+    from local_operator.tui.widgets.status_line import McpStatus
+
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+
+        status_line = app._status
+        assert status_line is not None
+
+        def band_for(*servers: tuple[str, str]) -> McpStatus:
+            captured: list[McpStatus] = []
+            status_line.update = lambda **kw: (  # type: ignore[method-assign]
+                captured.append(kw["mcp"]) if "mcp" in kw else None
+            )
+            app._apply_frontend_state(
+                FrontendSessionState(
+                    session_id="sess",
+                    epoch="owner",
+                    mcp_servers=[
+                        McpServerState(name=name, status=status) for name, status in servers
+                    ],
+                )
+            )
+            assert captured, "the apply did not repaint the band"
+            return captured[-1]
+
+        # The state the owner paints danger for.
+        assert band_for(("github", "connected"), ("notion", "auth-required")).failed is True
+        # …and the state it deliberately leaves calm.
+        assert band_for(("github", "connected"), ("slow", "connecting")).failed is False
+        # The projection's own placeholder still counts when no manager exists.
+        assert band_for(("github", "failed")).failed is True
+        assert band_for(("github", "connected")).failed is False


### PR DESCRIPTION
## What and why

**C2 — cross-session defect fix.** The operator runs ~9 concurrent `lop` processes sharing one credential store (`~/.local-operator/auth.db`). **Storage is unified; propagation is not.** Completing `/mcp reauth notion` in one session healed nothing in any other running session, for the rest of their lifetimes.

Confirmed live on this machine before the fix: two sessions booted 08:52 and 08:56 still showed `notion [disconnected]` at 13:30, against a grant re-authed at **12:31 with 8h of life left** — and one of them took a **turn-ending incident** from calling a server it had been told was dead.

### Root cause: three arms, two mechanisms, zero store reads

The defect is not "a latch that never clears". It is that **three** auth-failure arms each leave a server permanently un-retried, by **two different** mechanisms, and none of them ever re-reads the shared store:

| arm | what it did | why the server never came back |
| --- | --- | --- |
| `_reconnect` auth arm (`manager.py:2850`) | `self._reconnect_suspended.add(name)` | cleared only by `connect_configured_server` / `reconnect_server` / `_drop_removed_servers` — all **in-process, user-initiated** |
| `_finish_pending` after-gate arm (`manager.py:2242-2274`) | fired the incident + toast, then **nothing** | never suspended **and** never rescheduled: the server was simply **forgotten**, invisible to anything inspecting the breaker |
| `_reconnect_for_call` auth arm | recorded nothing at all | the next tool call re-presented the same dead grant |

The middle one matters most in practice. HTTP OAuth servers do PRM/ASM discovery and a possible token refresh before their transport opens, so they **almost always miss the 250 ms startup gate** and land in `_finish_pending` rather than in `_reconnect`. The incident text of the operator's dead sessions matches `manager.py:2258-2259` verbatim, so that is the state they were actually stuck in — and it is invisible to any fix that only clears `_reconnect_suspended`.

A related premise turned out to be wrong and is worth recording: **`_reconnect_for_call` is not a hot path here, it is unreachable.** `_execute_tool_call` calls `wait_for_connection` first; with no connection and no future that raises `McpConnectionError` and returns an error result before reaching the branch that would retry. So a call-site-only fix heals nothing.

### The fix

**1. The auth block is separated from the flap breaker.** They shared one set by accident of implementation and have nothing else in common: a breaker recovers on a **time** property (the server stops flapping), an auth block recovers on a **store** property (somebody obtained a fresh grant, possibly in another process). Fusing them is why the auth arm had to borrow the breaker's "permanent" semantics. `reconnect_suspended()` keeps reporting the breaker only — its meaning and its tests are unchanged — and both reconnect guards check the new set, so refusal behaviour is byte-identical.

**2. The grant marker is recorded at block time and revalidated against.** `_auth_grant_marker[name] = (tokens_obtained_at, grant_is_dead)`. `revalidate_auth_blocked()` re-reads that pair for **blocked servers only** and, when it moves, drops the block, resets the backoff ladder and attempts **one non-interactive** connect. Success routes through `_register_connection`, so the existing `on_recovery` sink fires and the model is told — no new sink, on every host. Failure re-blocks on the **new** marker, so a still-bad grant costs one attempt per genuine grant change, not one per tick.

**Keyed on `tokens_obtained_at`, not the row's `updated_at`** — this is load-bearing, not stylistic. Measured:

```
[1] seed_client_info()   updated_at moved: True   tokens_obtained_at moved: False
[2] mark_grant_dead()    updated_at moved: True   tokens_obtained_at moved: False
[3] set_tokens()         updated_at moved: True   tokens_obtained_at moved: True
```

`updated_at` moves on **any** write to the row — including the `seed_client_info` that `wire_oauth_auth` performs on **every connect** for a pinned-client server. Keying on it would make each session retry on its own writes, every tick, in nine processes, re-presenting a refresh token to a provider running **refresh-token reuse detection** — which answers by revoking the **entire token family**, logging every session out at once. That is exactly the storm `GRANT_DEAD_AT_KEY` exists to stop (`auth.py:103-108`: "39 POSTs for one server, 87 for another, across 26 boots"). `tokens_obtained_at` is written only by `set_tokens`, the single funnel every path that obtains a **working** token goes through. **`tests/unit/mcp/test_manager.py::test_a_client_info_write_is_not_a_new_grant` is the guard for this and must not be deleted or weakened** — its red-proof is below.

**We retry because the grant CHANGED, never because time passed.** A plain timer would have been simpler and would also have healed; it was rejected for the reason above.

**3. Driven from the composition root**, `session_factory.attach_mcp_dispose`, on a 60 s tick — the seam every host goes through, so CLI, headless, exec and server sessions heal too. Bolting it onto the TUI would cover one of six routes. Subagents deliberately never reach that function (they **borrow** the parent's manager), so a child starts no second poller against its parent's servers.

The cancel hook is registered **before** `manager.disconnect_all`: dispose runs hooks in **registration order** and `disconnect_all` bumps the manager's epoch, so a tick must not still be in flight when it does. `revalidate_auth_blocked` additionally re-checks `_disposed`/epoch after its await, as every other reconnect path does.

**4. `auth-required` is a fourth `get_connection_status` value.** An auth-blocked server was indistinguishable from one whose process died. Five surfaces render this string directly, so naming the actual fix costs nothing. One consumer needed a paired edit: the TUI status band computed `failed=any(status == "disconnected")` (`app.py:11083`), which would have silently **stopped counting** exactly the servers the segment exists to surface — a calm two-of-two lamp over a server unusable for hours. It is now `!= "connected"`.

Review round 1 found this enumeration incomplete: the **follower/remote** band (`app.py:6336`) computes the same segment from the frontend-state projection and tested `== "failed"`, a value `_mcp_state` overwrites with the manager's live status — so two surfaces reporting one session disagreed. Both bands now share one predicate, `not in ("connected", "connecting")`; `connecting` is excluded because the startup gate leaves slow servers there on every launch and a red lamp on every boot is the desensitisation the lamp exists to avoid. Every other equality check is a `== "connected"` test, which a new non-connected value cannot break. `app.py:28025`'s `reason == "disconnected"` is a runtime-disconnect reason, an unrelated variable.

### Cost

The poll reads **only** auth-blocked servers, so the healthy steady state is a single `if not self._auth_blocked: return` — zero SQLite, zero allocation, pinned by a test. One marker read measured **78.8 µs** over two `list_credentials` calls at the operator's real row count (16 `mcp-oauth` rows, 36 total), which puts the worst case (every server blocked, nine processes) at ~0.14 ms/s fleet-wide. *(Corrected in review round 1: the original text quoted 135 µs over one read, which was wrong on both counts — see minor-4/Q-2.)* 60 s was chosen because the thing being waited on is a **human completing a browser login**; a minute is imperceptible against that.

### Deliberately NOT in this PR

- **Any change to `mcp/auth.py`.** The tombstone, the cross-process refresh lock and the coordinating provider are correct and their comments encode measured incidents. This reads what they already write; it does not weaken the tombstone, and it never introduces a browser grant on a non-interactive path (asserted by a test).
- **Cross-session connection sharing so `/new` stops re-dialling.** A connection is an `AsyncExitStack` wrapping an `anyio` task group bound to the loop and task that opened it; sharing it means owning its lifetime, watchers, `closed_event` and epoch guard across a dispose that currently guarantees teardown — a rewrite of the manager's ownership model to save a few seconds on a command the user runs deliberately. The expensive part is **already shared**: the grant is in `auth.db` and endpoint discovery in `_DISCOVERED_ENDPOINTS_CACHE`, so `/new` re-dials with warm metadata and a valid token. Fixing the latch satisfies "don't drop MCP connections" for the case that actually hurts (hours of dead servers) rather than the one that costs three seconds.
- **A background poll for non-auth failures.** The breaker's recovery condition is time, not store state, and it has a documented manual recovery. `_reconnect_suspended` is untouched.

## Testing evidence

### 1. The defect and the fix, same scenario, two processes (the proof that matters)

`evidence_two_process.py` builds a real `McpManager` on a real `AuthStore` holding a stale grant, blocks it through the **real `_reconnect` auth arm**, then has a **genuine second process** perform a real `McpTokenStorage.set_tokens` against the same file. Run twice — once with `local_operator` resolving to `origin/main` (`a8f98be3b`), once to this branch. Verified which tree each run loaded:

```
BEFORE run resolves manager from: /private/tmp/lo-authprop-before/local_operator/mcp/manager.py
has revalidate_auth_blocked: False
AFTER  run resolves manager from: /private/tmp/lo-authprop-wt/local_operator/mcp/manager.py
has revalidate_auth_blocked: True
```

**BEFORE — origin/main a8f98be3b:**

```
[1] mid-session grant expiry -> status='disconnected' connect_attempts=1 incident=True
[2] peer process rc=0 out='peer[pid=54852]: /mcp reauth complete'
[3] 5 poll ticks after the peer re-auth: healed=[] new_connect_attempts=0
[4] FINAL status='disconnected' recovery_notice_to_model=[]
[5] VERDICT: session is STILL DEAD despite a valid shared grant
```

**AFTER — this branch:**

```
[1] mid-session grant expiry -> status='auth-required' connect_attempts=1 incident=True
[2] peer process rc=0 out='peer[pid=54766]: /mcp reauth complete'
[3] 5 poll ticks after the peer re-auth: healed=['notion'] new_connect_attempts=1
[4] FINAL status='connected' recovery_notice_to_model=[('notion', 1)]
[5] VERDICT: session recovered from the peer's re-auth
```

Zero further connect attempts before the fix; exactly one after, and the model gets its recovery notice.

### 2. The production seam, not a fake: a real `Session` dispose path

The above drives the manager directly. This drives the **production composition root** — `attach_mcp_dispose` and nothing else — with a real `McpManager`, a real `AuthStore`, and the peer re-auth again in a real subprocess. **No command is run in the healing session**; it only polls:

```
[1] blocked: status='auth-required' incident_to_model='MCP authorization failed; run /mcp reauth notion — authoriza'
[2] 3 ticks with the grant unchanged: status='auth-required'
[3] peer pid=61423 wrote a fresh grant
[4] NO command run in this session -> status='connected' recovery_to_model=[('notion', 1)]
[5] after dispose: revalidation tasks still alive = 0
```

Line [2] is the safety property (an unchanged grant is never retried) and line [5] is the dispose-race property (the poller does not outlive its session).

### 3. Negative controls — each new guard proven to fail against the defect

Not "the tests pass". Each guard was re-run against the specific regression it exists to catch:

**a. The retry-storm guard.** `_grant_marker` "simplified" to include `updated_at`, the exact change the design warns about:

```
$ pytest tests/unit/mcp/test_manager.py -k client_info_write -n0
FAILED test_a_client_info_write_is_not_a_new_grant - AssertionError: assert ['dd'] == []
  Left contains one more item: 'dd'
```

A `seed_client_info` write was mistaken for a new grant — the retry storm, caught.

**b. The after-gate hole.** `_block_on_auth` removed from `_finish_pending`, restoring pre-fix behaviour:

```
$ pytest tests/unit/mcp/test_manager.py -k startup_gate_auth_failure -n0
FAILED test_a_startup_gate_auth_failure_is_blocked_and_heals - AssertionError: assert False is True
 +  where False = auth_blocked('dd')
```

**c. The status band.** `!= "connected"` reverted to `== "disconnected"`:

```
$ pytest tests/unit/tui/test_app_pilot.py -k auth_blocked_server_as_failed -n0
FAILED test_the_band_counts_an_auth_blocked_server_as_failed -
  AssertionError: an auth-blocked server was not counted as failed
  assert False is True
 +  where False = McpStatus(configured=2, connected=1, failed=False, ...).failed
```

**d. The multi-process test**, against the pre-fix manager: `AttributeError: 'McpManager' object has no attribute 'auth_blocked'`.

### 4. The multi-process unit test

`tests/unit/mcp/test_auth.py::TestAPeersReauthReachesABlockedSession`, modelled on the existing subprocess precedent at `test_auth.py:2470-2495`. A second **connection** in-process would not prove the claim, so the re-auth runs in a real `subprocess` and the test asserts the child's **return code and stderr tail** — a child that dies of an import error fails loudly rather than passing as "no change detected":

```
$ pytest tests/unit/mcp/test_auth.py -k APeersReauth -q
1 passed in 1.66s
```

### 5. Rendered before/after — the user-visible `/mcp` change

Captured from the **real `OperatorApp`** via `scripts.visual_capture.save_capture` (isolated HOME/config), same seeded state, `notion`'s grant expiring mid-session. Geometry held constant: screen `98x24`, virtual `98x24`, no scrollbar, in both.

| | before | after |
| --- | --- | --- |
| `/mcp` row | `notion  disconnected  https://mcp.notion.com/mcp` | `notion  auth-required  https://mcp.notion.com/mcp` |
| band | `⊙ 1 MCP` (danger) | `⊙ 1 MCP` (danger) |
| `_mcp_status().failed` | `True` | `True` |

The band stays correct **because of** the paired edit — with the old `== "disconnected"` form the after-frame reports `failed=False` (negative control c above). Frames attached as a comment on this PR, never committed to the repo.

## Gates

Run in a fresh worktree cut from `origin/main` (`a8f98be3b`) with its **own** venv (`import local_operator` verified to resolve to the worktree), exactly as CI:

- `flake8` — clean
- `black==26.1.0 --check .` — clean (1169 files)
- `isort==5.13.2 --check-only .` — clean
- `pyright` (1.1.411, `--pythonpath .venv/bin/python`) — **0 errors, 0 warnings**
- `pytest tests/unit -q` — **17424 passed, 18 skipped** in 18:25 (whole tree, as CI, on the round-1 remediation head)
- `pytest tests/e2e -m e2e -n0 -q` — **93 passed, 7 skipped** in 114.83s, on **macOS**

The e2e leg is called out deliberately: #401 was an MCP OAuth lock deadlocking the event loop, and this PR adds a **periodic task touching the same store**. The macOS leg is the one that makes that stage a regression guard (`close()` blocks behind a sibling `flock()` on BSD and returns in microseconds on Linux), so it was run here rather than deferred to CI.

No version bump: `pyproject.toml` stays at `0.52.11`.

