### PR TITLE
chore(release): bump version to 0.52.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.52.17"
+version = "0.52.18"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release bump for the post-v0.52.17 window. **pyproject.toml only** — one line, `0.52.17` → `0.52.18`.

## Window contents

`git log v0.52.17..origin/main` — one commit:

| PR | SHA | Change |
|---|---|---|
| #867 | `79b11f5e0` | perf(sidebar): cut the catalog poll's per-directory work ~2.2x |

## Bump class: PATCH

A measured constant-factor performance win. No API addition, no wire/protocol change, no migration, no user-facing behaviour change.

## Window ownership

Claimed explicitly and announced to all 14 live lop peers before opening this PR. Six explicit yields received (pids 86049, 85537, 24942, 35567, 6972, 87549), zero competing claims, no open `chore(release)` PR at claim time. Latecomers (#871, #873, #838, the sidebar-reconnect fix) ride the next window by the latecomer rule.

## What #867 delivers

Sidebar catalog poll on the reporting host (1,946 session dirs): **125.74 ms → 25.01 ms**, **9,773 → 4,350 syscalls**, **6.29% → 1.25% of a core** per TUI with the sidebar open.

Deliberately NOT claimed: the poll remains O(total session directories) with a ~2.2x smaller constant, returning to today's cost around ~8,000 directories. The PR was retitled during remediation after review and QA independently caught the original framing overstating it.

## Gates on #867

- Agent review round 1: 0 blocker / 1 major / 3 minor / 1 nit — all remediated, clean and fresh on merged head.
- QA round 1: 24 rows, 22 PASS, 0 BLOCKED — the 2 FAILs were the single claim-accuracy finding, remediated.
- 16/16 CI green. Listing output byte-identical to the merge base, verified independently by two agents.