### PR TITLE
fix(mcp): keep OAuth capability evidence across a credential delete

### DIFF
--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -3616,23 +3616,21 @@ async def _mcp_login_server(name: str, cwd: Path) -> int:
         print(f"error: MCP server {name!r} is not configured", file=sys.stderr)
         return 1
     # NOT ``cfg.auth.type == 'oauth'`` any more — the same widening the TUI and
-    # runtime grant paths already made (issue #367). A config imported from a
-    # foreign tool (Codex) carries only a ``url``, because that tool keeps its
-    # OAuth grants elsewhere and its format has no auth block to copy. The
-    # static check refused those outright, so ``local-operator mcp login
-    # <codex-server>`` failed on exactly the servers ``/mcp login`` handles
-    # fine — two gates for one question, disagreeing.
+    # runtime grant paths already made (issue #367); for what counts as
+    # evidence and why a url-only foreign import has none of the static kind,
+    # see :func:`server_is_oauth_capable`. The static check refused exactly the
+    # servers ``/mcp login`` handles fine — two gates for one question,
+    # disagreeing.
     #
     # The split below preserves the F3 protection that motivated the strict
-    # check. ``server_rejects_oauth`` is the STATIC impossibility (a stdio
-    # server, or one whose config declares ``auth.type: apikey`` — the user
-    # stating how it authenticates), and it stays a free, hard refusal with the
-    # wording that tells them how to add an OAuth server. Only the genuinely
-    # undecidable url-only case pays for the live probe, which asks the network
-    # once instead of assuming every remote URL is authenticable.
+    # check: ``server_rejects_oauth`` is the STATIC impossibility, and it stays
+    # a free, hard refusal with the wording that tells them how to add an OAuth
+    # server. Only the genuinely undecidable url-only case pays for the live
+    # probe, which asks the network once instead of assuming every remote URL
+    # is authenticable.
     if server_rejects_oauth(cfg):
         print(
-            f"error: MCP server {name!r} is not OAuth-enabled; " "add a remote server with --oauth",
+            f"error: MCP server {name!r} is not OAuth-enabled; add a remote server with --oauth",
             file=sys.stderr,
         )
         return 1
@@ -3641,8 +3639,16 @@ async def _mcp_login_server(name: str, cwd: Path) -> int:
         # advertising an authorization server: it may be genuinely public, or
         # discovery may be unreachable. Distinct wording, because "add a remote
         # server with --oauth" is useless advice for a server that IS one.
+        #
+        # The parenthetical is load-bearing, not decoration: the probe swallows
+        # its transport exception and returns False for BOTH readings, so after
+        # the 30 s worst case against an unroutable host a bare "does not use
+        # OAuth login" tells the user a falsehood about their server when the
+        # real fault is the URL or the network. The message has to admit the
+        # ambiguity the code already acknowledges.
         print(
-            f"error: MCP server {name!r} does not use OAuth login",
+            f"error: MCP server {name!r} does not use OAuth login"
+            " (no authorization server discovered — check the URL and your network)",
             file=sys.stderr,
         )
         return 1
@@ -3673,11 +3679,39 @@ async def _mcp_reauth_server(name: str, cwd: Path) -> int:
     non-OAuth name so a typo does not turn into an unexpected browser tab)
     and then runs exactly the login connect path — one implementation of what
     "authenticated" means.
+
+    A failed removal is NOT automatically a failed reauth. Reauth's contract
+    is "end up authenticated", not "delete a row", so having nothing to delete
+    is a satisfied precondition rather than an error — see the gate below.
     """
-    from local_operator.mcp.auth import mcp_logout_server
+    from local_operator.mcp.auth import mcp_logout_server, server_rejects_oauth
+    from local_operator.mcp.config import load_all_mcp_configs
 
     error = mcp_logout_server(name, cwd)
     if error is not None:
+        # ``mcp_logout_server`` gates on ``server_is_oauth_capable`` — the
+        # STRICT test, deliberately unwidened because other callers (the
+        # ``/mcp logout`` picker) need it to mean "we actually hold something
+        # here". On a url-only Codex import with a cold ledger and no stored
+        # row that is False, so reauth used to exit 1 with "does not use OAuth
+        # login" on precisely the server ``mcp login`` accepts one line later:
+        # a false statement AND a dead end, for the exact user this path exists
+        # for.
+        #
+        # Fixed HERE rather than by loosening the shared helper. Nothing stored
+        # means the delete was a no-op, and a no-op delete leaves reauth's own
+        # precondition (no credential to reuse) already satisfied — so fall
+        # through to the login, which IS the rest of reauth. The refusals that
+        # matter survive because they are re-made downstream, not skipped: an
+        # unknown name still errors here (``cfg is None``), a statically
+        # ineligible server — stdio, or a declared ``auth.type: apikey`` — is
+        # refused by ``server_rejects_oauth`` here, and a remote server that
+        # advertises no authorization server is refused by the live probe
+        # inside ``_mcp_login_server``. A typo still cannot open a browser tab.
+        configs, _sources = load_all_mcp_configs(cwd)
+        cfg = configs.get(name)
+        if cfg is not None and not server_rejects_oauth(cfg):
+            return await _mcp_login_server(name, cwd)
         print(f"error: MCP reauth failed for {name!r}: {error}", file=sys.stderr)
         return 1
     return await _mcp_login_server(name, cwd)

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -3606,6 +3606,7 @@ async def _mcp_login_server(name: str, cwd: Path) -> int:
     therefore survives this short-lived manager and future Local Operator
     sessions reuse it without another browser round-trip.
     """
+    from local_operator.mcp.auth import probe_oauth_capability, server_rejects_oauth
     from local_operator.mcp.config import load_all_mcp_configs
     from local_operator.mcp.manager import McpManager
 
@@ -3614,10 +3615,34 @@ async def _mcp_login_server(name: str, cwd: Path) -> int:
     if cfg is None:
         print(f"error: MCP server {name!r} is not configured", file=sys.stderr)
         return 1
-    auth = getattr(cfg, "auth", None)
-    if auth is None or auth.type != "oauth":
+    # NOT ``cfg.auth.type == 'oauth'`` any more — the same widening the TUI and
+    # runtime grant paths already made (issue #367). A config imported from a
+    # foreign tool (Codex) carries only a ``url``, because that tool keeps its
+    # OAuth grants elsewhere and its format has no auth block to copy. The
+    # static check refused those outright, so ``local-operator mcp login
+    # <codex-server>`` failed on exactly the servers ``/mcp login`` handles
+    # fine — two gates for one question, disagreeing.
+    #
+    # The split below preserves the F3 protection that motivated the strict
+    # check. ``server_rejects_oauth`` is the STATIC impossibility (a stdio
+    # server, or one whose config declares ``auth.type: apikey`` — the user
+    # stating how it authenticates), and it stays a free, hard refusal with the
+    # wording that tells them how to add an OAuth server. Only the genuinely
+    # undecidable url-only case pays for the live probe, which asks the network
+    # once instead of assuming every remote URL is authenticable.
+    if server_rejects_oauth(cfg):
         print(
             f"error: MCP server {name!r} is not OAuth-enabled; " "add a remote server with --oauth",
+            file=sys.stderr,
+        )
+        return 1
+    if not await probe_oauth_capability(cfg):
+        # Reachable only for a remote server that answered the probe without
+        # advertising an authorization server: it may be genuinely public, or
+        # discovery may be unreachable. Distinct wording, because "add a remote
+        # server with --oauth" is useless advice for a server that IS one.
+        print(
+            f"error: MCP server {name!r} does not use OAuth login",
             file=sys.stderr,
         )
         return 1

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -3680,38 +3680,21 @@ async def _mcp_reauth_server(name: str, cwd: Path) -> int:
     and then runs exactly the login connect path — one implementation of what
     "authenticated" means.
 
-    A failed removal is NOT automatically a failed reauth. Reauth's contract
-    is "end up authenticated", not "delete a row", so having nothing to delete
-    is a satisfied precondition rather than an error — see the gate below.
+    A failed removal is NOT automatically a failed reauth, and a successful
+    login is not automatically a successful reauth. Reauth's contract is "end
+    up authenticated having genuinely re-granted", not "delete a row", so
+    having nothing to delete is a satisfied precondition, while a delete that
+    was ATTEMPTED and failed leaves a credential the coming grant would
+    silently reuse. :func:`clear_for_reauth` is the single place that tells
+    those apart — shared with the TUI's ``/mcp reauth`` so the two cannot
+    answer one question differently, which is the defect this path exists to
+    remove. A remote server that advertises no authorization server is still
+    refused downstream by the live probe inside :func:`_mcp_login_server`.
     """
-    from local_operator.mcp.auth import mcp_logout_server, server_rejects_oauth
-    from local_operator.mcp.config import load_all_mcp_configs
+    from local_operator.mcp.auth import clear_for_reauth
 
-    error = mcp_logout_server(name, cwd)
+    error = clear_for_reauth(name, cwd)
     if error is not None:
-        # ``mcp_logout_server`` gates on ``server_is_oauth_capable`` — the
-        # STRICT test, deliberately unwidened because other callers (the
-        # ``/mcp logout`` picker) need it to mean "we actually hold something
-        # here". On a url-only Codex import with a cold ledger and no stored
-        # row that is False, so reauth used to exit 1 with "does not use OAuth
-        # login" on precisely the server ``mcp login`` accepts one line later:
-        # a false statement AND a dead end, for the exact user this path exists
-        # for.
-        #
-        # Fixed HERE rather than by loosening the shared helper. Nothing stored
-        # means the delete was a no-op, and a no-op delete leaves reauth's own
-        # precondition (no credential to reuse) already satisfied — so fall
-        # through to the login, which IS the rest of reauth. The refusals that
-        # matter survive because they are re-made downstream, not skipped: an
-        # unknown name still errors here (``cfg is None``), a statically
-        # ineligible server — stdio, or a declared ``auth.type: apikey`` — is
-        # refused by ``server_rejects_oauth`` here, and a remote server that
-        # advertises no authorization server is refused by the live probe
-        # inside ``_mcp_login_server``. A typo still cannot open a browser tab.
-        configs, _sources = load_all_mcp_configs(cwd)
-        cfg = configs.get(name)
-        if cfg is not None and not server_rejects_oauth(cfg):
-            return await _mcp_login_server(name, cwd)
         print(f"error: MCP reauth failed for {name!r}: {error}", file=sys.stderr)
         return 1
     return await _mcp_login_server(name, cwd)

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -3756,9 +3756,29 @@ def mcp_command(args: argparse.Namespace) -> int:
 
         return asyncio.run(_mcp_login_server(args.name, Path.cwd()))
     if args.mcp_command == "logout":
-        from local_operator.mcp.auth import mcp_logout_server
+        from local_operator.mcp.auth import McpCredentialDeleteError, mcp_logout_server
 
-        error = mcp_logout_server(args.name, Path.cwd())
+        try:
+            error = mcp_logout_server(args.name, Path.cwd())
+        except McpCredentialDeleteError as exc:
+            # The row was FOUND and its delete FAILED, so the credential is
+            # still on disk and this server is still logged in. That is a
+            # retryable condition — a sibling session holding an EXCLUSIVE
+            # sqlite transaction is enough to cause it — so it is reported as
+            # one error line like every other failure at this boundary.
+            #
+            # Caught rather than left to propagate: an escaping exception
+            # reaches ``main``'s generic handler, which prints a stack trace
+            # and "Please review and correct the error to continue". That
+            # frames a locked store as a bug in local-operator rather than
+            # something the user can act on, and buries the one sentence that
+            # matters — the credential survived — under 30 lines of traceback.
+            print(
+                f"error: MCP logout failed: {exc}. Retry once the process holding "
+                "the credential store has released it.",
+                file=sys.stderr,
+            )
+            return 1
         if error is not None:
             print(f"error: MCP logout failed: {error}", file=sys.stderr)
             return 1

--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -262,6 +262,34 @@ class AbandonedGrantError(Exception):
     """
 
 
