### PR TITLE
docs(benchmarks): record the 9-task OSWorld rerun at the standard step budget

### DIFF
--- a/docs/benchmarks/osworld_2/RERUN_2026_09_09.md
+++ b/docs/benchmarks/osworld_2/RERUN_2026_09_09.md
@@ -40,27 +40,26 @@ and each got it wrong in the flattering direction:
   elapsed-time test judged rerun episodes against a wall that did not exist
   for them.
 
-  One honest gap: `batch-k3v4-0` and `batch-k3v4-2` — which supply the
-  before-episodes for `task_032` and `task_011` — **have no recorded snapshot
-  script**, and the budget events store digests rather than values, so their
-  2400 s ceiling is inferred from elapsed time rather than read. That is the
-  same class of inference this revision removed everywhere it could, and it is
-  named here rather than hidden. It does not affect membership, which comes
-  from the `truncated` field.
+  One provenance note: `batch-k3v4-0` and `batch-k3v4-2` — which supply the
+  before-episodes for `task_032` and `task_011` — have **no retained snapshot
+  script**, and the budget events store digests rather than values. Their
+  ceiling is still *read* rather than inferred: `runs/k3v4-0.log` and
+  `runs/k3v4-2.log` each record the batch's `run_episode.py` invocation
+  verbatim, with a literal `--max-wall-s 2400`.
 
 Read from the field, **8 of the 9 before-episodes are `truncated: true`**, all
 with `truncation_reason: budget-cap`; `task_098` is `truncated: false` and was
-never a member.
+never a member. The after arm removes one more pair: **`task_055`'s rerun is
+itself truncated** (`cost-spike`), so it is not a clean comparator. Both are
+still listed in the results table, marked, because their reruns are real data.
 
 `budget-cap` is a **multi-resource verdict** — spend, wall clock, cycles and
 tokens all emit it, and the resource that actually bound is not persisted. So
 the code alone does not prove *the wall* stopped these eight, and this
 document should not pretend it does. What does: all eight ran 2441–2503 s
 against the 2400 s ceiling while spending $1.15–$5.64 against a $6.00 cap. For
-contrast, `task_068` shows the other case — `budget-cap` at 1217 s having spent
-**$6.0093 against the $6.00 cap**, which is a cost stop, not a time stop. The after arm removes one more pair: **`task_055`'s rerun is
-itself truncated** (`cost-spike`), so it is not a clean comparator. Both are
-still listed in the results table, marked, because their reruns are real data.
+contrast, `task_068` shows the other case — `budget-cap` at 1217 s having
+spent **$6.0093 against the $6.00 cap**, a cost stop rather than a time stop.
 
 The conjunction the previous revision used happens to select the same 8 and
 the same 5 pairs, so the statistics below are unchanged — but it reached that

--- a/docs/benchmarks/osworld_2/RERUN_2026_09_09.md
+++ b/docs/benchmarks/osworld_2/RERUN_2026_09_09.md
@@ -35,13 +35,30 @@ and each got it wrong in the flattering direction:
   revision used it and would have admitted episodes at 732 s, 1217 s and
   1641 s that the bundles record as truncated for an entirely different
   reason (`cost-spike`, `budget-cap`) — not by the wall. It also paired the
-  arms against *different* ceilings: the before batches ran
-  `--max-wall-s 2400`, the rerun ran `18000`, so any elapsed-time test judged
-  rerun episodes against a wall that did not exist for them.
+  arms against *different* ceilings: the rerun ran `--max-wall-s 18000`
+  (verified in its recorded snapshot), against a 2400 s before arm, so any
+  elapsed-time test judged rerun episodes against a wall that did not exist
+  for them.
+
+  One honest gap: `batch-k3v4-0` and `batch-k3v4-2` — which supply the
+  before-episodes for `task_032` and `task_011` — **have no recorded snapshot
+  script**, and the budget events store digests rather than values, so their
+  2400 s ceiling is inferred from elapsed time rather than read. That is the
+  same class of inference this revision removed everywhere it could, and it is
+  named here rather than hidden. It does not affect membership, which comes
+  from the `truncated` field.
 
 Read from the field, **8 of the 9 before-episodes are `truncated: true`**, all
 with `truncation_reason: budget-cap`; `task_098` is `truncated: false` and was
-never a member. The after arm removes one more pair: **`task_055`'s rerun is
+never a member.
+
+`budget-cap` is a **multi-resource verdict** — spend, wall clock, cycles and
+tokens all emit it, and the resource that actually bound is not persisted. So
+the code alone does not prove *the wall* stopped these eight, and this
+document should not pretend it does. What does: all eight ran 2441–2503 s
+against the 2400 s ceiling while spending $1.15–$5.64 against a $6.00 cap. For
+contrast, `task_068` shows the other case — `budget-cap` at 1217 s having spent
+**$6.0093 against the $6.00 cap**, which is a cost stop, not a time stop. The after arm removes one more pair: **`task_055`'s rerun is
 itself truncated** (`cost-spike`), so it is not a clean comparator. Both are
 still listed in the results table, marked, because their reruns are real data.
 

