### PR TITLE
fix(tui): retry a sidebar reconnect instead of publishing a cold session

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1439,6 +1439,100 @@ SIDEBAR_IDLE_SWEEP_S = 15.0
 #: `mobile/daemon.py` bounds the identical call at the same 3 s.
 RETIRE_OFFER_TIMEOUT_S = 3.0
 
+#: First backoff between sidebar connect attempts, and the ceiling one attempt
+#: may wait. The pair only sets the SHAPE of the wait (exponential, capped);
+#: what the wait has to be long enough for is `SIDEBAR_CONNECT_ATTEMPTS`.
+SIDEBAR_CONNECT_BACKOFF_S = 0.25
+SIDEBAR_CONNECT_BACKOFF_CEILING_S = 3.0
+
+
+def sidebar_connect_backoff_s(attempt: int) -> float:
+    """Seconds to wait before re-dialling, for a 1-based `attempt` number.
+
+    Exponential from `SIDEBAR_CONNECT_BACKOFF_S`, capped at
+    `SIDEBAR_CONNECT_BACKOFF_CEILING_S`. Shared by the retry loop and by the
+    derivation of `SIDEBAR_CONNECT_ATTEMPTS` below, so the budget can never
+    describe a schedule the loop does not actually follow.
+    """
+    return min(SIDEBAR_CONNECT_BACKOFF_S * (2 ** (attempt - 1)), SIDEBAR_CONNECT_BACKOFF_CEILING_S)
+
+
+def _attempts_outlasting(span_s: float) -> int:
+    """The fewest attempts whose cumulative backoff exceeds `span_s`.
+
+    Solved rather than tabulated so the arithmetic — not a comment — is what
+    tracks `COLD_FALLBACK_S`. `session.remote` is imported inside the caller
+    rather than at module scope: `app.py` defers every other reference to that
+    module (~6 ms and five extra modules at boot), and this one derivation is
+    not a reason to change the TUI's import surface.
+    """
+    total = 0.0
+    attempts = 0
+    while total <= span_s:
+        attempts += 1
+        total += sidebar_connect_backoff_s(attempts)
+    return attempts
+
+
+def _sidebar_connect_attempts() -> int:
+    from local_operator.session.remote import COLD_FALLBACK_S
+
+    # 50% margin over the recovery bound: the last attempt must land clearly
+    # after `_go_cold`, not in a photo finish with it on a loaded machine.
+    return _attempts_outlasting(COLD_FALLBACK_S * 1.5)
+
+
+#: How many times `_connect_sidebar_source` re-dials a session whose connect
+#: failed, before surrendering the retry to the user.
+#:
+#: DERIVED from `COLD_FALLBACK_S` rather than written as a literal, because the
+#: quantity this budget has to outlast is the VIEWER RECOVERY LOOP'S OWN GIVE-UP
+#: BOUND, not a round number of attempts. A viewer that loses its owner — an
+#: attach-cap eviction, a socket blip, a runtime restart — sets `_recovering`
+#: and stays cold for up to `COLD_FALLBACK_S` before `_go_cold` releases it. For
+#: the whole of that window `_ensure_bound` refuses to bind, and says so by
+#: returning silently rather than by raising (see `_connect_sidebar_source`), so
+#: EVERY attempt inside the window fails for the same reason and healing is only
+#: possible on an attempt that lands after it. A budget that expires first
+#: reports "Connection unavailable" for a condition that was about to clear on
+#: its own — which is the defect this constant exists to close.
+#:
+#: Measured, not guessed: a ~4 s total span did NOT self-heal an evicted viewer
+#: (the facade was still `_recovering` when the last attempt ran); widening the
+#: span past `COLD_FALLBACK_S` healed it on the first post-give-up attempt, at
+#: t=9.9 s. Deriving keeps that relationship true when either constant moves. A
+#: bare literal would silently stop healing the moment `COLD_FALLBACK_S` grew,
+#: with no failing test and no symptom except the original bug returning — so
+#: `tests/unit/tui/test_sidebar_connect_retry.py` pins the RELATIONSHIP (total
+#: span > `COLD_FALLBACK_S`) rather than either number. Same shape as #849's
+#: `RECOVERY_GIVE_UP_S = 2 * HEARTBEAT_TIMEOUT_S`, for the same reason.
+#:
+#: DERIVED FROM `COLD_FALLBACK_S` AND NOT FROM `RECOVERY_GIVE_UP_S`, which is
+#: the other bound in the same neighbourhood and the wrong one to track here.
+#: The two apply to different facades, selected by `_can_go_cold`, and the
+#: sidebar's own two lease branches land on opposite sides of that split —
+#: verified by execution, because the natural assumption ("a parked source can
+#: never go cold") is false:
+#:
+#:   click / `saved_preview`  -> `_can_go_cold=True`  -> `COLD_FALLBACK_S` (8 s)
+#:   prewarm / `connect`      -> `_can_go_cold=False` -> `RECOVERY_GIVE_UP_S` (90 s)
+#:
+#: The CLICK path is what this budget is for, and measurement matches the
+#: derivation: `_recovering` cleared at t=8.3 s against a `COLD_FALLBACK_S` of
+#: 8.0. Sizing to 90 s instead would make the user watch "Connecting…" for a
+#: minute and a half on the common path, which is worse than the honest failure
+#: it replaced.
+#:
+#: On a source the PREWARM branch created, the budget deliberately expires
+#: inside the 90 s window and the user gets the terminal message. That is a
+#: smaller, honest failure rather than a regression: `_ensure_bound`'s first
+#: guard is `if not self._can_go_cold ... return`, so it is a NO-OP on that
+#: facade — no retry count can make it bind, and a measured such facade did not
+#: self-heal within 20 s either. The fix still converts that case from 15 s of
+#: false-connected transcript into a prompt failure. Widening the budget to
+#: cover it would buy nothing and cost every click path a longer wait.
+SIDEBAR_CONNECT_ATTEMPTS = _sidebar_connect_attempts()
+
 #: The chord that lifts the aside's full text to the clipboard.
 #:
 #: `omp`, the reference implementation this surface is modelled on, ships copy
@@ -5605,6 +5699,21 @@ class OperatorApp(App[None]):
         and a cancellation-resistant attach cannot hold the latest-wins lock.
         Reuse prepared widgets and the final generation fence for canonical
         replacement, rather than inventing a second replay/event reducer.
+
+        TWO POSTCONDITIONS THIS BODY IS RESPONSIBLE FOR, both learned the hard
+        way from a live reconnect defect:
+
+        1. It never commits a session that is not actually bound. A cold
+           session published as connected produces a transcript that looks live
+           and is not, for the full 15 s the readiness gate takes to give up.
+        2. A failure that is transient is retried rather than latched, so the
+           user is not asked to reselect a session that was going to come back
+           on its own. Only exhaustion of the budget reaches them.
+
+        The task therefore lives for up to ~`COLD_FALLBACK_S` + margin rather
+        than the fraction of a second it used to, which is why `prepared` is
+        released before each backoff and why `command_frame_pending` is
+        published false around the wait instead of only in `finally`.
         """
         from local_operator.session.remote import RemoteSession
         from local_operator.tui.session_navigation import PreparationInvalidated
@@ -5617,6 +5726,29 @@ class OperatorApp(App[None]):
             if not isinstance(session, RemoteSession):
                 return
             await session._ensure_bound()
+            if session.is_cold:
+                # A BIND THAT DID NOT BIND IS A FAILURE. `_ensure_bound` has
+                # two silent returns that look identical here — "already bound,
+                # nothing to do" and "cannot bind right now" (the facade is
+                # `_recovering`, remote.py) — and only the second leaves the
+                # session cold. Committing on that second one publishes a COLD
+                # session as connected: `display_only` goes False, the saved
+                # transcript is swapped in live, and then
+                # `_sidebar_gate_surface_ready` — whose FIRST check is
+                # `is_cold` — refuses every frame until `_await_sidebar_frame`'s
+                # 15 s timer gives up. Measured: 1,799 refused frames, each one
+                # requesting a full relayout, under a transcript the user had
+                # every reason to believe was live.
+                #
+                # Checked here rather than by giving `_ensure_bound` a
+                # `require_bound=True`: its other callers deliberately tolerate
+                # the silent return (a prompt waits on `_owner_ready` instead),
+                # so the postcondition is this call site's, not the method's.
+                #
+                # The message is the sentence the sync-failure path already
+                # uses, so the two ways a connect can fail read identically to
+                # the user and no new copy is introduced.
+                raise ConnectionError("the runtime is not responding")
             await session.ensure_display_current()
             if source.retired or not self._is_current(source):
                 return
@@ -5647,6 +5779,18 @@ class OperatorApp(App[None]):
             prepared = None
             if ready is not None:
                 await ready
+            # REFILL THE BUDGET ONLY ON A COMPLETED CONNECT, and only here at
+            # the very end of the success path. Resetting earlier — beside
+            # `display_only = False`, before the commit and the readiness gate
+            # can still raise — makes the budget UNEXHAUSTIBLE: every round
+            # would zero the counter, the `except` would raise it back to 1,
+            # and a permanently failing session would retry forever instead of
+            # ever reaching the user. Observed while building this, not
+            # theorised. Nor in `finally`: a task that returned early (retired,
+            # superseded, navigated away) never proved the owner is reachable,
+            # and crediting it would hand the next real failure a budget it did
+            # not earn.
+            source.connect_attempts = 0
         except asyncio.CancelledError:
             cancelled = True
             raise
@@ -5655,7 +5799,65 @@ class OperatorApp(App[None]):
             retry = True
         except Exception as error:
             source.display_only = True
-            source.connection_error = str(error) or "Connection unavailable"
+            source.connect_attempts += 1
+            # A TRANSIENT GETS RETRIED; ONLY EXHAUSTION LATCHES. Everything
+            # that lands here is a momentarily unreachable owner — an evicted
+            # attach slot, a socket blip, a runtime mid-restart, a facade still
+            # `_recovering` — and every one of them clears on its own within
+            # `COLD_FALLBACK_S`. Latching the first one made a self-healing
+            # condition into a dead session that only a manual reselect could
+            # revive, while the neighbouring `PreparationInvalidated` arm
+            # retried a purely LOCAL staleness race. That asymmetry was
+            # backwards; both are transient, and what stays terminal is the
+            # budget running out. See `SIDEBAR_CONNECT_ATTEMPTS` for why the
+            # budget is derived from `COLD_FALLBACK_S` and not written down.
+            #
+            # Not retried when this source is no longer on screen: the backoff
+            # keeps the connection task alive for ~10 s, and a task counts as
+            # `retained_for_local_work`, so retrying a source the user has
+            # navigated away from would strand an evicted hidden viewer for the
+            # whole budget instead of releasing it.
+            if (
+                source.connect_attempts <= SIDEBAR_CONNECT_ATTEMPTS
+                and not source.retired
+                and self._is_current(source)
+            ):
+                retry = True
+                # Empty, so the status renders "Connecting…" rather than
+                # "Connection unavailable · Reselect to retry": the app has not
+                # given up, and telling the user to act while it is still
+                # working asks them to fix something that is fixing itself.
+                source.connection_error = ""
+                if prepared is not None:
+                    # Released BEFORE the backoff rather than in `finally`. The
+                    # task now lives ~10 s instead of ~0.3 s, and holding a
+                    # preparation (and its widget/attach accounting) across a
+                    # wait nothing is watching is a leak in all but name.
+                    await self._release_sidebar_preparation(prepared)
+                    prepared = None
+                # Both are the "connecting" state, and the next round may take
+                # seconds to arrive. Publish it now so the surface is honest
+                # for the whole window, including a failure that arrived AFTER
+                # the commit had already flipped these.
+                source.command_frame_pending = False
+                self._show_sidebar_connection(source)
+                try:
+                    await asyncio.sleep(sidebar_connect_backoff_s(source.connect_attempts))
+                except asyncio.CancelledError:
+                    # A cancellation during the backoff is a cancellation of the
+                    # connect, not a failed attempt: mark it so `finally` skips
+                    # the status write and the re-arm, exactly as the outer
+                    # handler does. Re-raised, never swallowed by this branch.
+                    cancelled = True
+                    raise
+            else:
+                source.connection_error = str(error) or "Connection unavailable"
+                # Surrendered, so the counter goes back to zero: the status now
+                # reads "Reselect to retry", and that affordance has to mean a
+                # FULL budget, not one last single-shot attempt. Nothing re-arms
+                # automatically from here (`retry` stays False), so the only
+                # reader of a fresh count is the user's own next selection.
+                source.connect_attempts = 0
         finally:
             if prepared is not None:
                 await self._release_sidebar_preparation(prepared)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1457,24 +1457,47 @@ def sidebar_connect_backoff_s(attempt: int) -> float:
     return min(SIDEBAR_CONNECT_BACKOFF_S * (2 ** (attempt - 1)), SIDEBAR_CONNECT_BACKOFF_CEILING_S)
 
 
+#: Hard stop for the derivation loop below. Not a tuning knob and not reachable
+#: from any sane backoff — the shipped schedule solves in 7 — but the loop runs
+#: at IMPORT time, so an unbounded one turns a mistuned constant into a hung or
+#: overflowing boot rather than a message. A zeroed `SIDEBAR_CONNECT_BACKOFF_S`
+#: does exactly that today: the total never grows, and the doubling in
+#: `sidebar_connect_backoff_s` overflows before the loop can end. Since the
+#: constants above are precisely what a future agent has reason to tune, the
+#: failure they can cause should be loud and at the edit, not silent and at boot.
+_MAX_DERIVED_ATTEMPTS = 64
+
+
 def _attempts_outlasting(span_s: float) -> int:
     """The fewest attempts whose cumulative backoff exceeds `span_s`.
 
     Solved rather than tabulated so the arithmetic — not a comment — is what
