### PR TITLE
perf(analytics): collapse subagent rows behind a per-session disclosure

### DIFF
--- a/local_operator/tui/widgets/analytics_panel.py
+++ b/local_operator/tui/widgets/analytics_panel.py
@@ -1679,9 +1679,15 @@ class AnalyticsScreen(ModalScreen[None]):
         The hint is ``height: 2`` with ``padding-top: 1`` (see
         ``#analytics-hint`` in the stylesheet), i.e. exactly ONE content line.
         Anything wider wraps to a second line that is never painted — which is
-        why the width has to be measured rather than assumed. Falls back to the
-        card width before the widget is mounted, which is within a cell of the
-        real box at every terminal size measured (50→39/40, 120→102/101).
+        why the width has to be measured rather than assumed.
+
+        The pre-mount fallback to the card width is deliberately approximate and
+        is not load-bearing (review R8). It is reached only from ``compose``,
+        where the layout carries no rows yet, so the only candidates are
+        ``esc back · t cost/tokens`` (24 cells) and ``esc back`` — both inside
+        the 40-cell floor ``_card_width`` cannot go below — and ``_sync_hint``
+        replaces the text after the first refresh, before the frame the reader
+        sees. It only has to be sane, not exact.
         """
         hint = getattr(self, "_hint", None)
         if hint is not None and hint.is_mounted:
@@ -1719,7 +1725,14 @@ class AnalyticsScreen(ModalScreen[None]):
             candidates = [
                 "esc back · t cost/tokens · ↑↓ row · enter expand · e all",
                 "esc back · ↑↓ row · enter expand · e all",
-                "esc back · ↑↓ row · enter · e all",
+                # ``esc back`` goes BEFORE ``expand`` is abbreviated away — the
+                # rule two lines up, which the ladder used to contradict at its
+                # own third rung (review D5). A 33-cell box took
+                # ``esc back · ↑↓ row · enter · e all``, leaving ``enter · e
+                # all`` to be read as two unexplained keys, while the 29-cell
+                # tier below keeps ``enter expand`` and fits every box in the
+                # 44-50 column band (measured: 33-39 cells).
+                "↑↓ row · enter expand · e all",
                 "↑↓ row · enter · e all",
                 "enter · e all",
             ]
@@ -2222,8 +2235,29 @@ class AnalyticsScreen(ModalScreen[None]):
         """
         expandable = {node.session_id for node in _iter_nodes(self._forest()) if node.has_children}
         collapsing = bool(expandable) and expandable <= self._expanded
-        # Same reason as ``_set_expanded``: collapse-all hides every child row,
-        # so the cursor's ancestry has to be read while it is still painted.
+        # Read BEFORE the repaint, for two independent reasons.
+        #
+        # ``chain``: collapse-all hides every child row, so the cursor's
+        # ancestry has to be read while it is still painted (same as
+        # ``_set_expanded``).
+        #
+        # ``anchored``: whether to reveal the cursor afterwards at all. ``e`` is
+        # a GLOBAL action — it acts on every row, not on the row under the
+        # caret — so it must not move the viewport of a reader who is not
+        # standing in the table. Reviews D6/U8: the cursor is placed at MOUNT
+        # (D2), and the reveal below then dragged the opening frame down to
+        # table row 0, silently replacing the totals block the screen exists to
+        # show (+34 lines at 120x40, +43 at 120x30, +51 at 110x20, and pressing
+        # ``e`` again did not bring it back). On base the same call was a no-op
+        # only because no cursor existed yet, so the mount cursor turned a
+        # dormant call into a teleport.
+        #
+        # Revealing is still right when the cursor IS on screen: the reader is
+        # working in the table, expand-all moves their row hundreds of lines
+        # down the body, and keeping it in frame is what preserves their place.
+        # Same rule ``_move_cursor`` already uses — a cursor the reader cannot
+        # see is not a place to return to.
+        anchored = self._cursor_on_screen()
         chain = self._ancestor_chain() if collapsing else []
         if collapsing:
             self._expanded.clear()
@@ -2233,7 +2267,8 @@ class AnalyticsScreen(ModalScreen[None]):
         if chain:
             self._rehome_to_ancestor(chain)
             self._repaint()
-        self._scroll_cursor_into_view()
+        if anchored:
+            self._scroll_cursor_into_view()
         self.call_after_refresh(self._sync_hint)
 
     def _forest(self) -> list["SessionNode"]:

--- a/local_operator/tui/widgets/analytics_panel.py
+++ b/local_operator/tui/widgets/analytics_panel.py
@@ -28,8 +28,8 @@ it is the right way to pin what the screen SAYS.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Mapping, Protocol, Sequence
+from dataclasses import dataclass, field
+from typing import Collection, Mapping, Protocol, Sequence
 
 from rich.cells import cell_len
 from rich.style import Style
@@ -487,6 +487,10 @@ def build_report(
     monthly: list[UsagePeriod] | None = None,
     window_totals: UsagePeriod | None = None,
     metric: str = METRIC_COST,
+    expanded: "Collection[str] | None" = None,
+    cursor: str | None = None,
+    layout: ReportLayout | None = None,
+    forest: list["SessionNode"] | None = None,
 ) -> list[Text]:
     """Render one aggregate as a list of ``Text`` lines for the screen body.
 
@@ -502,6 +506,30 @@ def build_report(
     the screen's ``t`` key flips it. They default to ``None``/``cost`` so a
     caller with no rollups (or a pre-rollup test) gets exactly the original
     report.
+
+    ``expanded`` is the set of session IDs whose subagent rows are shown. The
+    default — none — is what the user asked for: the operator's ledger renders
+    2,240 session rows fully expanded, of which 1,645 are subagents nobody
+    asked to see, and the cost is paid again on EVERY rebuild (a terminal resize
+    emits a storm of them, which is the "freezing" in the report).
+
+    ``cursor`` is the SESSION ID the keyboard is on — an id and not a row index,
+    for the same reason the expansion set is: expanding a row inserts rows above
+    every later index, so an index-keyed cursor would slide onto a different
+    session on the very keypress that is supposed to leave it where it is.
+    ``layout``, if given, receives which rows were painted and where, which the
+    interactive screen needs to scroll the cursor into view; recomputing that
+    outside this function would be a second, possibly disagreeing, notion of
+    which rows are on screen.
+
+    ``forest`` lets a caller that already has one pass it in rather than paying
+    to rebuild it. It measured 34 ms on the operator's ledger — irrelevant for a
+    one-shot report, and the dominant cost of a REPAINT once every arrow key
+    triggers one (0.25 s per press, which does not read as a cursor). The screen
+    holds the aggregate immutable for its lifetime, so the forest it caches
+    cannot go stale; a caller that passes a forest built from a different
+    aggregate would get a report describing neither, which is why this is not
+    derived from a mutable field.
     """
     width = max(40, width)
     fg = semantic_style("fg")
@@ -750,16 +778,17 @@ def build_report(
     # keeps this column summing to the headline total above it: rolling up while
     # still listing children at top level inflates the table by $8,077 (12.7%)
     # on the operator's ledger. See ``build_session_forest``.
-    forest = build_session_forest(
-        aggregate.by_session, getattr(aggregate, "session_parents", {}) or {}
-    )
+    if forest is None:
+        forest = build_session_forest(
+            aggregate.by_session, getattr(aggregate, "session_parents", {}) or {}
+        )
     # STRUCTURE FIRST, LABELS SECOND. The walk yields ``(session_id, depth,
     # subtree total)`` and nothing about how a row reads, because the label
     # budget below cannot be computed until the numbers that share the row are
     # known, and the numbers come from the forest. Composing labels inside the
     # walk (as the nesting change first did) forces them to be built against a
     # constant, which is exactly the defect the budgeting work removed.
-    structure = _forest_rows(forest)
+    structure = _forest_rows(forest, expanded)
 
     # The label budget is decided BEFORE the labels are composed, from the frame
     # this report is being rendered into (design review D2). Composing against a
@@ -790,9 +819,18 @@ def build_report(
     # rollup later.
     overhead = max(
         _row_overhead(list(aggregate.by_provider.items()), width),
-        _row_overhead([(sid, agg) for sid, _, agg in structure], width),
+        _row_overhead([(row.session_id, row.aggregate) for row in structure], width),
     )
     name_cap = max(_MIN_NAME_COL, min(_MAX_NAME_COL, width - overhead))
+
+    # The disclosure gutter exists only when SOMETHING can be expanded, and that
+    # test is stable across expansion: roots are always visible, so "a visible
+    # row has descendants" is the same question as "this forest has children at
+    # all". It has to be stable, or opening a row would add a gutter to every
+    # other row and slide the whole table sideways on one keypress.
+    disclosure = any(row.expandable for row in structure)
+    markers = {row.session_id: _disclosure_marker(row, present=disclosure) for row in structure}
+    suffixes = {row.session_id: _row_suffix(row) for row in structure}
 
     # Keyed by SESSION ID, never by the rendered label. Two sessions can render
     # the same string (identical names, or names agreeing within the budget),
@@ -801,9 +839,29 @@ def build_report(
     # screen entirely. On the operator's ledger that hid 46 sessions before
     # subagent naming existed and 355 after it, so the table is built as
     # (label, depth, aggregate) triples whose identity is the id.
-    session_labels = _forest_labels(structure, names, name_cap)
+    session_labels = _forest_labels(
+        [(row.session_id, row.depth, row.aggregate) for row in structure],
+        names,
+        name_cap,
+        # The marker and the ``+N`` count are printed inside the name column, so
+        # they are charged to the label's budget for the same reason the nesting
+        # prefix is: a label composed to the full budget and THEN given a prefix
+        # is over the column, and the paint takes the tail back off with no
+        # marker to say it did.
+        reserved={
+            row.session_id: cell_len(markers[row.session_id]) + cell_len(suffixes[row.session_id])
+            for row in structure
+        },
+    )
     session_rows = [
-        (_row_prefix(depth) + session_labels[sid], depth, agg) for sid, depth, agg in structure
+        (
+            _row_prefix(row.depth, markers[row.session_id])
+            + session_labels[row.session_id]
+            + suffixes[row.session_id],
+            row.depth,
+            row.aggregate,
+        )
+        for row in structure
     ]
     all_names = [n for n in aggregate.by_provider] + [label for label, _, _ in session_rows]
     if all_names:
@@ -821,8 +879,27 @@ def build_report(
         # Meta says the rollup happened, because a row whose figure exceeds its
         # own spend must say why — and it is also what tells a reader the
         # indented rows are already counted in the row above them.
-        meta = "totals include subagents" if any(depth for _, depth, _ in session_rows) else ""
-        lines.append(_session_section(session_rows, width, name_col, meta))
+        #
+        # Keyed off ``disclosure`` (does the forest HAVE children) rather than
+        # off the visible depths, because with the table collapsed there are no
+        # indented rows on screen and the rollup has still happened. Reading it
+        # off the paint would drop the one sentence that explains why a root's
+        # figure exceeds its own spend, precisely in the default state.
+        meta = "totals include subagents" if disclosure else ""
+        if layout is not None:
+            # The header is the block's first line; row ``i`` is one line below
+            # it. Counted from the blocks composed SO FAR, because ``_repaint``
+            # joins them with a single newline each — the same arithmetic the
+            # body's line numbering uses, derived once here rather than guessed
+            # by a caller counting sections it cannot see.
+            layout.session_rows = structure
+            layout.session_first_line = sum(block.plain.count("\n") + 1 for block in lines) + 1
+        cursor_index = None
+        if cursor is not None:
+            cursor_index = next(
+                (i for i, row in enumerate(structure) if row.session_id == cursor), None
+            )
+        lines.append(_session_section(session_rows, width, name_col, meta, cursor=cursor_index))
 
     # Legend for the cost markers, drawn only when a ``+`` or ``$—`` is on
     # screen (review D1). ``dim`` so it reads as a footnote, not a row.
@@ -943,8 +1020,133 @@ def _tokens_col(groups: "Sequence[tuple[str, UsageAggregate]]") -> int:
 #: pushes the table past ``_WIDE_TABLE_MIN`` and costs everyone the cache column.
 _NEST_INDENT = 2
 
+#: Disclosure glyphs for a row whose subagent rows are hidden / shown. ``▸``/``▾``
+#: is the codebase's existing plain-fallback vocabulary (``glyphs.PLAIN_ICON_DEFAULT``
+#: is ``▸``) and both measure ONE cell, which the gutter arithmetic below relies
+#: on — a two-cell glyph would shift every numeric column by a cell, the exact
+#: class of defect ``_row_overhead`` exists to prevent.
+_DISCLOSURE_COLLAPSED = "▸"
+_DISCLOSURE_EXPANDED = "▾"
 
-def _row_prefix(depth: int) -> str:
+#: Cells the disclosure gutter costs a row: the glyph plus one space. Paid by
+#: EVERY row of the table once any row is expandable, so the names stay in one
+#: column — a table where expandable and childless rows start at different
+#: x-positions reads as ragged rather than as structured. It is not paid at all
+#: on a ledger with no subagents (see ``_disclosure_marker``), which is what
+#: keeps a flat table byte-identical to the one this screen has always shipped.
+_DISCLOSURE_CELLS = 2
+
+#: The row cursor. ``❯`` matches the command and session pickers (a caret rather
+#: than a reversed row: an inverted block reads as a selection the user MADE,
+#: not as the position they are on). It is painted into the two leading indent
+#: cells every row already spends, so a cursor costs the label budget nothing.
+_ROW_CURSOR = "❯"
+
+
+@dataclass(frozen=True)
+class SessionRow:
+    """One rendered row of the By-session table, before it has a label.
+
+    Identity is the SESSION ID all the way to the paint (never the rendered
+    label — two sessions can render the same string, and a label-keyed structure
+    silently drops all but one of them; that hid 355 sessions on the operator's
+    ledger). The screen keys its expansion state off ``session_id`` for the same
+    reason: a repaint at a different width recomposes every label, so anything
+    remembered by label would be forgotten by the next resize.
+
+    ``descendants`` is the size of the whole subtree under this row, not the
+    number of direct children. It is what the row advertises as the cost of
+    expanding, because the question the collapse creates is "how much is hidden
+    here" — and on the real ledger the two figures are equal for all but a
+    handful of rows (1,637 depth-1 nodes against 8 at depth 2).
+    """
+
+    session_id: str
+    depth: int
+    aggregate: "UsageAggregate"
+    descendants: int
+    expanded: bool
+
+    @property
+    def expandable(self) -> bool:
+        return bool(self.descendants)
+
+
+@dataclass
+class ReportLayout:
+    """What :func:`build_report` just painted, for a caller that must drive it.
+
+    A receiver rather than a return value because ``build_report`` returns the
+    rendered lines and three callers (two scripts and the plain-text tests) want
+    only those. The interactive screen needs one thing more — WHICH row is on
+    WHICH body line — so it can put a cursor on a row, scroll that row into
+    view, and map a mouse click back to the session it landed on. Recomputing
+    that outside the renderer would mean building the forest a second time
+    (31 ms on the operator's ledger) and, worse, would be a second definition of
+    which rows are visible that could disagree with the paint.
+    """
+
+    #: The visible rows, in paint order. Collapsed subtrees are simply absent.
+    session_rows: list[SessionRow] = field(default_factory=list)
+    #: Body line index of ``session_rows[0]``. The section header sits one line
+    #: above it, and row ``i`` is at ``session_first_line + i`` because every row
+    #: is composed ``no_wrap`` and truncated to the content box.
+    session_first_line: int = 0
+
+
+def _descendant_count(node: "SessionNode") -> int:
+    """Nodes beneath ``node``, at any depth. Bounded by the forest's own depth cap."""
+    return sum(1 + _descendant_count(child) for child in node.children)
+
+
+def _disclosure_marker(row: SessionRow, *, present: bool) -> str:
+    """The disclosure cell a row carries, or ``""`` when the table has no gutter.
+
+    ``present`` is false when NOTHING in the table can be expanded, and then no
+    row pays for the gutter. That is the same rule the hint line and the metric
+    toggle follow (design D5): a control that cannot act must not be advertised,
+    and a permanently blank two-cell column advertising an absent affordance is
+    the visual form of the same defect. It also means a ledger that never ran a
+    subagent renders exactly the table it rendered before this feature existed.
+
+    A childless row gets BLANK cells, never a glyph: it is not interactive, and
+    a glyph on it would promise a press that does nothing. 492 of the operator's
+    595 roots are childless, so this is the majority case, not an edge.
+    """
+    if not present:
+        return ""
+    if not row.expandable:
+        return " " * _DISCLOSURE_CELLS
+    return (_DISCLOSURE_EXPANDED if row.expanded else _DISCLOSURE_COLLAPSED) + " "
+
+
+def _row_suffix(row: SessionRow) -> str:
+    """The hidden-row count a row advertises after its name, or ``""``.
+
+    This is the information the collapse REMOVES, handed back in one cell-cheap
+    form: without it a user cannot tell an expensive leaf session from an
+    expensive session with ninety subagents under it, which is precisely the
+    distinction they opened the screen to make.
+
+    Shown in BOTH states, not just when collapsed. A suffix that disappeared on
+    expand would change the widest label in the table, ``name_col`` is sized to
+    that, and every numeric column would shift sideways on a keypress — a reflow
+    the reader sees as the table twitching. Its width is charged to the label
+    budget by :func:`_forest_labels`, exactly as the prefix is.
+
+    Spelled out ("+12 subagents") rather than a bare "+12", which costs about
+    ten cells of a 48-cell name column and is worth it: every other number on
+    this row is money, tokens or calls, so a bare ``+12`` beside them reads as a
+    quantity of the same kind. "subagents" is the word the section meta already
+    uses, so this borrows the table's own vocabulary rather than adding one.
+    """
+    if not row.expandable:
+        return ""
+    noun = "subagent" if row.descendants == 1 else "subagents"
+    return f" +{row.descendants} {noun}"
+
+
+def _row_prefix(depth: int, marker: str = "") -> str:
     """The indent-and-glyph a row at ``depth`` carries before its label.
 
     A child carries a ``└`` glyph, not just the indent and the dim style
@@ -955,6 +1157,13 @@ def _row_prefix(depth: int) -> str:
     surface section already uses ``└`` for exactly this, so this is the
     codebase's existing vocabulary rather than a new one.
 
+    ``marker`` is the disclosure cell (:func:`_disclosure_marker`) and it lands
+    AFTER the nesting indent, immediately before the name, rather than in a
+    fixed gutter at the far left. A disclosure glyph is a control attached to
+    one row's label; parked in a shared left gutter it would sit at the same
+    x-position for a root and its grandchild, so the column of glyphs would say
+    nothing about which of them a press would act on.
+
     Split out from the walk because the prefix is width the LABEL cannot also
     spend: it is prepended after condensing, so :func:`_forest_labels` has to
     subtract exactly this many cells from a nested row's budget. One function
@@ -962,17 +1171,29 @@ def _row_prefix(depth: int) -> str:
     cannot drift — the same rule ``_calls_col`` follows for the calls column.
     """
     if not depth:
-        return ""
-    return " " * ((depth - 1) * _NEST_INDENT) + "└ "
+        return marker
+    return " " * ((depth - 1) * _NEST_INDENT) + "└ " + marker
 
 
-def _forest_rows(forest: list["SessionNode"]) -> list[tuple[str, int, "UsageAggregate"]]:
-    """Flatten the session forest to ``(session_id, depth, aggregate)`` rows.
+def _forest_rows(
+    forest: list["SessionNode"],
+    expanded: "Collection[str] | None" = None,
+) -> list[SessionRow]:
+    """Flatten the session forest to the rows that are currently VISIBLE.
 
     Depth-first so a child sits directly under its parent, and each row carries
     the TREE total (own plus descendants) — the same figure its label is sorted
     by. A child row's dollars are therefore already counted in its parent's, and
-    the section meta says so; only the ROOT rows sum to the table total.
+    the section meta says so; only the ROOT rows sum to the table total. That
+    invariant is untouched by collapsing: a hidden child was never a row that
+    summed, and its parent's figure already contains it.
+
+    ``expanded`` is the set of session IDs whose children are shown; everything
+    else stops the walk at its own row. ``None`` means none — COLLAPSED is the
+    default, which is the whole point. The operator's ledger renders 2,240 rows
+    fully expanded against 595 collapsed, and the difference is a 0.65 s first
+    paint against 0.23 s plus a full rebuild on every one of the resize events a
+    terminal drag emits in a storm.
 
     Yields the session ID rather than a rendered label, because a label cannot
     be composed until the column budget is known and the budget is computed from
@@ -980,12 +1201,26 @@ def _forest_rows(forest: list["SessionNode"]) -> list[tuple[str, int, "UsageAggr
     paint, which is what stops two rows that read alike from collapsing into
     one; :func:`_forest_labels` turns these into display text.
     """
-    rows: list[tuple[str, int, "UsageAggregate"]] = []
+    open_ids = frozenset(expanded or ())
+    rows: list[SessionRow] = []
 
     def walk(node: "SessionNode", depth: int) -> None:
-        rows.append((node.session_id, depth, node.total))
-        for child in node.children:
-            walk(child, depth + 1)
+        is_open = node.session_id in open_ids
+        rows.append(
+            SessionRow(
+                session_id=node.session_id,
+                depth=depth,
+                aggregate=node.total,
+                descendants=_descendant_count(node),
+                expanded=is_open,
+            )
+        )
+        # A closed subtree is not walked at all. Skipping the RECURSION rather
+        # than filtering afterwards is what makes the collapsed report cheap:
+        # nothing under a closed row is measured, labelled, or composed.
+        if is_open:
+            for child in node.children:
+                walk(child, depth + 1)
 
     for root in forest:
         walk(root, 0)
@@ -996,6 +1231,7 @@ def _forest_labels(
     structure: "Sequence[tuple[str, int, UsageAggregate]]",
     names: Mapping[str, str],
     name_cap: int,
+    reserved: Mapping[str, int] | None = None,
 ) -> dict[str, str]:
     """Budgeted, collision-free display labels for every row, keyed by id.
 
@@ -1019,6 +1255,16 @@ def _forest_labels(
     the prefix first means the composed label plus its prefix is what
     ``name_cap`` promised, and the ellipsis lands where the reader can see it.
 
+    ``reserved`` extends that rule to everything else a row prints INSIDE the
+    name column — the disclosure marker and the ``+N`` hidden-row count — keyed
+    by session id because those two vary per ROW rather than per depth (an
+    expandable root and a childless one sit at the same depth and spend
+    different numbers of cells). Same reasoning as the prefix: whatever the row
+    prints beside its label is width the label cannot also have, and charging it
+    afterwards is what produced the unmarked mid-word cut this budgeting exists
+    to remove. When it is absent, only the prefix is charged, which is exactly
+    the behaviour every caller had before the disclosure column existed.
+
     Floored at ``_MIN_LABEL_CHARS`` by ``session_table_labels`` itself, so a
     pathologically deep tree on a narrow frame degrades to short labels rather
     than to empty ones.
@@ -1028,8 +1274,10 @@ def _forest_labels(
     # is decided against the width its members will really be composed at.
     by_budget: dict[int, dict[str, str]] = {}
     for sid, depth, _ in structure:
-        budget = name_cap - cell_len(_row_prefix(depth))
-        by_budget.setdefault(budget, {})[sid] = names.get(sid, "")
+        extra = cell_len(_row_prefix(depth))
+        if reserved is not None:
+            extra += reserved.get(sid, 0)
+        by_budget.setdefault(name_cap - extra, {})[sid] = names.get(sid, "")
     for budget, group in by_budget.items():
         labels.update(session_table_labels(group, budget))
     return labels
@@ -1040,6 +1288,8 @@ def _session_section(
     width: int,
     name_col: int,
     meta: str = "",
+    *,
+    cursor: int | None = None,
 ) -> Text:
     """The per-session table, pre-ordered and pre-indented by the forest walk.
 
@@ -1060,9 +1310,17 @@ def _session_section(
     cells and pushes ``% cache`` off the box). Sizing runs over the rows THIS
     table paints, which carry subtree totals, so it matches what
     ``build_report`` budgeted against.
+
+    ``cursor`` is the index in ``rows`` the keyboard is currently on, painted
+    into the two leading indent cells every row already spends — so the cursor
+    costs the label budget nothing and cannot shift a numeric column. ``None``
+    (the default, and what every non-interactive caller passes) paints no
+    cursor at all, which keeps the plain-text renderers and the scripts on the
+    same output they had before the row cursor existed.
     """
     fg = semantic_style("fg")
     dim = semantic_style("dim")
+    accent = semantic_style("accent")
     block = section_header("By session", meta)
     if not rows:
         block.append("\n  (none)", style=dim)
@@ -1073,18 +1331,26 @@ def _session_section(
     cost_col = max(len(format_cost(agg)) for _, agg in pairs)
     tokens_col = _tokens_col(pairs)
     calls_col = _calls_col(pairs)
-    for label, depth, agg in rows:
+    for index, (label, depth, agg) in enumerate(rows):
         block.append("\n")
         # A nested row is dimmed as well as indented: its dollars are already
         # inside the root above it, so it must not compete visually with the
         # rows that actually partition the total.
         style = fg if depth == 0 else dim
+        on_cursor = cursor is not None and index == cursor
+        if on_cursor:
+            block.append(f"{_ROW_CURSOR} ", style=accent)
+        else:
+            block.append("  ")
         # TRUNCATE as well as pad, in CELLS, exactly as ``_group_section`` does:
         # a bare ``{label:<{name_col}}`` pushes every numeric column right by
         # whatever the label overran, and the cost column is the one thing this
         # screen exists to let you scan straight down. Labels arrive budgeted
         # (prefix included), so this is a backstop rather than the mechanism.
-        block.append(f"  {truncate_cells(label, name_col):<{name_col}}", style=style)
+        block.append(
+            f"{truncate_cells(label, name_col):<{name_col}}",
+            style=accent if on_cursor else style,
+        )
         block.append(f"{format_tokens(agg.total_tokens):>{tokens_col}} tokens", style=style)
         block.append("   ")
         append_cost(block, agg, cost_col, style, dim)
@@ -1187,8 +1453,26 @@ class AnalyticsScreen(ModalScreen[None]):
         Binding("escape", "dismiss_screen", "Back", show=False),
         Binding("q", "dismiss_screen", "Back", show=False),
         Binding("t", "toggle_metric", "Cost/tokens", show=False),
-        Binding("up", "scroll_up", "Up", show=False),
-        Binding("down", "scroll_down", "Down", show=False),
+        # ``priority=True`` on the row keys, and it is load-bearing rather than
+        # defensive. Focus sits on the inner ``VerticalScroll``, which handles
+        # the arrows itself whenever it can still scroll — so a plain screen
+        # binding is reached only at the ends of the travel. That is why the
+        # ``action_scroll_up``/``down`` this replaces were effectively dead on
+        # any report tall enough to scroll, and why the cursor would otherwise
+        # move only on a short one (measured: it worked at 110x40, where the
+        # body fits, and never at 110x20, where it does not).
+        #
+        # Taking the arrows from the container is the deliberate half of the
+        # "one gesture owns the viewport" split: KEYS move the cursor and scroll
+        # it into view, while the WHEEL and the scrollbar still move the viewport
+        # alone and leave the cursor where it was.
+        Binding("up", "move_up", "Up", show=False, priority=True),
+        Binding("down", "move_down", "Down", show=False, priority=True),
+        Binding("enter", "toggle_row", "Expand/collapse", show=False, priority=True),
+        Binding("space", "toggle_row", "Expand/collapse", show=False, priority=True),
+        Binding("right", "expand_row", "Expand", show=False, priority=True),
+        Binding("left", "collapse_row", "Collapse", show=False, priority=True),
+        Binding("e", "toggle_all", "Expand/collapse all", show=False),
         Binding("pageup", "page_up", "Page up", show=False),
         Binding("pagedown", "page_down", "Page down", show=False),
         Binding("home", "scroll_home", "Top", show=False),
@@ -1218,6 +1502,36 @@ class AnalyticsScreen(ModalScreen[None]):
         #: Which metric the bar charts plot; ``t`` flips it. Cost by default
         #: (the historical view's stated purpose).
         self._metric = METRIC_COST
+        #: Session IDs whose subagent rows are shown. Empty by default: the
+        #: operator's ledger has 1,645 subagent rows against 595 roots, and
+        #: painting them all cost a 0.65 s first paint plus a full rebuild on
+        #: every resize event a terminal drag emits.
+        #:
+        #: Keyed by session ID and NEVER by the rendered label or the row index.
+        #: A label is recomposed at every width (two sessions can render the same
+        #: string; that silently dropped 355 sessions once), and an index moves
+        #: the moment any row above it expands.
+        self._expanded: set[str] = set()
+        #: Session ID the row cursor is on, or ``None`` before the first paint
+        #: has told us which rows exist. Same keying rule, same reasons.
+        self._cursor: str | None = None
+        #: What the last paint put where — the rows it drew and the body line the
+        #: first of them landed on. Written by ``build_report`` through the
+        #: ``ReportLayout`` receiver so cursor movement and scroll-to-cursor read
+        #: the SAME notion of visible rows the paint used, rather than a second
+        #: one derived alongside it that could disagree.
+        self._layout = ReportLayout()
+        #: Content-box width the body was last composed at. ``on_resize`` fires a
+        #: storm of events during a drag and each rebuild was 0.5-0.6 s on a real
+        #: ledger — the freeze in the user's report. Almost all of those events
+        #: leave ``_card_width()`` unchanged (the card is 90% of the terminal,
+        #: capped, and integer-floored, so several terminal widths map to one box
+        #: and the CAP makes every width past 156 identical), and a rebuild at an
+        #: unchanged width cannot produce different output. So the width is the
+        #: repaint's cache key.
+        self._painted_width: int | None = None
+        #: Lazily built by ``_forest()``; see there for why it is cached.
+        self._forest_cache: list["SessionNode"] | None = None
         self._title: Static
         self._body: Static
         self._scroll: VerticalScroll
@@ -1242,7 +1556,18 @@ class AnalyticsScreen(ModalScreen[None]):
         self.call_after_refresh(self._sync_hint)
 
     def on_resize(self, event) -> None:  # type: ignore[no-untyped-def]
-        self._repaint()
+        # NOT an unconditional rebuild. Dragging a terminal edge emits a burst of
+        # resize events, and rebuilding the whole report per event measured
+        # 0.5-0.6 s each against a real ledger — the "freezing" in the report,
+        # since the burst arrives faster than one rebuild finishes. ``_repaint``
+        # is a no-op when ``_card_width()`` is unchanged, and the card is a
+        # floored 90% of the terminal capped at 140, so many terminal widths map
+        # to one content box and every width past 156 maps to the same one.
+        #
+        # The HINT is still re-synced every time: it depends on whether the body
+        # overflows the viewport, which changes with HEIGHT, and height does not
+        # enter ``_card_width`` at all.
+        self._repaint(force=False)
         self.call_after_refresh(self._sync_hint)
 
     def _card_width(self) -> int:
@@ -1308,7 +1633,16 @@ class AnalyticsScreen(ModalScreen[None]):
         # follows). ``bool(series)`` is false for both ``None`` and ``[]``.
         if self._has_charts():
             hint.append(" · t cost/tokens", style=faint)
-        if scrollable:
+        # The expand keys are advertised only when a row can actually be
+        # expanded — the same D5 rule as the two hints above. A ledger that never
+        # ran a subagent has no expandable row, so ``enter`` and ``e`` would be
+        # dead controls, and the table it renders is the flat one this screen has
+        # always shown.
+        if self._expandable_rows():
+            hint.append(" · ↑↓ row · enter expand · e all", style=faint)
+        elif scrollable:
+            # ``↑↓`` still moves the cursor when rows exist, so it is described
+            # as "scroll" only where there is no cursor to move.
             hint.append(" · ↑↓ scroll", style=faint)
         return hint
 
@@ -1334,6 +1668,10 @@ class AnalyticsScreen(ModalScreen[None]):
         return bool(self._daily or self._monthly)
 
     def _report_lines(self) -> list[Text]:
+        # ``self._layout`` is the RECEIVER, refreshed by every render: the rows
+        # this paint drew and where it drew them. It must be written by the same
+        # call that composes the body or the cursor could point into a layout the
+        # screen is no longer showing.
         return build_report(
             self._aggregate,
             self._card_width(),
@@ -1341,11 +1679,42 @@ class AnalyticsScreen(ModalScreen[None]):
             monthly=self._monthly,
             window_totals=self._window_totals,
             metric=self._metric,
+            expanded=self._expanded,
+            cursor=self._cursor,
+            layout=self._layout,
+            # Every arrow key repaints, and rebuilding the forest each time was
+            # 34 ms of the ~0.25 s that made the cursor feel laggy rather than
+            # instant. Safe to share because the aggregate is a snapshot read on
+            # a worker thread before the screen was pushed and never mutates.
+            forest=self._forest(),
         )
 
-    def _repaint(self) -> None:
+    def _expandable_rows(self) -> bool:
+        """Whether the CURRENT paint has a row that can be expanded.
+
+        Read off the last layout rather than recomputed from the aggregate: this
+        gates a hint line, and a hint that describes a table other than the one
+        on screen is the defect the D5 rule exists to prevent. Before the first
+        paint the layout is empty and the answer is no, which is correct — no
+        rows are on screen to expand.
+        """
+        return any(row.expandable for row in self._layout.session_rows)
+
+    def _repaint(self, *, force: bool = True) -> None:
+        """Recompose the body, unless a width-driven repaint would change nothing.
+
+        ``force=False`` is the resize path (see ``on_resize``): a rebuild is
+        0.5-0.6 s on a real ledger and a terminal drag emits a burst of resize
+        events, so the ones that leave the content box unchanged must not each
+        pay for one. Every other caller changed the CONTENT (metric flipped, a
+        row expanded, the cursor moved) and forces, because the width is the same
+        by definition and only the content differs.
+        """
         body = getattr(self, "_body", None)
         if body is None or not body.is_mounted:
+            return
+        width = self._card_width()
+        if not force and width == self._painted_width:
             return
         combined = Text()
         for i, line in enumerate(self._report_lines()):
@@ -1353,6 +1722,7 @@ class AnalyticsScreen(ModalScreen[None]):
                 combined.append("\n")
             combined.append_text(line)
         body.update(combined)
+        self._painted_width = width
 
     def render_lines_for_test(self) -> list[str]:
         """The report as plain strings — what a user reads."""
@@ -1385,11 +1755,209 @@ class AnalyticsScreen(ModalScreen[None]):
         if title is not None and title.is_mounted:
             title.update(self._title_text())
 
-    def action_scroll_up(self) -> None:
-        self._scroll.scroll_up()
+    # -- the session-row cursor ----------------------------------------------
+    #
+    # ``↑↓`` used to scroll the container by a line. It now moves a row cursor
+    # and scrolls that row into view, which is the arrangement the codebase
+    # already settled on for every list that IS the page: the WHEEL and the
+    # scrollbar move the viewport and leave the cursor alone, while keys that
+    # move the CURSOR scroll it into view. Letting both drive the viewport from
+    # one gesture is what made ``/settings`` snap back to the top on a wheel
+    # notch at the bottom.
+    #
+    # ``pageup``/``pagedown``/``home``/``end`` deliberately stay pure VIEWPORT
+    # moves. This screen is mostly NOT a list — the totals, two charts and the
+    # input attribution sit above the table — so paging is how a reader travels
+    # between sections, and rebinding it to the cursor would strand them in the
+    # one section that has rows.
+    #
+    # Movement CLAMPS rather than wraps: this is a full-page surface several
+    # times its viewport, the documented exception (``/settings``,
+    # ``session_picker._move_to``). Wrapping from the last session back to the
+    # totals would throw the reader out of the section they were working in.
 
-    def action_scroll_down(self) -> None:
-        self._scroll.scroll_down()
+    def _visible_ids(self) -> list[str]:
+        return [row.session_id for row in self._layout.session_rows]
+
+    def _cursor_index(self) -> int | None:
+        """Where the cursor sits in the CURRENT paint, or ``None`` if nowhere.
+
+        The cursor is a session id, so it can legitimately be off-screen: the row
+        it names is inside a subtree that has since been collapsed. Callers treat
+        that as "no cursor" and re-home, rather than guessing an index.
+        """
+        if self._cursor is None:
+            return None
+        return next(
+            (
+                i
+                for i, row in enumerate(self._layout.session_rows)
+                if row.session_id == self._cursor
+            ),
+            None,
+        )
+
+    def _move_cursor(self, delta: int) -> None:
+        rows = self._layout.session_rows
+        if not rows:
+            return
+        index = self._cursor_index()
+        if index is None:
+            # First press, or the cursor's row was collapsed away. Land on the
+            # first row rather than jumping to wherever the delta points: the
+            # press should do something visible and predictable on its first try.
+            target = 0
+        else:
+            target = max(0, min(len(rows) - 1, index + delta))
+        self._cursor = rows[target].session_id
+        self._repaint()
+        self._scroll_cursor_into_view()
+
+    def _scroll_cursor_into_view(self) -> None:
+        """Put the cursor's body line inside the viewport, moving as little as possible.
+
+        The cursor is ALLOWED to be off screen — the wheel and the scrollbar move
+        the viewport without touching it — so a key that acts on the cursor has
+        to reveal it, or it writes to a row the reader cannot see and the frame
+        does not appear to change. Reveal-then-act, never an interlock that makes
+        the first press a no-op.
+        """
+        index = self._cursor_index()
+        if index is None:
+            return
+        scroll = getattr(self, "_scroll", None)
+        if scroll is None or not scroll.is_mounted:
+            return
+        line = self._layout.session_first_line + index
+        top = scroll.scroll_offset.y
+        height = scroll.size.height
+        if height <= 0:
+            return
+        # One row of slack at each edge so the cursor is never flush against the
+        # frame, where a reader cannot tell whether another row follows. The
+        # slack is dropped on a viewport too short to afford it (a 1-2 row body
+        # on a very short terminal): asking for context that does not fit makes
+        # the two branches fight and the cursor lands off screen, which is worse
+        # than no slack at all.
+        slack = 1 if height >= 3 else 0
+        if line < top + slack:
+            scroll.scroll_to(y=max(0, line - slack), animate=False)
+        elif line > top + height - 1 - slack:
+            scroll.scroll_to(y=max(0, line - height + 1 + slack), animate=False)
+
+    def action_move_up(self) -> None:
+        self._move_cursor(-1)
+
+    def action_move_down(self) -> None:
+        self._move_cursor(1)
+
+    def _set_expanded(self, session_id: str, open_: bool) -> None:
+        if open_:
+            self._expanded.add(session_id)
+        else:
+            self._expanded.discard(session_id)
+        self._repaint()
+        self._scroll_cursor_into_view()
+        # Expanding changes the body's height, so whether it overflows its
+        # viewport — and therefore whether the scroll hint is honest — can change
+        # with it. Deferred, because the new height is only known after the
+        # refresh that paints it.
+        self.call_after_refresh(self._sync_hint)
+
+    def _cursor_row(self) -> SessionRow | None:
+        index = self._cursor_index()
+        return None if index is None else self._layout.session_rows[index]
+
+    def action_toggle_row(self) -> None:
+        """Enter/space: open a closed row, close an open one.
+
+        With no cursor yet, the first press places it rather than toggling. The
+        user's report says "hits enter to expand that row", and there is no
+        "that row" until a cursor exists — toggling whatever happens to be first
+        would act on a row they never pointed at.
+        """
+        row = self._cursor_row()
+        if row is None:
+            self._move_cursor(0)
+            return
+        if not row.expandable:
+            return
+        self._set_expanded(row.session_id, not row.expanded)
+
+    def action_expand_row(self) -> None:
+        row = self._cursor_row()
+        if row is None:
+            self._move_cursor(0)
+            return
+        if row.expandable and not row.expanded:
+            self._set_expanded(row.session_id, True)
+
+    def action_collapse_row(self) -> None:
+        """Left: close this row, or step out to the parent of an already-closed one.
+
+        The step-out is what makes ``left`` usable inside a deep subtree — the
+        alternative is a key that does nothing on every row that is not itself an
+        open parent, which reads as broken rather than as restrained.
+        """
+        row = self._cursor_row()
+        if row is None:
+            self._move_cursor(0)
+            return
+        if row.expanded:
+            self._set_expanded(row.session_id, False)
+            return
+        if row.depth:
+            index = self._cursor_index()
+            rows = self._layout.session_rows
+            # The parent is the nearest row ABOVE this one at a shallower depth;
+            # the walk is depth-first, so scanning back is exact rather than a
+            # heuristic.
+            for candidate in range((index or 0) - 1, -1, -1):
+                if rows[candidate].depth < row.depth:
+                    self._cursor = rows[candidate].session_id
+                    self._repaint()
+                    self._scroll_cursor_into_view()
+                    return
+
+    def action_toggle_all(self) -> None:
+        """``e``: open every expandable row; press it again to close them all.
+
+        The test is "is EVERYTHING already open", not "is anything open". The
+        latter reads better as a safety rule — it makes the key an unconditional
+        way out of the expensive fully-expanded state — but it is wrong at the
+        keyboard: a reader who has opened one row and presses ``e`` meaning
+        "now show me all of it" gets everything HIDDEN instead, which is the
+        opposite of the request. Observed on the operator's ledger while
+        exercising the real screen.
+
+        Surprise is worse than slowness when the slowness is what was asked for.
+        Expanding all 2,240 rows measured 1.4 s and is one press to undo, so the
+        expensive state is reachable deliberately and never sticky.
+        """
+        expandable = {node.session_id for node in _iter_nodes(self._forest()) if node.has_children}
+        if expandable and expandable <= self._expanded:
+            self._expanded.clear()
+        else:
+            self._expanded = expandable
+        self._repaint()
+        self._scroll_cursor_into_view()
+        self.call_after_refresh(self._sync_hint)
+
+    def _forest(self) -> list["SessionNode"]:
+        """The full session forest, built once and cached.
+
+        ``build_report`` builds its own each paint (31 ms on the operator's
+        ledger), but ``expand all`` needs the ids of rows that are NOT currently
+        painted, so it cannot read them off the layout. Cached because the
+        aggregate is immutable for the life of the screen — it is a snapshot read
+        on a worker thread before the screen was pushed.
+        """
+        if self._forest_cache is None:
+            self._forest_cache = build_session_forest(
+                self._aggregate.by_session,
+                getattr(self._aggregate, "session_parents", {}) or {},
+            )
+        return self._forest_cache
 
     def action_page_up(self) -> None:
         self._scroll.scroll_page_up()

--- a/local_operator/tui/widgets/analytics_panel.py
+++ b/local_operator/tui/widgets/analytics_panel.py
@@ -899,7 +899,16 @@ def build_report(
             cursor_index = next(
                 (i for i, row in enumerate(structure) if row.session_id == cursor), None
             )
-        lines.append(_session_section(session_rows, width, name_col, meta, cursor=cursor_index))
+        lines.append(
+            _session_section(
+                session_rows,
+                width,
+                name_col,
+                meta,
+                cursor=cursor_index,
+                suffixes=[suffixes[row.session_id] for row in structure],
+            )
+        )
 
     # Legend for the cost markers, drawn only when a ``+`` or ``$—`` is on
     # screen (review D1). ``dim`` so it reads as a footnote, not a row.
@@ -1290,6 +1299,7 @@ def _session_section(
     meta: str = "",
     *,
     cursor: int | None = None,
+    suffixes: Sequence[str] | None = None,
 ) -> Text:
     """The per-session table, pre-ordered and pre-indented by the forest walk.
 
@@ -1317,6 +1327,14 @@ def _session_section(
     (the default, and what every non-interactive caller passes) paints no
     cursor at all, which keeps the plain-text renderers and the scripts on the
     same output they had before the row cursor existed.
+
+    ``suffixes`` is the ``+N subagents`` tail already composed into each label,
+    handed over separately ONLY so it can be painted ``dim`` (review D3). It is
+    metadata about the row, not part of the session's name, and at full
+    foreground it scanned as the end of the title — while ``calls``, ``% cache``
+    and the section meta beside it are all dim. Passing the string rather than a
+    length keeps the split honest under truncation: a suffix the budget cut is
+    simply not found at the tail and the row paints in one style, as before.
     """
     fg = semantic_style("fg")
     dim = semantic_style("dim")
@@ -1347,10 +1365,18 @@ def _session_section(
         # whatever the label overran, and the cost column is the one thing this
         # screen exists to let you scan straight down. Labels arrive budgeted
         # (prefix included), so this is a backstop rather than the mechanism.
-        block.append(
-            f"{truncate_cells(label, name_col):<{name_col}}",
-            style=accent if on_cursor else style,
-        )
+        clipped = truncate_cells(label, name_col)
+        pad = " " * max(0, name_col - cell_len(clipped))
+        suffix = suffixes[index] if suffixes is not None and index < len(suffixes) else ""
+        # The cursor row keeps ONE style across the whole label: the caret's
+        # highlight is what says "you are here", and breaking it in the middle
+        # would read as two spans rather than one selected row.
+        if suffix and not on_cursor and clipped.endswith(suffix):
+            block.append(clipped[: len(clipped) - len(suffix)], style=style)
+            block.append(suffix, style=dim)
+            block.append(pad)
+        else:
+            block.append(clipped + pad, style=accent if on_cursor else style)
         block.append(f"{format_tokens(agg.total_tokens):>{tokens_col}} tokens", style=style)
         block.append("   ")
         append_cost(block, agg, cost_col, style, dim)
@@ -1554,6 +1580,33 @@ class AnalyticsScreen(ModalScreen[None]):
         # After layout settles: ``max_scroll_y`` is only meaningful once the
         # body has been measured against the viewport.
         self.call_after_refresh(self._sync_hint)
+        self.call_after_refresh(self._place_initial_cursor)
+
+    def _place_initial_cursor(self) -> None:
+        """Draw the caret from frame 1, without moving the viewport.
+
+        The hint says ``enter expand`` on the opening frame, but with no cursor
+        set the first ``enter`` only PLACED one — so the advertised key took two
+        presses to do the advertised thing (review D2; the PR's own capture
+        script pressed ``enter`` twice for exactly this reason). Placing it at
+        mount makes every ``enter`` act.
+
+        Placed WITHOUT scrolling: the opening frame is the top of the report and
+        scrolling to row 0 of a table 57 lines down would throw the reader out of
+        the totals block they opened the screen to read. This is the same rule
+        U2 asks for — a cursor never teleports the viewport — so the two are one
+        behaviour, not two. When the table is off screen the cursor is simply
+        parked on row 0 unpainted; the first arrow press then line-scrolls
+        (``_table_on_screen``) rather than jumping to it.
+        """
+        if self._cursor is not None:
+            return
+        rows = self._layout.session_rows
+        if not rows:
+            return
+        index = self._visible_row_index()
+        self._cursor = rows[index if index is not None else 0].session_id
+        self._repaint()
 
     def on_resize(self, event) -> None:  # type: ignore[no-untyped-def]
         # NOT an unconditional rebuild. Dragging a terminal edge emits a burst of
@@ -1620,30 +1673,87 @@ class AnalyticsScreen(ModalScreen[None]):
         title.append("─" * max(1, self._card_width()), style=faint)
         return title
 
+    def _hint_width(self) -> int:
+        """Cells the hint ``Static`` can actually paint into on this frame.
+
+        The hint is ``height: 2`` with ``padding-top: 1`` (see
+        ``#analytics-hint`` in the stylesheet), i.e. exactly ONE content line.
+        Anything wider wraps to a second line that is never painted — which is
+        why the width has to be measured rather than assumed. Falls back to the
+        card width before the widget is mounted, which is within a cell of the
+        real box at every terminal size measured (50→39/40, 120→102/101).
+        """
+        hint = getattr(self, "_hint", None)
+        if hint is not None and hint.is_mounted:
+            width = hint.content_size.width
+            if width > 0:
+                return width
+        return self._card_width()
+
     def _hint_text(self, *, scrollable: bool) -> Text:
         # The scroll affordance is advertised only when there is something to
         # scroll (D5): the empty state and any report that fits told the user to
         # scroll a screen that could not, which reads as a dead control.
         faint = Style(color=theme_mod.semantic_color("faint"))
-        hint = Text()
-        hint.append("esc back", style=faint)
-        # The metric toggle is advertised only when there is a chart to toggle;
-        # an empty or rollup-less report has no bars, so the key is a no-op and
-        # promising it would be a dead control (the same rule the scroll hint
-        # follows). ``bool(series)`` is false for both ``None`` and ``[]``.
-        if self._has_charts():
-            hint.append(" · t cost/tokens", style=faint)
-        # The expand keys are advertised only when a row can actually be
-        # expanded — the same D5 rule as the two hints above. A ledger that never
-        # ran a subagent has no expandable row, so ``enter`` and ``e`` would be
-        # dead controls, and the table it renders is the flat one this screen has
-        # always shown.
-        if self._expandable_rows():
-            hint.append(" · ↑↓ row · enter expand · e all", style=faint)
+        # ``↑↓`` is described as "row" whenever session rows exist, NOT only when
+        # something is expandable (review R2). The cursor moves on every ledger
+        # with rows — ``_move_cursor`` never consults expandability — so the old
+        # ``↑↓ scroll`` on a subagent-free ledger described a control the screen
+        # did not have. It now also genuinely scrolls above the table, but "row"
+        # is the half a reader needs named: line-scrolling is the behaviour they
+        # already expect from an arrow on a report.
+        rows = bool(self._layout.session_rows)
+        expandable = self._expandable_rows()
+        # Ordered widest-first; the first one that FITS the real box is painted.
+        # Degrading by dropping whole clauses (rather than letting the tail wrap
+        # away unpainted) is the fix for U3: at 50 and 60 columns the cut used to
+        # eat ``enter expand · e all`` and leave a dangling ``·``, so exactly
+        # where the table is most cramped the expand keys stopped being
+        # documented while the ``▸`` glyphs stayed on screen inviting the press.
+        #
+        # ``esc back`` is shed BEFORE the expand keys because ``esc`` is the one
+        # key a reader tries unprompted on a modal; ``enter``/``e`` are the ones
+        # they cannot guess. Both keep their names in every tier that mentions
+        # them — an abbreviation that drops the key name documents nothing.
+        if expandable:
+            candidates = [
+                "esc back · t cost/tokens · ↑↓ row · enter expand · e all",
+                "esc back · ↑↓ row · enter expand · e all",
+                "esc back · ↑↓ row · enter · e all",
+                "↑↓ row · enter · e all",
+                "enter · e all",
+            ]
+            if not self._has_charts():
+                candidates = candidates[1:]
+        elif rows:
+            candidates = [
+                "esc back · t cost/tokens · ↑↓ row",
+                "esc back · ↑↓ row",
+                "↑↓ row",
+            ]
+            if not self._has_charts():
+                candidates = candidates[1:]
         elif scrollable:
-            # ``↑↓`` still moves the cursor when rows exist, so it is described
-            # as "scroll" only where there is no cursor to move.
-            hint.append(" · ↑↓ scroll", style=faint)
+            # No rows at all (an empty or provider-only report): there is no
+            # cursor to move, so the arrows only ever scroll and the hint says so.
+            candidates = [
+                "esc back · t cost/tokens · ↑↓ scroll",
+                "esc back · ↑↓ scroll",
+                "↑↓ scroll",
+            ]
+            if not self._has_charts():
+                candidates = candidates[1:]
+        else:
+            candidates = ["esc back · t cost/tokens", "esc back"]
+            if not self._has_charts():
+                candidates = ["esc back"]
+
+        width = self._hint_width()
+        # The narrowest tier is the floor: below it there is nothing left to shed
+        # and a clipped hint beats no hint.
+        text = next((c for c in candidates if cell_len(c) <= width), candidates[-1])
+        hint = Text(no_wrap=True, overflow="crop")
+        hint.append(text, style=faint)
         return hint
 
     def _sync_hint(self) -> None:
@@ -1797,16 +1907,102 @@ class AnalyticsScreen(ModalScreen[None]):
             None,
         )
 
+    def _table_on_screen(self) -> bool:
+        """Whether any session row is inside the viewport right now.
+
+        This is the hand-off test between the two jobs ``↑↓`` has to do on this
+        screen. The report is mostly NOT a list: on the operator's ledger the
+        session table starts ~57 body lines down, behind the totals block, both
+        bar charts and the input attribution. A cursor addresses ONLY table
+        rows, so while the reader is still up in that non-row content there is
+        nothing for the cursor to move and the arrows must keep doing what they
+        did before this feature existed — line-scroll the container.
+
+        Measured before the fix (real ledger, 120x40): ``end`` then 400 ``up``
+        presses left the viewport pinned at y=56, i.e. the top of the report was
+        unreachable by arrow key while the hint said ``↑↓ row`` (reviews
+        R1/R2/D1/U1/U2 — four streams, one root cause).
+        """
+        rows = self._layout.session_rows
+        scroll = getattr(self, "_scroll", None)
+        if not rows or scroll is None or not scroll.is_mounted:
+            return False
+        height = scroll.size.height
+        if height <= 0:
+            return False
+        top = scroll.scroll_offset.y
+        first = self._layout.session_first_line
+        last = first + len(rows) - 1
+        # Any overlap between [first, last] and the viewport [top, top+height).
+        return first <= top + height - 1 and last >= top
+
+    def _visible_row_index(self) -> int | None:
+        """Index of the first session row already ON SCREEN, or ``None``.
+
+        Used to place a cursor that has none instead of teleporting to row 0.
+        Homing to row 0 is what made ``up`` the largest jump on the keyboard
+        (review U2: after ``end`` at y=629, one ``up`` landed at y=56 — 570
+        lines BACKWARD), because ``_scroll_cursor_into_view`` then drags the
+        viewport to wherever row 0 happens to be. Landing on a row the reader
+        can already see keeps them where they were, which is the property that
+        makes a cursor feel like a cursor rather than a jump.
+        """
+        rows = self._layout.session_rows
+        scroll = getattr(self, "_scroll", None)
+        if not rows or scroll is None or not scroll.is_mounted:
+            return None
+        height = scroll.size.height
+        if height <= 0:
+            return None
+        top = scroll.scroll_offset.y
+        first = self._layout.session_first_line
+        # The first row at or below the viewport's top edge, if it is still
+        # inside the viewport.
+        index = max(0, top - first)
+        if index >= len(rows) or first + index > top + height - 1:
+            return None
+        return index
+
+    def _cursor_on_screen(self) -> bool:
+        """Whether the cursor's row is inside the viewport right now.
+
+        The cursor is ALLOWED to drift off screen — the wheel and the scrollbar
+        move the viewport without touching it, which is the split AGENTS.md
+        requires. But a KEY that acts on the cursor must not then drag the
+        viewport back to wherever it drifted to: that is the 570-line backward
+        jump review U2 measured after ``end``. So an arrow press re-homes an
+        off-screen cursor to a row the reader can see, rather than moving it
+        from a position they can no longer verify.
+        """
+        index = self._cursor_index()
+        scroll = getattr(self, "_scroll", None)
+        if index is None or scroll is None or not scroll.is_mounted:
+            return False
+        height = scroll.size.height
+        if height <= 0:
+            return False
+        top = scroll.scroll_offset.y
+        line = self._layout.session_first_line + index
+        return top <= line <= top + height - 1
+
     def _move_cursor(self, delta: int) -> None:
         rows = self._layout.session_rows
         if not rows:
             return
-        index = self._cursor_index()
+        index = self._cursor_index() if self._cursor_on_screen() else None
         if index is None:
-            # First press, or the cursor's row was collapsed away. Land on the
-            # first row rather than jumping to wherever the delta points: the
-            # press should do something visible and predictable on its first try.
-            target = 0
+            # No cursor to move. Two cases, and conflating them is the defect
+            # the round-2 remediation fixes:
+            #
+            # 1. The table is not on screen — the reader is up in the totals or
+            #    the charts. There is no row to point at, so the arrow keeps its
+            #    pre-feature meaning and line-scrolls the container. Handled by
+            #    the callers (``action_move_up``/``action_move_down``), which
+            #    check ``_table_on_screen`` before ever reaching here.
+            # 2. The table IS on screen but no cursor is set (first press, or
+            #    the cursor's row was collapsed away). Place it on a row the
+            #    reader can already SEE rather than scrolling to row 0.
+            target = self._visible_row_index() or 0
         else:
             target = max(0, min(len(rows) - 1, index + delta))
         self._cursor = rows[target].session_id
@@ -1845,18 +2041,108 @@ class AnalyticsScreen(ModalScreen[None]):
         elif line > top + height - 1 - slack:
             scroll.scroll_to(y=max(0, line - height + 1 + slack), animate=False)
 
+    def _scroll_by_line(self, delta: int) -> None:
+        """Move the viewport one line, the way the container did before the cursor.
+
+        ``animate=False`` deliberately: an animated single-line step makes an
+        autorepeating arrow queue animations behind each other and the viewport
+        lags the key by hundreds of milliseconds. Every other viewport move on
+        this screen (``_scroll_cursor_into_view``) is unanimated for the same
+        reason, so this keeps one feel across the surface.
+        """
+        scroll = getattr(self, "_scroll", None)
+        if scroll is None or not scroll.is_mounted:
+            return
+        scroll.scroll_relative(y=delta, animate=False)
+
     def action_move_up(self) -> None:
+        # The arrows serve the TABLE only once the table is on screen. Above it
+        # the report is charts and totals with no rows to address, so the key
+        # line-scrolls exactly as ``origin/main``'s ``Binding("up",
+        # "scroll_up")`` did. Without this the cursor's re-home clamped the
+        # viewport at the table's first line and the top of the report could not
+        # be reached by arrow at all (R1/D1/U1), and ``up`` at the bottom jumped
+        # 570 lines backward (U2).
+        if not self._table_on_screen():
+            self._scroll_by_line(-1)
+            return
+        # At the TOP of the table the arrow keeps travelling instead of
+        # clamping. Clamping here is what produced the hard floor: ``end`` then
+        # 400 ``up`` presses left the viewport stuck at y=56 forever, because
+        # every press re-pinned the cursor to row 0 and dragged the viewport
+        # back to it. Falling through to a line-scroll hands the reader back the
+        # 57 lines of totals and charts above the table.
+        if self._cursor_on_screen() and self._cursor_index() == 0:
+            self._scroll_by_line(-1)
+            return
         self._move_cursor(-1)
 
     def action_move_down(self) -> None:
+        if not self._table_on_screen():
+            self._scroll_by_line(1)
+            return
+        rows = self._layout.session_rows
+        # Symmetric to ``action_move_up``: at the last row the arrow scrolls on
+        # rather than dying, so the reader can reach the true bottom of the body
+        # with the same key that got them there.
+        if rows and self._cursor_on_screen() and self._cursor_index() == len(rows) - 1:
+            self._scroll_by_line(1)
+            return
         self._move_cursor(1)
 
+    def _ancestor_chain(self) -> list[str]:
+        """Session ids of the cursor row's ancestors, nearest parent first.
+
+        Read off the CURRENT paint, before the collapse that is about to hide
+        the cursor. The walk is depth-first, so the nearest row above the cursor
+        at each shallower depth is exactly its ancestor at that depth — the same
+        exact (not heuristic) scan ``action_collapse_row`` already uses to step
+        out to a parent.
+        """
+        index = self._cursor_index()
+        if index is None:
+            return []
+        rows = self._layout.session_rows
+        chain: list[str] = []
+        depth = rows[index].depth
+        for candidate in range(index - 1, -1, -1):
+            if rows[candidate].depth < depth:
+                depth = rows[candidate].depth
+                chain.append(rows[candidate].session_id)
+                if depth == 0:
+                    break
+        return chain
+
+    def _rehome_to_ancestor(self, chain: list[str]) -> None:
+        """After a collapse hid the cursor, put it on the nearest VISIBLE ancestor.
+
+        The root that swallowed the row is where the reader's attention already
+        is — it is the row still on screen at the position they were reading.
+        Leaving the cursor naming a hidden session instead (the pre-fix
+        behaviour) made the NEXT arrow press re-home to table row 0 and teleport
+        the viewport: observed at ~200 lines after collapse-all (review U2c).
+        """
+        if self._cursor_index() is not None:
+            return
+        visible = {row.session_id for row in self._layout.session_rows}
+        for ancestor in chain:
+            if ancestor in visible:
+                self._cursor = ancestor
+                return
+
     def _set_expanded(self, session_id: str, open_: bool) -> None:
+        # Captured BEFORE the repaint: collapsing a subtree removes the cursor's
+        # row from the layout, and the ancestry that says where to land is only
+        # readable while that row is still painted.
+        chain = [] if open_ else self._ancestor_chain()
         if open_:
             self._expanded.add(session_id)
         else:
             self._expanded.discard(session_id)
         self._repaint()
+        if chain:
+            self._rehome_to_ancestor(chain)
+            self._repaint()
         self._scroll_cursor_into_view()
         # Expanding changes the body's height, so whether it overflows its
         # viewport — and therefore whether the scroll hint is honest — can change
@@ -1935,11 +2221,18 @@ class AnalyticsScreen(ModalScreen[None]):
         expensive state is reachable deliberately and never sticky.
         """
         expandable = {node.session_id for node in _iter_nodes(self._forest()) if node.has_children}
-        if expandable and expandable <= self._expanded:
+        collapsing = bool(expandable) and expandable <= self._expanded
+        # Same reason as ``_set_expanded``: collapse-all hides every child row,
+        # so the cursor's ancestry has to be read while it is still painted.
+        chain = self._ancestor_chain() if collapsing else []
+        if collapsing:
             self._expanded.clear()
         else:
             self._expanded = expandable
         self._repaint()
+        if chain:
+            self._rehome_to_ancestor(chain)
+            self._repaint()
         self._scroll_cursor_into_view()
         self.call_after_refresh(self._sync_hint)
 

--- a/scripts/analytics_collapse_probe.py
+++ b/scripts/analytics_collapse_probe.py
@@ -1,0 +1,131 @@
+"""Measure what the ``/analytics`` session table costs to paint and to move in.
+
+Usage: python scripts/analytics_collapse_probe.py [LEDGER] [WIDTHxHEIGHT]
+
+Written for the collapsible-session-rows change and kept because the numbers it
+prints are the only ones that can answer "is the screen still slow?". The user's
+report was "my screen is freezing on /analytics" — a symptom that a unit test
+cannot see and that a single wall-clock sample mis-attributes, because three
+different costs hide inside it:
+
+* the STORE READ, which already runs on a worker thread (``_open_analytics_worker``)
+  and so delays the screen appearing without freezing anything;
+* the FIRST PAINT, which is on the event loop and is dominated by how many rows
+  ``build_report`` composes into the one body ``Static``;
+* every subsequent REBUILD — and the one that actually froze the terminal is
+  ``on_resize``, because a drag emits a storm of resize events and each one
+  used to re-render the whole report.
+
+So each is timed separately, against a real ledger rather than a fixture: the
+shape that hurts (hundreds of roots, a handful of them with dozens of subagent
+children) does not exist in any test fixture and cannot be conjured by scaling
+one up. Point it at a COPY of a real ledger; opening a store runs migrations and
+may build an index, so this must never be aimed at a live ``analytics.db``.
+
+The pilot runs headless with every ``CMUX_*`` identifier cleared and its own
+config dir (``scripts.probe_isolation``): a headless app that inherits
+``CMUX_WORKSPACE_ID`` renames the operator's real cmux workspaces.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Clear every multiplexer identifier BEFORE any application import (see module
+# docstring): inherited CMUX ids have previously been acted on by a headless app.
+for _key in tuple(os.environ):
+    if _key.startswith("CMUX_"):
+        os.environ.pop(_key)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import asyncio  # noqa: E402
+import time  # noqa: E402
+
+import scripts.probe_isolation  # noqa: E402, F401
+from local_operator.analytics.store import AnalyticsStore  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.analytics_panel import AnalyticsScreen  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+
+async def _timed(label: str, body) -> float:
+    """Run ``body`` and print how long it took, in the pilot's own frame."""
+    start = time.perf_counter()
+    await body()
+    elapsed = time.perf_counter() - start
+    print(f"{label:<34} {elapsed:>7.3f}s")
+    return elapsed
+
+
+async def main() -> None:
+    ledger = Path(sys.argv[1] if len(sys.argv) > 1 else "/tmp/an-probe.db")
+    size = sys.argv[2] if len(sys.argv) > 2 else "110x40"
+    width, height = (int(part) for part in size.split("x"))
+
+    store = AnalyticsStore(ledger)
+    start = time.perf_counter()
+    aggregate = store.aggregate()
+    daily = store.daily_series(30)
+    monthly = store.monthly_series(12)
+    window_totals = store.series_totals(daily_days=30)
+    read = time.perf_counter() - start
+    print(
+        f"{'store read (worker thread)':<34} {read:>7.3f}s  "
+        f"sessions={len(aggregate.by_session)}"
+    )
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(width, height)) as pilot:
+        await pilot.pause()
+        screen = AnalyticsScreen(
+            aggregate, daily=daily, monthly=monthly, window_totals=window_totals
+        )
+
+        async def _push() -> None:
+            await app.push_screen(screen)
+            await pilot.pause()
+
+        await _timed("push_screen + first paint", _push)
+
+        # The freeze the user reported. A terminal resize emits a burst of these,
+        # so the per-event cost is what decides whether a drag is smooth or wedged.
+        for index, term_width in enumerate((width - 2, width - 4, width - 4)):
+
+            async def _resize(w=term_width) -> None:
+                await pilot.resize_terminal(w, height)
+                await pilot.pause()
+
+            # The third resize repeats the second width on purpose: a rebuild that
+            # is skipped when the card width band is unchanged shows up here and
+            # nowhere else.
+            await _timed(f"resize #{index + 1} -> {term_width}", _resize)
+
+        async def _toggle() -> None:
+            await pilot.press("t")
+            await pilot.pause()
+
+        await _timed("metric toggle (full rebuild)", _toggle)
+
+        async def _arrow() -> None:
+            await pilot.press("down")
+            await pilot.pause()
+
+        await _timed("one down press", _arrow)
+
+        # Size of the thing being painted, recomposed off the timed path (the
+        # widget does not expose what it was handed). Lines and spans are the two
+        # quantities the paint cost tracks: Rich walks every span of every line.
+        report = screen._report_lines()
+        lines = sum(block.plain.count("\n") + 1 for block in report)
+        spans = sum(len(block.spans) for block in report)
+        print(f"{'body lines':<34} {lines:>8}")
+        print(f"{'style spans':<34} {spans:>8}")
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/analytics_collapse_shot.py
+++ b/scripts/analytics_collapse_shot.py
@@ -199,6 +199,27 @@ async def _capture(app, pilot, out: Path, state: str) -> dict[str, object]:
     }
 
 
+async def _walk_cursor_to(pilot, screen, *, expandable: bool, limit: int = 40) -> str:
+    """Walk the row cursor down until it stands on a row of the asked-for kind.
+
+    Frames are named after the STATE they show, so the state has to be asserted
+    rather than assumed. Round 1 shipped ``cursor-expandable.svg`` holding the
+    cursor on a childless root and ``cursor-childless.svg`` holding it on the
+    expandable one — the two were captured by press count, and the press count
+    that reaches an expandable row depends on the seeded ledger's ordering.
+
+    Returns the session id it stopped on so the caller can print it as evidence.
+    Raises rather than capturing a mislabelled frame.
+    """
+    for _ in range(limit):
+        row = screen._cursor_row()
+        if row is not None and row.expandable is expandable:
+            return row.session_id
+        await pilot.press("down")
+        await pilot.pause()
+    raise AssertionError(f"no row with expandable={expandable} within {limit} presses")
+
+
 async def main() -> None:
     out = Path(sys.argv[1]).resolve()
     out.mkdir(parents=True, exist_ok=True)
@@ -233,17 +254,22 @@ async def main() -> None:
         # pre-change code these keys do not exist, so the frames repeat the
         # previous state — which is the point of running one script on both sides.
         #
-        # TWO presses, deliberately: the first Enter PLACES the cursor (there is
-        # no "that row" to expand until one exists) and the second acts on it.
-        # A single press captured the cursor arriving on a still-collapsed row,
-        # which is a real state but not the one this frame is for.
+        # ONE press now. It used to take two, because the first Enter only
+        # PLACED the cursor; the cursor is placed at mount since review D2, so
+        # the advertised key acts on its first press and this script no longer
+        # has to paper over the difference.
+        #
+        # The cursor is walked onto an EXPANDABLE row explicitly rather than
+        # trusted to land on one by press count: which row a fixed number of
+        # presses reaches depends on the seeded ledger's ordering, and that is
+        # how the round-1 artifacts ended up with the frame named "expandable"
+        # holding the cursor on a childless root.
         await pilot.press("home")
         await pilot.pause()
         for _ in range(4):
             await pilot.press("pagedown")
             await pilot.pause()
-        await pilot.press("enter")
-        await pilot.pause()
+        await _walk_cursor_to(pilot, screen, expandable=True)
         await pilot.press("enter")
         await pilot.pause()
         await pilot.pause()

--- a/scripts/analytics_collapse_shot.py
+++ b/scripts/analytics_collapse_shot.py
@@ -1,0 +1,277 @@
+"""Capture the ``/analytics`` session table's collapsed/expanded states.
+
+Usage: python scripts/analytics_collapse_shot.py OUTDIR
+
+Sibling of ``analytics_width_band_shot.py`` (does a row FIT?) and
+``analytics_label_shot.py`` (what does a row SAY?). This one is about how much
+of the table is on screen at all, and it exists for the collapsible-rows change:
+a session with 90 subagents used to paint all 91 rows whether or not anyone
+wanted them, and the frames here are what shows that the default view is now the
+roots alone and that expanding one brings its children back.
+
+Runs against the SAME script on both sides of the change, deliberately. On the
+pre-change code the expand keys do not exist, so the "collapsed" and "expanded"
+frames come out identical — which is the before-state stated as an artifact
+rather than as a claim. Three consecutive captures per state, so a post-paint
+reflow shows up as two differing SVGs instead of being averaged away by one
+lucky shot.
+
+The fixture is seeded rather than read from a real ledger: the frames have to
+show a root with MANY children beside a root with NONE (the two shapes whose
+rendering differs), and a real ledger cannot be relied on to put both near the
+top of a cost-sorted table. Magnitudes follow ``analytics_width_band_shot``'s
+lead — real-sized call counts, because a fixture whose numbers are all toy-sized
+is evidence only about toy data.
+
+No provider request, live session or operator config is touched:
+``probe_isolation`` re-homes HOME and the config dir before any application
+import, and every ``CMUX_*`` identifier is cleared first (a headless pilot that
+inherits ``CMUX_WORKSPACE_ID`` renames the operator's real cmux workspaces).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Clear every multiplexer identifier BEFORE any application import (see above).
+for _key in tuple(os.environ):
+    if _key.startswith("CMUX_"):
+        os.environ.pop(_key)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import asyncio  # noqa: E402
+import hashlib  # noqa: E402
+import json  # noqa: E402
+from dataclasses import replace  # noqa: E402
+
+import scripts.probe_isolation  # noqa: E402, F401
+from local_operator.analytics.store import AnalyticsStore, default_db_path  # noqa: E402
+from local_operator.session.frontend_state import FrontendSessionState  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.analytics_panel import AnalyticsScreen  # noqa: E402
+from scripts.analytics_label_shot import LedgerSession, _svg_rows  # noqa: E402
+from scripts.visual_capture import save_capture  # noqa: E402
+from tests.unit.analytics.test_store import _snap  # noqa: E402
+from tests.unit.tui.test_slash_echo import _submit  # noqa: E402
+
+#: ``(session_id, name, usd, calls, parent_id)``. Ordered by spend because the
+#: table is, so the frame's first rows are these rows.
+#:
+#: The shape matters more than the numbers. Row 1 is an expensive root with a
+#: dozen subagents — the case the user reported, scaled down to what a 40-row
+#: frame can show at once. Row 2 is an expensive root with NONE, which is the
+#: majority case on the real ledger (492 of 595 roots are childless) and the one
+#: that must not grow a disclosure glyph or otherwise look interactive.
+FIXTURE: list[tuple[str, str, float, int, str]] = [
+    ("8f21ac93bb04", "Toggleable Sidebar for Session Switching in the TUI", 900.00, 4210, ""),
+    ("2b77de10c9a5", "Improve Support for Local Model Providers", 640.00, 3180, ""),
+    ("d40c81ff7a13", "Harden Against Credential Leak Paths in the runner", 420.00, 812, ""),
+    ("6b1d0e97ca42", "eval osworld/chrome-0421 · claude-sonnet-4-6", 310.00, 96, ""),
+    ("c19b4f7d3a08", "routine background polling", 120.00, 41, ""),
+    ("98bfe7686ffe", "", 60.00, 8, ""),
+]
+
+#: Subagent children of the first root: the "hundreds of rows of subagent cost"
+#: the report is about. Twelve is enough to overflow the frame from ONE root
+#: while leaving the childless roots visible beneath it in the collapsed shot.
+CHILD_ROLES = [
+    "coder",
+    "reviewer",
+    "qa-tester",
+    "designer",
+    "architect",
+    "ux-reviewer",
+    "scout",
+    "manager",
+    "coder",
+    "reviewer",
+    "qa-tester",
+    "scout",
+]
+CHILD_PARENT = FIXTURE[0][0]
+#: A second, shallower parent, so the frame shows that "has children" is not a
+#: property of the single most expensive row.
+SECOND_PARENT = FIXTURE[2][0]
+SECOND_CHILDREN = ["reviewer", "qa-tester"]
+
+
+def _children() -> list[tuple[str, str, float, int, str]]:
+    rows: list[tuple[str, str, float, int, str]] = []
+    for index, role in enumerate(CHILD_ROLES):
+        rows.append(
+            (
+                f"c{index:02d}a1b2c3d4e5"[:12],
+                f"{role} · Toggleable Sidebar for Session Switching",
+                42.00 - index,
+                120 + index * 7,
+                CHILD_PARENT,
+            )
+        )
+    for index, role in enumerate(SECOND_CHILDREN):
+        rows.append(
+            (
+                f"d{index:02d}f6e5d4c3b2"[:12],
+                f"{role} · Harden Against Credential Leak Paths",
+                18.00 - index,
+                64 + index * 5,
+                SECOND_PARENT,
+            )
+        )
+    return rows
+
+
+def seed(store: AnalyticsStore) -> None:
+    """Write the fixture into the isolated ledger, parent edges included.
+
+    ``UsageAggregate.calls`` is ``COUNT(*)`` over the ledger — there is no field
+    to set — so a row's call count costs that many inserts. Spend and tokens are
+    therefore divided across a row's calls, keeping the rendered ``$`` figures
+    fixed while the call counts stay real-sized.
+    """
+    snapshots = []
+    for index, (session_id, name, usd, calls, parent) in enumerate(FIXTURE + _children()):
+        for part in range(calls):
+            snapshots.append(
+                replace(
+                    _snap(
+                        session_id=session_id,
+                        provider="anthropic",
+                        model_id="claude-sonnet-4-6",
+                        context=(120_000 + index * 900) // calls,
+                        input_tokens=40_000 // calls,
+                        cache_read=70_000 // calls,
+                        cache_write=2_000 // calls,
+                        output_tokens=6_000 // calls,
+                        reasoning=1_200 // calls,
+                        cost_micro=int(usd * 1_000_000 / calls),
+                        chars={"conversation": 4000, "tool_results": 2200},
+                        ts_ms=1788602400000 + index * 61000 + part,
+                        ok=True,
+                    ),
+                    request_id=f"req-{index:04d}-{part}",
+                    purpose="turn",
+                    outcome="ok",
+                    duration_ms=2400,
+                    parent_session_id=parent,
+                )
+            )
+        if name:
+            store.upsert_session_name(session_id, name)
+    store.record_batch(snapshots)
+
+
+def _make_session() -> LedgerSession:
+    session = LedgerSession()
+    session.set_conversation_name("Analytics collapsible sessions")
+    session.frontend_state = FrontendSessionState(
+        session_id=session.session_id,
+        epoch="capture",
+        generation=1,
+        context_tokens=28400,
+        context_is_estimate=False,
+        context_window=200000,
+    )
+    return session
+
+
+def _factory_for(session):
+    from tests.unit.tui.test_app_pilot import _factory
+
+    return _factory(session)
+
+
+async def _capture(app, pilot, out: Path, state: str) -> dict[str, object]:
+    """Three consecutive frames of one state, plus what they actually contain."""
+    digests = []
+    for shot in range(3):
+        path = out / f"{state}-frame{shot}.svg"
+        save_capture(app, str(path))
+        digests.append(hashlib.sha256(path.read_bytes()).hexdigest())
+        await pilot.pause()
+    rows = [line for line in _svg_rows(out / f"{state}-frame0.svg") if " tokens" in line]
+    return {
+        "state": state,
+        "frames_identical": len(set(digests)) == 1,
+        "session_rows_on_screen": len(rows),
+        "rows": rows,
+    }
+
+
+async def main() -> None:
+    out = Path(sys.argv[1]).resolve()
+    out.mkdir(parents=True, exist_ok=True)
+
+    store = AnalyticsStore()
+    seed(store)
+    store.close()
+
+    ledger = default_db_path()
+    before = hashlib.sha256(ledger.read_bytes()).hexdigest() if ledger.exists() else None
+
+    app = OperatorApp(lambda: _factory_for(_make_session()))
+    states: list[dict[str, object]] = []
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "/analytics")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        screen = app.screen
+        assert isinstance(screen, AnalyticsScreen), f"expected /analytics, got {type(screen)}"
+
+        # Page down to the session table, which sits below the totals, the two
+        # charts and the input attribution.
+        for _ in range(4):
+            await pilot.press("pagedown")
+            await pilot.pause()
+        await pilot.pause()
+        states.append(await _capture(app, pilot, out, "collapsed"))
+
+        # Move the cursor onto the first expandable row and open it. On the
+        # pre-change code these keys do not exist, so the frames repeat the
+        # previous state — which is the point of running one script on both sides.
+        #
+        # TWO presses, deliberately: the first Enter PLACES the cursor (there is
+        # no "that row" to expand until one exists) and the second acts on it.
+        # A single press captured the cursor arriving on a still-collapsed row,
+        # which is a real state but not the one this frame is for.
+        await pilot.press("home")
+        await pilot.pause()
+        for _ in range(4):
+            await pilot.press("pagedown")
+            await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+        states.append(await _capture(app, pilot, out, "expanded"))
+
+        # A repaint must not silently close what the user opened: ``t`` rebuilds
+        # the whole report, so it is the cheapest proof that expansion state
+        # survives a rebuild.
+        await pilot.press("t")
+        await pilot.pause()
+        await pilot.pause()
+        states.append(await _capture(app, pilot, out, "expanded-after-toggle"))
+
+    after = hashlib.sha256(ledger.read_bytes()).hexdigest() if ledger.exists() else None
+    report = {
+        "source": str(Path(__file__).resolve().parents[1]),
+        "ledger_unchanged_by_capture": before == after,
+        "states": states,
+    }
+    (out / "states.json").write_text(json.dumps(report, indent=2) + "\n")
+
+    for state in states:
+        print(
+            f"{state['state']:<24} rows_on_screen={state['session_rows_on_screen']:>3} "
+            f"frames_identical={state['frames_identical']}"
+        )
+    print("ledger unchanged by capture:", report["ledger_unchanged_by_capture"])
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/analytics_cursor_shot.py
+++ b/scripts/analytics_cursor_shot.py
@@ -1,0 +1,123 @@
+"""Capture the row-cursor states of ``/analytics`` that the frames must prove.
+
+Three things the collapse feature claims and only a rendered frame can settle:
+
+1. The cursor on an EXPANDABLE root — the caret and the ``▸`` glyph have to be
+   legible together, and the dim ``+N subagents`` count must read as metadata
+   rather than as the tail of the session's name (review D3).
+2. The cursor on a CHILDLESS root — it must NOT look interactive: blank
+   disclosure cells, no count, and ``enter`` leaves the frame unchanged.
+3. The hint line at the two widths where it used to wrap to an unpainted second
+   line, losing exactly the copy that documents ``enter``/``e`` (review U3).
+
+The frames are named after the state they show, and the state is ASSERTED before
+the capture rather than reached by a fixed number of key presses. Round 1's
+artifacts had the expandable and childless frames swapped precisely because
+press count was used as a proxy for row kind, and which row N presses reaches
+depends on the seeded ledger's ordering.
+
+Usage: ``python -m scripts.analytics_cursor_shot <out-dir>``
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import scripts.probe_isolation  # noqa: F401  — isolates the config dir and clears CMUX_*
+from local_operator.analytics.store import AnalyticsStore
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.analytics_panel import AnalyticsScreen
+from scripts.analytics_collapse_shot import (
+    _factory_for,
+    _make_session,
+    _walk_cursor_to,
+    seed,
+)
+from scripts.visual_capture import save_capture
+from tests.unit.tui.test_slash_echo import _submit
+
+
+async def _open_analytics(pilot, app) -> AnalyticsScreen:
+    await pilot.pause()
+    await _submit(pilot, app, "/analytics")
+    await app.workers.wait_for_complete()
+    await pilot.pause()
+    screen = app.screen
+    assert isinstance(screen, AnalyticsScreen), f"expected /analytics, got {type(screen)}"
+    # Page down to the session table: it sits below the totals, both charts and
+    # the input attribution, and the cursor only addresses table rows.
+    for _ in range(4):
+        await pilot.press("pagedown")
+        await pilot.pause()
+    return screen
+
+
+async def main() -> None:
+    out = Path(sys.argv[1]).resolve()
+    out.mkdir(parents=True, exist_ok=True)
+
+    store = AnalyticsStore()
+    seed(store)
+    store.close()
+
+    states: list[dict[str, object]] = []
+
+    # -- the two cursor states, at the width the PR's other frames use ---------
+    app = OperatorApp(lambda: _factory_for(_make_session()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _open_analytics(pilot, app)
+
+        for name, expandable in (("cursor-expandable", True), ("cursor-childless", False)):
+            session_id = await _walk_cursor_to(pilot, screen, expandable=expandable)
+            row = screen._cursor_row()
+            assert row is not None and row.expandable is expandable
+            before = "\n".join(screen.render_lines_for_test())
+            await pilot.press("enter")
+            await pilot.pause()
+            after = "\n".join(screen.render_lines_for_test())
+            save_capture(app, str(out / f"{name}.svg"))
+            states.append(
+                {
+                    "state": name,
+                    "session_id": session_id,
+                    "expandable": row.expandable,
+                    "descendants": row.descendants,
+                    # A childless row must be inert: the blank gutter is the
+                    # whole signal, so the frame must not change on the press.
+                    "enter_changed_the_frame": before != after,
+                }
+            )
+            if expandable:
+                # Put it back so the next state starts from the collapsed table.
+                await pilot.press("enter")
+                await pilot.pause()
+
+    # -- the hint at the widths where it used to wrap --------------------------
+    for width, height in ((50, 16), (60, 20)):
+        app = OperatorApp(lambda: _factory_for(_make_session()))
+        async with app.run_test(size=(width, height)) as pilot:
+            screen = await _open_analytics(pilot, app)
+            hint = screen._hint_text(scrollable=True).plain
+            box = screen._hint.content_size.width
+            save_capture(app, str(out / f"hint-{width}col.svg"))
+            states.append(
+                {
+                    "state": f"hint-{width}col",
+                    "hint": hint,
+                    "hint_cells": len(hint),
+                    "hint_box_cells": box,
+                    "fits_one_line": len(hint) <= box,
+                    "names_expand_keys": "enter" in hint and "e all" in hint,
+                }
+            )
+
+    (out / "cursor-states.json").write_text(json.dumps(states, indent=2) + "\n")
+    for state in states:
+        print(json.dumps(state))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/unit/tui/test_analytics_panel.py
+++ b/tests/unit/tui/test_analytics_panel.py
@@ -24,6 +24,7 @@ from local_operator.tui.app import OperatorApp
 from local_operator.tui.widgets.analytics_panel import (
     _MAX_NAME_COL,
     _MIN_NAME_COL,
+    _ROW_CURSOR,
     _WIDE_TABLE_MIN,
     METRIC_COST,
     METRIC_TOKENS,
@@ -1560,7 +1561,11 @@ def _nested_screen_agg() -> UsageAggregate:
 
 
 def test_enter_expands_the_row_the_cursor_is_on():
-    """The user's words: "hits enter to expand that row"."""
+    """The user's words: "hits enter to expand that row".
+
+    No priming press: the cursor is placed at MOUNT (review D2), so the FIRST
+    ``enter`` does the thing the hint advertises instead of arming the next one.
+    """
     import asyncio
 
     async def run():
@@ -1568,8 +1573,6 @@ def test_enter_expands_the_row_the_cursor_is_on():
         async with app.run_test(size=(110, 40)) as pilot:
             screen = await _push(pilot, app, _nested_screen_agg())
             assert "kid1session" not in "\n".join(screen.render_lines_for_test())
-            await pilot.press("down")  # place the cursor on the first row
-            await pilot.pause()
             await pilot.press("enter")
             await pilot.pause()
             body = "\n".join(screen.render_lines_for_test())
@@ -1582,18 +1585,23 @@ def test_enter_expands_the_row_the_cursor_is_on():
     asyncio.run(run())
 
 
-def test_the_first_down_press_places_the_cursor_rather_than_moving_it():
-    """A press must do what it says on its FIRST try, not arm the next one."""
+def test_the_cursor_is_on_screen_from_the_first_frame():
+    """A press must do what it says on its FIRST try, not arm the next one.
+
+    The hint says ``enter expand`` on the opening frame, so a cursor has to
+    exist there (review D2) — otherwise the advertised key takes two presses.
+    Placed without scrolling, so the caret costs the reader none of the totals
+    block they opened the screen to read.
+    """
     import asyncio
 
     async def run():
         app = OperatorApp(lambda: _factory(FakeSession()))
         async with app.run_test(size=(110, 40)) as pilot:
             screen = await _push(pilot, app, _nested_screen_agg())
-            assert screen._cursor is None
-            await pilot.press("down")
-            await pilot.pause()
             assert screen._cursor == screen._layout.session_rows[0].session_id
+            assert screen._scroll.scroll_offset.y == 0, "placing the cursor scrolled the report"
+            assert _ROW_CURSOR in "\n".join(screen.render_lines_for_test())
 
     asyncio.run(run())
 
@@ -1813,6 +1821,11 @@ def test_the_cursor_is_scrolled_into_view_when_it_moves():
         app = OperatorApp(lambda: _factory(FakeSession()))
         async with app.run_test(size=(110, 12)) as pilot:
             screen = await _push(pilot, app, _nested_screen_agg())
+            # Bring the table into view first. Above it the arrows line-scroll
+            # (there is no row to address up there — R1/D1/U1), so the cursor
+            # contract this test is about only applies once rows are on screen.
+            await pilot.press("end")
+            await pilot.pause()
             await pilot.press("down")
             await pilot.pause()
             index = screen._cursor_index()
@@ -1848,5 +1861,190 @@ def test_the_row_keys_work_on_a_report_too_tall_to_fit():
                 assert (
                     screen._cursor is not None
                 ), f"the arrow never reached the screen at h={height}"
+
+    asyncio.run(run())
+
+
+def _tall_report_agg(roots: int = 40) -> UsageAggregate:
+    """A report shaped like the operator's real ledger: a table far BELOW the fold.
+
+    The defect these tests pin is only visible when the session table starts
+    below the viewport — on the real ledger it begins ~57 body lines down, behind
+    the totals block, both bar charts and the input attribution. The small
+    ``_nested_screen_agg`` fixture puts the table 17 lines down, which fits a
+    40-row terminal whole and hid the bug from every existing test.
+    """
+
+    def scope(micro, calls=1):
+        return UsageAggregate(
+            calls=calls,
+            ok_calls=calls,
+            context_tokens=micro,
+            cost_micro=micro,
+            cost_known_calls=calls,
+        )
+
+    agg = scope(1_000_000 * (roots + 2), calls=roots + 2)
+    by_session = {f"root{i:08d}": scope(1_000_000 * (roots - i)) for i in range(roots)}
+    # One expandable root so the disclosure gutter and the expand hints are live,
+    # exactly as on the real ledger where 103 of 595 roots have children.
+    by_session["kid00000001"] = scope(500_000)
+    agg.by_session = by_session
+    setattr(agg, "session_parents", {"kid00000001": "root00000000"})
+    setattr(agg, "session_names", {f"root{i:08d}": f"Session number {i}" for i in range(roots)})
+    agg.components = {k: 0 for k in COMPONENT_KEYS}
+    agg.components["conversation"] = 1_000
+    agg.by_provider = {"anthropic": copy.deepcopy(agg)}
+    return agg
+
+
+def test_the_top_of_the_report_is_reachable_with_the_arrow_keys():
+    """R1/R2/D1/U1/U2 — four review streams, one root cause.
+
+    ``↑``/``↓`` became ``priority=True`` row-moves, and the cursor only ever
+    addresses SESSION-TABLE rows. On the real ledger that table starts ~57 body
+    lines down, so every press re-pinned the cursor to table row 0 and dragged
+    the viewport back to it: measured at 120x40 on the operator's ledger,
+    ``end`` then 400 ``up`` presses left the viewport stuck at y=56 forever
+    while the hint on that same frame read ``↑↓ row``.
+
+    The invariant: from the BOTTOM, arrows alone must walk the viewport all the
+    way to y=0, one line per press where there is no row to move. Asserted as
+    reachability rather than as a per-press delta because the cursor legitimately
+    consumes presses while it crosses the table.
+    """
+    import asyncio
+
+    async def run():
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(110, 24)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            scroll = screen._scroll
+            assert scroll.max_scroll_y > 0, "fixture is not taller than the viewport"
+            assert (
+                screen._layout.session_first_line > scroll.size.height
+            ), "fixture's table is not below the fold, so it cannot pin this defect"
+
+            await pilot.press("end")
+            await pilot.pause()
+            bottom = scroll.scroll_offset.y
+            assert bottom > 0
+
+            # One ``up`` must never be a large backward jump (U2b: 570 lines).
+            await pilot.press("up")
+            await pilot.pause()
+            assert bottom - scroll.scroll_offset.y <= 1, (
+                f"one 'up' moved {bottom - scroll.scroll_offset.y} lines — the cursor re-home "
+                "is teleporting the viewport"
+            )
+
+            # Generous budget: the cursor eats one press per table row on the way
+            # through, and the assertion is reachability, not press count.
+            for _ in range(bottom + len(screen._layout.session_rows) + 10):
+                if scroll.scroll_offset.y <= 0:
+                    break
+                await pilot.press("up")
+            await pilot.pause()
+            floor = scroll.scroll_offset.y
+            assert floor == 0, f"the top of the report is unreachable by arrow (floor at y={floor})"
+
+    asyncio.run(run())
+
+
+def test_the_hint_fits_one_line_at_every_width():
+    """U3 — the hint grew 36→56 cells but its ``Static`` is ONE content line.
+
+    ``#analytics-hint`` is ``height: 2`` with ``padding-top: 1``, so anything
+    wider than the box wraps to a second line that is never painted. At 60x20
+    the user lost ``· e all``; at 50x16 they lost ``enter expand · e all`` and the
+    visible copy ended on a dangling ``·`` — exactly where the table is most
+    cramped, the expand keys stopped being documented while the ``▸`` glyphs
+    stayed on screen inviting the press.
+
+    Pinned at the two widths the review measured plus the ones that must not
+    regress, and the assertion is against the widget's REAL content box rather
+    than an assumed width.
+    """
+    import asyncio
+
+    async def run():
+        for width, height in ((50, 16), (60, 20), (70, 24), (110, 24), (160, 40)):
+            app = OperatorApp(lambda: _factory(FakeSession()))
+            async with app.run_test(size=(width, height)) as pilot:
+                screen = await _push(pilot, app, _tall_report_agg())
+                box = screen._hint.content_size.width
+                text = screen._hint_text(scrollable=True).plain
+                assert cell_len(text) <= box, (
+                    f"hint is {cell_len(text)} cells in a {box}-cell box at {width}x{height}: "
+                    f"{text!r} would wrap to an unpainted second line"
+                )
+                # Degrade by dropping whole clauses, never by losing the tail.
+                assert not text.rstrip().endswith(
+                    "·"
+                ), f"hint ends on a dangling separator: {text!r}"
+                # The keys a reader cannot guess must survive every tier.
+                assert "enter" in text and "e all" in text, (
+                    f"the expand keys are undocumented at {width}x{height} while the ▸ glyphs "
+                    f"remain on screen: {text!r}"
+                )
+
+    asyncio.run(run())
+
+
+def test_the_hint_says_row_even_on_a_subagent_free_ledger():
+    """R2 — the hint read ``↑↓ scroll`` where the keys did row-jumps.
+
+    ``_move_cursor`` never consults expandability, so the cursor moves on every
+    ledger that has session rows. Gating the wording on *expandability* made the
+    hint describe a control the screen did not have.
+    """
+    import asyncio
+
+    async def run():
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(110, 24)) as pilot:
+            flat = _tall_report_agg()
+            setattr(flat, "session_parents", {})
+            screen = await _push(pilot, app, flat)
+            text = screen._hint_text(scrollable=True).plain
+            assert "↑↓ row" in text, text
+            assert "↑↓ scroll" not in text, text
+            # and no dead controls advertised: nothing can expand here.
+            assert "expand" not in text and "e all" not in text, text
+
+    asyncio.run(run())
+
+
+def test_collapsing_keeps_the_cursor_on_the_visible_ancestor():
+    """U2c — collapse left ``_cursor`` naming a HIDDEN row.
+
+    ``_cursor_index()`` then returned ``None`` and the next arrow re-homed to
+    table row 0, teleporting the viewport ~200 lines on the real ledger. The
+    ancestry needed to land on the root that swallowed the row is already in the
+    layout, so the cursor follows it there instead.
+    """
+    import asyncio
+
+    async def run():
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _nested_screen_agg())
+            await pilot.press("enter")  # open the root the cursor mounted on
+            await pilot.pause()
+            await pilot.press("down")  # step onto its child
+            await pilot.pause()
+            child = screen._cursor_row()
+            assert child is not None and child.depth == 1
+
+            # ``e`` with only SOME rows open expands all (the documented
+            # contract); the second press is the collapse-all that hides the
+            # child the cursor is standing on.
+            await pilot.press("e")
+            await pilot.pause()
+            await pilot.press("e")
+            await pilot.pause()
+            assert screen._cursor_index() is not None, "the cursor was orphaned on a hidden row"
+            assert screen._cursor_row().depth == 0  # type: ignore[union-attr]
+            assert screen._cursor == "rootsession", screen._cursor
 
     asyncio.run(run())

--- a/tests/unit/tui/test_analytics_panel.py
+++ b/tests/unit/tui/test_analytics_panel.py
@@ -10,10 +10,16 @@ it is the right way to pin what the screen SAYS and that it closes.
 from __future__ import annotations
 
 import copy
+import re
 
 from rich.cells import cell_len
 
-from local_operator.analytics.model import COMPONENT_KEYS, UsageAggregate, UsagePeriod
+from local_operator.analytics.model import (
+    COMPONENT_KEYS,
+    UsageAggregate,
+    UsagePeriod,
+    build_session_forest,
+)
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.widgets.analytics_panel import (
     _MAX_NAME_COL,
@@ -23,6 +29,7 @@ from local_operator.tui.widgets.analytics_panel import (
     METRIC_TOKENS,
     AnalyticsScreen,
     _forest_labels,
+    _forest_rows,
     _row_overhead,
     _row_prefix,
     build_report,
@@ -1106,8 +1113,43 @@ def _session_rows(text: list[str]) -> list[str]:
     return rows
 
 
+def _all_expanded(aggregate: UsageAggregate) -> set[str]:
+    """Every session id with children, i.e. the fully-expanded table.
+
+    The table is COLLAPSED by default (that is the point of the feature), so a
+    test about how a CHILD row renders has to say which rows are open. Derived
+    from the forest rather than hard-coded per fixture, so a fixture gaining a
+    child does not silently stop being covered.
+    """
+    parents = getattr(aggregate, "session_parents", {}) or {}
+    return {
+        parent
+        for child, parent in parents.items()
+        if child != parent and child in aggregate.by_session and parent in aggregate.by_session
+    }
+
+
+def _row_name(row: str) -> str:
+    """The name a reader sees on ``row``, stripped of everything around it.
+
+    Rows lead with the cursor gutter, the nesting indent and glyph, and the
+    disclosure marker, and expandable rows trail a ``+N subagents`` count. All of
+    those are chrome around the name; a test asking "what does this row call
+    itself" must see through them, and doing it in ONE place is what stops each
+    test growing its own slightly different parser.
+    """
+    name = row.strip().lstrip("❯").strip().lstrip("└").strip()
+    name = name.lstrip("▸▾").strip()
+    # The name field ends at the run of spaces padding it out to ``name_col``.
+    name = name.split("   ")[0].rstrip()
+    return re.sub(r" \+\d+ subagents?$", "", name)
+
+
 def test_session_table_shows_roots_with_tree_totals_and_indents_children():
-    lines = [line.plain for line in build_report(_nested_aggregate(), 120)]
+    # Expanded explicitly: the table now hides children until a row is opened,
+    # and this test is about how the hierarchy renders once it IS open.
+    aggregate = _nested_aggregate()
+    lines = [line.plain for line in build_report(aggregate, 120, expanded=_all_expanded(aggregate))]
     rows = _session_rows(lines)
     # Two top-level rows only; the three children moved under their root.
     top = [r for r in rows if not _is_child_row(r)]
@@ -1273,19 +1315,23 @@ def test_no_session_row_is_cut_without_a_marker_at_any_width():
     """
     aggregate = _deep_named_aggregate()
     known = set((getattr(aggregate, "session_names", {}) or {}).values())
+    expanded = _all_expanded(aggregate)
     for width in range(96, 161):
-        lines = [line.plain for line in build_report(aggregate, width)]
-        block = "\n".join(lines).split("By session", 1)[-1]
-        for row in (r.rstrip() for r in block.splitlines() if " tokens" in r):
-            # The name field is everything up to the run of spaces padding it to
-            # ``name_col``; strip the indent and glyph a nested row leads with.
-            name = row.strip().lstrip("└").strip().split("   ")[0].rstrip()
-            if name.endswith("…"):
-                continue  # a MARKED cut is exactly what this fix produces
-            assert name in known, (
-                f"width {width}: {name!r} is neither a complete name nor marked as cut "
-                f"— it is a silent fragment"
-            )
+        # Swept in BOTH states: the disclosure marker and the ``+N subagents``
+        # count are charged to the same label budget the nesting prefix is, so
+        # each state composes a different label from the same name and either
+        # could be the one that overruns.
+        for opened in ((), expanded):
+            lines = [line.plain for line in build_report(aggregate, width, expanded=opened)]
+            block = "\n".join(lines).split("By session", 1)[-1]
+            for row in (r.rstrip() for r in block.splitlines() if " tokens" in r):
+                name = _row_name(row)
+                if name.endswith("…"):
+                    continue  # a MARKED cut is exactly what this fix produces
+                assert name in known, (
+                    f"width {width}: {name!r} is neither a complete name nor marked as cut "
+                    f"— it is a silent fragment"
+                )
 
 
 def test_the_budget_is_measured_over_subtree_totals_not_own_spend():
@@ -1327,13 +1373,480 @@ def test_two_children_of_one_parent_never_render_the_same_label():
     setattr(agg, "session_names", {"rootsession": "Root", **{k: shared for k in kids}})
     setattr(agg, "session_parents", {k: "rootsession" for k in kids})
 
-    text = "\n".join(line.plain for line in build_report(agg, 120))
+    text = "\n".join(line.plain for line in build_report(agg, 120, expanded=_all_expanded(agg)))
     rows = [r.rstrip() for r in text.split("By session", 1)[-1].splitlines() if " tokens" in r]
-    # The name field is everything before the run of spaces that pads it out to
-    # ``name_col``; a child row leads with its ``└ `` prefix, so strip that off
-    # first rather than splitting on it.
-    names = [
-        r.strip().lstrip("└").strip().split("   ")[0].strip() for r in rows if _is_child_row(r)
-    ]
+    names = [_row_name(r) for r in rows if _is_child_row(r)]
     assert len(names) == len(kids), names
     assert len(set(names)) == len(names), f"sibling rows collide: {names}"
+
+
+# ---------------------------------------------------------------------------
+# Collapsible session rows.
+#
+# The report against v0.52.15 was "my screen is freezing on /analytics ... each
+# session shows hundreds of rows of subagent cost". On the operator's ledger the
+# table painted 2,240 rows of which 1,645 were subagents nobody asked to see,
+# and the whole report was rebuilt on EVERY resize event — a terminal drag emits
+# a burst of them, which is what wedged the terminal. These pin the fix: the
+# default view is roots only, expanding is per-row and keyed by session id, and
+# the state survives the rebuilds that used to be free to discard it.
+# ---------------------------------------------------------------------------
+
+
+def test_children_are_hidden_until_their_root_is_expanded():
+    """THE fix: the default table is roots only, and nothing is lost by it."""
+    aggregate = _nested_aggregate()
+    rows = _session_rows([line.plain for line in build_report(aggregate, 120)])
+    assert len(rows) == 2, rows  # the root and the unrelated session
+    assert not any(_is_child_row(r) for r in rows)
+    # Nothing was DELETED — the same report expanded reaches every session.
+    opened = _session_rows(
+        [line.plain for line in build_report(aggregate, 120, expanded=_all_expanded(aggregate))]
+    )
+    assert len(opened) == 5, opened
+
+
+def test_a_collapsed_root_still_sums_to_the_headline_total():
+    """The load-bearing invariant, restated for the collapsed view.
+
+    Roots already carry their subtree's spend (``build_session_forest`` rolls it
+    up), so hiding the children cannot change what the column adds to. This is
+    the property the whole rollup exists to protect, and a collapse that broke it
+    would be a worse defect than the one being fixed.
+    """
+    aggregate = _nested_aggregate()
+    rows = _session_rows([line.plain for line in build_report(aggregate, 120)])
+    total = 0.0
+    for row in rows:
+        money = next(part for part in row.split() if part.startswith("$"))
+        total += float(money.strip("+").lstrip("$"))
+    assert abs(total - aggregate.cost_usd) < 0.01
+
+
+def test_only_an_expandable_row_carries_a_disclosure_glyph():
+    """A childless row must not look interactive: 492 of 595 real roots are one.
+
+    A glyph on a row whose Enter does nothing is the "never advertise a dead
+    control" rule (D5/U1/U4) in its per-row form.
+    """
+    aggregate = _nested_aggregate()
+    rows = _session_rows([line.plain for line in build_report(aggregate, 120)])
+    parent = next(r for r in rows if "Review and merge open PRs" in r)
+    childless = next(r for r in rows if "solosession" in r)
+    assert "▸" in parent
+    assert "▸" not in childless and "▾" not in childless
+    # The glyph flips to point DOWN once the row is open, so the frame says which
+    # state it is in rather than only which action is available.
+    opened = _session_rows(
+        [line.plain for line in build_report(aggregate, 120, expanded={"rootsession"})]
+    )
+    parent_open = next(r for r in opened if "Review and merge open PRs" in r)
+    assert "▾" in parent_open and "▸" not in parent_open
+
+
+def test_an_expandable_row_says_how_much_is_hidden_under_it():
+    """The count is the information the collapse removes, handed back.
+
+    Without it an expensive leaf and an expensive session with three subagents
+    under it are indistinguishable — which is the distinction the reader opened
+    the screen to make.
+    """
+    aggregate = _nested_aggregate()
+    rows = _session_rows([line.plain for line in build_report(aggregate, 120)])
+    parent = next(r for r in rows if "Review and merge open PRs" in r)
+    # Three descendants: two children and one grandchild. The SUBTREE, not the
+    # direct children, because that is what expanding eventually reveals.
+    assert "+3 subagents" in parent
+    assert "subagent" not in next(r for r in rows if "solosession" in r)
+
+
+def test_one_hidden_row_is_singular():
+    """A count is prose the user reads; "+1 subagents" is a visible defect."""
+    agg = UsageAggregate(calls=2, ok_calls=2, context_tokens=2, cost_micro=2, cost_known_calls=2)
+    scope = UsageAggregate(calls=1, ok_calls=1, context_tokens=1, cost_micro=1, cost_known_calls=1)
+    agg.by_session = {"rootsession": scope, "kid1session": scope}
+    setattr(agg, "session_names", {"rootsession": "Root"})
+    setattr(agg, "session_parents", {"kid1session": "rootsession"})
+    rows = _session_rows([line.plain for line in build_report(agg, 120)])
+    assert "+1 subagent " in next(r for r in rows if "Root" in r) + " "
+
+
+def test_a_flat_ledger_pays_nothing_for_a_gutter_it_cannot_use():
+    """No subagents anywhere means the table renders as it always has.
+
+    The disclosure column is charged to every row so the names stay in one
+    column, which is only defensible when SOMETHING can be expanded. A permanent
+    two-cell blank advertising an absent affordance is the same defect as a dead
+    hint.
+    """
+    aggregate = _nested_aggregate()
+    setattr(aggregate, "session_parents", {})
+    rows = _session_rows([line.plain for line in build_report(aggregate, 120)])
+    assert len(rows) == 5
+    for row in rows:
+        # Two leading cells for the cursor gutter and then straight into the
+        # name — no third pair of blanks where the glyph would sit.
+        assert not row.startswith("    "), row
+    assert "totals include subagents" not in "\n".join(rows)
+
+
+def test_the_rollup_note_survives_the_collapse():
+    """A root's figure exceeds its own spend in the DEFAULT view too.
+
+    The meta used to be derived from whether any indented row was on screen,
+    which with the table collapsed is never — dropping the one sentence that
+    explains the inflated figure exactly when the reader most needs it.
+    """
+    text = "\n".join(line.plain for line in build_report(_nested_aggregate(), 120))
+    assert "totals include subagents" in text
+
+
+def test_expanding_one_root_does_not_expand_its_sibling():
+    """Expansion is per row, not a global mode."""
+    aggregate = _nested_aggregate()
+    rows = _session_rows(
+        [line.plain for line in build_report(aggregate, 120, expanded={"rootsession"})]
+    )
+    # The root's two direct children appear; the grandchild does NOT, because its
+    # own parent (kid1session) is still closed.
+    assert any(_is_child_row(r) and "kid1session" in r for r in rows)
+    assert not any("grandkidses" in r for r in rows)
+
+
+def test_the_label_budget_pays_for_the_marker_and_the_count():
+    """Whatever a row prints beside its name is width the name cannot have.
+
+    Same rule the nesting prefix already follows, and the same failure if it is
+    skipped: a label composed to the full budget and THEN given a marker is over
+    the column, so the paint cuts the tail off with no ``…`` to say it did.
+    """
+    scope = UsageAggregate(calls=1, ok_calls=1, context_tokens=1, cost_micro=1, cost_known_calls=1)
+    long_name = "Toggleable Sidebar for Session Switching in the TUI"
+    names = {"rootsession": long_name, "kid1session": f"reviewer · {long_name}"}
+    structure = [("rootsession", 0, scope), ("kid1session", 1, scope)]
+    for cap in range(_MIN_NAME_COL, _MAX_NAME_COL + 1):
+        # A root with a marker and a count; the child with neither.
+        reserved = {"rootsession": cell_len("▸ ") + cell_len(" +1 subagent"), "kid1session": 0}
+        labels = _forest_labels(structure, names, cap, reserved=reserved)
+        rendered = "▸ " + labels["rootsession"] + " +1 subagent"
+        assert cell_len(rendered) <= cap, f"cap {cap}: {rendered!r} is {cell_len(rendered)} cells"
+
+
+def test_collapsing_leaves_far_fewer_rows_to_compose():
+    """The structural reason the screen got fast, asserted as a fact not a clock.
+
+    A wall-clock bound here would be a bet on machine load. The row count is what
+    the paint cost is proportional to and it is deterministic, so it is the
+    honest assertion — the measured timings live on the PR.
+    """
+    aggregate = _nested_aggregate()
+    forest = build_session_forest(
+        aggregate.by_session, getattr(aggregate, "session_parents", {}) or {}
+    )
+    assert len(_forest_rows(forest)) == 2
+    assert len(_forest_rows(forest, _all_expanded(aggregate))) == 5
+
+
+# -- the interactive screen ---------------------------------------------------
+
+
+def _nested_screen_agg() -> UsageAggregate:
+    """``_nested_aggregate`` with the fields the SCREEN needs to mount."""
+    agg = _nested_aggregate()
+    agg.components = {k: 0 for k in COMPONENT_KEYS}
+    agg.components["conversation"] = 1_000
+    agg.by_provider = {"anthropic": copy.deepcopy(agg)}
+    return agg
+
+
+def test_enter_expands_the_row_the_cursor_is_on():
+    """The user's words: "hits enter to expand that row"."""
+    import asyncio
+
+    async def run():
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _nested_screen_agg())
+            assert "kid1session" not in "\n".join(screen.render_lines_for_test())
+            await pilot.press("down")  # place the cursor on the first row
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+            body = "\n".join(screen.render_lines_for_test())
+            assert "kid1session" in body
+            # And Enter again closes it: one key, both directions.
+            await pilot.press("enter")
+            await pilot.pause()
+            assert "kid1session" not in "\n".join(screen.render_lines_for_test())
+
+    asyncio.run(run())
+
+
+def test_the_first_down_press_places_the_cursor_rather_than_moving_it():
+    """A press must do what it says on its FIRST try, not arm the next one."""
+    import asyncio
+
+    async def run():
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _nested_screen_agg())
+            assert screen._cursor is None
+            await pilot.press("down")
+            await pilot.pause()
+            assert screen._cursor == screen._layout.session_rows[0].session_id
+
+    asyncio.run(run())
+
+
+def test_the_cursor_clamps_at_both_ends():
+    """A full-page surface clamps; wrapping would throw the reader out of the
+    section they are working in (the documented ``/settings`` exception)."""
+    import asyncio
+
+    async def run():
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _nested_screen_agg())
+            for _ in range(8):
+                await pilot.press("down")
+                await pilot.pause()
+            assert screen._cursor == screen._layout.session_rows[-1].session_id
+            for _ in range(8):
+                await pilot.press("up")
+                await pilot.pause()
+            assert screen._cursor == screen._layout.session_rows[0].session_id
+
+    asyncio.run(run())
+
+
+def test_enter_on_a_childless_row_does_nothing():
+    """No glyph, no action — the row is not a control."""
+    import asyncio
+
+    async def run():
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _nested_screen_agg())
+            # solosession is the most expensive row, so it sorts first.
+            await pilot.press("down")
+            await pilot.pause()
+            row = next(r for r in screen._layout.session_rows if r.session_id == "solosession")
+            assert not row.expandable
+            screen._cursor = "solosession"
+            before = screen.render_lines_for_test()
+            await pilot.press("enter")
+            await pilot.pause()
+            assert screen.render_lines_for_test() == before
+
+    asyncio.run(run())
+
+
+def test_left_collapses_an_open_row_and_then_steps_out_to_the_parent():
+    import asyncio
+
+    async def run():
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _nested_screen_agg())
+            screen._cursor = "rootsession"
+            await pilot.press("right")
+            await pilot.pause()
+            assert "kid1session" in "\n".join(screen.render_lines_for_test())
+            # Standing on the CHILD, left steps out rather than doing nothing.
+            screen._cursor = "kid1session"
+            await pilot.press("left")
+            await pilot.pause()
+            assert screen._cursor == "rootsession"
+            # And now left closes the row it stepped out to.
+            await pilot.press("left")
+            await pilot.pause()
+            assert "kid1session" not in "\n".join(screen.render_lines_for_test())
+
+    asyncio.run(run())
+
+
+def test_expansion_survives_the_metric_toggle():
+    """``t`` rebuilds the whole report; it must not silently close what the user
+    opened. State is keyed by session ID precisely so a rebuild can find it."""
+    import asyncio
+
+    async def run():
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _nested_screen_agg(), daily=_daily())
+            screen._cursor = "rootsession"
+            await pilot.press("enter")
+            await pilot.pause()
+            assert "kid1session" in "\n".join(screen.render_lines_for_test())
+            await pilot.press("t")
+            await pilot.pause()
+            assert "kid1session" in "\n".join(screen.render_lines_for_test())
+
+    asyncio.run(run())
+
+
+def test_expansion_survives_a_resize():
+    """A resize recomposes every label at a new width, so anything remembered by
+    LABEL would be forgotten here. This is the regression that keying by id
+    prevents, and the resize path is also the one that skips rebuilds."""
+    import asyncio
+
+    async def run():
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _nested_screen_agg())
+            screen._cursor = "rootsession"
+            await pilot.press("enter")
+            await pilot.pause()
+            assert "kid1session" in "\n".join(screen.render_lines_for_test())
+            await pilot.resize_terminal(150, 40)
+            await pilot.pause()
+            await pilot.pause()
+            assert "kid1session" in "\n".join(screen.render_lines_for_test())
+
+    asyncio.run(run())
+
+
+def test_a_resize_that_does_not_change_the_card_width_does_not_rebuild():
+    """The freeze itself. A drag emits a burst of resize events and each rebuild
+    was 0.5-0.6 s on a real ledger; the card is a floored 90% of the terminal, so
+    most of those events cannot change a single cell of output.
+
+    Asserted structurally (did the renderer run?) rather than on a clock, which
+    would be a bet on machine load."""
+    import asyncio
+
+    async def run():
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _nested_screen_agg())
+            calls = 0
+            original = screen._report_lines
+
+            def counted():
+                nonlocal calls
+                calls += 1
+                return original()
+
+            setattr(screen, "_report_lines", counted)
+            width_before = screen._card_width()
+            # 110 -> 111 keeps the floored card width identical.
+            await pilot.resize_terminal(111, 40)
+            await pilot.pause()
+            assert screen._card_width() == width_before, "fixture no longer shares a width band"
+            assert calls == 0, "a resize that changes nothing rebuilt the whole report"
+            # A resize that DOES cross a band still repaints, or the frame lies.
+            await pilot.resize_terminal(150, 40)
+            await pilot.pause()
+            assert calls >= 1
+
+    asyncio.run(run())
+
+
+def test_e_expands_everything_and_then_collapses_everything():
+    import asyncio
+
+    async def run():
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _nested_screen_agg())
+            await pilot.press("e")
+            await pilot.pause()
+            body = "\n".join(screen.render_lines_for_test())
+            # Every session, grandchild included, is reachable in one press.
+            assert "grandkidses" in body and "kid2session" in body
+            await pilot.press("e")
+            await pilot.pause()
+            assert "grandkidses" not in "\n".join(screen.render_lines_for_test())
+
+    asyncio.run(run())
+
+
+def test_e_expands_all_when_only_some_rows_are_open():
+    """ "Expand all" must not mean "collapse" because one row happened to be open.
+
+    Found by driving the real screen: with a single row expanded, ``e`` closed
+    everything — the opposite of what a reader pressing it means. The test is
+    whether everything is ALREADY open, not whether anything is.
+    """
+    import asyncio
+
+    async def run():
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _nested_screen_agg())
+            screen._cursor = "rootsession"
+            await pilot.press("enter")  # one row open, the grandchild still not
+            await pilot.pause()
+            assert "grandkidses" not in "\n".join(screen.render_lines_for_test())
+            await pilot.press("e")
+            await pilot.pause()
+            assert "grandkidses" in "\n".join(screen.render_lines_for_test())
+
+    asyncio.run(run())
+
+
+def test_the_hint_advertises_the_expand_keys_only_when_a_row_can_expand():
+    """D5: never advertise a dead control."""
+    import asyncio
+
+    async def run():
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _nested_screen_agg())
+            assert "enter expand" in screen._hint_text(scrollable=True).plain
+            flat = _nested_screen_agg()
+            setattr(flat, "session_parents", {})
+            screen2 = await _push(pilot, app, flat)
+            assert "enter expand" not in screen2._hint_text(scrollable=True).plain
+
+    asyncio.run(run())
+
+
+def test_the_cursor_is_scrolled_into_view_when_it_moves():
+    """The cursor may be left off screen by the wheel, so a key that ACTS on it
+    has to reveal it first — otherwise it writes to a row the reader cannot see
+    and the frame appears not to change."""
+    import asyncio
+
+    async def run():
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(110, 12)) as pilot:
+            screen = await _push(pilot, app, _nested_screen_agg())
+            await pilot.press("down")
+            await pilot.pause()
+            index = screen._cursor_index()
+            assert index is not None
+            line = screen._layout.session_first_line + index
+            top = screen._scroll.scroll_offset.y
+            height = screen._scroll.size.height
+            assert (
+                top <= line < top + height
+            ), f"cursor line {line} is outside the viewport {top}..{top + height}"
+
+    asyncio.run(run())
+
+
+def test_the_row_keys_work_on_a_report_too_tall_to_fit():
+    """Focus sits on the inner ``VerticalScroll``, which eats the arrows while it
+    can still scroll — so a non-priority binding reaches the screen only at the
+    ends of the travel.
+
+    Pinned at two heights because the symptom is invisible at one: the cursor
+    moved fine at 110x40, where the body fits, and never at 110x20, where it does
+    not. A single-height test would have passed against the broken binding.
+    """
+    import asyncio
+
+    async def run():
+        for height in (40, 20, 12):
+            app = OperatorApp(lambda: _factory(FakeSession()))
+            async with app.run_test(size=(110, height)) as pilot:
+                screen = await _push(pilot, app, _nested_screen_agg())
+                await pilot.press("down")
+                await pilot.pause()
+                assert (
+                    screen._cursor is not None
+                ), f"the arrow never reached the screen at h={height}"
+
+    asyncio.run(run())