--- a/docs/benchmarks/osworld_2/RERUN_2026_09_09.md
+++ b/docs/benchmarks/osworld_2/RERUN_2026_09_09.md
@@ -1,4 +1,4 @@
-# The 9 wall-truncated tasks, re-run at the standard budget (2026-09-09)
+# The wall-truncated tasks, re-run at the standard budget (2026-09-09)
 
 Kimi K3 on `osworld-v2-2026.08.08`, harness `0.52.11` at merged `a8f98be3b`
 (PR #855), adapter `0.1.2`, `m5.xlarge`, route
@@ -8,53 +8,62 @@ Kimi K3 on `osworld-v2-2026.08.08`, harness `0.52.11` at merged `a8f98be3b`
 
 A previous 26-task cohort ran under a **2400 s wall clock this harness
 invented** — OSWorld 2.0 specifies a 500-step budget and no time limit. At the
-observed pace that wall bought ~88 steps, and 9 episodes were cut off
-mid-work. This re-runs exactly those 9 at the standard 500-step budget, on a
-harness that also fixes the action-ordering defect found while investigating.
+observed pace that wall bought ~88 steps, and 9 episodes were suspected of
+being cut off mid-work. This re-runs those 9 at the standard 500-step budget,
+on a harness that also fixes the action-ordering defect found while
+investigating.
 
-## The pairing rule, stated first because it changes the headline
+## The membership rule, stated first because it decides everything below
 
-Each task's "before" figure is **the episode that was actually
-wall-truncated** — elapsed >= 2280 s, within 5% of the 2400 s ceiling. This
-matters for exactly one task and it is worth naming: `task_063` has two scored
-old episodes, `0.0%` at 2503 s (truncated) and `60.0%` at 1869 s, and the
-second one **finished voluntarily 531 s inside the wall**. It was never
-truncated, so it is not a member of the phenomenon this document is about.
+An episode was **truncated** if and only if it **has no terminal action** in
+its evidence bundle — the model never emitted `finish`, so the run was stopped
+from outside. Elapsed time is *not* the test, and using it as a proxy is the
+mistake this document made twice:
 
-An earlier revision of this file took the 60.0% episode and reported a
-headline of −13.5 pp. That was wrong: it compared the rerun against an episode
-the wall never touched. Under the correct rule all three plausible selections
-(first scored, truncated-episode, lowest-partial) agree on the same answer.
+- **`task_063`** has two scored old episodes: `0.0%` at 2503 s with no
+  terminal, and `60.0%` at 1869 s ending in `finish`. The first revision paired
+  against the 60.0% one — an episode the wall never touched — and reported a
+  −13.5 pp headline that was an artifact of that choice.
+- **`task_098`** ran 2331 s and **ended with `finish`**. It looks truncated by
+  any time threshold and is not. The second revision moved the threshold to
+  ≥ 2280 s and admitted it anyway.
+
+So **8 of the 9 were genuinely truncated**; `task_098` was never a member and
+is excluded from the paired comparison. It is still listed in the results
+table, marked, because its rerun is real data.
 
 ## Headline: the limit was real, the score effect is not measurable
 
-| | before (40-min wall) | after (500 steps) |
+| | before (truncated) | after (500 steps) |
 |---|---|---|
-| paired mean partial | 12.8% | 7.9% |
-| paired difference | — | **−4.9 pp, 95% CI [−27.9, +18.1]** |
-| exact permutation p | — | **0.750** (all 128 sign flips enumerated) |
+| paired mean partial | 7.5% | 9.2% |
+| paired difference | — | **+1.7 pp, 95% CI [−18.7, +22.1]** |
+| exact permutation p | — | **0.750** (all 64 sign flips enumerated) |
 
-**This is not a regression and must not be reported as one** — and equally
-could not have been reported as a win had it fallen the other way. At one
-sample per task the design detects neither.
+n = 6 paired tasks (two of the eight failed on rerun and are unscored).
+
+**Do not read the sign.** Across the three membership rules this document has
+used, the point estimate moved −13.5 → −4.9 → +1.7 pp while `p` stayed at
+0.750 throughout. A statistic whose *direction* is set by a definitional
+choice, and which is insignificant under every one of them, says only that
+**this design cannot measure the effect** — not that the effect is positive.
 
 ## What did change, unambiguously
 
 The wall is gone, and it shows in the shape of the run rather than the score:
 
-| | before | after |
+| | before (the 8 truncated) | after (all 9) |
 |---|---|---|
-| elapsed, median / max | 2446 s / 2503 s | 2366 s / **7177 s** |
-| model calls, median / max | 92 / 126 | 80 / **352** |
-| episodes at the ceiling (>= 2280 s) | **9 of 9** | — |
+| elapsed, median / max | 2450 s / 2503 s | 2366 s / **7177 s** |
+| model calls, median / max | 90 / 126 | 80 / **352** |
 | episodes past the old 2400 s wall | — | 4 of 9 |
 | episodes past the old ~88-step budget | — | 4 of 9 |
 
-Before, all 9 finished between 2331 s and 2503 s — the top eight span 62 s.
-Nine independent tasks do not finish within a minute of each other; that is a
-limit binding. After, they spread from 289 s to 7177 s, so **task difficulty
-now sets episode length**. `task_108` went from 17 calls to 234 and from 0.0%
-to 30.1%.
+All eight truncated episodes finished between 2441 s and 2503 s — **a 62 s
+span across eight independent tasks**. That is a limit binding, not tasks
+completing. After, they spread from 289 s to 7177 s, so **task difficulty now
+sets episode length**. `task_108` went from 17 calls to 234 and from 0.0% to
+30.1%.
 
 **No episode came near the 500-step budget** — the longest used 352 of 500.
 The standard budget is not the new binding constraint, which is the strongest
@@ -76,18 +85,18 @@ have been executed out of order by the previous code.
 | task_063 | 0.0% / 50 | 0.0% / 8 | model called `finish` early |
 | task_070 | 45.0% / 110 | 15.0% / 70 | |
 | task_093 | 25.0% / 92 | **FAILED** / 28 | guest stopped returning screenshots |
-| task_098 | 44.4% / 98 | 0.0% / 163 | |
+| task_098 | *not truncated* | 0.0% / 163 | excluded from the pairing |
 | task_108 | 0.0% / 17 | 30.1% / 234 | |
 
-Cohort: 7 scored, 2 failed. Binary 0/7.
+Rerun cohort: 7 scored, 2 failed. Binary 0/7.
 
 ## Cost
 
 **$30.39 across all 9 attempts, $4.34 per scored task.** Reporting only the
 scored episodes would give $18.72 and hide what the failures cost.
 
-Extrapolated to the full 108 tasks: **~$469**. Treat that as a floor — these 9
-are the long-horizon tail and were expected to be expensive, but the two
+Extrapolated to the full 108 tasks: **~$469**. Treat that as a floor — these
+tasks are the long-horizon tail and were expected to be expensive, but the two
 failures show wasted spend is real (`task_011` burned $11.10 and produced no
 score).
 
@@ -101,14 +110,13 @@ score).
   path worked; the guest genuinely stopped responding. **Pre-existing**: 3 of
   the 58 old-cohort rows that actually ran an episode (5.2%).
 
