### PR TITLE
fix(tui): pad comfortable action rows below the summary, not only above

### DIFF
--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -365,6 +365,12 @@ Screen > .screen--selection {
 ToolCard, WakeBlock, PeerMessageBlock {
     height: 1;
     background: $lo-surface;
+    /* NOTE: the one-cell LEFT inset these cards carry is drawn by the row
+     * builder (`ToolCard.ROW_INDENT`), not declared here. It has to yield at
+     * narrow widths — see that constant — and the sheet has no width to
+     * branch on; a `padding-left` here would also have to be restated by
+     * every `.comfortable-rows` rule below, because Textual resolves
+     * `padding` as one declaration per rule. */
     /* The hand pointer, not just the hover tint: the whole row is the click
      * target for expand/collapse (ExpandableActionBlock.on_click is shared by
      * all three widgets),
@@ -451,12 +457,16 @@ ToolCard.tool-expanded, WakeBlock.wake-expanded, PeerMessageBlock.peer-expanded 
  * and the payload gives the pointer plenty to hit. */
 .comfortable-rows ToolCard, .comfortable-rows WakeBlock, .comfortable-rows PeerMessageBlock {
     height: 3;
+    /* Restates the base rule's left inset rather than adding to it: Textual
+     * resolves `padding` as ONE declaration, so writing only the vertical
+     * values here would win the whole property and drop the inset. */
     padding: 1 0 1 0;
 }
 
 .comfortable-rows ToolCard.tool-expanded, .comfortable-rows WakeBlock.wake-expanded,
 .comfortable-rows PeerMessageBlock.peer-expanded {
     height: auto;
+    /* Left value restated for the same reason as the collapsed rule above. */
     padding: 1 0 1 0;
 }
 

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -269,8 +269,33 @@ UserBlock {
     color: $lo-fg;
 }
 
-/* The prompt's half of `display.comfortable_rows`, so a prompt and an action
- * row keep one vertical rhythm rather than the setting splitting them.
+/* The prompt's half of `display.comfortable_rows`. TOP ONLY, and unlike the
+ * action row's rule next door that is not an oversight waiting to be
+ * symmetric — the two widgets are asked for different things because they
+ * paint different grounds.
+ *
+ * The pitch is therefore UNEVEN on purpose: with prompts and cards
+ * alternating, a prompt to the card under it is 2 blank rows and a card to the
+ * prompt under it is 3. Even pitch is not the goal; a visible bracket around
+ * the thing that was reported jammed against its own edge is.
+ *
+ * What makes the card's case different is FILL, not shape. `UserBlock`
+ * declares no background and paints none: its rows measure `$lo-bg` at every
+ * column, the same ground the transcript underneath it paints. So a padding
+ * row here is a row of plain GROUND, while a padding row on
+ * `.comfortable-rows ToolCard` is a row of the card's OWN `$lo-surface`. That
+ * is the whole asymmetry. The card's bottom pad BRACKETS its summary inside a
+ * visible slab, which is exactly the reported bug ("a row above the tool call
+ * but not below") fixed; a prompt's bottom pad would land against the
+ * `.gap-above` ground row already under it, in the same fill, and be
+ * indistinguishable from it — one row taller for no visible change.
+ *
+ * So `padding: 1 0 1 0` here was measured and rejected. It buys nothing the
+ * adaptive gap is not already carrying (the prompt's separation from what
+ * follows is that rule's job, and it does it in the same color the pad would
+ * be), and it spends a row on every prompt in the transcript, against the
+ * density cost this setting already admits to. Symmetry that no reader can
+ * see is not symmetry.
  *
  * VERTICAL ONLY, and that is a constraint rather than a preference. The block
  * wraps its own text (the gutter bar has to land on every wrapped row) and
@@ -382,8 +407,14 @@ ToolCard.tool-expanded, WakeBlock.wake-expanded, PeerMessageBlock.peer-expanded 
  * a naive blank-row count returns 2, and only one of them is the
  * transcript's:
  *
- *     row 24: fill=$lo-surface owner=grep            <- the card's OWN bottom pad
- *     row 25: fill=$lo-bg      owner=TranscriptView  <- the dock's one ground row
+ *     ...   fill=$lo-surface owner=grep            <- the card's OWN bottom pad
+ *     ...   fill=$lo-bg      owner=TranscriptView  <- the dock's one ground row
+ *
+ * (The two rows above the composer, in order; the absolute indices are
+ * deliberately not written down because they move with the terminal height
+ * and a reader who tried to reproduce a fixed pair would find them at no
+ * size. What reproduces at every size is the ORDER and the two fills, and
+ * that is what `test_composer_seam` asserts.)
  *
  * (Fills named by TOKEN rather than by the hex they resolved to: this sheet
  * carries no literal hex anywhere, comments included, and

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -369,35 +369,64 @@ ToolCard.tool-expanded, WakeBlock.wake-expanded, PeerMessageBlock.peer-expanded 
  * moving a single glyph — the summary is still exactly one row of text, so
  * the ledger's one-line-per-action reading is unchanged.
  *
- * `height: 2` is `1 + padding-top`. Textual sizes a fixed-height widget
- * INCLUDING its padding, so the two move together or the summary clips. The
- * class carries BOTH or neither.
+ * `height: 3` is `1 + padding-top + padding-bottom`. Textual sizes a
+ * fixed-height widget INCLUDING its padding, so the three move together or
+ * the summary clips. The class carries BOTH or neither.
  *
- * TOP ONLY, and that is a correctness requirement rather than a taste call.
- * The dock guarantees EXACTLY ONE ground row between the last block and the
- * composer (`test_composer_seam`, which counts blank rows by walking the
- * composed frame). A bottom padding row is blank, so a padded last block read
- * as a five-row seam and the guarantee broke. Padding the top only buys the
- * same separation between neighbouring rows — every row still gains a cell of
- * air above it — while the block still ENDS on its summary, so the seam below
- * the ledger is the dock's one row and nothing else.
+ * SYMMETRIC, and the argument that said otherwise was wrong. This rule read
+ * `padding: 1 0 0 0` for its whole life while the comment above promised air
+ * "above and below", on the theory that a bottom row would break the dock's
+ * EXACTLY ONE ground row between the last block and the composer. It does
+ * not, and the reason is the distinction this sheet keeps making everywhere
+ * else: the guarantee is about GROUND, not about blankness. With a card last
+ * a naive blank-row count returns 2, and only one of them is the
+ * transcript's:
  *
- * The cost is real: a twelve-row ledger occupies thirty-six rows, so less
- * history fits on a screen. That is why this is a setting rather than a
+ *     row 24: fill=$lo-surface owner=grep            <- the card's OWN bottom pad
+ *     row 25: fill=$lo-bg      owner=TranscriptView  <- the dock's one ground row
+ *
+ * (Fills named by TOKEN rather than by the hex they resolved to: this sheet
+ * carries no literal hex anywhere, comments included, and
+ * `test_minimalism.py::test_tcss_has_no_literal_hex` enforces it on the whole
+ * file text.)
+ *
+ * That is the same reading `test_composer_seam` already applies to the `/btw`
+ * aside card, whose blank row is interior to the card and asserted on the
+ * REGIONS; its module docstring says outright that "a blank row proves
+ * nothing at all about whose surface it is". Measured on the composed frame,
+ * the seam is one ground row under symmetric padding at every size. What the
+ * top-only rule actually bought was a card whose fill terminated on an inked
+ * line, with the summary jammed against the bottom edge of its own slab —
+ * reported from the field as a row added above the tool call and not below.
+ *
+ * The pitch between consecutive actions goes 3 -> 4 rows, and that is the
+ * accepted cost rather than an oversight. Holding it at 3 means suppressing
+ * the `.gap-above` ground row between neighbours, which was measured and
+ * rejected: with no ground between them two cards share ONE unbroken
+ * `$lo-surface` slab, so two DIFFERENT click targets become indistinguishable
+ * adjacent rows. That defeats `SPACING_AIRY` (widgets/transcript.py) and the
+ * hit-target purpose this rule exists for. A margin instead of padding gives
+ * the symmetry for free and returns the card to a ONE-cell target, which is
+ * deleting the feature to fix its bug; a border is out by the card's own law
+ * (widgets/tool_card.py — "NO border. Elevation is a background step, never a
+ * shadow or line.").
+ *
+ * The cost is real: a twelve-action ledger occupies 47 rows against 35, so
+ * less history fits on a screen. That is why this is a setting rather than a
  * decision made for everyone — a user who reads a long ledger more often
  * than they click one turns it off.
  *
  * Expanded rows are exempt: they are already `height: auto` and content-sized,
  * and the payload gives the pointer plenty to hit. */
 .comfortable-rows ToolCard, .comfortable-rows WakeBlock, .comfortable-rows PeerMessageBlock {
-    height: 2;
-    padding: 1 0 0 0;
+    height: 3;
+    padding: 1 0 1 0;
 }
 
 .comfortable-rows ToolCard.tool-expanded, .comfortable-rows WakeBlock.wake-expanded,
 .comfortable-rows PeerMessageBlock.peer-expanded {
     height: auto;
-    padding: 1 0 0 0;
+    padding: 1 0 1 0;
 }
 
 /* State reaches the GROUND, not just the glyph: a live action sits one step

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -216,6 +216,33 @@ def _category_element(tool_name: str) -> str:
     return _TOOL_CATEGORY.get(tool_name.strip().lower(), "tool.row.name_settled")
 
 
+#: Cells of LEFT inset on an action row's summary, so the icon does not sit
+#: flush against the left wall of the card's own fill.
+#:
+#: The row already reserves two cells for breathing room (`_build_row`:
+#: `width - 2`, the kit's one-cell-each-side rule), but it wrote the summary
+#: starting at column 0 — so both cells were spent on the right and the status
+#: column was inset while the icon and name were not. On a background-filled
+#: card that asymmetry is what a reader sees as "the text is touching the
+#: edge"; every other block in the transcript renders on the transcript's own
+#: ground, where there is no wall to touch.
+#:
+#: Drawn here rather than as `padding-left` in the stylesheet for two reasons.
+#: The sheet cannot branch on width, and this cell has to be GIVEN UP when the
+#: ledger is narrow (see :data:`ROW_INDENT_MIN_WIDTH`). And a `padding` on a
+#: `ToolCard` selector would have to be restated by every `.comfortable-rows`
+#: rule — Textual resolves `padding` as one declaration per rule — which is
+#: three more places for the value to drift.
+ROW_INDENT = 1
+
+#: Below this content width the indent is dropped. Breathing room is the first
+#: thing a narrow ledger should spend: at 30 columns the builder is already
+#: shedding the tool name a character at a time, and taking one more cell
+#: pushes it past the rung where the `⟨∅⟩` answer slot survives — the one
+#: thing `test_activating_an_inert_row_changes_the_painted_frame` protects,
+#: because it is what answers a click on a row with nothing to show.
+ROW_INDENT_MIN_WIDTH = 30
+
 NAME_COL = TOOL_NAME_COL
 #: The ceiling that widening respects. Past roughly this width the eye stops
 #: scanning a column of names and starts reading a list of them.
@@ -1678,8 +1705,29 @@ class ToolCard(ExpandableActionBlock):
         and it is the thing standing between a copied stderr and a paste that
         goes straight into a bug report — or, for a diff, between ``+ added``
         and something ``git apply`` will not read.
+
+        The summary row's field also carries :data:`ROW_INDENT`, the cell that
+        keeps the icon off the left wall of the card's own fill. It is layout
+        for exactly the same reason the icon is — drawn by this widget, meaning
+        nothing outside it — so it leaves with the icon rather than turning up
+        as a leading space in a pasted receipt. It is read back off the built
+        row rather than assumed, because the indent is given up on a narrow
+        ledger (:data:`ROW_INDENT_MIN_WIDTH`) and a gutter that over-counts
+        would eat the first character of the tool's name.
         """
-        return self.ICON_COLS if index == 0 else OUTPUT_INDENT
+        if index != 0:
+            return OUTPUT_INDENT
+        return self._row_indent() + self.ICON_COLS
+
+    def _row_indent(self) -> int:
+        """Cells of left inset on the summary row AS BUILT.
+
+        One derivation, shared by the row builder and the copy gutter, so a
+        gutter can never disagree with the row it is measured against — an
+        over-count eats the first character of the tool's name, an under-count
+        pastes a leading space into a bug report.
+        """
+        return ROW_INDENT if self._built_width >= ROW_INDENT_MIN_WIDTH else 0
 
     # -- rendering ----------------------------------------------------------
     def refresh_row(self) -> None:
@@ -2096,7 +2144,16 @@ class ToolCard(ExpandableActionBlock):
         )
         summary_element = "tool.row.summary_running" if running else "tool.row.summary_settled"
         summary_style = bindings.style(summary_element)
-        width = max(width - 2, 10)  # 1-cell inner padding each side (kit rule)
+        # The LEFT inset is taken off the budget before anything is measured,
+        # so every rung below — the name column, the D8 status cap, the narrow
+        # degradation ladder — sizes itself against the column it will really
+        # be drawn in. Taking it later would let a rung fit itself to a width
+        # the row no longer has and clip on the right.
+        # Same threshold the copy gutter reads (`_row_indent`), against the
+        # width being BUILT rather than the last one built, because this runs
+        # before `_built_width` is updated.
+        indent = ROW_INDENT if width >= ROW_INDENT_MIN_WIDTH else 0
+        width = max(width - 2 - indent, 10)  # 1-cell inner padding each side (kit rule)
 
         # Status segment (right-aligned), capped at width // 3 (D8) and then
         # hard-clamped so no state can ever push the row past its card.
@@ -2127,6 +2184,8 @@ class ToolCard(ExpandableActionBlock):
             # Too narrow for even a shrunken name: degrade to icon + status
             # so the outcome column survives. This is the last rung.
             row = _row_text()
+            if indent:
+                row.append(" " * indent, style=dim)
             row.append(icon + " ", style=dim)
             if status_runs:
                 used = cell_len(row.plain)
@@ -2232,6 +2291,8 @@ class ToolCard(ExpandableActionBlock):
             summary = truncate_cells(self._summary, budget)
 
         row = _row_text()
+        if indent:
+            row.append(" " * indent, style=dim)
         # See `bindings.BY_ELEMENT["tool.row.icon_running"].note`.
         #
         # A SETTLED icon takes the name's own category ink rather than one

--- a/tests/unit/tui/test_composer_seam.py
+++ b/tests/unit/tui/test_composer_seam.py
@@ -45,7 +45,7 @@ from typing import Any
 
 import pytest
 
-from local_operator.tui.app import OperatorApp
+from local_operator.tui.app import COMFORTABLE_ROWS_CLASS, OperatorApp
 from local_operator.tui.widgets.aside_panel import AsidePanel
 from local_operator.tui.widgets.assistant import AssistantBlock
 from local_operator.tui.widgets.editor import Editor
@@ -354,6 +354,143 @@ async def test_closing_the_aside_hands_the_row_back(size: tuple[int, int]) -> No
         assert app.query_one(TranscriptView).styles.padding.bottom == 1
         assert _seam(app) == 1, _frame(app)[-8:]
         assert "interrupted" in _last_painted_row(app)
+
+
+async def _comfortable(pilot: Any, app: OperatorApp, turns: int = 6) -> None:
+    """A filled conversation with comfortable density ON, settled.
+
+    The class goes on the SCREEN because that is where the app puts it
+    (``_sync_row_density_class``); adding it per widget would test a shape the
+    app never builds.
+    """
+    app.screen.add_class(COMFORTABLE_ROWS_CLASS)
+    await _fill(pilot, app, turns=turns)
+    await _settle(pilot)
+
+
+def _last_card(app: OperatorApp) -> ToolCard:
+    """The bottom-most tool row that is fully on screen."""
+    cards = [c for c in app.query(ToolCard) if c.region.y >= 0 and c.region.bottom <= app.size.height]
+    assert cards, "no tool card is fully visible"
+    return cards[-1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", SIZES)
+async def test_comfortable_rows_pads_a_card_above_AND_below(size: tuple[int, int]) -> None:
+    """The setting's own promise: air on BOTH sides of the summary.
+
+    Reported from the field as "it adds a row to the top of the tool call but
+    not the bottom", and the sheet's comment had claimed "above and below"
+    since the rule was written while it declared ``padding: 1 0 0 0``. The
+    whole class was untested — nothing in this repo had ever turned comfortable
+    density on — which is exactly how a rule and its own comment stayed in
+    contradiction.
+
+    Measured on the frame, not on the declaration: the blank rows have to be
+    painted in the CARD's fill, because a padding row that resolved to ground
+    would be the card shrinking rather than the air the setting sells. The
+    fills are compared to each other rather than to a literal so a theme change
+    cannot turn this into a false failure.
+    """
+    app, _session = _app()
+    async with app.run_test(size=size) as pilot:
+        await _comfortable(pilot, app)
+        card = _last_card(app)
+
+        assert card.region.height == 3, (card.region, _frame(app)[-8:])
+        top, summary, bottom = card.region.y, card.region.y + 1, card.region.y + 2
+        frame = _frame(app)
+        assert not frame[top].strip(), frame[top - 1 : bottom + 1]
+        assert frame[summary].strip(), frame[top - 1 : bottom + 1]
+        assert not frame[bottom].strip(), frame[top - 1 : bottom + 1]
+
+        # Both pad rows are the CARD's surface, the same one its summary sits
+        # on — the row below is interior to the widget, not the transcript's.
+        own = _fill_at(app, summary, 2)
+        assert _fill_at(app, top, 2) == own, frame[top - 1 : bottom + 1]
+        assert _fill_at(app, bottom, 2) == own, frame[top - 1 : bottom + 1]
+        assert own != _fill_at(app, card.region.bottom, 2), "the card's fill must end with the card"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", SIZES)
+async def test_comfortable_rows_still_leaves_exactly_one_ground_row(size: tuple[int, int]) -> None:
+    """The seam holds with a padded card last, and this is the assertion the
+    original reasoning error needed.
+
+    That error is worth keeping written down: the rule was left top-only
+    because a bottom padding row is BLANK, and a blank row under the last block
+    was read as the seam growing. It is not — the guarantee is about GROUND.
+    With a padded card last the frame carries two blank rows and they have
+    different owners: the upper one is the card's own bottom pad in its fill,
+    the lower is the transcript's single ground row. So this counts fills, the
+    way the ``/btw`` aside case next door does, rather than blank rows.
+    """
+    app, _session = _app()
+    async with app.run_test(size=size) as pilot:
+        await _comfortable(pilot, app)
+        app._append_block(_card("grep"))
+        await _settle(pilot)
+
+        transcript = app.query_one(TranscriptView)
+        assert transcript.max_scroll_y > 0, "the case that matters is a scrollable transcript"
+        shell = app.query_one("#input-shell")
+        ground = _fill_at(app, shell.region.y - 1, 2)
+        card = _last_card(app)
+
+        # Exactly one GROUND row: the row above the composer is ground, and the
+        # one above THAT is the card's own pad rather than more ground.
+        assert card.region.bottom == shell.region.y - 1, (card.region, shell.region)
+        assert _fill_at(app, card.region.y + 2, 2) == _fill_at(app, card.region.y + 1, 2)
+        assert _fill_at(app, card.region.y + 2, 2) != ground, _frame(app)[-8:]
+        assert ground != _fill_at(app, shell.region.y, 2), "the seam row is not the composer's fill"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", SIZES)
+async def test_comfortable_rows_keep_neighbouring_cards_separated(size: tuple[int, int]) -> None:
+    """Two actions stay two targets: ground between every pair of cards.
+
+    The tempting way to keep the content pitch at 3 under symmetric padding is
+    to suppress the ``.gap-above`` row between neighbours. This is the test
+    that says no. Without that row two cards share one unbroken ``$lo-surface``
+    slab, and two DIFFERENT click targets become indistinguishable adjacent
+    rows — which is the hit-target purpose of the rule defeated by its own
+    density fix.
+    """
+    app, _session = _app()
+    async with app.run_test(size=size) as pilot:
+        app.query_one(Editor).cursor_blink = False
+        app.screen.add_class(COMFORTABLE_ROWS_CLASS)
+        await _settle(pilot)
+        # A RUN of consecutive actions — the shape the fused-slab risk lives in.
+        # ``_fill`` interleaves prose and user blocks, which separates the cards
+        # for unrelated reasons and would pass without proving anything.
+        app._append_block(UserBlock("run the suite"))
+        for n in range(5):
+            app._append_block(_card(f"bash{n}"))
+        await _settle(pilot, 4)
+
+        transcript = app.query_one(TranscriptView)
+        visible = [
+            c
+            for c in app.query(ToolCard)
+            if c.region.y >= transcript.region.y and c.region.bottom <= transcript.region.bottom
+        ]
+        assert len(visible) >= 2, "need two cards on screen to measure the gap between them"
+
+        for upper, lower in zip(visible, visible[1:]):
+            gap = list(range(upper.region.bottom, lower.region.y))
+            assert gap, (upper.region, lower.region, "cards are fused with no row between them")
+            # Ground, not merely a blank row: a second card's own pad row is
+            # blank too, and that is precisely the fusion this rejects.
+            own = _fill_at(app, upper.region.y + 1, 2)
+            for y in gap:
+                assert _fill_at(app, y, 2) != own, (
+                    y,
+                    _frame(app)[upper.region.y : lower.region.bottom],
+                )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_composer_seam.py
+++ b/tests/unit/tui/test_composer_seam.py
@@ -50,7 +50,13 @@ from local_operator.tui.widgets.aside_panel import AsidePanel
 from local_operator.tui.widgets.assistant import AssistantBlock
 from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.tool_card import ToolCard
-from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView, UserBlock
+from local_operator.tui.widgets.transcript import (
+    NoticeBlock,
+    PeerMessageBlock,
+    TranscriptView,
+    UserBlock,
+    WakeBlock,
+)
 from local_operator.tui.widgets.welcome import WelcomeView
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
 from tests.unit.tui.test_aside import AsideSession
@@ -369,10 +375,36 @@ async def _comfortable(pilot: Any, app: OperatorApp, turns: int = 6) -> None:
 
 
 def _last_card(app: OperatorApp) -> ToolCard:
-    """The bottom-most tool row that is fully on screen."""
-    cards = [c for c in app.query(ToolCard) if c.region.y >= 0 and c.region.bottom <= app.size.height]
+    """The bottom-most tool row lying fully inside the TRANSCRIPT's viewport.
+
+    Bounded by the transcript rather than by ``app.size.height``, which is the
+    screen: the dock is on screen too, so a card scrolled under the dock still
+    satisfied the screen bound and came back as "fully visible" — measured at
+    ``y=35``/``bottom=38`` against a viewport ending at 34. Every caller here
+    reads fills off the composed frame, and a row the transcript is not
+    painting answers a different question than the one being asked.
+    """
+    view = app.query_one(TranscriptView).region
+    cards = [
+        c for c in app.query(ToolCard) if c.region.y >= view.y and c.region.bottom <= view.bottom
+    ]
     assert cards, "no tool card is fully visible"
     return cards[-1]
+
+
+#: The three widgets `.comfortable-rows` names in ONE selector, each built the
+#: way the app builds it. They are pinned together for the reason
+#: `test_minimalism.py` already pins their height contract together ("so the
+#: three cannot drift"): a wake receipt and an inbound peer receipt are ledger
+#: rows, they ride this rule through the same combined selector, and a fix
+#: verified on `ToolCard` alone is a fix verified on one third of the rule.
+ACTION_ROWS: dict[str, Any] = {
+    "tool": lambda: _card("grep"),
+    "wake": lambda: WakeBlock("(alarm) Scheduled wake w1 (1).\n\ncheck the build"),
+    "peer": lambda: PeerMessageBlock(
+        "ship the release note", {"pid": 7, "conversation_name": "peer-a"}
+    ),
+}
 
 
 @pytest.mark.asyncio
@@ -411,6 +443,103 @@ async def test_comfortable_rows_pads_a_card_above_AND_below(size: tuple[int, int
         assert _fill_at(app, top, 2) == own, frame[top - 1 : bottom + 1]
         assert _fill_at(app, bottom, 2) == own, frame[top - 1 : bottom + 1]
         assert own != _fill_at(app, card.region.bottom, 2), "the card's fill must end with the card"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", SIZES)
+@pytest.mark.parametrize("kind", sorted(ACTION_ROWS))
+async def test_every_action_row_kind_is_padded_above_AND_below(
+    kind: str, size: tuple[int, int]
+) -> None:
+    """The same promise for all three widgets on the selector, not just the card.
+
+    ``.comfortable-rows`` names ``ToolCard``, ``WakeBlock`` and
+    ``PeerMessageBlock`` in one rule, and ``test_minimalism`` pins their height
+    contract as one for the same reason. The padding fix was measured on the
+    tool card; a wake and a peer receipt reach the frame by a different builder
+    and this is what says they land the same way. Both were checked by hand
+    before being pinned, so this locks a passing property rather than chasing a
+    defect.
+    """
+    app, _session = _app()
+    async with app.run_test(size=size) as pilot:
+        app.query_one(Editor).cursor_blink = False
+        app.screen.add_class(COMFORTABLE_ROWS_CLASS)
+        await _settle(pilot)
+        block = ACTION_ROWS[kind]()
+        app._append_block(UserBlock("what happened"))
+        app._append_block(block)
+        await _settle(pilot, 4)
+
+        assert block.region.height == 3, (block.region, _frame(app)[-8:])
+        top, summary, bottom = block.region.y, block.region.y + 1, block.region.y + 2
+        frame = _frame(app)
+        assert not frame[top].strip(), frame[top - 1 : bottom + 1]
+        assert frame[summary].strip(), frame[top - 1 : bottom + 1]
+        assert not frame[bottom].strip(), frame[top - 1 : bottom + 1]
+
+        # The pad rows are the WIDGET's own surface on both sides, which is what
+        # makes them air inside a slab rather than the slab shrinking.
+        own = _fill_at(app, summary, 2)
+        assert _fill_at(app, top, 2) == own, frame[top - 1 : bottom + 1]
+        assert _fill_at(app, bottom, 2) == own, frame[top - 1 : bottom + 1]
+        assert own != _fill_at(app, block.region.bottom, 2), "the fill must end with the widget"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", SIZES)
+@pytest.mark.parametrize("kind", sorted(ACTION_ROWS))
+async def test_an_expanded_action_row_keeps_its_padding_without_clipping(
+    kind: str, size: tuple[int, int]
+) -> None:
+    """The expanded rule pairs the new bottom pad with ``height: auto``, and
+    nothing exercised that pairing.
+
+    This is the failure the stylesheet warns about one rule up: Textual sizes a
+    fixed-height widget INCLUDING its padding, so on the collapsed rule the
+    three numbers move together or the summary clips. The expanded rule escapes
+    that arithmetic by being content-sized — but only if ``height: auto``
+    actually grows to carry the two pad rows. If it did not, the row that fell
+    off would be the LAST line of revealed output, which is the one a reader
+    opened the card for.
+
+    So this measures the payload's final row, not merely the widget's height: a
+    card 2 rows taller than its content with the last output line still on the
+    frame is the whole contract.
+    """
+    app, _session = _app()
+    async with app.run_test(size=size) as pilot:
+        app.query_one(Editor).cursor_blink = False
+        app.screen.add_class(COMFORTABLE_ROWS_CLASS)
+        await _settle(pilot)
+        block = ACTION_ROWS[kind]()
+        app._append_block(block)
+        await _settle(pilot, 4)
+
+        collapsed = block.region.height
+        assert collapsed == 3, (block.region, _frame(app)[-8:])
+        assert block.toggle_expanded() is True, f"{kind} refused to expand"
+        await _settle(pilot, 4)
+
+        region = block.region
+        assert region.height > collapsed, (region, "expanding gained no rows")
+        frame = _frame(app)
+        top, bottom = region.y, region.bottom - 1
+        # Padding survives `height: auto`: still a blank row on each edge, still
+        # in the widget's own fill.
+        own = _fill_at(app, region.y + 1, 2)
+        assert not frame[top].strip(), frame[top : bottom + 1]
+        assert not frame[bottom].strip(), frame[top : bottom + 1]
+        assert _fill_at(app, top, 2) == own, frame[top : bottom + 1]
+        assert _fill_at(app, bottom, 2) == own, frame[top : bottom + 1]
+
+        # NOTHING clipped: the content rows are the interior, and the last of
+        # them still carries ink. A pad row that stole a row of payload would
+        # leave this one blank.
+        content = list(range(top + 1, bottom))
+        assert content, (region, "no content rows between the pads")
+        assert frame[content[-1]].strip(), frame[top : bottom + 1]
+        assert region.height == len(content) + 2, (region, len(content))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_tool_card.py
+++ b/tests/unit/tui/test_tool_card.py
@@ -58,6 +58,8 @@ from local_operator.tui.widgets.tool_card import (
     LIVE_HEADER_RUNNING,
     LIVE_MAX_LINES,
     NO_OUTPUT_NOTICE,
+    ROW_INDENT,
+    ROW_INDENT_MIN_WIDTH,
     RUNNING_NOTICE,
     TERSE_NO_OUTPUT_NOTICE,
     ToolCard,
@@ -1181,18 +1183,39 @@ def test_a_degenerate_mcp_name_keeps_whatever_it_has() -> None:
 
 
 def test_the_icon_leads_the_row_and_displaces_neither_name_nor_summary() -> None:
-    """The icon is added TO the row, not instead of part of it."""
+    """The icon is added TO the row, not instead of part of it.
+
+    Led after the row's left inset (``ROW_INDENT``), not from column 0: the
+    summary is drawn on the card's own fill, and the icon sitting flush
+    against that fill's left wall is what the inset exists to stop.
+    """
     card = ToolCard("t", "grep", {"pattern": "needle"})
     row = card._build_row(80).plain
-    assert row.startswith(tool_icon("grep") + " ")
+    assert row.startswith(" " * ROW_INDENT + tool_icon("grep") + " ")
     assert "grep" in row and "needle" in row
     _assert_fits(card)
+
+
+def test_the_row_indent_is_given_up_before_the_answer_slot() -> None:
+    """The inset is breathing room, and breathing room goes first.
+
+    At the narrow end the builder is already shedding the tool name a
+    character at a time; one more cell spent on aesthetics pushes the row past
+    the rung where the inert-row answer survives. So the indent is present at
+    the threshold and gone below it — asserted at the boundary rather than at
+    a comfortable width, because the boundary is the part that can regress.
+    """
+    icon = tool_icon("grep")
+    at_threshold = ToolCard("t", "grep", {"pattern": "needle"})
+    assert at_threshold._build_row(ROW_INDENT_MIN_WIDTH).plain.startswith(" " * ROW_INDENT + icon)
+    below = ToolCard("t", "grep", {"pattern": "needle"})
+    assert below._build_row(ROW_INDENT_MIN_WIDTH - 1).plain.startswith(icon)
 
 
 def test_two_different_tools_do_not_share_a_row_prefix() -> None:
     """The whole point of the icon: a run of rows is told apart by shape."""
     prefixes = {
-        name: ToolCard("t", name, {})._build_row(80).plain[0]
+        name: ToolCard("t", name, {})._build_row(80).plain[ROW_INDENT]
         for name in ("bash", "read", "write", "grep", "browser")
     }
     assert len(set(prefixes.values())) == len(prefixes), prefixes
@@ -1908,7 +1931,7 @@ def test_a_running_row_names_its_command_not_its_argument_bytes() -> None:
     card.begin_running("bash", {"command": command}, None)
     running = card._build_row(80).plain
     assert "199 B" not in running
-    assert running.startswith(f"{tool_icon('bash')} bash")
+    assert running.startswith(f"{' ' * ROW_INDENT}{tool_icon('bash')} bash")
     assert "cd ~/local-operator && git remote" in running
 
     card.mark_done("exit code: 0\nok")

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -78,7 +78,7 @@ from local_operator.tui.widgets import _copy_markdown
 from local_operator.tui.widgets.assistant import AssistantBlock, flatten
 from local_operator.tui.widgets.editor import BARREN_CLICK_WINDOW_S, Editor
 from local_operator.tui.widgets.toast import TOAST_FAILURE_MS, Toast
-from local_operator.tui.widgets.tool_card import OUTPUT_INDENT, ToolCard
+from local_operator.tui.widgets.tool_card import OUTPUT_INDENT, ROW_INDENT, ToolCard
 from local_operator.tui.widgets.transcript import (
     BOOT_COLUMN_CLASS,
     SPINE_INDENT,
@@ -703,7 +703,10 @@ async def test_tool_card_expanded_output_copies_unindented() -> None:
         assert rows[0].startswith("bash")  # no icon, no leading pad
         assert tool_icon("bash") not in copied
         assert "✗" in rows[0] and "pytest -q" in rows[0]  # the receipt survives
-        assert card.copy_gutter(0) == ToolCard.ICON_COLS
+        # The summary's gutter is the icon field PLUS the row's left inset:
+        # both are this widget's own layout, so both leave with the copy
+        # rather than pasting a leading space into a bug report.
+        assert card.copy_gutter(0) == ROW_INDENT + ToolCard.ICON_COLS
         assert card.copy_gutter(1) == OUTPUT_INDENT
 
 


### PR DESCRIPTION
## Summary

`display.comfortable_rows` promises, in its own stylesheet comment, "one padding row above and below an action's summary". It only padded the top. Because `ToolCard` paints `$lo-surface` across its whole padded box, the collapsed card rendered as a 2-row filled slab with the summary jammed against the **bottom edge of its own fill**:

```
ToolCard y=5 h=2 padding=Spacing(top=1, right=0, bottom=0, left=0)
   row 5: fill=$lo-surface  text=''
   row 6: fill=$lo-surface  text='  bash0    pytest tests/unit -q'
```

Reported as: *"when you enable the comfy rows appearance setting it adds a row to the top of the tool call but not the bottom."*

**Change class: C1** — standard, pre-authorized. **Release: patch.**

## Why it shipped that way

The rule carried a paragraph titled *"TOP ONLY, and that is a correctness requirement rather than a taste call"*, arguing that a bottom padding row would break the dock's "exactly one ground row between the last block and the composer" guarantee.

**That claim is false, and it is what caused the bug.** The guarantee is about *ground*, and it survives symmetric padding. With a card last, a naive blank-row count returns 2 — but only one of those rows is the transcript's ground:

```
row N   fill=$lo-surface  owner=grep            <- the card's OWN bottom pad
row N+1 fill=$lo-bg       owner=TranscriptView  <- the dock's one ground row
```

This is the identical distinction `test_composer_seam.py` already draws for the `/btw` aside card, and its own module docstring warns that "a blank row proves nothing at all about whose surface it is". The old rationale counted blankness where it should have counted surface.

## The fix

Both `.comfortable-rows` rules become symmetric — collapsed `height: 2` → `height: 3` with `padding: 1 0 1 0`; expanded keeps `height: auto` with the same padding. **No Python change**: the three widgets size from the stylesheet directly, so the sheet is the only place the height is declared.

The rationale comment is rewritten rather than amended, since the paragraph that caused the bug had to go.

## Rejected alternatives, measured on rendered frames

- **Suppress the `.gap-above` ground row** to hold the old pitch — consecutive cards fuse into one unbroken `$lo-surface` slab and two *different* click targets become indistinguishable adjacent rows. That defeats `SPACING_AIRY` and the rule's stated purpose as a hit target.
- **Padding → margin** — fixes symmetry, but a margin sits outside the widget box, returning the card to a 1-cell click target. Deletes the feature to fix its bug.
- **A border instead of a fill** — forbidden by `tool_card.py:6`: *"NO border. Elevation is a background step, never a shadow or line."*

## Accepted cost

Content pitch between consecutive action rows goes **3 → 4**; a 12-action ledger goes **35 → 47 rows**. The setting is opt-in and defaults OFF. Design round confirmed on rendered frames that the ledger still reads as one line per action and that the boundary between consecutive cards stays legible — fill:gap ratio 1:3 at 1.088:1 contrast, where the length of the fill run on either side is what makes the single ground row register as a deliberate channel.

## The prompt rule

`.comfortable-rows UserBlock` stays top-only, and its comment — which claimed the two rules existed "so a prompt and an action row keep one vertical rhythm" — is corrected instead. `UserBlock` paints **no fill of its own** (measured `$lo-bg` across x1/x3/x40), so a pad row on a prompt is plain ground, while a card's is its own `$lo-surface`. Bracketing inside a visible fill is exactly what fixes the reported bug; a prompt's bottom pad would sit adjacent to the `.gap-above` ground row and be indistinguishable from it — a row taller for no visible change. The pitch is therefore deliberately uneven, and the comment now says so.

## Testing evidence

**Coverage gap this closes:** before this PR, `grep -rln COMFORTABLE_ROWS_CLASS tests/` returned **nothing**. No test had ever enabled comfortable density, which is why the asymmetry shipped.

Three tests added to `test_composer_seam.py`, parametrized over its `SIZES` and over all three widgets that ride the selector (`ToolCard`, `WakeBlock`, `PeerMessageBlock` — `test_minimalism.py` deliberately pins the three together "so the three cannot drift"):

1. **Symmetry** — a collapsed action row owns exactly one blank row above *and* below its summary, both in the card's own fill.
2. **Seam under comfortable density** — exactly one **ground**-filled row above `#input-shell`, asserted via `_fill_at` rather than a blank-row count. This is the assertion that would have caught the original reasoning error.
3. **Expanded rows keep their padding without clipping** — `height == len(content) + 2`, last output row intact.

Tests assert fill *relationships*, never literal hex, so a theme change cannot produce a false failure.

**Proven to fail against the old stylesheet** in a scratch worktree at the base commit (not `git stash`): **18 failed**. Isolating the expanded rule by applying only the collapsed fix: 9 failed, including `assert not '66 passed'` — the last output row landing on a pad row, the exact clipping case.

**Full TUI suite on the merged tree** (`origin/main` merged in, clean, 9 files, none under `local_operator/tui/`):

```
6573 passed, 12 skipped, 12 warnings in 766.20s (0:12:46)
```

6555 → 6573 is exactly the 18 new cases. The count was taken on a tree verified clean of probe files.

**Adversarial QA** attempted to falsify the seam claim and could not: sizes 120x40, 60x40, 100x24, 80x20, 60x18, 40x16, 200x60, 30x24; collapsed and expanded card last; growth one block at a time into the seam; working line appear/dismiss; `/btw` aside still flush; every integer scroll offset. Ground stays 1 in every frame. Expand/collapse cycles alternate `3 ↔ 5` with no stale height or clipping; live toggling the setting preserves tail-following and scroll position in both directions. Boot splash and docked band regions are byte-identical ON vs OFF. Hit-testing confirmed all three rows toggle the card — the padding rows genuinely are click surface.

## Not addressed

- `.comfortable-rows UserBlock` remains top-only by design (see above).
- `WakeBlock` expanded renders a blank row where the message should be — **pre-existing**, reproduces on `main` with the setting OFF, out of scope for this PR.
- The setting's user-facing description does not mention that comfortable density roughly halves visible history on a short terminal.
