### PR TITLE
perf(sidebar): cut the catalog poll's per-directory work ~2.2x

### DIFF
--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -111,6 +111,17 @@ USER_ORIGINS: frozenset[str] = frozenset({ORIGIN_FORK})
 #: * ABSENCE is never cached. Unmarked already means user and is the cheap path,
 #:   and a directory the backfill stamps later must be re-read, not answered
 #:   from a stale "no marker" fact.
+#: * A MARKED-BUT-INACTIVE directory IS cached — an abandoned subagent
+#:   directory that never wrote a transcript or spool. It was not before the
+#:   gate reorder, which reached the activity check first and dropped such a
+#:   row (with its cache entry) on the way. This is intended, not a leak: the
+#:   set tracks which markers EXIST ON DISK, the verdict is a fact about the
+#:   marker rather than about the directory's activity, and retaining it avoids
+#:   re-reading those markers on every scan. Boundedness is unaffected — the
+#:   file is rewritten to exactly the names seen in the current scan, so a
+#:   disposed directory still drops out. Measured impact on the reporting
+#:   machine at the time of the change: 0 of 1,986 directories affected
+#:   (agent review round 1, R3).
 ORIGIN_CACHE_NAME = "origin-verdicts.json"
 
 #: Bumped when the cache's shape or key changes, so an older file is discarded
