### PR TITLE
fix(skills): resolve a skill authored mid-session without a restart

### DIFF
--- a/docs/design-skill-authoring-liveness.md
+++ b/docs/design-skill-authoring-liveness.md
@@ -200,7 +200,7 @@ def make_skill_resolver(
     skills: MutableMapping[str, Skill],
     roots: Sequence[Path] | None = None,
 ) -> Callable[[str], str | None]:
-    state = _RefreshState()  # last_check monotonic, last_fingerprint, threading.Lock
+    state = _RefreshState()  # last_fingerprint, threading.Lock
 
     def resolver(url: str) -> str | None:
         if not url.startswith("skill://"):

--- a/docs/design-skill-authoring-liveness.md
+++ b/docs/design-skill-authoring-liveness.md
@@ -1,0 +1,478 @@
+# Design: making a newly authored skill usable in the session that wrote it
+
+Status: proposal (architect). No implementation in this document.
+
+## 1. The problem as I found it
+
+An agent wrote a valid skill to `~/.local-operator/skills/lean-formalization/SKILL.md`
+— a native global root, exactly where the docs say to put one — and then neither
+it nor any subagent it launched could read it. A subagent whose standing
+instructions said "FIRST, EVERY TIME: read `skill://lean-formalization`" got
+`Unknown skill` and correctly refused to fabricate, so the operator's standing
+instructions were silently unfollowable for the rest of the session.
+
+The mechanism, confirmed in the tree at `f1ab7d346`:
+
+- `session_factory.py:1234` calls `discover_skills(default_skill_roots(Path.cwd()))`
+  exactly once, during session construction, and stores the result in
+  `hooks.skills_by_name` (`session_factory.py:1237`).
+- `_make_knowledge_resolver` (`session_factory.py:1361`) builds
+  `make_skill_resolver(hooks.skills_by_name)` (`skills/api.py:130`); that closure
+  is the session's `_skill_resolver` (`session/session.py:1901`) and reaches the
+  `read` tool through `ToolContext.resolve_internal_url`
+  (`session/session.py:6842` → `tools/builtin.py:2643`).
+- Children inherit the parent closure verbatim (`harness/subagent.py:1658`,
+  wired at `:1884`), so a child's skill catalogue **is** the parent's startup
+  snapshot.
+- There is no rescan path anywhere. `guide://extensions` (`GUIDE.md:57`)
+  documents the consequence — "Start a new session after adding or changing a
+  skill" — which is accurate but useless to an agent that has just been told to
+  author one.
+
+Two things make this worse than a missing feature.
+
+**The error is opaque.** `resolve_resource_url` raises
+`Unknown skill: <name>\nAvailable: ...` (`skills/protocol.py:404`) for *four*
+different causes that the agent cannot tell apart: not scanned yet, blank or
+missing `description` (silently dropped at `discovery.py:114-116`), frontmatter
+`name` disagreeing with the directory name (`discovery.py:118-122`), and a name
+collision shadowed by an earlier root (`discovery.py:236-242`, whose warning goes
+to a `warnings_out` list printed only at startup). The agent sees one message and
+has no next move except to give up or grep the filesystem — which the system
+prompt forbids.
+
+**Bodies are already live; only the *catalogue* is frozen.** Verified: after
+`discover_skills`, editing an existing `SKILL.md` in place changes what
+`skill://<name>` returns on the very next read, because `_read_text_capped`
+opens the file at resolve time (`protocol.py:42-53`). So the defect is narrower
+than "skills are a startup snapshot" — it is precisely *name → Skill* membership
+that is frozen. That narrows the fix considerably.
+
+I also verified the enabling fact independently. `make_skill_resolver` binds the
+mapping **by reference**, so an in-place mutation is visible through an
+already-constructed resolver, including one an already-running child captured:
+
+```
+child sees beta before: Unknown skill: beta / Available: alpha
+child sees beta after : '---\nname: beta\ndescription: Beta skill.\n---\n\nBeta body.\n'
+mapping id stable: True
+```
+
+### A secondary defect found on the way
+
+`_setup_knowledge` computes roots from `Path.cwd()` (`session_factory.py:1234`),
+not from the session's `cwd`. `effective_cwd` is already in scope at the call
+site (`session_factory.py:1950`, call at `:1952`) and is passed to everything
+else — `_seed_mcp_routing`, `_build_variable_store`, `load_repo_guidance`. A
+session created with an explicit `cwd` (`bootstrap.py:264`,
+`scheduler_service.py:777`, `session/runtime/owned.py:3832`) therefore discovers
+project-local skills for the **process** directory rather than its own. It is a
+one-line fix and it belongs in this PR, because the refresh path has to decide
+which roots it walks and shipping a refresh that is correct while startup stays
+wrong would bake in the inconsistency.
+
+## 2. Options for the surface
+
+### Option A — a new `skill` tool (`create` / `list` / `reload`)
+
+Rejected. This is rung 5 of the tool-surface footprint ladder
+(`AGENTS.md:1921`), and it does not clear the bar: skill authoring is rare,
+skill *reads* are constant. A `skill` tool ships its schema on every request in
+every session and every subagent, forever, to serve an action most sessions
+never take. The ladder's rung 1 answer applies directly — the capability is a
+variation of `write`, which already exists, already creates parent directories,
+and already routes an out-of-workspace path (which `~/.local-operator/skills`
+is, from a repo cwd) through the approval prompt via `_approval_description`
+(`tools/builtin.py:653`). Adding a tool would buy validation and a place to hang
+the refresh; §3 gets both for zero schema.
+
+### Option B — a write verb on the `skill://` protocol
+
+Rejected. `read` is the only tool that resolves internal URLs
+(`tools/builtin.py:2643`), and its whole contract is that resolution is a read.
+A URL scheme where `read` sometimes creates a file is a footgun, and the
+resolver contract (`skills/api.py:130-140`: returns content, returns `None` for
+other schemes, never raises) has no shape for reporting a partial write.
+
+### Option C — a CLI command (`lop skill new`)
+
+Rejected as the primary answer. It does not solve the problem at all: a
+subprocess cannot mutate the running session's `skills_by_name`, so the agent
+would create the skill correctly and *still* not be able to read it. It is the
+status quo with a nicer `mkdir`. (It remains fine as a later human convenience.)
+
+### Option D — rebuild the whole knowledge layer on demand
+
+Rejected. See §4 — it forces the synchronous resolver contract to become async
+and burns the prompt cache, to deliver semantic *selection* of a skill whose
+name the agent already knows.
+
+### Option E — documentation only
+
+Rejected: this is the status quo, and the status quo is what produced a subagent
+that could not follow its own standing instructions.
+
+## 3. Recommendation: refresh-on-miss, fingerprint-gated, in the skill resolver
+
+**Refresh membership only, only on a miss, only when the filesystem says
+something changed, and make the surviving miss self-diagnosing.**
+
+Concretely, `make_skill_resolver` gains optional roots. When a `skill://` URL
+names something not in the mapping (and only then):
+
+1. If less than `_REFRESH_COOLDOWN` (1.0 s) since the last check, skip
+   everything and return today's error. Bounds a hostile or looping agent to one
+   filesystem probe per second per session.
+2. Compute a cheap fingerprint of the roots. If unchanged, return today's error
+   without scanning.
+3. If changed, run `discover_skills(roots)` and **`dict.update`** the mapping
+   in place. Never rebind it.
+4. Retry the resolution. If it still misses, run a diagnostic that explains
+   *why* and return that instead of the bare `Unknown skill`.
+
+Cost on the frequent path — a skill that exists — is **one dict lookup**,
+because nothing above step 0 runs on a hit. That is the constraint the task set
+and it is met exactly.
+
+### Why fingerprint-gate rather than just rescanning
+
+Measured on this machine, 8 roots / 57 skill directories:
+
+| operation | cost |
+|---|---|
+| `discover_skills(roots)` (full scan, parses 57 files) | **17–25 ms** |
+| fingerprint: `stat` each root + `scandir` + `stat` each `SKILL.md` | **0.29 ms** |
+| `default_skill_roots(cwd)` | 0.15 ms |
+
+A typo'd skill name costs 0.29 ms rather than 17–25 ms — a ~60× reduction on the
+exact path the task flagged as the risk. The full scan is paid only when the
+tree actually changed, which is the case the feature exists for. This answers
+"is a filesystem walk on a typo acceptable, and should it be bounded" with: it
+is bounded twice, by the fingerprint and by the cooldown, and the residual is
+sub-millisecond.
+
+The 17–25 ms scan runs synchronously on the event loop that renders the TUI
+(`tools/builtin.py:2650` is inside an `async def` but the resolver is sync). That
+is about one frame, on a rare path, once per real change — I judge it acceptable
+and would not complicate the sync resolver contract to avoid it. The cooldown is
+what guarantees it cannot repeat in a loop.
+
+### What must be in the fingerprint
+
+I tested the mtime semantics rather than assuming them:
+
+| event | root dir mtime | child dir mtime | `SKILL.md` mtime/size |
+|---|---|---|---|
+| new skill dir created | **bumps** | — | — |
+| `SKILL.md` created in existing dir | no | **bumps** | **bumps** |
+| `SKILL.md` edited in place | no | no | **bumps** |
+
+Root mtime alone is not enough. The third row is a real case: a skill dropped at
+startup for a blank `description` is *not* in the mapping, so fixing its
+frontmatter in place is a miss that root and child mtimes both fail to notice.
+Including `(mtime_ns, size)` of each `SKILL.md` closes it and is what the 0.29 ms
+figure already measures. Use that fingerprint:
+
+```python
+# skills/discovery.py — mirrors scan_skills_dir's one-level walk on purpose:
+# a fingerprint that walked differently from the scanner would miss changes
+# the scanner would have seen.
+def roots_fingerprint(roots: Sequence[Path]) -> tuple: ...
+```
+
+### Shape of the change (illustrative)
+
+```python
+# skills/api.py — roots defaults to None, so every existing caller and the
+# parallel guide resolver keep today's behaviour untouched.
+def make_skill_resolver(
+    skills: MutableMapping[str, Skill],
+    roots: Sequence[Path] | None = None,
+) -> Callable[[str], str | None]:
+    state = _RefreshState()  # last_check monotonic, last_fingerprint, threading.Lock
+
+    def resolver(url: str) -> str | None:
+        if not url.startswith("skill://"):
+            return None
+        try:
+            return resolve_skill_url(url, skills)
+        except ValueError as exc:
+            if roots is None or not _is_unknown_name(exc):
+                return str(exc)
+            if not _refresh_if_changed(skills, roots, state):
+                return _diagnose(str(exc), url, roots)
+            try:
+                return resolve_skill_url(url, skills)
+            except (ValueError, OSError) as retry_exc:
+                return _diagnose(str(retry_exc), url, roots)
+        except OSError as exc:
+            return str(exc)
+    return resolver
+```
+
+Three details are load-bearing and belong in comments in the source:
+
+- **`skills.update(...)`, never `skills = {...}`.** The entire propagation
+  story is that `session_factory`, the parent resolver and every child hold the
+  same dict object. A rebinding refactor breaks children silently, with no test
+  failure unless one is written for it (§6).
+- **Refresh only ADDS; it never removes.** A skill deleted from disk stays in
+  the mapping. Removing it would let one agent's cleanup break a sibling child
+  mid-read, and the stale entry already degrades gracefully — verified, a
+  deleted skill's read returns `[Errno 2] No such file or directory: ...` through
+  the adapter's `OSError` catch (`api.py:147-150`), which is a clear message, not
+  a crash. Growth-only is the safe monotone direction.
+- **Only an "unknown name" `ValueError` triggers a refresh.** `resolve_skill_url`
+  also raises for traversal and unsafe child paths (`protocol.py:_resolve_child`);
+  rescanning on those would let a malformed URL drive filesystem work. Discriminate
+  before refreshing.
+
+### Locking
+
+Subagents run as asyncio tasks on one loop and the resolver is synchronous, so
+there is no `await` inside the refresh and it is already atomic with respect to
+the loop. But `exec_worker.py` and `exec_mode.py` build sessions on other
+execution paths, and the read-modify-write of the fingerprint state is not
+inherently thread-safe. Take an uncontended `threading.Lock` around steps 1–3.
+It costs nothing and removes the question permanently rather than leaving a
+reader to re-derive the GIL argument.
+
+### The diagnostic — the other half of the fix
+
+After a refresh that still misses, `_diagnose` looks for a directory named like
+the requested skill under the roots and explains what it found. This is where
+"validation on create" actually belongs (§5). Implement it as a new helper in
+`discovery.py` called **only** on the miss path, so `discover_skills`'s signature
+and its five existing callers (`session_factory.py:1234`, `tui/app.py:28733` and
+`:28835`, `server/routes/desktop_catalogues.py:192`,
+`scripts/calibrate_skill_threshold.py`) are untouched:
+
+```python
+def diagnose_missing_skill(name: str, roots: Sequence[Path]) -> str | None:
+    """Explain why <name> did not load, or None when there is nothing to say."""
+```
+
+Messages it must produce, one per real cause found in the current code:
+
+| what is on disk | message |
+|---|---|
+| `<root>/<name>/SKILL.md` missing | `A directory '<name>' exists at <root> but has no SKILL.md.` |
+| frontmatter `description` missing/blank | `<path> has no 'description' in its frontmatter; skills without one are not loaded. Add one and read the URL again.` |
+| frontmatter unparseable / unterminated `---` | `<path> has malformed YAML frontmatter (it must open and close with ---).` |
+| `enabled: false` | `'<name>' is disabled by 'enabled: false' in <path>.` |
+| frontmatter `name:` differs from dir name | `<path> declares name '<declared>'; read skill://<declared> (the frontmatter name wins over the directory name).` |
+| shadowed by an earlier root | `'<name>' at <path> is shadowed by the one at <winner> (earlier roots win). Rename it or edit the winner.` |
+
+Each line names the fix. That turns four indistinguishable failures into four
+actionable ones, and it is the difference between an agent that self-corrects in
+one round and one that gives up — which is what the transcript in the report
+actually shows.
+
+### Also invalidate the TUI's `$name` cache
+
+`_discovered_skills` (`tui/app.py:28708`) memoizes its own map for the life of
+the app, and its docstring (`:28712-28716`) explicitly justifies that by the
+restart rule this design removes. Gate it on the same `roots_fingerprint` so a
+new skill becomes typeable as `$name` too, and rewrite the docstring — otherwise
+the codebase carries a comment asserting a rule it no longer follows.
+(`_skills_block` at `:28820` already rescans on every call and needs no change.)
+
+## 4. Propagation semantics — exactly what is and is not covered
+
+**Covered by the in-place mutation** (all three share one dict object):
+
+| consumer | why | evidence |
+|---|---|---|
+| the parent session | `make_skill_resolver` closed over the dict | `api.py:130`, verified above |
+| **already-running** subagents | captured the parent closure at build | `subagent.py:1658` |
+| future subagents | same path | `subagent.py:1658`, `:1884` |
+
+**Deliberately not covered:**
+
+- `hooks.index` — the semantic vector index. A new skill is not auto-*selected*
+  until the next session.
+- `hooks.frozen_block` (`session_factory.py:1138`, set at `:1355`) — the
+  rendered `<skills>` listing in the prompt.
+- The child's inherited copy of that block (`subagent.py:1775`).
+- `hooks.skills_by_name` entries for skills *deleted* from disk (by design,
+  above).
+- Roots that did not exist at startup. `default_skill_roots` filters ecosystem
+  roots by existence (`api.py:83`), so creating `~/.claude/skills` mid-session is
+  not picked up. Rare; documented, not fixed.
+
+### Why resolution-only is the right scope, and not a hedge
+
+The task rightly asked me not to casually propose re-rendering the frozen block.
+I am proposing not to, and the argument is not cost-aversion:
+
+1. **It would burn the prompt cache for the whole session.** The frozen block
+   rides the system-prompt prefix, and the tools array rides the *same* prefix —
+   `tools/registry.py` orders the table specifically to keep that prefix stable
+   (`AGENTS.md:1921`). Re-rendering mid-turn invalidates both, for every
+   subsequent request. That is a real, repeated cost on every session, paid to
+   inform an agent of a skill it wrote thirty seconds ago.
+2. **It cannot be done from where the miss happens.** `SkillIndex.build()` is
+   `async` (`index.py:368`) and may call a network embedding backend
+   (`ApiEmbedder`). The resolver is `Callable[[str], str | None]` — synchronous,
+   by a contract declared in `harness/types.py:772` and consumed at
+   `tools/builtin.py:2650` and `subagent.py:1660`. Rebuilding the index on a
+   skill read means making internal-URL resolution async everywhere, which is a
+   far larger and riskier change than the defect warrants.
+3. **The author already knows the name.** Semantic selection exists to surface
+   skills an agent does not know about. The agent that just wrote
+   `lean-formalization`, and the subagent whose instructions name it literally,
+   both address it by name. Explicit `skill://` reads working is the whole
+   requirement.
+
+So: **semantic selection updates on the next session; explicit reads work
+immediately.** This is an acceptable, documented limitation, and `guide://extensions`
+must state it in exactly those terms so the next agent does not read it as a bug.
+
+## 5. Validation on create
+
+There is no create hook to validate in, because the recommendation deliberately
+adds no create tool — the agent uses `write`. Validation therefore lands at the
+point of confusion instead of the point of creation, which is strictly better:
+it also catches skills that were malformed *before* this change, and skills
+written by hand, by another harness, or by a git checkout.
+
+The rules being enforced (as diagnostics, per the table in §3) are the ones the
+existing code already applies silently:
+
+- **`description` is required** — missing or blank means the skill is dropped
+  (`discovery.py:114-116`). It is the entire routing signal.
+- **`name` is optional and wins when present** — it defaults to the directory
+  name (`discovery.py:118-122`). Disagreement is legal but confusing, so the
+  diagnostic names the URL that actually works rather than calling it an error.
+- **Collisions resolve to the earliest root** and the loser is dropped
+  (`discovery.py:236-242`). Note the live example: this machine currently
+  produces **37** shadow warnings at startup (native root shadowing
+  `~/.claude/skills`), all invisible after boot. The diagnostic is the first
+  time an agent can see one.
+- **Invalid frontmatter degrades, never crashes** (`discovery.py:66-87`) — keep
+  that; the diagnostic reports it.
+
+**On the frontmatter `name` vs directory name:** do not add enforcement. The
+divergence is deliberate ecosystem-compatible behaviour with a documented
+default, and turning it into an error would drop skills that work today.
+Diagnose, don't reject.
+
+## 6. Scope, files, tests, risks
+
+**Change class: C1/C2 — standard, pre-authorized.** It extends existing
+mechanisms rather than establishing one: no new tool schema, no new trust
+boundary, no new protocol. It is explicitly not C5 — the containment checks in
+`protocol.py` (`_contained`, `_resolver_would_accept`, dotfile and traversal
+rejection) are untouched, and the refresh reads only directories the session was
+already scanning at startup.
+
+**Release line:** `Release: patch — a skill authored mid-session becomes
+readable immediately, in the session and in its subagents.` A self-contained fix
+to a broken behaviour; it does not clear the step-function bar for a minor
+(`AGENTS.md:959`).
+
+### Files to touch
+
+| file | change |
+|---|---|
+| `skills/discovery.py` | add `roots_fingerprint(roots)` and `diagnose_missing_skill(name, roots)`. No change to `discover_skills` or its callers. |
+| `skills/api.py` | `make_skill_resolver(skills, roots=None)` — cooldown, fingerprint gate, in-place `update`, diagnostic on surviving miss, `threading.Lock`. Export the two new helpers. |
+| `session_factory.py` | `_KnowledgeHooks` gains `skill_roots: list[Path]`; `_setup_knowledge` takes `cwd` and stores the roots it used (fixes the `Path.cwd()` bug at `:1234`); call site `:1952` passes `effective_cwd`; `_make_knowledge_resolver` (`:1361`) passes `hooks.skill_roots`. |
+| `tui/app.py` | `_discovered_skills` (`:28708`) gated on the fingerprint; docstring at `:28712-28716` rewritten. |
+| `guides/extensions/GUIDE.md` | replace `:57` (below). |
+| `docs/` | this file. |
+
+`prompts_md/system.md` — **no change, deliberately.** A sentence about authoring
+would sit in the always-paid prefix to serve a rare action, which is what the
+footprint ladder warns against. The routing already exists: `system.md:237-246`
+tells an agent that a question about "skills and extensions" MUST go to
+`guide://<name>` first. The guide is where this belongs, and it costs nothing
+until read.
+
+### What `guide://extensions` must say
+
+`GUIDE.md:57` currently reads "Start a new session after adding or changing a
+skill." That becomes wrong on merge and must be replaced with something that
+states the split precisely — the sentence is what a future agent will trust:
+
+> A skill you create is readable immediately. The first `read skill://<name>`
+> that misses re-scans the skill roots, so the new skill resolves in this
+> session and in subagents already running — no restart. What does **not**
+> update until the next session is *semantic selection*: the skill will not
+> appear in the `<skills>` listing or be auto-suggested, because that listing is
+> frozen for prompt-cache stability. Read it by name, and tell subagents its
+> name. Editing an existing skill's **body** has always taken effect on the next
+> read; editing its `name`, `description` or `enabled` affects selection only,
+> and waits for the next session.
+
+The guide should also gain a short "where to put it" line — global
+`~/.local-operator/skills/<name>/SKILL.md` for practice that follows the
+operator everywhere, project-local `.local-operator/skills/<name>/SKILL.md` when
+it belongs to that repository and should be committed — and a pointer that a
+skill which fails to load will now say why when its URL is read.
+
+### Test surface
+
+Unit, `tests/unit/skills/test_api.py` and `test_discovery.py`:
+
+1. Miss → skill created on disk → same resolver instance resolves it.
+2. **The child test, and it is the important one:** build resolver A, derive
+   child resolver B that calls A (mirroring `subagent.py:1658`), create a skill,
+   resolve through **B**. This is the regression guard against a future
+   rebinding refactor and must assert the child, not the parent.
+3. Mapping identity: `skills` object is `is`-identical before and after refresh.
+4. Hit path does no filesystem work — monkeypatch `roots_fingerprint` to raise
+   and assert a successful resolve still succeeds.
+5. Fingerprint unchanged → `discover_skills` not called (patch and count).
+6. Cooldown: two misses inside the window produce one fingerprint call.
+7. Fingerprint detects each of the three mutation shapes in the §3 table,
+   especially in-place `SKILL.md` edit.
+8. Deleted skill stays in the mapping and reads as a clean `OSError` message.
+9. Traversal/unsafe-path `ValueError` does **not** trigger a refresh.
+10. `diagnose_missing_skill` for each row of the diagnostics table.
+11. `roots=None` (the default) reproduces today's behaviour byte-for-byte —
+    guards every existing caller and the `guide://` resolver.
+
+`tests/unit/test_session_factory.py`: `_setup_knowledge` uses the passed `cwd`,
+not `Path.cwd()`, and populates `hooks.skill_roots`.
+
+`tests/unit/tui/test_skill_invocation.py`: `$name` reaches a skill created after
+app start.
+
+**End-to-end evidence the PR must carry** (a green unit suite is not evidence of
+this): a real session that writes a skill and reads it back, and a real subagent
+launched *before* the skill existed that reads it successfully. That second one
+is the reported defect and it is the one that has to be shown working.
+
+### Risks to watch during rollout
+
+1. **Rebinding regression.** The single point of failure. Mitigated by test 2
+   and by a comment at the mutation site; nothing else will catch it.
+2. **Event-loop stall.** 17–25 ms sync scan on the loop that renders the TUI,
+   here ~one frame. Rare and cooldown-bounded. If a user reports a hitch on a
+   pathological tree, the fix is `to_thread` at the `read`-tool call site, not a
+   change to the resolver contract.
+3. **Pathological trees.** A root with tens of thousands of child directories
+   makes even the fingerprint slow. Bounded by the cooldown to one probe/second,
+   and note that startup already pays a larger version of the same cost — this
+   adds no new exposure class.
+4. **Symlinks and mid-walk mutation.** `scan_skills_dir` is one level deep,
+   realpath-dedupes and swallows `OSError` (`discovery.py:173-202`), so a symlink
+   loop or a directory vanishing mid-walk yields a shorter list, never an
+   exception. The fingerprint must walk one level with the same `OSError`
+   tolerance; do not make it stricter than the scanner it gates.
+5. **Concurrent refresh from two children.** Handled by the lock; verify no
+   `await` sneaks inside the locked region, which would deadlock the loop.
+6. **Shadow warnings becoming noisy.** The diagnostic can now surface a class of
+   message this machine produces 37 of at startup. It is emitted only for the
+   *one* name being read, so it stays targeted — but if a diagnostic ever grows
+   to list all warnings, that is a regression.
+
+## 7. What I am recommending against doing
+
+- Do not add a `skill` tool. Rung 5 for a rare action; `write` plus a
+  self-diagnosing miss covers it at zero schema cost.
+- Do not rebuild the semantic index or re-render the frozen block on refresh.
+- Do not remove deleted skills from the mapping.
+- Do not add a line to `system.md`. The guide routing already exists.
+- Do not enforce name/directory agreement. Diagnose it.