+class McpCredentialDeleteError(RuntimeError):
+    """A stored MCP credential was found and its deletion FAILED — the row lives.
+
+    The distinction this type exists to make is between the two ways a removal
+    can decline to remove anything, which are opposite facts about the store:
+
+    * there was no row, so there is nothing to delete and the caller's
+      "no credential is stored here" precondition is already satisfied;
+    * there WAS a row, the delete was attempted, and it failed — so the old
+      grant and its client registration are still on disk.
+
+    Collapsing both into a falsey return (which :meth:`McpTokenStorage.clear`
+    used to do, swallowing the store's exception into a ``logger.debug``) let
+    ``mcp reauth`` treat a failed delete as "nothing was stored" and proceed
+    into the login still holding the old credential: the SDK reused the
+    surviving token and ``client_info``, no consent screen came back up, and
+    reauth exited 0 for the account switch or scope change that silently did
+    not happen. This is reachable rather than theoretical — a sibling session
+    holding an EXCLUSIVE sqlite transaction is enough to make
+    ``delete_credential`` raise ``OperationalError: database is locked``.
+
+    Raised rather than returned so a caller CANNOT accidentally read it as the
+    benign outcome: the two shapes no longer share a channel, and no caller has
+    to string-match a human-readable message to make a security-relevant
+    control-flow decision.
+    """
+
+
 def mcp_oauth_credential_id(server_url: str) -> str:
     """Stable logical credential id for one MCP server's OAuth grant."""
     return f"{MCP_OAUTH_CREDENTIAL_PREFIX}{server_url}"
@@ -456,6 +484,35 @@ class McpTokenStorage:
                 return row
         return None
 
+    def has_stored_row(self) -> bool | None:
+        """Whether ANY credential row exists for this server URL.
+
+        Three-valued on purpose, and ``None`` ("the store could not be read")
+        is deliberately NOT folded into ``False`` the way :meth:`_read` folds
+        it — same reasoning as :func:`mcp_logged_out_servers` and
+        :meth:`grant_marker`. The caller is :func:`clear_for_reauth`, which
+        uses this to decide whether a fresh grant could silently reuse
+        something still on disk; for that question an unreadable store means
+        "cannot rule it out", which must not read as "nothing is there".
+
+        Asks about the ROW, not about a grant: a ``client_info``-only row is
+        not a grant (see :func:`payload_carries_grant`) but it is exactly what
+        short-circuits DCR on the next login, so reauth has to count it.
+
+        No store at all is a definite ``False``: nothing can be persisted in
+        that environment, so nothing can be reused either — consistent with
+        :meth:`clear` reporting ``False`` there.
+        """
+        store = self._store
+        if store is None:
+            return False
+        try:
+            rows = store.list_credentials(MCP_OAUTH_PROVIDER)
+        except Exception:
+            logger.debug("MCP row lookup failed for %s", self.credential_id, exc_info=True)
+            return None
+        return any(row.identity_key == self.server_url for row in rows)
+
     def _read(self) -> dict[str, Any] | None:
         """Row payload for this server URL, or ``None`` (no store/no row)."""
         row = self._read_row()