--- a/tests/unit/tui/test_analytics_panel.py
+++ b/tests/unit/tui/test_analytics_panel.py
@@ -1596,12 +1596,35 @@ def test_the_cursor_is_on_screen_from_the_first_frame():
     import asyncio
 
     async def run():
+        # 1. Table ON screen at mount: the caret must be genuinely VISIBLE.
         app = OperatorApp(lambda: _factory(FakeSession()))
         async with app.run_test(size=(110, 40)) as pilot:
             screen = await _push(pilot, app, _nested_screen_agg())
             assert screen._cursor == screen._layout.session_rows[0].session_id
             assert screen._scroll.scroll_offset.y == 0, "placing the cursor scrolled the report"
+            # Against the SCREEN, not the body. ``render_lines_for_test()`` is
+            # the whole 654-line report on the real ledger, so a caret painted
+            # far below the fold satisfied ``_ROW_CURSOR in body`` and this test
+            # passed while the thing it is named for was false (review R6).
+            assert screen._cursor_on_screen(), "the cursor is painted below the fold"
             assert _ROW_CURSOR in "\n".join(screen.render_lines_for_test())
+
+        # 2. Table BELOW the fold: the cursor is parked unpainted rather than
+        #    scrolled to. This leg is what kills the mutation R6 reported —
+        #    re-adding ``_scroll_cursor_into_view()`` to ``_place_initial_cursor``
+        #    reintroduces the exact D2/U2 teleport, and leg 1 cannot see it
+        #    because the small fixture's table is already on screen at 110x40.
+        for height in (30, 24, 20):
+            app = OperatorApp(lambda: _factory(FakeSession()))
+            async with app.run_test(size=(110, height)) as pilot:
+                screen = await _push(pilot, app, _tall_report_agg())
+                assert not screen._table_on_screen(), f"h={height} does not put the table below"
+                assert screen._cursor == screen._layout.session_rows[0].session_id
+                assert screen._scroll.scroll_offset.y == 0, (
+                    f"placing the cursor at mount scrolled the report to y="
+                    f"{screen._scroll.scroll_offset.y} at h={height}, costing the reader the "
+                    "totals block they opened the screen to read"
+                )
 
     asyncio.run(run())
 