@@ -1133,11 +1144,20 @@ def recent_sessions(config_dir: Path, limit: int | None = None) -> list[tuple[st
     concurrently) is skipped rather than raising out of an error path whose whole
     job is to be helpful.
 
-    The traversal is ``os.scandir``-based over the store. Each directory costs
-    ONE ``stat`` (the origin marker) plus, only for the sessions that survive
-    that gate, the activity stats — see the gate-order note in
-    :func:`_recent_sessions_with_origin`, which is where the per-directory cost
-    is actually decided. The store is scanned once rather than each directory
+    The traversal is ``os.scandir``-based over the store. Within THIS function
+    each directory costs ONE ``stat`` (the origin marker) plus, only for the
+    sessions that survive that gate, the activity stats — see the gate-order
+    note in :func:`_recent_sessions_with_origin`, which is where the
+    per-directory cost is actually decided.
+
+    That "one stat per directory" is this function's floor, NOT the sidebar
+    poll's: :func:`~local_operator.session.catalog.load_catalog` pays a second
+    unconditional stat per directory probing for the desktop draft marker
+    (measured at 0.99/dir, QA round 1 Q2), so a poll costs ~2.0-2.2 syscalls
+    per directory in total and remains linear in the whole store. Anyone
+    optimising this path next should count both sites, not this one alone.
+
+    The store is scanned once rather than each directory
     being scanned individually: the latter is what the origin design proposed,
     and it measures ~2x WORSE (1986 ms vs 1127 ms over 31,700 dirs) because it
     stats every entry in every directory to learn two filenames. Do not "fix"
@@ -1207,9 +1227,20 @@ def _recent_sessions_with_origin(
             # reporting machine 1,785 of 1,946 directories (92%) are subagent
             # sessions that this scan discards. Asking the activity question
             # first spent two stats on each of them to rank a row that was
-            # then thrown away — the scan's dominant cost, and the reason the
-            # 2-second sidebar poll scaled with every session ever created
-            # rather than with the user's own.
+            # then thrown away — the scan's dominant cost.
+            #
+            # What this buys, stated precisely: a hidden directory drops from
+            # three stats to one, so the 2-second poll pays a ~2.2x smaller
+            # CONSTANT per directory. It does NOT change the scaling. The poll
+            # is still O(total session directories) — this stat runs for every
+            # entry, and ``load_catalog``'s desktop-marker probe runs for every
+            # unlisted one (~2.0-2.2 syscalls/dir combined, measured flat from
+            # 150 to 4,050 directories in agent review / QA round 1). A store
+            # that grows large enough re-reaches today's cost at roughly 8,000
+            # directories. Making the poll genuinely track the user's own
+            # sessions needs an index or a persistent per-directory memo, which
+            # is a separate change — do not read this reordering as having
+            # solved it.
             #
             # Ordering it this way costs nothing when the gate does NOT fire:
             # the marker stat below has to happen for a user session anyway, so

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -1133,12 +1133,15 @@ def recent_sessions(config_dir: Path, limit: int | None = None) -> list[tuple[st
     concurrently) is skipped rather than raising out of an error path whose whole
     job is to be helpful.
 
-    The traversal is ``os.scandir``-based over the store, with one ``stat`` per
-    directory for the transcript and one for the marker. The store is scanned
-    once rather than each directory being scanned individually: the latter is
-    what the origin design proposed, and it measures ~2x WORSE (1986 ms vs
-    1127 ms over 31,700 dirs) because it stats every entry in every directory
-    to learn two filenames. Do not "fix" it back.
+    The traversal is ``os.scandir``-based over the store. Each directory costs
+    ONE ``stat`` (the origin marker) plus, only for the sessions that survive
+    that gate, the activity stats — see the gate-order note in
+    :func:`_recent_sessions_with_origin`, which is where the per-directory cost
+    is actually decided. The store is scanned once rather than each directory
+    being scanned individually: the latter is what the origin design proposed,
+    and it measures ~2x WORSE (1986 ms vs 1127 ms over 31,700 dirs) because it
+    stats every entry in every directory to learn two filenames. Do not "fix"
+    it back.
 
     The cost that matters is the ORIGIN check, which runs once per directory
     and therefore scales with the SUBAGENT population — ~10.6x the user
@@ -1178,7 +1181,7 @@ def _recent_sessions_with_origin(
     # Lazy and stdlib-only on the other side: ``retention`` imports nothing
     # heavier than ``logging``, and the CLI startup guard measures this
     # module's import, not this function's.
-    from local_operator.session.retention import session_activity
+    from local_operator.session.retention import session_activity_path
 
     rows: list[tuple[str, float, str]] = []
     try:
@@ -1195,22 +1198,26 @@ def _recent_sessions_with_origin(
     seen: set[str] = set()
     with scan:
         for entry in scan:
-            # ONE ranking clock, shared with the cleanup policy
-            # (``session.retention.session_activity``): the picker's "most
-            # recent" and the policy's "most recent" must be the same
-            # directories, or the policy removes rows the picker shows
-            # (QA round 1 Q2, UX round 2 U11). A directory with no activity
-            # is not a resumable session and gets no row.
-            activity = session_activity(Path(entry.path))
-            if activity is None:
-                continue
-            mtime = activity
-            # After the transcript stat, not before: the stat is what proves the
-            # directory is a session at all, and an unreadable marker must not
-            # cost a row.
+            # ---- ORDER OF THE TWO GATES IS A MEASURED CHOICE ----------------
+            # A row must pass BOTH "has activity" and "is user-visible". That
+            # is a conjunction, so evaluating the cheaper, more SELECTIVE gate
+            # first is output-identical and strictly less work.
             #
-            # This stat does double duty — it answers "is there a marker" AND
-            # produces the cache key — so the cache costs no extra syscall.
+            # The origin gate is far more selective in practice: on the
+            # reporting machine 1,785 of 1,946 directories (92%) are subagent
+            # sessions that this scan discards. Asking the activity question
+            # first spent two stats on each of them to rank a row that was
+            # then thrown away — the scan's dominant cost, and the reason the
+            # 2-second sidebar poll scaled with every session ever created
+            # rather than with the user's own.
+            #
+            # Ordering it this way costs nothing when the gate does NOT fire:
+            # the marker stat below has to happen for a user session anyway, so
+            # it is merely moved earlier, never added.
+            #
+            # This stat does triple duty — it answers "is there a marker",
+            # produces the verdict-cache key, AND gates visibility — so the
+            # cache still costs no extra syscall.
             marker = os.path.join(entry.path, ORIGIN_NAME)
             try:
                 marker_stat: os.stat_result | None = os.stat(marker)
@@ -1266,7 +1273,27 @@ def _recent_sessions_with_origin(
                 # No marker: the user's own session, and the cheap path this
                 # scan is careful to keep free of reads.
                 origin = ""
-            rows.append((entry.name, mtime, origin))
+            # ONE ranking clock, shared with the cleanup policy
+            # (``session.retention.session_activity``): the picker's "most
+            # recent" and the policy's "most recent" must be the same
+            # directories, or the policy removes rows the picker shows
+            # (QA round 1 Q2, UX round 2 U11). A directory with no activity
+            # is not a resumable session and gets no row.
+            #
+            # Runs AFTER the origin gate (see the note above) so the ~92% of
+            # directories that are subagent sessions never pay for it. Note the
+            # marker bookkeeping above is unaffected by this order: ``seen``
+            # tracks which markers EXIST on disk, which is a fact about the
+            # store and not about whether a row is emitted, so a marked
+            # directory that fails this gate still keeps its cached verdict
+            # rather than being dropped and re-read on every scan.
+            #
+            # ``session_activity_path`` over ``session_activity``: same clock,
+            # same answer, without building a ``Path`` per candidate.
+            activity = session_activity_path(entry.path)
+            if activity is None:
+                continue
+            rows.append((entry.name, activity, origin))
     merged = {
         name: entry for name, entry in cached.items() if name in seen and isinstance(entry, dict)
     }

--- a/local_operator/server/utils/desktop_sessions.py
+++ b/local_operator/server/utils/desktop_sessions.py
@@ -38,6 +38,7 @@ from local_operator.session.frontend_state import (
     sync_wire_payload,
 )
 from local_operator.session.remote import RemoteSession
+from local_operator.session.retention import DESKTOP_MARKER_NAME
 from local_operator.session.transcript import read_transcript_page
 
 logger = logging.getLogger(__name__)
@@ -518,7 +519,7 @@ class DesktopSessions:
                     )
             # An explicitly created desktop draft needs an identity after an
             # HTTP restart, unlike the TUI's uncommitted welcome-screen draft.
-            marker = path / "desktop.json"
+            marker = path / DESKTOP_MARKER_NAME
             marker.write_text(json.dumps({"version": 1, "cwd": str(directory)}))
             marker.chmod(0o600)
 
@@ -577,7 +578,7 @@ class DesktopSessions:
                 def locate() -> str:
                     if not path.is_dir() or not is_user_session(path):
                         raise KeyError("Unknown session")
-                    marker = path / "desktop.json"
+                    marker = path / DESKTOP_MARKER_NAME
                     if marker.exists():
                         return str(json.loads(marker.read_text())["cwd"])
                     # The cold facade restores cwd from the durable canonical

--- a/local_operator/session/catalog.py
+++ b/local_operator/session/catalog.py
@@ -8,6 +8,7 @@ The catalog has no acknowledgement path: listing a conversation is not reading i
 from __future__ import annotations
 
 import logging
+import os
 import sqlite3
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -456,10 +457,24 @@ def cached_session_rows(
     selected = (
         candidates if candidates is not None else _recent_sessions_with_origin(directory, limit)
     )
+    # Resolved ONCE for the store, not per row. ``Path.resolve()`` is a
+    # ``realpath`` — an ``lstat`` per path component — and the loop below called
+    # it twice for every row, which measured 2,880 realpath calls and 1,440
+    # lstats per poll on a 144-row listing: 21% of the poll's profile spent
+    # building a dictionary key. The variable part of that path is the session
+    # id, which is a single directory name, so resolving the parent captures
+    # everything a symlinked store could redirect.
+    #
+    # Safe even for the exotic case of an individual session directory being
+    # itself a symlink: this key is only ever an in-process memo key, never an
+    # I/O path, so a key that differs from the fully-resolved one can only cost
+    # a cache MISS (a row rebuilt from disk, which is correct by construction),
+    # never a wrong or stale row.
+    root = (directory / "sessions").resolve()
     for session_id, mtime, origin in selected:
         session_dir = directory / "sessions" / session_id
         key = _row_stat_key(session_dir)
-        cached = _ROW_CACHE.get(session_dir.resolve())
+        cached = _ROW_CACHE.get(root / session_id)
         if key is not None and cached is not None and cached[0] == key:
             # Same transcript bytes as last poll: the name and the fork mark
             # cannot have changed, so neither read is repeated. `mtime` is
@@ -476,7 +491,7 @@ def cached_session_rows(
             )
         rows.append(row)
         if key is not None:
-            fresh[session_dir.resolve()] = (key, row)
+            fresh[root / session_id] = (key, row)
     _ROW_CACHE.clear()
     _ROW_CACHE.update(fresh)
     return rows
@@ -510,24 +525,57 @@ def load_catalog(directory: Path, limit: int = CATALOG_SCAN_LIMIT) -> list[Catal
         )
         for session_id, mtime, _ in candidates
     ]
-    for marker in (directory / "sessions").glob("*/desktop.json"):
-        if marker.parent.name in source or not session_directory_name(marker.parent.name):
-            continue
-        # A marker is a draft fallback, never a competing source of historical
-        # title/mtime for a transcript that fell beyond a previous page bound.
-        if (marker.parent / TRANSCRIPT_FILENAME).exists():
-            continue
-        try:
-            rows.append(
-                SessionRow(
-                    marker.parent.name,
-                    marker.stat().st_mtime,
-                    "",
-                    created_at=session_created_at(marker.parent),
+    # One directory read plus a stat per unlisted candidate, NOT
+    # ``glob("*/desktop.json")``. The glob looks equivalent and is not: a
+    # pattern whose wildcard is a DIRECTORY component makes pathlib open and
+    # enumerate every session directory to learn one filename, so this line
+    # alone issued 1,946 ``scandir`` calls per poll on the reporting machine
+    # — 1.20 s of a 6.47 s profile, the single largest term in it — to find
+    # the ONE marker that store actually contains. Asking about the file
+    # directly answers the same question with a stat.
+    #
+    # Cheaper still, the ``in source`` test now runs BEFORE the filesystem is
+    # touched rather than after the glob has already paid for the directory:
+    # every session that is already listed costs nothing here at all.
+    try:
+        entries = os.scandir(directory / "sessions")
+    except OSError:
+        entries = None
+    if entries is not None:
+        with entries:
+            for entry in entries:
+                if entry.name in source:
+                    continue
+                try:
+                    # No ``is_dir()`` guard: a successful stat of a file INSIDE
+                    # the entry already proves it is a directory, so asking
+                    # first would spend a stat per entry to learn what this one
+                    # tells us for free. The common answer here is ENOENT.
+                    marker_mtime = os.stat(os.path.join(entry.path, "desktop.json")).st_mtime
+                    # A marker is a draft fallback, never a competing source of
+                    # historical title/mtime for a transcript that fell beyond a
+                    # previous page bound.
+                    if os.path.exists(os.path.join(entry.path, TRANSCRIPT_FILENAME)):
+                        continue
+                except OSError:
+                    # Includes the common case: no ``desktop.json`` here, which
+                    # the glob expressed as a non-match rather than an error.
+                    continue
+                # Checked only for an entry that actually carries a marker.
+                # It is a containment guard on names that may come from
+                # discovery metadata, not a filter this loop needs per entry,
+                # and it is pure-Python per-character work worth keeping off
+                # the path taken by every directory in the store.
+                if not session_directory_name(entry.name):
+                    continue
+                rows.append(
+                    SessionRow(
+                        entry.name,
+                        marker_mtime,
+                        "",
+                        created_at=session_created_at(Path(entry.path)),
+                    )
                 )
-            )
-        except OSError:
-            continue
     rows = decorate_rows(directory, rows, include_live=True)
     identities = {row.id: conversation_identity(directory / "sessions" / row.id) for row in rows}
     attention: dict[str, dict[str, Any]] = {}

--- a/local_operator/session/catalog.py
+++ b/local_operator/session/catalog.py
@@ -509,7 +509,10 @@ def load_catalog(directory: Path, limit: int = CATALOG_SCAN_LIMIT) -> list[Catal
 
     from local_operator.resume import _recent_sessions_with_origin
     from local_operator.session.attention import AttentionStore, conversation_identity
-    from local_operator.session.retention import TRANSCRIPT_FILENAME
+    from local_operator.session.retention import (
+        DESKTOP_MARKER_NAME,
+        TRANSCRIPT_FILENAME,
+    )
 
     candidates = _recent_sessions_with_origin(directory)
     source = {session_id: (session_id, mtime, origin) for session_id, mtime, origin in candidates}
@@ -551,7 +554,7 @@ def load_catalog(directory: Path, limit: int = CATALOG_SCAN_LIMIT) -> list[Catal
                     # the entry already proves it is a directory, so asking
                     # first would spend a stat per entry to learn what this one
                     # tells us for free. The common answer here is ENOENT.
-                    marker_mtime = os.stat(os.path.join(entry.path, "desktop.json")).st_mtime
+                    marker_mtime = os.stat(os.path.join(entry.path, DESKTOP_MARKER_NAME)).st_mtime
                     # A marker is a draft fallback, never a competing source of
                     # historical title/mtime for a transcript that fell beyond a
                     # previous page bound.

--- a/local_operator/session/retention.py
+++ b/local_operator/session/retention.py
@@ -110,6 +110,19 @@ _SIDECAR_NAMES = frozenset(
 #: this constant.
 TRANSCRIPT_FILENAME = "transcript.jsonl"
 
+#: The desktop draft marker: a session the HTTP frontend created that has no
+#: transcript yet. Spelled here beside :data:`TRANSCRIPT_FILENAME` and for the
+#: same import-weight reason — this module is the lean home for on-disk names,
+#: and the two call sites that need it (``session.catalog``'s poll and
+#: ``server.utils.desktop_sessions``' writer) sit on opposite sides of the
+#: server/session layering, so neither can own the literal without one
+#: importing the other.
+#:
+#: A constant rather than three copies of the string: the catalog's poll probes
+#: for this file once per unlisted directory, so a rename that missed one site
+#: would not fail loudly — it would silently stop listing every desktop draft.
+DESKTOP_MARKER_NAME = "desktop.json"
+
 #: The files whose mtime IS "when the user last worked here": the transcript
 #: (every turn appends to it) and the peer-message spool (a note the user has
 #: not read yet is activity waiting for them). Nothing else counts — see

--- a/local_operator/session/retention.py
+++ b/local_operator/session/retention.py
@@ -316,11 +316,39 @@ def session_activity(directory: Path) -> float | None:
     ``max_sessions`` or the recent-N guard, and is only ever a
     ``remove_empty`` candidate. Stdlib-only and import-light because the
     picker calls it per directory on every open.
+
+    A thin adapter over :func:`session_activity_path`, which holds the actual
+    rule. The two must never grow separate implementations — see that
+    function's note on why the clock is single-sourced.
+    """
+    return session_activity_path(os.fspath(directory))
+
+
+def session_activity_path(directory: str) -> float | None:
+    """:func:`session_activity` taking a plain path string. THE clock's body.
+
+    Identical rule, identical answer; only the argument type differs. It exists
+    because the sidebar's 2-second catalog poll calls this once per session
+    directory, and building two ``Path`` objects per candidate to stat two
+    fixed names is pure overhead there: profiling the poll against a
+    1,946-directory store attributed 1.21 s of a 6.47 s run to ``pathlib``
+    plumbing (``__fspath__``, ``__str__``, ``drive``, ``with_segments``) that
+    exists only to reach ``posix.stat``. ``os.stat(os.path.join(...))`` reaches
+    the same syscall with none of it.
+
+    **This is deliberately the ONLY body, with the ``Path`` form delegating to
+    it, rather than a faster copy for the hot caller.** The clock is shared
+    with ``session.cleanup`` precisely so the picker's "most recent" and the
+    retention policy's "most recent" are the same directories (see
+    :func:`session_activity`); a second implementation is exactly how those two
+    answers drift apart again, and the failure mode is the policy deleting rows
+    the picker is still showing (QA round 1 Q2, UX round 2 U11). Optimising the
+    call shape is safe; forking the rule is not.
     """
     newest: float | None = None
     for name in _ACTIVITY_FILES:
         try:
-            stamp = (directory / name).stat().st_mtime
+            stamp = os.stat(os.path.join(directory, name)).st_mtime
         except OSError:
             continue
         newest = stamp if newest is None else max(newest, stamp)

--- a/scripts/bench_catalog_scan.py
+++ b/scripts/bench_catalog_scan.py
@@ -64,11 +64,20 @@ def _counted() -> Iterator[collections.Counter[str]]:
     nothing else in the process pays for them.
 
     ``os.stat`` is patched on the ``os`` module, which is what application code
-    calls. ``pathlib`` reaches the C ``posix.stat`` directly and is therefore
-    NOT counted here — deliberately: a pathlib-mediated stat that this harness
-    cannot see would understate the BEFORE number and flatter the change, so
-    the modules under test call ``os.stat`` explicitly on the hot path and the
-    remaining pathlib traffic is reported by ``--profile`` instead.
+    calls. ``pathlib`` traffic IS counted too, on the supported interpreters:
+    ``Path.stat``/``Path.resolve``/``Path.glob`` delegate through ``os.*``
+    rather than reaching the C ``posix`` module directly, verified on the
+    pinned 3.12 (``Path.stat()`` -> one counted ``stat``; ``Path.resolve()`` ->
+    9 counted ``lstat``; ``Path.glob("*/x")`` -> a counted ``scandir``). That
+    is why the old ``glob("*/desktop.json")`` shows up here as 1,946 scandirs
+    at all — an uncounted implementation would have reported zero.
+    ``--profile`` still attributes calls to their call site, which the raw
+    totals cannot.
+
+    An earlier version of this docstring claimed the opposite (pathlib
+    uncounted, therefore the BEFORE number understated). It was wrong, and the
+    correction moves in the safe direction: the published BEFORE figures are
+    MORE complete than claimed, not less, so no number in the PR shrinks.
     """
     counts: collections.Counter[str] = collections.Counter()
     originals = {name: getattr(os, name) for name in ("stat", "lstat", "scandir", "open")}

--- a/scripts/bench_catalog_scan.py
+++ b/scripts/bench_catalog_scan.py
@@ -1,0 +1,274 @@
+"""Benchmark the sidebar's catalog poll: wall time AND syscalls per poll.
+
+Usage:
+
+    PYTHONPATH=. .venv/bin/python scripts/bench_catalog_scan.py ladder \
+        [--sizes 100,500,1000,2000,4000] [--json out.json]
+    PYTHONPATH=. .venv/bin/python scripts/bench_catalog_scan.py real \
+        [--store ~/.local-operator] [--json out.json]
+
+``PYTHONPATH=.`` matters for the reason ``bench_resume_picker.py`` documents:
+the script must import THIS checkout, not whatever an editable install
+resolves to.
+
+**Why this benchmark counts syscalls and not just milliseconds.** The cost it
+exists to measure is paid by the TUI every 2 seconds for as long as the sidebar
+is open, on a machine that routinely runs a dozen agent sessions at once. Wall
+time there is dominated by whatever else is scheduled — samples on the
+reporting machine varied 192-642 ms for the same work at load average 48 — so a
+wall-clock delta alone cannot distinguish a real improvement from a quiet
+minute. The syscall count is the honest invariant: it is a property of the
+algorithm, it does not move with load, and it is what the poll actually asks
+the filesystem for. Wall time is reported alongside it as corroboration, always
+with the load average that produced it.
+
+The ladder measures SCALING, which is the actual defect: the poll's cost grew
+with the total number of session directories ever created rather than with the
+user's own sessions, so it degraded permanently as the store accumulated.
+
+The ``real`` mode measures the operator's own store. It is strictly READ-ONLY:
+it never writes to the store it measures, so it is safe to point at a live
+``~/.local-operator`` while sessions are running. (The one write the scan can
+normally make — the origin verdict cache — is neutralised; see ``_no_writes``.)
+"""
+
+from __future__ import annotations
+
+import collections
+import contextlib
+import gc
+import json
+import os
+import shutil
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+from local_operator.resume import _recent_sessions_with_origin
+from local_operator.session.catalog import load_catalog
+
+REPS = 7
+
+
+@contextlib.contextmanager
+def _counted() -> Iterator[collections.Counter[str]]:
+    """Count the filesystem syscalls issued inside the block.
+
+    Patches the ``os`` entry points rather than sampling with ``dtrace``/
+    ``strace``: those need privileges this script must not require, and the
+    Python-level count is the one that maps back to a line of code. The
+    counters are installed around a single call and removed immediately, so
+    nothing else in the process pays for them.
+
+    ``os.stat`` is patched on the ``os`` module, which is what application code
+    calls. ``pathlib`` reaches the C ``posix.stat`` directly and is therefore
+    NOT counted here — deliberately: a pathlib-mediated stat that this harness
+    cannot see would understate the BEFORE number and flatter the change, so
+    the modules under test call ``os.stat`` explicitly on the hot path and the
+    remaining pathlib traffic is reported by ``--profile`` instead.
+    """
+    counts: collections.Counter[str] = collections.Counter()
+    originals = {name: getattr(os, name) for name in ("stat", "lstat", "scandir", "open")}
+
+    def wrap(name: str, real: Callable[..., Any]) -> Callable[..., Any]:
+        def counting(*args: Any, **kwargs: Any) -> Any:
+            counts[name] += 1
+            return real(*args, **kwargs)
+
+        return counting
+
+    for name, real in originals.items():
+        setattr(os, name, wrap(name, real))
+    try:
+        yield counts
+    finally:
+        for name, real in originals.items():
+            setattr(os, name, real)
+
+
+def _timed(fn: Callable[[], Any], reps: int = REPS) -> dict[str, float]:
+    """min/median/max milliseconds over ``reps`` runs.
+
+    The median is the headline and the min is kept alongside, because this
+    machine runs several agents' suites at once: a slow sample measures
+    contention rather than the code. ``gc.collect()`` before each sample so a
+    collection triggered by the previous run is not billed to this one.
+    """
+    samples = []
+    for _ in range(reps):
+        gc.collect()
+        start = time.perf_counter()
+        fn()
+        samples.append((time.perf_counter() - start) * 1000)
+    return {
+        "min_ms": round(min(samples), 2),
+        "median_ms": round(statistics.median(samples), 2),
+        "max_ms": round(max(samples), 2),
+    }
+
+
+@contextlib.contextmanager
+def _no_writes(store: Path) -> Iterator[None]:
+    """Make the measured call provably read-only against ``store``.
+
+    The scan persists an origin-verdict cache under ``<store>/cache``. That is
+    the only write on this path, and writing it into the operator's LIVE store
+    from a benchmark would both mutate what is being measured and race the real
+    sessions using it. Redirecting the cache is not enough on its own to prove
+    the point, so this also asserts that nothing opened a file for writing
+    anywhere under the store while the block ran.
+    """
+    from local_operator import resume
+
+    real_save = resume._save_origin_cache
+    written: list[str] = []
+
+    def refuse(path: Path, entries: dict[str, Any]) -> None:
+        written.append(str(path))
+
+    resume._save_origin_cache = refuse  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        resume._save_origin_cache = real_save  # type: ignore[assignment]
+    inside = [p for p in written if str(store) in p]
+    if inside:
+        raise AssertionError(f"benchmark attempted to write inside the store: {inside}")
+
+
+def _measure(store: Path, *, read_only: bool) -> dict[str, Any]:
+    """Cold and warm figures for one store, plus syscalls for one warm poll."""
+    guard = _no_writes(store) if read_only else contextlib.nullcontext()
+    with guard:
+        gc.collect()
+        start = time.perf_counter()
+        rows = load_catalog(store)
+        cold_ms = (time.perf_counter() - start) * 1000
+
+        catalog = _timed(lambda: load_catalog(store))
+        scan = _timed(lambda: _recent_sessions_with_origin(store))
+
+        # Counted on a WARM store: the steady state is what the sidebar
+        # actually pays every 2 s, and a cold count would measure the first
+        # poll after launch instead.
+        with _counted() as catalog_counts:
+            load_catalog(store)
+        with _counted() as scan_counts:
+            _recent_sessions_with_origin(store)
+
+    return {
+        "rows": len(rows),
+        "cold_ms": round(cold_ms, 2),
+        "load_catalog": catalog,
+        "scan": scan,
+        "load_catalog_syscalls": dict(catalog_counts),
+        "load_catalog_syscalls_total": sum(catalog_counts.values()),
+        "scan_syscalls": dict(scan_counts),
+        "scan_syscalls_total": sum(scan_counts.values()),
+    }
+
+
+def _build_store(root: Path, total: int) -> None:
+    """A synthetic store shaped like the real one.
+
+    The proportions matter more than the absolute size. On the reporting
+    machine 1,785 of 1,946 directories (92%) are SUBAGENT sessions that the
+    picker never lists, which is precisely the population the poll used to pay
+    full price for, so a synthetic store of only user sessions would measure a
+    case that does not occur and would hide the effect entirely.
+
+    The awkward shapes are represented on purpose, because they are where an
+    equivalence bug would hide: directories with no transcript at all, ones
+    carrying only an inbox spool, and forked sessions with an origin marker
+    that IS user-visible.
+    """
+    sessions = root / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    now = time.time()
+    for i in range(total):
+        sid = f"{i:012x}"
+        d = sessions / sid
+        d.mkdir(exist_ok=True)
+        kind = i % 100
+        if kind < 92:  # subagent: has a transcript, never listed
+            (d / "transcript.jsonl").write_text('{"type":"message"}\n', encoding="utf-8")
+            (d / "origin.json").write_text('{"origin":"subagent"}', encoding="utf-8")
+        elif kind < 95:  # fork: user-visible despite carrying a marker
+            (d / "transcript.jsonl").write_text('{"type":"message"}\n', encoding="utf-8")
+            (d / "origin.json").write_text('{"origin":"fork"}', encoding="utf-8")
+        elif kind < 97:  # plain user session
+            (d / "transcript.jsonl").write_text('{"type":"message"}\n', encoding="utf-8")
+        elif kind < 99:  # activity is the mail spool only
+            (d / "inbox.jsonl").write_text('{"from":"peer"}\n', encoding="utf-8")
+        else:  # no activity at all: never a row
+            (d / "notes.txt").write_text("x", encoding="utf-8")
+        stamp = now - (i % 5000)
+        for name in ("transcript.jsonl", "inbox.jsonl"):
+            with contextlib.suppress(OSError):
+                os.utime(d / name, (stamp, stamp))
+
+
+def _ladder(sizes: list[int]) -> list[dict[str, Any]]:
+    results = []
+    for size in sizes:
+        root = Path(tempfile.mkdtemp(prefix=f"lo-bench-{size}-"))
+        try:
+            _build_store(root, size)
+            # A fresh store's first call also builds the verdict cache, so the
+            # cache is warmed once before measuring the steady state.
+            load_catalog(root)
+            row = {"dirs": size, **_measure(root, read_only=False)}
+            results.append(row)
+            print(
+                f"  {size:>5} dirs: rows={row['rows']:<4} "
+                f"catalog={row['load_catalog']['median_ms']:>8.2f} ms  "
+                f"scan={row['scan']['median_ms']:>8.2f} ms  "
+                f"syscalls={row['load_catalog_syscalls_total']:>6}",
+                flush=True,
+            )
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+    return results
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+    mode = argv[0] if argv else "ladder"
+    out_json = None
+    if "--json" in argv:
+        out_json = argv[argv.index("--json") + 1]
+
+    payload: dict[str, Any] = {"loadavg": os.getloadavg(), "mode": mode}
+    print(f"load average: {os.getloadavg()}")
+
+    if mode == "ladder":
+        sizes = [100, 500, 1000, 2000, 4000]
+        if "--sizes" in argv:
+            sizes = [int(x) for x in argv[argv.index("--sizes") + 1].split(",")]
+        print("synthetic ladder (92% subagents, mirroring the real store's shape):")
+        payload["ladder"] = _ladder(sizes)
+    elif mode == "real":
+        store = Path(os.path.expanduser("~/.local-operator"))
+        if "--store" in argv:
+            store = Path(os.path.expanduser(argv[argv.index("--store") + 1]))
+        total = len(list((store / "sessions").iterdir()))
+        print(f"real store: {store} ({total} directories), READ-ONLY")
+        result = _measure(store, read_only=True)
+        payload["real"] = {"dirs": total, "store": str(store), **result}
+        print(json.dumps(payload["real"], indent=2))
+    else:
+        print(__doc__)
+        return 2
+
+    payload["loadavg_after"] = os.getloadavg()
+    if out_json:
+        Path(out_json).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        print(f"wrote {out_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/session/test_catalog_scan_cost.py
+++ b/tests/unit/session/test_catalog_scan_cost.py
@@ -1,14 +1,22 @@
 """The sidebar catalog poll's cost, and the contract that cost may not buy.
 
 The sidebar re-runs ``load_catalog`` every 2 seconds while it is open. That
-scan used to cost ``O(every session directory ever created)`` rather than
-``O(the user's own sessions)``: it asked "when was this last active" — two
-stats — for every directory in the store before asking the far more selective
-question "is this session even user-visible", and it located an unrelated
-marker file with a ``glob`` whose wildcard is a directory component, which
-opens and enumerates every session directory. On the reporting machine (1,946
-directories, 92% of them subagent sessions the picker never lists) one poll
-issued 9,773 syscalls and cost 126 ms, permanently, per TUI process.
+scan asked "when was this last active" — two stats — for every directory in
+the store before asking the far more selective question "is this session even
+user-visible", and it located an unrelated marker file with a ``glob`` whose
+wildcard is a directory component, which opens and enumerates every session
+directory. On the reporting machine (1,946 directories, 92% of them subagent
+sessions the picker never lists) one poll issued 9,773 syscalls and cost
+126 ms, permanently, per TUI process.
+
+What changed is the CONSTANT, and these tests are named for that. The poll
+went from ~5.8 to ~2.2 syscalls per directory (9,773 -> 4,350 on that store,
+126 ms -> 25 ms), but it is still ``O(every session directory ever created)``
+— two unconditional per-directory stats remain, the origin marker here and the
+desktop marker in ``load_catalog``. The store growing large enough still
+degrades the poll; it re-reaches the old cost at roughly 8,000 directories.
+Reaching ``O(the user's own sessions)`` needs an index or a persistent memo,
+which this change deliberately does not attempt.
 
 The fix is entirely a reordering and a call-shape change: no caching, no new
 source of truth, and above all **no second ranking clock**. These tests pin
@@ -264,9 +272,19 @@ class TestTheListingIsUnchanged:
 # ---------------------------------------------------------------------------
 
 
-class TestThePollCostScalesWithTheUsersSessions:
-    """The defect was that the poll scaled with the whole store. These pin the
-    shape of the cost, not a wall-clock number: timings on a loaded machine
+class TestThePollsPerDirectoryCostIsBounded:
+    """These pin the PER-DIRECTORY cost, which is what this change reduces —
+    not the scaling, which it does not change.
+
+    The poll remains O(total session directories): the origin-marker stat runs
+    for every entry and ``load_catalog``'s desktop-marker probe for every
+    unlisted one. What the reordering buys is the constant — a hidden directory
+    costs one stat where it cost three. Name these tests for that bound, so a
+    later reader does not take a green suite as proof the store no longer
+    matters; measured flat at ~2.0-2.2 syscalls/dir from 150 to 4,050
+    directories in agent review / QA round 1.
+
+    Asserted as syscall counts, not wall-clock: timings on a loaded machine
     measure contention, syscall counts measure the algorithm."""
 
     def test_a_hidden_session_costs_one_stat_not_three(self, tmp_path: Path) -> None:
@@ -299,13 +317,15 @@ class TestThePollCostScalesWithTheUsersSessions:
         # registry and attention stores read. Emphatically not one per session.
         assert counter.counts["scandir"] < 10
 
-    def test_hidden_sessions_do_not_change_what_a_poll_costs_per_row(self, tmp_path: Path) -> None:
-        """The scaling property itself: adding 200 subagent directories must
-        not multiply the poll's cost the way it used to.
+    def test_a_hidden_session_adds_one_stat_not_three(self, tmp_path: Path) -> None:
+        """Each added subagent directory costs ONE stat, down from three.
 
-        Asserted as a RATIO against a measured baseline rather than an absolute
-        ceiling, so the test says "cost tracks the user's sessions" instead of
-        encoding one machine's number."""
+        This is deliberately NOT "hidden sessions are free": the bound below is
+        linear in the directories added (200 dirs -> <=200 stats), because that
+        is the property that actually ships. It fails on the previous
+        implementation, which paid three. Asserted as a DELTA against a
+        measured baseline rather than an absolute ceiling, so it pins the
+        per-directory slope instead of encoding one machine's number."""
         for index in range(10):
             _session(tmp_path, f"{index:012x}", stamp=1000.0 + index)
         _recent_sessions_with_origin(tmp_path)

--- a/tests/unit/session/test_catalog_scan_cost.py
+++ b/tests/unit/session/test_catalog_scan_cost.py
@@ -1,0 +1,323 @@
+"""The sidebar catalog poll's cost, and the contract that cost may not buy.
+
+The sidebar re-runs ``load_catalog`` every 2 seconds while it is open. That
+scan used to cost ``O(every session directory ever created)`` rather than
+``O(the user's own sessions)``: it asked "when was this last active" — two
+stats — for every directory in the store before asking the far more selective
+question "is this session even user-visible", and it located an unrelated
+marker file with a ``glob`` whose wildcard is a directory component, which
+opens and enumerates every session directory. On the reporting machine (1,946
+directories, 92% of them subagent sessions the picker never lists) one poll
+issued 9,773 syscalls and cost 126 ms, permanently, per TUI process.
+
+The fix is entirely a reordering and a call-shape change: no caching, no new
+source of truth, and above all **no second ranking clock**. These tests pin
+both halves — that the answer is unchanged, and that the cost model is the new
+one — because an optimisation here is only worth having if the listing is
+byte-identical, and the failure mode of getting it wrong is the retention
+policy deleting rows the picker is still showing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+import local_operator.session.retention as retention
+from local_operator.resume import _recent_sessions_with_origin
+from local_operator.session.catalog import load_catalog
+from local_operator.session.retention import session_activity, session_activity_path
+
+
+def _session(
+    root: Path,
+    session_id: str,
+    *,
+    transcript: str | None = "{}\n",
+    inbox: str | None = None,
+    origin: str | None = None,
+    stamp: float | None = None,
+) -> Path:
+    """One session directory in whichever awkward shape a test needs."""
+    directory = root / "sessions" / session_id
+    directory.mkdir(parents=True, exist_ok=True)
+    if transcript is not None:
+        (directory / "transcript.jsonl").write_text(transcript, encoding="utf-8")
+    if inbox is not None:
+        (directory / "inbox.jsonl").write_text(inbox, encoding="utf-8")
+    if origin is not None:
+        (directory / "origin.json").write_text(json.dumps({"origin": origin}), encoding="utf-8")
+    if stamp is not None:
+        for name in ("transcript.jsonl", "inbox.jsonl"):
+            if (directory / name).exists():
+                os.utime(directory / name, (stamp, stamp))
+    return directory
+
+
+def _counting(names: tuple[str, ...] = ("stat", "lstat", "scandir")) -> Any:
+    """Count ``os`` filesystem calls made inside the context."""
+
+    class Counter:
+        def __init__(self) -> None:
+            self.counts: dict[str, int] = {name: 0 for name in names}
+            self._originals: dict[str, Callable[..., Any]] = {}
+
+        def __enter__(self) -> "Counter":
+            for name in names:
+                real = getattr(os, name)
+                self._originals[name] = real
+
+                def wrap(real: Callable[..., Any] = real, name: str = name) -> Any:
+                    def counting(*args: Any, **kwargs: Any) -> Any:
+                        self.counts[name] += 1
+                        return real(*args, **kwargs)
+
+                    return counting
+
+                setattr(os, name, wrap())
+            return self
+
+        def __exit__(self, *exc: Any) -> None:
+            for name, real in self._originals.items():
+                setattr(os, name, real)
+
+        @property
+        def total(self) -> int:
+            return sum(self.counts.values())
+
+    return Counter()
+
+
+# ---------------------------------------------------------------------------
+# The clock stays single-sourced
+# ---------------------------------------------------------------------------
+
+
+class TestTheRankingClockIsNotForked:
+    """``session_activity`` is shared with ``session.cleanup`` on purpose: the
+    picker's "most recent" and the policy's "most recent" must be the same
+    directories, or the policy deletes rows the picker shows (QA round 1 Q2,
+    UX round 2 U11). The fast path may change the CALL SHAPE and never the
+    rule."""
+
+    def test_the_path_form_is_the_only_body(self) -> None:
+        """``session_activity`` delegates rather than duplicating the loop, so
+        the two answers cannot drift apart by editing one of them."""
+        import inspect
+
+        source = inspect.getsource(session_activity)
+        assert "session_activity_path" in source
+        # The rule itself — iterating the activity files — lives in ONE place.
+        assert "_ACTIVITY_FILES" not in source
+
+    def test_both_forms_agree_on_every_shape(self, tmp_path: Path) -> None:
+        shapes = {
+            "both": _session(tmp_path, "a" * 12, transcript="{}\n", inbox="{}\n"),
+            "transcript only": _session(tmp_path, "b" * 12, transcript="{}\n"),
+            "inbox only": _session(tmp_path, "c" * 12, transcript=None, inbox="{}\n"),
+            "neither": _session(tmp_path, "d" * 12, transcript=None),
+            "absent": tmp_path / "sessions" / "nope",
+        }
+        for label, directory in shapes.items():
+            assert session_activity(directory) == session_activity_path(
+                str(directory)
+            ), f"forms disagree for {label}"
+
+    def test_the_clock_is_still_only_the_transcript_and_the_spool(self, tmp_path: Path) -> None:
+        """Bookkeeping the harness writes must not restamp "last activity", and
+        the DIRECTORY mtime is never the clock — that was the U11 defect."""
+        directory = _session(tmp_path, "e" * 12, stamp=1000.0)
+        (directory / "title-scan.json").write_text("{}", encoding="utf-8")
+        os.utime(directory, (time.time(), time.time()))
+        assert session_activity_path(str(directory)) == 1000.0
+
+    def test_the_scan_and_the_policy_rank_the_same_directories(self, tmp_path: Path) -> None:
+        """The property the shared clock exists to guarantee, end to end."""
+        for index in range(6):
+            _session(tmp_path, f"{index:012x}", stamp=1_000_000.0 + index)
+        listed = [row[0] for row in _recent_sessions_with_origin(tmp_path)]
+        ranked = sorted(
+            (p.name for p in (tmp_path / "sessions").iterdir()),
+            key=lambda name: -(retention.session_activity(tmp_path / "sessions" / name) or 0),
+        )
+        assert listed == ranked
+
+
+# ---------------------------------------------------------------------------
+# Invalidation: new activity must never be missed
+# ---------------------------------------------------------------------------
+
+
+class TestActivityBetweenPollsIsSeenImmediately:
+    """A listing that misses new activity is a worse bug than a slow one, so
+    every one of these asserts the NEXT poll — not an eventual one.
+
+    These are the regression guard for a tempting optimisation this change
+    deliberately does NOT make: gating the activity stat on the directory's
+    own mtime. Appending to an existing file does not change its directory's
+    mtime (POSIX only requires that for adding or removing entries; measured
+    on APFS), and ``mark_session_origin`` explicitly restores the directory
+    mtime after writing a marker — so a dir-mtime gate would silently miss
+    both."""
+
+    def test_an_appended_transcript_reranks_on_the_very_next_poll(self, tmp_path: Path) -> None:
+        older = _session(tmp_path, "a" * 12, stamp=1000.0)
+        _session(tmp_path, "b" * 12, stamp=2000.0)
+        assert [row[0] for row in _recent_sessions_with_origin(tmp_path)] == [
+            "b" * 12,
+            "a" * 12,
+        ]
+
+        with (older / "transcript.jsonl").open("a", encoding="utf-8") as handle:
+            handle.write("{}\n")
+        os.utime(older / "transcript.jsonl", (3000.0, 3000.0))
+
+        rows = _recent_sessions_with_origin(tmp_path)
+        assert [row[0] for row in rows] == ["a" * 12, "b" * 12]
+        assert rows[0][1] == 3000.0
+
+    def test_a_brand_new_session_appears_on_the_very_next_poll(self, tmp_path: Path) -> None:
+        _session(tmp_path, "a" * 12, stamp=1000.0)
+        assert len(_recent_sessions_with_origin(tmp_path)) == 1
+        _session(tmp_path, "b" * 12, stamp=2000.0)
+        assert len(_recent_sessions_with_origin(tmp_path)) == 2
+
+    def test_a_first_inbox_message_makes_a_silent_directory_rank(self, tmp_path: Path) -> None:
+        """Unread mail is activity waiting for a person, so a directory with
+        only a spool is a row."""
+        directory = _session(tmp_path, "a" * 12, transcript=None)
+        assert _recent_sessions_with_origin(tmp_path) == []
+        (directory / "inbox.jsonl").write_text("{}\n", encoding="utf-8")
+        os.utime(directory / "inbox.jsonl", (5000.0, 5000.0))
+        assert [row[0] for row in _recent_sessions_with_origin(tmp_path)] == ["a" * 12]
+
+    def test_a_marker_written_after_a_listing_hides_the_session_next_poll(
+        self, tmp_path: Path
+    ) -> None:
+        """The origin backfill stamps directories later; the gate must notice.
+
+        ``mark_session_origin`` restores the directory's mtime after writing,
+        which is exactly why the gate reads the MARKER's stat and not the
+        directory's.
+        """
+        from local_operator.resume import mark_session_origin
+
+        directory = _session(tmp_path, "a" * 12, stamp=1000.0)
+        assert [row[0] for row in _recent_sessions_with_origin(tmp_path)] == ["a" * 12]
+        before = directory.stat().st_mtime
+        mark_session_origin(directory, "subagent")
+        # The writer deliberately preserves the directory mtime, so this
+        # transition is invisible to anything keyed on it.
+        assert directory.stat().st_mtime == before
+        assert _recent_sessions_with_origin(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Visibility and ordering are unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestTheListingIsUnchanged:
+    """Reordering the gates is only sound because they are a CONJUNCTION: a row
+    needs activity AND user-visibility, so asking the selective question first
+    cannot change the answer."""
+
+    def test_every_awkward_shape_lands_on_the_right_side(self, tmp_path: Path) -> None:
+        _session(tmp_path, "a" * 12, stamp=5000.0)  # plain user session
+        _session(tmp_path, "b" * 12, origin="fork", stamp=4000.0)  # visible
+        _session(tmp_path, "c" * 12, origin="subagent", stamp=9000.0)  # hidden
+        _session(tmp_path, "d" * 12, transcript=None)  # no activity
+        _session(tmp_path, "e" * 12, transcript=None, inbox="{}\n", stamp=3000.0)
+        # A corrupt marker reads as the user's own session rather than
+        # vanishing: existence gates the READ, never the verdict.
+        corrupt = _session(tmp_path, "f" * 12, stamp=2000.0)
+        (corrupt / "origin.json").write_text("{not json", encoding="utf-8")
+
+        rows = _recent_sessions_with_origin(tmp_path)
+        assert [row[0] for row in rows] == ["a" * 12, "b" * 12, "e" * 12, "f" * 12]
+        assert dict((row[0], row[2]) for row in rows)["b" * 12] == "fork"
+
+    def test_equal_stamps_break_on_the_id_ascending(self, tmp_path: Path) -> None:
+        """A stable tie order is load-bearing: with an unstable one the policy's
+        first page and the picker's disagreed (QA round 2, Q10)."""
+        for name in ("c", "a", "b"):
+            _session(tmp_path, name * 12, stamp=7000.0)
+        assert [row[0] for row in _recent_sessions_with_origin(tmp_path)] == [
+            "a" * 12,
+            "b" * 12,
+            "c" * 12,
+        ]
+
+    def test_the_verdict_cache_still_answers_identically(self, tmp_path: Path) -> None:
+        """Two consecutive scans agree; the second is served from the cache."""
+        _session(tmp_path, "a" * 12, stamp=5000.0)
+        _session(tmp_path, "b" * 12, origin="subagent", stamp=6000.0)
+        _session(tmp_path, "c" * 12, origin="fork", stamp=7000.0)
+        assert _recent_sessions_with_origin(tmp_path) == _recent_sessions_with_origin(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# The cost model
+# ---------------------------------------------------------------------------
+
+
+class TestThePollCostScalesWithTheUsersSessions:
+    """The defect was that the poll scaled with the whole store. These pin the
+    shape of the cost, not a wall-clock number: timings on a loaded machine
+    measure contention, syscall counts measure the algorithm."""
+
+    def test_a_hidden_session_costs_one_stat_not_three(self, tmp_path: Path) -> None:
+        """The origin gate runs FIRST, so a subagent directory never pays for
+        the two activity stats whose answer would be discarded."""
+        for index in range(50):
+            _session(tmp_path, f"{index:012x}", origin="subagent", stamp=1000.0)
+        _recent_sessions_with_origin(tmp_path)  # warm the verdict cache
+
+        with _counting() as counter:
+            _recent_sessions_with_origin(tmp_path)
+        # One scandir for the store, then exactly one marker stat per hidden
+        # directory. Three per directory was the old shape.
+        assert counter.counts["scandir"] == 1
+        assert counter.counts["stat"] <= 50 + 5
+
+    def test_the_scan_does_not_open_every_session_directory(self, tmp_path: Path) -> None:
+        """``load_catalog`` located ``desktop.json`` with ``glob("*/desktop.json")``,
+        whose directory-component wildcard enumerates every session directory —
+        1,946 ``scandir`` calls per poll on the reporting machine to find one
+        file. A stat answers the same question."""
+        for index in range(40):
+            _session(tmp_path, f"{index:012x}", origin="subagent", stamp=1000.0)
+        _session(tmp_path, "f" * 12, stamp=2000.0)
+        load_catalog(tmp_path)  # warm every cache
+
+        with _counting() as counter:
+            load_catalog(tmp_path)
+        # A small constant: the sessions directory itself, plus whatever the
+        # registry and attention stores read. Emphatically not one per session.
+        assert counter.counts["scandir"] < 10
+
+    def test_hidden_sessions_do_not_change_what_a_poll_costs_per_row(self, tmp_path: Path) -> None:
+        """The scaling property itself: adding 200 subagent directories must
+        not multiply the poll's cost the way it used to.
+
+        Asserted as a RATIO against a measured baseline rather than an absolute
+        ceiling, so the test says "cost tracks the user's sessions" instead of
+        encoding one machine's number."""
+        for index in range(10):
+            _session(tmp_path, f"{index:012x}", stamp=1000.0 + index)
+        _recent_sessions_with_origin(tmp_path)
+        with _counting() as small:
+            _recent_sessions_with_origin(tmp_path)
+
+        for index in range(200):
+            _session(tmp_path, f"{index + 1000:012x}", origin="subagent", stamp=500.0)
+        _recent_sessions_with_origin(tmp_path)
+        with _counting() as large:
+            _recent_sessions_with_origin(tmp_path)
+
+        # Each added hidden directory costs ONE stat. The old code paid three,
+        # so this bound fails on the previous implementation.
+        assert large.total - small.total <= 200 + 10

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -1822,14 +1822,20 @@ def test_a_named_id_survives_a_stat_that_fails(tmp_path, monkeypatch) -> None:
     # and the mail spool), so that is the call made to fail. ``session_activity``
     # itself reads a failing stat as "no such file" — which lands here as the
     # same ResumeNotFound a missing session produces, never a traceback.
-    real_stat = Path.stat
+    #
+    # Patched at ``os.stat`` rather than ``Path.stat`` because the clock stats
+    # by string path (``session_activity_path``) to keep the sidebar's 2-second
+    # poll off pathlib. The PROPERTY under test is unchanged and is what this
+    # asserts: whatever the call shape, a stat that raises must surface as
+    # ResumeNotFound rather than as a traceback on the way to the TUI.
+    real_stat = os.stat
 
-    def flaky(self, *args, **kwargs):  # noqa: ANN001, ANN202
-        if self.name == resume_mod.TRANSCRIPT_NAME:
+    def flaky(path, *args, **kwargs):  # noqa: ANN001, ANN202
+        if str(path).endswith(resume_mod.TRANSCRIPT_NAME):
             raise PermissionError("stat denied")
-        return real_stat(self, *args, **kwargs)
+        return real_stat(path, *args, **kwargs)
 
-    monkeypatch.setattr(Path, "stat", flaky)
+    monkeypatch.setattr(os, "stat", flaky)
     with pytest.raises(resume_mod.ResumeNotFound):
         resume_mod.resume_dir(tmp_path, "sess-abc")
 


### PR DESCRIPTION
## What and why

**C1 — performance defect fix, no behaviour change.** The operator reports that "the lop TUI with the sidebar open seems to be slowing things down on some sessions, particularly longer ones."

The sidebar's catalog poll (`set_interval(2.0, self._refresh_sidebar)`, created paused and resumed on open — so the cost is paid **only** with the sidebar open, matching the report exactly) does a large amount of per-directory work over the whole session store on every tick. This PR **cuts that per-directory work by ~2.2x**: on the operator's real store one poll drops from **9,773 syscalls / 125.74 ms to 4,350 syscalls / 25.01 ms**.

### What this PR does NOT do — read this before quoting the numbers

**The poll remains `O(total session directories)`.** This is a **constant-factor** reduction, not a change of complexity class, and the earlier revision of this description (and the PR title) got that wrong. Two unconditional per-directory stats survive the change:

- `resume.py` — the origin-marker stat, one per directory in the store;
- `catalog.py` — the desktop-marker probe, one per unlisted directory (measured at 0.99/dir).

So the poll still costs **~2.0–2.2 syscalls per directory, forever**, where it used to cost ~5.8. Agent review round 1 and QA round 1 independently isolated this. QA's experiment is the cleanest statement of it — **user sessions held fixed at 50** while the subagent population varied 40x, on this branch:

| users | subagents | total dirs | rows | syscalls | per dir | ms |
| --- | --- | --- | --- | --- | --- | --- |
| 50 | 100 | 150 | 50 | 463 | 3.09 | 3.7 |
| 50 | 500 | 550 | 50 | 1,263 | 2.30 | 9.0 |
| 50 | 1,000 | 1,050 | 50 | 2,263 | 2.16 | 13.7 |
| 50 | 2,000 | 2,050 | 50 | 4,263 | 2.08 | 24.3 |
| 50 | 4,000 | 4,050 | 50 | 8,263 | 2.04 | 38.3 |

The user's own sessions never changed; the cost rose **17.8x**. The reviewer's independent before/after ladder shows the same thing from the other direction — the win *decays* from 4.26x to 2.15x as the store grows, which is the signature of a constant-factor win rather than a scaling fix.

**Practical consequence: the permanent degradation as the store grows is slowed, not removed. At roughly 8,000 directories the poll returns to today's cost.** Reaching genuine `O(the user's own sessions)` needs an index, a partitioned store, or a persistent per-directory memo — a larger design change than this PR should carry, and deliberately out of scope. The win here is real and worth shipping on its own; it is just not the win the original title claimed.

### Root cause: three costs, one theme — work proportional to the whole store

The store's shape is what makes this bite: **1,785 of 1,946 directories (92%) are subagent sessions the picker never lists.** Only 144 rows are user-visible.

| # | site | what it did | why it scaled with the store |
| --- | --- | --- | --- |
| 1 | `resume._recent_sessions_with_origin` | called `session_activity` (**two** stats) on every directory, *then* asked whether the session was user-visible | the 92% that get discarded each paid two stats to rank a row that was thrown away |
| 2 | `catalog.load_catalog` | located one marker with `glob("*/desktop.json")` | a wildcard in a **directory component** makes pathlib open and enumerate every session directory: **1,946 `scandir` calls per poll to find one file** — 1.20 s of a 6.47 s profile, the single largest term |
| 3 | `catalog.cached_session_rows` | `Path.resolve()` twice per row for a dict key | `realpath` is an `lstat` per path component: **1,440 lstats per poll** on a 144-row listing, 21% of the profile |

`CATALOG_SCAN_LIMIT = 200` bounds the *per-row* work above the scan (that memoization is already effective — only 0.139 s of 1.258 s). It does **not** bound the scan itself.

### The fix

**1. The two gates are reordered (#1).** A row must pass *both* "has activity" **and** "is user-visible". That is a **conjunction**, so evaluating the more selective gate first is output-identical and strictly less work. The marker stat has to happen for a user session anyway, so it is **moved earlier, never added** — and it already did double duty as the verdict-cache key, so the cache still costs no extra syscall. This is where the 3-stats-to-1 reduction per hidden directory comes from; it is why the constant falls and why the slope does not.

**2. `session_activity` gets a string-path form (`session_activity_path`) — one body, not two.** Profiling attributed **1.21 s of 6.47 s** to pathlib plumbing (`__fspath__`, `__str__`, `drive`, `with_segments`) that exists only to reach `posix.stat`.

**The ranking clock stays SHARED with `session.cleanup`, which is the load-bearing constraint here.** `session_activity` now delegates to the new function rather than a fast copy living beside it. Two rankings is the defect class behind **QA round 1 Q2 / UX round 2 U11**, where the retention policy deleted rows the picker was still showing. Only the *call shape* changed; the rule is single-sourced, and a test asserts `_ACTIVITY_FILES` appears in exactly one body.

**3. The glob becomes one directory read plus a stat (#2), and `resolve()` is hoisted out of the loop (#3).** The `in source` test now runs *before* the filesystem is touched, so an already-listed session costs nothing.

### A behaviour change worth recording: the origin-verdict cache retains more

Reordering the gates moved `seen.add()` above the activity gate, so a directory that carries a marker but has **no activity** — an abandoned subagent directory that never wrote a transcript — now keeps a cache entry where it previously did not. Measured by the reviewer on 500 such directories: `entries=0` before, `entries=500` after.

This is **intended, not a leak**: `seen` tracks which markers *exist on disk*, the verdict is a fact about the marker rather than about the directory's activity, and retaining it avoids re-reading those markers on every scan. The cache stays bounded by the live store (`merged` is rebuilt from `seen` each scan), so disposed directories still drop out. On the operator's real store the affected population is currently **0 of 1,986 directories**, so today's practical impact is nil. Now documented in the `ORIGIN_CACHE_NAME` docstring, which enumerates exactly what is and is not cached.

### Deliberately NOT done: a directory-mtime gate

The obvious next optimisation — skip a directory whose `DirEntry` mtime has not moved — is **unsound here, and the tests pin it**:

```
append to existing file bumps dir mtime : False   <-- the dominant activity
create new file        bumps dir mtime : True
os.replace             bumps dir mtime : True
```

Appending to a transcript does **not** change its directory's mtime (POSIX only requires that for adding/removing entries; measured above on APFS), and `mark_session_origin` explicitly `os.utime`s the directory mtime **back** after writing a marker. Such a gate would silently miss both real activity and a session becoming hidden. **A stale listing is a worse bug than a slow one**, so this direction was rejected rather than shipped behind a flag. The reviewer confirmed this by mutation-testing it: implementing the gate fails `test_an_appended_transcript_reranks_on_the_very_next_poll`.

Also rejected: **bounding the scan itself**, which changes which sessions are visible, and **an adaptive/backoff poll interval**, which hides the cost rather than removing it and trades away responsiveness.

## Testing evidence

### 1. The listing is byte-identical — the property that actually matters, now verified three times

The strongest risk is that the sidebar and `/resume` start listing a *different* set or order. Both implementations were run **in the same process against the same store** and their full `(id, mtime, origin)` sequences compared:

```
real store, pass 1:                  old=144 rows new=144 rows identical=True
real store, pass 2 (warm cache):     old=144 rows new=144 rows identical=True
synthetic 600 (cold cache):          old=42 rows  new=42 rows  identical=True
synthetic 600 (warm cache):          old=42 rows  new=42 rows  identical=True
synthetic 600 (after mid-scan touch):old=42 rows  new=42 rows  identical=True
EQUIVALENT
```

The synthetic store covers the awkward cases on purpose: forks with user-visible markers, **corrupt** markers (which must read as the user's own session, not vanish), spool-only directories, transcript-less directories, and **many equal stamps** to exercise the id tie-break.

**Both the reviewer and QA independently reproduced this equivalence and both found it byte-identical**, each against their own fixture corpus in their own worktree — including dot-directories, a `chmod 000` unreadable entry (skipped, no raise), a store larger than `CATALOG_SCAN_LIMIT` (caps at exactly 200; `/resume` still lists 260), and continuous create/delete mutation across 40 polls (0 exceptions on both sides). QA additionally confirmed the `desktop.json` fallback rows are identical in ids, mtimes and ordering.

**Both also independently verified the ranking clock is not forked in effect**: `session_activity` delegates to `session_activity_path` with no second body, `_ACTIVITY_FILES` is iterated in exactly one place, `cleanup.py` still calls the `Path` form, and the two forms agree exactly on every awkward shape. That is the load-bearing correctness evidence for this change, and it is now confirmed by two independent reviewers rather than by the author alone.

**Methodology warning for anyone re-running this comparison:** both trees must be pointed at **one shared store on disk**. QA's first attempt compared two separate *copies* of a store and got spurious `created_at` differences, because the copies have different directory birth times — a harness artifact that looks exactly like a regression. Run base and head against the same directory, and repeat the base run after the head run to prove the store was stable.

### 2. Before/after, on the real store and a synthetic ladder

Both measured with the same committed harness, `scripts/bench_catalog_scan.py`, the BEFORE numbers taken by stashing the change so it is the identical harness on both sides. **Syscalls are the honest invariant** — wall time on this machine (load average 45-122, twelve live sessions) is noisy, which the numbers below show directly.

`load_catalog` — one poll:

| store | before ms | after ms | speedup | before syscalls | after syscalls | reduction |
| --- | --- | --- | --- | --- | --- | --- |
| 100 dirs | 6.87 | 2.05 | 3.4x | 554 | 241 | 2.3x |
| 500 dirs | 34.84 | 8.49 | 4.1x | 2,742 | 1,141 | 2.4x |
| 1,000 dirs | 66.15 | 18.50 | 3.6x | 5,477 | 2,266 | 2.4x |
| 2,000 dirs | 121.26 | 30.36 | 4.0x | 10,947 | 4,516 | 2.4x |
| 4,000 dirs | 295.53 | 56.62 | **5.2x** | 20,267 | 8,914 | 2.3x |
| **real store (1,953)** | **125.74** | **25.01** | **5.0x** | **9,773** | **4,350** | **2.2x** |

Note the reduction column: **flat at 2.2–2.4x across a 40x range of store sizes.** That flatness is itself the evidence that this is a constant-factor win — a complexity fix would show the ratio *growing* with the store.

`_recent_sessions_with_origin` — the scan alone:

| store | before ms | after ms | before syscalls | after syscalls |
| --- | --- | --- | --- | --- |
| 4,000 dirs | 97.37 | 26.74 | 11,961 | 4,641 |
| **real store** | **34.42** | **13.65** | **5,839** | **2,284** |

Cold (first poll after launch) on the real store: **750 ms → 190 ms**.

Syscall breakdown for one warm poll on the real store:

```
before: {'scandir': 1946, 'stat': 6352, 'lstat': 1440}  total 9,738
after:  {'scandir':    3, 'stat': 4343, 'lstat':    4}  total 4,350
```

**What this means for the operator:** 6.29% → **1.25%** of a core per TUI with the sidebar open; **75.4% → 15.0%** across 12 concurrent sessions. QA independently measured the same effect on the real store at **5.34% → 1.55%** per TUI (~64% → ~19% across 12 sessions), and reproduced the published table to within **+1.3…+5.4%** on the before-column and **−0.4…−0.7%** on the after-column.

A note on why syscalls are the headline: a later run of the same after-code at load average **122** reported 139.59 ms while the syscall count was **unchanged at 4,356**. Wall time there measured contention, not code.

### 3. The real path, driven end to end

Not just the functions — the **assembled TUI**, via Textual's headless pilot, with its own timer, against an 800-directory store (fresh `HOME`, isolated config dir, every inherited `CMUX_*` variable stripped so it cannot touch the operator's live sessions):

```
sidebar rows rendered: 64
top row: 00000000031f
one live poll syscalls: {'scandir': 3, 'stat': 1797, 'lstat': 10} total=1810
after appending to 00000000005c: row mtime 1788978320 -> 1788988412
SIDEBAR DRIVE OK
```

It asserts the sidebar opens, lists **only** user sessions (never a subagent), and that **a transcript appended between polls is observed on the very next poll**. The assertion is on the row's activity stamp rather than its position, because the sidebar deliberately orders by the immutable `created_at` birth key (#800) so new activity updates a row's age without reshuffling the list under the user's cursor.

QA independently booted the composed `OperatorApp` headless with the sidebar open against an isolated config dir and asserted against the widget's own `entries`: append re-ranks, a new session appears, a deletion disappears, a spool touch is seen, and a sidebar close→open round trip is clean. QA also confirmed **the same freshness tests pass on the merge base** — the correct result, proving the tests are not tautological and that this PR *preserves* freshness rather than inventing it.

### 4. The new tests fail on the old code

`tests/unit/session/test_catalog_scan_cost.py` — 14 tests, all passing. To prove the cost tests are real guards rather than tautologies, they were run against the **pre-change** implementation:

```
FAILED ...::test_a_hidden_session_costs_one_stat_not_three - assert 150 <= (50 + 5)
FAILED ...::test_the_scan_does_not_open_every_session_directory - assert 44 < 10
FAILED ...::test_a_hidden_session_adds_one_stat_not_three - assert (631 - 31) <= (200 + 10)
3 failed, 11 passed
```

The 11 correctness tests pass on **both** implementations — exactly as they should, since behaviour is unchanged.

The cost tests are named for the bound they actually assert — **one stat per hidden directory, down from three** — rather than for a scaling property that does not ship. The third test above is explicitly linear in the directories added (200 dirs → ≤200 stats); that is the real behaviour, and its docstring now says so.

The reviewer additionally **mutation-tested the freshness guards** and both mutants were killed: a permanent memo on the clock fails 2 tests, and the rejected directory-mtime gate fails 1.

### 5. Gates

```
flake8                            clean (whole tree)
black --check                     1151 files unchanged
isort --check-only                clean
pyright                           0 errors, 0 warnings
```

Full unit suite and the e2e stage are reported in the round-1 remediation comment on this PR. QA's independent run: unit **17,419 passed, 18 skipped**; e2e **93 passed, 7 skipped**.

Also verified by hand, since the glob replacement had to be faithful rather than merely faster: `pathlib.glob("*/desktop.json")` does **not** skip dot-directories, and neither does the `scandir` loop — both return `['.hidden', 'normal', 'sub']` on the same tree.

## Not addressed

- **`session_created_at` is still read per row per poll** (0.538 s of the original 6.47 s profile, now a larger *share* of a much smaller total). It is memoizable on the same stat-key pattern used here, but it is a separate concern from the scan cost this PR fixes and would widen the diff; left for a follow-up rather than folded in.
- **True `O(user sessions)` polling.** As set out above, this PR does not attempt it; it needs an index or a persistent per-directory memo keyed on the marker stat.
- **The row cache's `(mtime, size)` key can serve a stale display name** (QA round 1, Q3) — a transcript rewritten to the same byte length with its mtime restored keeps the cached name. Both the reviewer and QA verified this is **pre-existing on the merge base** (base and head behave identically) and that the **ranking clock is unaffected**, since mtime is always taken fresh from the scan. Deferred rather than fixed here: it would widen the diff beyond the scan cost.
- **`_prewarm_sidebar` running per poll.** Checked as requested; it is **already bounded** and is not doing repeated wasted work — `PREWARM_PER_REFRESH = 2`, it only fills *free* slots of the presentation cache (never evicting, which was the earlier 110 ms defect), skips already-cached, current, and refused entries, and holds one prefetch worker at a time. No change needed.
- **`pyproject.toml` is untouched at 0.52.12** — no version bump, per the release policy.

## Coordination

Cut from current `origin/main` (`6fa563ab6`). PRs #856, #859, #860 and #861 are in flight from other sessions and touch sidebar/session code; this change is the catalog **scan** cost, a different concern. No overlap was hit — flagging rather than silently reconciling.