--- a/docs/design-skill-authoring-liveness.md
+++ b/docs/design-skill-authoring-liveness.md
@@ -120,15 +120,24 @@ something changed, and make the surviving miss self-diagnosing.**
 Concretely, `make_skill_resolver` gains optional roots. When a `skill://` URL
 names something not in the mapping (and only then):
 
-1. If less than `_REFRESH_COOLDOWN` (1.0 s) since the last check, skip
-   everything and return today's error. Bounds a hostile or looping agent to one
-   filesystem probe per second per session.
-2. Compute a cheap fingerprint of the roots. If unchanged, return today's error
-   without scanning.
-3. If changed, run `discover_skills(roots)` and **`dict.update`** the mapping
-   in place. Never rebind it.
-4. Retry the resolution. If it still misses, run a diagnostic that explains
-   *why* and return that instead of the bare `Unknown skill`.
+1. Compute a cheap fingerprint of the roots. If unchanged, skip the scan.
+2. If changed, run `discover_skills(roots)` and **`dict.update`** the mapping
+   in place. Never rebind it. Commit the fingerprint only after the scan
+   SUCCEEDS, so a transient `OSError` retries instead of poisoning the session.
+3. Retry the resolution **unconditionally** — the question is "is the name
+   resolvable now", not "did this call perform the scan", and under concurrency
+   another thread may have populated the mapping while this one waited on the
+   lock. If it still misses, run a diagnostic that explains *why* and return
+   that instead of the bare `Unknown skill`.
+
+> **Revised during review (round 1).** This originally opened with a 1.0 s
+> `_REFRESH_COOLDOWN` gating every probe. It was removed: it is shared by every
+> subagent, so a miss at t=0 made a skill written at t=0.05 unreadable until
+> t=1.0 — breaking write-then-read, the normal authoring sequence and the exact
+> case this design exists for — and it suppressed the diagnostic too. Measured,
+> it saved 0.224 ms → 0.002 ms per read on a looping typo. A 0.2 ms saving on an
+> error path does not buy a one-second window of wrong answers. The fingerprint
+> gate is the real bound and it is stat-based rather than clock-based.
 
 Cost on the frequent path — a skill that exists — is **one dict lookup**,
 because nothing above step 0 runs on a hit. That is the constraint the task set
@@ -148,14 +157,16 @@ A typo'd skill name costs 0.29 ms rather than 17–25 ms — a ~60× reduction o
 exact path the task flagged as the risk. The full scan is paid only when the
 tree actually changed, which is the case the feature exists for. This answers
 "is a filesystem walk on a typo acceptable, and should it be bounded" with: it
-is bounded twice, by the fingerprint and by the cooldown, and the residual is
-sub-millisecond.
+is bounded by the fingerprint, and the residual is sub-millisecond. A typo in a
+tight retry loop therefore pays one sub-millisecond stat per read and **never** a
+scan, because an unchanged tree compares equal every time.
 
 The 17–25 ms scan runs synchronously on the event loop that renders the TUI
 (`tools/builtin.py:2650` is inside an `async def` but the resolver is sync). That
 is about one frame, on a rare path, once per real change — I judge it acceptable
-and would not complicate the sync resolver contract to avoid it. The cooldown is
-what guarantees it cannot repeat in a loop.
+and would not complicate the sync resolver contract to avoid it. The fingerprint
+is what guarantees it cannot repeat in a loop: the scan runs only on a tree that
+actually changed, so repeating it requires repeatedly editing the filesystem.
 
 ### What must be in the fingerprint
 
@@ -376,7 +387,7 @@ to a broken behaviour; it does not clear the step-function bar for a minor
 | file | change |
 |---|---|
 | `skills/discovery.py` | add `roots_fingerprint(roots)` and `diagnose_missing_skill(name, roots)`. No change to `discover_skills` or its callers. |
-| `skills/api.py` | `make_skill_resolver(skills, roots=None)` — cooldown, fingerprint gate, in-place `update`, diagnostic on surviving miss, `threading.Lock`. Export the two new helpers. |
+| `skills/api.py` | `make_skill_resolver(skills, roots=None)` — fingerprint gate, in-place `update`, unconditional re-lookup after the refresh, diagnostic on surviving miss, `threading.Lock`. Export the two new helpers. |
 | `session_factory.py` | `_KnowledgeHooks` gains `skill_roots: list[Path]`; `_setup_knowledge` takes `cwd` and stores the roots it used (fixes the `Path.cwd()` bug at `:1234`); call site `:1952` passes `effective_cwd`; `_make_knowledge_resolver` (`:1361`) passes `hooks.skill_roots`. |
 | `tui/app.py` | `_discovered_skills` (`:28708`) gated on the fingerprint; docstring at `:28712-28716` rewritten. |
 | `guides/extensions/GUIDE.md` | replace `:57` (below). |
@@ -424,7 +435,10 @@ Unit, `tests/unit/skills/test_api.py` and `test_discovery.py`:
 4. Hit path does no filesystem work — monkeypatch `roots_fingerprint` to raise
    and assert a successful resolve still succeeds.
 5. Fingerprint unchanged → `discover_skills` not called (patch and count).
-6. Cooldown: two misses inside the window produce one fingerprint call.
+6. A looping typo probes per miss but never rescans (the stat is the bound);
+   a skill written milliseconds after a miss is readable at once; two THREADS
+   missing the same new name concurrently both resolve it; a transient scan
+   `OSError` does not freeze the fingerprint.
 7. Fingerprint detects each of the three mutation shapes in the §3 table,
    especially in-place `SKILL.md` edit.
 8. Deleted skill stays in the mapping and reads as a clean `OSError` message.
@@ -449,20 +463,29 @@ is the reported defect and it is the one that has to be shown working.
 1. **Rebinding regression.** The single point of failure. Mitigated by test 2
    and by a comment at the mutation site; nothing else will catch it.
 2. **Event-loop stall.** 17–25 ms sync scan on the loop that renders the TUI,
-   here ~one frame. Rare and cooldown-bounded. If a user reports a hitch on a
+   here ~one frame. Rare and fingerprint-bounded — it runs only on a tree that
+   actually changed. If a user reports a hitch on a
    pathological tree, the fix is `to_thread` at the `read`-tool call site, not a
    change to the resolver contract.
 3. **Pathological trees.** A root with tens of thousands of child directories
-   makes even the fingerprint slow. Bounded by the cooldown to one probe/second,
-   and note that startup already pays a larger version of the same cost — this
-   adds no new exposure class.
+   makes even the fingerprint slow, and with the cooldown removed it is paid per
+   miss rather than per second. Note that startup already pays a larger version
+   of the same cost, and a miss is an error path — this adds no new exposure
+   class. If it ever bites, gate the probe on something stat-based (a root-level
+   mtime pre-check), never on a clock: a clock is what made a just-written skill
+   unreadable in round 1.
 4. **Symlinks and mid-walk mutation.** `scan_skills_dir` is one level deep,
    realpath-dedupes and swallows `OSError` (`discovery.py:173-202`), so a symlink
    loop or a directory vanishing mid-walk yields a shorter list, never an
    exception. The fingerprint must walk one level with the same `OSError`
    tolerance; do not make it stricter than the scanner it gates.
-5. **Concurrent refresh from two children.** Handled by the lock; verify no
-   `await` sneaks inside the locked region, which would deadlock the loop.
+5. **Concurrent refresh from two children.** The lock serialises the refresh,
+   but serialising is not sufficient on its own: the thread that loses the race
+   must still RE-LOOK-UP the name after the lock releases, because the winner
+   populated the mapping while it waited. Gating that retry on the refresh's own
+   outcome ("did I scan?") makes the loser answer `Unknown skill` for a skill
+   already in the dict. Verify no `await` sneaks inside the locked region, which
+   would deadlock the loop.
 6. **Shadow warnings becoming noisy.** The diagnostic can now surface a class of
    message this machine produces 37 of at startup. It is emitted only for the
    *one* name being read, so it stays targeted — but if a diagnostic ever grows

--- a/local_operator/guides/extensions/GUIDE.md
+++ b/local_operator/guides/extensions/GUIDE.md
@@ -32,6 +32,8 @@ Global skill, available in every workspace:
 
 Local Operator walks from the current directory toward the filesystem root for `.local-operator/skills`, then checks the global root. Earlier, more-local roots win name collisions.
 
+Choose the root by who owns the practice: put it in `~/.local-operator/skills/<name>/SKILL.md` when it should follow the operator into every workspace, and in `<repo>/.local-operator/skills/<name>/SKILL.md` when it belongs to that repository and should be committed and shared with the team. The directory name is the `skill://` name unless frontmatter `name` overrides it — keep them the same and the URL is never a surprise.
+
 Minimal `SKILL.md`:
 
 ```markdown
@@ -52,9 +54,13 @@ Frontmatter fields:
 - `enabled: false`: exclude the skill entirely
 - `hide: true` or `disable-model-invocation: true`: keep direct `skill://` reads available but prevent semantic prompt listing
 
+`description` is required: a skill without a non-blank one is not loaded at all, because it is the entire routing signal. A skill that fails to load now explains itself — read its `skill://` URL and the error names the cause (no `SKILL.md`, missing `description`, malformed frontmatter, `enabled: false`, a frontmatter `name` that disagrees with the directory, or an earlier root shadowing it) and the fix.
+
 Keep `SKILL.md` procedural and small. Put large tables, examples, and narrow workflows under `references/`; the agent reads them only when the task reaches that branch. Dotfiles and paths escaping the skill directory are intentionally unreadable.
 
-Start a new session after adding or changing a skill. Discovery and semantic vectors are built at session creation, and the first task freezes the selected short listing for prompt-cache stability. Only the skill name and description enter the system context; `SKILL.md` enters after `read skill://my-skill`, and reference files enter only after their own reads.
+A skill you create is readable immediately. The first `read skill://<name>` that misses re-scans the skill roots, so the new skill resolves in this session and in subagents already running — no restart. What does **not** update until the next session is *semantic selection*: the skill will not appear in the `<skills>` listing or be auto-suggested, because that listing is frozen for prompt-cache stability. Read it by name, and tell subagents its name. Editing an existing skill's **body** has always taken effect on the next read; editing its `name`, `description` or `enabled` affects selection only, and waits for the next session.
+
+Only the skill name and description enter the system context; `SKILL.md` enters after `read skill://my-skill`, and reference files enter only after their own reads.
 
 ## Create an executable plugin with MCP
 

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -1135,6 +1135,12 @@ class _KnowledgeHooks:
     agent_hint_index: SkillIndex | None = None
     skills_by_name: dict[str, Skill] = field(default_factory=dict)
     guides_by_name: dict[str, Skill] = field(default_factory=dict)
+    #: The roots ``skills_by_name`` was discovered from, kept so the skill
+    #: resolver can rescan THE SAME set on a miss. Recomputing them at resolve
+    #: time would be subtly different: ``default_skill_roots`` filters
+    #: ecosystem roots by existence, so a root created mid-session would change
+    #: the list and quietly widen what the session scans.
+    skill_roots: list[Path] = field(default_factory=list)
     frozen_block: str | None = None
     #: Compaction entry id observed when ``frozen_block`` was computed. A
     #: change here (a new compaction marker) re-opens selection once — the
@@ -1212,6 +1218,7 @@ async def _setup_knowledge(
     config_dir: Path,
     agent_registry: AgentRegistry,
     warnings_out: list[str],
+    cwd: str | Path | None = None,
 ) -> _KnowledgeHooks:
     """Discover and index user skills, packaged guides, and private agent hints.
 
@@ -1231,7 +1238,13 @@ async def _setup_knowledge(
         )
         from local_operator.skills.embeddings import LocalEmbedder
 
-        skills, discovery_warnings = discover_skills(default_skill_roots(Path.cwd()))
+        # The SESSION's cwd, not the process's. A session created with an
+        # explicit cwd (bootstrap, the scheduler, owned runtimes) otherwise
+        # discovered project-local skills for whatever directory the process
+        # happened to start in -- every other consumer here already takes the
+        # session's cwd, and this one silently did not.
+        hooks.skill_roots = default_skill_roots(Path(cwd) if cwd is not None else None)
+        skills, discovery_warnings = discover_skills(hooks.skill_roots)
         warnings_out.extend(discovery_warnings)
         guides = discover_guides()
         hooks.skills_by_name = {skill.name: skill for skill in skills}
@@ -1364,7 +1377,12 @@ def _make_knowledge_resolver(hooks: _KnowledgeHooks) -> Callable[[str], str | No
     from local_operator.skills.api import make_skill_resolver
 
     guide_resolver = make_guide_resolver(hooks.guides_by_name)
-    skill_resolver = make_skill_resolver(hooks.skills_by_name)
+    # Passing the roots turns on the miss-path rescan, which is what makes a
+    # skill authored mid-session readable -- here and in subagents already
+    # running, because they inherit this closure and it mutates
+    # ``hooks.skills_by_name`` IN PLACE. Guides are packaged release resources
+    # and cannot change at runtime, so the guide resolver takes no roots.
+    skill_resolver = make_skill_resolver(hooks.skills_by_name, hooks.skill_roots)
 
     def resolver(url: str) -> str | None:
         guide_result = guide_resolver(url)
@@ -1950,7 +1968,7 @@ async def _prepare(
     effective_cwd = cwd if cwd is not None else os.getcwd()
     knowledge_warnings: list[str] = []
     hooks = await _setup_knowledge(
-        credential_manager, config_dir, agent_registry, knowledge_warnings
+        credential_manager, config_dir, agent_registry, knowledge_warnings, effective_cwd
     )
     # Configuration discovery is local filesystem work and must precede the
     # first prompt. The TUI deliberately defers live MCP connections; deriving

--- a/local_operator/skills/api.py
+++ b/local_operator/skills/api.py
@@ -362,10 +362,8 @@ def _diagnose(url: str, roots: Sequence[Path]) -> str | None:
     degrade to the plain ``Unknown skill`` message rather than replacing one
     unhelpful result with a traceback.
     """
-    from urllib.parse import unquote, urlsplit
-
     try:
-        name = unquote(urlsplit(url).netloc)
+        name = _url_name(url)
         return diagnose_missing_skill(name, roots)
     except Exception:  # noqa: BLE001 -- a diagnostic may never break the read
         return None

--- a/local_operator/skills/api.py
+++ b/local_operator/skills/api.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import os
 import threading
-import time
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from pathlib import Path
 
