### PR TITLE
fix(tools): gate `ask` on the hook alone, not on `has_ui`

### DIFF
--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -159,10 +159,16 @@ def _question_prose(question: Any) -> str:
     future rename of the model's field breaks in one place instead of silently
     degrading to the fallback in several.
 
-    ``getattr`` rather than ``question.question`` because this seam is also
-    handed the phone's decoded projections, which are duck-typed rather than
-    the pydantic model. The fallback is deliberately a sentence a human can
-    read on a notification banner, matching ``ask_pending_request``'s.
+    ``getattr`` rather than ``question.question`` is DEFENSIVE, not a caller
+    requirement: every current call site receives ``list[AskQuestion]`` straight
+    from ``AskUserFn``, and no path hands this a duck-typed object (the phone's
+    decode runs the other way, through ``ask_pending_request``). It is written
+    this way to match the sibling read in ``mobile/types.py`` and because a gate
+    announcement must degrade to a readable sentence rather than raise — an
+    ``AttributeError`` here would escape into the gate path and take down a
+    question a human was about to answer. The fallback is deliberately a
+    sentence a human can read on a notification banner, matching
+    ``ask_pending_request``'s.
     """
     return str(getattr(question, "question", "") or "the agent is asking")
 
@@ -469,21 +475,41 @@ class OwnedSessionHandle(SessionHandle):
                     )
                 )
                 self._notify()
+                prose = _question_prose(question)
                 # ``question``, not ``text``: :class:`AskQuestion` has no ``text``
-                # field and sets ``extra="forbid"``, so it can never grow one — the
-                # old read always fell through to the literal "question" and the
-                # desktop notification, the ``lop sessions`` pending state and the
-                # timeout row REPLAYED TO THE MODEL all named nothing. It survived
-                # because this whole gate was unreachable until #868: both its
-                # hosts build ``has_ui=False``, which the removed ``build_ask_tool``
-                # clause vetoed, so the body never ran. ``ask_pending_request``
-                # (mobile/types.py) reads the right field, which is why the phone
-                # card rendered correctly while these two did not.
-                self._announce_pending("ask", _question_prose(question), "")
+                # field and sets ``extra="forbid"``, so it can never grow one, and
+                # the old read always fell through to the literal "question". What
+                # that actually degraded is narrower than it looks: the projection
+                # card reads the field directly through ``ask_pending_request`` and
+                # was always right, and ``lop sessions`` publishes the KIND
+                # (``set_record_pending``) so prose never travelled there at all.
+                # The reads it did break are ``_parked_announcement`` /
+                # ``reannounce_pending`` and the timeout row REPLAYED TO THE MODEL.
+                # It survived because this whole gate was unreachable until #868:
+                # both its hosts build ``has_ui=False``, which the removed
+                # ``build_ask_tool`` clause vetoed, so the body never ran.
+                #
+                # The prose is passed as DETAIL as well as title because the
+                # notification body is composed from ``detail`` alone — a banner
+                # built from the title is unreachable when detail is empty, so an
+                # ask toast read the static "Waiting for your answer" while the
+                # approval toast beside it named its action ("write: /etc/hosts").
+                # A user who walked away could see that a decision was owed but
+                # not which one.
+                #
+                # EXCEPT for a secret question, which stays terse deliberately. Its
+                # prose names the credential being requested ("Paste your OpenAI
+                # key"), and a lock-screen banner is exactly the surface that must
+                # not enumerate which of the user's keys a session is missing. The
+                # VALUE was never at risk here — the gate announces before any
+                # answer exists — so this guards the QUESTION, and the shared
+                # ``BODIES["ask"]`` vocabulary is the right fallback for it.
+                announced = "" if getattr(question, "secret", False) else prose
+                self._announce_pending("ask", prose, announced)
                 try:
                     answer = await asyncio.wait_for(future, timeout=self._gate_timeout_s())
                 except TimeoutError:
-                    await self._record_gate_timeout("ask", _question_prose(question), kind="ask")
+                    await self._record_gate_timeout("ask", prose, kind="ask")
                     # A timed-out question ends the whole ask: report whatever
                     # earlier questions collected (partial, like the terminal's
                     # Escape) rather than blocking forever on the next one.

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -149,6 +149,24 @@ def _already_bounded(images: Any) -> bool:
     return not isinstance(images[0], Mapping)
 
 
+def _question_prose(question: Any) -> str:
+    """The human-readable prose of an ask, for surfaces that ANNOUNCE it.
+
+    One function rather than two ``getattr`` calls because the two call sites
+    below drifted together: both read a ``text`` attribute
+    :class:`~local_operator.harness.types.AskQuestion` does not have and, with
+    ``extra="forbid"``, cannot ever be given. Naming the read once means a
+    future rename of the model's field breaks in one place instead of silently
+    degrading to the fallback in several.
+
+    ``getattr`` rather than ``question.question`` because this seam is also
+    handed the phone's decoded projections, which are duck-typed rather than
+    the pydantic model. The fallback is deliberately a sentence a human can
+    read on a notification banner, matching ``ask_pending_request``'s.
+    """
+    return str(getattr(question, "question", "") or "the agent is asking")
+
+
 @dataclass
 class _PromptCommand:
     command_id: str
@@ -451,13 +469,21 @@ class OwnedSessionHandle(SessionHandle):
                     )
                 )
                 self._notify()
-                self._announce_pending("ask", getattr(question, "text", "") or "question", "")
+                # ``question``, not ``text``: :class:`AskQuestion` has no ``text``
+                # field and sets ``extra="forbid"``, so it can never grow one — the
+                # old read always fell through to the literal "question" and the
+                # desktop notification, the ``lop sessions`` pending state and the
+                # timeout row REPLAYED TO THE MODEL all named nothing. It survived
+                # because this whole gate was unreachable until #868: both its
+                # hosts build ``has_ui=False``, which the removed ``build_ask_tool``
+                # clause vetoed, so the body never ran. ``ask_pending_request``
+                # (mobile/types.py) reads the right field, which is why the phone
+                # card rendered correctly while these two did not.
+                self._announce_pending("ask", _question_prose(question), "")
                 try:
                     answer = await asyncio.wait_for(future, timeout=self._gate_timeout_s())
                 except TimeoutError:
-                    await self._record_gate_timeout(
-                        "ask", getattr(question, "text", "") or "question", kind="ask"
-                    )
+                    await self._record_gate_timeout("ask", _question_prose(question), kind="ask")
                     # A timed-out question ends the whole ask: report whatever
                     # earlier questions collected (partial, like the terminal's
                     # Escape) rather than blocking forever on the next one.

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -5253,6 +5253,12 @@ class Session:
         a child session is built without this handler and so never advertises a
         question it could only block on.
 
+        That paragraph described the DESIGN while the builder carried a second
+        ``has_ui`` clause that contradicted it, which is how #868 hid: the
+        detached runtime behind every interactive session builds with the flag
+        off and installs this hook anyway, so the tool was withheld from the
+        default path. The builder now matches this text; do not re-add the flag.
+
         Which is why the inventory is REBUILT here and not only in ``__init__``.
         The constructor's capability merge runs before any front end can install
         this hook (the TUI resolves its session in a worker and installs it in

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -703,16 +703,35 @@ def _default_convert_to_llm(messages: list[AgentMessage]) -> list[Message]:
             tool = str(details.get("tool") or "a tool")
             description = str(details.get("description") or "").strip()
             subject = f"{tool} ({description})" if description else tool
-            out.append(
-                _injected_user_message(
-                    (
-                        f"[system] The approval request for {subject} expired with "
-                        "nobody attached to this session and was denied automatically. "
-                        "This was a timeout, not a decision by the user."
-                    ),
-                    message.id,
+            # An `ask` is a QUESTION, and an unanswered question was not
+            # "denied" — the approval gate's vocabulary describes a refusal
+            # nobody issued, and a model told its question was denied re-plans
+            # around that phantom decision. `tui/app.py`'s parked-gate summary
+            # already branches here for the HUMAN (D12's copy note); this is
+            # the same row rendered for the model, and until #868 made the ask
+            # gate reachable it could only ever carry an approval.
+            #
+            # The ask arm ends the way ``ASK_UNANSWERED_TEXT`` does, on
+            # purpose: an expiry and a user pressing `esc` are both "no answer
+            # came back", so the two must leave the model in the same place
+            # rather than one nudging it to decide and the other implying it
+            # was refused.
+            kind = str(details.get("kind") or "approval").strip().lower()
+            if kind == "ask":
+                text = (
+                    f"[system] The question for {subject} was never answered: nobody "
+                    "was attached to this session and it expired. No decision was "
+                    "made — this was a timeout, not a choice by the user. Decide "
+                    "yourself (take your recommended option where you gave one), then "
+                    "say in one line what you assumed and carry on."
                 )
-            )
+            else:
+                text = (
+                    f"[system] The approval request for {subject} expired with "
+                    "nobody attached to this session and was denied automatically. "
+                    "This was a timeout, not a decision by the user."
+                )
+            out.append(_injected_user_message(text, message.id))
         elif message.custom_type in (
             "fork_boundary",
             WAKE_PROMPT_MESSAGE_TYPE,

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -10754,19 +10754,33 @@ def _ask_report(questions: list[AskQuestion], answers: dict[str, list[str]]) -> 
 def build_ask_tool(context: ToolContext) -> AgentTool | None:
     """CreateIf builder: the tool exists only where a human can answer it.
 
