### PR TITLE
chore(release): bump version to 0.52.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.52.15"
+version = "0.52.16"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Change authorization

**C0 — release bump.** One file, one line: `pyproject.toml` 0.52.15 → 0.52.16.

## Window

Post-v0.52.15 window, claimed by this session and yielded by all 12 live lop peers (no competing claim, no unmerged PR held for it).

Included:
- #849 (3f793fbb3) fix(session): bound owner recovery for a live-but-silent runtime

## Bump class: PATCH

A bounded-exit bug fix in `RemoteSession._recover_owner` plus tests. No API addition, no wire/protocol change, no migration. #838 (secret-store series, which would argue MINOR) is still OPEN and rides the next window per the latecomer rule.

## Scope check

```
pyproject.toml | 2 +-
1 file changed, 1 insertion(+), 1 deletion(-)
```