@@ -1865,7 +1888,7 @@ def test_the_row_keys_work_on_a_report_too_tall_to_fit():
     asyncio.run(run())
 
 
-def _tall_report_agg(roots: int = 40) -> UsageAggregate:
+def _tall_report_agg(roots: int = 40, kids: int = 1) -> UsageAggregate:
     """A report shaped like the operator's real ledger: a table far BELOW the fold.
 
     The defect these tests pin is only visible when the session table starts
@@ -1873,24 +1896,44 @@ def _tall_report_agg(roots: int = 40) -> UsageAggregate:
     the totals block, both bar charts and the input attribution. The small
     ``_nested_screen_agg`` fixture puts the table 17 lines down, which fits a
     40-row terminal whole and hid the bug from every existing test.
+
+    Two details are load-bearing rather than incidental, and both were added
+    because a mutation survived without them:
+
+    ``unpricedses`` draws the ``+ lower bound`` legend, which is what puts BODY
+    BELOW the last table row (measured: 2 lines, exactly as the real ledger).
+    Without it the table is the last thing in the report, so revealing the last
+    row already lands the viewport on ``max_scroll_y`` and ``action_move_down``'s
+    last-row fallthrough has nothing left to do — deleting it kept the suite
+    green (QA mutation M3).
+
+    ``kids`` hangs children off the PRICIEST root, which sorts first, so
+    expanding pushes every row below it down. At the default 1 the shift is one
+    line and a cursor parked anywhere stays on screen regardless, which makes
+    expand-all's cursor reveal unobservable; pass ~30 to move it off screen.
     """
 
