### PR TITLE
chore(release): bump version to 0.52.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.52.16"
+version = "0.52.17"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release lock PR for the post-v0.52.16 window. `pyproject.toml` only — one line, no code.

## Window contents

`git log v0.52.16..origin/main` — one commit:

- #866 (`15152e67c`) fix(mcp): propagate a peer session's re-auth to servers this session gave up on

## Bump class: PATCH

A bug fix on an existing surface. No API addition, no wire/protocol change, no migration. The one additive element is a fourth `get_connection_status` value (`auth-required`), which is an internal status string rendered by existing surfaces rather than a new capability.

Window ownership was claimed and announced; #838 (pid 83153) and #871 (pid 24942) both explicitly declined to ride this window and confirmed they are not ready, so this stays a single-PR patch.

## Scope check

```
 pyproject.toml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```