-On whether a longer budget makes episodes more fragile — the honest answer is
-that this run **cannot settle it**. Counting only old-cohort rows that
-actually started (26 of the 84 ledger rows never made a model call, and
-including them understates failure depth badly), failures occurred at a median
-of 23 model calls with a maximum of 158, against a median of 54 for completed
-episodes. Failures were therefore *not* uniformly early, and the new run's
-longest episode failed at 352 calls. Two failures in nine is too few to
-estimate a rate, let alone a trend against episode length.
+On whether a longer budget makes episodes more fragile — this run **cannot
+settle it**. Counting only rows that actually started (26 of the 84 old ledger
+rows never made a model call, and including them understates failure depth
+badly), old-cohort failures reached a median of 23 model calls; the deepest,
+at 158 calls, was `task_016`, which was *cancelled* with `ask-user was not
+answered` rather than crashing. Two failures in nine cannot estimate a rate,
+and the new run's longest episode failed at 352 calls.
 
 ## What this cannot be compared to
 
@@ -119,11 +127,11 @@ comparing different models.
 
 Two further reasons a leaderboard comparison is invalid here:
 
-1. **These 9 tasks are not a random sample.** They are the long-horizon tail —
+1. **These tasks are not a random sample.** They are the long-horizon tail —
    the subset that previously exhausted a time limit. In the old cohort they
    averaged 13.5% against 28.8% for the other 17 tasks. A number computed on
    them does not estimate a full-108 score.
-2. **n=7 scored, one sample each.**
+2. **n = 6 paired, one sample each.**
 
 The leaderboard's own methodology note applies: rows mix author runs, vendor
 self-reports and independent runs, with differing step budgets, releases and
@@ -132,16 +140,16 @@ sample, and repeat count.
 
 ## What would actually answer the score question
 
-The blocker is statistical, not infrastructural — but the size of the noise is
-**itself poorly measured**, and this document should not pretend otherwise.
+The blocker is statistical, and the size of the noise is **barely measured at
+all**.
 
-Four tasks in the old cohort were scored twice on identical code. Three of
-them moved by 0, 0 and 10 pp; one (`task_063`) moved 60 pp, from 0.0% to
-60.0%. So the evidence for a large per-task swing rests on a single
-observation, and a 0→60 range is ±30 pp about its own mean, not ±60. What can
-be said is that at least one task swings enough to swamp any effect this
-9-task design could detect, and that four repeat pairs cannot tell us how
-common that is.
+Four tasks in the old cohort were scored twice. One pair (`task_063`, 0.0% vs
+60.0%) is truncated-vs-voluntary, which this document's own membership rule
+disqualifies as a like-for-like comparison; another (`task_068`) is likewise
+mixed, though both its runs scored 0.0%. That leaves **two clean pairs, moving
+0 and 10.3 pp** — which is an argument that repeat variance may be *small*,
+resting on two observations, and is not strong enough to carry either
+conclusion.
 
 Establishing the noise floor is therefore the *first* experiment, not an
 afterthought: **3–5 repeats per task**, which on the full 108 at ~$4.34 per

--- a/docs/benchmarks/osworld_2/RERUN_2026_09_09.md
+++ b/docs/benchmarks/osworld_2/RERUN_2026_09_09.md
@@ -43,9 +43,9 @@ and each got it wrong in the flattering direction:
   One provenance note: `batch-k3v4-0` and `batch-k3v4-2` — which supply the
   before-episodes for `task_032` and `task_011` — have **no retained snapshot
   script**, and the budget events store digests rather than values. Their
-  ceiling is still *read* rather than inferred: `runs/k3v4-0.log` and
-  `runs/k3v4-2.log` each record the batch's `run_episode.py` invocation
-  verbatim, with a literal `--max-wall-s 2400`.
+  ceiling is still *read* rather than inferred: `~/worktrees/osworld/runs/`
+  holds `k3v4-0.log` and `k3v4-2.log`, which each record the batch's
+  `run_episode.py` invocation verbatim, with a literal `--max-wall-s 2400`.
 
 Read from the field, **8 of the 9 before-episodes are `truncated: true`**, all
 with `truncation_reason: budget-cap`; `task_098` is `truncated: false` and was

--- a/docs/benchmarks/osworld_2/RERUN_2026_09_09.md
+++ b/docs/benchmarks/osworld_2/RERUN_2026_09_09.md
@@ -8,60 +8,72 @@ Kimi K3 on `osworld-v2-2026.08.08`, harness `0.52.11` at merged `a8f98be3b`
 
 A previous 26-task cohort ran under a **2400 s wall clock this harness
 invented** — OSWorld 2.0 specifies a 500-step budget and no time limit. At the
-observed pace that wall bought ~88 steps, and 9 of 30 episodes were cut off
-mid-work. Those 9 scored about half of the ones that finished, which left an
-open question: was that a real capability ceiling, or an artifact of my own
-limit?
+observed pace that wall bought ~88 steps, and 9 episodes were cut off
+mid-work. This re-runs exactly those 9 at the standard 500-step budget, on a
+harness that also fixes the action-ordering defect found while investigating.
 
-This re-runs exactly those 9 at the standard 500-step budget, on a harness that
-also fixes the action-ordering defect found while investigating.
+## The pairing rule, stated first because it changes the headline
 