-    def scope(micro, calls=1):
+    def scope(micro, calls=1, known=None):
         return UsageAggregate(
             calls=calls,
             ok_calls=calls,
             context_tokens=micro,
             cost_micro=micro,
-            cost_known_calls=calls,
+            cost_known_calls=calls if known is None else known,
         )
 
     agg = scope(1_000_000 * (roots + 2), calls=roots + 2)
     by_session = {f"root{i:08d}": scope(1_000_000 * (roots - i)) for i in range(roots)}
-    # One expandable root so the disclosure gutter and the expand hints are live,
+    # Expandable roots so the disclosure gutter and the expand hints are live,
     # exactly as on the real ledger where 103 of 595 roots have children.
-    by_session["kid00000001"] = scope(500_000)
+    parents = {}
+    for kid in range(kids):
+        by_session[f"kid{kid:08d}"] = scope(500_000)
+        parents[f"kid{kid:08d}"] = "root00000000"
+    # An unpriced session, so the report has a tail below the table (see above).
+    by_session["unpricedses"] = scope(0, calls=1, known=0)
     agg.by_session = by_session
-    setattr(agg, "session_parents", {"kid00000001": "root00000000"})
+    setattr(agg, "session_parents", parents)
     setattr(agg, "session_names", {f"root{i:08d}": f"Session number {i}" for i in range(roots)})
     agg.components = {k: 0 for k in COMPONENT_KEYS}
     agg.components["conversation"] = 1_000