@@ -488,7 +545,16 @@ class McpTokenStorage:
 
     def clear(self) -> bool:
         """Delete this server's credential row entirely (logout). Returns
-        ``True`` when a row existed and was removed.
+        ``True`` when a row existed and was removed, ``False`` when there was
+        nothing to remove, and RAISES :class:`McpCredentialDeleteError` when a
+        row was found and the delete failed.
+
+        Those are three outcomes, not two, and the third must not be reported
+        as the second: a caller that reads "the delete failed" as "nothing was
+        stored" concludes the credential is gone while it is still on disk.
+        See :class:`McpCredentialDeleteError` for what that cost ``mcp reauth``.
+        This method is ours alone — the SDK's ``TokenStorage`` protocol does
+        not declare it — so the contract is free to say so.
 
         The row carries BOTH the OAuth grant and any client registration
         (``seed_client_info`` pins it via ``project_id``, DCR writes it via
@@ -506,9 +572,12 @@ class McpTokenStorage:
             return False
         try:
             store.delete_credential(row.id)
-        except Exception:
+        except Exception as exc:
             logger.debug("MCP credential delete failed for %s", self.credential_id, exc_info=True)
-            return False
+            raise McpCredentialDeleteError(
+                f"could not delete the stored credential for {self.server_url} ({exc}) — "
+                "it is still in place, so a fresh grant would silently reuse it"
+            ) from exc
         return True
 
     async def get_tokens(self) -> OAuthToken | None:
@@ -994,6 +1063,13 @@ def mcp_logout_server(
     distinguishing from a successful removal (the caller's message says
     which).
 
+    A FAILED delete is none of those three and does not come back as a string
+    at all: it raises :class:`McpCredentialDeleteError`, because the row is
+    still on disk and a caller must not be able to mistake that for the benign
+    "nothing was stored" outcome. Every caller either handles it (see
+    :func:`clear_for_reauth`) or already funnels exceptions into its own
+    failure notice.
+
     The deletion goes through the REAL store (``_resolve_store(None)``), not
     the session manager's possibly-injected one: logout must remove the
     persisted row every future process will read, which is the shared
@@ -1060,6 +1136,113 @@ def mcp_logout_server(
         # would put an unverified fact in a ledger whose entries are supposed
         # to be observations.
         record_oauth_challenge(url, oauth_available=True)
+    return None
+
+
+def clear_for_reauth(
+    name: str,
+    cwd: str | os.PathLike[str],
+    store: StructuralAuthStore | None = None,
+    removed: list[str] | None = None,
+) -> str | None:
+    """Remove ``name``'s credential for a REAUTH. ``None`` when the login may
+    proceed, an error string when it must not.
+
+    ``removed`` is an out-parameter appended to only when a row was genuinely
+    deleted, mirroring ``run_grant``'s ``forgotten``. It exists because this
+    function now returns ``None`` for TWO outcomes — a real deletion and a
+    no-op on a server holding nothing — and a caller that warns "your
+    credential is gone" after a cancelled grant must not say so for the second.
+
+    Reauth's contract is "end up authenticated having genuinely re-granted",
+    which needs a weaker precondition than logout's: logout must actually
+    delete something, while reauth only needs to KNOW that nothing is left for
+    the coming grant to reuse. A no-op delete satisfies that; a failed one does
+    not. :func:`mcp_logout_server` reports both as an error string, so a caller
+    branching on ``error is not None`` refuses the first case (the bug this PR
+    fixes) and a caller branching on nothing at all accepts the second (a
+    successful-looking reauth over a live credential).
+
+    This function is the ONE place that distinction is made, so the CLI's
+    ``mcp reauth`` and the TUI's ``/mcp reauth`` cannot answer it differently —
+    two gates disagreeing about one question is the defect this PR exists to
+    remove, and shipping it in a new place would only move it.
+
+    The decision is structural at every step, never a string match on
+    :func:`mcp_logout_server`'s human-readable message: that message is prose
+    for a user, and reading control flow — security-relevant control flow — out
+    of it would break silently the first time somebody rewords it.
+
+    Three refusals survive, and each is re-made here rather than inherited:
+
+    * an unknown name (``cfg is None``) is a typo, which must never turn into
+      a browser tab;
+    * a statically ineligible server (stdio, or a declared non-OAuth
+      ``auth.type``) can never take a grant — the F3 protection;
+    * a row that is STILL THERE after everything below has tried to remove it,
+      because the next login would reuse it.
+
+    The last case needs one extra step rather than only a check. A
+    ``client_info``-only row is not a grant (:func:`payload_carries_grant`), so
+    on a cold ledger it does not make the server ``server_is_oauth_capable``
+    and :func:`mcp_logout_server` declines to touch it — yet it is exactly what
+    short-circuits DCR and denies the user the fresh registration they ran
+    reauth for. Reauth therefore removes it directly here: "delete what would
+    be reused" IS reauth's contract, where logout's stricter "only remove a
+    server we demonstrably hold something on" correctly protects the picker.
+    No evidence is lost by that directness — this path is reachable only when
+    the capability test was False, which for a readable row means it carried no
+    grant, so :func:`mcp_logout_server` would have had nothing to transfer.
+    """
+    from local_operator.mcp.config import load_all_mcp_configs
+
+    try:
+        error = mcp_logout_server(name, cwd, store)
+    except McpCredentialDeleteError as exc:
+        # The row was found and the delete failed, so it is still on disk.
+        # Loud and terminal: this is the case that used to masquerade as
+        # "nothing was stored" and let the grant reuse the old credential.
+        return str(exc)
+    if error is None:
+        if removed is not None:
+            removed.append(name)
+        return None
+
+    configs, _sources = load_all_mcp_configs(cwd)
+    cfg = configs.get(name)
+    if cfg is None or server_rejects_oauth(cfg):
+        return error
+
+    # Only remote configs carry ``url``; a stdio config was refused one line
+    # above, so this is type narrowing rather than a guess.
+    url = getattr(cfg, "url", "")
+    stored = McpTokenStorage(url, store).has_stored_row()
+    if stored is None:
+        # Unreadable store. "Cannot rule out a surviving credential" is not
+        # "there is none" — refusing costs the user a retry, while proceeding
+        # costs them a reauth that silently did nothing.
+        return (
+            f"could not read the credential store for MCP server {name!r}, so it is "
+            "unknown whether a fresh grant would reuse an existing credential"
+        )
+    if stored:
+        storage = McpTokenStorage(url, store)
+        try:
+            deleted = storage.clear()
+        except McpCredentialDeleteError as exc:
+            return str(exc)
+        if deleted and removed is not None:
+            removed.append(name)
+        # Re-read rather than trusting the return: the point of this gate is
+        # the state of the store, not the outcome of one call, and a racing
+        # writer between the two is the whole reason this refusal exists.
+        if McpTokenStorage(url, store).has_stored_row() is not False:
+            return (
+                f"the stored credential for MCP server {name!r} is still in place after the "
+                "removal, so a fresh grant would silently reuse it"
+            )
+    # Nothing is stored: the delete was a no-op and reauth's precondition is
+    # already satisfied. This is the url-only Codex import the PR is about.
     return None
 
 

--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -1000,9 +1000,46 @@ def mcp_logout_server(
     # Only remote configs carry ``url``; a stdio config reaching here would
     # have already failed the OAuth check above, so the getattr is a type
     # narrowing rather than a guess.
-    storage = McpTokenStorage(getattr(cfg, "url", ""), store)
+    url = getattr(cfg, "url", "")
+    # Read the durable evidence BEFORE destroying it — see the transfer below.
+    had_stored_grant = server_has_stored_grant(url, store)
+    storage = McpTokenStorage(url, store)
     if not storage.clear():
         return f"no stored credential for MCP server {name!r} — nothing to log out of"
+    if had_stored_grant:
+        # EVIDENCE TRANSFER, not a guess. ``server_is_oauth_capable`` accepts
+        # three kinds of evidence that a server authenticates over OAuth: an
+        # explicit ``auth.type: oauth`` block, a stored grant for its URL, and
+        # an observed 401 challenge in ``OAUTH_CHALLENGES``. A config imported
+        # from a foreign tool (Codex, issue #367) carries only a ``url``, so
+        # the stored grant is its ONLY evidence — and the delete above is what
+        # erases it.
+        #
+        # That erasure is what broke ``/mcp reauth`` on those servers. Reauth
+        # is a delete followed by a reconnect, and the reconnect re-asks
+        # ``server_is_oauth_capable`` (via ``_build_oauth_auth``): with the row
+        # gone and the ledger cold, it answered False, attached no OAuth
+        # provider, and the connect went out unauthenticated and took a 401.
+        # The gate that authorised the reauth had already short-circuited on
+        # the very row being deleted, so nothing re-established the fact. It
+        # was intermittent only because the ledger is per-process: a session
+        # that had already watched this server 401 was warm and worked.
+        #
+        # Holding a token for ``url`` is STRONGER proof than the discovery
+        # probe that normally populates this ledger — an authorization server
+        # did not merely advertise itself, it issued us a grant — so recording
+        # it as an observed challenge asserts only what we just read. The
+        # record is deliberately made HERE, at the single point that destroys
+        # the row, so no caller can delete a credential without preserving
+        # what it proved (``/mcp reauth``, the CLI's ``mcp reauth``, and the
+        # desktop grant runner all funnel through this function).
+        #
+        # Scoped to ``had_stored_grant`` on purpose: a server that qualified
+        # only through a declared ``auth.type: oauth`` block keeps qualifying
+        # without the ledger, and claiming a discovery result we never ran
+        # would put an unverified fact in a ledger whose entries are supposed
+        # to be observations.
+        record_oauth_challenge(url, oauth_available=True)
     return None
 
 

--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -1066,9 +1066,23 @@ def mcp_logout_server(
     A FAILED delete is none of those three and does not come back as a string
     at all: it raises :class:`McpCredentialDeleteError`, because the row is
     still on disk and a caller must not be able to mistake that for the benign
-    "nothing was stored" outcome. Every caller either handles it (see
-    :func:`clear_for_reauth`) or already funnels exceptions into its own
-    failure notice.
+    "nothing was stored" outcome.
+
+    That raise is part of the contract, so every call site handles it. Named
+    rather than asserted, because "all callers handle this" is a claim that
+    silently decays the moment somebody adds the next caller — and it already
+    did once: ``mcp logout`` was left bare when the raise was introduced, and
+    a locked store printed a stack trace where it used to print one line.
+
+    * :func:`clear_for_reauth` catches it explicitly in both of its arms and
+      converts it into the refusal that stops the login;
+    * ``cli.mcp_command``'s ``logout`` branch catches it and prints one error
+      line, because reaching ``main``'s generic handler means a traceback;
+    * :func:`~local_operator.mcp.grants.logout_server` and
+      :func:`~local_operator.mcp.grants.clear_for_reauth_server` funnel it
+      through their ``except Exception`` into a notice body;
+    * the TUI's ``_mcp_logout`` wraps both verbs in one ``except Exception``
+      that becomes a system notice.
 
     The deletion goes through the REAL store (``_resolve_store(None)``), not
     the session manager's possibly-injected one: logout must remove the

--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -841,6 +841,19 @@ def server_has_stored_grant(server_url: str, store: StructuralAuthStore | None =
     except Exception:  # noqa: BLE001 — the store is best-effort here
         logger.debug("stored-grant lookup failed for %s", server_url, exc_info=True)
         return False
+    return payload_carries_grant(payload)
+
+
+def payload_carries_grant(payload: dict[str, Any] | None) -> bool:
+    """Whether a credential row payload holds an actual OAuth grant.
+
+    Split out of :func:`server_has_stored_grant` so the grant-vs-registration
+    distinction it documents lives in ONE place. ``mcp_logout_server`` needs
+    the same answer about a row it has already opened a storage for, and
+    re-deriving the test there would put this rule in two places — the drift
+    risk that matters most for a predicate whose whole point is that a
+    ``client_info``-only row is not a grant.
+    """
     if not payload:
         return False
     tokens = payload.get("tokens")
@@ -1001,19 +1014,26 @@ def mcp_logout_server(
     # have already failed the OAuth check above, so the getattr is a type
     # narrowing rather than a guess.
     url = getattr(cfg, "url", "")
-    # Read the durable evidence BEFORE destroying it — see the transfer below.
-    had_stored_grant = server_has_stored_grant(url, store)
     storage = McpTokenStorage(url, store)
+    # Read the durable evidence BEFORE destroying it — see the transfer below.
+    # Derived from THIS storage rather than via ``server_has_stored_grant``,
+    # which would open a second ``AuthStore`` (and a second sqlite connection)
+    # for a row we are about to open one for anyway.
+    #
+    # An unreadable store makes this False, so the transfer is skipped in
+    # exactly the case where the evidence is most likely to be lost for good.
+    # That is the deliberate direction and not an oversight: recording a
+    # challenge we could not substantiate would write a fact we never observed
+    # into an observation-only ledger, and the two reads here hit the same
+    # store microseconds apart, so a read that fails while the delete below
+    # succeeds is a very narrow window. Silence is the conservative error.
+    had_stored_grant = payload_carries_grant(storage._read())
     if not storage.clear():
         return f"no stored credential for MCP server {name!r} — nothing to log out of"
     if had_stored_grant:
-        # EVIDENCE TRANSFER, not a guess. ``server_is_oauth_capable`` accepts
-        # three kinds of evidence that a server authenticates over OAuth: an
-        # explicit ``auth.type: oauth`` block, a stored grant for its URL, and
-        # an observed 401 challenge in ``OAUTH_CHALLENGES``. A config imported
-        # from a foreign tool (Codex, issue #367) carries only a ``url``, so
-        # the stored grant is its ONLY evidence — and the delete above is what
-        # erases it.
+        # EVIDENCE TRANSFER, not a guess — for the three kinds of evidence and
+        # why a url-only Codex import (issue #367) has only this one, see
+        # :func:`server_is_oauth_capable`. The delete above is what erases it.
         #
         # That erasure is what broke ``/mcp reauth`` on those servers. Reauth
         # is a delete followed by a reconnect, and the reconnect re-asks

--- a/local_operator/mcp/grants.py
+++ b/local_operator/mcp/grants.py
@@ -134,6 +134,25 @@ def logout_server(name: str) -> str | None:
         return str(exc)
 
 
+def clear_for_reauth_server(name: str, removed: list[str] | None = None) -> str | None:
+    """Remove ``name``'s credential for a REAUTH. Error body, or ``None``.
+
+    Reauth needs a different precondition from logout — "nothing is left for
+    the coming grant to reuse" rather than "something was deleted" — and
+    :func:`~local_operator.mcp.auth.clear_for_reauth` is the ONE place that
+    distinction is made, shared with the CLI's ``mcp reauth`` so the two
+    surfaces cannot disagree about the same state. This wrapper only supplies
+    the cwd and keeps a failure a notice rather than a crash, exactly as
+    :func:`logout_server` does for the logout verb.
+    """
+    from local_operator.mcp.auth import clear_for_reauth
+
+    try:
+        return clear_for_reauth(name, os.getcwd(), removed=removed)
+    except Exception as exc:  # noqa: BLE001 — a failed removal is a notice, not a crash
+        return str(exc)
+
+
 async def run_grant(
     manager: Any, sub: str, name: str, forgotten: list[str] | None = None
 ) -> tuple[str, NoticeKind]:
@@ -172,11 +191,20 @@ async def run_grant(
         )
 
     if sub == "reauth":
-        error = logout_server(name)
+        # NOT ``logout_server``: reauth's precondition is "nothing is left to
+        # reuse", which a no-op delete already satisfies and a FAILED delete
+        # does not. Using the logout gate here refused a url-only server that
+        # simply had nothing stored (the CLI's own bug, one gate over) while
+        # accepting a delete that raised with the row still on disk. Both
+        # answers now come from the same helper the CLI calls.
+        # ``forgotten`` is passed THROUGH rather than appended to here: the
+        # gate now returns success for a no-op removal too (a server holding
+        # nothing), and telling a user whose grant was cancelled that their
+        # credential is gone would be false for that case. Only a real
+        # deletion appends.
+        error = clear_for_reauth_server(name, forgotten)
         if error is not None:
             return f"MCP reauth failed for {name!r}: {error}", "warning"
-        if forgotten is not None:
-            forgotten.append(name)
         try:
             await manager.disconnect_server(name)
         except Exception:  # noqa: BLE001 — a stuck teardown must not block the grant

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -30643,11 +30643,21 @@ class OperatorApp(App[None]):
     ) -> bool:
         """Remove the stored OAuth credential for ``name`` and disconnect it.
 
-        Returns whether the removal happened, so ``reauth`` can chain into the
-        login only when the old grant is actually gone. Deletion goes through
-        the module helper, which writes to the shared ``auth.db`` — the row
-        every future session will read — rather than any store this one
-        session was injected with.
+        Returns whether the login may proceed, so ``reauth`` can chain into it
+        only when no credential is left for a fresh grant to reuse. Deletion
+        goes through the module helper, which writes to the shared ``auth.db``
+        — the row every future session will read — rather than any store this
+        one session was injected with.
+
+        The two verbs ask DIFFERENT questions of that removal, so they call
+        different gates. Logout must actually delete something and reports a
+        no-op as a failure. Reauth only needs to know that nothing survives for
+        the coming grant to reuse: a server holding nothing already satisfies
+        that (and used to be refused here), while a delete that was attempted
+        and FAILED does not (and used to look like the former). That is
+        :func:`~local_operator.mcp.auth.clear_for_reauth`, shared with the
+        CLI's ``mcp reauth`` and with ``run_grant`` so all three surfaces
+        answer one question the same way.
 
         The live connection is torn down too, deliberately AFTER the row is
         deleted: the manager's auto-reconnect would otherwise read the stored
