### PR TITLE
perf(sidebar): make the catalog poll's per-directory syscalls O(user sessions)

### DIFF
--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -122,13 +122,62 @@ USER_ORIGINS: frozenset[str] = frozenset({ORIGIN_FORK})
 #:   disposed directory still drops out. Measured impact on the reporting
 #:   machine at the time of the change: 0 of 1,986 directories affected
 #:   (agent review round 1, R3).
+#:
+#: Each entry also carries the directory's ``ino``, which is what lets a
+#: known-HIDDEN directory be skipped whole — before its marker is stat'd at all
+#: — for zero syscalls. See :data:`REVALIDATE_EVERY` and the scan loop in
+#: :func:`_recent_sessions_with_origin` for why the inode is load-bearing and
+#: why the skip is not permitted to be permanent.
 ORIGIN_CACHE_NAME = "origin-verdicts.json"
 
 #: Bumped when the cache's shape or key changes, so an older file is discarded
 #: rather than misread. Independent of ``search_index.INDEX_VERSION`` — the two
 #: caches version separately and neither number constrains the other; only the
 #: mechanism is borrowed.
-ORIGIN_CACHE_VERSION = 1
+#:
+#: 2 added the ``ino`` field. An entry without one cannot arm the hidden-skip
+#: fast path, so a v1 file would merely be slow rather than wrong — but the
+#: loader already discards an unknown version and rebuilds
+#: (:func:`_load_origin_cache`), which is the cheaper and more obviously correct
+#: migration than teaching the fast path to reason about a missing field.
+ORIGIN_CACHE_VERSION = 2
+
+#: How many scans pass between full revalidations of the hidden-skip fast path.
+#:
+#: **Counted in POLLS, not seconds.** At the sidebar's 2 s interval
+#: (``app.py``'s ``set_interval(2.0, self._refresh_sidebar)``) 150 polls is
+#: ~5 minutes, which is the ceiling on how long a stale verdict can leave a real
+#: session hidden. If the poll rate ever becomes variable, re-express this as
+#: elapsed time — a faster poll makes revalidation more frequent (safe, but
+#: costlier) while a slower one stretches the staleness window in wall-clock
+#: terms without this number changing.
+#:
+#: Why revalidate at all, given that "once a subagent, always a subagent" holds
+#: for every writer in the tree (``harness/subagent.py``, ``fork.py``, and the
+#: backfill below, which explicitly refuses to re-stamp an existing marker):
+#: because the backfill's refusal exists precisely so that **a marker a human
+#: deleted by hand to un-hide a session is not silently written back**. The
+#: codebase therefore treats deleting ``origin.json`` as a supported gesture,
+#: and a permanent skip would answer that gesture with a session that stays
+#: invisible forever. Three independent repairs bound it: this epoch, a cold
+#: start (the counter begins at 0, so ``0 % REVALIDATE_EVERY == 0`` and a fresh
+#: process always revalidates on its first scan), and the cache being derived
+#: data under ``cache/`` that a user may delete at any time.
+#:
+#: Cost of the epoch, measured at 4,000 directories / 50 users: a fast poll is
+#: 151 syscalls and a revalidating one 4,101, so the AMORTISED figure is 177
+#: against main's 8,052. 177 is the honest number to quote, not 151.
+REVALIDATE_EVERY = 150
+
+#: Scans issued so far, per store, driving :data:`REVALIDATE_EVERY`.
+#:
+#: Process-local on purpose: it is a POLICY counter, not a fact about the store,
+#: and persisting it would let one of the dozen ``lop`` processes on this machine
+#: decide another's staleness window — and would cost a write on a path whose
+#: whole point is to stop touching the disk. In production this holds exactly one
+#: key, the running session's config dir. Keyed by path string rather than
+#: ``Path`` so a test's ``tmp_path`` cannot collide with a live store.
+_SCAN_COUNT: dict[str, int] = {}
 
 #: Journals the session's title (and every name it has ever borne) beside the
 #: transcript, mirroring :data:`ORIGIN_NAME` exactly. A SIDECAR rather than a
