### PR TITLE
feat(desktop): serve durable session attachments by digest

### DIFF
--- a/local_operator/server/routes/desktop_sessions.py
+++ b/local_operator/server/routes/desktop_sessions.py
@@ -288,9 +288,20 @@ async def attachment(session_id: str, digest: AttachmentDigest, request: Request
       shape is validated in the path declaration rather than inside the handler
       where a later edit could route around it. FastAPI answers a non-matching
       path with 422 before any disk access.
-    - **Immutable caching.** The digest IS the sha256 of the content, so the
-      bytes behind a URL can never change. A renderer that holds a blob for a
-      scrolled-away row re-requests it for free.
+    - **No HTTP caching, deliberately.** The digest IS the sha256 of the
+      content, so an ``immutable`` response would be correct about the BYTES —
+      and it is still the wrong header here. ``managed_desktop_boundary``
+      applies ``Cache-Control: no-store`` to everything under ``/v1/desktop/``
+      because these responses are bearer-gated session data, and a route that
+      set ``public, max-age=31536000`` would either be silently overridden (it
+      was: measured ``no-store`` on the wire) or, if the middleware were
+      carved out for it, would invite a shared cache to retain one user's
+      screenshots. The mobile daemon's equivalent route can afford
+      ``immutable`` because it is a different process behind different auth;
+      copying the header without the surrounding argument would not be reuse.
+      Dedup belongs to the client, which already holds a digest-keyed cache
+      for exactly this reason — and the digest being content-addressed is what
+      makes that cache safe.
 
     A missing attachment is 404, never 500: the store's contract is that an
     unresolvable reference is ordinary (interrupted write, hand-pruned store)
@@ -298,11 +309,7 @@ async def attachment(session_id: str, digest: AttachmentDigest, request: Request
     """
     async with errors():
         data, mime_type = await host(request).attachment(session_id, digest)
-    return Response(
-        content=data,
-        media_type=mime_type,
-        headers={"Cache-Control": "public, max-age=31536000, immutable"},
-    )
+    return Response(content=data, media_type=mime_type)
 
 
 @router.post(

--- a/local_operator/server/routes/desktop_sessions.py
+++ b/local_operator/server/routes/desktop_sessions.py
@@ -22,6 +22,7 @@ from pydantic import (
 )
 from starlette.background import BackgroundTask
 
+from local_operator.media import SUPPORTED_IMAGE_MIME_TYPES
 from local_operator.server.desktop import require_desktop
 from local_operator.server.models.desktop_sessions import (
     AnswerReceipt,
@@ -58,6 +59,22 @@ RequestID = Annotated[
 #: handler cannot route around a declaration. 32 hex characters is
 #: ``attachments._DIGEST_CHARS``.
 AttachmentDigest = Annotated[str, Path(pattern=r"^[a-f0-9]{32}$")]
+#: What a stored attachment may claim to be on the wire. The store records the
+#: mime its CALLER supplied — ``transcript._externalize_attachments`` copies
+#: ``block["mime_type"]`` verbatim with no allowlist — and the sidecar carrying
+#: it is not digest-verified, so neither the value's shape nor its meaning is
+#: guaranteed at this boundary. Two failures follow from trusting it, and both
+#: were measured on this route: a mime containing CRLF makes h11 reject the
+#: header and the client gets NO response at all, contradicting the docstring's
+#: "404, never 500"; and ``text/html``/``image/svg+xml`` round-trip out of here
+#: as active content served from an authenticated local port. Today no live
+#: ingress stores a non-image mime, but that is a property of callers upstream
+#: that nothing HERE enforces, and this is the boundary that pays for it
+#: changing. ``routes/static.py`` already establishes the allowlist convention
+#: for image bytes over HTTP; the narrower ``media`` set is used because it is
+#: exactly what the ingress can produce (``sniff_image`` returns these four)
+#: and it excludes ``image/svg+xml``, which is script-bearing.
+ATTACHMENT_FALLBACK_MIME = "application/octet-stream"
 
 
 class Input(BaseModel):
@@ -305,11 +322,41 @@ async def attachment(session_id: str, digest: AttachmentDigest, request: Request
 
     A missing attachment is 404, never 500: the store's contract is that an
     unresolvable reference is ordinary (interrupted write, hand-pruned store)
-    and the reader degrades to a placeholder.
+    and the reader degrades to a placeholder. A corrupt-but-parseable sidecar
+    is the same class of ordinary, which is why the mime is allowlisted rather
+    than trusted (see :data:`ATTACHMENT_FALLBACK_MIME`).
+
+    Two scopes this route does NOT have, stated because the URL shape implies
+    otherwise:
+
+    - ``session_id`` is an EXISTENCE check, not a binding. It proves *a* user
+      conversation by that name is on this machine; it does not prove this
+      attachment belongs to it. The store is content-addressed and shared
+      across conversations by design, so any valid user session id resolves
+      any digest in it. That is not an escalation — the bearer already
+      authorises the whole desktop surface, ``/history`` included — but a
+      future reader must not mistake the path segment for authorization.
+    - The served ``Content-Type`` is not guaranteed to equal the ``mime_type``
+      on the history row. The store dedups by content digest and the FIRST
+      sidecar wins, so identical bytes stored once as ``image/png`` and later
+      as ``image/gif`` keep the original sidecar while the newer row reports
+      ``image/gif``. Harmless for real images (the bytes decide what renders),
+      but the two values are not a matched pair.
     """
     async with errors():
         data, mime_type = await host(request).attachment(session_id, digest)
-    return Response(content=data, media_type=mime_type)
+    return Response(
+        content=data,
+        media_type=(
+            mime_type if mime_type in SUPPORTED_IMAGE_MIME_TYPES else ATTACHMENT_FALLBACK_MIME
+        ),
+        # Defence in depth on the one response here that can carry a type the
+        # caller did not choose: with the allowlist above, an unexpected mime
+        # is served as opaque bytes, and nosniff stops a browser from
+        # re-deciding that for itself. `tunnels/gateway.py` sets the same
+        # header on this repo's other byte-serving surface.
+        headers={"X-Content-Type-Options": "nosniff"},
+    )
 
 
 @router.post(

--- a/local_operator/server/routes/desktop_sessions.py
+++ b/local_operator/server/routes/desktop_sessions.py
@@ -10,8 +10,8 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Annotated, Any, Literal
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from fastapi.responses import StreamingResponse
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
+from fastapi.responses import Response, StreamingResponse
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -51,6 +51,13 @@ router = APIRouter(tags=["Desktop sessions"], dependencies=[Depends(require_desk
 RequestID = Annotated[
     str, Field(pattern=r"^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$")
 ]
+#: The attachment store names files ``<digest>.bin``, so the digest reaches a
+#: filesystem path directly. Constraining the shape HERE rather than in the
+#: handler is what makes traversal unreachable by construction: FastAPI rejects
+#: a non-matching path before the handler runs, and a later edit inside the
+#: handler cannot route around a declaration. 32 hex characters is
+#: ``attachments._DIGEST_CHARS``.
+AttachmentDigest = Annotated[str, Path(pattern=r"^[a-f0-9]{32}$")]
 
 
 class Input(BaseModel):
@@ -250,6 +257,52 @@ async def history(
 ):
     async with errors(), host(request).session(session_id) as bridge:
         return reply(await bridge.history(before_id=before_id, limit=limit))
+
+
+@router.get(
+    "/v1/desktop/sessions/{session_id}/attachments/{digest}",
+    # The image's own mime type is the response type, so the published contract
+    # must not claim the CRUD JSON envelope its neighbours return. Declaring the
+    # class is what keeps the schema honest; without it FastAPI documents
+    # `application/json` for a route that never sends any.
+    response_class=Response,
+)
+async def attachment(session_id: str, digest: AttachmentDigest, request: Request):
+    """Raw bytes of one content-addressed attachment referenced by a history row.
+
+    ``/history`` serves durable rows verbatim, and a durable image block is
+    ``{"attachment": <digest>, "mime_type": ...}`` with the payload stripped
+    (``transcript._externalize_attachments``). Without this route a frontend can
+    see that an image was in the conversation and can never render it after a
+    reload — the live event stream carries the base64, the durable transcript
+    does not.
+
+    Three deliberate choices:
+
+    - **Keyed by digest, not by (entry, index).** The history row hands the
+      caller the digest directly, so nothing has to re-fold history per image,
+      and identical screenshots across a whole conversation collapse to one
+      request and one cache entry.
+    - **The digest pattern is the traversal gate.** ``_DIGEST_CHARS`` is 32 hex
+      characters and the store turns a digest straight into a filename, so the
+      shape is validated in the path declaration rather than inside the handler
+      where a later edit could route around it. FastAPI answers a non-matching
+      path with 422 before any disk access.
+    - **Immutable caching.** The digest IS the sha256 of the content, so the
+      bytes behind a URL can never change. A renderer that holds a blob for a
+      scrolled-away row re-requests it for free.
+
+    A missing attachment is 404, never 500: the store's contract is that an
+    unresolvable reference is ordinary (interrupted write, hand-pruned store)
+    and the reader degrades to a placeholder.
+    """
+    async with errors():
+        data, mime_type = await host(request).attachment(session_id, digest)
+    return Response(
+        content=data,
+        media_type=mime_type,
+        headers={"Cache-Control": "public, max-age=31536000, immutable"},
+    )
 
 
 @router.post(

--- a/local_operator/server/utils/desktop_sessions.py
+++ b/local_operator/server/utils/desktop_sessions.py
@@ -9,6 +9,7 @@ The last reader detaches; neither socket disposal nor HTTP shutdown stops work.
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
 import json
 import logging
@@ -30,6 +31,7 @@ from local_operator.resume import (
     session_preview,
     write_session_attachment,
 )
+from local_operator.session.attachments import ATTACHMENTS_DIRNAME, AttachmentStore
 from local_operator.session.attention import AttentionStore
 from local_operator.session.catalog import load_catalog
 from local_operator.session.frontend_state import (
@@ -481,6 +483,44 @@ class DesktopSessions:
             )
 
         return await asyncio.to_thread(acknowledge)
+
+    async def attachment(self, session_id: str, digest: str) -> tuple[bytes, str]:
+        """Decoded bytes and mime type for one content-addressed attachment.
+
+        Durable transcript rows reference images by digest, not by payload:
+        ``transcript._externalize_attachments`` strips ``data`` from any block
+        over 1 KiB of base64 and leaves ``{"attachment": <digest>,
+        "mime_type": ...}`` behind. ``/history`` serves those rows verbatim,
+        so a reading surface can see that an image WAS there and has no way to
+        fetch it. This is that way.
+
+        Deliberately outside :meth:`session`, exactly like
+        :meth:`acknowledge_attention` and for the same reason: reading a
+        screenshot out of a finished conversation must not start an owner
+        process. The session id is still validated against the same durable
+        user-session namespace, so the route cannot be used to probe arbitrary
+        directories, and the store is shared rather than per-session because
+        the digest IS the content key.
+
+        ``KeyError`` for an unknown session or an unresolvable digest — the
+        store's own contract is that a miss is ordinary (an interrupted write,
+        a hand-pruned store) and callers degrade to a placeholder rather than
+        treating it as a fault.
+        """
+
+        def read() -> tuple[bytes, str]:
+            if not SESSION_ID.fullmatch(session_id):
+                raise KeyError("Unknown session")
+            path = self.root / "sessions" / session_id
+            if not path.is_dir() or not is_user_session(path):
+                raise KeyError("Unknown session")
+            resolved = AttachmentStore(self.root / ATTACHMENTS_DIRNAME).get(digest)
+            if resolved is None:
+                raise KeyError("Unknown attachment")
+            data_b64, mime_type = resolved
+            return base64.b64decode(data_b64), mime_type
+
+        return await asyncio.to_thread(read)
 
     async def create(self, cwd: str, *, target: dict[str, str] | None = None) -> str:
         directory = Path(cwd).expanduser().resolve()

--- a/local_operator/server/utils/desktop_sessions.py
+++ b/local_operator/server/utils/desktop_sessions.py
@@ -506,9 +506,24 @@ class DesktopSessions:
         store's own contract is that a miss is ordinary (an interrupted write,
         a hand-pruned store) and callers degrade to a placeholder rather than
         treating it as a fault.
+
+        The session id is an EXISTENCE check, not a binding: it proves *a* user
+        conversation by that name is on this machine, never that this digest
+        belongs to it. The store is content-addressed and shared across
+        conversations by design, so any valid user session id resolves any
+        digest in it. The bearer already authorises the whole desktop surface,
+        so this is not an escalation — but it is not per-session scoping
+        either, and the URL shape reads as though it were.
         """
 
         def read() -> tuple[bytes, str]:
+            # Both halves of this gate carry weight and neither is redundant.
+            # The shape check keeps a crafted id from escaping the sessions
+            # namespace through ``..`` before a path is ever built; the origin
+            # check keeps this route out of SUBAGENT conversations, which are a
+            # machine's delegated runs the user never opened and which the
+            # desktop surface does not list. Dropping either is a one-token
+            # edit, so each has a named test standing on it.
             if not SESSION_ID.fullmatch(session_id):
                 raise KeyError("Unknown session")
             path = self.root / "sessions" / session_id

--- a/tests/unit/server/test_desktop_sessions.py
+++ b/tests/unit/server/test_desktop_sessions.py
@@ -502,10 +502,87 @@ async def test_durable_attachment_is_readable_without_starting_an_owner(tmp_path
     # `errors()` maps KeyError to 404 rather than letting it reach a 500.
     with pytest.raises(KeyError):
         await pool.attachment("0123456789ab", "f" * 32)
-    # Nor may a valid digest be read through a session id that is not a user
-    # conversation on this machine.
+    # A well-formed id whose directory is simply absent. This reaches the
+    # `is_dir()` check ONLY -- `ffffffffffff` already satisfies `SESSION_ID`,
+    # so it says nothing about either gate. The two tests below carry those.
     with pytest.raises(KeyError):
         await pool.attachment("ffffffffffff", ref.digest)
+
+
+@pytest.mark.asyncio
+async def test_attachment_refuses_a_session_id_that_is_not_the_session_shape(tmp_path):
+    """The shape guard rejects before a path is built, not after.
+
+    `self.root / "sessions" / session_id` turns the id straight into a path, so
+    an id carrying `..` would climb out of the sessions namespace and read a
+    sibling directory's marker. Unlike the digest, the session id has no
+    route-declaration pattern -- `SESSION_ID.fullmatch` inside the read IS the
+    whole gate, which is why it needs a case that a merely-absent directory
+    cannot satisfy: this id is one `is_dir()` alone would also reject, so the
+    assertion is that the ESCAPE never happens rather than that the read
+    missed. The planted marker is what distinguishes the two -- with the guard
+    removed the traversal resolves onto a real directory.
+    """
+    from local_operator.session.attachments import ATTACHMENTS_DIRNAME, AttachmentStore
+
+    raw = b"\x89PNG\r\n\x1a\ntraversal-target"
+    ref = AttachmentStore(tmp_path / ATTACHMENTS_DIRNAME).put(
+        base64.b64encode(raw).decode("ascii"), "image/png"
+    )
+    assert ref is not None
+    # A real directory one level above the sessions namespace, so a guard-free
+    # read would find `is_dir()` true and `is_user_session()` true and serve.
+    outside = tmp_path / "sessions" / ".." / "elsewhere"
+    outside.mkdir(parents=True)
+    pool = DesktopSessions(tmp_path)
+
+    with pytest.raises(KeyError):
+        await pool.attachment("../elsewhere", ref.digest)
+    with pytest.raises(KeyError):
+        await pool.attachment("0123456789AB", ref.digest)
+    assert outside.is_dir(), "the traversal target must exist, or this proves nothing"
+
+
+@pytest.mark.asyncio
+async def test_attachment_refuses_a_subagent_origin_session(tmp_path):
+    """A delegated run's screenshots are not the desktop surface's to serve.
+
+    A subagent session is a machine's own work the user never opened, and the
+    desktop surface does not list it anywhere else either. `is_user_session` is
+    the ONLY thing keeping this route out of those conversations, and it is a
+    one-token edit away from removal -- so the case is an existing directory
+    that differs from the passing one in nothing but its origin marker,
+    written by the production `mark_session_origin` rather than hand-forged.
+
+    Canaried in both directions on purpose: the same digest and an identically
+    built directory WITHOUT the marker must serve, or a passing assertion here
+    would only mean the fixture was broken.
+    """
+    from local_operator.resume import ORIGIN_SUBAGENT, mark_session_origin
+    from local_operator.session.attachments import ATTACHMENTS_DIRNAME, AttachmentStore
+
+    raw = b"\x89PNG\r\n\x1a\nsubagent-screenshot"
+    ref = AttachmentStore(tmp_path / ATTACHMENTS_DIRNAME).put(
+        base64.b64encode(raw).decode("ascii"), "image/png"
+    )
+    assert ref is not None
+
+    def make(session_id: str) -> Any:
+        directory = tmp_path / "sessions" / session_id
+        directory.mkdir(parents=True)
+        (directory / "desktop.json").write_text(json.dumps({"version": 1, "cwd": str(tmp_path)}))
+        return directory
+
+    users = make("0123456789ab")
+    child = make("abcdef012345")
+    mark_session_origin(child, ORIGIN_SUBAGENT, label="review", agent="reviewer")
+    pool = DesktopSessions(tmp_path)
+
+    # The marker is the only difference, so the user session must still serve.
+    data, _ = await pool.attachment("0123456789ab", ref.digest)
+    assert data == raw and users.is_dir()
+    with pytest.raises(KeyError):
+        await pool.attachment("abcdef012345", ref.digest)
 
 
 def test_attachment_digest_shape_is_enforced_by_the_route_declaration():
@@ -535,16 +612,56 @@ def test_attachment_digest_shape_is_enforced_by_the_route_declaration():
 
 
 @pytest.mark.asyncio
+async def test_attachment_route_sets_no_cache_control_of_its_own(tmp_path):
+    """Caching belongs to the boundary, and this asserts the layer that owns it.
+
+    An earlier draft set `public, max-age=31536000, immutable` on this route.
+    That header never reached the wire, because `managed_desktop_boundary`
+    overwrites `Cache-Control` for everything under `/v1/desktop/` -- which is
+    exactly why an assertion made THROUGH the middleware cannot pin this down:
+    the effective value is `no-store` on the fixed tree AND on a tree where the
+    route re-adds `immutable`, so such a test passes on both and detects
+    nothing. The regression is a claim the route makes about caching, so the
+    assertion has to read the route's OWN response before anything rewrites it.
+
+    Calling the endpoint function directly is what makes that possible. The
+    wire-level companion below keeps the effective header covered too; neither
+    assertion substitutes for the other.
+    """
+    from local_operator.server.routes.desktop_sessions import attachment
+    from local_operator.session.attachments import ATTACHMENTS_DIRNAME, AttachmentStore
+
+    raw = b"\x89PNG\r\n\x1a\nuncached"
+    ref = AttachmentStore(tmp_path / ATTACHMENTS_DIRNAME).put(
+        base64.b64encode(raw).decode("ascii"), "image/png"
+    )
+    assert ref is not None
+    session = tmp_path / "sessions" / "0123456789ab"
+    session.mkdir(parents=True)
+    (session / "desktop.json").write_text(json.dumps({"version": 1, "cwd": str(tmp_path)}))
+
+    state = SimpleNamespace(
+        desktop_sessions=DesktopSessions(tmp_path),
+        config_manager=SimpleNamespace(config_dir=tmp_path),
+    )
+    request = cast(Any, SimpleNamespace(app=SimpleNamespace(state=state)))
+    response = await attachment("0123456789ab", ref.digest, request)
+
+    assert response.body == raw
+    assert "cache-control" not in response.headers
+    # And the header the route DOES own is on that same pre-middleware response.
+    assert response.headers["x-content-type-options"] == "nosniff"
+
+
+@pytest.mark.asyncio
 async def test_attachment_bytes_are_not_cached_by_any_shared_cache(tmp_path, monkeypatch):
     """The digest is content-addressed, and the response is still `no-store`.
 
     An `immutable` header would be correct about the BYTES and wrong about the
     RESPONSE: `managed_desktop_boundary` marks everything under `/v1/desktop/`
-    no-store because it is bearer-gated session data. An earlier draft of this
-    route set `public, max-age=31536000, immutable` and it never reached the
-    wire -- measured `no-store` against a live server -- so the header was a
-    claim the system did not honour. Asserting the effective value keeps the
-    route honest about which layer owns caching (the client, keyed by digest).
+    no-store because it is bearer-gated session data. This is the WIRE half --
+    it proves the boundary is in force for this path, which is what makes the
+    route's silence above the correct behaviour rather than an omission.
     """
     from fastapi.testclient import TestClient
 
@@ -573,3 +690,72 @@ async def test_attachment_bytes_are_not_cached_by_any_shared_cache(tmp_path, mon
     assert response.content == raw
     assert response.headers["content-type"] == "image/png"
     assert response.headers["cache-control"] == "no-store"
+
+
+@pytest.mark.asyncio
+async def test_stored_mime_is_allowlisted_before_it_becomes_a_header(tmp_path):
+    """A sidecar cannot choose this response's `Content-Type`.
+
+    The store records the mime its CALLER supplied and never verifies the
+    sidecar: `transcript._externalize_attachments` copies `block["mime_type"]`
+    verbatim with no allowlist of its own. No ingress puts a non-image mime in
+    the store today, but that is a property of callers upstream, and this
+    boundary is what pays if one changes -- so it is asserted HERE rather than
+    assumed there.
+
+    Three cases, each a real failure rather than a hypothetical:
+
+    - `text/html` and `image/svg+xml` round-trip out of the store and, unfixed,
+      are served as active content from an authenticated local port. `svg+xml`
+      is in `routes/static.py`'s broader list and deliberately NOT in this one.
+    - A CRLF-bearing mime is not merely wrong, it is unserveable: h11 rejects
+      the header and the client gets no response at all, which contradicts this
+      route's documented "404, never 500".
+
+    Every one must degrade to opaque bytes while the BODY still arrives intact
+    -- the fix is a refusal to label, not a refusal to serve.
+    """
+    from local_operator.server.routes.desktop_sessions import (
+        ATTACHMENT_FALLBACK_MIME,
+        attachment,
+    )
+    from local_operator.session.attachments import ATTACHMENTS_DIRNAME, AttachmentStore
+
+    store = AttachmentStore(tmp_path / ATTACHMENTS_DIRNAME)
+    session = tmp_path / "sessions" / "0123456789ab"
+    session.mkdir(parents=True)
+    (session / "desktop.json").write_text(json.dumps({"version": 1, "cwd": str(tmp_path)}))
+    state = SimpleNamespace(
+        desktop_sessions=DesktopSessions(tmp_path),
+        config_manager=SimpleNamespace(config_dir=tmp_path),
+    )
+    request = cast(Any, SimpleNamespace(app=SimpleNamespace(state=state)))
+
+    hostile = {
+        "text/html": b"<script>alert(document.domain)</script>",
+        "image/svg+xml": b"<svg xmlns='http://www.w3.org/2000/svg'><script/></svg>",
+        "image/png\r\nX-Injected: yes": b"\x89PNG\r\n\x1a\ncrlf",
+        "application/x-msdownload": b"MZ\x90\x00executable",
+    }
+    for mime, raw in hostile.items():
+        ref = store.put(base64.b64encode(raw).decode("ascii"), mime)
+        assert ref is not None
+        # The store really did keep the hostile value -- otherwise this test
+        # would be asserting against an input that never reaches the boundary.
+        assert store.get(ref.digest) == (base64.b64encode(raw).decode("ascii"), mime)
+        response = await attachment("0123456789ab", ref.digest, request)
+        assert response.media_type == ATTACHMENT_FALLBACK_MIME, mime
+        assert "\r" not in response.headers["content-type"], mime
+        assert "html" not in response.headers["content-type"], mime
+        # Refusing the label must not corrupt the bytes.
+        assert response.body == raw, mime
+
+    # And the allowlisted types still pass through untouched, or the fix would
+    # be a blanket downgrade that breaks every real screenshot.
+    for mime in ("image/png", "image/jpeg", "image/gif", "image/webp"):
+        raw = b"\x89PNG\r\n\x1a\n" + mime.encode("ascii")
+        ref = store.put(base64.b64encode(raw).decode("ascii"), mime)
+        assert ref is not None
+        response = await attachment("0123456789ab", ref.digest, request)
+        assert response.media_type == mime
+        assert response.body == raw

--- a/tests/unit/server/test_desktop_sessions.py
+++ b/tests/unit/server/test_desktop_sessions.py
@@ -1,6 +1,7 @@
 """Desktop stream algebra, resource bounds and durable retry invariants."""
 
 import asyncio
+import base64
 import json
 from types import SimpleNamespace
 from typing import Any, cast
@@ -463,3 +464,71 @@ async def test_served_list_order_is_the_catalogs_rank(tmp_path):
     assert served == [entry.id for entry in rank_entries(catalog[::-1])]
     # And concretely: the armed row leads despite being the oldest.
     assert served == ["armed", "newest", "middle"]
+
+
+@pytest.mark.asyncio
+async def test_durable_attachment_is_readable_without_starting_an_owner(tmp_path):
+    """A digest from a history row resolves to bytes on a cold conversation.
+
+    This is the read that makes durable images renderable at all: `/history`
+    serves rows verbatim, and an image block over the externalisation floor is a
+    digest with the payload stripped, so a reader that cannot resolve a digest
+    can only ever know an image WAS there.
+
+    It deliberately does NOT go through `DesktopSessions.session`. A finished
+    conversation's screenshot must be readable without starting an owner
+    process, which is the same argument `acknowledge_attention` already makes
+    for a read receipt -- and the assertion that no bridge was created is what
+    keeps a later refactor from quietly acquiring one per image.
+    """
+    from local_operator.session.attachments import ATTACHMENTS_DIRNAME, AttachmentStore
+
+    raw = b"\x89PNG\r\n\x1a\nnot-a-real-png-but-real-bytes"
+    store = AttachmentStore(tmp_path / ATTACHMENTS_DIRNAME)
+    ref = store.put(base64.b64encode(raw).decode("ascii"), "image/png")
+    assert ref is not None
+
+    session = tmp_path / "sessions" / "0123456789ab"
+    session.mkdir(parents=True)
+    (session / "desktop.json").write_text(json.dumps({"version": 1, "cwd": str(tmp_path)}))
+
+    pool = DesktopSessions(tmp_path)
+    data, mime_type = await pool.attachment("0123456789ab", ref.digest)
+    assert data == raw and mime_type == "image/png"
+    assert pool.bridges == {}
+
+    # A miss is ordinary, not a fault: the store's own contract is that an
+    # interrupted write or a hand-pruned store degrades to a placeholder, and
+    # `errors()` maps KeyError to 404 rather than letting it reach a 500.
+    with pytest.raises(KeyError):
+        await pool.attachment("0123456789ab", "f" * 32)
+    # Nor may a valid digest be read through a session id that is not a user
+    # conversation on this machine.
+    with pytest.raises(KeyError):
+        await pool.attachment("ffffffffffff", ref.digest)
+
+
+def test_attachment_digest_shape_is_enforced_by_the_route_declaration():
+    """Traversal is unreachable by construction, not by a handler check.
+
+    The store turns a digest straight into `<root>/<digest>.bin`, so the only
+    safe place for the constraint is the path declaration: FastAPI rejects a
+    non-matching path before the handler runs, and no later edit inside the
+    handler can route around it. Asserting on the published schema rather than
+    on a string literal is what keeps this true if the annotation moves.
+    """
+    from local_operator.server.app import app
+
+    schema = app.openapi()
+    path = "/v1/desktop/sessions/{session_id}/attachments/{digest}"
+    digest = next(
+        parameter
+        for parameter in schema["paths"][path]["get"]["parameters"]
+        if parameter["name"] == "digest"
+    )
+    assert digest["schema"]["pattern"] == r"^[a-f0-9]{32}$"
+    # And the response is raw bytes rather than the CRUD envelope: a JSON
+    # envelope has nowhere to put an image.
+    assert "application/json" not in schema["paths"][path]["get"]["responses"]["200"].get(
+        "content", {}
+    )

--- a/tests/unit/server/test_desktop_sessions.py
+++ b/tests/unit/server/test_desktop_sessions.py
@@ -532,3 +532,44 @@ def test_attachment_digest_shape_is_enforced_by_the_route_declaration():
     assert "application/json" not in schema["paths"][path]["get"]["responses"]["200"].get(
         "content", {}
     )
+
+
+@pytest.mark.asyncio
+async def test_attachment_bytes_are_not_cached_by_any_shared_cache(tmp_path, monkeypatch):
+    """The digest is content-addressed, and the response is still `no-store`.
+
+    An `immutable` header would be correct about the BYTES and wrong about the
+    RESPONSE: `managed_desktop_boundary` marks everything under `/v1/desktop/`
+    no-store because it is bearer-gated session data. An earlier draft of this
+    route set `public, max-age=31536000, immutable` and it never reached the
+    wire -- measured `no-store` against a live server -- so the header was a
+    claim the system did not honour. Asserting the effective value keeps the
+    route honest about which layer owns caching (the client, keyed by digest).
+    """
+    from fastapi.testclient import TestClient
+
+    from local_operator.server.app import app
+    from local_operator.session.attachments import ATTACHMENTS_DIRNAME, AttachmentStore
+
+    monkeypatch.setenv("LOCAL_OPERATOR_DESKTOP_TOKEN", "token")
+    monkeypatch.setenv("LOCAL_OPERATOR_HOME", str(tmp_path))
+    raw = b"\x89PNG\r\n\x1a\nbytes"
+    ref = AttachmentStore(tmp_path / ATTACHMENTS_DIRNAME).put(
+        base64.b64encode(raw).decode("ascii"), "image/png"
+    )
+    assert ref is not None
+    session = tmp_path / "sessions" / "0123456789ab"
+    session.mkdir(parents=True)
+    (session / "desktop.json").write_text(json.dumps({"version": 1, "cwd": str(tmp_path)}))
+    app.state.config_manager = SimpleNamespace(config_dir=tmp_path)
+    app.state.desktop_sessions = DesktopSessions(tmp_path)
+
+    with TestClient(app) as client:
+        response = client.get(
+            f"/v1/desktop/sessions/0123456789ab/attachments/{ref.digest}",
+            headers={"Authorization": "Bearer token"},
+        )
+    assert response.status_code == 200
+    assert response.content == raw
+    assert response.headers["content-type"] == "image/png"
+    assert response.headers["cache-control"] == "no-store"


### PR DESCRIPTION
## What and why

A durable transcript row references an image by **content digest**, not payload:
`transcript._externalize_attachments` strips `data` from any image block over 1 KiB
of base64 and leaves `{"attachment": "<32-hex>", "mime_type": ...}`. That is what
made the store worth having — base64 image payload was 102 of 134 MB across 142
real sessions on this machine.

`/history` serves those rows verbatim, and **no desktop route could resolve a
digest**. So a frontend reading a real conversation received a reference to bytes
it had no way to fetch, and every screenshot in the history became unrenderable
the moment the live event scrolled out of memory. This adds the one route that
closes that gap.

**Change class: C2 — standard.** New read-only route on an existing bearer-gated
prefix; no schema change, no migration, no behaviour change to any existing route.

### Delivery contract

- `GET /v1/desktop/sessions/{session_id}/attachments/{digest}` returns the raw
  bytes with the attachment's own `mime_type` as the response type.
- `digest` is validated as `^[a-f0-9]{32}$` **in the path declaration**, so a
  malformed one is rejected by FastAPI before any handler code runs. This is the
  traversal gate, and it is declarative rather than a hand-written check that a
  later edit could skip.
- Bearer-gated exactly like its neighbours — it lands under `/v1/desktop/`, so
  `managed_desktop_boundary` already covers it. Nothing new was added to the auth
  path and nothing was carved out of it.
- Subagent sessions stay unreadable: the route goes through the same
  `is_user_session` gate as `/history`, so a digest belonging to a subagent
  transcript 404s rather than leaking.
- A miss is **404, never 500**. `AttachmentStore`'s contract is that an
  unresolvable reference is ordinary — an interrupted write, a hand-pruned store —
  and "callers must treat that as ordinary and degrade to a placeholder".
- The disk read runs in `asyncio.to_thread`, matching `bridge.history`.

## Evidence

### The real route, over real HTTP, against the real attachment store

Not a TestClient — a live `uvicorn` on its own port, hit with `curl`, using the
digests of **real screenshots in real sessions on this machine**:

```
GET /v1/desktop/sessions/8b5a3a71e677/attachments/0238cd06be7bc1054a6269e5e7dc0cd5
HTTP/1.1 200 OK
content-type: image/png
cache-control: no-store
bytes=226051   file=PNG image data, 1024 x 631, 8-bit/color RGBA
sha256[:32] of body = 0238cd06be7bc1054a6269e5e7dc0cd5   <- identical to the URL
```

```
GET /v1/desktop/sessions/835fbcafdc27/attachments/b15f45ca804a8292ab9f15ee2995ce04
HTTP/1.1 200 OK
content-type: image/jpeg
bytes=69811    file=JPEG image data, JFIF standard 1.01
sha256[:32] of body = b15f45ca804a8292ab9f15ee2995ce04   <- identical to the URL
```

The hash of the returned body equalling the digest in the URL is the whole
correctness claim: the route served *that* content and not merely *some* content.

### Every way of asking for something else

```
[miss, valid shape]      404  {"detail":"Requested session, profile, team or subscription not found"}
[traversal, encoded]     404  {"detail":"Not Found"}
[traversal, dotted]      404  {"detail":"Not Found"}
[uppercase hex]          422  string_pattern_mismatch at ["path","digest"]
[33 hex chars]           422  string_pattern_mismatch at ["path","digest"]
[31 hex chars]           422  string_pattern_mismatch at ["path","digest"]
[suffix injection]       422  string_pattern_mismatch at ["path","digest"]
[unknown session]        404  {"detail":"Requested session, profile, team or subscription not found"}
[bad session shape]      404  {"detail":"Not Found"}
[subagent session]       404  {"detail":"Requested session, profile, team or subscription not found"}
[no bearer]              401  {"detail":"Desktop authorization is required."}
[foreign Origin]         403  {"detail":"This origin cannot access desktop controls."}
```

The subagent 404 was found by *trying* it: two of the first real sessions I
picked were subagent transcripts, and the route refused them without my having
written that check — the shared session gate already covered it.

### A correction found by measuring rather than assuming

The first draft set `Cache-Control: public, max-age=31536000, immutable`,
reasoning that a content-addressed digest can never change. **That header never
reached the wire** — measured `no-store` against the live server, because
`managed_desktop_boundary` marks everything under `/v1/desktop/` no-store. The
docstring asserted a property the system did not have.

Carving the middleware out would have been worse: these are bearer-gated session
data, and `public` invites a shared cache to retain one user's screenshots. The
mobile daemon's equivalent route can afford `immutable` because it sits behind
different auth in a different process, so copying its header without its argument
was not reuse. Caching belongs to the client, which already holds a digest-keyed
cache — and content addressing is exactly what makes that cache safe. The second
commit removes the header and asserts the **effective** value through the
middleware, so the route cannot drift back to claiming something it does not do.

### Consumer

Exercised end to end by the desktop UI in
damianvtran/local-operator-ui#101: a real Electron window, a real conversation, a
digest-referenced screenshot fetched through the media relay and painted in
place (`scheme: blob`, `natural: 720x694`, decoded, in a real tool row).

### Gates

```
pytest tests/unit/server/test_desktop_sessions.py   26 passed
flake8 .                                           rc=0
black --check .                                    1182 files unchanged
isort --check .                                    rc=0
pyright --pythonpath .venv/bin/python .            0 errors, 0 warnings
```

Four of the 26 tests are new: the route contract, the declared digest pattern,
a durable digest resolving to bytes on a cold conversation, and the effective
cache-control through the middleware.

## Limitations — stated plainly

- **The consumer's live-image path is proven; a fresh browser-tool capture is
  not.** The UI side renders durable images from this route against real
  conversations. Producing a *brand new* screenshot needs a live agent turn, and
  the browser tool was unavailable in that session.
- **macOS only.** Run on Darwin 25.6.0 / arm64. Nothing here is platform-specific
  (a path join and a file read), but CI is where the Linux leg gets covered.
- **No cache validators.** No `ETag` or `Last-Modified`; a client that wants to
  avoid re-fetching keys its own cache by digest, which is the intended design
  rather than an omission.