-    tracks `COLD_FALLBACK_S`. `session.remote` is imported inside the caller
-    rather than at module scope: `app.py` defers every other reference to that
-    module (~6 ms and five extra modules at boot), and this one derivation is
-    not a reason to change the TUI's import surface.
+    tracks `COLD_FALLBACK_S`.
     """
     total = 0.0
     attempts = 0
     while total <= span_s:
         attempts += 1
+        if attempts > _MAX_DERIVED_ATTEMPTS:
+            raise ValueError(
+                "sidebar connect backoff cannot outlast "
+                f"{span_s}s in {_MAX_DERIVED_ATTEMPTS} attempts: "
+                f"check SIDEBAR_CONNECT_BACKOFF_S={SIDEBAR_CONNECT_BACKOFF_S} and "
+                f"SIDEBAR_CONNECT_BACKOFF_CEILING_S={SIDEBAR_CONNECT_BACKOFF_CEILING_S}"
+            )
         total += sidebar_connect_backoff_s(attempts)
     return attempts
 
 
 def _sidebar_connect_attempts() -> int:
+    # IMPORTED HERE, AND THIS DOES NOT DEFER ANYTHING. The call below is at
+    # module scope, so `session.remote` (five modules, ~6.7 ms) loads whenever
+    # `tui.app` does — an earlier version of this comment claimed the local
+    # import avoided that cost, which its own call site falsified. Kept local
+    # only because it reads at the one place that needs the constant; the honest
+    # statement of the cost is that `tui.app` now pulls in `session.remote` at
+    # import. No user-facing boot regression: the CLI defers `tui.app` itself, so
+    # `import local_operator.cli` loads neither — verified on both trees.
     from local_operator.session.remote import COLD_FALLBACK_S
 
     # 50% margin over the recovery bound: the last attempt must land clearly
@@ -4659,8 +4682,14 @@ class OperatorApp(App[None]):
 
         def expired() -> None:
             if not future.done():
+                # `SurfaceNotReady`, not a bare `RuntimeError`: it subclasses
+                # one, so every existing handler is unaffected, but the sidebar
+                # connect path can now tell a PAINT failure from an unreachable
+                # owner and decline to retry it. The message is unchanged.
+                from local_operator.tui.session_navigation import SurfaceNotReady
+
                 future.set_exception(
-                    RuntimeError(
+                    SurfaceNotReady(
                         "The conversation connected but its input surface did not become ready"
                     )
                 )
@@ -5650,19 +5679,33 @@ class OperatorApp(App[None]):
         if not self._is_current(source):
             return
         status = ""
+        connecting = False
         if source.display_only:
             saved = (
                 "Saved excerpt"
                 if getattr(source.session, "saved_preview_partial", False)
                 else "Saved"
             )
+            connecting = not source.connection_error
+            # "Reconnect failed", not "Connection unavailable": by the time this
+            # is shown the app has spent its whole budget re-dialling, and the
+            # old wording described a state rather than an outcome — so the
+            # advice that follows read as "try the thing I was already doing",
+            # which makes a genuinely useful affordance look like a shrug. (A
+            # reselect really does earn a full fresh budget; see
+            # `_start_sidebar_connection`.) "Select again" also drops the coined
+            # verb "Reselect" for the action the user actually performs. Two
+            # characters shorter than what it replaces, so it is not a fit risk.
             status = (
-                f"{saved} · Connection unavailable · Reselect to retry"
+                f"{saved} · Reconnect failed · Select again to retry"
                 if source.connection_error
                 else f"{saved} · Connecting…"
             )
         if self._status is not None:
             self._status.update(connection=status)
+            # The glyph is what tells the user the app is working rather than
+            # wedged; see `StatusLine.set_connecting`.
+            self._status.set_connecting(connecting)
         editor = self._editor()
         if editor.read_only:
             editor.placeholder = READ_ONLY_PLACEHOLDER
@@ -5673,10 +5716,43 @@ class OperatorApp(App[None]):
         else:
             editor.placeholder = "Draft a message…" if status else editor.resting_placeholder
 
-    def _start_sidebar_connection(self, source: SessionInteraction) -> None:
+    def _start_sidebar_connection(
+        self, source: SessionInteraction, *, continues_retry: bool = False
+    ) -> None:
+        """Start (or continue) this source's connect task.
+
+        ``continues_retry`` distinguishes the retry loop's own re-arm from every
+        OTHER caller, and only the retry loop passes it. A user-initiated start —
+        selecting the session, or reselecting after a failure — is BY DEFINITION
+        a fresh budget, so it zeroes `connect_attempts`; the internal re-arm must
+        not, because that is the counter the budget is spent from.
+
+        WHY THE FLAG RATHER THAN AN UNCONDITIONAL RESET HERE. Review round 1
+        (F2/Q1) proposed clearing the counter beside `connection_error`, which is
+        the right intent and the right place. Taken literally it also catches the
+        `call_soon` re-arm in `_connect_sidebar_source`'s `finally`, and then the
+        budget can never be spent: each round zeroes the counter the previous
+        round incremented. Measured against a permanently unreachable owner —
+        `attempts=1` on every round, 16 rounds and still climbing, no terminal
+        state ever reached, which is an infinite reconnect loop rather than a
+        shortened one. The distinction is what makes the reset safe.
+        """
         if source.connection_task is not None and not source.connection_task.done():
             return
         source.connection_error = ""
+        if not continues_retry:
+            # THE BUDGET BELONGS TO AN ATTEMPT THE USER ASKED FOR. A source that
+            # was navigated away from mid-retry keeps its spent counter — the
+            # chain stops because the `finally` declines to re-arm a source that
+            # is no longer current, not because anything reset it — and a later
+            # reselect would then inherit a partial budget. At 5 of 7 spent that
+            # residue no longer outlasts `COLD_FALLBACK_S`, which reintroduces
+            # the exact non-healing mode `SIDEBAR_CONNECT_ATTEMPTS` is derived to
+            # prevent, through state instead of through arithmetic. Reported
+            # independently by review (F2) and QA (Q1), the latter reproducing a
+            # real eviction that failed on a carried budget where the same
+            # eviction healed from a fresh one.
+            source.connect_attempts = 0
         source.connection_task = asyncio.create_task(self._connect_sidebar_source(source))
 
         def settled(task: asyncio.Task[None]) -> None:
@@ -5716,7 +5792,10 @@ class OperatorApp(App[None]):
         published false around the wait instead of only in `finally`.
         """
         from local_operator.session.remote import RemoteSession
-        from local_operator.tui.session_navigation import PreparationInvalidated
+        from local_operator.tui.session_navigation import (
+            PreparationInvalidated,
+            SurfaceNotReady,
+        )
 
         prepared = None
         retry = False
@@ -5794,6 +5873,25 @@ class OperatorApp(App[None]):
         except asyncio.CancelledError:
             cancelled = True
             raise
+        except SurfaceNotReady as error:
+            # A PAINT FAILURE IS NOT A TRANSIENT OWNER, so it is terminal on the
+            # first occurrence — ordered ABOVE the generic handler precisely so
+            # the retry never sees it.
+            #
+            # The readiness gate runs its own 15 s timer to expiry before
+            # raising, so retrying it does not re-dial anything: it re-commits
+            # a session that is already bound and waits out that timer again.
+            # Measured through the real connect body with a gate that never
+            # passes: 8 commits and ~120 s of "Connecting…" before the user was
+            # told anything, against a single 15 s failure pre-fix — plus 8
+            # forced full-screen arming relayouts through #856's retained
+            # recovery branch, which that PR's author documents as a path whose
+            # firing is itself a signal. The budget exists to outlast
+            # `COLD_FALLBACK_S`; a gate timeout is not a thing `COLD_FALLBACK_S`
+            # bounds, so spending the budget on it is category error.
+            source.display_only = True
+            source.connection_error = str(error) or "Connection unavailable"
+            source.connect_attempts = 0
         except PreparationInvalidated:
             source.display_only = True
             retry = True
@@ -5865,7 +5963,12 @@ class OperatorApp(App[None]):
             if not source.retired and not cancelled:
                 self._show_sidebar_connection(source)
                 if retry and self._is_current(source):
-                    asyncio.get_running_loop().call_soon(self._start_sidebar_connection, source)
+                    # `continues_retry`: this is the SAME attempt sequence, so it
+                    # spends the budget rather than refilling it. See
+                    # `_start_sidebar_connection`.
+                    asyncio.get_running_loop().call_soon(
+                        partial(self._start_sidebar_connection, source, continues_retry=True)
+                    )
 
     def on_session_sidebar_selected(self, message: SessionSidebar.Selected) -> None:
         message.stop()
@@ -10274,18 +10377,41 @@ class OperatorApp(App[None]):
         if self._source_commands_ready(source):
             return True
         if source is None or self._is_current(source):