@@ -29,6 +28,7 @@ from local_operator.skills.discovery import (
     Skill,
     diagnose_missing_skill,
     discover_skills,
+    is_plain_skill_name,
     roots_fingerprint,
 )
 from local_operator.skills.embeddings import (
@@ -52,6 +52,7 @@ __all__ = [
     "default_skill_roots",
     "diagnose_missing_skill",
     "discover_skills",
+    "is_plain_skill_name",
     "make_skill_resolver",
     "roots_fingerprint",
     "render_block",
@@ -136,11 +137,6 @@ def default_skill_roots(cwd: Path | None = None) -> list[Path]:
     return roots
 
 
-#: Minimum seconds between two filesystem probes on the miss path. Bounds a
-#: looping or hostile agent to one probe per second per session: a typo'd
-#: skill name in a retry loop costs one 0.29 ms fingerprint, not one per read.
-_REFRESH_COOLDOWN = 1.0
-
 #: The prefix ``resolve_skill_url`` uses for an unresolvable NAME. It also
 #: raises for traversal, dotfiles and unsafe child paths, and those must NOT
 #: trigger a rescan -- otherwise a malformed URL drives filesystem work.
@@ -159,34 +155,33 @@ class _RefreshState:
     argument.
     """
 
-    __slots__ = ("last_check", "fingerprint", "lock")
+    __slots__ = ("fingerprint", "lock")
 
     def __init__(self) -> None:
-        self.last_check: float = 0.0
         # None means "never probed": distinct from an empty tuple, which is a
         # real fingerprint for roots that exist and hold no skills.
         self.fingerprint: tuple[object, ...] | None = None
         self.lock = threading.Lock()
 
 
-#: Outcome of a miss-path refresh attempt. ``COOLDOWN`` is distinct from
-#: ``UNCHANGED`` because it governs whether the DIAGNOSTIC may run: inside the
-#: cooldown the resolver does no filesystem work at all, so a looping agent is
-#: bounded to one probe per second including diagnosis.
-_COOLDOWN = "cooldown"
-_UNCHANGED = "unchanged"
-_REFRESHED = "refreshed"
-
-
 def _refresh_if_changed(
     skills: MutableMapping[str, Skill],
     roots: Sequence[Path],
     state: _RefreshState,
-) -> str:
+) -> None:
     """Rescan the roots into ``skills`` when the tree changed.
 
-    Returns which of :data:`_COOLDOWN`, :data:`_UNCHANGED` or
-    :data:`_REFRESHED` happened, because the caller treats them differently.
+    Returns nothing DELIBERATELY. An earlier revision returned an outcome enum
+    (refreshed / unchanged / cooldown) and the caller retried the lookup only
+    on "refreshed" -- which conflates two different questions. "Did MY call do
+    the scan?" is not "is the name resolvable now?": under concurrency the
+    thread that loses the race blocks on the lock, is released AFTER the winner
+    has populated the shared mapping, computes a fingerprint that now matches,
+    and reports "unchanged" for a tree it never scanned -- so it answered
+    ``Unknown skill`` for a skill demonstrably present in the mapping it was
+    holding. Only the caller's own re-lookup answers the resolvability
+    question, so the caller now always re-looks-up and this returns nothing an
+    outcome test could be written against again.
 
     Three properties here are load-bearing:
 
@@ -203,30 +198,45 @@ def _refresh_if_changed(
        sibling child mid-read, and the stale entry already degrades gracefully:
        the read returns a clean ``[Errno 2] No such file or directory`` through
        the adapter's ``OSError`` catch. Growth-only is the safe direction.
-    3. **The cooldown is checked before the fingerprint**, so the cheap probe
-       is itself rate-limited rather than merely the expensive scan.
+    3. **The fingerprint is committed only AFTER a successful scan.** Assigning
+       it before ``discover_skills`` meant one transient failure (EMFILE, an
+       NFS blip, a permissions hiccup) left the state claiming it had already
+       ingested that tree: every later miss compared equal, never rescanned,
+       and the skill stayed unreadable for the WHOLE SESSION even once the
+       filesystem recovered -- a permanent regression from a one-off error, and
+       worse than the pre-refresh behaviour it replaced. Committing after the
+       scan means a failed scan simply retries on the next miss.
+
+    There is deliberately NO time-based cooldown. One existed and was removed:
+    it stamped on any miss and was shared by every subagent, so a miss at t=0
+    made a skill written at t=0.05 unreadable until t=1.0 -- write-then-read is
+    the NORMAL authoring sequence, so the 1 s window broke the exact case this
+    code exists for, and it suppressed the diagnostic too. Measured, it bought
+    0.224 ms -> 0.002 ms per read on a looping typo: 0.2 ms on an error path,
+    paid for with the feature being wrong for a second. The fingerprint gate is
+    the real bound and it is stat-based rather than clock-based -- a typo in a
+    tight loop pays one sub-millisecond probe per read and NEVER a scan,
+    because an unchanged tree compares equal.
     """
-    now = time.monotonic()
     with state.lock:
-        if state.fingerprint is not None and now - state.last_check < _REFRESH_COOLDOWN:
-            return _COOLDOWN
-        state.last_check = now
         try:
             fingerprint = roots_fingerprint(roots)
         except OSError:
             # The fingerprint swallows OSError per-entry already; this is the
             # belt-and-braces case, and a resolver may never raise.
-            return _UNCHANGED
+            return
         if fingerprint == state.fingerprint:
-            return _UNCHANGED
-        state.fingerprint = fingerprint
+            return
         try:
             discovered, _warnings = discover_skills(roots)
         except OSError:
-            return _UNCHANGED
+            # Do NOT commit the fingerprint here. See point 3 above.
+            return
         # In place. See point 1 above before changing this line.
         skills.update({skill.name: skill for skill in discovered})
-        return _REFRESHED
+        # Committed last: reaching this line is the only proof the tree was
+        # actually ingested.
+        state.fingerprint = fingerprint
 
 
 def make_skill_resolver(
@@ -283,22 +293,35 @@ def make_skill_resolver(
                 refresh_roots is None
                 or refresh_target is None
                 or not message.startswith(_UNKNOWN_PREFIX)
+                or not is_plain_skill_name(_url_name(url))
             ):
                 # Traversal, dotfile and unsafe-child-path errors land here and
                 # must not cause a rescan.
+                #
+                # The name check is the same rule, applied where the guards
+                # above cannot reach: those only inspect a URL's PATH, but a
+                # skill name is its NETLOC, so ``skill://..`` and
+                # ``skill://%2fetc`` arrive as a perfectly ordinary
+                # "Unknown skill" and used to drive a full fingerprint probe.
+                # A name no one-level root scan could produce is never made
+                # resolvable by rescanning, so the work is pure waste on
+                # attacker-chosen input.
                 return message
-            outcome = _refresh_if_changed(refresh_target, refresh_roots, state)
-            if outcome == _COOLDOWN:
-                # Bounded: no scan AND no diagnostic, so a retry loop cannot
-                # turn a typo into repeated filesystem work.
-                return message
-            if outcome == _REFRESHED:
-                try:
-                    return resolve_skill_url(url, skills)
-                except ValueError as retry_exc:
-                    message = str(retry_exc)
-                except OSError as retry_exc:
-                    return str(retry_exc)
+            _refresh_if_changed(refresh_target, refresh_roots, state)
+            # ALWAYS re-resolve, whatever the refresh did or did not do. The
+            # only question that matters here is "is the name resolvable NOW",
+            # and the mapping is shared: a concurrent reader may have populated
+            # it while this thread waited on the lock, and a refresh that found
+            # nothing new still leaves the answer to a lookup rather than to an
+            # inference about which call performed the scan. Gating this retry
+            # on the refresh's own outcome is what made the losing thread of a
+            # race report ``Unknown skill`` for a skill already in the dict.
+            try:
+                return resolve_skill_url(url, skills)
+            except ValueError as retry_exc:
+                message = str(retry_exc)
+            except OSError as retry_exc:
+                return str(retry_exc)
             # Still missing: say WHY, because the bare message covers four
             # distinct causes an agent cannot otherwise tell apart.
             reason = _diagnose(url, refresh_roots)
@@ -309,6 +332,23 @@ def make_skill_resolver(
             return str(exc)
 
     return resolver
+
+
+def _url_name(url: str) -> str:
+    """The decoded NAME a ``skill://`` URL addresses, or ``""``.
+
+    The name is the URL's netloc, which is precisely the part
+    ``resolve_skill_url``'s traversal and dotfile guards never inspect -- they
+    police the child PATH. Decoding it here, from the URL rather than from the
+    error text, keeps the miss path's safety check independent of message
+    wording: a reworded ``Unknown skill`` must not silently reopen the hole.
+    """
+    from urllib.parse import unquote, urlsplit
+
+    try:
+        return unquote(urlsplit(url).netloc)
+    except Exception:  # noqa: BLE001 -- a malformed URL is simply not a name
+        return ""
 
 
 def _diagnose(url: str, roots: Sequence[Path]) -> str | None:

--- a/local_operator/skills/api.py
+++ b/local_operator/skills/api.py
@@ -20,10 +20,17 @@ makes native roots authoritative over imported ones.
 from __future__ import annotations
 
 import os
-from collections.abc import Callable, Mapping
+import threading
+import time
+from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from pathlib import Path
 
-from local_operator.skills.discovery import Skill, discover_skills
+from local_operator.skills.discovery import (
+    Skill,
+    diagnose_missing_skill,
+    discover_skills,
+    roots_fingerprint,
+)
 from local_operator.skills.embeddings import (
     ApiEmbedder,
     EmbeddingBackend,
@@ -43,8 +50,10 @@ __all__ = [
     "SkillIndex",
     "default_backend_from_env",
     "default_skill_roots",
+    "diagnose_missing_skill",
     "discover_skills",
     "make_skill_resolver",
+    "roots_fingerprint",
     "render_block",
     "resolve_skill_url",
 ]
@@ -127,7 +136,103 @@ def default_skill_roots(cwd: Path | None = None) -> list[Path]:
     return roots
 
 
-def make_skill_resolver(skills: Mapping[str, Skill]) -> Callable[[str], str | None]:
+#: Minimum seconds between two filesystem probes on the miss path. Bounds a
+#: looping or hostile agent to one probe per second per session: a typo'd
+#: skill name in a retry loop costs one 0.29 ms fingerprint, not one per read.
+_REFRESH_COOLDOWN = 1.0
+
+#: The prefix ``resolve_skill_url`` uses for an unresolvable NAME. It also
+#: raises for traversal, dotfiles and unsafe child paths, and those must NOT
+#: trigger a rescan -- otherwise a malformed URL drives filesystem work.
+_UNKNOWN_PREFIX = "Unknown skill: "
+
+
+class _RefreshState:
+    """Mutable bookkeeping for the miss-path refresh, one instance per resolver.
+
+    Guarded by ``lock``. Subagents run as asyncio tasks on a single loop and
+    the resolver is synchronous, so the refresh is already atomic with respect
+    to that loop -- but sessions are also built on other execution paths
+    (``exec_worker.py``, ``exec_mode.py``), and this read-modify-write is not
+    inherently thread-safe. The lock is uncontended in practice and removes the
+    question permanently rather than leaving a reader to re-derive the GIL
+    argument.
+    """
+
+    __slots__ = ("last_check", "fingerprint", "lock")
+
+    def __init__(self) -> None:
+        self.last_check: float = 0.0
+        # None means "never probed": distinct from an empty tuple, which is a
+        # real fingerprint for roots that exist and hold no skills.
+        self.fingerprint: tuple[object, ...] | None = None
+        self.lock = threading.Lock()
+
+
+#: Outcome of a miss-path refresh attempt. ``COOLDOWN`` is distinct from
+#: ``UNCHANGED`` because it governs whether the DIAGNOSTIC may run: inside the
+#: cooldown the resolver does no filesystem work at all, so a looping agent is
+#: bounded to one probe per second including diagnosis.
+_COOLDOWN = "cooldown"
+_UNCHANGED = "unchanged"
+_REFRESHED = "refreshed"
+
+
+def _refresh_if_changed(
+    skills: MutableMapping[str, Skill],
+    roots: Sequence[Path],
+    state: _RefreshState,
+) -> str:
+    """Rescan the roots into ``skills`` when the tree changed.
+
+    Returns which of :data:`_COOLDOWN`, :data:`_UNCHANGED` or
+    :data:`_REFRESHED` happened, because the caller treats them differently.
+
+    Three properties here are load-bearing:
+
+    1. **``skills.update(...)``, never ``skills = {...}``.** The whole
+       propagation story is that ``session_factory``, this closure and every
+       subagent hold the SAME dict object (``harness/subagent.py`` passes the
+       parent's resolver to the child verbatim). Rebinding the local name
+       leaves every one of those holders looking at the old mapping, and it
+       breaks children SILENTLY -- no exception, no test failure unless one is
+       written for it. ``tests/unit/skills/test_api.py`` asserts liveness
+       through a CHILD resolver for exactly this reason.
+    2. **The refresh only ADDS; it never removes.** A skill deleted from disk
+       stays in the mapping. Dropping it would let one agent's cleanup break a
+       sibling child mid-read, and the stale entry already degrades gracefully:
+       the read returns a clean ``[Errno 2] No such file or directory`` through
+       the adapter's ``OSError`` catch. Growth-only is the safe direction.
+    3. **The cooldown is checked before the fingerprint**, so the cheap probe
+       is itself rate-limited rather than merely the expensive scan.
+    """
+    now = time.monotonic()
+    with state.lock:
+        if state.fingerprint is not None and now - state.last_check < _REFRESH_COOLDOWN:
+            return _COOLDOWN
+        state.last_check = now
+        try:
+            fingerprint = roots_fingerprint(roots)
+        except OSError:
+            # The fingerprint swallows OSError per-entry already; this is the
+            # belt-and-braces case, and a resolver may never raise.
+            return _UNCHANGED
+        if fingerprint == state.fingerprint:
+            return _UNCHANGED
+        state.fingerprint = fingerprint
+        try:
+            discovered, _warnings = discover_skills(roots)
+        except OSError:
+            return _UNCHANGED
+        # In place. See point 1 above before changing this line.
+        skills.update({skill.name: skill for skill in discovered})
+        return _REFRESHED
+
+
+def make_skill_resolver(
+    skills: Mapping[str, Skill],
+    roots: Sequence[Path] | None = None,
+) -> Callable[[str], str | None]:
     """Build the ``SkillResolver`` adapter for the ``read`` tool.
 
     Contract (docs/REWRITE.md §C, ``harness/types.py``
@@ -137,16 +242,86 @@ def make_skill_resolver(skills: Mapping[str, Skill]) -> Callable[[str], str | No
     unknown names and unsafe paths; this adapter catches it and returns the
     message AS CONTENT, so the available-names list reaches the model as a
     clean tool result and it can self-correct with a retry.
+
+    When ``roots`` is given, an unknown NAME additionally triggers a
+    fingerprint-gated rescan, so a skill authored mid-session becomes readable
+    without a restart -- in this session and in subagents already running,
+    which inherit this exact closure. That was the defect: an agent wrote a
+    valid skill and a subagent whose standing instructions named it got
+    ``Unknown skill`` for the rest of the session.
+
+    **Cost on the frequent path is one dict lookup.** Nothing above the
+    ``resolve_skill_url`` call runs on a hit; the fingerprint (~0.29 ms) and
+    the full scan (17-25 ms) are miss-path only, and the scan runs only when
+    the fingerprint says the tree actually changed.
+
+    ``roots=None`` is the default so every existing caller -- and the parallel
+    guide resolver, whose resources are packaged and cannot change at runtime
+    -- keeps today's behaviour exactly.
     """
+    state = _RefreshState()
+    # Narrowed ONCE here rather than re-tested inside the closure, so the hot
+    # path carries no type checks. Only a MutableMapping can be refreshed in
+    # place: callers pass a plain dict, the read-only ``Mapping`` annotation
+    # stays for the resolver's contract, and a caller that genuinely passes an
+    # immutable mapping degrades to today's behaviour instead of raising a
+    # TypeError on an error path.
+    refresh_roots: Sequence[Path] | None = None
+    refresh_target: MutableMapping[str, Skill] | None = None
+    if roots is not None and isinstance(skills, MutableMapping):
+        refresh_roots = roots
+        refresh_target = skills
 
     def resolver(url: str) -> str | None:
         if not url.startswith("skill://"):
             return None
         try:
             return resolve_skill_url(url, skills)
-        except (ValueError, OSError) as exc:
+        except ValueError as exc:
+            message = str(exc)
+            if (
+                refresh_roots is None
+                or refresh_target is None
+                or not message.startswith(_UNKNOWN_PREFIX)
+            ):
+                # Traversal, dotfile and unsafe-child-path errors land here and
+                # must not cause a rescan.
+                return message
+            outcome = _refresh_if_changed(refresh_target, refresh_roots, state)
+            if outcome == _COOLDOWN:
+                # Bounded: no scan AND no diagnostic, so a retry loop cannot
+                # turn a typo into repeated filesystem work.
+                return message
+            if outcome == _REFRESHED:
+                try:
+                    return resolve_skill_url(url, skills)
+                except ValueError as retry_exc:
+                    message = str(retry_exc)
+                except OSError as retry_exc:
+                    return str(retry_exc)
+            # Still missing: say WHY, because the bare message covers four
+            # distinct causes an agent cannot otherwise tell apart.
+            reason = _diagnose(url, refresh_roots)
+            return f"{message}\n{reason}" if reason else message
+        except OSError as exc:
             # OSError: a SKILL.md deleted or chmod-000'd between discovery and
             # the read. The adapter's contract is "never raises".
             return str(exc)
 
     return resolver
+
+
+def _diagnose(url: str, roots: Sequence[Path]) -> str | None:
+    """Best-effort explanation for a surviving miss; never raises.
+
+    Diagnosis is a convenience on an error path, so any failure inside it must
+    degrade to the plain ``Unknown skill`` message rather than replacing one
+    unhelpful result with a traceback.
+    """
+    from urllib.parse import unquote, urlsplit
+
+    try:
+        name = unquote(urlsplit(url).netloc)
+        return diagnose_missing_skill(name, roots)
+    except Exception:  # noqa: BLE001 -- a diagnostic may never break the read
+        return None

--- a/local_operator/skills/api.py
+++ b/local_operator/skills/api.py
@@ -23,6 +23,7 @@ import os
 import threading
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from pathlib import Path
+from urllib.parse import unquote, urlsplit
 
 from local_operator.skills.discovery import (
     Skill,
@@ -205,7 +206,12 @@ def _refresh_if_changed(
        and the skill stayed unreadable for the WHOLE SESSION even once the
        filesystem recovered -- a permanent regression from a one-off error, and
        worse than the pre-refresh behaviour it replaced. Committing after the
-       scan means a failed scan simply retries on the next miss.
+       scan means a failed scan simply retries on the next miss. The accepted
+       cost is that a SUSTAINED failure re-attempts a scan on every miss rather
+       than backing off (measured: 50 misses -> 50 attempts, 0.17 ms/read).
+       That is the deliberate direction -- a bounded per-miss cost on an error
+       path beats a session-long unreadable skill -- and the stat-gated
+       fingerprint still keeps the healthy path at one scan per real change.
 
     There is deliberately NO time-based cooldown. One existed and was removed:
     it stamped on any miss and was shared by every subagent, so a miss at t=0
@@ -343,8 +349,6 @@ def _url_name(url: str) -> str:
     error text, keeps the miss path's safety check independent of message
     wording: a reworded ``Unknown skill`` must not silently reopen the hole.
     """
-    from urllib.parse import unquote, urlsplit
-
     try:
         return unquote(urlsplit(url).netloc)
     except Exception:  # noqa: BLE001 -- a malformed URL is simply not a name

--- a/local_operator/skills/discovery.py
+++ b/local_operator/skills/discovery.py
@@ -359,6 +359,13 @@ def _frontmatter_yaml_error(text: str) -> str | None:
     return None
 
 
+# WHY a module constant instead of an inline ``os.name`` test: this is the seam
+# both directions of the platform-divergent drive rule are tested through, so
+# the POSIX-admits case and the Windows-denies case each run on every CI leg
+# rather than only on the leg whose native semantics happen to match.
+_DRIVE_RESETS_JOIN = os.name == "nt"
+
+
 def is_plain_skill_name(name: str) -> bool:
     """Whether ``name`` is a single plain segment safe to join onto a root.
 
@@ -392,19 +399,45 @@ def is_plain_skill_name(name: str) -> bool:
     portion, and ``skill://%2fetc`` decodes to ``/etc`` where ``root / "/etc"``
     is ``/etc`` outright -- an existence oracle for any absolute path, and a
     reader of out-of-root frontmatter ``name`` values.
+
+    THE DRIVE RULE IS DELIBERATELY PLATFORM-DIVERGENT -- do not "simplify" it
+    back to one unconditional test. What is rejected where, and why:
+
+    * Separators, NUL, ``.`` and ``..``, and a ROOT anchor are rejected
+      EVERYWHERE. They reset or escape the join on every platform.
+    * A DRIVE anchor (``D:x``, ``a:b``, ``C:``, and -- since pathlib accepts
+      any single printable character as a drive letter -- ``1:x`` and ``#:x``)
+      is rejected ONLY when running on Windows.
+
+    The asymmetry is correct because the join that actually executes is the
+    RUNNING platform's, not a portable abstraction over both. On Windows
+    ``PureWindowsPath(root) / "D:x"`` is ``"D:x"`` outright -- drive-relative
+    names are not absolute by ``is_absolute()`` yet still reset the join, so
+    the drive is a genuine existence oracle and that door must stay shut. On
+    POSIX ``:`` is an ordinary, legal directory character and
+    ``PurePosixPath(root) / "a:b"`` is ``<root>/a:b`` -- a contained direct
+    child with nothing to escape through. Rejecting it there buys no safety
+    and costs a real feature: ``scan_skills_dir`` genuinely registers a
+    POSIX skill directory named ``a:b``, so an unconditional drive test makes
+    this predicate disagree with the scanner, silently denying that skill the
+    mid-session authoring refresh AND its miss-path diagnostic.
     """
     if not name or name in (".", ".."):
         return False
     if "/" in name or "\\" in name or "\x00" in name:
         return False
-    # ANCHOR, not is_absolute(). A Windows drive-RELATIVE name (``D:x``,
-    # ``a:b``, ``C:``) is not absolute, yet it still resets the join --
-    # ``PureWindowsPath(root) / "D:x"`` is ``"D:x"`` -- reopening the same
-    # existence oracle through the drive door instead of the separator door.
-    # ``anchor`` is drive-or-root, so it also rejects root-anchored shapes
-    # without depending on the separator check above having run first, and it
-    # is empty for every name a one-level scan can produce.
-    return not PureWindowsPath(name).anchor
+    # PureWindowsPath parses BOTH separators, so its ``root`` is the superset
+    # of the POSIX one and covers either platform in a single test. Checked
+    # unconditionally, and kept even though the separator test above already
+    # implies it: a root anchor needs a separator, so this is the defence that
+    # does not depend on that check having run first.
+    shape = PureWindowsPath(name)
+    if shape.root:
+        return False
+    # DRIVE, not anchor: the one term gated on the running platform, per the
+    # docstring. ``drive`` rather than ``is_absolute()`` because a
+    # drive-RELATIVE name resets the join without being absolute.
+    return not (_DRIVE_RESETS_JOIN and shape.drive)
 
 
 def _diagnose_one(name: str, root: Path, skill_md: Path) -> str | None:

--- a/local_operator/skills/discovery.py
+++ b/local_operator/skills/discovery.py
@@ -247,3 +247,176 @@ def discover_skills(roots: Sequence[Path]) -> tuple[list[Skill], list[str]]:
 
     final.sort(key=_sort_key)
     return final, warnings
+
+
+def roots_fingerprint(roots: Sequence[Path]) -> tuple[object, ...]:
+    """Cheap change-detector for the skill tree, used to gate a full rescan.
+
+    Mirrors :func:`scan_skills_dir`'s one-level walk ON PURPOSE: a fingerprint
+    that walked differently from the scanner would miss changes the scanner
+    would have seen, and the entire value of this function is that an unchanged
+    fingerprint is a trustworthy "do not bother scanning".
+
+    Root-directory mtime alone is NOT sufficient, and that was measured rather
+    than assumed: creating a skill directory bumps the root's mtime, creating a
+    ``SKILL.md`` inside an existing directory bumps only the child's, and
+    editing a ``SKILL.md`` in place bumps NEITHER. That third row is a real
+    case, not a hypothetical -- a skill dropped at discovery for a blank
+    ``description`` is absent from the mapping, so repairing its frontmatter in
+    place is precisely a miss that root and child mtimes both fail to notice.
+    Hence per-file ``(mtime_ns, size)``.
+
+    Never raises, and its ``OSError`` tolerance deliberately matches the
+    scanner's: a directory vanishing mid-walk or a symlink loop yields a
+    shorter tuple rather than an exception. Making the gate stricter than the
+    scanner it gates would turn a tree the scanner survives into a hard failure
+    on the read path.
+
+    Costs ~0.29 ms across 8 roots / 57 skills, against 17-25 ms for the full
+    scan it decides whether to run.
+    """
+    entries: list[object] = []
+    for raw_root in roots:
+        root = Path(raw_root).expanduser()
+        try:
+            root_stat = root.stat()
+        except OSError:
+            # Absent roots are still part of the fingerprint: a root that comes
+            # into existence has to read as a change, not as "same as before".
+            entries.append((str(root), None))
+            continue
+        entries.append((str(root), root_stat.st_mtime_ns))
+        try:
+            children = sorted(os.scandir(root), key=lambda entry: entry.name)
+        except OSError:
+            continue
+        for child in children:
+            if child.name.startswith("."):
+                continue
+            try:
+                if not child.is_dir():
+                    continue
+                skill_stat = os.stat(os.path.join(child.path, "SKILL.md"))
+            except OSError:
+                continue
+            entries.append((child.path, skill_stat.st_mtime_ns, skill_stat.st_size))
+    return tuple(entries)
+
+
+def _has_frontmatter_block(text: str) -> bool:
+    """Whether ``text`` opens AND closes a ``---`` block.
+
+    :func:`parse_frontmatter` collapses "no frontmatter", "unterminated",
+    "malformed YAML" and "well-formed but empty" into the same ``{}``, which is
+    the right degradation for discovery but the wrong answer for a diagnostic:
+    reporting "malformed frontmatter" to an author whose block is perfectly
+    well-formed and merely missing a ``description`` sends them to fix the one
+    thing that is not broken. This distinguishes the structural failure from
+    the content failure so each gets its own message.
+    """
+    if not text.startswith("---"):
+        return False
+    lines = text.split("\n")
+    return any(lines[i].strip() == "---" for i in range(1, len(lines)))
+
+
+def _diagnose_one(name: str, root: Path, skill_md: Path) -> str | None:
+    """Why this one SKILL.md would not load under ``name``, or None if it would.
+
+    Applies exactly the drop rules :func:`_skill_from_file` applies silently,
+    in the same order, so the message an author gets describes the rule that
+    actually rejected their file.
+    """
+    try:
+        text = skill_md.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return f"{skill_md} could not be read: {exc}"
+
+    meta = parse_frontmatter(text)
+    if not meta and not _has_frontmatter_block(text):
+        return f"{skill_md} has malformed YAML frontmatter (it must open and close with ---)."
+
+    enabled = meta.get("enabled")
+    if enabled is not None and (
+        not enabled or str(enabled).strip().lower() in ("false", "no", "off")
+    ):
+        return f"'{name}' is disabled by 'enabled: false' in {skill_md}."
+
+    description = meta.get("description")
+    if not isinstance(description, str) or not description.strip():
+        return (
+            f"{skill_md} has no 'description' in its frontmatter; skills without one "
+            "are not loaded. Add one and read the URL again."
+        )
+
+    declared = meta.get("name")
+    if isinstance(declared, str) and declared.strip() and declared.strip() != name:
+        return (
+            f"{skill_md} declares name '{declared.strip()}'; read "
+            f"skill://{declared.strip()} (the frontmatter name wins over the "
+            "directory name)."
+        )
+    return None
+
+
+def diagnose_missing_skill(name: str, roots: Sequence[Path]) -> str | None:
+    """Explain why ``name`` did not load, or ``None`` when there is nothing to say.
+
+    ``Unknown skill: <name>`` is emitted identically for four distinct causes --
+    not yet scanned, a blank ``description`` silently dropping the skill, a
+    frontmatter ``name`` disagreeing with the directory, and collision
+    shadowing -- and an agent that hits it has no next move except to give up or
+    grep the filesystem, which the system prompt forbids. Every message
+    produced here names its own remedy instead.
+
+    Called ONLY on the miss path, after a refresh has already failed to find
+    the name, so the filesystem work below is never paid on a hit. It reports
+    on the ONE name being read rather than on the tree as a whole: this machine
+    emits 37 shadow warnings at startup, and a diagnostic that dumped them all
+    would be noise where an answer is needed.
+    """
+    if not name:
+        return None
+
+    # Candidates in root precedence order -- earlier roots win, so found[0] is
+    # the one that would claim the name if it loads at all.
+    found: list[tuple[Path, Path]] = []
+    for raw_root in roots:
+        root = Path(raw_root).expanduser()
+        candidate = root / name
+        try:
+            if not candidate.is_dir():
+                continue
+            skill_md = candidate / "SKILL.md"
+            if not skill_md.is_file():
+                return f"A directory '{name}' exists at {root} but has no SKILL.md."
+        except OSError:
+            continue
+        found.append((root, skill_md))
+
+    if not found:
+        return None
+
+    # Walk in root precedence order and report the first candidate that has a
+    # problem. Reaching here at all means the name genuinely missed, so no
+    # candidate registered under it -- each one is either unloadable or
+    # declares a different frontmatter name, and the earliest such file is the
+    # one an author following root precedence will look at first.
+    for root, skill_md in found:
+        problem = _diagnose_one(name, root, skill_md)
+        if problem is not None:
+            return problem
+
+    if len(found) > 1:
+        # Every candidate loads cleanly on its own terms. On the resolver's
+        # miss path this is defensive rather than routine -- if the earliest
+        # copy loads, it also claims the name, so the read would have hit. It
+        # stays because this helper is callable outside that path (against an
+        # arbitrary root list) and because "shadowed" is the one collision
+        # outcome a user can otherwise never see: the warning discover_skills
+        # raises for it goes to a list printed only at startup.
+        return (
+            f"'{name}' at {found[1][1]} is shadowed by the one at {found[0][1]} "
+            "(earlier roots win). Rename it or edit the winner."
+        )
+    return None

--- a/local_operator/skills/discovery.py
+++ b/local_operator/skills/discovery.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Sequence
-from pathlib import Path, PurePosixPath, PureWindowsPath
+from pathlib import Path, PureWindowsPath
 from typing import Literal
 
 import yaml
@@ -360,13 +360,23 @@ def _frontmatter_yaml_error(text: str) -> str | None:
 
 
 def is_plain_skill_name(name: str) -> bool:
-    """Whether ``name`` can name a skill directory a root scan would produce.
+    """Whether ``name`` is a single plain segment safe to join onto a root.
 
-    A registered skill name comes from ``<root>/<child>`` where ``child`` is a
-    DIRECT entry of a root (:func:`scan_skills_dir` walks exactly one level),
-    so anything carrying a separator, a traversal token or an absolute-path
-    shape can never correspond to a scanned directory and must not be joined
-    onto a root at all.
+    The shape this admits is the DIRECT child of a root that
+    :func:`scan_skills_dir` produces (it walks exactly one level), so anything
+    carrying a separator, a traversal token or a path anchor can never name
+    such a directory and must not be joined onto a root at all.
+
+    NOT every registered skill name has this shape. :func:`_skill_from_file`
+    prefers the frontmatter ``name:`` over the directory name, so a skill
+    declaring ``name: group/sub`` registers under a separator-bearing name and
+    is rejected here. That is deliberate and its cost is bounded: such a skill
+    still resolves at startup and after any later rescan, and loses only the
+    mid-session authoring refresh on the read that created it. Widening the
+    predicate to admit it would hand every hostile netloc (``skill://..``,
+    ``skill://%2fetc``) the filesystem work and the join this guard exists to
+    deny, which is not a trade worth making for a name shape the harness
+    itself never generates.
 
     WHY this is a name check and not a resolved-path containment check
     (``protocol._contained``): ``scan_skills_dir`` deliberately FOLLOWS a
@@ -387,7 +397,14 @@ def is_plain_skill_name(name: str) -> bool:
         return False
     if "/" in name or "\\" in name or "\x00" in name:
         return False
-    return not PurePosixPath(name).is_absolute() and not PureWindowsPath(name).is_absolute()
+    # ANCHOR, not is_absolute(). A Windows drive-RELATIVE name (``D:x``,
+    # ``a:b``, ``C:``) is not absolute, yet it still resets the join --
+    # ``PureWindowsPath(root) / "D:x"`` is ``"D:x"`` -- reopening the same
+    # existence oracle through the drive door instead of the separator door.
+    # ``anchor`` is drive-or-root, so it also rejects root-anchored shapes
+    # without depending on the separator check above having run first, and it
+    # is empty for every name a one-level scan can produce.
+    return not PureWindowsPath(name).anchor
 
 
 def _diagnose_one(name: str, root: Path, skill_md: Path) -> str | None:

--- a/local_operator/skills/discovery.py
+++ b/local_operator/skills/discovery.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Sequence
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Literal
 
 import yaml
@@ -320,6 +320,76 @@ def _has_frontmatter_block(text: str) -> bool:
     return any(lines[i].strip() == "---" for i in range(1, len(lines)))
 
 
+def _frontmatter_yaml_error(text: str) -> str | None:
+    """The YAML parser's own complaint about a delimited block, or ``None``.
+
+    WHY this exists rather than reusing ``_has_frontmatter_block`` as the
+    malformed-YAML discriminator: a block whose ``---`` delimiters are BOTH
+    present but whose YAML is invalid is the overwhelmingly common authoring
+    error -- an unquoted colon, ``description: Lean 4: formalize proofs`` --
+    and it yields ``{}`` with the delimiters intact. Keying "malformed" off
+    the delimiters alone therefore sent that author down the *description*
+    branch, which told them to add a description their file visibly already
+    had, and following that remedy provably does not fix the file. The only
+    thing that can tell "invalid YAML" apart from "valid YAML that happens to
+    be empty" is the parser, so ask it.
+
+    :func:`parse_frontmatter` deliberately discards this exception -- discovery
+    must degrade silently and never pay for error text on the scan path. Here,
+    on a miss that has already failed, the re-parse costs nothing that matters
+    and it is the difference between a next move and a wrong next move.
+    """
+    if not text.startswith("---"):
+        return None
+    lines = text.split("\n")
+    end: int | None = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            end = i
+            break
+    if end is None:
+        # Unterminated: a structural failure, reported by the delimiter branch.
+        return None
+    try:
+        yaml.safe_load("\n".join(lines[1:end]))
+    except yaml.YAMLError as exc:
+        # Collapse to one line: the parser appends a multi-line context/snippet
+        # block that is noise inside a one-line diagnostic.
+        return " ".join(str(exc).split())
+    return None
+
+
+def is_plain_skill_name(name: str) -> bool:
+    """Whether ``name`` can name a skill directory a root scan would produce.
+
+    A registered skill name comes from ``<root>/<child>`` where ``child`` is a
+    DIRECT entry of a root (:func:`scan_skills_dir` walks exactly one level),
+    so anything carrying a separator, a traversal token or an absolute-path
+    shape can never correspond to a scanned directory and must not be joined
+    onto a root at all.
+
+    WHY this is a name check and not a resolved-path containment check
+    (``protocol._contained``): ``scan_skills_dir`` deliberately FOLLOWS a
+    symlinked child directory, so a resolved-target containment test would
+    reject skills the scanner accepts and make the diagnostic disagree with
+    discovery. Once the name is a single plain segment, ``root / name`` is a
+    direct child of ``root`` by construction and there is nothing left to
+    escape with -- the check is complete without resolving anything, which is
+    also what keeps an unsafe URL from spending filesystem work.
+
+    The concrete leaks this closes: ``skill://..`` parses the traversal token
+    as the URL's netloc, sailing past the guards that only inspect the PATH
+    portion, and ``skill://%2fetc`` decodes to ``/etc`` where ``root / "/etc"``
+    is ``/etc`` outright -- an existence oracle for any absolute path, and a
+    reader of out-of-root frontmatter ``name`` values.
+    """
+    if not name or name in (".", ".."):
+        return False
+    if "/" in name or "\\" in name or "\x00" in name:
+        return False
+    return not PurePosixPath(name).is_absolute() and not PureWindowsPath(name).is_absolute()
+
+
 def _diagnose_one(name: str, root: Path, skill_md: Path) -> str | None:
     """Why this one SKILL.md would not load under ``name``, or None if it would.
 
@@ -333,8 +403,20 @@ def _diagnose_one(name: str, root: Path, skill_md: Path) -> str | None:
         return f"{skill_md} could not be read: {exc}"
 
     meta = parse_frontmatter(text)
-    if not meta and not _has_frontmatter_block(text):
-        return f"{skill_md} has malformed YAML frontmatter (it must open and close with ---)."
+    if not meta:
+        if not _has_frontmatter_block(text):
+            return f"{skill_md} has malformed YAML frontmatter (it must open and close with ---)."
+        yaml_error = _frontmatter_yaml_error(text)
+        if yaml_error is not None:
+            # A well-formed pair of delimiters wrapping YAML that does not
+            # parse. Quote the parser rather than guessing: "mapping values are
+            # not allowed here" names the unquoted colon, which no rule of ours
+            # can locate. A block that parses to nothing (an EMPTY one) falls
+            # through instead -- "has no 'description'" is the true answer there.
+            return (
+                f"{skill_md} has invalid YAML in its frontmatter: {yaml_error}. "
+                "Quote any value containing a colon, then read the URL again."
+            )
 
     enabled = meta.get("enabled")
     if enabled is not None and (
@@ -375,11 +457,15 @@ def diagnose_missing_skill(name: str, roots: Sequence[Path]) -> str | None:
     emits 37 shadow warnings at startup, and a diagnostic that dumped them all
     would be noise where an answer is needed.
     """
-    if not name:
+    if not is_plain_skill_name(name):
+        # BEFORE ANY FILESYSTEM WORK. ``root / name`` is unguarded join: a
+        # traversal token or an absolute path in the NAME position escapes the
+        # roots entirely, and the resolver's own path-portion guards never see
+        # it because a name is the URL's netloc, not its path. Returning None
+        # keeps the bare "Unknown skill" -- which is the honest answer for a
+        # name no scan could ever have produced -- and, equally deliberately,
+        # spends no probe on a malformed URL (design §3).
         return None
-
-    # Candidates in root precedence order -- earlier roots win, so found[0] is
-    # the one that would claim the name if it loads at all.
     found: list[tuple[Path, Path]] = []
     for raw_root in roots:
         root = Path(raw_root).expanduser()

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2932,10 +2932,13 @@ class OperatorApp(App[None]):
         #: in-tree sessions take the keyword, so no shipping path relies on it.
         self._pending_user_echoes = []
         #: Discovered skills by name, for the ``$skill`` composer prefix.
-        #: ``None`` until the first submit or picker sync asks; see
-        #: :meth:`_discovered_skills` for why one discovery per session is the
-        #: right lifetime rather than a per-keystroke filesystem walk.
+        #: ``None`` until the first submit or picker sync asks. Refreshed only
+        #: when a cheap fingerprint says the skill tree changed -- see
+        #: :meth:`_discovered_skills` for why that gate replaces a
+        #: session-lifetime cache without costing a per-keystroke walk.
         self._skills_by_name: dict[str, Skill] | None = None
+        #: Fingerprint of the skill roots when ``_skills_by_name`` was built.
+        self._skills_fingerprint: tuple[object, ...] | None = None
         #: Wake receipts painted LIVE this session, as ``(wake_id, occurrence)``
         #: keys. ``on_wake_delivered`` records each; the history replay skips a
         #: persisted ``wake_prompt`` whose key is already here — otherwise a
@@ -29838,14 +29841,20 @@ class OperatorApp(App[None]):
         return RichBlock(Group(*lines))
 
     def _discovered_skills(self) -> dict[str, Skill]:
-        """Discovered skills by name, computed once per session.
+        """Discovered skills by name, rescanned only when the tree changed.
 
-        Cached because it is read on EVERY submit to decide whether a leading
-        ``$`` is an invocation, and discovery walks the filesystem. The cache
-        matches the lifetime the rest of the skills subsystem already assumes:
-        discovery and the semantic index are built at session creation, so a
-        skill added mid-session is not visible to routing either and telling
-        the user to restart is one consistent rule rather than two.
+        Read on EVERY submit to decide whether a leading ``$`` is an
+        invocation, so a bare rescan here would put a 17-25 ms filesystem walk
+        on the keystroke path. A ``roots_fingerprint`` probe (~0.29 ms) gates
+        it instead: the walk runs only when a ``SKILL.md`` was added or edited.
+
+        It used to cache for the whole session, justified by the rule that a
+        skill added mid-session needed a restart to be visible anywhere. The
+        skill resolver now rescans on a miss, so that rule is gone and the
+        cache would have made ``$name`` the one surface still requiring a
+        restart -- the opposite of one consistent rule. Semantic SELECTION is
+        still frozen for prompt-cache stability; naming a skill by hand, here
+        or by URL, is not.
 
         Hidden skills are KEPT (unlike :meth:`_skills_block`, which lists what
         routing can select). ``hide`` suppresses automatic selection; naming a
@@ -29853,18 +29862,26 @@ class OperatorApp(App[None]):
 
         Never raises: a broken skills tree degrades to "no invocations", which
         sends the user's ``$foo`` through as the prose it is indistinguishable
-        from at that point.
+        from at that point. A fingerprint failure keeps the last good map for
+        the same reason.
         """
-        if self._skills_by_name is None:
-            try:
-                from pathlib import Path
+        try:
+            from pathlib import Path
 
-                from local_operator.skills.api import default_skill_roots
-                from local_operator.skills.discovery import discover_skills
+            from local_operator.skills.api import default_skill_roots
+            from local_operator.skills.discovery import (
+                discover_skills,
+                roots_fingerprint,
+            )
 
-                skills, _warnings = discover_skills(default_skill_roots(Path(os.getcwd())))
+            roots = default_skill_roots(Path(os.getcwd()))
+            fingerprint = roots_fingerprint(roots)
+            if self._skills_by_name is None or fingerprint != self._skills_fingerprint:
+                skills, _warnings = discover_skills(roots)
                 self._skills_by_name = {skill.name: skill for skill in skills}
-            except Exception:
+                self._skills_fingerprint = fingerprint
+        except Exception:
+            if self._skills_by_name is None:
                 self._skills_by_name = {}
         return self._skills_by_name
 

--- a/scripts/evidence_skill_liveness.py
+++ b/scripts/evidence_skill_liveness.py
@@ -1,0 +1,235 @@
+"""End-to-end evidence for the skill-authoring liveness fix.
+
+NOT a test and not part of any suite. It exists because a green unit suite is
+not evidence of THIS fix: the reported defect is that a subagent launched
+before a skill existed could not read it for the rest of the session, and the
+only way to show that gone is to build a real session, build a real child from
+it, author the skill afterwards, and read it back through the child's own
+``read`` tool.
+
+Every layer below is the shipping one -- ``create_session`` composes the
+session, ``_build_child_session`` composes the child exactly as ``task`` does,
+and the read goes through ``ToolContext.resolve_internal_url``. The
+``hosting="test"`` model is the only stand-in, because no provider call is
+needed to resolve a ``skill://`` URL.
+
+Run it against the worktree's own venv:
+
+    .venv/bin/python scripts/evidence_skill_liveness.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Scripts self-correct their import root so they read the tree they live in
+# rather than whatever an editable install points at (AGENTS.md).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def _args(**overrides: object) -> argparse.Namespace:
+    base: dict[str, object] = {
+        "hosting": "test",
+        "model": "test",
+        "agent_name": None,
+        "agent_id": None,
+        "yolo": True,
+        "train": False,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _say(label: str, value: object) -> None:
+    print(f"\n--- {label} ---")
+    print(value)
+
+
+async def main() -> int:
+    sandbox = Path(tempfile.mkdtemp(prefix="skill-liveness-evidence-"))
+    home = sandbox / "home"
+    project = sandbox / "project"
+    (home / ".local-operator").mkdir(parents=True)
+    project.mkdir(parents=True)
+
+    # Isolate HOME and the config dir: this script must never write into the
+    # operator's real ~/.local-operator (AGENTS.md, "Isolating a run").
+    os.environ["HOME"] = str(home)
+    os.environ["LOCAL_OPERATOR_CONFIG_DIR"] = str(home / ".local-operator")
+    os.environ["LOCAL_OPERATOR_SKILL_EXTRA_ROOTS"] = ""
+    os.chdir(project)
+
+    from local_operator.agents import AgentRegistry
+    from local_operator.config import ConfigManager
+    from local_operator.credentials import CredentialManager
+    from local_operator.harness.subagent import _build_child_session
+    from local_operator.session_factory import create_session
+
+    config_dir = home / ".local-operator"
+    global_skills = home / ".local-operator" / "skills"
+
+    print(f"sandbox HOME       : {home}")
+    print(f"global skill root  : {global_skills}")
+    print(f"session cwd        : {project}")
+    print(f"skill exists yet?  : {(global_skills / 'lean-formalization').exists()}")
+
+    from local_operator.session.session import Session
+
+    built = await create_session(
+        _args(),
+        ConfigManager(config_dir),
+        CredentialManager(config_dir),
+        AgentRegistry(config_dir),
+    )
+    # create_session may hand back a RemoteSession when attaching to an owned
+    # runtime; this sandbox never does, and the child builder needs the real
+    # Session, so assert rather than silently proving nothing.
+    assert isinstance(built, Session), f"expected a local Session, got {type(built).__name__}"
+    session = built
+
+    # The child is built BEFORE the skill exists -- this is the reported
+    # defect's exact shape: standing instructions that name a skill authored
+    # after the child was launched.
+    child = await _build_child_session(
+        label="evidence-child",
+        prompt="FIRST, EVERY TIME: read skill://lean-formalization",
+        parent_session=session,
+        model_spec=None,
+        job_id="evidence-job",
+    )
+
+    # ``_build_tool_context`` is what runs at the start of every turn and is
+    # what hands the ``read`` tool its resolver, so going through it is the
+    # real path rather than a stashed reference.
+    def _reader(target: Session):
+        def read(url: str) -> str | None:
+            resolve = target._build_tool_context().resolve_internal_url
+            # A session without a resolver would make every read below return
+            # None and the evidence vacuously "pass"; fail loudly instead.
+            assert resolve is not None, "session has no internal-URL resolver"
+            return resolve(url)
+
+        return read
+
+    parent_read = _reader(session)
+    child_read = _reader(child)
+
+    _say(
+        "BEFORE — parent reads skill://lean-formalization",
+        parent_read("skill://lean-formalization"),
+    )
+    _say(
+        "BEFORE — child reads skill://lean-formalization", child_read("skill://lean-formalization")
+    )
+
+    # Author the skill exactly where the docs say to put a global one. This is
+    # what an agent does with the `write` tool.
+    skill_dir = global_skills / "lean-formalization"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: lean-formalization\n"
+        "description: Formalize mathematical arguments in Lean 4.\n"
+        "---\n"
+        "\n"
+        "# Lean formalization\n"
+        "\n"
+        "State the theorem before writing tactics.\n"
+    )
+    print(f"\nauthored           : {skill_dir / 'SKILL.md'}")
+
+    # The refresh is cooldown-bounded to one filesystem probe per second, and
+    # the BEFORE reads above just spent it. Showing the blocked read rather
+    # than hiding it behind a sleep: this is the designed bound, not a defect,
+    # and a real agent turn is seconds long so it is not reachable in practice.
+    _say(
+        "IMMEDIATELY AFTER (inside the 1s cooldown - probe bounded, still misses)",
+        child_read("skill://lean-formalization"),
+    )
+
+    await asyncio.sleep(1.1)
+    _say(
+        "AFTER — parent reads skill://lean-formalization", parent_read("skill://lean-formalization")
+    )
+    after_child = child_read("skill://lean-formalization")
+    _say("AFTER — child reads skill://lean-formalization", after_child)
+
+    # --- the four causes that used to share one opaque message -------------
+    print("\n=== diagnostics: four causes, four remedies ===")
+    cases: list[tuple[str, str, str]] = [
+        ("no SKILL.md", "empty-dir", ""),
+        (
+            "blank description",
+            "blank-desc",
+            "---\nname: blank-desc\n---\n\n# Body\n",
+        ),
+        (
+            "frontmatter name != directory",
+            "misnamed",
+            "---\nname: actually-this\ndescription: Renamed in frontmatter.\n---\n\n# Body\n",
+        ),
+        (
+            "malformed frontmatter",
+            "broken-yaml",
+            "---\ndescription: Unterminated block.\n\n# Body\n",
+        ),
+        (
+            "disabled",
+            "switched-off",
+            "---\nname: switched-off\ndescription: Turned off.\nenabled: false\n---\n\n# Body\n",
+        ),
+    ]
+    for label, dirname, content in cases:
+        case_dir = global_skills / dirname
+        case_dir.mkdir(parents=True, exist_ok=True)
+        if content:
+            (case_dir / "SKILL.md").write_text(content)
+        # Past the 1.0 s cooldown, so each read genuinely re-probes.
+        await asyncio.sleep(1.1)
+        _say(f"diagnostic — {label}", child_read(f"skill://{dirname}"))
+
+    # The shadow case, shown honestly: it is NOT reachable through a URL read,
+    # because if the winning copy loads it also claims the name and the read
+    # HITS. Both halves are shown -- the read succeeding with the project copy,
+    # and the helper naming the shadowing the read cannot surface.
+    project_skills = project / ".local-operator" / "skills" / "shadowed"
+    project_skills.mkdir(parents=True)
+    (project_skills / "SKILL.md").write_text(
+        "---\nname: shadowed\ndescription: The project copy wins.\n---\n\n# Project copy\n"
+    )
+    global_shadow = global_skills / "shadowed"
+    global_shadow.mkdir(parents=True)
+    (global_shadow / "SKILL.md").write_text(
+        "---\nname: shadowed\ndescription: The global copy loses the name.\n---\n\n# Global copy\n"
+    )
+    await asyncio.sleep(1.1)
+    _say(
+        "shadowing — the READ hits the winner (project root beats global)",
+        child_read("skill://shadowed"),
+    )
+
+    from local_operator.skills.discovery import diagnose_missing_skill
+
+    _say(
+        "shadowing — diagnose_missing_skill names the loser and the winner",
+        diagnose_missing_skill(
+            "shadowed",
+            [project / ".local-operator" / "skills", global_skills],
+        ),
+    )
+
+    await child.dispose()
+    await session.dispose()
+
+    ok = after_child is not None and "State the theorem before writing tactics." in after_child
+    print(f"\n=== RESULT: child resolved the late-authored skill: {ok} ===")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/evidence_skill_liveness.py
+++ b/scripts/evidence_skill_liveness.py
@@ -143,16 +143,15 @@ async def main() -> int:
     )
     print(f"\nauthored           : {skill_dir / 'SKILL.md'}")
 
-    # The refresh is cooldown-bounded to one filesystem probe per second, and
-    # the BEFORE reads above just spent it. Showing the blocked read rather
-    # than hiding it behind a sleep: this is the designed bound, not a defect,
-    # and a real agent turn is seconds long so it is not reachable in practice.
+    # Read back IMMEDIATELY, with no sleep. Write-then-read is the normal
+    # authoring sequence, so the interesting evidence is that it works in the
+    # same millisecond: the refresh is gated on a stat, not on a clock, and a
+    # time-based cooldown here used to make exactly this read fail.
     _say(
-        "IMMEDIATELY AFTER (inside the 1s cooldown - probe bounded, still misses)",
+        "IMMEDIATELY AFTER the write - no sleep",
         child_read("skill://lean-formalization"),
     )
 
-    await asyncio.sleep(1.1)
     _say(
         "AFTER — parent reads skill://lean-formalization", parent_read("skill://lean-formalization")
     )
@@ -179,6 +178,13 @@ async def main() -> int:
             "---\ndescription: Unterminated block.\n\n# Body\n",
         ),
         (
+            # The commonest real authoring mistake: delimiters intact, YAML
+            # invalid. This used to be reported as a MISSING description.
+            "invalid YAML (unquoted colon)",
+            "unquoted-colon",
+            "---\nname: unquoted-colon\ndescription: Lean 4: formalize proofs\n---\n\n# Body\n",
+        ),
+        (
             "disabled",
             "switched-off",
             "---\nname: switched-off\ndescription: Turned off.\nenabled: false\n---\n\n# Body\n",
@@ -189,8 +195,6 @@ async def main() -> int:
         case_dir.mkdir(parents=True, exist_ok=True)
         if content:
             (case_dir / "SKILL.md").write_text(content)
-        # Past the 1.0 s cooldown, so each read genuinely re-probes.
-        await asyncio.sleep(1.1)
         _say(f"diagnostic — {label}", child_read(f"skill://{dirname}"))
 
     # The shadow case, shown honestly: it is NOT reachable through a URL read,
@@ -207,7 +211,6 @@ async def main() -> int:
     (global_shadow / "SKILL.md").write_text(
         "---\nname: shadowed\ndescription: The global copy loses the name.\n---\n\n# Global copy\n"
     )
-    await asyncio.sleep(1.1)
     _say(
         "shadowing — the READ hits the winner (project root beats global)",
         child_read("skill://shadowed"),

--- a/tests/unit/skills/test_api.py
+++ b/tests/unit/skills/test_api.py
@@ -3,7 +3,8 @@ make_skill_resolver adapter (RS-09)."""
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+import time
+from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
@@ -153,28 +154,6 @@ class TestResolverRefreshOnMiss:
     construction and the resolver closed over that snapshot.
     """
 
-    @staticmethod
-    def _fake_clock(monkeypatch: pytest.MonkeyPatch) -> Callable[[float], None]:
-        """Advance ``time.monotonic`` explicitly instead of sleeping.
-
-        The refresh is cooldown-bounded to one probe per second, so a test that
-        writes a skill and reads it back in the same millisecond is asserting
-        against the cooldown rather than against the refresh. Real turns are
-        seconds apart; a controlled clock reproduces that without adding a
-        second of wall time per test.
-        """
-        current = 1000.0
-
-        def now() -> float:
-            return current
-
-        def advance(seconds: float) -> None:
-            nonlocal current
-            current += seconds
-
-        monkeypatch.setattr(api_module.time, "monotonic", now)
-        return advance
-
     def _write_skill_file(
         self,
         root: Path,
@@ -202,7 +181,6 @@ class TestResolverRefreshOnMiss:
     def test_skill_created_after_the_resolver_resolves_on_the_next_read(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        advance = self._fake_clock(monkeypatch)
         root = tmp_path / "roots"
         root.mkdir()
         skills: dict[str, Skill] = {}
@@ -212,7 +190,6 @@ class TestResolverRefreshOnMiss:
         assert before is not None and "Unknown skill: late" in before
 
         self._write_skill_file(root, "late", body="# late body")
-        advance(2.0)
         after = resolver("skill://late")
         assert after is not None
         assert "# late body" in after
@@ -228,7 +205,6 @@ class TestResolverRefreshOnMiss:
         calling ``.update()`` still passes every parent-side test and breaks
         every already-running subagent silently. Assert the child.
         """
-        advance = self._fake_clock(monkeypatch)
         root = tmp_path / "roots"
         root.mkdir()
         skills: dict[str, Skill] = {"alpha": _make_skill(tmp_path / "existing", "alpha")}
@@ -245,7 +221,6 @@ class TestResolverRefreshOnMiss:
         assert before is not None and "Unknown skill: lean-formalization" in before
 
         self._write_skill_file(root, "lean-formalization", body="# lean body")
-        advance(2.0)
 
         after = child("skill://lean-formalization")
         assert after is not None, "child resolver must see the new skill"
@@ -261,12 +236,10 @@ class TestResolverRefreshOnMiss:
         root.mkdir()
         skills: dict[str, Skill] = {}
         original_id = id(skills)
-        advance = self._fake_clock(monkeypatch)
         resolver = make_skill_resolver(skills, [root])
         resolver("skill://nope")
 
         self._write_skill_file(root, "fresh")
-        advance(2.0)
         resolver("skill://fresh")
 
         assert id(skills) == original_id
@@ -297,78 +270,128 @@ class TestResolverRefreshOnMiss:
             return [], []
 
         monkeypatch.setattr(api_module, "discover_skills", counting_discover)
-        advance = self._fake_clock(monkeypatch)
         resolver = make_skill_resolver({}, [root])
 
         # First miss establishes the fingerprint and scans once.
         resolver("skill://nope")
         assert len(calls) == 1
 
-        # Past the cooldown, so the cooldown cannot be what stops the second
-        # scan -- the fingerprint has to. Advancing rather than jumping the
-        # clock matters: a clock that moves BACKWARDS makes the cooldown
-        # comparison short-circuit and the test would pass without ever
-        # reaching the fingerprint it exists to check.
-        advance(2.0)
+        # The fingerprint is the ONLY thing that can stop the second scan --
+        # there is no clock in this path any more, so a repeat miss on an
+        # unchanged tree must still not rescan.
         resolver("skill://nope")
         assert len(calls) == 1
 
-    def test_cooldown_bounds_probes_within_the_window(
+    def test_looping_typo_probes_but_never_rescans(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # A looping agent retrying a typo'd name pays one probe per second,
-        # not one per read.
+        """The bound on a looping agent is the STAT, not a clock.
+
+        R2: the time-based cooldown that used to provide this bound also made a
+        skill written 50 ms after a miss unreadable for a second -- the exact
+        write-then-read sequence the feature exists for. It was removed, so
+        this pins what replaced it: every miss pays a sub-millisecond probe and
+        an unchanged tree is NEVER rescanned, which is where the real cost is.
+        """
         root = tmp_path / "roots"
         root.mkdir()
         probes: list[object] = []
+        scans: list[object] = []
         real_fingerprint = api_module.roots_fingerprint
 
         def counting_fingerprint(roots: Sequence[Path]) -> tuple[object, ...]:
             probes.append(roots)
             return real_fingerprint(roots)
 
+        def counting_discover(roots: Sequence[Path]) -> tuple[list[Skill], list[str]]:
+            scans.append(roots)
+            return [], []
+
         monkeypatch.setattr(api_module, "roots_fingerprint", counting_fingerprint)
-        advance = self._fake_clock(monkeypatch)
+        monkeypatch.setattr(api_module, "discover_skills", counting_discover)
         resolver = make_skill_resolver({}, [root])
 
-        resolver("skill://nope")
-        advance(0.1)
-        resolver("skill://nope")
-        advance(0.1)
-        resolver("skill://nope")
-        assert len(probes) == 1
+        for _ in range(20):
+            resolver("skill://nope")
 
-        # And the window does expire: the next read past it probes again.
-        advance(2.0)
-        resolver("skill://nope")
-        assert len(probes) == 2
+        assert len(probes) == 20, "the cheap probe runs per miss; that is the design"
+        assert len(scans) == 1, "an unchanged tree must never be rescanned"
 
-    def test_cooldown_suppresses_the_diagnostic_too(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Inside the window the resolver does NO filesystem work at all.
+    def test_skill_written_immediately_after_a_miss_is_readable(self, tmp_path: Path) -> None:
+        """R2 regression: no time window may hide a just-authored skill.
 
-        Diagnosis walks the roots, so letting it run inside the cooldown would
-        reopen the very hole the cooldown closes: a retry loop on a bad name
-        would still drive a walk per read.
+        Reproduces the reported shape exactly -- a child probes for the skill,
+        the parent writes it milliseconds later, the child reads again. Under
+        the removed 1 s cooldown the second read returned ``Unknown skill``
+        with no diagnostic; write-then-read is the normal authoring sequence,
+        so this is the headline behaviour, not an edge case. No sleep and no
+        fake clock: both reads happen in the same millisecond, which is the
+        point.
         """
         root = tmp_path / "roots"
         root.mkdir()
+        skills: dict[str, Skill] = {}
+        parent = make_skill_resolver(skills, [root])
+
+        def child(url: str) -> str | None:
+            return parent(url)
+
+        first = child("skill://lean-formalization")
+        assert first is not None and "Unknown skill" in first
+
+        self._write_skill_file(root, "lean-formalization", body="# lean body")
+
+        second = child("skill://lean-formalization")
+        assert second is not None, "a skill written after a miss must resolve at once"
+        assert "# lean body" in second
+
+    def test_diagnostic_is_not_suppressed_on_a_repeat_miss(self, tmp_path: Path) -> None:
+        # The cooldown used to suppress diagnosis too, so the second read of a
+        # broken skill lost its remedy. Every miss now explains itself.
+        root = tmp_path / "roots"
+        root.mkdir()
         self._write_skill_file(root, "blank", description=None)
-        advance = self._fake_clock(monkeypatch)
         resolver = make_skill_resolver({}, [root])
 
-        first = resolver("skill://blank")
-        assert first is not None and "no 'description'" in first
+        for _ in range(3):
+            content = resolver("skill://blank")
+            assert content is not None and "no 'description'" in content
 
-        advance(0.1)
-        throttled = resolver("skill://blank")
-        assert throttled is not None
-        assert "no 'description'" not in throttled
+    def test_transient_scan_failure_does_not_poison_the_session(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """R3 regression: a one-off OSError must not freeze the fingerprint.
 
-        advance(2.0)
-        recovered = resolver("skill://blank")
-        assert recovered is not None and "no 'description'" in recovered
+        The fingerprint used to be committed BEFORE ``discover_skills`` ran, so
+        a single EMFILE blip left the state claiming it had ingested a tree it
+        never read. Every later miss then compared equal and never rescanned --
+        the skill stayed unreadable for the whole session even after the
+        filesystem recovered, which is worse than the behaviour this replaced.
+        """
+        root = tmp_path / "roots"
+        root.mkdir()
+        self._write_skill_file(root, "lean", body="# lean body")
+
+        real_discover = api_module.discover_skills
+        failures: list[int] = []
+
+        def flaky_discover(roots: Sequence[Path]) -> tuple[list[Skill], list[str]]:
+            if not failures:
+                failures.append(1)
+                raise OSError(24, "Too many open files")
+            return real_discover(roots)
+
+        monkeypatch.setattr(api_module, "discover_skills", flaky_discover)
+        resolver = make_skill_resolver({}, [root])
+
+        during_failure = resolver("skill://lean")
+        assert during_failure is not None and "Unknown skill" in during_failure
+
+        # The tree has NOT changed since that failed read. Only an uncommitted
+        # fingerprint can make this second read scan again.
+        recovered = resolver("skill://lean")
+        assert recovered is not None, "a healthy filesystem must be re-scanned"
+        assert "# lean body" in recovered
 
     def test_unsafe_path_error_does_not_trigger_a_refresh(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -388,7 +411,6 @@ class TestResolverRefreshOnMiss:
     ) -> None:
         # Growth-only: removing entries would let one agent's cleanup break a
         # sibling child mid-read. The stale entry degrades to a clear message.
-        self._fake_clock(monkeypatch)
         root = tmp_path / "roots"
         root.mkdir()
         skill_md = self._write_skill_file(root, "doomed")
@@ -402,6 +424,92 @@ class TestResolverRefreshOnMiss:
         assert content is not None
         assert "No such file or directory" in content
         assert "doomed" in skills
+
+    def test_concurrent_readers_both_resolve_the_same_new_skill(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """R1 regression: the thread that LOSES the refresh race must still hit.
+
+        Two real threads, because the failure only exists between them. The
+        loser blocks on ``state.lock``, is released after the winner has
+        already populated the shared mapping, and computes a fingerprint that
+        now matches -- so a retry gated on "did MY call rescan?" skipped the
+        re-lookup and answered ``Unknown skill`` for a skill sitting in the
+        dict it was holding. The final assertion is the whole point: the
+        mapping provably contains the name at the moment B answered.
+
+        The scan is slowed to widen a window that is 17-42 ms in reality; a
+        barrier makes both threads arrive inside it deterministically rather
+        than by luck, so this cannot pass by timing.
+        """
+        import threading
+
+        root = tmp_path / "roots"
+        root.mkdir()
+        self._write_skill_file(root, "lean", body="# lean body")
+
+        real_discover = api_module.discover_skills
+        entered = threading.Event()
+
+        def slow_discover(roots: Sequence[Path]) -> tuple[list[Skill], list[str]]:
+            entered.set()
+            # Held long enough that the second thread is provably parked on the
+            # lock before this one commits.
+            time.sleep(0.3)
+            return real_discover(roots)
+
+        monkeypatch.setattr(api_module, "discover_skills", slow_discover)
+        skills: dict[str, Skill] = {}
+        resolver = make_skill_resolver(skills, [root])
+
+        results: dict[str, str | None] = {}
+
+        def read(tag: str) -> None:
+            results[tag] = resolver("skill://lean")
+
+        winner = threading.Thread(target=read, args=("A",))
+        winner.start()
+        # Only start B once A is inside the scan: that is the race, made
+        # deterministic instead of hoped for.
+        assert entered.wait(5.0), "the first reader never reached the scan"
+        loser = threading.Thread(target=read, args=("B",))
+        loser.start()
+        winner.join(10.0)
+        loser.join(10.0)
+
+        assert "lean" in skills, "precondition: the refresh populated the shared mapping"
+        assert results["A"] is not None and "# lean body" in results["A"]
+        assert results["B"] is not None, "the losing reader returned nothing"
+        assert "# lean body" in results["B"], (
+            "the losing reader reported a miss for a skill already in the mapping: "
+            f"{results['B']!r}"
+        )
+
+    def test_unsafe_name_in_the_netloc_drives_no_filesystem_work(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Q1 at the resolver: a traversal NAME must not spend a probe either.
+
+        ``test_unsafe_path_error_does_not_trigger_a_refresh`` covers the PATH
+        portion. This covers the netloc, which the protocol's guards never
+        inspect: ``skill://..`` and ``skill://%2fetc`` arrive as an ordinary
+        "Unknown skill" and used to drive a full fingerprint probe on
+        attacker-chosen input.
+        """
+
+        def explode(_roots: Sequence[Path]) -> tuple[object, ...]:
+            raise AssertionError("an unsafe NAME must not cause a probe")
+
+        monkeypatch.setattr(api_module, "roots_fingerprint", explode)
+        root = tmp_path / "roots"
+        root.mkdir()
+        resolver = make_skill_resolver({}, [root])
+
+        for url in ("skill://..", "skill://%2fetc", "skill://a%2fb", "skill://..%2f..%2fx"):
+            content = resolver(url)
+            assert content is not None and "Unknown skill" in content
+            # And nothing from outside the roots comes back with it.
+            assert "SKILL.md" not in content
 
     def test_roots_none_preserves_todays_behaviour(self, tmp_path: Path) -> None:
         # Guards every existing caller and the parallel guide resolver: with no

--- a/tests/unit/skills/test_api.py
+++ b/tests/unit/skills/test_api.py
@@ -11,7 +11,11 @@ import pytest
 
 import local_operator.skills.api as api_module
 import local_operator.skills.discovery as discovery_module
-from local_operator.skills.api import default_skill_roots, make_skill_resolver
+from local_operator.skills.api import (
+    _url_name,
+    default_skill_roots,
+    make_skill_resolver,
+)
 from local_operator.skills.discovery import Skill
 from local_operator.skills.protocol import MAX_READ_BYTES
 
@@ -581,3 +585,38 @@ class TestResolverRefreshOnMiss:
         assert content is not None
         assert "Unknown skill: blank" in content
         assert "no 'description'" in content
+
+
+class TestUrlNameDecodesPercentEncoding:
+    """R11: the safety check runs on the DECODED name, so the decode is load-bearing.
+
+    ``_url_name`` feeds ``is_plain_skill_name``, and percent-encoding is the
+    delivery vehicle for every netloc attack this PR closes: ``%2fetc`` and
+    ``%44%3ax`` are plain-looking single segments until they are decoded, and a
+    ``_url_name`` that skipped the decode would hand both of them the refresh
+    and the filesystem work the guard exists to deny. The resolver-level tests
+    exercise that consequence; these pin the decode itself, so dropping the
+    ``unquote`` cannot pass unnoticed on the strength of the URL's raw text
+    happening to look safe.
+    """
+
+    def test_percent_encoded_name_is_decoded(self) -> None:
+        # %44%3ax -> D:x: the drive shape arrives ONLY after decoding.
+        assert _url_name("skill://%44%3ax") == "D:x"
+        assert _url_name("skill://%2fetc") == "/etc"
+        assert _url_name("skill://a%2fb") == "a/b"
+        assert _url_name("skill://%2e%2e") == ".."
+
+    def test_plain_name_survives_the_decode_unchanged(self) -> None:
+        # The decode must not mangle the ordinary case it sits in front of.
+        assert _url_name("skill://lean-formalization") == "lean-formalization"
+        assert _url_name("skill://notes:2024") == "notes:2024"
+
+    def test_the_decoded_name_is_what_the_safety_check_sees(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The decode and the predicate, wired together as the resolver wires them."""
+        monkeypatch.setattr(discovery_module, "_DRIVE_RESETS_JOIN", True)
+        # Encoded, it looks like one plain segment; decoded, it is drive-anchored.
+        assert discovery_module.is_plain_skill_name("%44%3ax") is True
+        assert discovery_module.is_plain_skill_name(_url_name("skill://%44%3ax")) is False

--- a/tests/unit/skills/test_api.py
+++ b/tests/unit/skills/test_api.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 import local_operator.skills.api as api_module
+import local_operator.skills.discovery as discovery_module
 from local_operator.skills.api import default_skill_roots, make_skill_resolver
 from local_operator.skills.discovery import Skill
 from local_operator.skills.protocol import MAX_READ_BYTES
@@ -509,6 +510,54 @@ class TestResolverRefreshOnMiss:
             content = resolver(url)
             assert content is not None and "Unknown skill" in content
             # And nothing from outside the roots comes back with it.
+            assert "SKILL.md" not in content
+
+    def test_posix_colon_named_skill_authored_mid_session_resolves(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """R9 at the resolver: the headline feature, for a legal POSIX name.
+
+        ``:`` is an ordinary directory character on POSIX and the scanner
+        registers ``a:b``, so gating the refresh on a name predicate that
+        rejected it cost that skill the very liveness this resolver adds --
+        silently, since the miss still read as a plain "Unknown skill".
+        """
+        monkeypatch.setattr(discovery_module, "_DRIVE_RESETS_JOIN", False)
+        root = tmp_path / "roots"
+        root.mkdir()
+        skills: dict[str, Skill] = {}
+        resolver = make_skill_resolver(skills, [root])
+
+        before = resolver("skill://a:b")
+        assert before is not None and "Unknown skill: a:b" in before
+
+        self._write_skill_file(root, "a:b", body="# colon body")
+        after = resolver("skill://a:b")
+        assert after is not None and "# colon body" in after
+        # In place, not rebound -- the mapping the session already holds.
+        assert "a:b" in skills
+
+    def test_windows_drive_name_in_the_netloc_still_drives_no_probe(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """R9's other direction: the drive door stays shut under Windows semantics.
+
+        Percent-encoding is the delivery vehicle that matters -- ``%44%3ax``
+        decodes to ``D:x`` in the NETLOC, which no path-portion guard inspects.
+        """
+        monkeypatch.setattr(discovery_module, "_DRIVE_RESETS_JOIN", True)
+
+        def explode(_roots: Sequence[Path]) -> tuple[object, ...]:
+            raise AssertionError("a drive-anchored NAME must not cause a probe")
+
+        monkeypatch.setattr(api_module, "roots_fingerprint", explode)
+        root = tmp_path / "roots"
+        root.mkdir()
+        resolver = make_skill_resolver({}, [root])
+
+        for url in ("skill://D:x", "skill://%44%3ax", "skill://a%3ab", "skill://C%3A"):
+            content = resolver(url)
+            assert content is not None and "Unknown skill" in content
             assert "SKILL.md" not in content
 
     def test_roots_none_preserves_todays_behaviour(self, tmp_path: Path) -> None:

--- a/tests/unit/skills/test_api.py
+++ b/tests/unit/skills/test_api.py
@@ -3,10 +3,12 @@ make_skill_resolver adapter (RS-09)."""
 
 from __future__ import annotations
 
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
 import pytest
 
+import local_operator.skills.api as api_module
 from local_operator.skills.api import default_skill_roots, make_skill_resolver
 from local_operator.skills.discovery import Skill
 from local_operator.skills.protocol import MAX_READ_BYTES
@@ -140,3 +142,285 @@ class TestMakeSkillResolver:
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))
+
+
+class TestResolverRefreshOnMiss:
+    """A skill authored mid-session must resolve without a restart.
+
+    The defect these guard: an agent wrote a valid skill to a native global
+    root and neither it nor any subagent it launched could read it for the rest
+    of the session, because ``discover_skills`` ran once at session
+    construction and the resolver closed over that snapshot.
+    """
+
+    @staticmethod
+    def _fake_clock(monkeypatch: pytest.MonkeyPatch) -> Callable[[float], None]:
+        """Advance ``time.monotonic`` explicitly instead of sleeping.
+
+        The refresh is cooldown-bounded to one probe per second, so a test that
+        writes a skill and reads it back in the same millisecond is asserting
+        against the cooldown rather than against the refresh. Real turns are
+        seconds apart; a controlled clock reproduces that without adding a
+        second of wall time per test.
+        """
+        current = 1000.0
+
+        def now() -> float:
+            return current
+
+        def advance(seconds: float) -> None:
+            nonlocal current
+            current += seconds
+
+        monkeypatch.setattr(api_module.time, "monotonic", now)
+        return advance
+
+    def _write_skill_file(
+        self,
+        root: Path,
+        dirname: str,
+        *,
+        name: str | None = None,
+        description: str | None = "Does things.",
+        enabled: object | None = None,
+        body: str = "# body",
+    ) -> Path:
+        skill_dir = root / dirname
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        lines = ["---"]
+        if name is not None:
+            lines.append(f"name: {name}")
+        if description is not None:
+            lines.append(f"description: {description}")
+        if enabled is not None:
+            lines.append(f"enabled: {enabled}")
+        lines.extend(["---", "", body])
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text("\n".join(lines))
+        return skill_md
+
+    def test_skill_created_after_the_resolver_resolves_on_the_next_read(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        advance = self._fake_clock(monkeypatch)
+        root = tmp_path / "roots"
+        root.mkdir()
+        skills: dict[str, Skill] = {}
+        resolver = make_skill_resolver(skills, [root])
+
+        before = resolver("skill://late")
+        assert before is not None and "Unknown skill: late" in before
+
+        self._write_skill_file(root, "late", body="# late body")
+        advance(2.0)
+        after = resolver("skill://late")
+        assert after is not None
+        assert "# late body" in after
+
+    def test_child_resolver_sees_a_skill_created_after_it_was_built(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The regression guard that matters: liveness through a CHILD.
+
+        ``harness/subagent.py`` hands a child the PARENT's resolver closure, so
+        propagation depends entirely on the refresh mutating the shared mapping
+        IN PLACE. A future refactor that rebinds (``skills = {...}``) instead of
+        calling ``.update()`` still passes every parent-side test and breaks
+        every already-running subagent silently. Assert the child.
+        """
+        advance = self._fake_clock(monkeypatch)
+        root = tmp_path / "roots"
+        root.mkdir()
+        skills: dict[str, Skill] = {"alpha": _make_skill(tmp_path / "existing", "alpha")}
+        parent = make_skill_resolver(skills, [root])
+
+        # Mirrors subagent.py: the child chains its own resolvers and falls
+        # through to the parent's closure for skill:// URLs.
+        def child(url: str) -> str | None:
+            if url.startswith("mcp://"):
+                return None
+            return parent(url)
+
+        before = child("skill://lean-formalization")
+        assert before is not None and "Unknown skill: lean-formalization" in before
+
+        self._write_skill_file(root, "lean-formalization", body="# lean body")
+        advance(2.0)
+
+        after = child("skill://lean-formalization")
+        assert after is not None, "child resolver must see the new skill"
+        assert "# lean body" in after
+
+    def test_refresh_mutates_the_mapping_in_place(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The identity assertion behind the child test above, stated directly:
+        # session_factory, the parent resolver and every child hold this one
+        # object, so a rebind would orphan all of them.
+        root = tmp_path / "roots"
+        root.mkdir()
+        skills: dict[str, Skill] = {}
+        original_id = id(skills)
+        advance = self._fake_clock(monkeypatch)
+        resolver = make_skill_resolver(skills, [root])
+        resolver("skill://nope")
+
+        self._write_skill_file(root, "fresh")
+        advance(2.0)
+        resolver("skill://fresh")
+
+        assert id(skills) == original_id
+        assert "fresh" in skills
+
+    def test_hit_path_does_no_filesystem_work(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The cost constraint: a skill that exists resolves on one dict lookup.
+        # Making the fingerprint raise proves nothing above the lookup runs.
+        def explode(_roots: Sequence[Path]) -> tuple[object, ...]:
+            raise AssertionError("fingerprint must not run on the hit path")
+
+        monkeypatch.setattr(api_module, "roots_fingerprint", explode)
+        resolver = make_skill_resolver({"alpha": _make_skill(tmp_path, "alpha")}, [tmp_path])
+        content = resolver("skill://alpha")
+        assert content is not None and "# alpha" in content
+
+    def test_unchanged_fingerprint_skips_the_full_scan(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / "roots"
+        root.mkdir()
+        calls: list[object] = []
+
+        def counting_discover(roots: Sequence[Path]) -> tuple[list[Skill], list[str]]:
+            calls.append(roots)
+            return [], []
+
+        monkeypatch.setattr(api_module, "discover_skills", counting_discover)
+        advance = self._fake_clock(monkeypatch)
+        resolver = make_skill_resolver({}, [root])
+
+        # First miss establishes the fingerprint and scans once.
+        resolver("skill://nope")
+        assert len(calls) == 1
+
+        # Past the cooldown, so the cooldown cannot be what stops the second
+        # scan -- the fingerprint has to. Advancing rather than jumping the
+        # clock matters: a clock that moves BACKWARDS makes the cooldown
+        # comparison short-circuit and the test would pass without ever
+        # reaching the fingerprint it exists to check.
+        advance(2.0)
+        resolver("skill://nope")
+        assert len(calls) == 1
+
+    def test_cooldown_bounds_probes_within_the_window(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A looping agent retrying a typo'd name pays one probe per second,
+        # not one per read.
+        root = tmp_path / "roots"
+        root.mkdir()
+        probes: list[object] = []
+        real_fingerprint = api_module.roots_fingerprint
+
+        def counting_fingerprint(roots: Sequence[Path]) -> tuple[object, ...]:
+            probes.append(roots)
+            return real_fingerprint(roots)
+
+        monkeypatch.setattr(api_module, "roots_fingerprint", counting_fingerprint)
+        advance = self._fake_clock(monkeypatch)
+        resolver = make_skill_resolver({}, [root])
+
+        resolver("skill://nope")
+        advance(0.1)
+        resolver("skill://nope")
+        advance(0.1)
+        resolver("skill://nope")
+        assert len(probes) == 1
+
+        # And the window does expire: the next read past it probes again.
+        advance(2.0)
+        resolver("skill://nope")
+        assert len(probes) == 2
+
+    def test_cooldown_suppresses_the_diagnostic_too(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Inside the window the resolver does NO filesystem work at all.
+
+        Diagnosis walks the roots, so letting it run inside the cooldown would
+        reopen the very hole the cooldown closes: a retry loop on a bad name
+        would still drive a walk per read.
+        """
+        root = tmp_path / "roots"
+        root.mkdir()
+        self._write_skill_file(root, "blank", description=None)
+        advance = self._fake_clock(monkeypatch)
+        resolver = make_skill_resolver({}, [root])
+
+        first = resolver("skill://blank")
+        assert first is not None and "no 'description'" in first
+
+        advance(0.1)
+        throttled = resolver("skill://blank")
+        assert throttled is not None
+        assert "no 'description'" not in throttled
+
+        advance(2.0)
+        recovered = resolver("skill://blank")
+        assert recovered is not None and "no 'description'" in recovered
+
+    def test_unsafe_path_error_does_not_trigger_a_refresh(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Traversal and dotfile rejections are ValueErrors too. Rescanning on
+        # them would let a malformed URL drive filesystem work.
+        def explode(_roots: Sequence[Path]) -> tuple[object, ...]:
+            raise AssertionError("an unsafe path must not cause a rescan")
+
+        monkeypatch.setattr(api_module, "roots_fingerprint", explode)
+        resolver = make_skill_resolver({"alpha": _make_skill(tmp_path, "alpha")}, [tmp_path])
+        content = resolver("skill://alpha/../../etc/passwd")
+        assert content is not None and "not allowed" in content
+
+    def test_deleted_skill_stays_in_the_mapping_and_reads_as_oserror(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Growth-only: removing entries would let one agent's cleanup break a
+        # sibling child mid-read. The stale entry degrades to a clear message.
+        self._fake_clock(monkeypatch)
+        root = tmp_path / "roots"
+        root.mkdir()
+        skill_md = self._write_skill_file(root, "doomed")
+        skills: dict[str, Skill] = {}
+        resolver = make_skill_resolver(skills, [root])
+        assert resolver("skill://doomed") is not None
+        assert "doomed" in skills
+
+        skill_md.unlink()
+        content = resolver("skill://doomed")
+        assert content is not None
+        assert "No such file or directory" in content
+        assert "doomed" in skills
+
+    def test_roots_none_preserves_todays_behaviour(self, tmp_path: Path) -> None:
+        # Guards every existing caller and the parallel guide resolver: with no
+        # roots there is no rescan and no diagnostic, just the bare message.
+        root = tmp_path / "roots"
+        root.mkdir()
+        self._write_skill_file(root, "present")
+        resolver = make_skill_resolver({})
+        content = resolver("skill://present")
+        assert content == "Unknown skill: present\nAvailable: (none)"
+
+    def test_surviving_miss_explains_the_cause(self, tmp_path: Path) -> None:
+        # A skill dropped for a blank description is invisible; without the
+        # diagnostic the author sees only "Unknown skill".
+        root = tmp_path / "roots"
+        root.mkdir()
+        self._write_skill_file(root, "blank", description=None)
+        resolver = make_skill_resolver({}, [root])
+        content = resolver("skill://blank")
+        assert content is not None
+        assert "Unknown skill: blank" in content
+        assert "no 'description'" in content

--- a/tests/unit/skills/test_discovery.py
+++ b/tests/unit/skills/test_discovery.py
@@ -407,3 +407,113 @@ class TestDiagnoseMissingSkill:
         root = tmp_path / "skills"
         root.mkdir()
         assert diagnose_missing_skill("absent", [root]) is None
+
+    def test_unquoted_colon_is_reported_as_invalid_yaml(self, tmp_path: Path) -> None:
+        """R4 regression: the commonest authoring error must name its own cause.
+
+        The malformed branch used to require the ``---`` delimiters to be
+        ABSENT, so a file with both delimiters and invalid YAML fell through to
+        the description branch and was told "has no 'description'" -- about a
+        file that visibly has one, with a remedy that provably does not fix it.
+        """
+        root = tmp_path / "skills"
+        (root / "lean").mkdir(parents=True)
+        # An unquoted colon in the value: valid-looking to a human, invalid YAML.
+        (root / "lean" / "SKILL.md").write_text(
+            "---\nname: lean\ndescription: Lean 4: formalize proofs\n---\n\n# Body\n"
+        )
+        message = diagnose_missing_skill("lean", [root])
+        assert message is not None
+        assert "invalid YAML in its frontmatter" in message
+        assert "Quote any value containing a colon" in message
+        # The wrong remedy must be gone, not merely accompanied.
+        assert "no 'description'" not in message
+        # And the parser's own words, which are the only thing that locates it.
+        assert "mapping values are not allowed" in message
+
+    def test_empty_but_well_formed_block_still_reports_the_description(
+        self, tmp_path: Path
+    ) -> None:
+        # The other side of R4: a block that PARSES to nothing is not malformed,
+        # and telling that author to quote a colon would be the same class of
+        # wrong answer in the opposite direction.
+        root = tmp_path / "skills"
+        (root / "alpha").mkdir(parents=True)
+        (root / "alpha" / "SKILL.md").write_text("---\n---\n\n# Body\n")
+        message = diagnose_missing_skill("alpha", [root])
+        assert message is not None
+        assert "no 'description'" in message
+        assert "invalid YAML" not in message
+
+
+class TestDiagnoseMissingSkillContainment:
+    """Q1: a name is a directory entry, never a path. It may not leave the roots.
+
+    ``root / name`` is an unguarded join and a skill NAME is a URL's netloc, so
+    the resolver's path-portion guards never inspect it. Each shape below
+    reached the filesystem outside every configured root.
+    """
+
+    @staticmethod
+    def _outside(tmp_path: Path) -> Path:
+        """A skill-shaped directory OUTSIDE the roots, to be reached or not."""
+        secret = tmp_path / "outside" / "private-project"
+        secret.mkdir(parents=True)
+        (secret / "SKILL.md").write_text(
+            "---\nname: internal-codename\ndescription: Secret.\n---\n# body\n"
+        )
+        return secret
+
+    def test_parent_traversal_name_reads_nothing(self, tmp_path: Path) -> None:
+        # skill://.. -- ".." parses as the netloc, so no path guard ever saw it.
+        root = tmp_path / "roots" / "skills"
+        root.mkdir(parents=True)
+        assert diagnose_missing_skill("..", [root]) is None
+
+    def test_absolute_name_is_not_an_existence_oracle(self, tmp_path: Path) -> None:
+        # skill://%2fetc decodes to "/etc", and Path(root) / "/etc" IS "/etc":
+        # the diagnostic distinguished "this absolute path exists" from "it does
+        # not" for ANY path on the host.
+        root = tmp_path / "roots" / "skills"
+        root.mkdir(parents=True)
+        existing = tmp_path / "outside"
+        existing.mkdir()
+        assert diagnose_missing_skill(str(existing), [root]) is None
+        assert diagnose_missing_skill("/definitely/not/there/xyz", [root]) is None
+
+    def test_relative_traversal_name_does_not_leak_frontmatter(self, tmp_path: Path) -> None:
+        # The leak with teeth: an out-of-root SKILL.md's frontmatter `name`
+        # came back in the "declares name '...'" message.
+        secret = self._outside(tmp_path)
+        root = tmp_path / "roots" / "skills"
+        root.mkdir(parents=True)
+        message = diagnose_missing_skill(f"../../outside/{secret.name}", [root])
+        assert message is None
+
+    def test_separator_bearing_names_never_touch_the_filesystem(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Rejection happens BEFORE any stat, not merely before the message.
+
+        A malformed URL that still spends a real probe defeats the design rule
+        that unsafe input must not drive filesystem work, even when its output
+        is safe.
+        """
+        import local_operator.skills.discovery as discovery_module
+
+        root = tmp_path / "roots" / "skills"
+        root.mkdir(parents=True)
+
+        def explode(*_args: object, **_kwargs: object) -> bool:
+            raise AssertionError("an unsafe name must not reach the filesystem")
+
+        monkeypatch.setattr(discovery_module.Path, "is_dir", explode)
+        for name in ("..", "/etc", "a/b", "..\\..\\x", ".", ""):
+            assert diagnose_missing_skill(name, [root]) is None
+
+    def test_a_plain_name_still_diagnoses(self, tmp_path: Path) -> None:
+        # The guard must not swallow the legitimate case it sits in front of.
+        root = tmp_path / "roots" / "skills"
+        (root / "alpha").mkdir(parents=True)
+        message = diagnose_missing_skill("alpha", [root])
+        assert message is not None and "has no SKILL.md" in message

--- a/tests/unit/skills/test_discovery.py
+++ b/tests/unit/skills/test_discovery.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
 
 from local_operator.skills.discovery import (
     Skill,
+    diagnose_missing_skill,
     discover_skills,
     parse_frontmatter,
+    roots_fingerprint,
     scan_skills_dir,
 )
 
@@ -269,3 +272,138 @@ class TestDiscoverSkills:
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))
+
+
+class TestRootsFingerprint:
+    """The gate that decides whether a full 17-25 ms scan runs at all."""
+
+    def test_new_skill_directory_changes_the_fingerprint(self, tmp_path: Path) -> None:
+        root = tmp_path / "skills"
+        root.mkdir()
+        before = roots_fingerprint([root])
+        _write_skill(root, "alpha")
+        assert roots_fingerprint([root]) != before
+
+    def test_skill_md_created_in_an_existing_directory_changes_it(self, tmp_path: Path) -> None:
+        root = tmp_path / "skills"
+        root.mkdir()
+        (root / "alpha").mkdir()
+        before = roots_fingerprint([root])
+        (root / "alpha" / "SKILL.md").write_text("---\ndescription: A skill.\n---\n# Body")
+        assert roots_fingerprint([root]) != before
+
+    def test_skill_md_edited_in_place_changes_it(self, tmp_path: Path) -> None:
+        """The row that makes per-file stats mandatory.
+
+        Neither the root's nor the child's mtime moves for an in-place edit, so
+        a fingerprint built from directory mtimes alone would report "no
+        change" -- and this is a REAL case: a skill dropped at discovery for a
+        blank ``description`` is absent from the mapping, so repairing its
+        frontmatter is exactly a miss the gate has to notice.
+        """
+        root = tmp_path / "skills"
+        root.mkdir()
+        skill_md = _write_skill(root, "alpha", description=None)
+        root_mtime = root.stat().st_mtime_ns
+        child_mtime = (root / "alpha").stat().st_mtime_ns
+        before = roots_fingerprint([root])
+
+        # Rewrite with a description and a different length, preserving the
+        # directory mtimes the naive fingerprint would have relied on.
+        os.utime(skill_md, ns=(root_mtime + 1_000_000, root_mtime + 1_000_000))
+        skill_md.write_text("---\ndescription: Now it has one.\n---\n# Body")
+        os.utime(root, ns=(root_mtime, root_mtime))
+        os.utime(root / "alpha", ns=(child_mtime, child_mtime))
+
+        assert root.stat().st_mtime_ns == root_mtime
+        assert (root / "alpha").stat().st_mtime_ns == child_mtime
+        assert roots_fingerprint([root]) != before
+
+    def test_unchanged_tree_is_stable(self, tmp_path: Path) -> None:
+        root = tmp_path / "skills"
+        root.mkdir()
+        _write_skill(root, "alpha")
+        assert roots_fingerprint([root]) == roots_fingerprint([root])
+
+    def test_missing_root_appearing_is_a_change(self, tmp_path: Path) -> None:
+        root = tmp_path / "later"
+        before = roots_fingerprint([root])
+        root.mkdir()
+        assert roots_fingerprint([root]) != before
+
+    def test_never_raises_on_a_hostile_tree(self, tmp_path: Path) -> None:
+        # Tolerance must match the scanner's: a symlink loop or a vanishing
+        # entry yields a shorter tuple, never an exception on the read path.
+        root = tmp_path / "skills"
+        root.mkdir()
+        (root / "loop").symlink_to(root)
+        (root / "dangling").symlink_to(tmp_path / "nowhere")
+        (root / "plain.txt").write_text("not a directory")
+        assert isinstance(roots_fingerprint([root]), tuple)
+
+
+class TestDiagnoseMissingSkill:
+    """One message per real cause, each naming its own remedy."""
+
+    def test_directory_without_skill_md(self, tmp_path: Path) -> None:
+        root = tmp_path / "skills"
+        (root / "alpha").mkdir(parents=True)
+        message = diagnose_missing_skill("alpha", [root])
+        assert message is not None
+        assert "has no SKILL.md" in message
+
+    def test_missing_description(self, tmp_path: Path) -> None:
+        root = tmp_path / "skills"
+        root.mkdir()
+        _write_skill(root, "alpha", description=None)
+        message = diagnose_missing_skill("alpha", [root])
+        assert message is not None
+        assert "no 'description'" in message
+        assert "Add one and read the URL again" in message
+
+    def test_malformed_frontmatter(self, tmp_path: Path) -> None:
+        root = tmp_path / "skills"
+        (root / "alpha").mkdir(parents=True)
+        # Opens a block and never closes it.
+        (root / "alpha" / "SKILL.md").write_text("---\ndescription: Unterminated.\n\n# Body")
+        message = diagnose_missing_skill("alpha", [root])
+        assert message is not None
+        assert "malformed YAML frontmatter" in message
+
+    def test_disabled_skill(self, tmp_path: Path) -> None:
+        root = tmp_path / "skills"
+        root.mkdir()
+        _write_skill(root, "alpha", enabled=False)
+        message = diagnose_missing_skill("alpha", [root])
+        assert message is not None
+        assert "disabled by 'enabled: false'" in message
+
+    def test_frontmatter_name_differs_from_directory(self, tmp_path: Path) -> None:
+        root = tmp_path / "skills"
+        root.mkdir()
+        _write_skill(root, "alpha", name="actual-name")
+        message = diagnose_missing_skill("alpha", [root])
+        assert message is not None
+        # Names the URL that actually works rather than calling it an error:
+        # the divergence is legal, documented behaviour.
+        assert "skill://actual-name" in message
+        assert "frontmatter name wins" in message
+
+    def test_shadowed_by_an_earlier_root(self, tmp_path: Path) -> None:
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        first.mkdir()
+        second.mkdir()
+        _write_skill(first, "alpha")
+        _write_skill(second, "alpha")
+        message = diagnose_missing_skill("alpha", [first, second])
+        assert message is not None
+        assert "is shadowed by the one at" in message
+        assert "earlier roots win" in message
+
+    def test_nothing_on_disk_says_nothing(self, tmp_path: Path) -> None:
+        # A genuine typo has no remedy to name; the bare "Unknown skill" with
+        # its available-names list is already the right answer.
+        root = tmp_path / "skills"
+        root.mkdir()
+        assert diagnose_missing_skill("absent", [root]) is None

--- a/tests/unit/skills/test_discovery.py
+++ b/tests/unit/skills/test_discovery.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import importlib.util
 import os
+import types
 from pathlib import Path
 
 import pytest
@@ -17,6 +19,37 @@ from local_operator.skills.discovery import (
     roots_fingerprint,
     scan_skills_dir,
 )
+
+
+def _discovery_under_os_name(platform_name: str) -> types.ModuleType:
+    """Re-execute ``discovery.py`` with ``os.name`` forced, and return the copy.
+
+    Module-level constants derived from the platform are fixed at import time,
+    so the only way to observe the DERIVATION (rather than its result on this
+    host) is to run the module body again under each platform name.
+
+    Loaded under a distinct module name rather than ``importlib.reload``-ing
+    the live one, matching ``tests/unit/test_xdist_worker_budget.py``: the
+    session running this test already holds
+    ``local_operator.skills.discovery`` and many other modules hold references
+    INTO it, so rebinding its constant -- even transiently -- would change the
+    behaviour of concurrently running tests in the same worker. This private
+    copy is discarded when the test ends.
+
+    The spec is built BEFORE the patch and only ``exec_module`` runs under it:
+    importlib resolves a source path with the running platform's rules, so a
+    spec created while ``os.name == "nt"`` treats this absolute POSIX path as
+    relative, joins it onto the cwd with backslashes, and raises
+    ``FileNotFoundError`` before the module body ever runs.
+    """
+    source = Path(discovery_module.__file__)
+    spec = importlib.util.spec_from_file_location("_skills_discovery_under_test", source)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(os, "name", platform_name)
+        spec.loader.exec_module(module)
+    return module
 
 
 def _write_skill(
@@ -549,6 +582,34 @@ class TestPlainSkillNameDriveRuleIsPlatformGated:
         and opening the drive door on Windows, which is precisely the bug.
         """
         assert discovery_module._DRIVE_RESETS_JOIN == (os.name == "nt")
+
+    def test_the_gate_derives_both_ways_from_os_name(self) -> None:
+        """R10/Q2: the derivation above is TAUTOLOGICAL on the host that runs it.
+
+        ``_DRIVE_RESETS_JOIN == (os.name == "nt")`` compares the constant to the
+        same expression that produced it, so on this POSIX host both sides are
+        ``False`` for any module whose constant is ``False`` -- including a
+        hardcoded ``False``, which is exactly the direction that reopens the
+        Windows existence oracle the drive rule exists to close. (An INVERTED
+        or hardcoded-``True`` derivation is caught, because those disagree with
+        POSIX; only the dangerous direction survives.) No CI leg closes it
+        either: ``filesystem-boundaries-windows`` runs two boundary files and
+        never these tests, and it cannot be widened to run them -- three tests
+        here ``mkdir`` a literal ``a:b`` directory, which Windows parses as
+        drive-relative and refuses to create.
+
+        So evaluate the derivation itself under BOTH platform names, which
+        needs no Windows runner: re-execute the module source with ``os.name``
+        patched and read what the constant comes out as. A constant that
+        ignores ``os.name`` now fails on the ``nt`` side.
+        """
+        for platform_name, expected in (("nt", True), ("posix", False)):
+            fresh = _discovery_under_os_name(platform_name)
+            assert fresh._DRIVE_RESETS_JOIN is expected, platform_name
+            # The derivation is only worth pinning because the predicate reads
+            # it: prove the gate actually reaches behaviour in this same copy.
+            assert fresh.is_plain_skill_name("D:x") is (not expected), platform_name
+            assert fresh.is_plain_skill_name("plain-one") is True, platform_name
 
     def test_unpatched_predicate_matches_this_hosts_semantics(self) -> None:
         """End-to-end on the REAL host, with no seam patched at all.

--- a/tests/unit/skills/test_discovery.py
+++ b/tests/unit/skills/test_discovery.py
@@ -498,6 +498,13 @@ class TestDiagnoseMissingSkillContainment:
         A malformed URL that still spends a real probe defeats the design rule
         that unsafe input must not drive filesystem work, even when its output
         is safe.
+
+        ``D:x`` and ``a:b`` are the DRIVE-RELATIVE shapes: not absolute by
+        ``is_absolute()``, yet ``PureWindowsPath(root) / "D:x"`` is ``"D:x"``
+        outright, so on Windows they reset the join exactly as an absolute path
+        does. They are listed here rather than in a Windows-only test because
+        the predicate is platform-independent by design -- see
+        :func:`is_plain_skill_name`.
         """
         import local_operator.skills.discovery as discovery_module
 
@@ -508,7 +515,7 @@ class TestDiagnoseMissingSkillContainment:
             raise AssertionError("an unsafe name must not reach the filesystem")
 
         monkeypatch.setattr(discovery_module.Path, "is_dir", explode)
-        for name in ("..", "/etc", "a/b", "..\\..\\x", ".", ""):
+        for name in ("..", "/etc", "a/b", "..\\..\\x", ".", "", "D:x", "a:b"):
             assert diagnose_missing_skill(name, [root]) is None
 
     def test_a_plain_name_still_diagnoses(self, tmp_path: Path) -> None:

--- a/tests/unit/skills/test_discovery.py
+++ b/tests/unit/skills/test_discovery.py
@@ -7,10 +7,12 @@ from pathlib import Path
 
 import pytest
 
+import local_operator.skills.discovery as discovery_module
 from local_operator.skills.discovery import (
     Skill,
     diagnose_missing_skill,
     discover_skills,
+    is_plain_skill_name,
     parse_frontmatter,
     roots_fingerprint,
     scan_skills_dir,
@@ -499,12 +501,9 @@ class TestDiagnoseMissingSkillContainment:
         that unsafe input must not drive filesystem work, even when its output
         is safe.
 
-        ``D:x`` and ``a:b`` are the DRIVE-RELATIVE shapes: not absolute by
-        ``is_absolute()``, yet ``PureWindowsPath(root) / "D:x"`` is ``"D:x"``
-        outright, so on Windows they reset the join exactly as an absolute path
-        does. They are listed here rather than in a Windows-only test because
-        the predicate is platform-independent by design -- see
-        :func:`is_plain_skill_name`.
+        The DRIVE-RELATIVE shapes (``D:x``, ``a:b``) are deliberately absent
+        from this list: they are rejected only on Windows, and are covered in
+        both directions by :class:`TestPlainSkillNameDriveRuleIsPlatformGated`.
         """
         import local_operator.skills.discovery as discovery_module
 
@@ -515,7 +514,7 @@ class TestDiagnoseMissingSkillContainment:
             raise AssertionError("an unsafe name must not reach the filesystem")
 
         monkeypatch.setattr(discovery_module.Path, "is_dir", explode)
-        for name in ("..", "/etc", "a/b", "..\\..\\x", ".", "", "D:x", "a:b"):
+        for name in ("..", "/etc", "a/b", "..\\..\\x", ".", ""):
             assert diagnose_missing_skill(name, [root]) is None
 
     def test_a_plain_name_still_diagnoses(self, tmp_path: Path) -> None:
@@ -524,3 +523,106 @@ class TestDiagnoseMissingSkillContainment:
         (root / "alpha").mkdir(parents=True)
         message = diagnose_missing_skill("alpha", [root])
         assert message is not None and "has no SKILL.md" in message
+
+
+class TestPlainSkillNameDriveRuleIsPlatformGated:
+    """R9: the drive door shuts on Windows only, because ``:`` is legal on POSIX.
+
+    Gating the drive rejection on every platform rejected a name the POSIX
+    scanner genuinely registers, so a legitimately-named skill silently lost
+    the mid-session authoring refresh this PR exists to deliver -- and its
+    miss-path diagnostic with it. Both directions are asserted here rather
+    than left to whichever CI leg happens to run, by driving
+    ``_DRIVE_RESETS_JOIN`` (the seam) in each position.
+    """
+
+    # Every shape pathlib parses as a drive: it accepts ANY single printable
+    # character as a drive letter, so the rule is not limited to ``[A-Za-z]``.
+    _DRIVE_SHAPES = ("D:x", "a:b", "C:", "1:x", "#:x")
+
+    def test_the_gate_is_derived_from_the_running_platform(self) -> None:
+        """The seam every other test in this class DRIVES must itself be right.
+
+        Patching ``_DRIVE_RESETS_JOIN`` proves what each branch does but says
+        nothing about which branch a real host takes -- an inverted derivation
+        would satisfy every other assertion here while denying POSIX skills
+        and opening the drive door on Windows, which is precisely the bug.
+        """
+        assert discovery_module._DRIVE_RESETS_JOIN == (os.name == "nt")
+
+    def test_unpatched_predicate_matches_this_hosts_semantics(self) -> None:
+        """End-to-end on the REAL host, with no seam patched at all.
+
+        Belt and braces for the test above: on POSIX ``a:b`` must be admitted
+        for real, not merely when the constant is forced.
+        """
+        expected = os.name != "nt"
+        for name in self._DRIVE_SHAPES:
+            assert is_plain_skill_name(name) is expected, name
+
+    def test_posix_admits_drive_relative_shapes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """On POSIX ``root / "a:b"`` is a contained child, so it must be admitted."""
+        monkeypatch.setattr(discovery_module, "_DRIVE_RESETS_JOIN", False)
+        for name in self._DRIVE_SHAPES:
+            assert is_plain_skill_name(name) is True, name
+
+    def test_windows_rejects_drive_relative_shapes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """On Windows the drive resets the join, so it stays an existence oracle."""
+        monkeypatch.setattr(discovery_module, "_DRIVE_RESETS_JOIN", True)
+        for name in self._DRIVE_SHAPES:
+            assert is_plain_skill_name(name) is False, name
+
+    def test_root_and_separator_rejection_is_unconditional(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only the DRIVE term is gated; every other rejection holds everywhere."""
+        for gate in (False, True):
+            monkeypatch.setattr(discovery_module, "_DRIVE_RESETS_JOIN", gate)
+            for name in ("", ".", "..", "/etc", "\\x", "a/b", "a\\b", "a\x00b", "D:/x"):
+                assert is_plain_skill_name(name) is False, (gate, name)
+            for name in ("plain-one", "notes:2024", "alpha"):
+                assert is_plain_skill_name(name) is True, (gate, name)
+
+    def test_scanner_and_predicate_agree_on_posix(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The regression with teeth: the real scanner DOES produce ``a:b``.
+
+        A predicate that rejects a name ``scan_skills_dir`` registers makes the
+        refresh gate disagree with discovery, which is exactly how the skill
+        lost its liveness.
+        """
+        monkeypatch.setattr(discovery_module, "_DRIVE_RESETS_JOIN", False)
+        root = tmp_path / "roots" / "skills"
+        root.mkdir(parents=True)
+        for dirname in ("a:b", "notes:2024", "plain-one"):
+            _write_skill(root, dirname, name=dirname)
+        registered = [s.name for s in scan_skills_dir(root, "test")]
+        assert "a:b" in registered
+        for name in registered:
+            assert is_plain_skill_name(name) is True, name
+
+    def test_posix_drive_shape_still_gets_a_diagnostic(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Admitting the name must also restore the miss-path explanation."""
+        monkeypatch.setattr(discovery_module, "_DRIVE_RESETS_JOIN", False)
+        root = tmp_path / "roots" / "skills"
+        (root / "a:b").mkdir(parents=True)
+        message = diagnose_missing_skill("a:b", [root])
+        assert message is not None and "has no SKILL.md" in message
+
+    def test_windows_drive_shapes_spend_no_filesystem_work(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Under Windows semantics the denial is still BEFORE any stat."""
+        monkeypatch.setattr(discovery_module, "_DRIVE_RESETS_JOIN", True)
+        root = tmp_path / "roots" / "skills"
+        root.mkdir(parents=True)
+
+        def explode(*_args: object, **_kwargs: object) -> bool:
+            raise AssertionError("a drive-anchored name must not reach the filesystem")
+
+        monkeypatch.setattr(discovery_module.Path, "is_dir", explode)
+        for name in self._DRIVE_SHAPES:
+            assert diagnose_missing_skill(name, [root]) is None, name

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -752,6 +752,44 @@ async def test_knowledge_backend_failure_degrades_to_no_listing(
 
 
 @pytest.mark.asyncio
+async def test_knowledge_discovery_uses_the_session_cwd_not_the_process_cwd(
+    tmp_config_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Project-local skills must follow the SESSION's cwd.
+
+    Sessions are created with an explicit cwd by bootstrap, the scheduler and
+    owned runtimes; discovery used ``Path.cwd()`` and so scanned whatever
+    directory the process happened to start in. Every other consumer in
+    ``create_session`` already takes the session's cwd.
+    """
+    session_dir = tmp_path / "session-project"
+    process_dir = tmp_path / "process-project"
+    for base, skill_name in ((session_dir, "session-skill"), (process_dir, "process-skill")):
+        skill_dir = base / ".local-operator" / "skills" / skill_name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {skill_name}\ndescription: Belongs to {base.name}.\n---\n\nBody."
+        )
+    # The process sits in the WRONG directory: if the cwd argument were
+    # ignored, discovery would find process-skill instead.
+    monkeypatch.chdir(process_dir)
+
+    warnings: list[str] = []
+    hooks = await session_factory._setup_knowledge(
+        MagicMock(),
+        tmp_config_dir,
+        cast(Any, FakeRegistry(tmp_config_dir)),
+        warnings,
+        str(session_dir),
+    )
+
+    assert "session-skill" in hooks.skills_by_name
+    assert "process-skill" not in hooks.skills_by_name
+    # The roots are retained so the resolver can rescan the SAME set on a miss.
+    assert session_dir / ".local-operator" / "skills" in hooks.skill_roots
+
+
+@pytest.mark.asyncio
 async def test_knowledge_backend_failure_falls_back_to_local_routing(
     tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/tui/test_skill_invocation.py
+++ b/tests/unit/tui/test_skill_invocation.py
@@ -131,6 +131,37 @@ async def test_invocation_sends_body_and_request(skill_root) -> None:
 
 
 @pytest.mark.asyncio
+async def test_skill_created_after_app_start_is_invocable(skill_root) -> None:
+    """``$name`` must reach a skill authored mid-session, without a restart.
+
+    ``_discovered_skills`` used to cache for the life of the app, justified by
+    the rule that a new skill needed a restart to be visible anywhere. The
+    resolver now rescans on a miss, so leaving this cached would have made the
+    composer the one surface still requiring a restart.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        # Populate the cache first: the interesting case is invalidation, not
+        # a cold read that would have walked the filesystem anyway.
+        assert "research" in app._discovered_skills()
+
+        late = skill_root / "late-arrival"
+        late.mkdir(parents=True)
+        (late / "SKILL.md").write_text(
+            "---\nname: late-arrival\ndescription: Arrived late.\n---\n\nLate body."
+        )
+
+        await _submit(app, pilot, "$late-arrival do the thing")
+        await _await_prompt(pilot, session)
+    assert len(session.prompts) == 1
+    sent = session.prompts[0]
+    assert "Late body." in sent
+    assert "do the thing" in sent
+
+
+@pytest.mark.asyncio
 async def test_transcript_shows_what_was_typed_not_the_body(skill_root) -> None:
     """The row is the user's line; the injected body never lands in the ledger."""
     session = FakeSession()


### PR DESCRIPTION
## What

A skill authored mid-session is now readable immediately — in the session that wrote it **and in subagents already running** — without a restart.

Design: `docs/design-skill-authoring-liveness.md` (written by the architect this session, included in this PR). It weighs the alternatives; this PR implements its recommendation.

## The defect, as reported

An agent wrote a valid skill to `~/.local-operator/skills/lean-formalization/SKILL.md` — a native global root, exactly where the docs say to put one. It was then invisible to `read skill://lean-formalization` for the rest of the session. A subagent launched afterward, whose standing instructions said *"FIRST, EVERY TIME: read `skill://lean-formalization`"*, got `Unknown skill`, **correctly refused to fabricate**, and improvised from the repo instead. The operator's standing instructions were silently unfollowable.

Root cause: `discover_skills` ran **once** at session construction; `make_skill_resolver` closed over that snapshot; children inherit the parent's closure verbatim, so a child's skill catalogue *was* the parent's startup snapshot. No rescan path existed anywhere.

Narrower than it looks: skill *bodies* were always live (the file is opened at resolve time). Only `name → Skill` **membership** was frozen. That is what this fixes.

## How

**Refresh-on-miss, fingerprint-gated, in the resolver.** On a miss only: a cheap fingerprint; the full scan runs only when the tree actually changed. The gate is a **stat, never a clock** — a 1 s cooldown was in round 1 and was removed in remediation (R2), because it made a skill written 50 ms after a miss unreadable for a second.

Measured on this machine (7 roots, 17 skills), matching the design's figures:

| operation | cost |
|---|---|
| full `discover_skills` scan | **27.6 ms** |
| fingerprint probe | **0.278 ms** (99× cheaper) |
| **hit path** (dict lookup + file read) | **0.206 ms** |

The hit path is untouched: nothing above the lookup runs when the skill exists.

The fingerprint is per-`SKILL.md` `(mtime_ns, size)`, not root-dir mtime. That is load-bearing and measured, not assumed: editing a `SKILL.md` **in place bumps neither the root nor the child directory mtime** — and that is a real case, because a skill dropped for a blank `description` is absent from the mapping, so repairing its frontmatter is exactly a miss a dir-mtime gate cannot see. `tests/unit/skills/test_discovery.py::test_skill_md_edited_in_place_changes_it` pins the mtimes back to prove it.

**The refresh mutates the mapping IN PLACE (`.update()`, never rebinding).** This is the entire propagation story — `session_factory`, the parent resolver and every child hold one dict object. A rebinding refactor breaks every running child **silently**, with no exception and no test failure unless one is written for it. So the guard test asserts liveness **through a child resolver**, not the parent. Verified it works as a guard by mutating the source to `skills = {**skills, ...}`: 4 tests fail, including the child test. Restored, green.

> **Corrected after QA round 1.** The claim above is right for that rebinding shape but was overstated as a general one, and QA reproduced the counter-example. The other plausible refactor — a defensive copy, `skills = dict(skills)` at the top of `make_skill_resolver` — fails only **2** tests (`test_refresh_mutates_the_mapping_in_place`, `test_deleted_skill_stays_in_the_mapping_and_reads_as_oserror`), and the CHILD test **passes**, because that test builds its child from the same resolver whose copy is being mutated. The guard genuinely holds for both shapes, but for the defensive-copy shape the surviving guard is the **identity** test, not the child test. Both are load-bearing; neither is redundant.

Refresh only **adds**, never removes: a skill deleted from disk keeps its entry and degrades to a clean `[Errno 2]` message, so one agent's cleanup cannot break a sibling child mid-read.

Only an *unknown-name* `ValueError` **whose name is a plain path segment** triggers a rescan — traversal and dotfile rejections must not let a malformed URL drive filesystem work, and a skill name is a URL's *netloc*, which the protocol's path guards never inspect (Q1).

## Diagnostics: one opaque message became six actionable ones

`Unknown skill` was emitted identically for causes an agent could not tell apart, leaving it no next move except grepping the filesystem — which the system prompt forbids. Real output, captured from the run below:

| cause | message |
|---|---|
| no `SKILL.md` | `A directory 'empty-dir' exists at <root> but has no SKILL.md.` |
| blank `description` | `<path> has no 'description' in its frontmatter; skills without one are not loaded. Add one and read the URL again.` |
| frontmatter `name` ≠ dir | `<path> declares name 'actually-this'; read skill://actually-this (the frontmatter name wins over the directory name).` |
| malformed frontmatter | `<path> has malformed YAML frontmatter (it must open and close with ---).` |
| `enabled: false` | `'switched-off' is disabled by 'enabled: false' in <path>.` |
| shadowed | `'shadowed' at <loser> is shadowed by the one at <winner> (earlier roots win). Rename it or edit the winner.` |

Diagnosis runs **only** after a refresh has already failed, and only for a name a root scan could actually have produced. A retry loop on a typo pays one sub-millisecond stat per read and **never** a scan, because an unchanged tree compares equal — that, not a clock, is the bound.

## Secondary bug fixed (in scope, per the design)

`_setup_knowledge` computed roots from `Path.cwd()` rather than the session's cwd, so a session created with an explicit cwd (bootstrap, scheduler, owned runtimes) discovered project-local skills for **whatever directory the process happened to start in**. `effective_cwd` was already in scope and already passed to every other consumer. Test proves it by putting the process in the wrong directory; reverting the fix makes it fail with `process-skill` found instead of `session-skill`.

## Evidence — the reported defect, gone

A green unit suite is **not** evidence of this fix, so `scripts/evidence_skill_liveness.py` builds a **real session**, builds a **real child before the skill exists** (via `_build_child_session`, the same path `task` uses), authors the skill, and reads it back through `_build_tool_context().resolve_internal_url` — the actual `read`-tool path. Sandboxed `HOME` + config dir; confirmed no artifacts reached the operator's real skill root.

```
skill exists yet?  : False

--- BEFORE — child reads skill://lean-formalization ---
Unknown skill: lean-formalization
Available: (none)

authored           : .../home/.local-operator/skills/lean-formalization/SKILL.md

--- IMMEDIATELY AFTER the write - no sleep ---
---
name: lean-formalization
description: Formalize mathematical arguments in Lean 4.
---

# Lean formalization

State the theorem before writing tactics.

--- AFTER — child reads skill://lean-formalization ---
---
name: lean-formalization
description: Formalize mathematical arguments in Lean 4.
---

# Lean formalization

State the theorem before writing tactics.

=== RESULT: child resolved the late-authored skill: True ===
```

**Re-captured after remediation.** In round 1 this same read returned `Unknown skill` because the cooldown had not expired; it is now shown with **no sleep at all**, because write-then-read in the same millisecond is the normal authoring sequence and it must work.

Two things I found while capturing this and am reporting rather than papering over:

- **The shadow case is not reachable through a URL read.** If the winning copy loads, it also claims the name, so the read *hits*. The evidence shows both halves honestly — the read returning the project copy, and `diagnose_missing_skill` naming loser and winner. The message still matters: it is the one collision outcome a user can otherwise never see (the startup warning list is printed once and lost — this machine emits 37 of them).
- **`parse_frontmatter` collapses "malformed" and "well-formed but empty" into `{}`.** Reporting "malformed frontmatter" to an author whose block is fine but lacks a `description` sends them to fix the one thing that is not broken, so the diagnostic distinguishes them.

## Tests

- **The child-resolver guard** (the important one) — liveness asserted through a child, catching the silent rebinding refactor.
- Mapping identity is `is`-stable across a refresh.
- Hit path does no filesystem work (fingerprint monkeypatched to raise).
- Unchanged fingerprint skips the scan; a looping typo probes per miss but never rescans (the stat is the bound). No fake clock is needed any more, because no clock is in the path.
- **Two real threads** missing the same new name concurrently both resolve it (R1) — the test asserts the mapping provably contains the name at the moment the losing reader answered.
- A transient scan `OSError` does not freeze the fingerprint (R3); an unquoted colon is reported as invalid YAML rather than a missing description (R4); `skill://..`, `skill://%2fetc` and separator-bearing names return nothing and spend **zero** probes (Q1).
- Unsafe-path `ValueError` does not trigger a refresh; deleted skill degrades cleanly; `roots=None` reproduces today's behaviour byte-for-byte.
- All three fingerprint mutation shapes, incl. the in-place edit; hostile tree (symlink loop, dangling link) never raises.
- Every diagnostic row; `$name` reaches a skill created after app start (verified failing against the old session-lifetime cache).

## Not done, deliberately

- **No `skill` tool** (design §2A: rung 5 of the footprint ladder for a rare action — `write` already does it).
- **The semantic index and frozen `<skills>` block are not rebuilt.** Rebuilding burns the prompt-cache prefix for the whole session, and `SkillIndex.build()` is async while the resolver is synchronous by contract (`harness/types.py:772`) — making it async would mean async internal-URL resolution everywhere. So: **semantic selection updates next session; explicit reads work immediately.** `guide://extensions` now states that split in those terms instead of "start a new session", and gains where-to-put-it and required-frontmatter guidance.
- Roots that did not exist at startup are still not picked up (documented in the design, not fixed).

## Gates

flake8, `black --check` (26.1.0), `isort --check` (5.13.2), pyright (1.1.411 pin) — all clean over the whole tree. Full unit suite run via `.venv/bin/python` exactly as CI; TUI tests under `env -u NO_COLOR TERM=xterm-256color`.

No version bump — `pyproject.toml` stays at 0.53.1.



---

## Round 1 remediation

All five findings (R1 blocker, R2–R4 major, Q1 major) are fixed in `de1549b7a`, one batched commit. See the remediation comment for the per-finding disposition and the before/after test evidence. `pyproject.toml` still at 0.53.1 — no version bump.