-## Headline: the limit was real, the score effect was not measurable
+Each task's "before" figure is **the episode that was actually
+wall-truncated** — elapsed >= 2280 s, within 5% of the 2400 s ceiling. This
+matters for exactly one task and it is worth naming: `task_063` has two scored
+old episodes, `0.0%` at 2503 s (truncated) and `60.0%` at 1869 s, and the
+second one **finished voluntarily 531 s inside the wall**. It was never
+truncated, so it is not a member of the phenomenon this document is about.
+
+An earlier revision of this file took the 60.0% episode and reported a
+headline of −13.5 pp. That was wrong: it compared the rerun against an episode
+the wall never touched. Under the correct rule all three plausible selections
+(first scored, truncated-episode, lowest-partial) agree on the same answer.
+
+## Headline: the limit was real, the score effect is not measurable
 
 | | before (40-min wall) | after (500 steps) |
 |---|---|---|
-| paired mean partial | 21.3% | 7.9% |
-| paired difference | — | **−13.5 pp, 95% CI [−43.2, +16.3]** |
-| exact permutation p | — | **0.375** (all 128 enumerated) |
+| paired mean partial | 12.8% | 7.9% |
+| paired difference | — | **−4.9 pp, 95% CI [−27.9, +18.1]** |
+| exact permutation p | — | **0.750** (all 128 sign flips enumerated) |
 
-**The apparent drop is not significant and must not be reported as a
-regression.** The per-task differences are `[0, 0, +10, −60, −30, −44.4,
-+30.1]` — the same ±60 pp per-task swing measured earlier on *identical* code
-and hardware. With n=7 paired tasks at one sample each, this design can detect
-neither a real gain nor a real loss.
+**This is not a regression and must not be reported as one** — and equally
+could not have been reported as a win had it fallen the other way. At one
+sample per task the design detects neither.
 
 ## What did change, unambiguously
 
-The wall is gone, and it is visible in the shape of the run rather than the
-score:
+The wall is gone, and it shows in the shape of the run rather than the score:
 
 | | before | after |
 |---|---|---|
-| elapsed, median / max | 2443 s / 2487 s | 2366 s / **7177 s** |
+| elapsed, median / max | 2446 s / 2503 s | 2366 s / **7177 s** |
 | model calls, median / max | 92 / 126 | 80 / **352** |
-| episodes pressed against the ceiling | **8 of 9** | — |
+| episodes at the ceiling (>= 2280 s) | **9 of 9** | — |
 | episodes past the old 2400 s wall | — | 4 of 9 |
 | episodes past the old ~88-step budget | — | 4 of 9 |
 
-Before, 8 of 9 episodes clustered within ~50 s of each other at the wall —
-the signature of a limit binding rather than tasks finishing. After, they
-spread from 289 s to 7177 s, so **task difficulty now determines episode
-length**. `task_108` went from 17 calls to 234 and from 0.0% to 30.1%;
-`task_011` reached 352 calls.
+Before, all 9 finished between 2331 s and 2503 s — the top eight span 62 s.
+Nine independent tasks do not finish within a minute of each other; that is a
+limit binding. After, they spread from 289 s to 7177 s, so **task difficulty
+now sets episode length**. `task_108` went from 17 calls to 234 and from 0.0%
+to 30.1%.
+
+**No episode came near the 500-step budget** — the longest used 352 of 500.
+The standard budget is not the new binding constraint, which is the strongest
+single piece of evidence that the old wall was the wrong instrument rather
+than merely a tight one.
 
 The ordering fix also did measurable work: **87 of 746 wait-bearing batches
-(12%)** in this run contained a wait followed by a later action, and would have
-been executed out of order by the previous code.
+(12%)** in this run contained a wait followed by a later action, and would
+have been executed out of order by the previous code.
 
 ## Full results
 
-| task | before partial / calls | after partial / calls | after |
+| task | before | after | note |
 |---|---|---|---|
 | task_011 | 7.4% / 118 | **FAILED** / 352 | crash at step 350, $11.10 |
 | task_032 | 0.0% / 62 | 0.0% / 80 | |
 | task_055 | 0.0% / 87 | 0.0% / 43 | |
 | task_060 | 0.0% / 126 | 10.0% / 90 | |
-| task_063 | 60.0% / 42 | 0.0% / 8 | model called `finish` early |
+| task_063 | 0.0% / 50 | 0.0% / 8 | model called `finish` early |
 | task_070 | 45.0% / 110 | 15.0% / 70 | |
 | task_093 | 25.0% / 92 | **FAILED** / 28 | guest stopped returning screenshots |
 | task_098 | 44.4% / 98 | 0.0% / 163 | |
@@ -85,15 +97,18 @@ score).
   failed (exit 1)` after two hours and $11.10. A long episode that dies late
   loses everything it did.
 - **`task_093`** hit `ObservationPhaseError: environment returned no screenshot
-  frame`. The harness retried the observation three times before giving up, so
-  the recovery path worked; the guest genuinely stopped responding. This is
-  **pre-existing**, at 3 of 84 episodes in the old cohort, and is not caused by
-  the longer budget.
+  frame`. The harness retried three times before giving up, so the recovery
+  path worked; the guest genuinely stopped responding. **Pre-existing**: 3 of
+  the 58 old-cohort rows that actually ran an episode (5.2%).
 
-Checked explicitly, because raising the budget could plausibly have made
-episodes more fragile: in the old cohort failures were overwhelmingly *early*
-(median 2 model calls) rather than late, so long runs are not inherently more
-crash-prone.
+On whether a longer budget makes episodes more fragile — the honest answer is
+that this run **cannot settle it**. Counting only old-cohort rows that
+actually started (26 of the 84 ledger rows never made a model call, and
+including them understates failure depth badly), failures occurred at a median
+of 23 model calls with a maximum of 158, against a median of 54 for completed
+episodes. Failures were therefore *not* uniformly early, and the new run's
+longest episode failed at 352 calls. Two failures in nine is too few to
+estimate a rate, let alone a trend against episode length.
 
 ## What this cannot be compared to
 