-    Gated on the HOOK, not on ``has_ui``: a subagent inherits ``has_ui`` from
-    its parent and has no human at its keyboard, so gating on the flag alone
-    would let a delegated child mount a question on the parent's screen — for
-    work the person watching it never asked about — and block on it. A child
-    session is built without an ask handler, which makes the hook's absence the
-    honest signal for every unanswerable case at once: server, exec mode,
-    scheduler runs and subagents.
+    Gated on the HOOK ALONE, and not additionally on ``has_ui``: a subagent
+    inherits ``has_ui`` from its parent and has no human at its keyboard, so
+    gating on the flag would let a delegated child mount a question on the
+    parent's screen — for work the person watching it never asked about — and
+    block on it. A child session is built without an ask handler, which makes
+    the hook's absence the honest signal for every unanswerable case at once:
+    server, exec mode, scheduler runs and subagents.
 
-    ``has_ui`` is still required, and not as a duplicate of that check: a host
-    declaring no UI is asserting it cannot mount a prompt, and a tool must
-    believe that over a handler somebody left installed.
+    ``has_ui`` was a second clause here until #868, and it was the accident
+    rather than the design (the ``set_ask_handler`` docstring already described
+    the hook-only rule this now implements). The flag means "this host drives a
+    rich frontend state store", NOT "a human is present": ``spawn_owned_session``
+    — the detached runtime every interactive ``lop`` session has booted through
+    since 0.45.0 — constructs with ``has_ui=False`` and *then* installs a real
+    ask gate, so the flag vetoed the tool on the default path while a person sat
+    at the terminal ready to answer. ``ask`` reached no model there at all.
+
+    Flipping that construction to ``has_ui=True`` instead is not available:
+    ``session_factory`` keys the RemoteSession takeover branch on
+    ``has_ui and resume_id is not None`` and ``spawn_owned_session`` passes
+    ``resume``, so the daemon's writer path would divert into follower takeover.
+
+    ``exec --control`` gains the tool under this rule, which is correct rather
+    than a leak: it opts into the gate explicitly (``install_gates=supervised``)
+    and ``runtime/server.py`` serves an ``ask_answer`` op for the supervisor.
     """
-    if context.ask_user is None or not context.has_ui:
+    if context.ask_user is None:
         return None
     return AgentTool(
         name="ask",

--- a/tests/e2e/test_ask_tool_e2e.py
+++ b/tests/e2e/test_ask_tool_e2e.py
@@ -1,0 +1,221 @@
+"""End-to-end: `ask` reaches the model, and a human can answer it on screen.
+
+Why this file exists
+--------------------
+
+#868 shipped for eleven releases with a green unit suite. ``build_ask_tool``
+gated on an installed ask hook AND on ``has_ui``, and the detached runtime that
+has been the default ``lop`` path since 0.45.0 constructs ``has_ui=False`` and
+*then* installs a real ask gate. So the tool was withheld from every ordinary
+interactive session while the system prompt instructed the model at length to
+use it — and nothing noticed, because every test that asserted the gate either
+built a ToolContext by hand or built a session with the flag on.
+
+That is an assembled-application defect: each half was individually correct and
+the wiring between them was not. So the coverage belongs at the stage that
+drives the assembled application, and the assertions here are deliberately
+about the ARRAY THE PROVIDER RECEIVES and the ANSWER THE MODEL READS BACK,
+rather than about a builder's return value.
+
+Two host paths, because they install the hook at different times and the fix
+has to hold for both:
+
+* the **TUI host** (``OperatorApp._adopt_session`` → ``set_ask_handler``),
+  which is the path Ben's verification on the issue explicitly did not cover;
+  and
+* the **detached runtime** shape (``spawn_owned_session``: ``has_ui=False``
+  plus a gate), which is the one the defect was actually reported against.
+
+The provider is scripted, for the reason the module docstring of
+``test_tui_e2e`` gives at length: this regression is not model-shaped, and a
+stage whose failure signal is "the question was never answerable" must not have
+live provider latency inside its bound.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.harness.types import AskOption, AskQuestion
+from local_operator.session.session import Session
+from local_operator.tui.app import OperatorApp
+from tests.e2e.harness import (
+    ScriptedStream,
+    build_session,
+    dispose_quietly,
+    drain,
+    text_turn,
+    tool_call_turn,
+    wait_for_adoption,
+)
+from tests.e2e.watchdog import bounded
+
+pytestmark = pytest.mark.e2e
+
+SCREEN = (120, 40)
+BOUND_S = 60.0
+
+QUESTION = AskQuestion(
+    id="deploy",
+    question="Deploy to production or roll back?",
+    options=[
+        AskOption(label="Deploy", description="ships the current head"),
+        AskOption(label="Roll back", description="returns to the last tag"),
+    ],
+)
+
+
+def _ask_args() -> dict[str, Any]:
+    """The arguments a model sends when it calls ``ask``."""
+    return {
+        "questions": [
+            {
+                "id": QUESTION.id,
+                "question": QUESTION.question,
+                "options": [
+                    {"label": o.label, "description": o.description} for o in QUESTION.options
+                ],
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_the_tui_host_advertises_ask_and_a_person_can_answer_it(
+    headless_tui_env: Path,
+) -> None:
+    """The TUI path: adoption installs the hook, so ``ask`` must reach the model.
+
+    The session here carries ``has_ui=False`` (the ``Session`` default, which
+    ``build_session`` does not override) and that is FAITHFUL rather than a
+    convenience: since #576 ``lop``'s own TUI boots as a viewer over the
+    detached-runtime machinery, so a real interactive session reaches
+    ``_adopt_session`` with the flag off and receives its ask handler there.
+    That combination is the defect, and this is the host that ships it.
+
+    Asserted on the tools array of the request the provider actually received.
+    A session attribute would not do: the bug lived precisely in the gap
+    between "the session has a hook" and "the tool reached the wire".
+    """
+    stream = ScriptedStream([text_turn("ready")])
+    session = build_session(
+        headless_tui_env / "sessions" / "ask-tui",
+        stream,
+        cwd=headless_tui_env,
+    )
+
+    async def factory() -> Session:
+        return session
+
+    app = OperatorApp(factory)
+    try:
+        with bounded(BOUND_S, "TUI boot and one turn with `ask` advertised"):
+            async with app.run_test(size=SCREEN) as pilot:
+                await wait_for_adoption(app, pilot)
+                await drain(pilot)
+
+                # The real host installed the real hook during adoption.
+                assert session._ask_user is not None, (
+                    "the TUI adopted the session without installing an ask handler; "
+                    "this test can no longer prove anything about the gate"
+                )
+
+                await session.prompt("hello")
+
+                advertised = [tool.name for tool in stream.requests[-1].tools]
+                assert "ask" in advertised, (
+                    "a TUI session with a human at the keyboard did not advertise "
+                    f"`ask`; got {advertised}"
+                )
+    finally:
+        await dispose_quietly(session)
+
+
+@pytest.mark.asyncio
+async def test_the_detached_runtime_shape_advertises_ask_and_answers_it(
+    tmp_path: Path,
+) -> None:
+    """The reported path, end to end: advertised, called, answered, read back.
+
+    ``has_ui=False`` plus an installed handler is exactly what
+    ``spawn_owned_session`` builds. The turn script makes the model CALL the
+    tool rather than merely be offered it, and the answer is asserted on the
+    tool result the next request carries — the round trip, not the gate alone.
+    A tool that is advertised but unanswerable would pass an advertisement-only
+    assertion and fail this one.
+    """
+    answered: list[list[AskQuestion]] = []
+
+    async def answer_on_screen(questions: list[AskQuestion]) -> dict[str, list[str]] | None:
+        """Stands in for the person: picks an option, as the picker does."""
+        answered.append(questions)
+        return {questions[0].id: ["Roll back"]}
+
+    stream = ScriptedStream(
+        [
+            tool_call_turn(
+                text="Let me confirm which way to go.",
+                tool_name="ask",
+                tool_call_id="ask-1",
+                arguments=_ask_args(),
+            ),
+            text_turn("Rolling back."),
+        ]
+    )
+    session = build_session(tmp_path / "ask-detached", stream, cwd=tmp_path)
+    # The shape the runtime builds: no frontend store, and the gate installed
+    # afterwards. ``has_ui`` is a construction argument, so it is set directly;
+    # the handler arrives late exactly as ``_install_gates`` delivers it.
+    session._has_ui = False
+    session.set_ask_handler(answer_on_screen)
+
+    try:
+        with bounded(BOUND_S, "a detached-shape session asking and being answered"):
+            first = [tool.name for tool in (stream.requests[0].tools if stream.requests else [])]
+            await session.prompt("decide the release")
+
+            advertised = [tool.name for tool in stream.requests[0].tools]
+            assert "ask" in advertised, (
+                "a runtime that CAN mount a question did not advertise `ask`; "
+                f"got {advertised} (first: {first})"
+            )
+
+            # It was really asked, with the prose intact rather than a placeholder.
+            assert answered, "the model called `ask` but the host was never asked"
+            assert answered[0][0].question == QUESTION.question
+
+            # And the answer came BACK to the model, which is the half that
+            # makes the tool worth advertising at all.
+            follow_up = stream.requests[-1]
+            transcript = "\n".join((message.text or "") for message in follow_up.messages)
+            assert (
+                "Roll back" in transcript
+            ), "the user's answer never reached the model's next request"
+    finally:
+        await dispose_quietly(session)
+
+
+@pytest.mark.asyncio
+async def test_a_host_with_no_one_to_answer_still_gets_no_ask(tmp_path: Path) -> None:
+    """The other half of the gate, at the same level.
+
+    Widening the gate from two clauses to one is only safe if the remaining
+    clause still refuses every unattended host. A plain ``lop exec`` run, the
+    scheduler and a subagent all reach the engine with no handler installed,
+    and none of them may be offered a question they could only block on.
+    """
+    stream = ScriptedStream([text_turn("working")])
+    session = build_session(tmp_path / "ask-unattended", stream, cwd=tmp_path)
+
+    try:
+        with bounded(BOUND_S, "an unattended session refusing `ask`"):
+            await session.prompt("do the work")
+            advertised = [tool.name for tool in stream.requests[-1].tools]
+            assert (
+                "ask" not in advertised
+            ), f"a host with no ask handler was offered `ask`; got {advertised}"
+    finally:
+        await dispose_quietly(session)

--- a/tests/unit/session/runtime/test_owned.py
+++ b/tests/unit/session/runtime/test_owned.py
@@ -596,9 +596,12 @@ async def test_a_parked_ask_names_the_question_it_is_waiting_on() -> None:
     Regression origin (#868): both announcing reads in ``ask_gate`` asked for a
     ``text`` attribute :class:`AskQuestion` does not have — and, with
     ``extra="forbid"``, can never be given — so both always fell through to the
-    literal string ``"question"``. The parked-gate desktop notification, the
-    ``pending`` state ``lop sessions`` reads, and the timeout row REPLAYED TO
-    THE MODEL therefore all named nothing at all.
+    literal string ``"question"``. The reads that degraded are
+    ``_parked_announcement`` (which ``reannounce_pending`` replays) and the
+    timeout row REPLAYED TO THE MODEL. Two neighbouring surfaces were NOT
+    affected and must not be claimed here: the projection card reads the field
+    directly and was always correct, and ``lop sessions`` publishes only the
+    gate KIND, so prose never travelled to it at all.
 
     It stayed invisible because this entire gate was unreachable: both of its
     hosts build ``has_ui=False``, which the ``build_ask_tool`` clause removed in
@@ -634,9 +637,18 @@ async def test_a_parked_ask_names_the_question_it_is_waiting_on() -> None:
     await asyncio.sleep(0)
 
     assert handle._parked_announcement is not None
-    kind, title, _detail = handle._parked_announcement
+    kind, title, detail = handle._parked_announcement
     assert kind == "ask"
     assert title == prose, f"the parked ask announced {title!r} instead of the question"
+    # DETAIL, not just title: ``_announce_pending`` composes the notification
+    # body from ``detail`` alone, so a banner built from the title is
+    # unreachable. Passing prose only as the title left the ask toast reading
+    # the static "Waiting for your answer" while the approval toast beside it
+    # named its action (review R1 / UX U2 / QA Q2).
+    assert detail == prose, (
+        "the notification body reads `detail`, so an ask that passes prose only "
+        f"as the title cannot name the question; got {detail!r}"
+    )
 
     # 2. The projection seam, on the same question. Correct before this fix and
     #    after it — which is what localises the defect to the two reads above.
@@ -663,6 +675,55 @@ async def test_a_parked_ask_names_the_question_it_is_waiting_on() -> None:
         "the timeout row replayed to the model named "
         f"{row.details['description']!r} instead of the question"
     )
+
+
+@pytest.mark.asyncio
+async def test_a_parked_secret_ask_keeps_its_prose_off_the_notification() -> None:
+    """A secret question must not name the credential on an OS banner.
+
+    The counterpart to the prose-in-`detail` fix above, and the reason that fix
+    is conditional rather than unconditional. A secret ask's prose names the key
+    being requested ("Paste your OpenAI key"), and a desktop notification is
+    delivered to a lock screen — the one surface that must not enumerate which
+    of the user's credentials a session is missing. The VALUE was never exposed
+    here (the announcement happens before any answer exists), so what this
+    guards is the QUESTION.
+
+    The card still carries it: a person who opens the session needs to know what
+    is being asked, and the projection is not a lock screen. So this asserts the
+    two surfaces DISAGREE on purpose — the terse fallback out of band, the full
+    prose in band.
+    """
+    handle, _ = make_handle(auto_approve=False)
+
+    question = AskQuestion(id="OPENAI_API_KEY", question="Paste your OpenAI key", secret=True)
+    asked = asyncio.ensure_future(handle._ask_gate([question]))
+    await asyncio.sleep(0)
+
+    assert handle._parked_announcement is not None
+    _kind, title, detail = handle._parked_announcement
+    assert detail == "", (
+        "a secret question's prose reached the notification body, which is "
+        f"delivered to a lock screen; got {detail!r}"
+    )
+    # The title is only consumed in-process (``reannounce_pending``), and the
+    # notification's own composition cannot promote it to the body when detail
+    # is empty — so carrying the prose here costs nothing and keeps the replay
+    # honest.
+    assert title == "Paste your OpenAI key"
+
+    # In band, the card names it: this is what a person opening the session
+    # reads, and it must not be degraded to protect a banner.
+    pending = handle._fold.projection.pending
+    assert pending is not None
+    assert pending.title == "Paste your OpenAI key"
+    assert pending.secret is True
+
+    await handle.ask_answer(pending.request_id, "sk-topsecret")
+    assert await asyncio.wait_for(asked, 1) == {"OPENAI_API_KEY": ["sk-topsecret"]}
+    # And the pasted value never rode either surface.
+    assert "sk-topsecret" not in json.dumps(handle._fold.projection.to_json())
+    assert handle._parked_announcement is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/runtime/test_owned.py
+++ b/tests/unit/session/runtime/test_owned.py
@@ -590,6 +590,82 @@ async def test_ask_gate_projects_secret_flag_without_the_value() -> None:
 
 
 @pytest.mark.asyncio
+async def test_a_parked_ask_names_the_question_it_is_waiting_on() -> None:
+    """The announcement surfaces must carry the QUESTION, not a placeholder.
+
+    Regression origin (#868): both announcing reads in ``ask_gate`` asked for a
+    ``text`` attribute :class:`AskQuestion` does not have — and, with
+    ``extra="forbid"``, can never be given — so both always fell through to the
+    literal string ``"question"``. The parked-gate desktop notification, the
+    ``pending`` state ``lop sessions`` reads, and the timeout row REPLAYED TO
+    THE MODEL therefore all named nothing at all.
+
+    It stayed invisible because this entire gate was unreachable: both of its
+    hosts build ``has_ui=False``, which the ``build_ask_tool`` clause removed in
+    the same change vetoed, so ``ask`` was never advertised and the body never
+    ran. Fixing that gate is what makes this reachable, which is why the two
+    land together.
+
+    Both reads are asserted, and so is ``ask_pending_request`` on the SAME
+    question. That pairing is the point: the projection seam was always correct,
+    so a card that renders the prose while these two do not is what proves a
+    wrong-attribute bug rather than a question nobody supplied.
+    """
+    handle, session = make_handle(auto_approve=False)
+
+    appended: list[Any] = []
+
+    class _Transcript:
+        async def append_message(self, message):  # noqa: ANN001
+            appended.append(message)
+
+    setattr(session, "transcript", _Transcript())
+
+    prose = "Deploy to production or roll back?"
+    question = AskQuestion(
+        id="deploy",
+        question=prose,
+        options=[AskOption(label="Deploy"), AskOption(label="Roll back")],
+    )
+
+    # 1. The live announcement: what the notification and the record's pending
+    #    state are handed while the gate is parked.
+    asked = asyncio.ensure_future(handle._ask_gate([question]))
+    await asyncio.sleep(0)
+
+    assert handle._parked_announcement is not None
+    kind, title, _detail = handle._parked_announcement
+    assert kind == "ask"
+    assert title == prose, f"the parked ask announced {title!r} instead of the question"
+
+    # 2. The projection seam, on the same question. Correct before this fix and
+    #    after it — which is what localises the defect to the two reads above.
+    pending = handle._fold.projection.pending
+    assert pending is not None
+    assert pending.title == prose
+
+    pending_request_id = pending.request_id
+    await handle.ask_answer(pending_request_id, "Deploy")
+    assert await asyncio.wait_for(asked, 1) == {"deploy": ["Deploy"]}
+
+    # 3. The timeout row, which is the read the MODEL sees on replay. Driven
+    #    through the REAL gate rather than by calling ``_record_gate_timeout``
+    #    directly: the defect was in what the gate PASSES that recorder, so a
+    #    direct call would assert the argument this test supplied itself.
+    handle._gate_timeout_s = lambda: 0.01  # type: ignore[method-assign]
+    timed_out = await asyncio.wait_for(handle._ask_gate([question]), 2)
+
+    assert timed_out is None, "an unanswered ask must settle to None, not hang"
+    assert appended, "the expiry was not recorded at all"
+    row = appended[0]
+    assert row.details["kind"] == "ask"
+    assert row.details["description"] == prose, (
+        "the timeout row replayed to the model named "
+        f"{row.details['description']!r} instead of the question"
+    )
+
+
+@pytest.mark.asyncio
 async def test_ask_gate_asks_multiple_questions_one_at_a_time() -> None:
     """U1: an owned multi-question ask projects and resolves question by
     question — answering Q1 advances to Q2 rather than settling the whole set,

--- a/tests/unit/session/runtime/test_parked_gates.py
+++ b/tests/unit/session/runtime/test_parked_gates.py
@@ -279,6 +279,76 @@ def test_a_timed_out_gate_reaches_the_model_on_replay() -> None:
     assert "bash" in text
 
 
+def _rendered_timeout_text(kind: str) -> str:
+    """The MODEL-facing text for one expired gate of ``kind``."""
+    from local_operator.harness.approval import GATE_TIMEOUT_CUSTOM_TYPE
+    from local_operator.harness.types import CustomMessage, TextContent
+    from local_operator.session.session import _default_convert_to_llm
+
+    rendered = _default_convert_to_llm(
+        [
+            CustomMessage(
+                custom_type=GATE_TIMEOUT_CUSTOM_TYPE,
+                attribution="system",
+                details={
+                    "tool": "ask",
+                    "description": "Deploy to production or roll back?",
+                    "kind": kind,
+                    "waited_s": 86400.0,
+                },
+            )
+        ]
+    )
+    assert len(rendered) == 1
+    block = rendered[0].content[0]
+    assert isinstance(block, TextContent)
+    return block.text
+
+
+def test_an_expired_question_is_not_reported_to_the_model_as_a_denial() -> None:
+    """An unanswered ASK must not be phrased in the approval gate's vocabulary.
+
+    ``ask_gate`` records ``kind="ask"`` and ``tui/app.py``'s parked-gate summary
+    has always branched on it for the HUMAN ("then moved on", D12's copy note).
+    The model-facing renderer never grew that arm, so the two audiences read
+    opposite things off the SAME row: the human was told the agent moved on
+    while the model was told its question "was denied automatically" — inviting
+    it to re-plan around a refusal nobody issued.
+
+    It could not bite before #868, because the ask gate was unreachable and this
+    row only ever carried an approval. It lands hardest on the wake path that
+    change deliberately enables, which is the one most likely to expire with
+    nobody there.
+    """
+    ask = _rendered_timeout_text("ask")
+
+    # The denial vocabulary must be gone, not merely softened.
+    assert "denied" not in ask.lower(), f"an unanswered question was reported as denied: {ask}"
+    assert "approval request" not in ask.lower()
+    # It must still say WHAT went unanswered and that nothing was decided...
+    assert "Deploy to production or roll back?" in ask
+    assert "never answered" in ask and "No decision was made" in ask
+    # ...and leave the model where pressing `esc` leaves it, since both mean
+    # "no answer came back" (see ASK_UNANSWERED_TEXT).
+    assert "Decide yourself" in ask and "what you assumed" in ask
+
+
+def test_an_expired_approval_still_reads_as_the_automatic_denial_it_is() -> None:
+    """The other arm, so the ask branch cannot be widened over both.
+
+    An approval that expires genuinely WAS denied — the tool did not run — and
+    saying otherwise would understate a refusal the model must plan around.
+    """
+    approval = _rendered_timeout_text("approval")
+
+    assert "denied automatically" in approval
+    assert "not a decision by the user" in approval
+
+    # A row with no `kind` at all predates the field; it must keep reading as an
+    # approval rather than silently becoming a question.
+    assert _rendered_timeout_text("") == approval
+
+
 def test_a_phone_watching_parks_for_the_configured_day(monkeypatch) -> None:
     """Reachability is not "a terminal is attached".
 

--- a/tests/unit/session/test_late_capability_tools.py
+++ b/tests/unit/session/test_late_capability_tools.py
@@ -129,16 +129,25 @@ class RecordingStream:
         return names
 
 
-def make_session(tmp_path, stream: RecordingStream, **kwargs: Any) -> Session:
+def make_session(
+    tmp_path, stream: RecordingStream, *, has_ui: bool = True, **kwargs: Any
+) -> Session:
+    """A session in the shape a rich front end builds it, unless told otherwise.
+
+    ``has_ui`` is a keyword with a default rather than a hard-coded argument
+    because it is NOT what gates ``ask`` — the hook is (see ``build_ask_tool``)
+    — and the detached runtime that every interactive ``lop`` session goes
+    through builds with the flag OFF. A helper that could only produce
+    ``has_ui=True`` could not express that shape, which is how #868 went
+    unnoticed by this file.
+    """
     return Session(
         model=MODEL,
         stream_fn=stream,
         tools=[],
         transcript=Transcript(tmp_path / "sess"),
         system_blocks_provider=lambda: ["stable"],
-        # A host that owns a terminal, which is the only kind that can answer a
-        # question: ``build_ask_tool`` requires both the hook and this flag.
-        has_ui=True,
+        has_ui=has_ui,
         **kwargs,
     )
 
@@ -194,6 +203,36 @@ async def test_an_ask_handler_installed_after_construction_is_advertised(tmp_pat
     assert "ask" in stream.advertised()
     # The rescue is additive: nothing the session already advertised moved out.
     assert {"task", "wait", "jobs", "wake", "hub"} <= set(stream.advertised())
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_detached_runtimes_session_shape_still_advertises_ask(tmp_path) -> None:
+    """#868: the DEFAULT ``lop`` path built a session that could answer and was
+    still refused the tool.
+
+    ``spawn_owned_session`` constructs with ``has_ui=False`` — correctly, since
+    that flag means "this host drives a rich frontend state store", not "a human
+    is present" — and then installs a real ask gate
+    (``OwnedSessionHandle._install_gates``). A human sits at the terminal (or
+    reaches it over the control socket) and can answer, but the old second
+    clause in ``build_ask_tool`` vetoed the tool on the flag, so ``ask`` reached
+    no model on the path every interactive session has taken since 0.45.0.
+
+    This reproduces that wiring rather than the builder in isolation, because
+    the builder's unit test passed throughout: the defect only appears once the
+    two halves are assembled the way the shipped runtime assembles them.
+    """
+    stream = RecordingStream()
+    session = make_session(tmp_path, stream, has_ui=False)
+    session.set_ask_handler(answer_nothing)
+
+    await session.prompt("hi")
+
+    assert "ask" in stream.advertised(), (
+        "a runtime that CAN mount a question does not advertise `ask`; "
+        f"got {stream.advertised()}"
+    )
     await session.dispose()
 
 

--- a/tests/unit/test_prompts_api.py
+++ b/tests/unit/test_prompts_api.py
@@ -538,9 +538,10 @@ def test_inventory_block_matches_default_tool_order() -> None:
             subagent_launcher=lambda label, prompt, *, agent="task", effort=None: "job-x",
             jobs=_FakeJobsForBlocks(),
             subagent_comms=_FakeCommsForBlocks(),
-            # `ask` is createIf-gated on a UI that can draw its picker AND on the
-            # hook that answers it, so the fully-capable context this test needs
-            # has to carry both or the tool drops out of the inventory.
+            # `ask` is createIf-gated on the HOOK that answers it, and on that
+            # alone (#868) — so `ask_user` below is what keeps the tool in this
+            # fully-capable inventory. `has_ui` is set only to describe a host
+            # that drives a frontend state store; it no longer gates any tool.
             has_ui=True,
             ask_user=_fake_ask_for_blocks,
             # `agent` is createIf-gated on a registry to persist roles into;

--- a/tests/unit/tools/test_ask_tool.py
+++ b/tests/unit/tools/test_ask_tool.py
@@ -72,15 +72,21 @@ def test_ask_exists_when_a_host_can_actually_answer_it() -> None:
     assert "ask" in _tools(_context(hook))
 
 
-def test_ask_is_absent_without_a_ui_to_draw_the_question_on() -> None:
-    """A server, exec mode or a scheduler run has nobody at a keyboard. An
-    advertised tool that can only fail to be answered is worse than none: the
-    model spends a call finding out what the tool list could have told it."""
+def test_ask_exists_for_a_host_that_can_answer_without_driving_a_frontend() -> None:
+    """#868: ``has_ui`` is not the "a human is present" signal it looks like.
+
+    It means "this host drives a rich frontend state store", and the detached
+    runtime behind every interactive ``lop`` session since 0.45.0 constructs
+    with it OFF and then installs a working ask gate. Gating on the flag as
+    well as the hook therefore withheld the tool from the default path — a
+    person at the terminal, ready to answer, and ``ask`` advertised to nobody.
+    The hook is the whole gate.
+    """
 
     async def hook(questions: list[AskQuestion]) -> dict[str, list[str]] | None:
         return None
 
-    assert "ask" not in _tools(_context(hook, has_ui=False))
+    assert "ask" in _tools(_context(hook, has_ui=False))
 
 
 def test_ask_is_absent_without_an_ask_hook_even_when_a_ui_is_claimed() -> None:

--- a/tests/unit/tools/test_registry.py
+++ b/tests/unit/tools/test_registry.py
@@ -56,9 +56,9 @@ async def _ask_user(questions: list[Any]) -> dict[str, list[str]] | None:
 def _engine_context(**kwargs) -> ToolContext:
     """A context carrying every capability the default surface reads, so the
     whole table can build: the wake scheduler, the subagent launcher, the job
-    manager, the agent registry, and the ask hook plus the ``has_ui`` flag
-    ``ask`` needs (it is gated on both — the hook is what a subagent lacks,
-    the flag is what a headless host declares)."""
+    manager, the agent registry, and the ask hook ``ask`` is gated on (the hook,
+    and only the hook — it is what a subagent lacks; ``has_ui`` is set here
+    merely to describe a rich front end, not to satisfy that gate)."""
     base: dict[str, Any] = dict(
         wake_scheduler=_FakeScheduler(),
         subagent_launcher=_launcher,
@@ -118,12 +118,17 @@ def test_default_set_drops_ask_without_a_host_that_can_answer_it() -> None:
     assert without == [name for name in withhook if name != "ask"]
 
 
-def test_default_set_drops_ask_without_a_ui_to_draw_it_on() -> None:
-    """A host declaring no UI is asserting it cannot mount a prompt, and the tool
-    believes that over a handler somebody left installed."""
+def test_default_set_keeps_ask_for_a_host_with_a_hook_but_no_frontend_store() -> None:
+    """``has_ui`` must not subtract from the surface (#868).
+
+    The detached runtime that every interactive ``lop`` session boots through
+    builds with ``has_ui=False`` and installs a real ask gate, so a flag clause
+    here took ``ask`` off the default path entirely. The flag describes a
+    frontend state store; the hook describes who can answer.
+    """
     withui = [tool.name for tool in create_tools(_engine_context())]
     without = [tool.name for tool in create_tools(_engine_context(has_ui=False))]
-    assert without == [name for name in withui if name != "ask"]
+    assert without == withui
 
 
 def _invalid_enum_nodes(node: Any) -> list[str]:


### PR DESCRIPTION
## What and why

**C1 — regression fix.** `ask` has not been advertised to any model on the default `lop` path since **0.45.0**. The system prompt instructs the model at length to use the tool; the tool was never in the array.

Fixes #868.

### Root cause

`build_ask_tool` gated on **two** conditions:

```python
if context.ask_user is None or not context.has_ui:
    return None
```

The detached runtime that has been the default `lop` path since 0.45.0 satisfies the first and fails the second. `spawn_owned_session` builds the session with the flag off and *then* installs a real ask gate:

```
local_operator/session/runtime/owned.py:3974   has_ui=False,
local_operator/session/runtime/owned.py:487    self._session.set_ask_handler(ask_gate)
```

So the hook existed, a human sat at the terminal ready to answer, and the flag vetoed the tool.

`session/session.py::set_ask_handler` already documented the intended design and **contradicted the code** — "the tool's createIf builder gates on the hook rather than on `has_ui`". That sibling docstring is the evidence the flag clause was the accident rather than the design.

### The decision, and why the alternative was rejected

**Gate on the hook alone.** The hook is the safer of the two signals *precisely because it is not inherited*. A subagent inherits `has_ui` from its parent (`harness/subagent.py:1713`, `1853`) but is deliberately built with **no** ask handler — `harness/subagent.py` contains zero occurrences of `ask_user` or `set_ask_handler`. So the hook's absence is what actually keeps a delegated child from mounting an unanswerable question on the parent's screen, and every unattended context (plain `lop exec`, scheduler, bootstrap/server, subagents) installs no handler and stays correctly ask-less.

**Setting `has_ui=True` in `spawn_owned_session` was rejected**, not merely un-chosen. `session_factory.py:2578` keys the RemoteSession takeover branch on `has_ui and resume_id is not None`, and `spawn_owned_session` passes `resume` — so flipping the flag would divert the daemon's writer path into follower takeover. `has_ui` also gates frontend-store construction and checkpoint/emit behaviour. It means *"this host drives a rich frontend state store"*, **not** *"a human is present"*.

### A latent defect this change makes live — fixed in the same PR

`owned.py`'s `ask_gate` was **unreachable dead code**: both of its hosts build `has_ui=False`, so the old gate vetoed the tool and the body never ran. Removing the clause runs it for the first time — and it read a field that does not exist:

```python
self._announce_pending("ask", getattr(question, "text", "") or "question", "")
```

`AskQuestion` has fields `['id', 'multi', 'options', 'question', 'recommended', 'secret']` and sets `extra="forbid"`, so `text` can never exist and the fallback always won.

**An earlier revision of this description overclaimed the blast radius, and reviewer, UX and QA each caught it independently (R1 / U2 / Q2). Corrected here.** It named three surfaces; only these were degraded:

| surface | was it degraded by the `text` read? |
|---|---|
| gate-timeout row **replayed to the model** | **yes** — read `"question"`, now reads the prose |
| `_parked_announcement` / `reannounce_pending` | **yes** — same read |
| projection card (phone / TUI) | **no** — `ask_pending_request` reads `question` directly and was always correct |
| `lop sessions` NEEDS column | **no** — `set_record_pending(kind)` publishes the *kind*; prose never travelled there and structurally cannot |
| desktop notification body | **no** — composed from `detail`, which the ask path hardcoded to `""`, so it read the static `BODIES["ask"]` before *and* after |

Shipping the gate fix alone would still have shipped a real regression — the model-facing row — which is why it lands here rather than as a follow-up. Both reads now go through one `_question_prose` helper. The in-tree comment and test docstring that repeated the wrong claim are corrected in the remediation commit.

## Testing evidence

### Before / after, on the real default path

A **live turn** through the production composition root — `spawn_owned_session`, the function every interactive `lop` session boots through — in an isolated `HOME`, against a real provider, recording the tools array that actually reaches the wire:

| | `has_ui` | ask handler | advertised inventory (tail) | `ask`? |
|---|---|---|---|---|
| **before** (`origin/main` @ `82262483`) | `false` | `true` | `… task, wait, jobs, wake, hub` | **no** |
| **after** (this branch) | `false` | `true` | `… task, wait, jobs, wake, hub, ask` | **yes** |

The before-tail is byte-for-byte the symptom the issue predicted.

### The question is answerable, not merely advertised

Same live runtime, model instructed to call `ask`, answered through the handle's `ask_answer` op — the exact path `runtime/server.py` serves to a viewer or phone:

```json
{
  "question_ids_answered": ["colour | announced='What is your preferred colour?'"],
  "ask_tool_result_seen_by_model": "The user answered:\ncolour — What is your preferred colour?\n  answer: Cerulean",
  "assistant_final_reply": "Cerulean",
  "answer_reached_the_model": true
}
```

On `origin/main` the same probe produces no ask at all — the model, told to ask, improvises into another tool: *"It seems there is no session with the ID 'colour' to address my question."*

### The announcement fix, isolated

Driving the real `ask_gate` on the live runtime, comparing a **gate-fix-only** tree against this branch. The projection card is correct in both, which is what localises the defect to the announcing read rather than to a missing question:

| tree | `_parked_announcement` title | projection card title |
|---|---|---|
| gate fix **alone** (what would have shipped) | `"question"` | `"Deploy to production or roll back?"` |
| **this branch** | `"Deploy to production or roll back?"` | `"Deploy to production or roll back?"` |

### The notification banner, before and after the remediation

Separate from the above, and added in round 1 remediation. The banner is composed from `detail`, which the ask path passed as `""` — so it never read `"question"` and it never read the prose either. Driven through the **shipped gate call** on both trees (the probe extracts the real `_announce_pending(...)` line rather than re-implementing its argument choice, so it reports each tree's own behaviour), with `detached_notify` captured and no watching surfaces so the OS leg is genuinely taken:

| case | before remediation | after |
|---|---|---|
| ordinary ask | `Waiting for your answer` | **`Deploy to production or roll back?`** |
| **secret** ask | `Waiting for your answer` | `Waiting for your answer` — deliberately unchanged |
| approval (contrast) | `write: /etc/hosts` | `write: /etc/hosts` |

The secret case is why the fix is conditional rather than a one-liner: a secret question's prose names the credential being requested (`"Paste your OpenAI key"`), and a desktop notification reaches a lock screen — the one surface that must not enumerate which of a user's keys a session is missing. The pasted *value* was never at risk (the announcement happens before any answer exists); what is guarded is the question. The in-band card still carries the full prose, and a test asserts the two surfaces disagree on purpose.

### The safety invariant, on a real child

Not a hand-made `ToolContext` — a real subagent built by the shipped `_build_child_session`, under a real `spawn_owned_session` parent that *has* a handler and `has_ui=False` (the combination the removed clause used to mask):

```json
{
  "parent_has_ui": false,
  "parent_ask_handler": true,
  "parent_advertises_ask": true,
  "children_built": 1,
  "child_advertises_ask": [false]
}
```

Plus the builder against every shipped shape:

| context | `ask`? |
|---|---|
| subagent, inherits `has_ui=True`, no hook | no |
| subagent under a detached parent, no hook | no |
| plain `lop exec` / scheduler / bootstrap, no hook | no |
| TUI-shaped host, hook | **yes** |
| detached runtime / `exec --control`, hook | **yes** |

### Red-before / green-after, per test

Every new test was confirmed failing on the unfixed tree before the fix:

- `test_the_detached_runtimes_session_shape_still_advertises_ask` — `AssertionError: a runtime that CAN mount a question does not advertise 'ask'; got ['task', 'wait', 'jobs', 'wake', 'hub']`
- `tests/e2e/test_ask_tool_e2e.py` (2 of 3) — red on the two-clause builder with the same inventory tail; the negative test stayed green throughout, which is what shows the widened gate did not simply pass everything.
- `test_a_parked_ask_names_the_question_it_is_waiting_on` — red on the stale reads: `the parked ask announced 'question' instead of the question`. Fixing only the first read leaves it red on the second (`the timeout row replayed to the model named 'question'`), so both reads are independently asserted.

### Suites

- **Unit:** `17467 passed, 18 skipped` locally. One unrelated failure in `tests/unit/tui/test_session_sidebar.py::test_tooltip_survives_in_row_movement_and_the_catalog_poll`, under load average 111 on a shared host — a wall-clock `asyncio.sleep(0.3)` in a file this diff does not touch. Established as a load flake rather than a regression, three independent ways: it passes on clean `origin/main`; it passes 6/6 on this branch (isolated, whole-file, and under xdist); and **CI's five unit shards all pass on this exact head**, which is the authoritative full-suite signal here. A local confirming re-run was killed by host contention at 96% and is not being reported as a result.
- **E2E:** `98 passed, 7 skipped` (`tests/e2e -m e2e -n0`), including the three new tests.
- **Gate:** flake8, `black --check` (26.1.0), `isort --check` (5.13.2), pyright 1.1.411 — all clean.
- **No version bump.** `pyproject.toml` stays at `0.52.15`.

### Independent verification by @bbqben

Reported separately on [#868](https://github.com/damianvtran/local-operator/issues/868) — **evidence produced by the reporter, not by me**, and kept separate from the above on purpose. He drove the safety invariant through the shipped `_build_child_session`: `child._ask_user is None` for a parent with `has_ui=True` + hook, a parent with `has_ui=False` + hook, a grandchild, a handler installed *after* the child exists, and a child of the real `spawn_owned_session` runtime. Other unattended paths through the real spawners: `create_session(has_ui=False)` → no `ask`; plain `lop exec` (`supervised=False`) → no `ask`; `RemoteSession` never calls `create_tools` at all.

He also drove **`exec --control` end to end over a real control socket** with a real supervisor: `ask_answer` returned `{'colour': ['red']}`; forged `request_id` rejected, replay rejected, unauthenticated socket client rejected, two concurrent asks answerable out of order. So that path is genuinely answerable rather than advertised-and-unanswerable.

His stated limits: he did not run a full `tests/unit` sweep to completion, and did not exercise the real TUI host path, the mobile daemon, or the rendered notification banner. The full suite and the TUI host path are covered above (`test_the_tui_host_advertises_ask_and_a_person_can_answer_it` drives the real `OperatorApp` through `run_test`); the OS banner is now covered too: round 1 remediation drives the real `_announce_pending` with `detached_notify` captured, asserting the composed body rather than only the title handed in. The *rendered* banner (pixels on a lock screen) remains unasserted, as it was for Ben.

## New behaviour we are deliberately accepting

**The wake path also gains `ask`**, because a due wake engages the same `spawn_owned_session` runtime (`wakes/supervisor.py` → `engage_runtime` → `runtime/process.py` → `spawn_owned_session`). Called out rather than suppressed, and accepted for these reasons:

- an unattended parked ask is **bounded at the configured park — 24 hours by default**, not 30 seconds. *(Corrected: an earlier revision claimed 30 s, and QA Q1 proved it wrong by measurement. A wake always publishes a `RuntimeServer` (`process.py::amain`), so `_registrant` is never `None` there and the 30 s branch — which is the "no control socket at all" embedded-host case — is unreachable on that path. With notifications on by default, `_gate_timeout_s()` returns `86400.0`. Measured on the real handle: no registrant → `30.0`; wake shape with notifications on → `86400.0`; registrant with notifications off → `30.0`.)* The behaviour is unchanged by this PR and is deliberate — `_gate_timeout_s`'s own docstring argues for parking over denying, since denying a user's tool after 30 s answers a question nobody asked — and `runtime.unattended_gate_timeout` is a user-facing setting;
- it **settles to `None`** rather than hanging the run, which the new regression test asserts directly; and
- it is **visible** while it lasts, as `pending='ask'` on the record `lop sessions` reads.

`exec --control` likewise gains the tool, which is correct rather than a leak: it opts into the gate explicitly (`install_gates=supervised`) and `runtime/server.py` serves an `ask_answer` op for the supervisor.

## Review round 1 remediation

One unified commit (`a0624a3`) answering all three streams; full detail in the `### Agent review remediation — round 1` comment.

- **U1 = Q3 (MAJOR) — fixed.** The gate-timeout row the *model* reads called an expired question an "approval request … denied automatically". `session.py`'s renderer ignored `details["kind"]` while `tui/app.py` had always branched on it for the human, so the two audiences read opposite things off the same row. The ask arm now ends the way `ASK_UNANSWERED_TEXT` does, so an expiry and a user pressing `esc` leave the model in the same place.
- **R1 = U2 = Q2 (MAJOR/MINOR) — fixed, and the description corrected.** The banner now names the question (secret asks excepted, see above), and the three-surface claim is corrected in this body, in the `owned.py` comment block and in the test docstring.
- **Q1 (MAJOR) — description corrected**, behaviour deliberately unchanged. See the wake-path bullet above.
- **R2 (MINOR) — fixed.** `_question_prose`'s docstring justified its defensive `getattr` with a duck-typed caller that does not exist; the `getattr` stays (a gate announcement must degrade rather than raise) with the real reason stated.

Rebased onto `d35af1616` (v0.52.18) before remediating; `git range-diff` reports `=` for the original commit and no file in this diff is touched by anything that landed since, so there is no semantic convergence surface.

## Deferred

**Surfaced by restoring the flow — pre-existing, not introduced here.** This PR brings back a flow nobody could reach for five days; widening it into picker polish is how it stops shipping.

- **deferred — pre-existing, surfaced by restoring the flow (U3).** Below ~46 columns the card mounts but has no room for an option row: the question truncates, nothing is selectable, and the footer offers only `esc skip`, so the question reads as skip-only when it is merely too narrow to answer.
- **deferred — pre-existing, surfaced by restoring the flow (U4).** A long question is clamped at `MAX_QUESTION_ROWS = 4` with `…` and no gesture reveals the rest; `ctrl+e` lifts the cap on the selected *option*'s description only.
- **deferred — pre-existing, surfaced by restoring the flow (U5).** The phone card hoists the recommended option to first position but carries no `▸ RECOMMENDED` badge (`AskOptionWire` has only `label`/`description`), so a phone user cannot tell the agent's recommendation from the merely-first option.
- **deferred — pre-existing, structural (U6).** The `lop sessions` NEEDS column shows a bare `ask`; `set_record_pending` takes only a kind, so prose cannot travel there.
- **deferred — pre-existing, display-only (U7).** An answered ask collapses to `ask ask ✓ 0.4s` without showing the choice; the answer reaches the model intact, but a decision a human made is the one thing worth finding on scrollback.

**Confirmed correct by all three streams and left deferred:**

- **deferred — `ToolContext.has_ui` is now dead as a createIf gate; retiring it is a cross-subsystem change that does not belong in a bug fix.** After this change no tool builder in the default surface reads it (`builtin.py` was the last; verified by grep over `local_operator/tools/`). It stays set by ~20 call sites and read by none as a createIf gate, surviving as a plumbed field whose real production meaning is "this host drives a rich frontend state store" — arguably the root cause of this whole bug class. Wants an architect separately.
- **deferred — `exec_control.py:209` `maybe_start_exec_control` has zero production callers and defaults `supervised=True`, unlike the live path which passes it explicitly.** Confirmed: the only non-test hit is the definition. Harmless today; whoever wires it up next silently installs an ask gate on an unsupervised run. Out of scope here.

## Release note

**Patch.** `ask` is advertised and answerable again in an ordinary `lop` session.

The regression window is **0.17.4 → 0.45.0**: `ask` worked in a normal TUI session from 0.17.4 (#130, 2026-08-17, which introduced the picker) until 0.45.0 (#576, 2026-09-04), which rewired `lop`'s own TUI to boot as a viewer over the detached-runtime machinery built for phone-started sessions. That path has always constructed `has_ui=False` — correctly, for its own purposes. Before it, the interactive TUI called `create_session(..., has_ui=True, ...)` directly, so both clauses passed.

**The 0.51.12 note for #771 is misleading in hindsight and this supersedes it.** That note claimed the "`ask` appeared in 0 of 880 rendered inventories" measurement as resolved. The measurement had **two independent causes** — a stale prompt inventory and this gate — and #771 fixed only the stale-prompt one. Sessions on 0.51.12 through 0.52.15 still had no `ask` in the tools array at all.