-            hint = (
-                " Select this session again to retry." if self._interaction.connection_error else ""
+            # Same three-state guidance as the composer's refusal: a slash
+            # command typed mid-retry raises the identical "wait or act?"
+            # question and must not answer it with less than the exhausted case.
+            self._notice(
+                f"Commands unavailable until connected.{self._unavailable_hint()}", "warning"
             )
-            self._notice(f"Commands unavailable until connected.{hint}", "warning")
         return False
+
+    def _unavailable_hint(self) -> str:
+        """The "wait or act?" half of an unavailable-while-disconnected notice.
+
+        Three states, and the guidance is different in each — which is the whole
+        point, because the state with the MOST uncertainty used to carry the
+        LEAST information. `connection_error` is cleared between retry attempts
+        so the band can say "Connecting…", and that cleared value was also the
+        only thing gating the old hint: pressing Enter mid-retry therefore got a
+        bare "unavailable" with no answer to the question it raises, while
+        pressing it after the app had given up — when the answer is simply
+        "reselect" — got the fuller sentence.
+
+        Suppressing the reselect advice mid-retry is correct (reselecting while a
+        retry is in flight is not what the user should do); nothing had replaced
+        it. Now the retry window says the app is working and no action is owed,
+        which is the answer, and a spent budget keeps the actionable advice.
+        """
+        source = self._interaction
+        if source.connection_error:
+            return " Select this session again to retry."
+        if source.connect_attempts:
+            return " Reconnecting — it will keep trying for a few more seconds."
+        return ""
 
     def composer_submission_refused(self) -> None:
         if self._interaction.display_only or self._interaction.command_frame_pending:
-            hint = (
-                " Select this session again to retry." if self._interaction.connection_error else ""
-            )
-            self._notice(f"Send unavailable until connected.{hint}", "warning")
+            self._notice(f"Send unavailable until connected.{self._unavailable_hint()}", "warning")
 
     def composer_submission_blocked(
         self, text: str | None = None, *, shell: bool | None = None

--- a/local_operator/tui/session_interaction.py
+++ b/local_operator/tui/session_interaction.py
@@ -141,10 +141,17 @@ class SessionInteraction:
     #: Lives on the SOURCE rather than in the connect task because the retry is
     #: re-armed as a NEW task each round (`_start_sidebar_connection` via the
     #: `finally` block), so a task-local counter would restart at zero every
-    #: time and never exhaust. Reset on a successful commit, which is what makes
-    #: the next disruption start from a full budget; a manual reselect also
-    #: starts fresh, since `_start_sidebar_connection` clears the error on entry
-    #: and a source that connected has already zeroed this.
+    #: time and never exhaust.
+    #:
+    #: Zeroed on exactly three transitions, and the third was a defect found in
+    #: review: a completed commit (the owner is provably reachable), exhaustion
+    #: (surrender hands the user's next attempt a full budget), and any
+    #: USER-INITIATED start. An earlier version claimed the last of those came
+    #: for free "since `_start_sidebar_connection` clears the error on entry" —
+    #: it did not, and a source navigated away from mid-retry kept its spent
+    #: counter, so the next reselect inherited a residue that at 5 of 7 no longer
+    #: outlasts `COLD_FALLBACK_S`. `_start_sidebar_connection` now resets it
+    #: explicitly, and only the retry loop's own re-arm opts out.
     connect_attempts: int = 0
     scroll_revision: int = 0
     preview_scroll_revision: int = 0

--- a/local_operator/tui/session_interaction.py
+++ b/local_operator/tui/session_interaction.py
@@ -134,6 +134,18 @@ class SessionInteraction:
     command_frame_pending: bool = False
     connection_task: asyncio.Task[None] | None = field(default=None, repr=False)
     connection_error: str = ""
+    #: Consecutive failed connect attempts for this source, counted so
+    #: `_connect_sidebar_source` can retry a transient owner loss instead of
+    #: latching it, and still surrender to the user once the budget is spent.
+    #:
+    #: Lives on the SOURCE rather than in the connect task because the retry is
+    #: re-armed as a NEW task each round (`_start_sidebar_connection` via the
+    #: `finally` block), so a task-local counter would restart at zero every
+    #: time and never exhaust. Reset on a successful commit, which is what makes
+    #: the next disruption start from a full budget; a manual reselect also
+    #: starts fresh, since `_start_sidebar_connection` clears the error on entry
+    #: and a source that connected has already zeroed this.
+    connect_attempts: int = 0
     scroll_revision: int = 0
     preview_scroll_revision: int = 0
     # A gate draft can contain a secret. It stays only in this live context,

--- a/local_operator/tui/session_navigation.py
+++ b/local_operator/tui/session_navigation.py
@@ -20,6 +20,27 @@ class PreparationInvalidated(RuntimeError):
     """The authoritative replay changed before presentation ownership moved."""
 
 
+class SurfaceNotReady(RuntimeError):
+    """A committed session's input surface never painted a usable frame.
+
+    A PAINT failure, not a connection failure, and the distinction is the whole
+    reason this type exists rather than a bare ``RuntimeError``. The session on
+    the far side is bound and reachable; what did not happen is local. So it
+    must NOT be retried the way an unreachable owner is: the readiness gate runs
+    its own 15 s timer to expiry on every attempt, so folding it into a bounded
+    reconnect budget multiplies one 15 s failure by the attempt count — measured
+    at 8 commits, ~120 s of "Connecting…", and 8 forced full-screen arming
+    relayouts, where the honest behaviour is a single 15 s failure.
+
+    Subclasses ``RuntimeError`` because that is what ``_await_sidebar_frame``
+    raised before it was named, and every existing handler that catches it —
+    ``_commit_sidebar_session``'s callers, the navigation coordinator's
+    ``failed`` hook — must keep catching it unchanged. Naming it only lets the
+    ONE handler that needs to tell paint from connectivity do so, instead of
+    matching on the message text.
+    """
+
+
 class SessionNavigation(Generic[Prepared]):
     def __init__(
         self,

--- a/local_operator/tui/widgets/status_line.py
+++ b/local_operator/tui/widgets/status_line.py
@@ -1032,6 +1032,11 @@ class StatusLine:
         #: True while a runtime is being started for a cold viewer; see
         #: :meth:`set_starting`.
         self._starting: bool = False
+        #: True while a sidebar source is RE-dialling an owner it lost, which is
+        #: the one state in this family that occupies the connection segment
+        #: instead of the segment ladder. Animated for the same reason
+        #: ``_starting`` is: see :meth:`set_connecting`.
+        self._connecting: bool = False
         self._spinner_timer = None
         #: Interval the live timer was created with; a focus change compares
         #: against it to decide whether the timer must be replaced.
@@ -1121,6 +1126,35 @@ class StatusLine:
         if self._starting == starting:
             return
         self._starting = starting
+        self._sync_spinner_timer()
+        self.refresh()
+
+    def set_connecting(self, connecting: bool) -> None:
+        """Animate the connection segment while a lost owner is being re-dialled.
+
+        The SAME glyph and cadence as :meth:`set_starting` and the working
+        indicator, for the reason that method's docstring already gives: all
+        three mean "busy with something you are waiting for", and the caption is
+        what distinguishes them. A reconnect in flight is exactly that, and was
+        the one member of the family rendering without the glyph.
+
+        WHY IT IS NOT `set_starting(True)`. That flag renders its own
+        ``starting…`` rung in the segment ladder, which alongside the connection
+        segment's own caption would put two captions on one fact
+        (``Saved · Connecting… · ⠙ starting…``). The connection segment carries
+        the glyph itself instead, reusing the existing frames and the existing
+        timer rather than introducing a second animation vocabulary.
+
+        WHY IT MATTERS HERE AND DID NOT BEFORE. Until the reconnect retry landed,
+        ``Saved · Connecting…`` was a sub-frame flicker — measured at 1 sample in
+        6 at 20 Hz on a healthy switch. The retry turns it into a ~12.75 s dwell,
+        and a design round measured six frames spanning t=0.5 s to t=12.0 s
+        hashing to ONE byte-identical file: seven attempts behind a surface that
+        acknowledged none of them, which reads as a hang rather than as work.
+        """
+        if self._connecting == connecting:
+            return
+        self._connecting = connecting
         self._sync_spinner_timer()
         self.refresh()
 
@@ -1568,7 +1602,33 @@ class StatusLine:
             # Connection authority outranks live cost/model details from a saved
             # checkpoint. Reuse the existing row so reconnect never moves the
             # transcript or steals the reader's scroll anchor.
-            left = Text(connection, style=muted)
+            #
+            # IN-PROGRESS AND FAILED MUST NOT LOOK ALIKE. Both states rendered in
+            # `muted` until a design round measured it: `Saved · Connecting…` and
+            # `Saved · Connection unavailable · …` came out the identical
+            # `#b5afa2`, so two messages with opposite instructions ("keep
+            # waiting" / "act now") were distinguishable only by reading them —
+            # which the retry made a real task rather than a theoretical one, by
+            # putting the two seconds apart on one surface. The failed state
+            # takes `danger`; the working state keeps `muted` and gains the
+            # glyph below, so the eye has a non-textual cue either way and the
+            # accent budget is untouched (no green for a session that is not
+            # live).
+            connecting = getattr(self, "_connecting", False)
+            left = Text()
+            if connecting:
+                from local_operator.tui.shimmer import shimmer_enabled
+
+                # Same gate the working indicator uses: with animation off the
+                # glyph would be a frozen decoration, and the caption is already
+                # a complete statement without it.
+                if shimmer_enabled():
+                    left.append(_SPINNER_FRAMES[self._spinner_index], style=muted)
+                    left.append(" ", style=dim)
+            left.append(
+                connection,
+                style=muted if connecting else Style(color=theme_mod.semantic_color("danger")),
+            )
             left.truncate(max(0, width), overflow="ellipsis")
             right = Text(self._conversation_name, style=dim)
             right.truncate(max(0, width - left.cell_len - 3), overflow="ellipsis")
@@ -2159,10 +2219,11 @@ class StatusLine:
         return _SPINNER_INTERVAL_S if animation_focused() else BLURRED_SPINNER_INTERVAL_S
 
     def _sync_spinner_timer(self) -> None:
-        # One timer for both animated states: a runtime starting and a turn
-        # streaming are never usefully distinguished by cadence, and a second
-        # timer would be a second thing to leak.
-        animating = self._streaming or self._starting
+        # One timer for every animated state: a runtime starting, a turn
+        # streaming and an owner being re-dialled are never usefully
+        # distinguished by cadence, and a second timer would be a second thing
+        # to leak.
+        animating = self._streaming or self._starting or getattr(self, "_connecting", False)
         if animating and self._spinner_timer is None:
             self._spinner_rate = self._spinner_interval()
             self._spinner_timer = self._dock.set_interval(self._spinner_rate, self._advance_spinner)

--- a/tests/e2e/test_sidebar_display_e2e.py
+++ b/tests/e2e/test_sidebar_display_e2e.py
@@ -16,7 +16,12 @@ import pytest
 from local_operator.session.remote import RemoteSession
 from local_operator.session.runtime.owned import OwnedSessionHandle
 from local_operator.session.runtime.server import RuntimeServer
-from local_operator.tui.app import ASIDE_PLACEHOLDER, OperatorApp, ToolCard
+from local_operator.tui.app import (
+    ASIDE_PLACEHOLDER,
+    SIDEBAR_CONNECT_ATTEMPTS,
+    OperatorApp,
+    ToolCard,
+)
 from local_operator.tui.session_interaction import SessionDraft
 from local_operator.tui.widgets.copy_picker import CopyPickerScreen
 from tests.e2e.harness import (
@@ -201,7 +206,24 @@ async def test_saved_view_switches_while_authenticated_owner_sync_is_held(
                     await asyncio.wait_for(app._sidebar_navigation.select("neighbour"), 10)
                 if fail_sync:
                     assert source.connection_task is not None
-                    await asyncio.wait_for(asyncio.shield(source.connection_task), 10)
+                    # DRAINED TO EXHAUSTION, not awaited once. A failed connect
+                    # is no longer terminal on its first attempt: a momentarily
+                    # unreachable owner is retried up to
+                    # `SIDEBAR_CONNECT_ATTEMPTS` times, each round a NEW task
+                    # re-armed from the previous one's `finally`, and only a
+                    # spent budget reaches the user. `fail_sync` holds the sync
+                    # broken for every one of those attempts, so the chain runs
+                    # the full budget and then latches — which is exactly the
+                    # terminal state this block goes on to assert, reached the
+                    # way the user now reaches it.
+                    for _ in range(SIDEBAR_CONNECT_ATTEMPTS + 2):
+                        task = source.connection_task
+                        if task is None:
+                            break
+                        await asyncio.wait_for(asyncio.shield(task), 10)
+                        await pilot.pause()
+                        if source.connection_error or source.connection_task is task:
+                            break
                     assert source.connection_error == "the runtime is not responding"
                     assert source.display_only and app.composer_submission_blocked()
                     assert initial_content in visible_text(app)

--- a/tests/e2e/test_sidebar_display_e2e.py
+++ b/tests/e2e/test_sidebar_display_e2e.py
@@ -228,7 +228,10 @@ async def test_saved_view_switches_while_authenticated_owner_sync_is_held(
                     assert source.display_only and app.composer_submission_blocked()
                     assert initial_content in visible_text(app)
                     assert editor.text == "Keep this unsent draft"
-                    assert "Connection unavailable" in app._status.render_text(80).plain
+                    # "Reconnect failed", not "Connection unavailable": the
+                    # terminal copy now says the app already tried, since by the
+                    # time it is shown a whole retry budget has been spent.
+                    assert "Reconnect failed" in app._status.render_text(80).plain
                     assert "retry" in app._status.render_text(80).plain
                     fail_sync = False
                     released.set()

--- a/tests/e2e/test_sidebar_reconnect_e2e.py
+++ b/tests/e2e/test_sidebar_reconnect_e2e.py
@@ -213,7 +213,7 @@ async def test_an_evicted_viewer_reconnects_without_ever_looking_connected(
                 else:
                     assert not viewer._recovering
 
-                # THE USER ACTION: "Reselect to retry" on the sidebar.
+                # THE USER ACTION: selecting the session again from the sidebar.
                 recoveries_before = app._sidebar_gate_recoveries
                 app._start_sidebar_connection(source)
                 seen = await _settle(app, pilot, source)

--- a/tests/e2e/test_sidebar_reconnect_e2e.py
+++ b/tests/e2e/test_sidebar_reconnect_e2e.py
@@ -1,0 +1,314 @@
+"""A viewer that lost its owner reconnects itself, against a real runtime.
+
+WHAT THIS STAGE ADDS OVER THE UNIT TESTS. The unit file
+(``tests/unit/tui/test_sidebar_connect_retry.py``) drives a `RemoteSession`
+subclass that reproduces the silent-bind outcome directly. It pins the policy,
+but it cannot prove the state it simulates is the one a real disruption
+produces. These tests take the disruption itself — a real `RuntimeServer`, real
+attach sockets, a real eviction — and assert the user-visible outcome.
+
+THE TRIGGER, AND WHY IT IS NOT THE ROOT CAUSE. `ATTACH_MAX_CLIENTS` is 4 per
+runtime and the cap evicts LRU with no goodbye, so a viewer learns it was
+dropped only through EOF, which routes to `_on_disconnected` and sets
+`_recovering`. That is the dominant trigger on a heavily-multiplexed host
+(several TUIs, a desktop proxy, a mobile bridge, sidebar sources, all on one
+runtime). But the defect is a property of ANY owner loss:
+``test_a_plain_socket_loss_reconnects_with_no_attach_pressure`` reproduces it
+from a bare socket close with zero attach clients, which is why the fix is at
+the bind postcondition rather than at the cap.
+
+THE TWO WINDOWS ARE BOTH ASSERTED, and that is deliberate. A disruption leaves
+the facade `_recovering` for up to `COLD_FALLBACK_S`, after which `_go_cold`
+releases it. Reselecting inside that window used to fail; reselecting after it
+always worked. Parametrising both is what keeps this a regression guard in
+BOTH directions — the ``after`` case passed before the fix and must keep
+passing, so a "fix" that broke the healthy path would be caught here.
+
+ISOLATION. `headless_tui_env` gives every test its own config dir, the runtimes
+are in-process, and the session ids are synthetic. Nothing here can attach to,
+evict or disturb a session outside the test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from local_operator.session.remote import RemoteSession
+from local_operator.session.runtime.owned import OwnedSessionHandle
+from local_operator.session.runtime.server import RuntimeServer
+from local_operator.session.runtime.types import ATTACH_MAX_CLIENTS
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.session_interaction import SessionInteraction
+from tests.e2e.harness import (
+    ScriptedStream,
+    assistant_message,
+    build_session,
+    seed_transcript,
+    user_message,
+    wait_for_adoption,
+)
+
+#: How long a settled connect is waited for. A BACKSTOP, not an assertion: the
+#: loop below exits the moment the task finishes, so a healthy run never spends
+#: it. Sized well above the retry budget (~13 s) so a slow CI runner cannot
+#: turn a passing reconnect into a timeout.
+_SETTLE_BACKSTOP_S = 60.0
+
+#: Gate recoveries a single reconnect may spend before it counts as a spin.
+#:
+#: The defect turned `post_display_hook`'s recovery branch into a hot loop —
+#: measured on this tree at 1,268 recoveries in ONE reselect, because a cold
+#: session published as connected can never satisfy the gate and the branch
+#: bought a full-screen relayout on every frame until the timer fired. After
+#: the fix the same reselect spends 0 or 1, the same as a healthy first connect.
+#:
+#: Sized to separate those two populations by orders of magnitude rather than to
+#: pin an exact frame count, which legitimately varies with which paint carries
+#: the completed compositor map.
+_GATE_RECOVERY_CEILING = 8
+
+
+async def _runtime(config: Path, session_id: str) -> RuntimeServer:
+    """A real in-process runtime owning a two-message saved transcript."""
+    directory = config / "sessions" / session_id
+    await seed_transcript(
+        directory,
+        [user_message(f"{session_id} q"), assistant_message(f"{session_id} saved answer")],
+    )
+    owner = build_session(directory, ScriptedStream([]), cwd=config)
+    handle = OwnedSessionHandle(owner, asyncio.get_running_loop(), cwd=str(config))
+    server = RuntimeServer(handle, kind="daemon")
+    await server.start_in_process()
+    return server
+
+
+async def _never_take_over() -> None:
+    raise AssertionError("a viewer must not take over during this test")
+
+
+async def _settle(app: OperatorApp, pilot, source: SessionInteraction) -> list[tuple[bool, bool]]:
+    """Pump until the connect task finishes, sampling what the user can see.
+
+    Each sample is ``(display_only, is_cold)``. The false-connected state the
+    defect produced is ``(False, True)`` — a live-looking transcript over a
+    session with no runtime attached — so collecting the samples lets the
+    caller assert that state never existed, without asserting how long
+    anything took.
+    """
+    seen: list[tuple[bool, bool]] = []
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _SETTLE_BACKSTOP_S
+    while loop.time() < deadline:
+        await pilot.pause()
+        seen.append((source.display_only, bool(getattr(source.session, "is_cold", False))))
+        await asyncio.sleep(0.05)
+        current = source.connection_task
+        if current is None:
+            break
+        if current.done():
+            # A FINISHED TASK IS NOT A SETTLED CONNECT. Every retry round is a
+            # NEW task, re-armed from the previous one's `finally` through
+            # `call_soon`, so between rounds the current task is briefly `done`
+            # with its successor not yet installed. Breaking on `done()` alone
+            # returned mid-chain and reported the in-flight `display_only=True`
+            # as the outcome — which is how this read as a failure under load,
+            # where a slower machine simply lands the sample inside a backoff
+            # rather than after the last attempt. Settled means the task
+            # finished AND nothing replaced it.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            if source.connection_task is current:
+                break
+    await pilot.pause()
+    seen.append((source.display_only, bool(getattr(source.session, "is_cold", False))))
+    return seen
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reselect_after_s, window", [(1.0, "during"), (10.0, "after")])
+async def test_an_evicted_viewer_reconnects_without_ever_looking_connected(
+    headless_tui_env: Path,
+    reselect_after_s: float,
+    window: str,
+) -> None:
+    """Evict the sidebar's viewer with real clients, then reselect it.
+
+    ``during``: the reselect lands while the facade is still `_recovering`, so
+    the bind cannot succeed yet. Before the fix this either latched terminally
+    or — the case this asserts — committed a cold session and showed a live
+    transcript for 15 s before reverting. Now the connect retries past
+    `COLD_FALLBACK_S` and lands connected, with no intermediate live-looking
+    state at all.
+
+    ``after``: the reselect lands past the recovery bound. This case worked
+    before the fix and must keep working; it is the guard against a retry
+    policy that slows down or breaks the healthy path.
+    """
+    config = headless_tui_env
+    servers = {name: await _runtime(config, name) for name in ("origin", "target")}
+
+    def find_owner(_config_dir, session_id):
+        server = servers.get(session_id)
+        return (server._record, server._record.pid) if server else (None, None)
+
+    async def resume(session_id):
+        return await RemoteSession.connect(
+            servers[session_id]._record,
+            session_id,
+            config_dir=config,
+            takeover_factory=_never_take_over,
+            display_window=True,
+        )
+
+    app = OperatorApp(lambda: resume("origin"), resume_factory=resume)
+    with patch("local_operator.mobile.attach_client.find_owner_record", find_owner):
+        async with app.run_test(size=(120, 36)) as pilot:
+            await wait_for_adoption(app, pilot)
+            await asyncio.wait_for(app._sidebar_navigation.select("target"), 30)
+            source = app._sidebar_sources["target"]
+            if source.connection_task is not None:
+                await asyncio.wait_for(asyncio.shield(source.connection_task), 30)
+            await pilot.pause()
+            # Narrowed once: the source's session is typed as the general
+            # protocol, but the recovery state under test (`is_cold`,
+            # `_recovering`) is the viewer facade's.
+            viewer = source.session
+            assert isinstance(viewer, RemoteSession)
+            assert not source.display_only
+            assert not viewer.is_cold
+            # PRECONDITION for the counter assertion below: the gate really is
+            # armed on this rig, so a small count there cannot be satisfied by a
+            # switch that never consulted it (#856's own note on why
+            # `_sidebar_gate_reached` exists beside `_sidebar_gate_recoveries`).
+            assert app._sidebar_gate_reached > 0
+
+            # `ATTACH_MAX_CLIENTS` other attach-class clients on the SAME
+            # runtime: the ordinary shape of a multiplexed host, and enough to
+            # evict the sidebar's viewer through the LRU cap.
+            hogs = [
+                await RemoteSession.connect(
+                    servers["target"]._record,
+                    "target",
+                    config_dir=config,
+                    takeover_factory=_never_take_over,
+                    display_window=True,
+                )
+                for _ in range(ATTACH_MAX_CLIENTS)
+            ]
+            try:
+                loop = asyncio.get_running_loop()
+                until = loop.time() + reselect_after_s
+                while loop.time() < until:
+                    await pilot.pause()
+                    await asyncio.sleep(0.05)
+                # PRECONDITION: the eviction actually landed, so a pass cannot
+                # mean "nothing was ever broken".
+                assert viewer.is_cold
+                if window == "during":
+                    assert viewer._recovering
+                else:
+                    assert not viewer._recovering
+
+                # THE USER ACTION: "Reselect to retry" on the sidebar.
+                recoveries_before = app._sidebar_gate_recoveries
+                app._start_sidebar_connection(source)
+                seen = await _settle(app, pilot, source)
+
+                assert source.display_only is False
+                assert source.connection_error == ""
+                assert viewer.is_cold is False
+                # THE HEADLINE PROPERTY: at no sampled point was a cold session
+                # presented as connected. That state is what the user saw for
+                # 15 s, and it is what the readiness gate can never satisfy.
+                assert (False, True) not in seen
+                # The readiness gate is genuinely reachable now, rather than
+                # structurally refused for the life of the switch.
+                assert app._sidebar_gate_surface_ready(source)
+                # AND THE SPIN IS GONE, in #856's counters. A cold session
+                # published as connected made the gate unsatisfiable, so
+                # `post_display_hook`'s recovery branch bought a full-screen
+                # relayout on EVERY frame until the 15 s timer fired — measured
+                # on this tree at 1,268 refusals, all of them recoveries.
+                #
+                # A CEILING, not an equality, and deliberately loose. #856's
+                # unit rig reaches a flat zero, but this one drives real
+                # runtimes through a real eviction and spends 0 or 1 depending
+                # on which paint carries the completed compositor map — a
+                # painted-map refusal that has nothing to do with `is_cold`
+                # (verified at the refusal: current=True, display_only=False,
+                # cold=False, hist=True). Pinning 0 would assert that timing,
+                # not this fix.
+                #
+                # What IS this fix's property is that the count is BOUNDED
+                # rather than proportional to the 15 s window: the defect made
+                # this a hot spin whose size was set by how long the timer ran.
+                # The ceiling separates 1,268 from 0-1 by three orders of
+                # magnitude, so a spin cannot come in under it while honest
+                # paint jitter cannot exceed it. A COUNT is also
+                # load-independent — a busy machine changes how long the frames
+                # take, not how many the gate refuses.
+                assert app._sidebar_gate_recoveries - recoveries_before <= _GATE_RECOVERY_CEILING
+            finally:
+                for hog in hogs:
+                    await hog.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_plain_socket_loss_reconnects_with_no_attach_pressure(
+    headless_tui_env: Path,
+) -> None:
+    """GENERALITY: the fix addresses owner loss, not the attach cap.
+
+    Raising `ATTACH_MAX_CLIENTS` was explicitly rejected as a fix for exactly
+    this reason. Here the socket is dropped the way a send timeout or an owner
+    blip drops it — one viewer, zero other clients, no cap involved — and the
+    facade lands in the same `is_cold` + `_recovering` state, so a connect that
+    trusts `_ensure_bound`'s silent return fails identically.
+    """
+    config = headless_tui_env
+    session_id = "target"
+    server = await _runtime(config, session_id)
+
+    def find_owner(_config_dir, requested):
+        return (server._record, server._record.pid) if requested == session_id else (None, None)
+
+    with patch("local_operator.mobile.attach_client.find_owner_record", find_owner):
+        viewer = await RemoteSession.saved_preview(
+            session_id,
+            config_dir=config,
+            cwd=str(config),
+            takeover_factory=_never_take_over,
+        )
+        try:
+            await viewer._ensure_bound()
+            await viewer.ensure_display_current()
+            assert not viewer.is_cold
+            assert server.attach_clients() == 1
+
+            client = viewer._client
+            assert client is not None
+            client.close()
+            await asyncio.sleep(0)
+            for _ in range(20):
+                await asyncio.sleep(0.05)
+                if viewer.is_cold:
+                    break
+            # No cap, no eviction, no competing client — and the same state.
+            assert viewer.is_cold
+            assert viewer._recovering
+            assert server.attach_clients() == 0
+
+            # THE DEFECT, in the two calls the connect body makes: the bind
+            # neither binds nor raises, so a caller that does not check the
+            # postcondition proceeds against a cold session.
+            await viewer._ensure_bound()
+            assert viewer.is_cold, (
+                "_ensure_bound bound the facade; this test no longer covers the "
+                "silent-return outcome the fix exists to catch"
+            )
+        finally:
+            await viewer.dispose()

--- a/tests/unit/tui/test_sidebar_connect_retry.py
+++ b/tests/unit/tui/test_sidebar_connect_retry.py
@@ -46,7 +46,16 @@ from local_operator.session.remote import COLD_FALLBACK_S, RemoteSession
 from local_operator.tui import app as app_module
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.session_interaction import SessionInteraction
+from local_operator.tui.session_navigation import SurfaceNotReady
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+#: The shipped schedule, captured at import BEFORE any test patches it for
+#: speed. `_shipped_span_from` asserts against these rather than against the
+#: live module attributes, because the property under test is what a user's
+#: next connect actually gets.
+_SHIPPED_BACKOFF_S = app_module.SIDEBAR_CONNECT_BACKOFF_S
+_SHIPPED_CEILING_S = app_module.SIDEBAR_CONNECT_BACKOFF_CEILING_S
+_SHIPPED_ATTEMPTS = app_module.SIDEBAR_CONNECT_ATTEMPTS
 
 
 @pytest.fixture(autouse=True)
@@ -147,6 +156,19 @@ class UnreachableRemote(RecoveringRemote):
         if heals is not None and self.display_calls >= heals:
             return None
         raise ConnectionError("history owner is unavailable")
+
+
+def _shipped_span_from(spent: int) -> float:
+    """Total backoff still available after `spent` attempts, on the SHIPPED schedule.
+
+    Deliberately reads the module's real constants rather than whatever a test
+    has patched for speed: the property under test is what a user's next connect
+    actually gets, which is a fact about the shipped numbers.
+    """
+    return sum(
+        min(_SHIPPED_BACKOFF_S * (2 ** (attempt - 1)), _SHIPPED_CEILING_S)
+        for attempt in range(spent + 1, _SHIPPED_ATTEMPTS + 1)
+    )
 
 
 async def _current_source(
@@ -263,8 +285,10 @@ async def test_a_bind_that_did_not_bind_is_not_committed(monkeypatch):
         commit.assert_not_called()
         assert source.display_only is True
         # The failure is not the end of the story — it re-arms rather than
-        # latching — but nothing was published in the meantime.
-        rearmed.assert_called_once_with(source)
+        # latching — but nothing was published in the meantime. `continues_retry`
+        # is what stops that re-arm refilling the budget it is spending; see
+        # `test_the_retry_loops_own_rearm_still_spends_the_budget`.
+        rearmed.assert_called_once_with(source, continues_retry=True)
 
 
 @pytest.mark.asyncio
@@ -385,8 +409,11 @@ async def test_only_exhaustion_latches_and_it_says_so_honestly(monkeypatch):
         assert source.connection_error == "the runtime is not responding"
         assert app._status is not None
         status = app._status.render_text(120).plain
-        assert "Connection unavailable" in status
-        assert "Reselect" in status
+        # The terminal copy now says the app already TRIED (design round D3):
+        # "Connection unavailable" described a state, so the advice that
+        # followed read as "try the thing I was already doing".
+        assert "Reconnect failed" in status
+        assert "Select again to retry" in status
         # Surrendering hands the user a FULL budget, not one last attempt.
         assert source.connect_attempts == 0
 
@@ -571,6 +598,260 @@ async def test_the_retry_releases_its_preparation_before_waiting(monkeypatch):
         # Once per attempt, not once at the end of the whole sequence.
         assert len(released) == app_module.SIDEBAR_CONNECT_ATTEMPTS + 1
         assert source.command_frame_pending is False
+
+
+@pytest.mark.asyncio
+async def test_a_reselect_after_navigating_away_gets_a_full_budget(monkeypatch):
+    """F2/Q1: the budget available ON A RESELECT, not merely at birth.
+
+    THE DEFECT THIS PINS. A source navigated away from mid-retry keeps its spent
+    `connect_attempts`: the chain stops because the `finally` declines to re-arm
+    a source that is no longer current, and nothing on that path resets the
+    counter. The user's next reselect then started partway through the budget —
+    reproduced independently by review (carried 4, resuming at 5 of 7) and by QA
+    against a real attach-cap eviction (carried 6 → 3.0 s remaining → failed,
+    where the identical eviction from a fresh budget healed).
+
+    WHY THE EXISTING RELATIONSHIP TEST DOES NOT COVER THIS.
+    `test_the_retry_budget_outlasts_the_recovery_give_up_bound` asserts the
+    span of the FULL schedule and passes while this defect is live, because the
+    arithmetic never changed — what changed was how much of it a reselect gets
+    to use. This test therefore asserts the property in the units the defect
+    speaks: the remaining span at the moment a user-initiated connect begins.
+    """
+    session = RecoveringRemote("recovering")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        source = await _current_source(app, pilot, session)
+        # A SHORT REAL BACKOFF, not a zeroed one. The residue is left by a
+        # chain stopped BETWEEN rounds — the user switches away while a backoff
+        # is sleeping — so the window has to exist for the test to enter it.
+        monkeypatch.setattr(app_module, "SIDEBAR_CONNECT_BACKOFF_S", 0.05)
+        monkeypatch.setattr(app_module, "SIDEBAR_CONNECT_BACKOFF_CEILING_S", 0.05)
+        monkeypatch.setattr(app_module, "SIDEBAR_CONNECT_ATTEMPTS", 7)
+
+        app._start_sidebar_connection(source)
+        # Part-way through, NOT to exhaustion: an exhausted budget resets itself
+        # on surrender, and the residue this pins is the one a chain leaves when
+        # it is stopped early.
+        for _ in range(3):
+            await asyncio.sleep(0.06)
+        assert source.connect_attempts > 0, "the precondition never spent any budget"
+        assert source.connect_attempts < app_module.SIDEBAR_CONNECT_ATTEMPTS
+
+        # The user navigates away mid-backoff; the chain stops itself.
+        app._interaction = SessionInteraction(FakeSession())
+        task = source.connection_task
+        if task is not None:
+            await task
+        await asyncio.sleep(0)
+        carried = source.connect_attempts
+        assert carried > 0, "the precondition left no residue to clear"
+        assert not source.connection_error, "the budget was spent, not carried"
+
+        # The user comes back and reselects. Sampled SYNCHRONOUSLY, before the
+        # new task gets a turn: the budget a connect begins with is the property
+        # under test, and letting the task run first hides it — a successful
+        # connect zeroes the counter on its own, so a later sample reads 0 even
+        # on a tree where the reselect inherited a spent budget. That made an
+        # earlier version of this test survive its own mutation.
+        app._interaction = source
+        app._start_sidebar_connection(source)
+
+        assert source.connect_attempts == 0, "a reselect inherited a spent budget"
+
+        # AND IN THE UNITS THE DEFECT SPEAKS: the span still available at the
+        # moment a user-initiated connect begins must outlast the bound the
+        # whole constant is derived from. Computed from the SHIPPED schedule
+        # (this test patches the backoff to keep itself fast, and a span
+        # measured off the patched values would assert nothing about what
+        # users get).
+        shipped = _shipped_span_from(source.connect_attempts)
+        assert shipped > COLD_FALLBACK_S
+        # NOT VACUOUS, in two steps. Carrying a residue strictly shortens what
+        # the next connect gets...
+        assert _shipped_span_from(carried) < shipped
+        # ...and carrying enough of one takes it below the bound entirely, which
+        # is the failure QA reproduced against a real eviction (carried 6 → 3.0 s
+        # → failed, where the same eviction healed from a fresh budget). Pinned
+        # as the existence of such a value rather than as one number, so it
+        # keeps meaning the same thing if the schedule is retuned.
+        assert any(
+            _shipped_span_from(spent) < COLD_FALLBACK_S for spent in range(1, _SHIPPED_ATTEMPTS + 1)
+        ), "no residue could ever break the bound; this test would be vacuous"
+
+
+@pytest.mark.asyncio
+async def test_the_retry_loops_own_rearm_still_spends_the_budget(monkeypatch):
+    """The other half of F2/Q1: the reset must not make the budget infinite.
+
+    The reviewers' proposed one-liner — clear the counter beside
+    `connection_error` in `_start_sidebar_connection` — is the right place and
+    the right intent, but the retry loop re-arms through that same method. Taken
+    unconditionally it zeroes the counter the previous round just incremented,
+    and a permanently unreachable owner is re-dialled forever instead of
+    surrendering: measured at `attempts=1` on every round for 16 rounds with no
+    terminal state, which is a worse bug than the one being fixed.
+
+    So this asserts the pair: a user start refills, the loop's own re-arm does
+    not, and exhaustion is still reachable.
+    """
+    session = RecoveringRemote("gone")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        source = await _current_source(app, pilot, session)
+        _instant_backoff(monkeypatch, attempts=3)
+
+        app._start_sidebar_connection(source)
+        await _drain_retries(app, source)
+
+        assert source.connection_error == "the runtime is not responding"
+        assert session.bind_calls == app_module.SIDEBAR_CONNECT_ATTEMPTS + 1
+
+
+@pytest.mark.asyncio
+async def test_a_readiness_gate_timeout_is_not_retried(monkeypatch):
+    """F1: a PAINT failure is terminal on the first occurrence.
+
+    `_await_sidebar_frame` runs its own 15 s timer to expiry before raising, so
+    folding its failure into the reconnect budget does not re-dial anything — it
+    re-commits an already-bound session and waits the timer out again, once per
+    attempt. Reviewer measured 8 commits and ~120 s of "Connecting…" where the
+    honest behaviour is a single 15 s failure, plus 8 forced full-screen arming
+    relayouts through a recovery branch whose author documents any firing as a
+    signal.
+
+    Asserted as a COUNT of commits, not a duration: the defect is "the budget is
+    spent on this", which is a fact about how many times the body ran.
+    """
+    session = RecoveringRemote("painting", heals_after=1)
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        source = await _current_source(app, pilot, session)
+        prepared: Any = (source, object())
+        monkeypatch.setattr(app, "_prepare_sidebar_session", _always(prepared))
+        commits = {"n": 0}
+
+        def commit(*_args: Any, **_kwargs: Any) -> Any:
+            commits["n"] += 1
+            future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+            # Exactly what `expired()` does when the 15 s timer fires.
+            future.set_exception(
+                SurfaceNotReady(
+                    "The conversation connected but its input surface did not become ready"
+                )
+            )
+            return future
+
+        monkeypatch.setattr(app, "_commit_sidebar_session", commit)
+        _instant_backoff(monkeypatch, attempts=7)
+
+        app._start_sidebar_connection(source)
+        await _drain_retries(app, source)
+
+        assert commits["n"] == 1, "a readiness-gate timeout was retried"
+        assert source.display_only is True
+        assert source.connection_error == (
+            "The conversation connected but its input surface did not become ready"
+        )
+        # Surrendering on a paint failure still hands the user a full budget for
+        # the connection attempt their reselect will make.
+        assert source.connect_attempts == 0
+
+
+@pytest.mark.asyncio
+async def test_the_retry_window_animates_and_the_failed_state_does_not(monkeypatch):
+    """D1/D4: the band moves while it is working, and stops when it is not.
+
+    The retry window was a byte-identical frozen frame for its whole ~12.75 s —
+    a design round measured six frames from t=0.5s to t=12.0s hashing to one
+    file, because `_sync_spinner_timer` animates only on `_streaming or
+    _starting` and the reconnect path sets neither. Seven attempts behind a
+    surface that acknowledged none of them reads as a hang.
+
+    Asserted on the band's own STATE rather than on rendered pixels, so it
+    cannot flake on paint timing; the rendered frames are attached to the PR.
+    """
+    session = RecoveringRemote("recovering")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        source = await _current_source(app, pilot, session)
+        _instant_backoff(monkeypatch, attempts=4)
+        assert app._status is not None
+
+        # Mid-retry: working, so it animates. Published through the same method
+        # the connect body calls, which is what owns this state.
+        source.display_only = True
+        source.connect_attempts = 2
+        source.connection_error = ""
+        app._show_sidebar_connection(source)
+        await pilot.pause()
+        assert app._status._connecting is True
+        assert app._status._spinner_timer is not None, "the retry window has no animation"
+        frame = app._status._spinner_index
+        app._status._advance_spinner()
+        assert app._status._spinner_index != frame
+
+        # Exhausted: not working, so the motion stops — which is the state
+        # change the eye catches without reading the words.
+        source.connection_error = "the runtime is not responding"
+        app._show_sidebar_connection(source)
+        await pilot.pause()
+        assert app._status._connecting is False
+        assert app._status._spinner_timer is None
+
+
+@pytest.mark.asyncio
+async def test_guidance_answers_wait_or_act_in_every_disconnected_state(monkeypatch):
+    """D2: the state with the most uncertainty must not carry the least advice.
+
+    `connection_error` is cleared between attempts so the band can say
+    "Connecting…", and it was also the only thing gating the refusal hint — so
+    pressing Enter mid-retry produced a bare "unavailable" with no answer, while
+    pressing it after the app gave up produced the fuller sentence. Inverted
+    against need. Suppressing the reselect advice mid-retry is right; nothing
+    had replaced it.
+    """
+    session = RecoveringRemote("recovering")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        source = await _current_source(app, pilot, session)
+        source.display_only = True
+        notices: list[str] = []
+        monkeypatch.setattr(app, "_notice", lambda text, kind="info": notices.append(text))
+
+        # Mid-retry: the app is working and the user need not act.
+        source.connect_attempts = 2
+        source.connection_error = ""
+        app.composer_submission_refused()
+        assert "Reconnecting" in notices[-1]
+        assert "Select this session again" not in notices[-1]
+
+        # Exhausted: the app has stopped, and reselecting is the right advice.
+        source.connection_error = "the runtime is not responding"
+        app.composer_submission_refused()
+        assert "Select this session again to retry." in notices[-1]
+
+        # Never-attempted: nothing to say beyond the refusal itself.
+        source.connect_attempts = 0
+        source.connection_error = ""
+        app.composer_submission_refused()
+        assert notices[-1] == "Send unavailable until connected."
+
+
+def test_the_derivation_refuses_a_backoff_it_cannot_solve(monkeypatch):
+    """F4: a mistuned constant fails loudly at the edit, not at import.
+
+    `_attempts_outlasting` runs at module scope, so its unbounded loop put a
+    hang — or, with a zeroed backoff, an `OverflowError` from the doubling — at
+    IMPORT time of `app.py`. Unreachable from the shipped values, but the
+    trigger is a one-character edit to constants a future agent has explicit
+    reason to tune, which is the worst place for a silent failure.
+    """
+    monkeypatch.setattr(app_module, "SIDEBAR_CONNECT_BACKOFF_S", 0.0)
+    monkeypatch.setattr(app_module, "SIDEBAR_CONNECT_BACKOFF_CEILING_S", 0.0)
+    with pytest.raises(ValueError, match="cannot outlast"):
+        app_module._attempts_outlasting(COLD_FALLBACK_S)
 
 
 async def _noop() -> None:

--- a/tests/unit/tui/test_sidebar_connect_retry.py
+++ b/tests/unit/tui/test_sidebar_connect_retry.py
@@ -1,0 +1,592 @@
+"""A sidebar connect never publishes a session it did not actually bind.
+
+THE DEFECT THESE PIN. ``RemoteSession._ensure_bound`` has three outcomes and
+only two of them are distinguishable at the call site: it binds, it raises, or
+— while the facade is ``_recovering`` after an owner loss — it returns
+SILENTLY, without binding, leaving the session cold. ``_connect_sidebar_source``
+read that third outcome as success. What followed depended only on whether the
+display window happened to be invalidated:
+
+* invalidated: the next call raised ``ConnectionError`` and the bare
+  ``except Exception`` latched a terminal failure, so a condition that clears
+  itself in under ``COLD_FALLBACK_S`` seconds became a dead session only a
+  manual reselect could revive;
+* not invalidated: nothing raised, the commit went through, and the user
+  watched a live-looking transcript of a COLD session for 15 s — 1,799 refused
+  frames, each requesting a full relayout — until ``_await_sidebar_frame``'s
+  timer gave up and reverted to the failure view.
+
+Every existing test of this path drives a facade that either binds or raises.
+None covered the silent third outcome, which is exactly why it shipped. The
+load-bearing assertion in this file is therefore the postcondition:
+**after a connect commits, the session is not cold.**
+
+WHY THE DOUBLE IS A REAL SUBCLASS. ``_connect_sidebar_source`` opens with an
+``isinstance(session, RemoteSession)`` check and returns quietly for anything
+else, so a duck-typed stand-in would make every assertion here vacuously true
+by never reaching the code under test.
+
+NO WALL-CLOCK ASSERTIONS. Per AGENTS.md "Timing, flakes": the retry budget is
+asserted as a RELATIONSHIP between two constants and as a COUNT of attempts,
+never as an elapsed duration, and the gate-spin guard asserts the structural
+fact (the readiness gate is never armed for a bind that failed) rather than a
+rate of refusals.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from local_operator.session.remote import COLD_FALLBACK_S, RemoteSession
+from local_operator.tui import app as app_module
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.session_interaction import SessionInteraction
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+@pytest.fixture(autouse=True)
+def isolate(tmp_path, monkeypatch):
+    # An inherited CMUX_* variable lets a headless app rename the operator's
+    # real multiplexer workspaces; HOME is redirected too because the cache
+    # root is derived from it independently of LOCAL_OPERATOR_CONFIG_DIR.
+    for key in tuple(os.environ):
+        if key.startswith("CMUX_"):
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_NOTIFICATIONS", "1")
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_TERMINAL_TITLE", "1")
+    monkeypatch.setattr(OperatorApp, "_check_for_update", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_update_check", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_terminal_title", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_multiplexer_broadcast", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_herdr_reporter", lambda _self: None)
+
+
+class RecoveringRemote(RemoteSession):
+    """A viewer that reproduces the ``_recovering`` silent return.
+
+    ``_ensure_bound`` returns without raising and without clearing ``is_cold``,
+    which is what the real method does at ``remote.py`` when the facade is
+    mid-recovery. ``heals_after`` binds on the Nth call so the retry budget has
+    something to succeed against, mirroring the real timeline where the facade
+    stops being ``_recovering`` once ``COLD_FALLBACK_S`` elapses.
+
+    Deliberately does NOT call ``RemoteSession.__init__``: constructing a real
+    one dials a runtime. Only the surface the connect path reads is provided.
+    """
+
+    def __init__(self, session_id: str, *, heals_after: int | None = None) -> None:
+        self._session_id = session_id
+        self._cold = True
+        self._heals_after = heals_after
+        self.bind_calls = 0
+        self.disposed = False
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    @property
+    def is_cold(self) -> bool:
+        return self._cold
+
+    # Both are read-only properties on the real class, so they are overridden
+    # rather than assigned. "Current" is the state that makes the SILENT bind
+    # failure reachable: an invalidated window would make the next call raise
+    # instead, which is the symptom this defect's other face already produced.
+    @property
+    def display_history_current(self) -> bool:
+        return True
+
+    @property
+    def display_history_revision(self) -> int:
+        return 1
+
+    async def _ensure_bound(self, *, foreground: bool = True) -> None:
+        self.bind_calls += 1
+        if self._heals_after is not None and self.bind_calls >= self._heals_after:
+            self._cold = False
+
+    async def ensure_display_current(self) -> None:
+        return None
+
+    async def dispose(self) -> None:
+        # App teardown disposes every source it is holding. The real method
+        # walks socket and waiter state this double never built, so it is
+        # replaced rather than left to fail the unmount of every test here.
+        self.disposed = True
+
+
+class UnreachableRemote(RecoveringRemote):
+    """A viewer that BINDS but whose owner is momentarily unreachable.
+
+    The other face of the same disruption: ``_ensure_bound`` succeeds, and the
+    display refresh is what fails (``ConnectionError("history owner is
+    unavailable")``, raised when the client is gone and the window is stale).
+    This is the shape that used to latch terminally with no auto-retry.
+    """
+
+    def __init__(self, session_id: str, *, heals_after: int | None = None) -> None:
+        super().__init__(session_id, heals_after=None)
+        self._cold = False
+        self._display_heals_after = heals_after
+        self.display_calls = 0
+
+    async def _ensure_bound(self, *, foreground: bool = True) -> None:
+        self.bind_calls += 1
+
+    async def ensure_display_current(self) -> None:
+        self.display_calls += 1
+        heals = self._display_heals_after
+        if heals is not None and self.display_calls >= heals:
+            return None
+        raise ConnectionError("history owner is unavailable")
+
+
+async def _current_source(
+    app: OperatorApp, pilot: Any, session: RemoteSession
+) -> SessionInteraction:
+    """Make ``session`` the app's current sidebar source, as a click would.
+
+    ``display_only`` starts True because that is the state the connect task is
+    always entered from: the saved excerpt is on screen and the socket work has
+    not happened yet.
+
+    The pilot is pumped to completion FIRST because boot installs its own
+    interaction asynchronously: a source assigned before that lands is replaced
+    by the boot session's, `_is_current` goes False, and the retry branch —
+    which is conditioned on the source still being on screen — silently stops
+    being exercised. That produced a test that passed while asserting nothing.
+    """
+    for _ in range(60):
+        await pilot.pause()
+    source = SessionInteraction(session)
+    source.display_only = True
+    app._interaction = source
+    app._interactions[id(session)] = source
+    app._sidebar_sources[session.session_id] = source
+    return source
+
+
+async def _drain_retries(app: OperatorApp, source: SessionInteraction, *, rounds: int = 40) -> None:
+    """Await the whole retry chain, round by round, as the app drives it.
+
+    Each round is a NEW task: the `finally` block re-arms through `call_soon`,
+    so following the chain means awaiting the current task, yielding twice to
+    let the callback run, and picking up whatever task it installed. Awaiting
+    the FIRST task alone would only ever see attempt one.
+
+    Awaited rather than pumped with `pilot.pause()`, which costs ~1 s a turn
+    here and made an earlier version of this file take eight minutes. `rounds`
+    is a runaway backstop, not a budget: a chain that has settled breaks out
+    immediately, and one that has not is the bug.
+    """
+    for _ in range(rounds):
+        task = source.connection_task
+        if task is None:
+            return
+        try:
+            await task
+        except asyncio.CancelledError:
+            return
+        # Two turns: one for the `call_soon` re-arm to run, one for the task it
+        # creates to be scheduled.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        if source.connection_task is task or source.connection_task is None:
+            return
+    raise AssertionError("the retry chain never settled")
+
+
+def _instant_backoff(monkeypatch, *, attempts: int | None = None) -> None:
+    """Collapse the backoff schedule so the retry policy is testable at speed.
+
+    Only the WAIT is shortened. The attempt COUNT and the exhaustion behaviour
+    are the properties under test, and the derivation that sizes the real count
+    is asserted separately in
+    ``test_the_retry_budget_outlasts_the_recovery_give_up_bound``.
+    """
+    monkeypatch.setattr(app_module, "SIDEBAR_CONNECT_BACKOFF_S", 0.0)
+    monkeypatch.setattr(app_module, "SIDEBAR_CONNECT_BACKOFF_CEILING_S", 0.0)
+    if attempts is not None:
+        monkeypatch.setattr(app_module, "SIDEBAR_CONNECT_ATTEMPTS", attempts)
+
+
+@pytest.mark.asyncio
+async def test_a_bind_that_did_not_bind_is_not_committed(monkeypatch):
+    """THE ROOT CAUSE, in one assertion: a cold session is never published.
+
+    Fails on the pre-fix tree, where ``_ensure_bound``'s silent return was read
+    as success and the commit ran against ``is_cold=True``.
+    """
+    session = RecoveringRemote("recovering")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        source = await _current_source(app, pilot, session)
+        # RECORDED, never raised. An earlier version of this test stubbed both
+        # with `side_effect=AssertionError(...)` and passed against a tree with
+        # the fix reverted: the retry's `except Exception` catches an
+        # AssertionError like any other, so the test asserted nothing. Mutation
+        # testing found it; the collaborators now record and the assertions are
+        # made afterwards, out of reach of the handler.
+        reached: list[bool] = []
+        prepared: Any = (source, object())
+
+        async def prepare(*_args: Any, **_kwargs: Any) -> Any:
+            reached.append(session.is_cold)
+            return prepared
+
+        commit = Mock(return_value=None)
+        monkeypatch.setattr(app, "_prepare_sidebar_session", prepare)
+        monkeypatch.setattr(app, "_commit_sidebar_session", commit)
+        _instant_backoff(monkeypatch, attempts=2)
+        # Stubbed so this test observes exactly ONE attempt: the re-arm is a
+        # separate property, asserted in the retry tests below, and letting the
+        # chain run here would obscure which attempt refused to commit.
+        rearmed = Mock()
+        monkeypatch.setattr(app, "_start_sidebar_connection", rearmed)
+
+        await app._connect_sidebar_source(source)
+        await asyncio.sleep(0)  # the re-arm is a `call_soon` callback
+
+        assert session.bind_calls == 1
+        # THE POSTCONDITION. Nothing downstream of the bind ran at all, so no
+        # cold session could reach a commit; `reached` would carry a True on
+        # the pre-fix tree, where preparation proceeded against `is_cold`.
+        assert reached == []
+        commit.assert_not_called()
+        assert source.display_only is True
+        # The failure is not the end of the story — it re-arms rather than
+        # latching — but nothing was published in the meantime.
+        rearmed.assert_called_once_with(source)
+
+
+@pytest.mark.asyncio
+async def test_no_frame_ever_shows_a_cold_session_as_connected(monkeypatch):
+    """The invariant the false-connected window violated, sampled per loop turn.
+
+    Every state the user can see is published between awaits, so sampling on
+    each turn of the loop for the life of the connect task covers the whole
+    window without measuring how long it was. States the pre-fix code passed
+    through — ``display_only=False`` while ``is_cold=True`` — are what the
+    assertion excludes.
+    """
+    session = RecoveringRemote("recovering", heals_after=3)
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        source = await _current_source(app, pilot, session)
+        prepared: Any = (source, object())
+        monkeypatch.setattr(app, "_prepare_sidebar_session", _always(prepared))
+        monkeypatch.setattr(app, "_commit_sidebar_session", Mock(return_value=None))
+        _instant_backoff(monkeypatch)
+
+        observed: list[tuple[bool, bool]] = []
+        task = asyncio.ensure_future(app._connect_sidebar_source(source))
+        while not task.done():
+            observed.append((source.display_only, session.is_cold))
+            await asyncio.sleep(0)
+        observed.append((source.display_only, session.is_cold))
+        await task
+        await pilot.pause()
+
+        assert observed, "the watcher never sampled the connect task"
+        assert not [
+            state for state in observed if state == (False, True)
+        ], "a cold session was published as connected"
+        # The connect still SUCCEEDS once the facade heals: the invariant must
+        # not be satisfied by simply never connecting.
+        assert source.display_only is False
+        assert session.is_cold is False
+
+
+@pytest.mark.asyncio
+async def test_a_transient_failure_retries_instead_of_latching(monkeypatch):
+    """A momentarily unreachable owner heals with no user action at all.
+
+    The asymmetry this corrects: ``PreparationInvalidated`` — a purely LOCAL
+    staleness race — already retried, while a transient owner unreachability
+    did not. Both are transient; only exhaustion is terminal.
+    """
+    session = UnreachableRemote("blipping", heals_after=3)
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        source = await _current_source(app, pilot, session)
+        prepared: Any = (source, object())
+        monkeypatch.setattr(app, "_prepare_sidebar_session", _always(prepared))
+        monkeypatch.setattr(app, "_commit_sidebar_session", Mock(return_value=None))
+        _instant_backoff(monkeypatch)
+
+        # The production re-arm goes through `call_soon`; drive it the same way
+        # the app does rather than calling the coroutine in a loop, so the
+        # `finally` block's re-arm is what is under test.
+        app._start_sidebar_connection(source)
+        await _drain_retries(app, source)
+
+        assert session.display_calls == 3, "the connect did not retry the transient failure"
+        assert source.display_only is False
+        assert source.connection_error == ""
+        # A successful commit refills the budget for the NEXT disruption.
+        assert source.connect_attempts == 0
+
+
+@pytest.mark.asyncio
+async def test_the_status_stays_on_connecting_while_the_retry_is_live(monkeypatch):
+    """Mid-retry the app has not given up, so it must not tell the user it has.
+
+    ``connection_error`` is what flips the status from ``Saved · Connecting…``
+    to ``Saved · Connection unavailable · Reselect to retry``. Asking the user
+    to act while the app is still working asks them to fix something that is
+    fixing itself.
+    """
+    session = RecoveringRemote("recovering")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        source = await _current_source(app, pilot, session)
+        _instant_backoff(monkeypatch, attempts=4)
+        # One attempt only: the status under test is the one shown BETWEEN
+        # attempts, which a chain run to exhaustion would immediately overwrite
+        # with the terminal copy.
+        monkeypatch.setattr(app, "_start_sidebar_connection", Mock())
+
+        await app._connect_sidebar_source(source)
+
+        assert source.connect_attempts == 1
+        assert source.connection_error == ""
+        assert app._status is not None  # the band exists from on_mount
+        status = app._status.render_text(120).plain
+        assert "Connecting" in status
+        assert "Reselect" not in status
+
+
+@pytest.mark.asyncio
+async def test_only_exhaustion_latches_and_it_says_so_honestly(monkeypatch):
+    """A genuinely unreachable owner still reaches the user — after the budget.
+
+    The terminal state is what the retry is FOR, not an alternative to it, so
+    the exhausted case must still land on the existing failure copy.
+    """
+    session = RecoveringRemote("gone")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        source = await _current_source(app, pilot, session)
+        _instant_backoff(monkeypatch, attempts=3)
+
+        app._start_sidebar_connection(source)
+        await _drain_retries(app, source)
+
+        assert session.bind_calls == app_module.SIDEBAR_CONNECT_ATTEMPTS + 1
+        assert source.display_only is True
+        assert source.connection_error == "the runtime is not responding"
+        assert app._status is not None
+        status = app._status.render_text(120).plain
+        assert "Connection unavailable" in status
+        assert "Reselect" in status
+        # Surrendering hands the user a FULL budget, not one last attempt.
+        assert source.connect_attempts == 0
+
+
+def test_the_retry_budget_outlasts_the_recovery_give_up_bound():
+    """THE RELATIONSHIP, not the number — the way this fix regresses quietly.
+
+    A viewer that lost its owner refuses to bind for up to ``COLD_FALLBACK_S``
+    and says so by returning silently, so every attempt inside that window
+    fails identically and healing is only possible on an attempt that lands
+    AFTER it. Measured during the investigation: a ~4 s total span did not heal
+    an evicted viewer; a span past ``COLD_FALLBACK_S`` healed it at t=9.9 s.
+
+    Pinned as an inequality between the two constants because that is the
+    property. Asserting either number instead would go green on a tree where
+    ``COLD_FALLBACK_S`` had grown past the budget — which is the original bug,
+    silently restored.
+    """
+    schedule = [
+        app_module.sidebar_connect_backoff_s(attempt)
+        for attempt in range(1, app_module.SIDEBAR_CONNECT_ATTEMPTS + 1)
+    ]
+    assert sum(schedule) > COLD_FALLBACK_S
+    # And it is not merely wider by a rounding error: the last attempt has to
+    # land clearly past the recovery bound on a loaded machine, not tie with it.
+    assert sum(schedule) > COLD_FALLBACK_S * 1.25
+    # One attempt fewer must NOT clear the bound, which is what makes the
+    # derived count minimal rather than an arbitrary large number.
+    assert sum(schedule[:-1]) <= COLD_FALLBACK_S * 1.5
+
+
+@pytest.mark.asyncio
+async def test_a_failed_connect_never_arms_the_readiness_gate(monkeypatch):
+    """NO GATE SPIN, in #856's own counters.
+
+    ``_sidebar_gate_surface_ready``'s first check is ``is_cold``, so a cold
+    session committed as connected made the gate STRUCTURALLY unsatisfiable:
+    ``post_display_hook``'s recovery branch bought a full-screen relayout for
+    it on every frame until the 15 s timer fired. Measured on this tree —
+    post-#856, both halves re-run here — **1,268 refusals, every one of them a
+    recovery**, against 0 after the fix.
+
+    #856 is what makes this assertion sharp rather than merely small. Its
+    arming refresh dirties the whole screen region, so the first post-commit
+    paint is a full ``LayoutUpdate`` the gate passes on, and
+    ``_sidebar_gate_recoveries`` is expected to be ZERO on a healthy switch —
+    its own test asserts the branch stays dead, and its comment says a firing
+    recovery is now a signal. A failed connect must not resurrect it.
+
+    ``_sidebar_gate_reached`` is asserted alongside for the reason #856's own
+    comment gives: a zero meaning "the gate was never armed" reads identically
+    to one meaning "the gate never refused", and only the second is worth
+    pinning. Refusing to commit means it is never armed, so both are zero here
+    — and the direct spy proves the stronger fact that the predicate is not
+    consulted for this source even once.
+
+    Facts, not rates, per AGENTS.md: counter deltas and an unarmed ready-frame.
+    """
+    session = RecoveringRemote("recovering")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        source = await _current_source(app, pilot, session)
+        _instant_backoff(monkeypatch, attempts=2)
+
+        refusals: list[bool] = []
+        original = OperatorApp._sidebar_gate_surface_ready
+
+        def counting(self, candidate):
+            result = original(self, candidate)
+            if candidate is source:
+                refusals.append(result)
+            return result
+
+        monkeypatch.setattr(OperatorApp, "_sidebar_gate_surface_ready", counting)
+        reached_before = app._sidebar_gate_reached
+        recoveries_before = app._sidebar_gate_recoveries
+
+        await app._connect_sidebar_source(source)
+        for _ in range(20):
+            await pilot.pause()
+
+        assert refusals == []
+        assert app._sidebar_gate_recoveries - recoveries_before == 0
+        assert app._sidebar_gate_reached - reached_before == 0
+        assert app._sidebar_ready_frame is None
+
+
+@pytest.mark.asyncio
+async def test_navigating_away_mid_retry_stops_the_retry(monkeypatch):
+    """The backoff keeps the task alive ~10 s; a hidden source must not hold it.
+
+    A live connection task counts as ``retained_for_local_work``, so retrying a
+    source the user has navigated away from would strand an evicted hidden
+    viewer for the whole budget instead of releasing it. The retry is therefore
+    conditioned on the source still being current.
+    """
+    session = RecoveringRemote("recovering")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        source = await _current_source(app, pilot, session)
+        _instant_backoff(monkeypatch, attempts=6)
+        # The user switched away before the connect task ran.
+        app._interaction = SessionInteraction(FakeSession())
+
+        await app._connect_sidebar_source(source)
+        await pilot.pause()
+
+        assert session.bind_calls == 1, "a hidden source kept retrying"
+        assert source.connection_error == "the runtime is not responding"
+
+
+@pytest.mark.asyncio
+async def test_cancelling_during_the_backoff_is_a_cancellation_not_a_failure(monkeypatch):
+    """``CancelledError`` must survive the grown ``except`` body.
+
+    The retry adds an ``await`` inside the exception handler, which is a new
+    place a cancellation can land. It has to propagate — and suppress the
+    status write and the re-arm — exactly as a cancellation anywhere else in
+    the body does, rather than being absorbed as one more failed attempt.
+    """
+    session = RecoveringRemote("recovering")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        source = await _current_source(app, pilot, session)
+        # A real (non-zero) backoff, so the cancellation lands inside the sleep.
+        monkeypatch.setattr(app_module, "SIDEBAR_CONNECT_BACKOFF_S", 30.0)
+        monkeypatch.setattr(app_module, "SIDEBAR_CONNECT_BACKOFF_CEILING_S", 30.0)
+        rearmed = Mock()
+        monkeypatch.setattr(app, "_start_sidebar_connection", rearmed)
+
+        task = asyncio.ensure_future(app._connect_sidebar_source(source))
+        for _ in range(50):
+            await pilot.pause()
+            await asyncio.sleep(0)
+            if session.bind_calls:
+                break
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await pilot.pause()
+
+        assert task.cancelled()
+        rearmed.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_the_retry_releases_its_preparation_before_waiting(monkeypatch):
+    """A ~10 s task must not hold prepared widgets across a wait nothing watches.
+
+    The failure can arrive AFTER ``_prepare_sidebar_session`` has handed over a
+    preparation — a commit that raises. Leaving it held for the backoff is a
+    leak in all but name, and the ``finally`` block only runs once, at the end
+    of the whole retry sequence.
+    """
+    session = UnreachableRemote("blipping")
+    session._display_heals_after = None
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        source = await _current_source(app, pilot, session)
+        prepared: Any = (source, object())
+        monkeypatch.setattr(app, "_prepare_sidebar_session", _always(prepared))
+        monkeypatch.setattr(
+            app,
+            "_commit_sidebar_session",
+            Mock(side_effect=ConnectionError("history owner is unavailable")),
+        )
+        released: list[Any] = []
+
+        async def release(item):
+            released.append(item)
+
+        monkeypatch.setattr(app, "_release_sidebar_preparation", release)
+        # Bind and display succeed; the COMMIT is what fails, so a preparation
+        # is in hand when the retry branch is reached.
+        session.ensure_display_current = _noop  # type: ignore[method-assign]
+        _instant_backoff(monkeypatch, attempts=3)
+
+        app._start_sidebar_connection(source)
+        await _drain_retries(app, source)
+
+        assert source.connection_error
+        # Once per attempt, not once at the end of the whole sequence.
+        assert len(released) == app_module.SIDEBAR_CONNECT_ATTEMPTS + 1
+        assert source.command_frame_pending is False
+
+
+async def _noop() -> None:
+    return None
+
+
+def _always(value: Any) -> Any:
+    """A coroutine-function stub returning ``value`` on EVERY call.
+
+    A ``Mock(return_value=<coroutine>)`` cannot stand in: a coroutine object is
+    single-use, so the second retry attempt would await an already-consumed one
+    and fail with a ``RuntimeError`` that has nothing to do with the code under
+    test. The retry is the whole point here, so the stub has to be re-callable.
+    """
+
+    async def prepare(*_args: Any, **_kwargs: Any) -> Any:
+        return value
+
+    return prepare

--- a/tests/unit/tui/test_sidebar_connect_retry.py
+++ b/tests/unit/tui/test_sidebar_connect_retry.py
@@ -826,10 +826,20 @@ async def test_guidance_answers_wait_or_act_in_every_disconnected_state(monkeypa
         app.composer_submission_refused()
         assert "Reconnecting" in notices[-1]
         assert "Select this session again" not in notices[-1]
+        # The SLASH-COMMAND refusal carries the same three-state guidance. It is
+        # a second caller of `_unavailable_hint` with eight call sites of its
+        # own, and it reads the hint through a different guard — so the composer
+        # assertions above do not cover it, and the inverted-guidance bug was
+        # fixed here separately.
+        assert app._allow_source_command() is False, "a cold source must refuse the command"
+        assert "Reconnecting" in notices[-1]
+        assert "Select this session again" not in notices[-1]
 
         # Exhausted: the app has stopped, and reselecting is the right advice.
         source.connection_error = "the runtime is not responding"
         app.composer_submission_refused()
+        assert "Select this session again to retry." in notices[-1]
+        assert app._allow_source_command() is False, "a cold source must refuse the command"
         assert "Select this session again to retry." in notices[-1]
 
         # Never-attempted: nothing to say beyond the refusal itself.
@@ -837,6 +847,8 @@ async def test_guidance_answers_wait_or_act_in_every_disconnected_state(monkeypa
         source.connection_error = ""
         app.composer_submission_refused()
         assert notices[-1] == "Send unavailable until connected."
+        assert app._allow_source_command() is False, "a cold source must refuse the command"
+        assert notices[-1] == "Commands unavailable until connected."
 
 
 def test_the_derivation_refuses_a_backoff_it_cannot_solve(monkeypatch):


### PR DESCRIPTION
## Change authorization

**C1 — standard / pre-authorized bug fix.** This PR is the change record. No version bump (`pyproject.toml` untouched at `0.53.3`; the release owner for the current window bundles it).

`Release: patch — a sidebar conversation whose runtime blipped now reconnects itself instead of showing a live-looking transcript that was never live, then reverting.`

## The defect

Reported from a live session, two symptoms that read as one intermittent bug:

1. **"Reselect to retry" fails outright** and stays failed — only another manual reselect clears it.
2. **It seems to connect, then refreshes to the failure view.** The transcript renders, looks live for ~15 seconds, then reverts to `Saved · Connection unavailable · Reselect to retry`.

The owner runtime was healthy throughout (a live pid on a 2 s heartbeat). The problem was entirely in the viewer's own facade.

## Root cause

**One cause, two faces: a bind that did not bind reported success.**

`RemoteSession._ensure_bound()` has *three* outcomes and the call site could only distinguish two:

```python
if not self._can_go_cold or self._disposed:
    return
if self._recovering:
    if self._model_selection_override and self._birth_model is not None:
        raise ConnectionError(_MODEL_INTENT_PENDING)
    return          # <-- silent, and is_cold stays True
if not self.is_cold and not self._model_selection_override:
    return
```

"Already bound, nothing to do" and "cannot bind right now, still cold" are **both `None`**. `_connect_sidebar_source` assumed the first and committed a **cold** session as connected. What happened next depended only on whether the display window happened to be invalidated:

- **Invalidated** → the next call raises `ConnectionError("history owner is unavailable")` → the bare `except Exception` latched it, `retry` stayed `False` → **symptom 1**, a self-healing condition frozen into a terminal one.

> **Precision on symptom 1, corrected after QA round 1.** Symptom 1 has two halves and **this PR fixes one of them.** The *latch-without-retry* half is fixed: the failure is retried across the full budget instead of latching on the first occurrence. The *cached-failure* half is **not**, and is pre-existing — `_invalidate_display_history()` caches a failed `_display_refresh_task` that `ensure_display_current()` re-awaits forever, so on that specific path the retry spends its whole budget and still surrenders. QA reproduced it 6/6 deterministically and confirmed it **byte-identical on base**; it lives in `remote.py`, not in the sidebar. Tracked in this thread as `deferred — pre-existing, separate PR (remote.py cached-failure task)`. What ships here is strictly better than base on that path (base: one attempt then latch; head: the full budget, with Fix A preventing any false-connected window throughout) but it is **not a cure for the invalidated-display case**.
- **Not invalidated** → nothing raised, `display_only = False`, the transcript swapped in live — and then `_sidebar_gate_surface_ready`, **whose first check is `is_cold`**, refused every frame until `_await_sidebar_frame`'s 15 s timer fired into the same handler → **symptom 2**.

**The trigger is any owner loss, not the attach cap.** `ATTACH_MAX_CLIENTS = 4` with silent LRU eviction is the dominant trigger on a multiplexed host, but a plain socket close with **zero** attach clients reaches the identical state — verified, and covered by a test here, which is why the fix is at the bind postcondition and not at the cap.

**Why it read as intermittent:** `COLD_FALLBACK_S = 8.0` gives two windows. Reselect within ~8 s of the disruption hits the defect; reselect after it connects cleanly. Measured on this tree: `_recovering` cleared at **t=8.3 s** against a `COLD_FALLBACK_S` of 8.0.

## The fix

Two changes, both in `_connect_sidebar_source`. The seams were correct; the postcondition was simply missing.

**Fix A — a bind that did not bind is a failure.** After `_ensure_bound()`, check the postcondition and raise if the facade is still cold. Reuses the existing `"the runtime is not responding"` sentence, so **no new user-facing copy** is introduced and both failure paths read identically.

Checked at the call site rather than as `_ensure_bound(require_bound=True)` because that method's other callers *deliberately* tolerate the silent return (a prompt waits on `_owner_ready` instead). The structurally cleaner alternative — moving the postcondition onto the facade so no future caller can fall into the same trap — is noted below as a possible follow-up.

**Fix B — a transient gets retried; only exhaustion latches.** Everything reaching that handler is a momentarily unreachable owner, and all of them clear within `COLD_FALLBACK_S`. This also **corrects an inverted asymmetry**: `PreparationInvalidated` — a purely *local* staleness race — already retried, while a *transient owner unreachability* did not. Both are transient. What stays terminal is the budget running out.

**The retry budget is the load-bearing part, and it is DERIVED, not written down.**

```python
SIDEBAR_CONNECT_ATTEMPTS = _sidebar_connect_attempts()   # solves for COLD_FALLBACK_S * 1.5
# -> 7 attempts, 12.75s span, against COLD_FALLBACK_S = 8.0
```

The quantity being waited out is **the recovery loop's own give-up bound**, so the budget tracks it by arithmetic — exactly as #849 derived `RECOVERY_GIVE_UP_S = 2 * HEARTBEAT_TIMEOUT_S`. This is measured, not guessed: a ~4 s span did **not** heal an evicted viewer (the facade was still `_recovering` when the last attempt ran); a span past `COLD_FALLBACK_S` healed on the first post-give-up attempt. **A test pins the relationship, not the number** — a bare literal would silently stop healing the moment `COLD_FALLBACK_S` grew, with no failing test and no symptom except the original bug returning.

### Which bound, and the one that is deliberately not tracked

`RECOVERY_GIVE_UP_S` (90 s) is the other bound in this neighbourhood and is the **wrong** one to size against. The two apply to different facades via `_can_go_cold`, and the sidebar's own lease branches land on opposite sides — verified by execution, because the natural assumption is false:

```
branch 1 (click / saved_preview)  _can_go_cold = True   -> COLD_FALLBACK_S  (8s)
branch 2 (prewarm / connect)      _can_go_cold = False  -> RECOVERY_GIVE_UP_S (90s)
VERDICT: "a parked source can never go cold" is FALSE — the click path is cold-capable at birth
```

The **click** path is what this budget serves. Sizing to 90 s would make the user watch "Connecting…" for a minute and a half on the common path.

On a **prewarm**-created source the budget deliberately expires inside the 90 s window and the user gets the terminal message. That is honest rather than a regression: `_ensure_bound`'s first guard is `if not self._can_go_cold ... return`, so it is a **no-op** on that facade — no retry count can make it bind, and such a facade was measured not to self-heal within 20 s either. The fix still converts that case from 15 s of false-connected transcript into a prompt failure.

## Testing evidence

All figures below are **counts and state transitions** (load-independent). Wall times are labelled with their load conditions; the host was heavily oversubscribed tonight (load average 26–108 across these runs), so timings are context, not evidence.

### The headline: the false-connected window, and the spin behind it

Measured on **this** tree with both halves re-run — the two fixes reverted in place, so the comparison is on identical code otherwise. `_sidebar_gate_recoveries` / `_sidebar_gate_reached` are #856's counters, which landed during this work.

```
[pre-fix]  RESELECT settled
  post_display_hook calls    = 1271
  gate refusals (counted)    = 1268
  gate_recoveries delta      = 1268
  false-connected state seen = True
  states observed            = [(False, True), (True, True)]     <- (display_only, is_cold)
  final display_only=True err='The conversation connected but its input surface did not become ready' cold=True
  (wall 15.1s — load-dependent, not evidence)

[fixed]    RESELECT settled
  post_display_hook calls    = 15
  gate refusals (counted)    = 0
  gate_recoveries delta      = 0
  false-connected state seen = False
  states observed            = [(False, False), (True, True)]
  final display_only=False err='' cold=False
  (wall 10.0s — load-dependent, not evidence)
```

The state-machine facts, which are what the tests assert:

| property | before | after |
|---|---|---|
| `(display_only=False, is_cold=True)` ever observed | **yes** | **no** |
| gate refusals for one reselect | **1,598** / **1,268** (two runs, different load) | **0-1** |
| heals without user action | no — needs a manual reselect | **yes** |
| final state | terminal failure | connected |

**Note on the refusal figure.** The diagnosis measured **1,799** pre-#856; that number is stale and is not used here. Two independent re-measurements on the current base, under different load: **1,598** (QA round 1 — `gate_reached +1598`, `gate_recoveries +1598`, load average 19.9-70.4) and **1,268** (this PR's own run, load average 26-108). Same phenomenon; the spread is load, which is exactly why the table and the assertions are **counts and state transitions** rather than durations. Post-fix both agree: refusals in the low single digits (QA `+2` reached / `+1` recovery; this run 0).

### Generality — not the attach cap

```
prewarm facade: _can_go_cold=False is_cold=False
after socket loss: is_cold=True _recovering=True _can_go_cold=False
_ensure_bound: raised=None cold_after=True
```

A plain socket close, zero attach clients, no cap involved — the same silent-return state. Covered by `test_a_plain_socket_loss_reconnects_with_no_attach_pressure`.

### Tests, and proof each one can fail

**11 new tests** (9 unit + 2 e2e, the latter parametrised on both recovery windows). The load-bearing one is the postcondition: *after `_connect_sidebar_source` commits, `session.is_cold` must be False.* No existing test covered `_ensure_bound`'s third outcome, which is why this shipped.

Mutation-tested — **each fix reverted in place** on the rebased tree, not merely run against an older tree (which would fail for the wrong reason, on a missing constant):

```
=== M1: Fix A reverted ===
FAILED test_a_bind_that_did_not_bind_is_not_committed        - assert [True] == []
FAILED test_no_frame_ever_shows_a_cold_session_as_connected  - a cold session was published as connected
FAILED test_only_exhaustion_latches_and_it_says_so_honestly  - assert "...frontend_store'" == 'the runtime is not responding'
FAILED test_navigating_away_mid_retry_stops_the_retry        - assert '' == 'the runtime is not responding'
FAILED test_an_evicted_viewer_reconnects...[1.0-during]      - assert (False, True) not in [(False, True), ...]
5 failed, 8 passed

=== M2: Fix B reverted (terminal except) ===
7 failed, 3 passed

=== M3: budget written as a literal 4 (~3.75s span) ===
FAILED test_the_retry_budget_outlasts_the_recovery_give_up_bound - assert 3.75 > 8.0

=== M4: literal 7 kept, COLD_FALLBACK_S grown to 30.0 ===
FAILED test_the_retry_budget_outlasts_the_recovery_give_up_bound - assert 12.75 > 30.0
```

**M4 is the one that matters most.** It is the silent-regression mode this constant exists to prevent: a literal budget that still *looks* right after the bound it tracks has moved.

One test in this file was itself found vacuous by mutation testing and fixed: it stubbed collaborators with `side_effect=AssertionError(...)`, which the retry's `except Exception` catches like any other exception, so it passed against a reverted tree. It now records and asserts outside the handler's reach.

### An existing test encoded the old contract

`test_sidebar_display_e2e.py::...[fail_sync]` asserted the terminal state after awaiting **one** connect task. Fix B makes that first failure retry, so the test now drains the chain to exhaustion and asserts the same terminal state — reached the way a user now reaches it. The assertions are unchanged; only how the test gets there is.

### Gates (whole tree, exactly as CI)

```
flake8                       clean
black --check (26.1.0)       1184 files unchanged
isort --check-only (5.13.2)  clean
pyright (1.1.411)            0 errors, 0 warnings, 0 informations
tests/unit                   17581 passed, 18 skipped   (57:33, load avg ~26-108)
tests/e2e -m e2e -n0         98 passed, 7 skipped
```

The reconnect tests were run **3 consecutive times** (13/13 each) to confirm they are not load-sensitive.

## Visual evidence

User-visible, so before/after frames were captured per AGENTS.md — both rendered from a **verified tree** (`import local_operator` path printed at capture time; the "before" set from a clean worktree at current `origin/main`, the "after" from this branch's HEAD), against real runtimes through a real eviction.

**In flight (3 s after the reselect):**

| | status line | composer placeholder | truth |
|---|---|---|---|
| before | `◆ test/e2e-model › ⌂ ~/config` — fully connected | `Message Local Operator…` | `is_cold=True` — **the lie** |
| after | `Saved · Connecting…` | `Draft a message…` | `is_cold=True` — **honest** |

**Settled:**

| | status line | submission |
|---|---|---|
| before | `Saved · Connection unavailable · Reselect to retry` | blocked |
| after | `◆ test/e2e-model › ⌂ ~/config` | live, `is_cold=False` |

The before-frame's composer inconsistency is visible in the stills: it showed the writable `Message Local Operator…` placeholder while `composer_submission_blocked()` was `True`. Fix A removes that state entirely.

## Design review scope

The user-visible surface, for the design round:

1. **Retry becomes automatic** — a transient failure no longer demands a manual reselect. This is the substantive UX change: how long should the app persist before surrendering?
2. **"Connecting…" now persists ~10 s**, longer than it has ever been shown. It is the existing string on the existing branch; no new copy.
3. **`Reselect to retry` after exhaustion** now means "try again anyway" rather than "nothing has been tried", since the app has already made 7 attempts.
4. **The 15 s false-connected window is gone** — strictly an improvement, but a visible behaviour change.
5. **The composer inconsistency disappears** with it.

## Not addressed

- **`ATTACH_MAX_CLIENTS = 4`.** Ruled out as a fix — it treats the amplifier, and a plain socket loss reproduces the defect without it. Worth a separate conversation (a successful reconnect itself evicts an incumbent, which under sustained pressure is a rotating churn), but different risk and a different PR.
- **The 15 s `_await_sidebar_frame` timer.** A correct backstop for genuine paint failures. Fix A stops feeding it an unsatisfiable gate; the timer stays.
- **Clearing `_recovering` early.** #849 rejected this for a good reason (`_recover_owner` never takes `_bind_lock`, so the flag is the only thing serialising it).
- **Moving the postcondition onto `RemoteSession`** (`_ensure_bound(require_bound=True)` or `bound_or_raise()`), so the invariant lives with the class and no future caller can fall into the same silent-return trap. Structurally cleaner and deliberately deferred: `_ensure_bound`'s other callers rely on the tolerant behaviour, so it is a wider change than this fix needs. Happy to take it as a follow-up if a reviewer prefers it.



---

## Round 1 outcome

Three review streams reported (code, QA, design): **0 blockers, 4 MAJOR, 5 MINOR, 2 NIT.** All worked as one remediation commit. Every finding is answered in the three `— round 1` comments below. Two things the description above asserted that round 1 qualified, both now corrected in place:

1. **The `except Exception` comment claimed everything arriving there is a momentarily unreachable owner.** A readiness-gate timeout is not (F1), and it was being retried — 8 commits and ~120 s of "Connecting…" where the honest behaviour is one 15 s failure. Now raised as a named `SurfaceNotReady` and caught above the generic branch.
2. **The `connect_attempts` comment claimed a manual reselect always starts fresh.** It did not after a navigate-away (F2/Q1, found independently by reviewer and QA). Fixed, with the correction below.

**A note on the F2/Q1 fix, because the obvious form of it is wrong.** Both reviewers proposed clearing the counter in `_start_sidebar_connection` beside `connection_error` — right place, right intent. Taken literally it also catches the retry loop's own `call_soon` re-arm, which routes through that same method, and the budget then can never be spent. Measured before adopting it: `attempts=1` on every round, 16 rounds, no terminal state ever reached — an infinite reconnect loop, which is worse than the shortened one being fixed. The reset is therefore gated on a `continues_retry` flag that only the retry loop passes. `test_the_retry_loops_own_rearm_still_spends_the_budget` pins that half, and reverting the gate to an unconditional reset fails three tests with "the retry chain never settled".

**The design round's evidence gap is closed.** D5 was right that no posted frame showed the fixed tree after exhaustion. The re-captured set is a seven-mark sample of one continuous window against a permanently unreachable owner, so the retry window, the transition, and the terminal state are all in one run.

### Remediation mutation evidence

Each new fix reverted in place on the remediated head, so every guard is proved to bite:

```
M5  F2/Q1 reset removed        FAILED test_a_reselect_after_navigating_away_gets_a_full_budget
                                      - a reselect inherited a spent budget
M6  F2 reset made unconditional 3 failed - "the retry chain never settled" (the infinite-loop trap)
M7  F1 branch removed          FAILED test_a_readiness_gate_timeout_is_not_retried
                                      - a readiness-gate timeout was retried
M8  D1 animation reverted      FAILED test_the_retry_window_animates_and_the_failed_state_does_not
                                      - the retry window has no animation
M9  D2 guidance reverted       FAILED test_guidance_answers_wait_or_act_in_every_disconnected_state
M10 D3 copy reverted           FAILED test_only_exhaustion_latches_and_it_says_so_honestly
```

M5 initially did **not** fail, and the reason is worth recording: the test sampled `connect_attempts` after a yield, by which point the newly-started task had zeroed it on its own success — so it read 0 on a tree with the fix reverted. It now samples synchronously, before the new task gets a turn. That is the second vacuous test mutation testing has caught in this PR.

### Not addressed, deliberately

- **Q2** — `deferred — pre-existing, separate PR (remote.py cached-failure task)`. Confirmed byte-identical on base by QA; the description's symptom-1 claim is corrected above rather than the code being changed here.
- **Q3** (two unit failures under load that pass in isolation, untouched by the diff) and **Q4** (`_sidebar_gate_recoveries` firing once per first-visit switch, byte-identical on base and head) — environmental and pre-existing respectively, no action.
- **D6** (narrow 62-column band crowds but does not break) — NIT, judgement call, left alone. The new terminal string is two characters shorter than the one it replaces, so the narrow case is marginally better than before rather than worse.
- **`require_bound=True` on `_ensure_bound`** — still the structurally cleaner home for the postcondition, still deferred for the reason given above.

