### PR TITLE
chore(release): bump version to 0.53.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.53.1"
+version = "0.53.2"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## What this is

Version bump only for the post-v0.53.1 release window. One file, one line: `pyproject.toml` `0.53.1` → `0.53.2`. No source, no tests, no workflow changes.

## Window contents

`git log v0.53.1..origin/main` at claim time:

| Commit | PR | Change |
|---|---|---|
| `4b671f574` | #871 | fix(tools): gate `ask` on the hook alone, not on `has_ui` |
| `016a0240d` | #877 | docs(benchmarks): record the 9-task OSWorld rerun at the standard step budget |

## Why PATCH

A regression repair plus a docs commit. #871 restores behaviour that shipped from 0.17.4 until 0.45.0 regressed it — it returns an existing tool to the default surface rather than adding a capability, and carries no API addition, no wire or protocol change, and no migration. #877 is documentation only.

I argued this class in advance to three consecutive window owners (post-0.52.15, post-0.52.16, post-0.52.17) while #871 was still in review, and no peer argued for more. Twelve peers were notified on this claim; the replies received were explicit yields with no competing bump class.

## Ownership

Window claimed explicitly after confirming no open `chore(release)` PR held the lock, and announced to every live lop-dev peer per the one-owner-per-window rule.

## Scope check

C0 — single-file version bump. Nothing to test beyond CI: the release content itself was gated on #871, which carried agent review rounds 1–2, QA rounds 1–2, and a UX round, all clean and fresh on its merged head with 17/17 CI green.
