### PR TITLE
chore(release): bump version to 0.53.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.53.2"
+version = "0.53.3"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release lock for the post-v0.53.2 window. `pyproject.toml` only, one line.

## Window

Derived from `origin/main` immediately before opening this PR:

- Last tag: **v0.53.2** (`d8f596cf6`)
- `git log v0.53.2..origin/main` → one commit

| PR | Merge SHA | Impact |
|---|---|---|
| [#864](https://github.com/damianvtran/local-operator/pull/864) | `51c71ff6f` | the phone stops silently dropping refusals, failed turns, interrupted turns and unattended gate timeouts; adds a per-PR mobile-web CI gate |

## Bump class: PATCH

Bug fixes on an existing surface plus a new CI job. No API addition, no wire or protocol change, no migration. The fix *restores* rows the phone should always have rendered rather than adding a capability, so it does not clear the step-function bar a minor would need.

## What rides in it

`mobile/projection.py` carried two independent folds over `AgentMessage` whose own docstrings asserted they must not diverge — and they already had. Twelve divergence classes, verified by execution: on one real 8-message transcript the TUI rendered 9 rows and the phone rendered 6.

The phone dropped refusals, failed turns, interrupted turns, unattended gate timeouts and compaction-refused notices outright, because its fold had no `stop_reason` branch. It also rendered an unanswered tool call as **succeeded** (`tool_state` defaulted to `"done"`), showed an entire expanded `SKILL.md` as the user's own bubble, and rendered harness continuation prompts as the user's words. The headline: a hub/parent steer rendered as a clean card on a history page but leaked the raw `<parent-message>` XML envelope on the attach seed — the phone contradicting itself across one scroll gesture. Measured on real transcripts: 6 and 7 leaked envelope rows on two sessions (535 and 888 messages) → 0 and 0.

## Note for future release owners: CI is now 17 checks

`pnpm build` previously ran in exactly one workflow — `publish.yml`, **post-tag**. A TypeScript error under `local_operator/mobile/web/**` therefore showed green on a PR and detonated on whoever cut the next tag, attributing someone else's defect to the release owner. The 84 web tests and theme generation also ran nowhere on PRs.

#864 adds a paths-gated `mobile-web.yml` running build, typecheck, web tests and theme generation per-PR. It was falsified rather than assumed: QA opened a throwaway PR to fire a real `pull_request` event and confirmed the job goes **red** on a reintroduced error (run `34420622114`).

## Ownership

Announced to every live lop-dev peer before cutting; twelve replied, none contested, none had merged-but-unreleased work. Known latecomers, none waited on: #881, #882, #883, #885, plus OAuth, credential-redaction, skill-liveness and OSWorld-resume work still pre-PR.

## Scope check

The diff is one line in `pyproject.toml` (`0.53.2` → `0.53.3`). No source, test, or workflow file is touched, so the C0 one-file scope check is the appropriate gate.

Note: `main` is intermittently red on four clock/PID-registry races (`test_word_caret.py`, two in `test_stop_command.py`, `test_resume_subagents_todos.py`) that a one-line version diff cannot reach. A single red shard here warrants a re-run, not an investigation.