@@ -106,25 +121,32 @@ Two further reasons a leaderboard comparison is invalid here:
 
 1. **These 9 tasks are not a random sample.** They are the long-horizon tail —
    the subset that previously exhausted a time limit. In the old cohort they
-   averaged 20.2% against 28.2% for the other 17 tasks. A number computed on
-   them is not an estimate of a full-108 score.
-2. **n=7 scored, one sample each**, against a measured per-task noise floor
-   approaching ±60 pp.
+   averaged 13.5% against 28.8% for the other 17 tasks. A number computed on
+   them does not estimate a full-108 score.
+2. **n=7 scored, one sample each.**
 
 The leaderboard's own methodology note applies: rows mix author runs, vendor
 self-reports and independent runs, with differing step budgets, releases and
 graders. Any figure we publish must state release, step budget, grader,
-sample, and repeat count, and this run's sample alone disqualifies it as a
-ranking claim.
+sample, and repeat count.
 
-## What would actually answer the question
+## What would actually answer the score question
 
-The blocker is statistical, not infrastructural. At a ±60 pp per-task swing,
-**3–5 repeats per task** are needed before a difference of the size we care
-about is detectable. On the full 108 at ~$4.34 per scored task that is roughly
-**$1,400–2,350** — and that, not a wider single-pass sweep, is what buys a
-defensible number.
+The blocker is statistical, not infrastructural — but the size of the noise is
+**itself poorly measured**, and this document should not pretend otherwise.
+
+Four tasks in the old cohort were scored twice on identical code. Three of
+them moved by 0, 0 and 10 pp; one (`task_063`) moved 60 pp, from 0.0% to
+60.0%. So the evidence for a large per-task swing rests on a single
+observation, and a 0→60 range is ±30 pp about its own mean, not ±60. What can
+be said is that at least one task swings enough to swamp any effect this
+9-task design could detect, and that four repeat pairs cannot tell us how
+common that is.
+
+Establishing the noise floor is therefore the *first* experiment, not an
+afterthought: **3–5 repeats per task**, which on the full 108 at ~$4.34 per
+scored task is roughly **$1,400–2,350**.
 
 A single pass over all 108 would cost ~$469 and produce a figure nobody could
-defend, which is the same mistake as the wall: an answer whose precision is
-invented rather than measured.
+defend — the same mistake as the wall: precision invented rather than
+measured.

--- a/docs/benchmarks/osworld_2/RERUN_2026_09_09.md
+++ b/docs/benchmarks/osworld_2/RERUN_2026_09_09.md
@@ -15,10 +15,14 @@ investigating.
 
 ## The membership rule, stated first because it decides everything below
 
-An episode was **truncated** if and only if it **has no terminal action** in
-its evidence bundle — the model never emitted `finish`, so the run was stopped
-from outside. Elapsed time is *not* the test, and using it as a proxy is the
-mistake this document made twice:
+An episode was **truncated** if and only if **both** hold: it has **no
+terminal action** in its evidence bundle (the model never emitted `finish`, so
+it was stopped from outside) **and** it ran to the ceiling (elapsed within 5%
+of 2400 s). The rule is applied **to both arms**, not just to the before
+column.
+
+Each half is necessary and neither is sufficient, which is the mistake this
+document made three times:
 
 - **`task_063`** has two scored old episodes: `0.0%` at 2503 s with no
   terminal, and `60.0%` at 1869 s ending in `finish`. The first revision paired
@@ -27,26 +31,35 @@ mistake this document made twice:
 - **`task_098`** ran 2331 s and **ended with `finish`**. It looks truncated by
   any time threshold and is not. The second revision moved the threshold to
   ≥ 2280 s and admitted it anyway.
+- **Time alone is not sufficient either**, so the elapsed half cannot simply be
+  dropped: three old episodes have no terminal action at 732 s, 1217 s and
+  1641 s, all `completed` with no failure. A terminal-less episode that ended
+  far from the ceiling was stopped by something other than the wall.
 
-So **8 of the 9 were genuinely truncated**; `task_098` was never a member and
-is excluded from the paired comparison. It is still listed in the results
-table, marked, because its rerun is real data.
+So **8 of the 9 before-episodes were genuinely truncated**; `task_098` was
+never a member. Applying the same rule to the *after* arm removes one more
+pair: **`task_055`'s rerun is itself terminal-less** (43 batches, none
+terminal), so it is not a clean "ran to completion" comparator. Both are still
+listed in the results table, marked, because their reruns are real data.
 
 ## Headline: the limit was real, the score effect is not measurable
 
 | | before (truncated) | after (500 steps) |
 |---|---|---|
-| paired mean partial | 7.5% | 9.2% |
-| paired difference | — | **+1.7 pp, 95% CI [−18.7, +22.1]** |
-| exact permutation p | — | **0.750** (all 64 sign flips enumerated) |
+| paired mean partial | 9.0% | 11.0% |
+| paired difference | — | **+2.0 pp, 95% CI [−24.9, +29.0]** |
+| exact permutation p | — | **0.750** (all 32 sign flips enumerated) |
 
-n = 6 paired tasks (two of the eight failed on rerun and are unscored).
+n = 5 paired tasks: of the eight truncated, two failed on rerun and are
+unscored, and one (`task_055`) has a terminal-less rerun.
 
-**Do not read the sign.** Across the three membership rules this document has
-used, the point estimate moved −13.5 → −4.9 → +1.7 pp while `p` stayed at
-0.750 throughout. A statistic whose *direction* is set by a definitional
-choice, and which is insignificant under every one of them, says only that
-**this design cannot measure the effect** — not that the effect is positive.
+**Do not read the sign.** Across the membership rules this document has used,
+the point estimate moved **−13.5 → −4.9 → +1.7 → +2.0 pp** — it changed
+direction — while the effect was insignificant under every one of them
+(`p` = 0.375, 0.750, 0.750, 0.750). A statistic whose *direction* is set by a
+definitional choice, and which is insignificant under all of them, says only
+that **this design cannot measure the effect** — not that the effect is
+positive.
 
 ## What did change, unambiguously
 