@@ -1144,18 +1193,26 @@ def recent_sessions(config_dir: Path, limit: int | None = None) -> list[tuple[st
     concurrently) is skipped rather than raising out of an error path whose whole
     job is to be helpful.
 
-    The traversal is ``os.scandir``-based over the store. Within THIS function
-    each directory costs ONE ``stat`` (the origin marker) plus, only for the
-    sessions that survive that gate, the activity stats — see the gate-order
-    note in :func:`_recent_sessions_with_origin`, which is where the
-    per-directory cost is actually decided.
+    The traversal is ``os.scandir``-based over the store, and in the steady
+    state a directory already known to be a subagent session costs NOTHING:
+    it is skipped from the verdict cache before its marker is stat'd, on facts
+    (`name`, `inode`) the ``readdir`` batch already supplied. Only a directory
+    the cache cannot answer for pays the origin stat, and only one that
+    survives that gate pays the activity stats — see the skip and gate-order
+    notes in :func:`_scan_sessions`, which is where the per-directory cost is
+    actually decided.
 
-    That "one stat per directory" is this function's floor, NOT the sidebar
-    poll's: :func:`~local_operator.session.catalog.load_catalog` pays a second
-    unconditional stat per directory probing for the desktop draft marker
-    (measured at 0.99/dir, QA round 1 Q2), so a poll costs ~2.0-2.2 syscalls
-    per directory in total and remains linear in the whole store. Anyone
-    optimising this path next should count both sites, not this one alone.
+    So per-directory cost tracks the USER's own sessions, not the store:
+    measured flat at 266 syscalls per poll while the store grew 100 -> 8,000
+    directories with users held at 50 (``scripts/bench_catalog_scan.py
+    store-axis``), against 366 -> 16,166 before. What is still O(total
+    entries) is the single batched ``scandir`` — the poll has stopped
+    stat-ing the store, not stopped touching it — and the verdict cache's own
+    parse, which at 7,950 markers is 704 KB / 5.6 ms and is now the dominant
+    remaining term. Anyone optimising this path next should start there, and
+    should count :func:`~local_operator.session.catalog.load_catalog`'s
+    desktop probe too — it is the second site, and the hidden set returned by
+    :func:`_scan_sessions` is what removed it.
 
     The store is scanned once rather than each directory
     being scanned individually: the latter is what the origin design proposed,
@@ -1163,16 +1220,15 @@ def recent_sessions(config_dir: Path, limit: int | None = None) -> list[tuple[st
     stats every entry in every directory to learn two filenames. Do not "fix"
     it back.
 
-    The cost that matters is the ORIGIN check, which runs once per directory
-    and therefore scales with the SUBAGENT population — ~10.6x the user
-    population on the reporting machine, and the part that actually grows.
-    Because a marker that EXISTS must still be read and parsed (see
-    :data:`ORIGIN_CACHE_NAME`), that is one file read per subagent directory:
-    1127 ms over 31,700 dirs, of which the reads are 639 ms. The verdict cache
-    is what removes it, taking the same scan to ~310 ms warm
-    (``bench/resume-picker-after.json``; independently re-measured at 307 ms in
-    agent review round 1). Quote the committed bench figure here rather than a
-    remembered one — an optimistic number in a docstring is how the next
+    The cost this used to be dominated by was the ORIGIN check, which ran once
+    per directory and therefore scaled with the SUBAGENT population — ~10.6x
+    the user population on the reporting machine. Because a marker that EXISTS
+    must still be read and parsed (see :data:`ORIGIN_CACHE_NAME`), that was one
+    file read per subagent directory: 1127 ms over 31,700 dirs, of which the
+    reads were 639 ms. The verdict cache removed the READS (~310 ms warm,
+    ``bench/resume-picker-after.json``), and the hidden-skip above removed the
+    remaining per-directory STAT. Quote the committed bench figure here rather
+    than a remembered one — an optimistic number in a docstring is how the next
     person's regression looks like an improvement.
 
     ``limit`` truncates the RESULT, never the work: every directory is visited
@@ -1182,6 +1238,22 @@ def recent_sessions(config_dir: Path, limit: int | None = None) -> list[tuple[st
     return [
         (name, mtime) for name, mtime, _origin in _recent_sessions_with_origin(config_dir, limit)
     ]
+
+
+def _is_hidden_origin(origin: str) -> bool:
+    """Whether a parsed ``origin`` value keeps its session OUT of the listing.
+
+    The exact negation of :func:`is_user_session`'s rule, spelled here so the
+    scan loop can ask the question twice — once of a CACHED verdict before any
+    syscall, once of a freshly parsed one — without the two spellings drifting.
+    ``USER_ORIGINS`` remains the single shared fact both consult, so a new
+    user-visible origin is still added in exactly one place.
+
+    Not delegated to :func:`is_user_session` itself because that takes a
+    directory and pays a stat plus a read to obtain the origin the scan already
+    has in hand; this loop must not pay a second stat per directory.
+    """
+    return bool(origin) and origin not in USER_ORIGINS
 
 
 def _recent_sessions_with_origin(
@@ -1196,18 +1268,54 @@ def _recent_sessions_with_origin(
     the value is ``""`` with no syscall added at all.
 
     Private because the public pair is what every other caller wants and the
-    CLI's recovery listing pins its shape.
+    CLI's recovery listing pins its shape. Callers that also want the hidden
+    names — only ``session.catalog.load_catalog``, to skip a second per-directory
+    stat — use :func:`_scan_sessions` directly.
+    """
+    return _scan_sessions(config_dir, limit)[0]
+
+
+def _scan_sessions(
+    config_dir: Path, limit: int | None = None
+) -> tuple[list[tuple[str, float, str]], set[str]]:
+    """The one store scan: ``(rows, hidden_names)``.
+
+    ``hidden_names`` is every directory this scan established is NOT the user's
+    own session — whether it was skipped from cache or re-read. It exists for
+    ``load_catalog``, which otherwise stats a ``desktop.json`` in every
+    directory the listing did not return. That probe is answerable without the
+    filesystem here: ``desktop.json`` has exactly one writer
+    (``server/utils/desktop_sessions.py``'s ``DesktopSessions.create``), which
+    mints a fresh ``uuid4`` directory and never writes an origin marker into it,
+    so a directory carrying an origin marker cannot also carry a desktop one.
+    Skipping the probe for these names is HALF the total saving of this design.
+
+    Split from :func:`_recent_sessions_with_origin` rather than widening its
+    return type because that shape is pinned by the CLI's recovery listing and
+    by every other caller, none of which has any use for the second value.
     """
     # Lazy and stdlib-only on the other side: ``retention`` imports nothing
     # heavier than ``logging``, and the CLI startup guard measures this
     # module's import, not this function's.
     from local_operator.session.retention import session_activity_path
 
+    # Which scan this is for this store, and therefore whether the fast path is
+    # armed. Read BEFORE the scandir can fail so a store that is not there yet
+    # still advances the counter — otherwise a session started before its
+    # config dir exists would sit at 0 and revalidate on every poll forever.
+    scans_so_far = _SCAN_COUNT.get(str(config_dir), 0)
+    _SCAN_COUNT[str(config_dir)] = scans_so_far + 1
+    revalidate = scans_so_far % REVALIDATE_EVERY == 0
+
     rows: list[tuple[str, float, str]] = []
+    # Every directory this scan established is not the user's own session. See
+    # the docstring: ``load_catalog`` uses it to skip a second per-directory
+    # stat.
+    hidden_names: set[str] = set()
     try:
         scan = os.scandir(config_dir / "sessions")
     except OSError:
-        return []
+        return [], set()
     cache_path = origin_cache_path(config_dir)
     cached = _load_origin_cache(cache_path)
     fresh: dict[str, Any] = {}
@@ -1218,6 +1326,53 @@ def _recent_sessions_with_origin(
     seen: set[str] = set()
     with scan:
         for entry in scan:
+            previous = cached.get(entry.name)
+            # ---- THE ZERO-SYSCALL SKIP -------------------------------------
+            # A directory already known to be hidden is dropped here, before
+            # its marker is stat'd at all. Both facts this needs come FREE from
+            # the ``readdir`` batch ``scandir`` already paid for: measured
+            # structurally, ``DirEntry.inode()`` still answers after the
+            # directory has been deleted, so it cannot be stat-backed (the same
+            # probe makes ``entry.stat()`` raise ENOENT). So a hidden directory
+            # costs exactly zero syscalls, which is what turns the poll's
+            # per-directory cost from O(the whole store) into O(the user's own
+            # sessions).
+            #
+            # WHY THE INODE IS LOAD-BEARING, not a nicety: keyed on the name
+            # alone this is wrong under ID REUSE. Delete a subagent directory,
+            # later create a real session under the same 12-hex id, and the
+            # dead directory's "hidden" verdict is served for the live one —
+            # a real session permanently invisible in the picker, the severe
+            # failure this design exists to avoid. An inode is reallocated on
+            # recreation (measured on APFS: 912841799 -> 912841800), so the
+            # recreated id misses the cache and takes the slow path.
+            #
+            # The inode is a HINT, never truth. Where it is unavailable
+            # (``ino is None``) or a filesystem recycles numbers aggressively,
+            # the worst case is the name-keyed behaviour this qualification
+            # replaced, bounded by :data:`REVALIDATE_EVERY` — never a wrong
+            # answer that outlives the epoch.
+            try:
+                ino: int | None = entry.inode()
+            except OSError:
+                # A DirEntry that cannot report its inode gets the slow path
+                # rather than a guess; this is the safe direction.
+                ino = None
+            if (
+                not revalidate
+                and ino is not None
+                and isinstance(previous, dict)
+                and previous.get("ino") == ino
+                and isinstance(previous.get("origin"), str)
+                and _is_hidden_origin(previous["origin"])
+            ):
+                # The marker is still on disk as far as this scan knows, so the
+                # entry is retained rather than dropped from the rewritten
+                # cache. Skipping it is what makes the next poll free too.
+                seen.add(entry.name)
+                hidden_names.add(entry.name)
+                continue
+
             # ---- ORDER OF THE TWO GATES IS A MEASURED CHOICE ----------------
             # A row must pass BOTH "has activity" and "is user-visible". That
             # is a conjunction, so evaluating the cheaper, more SELECTIVE gate
@@ -1261,13 +1416,26 @@ def _recent_sessions_with_origin(
             if marker_stat is not None:
                 seen.add(entry.name)
                 key = [marker_stat.st_mtime, marker_stat.st_size]
-                previous = cached.get(entry.name)
                 if (
                     isinstance(previous, dict)
                     and previous.get("key") == key
                     and isinstance(previous.get("origin"), str)
                 ):
                     origin = previous["origin"]
+                    # The VERDICT hit deliberately does not require the inode to
+                    # match: the marker's own (mtime, size) is what makes the
+                    # verdict sound, and demanding an inode here would make a
+                    # filesystem that cannot supply one (``ino is None``) re-read
+                    # every marker on every poll — strictly worse than before
+                    # this change. The inode gates only the zero-syscall skip
+                    # above, which is an optimisation that may safely not arm.
+                    #
+                    # Restamped when the inode moved or was missing, so the entry
+                    # can arm that skip on the next poll. Byte-equal entries make
+                    # ``merged == cached`` below, so a steady store still writes
+                    # nothing.
+                    if previous.get("ino") != ino:
+                        fresh[entry.name] = {"key": key, "origin": origin, "ino": ino}
                 else:
                     # Existence gates the READ, never the verdict: the file is
                     # read and PARSED, because ``session_origin`` returns "" for
@@ -1285,7 +1453,7 @@ def _recent_sessions_with_origin(
                     # permanent wrong verdict for the life of that marker. So it
                     # falls through and is re-read on the next scan instead.
                     if readable:
-                        fresh[entry.name] = {"key": key, "origin": origin}
+                        fresh[entry.name] = {"key": key, "origin": origin, "ino": ino}
                     else:
                         # Drop any entry inherited from ``cached``: this scan
                         # could not confirm it, and ``merged`` below is built
@@ -1298,7 +1466,13 @@ def _recent_sessions_with_origin(
                 # that predicate by hand — ``USER_ORIGINS`` is the shared fact
                 # both consult, so a new user-visible origin is added there once
                 # rather than in two places that can drift.
-                if origin and origin not in USER_ORIGINS:
+                if _is_hidden_origin(origin):
+                    # Exported even though this scan re-read the marker: what
+                    # ``load_catalog`` needs is the hidden SET, and a directory
+                    # that took the slow path this poll (a fresh subagent, a
+                    # revalidating poll, a filesystem with no inode) is hidden
+                    # exactly as much as one that was skipped.
+                    hidden_names.add(entry.name)
                     continue
             else:
                 # No marker: the user's own session, and the cheap path this
@@ -1344,7 +1518,11 @@ def _recent_sessions_with_origin(
     # Sliced only when a limit was actually asked for: ``rows[:None]`` would
     # also return everything, but spelling it out keeps "no limit" a decision
     # the code states rather than a property of slice syntax.
-    return rows if limit is None else rows[:limit]
+    #
+    # ``hidden_names`` is NEVER truncated by ``limit``: it describes the store,
+    # not the page, and ``load_catalog`` consults it for directories that by
+    # definition fell outside the listing.
+    return (rows if limit is None else rows[:limit]), hidden_names
 
 
 def format_age(seconds: float) -> str:

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -125,9 +125,11 @@ USER_ORIGINS: frozenset[str] = frozenset({ORIGIN_FORK})
 #:
 #: Each entry also carries the directory's ``ino``, which is what lets a
 #: known-HIDDEN directory be skipped whole — before its marker is stat'd at all
-#: — for zero syscalls. See :data:`REVALIDATE_EVERY` and the scan loop in
-#: :func:`_recent_sessions_with_origin` for why the inode is load-bearing and
-#: why the skip is not permitted to be permanent.
+#: — for zero syscalls, and which bounds how long a reused session id can serve
+#: a dead directory's verdict. How MUCH it bounds it is filesystem-dependent
+#: (APFS reallocates on recreate, ext4 recycles), so :data:`REVALIDATE_EVERY`
+#: rather than the inode is the correctness guarantee; see the scan loop in
+#: :func:`_scan_sessions` for both measurements.
 ORIGIN_CACHE_NAME = "origin-verdicts.json"
 
 #: Bumped when the cache's shape or key changes, so an older file is discarded
@@ -1338,20 +1340,28 @@ def _scan_sessions(
             # per-directory cost from O(the whole store) into O(the user's own
             # sessions).
             #
-            # WHY THE INODE IS LOAD-BEARING, not a nicety: keyed on the name
-            # alone this is wrong under ID REUSE. Delete a subagent directory,
-            # later create a real session under the same 12-hex id, and the
-            # dead directory's "hidden" verdict is served for the live one —
-            # a real session permanently invisible in the picker, the severe
-            # failure this design exists to avoid. An inode is reallocated on
-            # recreation (measured on APFS: 912841799 -> 912841800), so the
-            # recreated id misses the cache and takes the slow path.
+            # WHY THE INODE IS HERE: keyed on the name alone this is wrong
+            # under ID REUSE. Delete a subagent directory, later create a real
+            # session under the same 12-hex id, and the dead directory's
+            # "hidden" verdict is served for the live one — a real session
+            # invisible in the picker, the severe failure this design must
+            # bound. Where the filesystem reallocates on recreate the inode
+            # closes that hole outright: measured on APFS (912841799 ->
+            # 912841800), the recreated id misses the cache and is visible on
+            # the very next poll.
             #
-            # The inode is a HINT, never truth. Where it is unavailable
-            # (``ino is None``) or a filesystem recycles numbers aggressively,
-            # the worst case is the name-keyed behaviour this qualification
-            # replaced, bounded by :data:`REVALIDATE_EVERY` — never a wrong
-            # answer that outlives the epoch.
+            # The inode is a HINT, never truth, and HOW MUCH it buys is a
+            # property of the filesystem rather than of this code. ext4
+            # recycles the number immediately (measured in python:3.12-slim:
+            # 67634 -> 67634), so there the skip still fires and the case
+            # degrades to exactly the name-keyed behaviour — repaired by
+            # :data:`REVALIDATE_EVERY` rather than at once. Same where the
+            # inode is unavailable (``ino is None``). So the epoch is the
+            # correctness guarantee and the inode is the latency improvement on
+            # top of it; do not delete the epoch on the strength of the inode,
+            # and do not assume the APFS timing holds on the Linux CI leg.
+            # ``test_a_recreated_id_is_visible_rather_than_serving_a_dead_verdict``
+            # asserts both behaviours explicitly for this reason.
             try:
                 ino: int | None = entry.inode()
             except OSError:

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -166,9 +166,39 @@ ORIGIN_CACHE_VERSION = 2
 #: process always revalidates on its first scan), and the cache being derived
 #: data under ``cache/`` that a user may delete at any time.
 #:
-#: Cost of the epoch, measured at 4,000 directories / 50 users: a fast poll is
-#: 151 syscalls and a revalidating one 4,101, so the AMORTISED figure is 177
-#: against main's 8,052. 177 is the honest number to quote, not 151.
+#: THE COUNTER ADVANCES PER POLL, NOT PER SECOND, so the "~5 minutes" ceiling
+#: holds only for a sidebar that is actually polling. A closed sidebar pauses
+#: its timer (``_sidebar_timer.pause()``), which freezes the counter: wall-clock
+#: staleness is UNBOUNDED while the sidebar is shut, and reopening it does not
+#: force a revalidation — the first poll after reopening serves the armed fast
+#: path and the epoch resumes from wherever it stopped. A cold start still
+#: revalidates, so this is bounded per PROCESS, never per wall-clock. The
+#: variable-poll-rate case below is the same hazard in continuous form.
+#:
+#: One caller opts out of all of this rather than living with the window:
+#: ``session.cleanup`` passes ``revalidate=True`` through
+#: :func:`recent_sessions`, because its listing is the recent-N deletion guard
+#: and a stale row there is an irreversible loss rather than a late redraw
+#: (agent review round 1, R2). That forced scan does NOT make a reopened
+#: sidebar fresh — it is scoped to the cleanup call and restarts the epoch as a
+#: side effect of being a genuine revalidation.
+#:
+#: Cost of the epoch, measured at 4,000 directories / 50 users. Quote the
+#: figure for the surface you mean — these are FULL ``load_catalog`` polls,
+#: which is what the sidebar actually pays, and they differ from a bare
+#: :func:`_scan_sessions` call by ``load_catalog``'s own per-row work (the
+#: scan alone is 151 armed / 4,101 revalidating on the same store, which is
+#: what an earlier revision of this comment quoted without saying so):
+#:
+#: * a fast poll is 266 syscalls, a revalidating one 4,216, so the AMORTISED
+#:   figure is 292 against main's 8,166 — a 28.0x reduction.
+#: * 292 is the honest number to quote, not 266.
+#:
+#: Independently reproduced in QA round 1 as 265 / 4,215 / 291.3 / 8,165, and
+#: the PR body's table matches; the ~1-syscall spread is where each counter
+#: hooks ``os``, not a disagreement. The earlier 151 / 4,101 / 177 / 8,052
+#: figures in this comment were the SCAN-only path quoted as if they were the
+#: poll — same structure and ratio, wrong surface (QA round 1, Q2).
 REVALIDATE_EVERY = 150
 
 #: Scans issued so far, per store, driving :data:`REVALIDATE_EVERY`.
@@ -1168,7 +1198,9 @@ def _save_origin_cache(path: Path, entries: dict[str, Any]) -> None:
         return
 
 
-def recent_sessions(config_dir: Path, limit: int | None = None) -> list[tuple[str, float]]:
+def recent_sessions(
+    config_dir: Path, limit: int | None = None, *, revalidate: bool = False
+) -> list[tuple[str, float]]:
     """``(id, mtime)`` for the USER's resumable sessions, newest first.
 
     ``limit=None`` means NO TRUNCATION and is the default, so a caller that says
@@ -1204,14 +1236,40 @@ def recent_sessions(config_dir: Path, limit: int | None = None) -> list[tuple[st
     notes in :func:`_scan_sessions`, which is where the per-directory cost is
     actually decided.
 
-    So per-directory cost tracks the USER's own sessions, not the store:
-    measured flat at 266 syscalls per poll while the store grew 100 -> 8,000
-    directories with users held at 50 (``scripts/bench_catalog_scan.py
-    store-axis``), against 366 -> 16,166 before. What is still O(total
-    entries) is the single batched ``scandir`` — the poll has stopped
-    stat-ing the store, not stopped touching it — and the verdict cache's own
-    parse, which at 7,950 markers is 704 KB / 5.6 ms and is now the dominant
-    remaining term. Anyone optimising this path next should start there, and
+    So per-directory cost is **O(user sessions + directories that are neither
+    listed nor cached-hidden)**, not O(the store): measured flat at 266
+    syscalls per poll while the store grew 100 -> 8,000 directories with users
+    held at 50 (``scripts/bench_catalog_scan.py store-axis``), against
+    366 -> 16,166 before.
+
+    STATE THAT MIDDLE TERM, do not round it away. A directory with NEITHER an
+    origin marker NOR any activity is in neither ``rows`` nor
+    ``hidden_names``: it can never arm the skip, so it pays its origin stat
+    and ``load_catalog``'s desktop probe on EVERY poll, forever, while never
+    being listable. Measured with users fixed at 50 and hidden fixed at 500,
+    varying only that third population (``bench_catalog_scan.py
+    unmarked-axis``): 266 / 2,266 / 8,266 / 32,266 at 0 / 500 / 2,000 / 8,000
+    — strictly linear at 4.0 syscalls each (agent review round 1, R1, which
+    measured 268 -> 32,268 with a counter that also counts ``open`` and
+    ``listdir``; the slope is the claim, not the constant). Pinned by
+    ``unmarked-axis`` and
+    ``test_the_cost_is_linear_in_directories_that_are_neither_listed_nor_hidden``).
+    A corrupt marker and ``{"origin": ""}`` behave identically, and the
+    corrupt case is the very fail-safe this design preserves. The store
+    accumulates these from idle open-and-quit launches — 23 on the reporting
+    machine. It is a real limit, RECORDED here rather than left to be
+    rediscovered: "tracks the user's own sessions" is true of the hidden
+    population and false of this one.
+
+    Fixing that cost is a separate change and is deliberately NOT attempted
+    here: caching "unmarked" is refused for the reason stated at the marker
+    stat below, and the refusal is load-bearing.
+
+    What is still O(total entries) is the single batched ``scandir`` — the
+    poll has stopped stat-ing the store, not stopped touching it — and the
+    verdict cache's own parse, which at 7,950 markers is 704 KB / 5.6 ms.
+    Those two and the never-active population above are the dominant
+    remaining terms; anyone optimising this path next should start there, and
     should count :func:`~local_operator.session.catalog.load_catalog`'s
     desktop probe too — it is the second site, and the hidden set returned by
     :func:`_scan_sessions` is what removed it.
@@ -1236,9 +1294,20 @@ def recent_sessions(config_dir: Path, limit: int | None = None) -> list[tuple[st
     ``limit`` truncates the RESULT, never the work: every directory is visited
     regardless, so a caller asking for all sessions costs the same as one
     asking for ten.
+
+    ``revalidate=True`` opts OUT of the skip for this call, re-reading every
+    marker so the answer reflects the store as it is now rather than as the
+    last revalidating scan found it. It is for a caller whose decision is
+    IRREVERSIBLE — ``session.cleanup`` protects the recent-N by this listing,
+    so a stale row there is a deleted conversation, not a missing one. A caller
+    that merely DISPLAYS the listing must not set it: the whole point of the
+    epoch is that a 2-second poll does not pay a full scan.
     """
     return [
-        (name, mtime) for name, mtime, _origin in _recent_sessions_with_origin(config_dir, limit)
+        (name, mtime)
+        for name, mtime, _origin in _recent_sessions_with_origin(
+            config_dir, limit, revalidate=revalidate
+        )
     ]
 
 
@@ -1259,7 +1328,7 @@ def _is_hidden_origin(origin: str) -> bool:
 
 
 def _recent_sessions_with_origin(
-    config_dir: Path, limit: int | None = None
+    config_dir: Path, limit: int | None = None, *, revalidate: bool = False
 ) -> list[tuple[str, float, str]]:
     """:func:`recent_sessions`, plus the ``origin`` this scan already parsed.
 
@@ -1273,14 +1342,23 @@ def _recent_sessions_with_origin(
     CLI's recovery listing pins its shape. Callers that also want the hidden
     names — only ``session.catalog.load_catalog``, to skip a second per-directory
     stat — use :func:`_scan_sessions` directly.
+
+    ``revalidate`` is forwarded verbatim; see :func:`_scan_sessions`.
     """
-    return _scan_sessions(config_dir, limit)[0]
+    return _scan_sessions(config_dir, limit, revalidate=revalidate)[0]
 
 
 def _scan_sessions(
-    config_dir: Path, limit: int | None = None
+    config_dir: Path, limit: int | None = None, *, revalidate: bool = False
 ) -> tuple[list[tuple[str, float, str]], set[str]]:
     """The one store scan: ``(rows, hidden_names)``.
+
+    ``revalidate=True`` forces this scan to re-read every marker instead of
+    serving the armed fast path — the caller declaring that a stale verdict is
+    not acceptable to IT, whatever the epoch says. Only a caller that ACTS on
+    the listing rather than displaying it should ask for this; see
+    ``session.cleanup._picker_rows``, which is a deletion authority and must
+    never decide from a speculatively-stale answer.
 
     ``hidden_names`` is every directory this scan established is NOT the user's
     own session — whether it was skipped from cache or re-read. It exists for
@@ -1306,8 +1384,19 @@ def _scan_sessions(
     # still advances the counter — otherwise a session started before its
     # config dir exists would sit at 0 and revalidate on every poll forever.
     scans_so_far = _SCAN_COUNT.get(str(config_dir), 0)
-    _SCAN_COUNT[str(config_dir)] = scans_so_far + 1
-    revalidate = scans_so_far % REVALIDATE_EVERY == 0
+    if revalidate:
+        # A FORCED revalidation is the epoch's expensive scan, merely arriving
+        # early, so it RESTARTS the epoch rather than counting as one more
+        # armed poll. Leaving the counter to advance would let the fast path
+        # stay armed on a scan that just re-read the store — the counter would
+        # then describe polls issued rather than staleness accrued since the
+        # last fresh verdict, which is the only thing it exists to bound. 1,
+        # not 0, because this scan IS the revalidating one: the next poll is
+        # legitimately allowed to be cheap.
+        _SCAN_COUNT[str(config_dir)] = 1
+    else:
+        _SCAN_COUNT[str(config_dir)] = scans_so_far + 1
+        revalidate = scans_so_far % REVALIDATE_EVERY == 0
 
     rows: list[tuple[str, float, str]] = []
     # Every directory this scan established is not the user's own session. See

--- a/local_operator/session/catalog.py
+++ b/local_operator/session/catalog.py
@@ -507,14 +507,18 @@ def load_catalog(directory: Path, limit: int = CATALOG_SCAN_LIMIT) -> list[Catal
     """
     from dataclasses import replace
 
-    from local_operator.resume import _recent_sessions_with_origin
+    from local_operator.resume import _scan_sessions
     from local_operator.session.attention import AttentionStore, conversation_identity
     from local_operator.session.retention import (
         DESKTOP_MARKER_NAME,
         TRANSCRIPT_FILENAME,
     )
 
-    candidates = _recent_sessions_with_origin(directory)
+    # The scan's second return value is every directory it established is not
+    # the user's own session. Taken here rather than recomputed because it is
+    # what removes this function's own O(store) stat; see the desktop-probe loop
+    # below for why a hidden directory cannot carry a desktop marker.
+    candidates, hidden = _scan_sessions(directory)
     source = {session_id: (session_id, mtime, origin) for session_id, mtime, origin in candidates}
     # Creation time is the immutable ordering key (#800), so every construction
     # site must stamp it. Rows left at the 0.0 default all tie and fall through
@@ -548,6 +552,18 @@ def load_catalog(directory: Path, limit: int = CATALOG_SCAN_LIMIT) -> list[Catal
         with entries:
             for entry in entries:
                 if entry.name in source:
+                    continue
+                # A directory the scan established is a subagent/hidden session
+                # cannot carry a desktop marker, so the stat below asks a
+                # question whose answer is already known. ``desktop.json`` has
+                # exactly ONE writer — ``DesktopSessions.create`` in
+                # ``server/utils/desktop_sessions.py`` — which mints a fresh
+                # ``uuid4`` directory and never writes an origin marker into it;
+                # nothing anywhere adds a desktop marker to a directory that
+                # already exists. Skipping these is HALF the saving of the
+                # inode-qualified scan, because the hidden population is ~91% of
+                # the store and every one of them landed here.
+                if entry.name in hidden:
                     continue
                 try:
                     # No ``is_dir()`` guard: a successful stat of a file INSIDE

--- a/local_operator/session/cleanup.py
+++ b/local_operator/session/cleanup.py
@@ -550,11 +550,34 @@ def _picker_rows(config_dir: Path) -> list[str]:
     recent guard; the whole list is the unit ``max_sessions`` counts in. A
     picker that cannot be listed is a guard that cannot be evaluated:
     :class:`GuardUnavailable`, never an empty list.
+
+    ``revalidate=True`` IS THE GUARD, NOT AN OPTIMISATION KNOB. The scan
+    normally serves an armed fast path that can report a session as hidden for
+    up to ``REVALIDATE_EVERY`` polls after its marker was removed — cheap and
+    correct for a sidebar that re-polls every 2 seconds and self-heals. But
+    the recent-N guard IS this listing, so a session missing from it is not
+    merely invisible here: it is UNPROTECTED, and this module deletes. Agent
+    review round 1 (R2) reproduced it in production order — the TUI's first
+    poll arms the path, the operator deletes ``origin.json`` by hand (the
+    supported un-hide gesture), and startup maintenance 0.75 s later chose
+    that session for removal while a fresh scan protected it as "one of the
+    10 most recent". Deletion is irreversible; a stale display is not.
+
+    The cost is deliberate and measured: this scan is 4,101 syscalls against
+    an armed scan's 151 on a 4,000-directory store, paid ONCE per cleanup run
+    — startup maintenance and periodic sweeps — rather than every 2 seconds,
+    which is the poll this optimisation exists to make cheap. The sidebar's
+    own steady-state poll is unchanged at 266 and still flat across a 40x
+    store. It also makes the guard independent of whichever poll happened to
+    precede it, which is the property that makes this decidable at all, and it
+    does not starve the sidebar's repair: a forced revalidation rewrites the
+    verdict cache, so a hand-un-hidden session becomes visible at that scan
+    rather than later.
     """
     try:
         from local_operator.resume import recent_sessions
 
-        return [name for name, _stamp in recent_sessions(config_dir, limit=None)]
+        return [name for name, _stamp in recent_sessions(config_dir, limit=None, revalidate=True)]
     except Exception as exc:  # noqa: BLE001 — re-raised as the typed refusal
         raise GuardUnavailable(f"recent-session picker: {type(exc).__name__}: {exc}") from exc
 

--- a/scripts/bench_catalog_scan.py
+++ b/scripts/bench_catalog_scan.py
@@ -8,6 +8,8 @@ Usage:
         [--sizes 100,500,1000,2000,4000,8000] [--users 50] [--json out.json]
     PYTHONPATH=. .venv/bin/python scripts/bench_catalog_scan.py users-axis \
         [--users 10,50,200] [--dirs 4000] [--json out.json]
+    PYTHONPATH=. .venv/bin/python scripts/bench_catalog_scan.py unmarked-axis \
+        [--counts 0,500,2000,8000] [--users 50] [--hidden 500] [--json out.json]
     PYTHONPATH=. .venv/bin/python scripts/bench_catalog_scan.py real \
         [--store ~/.local-operator] [--json out.json]
 
@@ -40,6 +42,22 @@ O(total directories) rises linearly. ``users-axis`` is its complement: it fixes
 the store and varies users, showing the remaining per-user cost is linear and
 small rather than the design being O(1) by answering the wrong question. Any
 performance claim about this poll must be backed by both, not by the ladder.
+
+**``unmarked-axis`` is where the claim STOPS, and it is not optional either.**
+Both axes above grow the store with directories the skip can arm on, so both
+report a flat column while a third population costs linearly forever: a
+directory with neither an origin marker nor any activity is in neither the
+listing nor the hidden set, never arms the skip, and pays ~4 syscalls per poll
+for the life of the store while never being listable. Measured by this mode
+with users fixed at 50 and hidden at 500: 266 / 2,266 / 8,266 / 32,266 over
+0 / 500 / 2,000 / 8,000, a slope of exactly 4.0 (agent review round 1, R1,
+which measured the same slope at 268 -> 32,268 with a counter that also hooks
+``open`` and ``listdir`` — the slope is the claim, the constant is the
+instrument). The honest statement of the result is
+therefore **O(user sessions + directories that are neither listed nor
+cached-hidden)**, and this mode is what keeps that qualifier attached to a
+number instead of to a memory. A flat ``store-axis`` alone is precisely the
+evidence that let #867 overstate its scaling.
 
 The ``real`` mode measures the operator's own store. It is strictly READ-ONLY:
 it never writes to the store it measures, so it is safe to point at a live
@@ -238,13 +256,22 @@ def _build_store(root: Path, total: int) -> None:
                 os.utime(d / name, (stamp, stamp))
 
 
-def _build_axis_store(root: Path, *, users: int, hidden: int) -> None:
-    """A store with the two populations controlled INDEPENDENTLY.
+def _build_axis_store(root: Path, *, users: int, hidden: int, unmarked: int = 0) -> None:
+    """A store with the three populations controlled INDEPENDENTLY.
 
     ``_build_store`` mixes them at a fixed ratio, which is right for modelling
     the real store but useless for separating "cost tracks the store" from
     "cost tracks the user's sessions" — both rise together there. Here the
     caller pins one and varies the other.
+
+    ``unmarked`` is the THIRD population, and it is the one that bounds the
+    claim. A directory with neither an origin marker nor any activity is in
+    neither the listing nor the hidden set, so it can never arm the
+    zero-syscall skip and pays its stats on every poll forever while never
+    being listable. ``store-axis`` and ``users-axis`` both hold it at 0, which
+    is exactly how a cost that is linear in it stays invisible to them — the
+    same shape of blind spot that let #867 overstate its scaling. Defaulting to
+    0 keeps those two experiments unchanged; ``unmarked-axis`` varies it.
 
     Names are prefixed rather than sequential hex so a reader of a failing
     assertion can see at a glance which population a directory belongs to. The
@@ -268,6 +295,12 @@ def _build_axis_store(root: Path, *, users: int, hidden: int) -> None:
         )
         stamp = now - 100000 - index
         os.utime(directory / "transcript.jsonl", (stamp, stamp))
+    for index in range(unmarked):
+        # No marker and no transcript: the shape an idle open-and-quit launch
+        # leaves behind. Deliberately not given an origin marker — that would
+        # make it hidden and therefore skippable, which is the population this
+        # one exists to be distinguished from.
+        (sessions / f"idle{index:08x}").mkdir(exist_ok=True)
 
 
 def _steady_state(root: Path) -> dict[str, Any]:
@@ -340,6 +373,51 @@ def _users_axis(user_counts: list[int], dirs: int) -> list[dict[str, Any]]:
             )
         finally:
             shutil.rmtree(root, ignore_errors=True)
+    return results
+
+
+def _unmarked_axis(counts: list[int], users: int, hidden: int) -> list[dict[str, Any]]:
+    """THE LIMIT OF THE CLAIM: both listed populations fixed, never-active varied.
+
+    ``store-axis`` proves the poll is flat as the store grows, but it grows the
+    store with HIDDEN directories only — the population the skip can arm on. A
+    directory that is neither listed nor hidden is in neither set, so it never
+    arms and never stops costing. This axis is the same experimental design run
+    against the one input the other two do not vary, so the linear term is
+    RECORDED rather than discovered later by whoever inherits the claim.
+
+    Reported as syscalls per never-active directory, because the honest way to
+    state a linear cost is its slope: a flat column here would be a genuinely
+    O(user sessions) poll, and it is not one.
+    """
+    results = []
+    for count in counts:
+        root = Path(tempfile.mkdtemp(prefix=f"lo-unmarked-{count}-"))
+        try:
+            _build_axis_store(root, users=users, hidden=hidden, unmarked=count)
+            row = {
+                "dirs": users + hidden + count,
+                "users": users,
+                "hidden": hidden,
+                "unmarked": count,
+                **_steady_state(root),
+            }
+            results.append(row)
+            print(
+                f"  {count:>5} never-active (+{users} users, {hidden} hidden): "
+                f"rows={row['rows']:<4} syscalls/poll={row['syscalls']:>6}",
+                flush=True,
+            )
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+    if len(results) > 1:
+        span = results[-1]["unmarked"] - results[0]["unmarked"]
+        rise = results[-1]["syscalls"] - results[0]["syscalls"]
+        if span:
+            print(
+                f"  slope: {rise / span:.1f} syscalls per never-active directory per poll "
+                "(a flat column here would mean O(user sessions); it is not flat)"
+            )
     return results
 
 
@@ -490,6 +568,21 @@ def main() -> int:
             dirs = int(argv[argv.index("--dirs") + 1])
         print(f"complementary axis: store FIXED at {dirs} directories, users varied")
         payload["users_axis"] = _users_axis(user_counts, dirs)
+    elif mode == "unmarked-axis":
+        counts = [0, 500, 2000, 8000]
+        if "--counts" in argv:
+            counts = [int(x) for x in argv[argv.index("--counts") + 1].split(",")]
+        users = 50
+        if "--users" in argv:
+            users = int(argv[argv.index("--users") + 1])
+        hidden = 500
+        if "--hidden" in argv:
+            hidden = int(argv[argv.index("--hidden") + 1])
+        print(
+            f"LIMIT OF THE CLAIM: users FIXED at {users}, hidden FIXED at {hidden}, "
+            "never-active directories varied"
+        )
+        payload["unmarked_axis"] = _unmarked_axis(counts, users, hidden)
     elif mode == "compare":
         # Not a measurement: an assertion over two JSON files this script wrote.
         if "--before" not in argv or "--after" not in argv:

--- a/scripts/bench_catalog_scan.py
+++ b/scripts/bench_catalog_scan.py
@@ -4,6 +4,10 @@ Usage:
 
     PYTHONPATH=. .venv/bin/python scripts/bench_catalog_scan.py ladder \
         [--sizes 100,500,1000,2000,4000] [--json out.json]
+    PYTHONPATH=. .venv/bin/python scripts/bench_catalog_scan.py store-axis \
+        [--sizes 100,500,1000,2000,4000,8000] [--users 50] [--json out.json]
+    PYTHONPATH=. .venv/bin/python scripts/bench_catalog_scan.py users-axis \
+        [--users 10,50,200] [--dirs 4000] [--json out.json]
     PYTHONPATH=. .venv/bin/python scripts/bench_catalog_scan.py real \
         [--store ~/.local-operator] [--json out.json]
 
@@ -25,6 +29,17 @@ with the load average that produced it.
 The ladder measures SCALING, which is the actual defect: the poll's cost grew
 with the total number of session directories ever created rather than with the
 user's own sessions, so it degraded permanently as the store accumulated.
+
+**``store-axis`` is the decisive experiment, and the ladder is not.** The ladder
+grows users and hidden directories together, so a cost that tracks EITHER rises
+and the two hypotheses are indistinguishable — which is exactly how PR #867
+shipped a title bigger than its measurement and had to be retitled mid-review.
+``store-axis`` holds the USER population FIXED and varies only the total store,
+so a design that is O(user sessions) holds a FLAT column while one that is
+O(total directories) rises linearly. ``users-axis`` is its complement: it fixes
+the store and varies users, showing the remaining per-user cost is linear and
+small rather than the design being O(1) by answering the wrong question. Any
+performance claim about this poll must be backed by both, not by the ladder.
 
 The ``real`` mode measures the operator's own store. It is strictly READ-ONLY:
 it never writes to the store it measures, so it is safe to point at a live
@@ -170,6 +185,9 @@ def _measure(store: Path, *, read_only: bool) -> dict[str, Any]:
 
     return {
         "rows": len(rows),
+        # Kept so ``compare`` can assert the listing is byte-identical before
+        # and after. Cost without the answer proves nothing.
+        "listing": [entry.id for entry in rows],
         "cold_ms": round(cold_ms, 2),
         "load_catalog": catalog,
         "scan": scan,
@@ -220,6 +238,201 @@ def _build_store(root: Path, total: int) -> None:
                 os.utime(d / name, (stamp, stamp))
 
 
+def _build_axis_store(root: Path, *, users: int, hidden: int) -> None:
+    """A store with the two populations controlled INDEPENDENTLY.
+
+    ``_build_store`` mixes them at a fixed ratio, which is right for modelling
+    the real store but useless for separating "cost tracks the store" from
+    "cost tracks the user's sessions" — both rise together there. Here the
+    caller pins one and varies the other.
+
+    Names are prefixed rather than sequential hex so a reader of a failing
+    assertion can see at a glance which population a directory belongs to. The
+    shapes are exactly what ``mark_session_origin`` and a real session write.
+    """
+    sessions = root / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    now = time.time()
+    for index in range(users):
+        directory = sessions / f"user{index:08x}"
+        directory.mkdir(exist_ok=True)
+        (directory / "transcript.jsonl").write_text('{"type":"message"}\n', encoding="utf-8")
+        stamp = now - index
+        os.utime(directory / "transcript.jsonl", (stamp, stamp))
+    for index in range(hidden):
+        directory = sessions / f"sub{index:09x}"
+        directory.mkdir(exist_ok=True)
+        (directory / "transcript.jsonl").write_text('{"type":"message"}\n', encoding="utf-8")
+        (directory / "origin.json").write_text(
+            json.dumps({"origin": "subagent", "label": "reviewer"}), encoding="utf-8"
+        )
+        stamp = now - 100000 - index
+        os.utime(directory / "transcript.jsonl", (stamp, stamp))
+
+
+def _steady_state(root: Path) -> dict[str, Any]:
+    """Syscalls for one STEADY-STATE poll, plus the listing it produced.
+
+    Warmed twice before measuring, not once: the first call builds the verdict
+    cache and the second is the first poll able to use it, so measuring at the
+    third is the first sample that represents what the sidebar pays minute after
+    minute. Measuring earlier reports a cold poll and flatters nothing.
+
+    The listing is recorded so ``compare`` can assert byte-identical ``(id,
+    order)`` between a before run and an after run. A cheaper poll that lists
+    differently is not an optimisation, and the only way to know is to keep the
+    answer beside the cost.
+    """
+    load_catalog(root)
+    load_catalog(root)
+    with _counted() as catalog_counts:
+        rows = load_catalog(root)
+    with _counted() as scan_counts:
+        _recent_sessions_with_origin(root)
+    return {
+        "rows": len(rows),
+        "listing": [entry.id for entry in rows],
+        "syscalls": sum(catalog_counts.values()),
+        "syscalls_detail": dict(catalog_counts),
+        "scan_syscalls": sum(scan_counts.values()),
+    }
+
+
+def _store_axis(sizes: list[int], users: int) -> list[dict[str, Any]]:
+    """THE DECISIVE EXPERIMENT: users fixed, total directories varied."""
+    results = []
+    for size in sizes:
+        hidden = max(size - users, 0)
+        root = Path(tempfile.mkdtemp(prefix=f"lo-axis-{size}-"))
+        try:
+            _build_axis_store(root, users=users, hidden=hidden)
+            row = {"dirs": size, "users": users, "hidden": hidden, **_steady_state(root)}
+            results.append(row)
+            print(
+                f"  {size:>5} dirs ({hidden:>5} hidden): rows={row['rows']:<4} "
+                f"syscalls/poll={row['syscalls']:>6}  scan={row['scan_syscalls']:>6}",
+                flush=True,
+            )
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+    if results:
+        growth = results[-1]["syscalls"] / max(results[0]["syscalls"], 1)
+        span = results[-1]["dirs"] / max(results[0]["dirs"], 1)
+        print(f"  growth over a {span:.0f}x store: {growth:.1f}x")
+    return results
+
+
+def _users_axis(user_counts: list[int], dirs: int) -> list[dict[str, Any]]:
+    """The complementary axis: store fixed, user population varied."""
+    results = []
+    for users in user_counts:
+        hidden = max(dirs - users, 0)
+        root = Path(tempfile.mkdtemp(prefix=f"lo-users-{users}-"))
+        try:
+            _build_axis_store(root, users=users, hidden=hidden)
+            row = {"dirs": dirs, "users": users, "hidden": hidden, **_steady_state(root)}
+            row["per_user"] = round(row["syscalls"] / max(users, 1), 2)
+            results.append(row)
+            print(
+                f"  {users:>4} users of {dirs} dirs: rows={row['rows']:<4} "
+                f"syscalls/poll={row['syscalls']:>6}  per user={row['per_user']:>6.2f}",
+                flush=True,
+            )
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+    return results
+
+
+def _compare(before_path: Path, after_path: Path) -> int:
+    """Assert the listings are byte-identical between two runs of this script.
+
+    The equivalence check that makes a performance number meaningful. Compares
+    ``(id, order)`` — the list as-is, so a reordering fails as loudly as a
+    missing row — for every size in every axis both files carry.
+    """
+    before = json.loads(before_path.read_text(encoding="utf-8"))
+    after = json.loads(after_path.read_text(encoding="utf-8"))
+    failures = 0
+
+    def _label(row: dict[str, Any]) -> str:
+        return f"{row.get('dirs')}/{row.get('users')}"
+
+    for section in ("store_axis", "users_axis", "ladder"):
+        rows_before = {_label(r): r for r in before.get(section, [])}
+        for row in after.get(section, []):
+            label = _label(row)
+            other = rows_before.get(label)
+            if other is None or "listing" not in row or "listing" not in other:
+                continue
+            same = row["listing"] == other["listing"]
+            gain = other["syscalls"] / max(row["syscalls"], 1)
+            print(
+                f"  {section:>10} {label:>12}: listing identical={same}  "
+                f"{other['syscalls']} -> {row['syscalls']} syscalls ({gain:.1f}x)"
+            )
+            if not same:
+                failures += 1
+    for section in ("real",):
+        row = after.get(section)
+        other = before.get(section)
+        if isinstance(row, dict) and isinstance(other, dict) and "listing" in row:
+            same = row["listing"] == other.get("listing")
+            print(f"  {section:>10}: listing identical={same}")
+            if not same:
+                failures += 1
+    print("EQUIVALENT" if not failures else f"{failures} LISTING MISMATCHES")
+    return 1 if failures else 0
+
+
+def _mirror_real_store(source: Path, destination: Path) -> dict[str, int]:
+    """Copy the facts the poll consults out of a LIVE store, reading only.
+
+    Why a mirror rather than measuring the store in place. The steady state this
+    benchmark reports is the one where the verdict cache is warm, and warming it
+    means WRITING it — into a store a dozen other ``lop`` processes are using
+    right now. ``_no_writes`` correctly refuses that, which leaves an in-place
+    ``real`` run permanently cold and measuring the wrong thing. Mirroring gives
+    a writable copy whose syscall counts transfer exactly, because the poll
+    consults only four facts: which directories exist, which carry an origin
+    marker, what that marker says, and the activity mtimes.
+
+    Transcripts are recreated EMPTY with the real mtimes. The scan stats them
+    and never reads them, so their 1.7 GB of content changes no count while
+    copying it would take minutes and fill the disk.
+
+    Every operation against ``source`` here is a read: ``scandir``, ``stat``,
+    ``read_bytes``. Nothing writes a byte inside it.
+    """
+    sessions = destination / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    stats = {"dirs": 0, "marked": 0, "with_transcript": 0}
+    with os.scandir(source / "sessions") as entries:
+        for entry in entries:
+            if not entry.is_dir(follow_symlinks=False):
+                continue
+            stats["dirs"] += 1
+            target = sessions / entry.name
+            target.mkdir(exist_ok=True)
+            for name in ("origin.json", "desktop.json"):
+                try:
+                    payload = (Path(entry.path) / name).read_bytes()
+                except OSError:
+                    continue
+                (target / name).write_bytes(payload)
+                if name == "origin.json":
+                    stats["marked"] += 1
+            for name in ("transcript.jsonl", "inbox.jsonl"):
+                try:
+                    stamp = (Path(entry.path) / name).stat().st_mtime
+                except OSError:
+                    continue
+                (target / name).write_bytes(b"")
+                os.utime(target / name, (stamp, stamp))
+                if name == "transcript.jsonl":
+                    stats["with_transcript"] += 1
+    return stats
+
+
 def _ladder(sizes: list[int]) -> list[dict[str, Any]]:
     results = []
     for size in sizes:
@@ -259,15 +472,54 @@ def main() -> int:
             sizes = [int(x) for x in argv[argv.index("--sizes") + 1].split(",")]
         print("synthetic ladder (92% subagents, mirroring the real store's shape):")
         payload["ladder"] = _ladder(sizes)
+    elif mode == "store-axis":
+        sizes = [100, 500, 1000, 2000, 4000, 8000]
+        if "--sizes" in argv:
+            sizes = [int(x) for x in argv[argv.index("--sizes") + 1].split(",")]
+        users = 50
+        if "--users" in argv:
+            users = int(argv[argv.index("--users") + 1])
+        print(f"DECISIVE EXPERIMENT: users FIXED at {users}, total directories varied")
+        payload["store_axis"] = _store_axis(sizes, users)
+    elif mode == "users-axis":
+        user_counts = [10, 50, 200]
+        if "--users" in argv:
+            user_counts = [int(x) for x in argv[argv.index("--users") + 1].split(",")]
+        dirs = 4000
+        if "--dirs" in argv:
+            dirs = int(argv[argv.index("--dirs") + 1])
+        print(f"complementary axis: store FIXED at {dirs} directories, users varied")
+        payload["users_axis"] = _users_axis(user_counts, dirs)
+    elif mode == "compare":
+        # Not a measurement: an assertion over two JSON files this script wrote.
+        if "--before" not in argv or "--after" not in argv:
+            print("compare needs --before <json> --after <json>")
+            return 2
+        return _compare(
+            Path(argv[argv.index("--before") + 1]),
+            Path(argv[argv.index("--after") + 1]),
+        )
     elif mode == "real":
         store = Path(os.path.expanduser("~/.local-operator"))
         if "--store" in argv:
             store = Path(os.path.expanduser(argv[argv.index("--store") + 1]))
-        total = len(list((store / "sessions").iterdir()))
-        print(f"real store: {store} ({total} directories), READ-ONLY")
-        result = _measure(store, read_only=True)
-        payload["real"] = {"dirs": total, "store": str(store), **result}
-        print(json.dumps(payload["real"], indent=2))
+        mirror = Path(tempfile.mkdtemp(prefix="lo-bench-real-"))
+        try:
+            shape = _mirror_real_store(store, mirror)
+            print(
+                f"real store: {store} — mirrored READ-ONLY "
+                f"({shape['dirs']} directories, {shape['marked']} marked, "
+                f"{shape['with_transcript']} with a transcript)"
+            )
+            result = _steady_state(mirror)
+            payload["real"] = {"users": result["rows"], "store": str(store), **shape, **result}
+            print(
+                f"  syscalls/poll={result['syscalls']}  scan={result['scan_syscalls']}  "
+                f"rows={result['rows']}  "
+                f"per listed session={result['syscalls'] / max(result['rows'], 1):.2f}"
+            )
+        finally:
+            shutil.rmtree(mirror, ignore_errors=True)
     else:
         print(__doc__)
         return 2

--- a/tests/unit/session/test_catalog_scan_cost.py
+++ b/tests/unit/session/test_catalog_scan_cost.py
@@ -15,16 +15,31 @@ The first fix (#867) reordered the two gates, which improved the CONSTANT —
 stats remained, the origin marker in the scan and the desktop marker in
 ``load_catalog``.
 
-The second fix removed the scaling itself. A directory already known to be
-hidden is now skipped whole, for ZERO syscalls, because both facts that
-decision needs — the name and the inode — come free from the ``readdir`` batch
-``scandir`` already paid for. Per-directory cost therefore tracks the USER's
-own sessions: measured flat at 266 syscalls per poll while the store grew from
-100 to 8,000 directories with users held at 50, against 366 -> 16,166 before.
+The second fix removed the scaling for the population that dominates a real
+store. A directory already known to be hidden is now skipped whole, for ZERO
+syscalls, because both facts that decision needs — the name and the inode —
+come free from the ``readdir`` batch ``scandir`` already paid for. Per-directory
+cost is therefore **O(user sessions + directories that are neither listed nor
+cached-hidden)**: measured flat at 266 syscalls per poll while the store grew
+from 100 to 8,000 directories with users held at 50, against 366 -> 16,166
+before.
+
+That middle term is not a rounding error and is stated rather than elided. A
+directory with neither an origin marker nor any activity is in neither the
+listing nor the hidden set, so it never arms the skip and pays ~4 syscalls per
+poll forever while never being listable — 266 / 2,266 / 8,266 / 32,266 over
+0 / 500 / 2,000 / 8,000 of them with both other populations fixed
+(``bench_catalog_scan.py unmarked-axis``; agent review round 1, R1 measured the
+same 4.0 slope on a counter with a different constant). "Tracks the user's own
+sessions" is true of the hidden population
+and false of this one, and
+``test_the_cost_is_linear_in_directories_that_are_neither_listed_nor_hidden``
+pins the limit so it cannot quietly detach from the claim again.
+
 What remains O(total entries) is the single batched ``scandir`` — the poll
 still touches the store, it just stops stat-ing it — and the verdict cache's
-own parse (704 KB / 5.6 ms at 7,950 markers), which is now the dominant
-remaining term.
+own parse (704 KB / 5.6 ms at 7,950 markers). Those and the never-active
+population are the dominant remaining terms.
 
 Neither fix is allowed to buy that with a different answer: no second source of
 truth, and above all **no second ranking clock**. These tests pin both halves —
@@ -367,6 +382,56 @@ class TestThePollsPerDirectoryCostIsBounded:
 
         assert measurements[0] == measurements[1] == measurements[2], measurements
 
+    def test_the_cost_is_linear_in_directories_that_are_neither_listed_nor_hidden(
+        self, tmp_path: Path
+    ) -> None:
+        """WHERE THE FLATNESS ABOVE STOPS — recorded, not left to be discovered.
+
+        A directory with neither an origin marker nor any activity is in
+        neither ``rows`` nor ``hidden_names``. It therefore can never arm the
+        zero-syscall skip, and pays its origin stat on every poll forever while
+        never being listable. The test above grows the store with HIDDEN
+        directories, which is exactly the population the skip handles, so it
+        reports flat while this cost rises — the same blind spot that let #867
+        present a true statement about one axis as a general scaling property
+        (agent review round 1, R1).
+
+        This is deliberately a POSITIVE assertion of the limit rather than a
+        bound to be improved: the honest claim is O(user sessions + directories
+        that are neither listed nor cached-hidden), and a test that merely
+        capped the cost would let the qualifier quietly detach from the number.
+        Fixing the cost is refused on purpose — caching "unmarked" would serve a
+        stale verdict for a directory the backfill stamps later — so this pins
+        the consequence of that refusal.
+
+        Asserted as a strict rise per batch rather than an exact slope: the
+        per-directory constant is an implementation detail (~4 syscalls today,
+        origin stat plus desktop probe), while "not flat" is the property.
+        """
+        for index in range(10):
+            _session(tmp_path, f"user{index:08x}", stamp=1000.0 + index)
+        for index in range(50):
+            _session(tmp_path, f"sub{index:09x}", origin="subagent", stamp=500.0)
+
+        measurements = []
+        for batch in range(3):
+            for index in range(100):
+                # No transcript and no origin marker: the shape an idle
+                # open-and-quit launch leaves behind.
+                (tmp_path / "sessions" / f"idle{batch:03x}{index:06x}").mkdir(parents=True)
+            _recent_sessions_with_origin(tmp_path)
+            _recent_sessions_with_origin(tmp_path)
+            with _counting() as counter:
+                rows = _recent_sessions_with_origin(tmp_path)
+            measurements.append(counter.total)
+            assert len(rows) == 10, "a never-active directory is never listable"
+
+        assert measurements[0] < measurements[1] < measurements[2], measurements
+        first_step = measurements[1] - measurements[0]
+        second_step = measurements[2] - measurements[1]
+        assert first_step == second_step, (measurements, "linear, not accelerating")
+        assert first_step >= 100, "at least one syscall per never-active directory"
+
     def test_the_desktop_probe_skips_known_hidden_directories(self, tmp_path: Path) -> None:
         """``load_catalog``'s SECOND O(store) stat, removed the same way.
 
@@ -389,6 +454,45 @@ class TestThePollsPerDirectoryCostIsBounded:
         # equality because ``load_catalog`` also reads the registry and the
         # attention store, whose constant is not this test's subject.
         assert counter.counts["stat"] < 60
+
+    def test_a_directory_carrying_both_markers_resolves_to_the_origin_verdict(
+        self, tmp_path: Path
+    ) -> None:
+        """PINS THE CROSS-MODULE INVARIANT THE PROBE SKIP RESTS ON.
+
+        The skip above is sound because ``desktop.json`` has exactly one writer
+        (``DesktopSessions.create``), which mints a fresh directory and never
+        writes an origin marker into it — so a directory cannot carry both.
+        That is correct today, but it is a coupling between two modules
+        enforced only by prose: a future writer in ``desktop_sessions.py`` that
+        stamped a desktop marker into an existing session directory would
+        silently drop that row, with nothing failing (agent review round 1, R4).
+
+        This asserts what the code does today so that change trips HERE, next to
+        the reasoning, rather than as a missing sidebar row somebody bisects
+        later. The behaviour pinned is deliberately the current one, not a
+        wished-for one: the origin verdict WINS, the both-marker directory is
+        hidden and its draft is not offered, and a legitimate desktop draft
+        beside it is unaffected. If the single-writer premise is ever
+        intentionally broken, this test is the place to state the new rule.
+        """
+        both = tmp_path / "sessions" / ("b" * 12)
+        both.mkdir(parents=True)
+        (both / "origin.json").write_text(json.dumps({"origin": "subagent"}), encoding="utf-8")
+        (both / "desktop.json").write_text(json.dumps({"title": "draft"}), encoding="utf-8")
+        # The shape the probe legitimately exists to find, as a control: if the
+        # skip ever swallowed drafts wholesale this row would vanish too.
+        draft = tmp_path / "sessions" / ("c" * 12)
+        draft.mkdir(parents=True)
+        (draft / "desktop.json").write_text(json.dumps({"title": "real"}), encoding="utf-8")
+
+        # Across an armed poll as well as the cold one: the skip is what makes
+        # the second cheap, so the verdict must not differ between them.
+        for poll in range(3):
+            rows = _recent_sessions_with_origin(tmp_path)
+            catalog = [entry.id for entry in load_catalog(tmp_path)]
+            assert [row[0] for row in rows] == [], f"poll {poll}: origin marker hides the row"
+            assert catalog == ["c" * 12], f"poll {poll}: the legitimate draft is still offered"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/session/test_catalog_scan_cost.py
+++ b/tests/unit/session/test_catalog_scan_cost.py
@@ -409,33 +409,56 @@ class TestTheHiddenSkipCannotHideRealWork:
     def test_a_recreated_id_is_visible_rather_than_serving_a_dead_verdict(
         self, tmp_path: Path
     ) -> None:
-        """ID REUSE — the case that fails a name-keyed cache.
+        """ID REUSE — the case that motivates the inode qualification.
 
         Delete a subagent directory, then create a REAL session under the same
         12-hex id. Keyed on the name alone the dead directory's hidden verdict
-        is served for the live session and it never appears. The inode closes
-        it: a recreated directory gets a different inode, so it misses the
-        cache and takes the slow path.
+        is served for the live session, and the ONLY thing that ever repairs it
+        is the epoch.
 
-        This is why the inode qualification is load-bearing rather than a
-        nicety, and it is the one assertion that distinguishes the shipped
-        design from the cheaper one.
+        The inode is what usually repairs it sooner, and how much sooner is a
+        property of the FILESYSTEM, which is why this test asserts two
+        different bars:
+
+        * where the inode is REALLOCATED on recreate (measured on APFS:
+          912841799 -> 912841800), the recreated id misses the cache and is
+          visible on the VERY NEXT poll;
+        * where it is RECYCLED immediately (measured on ext4 in
+          ``python:3.12-slim``: 67634 -> 67634), the skip still fires and the
+          session is hidden until the epoch — the documented degradation, since
+          the inode is a hint and never a source of truth.
+
+        Both are asserted rather than one being assumed, because the CI matrix
+        runs both filesystems and an assertion written for APFS alone is how a
+        Linux-only failure ships. What is NOT allowed on either is the session
+        staying invisible forever, so the revalidation bar is checked
+        unconditionally at the end.
         """
         import shutil
 
         reused = "a" * 12
-        _session(tmp_path, reused, origin="subagent", stamp=1000.0)
+        directory = _session(tmp_path, reused, origin="subagent", stamp=1000.0)
+        before_ino = directory.stat().st_ino
         _session(tmp_path, "b" * 12, stamp=2000.0)
         _recent_sessions_with_origin(tmp_path)
         # Arm the fast path: this is the poll that would serve the stale answer.
         assert [row[0] for row in _recent_sessions_with_origin(tmp_path)] == ["b" * 12]
 
         shutil.rmtree(tmp_path / "sessions" / reused)
-        _session(tmp_path, reused, stamp=3000.0)
+        recreated = _session(tmp_path, reused, stamp=3000.0)
+        reallocated = recreated.stat().st_ino != before_ino
 
         listed = [row[0] for row in _recent_sessions_with_origin(tmp_path)]
-        assert reused in listed, "a session recreated under a reused id must be visible"
-        assert listed == [reused, "b" * 12]
+        if reallocated:
+            assert listed == [reused, "b" * 12], "a moved inode must miss the cache at once"
+        else:
+            assert listed == ["b" * 12], "a recycled inode degrades to the epoch, by design"
+
+        # The bar that holds on EVERY filesystem: never invisible for good.
+        from local_operator import resume as resume_mod
+
+        resume_mod._SCAN_COUNT[str(tmp_path)] = resume_mod.REVALIDATE_EVERY
+        assert [row[0] for row in _recent_sessions_with_origin(tmp_path)] == [reused, "b" * 12]
 
     def test_a_missing_inode_degrades_to_the_slow_path_not_to_a_guess(
         self, tmp_path: Path, monkeypatch: Any
@@ -678,12 +701,21 @@ class TestTheHiddenSkipCannotHideRealWork:
         assert len(page) == CATALOG_SCAN_LIMIT
         assert [entry.id for entry in load_catalog(tmp_path)] == [entry.id for entry in page]
 
-    def test_resume_and_the_sidebar_list_the_same_set_in_the_same_order(
-        self, tmp_path: Path
-    ) -> None:
-        """The invariant the whole change is measured against. Both surfaces
-        share one scan, so they cannot diverge — pinned here so a future
-        'optimisation' that gives the sidebar its own path fails loudly."""
+    def test_resume_and_the_sidebar_select_the_same_sessions(self, tmp_path: Path) -> None:
+        """The invariant the whole change is measured against: both surfaces
+        must SELECT the same sessions, because they share one scan.
+
+        Set equality, not order equality — the two deliberately order
+        differently and always have. ``_recent_sessions_with_origin`` ranks by
+        the activity clock, while the sidebar re-ranks by ``CatalogEntry.rank``
+        (``tier, wake_rank, -birth, id``), which is birth order inside a tier.
+        Asserting a prefix relationship here would pin a coincidence rather
+        than the contract, and would fail on any store where creation order and
+        activity order differ.
+
+        What must never happen is the two ranging over different SETS: the
+        hidden-skip changes visibility, and a session the picker offers but the
+        sidebar cannot show (or the reverse) is the divergence this pins."""
         for index in range(20):
             _session(tmp_path, f"user{index:08x}", stamp=1000.0 + index)
         for index in range(40):
@@ -691,6 +723,7 @@ class TestTheHiddenSkipCannotHideRealWork:
         _recent_sessions_with_origin(tmp_path)
         _recent_sessions_with_origin(tmp_path)
 
-        picker = [row[0] for row in _recent_sessions_with_origin(tmp_path)]
-        sidebar = [entry.id for entry in load_catalog(tmp_path)]
-        assert sidebar == picker[: len(sidebar)]
+        picker = {row[0] for row in _recent_sessions_with_origin(tmp_path)}
+        sidebar = {entry.id for entry in load_catalog(tmp_path)}
+        assert sidebar == picker
+        assert len(picker) == 20, "every subagent session must stay hidden from both"

--- a/tests/unit/session/test_catalog_scan_cost.py
+++ b/tests/unit/session/test_catalog_scan_cost.py
@@ -9,21 +9,29 @@ directory. On the reporting machine (1,946 directories, 92% of them subagent
 sessions the picker never lists) one poll issued 9,773 syscalls and cost
 126 ms, permanently, per TUI process.
 
-What changed is the CONSTANT, and these tests are named for that. The poll
-went from ~5.8 to ~2.2 syscalls per directory (9,773 -> 4,350 on that store,
-126 ms -> 25 ms), but it is still ``O(every session directory ever created)``
-— two unconditional per-directory stats remain, the origin marker here and the
-desktop marker in ``load_catalog``. The store growing large enough still
-degrades the poll; it re-reaches the old cost at roughly 8,000 directories.
-Reaching ``O(the user's own sessions)`` needs an index or a persistent memo,
-which this change deliberately does not attempt.
+The first fix (#867) reordered the two gates, which improved the CONSTANT —
+~5.8 to ~2.2 syscalls per directory — while leaving the poll
+``O(every session directory ever created)``: two unconditional per-directory
+stats remained, the origin marker in the scan and the desktop marker in
+``load_catalog``.
 
-The fix is entirely a reordering and a call-shape change: no caching, no new
-source of truth, and above all **no second ranking clock**. These tests pin
-both halves — that the answer is unchanged, and that the cost model is the new
-one — because an optimisation here is only worth having if the listing is
-byte-identical, and the failure mode of getting it wrong is the retention
-policy deleting rows the picker is still showing.
+The second fix removed the scaling itself. A directory already known to be
+hidden is now skipped whole, for ZERO syscalls, because both facts that
+decision needs — the name and the inode — come free from the ``readdir`` batch
+``scandir`` already paid for. Per-directory cost therefore tracks the USER's
+own sessions: measured flat at 266 syscalls per poll while the store grew from
+100 to 8,000 directories with users held at 50, against 366 -> 16,166 before.
+What remains O(total entries) is the single batched ``scandir`` — the poll
+still touches the store, it just stops stat-ing it — and the verdict cache's
+own parse (704 KB / 5.6 ms at 7,950 markers), which is now the dominant
+remaining term.
+
+Neither fix is allowed to buy that with a different answer: no second source of
+truth, and above all **no second ranking clock**. These tests pin both halves —
+that the listing is byte-identical, and that the cost model is the new one —
+because the failure mode of getting the first wrong is the retention policy
+deleting rows the picker is still showing, and the failure mode of getting the
+skip wrong is a real session invisible in the picker forever.
 """
 
 from __future__ import annotations
@@ -273,33 +281,38 @@ class TestTheListingIsUnchanged:
 
 
 class TestThePollsPerDirectoryCostIsBounded:
-    """These pin the PER-DIRECTORY cost, which is what this change reduces —
-    not the scaling, which it does not change.
+    """These pin the PER-DIRECTORY cost, which is now O(the user's own
+    sessions) rather than O(the store).
 
-    The poll remains O(total session directories): the origin-marker stat runs
-    for every entry and ``load_catalog``'s desktop-marker probe for every
-    unlisted one. What the reordering buys is the constant — a hidden directory
-    costs one stat where it cost three. Name these tests for that bound, so a
-    later reader does not take a green suite as proof the store no longer
-    matters; measured flat at ~2.0-2.2 syscalls/dir from 150 to 4,050
-    directories in agent review / QA round 1.
+    A directory already known to be hidden is skipped before its marker is
+    stat'd, for zero syscalls. What remains O(total entries) is the single
+    batched ``scandir`` — one call, not a stat each — so these tests assert a
+    FLAT syscall count as the hidden population grows, which is precisely the
+    assertion the previous round lacked and which would have caught #867's
+    original overstatement.
 
     Asserted as syscall counts, not wall-clock: timings on a loaded machine
     measure contention, syscall counts measure the algorithm."""
 
-    def test_a_hidden_session_costs_one_stat_not_three(self, tmp_path: Path) -> None:
-        """The origin gate runs FIRST, so a subagent directory never pays for
-        the two activity stats whose answer would be discarded."""
+    def test_a_hidden_session_costs_no_syscalls_at_all(self, tmp_path: Path) -> None:
+        """The steady-state poll skips a known-hidden directory whole.
+
+        One ``scandir`` for the store and nothing else: ``DirEntry.inode()``
+        and ``is_dir()`` are both answered from the ``readdir`` batch that call
+        already paid for.
+        """
         for index in range(50):
             _session(tmp_path, f"{index:012x}", origin="subagent", stamp=1000.0)
-        _recent_sessions_with_origin(tmp_path)  # warm the verdict cache
+        # Two warm-ups: the first builds the verdict cache AND is the cold-start
+        # revalidating scan, so the second is the first poll able to use it.
+        _recent_sessions_with_origin(tmp_path)
+        _recent_sessions_with_origin(tmp_path)
 
         with _counting() as counter:
             _recent_sessions_with_origin(tmp_path)
-        # One scandir for the store, then exactly one marker stat per hidden
-        # directory. Three per directory was the old shape.
         assert counter.counts["scandir"] == 1
-        assert counter.counts["stat"] <= 50 + 5
+        assert counter.counts["stat"] == 0
+        assert counter.total == 1
 
     def test_the_scan_does_not_open_every_session_directory(self, tmp_path: Path) -> None:
         """``load_catalog`` located ``desktop.json`` with ``glob("*/desktop.json")``,
@@ -317,27 +330,367 @@ class TestThePollsPerDirectoryCostIsBounded:
         # registry and attention stores read. Emphatically not one per session.
         assert counter.counts["scandir"] < 10
 
-    def test_a_hidden_session_adds_one_stat_not_three(self, tmp_path: Path) -> None:
-        """Each added subagent directory costs ONE stat, down from three.
+    def test_the_cost_is_flat_as_the_hidden_population_grows(self, tmp_path: Path) -> None:
+        """THE DECISIVE ASSERTION: users held fixed, hidden directories varied.
 
-        This is deliberately NOT "hidden sessions are free": the bound below is
-        linear in the directories added (200 dirs -> <=200 stats), because that
-        is the property that actually ships. It fails on the previous
-        implementation, which paid three. Asserted as a DELTA against a
-        measured baseline rather than an absolute ceiling, so it pins the
-        per-directory slope instead of encoding one machine's number."""
+        This is the shape of the experiment, run in miniature. A cost that
+        tracks the STORE rises with each batch; a cost that tracks the USER's
+        sessions does not move at all. The previous implementation adds one stat
+        per directory here and fails on the first batch, which is exactly the
+        guard the earlier round lacked — a ladder that grows both populations
+        together cannot tell the two hypotheses apart, and that is how #867
+        shipped a claim bigger than its measurement.
+
+        Asserted as EQUALITY, not a bound: 'flat' is the property, and a
+        tolerance would let the slope creep back in unnoticed.
+        """
         for index in range(10):
-            _session(tmp_path, f"{index:012x}", stamp=1000.0 + index)
-        _recent_sessions_with_origin(tmp_path)
-        with _counting() as small:
-            _recent_sessions_with_origin(tmp_path)
+            _session(tmp_path, f"user{index:08x}", stamp=1000.0 + index)
 
-        for index in range(200):
-            _session(tmp_path, f"{index + 1000:012x}", origin="subagent", stamp=500.0)
-        _recent_sessions_with_origin(tmp_path)
-        with _counting() as large:
+        measurements = []
+        for batch in range(3):
+            for index in range(200):
+                _session(
+                    tmp_path,
+                    f"sub{batch:03x}{index:06x}",
+                    origin="subagent",
+                    stamp=500.0,
+                )
+            # Two scans: the first discovers the new directories, the second is
+            # the steady state the sidebar actually pays.
             _recent_sessions_with_origin(tmp_path)
+            _recent_sessions_with_origin(tmp_path)
+            with _counting() as counter:
+                rows = _recent_sessions_with_origin(tmp_path)
+            measurements.append(counter.total)
+            assert len(rows) == 10, "the listing must not move while cost is measured"
 
-        # Each added hidden directory costs ONE stat. The old code paid three,
-        # so this bound fails on the previous implementation.
-        assert large.total - small.total <= 200 + 10
+        assert measurements[0] == measurements[1] == measurements[2], measurements
+
+    def test_the_desktop_probe_skips_known_hidden_directories(self, tmp_path: Path) -> None:
+        """``load_catalog``'s SECOND O(store) stat, removed the same way.
+
+        It probed ``desktop.json`` in every directory the listing did not
+        return, which is the ~91% hidden population. A hidden directory cannot
+        carry a desktop marker — ``DesktopSessions.create`` is the only writer
+        and mints a fresh directory it never marks — so the probe asked a
+        question already answered. This is half the total saving, so it gets its
+        own pin.
+        """
+        for index in range(60):
+            _session(tmp_path, f"sub{index:09x}", origin="subagent", stamp=1000.0)
+        _session(tmp_path, "f" * 12, stamp=2000.0)
+        load_catalog(tmp_path)
+        load_catalog(tmp_path)
+
+        with _counting() as counter:
+            load_catalog(tmp_path)
+        # Well under one per hidden directory. Left as a bound rather than an
+        # equality because ``load_catalog`` also reads the registry and the
+        # attention store, whose constant is not this test's subject.
+        assert counter.counts["stat"] < 60
+
+
+# ---------------------------------------------------------------------------
+# The hidden-skip fast path: what makes skipping a directory safe
+# ---------------------------------------------------------------------------
+
+
+class TestTheHiddenSkipCannotHideRealWork:
+    """The fast path returns an answer WITHOUT looking at the directory, so
+    every way that answer could be wrong is a real session missing from the
+    picker — the severe failure this design exists to avoid.
+
+    Each test here corresponds to one of the repairs the design carries: the
+    inode qualification (id reuse), the revalidation epoch and the cold start
+    (a hand-deleted marker), and the fail-safe that a corrupt marker is never
+    memoised as hidden in the first place."""
+
+    def test_a_recreated_id_is_visible_rather_than_serving_a_dead_verdict(
+        self, tmp_path: Path
+    ) -> None:
+        """ID REUSE — the case that fails a name-keyed cache.
+
+        Delete a subagent directory, then create a REAL session under the same
+        12-hex id. Keyed on the name alone the dead directory's hidden verdict
+        is served for the live session and it never appears. The inode closes
+        it: a recreated directory gets a different inode, so it misses the
+        cache and takes the slow path.
+
+        This is why the inode qualification is load-bearing rather than a
+        nicety, and it is the one assertion that distinguishes the shipped
+        design from the cheaper one.
+        """
+        import shutil
+
+        reused = "a" * 12
+        _session(tmp_path, reused, origin="subagent", stamp=1000.0)
+        _session(tmp_path, "b" * 12, stamp=2000.0)
+        _recent_sessions_with_origin(tmp_path)
+        # Arm the fast path: this is the poll that would serve the stale answer.
+        assert [row[0] for row in _recent_sessions_with_origin(tmp_path)] == ["b" * 12]
+
+        shutil.rmtree(tmp_path / "sessions" / reused)
+        _session(tmp_path, reused, stamp=3000.0)
+
+        listed = [row[0] for row in _recent_sessions_with_origin(tmp_path)]
+        assert reused in listed, "a session recreated under a reused id must be visible"
+        assert listed == [reused, "b" * 12]
+
+    def test_a_missing_inode_degrades_to_the_slow_path_not_to_a_guess(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """Inode behaviour was measured on APFS; a filesystem that cannot
+        supply one must stay CORRECT, merely slower.
+
+        Simulated by making ``DirEntry.inode()`` raise, which is the shape of
+        the failure on a filesystem that does not answer it. The listing must
+        be unchanged and the marker must be re-read — never a cached verdict
+        accepted on a key that could not be qualified.
+        """
+        _session(tmp_path, "a" * 12, origin="subagent", stamp=1000.0)
+        _session(tmp_path, "b" * 12, stamp=2000.0)
+        with_inode = _recent_sessions_with_origin(tmp_path)
+        _recent_sessions_with_origin(tmp_path)
+
+        real_scandir = os.scandir
+
+        class _NoInode:
+            """A DirEntry whose inode is unavailable, delegating everything else."""
+
+            def __init__(self, entry: Any) -> None:
+                self._entry = entry
+                self.name = entry.name
+                self.path = entry.path
+
+            def inode(self) -> int:
+                raise OSError("inode unavailable on this filesystem")
+
+            def __getattr__(self, item: str) -> Any:
+                return getattr(self._entry, item)
+
+        class _Scan:
+            """Both a context manager and an iterator, exactly as
+            ``os.scandir`` returns — the scan uses it as both."""
+
+            def __init__(self, inner: Any) -> None:
+                self._inner = inner
+
+            def __iter__(self) -> Any:
+                return (_NoInode(entry) for entry in self._inner)
+
+            def __enter__(self) -> Any:
+                return self
+
+            def __exit__(self, *exc: Any) -> None:
+                self._inner.close()
+
+        monkeypatch.setattr(os, "scandir", lambda path: _Scan(real_scandir(path)))
+        assert _recent_sessions_with_origin(tmp_path) == with_inode
+
+    def test_a_hand_deleted_marker_is_repaired_by_revalidation(self, tmp_path: Path) -> None:
+        """Deleting ``origin.json`` is a SUPPORTED un-hide gesture.
+
+        The origin backfill refuses to re-stamp an existing marker precisely so
+        that a marker a human removed is not silently written back, so a
+        permanent skip would answer that gesture with a session hidden forever.
+        The epoch bounds it: while the fast path is armed the session stays
+        hidden, and the revalidating poll finds it.
+        """
+        from local_operator import resume as resume_mod
+
+        directory = _session(tmp_path, "a" * 12, origin="subagent", stamp=1000.0)
+        _recent_sessions_with_origin(tmp_path)
+        assert _recent_sessions_with_origin(tmp_path) == []
+
+        (directory / "origin.json").unlink()
+        assert _recent_sessions_with_origin(tmp_path) == [], "stale while armed, by design"
+
+        # Drive the counter to the epoch rather than waiting 150 polls: the
+        # arithmetic is the subject, not the wall time.
+        resume_mod._SCAN_COUNT[str(tmp_path)] = resume_mod.REVALIDATE_EVERY
+        assert [row[0] for row in _recent_sessions_with_origin(tmp_path)] == ["a" * 12]
+
+    def test_a_cold_start_always_revalidates(self, tmp_path: Path) -> None:
+        """Restarting ``lop`` repairs a stale verdict immediately.
+
+        The counter starts at 0 for a fresh process, so ``0 % REVALIDATE_EVERY``
+        is 0 and the first scan of every process is a revalidating one. That is
+        the second of the three independent repairs, and the one an operator
+        reaches for without being told about epochs.
+        """
+        from local_operator import resume as resume_mod
+
+        directory = _session(tmp_path, "a" * 12, origin="subagent", stamp=1000.0)
+        _recent_sessions_with_origin(tmp_path)
+        _recent_sessions_with_origin(tmp_path)
+        (directory / "origin.json").unlink()
+        assert _recent_sessions_with_origin(tmp_path) == []
+
+        resume_mod._SCAN_COUNT.pop(str(tmp_path), None)  # a fresh process
+        assert [row[0] for row in _recent_sessions_with_origin(tmp_path)] == ["a" * 12]
+
+    def test_a_corrupt_marker_stays_visible_on_every_poll(self, tmp_path: Path) -> None:
+        """The fail-safe the fast path must not invert.
+
+        A truncated or hand-edited marker parses to ``""`` — the user's own
+        session — so it is never a HIDDEN verdict and can never arm the skip.
+        Asserted over five consecutive polls because the bug this guards
+        against is one that appears only once the cache is warm.
+        """
+        corrupt = _session(tmp_path, "a" * 12, stamp=1000.0)
+        (corrupt / "origin.json").write_text('{"origin": "suba', encoding="utf-8")
+        # Cut inside a multi-byte character: the read must not raise either.
+        truncated = _session(tmp_path, "b" * 12, stamp=900.0)
+        (truncated / "origin.json").write_bytes('{"origin": "sübagent'.encode("utf-8")[:-3])
+
+        for poll in range(5):
+            listed = [row[0] for row in _recent_sessions_with_origin(tmp_path)]
+            assert listed == ["a" * 12, "b" * 12], f"vanished on poll {poll}"
+
+    def test_an_unreadable_marker_is_never_memoised_as_a_verdict(self, tmp_path: Path) -> None:
+        """A transient EMFILE describes the MOMENT, not the file.
+
+        The scan creates descriptor pressure itself, so a read failure must
+        fall through and be retried on the next scan rather than being frozen
+        into the cache for the life of the marker. The session stays visible
+        (fail-safe) and the verdict is re-derived once the read succeeds.
+        """
+        from local_operator import resume as resume_mod
+
+        directory = _session(tmp_path, "a" * 12, origin="subagent", stamp=1000.0)
+        real_read = resume_mod._session_origin_read
+        calls: list[Path] = []
+
+        def failing(path: Path) -> tuple[str, bool]:
+            calls.append(path)
+            return "", False
+
+        resume_mod._session_origin_read = failing  # type: ignore[assignment]
+        try:
+            assert [row[0] for row in _recent_sessions_with_origin(tmp_path)] == ["a" * 12]
+            assert [row[0] for row in _recent_sessions_with_origin(tmp_path)] == ["a" * 12]
+            assert len(calls) == 2, "an unreadable marker must be re-read, not memoised"
+        finally:
+            resume_mod._session_origin_read = real_read  # type: ignore[assignment]
+
+        assert directory.is_dir()
+        # Once the read succeeds the verdict is derived normally and the
+        # session hides, proving nothing wrong was cached in the meantime.
+        assert _recent_sessions_with_origin(tmp_path) == []
+
+    def test_a_new_subagent_hides_immediately_while_the_fast_path_is_armed(
+        self, tmp_path: Path
+    ) -> None:
+        """The skip only ever SUPPRESSES work for a directory already known
+        hidden; an unknown directory always takes the slow path, so a subagent
+        created mid-poll-cycle is hidden on the very next poll rather than
+        waiting for an epoch."""
+        _session(tmp_path, "a" * 12, stamp=1000.0)
+        _recent_sessions_with_origin(tmp_path)
+        _recent_sessions_with_origin(tmp_path)
+
+        _session(tmp_path, "b" * 12, origin="subagent", stamp=2000.0)
+        assert [row[0] for row in _recent_sessions_with_origin(tmp_path)] == ["a" * 12]
+
+    def test_the_skip_does_not_change_the_listing_on_any_awkward_shape(
+        self, tmp_path: Path
+    ) -> None:
+        """Every shape at once, over enough polls that the fast path is armed
+        for all of them. The listing is the contract; the cost is not allowed
+        to buy a different one."""
+        _session(tmp_path, "a" * 12, stamp=5000.0)
+        _session(tmp_path, "b" * 12, origin="fork", stamp=4000.0)
+        _session(tmp_path, "c" * 12, origin="subagent", stamp=9000.0)
+        _session(tmp_path, "d" * 12, transcript=None)
+        _session(tmp_path, "e" * 12, transcript=None, inbox="{}\n", stamp=3000.0)
+        _session(tmp_path, "f" * 12, origin="subagent", transcript=None)
+
+        expected = ["a" * 12, "b" * 12, "e" * 12]
+        for poll in range(4):
+            assert [row[0] for row in _recent_sessions_with_origin(tmp_path)] == expected, poll
+
+    def test_a_symlinked_session_directory_agrees_across_polls(self, tmp_path: Path) -> None:
+        """A store may contain a symlink to a session directory. Whatever the
+        first poll decides, the warm polls must decide identically — the point
+        being that the fast path introduces no divergence of its own."""
+        target = _session(tmp_path, "a" * 12, stamp=1000.0)
+        _session(tmp_path, "b" * 12, origin="subagent", stamp=2000.0)
+        link = tmp_path / "sessions" / ("c" * 12)
+        try:
+            link.symlink_to(target, target_is_directory=True)
+        except OSError:  # pragma: no cover - platforms without symlink permission
+            import pytest
+
+            pytest.skip("symlinks unavailable")
+
+        first = _recent_sessions_with_origin(tmp_path)
+        for _ in range(3):
+            assert _recent_sessions_with_origin(tmp_path) == first
+
+    def test_an_unknown_cache_version_rebuilds_rather_than_misreading(self, tmp_path: Path) -> None:
+        """The migration path for the added ``ino`` field.
+
+        A cache written by an older version has no inode to qualify anything
+        with, so it is discarded wholesale — which the loader already did for
+        any unknown version. Asserted end to end: the listing is right and the
+        rewritten file carries the current version.
+        """
+        from local_operator import resume as resume_mod
+
+        _session(tmp_path, "a" * 12, stamp=1000.0)
+        _session(tmp_path, "b" * 12, origin="subagent", stamp=2000.0)
+        _recent_sessions_with_origin(tmp_path)
+
+        cache = resume_mod.origin_cache_path(tmp_path)
+        stale = json.loads(cache.read_text(encoding="utf-8"))
+        stale["version"] = resume_mod.ORIGIN_CACHE_VERSION - 1
+        for entry in stale["entries"].values():
+            entry.pop("ino", None)
+        cache.write_text(json.dumps(stale), encoding="utf-8")
+
+        assert [row[0] for row in _recent_sessions_with_origin(tmp_path)] == ["a" * 12]
+        rebuilt = json.loads(cache.read_text(encoding="utf-8"))
+        assert rebuilt["version"] == resume_mod.ORIGIN_CACHE_VERSION
+        assert all("ino" in entry for entry in rebuilt["entries"].values())
+
+    def test_a_store_past_the_scan_limit_still_lists_identically(self, tmp_path: Path) -> None:
+        """``CATALOG_SCAN_LIMIT`` caps the PAGE, never the scan.
+
+        With more user sessions than the cap, the scan must still return all of
+        them (``/resume`` shows the whole store) while ``load_catalog`` shows a
+        capped, correctly ordered prefix — and both must be stable once the fast
+        path is armed.
+        """
+        from local_operator.session.catalog import CATALOG_SCAN_LIMIT
+
+        users = CATALOG_SCAN_LIMIT + 50
+        for index in range(users):
+            _session(tmp_path, f"user{index:08x}", stamp=1000.0 + index)
+        for index in range(300):
+            _session(tmp_path, f"sub{index:09x}", origin="subagent", stamp=500.0)
+
+        first = [row[0] for row in _recent_sessions_with_origin(tmp_path)]
+        assert len(first) == users
+        warm = [row[0] for row in _recent_sessions_with_origin(tmp_path)]
+        assert warm == first
+        page = load_catalog(tmp_path)
+        assert len(page) == CATALOG_SCAN_LIMIT
+        assert [entry.id for entry in load_catalog(tmp_path)] == [entry.id for entry in page]
+
+    def test_resume_and_the_sidebar_list_the_same_set_in_the_same_order(
+        self, tmp_path: Path
+    ) -> None:
+        """The invariant the whole change is measured against. Both surfaces
+        share one scan, so they cannot diverge — pinned here so a future
+        'optimisation' that gives the sidebar its own path fails loudly."""
+        for index in range(20):
+            _session(tmp_path, f"user{index:08x}", stamp=1000.0 + index)
+        for index in range(40):
+            _session(tmp_path, f"sub{index:09x}", origin="subagent", stamp=500.0)
+        _recent_sessions_with_origin(tmp_path)
+        _recent_sessions_with_origin(tmp_path)
+
+        picker = [row[0] for row in _recent_sessions_with_origin(tmp_path)]
+        sidebar = [entry.id for entry in load_catalog(tmp_path)]
+        assert sidebar == picker[: len(sidebar)]

--- a/tests/unit/session/test_cleanup.py
+++ b/tests/unit/session/test_cleanup.py
@@ -1148,3 +1148,66 @@ def test_any_viewer_takes_the_record_once_the_writer_is_gone(tmp_path: Path) -> 
     _record(sessions, writer.pid)
     taken = take_unannounced_cleanup(sessions, runtime_pid=None)
     assert taken is not None and taken["removed"] == 2
+
+
+def test_a_stale_hidden_verdict_cannot_cost_a_session_its_recent_guard(tmp_path: Path) -> None:
+    """THE DELETION AUTHORITY MUST NOT DECIDE FROM A SPECULATIVELY-STALE SCAN.
+
+    ``resume``'s catalog scan serves an armed fast path that can keep reporting
+    a directory as hidden for up to ``REVALIDATE_EVERY`` polls after its origin
+    marker was removed. For the sidebar that is a cheap, self-healing display
+    lag. For this module it is not a display at all: the recent-N guard IS the
+    picker's rows, so a session missing from that listing is not merely
+    invisible, it is UNPROTECTED — and removal is irreversible while a late
+    redraw is not.
+
+    Reproduced by agent review round 1 (R2) in production order, which is what
+    this test replays: the TUI's ``on_mount`` opens the sidebar and polls once
+    (arming the path), the operator deletes ``origin.json`` by hand — the
+    SUPPORTED un-hide gesture, which the backfill deliberately never undoes —
+    and startup maintenance runs ``cleanup_from_config`` 0.75 s later
+    (``_STORE_MAINTENANCE_IDLE_DELAY_SECONDS``). Before the fix that sequence
+    chose the un-hidden session for deletion; a scan one epoch later protected
+    it as "one of the 10 most recent".
+
+    The assertion is deliberately the STRONG one — the stale-window result must
+    equal the fresh-scan result — rather than merely "the victim survives".
+    Anything weaker would pass again the moment some other guard happened to
+    cover this particular victim, which is how the window would return
+    unnoticed.
+    """
+    from local_operator.resume import _SCAN_COUNT, mark_session_origin, recent_sessions
+
+    mark_store(tmp_path / "sessions")
+    # Twelve sessions, all idle past ``max_inactive_days`` so the limit has
+    # something to take; only the recent-N guard stands between them and it.
+    for index in range(12):
+        _session(tmp_path, f"v{index:011d}", age_days=40 + index)
+    victim = tmp_path / "sessions" / "v00000000001"
+    mark_session_origin(victim, "subagent", label="reviewer")
+
+    policy = CleanupPolicy(
+        enabled=True, max_sessions=0, max_inactive_days=30, max_total_bytes=0, remove_empty=False
+    )
+
+    _SCAN_COUNT.clear()
+    # Poll #1: the cold start, which always revalidates and arms the path.
+    recent_sessions(tmp_path, limit=None)
+    # The operator un-hides the session by deleting the marker by hand.
+    (victim / "origin.json").unlink()
+    # Poll #2: the fast path is armed, so the sidebar still shows it hidden.
+    assert "v00000000001" not in [
+        name for name, _stamp in recent_sessions(tmp_path, limit=None)
+    ], "precondition: the display lag this test exists to keep OUT of the policy"
+
+    stale = run_cleanup(tmp_path, policy, now=NOW, dry_run=True, force=True)
+
+    # The policy re-read the store rather than inheriting the sidebar's verdict.
+    assert ("v00000000001", "one of the 10 most recent") in stale.protected
+    assert "v00000000001" not in [candidate.session for candidate in stale.chosen]
+
+    # And it decided exactly as a scan with no stale state at all would.
+    _SCAN_COUNT.clear()
+    fresh = run_cleanup(tmp_path, policy, now=NOW, dry_run=True, force=True)
+    assert sorted(c.session for c in stale.chosen) == sorted(c.session for c in fresh.chosen)
+    assert sorted(stale.protected) == sorted(fresh.protected)

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -3249,6 +3249,21 @@ def test_the_origin_cache_re_reads_a_marker_that_changed(tmp_path: Path) -> None
 
     This is the backfill's path: a session unmarked at one open can be stamped
     before the next, and a session's marker can be corrected by hand.
+
+    The two directions are deliberately NOT symmetric, and the asymmetry is the
+    design rather than an oversight. HIDING is immediate: absence is never
+    cached, so a directory the backfill stamps takes the slow path and is
+    hidden on the very next scan. UN-HIDING is bounded instead of immediate,
+    because the hidden-skip fast path answers from the cache without touching
+    the directory at all, and a marker rewritten IN PLACE moves the marker's
+    ``(mtime, size)`` without moving the DIRECTORY's inode — the only fact the
+    skip consults. ``REVALIDATE_EVERY`` is what repairs it: ~5 minutes at the
+    sidebar's poll rate, or immediately on restart.
+
+    The failure direction matters here. Being slow to un-hide costs a session
+    that is still resumable by id and reappears within five minutes; being slow
+    to hide would leak every subagent run into the picker, which is the bug the
+    marker exists to fix.
     """
     sessions = tmp_path / "sessions"
     (sessions / "s1").mkdir(parents=True)
@@ -3261,9 +3276,14 @@ def test_the_origin_cache_re_reads_a_marker_that_changed(tmp_path: Path) -> None
     resume_mod.mark_session_origin(sessions / "s1", resume_mod.ORIGIN_SUBAGENT)
     assert resume_mod.recent_sessions(tmp_path, limit=10**9) == []
 
-    # Corrected back by hand: a changed marker re-derives rather than serving
-    # the cached "subagent".
+    # Corrected back by hand. The verdict cache keyed on the marker would
+    # re-derive immediately, but the skip above it does not look at the marker,
+    # so this is repaired at the epoch rather than at the next poll.
     (sessions / "s1" / resume_mod.ORIGIN_NAME).write_text('{"origin": ""}', encoding="utf-8")
+    assert resume_mod.recent_sessions(tmp_path, limit=10**9) == [], "stale while armed, by design"
+
+    # The epoch (equivalently: a restart, which starts the counter at 0).
+    resume_mod._SCAN_COUNT[str(tmp_path)] = resume_mod.REVALIDATE_EVERY
     assert [row[0] for row in resume_mod.recent_sessions(tmp_path, limit=10**9)] == ["s1"]
 
 


### PR DESCRIPTION
# PR Description

## Summary of Changes

The sidebar re-runs `load_catalog` every 2 seconds while it is open. That poll paid **two unconditional stats for every session directory** — the origin marker in `resume.py`'s scan, and the desktop marker in `load_catalog` — before anything knew that ~91% of those directories are subagent sessions the very next line discards. #867 improved that *constant* by ~2.2x but deliberately left the scaling alone: the poll was still `O(every session directory ever created)`, so it degraded permanently as the store accumulated.

This makes the per-directory cost track **the user's own sessions** instead.

- The existing origin-verdict cache now also records **whether the verdict is hidden**, qualified by the directory's **inode**. A directory already known to be hidden is skipped whole, before its marker is stat'd — **zero syscalls**. Both facts that decision needs (`DirEntry.inode()`, `is_dir()`) come free from the `readdir` batch `scandir` already paid for.
- The scan returns the hidden set, so `load_catalog` skips its desktop probe for those names. That is **half the total saving**, and it is sound because `desktop.json` has exactly one writer — `DesktopSessions.create` (`server/utils/desktop_sessions.py`) — which mints a fresh `uuid4` directory and never origin-marks it. A directory carrying an origin marker cannot carry a desktop one, so the probe asked a question whose answer was already known.
- `ORIGIN_CACHE_VERSION` → 2. An unknown version already degrades to a clean rebuild, which is the migration path.

Design doc: the architect's `sidebar-user-scan.md` (option **B′**, inode-qualified hidden-skip). Options B (name-keyed), C (stat-validated) and a sqlite index were prototyped and measured; B alone fails id reuse, C stays `O(store)`, and sqlite measured 1.5x the existing JSON mechanism for an entire new subsystem.

### Why the inode qualification is here — and what it is *not*

Keyed on the **name alone**, this design has a real bug: **id reuse**. Delete a subagent directory, then create a new session under the same 12-hex id, and the dead directory's `hidden` verdict is served for the live one.

The inode bounds that, but **how much it buys is a property of the filesystem, not of this code**, and CI caught me over-claiming it. Both behaviours are now measured and asserted rather than one being assumed:

| filesystem | inode on recreate | id-reuse repaired |
|---|---|---|
| APFS (macOS) | **reallocated** — `912841799 → 912841800` | next poll |
| ext4 (`python:3.12-slim`) | **recycled** — `67634 → 67634` | at the epoch (~5 min) |

So the honest framing is: **the epoch is the correctness guarantee; the inode is a latency improvement on top of it.** On APFS a reused id is visible immediately; on ext4 it degrades to exactly the name-keyed behaviour and is repaired by revalidation. What holds on *every* filesystem — and is asserted unconditionally — is that the session is never invisible for good. `test_a_recreated_id_is_visible_rather_than_serving_a_dead_verdict` asserts the filesystem-appropriate bar plus the universal one; the `ino is None` path has its own test.

This is worth stating plainly because the first version of this PR asserted the APFS timing as universal and **failed the Linux CI shard**. That is the correct outcome — the matrix exists for this — and the fix was to make the test honest, not to weaken it.

### Why the skip is bounded rather than permanent

"Once a subagent, always a subagent" holds for all three writers (`harness/subagent.py`, `fork.py`, and the backfill, which explicitly refuses to re-stamp) — **but** that refusal exists precisely so *a marker a human deleted by hand to un-hide a session is not silently written back*. The codebase therefore treats deleting `origin.json` as a supported gesture, and a permanent index would answer it with a session hidden forever. Three independent repairs:

1. **`REVALIDATE_EVERY = 150` polls** (~5 min at the 2 s interval) disarms the fast path and re-reads the store. Documented as a named constant with its arithmetic, and **counted in POLLS, not seconds** — if the poll rate ever becomes variable this should be re-expressed as elapsed time.
2. **Cold start always revalidates** — the counter starts at 0, so `0 % 150 == 0`. Restarting `lop` is an immediate repair.
3. **The cache stays user-deletable derived data** under `cache/`.

## Related Issue(s)

- Follows: #867 (which improved the constant; this removes the scaling)

## Impact

No behaviour change to the listing. `/resume` and the sidebar share one scan, so they cannot diverge; equivalence is asserted rather than argued (below).

**Not a breaking change.** A v1 verdict cache is discarded and rebuilt on first scan.

**One accepted, bounded semantic change**, called out because it is real: editing or deleting `origin.json` **in place** to un-hide a session is now repaired at the epoch (~5 min, or immediately on restart) instead of on the next poll — the directory's inode does not move when a file inside it changes, and the skip does not look at the marker. The failure directions are deliberately asymmetric: **hiding stays immediate** (absence is never cached, so a directory the backfill stamps is hidden on the very next scan), because a slow un-hide costs a session that is still resumable by id and returns within five minutes, while a slow hide would leak every subagent run into the picker. `test_the_origin_cache_re_reads_a_marker_that_changed` now pins both halves.

### Performance

**All primary evidence is syscall counts.** This machine ran at load average 83–196 throughout (`uptime` reported beside each run); wall-clock here measures contention, not the algorithm, so no timing is used as a headline.

#### The decisive experiment — users held FIXED at 50, store varied

This is the experiment that distinguishes `O(users)` from `O(store)`, and it is exactly what caught #867's original overstatement: a ladder that grows both populations together cannot tell the two hypotheses apart. `scripts/bench_catalog_scan.py store-axis`, full `load_catalog` poll:

| total dirs | hidden | main | this PR | listing identical |
|---:|---:|---:|---:|:---:|
| 100 | 50 | 366 | **266** | yes |
| 500 | 450 | 1,166 | **266** | yes |
| 1,000 | 950 | 2,166 | **266** | yes |
| 2,000 | 1,950 | 4,166 | **266** | yes |
| 4,000 | 3,950 | 8,166 | **266** | yes |
| 8,000 | 7,950 | 16,166 | **266** | yes |
| **growth over an 80x store** | | **44.2x** | **1.0x** | |

#### The complementary axis — store fixed at 4,000, users varied

Proves the cost is `O(users)` rather than `O(1)`-by-answering-the-wrong-question:

| users | main | this PR | per user |
|---:|---:|---:|---:|
| 10 | 8,046 | **66** | 6.60 |
| 50 | 8,166 | **266** | 5.32 |
| 200 | 8,616 | **1,016** | 5.08 |

#### The operator's real store — 2,067 directories, strictly read-only

Measured against a **frozen mirror** of structure + sidecars + activity mtimes; nothing writes a byte under `~/.local-operator`. Five consecutive polls, both sides against the identical snapshot:

```
main    : 4,663 syscalls/poll
this PR :   887 syscalls/poll      5.3x, 5.61 per listed session
sidebar listing byte-identical: True (158 rows, all 5 polls)
picker  listing byte-identical: True (156 rows, all 5 polls)
```

#### Amortising the revalidation — the honest number

At 4,000 dirs / 50 users, a fast poll is 266 syscalls and a revalidating one 4,216. With `REVALIDATE_EVERY = 150` that is **292 amortised against main's 8,166 — 28x**. Quote 292, not 266.

### The claim, stated precisely

> Per-directory syscalls become **O(user sessions + directories that are neither listed nor cached-hidden)** — flat at 266 per poll while the *hidden* population grew the store 100 → 8,000 with users held at 50, against 366 → 16,166 before — **plus one batched directory enumeration that remains O(total entries)** but is a single `scandir` (4.24 ms at 8,000 directories), not a stat each. Amortising the every-150-polls revalidation: **292 vs 8,166 syscalls, 28x**. On the operator's real 2,067-directory store the poll falls **4,663 → 887 (5.3x)** with a byte-identical listing.

**The middle term is real and is now pinned** (agent review round 1, R1). A directory with *neither* an origin marker *nor* any activity is in neither the listing nor the hidden set, so it can never arm the skip: it pays ~4 syscalls **every poll, forever, while never being listable**. The store accumulates these from idle open-and-quit launches — 23 on the operator's machine today. Measured with users FIXED at 50 and hidden FIXED at 500, varying only that third population (`bench_catalog_scan.py unmarked-axis`, added in this round):

| never-active dirs | 0 | 500 | 2,000 | 8,000 |
|---|---:|---:|---:|---:|
| syscalls/poll | 266 | 2,266 | 8,266 | 32,266 |

Strictly linear, slope **exactly 4.0**. The reviewer measured the same slope at 268 → 32,268 on a counter that also hooks `open`/`listdir` — the slope is the claim, the constant is the instrument. `main` on the same inputs is 1,268 → 33,268, so this is still a large absolute improvement (it removes ~1,000 syscalls of hidden-population cost), but the *scaling* statement had to be narrowed to survive it. Corrupt-marker and `{"origin": ""}` directories behave identically, and the corrupt case is the very fail-safe this design preserves.

**Not fixed here, deliberately.** Caching "unmarked" is refused for a stated reason — a directory the backfill stamps later must be re-read, not answered from a stale absence. So this is the *next* bottleneck alongside the cache parse, recorded rather than left to be rediscovered.

**What this does NOT claim**, explicitly:

- **Not `O(1)`.** It is `O(users)` plus the never-active term above; the complementary axis is what proves the distinction rather than assuming it.
- **Not "no directory can cost per poll".** A directory that is neither listed nor cached-hidden costs ~4 syscalls per poll forever — quantified and pinned above. An earlier revision of this body and of `resume.py`'s docstring said per-directory cost "tracks the USER's own sessions", from which that inference was reasonable and false.
- **Not "the poll stops touching the store."** It does touch it — it just stops *stat*-ing it. The `scandir` is unavoidable and remains `O(total entries)`.
- **No wall-clock headline.** Load average moved between 83 and 196 across these runs.
- **The cache PARSE is not flat, and is now the dominant remaining term.** Measured: **704 KB / 5.6 ms at 7,950 markers**, i.e. 0.28% of a 2 s poll. Main already pays this — the change does not add it — but by removing everything around it this PR makes it the next bottleneck, so it is stated here rather than left for a reviewer to find. If it ever matters, that is when a real index earns its place; at 1.5x the existing JSON mechanism it does not today.

### Risks, and how you would notice

1. **A stale hidden verdict hides real work** — the severe risk. Bounded to ~5 min by the epoch and to zero by a restart. **How an operator notices: a session that exists on disk but is missing from `/resume`.** Mitigation if seen: lower `REVALIDATE_EVERY`, or fall back to the stat-validated variant (2x, no staleness).
   - **The staleness bound is per-POLL, not per wall-clock** (R3). A closed sidebar pauses its timer, freezing the counter, and reopening does *not* force a revalidation — so "~5 minutes" holds only for a sidebar that is actually polling. A cold start still revalidates, so the bound is per-process, never unbounded in practice. Now stated in `REVALIDATE_EVERY`'s docstring.
   - **`cleanup` no longer consumes that stale window at all** (R2, below).
2. **~~A stale row could lose `cleanup`'s recent-N guard~~ — FIXED in this round, was the one irreversible consequence.** The recent-N guard *is* the picker's rows, so a stale-hidden session was not merely invisible: it was unprotected, and an enabled cleanup policy could delete it. `cleanup._picker_rows` now forces a revalidating scan (`recent_sessions(..., revalidate=True)`), so a deletion authority never decides from a speculatively-stale listing. Cost: 4,101 vs 151 syscalls, paid once per cleanup run rather than every 2 s — the sidebar's own poll is **unchanged at 266 and still flat across a 40x store**.
3. **Cache bytes are `O(store)`** (not syscalls) — see the parse figure above.
4. **Inode behaviour is filesystem-dependent, and was verified on two.** APFS reallocates; ext4 recycles (both measured — see the table above), so on Linux a reused session id is repaired at the epoch rather than immediately. A network filesystem could differ again; the design degrades safely in every direction (`ino is None` → slow path) because the epoch, not the inode, carries correctness. The full test file passes on both macOS/APFS and Linux/ext4 (27/27 on each, the latter run in `python:3.12-slim`).

## Testing Details

Gates, run exactly as CI, on the rebased branch:

| gate | result |
|---|---|
| `flake8 .` | clean |
| `black --check .` (26.1.0, pinned) | 1,182 files unchanged |
| `isort --check-only .` (5.13.2, pinned) | clean |
| `pyright --pythonpath .venv/bin/python .` (1.1.411, pinned) | **0 errors, 0 warnings** |
| `pytest tests/unit/session tests/unit/test_session_factory.py tests/unit/test_fork.py` | **2,092 passed, 1 failed** — the failure is `test_process_reaper.py::test_phone_watchers_do_not_change_idle_timing`, a timing assertion (40 ms spread) at load average 120, in a file this diff does not touch. Passes 3/3 in isolation at the same load. |
| `pytest tests/e2e -m e2e -n0` | **98 passed, 7 skipped** (was 95 — the 3 new tests) |
| `pytest tests/unit/session/test_catalog_scan_cost.py` on **Linux/ext4** (`python:3.12-slim`) | **27 passed** |

### Remediation round 1 — evidence for the fixes

**R2, the one with an irreversible consequence.** The reviewer's exact sequence, replayed in production order, **fails on the pre-remediation head and passes after** — that ordering was checked explicitly rather than assumed:

```
# on aadff766 (pre-fix): the victim is CHOSEN FOR DELETION
FAILED test_a_stale_hidden_verdict_cannot_cost_a_session_its_recent_guard
  assert ('v00000000001', 'one of the 10 most recent') in stale.protected
  chosen=[Candidate(session='v00000000001', policy='max_inactive_days', reason='idle over 30d')]

# after the fix
1 passed
```

The test asserts the strong property — the stale-window result must **equal** the fresh-scan result, both `chosen` and `protected` — rather than merely "the victim survives", which would pass again the moment some unrelated guard happened to cover this particular victim.

**Cost of the R2 fix, measured rather than asserted:**

| path | syscalls | frequency |
|---|---:|---|
| `cleanup`'s forced revalidating scan | 4,101 | once per cleanup run (startup maintenance, periodic sweeps) |
| an armed scan (what it replaced) | 151 | — |
| **the sidebar's steady-state poll** | **266, unchanged** | every 2 s |

`store-axis` re-run after the fix: **266 / 266 / 266** at 100 / 1,000 / 4,000 directories — 1.0x growth over a 40x store, so the flatness this PR exists for is intact.

**No starvation from the epoch reset.** A forced revalidation sets the counter to 1 rather than 0 (it *is* the expensive scan, so the next poll may legitimately be cheap). Checked that this cannot delay the sidebar's own repair: with a cleanup interleaved every 100 polls, a hand-un-hidden session was repaired at **poll 100** — earlier than the 150 bound, because the forced scan rewrites the verdict cache — and `_picker_rows` itself sees the un-hidden session **immediately**.

**R1** — new `unmarked-axis` bench mode and `test_the_cost_is_linear_in_directories_that_are_neither_listed_nor_hidden`, both reproducing the 4.0 slope (table above). The test asserts a strict rise with **equal steps** per batch, so a cost that turned super-linear would fail too.

**R4** — `test_a_directory_carrying_both_markers_resolves_to_the_origin_verdict` builds the combination the desktop-probe skip assumes impossible and pins today's behaviour across 3 polls (cold and armed): the origin verdict wins, the both-marker row is hidden, and a legitimate desktop draft beside it is still offered. A future writer in `desktop_sessions.py` that broke the single-writer premise now trips this test next to the reasoning that depends on it.

**Q2** — `REVALIDATE_EVERY`'s docstring quoted **151 / 4,101 / 177 / 8,052**, which were the **scan-only** numbers presented as if they were the poll. Re-measured through the repo's own harness at the same cell (4,000 dirs / 50 users): **266 armed / 4,216 revalidating / 292 amortised / 8,166 base**, matching QA's independent 265 / 4,215 / 291.3 / 8,165 to within one syscall. The docstring now states which surface it is quoting so the two cannot drift apart again.

**Correctness matrix — real execution, not a green suite.** 27 tests in `test_catalog_scan_cost.py` (was 15). New class `TestTheHiddenSkipCannotHideRealWork` covers every way the fast path could return a wrong answer:

| case | expectation | result |
|---|---|---|
| **id reuse** (delete subagent dir, recreate under same id) | visible next poll where the inode moves (APFS); at the epoch where it is recycled (ext4); **never invisible for good** on either | PASS on both |
| `ino is None` (filesystem cannot supply one) | listing unchanged, slow path | PASS |
| hand-deleted marker | hidden while armed, **repaired by revalidation** | PASS |
| cold start with a stale verdict | repaired on first scan | PASS |
| corrupt marker, incl. cut inside a multi-byte char | **visible**, over 5 consecutive polls | PASS |
| unreadable marker (EMFILE) | never memoised; re-read next scan | PASS |
| new subagent created while fast path armed | hides immediately | PASS |
| every awkward shape (spool-only, no-activity, fork, marked-inactive) | listing unchanged over 4 polls | PASS |
| symlinked session directory | agrees across polls | PASS |
| unknown cache version | rebuilds, all entries carry `ino` | PASS |
| store past `CATALOG_SCAN_LIMIT` (250 users) | scan returns all, page caps at 200, stable | PASS |
| `/resume` and sidebar select identically | same **set** (they order differently by design — see below) | PASS |
| **cost is flat as hidden population grows** | equality, not a bound | PASS |
| desktop probe skips known-hidden | `stat` well under one per hidden dir | PASS |

Verified outside the test suite, against the real path:

- **The real store, five consecutive polls**, before and after, against one frozen snapshot — listings byte-identical (table above). The mirror is read-only by construction; the live cache's mtime was unchanged after the runs.
- **12 concurrent poller processes × 25 polls** on a shared 400-directory store: **1 distinct listing, 0 cache parse failures**, final cache parseable with all 300 entries, every one carrying `ino`.
- **Unreadable directory** (`chmod 000`): no raise, subagent still hidden, user session still listed, stable over 4 polls.
- **A correction CI earned, recorded rather than quietly fixed:** the sidebar was never an *order*-prefix of `/resume`. Both surfaces share one scan and so must select the same **set**, but the sidebar re-ranks by `CatalogEntry.rank` (`tier, wake_rank, -birth, id`) while the scan ranks by the activity clock. My first assertion pinned a coincidence that only holds when creation order and activity order agree. It now asserts set equality — which is the contract the hidden-skip could actually break.
- **Equivalence assertions in the harness itself** — `bench_catalog_scan.py compare` asserts `(id, order)` byte-identical old vs new at every size on both axes and on the real store. EQUIVALENT at 100/500/1000/2000/4000/8000 and at 10/50/200 users.

`scripts/bench_catalog_scan.py` was **extended, not duplicated**: new `store-axis`, `users-axis`, `unmarked-axis` and `compare` modes, plus a read-only real-store mirror (the previous `real` mode measured in place, where `_no_writes` correctly blocks the cache write and so could only ever report a cold poll). `_build_axis_store` gained a third population defaulting to 0, so the two existing experiments are unchanged.

**Deliberately not touched:** `_prewarm_sidebar` and the presentation/retention caches. Whether the sidebar is *invoked* more often than every 2 s is a separate defect — how often work happens, not what one poll costs — and is a separate PR so both stay reviewable. The two compose: this reduces the cost of each redundant poll without removing the redundancy.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.