@@ -30661,10 +30671,13 @@ class OperatorApp(App[None]):
         logout can honestly leave behind — the tools drop out on the next
         tools-changed repaint.
         """
-        from local_operator.mcp.auth import mcp_logout_server
+        from local_operator.mcp.auth import clear_for_reauth, mcp_logout_server
 
         try:
-            error = mcp_logout_server(name, os.getcwd())
+            if verb == "reauth":
+                error = clear_for_reauth(name, os.getcwd())
+            else:
+                error = mcp_logout_server(name, os.getcwd())
         except Exception as exc:  # noqa: BLE001 — a failed logout is a notice, not a crash
             self._system_notice(f"MCP {verb} failed for {name!r}: {exc}", "error")
             return False

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -413,6 +413,57 @@ class TestLogoutHelpers:
         not_oauth = mcp_logout_server("stdio", Path("/anywhere")) or ""
         assert "does not use OAuth" in not_oauth
 
+    def test_deleting_a_url_only_grant_preserves_what_it_proved(self, monkeypatch) -> None:
+        """The ``/mcp reauth`` regression: the delete must not erase capability.
+
+        A Codex-imported config is url-only, so its stored grant is its ONLY
+        evidence under ``server_is_oauth_capable``. Reauth deletes that row and
+        immediately reconnects, and the reconnect re-asks the same question:
+        without this transfer it answered False, attached no OAuth provider,
+        and the connect went out unauthenticated and took a 401.
+        """
+        url = "https://codex.example/mcp"
+        auth_mod.OAUTH_CHALLENGES.clear()
+        monkeypatch.setattr(
+            "local_operator.mcp.config.load_all_mcp_configs",
+            lambda cwd: ({"codex": MCPHttpServerConfig(url=url)}, {}),
+        )
+        store = FakeAuthStore()
+        McpTokenStorage(url, store)._write({"tokens": {"access_token": "a"}})
+
+        assert mcp_logout_server("codex", Path("/anywhere"), store) is None
+        assert auth_mod.server_has_stored_grant(url, store) is False
+        # The row is gone, but the server is still known to take OAuth.
+        assert auth_mod.server_is_oauth_capable(MCPHttpServerConfig(url=url), store) is True
+
+    def test_deleting_a_registration_only_row_records_no_challenge(self, monkeypatch) -> None:
+        """Only a grant we actually HELD is evidence of a live challenge.
+
+        The row deleted here carries just a dynamic client registration — the
+        artifact the SDK writes when it merely DISCOVERS a server, before anyone
+        authorizes (see ``server_has_stored_grant``). Deleting it proves nothing
+        was ever issued, so recording an observed 401 for that URL would put a
+        fact we never established into an observation-only ledger. The config's
+        explicit ``auth.type: oauth`` is what keeps this server capable, and it
+        needs no ledger entry to stay that way.
+        """
+        url = "https://declared.example/mcp"
+        auth_mod.OAUTH_CHALLENGES.clear()
+        cfg = MCPHttpServerConfig(url=url, auth=MCPAuthConfig(type="oauth"))
+        monkeypatch.setattr(
+            "local_operator.mcp.config.load_all_mcp_configs",
+            lambda cwd: ({"declared": cfg}, {}),
+        )
+        store = FakeAuthStore()
+        McpTokenStorage(url, store).seed_client_info("client-1")
+        assert auth_mod.server_has_stored_grant(url, store) is False
+
+        # The delete succeeds: a registration row exists and is removed.
+        assert mcp_logout_server("declared", Path("/anywhere"), store) is None
+        assert url not in auth_mod.OAUTH_CHALLENGES
+        # Still capable — on the declared block alone, as it should be.
+        assert auth_mod.server_is_oauth_capable(cfg, store) is True
+
     def test_logged_out_servers_keys_by_url(self) -> None:
         """The picker list is keyed by server NAME but the store by URL; the
         helper returns the store's keys so the caller can do the mapping."""

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -22,8 +22,10 @@ from local_operator.mcp.auth import (
     DEFAULT_CALLBACK_PATH,
     DEFAULT_CALLBACK_PORT,
     MCP_OAUTH_PROVIDER,
+    McpCredentialDeleteError,
     McpTokenStorage,
     StructuralAuthStore,
+    clear_for_reauth,
     mcp_logged_out_servers,
     mcp_logout_server,
     mcp_oauth_credential_id,
@@ -267,10 +269,16 @@ class TestMcpTokenStorage:
         storage._store = None
         assert storage.clear() is False
 
-    def test_clear_when_the_delete_itself_fails_reports_false_and_keeps_the_row(self) -> None:
-        """The case the reauth safety depends on: a FAILED delete must never
-        be reported as a successful logout — clear() is False and the row
-        survives, so the caller refuses to run a "fresh" grant on top of it."""
+    def test_clear_when_the_delete_itself_fails_raises_and_keeps_the_row(self) -> None:
+        """The case the reauth safety depends on: a FAILED delete must never be
+        reported as a successful logout, NOR as the benign "nothing was stored".
+
+        It used to return False for both, and that single falsey channel is
+        what let ``mcp reauth`` read a delete that raised as "the row was
+        already gone" and log in over the surviving credential. Raising gives
+        the two outcomes different channels, so no caller can conflate them by
+        accident and none has to string-match a message to tell them apart.
+        """
 
         class RefusingStore(FakeAuthStore):
             def delete_credential(self, credential_id: int) -> None:
@@ -279,8 +287,30 @@ class TestMcpTokenStorage:
         store = RefusingStore()
         storage = McpTokenStorage("https://srv.example/mcp", store)
         storage._write({"tokens": {"access_token": "a"}})
-        assert storage.clear() is False
+        with pytest.raises(McpCredentialDeleteError, match="still in place"):
+            storage.clear()
+        # The row survives — which is the whole reason the failure is loud.
         assert len(store.list_credentials(MCP_OAUTH_PROVIDER)) == 1
+
+    def test_clear_distinguishes_an_absent_row_from_a_failed_delete(self) -> None:
+        """Both used to be ``False``; only one means "nothing is stored here".
+
+        The distinction is the fix, so it gets a test that fails if the two
+        ever share a channel again — the observation gap that let a widened
+        fall-through ship past a green suite.
+        """
+
+        class RefusingStore(FakeAuthStore):
+            def delete_credential(self, credential_id: int) -> None:
+                raise RuntimeError("database is locked")
+
+        absent = McpTokenStorage("https://srv.example/mcp", FakeAuthStore())
+        assert absent.clear() is False  # no row: a reportable no-op
+
+        blocked = McpTokenStorage("https://srv.example/mcp", RefusingStore())
+        blocked._write({"tokens": {"access_token": "a"}})
+        with pytest.raises(McpCredentialDeleteError):
+            blocked.clear()  # a row that is still there: never a no-op
 
 
 class TestRealAuthStoreConformance:
@@ -402,6 +432,31 @@ class TestLogoutHelpers:
         error = mcp_logout_server("linear", Path("/anywhere"), FakeAuthStore())
         assert error is not None and "nothing to log out of" in error
 
+    def test_logout_surfaces_a_failed_delete_as_a_raise_not_an_error_string(
+        self, monkeypatch
+    ) -> None:
+        """A failed delete must not join the "nothing stored" error channel.
+
+        ``mcp_logout_server`` reports its three benign failures as strings, so
+        a caller branching on ``error is not None`` cannot distinguish them —
+        which is why the row-survives case leaves through a different door.
+        """
+        monkeypatch.setattr(
+            "local_operator.mcp.config.load_all_mcp_configs",
+            lambda cwd: (self._configs(), {}),
+        )
+
+        class RefusingStore(FakeAuthStore):
+            def delete_credential(self, credential_id: int) -> None:
+                raise RuntimeError("database is locked")
+
+        store = RefusingStore()
+        McpTokenStorage("https://mcp.linear.app/mcp", store)._write(
+            {"tokens": {"access_token": "a"}}
+        )
+        with pytest.raises(McpCredentialDeleteError):
+            mcp_logout_server("linear", Path("/anywhere"), store)
+
     def test_logout_of_unknown_or_non_oauth_server_is_an_error(self, monkeypatch) -> None:
         """A name the config does not know is a typo the user wants told
         about — silently succeeding would claim a credential was removed."""
@@ -485,6 +540,136 @@ class TestLogoutHelpers:
                 raise RuntimeError("database is locked")
 
         assert mcp_logged_out_servers(ExplodingStore()) is None
+
+
+class TestClearForReauth:
+    """``clear_for_reauth`` — the ONE gate both reauth surfaces ask.
+
+    Reauth needs a weaker precondition than logout ("nothing is left for the
+    coming grant to reuse", not "something was deleted") and a stricter one
+    than nothing at all. Every outcome below used to be answered differently by
+    the CLI arm and the TUI arm, or collapsed into a single error channel.
+    """
+
+    URL = "https://codex.example/mcp"
+
+    def _pin(self, monkeypatch, store, cfg=None) -> None:
+        """Point config discovery and store resolution at the fakes.
+
+        ``_resolve_store`` is stubbed the way the real one behaves — an
+        explicitly passed store wins, ``None`` falls back — because the gate
+        re-reads the store to confirm the row is gone, and a stub that ignored
+        its argument would silently redirect an injected store.
+        """
+        cfg = cfg if cfg is not None else MCPHttpServerConfig(url=self.URL)
+        auth_mod.OAUTH_CHALLENGES.clear()
+        monkeypatch.setattr(
+            "local_operator.mcp.config.load_all_mcp_configs",
+            lambda cwd: ({"codex": cfg}, {}),
+        )
+        monkeypatch.setattr(auth_mod, "_resolve_store", lambda given: given or store)
+
+    def test_nothing_stored_lets_the_login_proceed(self, monkeypatch) -> None:
+        """The PR's bug: a url-only Codex import with a cold ledger and no row
+        satisfies none of ``server_is_oauth_capable``'s evidence kinds, so the
+        removal declines — but a no-op delete leaves reauth's precondition
+        already met, so it must fall through rather than dead-end."""
+        store = FakeAuthStore()
+        self._pin(monkeypatch, store)
+        removed: list[str] = []
+        assert clear_for_reauth("codex", Path("/anywhere"), store, removed) is None
+        # Nothing was deleted, so the cancellation notice must not claim it was.
+        assert removed == []
+
+    def test_a_real_grant_is_deleted_and_reported_as_removed(self, monkeypatch) -> None:
+        store = FakeAuthStore()
+        McpTokenStorage(self.URL, store)._write({"tokens": {"access_token": "a"}})
+        self._pin(monkeypatch, store)
+        removed: list[str] = []
+        assert clear_for_reauth("codex", Path("/anywhere"), store, removed) is None
+        assert store.list_credentials(MCP_OAUTH_PROVIDER) == []
+        assert removed == ["codex"]
+
+    def test_a_failed_delete_refuses_loudly(self, monkeypatch) -> None:
+        """THE regression this round exists for.
+
+        A delete that raised used to be indistinguishable from "nothing was
+        stored", so reauth fell through and logged in over a credential still
+        on disk: the SDK reused the token and ``client_info``, no consent
+        screen appeared, and reauth exited 0 for the account switch that
+        silently did not happen. Reachable via ``database is locked`` from a
+        concurrent writer.
+        """
+
+        class RefusingStore(FakeAuthStore):
+            def delete_credential(self, credential_id: int) -> None:
+                raise RuntimeError("database is locked")
+
+        store = RefusingStore()
+        McpTokenStorage(self.URL, store)._write({"tokens": {"access_token": "OLD"}})
+        self._pin(monkeypatch, store)
+        removed: list[str] = []
+        error = clear_for_reauth("codex", Path("/anywhere"), store, removed)
+        assert error is not None and "still in place" in error
+        # The row survives — which is exactly why the grant must not run.
+        assert len(store.list_credentials(MCP_OAUTH_PROVIDER)) == 1
+        assert removed == []
+
+    def test_a_client_info_only_row_is_removed_rather_than_refused(self, monkeypatch) -> None:
+        """Not a grant, but exactly what short-circuits DCR on the next login.
+
+        ``payload_carries_grant`` is False here, so on a cold ledger the server
+        is not ``server_is_oauth_capable`` and the removal declines to touch
+        it. Leaving it would deny the user the fresh registration they ran
+        reauth for, so the gate deletes it directly — "remove what would be
+        reused" IS reauth's contract.
+        """
+        store = FakeAuthStore()
+        McpTokenStorage(self.URL, store).seed_client_info("client-1")
+        self._pin(monkeypatch, store)
+        removed: list[str] = []
+        assert clear_for_reauth("codex", Path("/anywhere"), store, removed) is None
+        assert store.list_credentials(MCP_OAUTH_PROVIDER) == []
+        assert removed == ["codex"]
+
+    def test_an_unreadable_store_refuses_rather_than_assuming_empty(self, monkeypatch) -> None:
+        """ "Cannot rule out a surviving credential" is not "there is none".
+
+        Refusing costs the user a retry; proceeding costs them a reauth that
+        silently did nothing — so the unknown resolves toward the refusal.
+        """
+
+        class BlindStore(FakeAuthStore):
+            def list_credentials(  # type: ignore[no-untyped-def]
+                self, provider=None, include_disabled=False
+            ):
+                raise RuntimeError("database is locked")
+
+        store = BlindStore()
+        self._pin(monkeypatch, store)
+        error = clear_for_reauth("codex", Path("/anywhere"), store)
+        assert error is not None and "could not read the credential store" in error
+
+    def test_static_refusals_survive_the_fall_through(self, monkeypatch) -> None:
+        """The F3 protection: falling through on a declined removal must not
+        let a typo or an API-key server reach a browser tab."""
+        configs = {
+            "apikey": MCPHttpServerConfig(
+                url="https://api.example/mcp", auth=MCPAuthConfig(type="apikey")
+            ),
+            "stdio": MCPStdioServerConfig(command="run-me"),
+        }
+        auth_mod.OAUTH_CHALLENGES.clear()
+        monkeypatch.setattr(
+            "local_operator.mcp.config.load_all_mcp_configs",
+            lambda cwd: (configs, {}),
+        )
+        store = FakeAuthStore()
+        for name in ("apikey", "stdio"):
+            error = clear_for_reauth(name, Path("/anywhere"), store)
+            assert error is not None and "does not use OAuth" in error
+        unknown = clear_for_reauth("nosuch", Path("/anywhere"), store)
+        assert unknown is not None and "not configured" in unknown
 
 
 class TestCallbackInputParsing:

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -31,6 +31,7 @@ from local_operator.mcp.auth import (
     mcp_oauth_credential_id,
     oauth_server_names,
     parse_oauth_callback_input,
+    payload_carries_grant,
     wire_oauth_auth,
 )
 from local_operator.mcp.config import (
@@ -631,6 +632,52 @@ class TestClearForReauth:
         assert clear_for_reauth("codex", Path("/anywhere"), store, removed) is None
         assert store.list_credentials(MCP_OAUTH_PROVIDER) == []
         assert removed == ["codex"]
+
+    def test_a_client_info_only_row_that_cannot_be_deleted_refuses(self, monkeypatch) -> None:
+        """The SECOND arm's failed delete — the one no test reached.
+
+        The two cases above cover this gate's arms separately: a grant row
+        whose delete fails (refused) and a ``client_info``-only row that
+        deletes cleanly (removed). Their intersection is its own path — the
+        direct removal in the second arm, reached only when the capability
+        test was False — and mutating away either of its guards left all 261
+        tests green, so nothing pinned it.
+
+        It has to refuse for the same reason the first arm does, and the
+        reason is stronger here than "a row survived": a surviving
+        ``client_info`` short-circuits DCR, so the login would reuse the very
+        registration the user ran reauth to replace, and would do it while
+        reporting success. ``removed`` must stay empty — a caller that warns
+        "your credential is gone" after a cancelled grant must not say so for
+        a row that is still on disk.
+
+        The refusal is DOUBLE-COVERED and both layers are load-bearing:
+        the ``except`` here, and the re-read below that asks the store rather
+        than trusting the call's return. Measured, not assumed — swallowing
+        the exception alone still leaves this test green, because the re-read
+        catches it; only removing BOTH lets the reauth proceed. That is
+        defence in depth against a racing writer, not redundancy, so neither
+        layer may be deleted as "already handled by the other".
+        """
+
+        class RefusingStore(FakeAuthStore):
+            def delete_credential(self, credential_id: int) -> None:
+                raise RuntimeError("database is locked")
+
+        store = RefusingStore()
+        McpTokenStorage(self.URL, store).seed_client_info("client-1")
+        self._pin(monkeypatch, store)
+        # The precondition that puts us in the second arm at all: no grant, so
+        # the strict capability test is False and the first removal declines.
+        # Asserted rather than assumed — if this were a grant the test would
+        # silently exercise the arm above and prove nothing new.
+        assert payload_carries_grant(McpTokenStorage(self.URL, store)._read()) is False
+
+        removed: list[str] = []
+        error = clear_for_reauth("codex", Path("/anywhere"), store, removed)
+        assert error is not None and "still in place" in error
+        assert len(store.list_credentials(MCP_OAUTH_PROVIDER)) == 1  # really survived
+        assert removed == []
 
     def test_an_unreadable_store_refuses_rather_than_assuming_empty(self, monkeypatch) -> None:
         """ "Cannot rule out a surviving credential" is not "there is none".

--- a/tests/unit/mcp/test_grants.py
+++ b/tests/unit/mcp/test_grants.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import pytest
 
+from local_operator.mcp import auth as auth_mod
 from local_operator.mcp.grants import (
     GRANT_SUBCOMMANDS,
     REMOTE_GRANT_NOTICE,
@@ -20,6 +21,12 @@ from local_operator.mcp.grants import (
     run_grant,
     start_grant,
 )
+
+#: The genuine credential delete, captured at IMPORT time. The autouse fixture
+#: below replaces the module attribute for every test, so a test that needs the
+#: real deletion (against an injected store) cannot recover it by reading the
+#: module afterwards — it would get the fake back and pass vacuously.
+_REAL_MCP_LOGOUT = auth_mod.mcp_logout_server
 
 
 class _Conn:
@@ -525,3 +532,64 @@ async def test_the_last_notice_never_claims_a_deleted_credential_is_intact(
     assert "the stored credential is unchanged" not in last, last
     # Whatever it says, it must leave the user with the step that fixes it.
     assert "/mcp login notion" in last, last
+
+
+@pytest.mark.asyncio
+async def test_reauth_on_a_url_only_server_reconnects_authenticated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The operator's bug: `/mcp reauth` 401'd where `/mcp login` then worked.
+
+    Runs the REAL credential delete (the autouse fake is opted out of via an
+    injected store) because the delete is where the defect lived. A
+    Codex-imported config is url-only, so the stored grant is its only evidence
+    under ``server_is_oauth_capable``; reauth deleted it and then re-asked the
+    same question, got False, attached no OAuth provider, and connected
+    unauthenticated. Intermittent only because the challenge ledger is
+    per-process — a session that had already seen this server 401 was warm.
+    """
+    from local_operator.mcp.config import MCPHttpServerConfig
+
+    url = "https://codex.example/mcp"
+    cfg = MCPHttpServerConfig(url=url)
+    auth_mod.OAUTH_CHALLENGES.clear()
+
+    from tests.unit.mcp.test_auth import FakeAuthStore
+
+    store = FakeAuthStore()
+    auth_mod.McpTokenStorage(url, store)._write({"tokens": {"access_token": "a"}})
+    monkeypatch.setattr(
+        "local_operator.mcp.config.load_all_mcp_configs",
+        lambda cwd: ({"codex": cfg}, {}),
+    )
+    # Undo the autouse logout stub and run the REAL delete against an
+    # in-memory store: the delete is the code under test here, so a fake that
+    # skips it would leave the stored-grant evidence intact and pass either
+    # way. The store is injected, so the developer's real auth.db is untouched.
+    monkeypatch.setattr(
+        "local_operator.mcp.auth.mcp_logout_server",
+        lambda name, cwd: _REAL_MCP_LOGOUT(name, cwd, store),
+    )
+
+    class _AuthAwareManager(_Manager):
+        """Records the answer ``_build_oauth_auth`` gets at reconnect time."""
+
+        capable_at_connect: bool | None = None
+
+        async def connect_configured_server(
+            self, name: str, *, timeout_ms: float | None = None
+        ) -> _Conn:
+            self.capable_at_connect = auth_mod.server_is_oauth_capable(cfg, store)
+            if not self.capable_at_connect:
+                raise RuntimeError(f"MCP server at {url} refused the connection (401)")
+            return await super().connect_configured_server(name, timeout_ms=timeout_ms)
+
+    manager = _AuthAwareManager(cfg=cfg)
+    text, kind = await run_grant(manager, "reauth", "codex")
+
+    # The row really was deleted — reauth stays destructive-then-constructive.
+    assert auth_mod.server_has_stored_grant(url, store) is False
+    # ...but the fact it proved survived the delete, so OAuth is still wired.
+    assert manager.capable_at_connect is True
+    assert kind == "success", text
+    assert "refused the connection (401)" not in text

--- a/tests/unit/mcp/test_grants.py
+++ b/tests/unit/mcp/test_grants.py
@@ -535,7 +535,7 @@ async def test_the_last_notice_never_claims_a_deleted_credential_is_intact(
 
 
 @pytest.mark.asyncio
-async def test_reauth_on_a_url_only_server_reconnects_authenticated(
+async def test_reauth_run_grant_on_a_url_only_server_reconnects_authenticated(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The operator's bug: `/mcp reauth` 401'd where `/mcp login` then worked.

--- a/tests/unit/mcp/test_grants.py
+++ b/tests/unit/mcp/test_grants.py
@@ -87,7 +87,11 @@ def _no_real_credential_writes(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     """Never touch the developer's real ``auth.db`` from a unit test."""
     removed: list[str] = []
 
-    def _fake_logout(name: str, cwd: str) -> str | None:
+    # Mirrors the real helper's full signature, ``store`` included: the reauth
+    # gate passes it positionally, and a two-argument fake would raise a
+    # TypeError that the gate reports as a failed removal — a green-looking
+    # refusal caused entirely by the stub.
+    def _fake_logout(name: str, cwd: str, store: Any = None) -> str | None:
         removed.append(name)
         return None
 
@@ -568,8 +572,11 @@ async def test_reauth_run_grant_on_a_url_only_server_reconnects_authenticated(
     # way. The store is injected, so the developer's real auth.db is untouched.
     monkeypatch.setattr(
         "local_operator.mcp.auth.mcp_logout_server",
-        lambda name, cwd: _REAL_MCP_LOGOUT(name, cwd, store),
+        lambda name, cwd, _store=None: _REAL_MCP_LOGOUT(name, cwd, store),
     )
+    # The gate re-reads the store directly to confirm nothing survived the
+    # delete, and resolves the REAL ``auth.db`` to do it unless pinned here.
+    monkeypatch.setattr(auth_mod, "_resolve_store", lambda given: given or store)
 
     class _AuthAwareManager(_Manager):
         """Records the answer ``_build_oauth_auth`` gets at reconnect time."""
@@ -593,3 +600,74 @@ async def test_reauth_run_grant_on_a_url_only_server_reconnects_authenticated(
     assert manager.capable_at_connect is True
     assert kind == "success", text
     assert "refused the connection (401)" not in text
+
+
+@pytest.mark.asyncio
+async def test_reauth_run_grant_agrees_with_the_cli_on_every_removal_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The TUI and CLI reauth arms must answer one question identically.
+
+    This PR's thesis is that two gates disagreeing about one state is the
+    defect, so a fix that made the CLI fall through while ``run_grant`` still
+    refused would only move the defect rather than remove it (QA round 2, Q1
+    addendum). Both arms now call ``clear_for_reauth``; this pins the three
+    outcomes that used to diverge, driving the REAL gate over an injected store
+    so the answers come from the shipped code path rather than a stub.
+
+    The failed-delete row is the one that matters most: it must refuse on BOTH
+    surfaces, because a fresh grant would otherwise silently reuse a credential
+    that is still on disk.
+    """
+    from local_operator.mcp.config import MCPHttpServerConfig
+    from tests.unit.mcp.test_auth import FakeAuthStore
+
+    class RefusingStore(FakeAuthStore):
+        def delete_credential(self, credential_id: int) -> None:
+            raise RuntimeError("database is locked")
+
+    url = "https://codex.example/mcp"
+    cfg = MCPHttpServerConfig(url=url)
+    monkeypatch.setattr(
+        "local_operator.mcp.config.load_all_mcp_configs",
+        lambda cwd: ({"codex": cfg}, {}),
+    )
+    # Undo the autouse logout stub: the removal is the code under test.
+    monkeypatch.setattr(
+        "local_operator.mcp.auth.mcp_logout_server",
+        lambda name, cwd, store=None: _REAL_MCP_LOGOUT(name, cwd, store),
+    )
+
+    async def _tui(store: Any) -> tuple[str, str]:
+        auth_mod.OAUTH_CHALLENGES.clear()
+        monkeypatch.setattr(auth_mod, "_resolve_store", lambda given: given or store)
+        return await run_grant(_Manager(cfg=cfg), "reauth", "codex")
+
+    # 1. Nothing stored (the url-only Codex import): both proceed to the login.
+    empty = FakeAuthStore()
+    text, kind = await _tui(empty)
+    assert kind == "success", text
+    assert auth_mod.clear_for_reauth("codex", "/anywhere", empty) is None
+
+    # 2. A real grant: both delete it and proceed.
+    good = FakeAuthStore()
+    auth_mod.McpTokenStorage(url, good)._write({"tokens": {"access_token": "a"}})
+    text, kind = await _tui(good)
+    assert kind == "success", text
+    assert auth_mod.server_has_stored_grant(url, good) is False
+
+    # 3. The delete FAILS and the row survives: both refuse, and neither
+    #    reaches a connect that would reuse the surviving credential.
+    locked = RefusingStore()
+    auth_mod.McpTokenStorage(url, locked)._write({"tokens": {"access_token": "OLD-TOKEN"}})
+    manager = _Manager(cfg=cfg)
+    auth_mod.OAUTH_CHALLENGES.clear()
+    monkeypatch.setattr(auth_mod, "_resolve_store", lambda given: given or locked)
+    text, kind = await run_grant(manager, "reauth", "codex")
+    assert kind == "warning", text
+    assert "still in place" in text
+    assert manager.connected == []  # no grant ran over the surviving row
+    assert auth_mod.server_has_stored_grant(url, locked) is True
+    # ...and the CLI's gate says the same thing about the same state.
+    cli_error = auth_mod.clear_for_reauth("codex", "/anywhere", locked)
+    assert cli_error is not None and "still in place" in cli_error

--- a/tests/unit/session/runtime/test_owned.py
+++ b/tests/unit/session/runtime/test_owned.py
@@ -1136,7 +1136,11 @@ def fake_mcp_logout(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     """
     removed: list[str] = []
 
-    def _fake(name: str, cwd: str) -> str | None:
+    # Mirrors the real helper's full signature, ``store`` included: the reauth
+    # gate passes it positionally, and a narrower stub raises TypeError that
+    # the gate reports as a failed removal — a refusal caused by the stub
+    # rather than by the code under test.
+    def _fake(name: str, cwd: str, store: object | None = None) -> str | None:
         removed.append(name)
         return None
 

--- a/tests/unit/test_cli_new.py
+++ b/tests/unit/test_cli_new.py
@@ -695,7 +695,14 @@ def test_main_exec_dispatch(
 async def test_mcp_login_connects_and_disconnects_target(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
 ) -> None:
-    config = types.SimpleNamespace(auth=types.SimpleNamespace(type="oauth"))
+    # ``url`` is part of the shape, not decoration: an OAuth server with no URL
+    # is a contradiction (a stdio transport cannot carry a bearer token), and
+    # the real ``MCPHttpServerConfig`` always has one. The gate now asks
+    # ``server_rejects_oauth``, which reads the transport as well as the auth
+    # block, so a double omitting it describes a server that cannot exist.
+    config = types.SimpleNamespace(
+        auth=types.SimpleNamespace(type="oauth"), url="https://linear.example/mcp"
+    )
     monkeypatch.setattr(
         "local_operator.mcp.config.load_all_mcp_configs",
         lambda _cwd: ({"linear": config}, {"linear": tmp_path / "mcp.json"}),
@@ -780,6 +787,129 @@ async def test_mcp_reauth_stops_when_removal_fails(
     monkeypatch.setattr(cli, "_mcp_login_server", fake_login)
     assert await cli._mcp_reauth_server("linar", tmp_path) == 1
     assert "not configured" in capsys.readouterr().err
+
+
+@pytest.mark.asyncio
+async def test_mcp_login_accepts_a_url_only_oauth_capable_server(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """A Codex-imported server has no auth block, and the CLI must not refuse it.
+
+    The static ``cfg.auth.type == 'oauth'`` gate this replaced rejected exactly
+    the servers ``/mcp login`` in the TUI handles fine — one question with two
+    gates that disagreed. Capability is decided by the same live probe the rest
+    of the code uses.
+    """
+    config = types.SimpleNamespace(auth=None, url="https://codex.example/mcp")
+    monkeypatch.setattr(
+        "local_operator.mcp.config.load_all_mcp_configs",
+        lambda _cwd: ({"codex": config}, {"codex": tmp_path / "config.toml"}),
+    )
+
+    async def _capable(cfg, store=None):
+        return True
+
+    monkeypatch.setattr("local_operator.mcp.auth.probe_oauth_capability", _capable)
+
+    class FakeManager:
+        def __init__(self, cwd: Path) -> None:
+            self.disconnected = False
+
+        async def connect_configured_server(self, name, *, timeout_ms=None):
+            return types.SimpleNamespace(tools=[object()])
+
+        async def disconnect_all(self) -> None:
+            self.disconnected = True
+
+    monkeypatch.setattr("local_operator.mcp.manager.McpManager", FakeManager)
+
+    assert await cli._mcp_login_server("codex", tmp_path) == 0
+    assert "discovered 1 tools" in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_mcp_login_still_refuses_a_server_that_cannot_take_oauth(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """F3: an apikey or stdio server stays a HARD refusal, with no probe.
+
+    An ``auth.type: apikey`` entry is the user stating how the server
+    authenticates; starting an OAuth flow there answers a question they already
+    answered. The refusal must also stay free — no network round trip to learn
+    something the config already settles.
+    """
+
+    async def _must_not_probe(cfg, store=None):
+        raise AssertionError("a statically-ineligible server must not be probed")
+
+    monkeypatch.setattr("local_operator.mcp.auth.probe_oauth_capability", _must_not_probe)
+
+    apikey = types.SimpleNamespace(
+        auth=types.SimpleNamespace(type="apikey"), url="https://api.example/mcp"
+    )
+    stdio = types.SimpleNamespace(auth=None, url=None)
+    monkeypatch.setattr(
+        "local_operator.mcp.config.load_all_mcp_configs",
+        lambda _cwd: ({"apikey": apikey, "stdio": stdio}, {}),
+    )
+
+    for name in ("apikey", "stdio"):
+        assert await cli._mcp_login_server(name, tmp_path) == 1
+        assert "not OAuth-enabled" in capsys.readouterr().err
+
+
+@pytest.mark.asyncio
+async def test_mcp_reauth_on_a_url_only_server_reconnects_authenticated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The CLI reauth path shares the TUI's evidence-loss bug and its fix.
+
+    ``_mcp_reauth_server`` is its own function — it does not go through
+    ``run_grant`` — so it deletes the row via the same helper and then logs in.
+    With the stored grant as a url-only config's ONLY capability evidence, the
+    delete used to make the subsequent connect unauthenticated.
+    """
+    from local_operator.mcp import auth as auth_mod
+    from local_operator.mcp.config import MCPHttpServerConfig
+    from tests.unit.mcp.test_auth import FakeAuthStore
+
+    url = "https://codex.example/mcp"
+    cfg = MCPHttpServerConfig(url=url)
+    auth_mod.OAUTH_CHALLENGES.clear()
+    store = FakeAuthStore()  # never the developer's real auth.db
+    auth_mod.McpTokenStorage(url, store)._write({"tokens": {"access_token": "a"}})
+
+    monkeypatch.setattr(
+        "local_operator.mcp.config.load_all_mcp_configs",
+        lambda _cwd: ({"codex": cfg}, {}),
+    )
+    real_logout = auth_mod.mcp_logout_server
+    monkeypatch.setattr(
+        "local_operator.mcp.auth.mcp_logout_server",
+        lambda name, cwd: real_logout(name, cwd, store),
+    )
+
+    seen: dict[str, bool] = {}
+
+    class FakeManager:
+        def __init__(self, cwd: Path) -> None:
+            pass
+
+        async def connect_configured_server(self, name, *, timeout_ms=None):
+            # The question ``_build_oauth_auth`` asks before wiring the provider.
+            seen["capable"] = auth_mod.server_is_oauth_capable(cfg, store)
+            if not seen["capable"]:
+                raise RuntimeError(f"MCP server at {url} refused the connection (401)")
+            return types.SimpleNamespace(tools=[object()])
+
+        async def disconnect_all(self) -> None:
+            pass
+
+    monkeypatch.setattr("local_operator.mcp.manager.McpManager", FakeManager)
+
+    assert await cli._mcp_reauth_server("codex", tmp_path) == 0
+    assert auth_mod.server_has_stored_grant(url, store) is False  # really deleted
+    assert seen["capable"] is True  # ...but still known to take OAuth
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_cli_new.py
+++ b/tests/unit/test_cli_new.py
@@ -859,7 +859,7 @@ async def test_mcp_login_still_refuses_a_server_that_cannot_take_oauth(
 
 
 @pytest.mark.asyncio
-async def test_mcp_reauth_on_a_url_only_server_reconnects_authenticated(
+async def test_mcp_reauth_cli_on_a_url_only_server_reconnects_authenticated(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The CLI reauth path shares the TUI's evidence-loss bug and its fix.
@@ -910,6 +910,84 @@ async def test_mcp_reauth_on_a_url_only_server_reconnects_authenticated(
     assert await cli._mcp_reauth_server("codex", tmp_path) == 0
     assert auth_mod.server_has_stored_grant(url, store) is False  # really deleted
     assert seen["capable"] is True  # ...but still known to take OAuth
+
+
+@pytest.mark.asyncio
+async def test_mcp_reauth_with_nothing_stored_proceeds_into_the_login(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """Reauth on a url-only server holding no grant must log in, not dead-end.
+
+    The removal fails here because ``mcp_logout_server`` gates on the STRICT
+    ``server_is_oauth_capable``, and a Codex-imported config with a cold ledger
+    and no stored row satisfies none of its three evidence kinds. That used to
+    exit 1 saying the server "does not use OAuth login" — false for a server
+    the login probe accepts, and a dead end for the user this path is for.
+    Reauth's contract is "end up authenticated", so a no-op delete is a
+    satisfied precondition.
+    """
+    from local_operator.mcp import auth as auth_mod
+    from local_operator.mcp.config import MCPHttpServerConfig
+
+    auth_mod.OAUTH_CHALLENGES.clear()
+    cfg = MCPHttpServerConfig(url="https://codex.example/mcp")
+    monkeypatch.setattr(
+        "local_operator.mcp.config.load_all_mcp_configs",
+        lambda _cwd: ({"codex": cfg}, {}),
+    )
+
+    logged_in: list[str] = []
+
+    async def fake_login(name: str, cwd: Path) -> int:
+        logged_in.append(name)
+        return 0
+
+    monkeypatch.setattr(cli, "_mcp_login_server", fake_login)
+
+    assert await cli._mcp_reauth_server("codex", tmp_path) == 0
+    assert logged_in == ["codex"]  # fell through instead of erroring
+    assert capsys.readouterr().err == ""
+
+
+@pytest.mark.asyncio
+async def test_mcp_reauth_still_refuses_a_server_that_cannot_take_oauth(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """Falling through on a failed removal must not weaken the static refusals.
+
+    A stdio server and a declared ``auth.type: apikey`` server both fail the
+    removal for the same "not OAuth" reason as the url-only case above, but
+    they are statically ineligible — the F3 protection. They must still exit 1
+    without reaching a login, or a typo could open a browser tab.
+    """
+    from local_operator.mcp.config import (
+        MCPAuthConfig,
+        MCPHttpServerConfig,
+        MCPStdioServerConfig,
+    )
+
+    configs = {
+        "apikey": MCPHttpServerConfig(
+            url="https://api.example/mcp", auth=MCPAuthConfig(type="apikey")
+        ),
+        "stdio": MCPStdioServerConfig(command="run-me"),
+    }
+    monkeypatch.setattr(
+        "local_operator.mcp.config.load_all_mcp_configs",
+        lambda _cwd: (configs, {}),
+    )
+
+    async def fake_login(name: str, cwd: Path) -> int:
+        raise AssertionError("an ineligible or unknown server must not reach the login")
+
+    monkeypatch.setattr(cli, "_mcp_login_server", fake_login)
+
+    for name in ("apikey", "stdio"):
+        assert await cli._mcp_reauth_server(name, tmp_path) == 1
+        assert "does not use OAuth login" in capsys.readouterr().err
+    # An unknown name is still a typo the user wants told about, not a login.
+    assert await cli._mcp_reauth_server("nosuch", tmp_path) == 1
+    assert "not configured" in capsys.readouterr().err
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_cli_new.py
+++ b/tests/unit/test_cli_new.py
@@ -758,9 +758,12 @@ async def test_mcp_reauth_removes_then_logs_in(
     row would reuse the stored registration and never show the consent
     screen, which is the entire reason reauth exists."""
     calls: list[str] = []
+    # ``store`` is part of the real signature and the reauth gate passes it, so
+    # the stub accepts it too — a narrower stub raises TypeError, which the
+    # gate would report as a failed removal and refuse for the wrong reason.
     monkeypatch.setattr(
         "local_operator.mcp.auth.mcp_logout_server",
-        lambda name, cwd: calls.append("logout") or None,
+        lambda name, cwd, store=None: calls.append("logout") or None,
     )
 
     async def fake_login(name: str, cwd: Path) -> int:
@@ -778,7 +781,7 @@ async def test_mcp_reauth_stops_when_removal_fails(
 ) -> None:
     monkeypatch.setattr(
         "local_operator.mcp.auth.mcp_logout_server",
-        lambda name, cwd: "MCP server 'linar' is not configured",
+        lambda name, cwd, store=None: "MCP server 'linar' is not configured",
     )
 
     async def fake_login(name: str, cwd: Path) -> int:
@@ -886,8 +889,11 @@ async def test_mcp_reauth_cli_on_a_url_only_server_reconnects_authenticated(
     real_logout = auth_mod.mcp_logout_server
     monkeypatch.setattr(
         "local_operator.mcp.auth.mcp_logout_server",
-        lambda name, cwd: real_logout(name, cwd, store),
+        lambda name, cwd, _store=None: real_logout(name, cwd, store),
     )
+    # The reauth gate re-reads the store to confirm nothing survived the
+    # delete, and would resolve the real shared ``auth.db`` to do it.
+    monkeypatch.setattr(auth_mod, "_resolve_store", lambda given: given or store)
 
     seen: dict[str, bool] = {}
 
@@ -947,6 +953,62 @@ async def test_mcp_reauth_with_nothing_stored_proceeds_into_the_login(
     assert await cli._mcp_reauth_server("codex", tmp_path) == 0
     assert logged_in == ["codex"]  # fell through instead of erroring
     assert capsys.readouterr().err == ""
+
+
+@pytest.mark.asyncio
+async def test_mcp_reauth_refuses_when_the_credential_delete_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """A FAILED delete must never look like "nothing was stored".
+
+    The hazard the fall-through above opens if the two are conflated: both
+    outcomes made ``mcp_logout_server`` return an error string, so falling
+    through on "an error" also fell through when the delete had been ATTEMPTED
+    and had RAISED — leaving the row on disk. The SDK then reuses the surviving
+    token and ``client_info``, no consent screen comes back up, and reauth
+    exits 0 for the account switch that silently did not happen.
+
+    Reachable rather than theoretical: a sibling session holding an EXCLUSIVE
+    sqlite transaction makes ``delete_credential`` raise ``database is locked``,
+    which is what ``RefusingStore`` reproduces here.
+
+    This test is the one that can SEE the distinction. Asserting only "reauth
+    errors when nothing is stored" cannot: it is satisfied by a gate that
+    refuses everything. So it drives the real ``_mcp_reauth_server`` against a
+    real ``McpTokenStorage`` over a store whose delete raises, and asserts all
+    three of rc=1, the login NOT reached, and the row still present.
+    """
+    from local_operator.mcp import auth as auth_mod
+    from local_operator.mcp.config import MCPHttpServerConfig
+    from tests.unit.mcp.test_auth import FakeAuthStore
+
+    class RefusingStore(FakeAuthStore):
+        """A store whose row cannot be deleted — `OperationalError` in the field."""
+
+        def delete_credential(self, credential_id: int) -> None:
+            raise RuntimeError("database is locked")
+
+    url = "https://codex.example/mcp"
+    store = RefusingStore()
+    auth_mod.OAUTH_CHALLENGES.clear()
+    auth_mod.McpTokenStorage(url, store)._write({"tokens": {"access_token": "OLD-TOKEN"}})
+    monkeypatch.setattr(
+        "local_operator.mcp.config.load_all_mcp_configs",
+        lambda _cwd: ({"codex": MCPHttpServerConfig(url=url)}, {}),
+    )
+    # The CLI resolves the real shared ``auth.db``; pin it to the in-memory
+    # store so the developer's own credentials are never touched.
+    monkeypatch.setattr(auth_mod, "_resolve_store", lambda given: given or store)
+
+    async def fake_login(name: str, cwd: Path) -> int:
+        raise AssertionError("a surviving credential must not be reused by a fresh grant")
+
+    monkeypatch.setattr(cli, "_mcp_login_server", fake_login)
+
+    assert await cli._mcp_reauth_server("codex", tmp_path) == 1
+    assert "still in place" in capsys.readouterr().err
+    # The row really did survive — which is precisely why the login was refused.
+    assert auth_mod.server_has_stored_grant(url, store) is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_cli_new.py
+++ b/tests/unit/test_cli_new.py
@@ -750,6 +750,82 @@ def test_mcp_logout_command_reports_removal(
     assert "nothing" not in capsys.readouterr().out  # reason goes to stderr
 
 
+def test_mcp_logout_reports_a_failed_delete_as_one_actionable_line(
+    tmp_home: Path, quiet_env: None, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """A locked store must produce ONE error line, not a stack-trace banner.
+
+    ``McpTokenStorage.clear`` RAISES when a row is found and its delete fails,
+    so that a caller cannot read it as the benign "nothing was stored". The
+    logout branch is the one caller with no reauth gate in front of it: left
+    bare, the exception reached ``main``'s generic handler, which printed
+    "Error: ...", a 30-line traceback, and "Please review and correct the
+    error to continue" for a sibling process holding a sqlite write lock.
+
+    That framing is wrong twice — it presents a retryable, user-fixable
+    condition as a defect in local-operator, and it buries the sentence that
+    matters (the credential is still there) under the trace.
+
+    Driven through the real ``main()`` over a real ``AuthStore``, because the
+    defect lived in the seam BETWEEN the helper and the entry point: every
+    layer below was already correct and a test calling ``mcp_command``
+    directly still passes the generic handler by. The store is a real one on
+    ``tmp_home`` whose delete raises the real ``OperationalError`` a locked
+    db raises, rather than a mock raising the app's own exception type.
+    """
+    import json
+    import sqlite3
+
+    from local_operator.mcp import auth as auth_mod
+    from local_operator.providers.auth_store import AuthStore
+
+    class LockedStore(AuthStore):
+        """Real store, real rows — but its delete hits a held write lock."""
+
+        deletes_attempted = 0
+
+        def delete_credential(self, credential_id: int) -> None:
+            type(self).deletes_attempted += 1
+            raise sqlite3.OperationalError("database is locked")
+
+    url = "https://locktest.example/mcp"
+    (tmp_home / ".local-operator").mkdir(parents=True, exist_ok=True)
+    (tmp_home / ".local-operator" / "mcp.json").write_text(
+        json.dumps({"mcpServers": {"locktest": {"url": url}}})
+    )
+    store = LockedStore(tmp_home / ".local-operator" / "auth.db")
+    monkeypatch.setattr(auth_mod, "_resolve_store", lambda given: given or store)
+    # A stored grant is what makes the server OAuth-capable AND what the
+    # delete then fails on — both preconditions come from this one row.
+    auth_mod.McpTokenStorage(url, store)._write({"tokens": {"access_token": "SURVIVOR"}})
+    auth_mod.OAUTH_CHALLENGES.clear()
+
+    # The observation path must be LIVE before its silence means anything: a
+    # missing row, or a config the loader never saw, would make the command
+    # fail for an unrelated reason and this test pass without ever reaching
+    # the raise. Assert the setup landed instead of assuming it.
+    assert auth_mod.server_has_stored_grant(url, store) is True
+
+    monkeypatch.setattr(sys, "argv", ["program", "mcp", "logout", "locktest"])
+    assert main() == 1
+
+    err = capsys.readouterr().err
+    # The delete was really attempted — this is the failed-delete path and not
+    # some earlier refusal (unknown name, not-OAuth) wearing the same rc.
+    assert LockedStore.deletes_attempted == 1
+    # The credential really did survive, which is what the message must say.
+    assert auth_mod.server_has_stored_grant(url, store) is True
+    assert "still in place" in err
+    assert "Retry once" in err  # actionable: names what the user can do
+    # NOT the old message, which claimed nothing was stored while the row
+    # survived — the conflation this PR removed.
+    assert "nothing to log out of" not in err
+    # The regression itself: no traceback banner, and one line of output.
+    assert "Stack Trace" not in err
+    assert "Please review and correct the error" not in err
+    assert len([line for line in err.splitlines() if line.strip()]) == 1
+
+
 @pytest.mark.asyncio
 async def test_mcp_reauth_removes_then_logs_in(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -6509,7 +6509,17 @@ async def test_mcp_login_worker_cancellation_is_acknowledged() -> None:
 async def test_mcp_reauth_never_logs_in_on_top_of_a_surviving_row() -> None:
     """A login over a row that failed to delete is NOT a re-auth — the stored
     registration would short-circuit the grant — so a failed removal stops the
-    chain instead of popping a misleading browser tab."""
+    chain instead of popping a misleading browser tab.
+
+    The removal is made to fail the way it fails in the field: the delete is
+    ATTEMPTED and raises, which is what leaves the row behind. This test used
+    to simulate that with the "nothing to log out of" string instead, but that
+    message is the OPPOSITE fact — it means no row existed, so nothing can be
+    reused and the login may proceed. Conflating the two is precisely the
+    defect this path was fixed for, so the test now names the surviving-row
+    case by its own signal rather than borrowing another outcome's message.
+    """
+    from local_operator.mcp.auth import McpCredentialDeleteError
     from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
 
     configs = {
@@ -6532,7 +6542,11 @@ async def test_mcp_reauth_never_logs_in_on_top_of_a_surviving_row() -> None:
             ),
             patch(
                 "local_operator.mcp.auth.mcp_logout_server",
-                return_value="no stored credential for MCP server 'linear' — nothing to log out of",
+                side_effect=McpCredentialDeleteError(
+                    "could not delete the stored credential for "
+                    "https://mcp.linear.app/mcp (database is locked) — it is still "
+                    "in place, so a fresh grant would silently reuse it"
+                ),
             ),
         ):
             await _type_command(pilot, app, "mcp reauth linear")


### PR DESCRIPTION
## Summary of Changes

`/mcp reauth <server>` fails with a 401 while `/mcp login <server>` run immediately afterwards succeeds — reported as "occasional", and it is not: it is deterministic per session state. Both the TUI/runtime path and the CLI path are fixed here, at the one place they share.

C1. Bugfix, no schema or config change, no new surface. No version bump (`pyproject.toml` untouched).

Release: patch — `/mcp reauth` no longer 401s on servers imported from Codex, and `local-operator mcp login/reauth` stops refusing them outright.

### The bug

`server_is_oauth_capable` accepts **three kinds of evidence** that a server authenticates over OAuth:

1. an explicit `auth.type: oauth` block,
2. a stored OAuth credential for the URL (durable, cross-process),
3. an observed 401 challenge in the `OAUTH_CHALLENGES` ledger (per-process).

A config imported from a foreign tool — Codex's `config.toml`, issue #367 — is **url-only**: that tool keeps its grants elsewhere, so its format has no auth block to copy. For those servers **only #2 applies**, and `reauth` is a delete followed by a reconnect. The delete erases the only evidence; the reconnect re-asks `server_is_oauth_capable` via `_build_oauth_auth`, gets `False`, attaches no OAuth provider, and the connect goes out unauthenticated and takes a 401.

The gate that authorised the reauth (`probe_oauth_capability`) had already short-circuited on the very row about to be deleted, so it never reached the discovery branch that would have called `record_oauth_challenge`. Evidence destroyed, nothing replacing it.

**Why `/mcp login` then works, and why it looks intermittent.** The failed connect's error path (`_challenge_error`) runs discovery and records the challenge, so the *next* attempt sees a capable server. And `OAUTH_CHALLENGES` is a per-process dict: in a session where something already made the server 401 (a startup connect on an expired token), the ledger is warm and reauth works. In a fresh session whose stored token was valid at boot, it is cold and reauth breaks. On this machine that is `minerva-qa`, `gitlab` and `launchdarkly`. Servers defined natively in `mcp.json` carry `auth.type: oauth` and satisfy #1 unconditionally, so they were never affected.

### The fix

**`mcp_logout_server` records the challenge for a row that actually carried a grant, before deleting it.** This is an evidence *transfer*, not a guess: holding a token for that URL is strictly stronger proof than the discovery probe that normally populates the ledger — an authorization server did not merely advertise itself, it issued us a grant.

It goes **at the delete**, not in `run_grant`, because that is the choke point all three destructive paths share (`grep` confirms `auth.py:1007` is the only credential-delete site in the tree): the TUI/runtime `run_grant`, the desktop grant runner, and the CLI's `_mcp_reauth_server` — which does **not** go through `run_grant` and would have needed a second, driftable copy. No caller can now destroy a credential without preserving what it proved.

Scoped to `had_stored_grant` deliberately: deleting a **registration-only** row (the DCR artifact the SDK writes on mere discovery) proves nothing was ever issued, and recording a 401 we never observed would put an unverified fact into an observation-only ledger.

### Bug 2, same root cause

`cli.py::_mcp_login_server` still gated on the static `cfg.auth.type == "oauth"` — the check the other paths deliberately stopped using — so `local-operator mcp login minerva-qa` refused a Codex-imported server outright while the TUI equivalent worked. One question, two gates, disagreeing. It now splits:

- `server_rejects_oauth` — the **static impossibility** (stdio, or a declared non-OAuth type). Still a free hard refusal with the original wording. This is the **F3 protection**: an `auth.type: apikey` entry is the user stating how the server authenticates, and starting an OAuth flow there answers a question they already answered. **No probe is run** for these — verified by a test that raises if one is.
- `probe_oauth_capability` — only the genuinely undecidable url-only case pays for the network round trip.

`_mcp_reauth_server` calls `mcp_logout_server` then `_mcp_login_server`, so it inherits the evidence fix from the shared helper.

### Not done, deliberately

`OAUTH_CHALLENGES` remains per-process. A durable challenge ledger is a real design question but a much larger change with its own invalidation story, and it is not needed here: the durable signal is the stored credential row, and this fix keeps that signal from being lost. Flagging rather than expanding scope.

## Related Issue(s)

None filed; reported directly by the operator against `minerva-qa`.

## Reproduction and actual execution

Isolated per `AGENTS.md`: **both** `HOME` and `LOCAL_OPERATOR_CONFIG_DIR` redirected (the override alone does not isolate a run — the cache derives its root from home independently). The operator's real `~/.local-operator/auth.db` was checked before and after every cell: mtime `1788957656` **unchanged throughout**. No real OAuth grant was attempted against any live server.

### 1. The bug, at module level, before the fix

```
challenge ledger at start:            {}
probe_oauth_capability (pre-logout):  True
  ledger after the gate:              {} <- short-circuited on the stored grant, never recorded
stored grant after logout:            False
server_is_oauth_capable at connect:   False
  -> OAuth provider attached?          False
VERDICT: connects UNAUTHENTICATED -> 401
after the 401 is recorded, capable:   True <- why /mcp login right after works
```

### 2. Driving the real `run_grant` reauth arm, before vs after

Same script, same fixture; only `local_operator/mcp/auth.py` differs.

```
=== WITH FIX ===
OAuth provider attached on reauth connect: True
receipt: success | authenticated MCP server 'minerva-qa'; 3 tools available.

=== PRE-FIX (auth.py reverted) ===
OAuth provider attached on reauth connect: False
receipt: error | MCP login failed for 'minerva-qa': MCP server at https://mcp.qa.example.com/mcp refused the connection (401)
```

The pre-fix receipt is **the operator's reported error, verbatim in shape**.

### 3. The real CLI binary, isolated config

```
$ mcp login apikeysrv          # F3: declared apikey
error: MCP server 'apikeysrv' is not OAuth-enabled; add a remote server with --oauth
exit=1                          # hard refusal preserved

$ mcp reauth urlonly           # PRE-FIX tree, url-only server
error: MCP server 'urlonly' is not OAuth-enabled; add a remote server with --oauth
exit=1                          # bug 2: refused before it could even try
```

Post-fix the same command proceeds past the gate and fails only on the deliberately unroutable `.invalid` host. That traceback is **pre-existing and unrelated** — confirmed by reproducing it on the **unmodified tree** with a `auth.type: oauth` server the old gate accepted (2 tracebacks, same shape), so it is the unroutable host, not this change.

### 4. Against the real Minerva QA endpoint (read-only, no grant)

Corroborates that the transferred fact is the true one — live discovery independently reaches the same conclusion the stored grant did:

```
live discovery found an authorization server: True
stored grant in THIS isolated store:          False
capable with a cold ledger + no row:          False
capable after the transfer records it:        True
```

### 5. No added latency on the common path

A declared-`oauth` server must still answer from static evidence alone. Discovery patched to raise if called:

```
declared-oauth server capable: True | discovery calls: 0 -> no added latency on the common path
```

## Regression tests: proven able to fail

Five tests, each verified to fail without its fix — a guard that cannot go red is decoration (`AGENTS.md`, "Prove the test can still fail").

Four fail on the **pre-fix source with the tests kept**:

```
FAILED tests/unit/mcp/test_auth.py::TestLogoutHelpers::test_deleting_a_url_only_grant_preserves_what_it_proved
        AssertionError: assert False is True
FAILED tests/unit/mcp/test_grants.py::test_reauth_on_a_url_only_server_reconnects_authenticated
        assert False is True  (.capable_at_connect)
FAILED tests/unit/test_cli_new.py::test_mcp_login_accepts_a_url_only_oauth_capable_server
        assert 1 == 0  | stderr: 'codex' is not OAuth-enabled
FAILED tests/unit/test_cli_new.py::test_mcp_reauth_on_a_url_only_server_reconnects_authenticated
        assert 1 == 0
```

The two guarding the **new** code cannot fail that way, so they were **mutation-tested** instead:

- drop the `had_stored_grant` scope ⇒ `test_deleting_a_registration_only_row_records_no_challenge` fails (`'https://declared.example/mcp' not in {...: True}`)
- drop `server_rejects_oauth` from the CLI gate ⇒ `test_mcp_login_still_refuses_a_server_that_cannot_take_oauth` fails (`a statically-ineligible server must not be probed`)

**Two vacuous tests were caught this way and rewritten**, which is the reason for the ceremony: the `run_grant` test initially passed against the pre-fix tree because the file's autouse fixture had already stubbed out the real delete (fixed by capturing the genuine helper at import time and running it against an injected in-memory store), and the registration-only test passed under mutation because `clear()` returned early before reaching the guard.

### One pre-existing test fixture corrected

`test_mcp_login_connects_and_disconnects_target` built its config double as `SimpleNamespace(auth=SimpleNamespace(type="oauth"))` — **an OAuth server with no `url`**, which is a contradiction: a stdio transport cannot carry a bearer token, and the real `MCPHttpServerConfig` always has one. The old gate read only `auth.type` so it never noticed; the new gate reads the transport too and correctly refuses it. Fixed by giving the double a `url`, with a comment recording why it is load-bearing rather than decoration.

## Quality gates

Run in the worktree's `.venv`, exactly as CI:

| gate | result |
| --- | --- |
| `flake8 .` | clean |
| `black==26.1.0 --check .` | 1180 files unchanged |
| `isort==5.13.2 --check .` | clean |
| `pyright` (pinned 1.1.411) | **0 errors, 0 warnings** |
| `pytest tests/unit` | **17563 passed, 18 skipped**, 0 failed (23:32) |

Full suite run to green on final head. `pyproject.toml` is not in the diff; `version = "0.52.18"` unchanged.
