### PR TITLE
chore(release): bump version to 0.53.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.52.18"
+version = "0.53.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window bump. Owner session pid: 83153.

Window (everything on `origin/main` since `v0.52.18`):

- [x] #838 `24607d3e5` — `Release: minor` — agents can now persist and use long-term secrets (`secret` tool, `secrets["NAME"]` in eval), and a `$(lop secret get ...)` value is no longer painted in the live bash view.

## Bump: minor → 0.53.0

Per "Versioning: choose the bump by materiality", a minor requires a *single*
PR in the window to clear the step-function bar on its own, and to be nameable
in the release title. #838 is the fourth and final PR of the encrypted
secret-store series and is the one that makes agents able to reach stored
secrets **at all**: a new agent-facing `secret` tool, a new eval-runtime
library, and `$(lop secret get NAME)` from bash, with the redaction wiring that
makes those safe. The v0.52.0 and v0.52.8 notes each stated that agents cannot
reach stored secrets; this release retires that statement. That is a new
surface a user would notice and adopt, so it is a minor rather than a patch.

## Scope

`pyproject.toml` only, one line, `0.52.18` → `0.53.0`. No code.
`git diff v0.52.18..origin/main -- pyproject.toml` was empty before this
commit, so no PR in the window consumed the number.