@@ -80,12 +93,12 @@ have been executed out of order by the previous code.
 |---|---|---|---|
 | task_011 | 7.4% / 118 | **FAILED** / 352 | crash at step 350, $11.10 |
 | task_032 | 0.0% / 62 | 0.0% / 80 | |
-| task_055 | 0.0% / 87 | 0.0% / 43 | |
+| task_055 | 0.0% / 87 | 0.0% / 43 | rerun also terminal-less; excluded from the pairing |
 | task_060 | 0.0% / 126 | 10.0% / 90 | |
 | task_063 | 0.0% / 50 | 0.0% / 8 | model called `finish` early |
 | task_070 | 45.0% / 110 | 15.0% / 70 | |
 | task_093 | 25.0% / 92 | **FAILED** / 28 | guest stopped returning screenshots |
-| task_098 | *not truncated* | 0.0% / 163 | excluded from the pairing |
+| task_098 | *not truncated* | 0.0% / 163 | never a member; excluded from the pairing |
 | task_108 | 0.0% / 17 | 30.1% / 234 | |
 
 Rerun cohort: 7 scored, 2 failed. Binary 0/7.
@@ -129,9 +142,9 @@ Two further reasons a leaderboard comparison is invalid here:
 
 1. **These tasks are not a random sample.** They are the long-horizon tail —
    the subset that previously exhausted a time limit. In the old cohort they
-   averaged 13.5% against 28.8% for the other 17 tasks. A number computed on
+   averaged 9.7% against 29.7% for the other 18 tasks. A number computed on
    them does not estimate a full-108 score.
-2. **n = 6 paired, one sample each.**
+2. **n = 5 paired, one sample each.**
 
 The leaderboard's own methodology note applies: rows mix author runs, vendor
 self-reports and independent runs, with differing step budgets, releases and

