### PR TITLE
chore(release): bump version to 0.53.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.53.0"
+version = "0.53.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

Release bump for the v0.53.1 window. `pyproject.toml` only, one line, `0.53.0` -> `0.53.1`.

Window (everything on `origin/main` since `v0.53.0`):

- [x] #856 — `perf(tui): land the session switch in one settled state` (`b3a7da0e4`)

## Bump rationale

**PATCH.** #856 is a behaviour/perf fix on an existing surface: no API addition, no wire-format change, no migration. It is user-visible and broad within the TUI, but it does not clear the step-function bar that a minor requires.

## Scope

`git diff v0.53.0..origin/main -- pyproject.toml` was empty before this branch, so no merged PR in the window consumed the number.

Release: patch — release bump only, no runtime change.
