### PR TITLE
chore(release): bump version to 0.52.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.52.14"
+version = "0.52.15"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

Release bump for the post-v0.52.14 window: `pyproject.toml` `0.52.14` → `0.52.15`. One file, one line, no code change.

## Window contents

| PR | Merge SHA | Change |
|---|---|---|
| #825 | `df4d15b44` | `fix(analytics): classify malformed tool arguments as a model fault` |

Window derivation: `git log v0.52.14..origin/main` at claim time returned exactly `df4d15b44`, and no `chore(release)` PR was open, so no lock was held. Ownership was claimed and announced to every live lop-dev peer; four replied and all four yielded explicitly (pids 83638/#849, 65121/#856, 80485/`perf/catalog-scan`, 88791/#861+#864), each confirming their work is not merge-ready and rides a later window.

## Bump class: PATCH

`0.52.15`, not `0.53.0`. #825 corrects a misclassification inside an existing metric — no API addition, no wire or protocol change, no migration, no new surface. It does not clear the step-function bar a minor requires.

## Note for the release notes

#825 moves a **published benchmarking figure**. `invalid_arguments` is in `analytics.model.MODEL_FAULTS`, so `validity` and `tool_call_error_rate` report **higher from v0.52.15 on identical behaviour**. Argument-shape rejections raised from inside a tool body — a malformed `read` range, an uncompilable `grep` regex, an invented `effort` tier — were previously indistinguishable from genuine execution failures and were laundered into the `execution` bucket. The direction is the correct one (the metric was under-reporting), but figures either side of this tag are not comparable, and anyone tracking those numbers should not read the step as a regression.

## Scope check

`git diff` is one line of `pyproject.toml`. No source, no tests, no docs. C0.