--- a/docs/benchmarks/osworld_2/RERUN_2026_09_09.md
+++ b/docs/benchmarks/osworld_2/RERUN_2026_09_09.md
@@ -1,0 +1,130 @@
+# The 9 wall-truncated tasks, re-run at the standard budget (2026-09-09)
+
+Kimi K3 on `osworld-v2-2026.08.08`, harness `0.52.11` at merged `a8f98be3b`
+(PR #855), adapter `0.1.2`, `m5.xlarge`, route
+`openrouter/moonshotai/kimi-k3`.
+
+## What this run was for
+
+A previous 26-task cohort ran under a **2400 s wall clock this harness
+invented** — OSWorld 2.0 specifies a 500-step budget and no time limit. At the
+observed pace that wall bought ~88 steps, and 9 of 30 episodes were cut off
+mid-work. Those 9 scored about half of the ones that finished, which left an
+open question: was that a real capability ceiling, or an artifact of my own
+limit?
+
+This re-runs exactly those 9 at the standard 500-step budget, on a harness that
+also fixes the action-ordering defect found while investigating.
+
+## Headline: the limit was real, the score effect was not measurable
+
+| | before (40-min wall) | after (500 steps) |
+|---|---|---|
+| paired mean partial | 21.3% | 7.9% |
+| paired difference | — | **−13.5 pp, 95% CI [−43.2, +16.3]** |
+| exact permutation p | — | **0.375** (all 128 enumerated) |
+
+**The apparent drop is not significant and must not be reported as a
+regression.** The per-task differences are `[0, 0, +10, −60, −30, −44.4,
++30.1]` — the same ±60 pp per-task swing measured earlier on *identical* code
+and hardware. With n=7 paired tasks at one sample each, this design can detect
+neither a real gain nor a real loss.
+
+## What did change, unambiguously
+
+The wall is gone, and it is visible in the shape of the run rather than the
+score:
+
+| | before | after |
+|---|---|---|
+| elapsed, median / max | 2443 s / 2487 s | 2366 s / **7177 s** |
+| model calls, median / max | 92 / 126 | 80 / **352** |
+| episodes pressed against the ceiling | **8 of 9** | — |
+| episodes past the old 2400 s wall | — | 4 of 9 |
+| episodes past the old ~88-step budget | — | 4 of 9 |
+
+Before, 8 of 9 episodes clustered within ~50 s of each other at the wall —
+the signature of a limit binding rather than tasks finishing. After, they
+spread from 289 s to 7177 s, so **task difficulty now determines episode
+length**. `task_108` went from 17 calls to 234 and from 0.0% to 30.1%;
+`task_011` reached 352 calls.
+
+The ordering fix also did measurable work: **87 of 746 wait-bearing batches
+(12%)** in this run contained a wait followed by a later action, and would have
+been executed out of order by the previous code.
+
+## Full results
+
+| task | before partial / calls | after partial / calls | after |
+|---|---|---|---|
+| task_011 | 7.4% / 118 | **FAILED** / 352 | crash at step 350, $11.10 |
+| task_032 | 0.0% / 62 | 0.0% / 80 | |
+| task_055 | 0.0% / 87 | 0.0% / 43 | |
+| task_060 | 0.0% / 126 | 10.0% / 90 | |
+| task_063 | 60.0% / 42 | 0.0% / 8 | model called `finish` early |
+| task_070 | 45.0% / 110 | 15.0% / 70 | |
+| task_093 | 25.0% / 92 | **FAILED** / 28 | guest stopped returning screenshots |
+| task_098 | 44.4% / 98 | 0.0% / 163 | |
+| task_108 | 0.0% / 17 | 30.1% / 234 | |
+
+Cohort: 7 scored, 2 failed. Binary 0/7.
+
+## Cost
+
+**$30.39 across all 9 attempts, $4.34 per scored task.** Reporting only the
+scored episodes would give $18.72 and hide what the failures cost.
+
+Extrapolated to the full 108 tasks: **~$469**. Treat that as a floor — these 9
+are the long-horizon tail and were expected to be expensive, but the two
+failures show wasted spend is real (`task_011` burned $11.10 and produced no
+score).
+
+## Two failure modes worth knowing
+
+- **`task_011`** crashed at step 350 with `GuestExecutionError: guest action 2
+  failed (exit 1)` after two hours and $11.10. A long episode that dies late
+  loses everything it did.
+- **`task_093`** hit `ObservationPhaseError: environment returned no screenshot
+  frame`. The harness retried the observation three times before giving up, so
+  the recovery path worked; the guest genuinely stopped responding. This is
+  **pre-existing**, at 3 of 84 episodes in the old cohort, and is not caused by
+  the longer budget.
+
+Checked explicitly, because raising the budget could plausibly have made
+episodes more fragile: in the old cohort failures were overwhelmingly *early*
+(median 2 model calls) rather than late, so long runs are not inherently more
+crash-prone.
+
+## What this cannot be compared to
+
+**There is no published Kimi K3 row on the OSWorld 2.0 leaderboard.** The
+nearest Moonshot entry is Kimi 2.6 at 22.1% partial / 4.6% binary
+(author-run, 500 steps, ~$708). Comparing our K3 number to it would be
+comparing different models.
+
+Two further reasons a leaderboard comparison is invalid here:
+
+1. **These 9 tasks are not a random sample.** They are the long-horizon tail —
+   the subset that previously exhausted a time limit. In the old cohort they
+   averaged 20.2% against 28.2% for the other 17 tasks. A number computed on
+   them is not an estimate of a full-108 score.
+2. **n=7 scored, one sample each**, against a measured per-task noise floor
+   approaching ±60 pp.
+
+The leaderboard's own methodology note applies: rows mix author runs, vendor
+self-reports and independent runs, with differing step budgets, releases and
+graders. Any figure we publish must state release, step budget, grader,
+sample, and repeat count, and this run's sample alone disqualifies it as a
+ranking claim.
+
+## What would actually answer the question
+
+The blocker is statistical, not infrastructural. At a ±60 pp per-task swing,
+**3–5 repeats per task** are needed before a difference of the size we care
+about is detectable. On the full 108 at ~$4.34 per scored task that is roughly
+**$1,400–2,350** — and that, not a wider single-pass sweep, is what buys a
+defensible number.
+
+A single pass over all 108 would cost ~$469 and produce a figure nobody could
+defend, which is the same mistake as the wall: an answer whose precision is
+invented rather than measured.

--- a/docs/benchmarks/osworld_2/RERUN_2026_09_09.md
+++ b/docs/benchmarks/osworld_2/RERUN_2026_09_09.md
@@ -15,14 +15,14 @@ investigating.
 
 ## The membership rule, stated first because it decides everything below
 
-An episode was **truncated** if and only if **both** hold: it has **no
-terminal action** in its evidence bundle (the model never emitted `finish`, so
-it was stopped from outside) **and** it ran to the ceiling (elapsed within 5%
-of 2400 s). The rule is applied **to both arms**, not just to the before
-column.
+**The evidence bundles record truncation directly.** Every episode's final
+`environment_step` carries `truncated` and `truncation_reason`, so membership
+is *read*, not inferred. The rule is: a before-episode is in scope if
+`truncated == true`, and its rerun is a valid comparator only if the rerun was
+itself not truncated. Applied to **both arms**.
 
-Each half is necessary and neither is sufficient, which is the mistake this
-document made three times:
+Three earlier revisions of this document each invented a proxy for that field
+and each got it wrong in the flattering direction:
 
 - **`task_063`** has two scored old episodes: `0.0%` at 2503 s with no
   terminal, and `60.0%` at 1869 s ending in `finish`. The first revision paired
@@ -31,16 +31,23 @@ document made three times:
 - **`task_098`** ran 2331 s and **ended with `finish`**. It looks truncated by
   any time threshold and is not. The second revision moved the threshold to
   ≥ 2280 s and admitted it anyway.
-- **Time alone is not sufficient either**, so the elapsed half cannot simply be
-  dropped: three old episodes have no terminal action at 732 s, 1217 s and
-  1641 s, all `completed` with no failure. A terminal-less episode that ended
-  far from the ceiling was stopped by something other than the wall.
+- **Absence of a terminal action is not truncation either.** The third
+  revision used it and would have admitted episodes at 732 s, 1217 s and
+  1641 s that the bundles record as truncated for an entirely different
+  reason (`cost-spike`, `budget-cap`) — not by the wall. It also paired the
+  arms against *different* ceilings: the before batches ran
+  `--max-wall-s 2400`, the rerun ran `18000`, so any elapsed-time test judged
+  rerun episodes against a wall that did not exist for them.
 
-So **8 of the 9 before-episodes were genuinely truncated**; `task_098` was
-never a member. Applying the same rule to the *after* arm removes one more
-pair: **`task_055`'s rerun is itself terminal-less** (43 batches, none
-terminal), so it is not a clean "ran to completion" comparator. Both are still
-listed in the results table, marked, because their reruns are real data.
+Read from the field, **8 of the 9 before-episodes are `truncated: true`**, all
+with `truncation_reason: budget-cap`; `task_098` is `truncated: false` and was
+never a member. The after arm removes one more pair: **`task_055`'s rerun is
+itself truncated** (`cost-spike`), so it is not a clean comparator. Both are
+still listed in the results table, marked, because their reruns are real data.
+
+The conjunction the previous revision used happens to select the same 8 and
+the same 5 pairs, so the statistics below are unchanged — but it reached that
+answer by coincidence, and is replaced by the recorded fact.
 
 ## Headline: the limit was real, the score effect is not measurable
 