@@ -1951,6 +1994,76 @@ def test_the_top_of_the_report_is_reachable_with_the_arrow_keys():
     asyncio.run(run())
 
 
+def test_the_bottom_of_the_report_is_reachable_with_the_arrow_keys():
+    """The mirror of the top-reachability test, and it had NO coverage.
+
+    ``action_move_down`` line-scrolls past the LAST table row for the same
+    reason ``action_move_up`` line-scrolls above the first: the body continues
+    below the table (the rollup note, and whatever sections follow), so an arrow
+    that clamped on the last row would leave the tail of the report unreachable
+    by the key that got the reader there.
+
+    Pinned because deleting that fallthrough left **79 tests passing** (QA
+    mutation M3): real behaviour with zero coverage is exactly what a future
+    cleanup removes against a green suite.
+    """
+    import asyncio
+
+    async def run():
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(110, 24)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            scroll = screen._scroll
+            assert scroll.max_scroll_y > 0, "fixture is not taller than the viewport"
+
+            body = screen.render_lines_for_test()
+            rows = screen._layout.session_rows
+            last_table_line = screen._layout.session_first_line + len(rows) - 1
+            assert len(body) - 1 > last_table_line, (
+                "the fixture's table is the LAST thing in the report, so revealing its "
+                "last row already reaches max_scroll_y and this test cannot see the "
+                "fallthrough it exists to pin"
+            )
+
+            await pilot.press("home")
+            await pilot.pause()
+            assert scroll.scroll_offset.y == 0
+
+            # Walk down until the cursor is standing on the LAST row. Up to here
+            # the cursor's own reveal is what moves the viewport.
+            for _ in range(int(scroll.max_scroll_y) + len(rows) + 10):
+                if screen._cursor_index() == len(rows) - 1 and screen._cursor_on_screen():
+                    break
+                await pilot.press("down")
+            await pilot.pause()
+            parked = scroll.scroll_offset.y
+            assert parked < scroll.max_scroll_y, (
+                "the cursor's own reveal already reached the bottom, so the remaining "
+                "presses prove nothing"
+            )
+
+            # From here only the fallthrough can move the viewport: the cursor
+            # has nowhere left to go, and the tail of the report is still below.
+            for _ in range(int(scroll.max_scroll_y - parked) + 10):
+                if scroll.scroll_offset.y >= scroll.max_scroll_y:
+                    break
+                await pilot.press("down")
+            await pilot.pause()
+            assert scroll.scroll_offset.y == scroll.max_scroll_y, (
+                "the bottom of the report is unreachable by arrow: the cursor clamped on "
+                f"the last row at y={scroll.scroll_offset.y} of {scroll.max_scroll_y}"
+            )
+            # And the last body line is genuinely painted, not merely the scroll
+            # offset agreeing with itself.
+            last = next(line for line in reversed(body) if line.strip())
+            painted = "\n".join(
+                body[int(scroll.scroll_offset.y) : int(scroll.scroll_offset.y) + scroll.size.height]
+            )
+            assert last in painted, "the last body line never entered the viewport"
+
+    asyncio.run(run())
+
+
 def test_the_hint_fits_one_line_at_every_width():
     """U3 — the hint grew 36→56 cells but its ``Static`` is ONE content line.
 
@@ -1987,6 +2100,41 @@ def test_the_hint_fits_one_line_at_every_width():
                     f"the expand keys are undocumented at {width}x{height} while the ▸ glyphs "
                     f"remain on screen: {text!r}"
                 )
+
+    asyncio.run(run())
+
+
+def test_the_hint_sheds_esc_before_it_abbreviates_the_expand_key():
+    """D5 — the ladder contradicted its own documented rule at its third rung.
+
+    The rule beside the tiers is that ``esc back`` is shed BEFORE the expand
+    keys: ``esc`` is the one key a reader tries unprompted on a modal, and
+    ``enter``/``e`` are the ones they cannot guess. The 44-50 column band broke
+    it — boxes of 33-39 cells took ``esc back · ↑↓ row · enter · e all`` (33
+    cells) and left ``enter · e all`` to be read as two unexplained keys, while
+    ``↑↓ row · enter expand · e all`` is 29 cells and fits every box in the band.
+
+    Pinned as the rule rather than as a string: any tier that keeps ``esc back``
+    while abbreviating ``expand`` away is the inversion, at any width.
+    """
+    import asyncio
+
+    async def run():
+        seen_short_tier = False
+        for width in range(40, 76, 2):
+            app = OperatorApp(lambda: _factory(FakeSession()))
+            async with app.run_test(size=(width, 24)) as pilot:
+                screen = await _push(pilot, app, _tall_report_agg())
+                text = screen._hint_text(scrollable=True).plain
+                assert cell_len(text) <= screen._hint.content_size.width, text
+                if "esc back" in text:
+                    assert "enter expand" in text, (
+                        f"at {width} columns the hint keeps 'esc back' but abbreviates the "
+                        f"expand key away, inverting the ladder's documented rule: {text!r}"
+                    )
+                else:
+                    seen_short_tier = True
+        assert seen_short_tier, "no width in the band exercised a tier below 'esc back'"
 
     asyncio.run(run())
 
@@ -2046,5 +2194,103 @@ def test_collapsing_keeps_the_cursor_on_the_visible_ancestor():
             assert screen._cursor_index() is not None, "the cursor was orphaned on a hidden row"
             assert screen._cursor_row().depth == 0  # type: ignore[union-attr]
             assert screen._cursor == "rootsession", screen._cursor
+
+    asyncio.run(run())
+
+
+def test_expand_all_from_the_opening_frame_leaves_the_viewport_alone():
+    """D6/U8 — ``e`` scrolled the totals block off the OPENING frame.
+
+    ``e`` is a GLOBAL action, so it must not move the viewport of a reader who
+    is not standing in the table. The mount-placed cursor (D2) met
+    ``action_toggle_all``'s pre-existing ``_scroll_cursor_into_view()``, which
+    on base was a no-op because no cursor existed yet; on the round-2 head it
+    dragged the opening frame down to table row 0 — measured on the operator's
+    ledger at +34 lines (120x40), +43 (120x30), +48 (120x24 and 80x24) and +51
+    (110x20 and 100x20) — and a second ``e`` did not bring it back.
+
+    Heights chosen so the cursor is BELOW the fold at mount: at 110x40 the
+    small fixture's table fits on the opening screen, which is the geometry
+    that hid this from the round-2 frames. Asserted on ``scroll_offset``, which
+    the sibling collapse test never looked at.
+    """
+    import asyncio
+
+    async def run():
+        for height in (30, 24, 20):
+            app = OperatorApp(lambda: _factory(FakeSession()))
+            async with app.run_test(size=(110, height)) as pilot:
+                screen = await _push(pilot, app, _tall_report_agg())
+                scroll = screen._scroll
+                assert not screen._cursor_on_screen(), (
+                    f"h={height} puts the cursor on the opening frame, so it cannot pin D6 "
+                    "(that is the geometry the defect hid behind)"
+                )
+                before = scroll.scroll_offset.y
+                rows = len(screen._layout.session_rows)
+
+                await pilot.press("e")
+                await pilot.pause()
+                assert len(screen._layout.session_rows) > rows, "'e' did not expand anything"
+                assert scroll.scroll_offset.y == before, (
+                    f"'e' moved the viewport {scroll.scroll_offset.y - before} lines at "
+                    f"h={height}: a global action is teleporting the reader to the cursor"
+                )
+
+                # The reverse press must not move it either — the reader who
+                # undoes an expansion is owed the frame they started from.
+                await pilot.press("e")
+                await pilot.pause()
+                assert len(screen._layout.session_rows) == rows, "'e' did not collapse back"
+                assert scroll.scroll_offset.y == before, (
+                    f"collapse-all moved the viewport {scroll.scroll_offset.y - before} lines "
+                    f"at h={height}"
+                )
+
+    asyncio.run(run())
+
+
+def test_expand_all_keeps_a_cursor_the_reader_can_see_in_frame():
+    """The other half of D6: the reveal is right when the cursor IS on screen.
+
+    A reader working IN the table has a place in it; expand-all pushes their row
+    hundreds of lines down the body, and keeping it in frame is what preserves
+    that place. Without this, "skip the scroll" would be over-applied into
+    "never scroll", which loses the reader in the other direction.
+    """
+    import asyncio
+
+    async def run():
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(110, 24)) as pilot:
+            # 30 children on the priciest root, so expanding shifts every row
+            # below it by 30 lines — more than the viewport is tall, which is
+            # what makes the reveal observable at all (at the default 1 child the
+            # cursor stays on screen whether or not anything reveals it).
+            screen = await _push(pilot, app, _tall_report_agg(kids=30))
+            scroll = screen._scroll
+            rows = screen._layout.session_rows
+
+            # Park the reader in the MIDDLE of the table, below the expandable
+            # root, and reveal them — this is a reader working in the table.
+            park = rows[len(rows) // 2].session_id
+            screen._cursor = park
+            screen._repaint()
+            screen._scroll_cursor_into_view()
+            await pilot.pause()
+            assert screen._cursor_on_screen()
+            before = scroll.scroll_offset.y
+
+            await pilot.press("e")
+            await pilot.pause()
+            assert screen._cursor == park, "expand-all moved the cursor off the reader's row"
+            assert scroll.scroll_offset.y > before, (
+                "the viewport did not follow the reader's row, so 'skip the scroll' has "
+                "been over-applied from 'the cursor is off screen' to 'never scroll'"
+            )
+            assert screen._cursor_on_screen(), (
+                "expand-all left the reader's own row off screen: the cursor was visible "
+                "before the press and 30 rows appeared above it"
+            )
 
     asyncio.run(run())


### PR DESCRIPTION
## What and why

`/analytics` froze on open and again on every terminal resize. Reported by the operator: "the loadup is slow and once it loads there's too much information... each session shows hundreds of rows of subagent cost."

**Root cause.** The "By session" table flattened the whole session forest into one `Text` pushed into a single `Static`. Against the operator's real ledger (128 MB, 602,404 calls, **2,240 sessions**) that is **2,299 lines / 11,543 style spans / ~16,100 segments** rebuilt from scratch on every repaint — and `on_resize` repaints unconditionally, so a resize storm is what actually reads as a freeze.

The shape of the data is what makes collapsing the right fix: of 2,240 rows, **1,637 are subagent children**, and only **103 of 595 roots have any children at all** (492 are childless; worst root has 90 descendants). The default view spent ~73% of its rows on detail nobody asked for yet.

Root rows already carry subtree totals (`build_session_forest` rolls up), so **collapsing loses no cost information** and the per-session column still sums to the headline total — the invariant recorded in `AGENTS.md`.

## Changes

- Session rows are **collapsed by default**; only depth-0 roots render.
- A root with children shows a `▸`/`▾` disclosure plus a **child count** (`+12 subagents`), so the reader knows what expanding costs. Childless roots get no glyph and do not look interactive.
- Row cursor (`↑`/`↓`) with `enter`/`space` to toggle, `→` expand, `←` collapse, `e` expand/collapse all. Cursor is scrolled into view when it moves.
- Expansion state is keyed by **session ID**, never by rendered label, and survives resize and the `t` metric toggle.
- `on_resize` now skips the rebuild when the effective card width is unchanged — a large share of the resize cost was rebuilding an identical report.
- Hint line advertises the new keys only when a row can actually expand (existing "never advertise a dead control" rule).

## Performance evidence

Interleaved A/B, base (`origin/main` @ 82262483f) vs head, **same process conditions, alternating runs** on a loaded machine, real headless pilot at 120x40 against a read-only copy of the operator's 128 MB ledger:

| Metric | base | head | |
|---|---|---|---|
| first paint | 2.267s / 2.487s | **0.755s / 0.615s** | ~3.4x |
| resize (median) | 2.190s / 2.600s | **0.506s / 0.479s** | ~4.6x |
| resize (max) | 2.600s / 3.013s | **0.655s / 0.740s** | |
| `t` toggle | 1.228s / 1.673s | **0.439s / 0.588s** | ~2.6x |

Absolute figures are inflated by concurrent worktree load (load average ~285); the A/B is interleaved precisely so the ratio is meaningful. On an idle machine the same pilot measured first paint 0.650s → 0.225s, section render 0.073s → 0.017s, segments 15,819 → 4,253.

`scroll end` is ~1.06s in **both** states — that is scroll animation, not row cost. This PR does not claim to fix it.

## Visual evidence

Rendered frames from the real app (stylesheet-loading host), consecutive frames captured to confirm no reflow (`frames_identical: true` in `states.json`):

- collapsed default, expanded row, childless row, cursor states — `/tmp/an-fix/shots/after/`
- Verified the capture does not mutate the ledger (`ledger_unchanged_by_capture: true`).

## Gates

- `flake8`, `black --check`, `isort --check-only`, `pyright` (0 errors) clean.
- `tests/unit/tui/test_analytics_panel.py`: **75 passed**. Full suite clean through the run (machine saturation made a full serial pass impractical in-session; CI is the authority).
- Tests unset every inherited `CMUX_*` var and use an isolated config dir.

## Not addressed (out of scope)

- At card widths ≤70 the **totals** block (`Context read`) overruns by 5 cells. Reproduced on `origin/main` — **pre-existing, unrelated to this change**, not a regression introduced here.
- Root list is not capped; 595 roots still render. Cheap follow-up if the collapsed view still feels long.

No version bump on this branch (stays 0.52.15) per the release rule.