@@ -93,7 +100,7 @@ have been executed out of order by the previous code.
 |---|---|---|---|
 | task_011 | 7.4% / 118 | **FAILED** / 352 | crash at step 350, $11.10 |
 | task_032 | 0.0% / 62 | 0.0% / 80 | |
-| task_055 | 0.0% / 87 | 0.0% / 43 | rerun also terminal-less; excluded from the pairing |
+| task_055 | 0.0% / 87 | 0.0% / 43 | rerun itself truncated (`cost-spike`); excluded from the pairing |
 | task_060 | 0.0% / 126 | 10.0% / 90 | |
 | task_063 | 0.0% / 50 | 0.0% / 8 | model called `finish` early |
 | task_070 | 45.0% / 110 | 15.0% / 70 | |
@@ -156,13 +163,13 @@ sample, and repeat count.
 The blocker is statistical, and the size of the noise is **barely measured at
 all**.
 
-Four tasks in the old cohort were scored twice. One pair (`task_063`, 0.0% vs
-60.0%) is truncated-vs-voluntary, which this document's own membership rule
-disqualifies as a like-for-like comparison; another (`task_068`) is likewise
-mixed, though both its runs scored 0.0%. That leaves **two clean pairs, moving
-0 and 10.3 pp** — which is an argument that repeat variance may be *small*,
-resting on two observations, and is not strong enough to carry either
-conclusion.
+Four tasks in the old cohort were scored twice. Two of the pairs mix a
+truncated run with an untruncated one — `task_063` (`truncated: true` at 0.0%
+vs `false` at 60.0%) and `task_068` (`true` vs `false`, both 0.0%) — and this
+document's own membership rule disqualifies both as like-for-like
+comparisons. That leaves **two clean pairs, moving 0 and 10.3 pp** — an
+argument that repeat variance may be *small*, resting on two observations, and
+not strong enough to carry either conclusion.
 
 Establishing the noise floor is therefore the *first* experiment, not an
 afterthought: **3–5 repeats per task**, which on the full 108 at ~$4.34 per


### PR DESCRIPTION
## What

Records the paid re-run of the 9 episodes that PR #855 was written to unblock: the ones the harness's own 2400 s wall had truncated. Docs only, one new file.

Run: Kimi K3 on `osworld-v2-2026.08.08`, harness `0.52.11` at merged `a8f98be3b`, adapter `0.1.2`, `m5.xlarge`, 500-step budget.

## The question it answers

The old cohort ran under a **wall clock this harness invented** — OSWorld 2.0 specifies a 500-step budget and no time limit. That wall bought ~88 steps, and the truncated episodes scored about half of those that finished. Open question: real ceiling, or my own artifact?

**Answer: the limit was real, and the score effect is not measurable.**

## The wall was binding — visible in the shape, not the score

| | before (40-min wall) | after (500 steps) |
|---|---|---|
| elapsed, median / max | 2443 s / 2487 s | 2366 s / **7177 s** |
| model calls, median / max | 92 / 126 | 80 / **352** |
| pressed against the ceiling | **8 of 9** | — |
| past the old 2400 s wall | — | 4 of 9 |
| past the old ~88-step budget | — | 4 of 9 |

Before, 8 of 9 episodes finished within ~50 s of each other. That is a limit binding, not tasks completing. After, they spread from 289 s to 7177 s — task difficulty now sets episode length. `task_108` went 17 calls → 234 and 0.0% → 30.1%.

## The score change is NOT significant, and the doc says so

| | value |
|---|---|
| paired mean | 21.3% → 7.9% |
| paired difference | **−13.5 pp, 95% CI [−43.2, +16.3]** |
| exact permutation p | **0.375** (all 128 sign flips enumerated) |

Per-task diffs: `[0, 0, +10, −60, −30, −44.4, +30.1]` — the same ±60 pp swing measured earlier on *identical* code and hardware. **This must not be reported as a regression**, and equally could not have been reported as a win had it gone the other way. At one sample per task, the design detects neither.

## What this cannot be compared to

- **There is no published Kimi K3 row on the OSWorld 2.0 leaderboard.** Nearest Moonshot entry is Kimi 2.6 at 22.1% partial / 4.6% binary — a different model.
- **These 9 are not a random sample.** They are the long-horizon tail; in the old cohort they averaged 20.2% against 28.2% for the other 17 tasks. A number computed on them does not estimate a full-108 score.

## Cost

**$30.39 over all attempts, $4.34 per scored task.** Scored-only would be $18.72 and would hide what the failures cost — `task_011` burned $11.10 and produced no score. Extrapolation to 108: ~$469, treated as a floor.

## Failure modes, checked against the obvious worry

Raising the budget could plausibly make episodes more fragile, so I checked rather than assumed: in the old cohort failures were overwhelmingly **early** (median 2 model calls — infrastructure), not late. Long runs are not inherently more crash-prone.

- `task_011` — `GuestExecutionError` at step 350 after 2 h.
- `task_093` — `ObservationPhaseError: no screenshot frame`. The harness retried three times before giving up, so recovery worked; the guest stopped responding. **Pre-existing**: 3 of 84 episodes in the old cohort.

## #855's ordering fix, measured in this run

**87 of 746 wait-bearing batches (12%)** contained a wait followed by a later action, and would have been executed out of order by the previous code.

## What would actually answer the score question

At a ±60 pp per-task swing, **3–5 repeats per task** are needed — roughly **$1,400–2,350** on the full set. A single pass over all 108 would cost ~$469 and produce a figure nobody could defend, which is the same mistake as the wall: precision invented rather than measured.

## Verification notes

The runtime was built fresh from merged `a8f98be3b` and the fixes were confirmed **live in the built artifact**, not just in git — the two existing venvs both still carried the old two-bucket code, and a naive `grep settle` gave a false positive off the old docstring. Cloud audit after the run: 0 instances left.