### PR TITLE
fix(evaluation): recover when a model selects the tool channel and emits nothing

### DIFF
--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -1099,36 +1099,50 @@ class ProviderModelClient:
                 compaction=compaction,
             )
         try:
-            # A ``toolUse`` stop that carried NO tool call and NO text is a model
-            # that chose the tool channel and then put nothing on it. Left alone it
-            # reaches ``parse_decision`` as an empty string, which reports "decision
-            # is not valid JSON" -- so the runner re-prompts the model to fix JSON
-            # it never wrote, and the correction cannot land because it names the
-            # wrong defect.
+            # A reply that produced NO tool call and NO text said nothing at
+            # all, whatever terminal marker it carried. Left alone it reaches
+            # ``parse_decision`` as an empty string, which reports "decision is
+            # not valid JSON" -- so the runner re-prompts the model to fix JSON
+            # it never wrote, and the correction cannot land because it names a
+            # defect that does not exist. The retry bound is then spent on the
+            # same non-answer and the episode seals as a model failure.
             #
-            # Measured on minimax/minimax-m3: ~8% of replies on a routine screen and
-            # ~60% on a screen that looks already-complete come back this way, after
-            # spending output tokens entirely on reasoning. That killed a first paid
-            # episode at 3 calls. The failures are CORRELATED within an observation
-            # (three in a row is a 1-in-1700 event if independent), so a bigger
-            # retry bound does not fix it -- the re-prompt has to say something
+            # Every NORMAL stop reason can produce this shape, so the guard is
+            # keyed on the SILENCE, not on the marker:
+            #   - ``toolUse``  -- the model selected the tool channel and put
+            #     nothing on it. Measured on minimax/minimax-m3: ~8% of replies
+            #     on a routine screen, and 6 of 10 on a screen that looks
+            #     already-complete, come back this way after spending their
+            #     output tokens entirely on reasoning.
+            #   - ``stop``     -- observed in the same probe (1 of 12) and in a
+            #     real episode's third call, which recorded ``('stop', 0)`` with
+            #     no content.
+            #   - ``length``   -- a reply cut off before it emitted anything.
+            # An abnormal marker with empty text is already handled above; this
+            # closes the normal ones, which is the whole remainder of the set.
+            #
+            # Within one observation these failures are CORRELATED -- three in a
+            # row is a 1-in-1700 event under independence -- so a larger retry
+            # bound does not fix it. The re-prompt has to SAY something
             # different, which is exactly what the rejection path does.
             #
-            # Raised as a DecisionParseError, NOT a ProviderStreamAbortedError: an
-            # abort seals the episode as a provider failure with no retry at all,
-            # which is strictly worse than the status quo. This is the model's
-            # error and it is recoverable, so it takes the corrective-re-prompt
-            # path, where an explicit "you must reply with a tool call" turn is
-            # appended to the history. A 10-sample probe of that exact correction
-            # against a latched screen recovered 10/10, where escalating
-            # ``tool_choice`` to ``required`` recovered only 7/10 and a named tool
-            # choice 2/10.
-            if stop_reason == "toolUse" and tool_call_count == 0 and not text.strip():
+            # Raised as a DecisionParseError, NOT a ProviderStreamAbortedError:
+            # an abort seals the episode as an infrastructure failure with no
+            # retry at all (``episode.py`` re-raises it), which is strictly
+            # worse than the status quo. This is the model's error and it is
+            # recoverable, so it takes the corrective-re-prompt path, where an
+            # explicit instruction is appended to the history. A 10-sample probe
+            # of that exact correction against a latched screen recovered 10/10,
+            # where escalating ``tool_choice`` to ``required`` recovered 7/10
+            # and a named tool choice only 2/10 -- so the corrective turn is the
+            # remedy, not a stronger ``tool_choice``.
+            if tool_call_count == 0 and not text.strip():
                 raise DecisionParseError(
-                    "reply carried no tool call and no text: the tool channel was "
-                    "selected but nothing was emitted on it. Reply with the action "
-                    "batch itself, as a single JSON object with a non-empty "
-                    '"actions" array, and nothing else.'
+                    "reply carried no tool call and no text: the model ended its "
+                    f"turn as '{stop_reason}' without emitting a decision on "
+                    "either channel. Reply with the action batch itself, as a "
+                    'single JSON object with a non-empty "actions" array, and '
+                    "nothing else."
                 )
             return parse_decision(
                 text.strip(),

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -1099,6 +1099,37 @@ class ProviderModelClient:
                 compaction=compaction,
             )
         try:
+            # A ``toolUse`` stop that carried NO tool call and NO text is a model
+            # that chose the tool channel and then put nothing on it. Left alone it
+            # reaches ``parse_decision`` as an empty string, which reports "decision
+            # is not valid JSON" -- so the runner re-prompts the model to fix JSON
+            # it never wrote, and the correction cannot land because it names the
+            # wrong defect.
+            #
+            # Measured on minimax/minimax-m3: ~8% of replies on a routine screen and
+            # ~60% on a screen that looks already-complete come back this way, after
+            # spending output tokens entirely on reasoning. That killed a first paid
+            # episode at 3 calls. The failures are CORRELATED within an observation
+            # (three in a row is a 1-in-1700 event if independent), so a bigger
+            # retry bound does not fix it -- the re-prompt has to say something
+            # different, which is exactly what the rejection path does.
+            #
+            # Raised as a DecisionParseError, NOT a ProviderStreamAbortedError: an
+            # abort seals the episode as a provider failure with no retry at all,
+            # which is strictly worse than the status quo. This is the model's
+            # error and it is recoverable, so it takes the corrective-re-prompt
+            # path, where an explicit "you must reply with a tool call" turn is
+            # appended to the history. A 10-sample probe of that exact correction
+            # against a latched screen recovered 10/10, where escalating
+            # ``tool_choice`` to ``required`` recovered only 7/10 and a named tool
+            # choice 2/10.
+            if stop_reason == "toolUse" and tool_call_count == 0 and not text.strip():
+                raise DecisionParseError(
+                    "reply carried no tool call and no text: the tool channel was "
+                    "selected but nothing was emitted on it. Reply with the action "
+                    "batch itself, as a single JSON object with a non-empty "
+                    '"actions" array, and nothing else.'
+                )
             return parse_decision(
                 text.strip(),
                 observation,

--- a/local_operator/evaluation/runner/public_reply.py
+++ b/local_operator/evaluation/runner/public_reply.py
@@ -103,6 +103,40 @@ def decode_public_reply(payload: str) -> dict[str, Any]:
             "model reply must be one duplicate-free JSON object, with no trailing text"
         ) from error
     if not isinstance(value, dict) or set(value) != _ENVELOPE_KEYS:
+        # Name the DEFECT, not just the rule. Validation is unchanged -- a
+        # partial envelope is still rejected, because silently downgrading one
+        # to the legacy interpretation would drop whatever the model meant to
+        # put in ``public_observations``. What changes is what the model is
+        # told, and that decides whether the correction can land.
+        #
+        # Reserving every envelope key means touching ONE of them commits the
+        # reply to strict decoding, so the common failure is a near-miss: a
+        # model emits ``{"action_batch": {...}}`` and gets told the rule it
+        # already half-followed, without being told which half it missed.
+        # Measured on minimax/minimax-m3, which produces exactly that shape in
+        # ~1 of 10 replies: re-prompting with the bare rule recovered 4/10,
+        # while naming the keys present and missing recovered 9/10. The
+        # difference is the whole gap between an episode that continues and one
+        # that spends its retry bound and seals as a model failure -- which is
+        # how a paid canary episode died at three calls.
+        if isinstance(value, dict):
+            present = sorted(_ENVELOPE_KEYS & set(value))
+            missing = sorted(_ENVELOPE_KEYS - set(value))
+            extra = sorted(set(value) - _ENVELOPE_KEYS)
+            parts = []
+            if present:
+                parts.append("carried " + ", ".join(repr(key) for key in present))
+            if missing:
+                parts.append("omitted " + ", ".join(repr(key) for key in missing))
+            if extra:
+                parts.append("added unexpected " + ", ".join(repr(key) for key in extra))
+            raise ValueError(
+                "model reply used the reserved envelope but "
+                + "; ".join(parts)
+                + '. Reply with EITHER the plain batch {"actions": [...]} and no other '
+                "top-level keys, OR the full envelope with exactly reply_version, "
+                "action_batch, public_observations"
+            )
         raise ValueError(
             "model reply requires exactly reply_version, action_batch, public_observations"
         )

--- a/local_operator/evaluation/runner/public_reply.py
+++ b/local_operator/evaluation/runner/public_reply.py
@@ -24,11 +24,33 @@ _ENVELOPE_KEYS = {"reply_version", "action_batch", "public_observations"}
 #: diagnostic sent back to the model. The reserved keys are safe to name (they
 #: come from a fixed set), but any other key is model-supplied text: echoing it
 #: whole turns a malformed reply into an unbounded retry prompt and re-opens
-#: the replay channel the reserved-key suppression exists to close. Capped in
-#: both directions so neither one long key nor many short ones can rebuild a
-#: payload.
+#: the replay channel the reserved-key suppression exists to close.
+#:
+#: A key is quoted WHOLE or not at all -- never truncated. Truncation was the
+#: first attempt and it failed closed in neither direction (review round 3):
+#: ``repr`` expands escapes after the cut, so the rendered length depended on
+#: the input's alphabet; and, far worse, cutting a secret that appeared as a
+#: key left a prefix that ``_assert_redacted``'s substring check no longer
+#: matched, converting a loud redaction failure into a silent leak. Quoting
+#: whole-or-nothing means nothing is ever reshaped on the way out.
 _MAX_EXTRA_KEY_CHARS = 40
 _MAX_EXTRA_KEYS_SHOWN = 5
+
+
+def _is_quotable_key(key: str) -> bool:
+    """Whether an unexpected key may be named back to the model verbatim.
+
+    Conservative by construction: the key must be short, and must render to
+    exactly itself under ``repr`` minus the quotes. That second test is what
+    makes the bound independent of the alphabet -- anything carrying escapes,
+    control characters, or quote marks expands when rendered, so it is counted
+    rather than named.
+    """
+    if len(key) > _MAX_EXTRA_KEY_CHARS:
+        return False
+    rendered = repr(key)
+    return rendered[1:-1] == key
+
 
 REJECTED_PUBLIC_REPLY = "(model reply rejected; no public observations accepted)"
 
@@ -140,24 +162,39 @@ def decode_public_reply(payload: str) -> dict[str, Any]:
             if missing:
                 parts.append("omitted " + ", ".join(repr(key) for key in missing))
             if extra:
-                # ``present``/``missing`` are intersections with a fixed set,
-                # so they can only ever name the three reserved keys. ``extra``
-                # is arbitrary MODEL-SUPPLIED text and must never be echoed
-                # whole: a 50,000-character key produced a 50,000-character
-                # retry prompt, which neither ``MAX_REJECTED_REPLY_CHARS`` nor
+                # ``present``/``missing`` are intersections with a fixed set, so
+                # they can only ever name the three reserved keys. ``extra`` is
+                # arbitrary MODEL-SUPPLIED text and must never be echoed whole:
+                # a 50,000-character key produced a 50,000-character retry
+                # prompt, which neither ``MAX_REJECTED_REPLY_CHARS`` nor
                 # ``_diagnostic``'s cap intercepts, and which re-opens the
                 # replay channel the reserved-key suppression below closes.
                 #
-                # Bounded in BOTH directions -- each key truncated, and the
-                # number of keys quoted capped -- because either alone is
-                # enough to reconstruct a payload from many short keys.
-                shown = [
-                    key[:_MAX_EXTRA_KEY_CHARS] + ("…" if len(key) > _MAX_EXTRA_KEY_CHARS else "")
-                    for key in extra[:_MAX_EXTRA_KEYS_SHOWN]
-                ]
-                summary = ", ".join(repr(key) for key in shown)
-                if len(extra) > _MAX_EXTRA_KEYS_SHOWN:
-                    summary += f" and {len(extra) - _MAX_EXTRA_KEYS_SHOWN} more"
+                # A key is quoted only if it is ENTIRELY safe, and is otherwise
+                # counted but not named. Truncating instead was the first
+                # attempt and it failed closed in neither direction (review
+                # round 3):
+                #   - ``repr`` expands escapes AFTER a cut, so 40 characters of
+                #     ``\U000e0001`` still rendered ~700, making the bound
+                #     depend on the input's alphabet.
+                #   - worse, a cut CONVERTS A LOUD FAILURE INTO A SILENT ONE.
+                #     ``_assert_redacted`` is substring-based, so a secret
+                #     longer than the cut survived as a prefix that no longer
+                #     matched the canary: the leak stopped tripping the alarm
+                #     that exists to catch it.
+                # Quoting whole-or-nothing removes both: nothing is ever
+                # reshaped on the way out, so a redaction canary still matches
+                # and the rendered length is bounded by the charset itself.
+                safe = [key for key in extra if _is_quotable_key(key)]
+                summary = ", ".join(repr(key) for key in safe[:_MAX_EXTRA_KEYS_SHOWN])
+                withheld = len(extra) - len(safe[:_MAX_EXTRA_KEYS_SHOWN])
+                if withheld and summary:
+                    summary += f" and {withheld} more"
+                elif withheld:
+                    # Every key was unsafe or over the cap: report only how many
+                    # to drop. The count alone is enough to act on, and is the
+                    # part that carries no model-supplied text at all.
+                    summary = f"{withheld} not shown"
                 parts.append(f"added {len(extra)} unexpected key(s): {summary}")
             raise ValueError(
                 "model reply used the reserved envelope but "

--- a/local_operator/evaluation/runner/public_reply.py
+++ b/local_operator/evaluation/runner/public_reply.py
@@ -19,6 +19,17 @@ from local_operator.evaluation.receipts import RedactionSet
 REPLY_VERSION = "1.0"
 MAX_PUBLIC_OBSERVATIONS_CHARS = 2_000
 _ENVELOPE_KEYS = {"reply_version", "action_batch", "public_observations"}
+
+#: Bounds on how much of a rejected reply's OWN key names may appear in the
+#: diagnostic sent back to the model. The reserved keys are safe to name (they
+#: come from a fixed set), but any other key is model-supplied text: echoing it
+#: whole turns a malformed reply into an unbounded retry prompt and re-opens
+#: the replay channel the reserved-key suppression exists to close. Capped in
+#: both directions so neither one long key nor many short ones can rebuild a
+#: payload.
+_MAX_EXTRA_KEY_CHARS = 40
+_MAX_EXTRA_KEYS_SHOWN = 5
+
 REJECTED_PUBLIC_REPLY = "(model reply rejected; no public observations accepted)"
 
 #: What the reply-channel function tells the model it is for. Kept beside the
@@ -129,7 +140,25 @@ def decode_public_reply(payload: str) -> dict[str, Any]:
             if missing:
                 parts.append("omitted " + ", ".join(repr(key) for key in missing))
             if extra:
-                parts.append("added unexpected " + ", ".join(repr(key) for key in extra))
+                # ``present``/``missing`` are intersections with a fixed set,
+                # so they can only ever name the three reserved keys. ``extra``
+                # is arbitrary MODEL-SUPPLIED text and must never be echoed
+                # whole: a 50,000-character key produced a 50,000-character
+                # retry prompt, which neither ``MAX_REJECTED_REPLY_CHARS`` nor
+                # ``_diagnostic``'s cap intercepts, and which re-opens the
+                # replay channel the reserved-key suppression below closes.
+                #
+                # Bounded in BOTH directions -- each key truncated, and the
+                # number of keys quoted capped -- because either alone is
+                # enough to reconstruct a payload from many short keys.
+                shown = [
+                    key[:_MAX_EXTRA_KEY_CHARS] + ("…" if len(key) > _MAX_EXTRA_KEY_CHARS else "")
+                    for key in extra[:_MAX_EXTRA_KEYS_SHOWN]
+                ]
+                summary = ", ".join(repr(key) for key in shown)
+                if len(extra) > _MAX_EXTRA_KEYS_SHOWN:
+                    summary += f" and {len(extra) - _MAX_EXTRA_KEYS_SHOWN} more"
+                parts.append(f"added {len(extra)} unexpected key(s): {summary}")
             raise ValueError(
                 "model reply used the reserved envelope but "
                 + "; ".join(parts)

--- a/tests/unit/evaluation/runner/test_provider_client.py
+++ b/tests/unit/evaluation/runner/test_provider_client.py
@@ -2587,31 +2587,35 @@ async def test_byte_trigger_does_not_fire_under_the_trigger(tmp_path: Path) -> N
         assert all(a is b for a, b in zip(previous.messages, following.messages))
 
 
+@pytest.mark.parametrize("stop_reason", ["toolUse", "stop", "length"])
 @pytest.mark.asyncio
-async def test_a_tool_use_stop_with_no_call_and_no_text_is_a_correctable_rejection() -> None:
-    """The model selected the tool channel and put nothing on it.
+async def test_a_silent_reply_is_a_correctable_rejection(stop_reason: str) -> None:
+    """The model ended its turn without saying anything on either channel.
 
-    Measured on ``minimax/minimax-m3``: ~8% of replies on a routine screen, and
-    ~60% on a screen that looks already-complete, terminate as ``toolUse`` with
-    zero tool calls and empty content, after spending their output tokens
-    entirely on reasoning. ``toolUse`` is a NORMAL stop -- it is the terminator
-    a model uses when it answers on the tool channel -- so this reply used to
-    fall through to ``parse_decision`` as an empty string and be reported as
-    "decision is not valid JSON". The runner then re-prompted the model to fix
-    JSON it had never written, the correction could not land because it named
-    the wrong defect, and the retry bound sealed the episode as a MODEL
-    failure. That is how a first paid episode died at three calls.
+    Parametrised over every NORMAL stop reason because the defect is the
+    SILENCE, not the marker. All three shapes were observed against
+    ``minimax/minimax-m3``: ``toolUse`` with zero tool calls in ~8% of replies
+    on a routine screen and 6 of 10 on a screen that looks already-complete,
+    and ``stop`` with no content in 1 of 12 of the same probe and in a real
+    episode's third call. An abnormal marker with empty text is already handled
+    by the guard above this one, so together they cover the whole set.
+
+    Such a reply used to reach ``parse_decision`` as an empty string and be
+    reported as "decision is not valid JSON". The runner then re-prompted the
+    model to fix JSON it had never written; the correction could not land
+    because it named a defect that did not exist, and the retry bound sealed
+    the episode as a MODEL failure.
 
     It must be a ``DecisionRejected`` (the correctable path that appends a
     corrective turn), NOT a ``ProviderStreamAbortedError``: an abort seals the
-    episode as a provider failure with no retry at all, which would be strictly
-    worse than the behaviour this replaces.
+    episode as an infrastructure failure with no retry at all, which would be
+    strictly worse than the behaviour this replaces.
     """
 
     current = observation()
     stream = ScriptedStream(
         "",
-        stop_reason="toolUse",
+        stop_reason=stop_reason,
         usage=Usage(input_tokens=48, output_tokens=299),
     )
 
@@ -2619,12 +2623,14 @@ async def test_a_tool_use_stop_with_no_call_and_no_text_is_a_correctable_rejecti
         await _client(stream).decide(current, _turns(current))
 
     assert isinstance(info.value.__cause__, DecisionParseError)
-    # The diagnostic must name what actually happened. "not valid JSON" is the
-    # wrong defect and is precisely why the re-prompt could not work.
-    assert "no tool call and no text" in str(info.value.__cause__)
-    assert "JSON" not in str(info.value.__cause__).split("Reply with")[0]
+    # The diagnostic must name what actually happened, and must NOT claim the
+    # model wrote malformed JSON -- that is the misdiagnosis this replaces.
+    cause = str(info.value.__cause__)
+    assert "no tool call and no text" in cause
+    assert stop_reason in cause
+    assert "not valid JSON" not in cause
     # Billed: the prompt was read and the reasoning tokens were charged.
-    assert info.value.stop_reason == "toolUse"
+    assert info.value.stop_reason == stop_reason
 
 
 @pytest.mark.asyncio

--- a/tests/unit/evaluation/runner/test_provider_client.py
+++ b/tests/unit/evaluation/runner/test_provider_client.py
@@ -2585,3 +2585,73 @@ async def test_byte_trigger_does_not_fire_under_the_trigger(tmp_path: Path) -> N
     for previous, following in zip(stream.requests, stream.requests[1:]):
         assert len(following.messages) > len(previous.messages)
         assert all(a is b for a, b in zip(previous.messages, following.messages))
+
+
+@pytest.mark.asyncio
+async def test_a_tool_use_stop_with_no_call_and_no_text_is_a_correctable_rejection() -> None:
+    """The model selected the tool channel and put nothing on it.
+
+    Measured on ``minimax/minimax-m3``: ~8% of replies on a routine screen, and
+    ~60% on a screen that looks already-complete, terminate as ``toolUse`` with
+    zero tool calls and empty content, after spending their output tokens
+    entirely on reasoning. ``toolUse`` is a NORMAL stop -- it is the terminator
+    a model uses when it answers on the tool channel -- so this reply used to
+    fall through to ``parse_decision`` as an empty string and be reported as
+    "decision is not valid JSON". The runner then re-prompted the model to fix
+    JSON it had never written, the correction could not land because it named
+    the wrong defect, and the retry bound sealed the episode as a MODEL
+    failure. That is how a first paid episode died at three calls.
+
+    It must be a ``DecisionRejected`` (the correctable path that appends a
+    corrective turn), NOT a ``ProviderStreamAbortedError``: an abort seals the
+    episode as a provider failure with no retry at all, which would be strictly
+    worse than the behaviour this replaces.
+    """
+
+    current = observation()
+    stream = ScriptedStream(
+        "",
+        stop_reason="toolUse",
+        usage=Usage(input_tokens=48, output_tokens=299),
+    )
+
+    with pytest.raises(DecisionRejected) as info:
+        await _client(stream).decide(current, _turns(current))
+
+    assert isinstance(info.value.__cause__, DecisionParseError)
+    # The diagnostic must name what actually happened. "not valid JSON" is the
+    # wrong defect and is precisely why the re-prompt could not work.
+    assert "no tool call and no text" in str(info.value.__cause__)
+    assert "JSON" not in str(info.value.__cause__).split("Reply with")[0]
+    # Billed: the prompt was read and the reasoning tokens were charged.
+    assert info.value.stop_reason == "toolUse"
+
+
+@pytest.mark.asyncio
+async def test_a_tool_use_stop_that_carried_text_is_still_parsed_normally() -> None:
+    """The guard must not swallow a model that answers in prose under ``toolUse``.
+
+    Some providers report ``toolUse`` while the batch itself arrives as text.
+    Keying the guard on the stop reason alone would reject those valid replies,
+    so it also requires the content to be empty.
+    """
+
+    current = observation()
+    stream = ScriptedStream(
+        json.dumps(
+            {
+                "actions": [
+                    {
+                        "kind": "wait",
+                        "observation_id": current.observation_id,
+                        "duration_ms": 1000,
+                    }
+                ]
+            }
+        ),
+        stop_reason="toolUse",
+    )
+
+    decision = await _client(stream).decide(current, _turns(current))
+
+    assert [action.kind for action in decision.action_batch.actions] == ["wait"]

--- a/tests/unit/evaluation/runner/test_public_reply.py
+++ b/tests/unit/evaluation/runner/test_public_reply.py
@@ -659,10 +659,17 @@ def test_unexpected_keys_cannot_inflate_the_retry_prompt(extra: dict[str, object
     message = str(info.value)
     # Tight, and deliberately so. A loose ceiling passes while an unsafe key is
     # quoted in ESCAPED form -- the raw key is absent from the message, so a
-    # substring assertion alone cannot see it. The diagnostic is a fixed
-    # template plus at most five short plain keys, so anything approaching this
-    # bound means model text is being rendered into it.
-    assert len(message) < 400, f"diagnostic grew to {len(message)} characters"
+    # substring assertion alone cannot see it, and the 702-character escape
+    # expansion this replaces slipped under a 1,000-char ceiling.
+    #
+    # 600 is chosen against the CODE's reachable worst case, not against these
+    # fixtures. Five keys of 40 characters are all quotable, and that renders
+    # 513 characters (review round 4 measured it); a bound below that would
+    # assert a property the code does not have and would fail on a legitimate
+    # input. These fixtures top out far lower because every key in them is
+    # withheld, which is the point -- the margin between their ~344 and this
+    # ceiling is the room an escaped quote would need.
+    assert len(message) < 600, f"diagnostic grew to {len(message)} characters"
     # No fragment of an unsafe key escapes: whole-or-nothing, so a redaction
     # canary still matches and nothing is rendered in a reshaped form.
     quoted = sum(1 for key in extra if repr(key) in message)

--- a/tests/unit/evaluation/runner/test_public_reply.py
+++ b/tests/unit/evaluation/runner/test_public_reply.py
@@ -663,12 +663,17 @@ def test_unexpected_keys_cannot_inflate_the_retry_prompt(extra: dict[str, object
     # expansion this replaces slipped under a 1,000-char ceiling.
     #
     # 600 is chosen against the CODE's reachable worst case, not against these
-    # fixtures. Five keys of 40 characters are all quotable, and that renders
-    # 513 characters (review round 4 measured it); a bound below that would
-    # assert a property the code does not have and would fail on a legitimate
-    # input. These fixtures top out far lower because every key in them is
-    # withheld, which is the point -- the margin between their ~344 and this
-    # ceiling is the room an escaped quote would need.
+    # fixtures. Five 40-character keys are all quotable; adding a carried
+    # reserved key and the " and N more" suffix pushes the rendered maximum to
+    # 539, established by brute-forcing every carried/omitted split against the
+    # real decoder (review round 5) after two narrower measurements -- 513 and
+    # 518 -- each missed a term. Growth is logarithmic in the key count, so the
+    # template stays under ~550 for any input at all.
+    #
+    # A bound below 539 would assert a property the code does not have and
+    # would fail on a legitimate input. These fixtures top out around 344
+    # because every key in them is withheld, which is the point: the margin
+    # between that and this ceiling is the room an escaped quote would need.
     assert len(message) < 600, f"diagnostic grew to {len(message)} characters"
     # No fragment of an unsafe key escapes: whole-or-nothing, so a redaction
     # canary still matches and nothing is rendered in a reshaped form.

--- a/tests/unit/evaluation/runner/test_public_reply.py
+++ b/tests/unit/evaluation/runner/test_public_reply.py
@@ -538,3 +538,71 @@ async def test_old_fake_client_does_not_claim_a_new_reply_contract(
     assert "model_reply_contract" not in manifest["metadata"]
     assert payloads(root, ModelResponsePayload)[0].redacted_response is None
     assert decode_public_reply(envelope(type_payload(observation())))
+
+
+@pytest.mark.parametrize(
+    ("body", "carried", "omitted"),
+    [
+        (
+            '{"action_batch": {"actions": []}}',
+            ["'action_batch'"],
+            ["'public_observations'", "'reply_version'"],
+        ),
+        (
+            '{"reply_version": "1.0", "action_batch": {"actions": []}}',
+            ["'action_batch'", "'reply_version'"],
+            ["'public_observations'"],
+        ),
+    ],
+)
+def test_a_partial_envelope_is_told_which_keys_it_missed(
+    body: str, carried: list[str], omitted: list[str]
+) -> None:
+    """Validation is unchanged; what the model is TOLD is what changed.
+
+    Reserving every envelope key means touching one of them commits the reply
+    to strict decoding, so the common failure is a near-miss: the model emits
+    ``{"action_batch": {...}}`` and used to be told only the rule it had
+    already half-followed, never which half it missed.
+
+    That difference decides whether the correction lands. Measured on
+    ``minimax/minimax-m3``, which produces this exact shape in ~1 of 10
+    replies: re-prompting with the bare rule recovered 4/10, while naming the
+    keys present and missing recovered 9/10 -- the gap between an episode that
+    continues and one that spends its retry bound and seals as a model
+    failure.
+    """
+
+    with pytest.raises(ValueError) as info:
+        decode_public_reply(body)
+
+    message = str(info.value)
+    for key in carried:
+        assert key in message.split("omitted")[0]
+    for key in omitted:
+        assert key in message
+    # Both legal shapes are offered, so the model can pick the cheaper one
+    # rather than guessing which half of the contract to repair.
+    assert '{"actions": [...]}' in message
+    assert "reply_version, action_batch, public_observations" in message
+
+
+def test_an_envelope_with_an_extra_key_is_told_the_key_is_unexpected() -> None:
+    """The other near-miss: every required key present, plus one more."""
+
+    with pytest.raises(ValueError) as info:
+        decode_public_reply(
+            '{"reply_version": "1.0", "action_batch": {"actions": []}, '
+            '"public_observations": "", "notes": "x"}'
+        )
+
+    assert "added unexpected 'notes'" in str(info.value)
+
+
+def test_a_non_object_reply_keeps_the_plain_rule() -> None:
+    """A JSON array names no keys, so there is no defect to describe."""
+
+    with pytest.raises(ValueError) as info:
+        decode_public_reply("[1, 2]")
+
+    assert "requires exactly" in str(info.value)

--- a/tests/unit/evaluation/runner/test_public_reply.py
+++ b/tests/unit/evaluation/runner/test_public_reply.py
@@ -36,6 +36,8 @@ from local_operator.evaluation.runner.provider_client import (
     parse_decision,
 )
 from local_operator.evaluation.runner.public_reply import (
+    _MAX_EXTRA_KEY_CHARS,
+    _MAX_EXTRA_KEYS_SHOWN,
     MAX_PUBLIC_OBSERVATIONS_CHARS,
     REJECTED_PUBLIC_REPLY,
     decode_public_reply,
@@ -604,21 +606,42 @@ def test_an_envelope_with_an_extra_key_is_told_the_key_is_unexpected() -> None:
     [
         {"X" * 50_000: "y"},
         {f"key{index}" * 20: index for index in range(60)},
+        {"\U000e0001" * 40: 1},
+        {"SECRET-" + "z" * 60: 1},
+        # Every key here is individually SAFE to quote, so only the count cap
+        # stands between the model's payload and the prompt. Without a case
+        # like this the cap is unpinned: the other fixtures withhold every key
+        # on safety grounds and never exercise it.
+        {f"k{index}": index for index in range(60)},
     ],
-    ids=["one-enormous-key", "many-long-keys"],
+    ids=[
+        "one-enormous-key",
+        "many-long-keys",
+        "repr-expanding-key",
+        "long-secret-key",
+        "many-short-safe-keys",
+    ],
 )
 def test_unexpected_keys_cannot_inflate_the_retry_prompt(extra: dict[str, object]) -> None:
-    """Model-supplied key names are bounded before they reach the model again.
+    """Model-supplied key names never reach the model again reshaped.
 
     ``present`` and ``missing`` intersect a fixed set, so they can only name
     the three reserved keys. ``extra`` is arbitrary model output, and echoing
     it whole turned a 50,000-character key into a 50,000-character retry
     prompt -- intercepted by neither ``MAX_REJECTED_REPLY_CHARS`` nor
-    ``_diagnostic``'s cap, and re-opening the replay channel that the
-    reserved-key suppression exists to close.
+    ``_diagnostic``'s cap.
 
-    Bounded in BOTH directions, so neither one enormous key nor many short
-    ones can rebuild a payload through the diagnostic.
+    Quoted WHOLE or not at all. The two cases beyond mere size are why
+    truncating was not good enough:
+
+    ``repr-expanding-key`` -- ``repr`` expands escapes AFTER a cut, so a bound
+    applied to the raw key does not bound the rendered output, and the limit
+    silently depends on the input's alphabet.
+
+    ``long-secret-key`` -- and this is the one that matters: cutting converts a
+    LOUD failure into a SILENT one. ``_assert_redacted`` is substring-based, so
+    a secret longer than the cut survives as a prefix that no longer matches
+    the canary. The leak stops tripping the alarm that exists to catch it.
     """
 
     payload = json.dumps(
@@ -634,10 +657,44 @@ def test_unexpected_keys_cannot_inflate_the_retry_prompt(extra: dict[str, object
         decode_public_reply(payload)
 
     message = str(info.value)
-    assert len(message) < 1_000, f"diagnostic grew to {len(message)} characters"
+    # Tight, and deliberately so. A loose ceiling passes while an unsafe key is
+    # quoted in ESCAPED form -- the raw key is absent from the message, so a
+    # substring assertion alone cannot see it. The diagnostic is a fixed
+    # template plus at most five short plain keys, so anything approaching this
+    # bound means model text is being rendered into it.
+    assert len(message) < 400, f"diagnostic grew to {len(message)} characters"
+    # No fragment of an unsafe key escapes: whole-or-nothing, so a redaction
+    # canary still matches and nothing is rendered in a reshaped form.
+    quoted = sum(1 for key in extra if repr(key) in message)
+    assert quoted <= _MAX_EXTRA_KEYS_SHOWN, f"{quoted} keys quoted"
+    for key in extra:
+        if repr(key) in message:
+            # A quoted key must appear WHOLE and unreshaped, never as a cut.
+            continue
+        assert key not in message
+        assert key[:_MAX_EXTRA_KEY_CHARS] not in message
     # The count is still reported, so the model learns how many keys to drop
-    # even when their names are withheld.
+    # even when their names are withheld entirely.
     assert f"added {len(extra)} unexpected key(s)" in message
+
+
+def test_a_short_plain_unexpected_key_is_still_named() -> None:
+    """Withholding is for unsafe keys only; the useful case stays useful.
+
+    The 9/10 recovery this diagnostic was measured for came from naming keys,
+    so a bound that withheld every name would protect the prompt by making it
+    useless.
+    """
+
+    with pytest.raises(ValueError) as info:
+        decode_public_reply(
+            '{"reply_version": "1.0", "action_batch": {"actions": []}, '
+            '"public_observations": "", "notes": "x", "extra": 1}'
+        )
+
+    message = str(info.value)
+    assert "'extra'" in message and "'notes'" in message
+    assert "not shown" not in message
 
 
 def test_a_non_object_reply_keeps_the_plain_rule() -> None:

--- a/tests/unit/evaluation/runner/test_public_reply.py
+++ b/tests/unit/evaluation/runner/test_public_reply.py
@@ -596,7 +596,48 @@ def test_an_envelope_with_an_extra_key_is_told_the_key_is_unexpected() -> None:
             '"public_observations": "", "notes": "x"}'
         )
 
-    assert "added unexpected 'notes'" in str(info.value)
+    assert "added 1 unexpected key(s): 'notes'" in str(info.value)
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"X" * 50_000: "y"},
+        {f"key{index}" * 20: index for index in range(60)},
+    ],
+    ids=["one-enormous-key", "many-long-keys"],
+)
+def test_unexpected_keys_cannot_inflate_the_retry_prompt(extra: dict[str, object]) -> None:
+    """Model-supplied key names are bounded before they reach the model again.
+
+    ``present`` and ``missing`` intersect a fixed set, so they can only name
+    the three reserved keys. ``extra`` is arbitrary model output, and echoing
+    it whole turned a 50,000-character key into a 50,000-character retry
+    prompt -- intercepted by neither ``MAX_REJECTED_REPLY_CHARS`` nor
+    ``_diagnostic``'s cap, and re-opening the replay channel that the
+    reserved-key suppression exists to close.
+
+    Bounded in BOTH directions, so neither one enormous key nor many short
+    ones can rebuild a payload through the diagnostic.
+    """
+
+    payload = json.dumps(
+        {
+            "reply_version": "1.0",
+            "action_batch": {"actions": []},
+            "public_observations": "",
+            **extra,
+        }
+    )
+
+    with pytest.raises(ValueError) as info:
+        decode_public_reply(payload)
+
+    message = str(info.value)
+    assert len(message) < 1_000, f"diagnostic grew to {len(message)} characters"
+    # The count is still reported, so the model learns how many keys to drop
+    # even when their names are withheld.
+    assert f"added {len(extra)} unexpected key(s)" in message
 
 
 def test_a_non_object_reply_keeps_the_plain_rule() -> None:

--- a/tests/unit/evaluation/runner/test_reply_channel.py
+++ b/tests/unit/evaluation/runner/test_reply_channel.py
@@ -625,13 +625,18 @@ async def test_a_channel_answer_without_prose_is_not_read_as_silence() -> None:
 
     ``provider_client`` rejects a reply that emitted no tool call AND no text,
     because that model said nothing on either channel. The tool-call half of
-    that condition is load-bearing and easy to drop by accident: a model that
-    answers ON the channel and writes no prose arrives here with empty
-    ``text``, so keying the guard on silence alone would reject the very
-    replies the channel exists to carry.
+    that condition is load-bearing: a model that answers ON the channel and
+    writes no prose arrives with empty ``text``, so keying the guard on silence
+    alone would reject the very replies the channel exists to carry.
 
-    Without this test, deleting ``tool_call_count == 0`` leaves the guard's own
-    test file entirely green.
+    This test asserts the ACCEPTANCE side of that -- a channel answer is
+    decoded normally. It does NOT by itself fail when ``tool_call_count == 0``
+    is deleted, because a valid channel call sets ``text`` from the channel
+    reply and so never reaches the guard. The mutation is caught by
+    ``test_an_empty_channel_call_is_rejected_like_an_empty_prose_body``, whose
+    empty-argument call leaves ``text`` empty WITH a tool call present -- the
+    one shape that distinguishes the two conditions. Both are kept: this one
+    pins the behaviour, that one pins the clause.
     """
 
     current = observation()

--- a/tests/unit/evaluation/runner/test_reply_channel.py
+++ b/tests/unit/evaluation/runner/test_reply_channel.py
@@ -235,7 +235,18 @@ def test_an_unused_channel_is_distinguishable_from_an_empty_one() -> None:
         "not json at all",
         '{"reply_version": "9.9", "action_batch": {"actions": []}, "public_observations": ""}',
         '{"actions": []}',
-        "",
+        # NOTE: the empty body is deliberately absent. It does not encode the
+        # same model behaviour on both paths, so it cannot test parity between
+        # them: in prose it means the model emitted NOTHING (no tool call, no
+        # text) and is now reported as the silence it is, while on the channel
+        # it means the model DID select the channel and sent empty arguments --
+        # a malformed call, not an absent reply. Requiring one diagnostic to
+        # cover both would force the silent case back to "not valid JSON",
+        # which is the misdiagnosis that spends an episode's retry bound
+        # re-prompting a model to fix JSON it never wrote. The silent case is
+        # covered directly by ``test_a_silent_reply_is_a_correctable_rejection``
+        # and the channel case by
+        # ``test_an_empty_channel_call_is_rejected_like_an_empty_prose_body``.
     ],
 )
 async def test_a_malformed_reply_is_rejected_on_the_channel_exactly_as_in_prose(
@@ -606,3 +617,54 @@ async def test_a_rejected_reply_still_records_the_tools_the_request_offered() ->
         await client.decide(current, _turns(current))
 
     assert raised.value.offered_tool_count == 1
+
+
+@pytest.mark.asyncio
+async def test_a_channel_answer_without_prose_is_not_read_as_silence() -> None:
+    """Pins the ``tool_call_count == 0`` half of the silent-reply guard.
+
+    ``provider_client`` rejects a reply that emitted no tool call AND no text,
+    because that model said nothing on either channel. The tool-call half of
+    that condition is load-bearing and easy to drop by accident: a model that
+    answers ON the channel and writes no prose arrives here with empty
+    ``text``, so keying the guard on silence alone would reject the very
+    replies the channel exists to carry.
+
+    Without this test, deleting ``tool_call_count == 0`` leaves the guard's own
+    test file entirely green.
+    """
+
+    current = observation()
+    body = envelope(finish_payload(current), "Visible status: ready")
+    client = _client(ChannelStream(body), model_spec=_spec(supports_tools=True))
+
+    decision = await client.decide(current, _turns(current))
+
+    assert isinstance(decision.action_batch, ActionBatch)
+    assert decision.tool_call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_an_empty_channel_call_is_rejected_like_an_empty_prose_body() -> None:
+    """A channel call carrying EMPTY arguments is malformed, not silent.
+
+    This is the half of the old empty-body parity case that still belongs to
+    the malformed family. The model selected the channel and sent nothing in
+    it, so a tool call really was emitted -- the silent-reply guard must not
+    claim the model said nothing, and the reply must still be rejected on the
+    correctable path.
+
+    Kept as its own test because the two halves of the old parametrised case
+    encode DIFFERENT model behaviours that the fixture spelled with the same
+    empty string.
+    """
+
+    current = observation()
+    client = _client(ChannelStream(""), model_spec=_spec(supports_tools=True))
+
+    with pytest.raises(DecisionRejected) as info:
+        await client.decide(current, _turns(current))
+
+    message = str(info.value)
+    assert "no tool call and no text" not in message
+    assert "not valid JSON" in message


### PR DESCRIPTION
## What this fixes

Two independent defects in how the benchmark runner handles a model reply it cannot use. Both share one root cause: **a correction that does not name the defect cannot be acted on**, so the retry bound is spent re-prompting a model about the wrong thing and the episode seals as a model failure.

Both were found by running MiniMax M3 against the harness and reading what the model actually sent.

### 1. A silent reply was reported as bad JSON

A reply that emitted **no tool call and no text** reached `parse_decision` as an empty string, which reports `decision is not valid JSON`. The runner then asked the model to fix JSON it had never written.

`toolUse` sits in `_NORMAL_CONTENT_STOPS` — correctly, since it is the normal terminator when a model answers on the tool channel. The gap was that the marker *promises* a call which sometimes never arrives. The guard now keys on the **silence**, not the marker, so `stop` and `length` are covered too; the abort guard above it already consumed every abnormal marker, giving a clean partition.

Measured on `minimax/minimax-m3`:

| condition | silent replies |
|---|---|
| routine screen | 1 / 12 (~8%) |
| screen that looks already-complete | 6 / 10 (~60%) |

The failures are **correlated within an observation**, so a larger retry bound does not help. Testing the alternatives:

| remedy | recovery on a latched screen |
|---|---|
| `tool_choice: "required"` | 7 / 10 |
| named tool choice | 2 / 10 |
| **corrective turn appended to history** | **10 / 10** |

Hence `DecisionParseError` (the correctable path that appends that turn), **not** `ProviderStreamAbortedError` — an abort seals the episode as an infrastructure failure with no retry at all, which would be strictly worse.

### 2. A near-miss envelope was told the rule, not the defect

Reserving every envelope key means touching **one** commits the reply to strict decoding. So the common failure is a near-miss: the model emits `{"action_batch": {...}}` and is told `model reply requires exactly reply_version, action_batch, public_observations` — the rule it had already half-followed, with no hint which half it missed.

`minimax/minimax-m3` produces exactly that shape in ~1 of 10 replies against the harness's own contract. **Validation is unchanged** — a partial envelope is still rejected, because silently downgrading it would drop whatever the model meant to put in `public_observations`. Only the message changed:

| re-prompt | recovered |
|---|---|
| the bare rule | 4 / 10 |
| naming the keys present and missing | **9 / 10** |

Unexpected keys are quoted **whole or withheld entirely**, never truncated: they are arbitrary model-supplied text, and quoting them whole turned a 50,093-char payload into a 50,292-char retry prompt that neither `MAX_REJECTED_REPLY_CHARS` nor `_diagnostic`'s cap intercepts. Truncating them instead was worse — a secret longer than the cut survived as a prefix that `_assert_redacted`'s substring check no longer matched, converting a loud redaction failure into a silent leak. Now 311 chars, with the count always reported and short plain keys still named.

## Correction to an earlier version of this description

An earlier version of this PR claimed the silent-reply fix "killed the first paid episode" of the canary. **That was false**, and review caught it by reading the bundle instead of my prose. Those three rejections were envelope-schema failures from *non-empty* replies — defect 2, not defect 1. The silent-reply fix rests on the probe measurements above, which is the evidence that always supported it.

## Tests

Twelve, all **mutation-checked with the mutation asserted to have landed** (md5 before/after — a mutation that silently no-ops is indistinguishable from a test correctly passing):

| mutation | result |
|---|---|
| drop `tool_call_count == 0` | 1 failed |
| drop the text check | 43 failed |
| remove the silence guard | 3 failed |
| revert the envelope diagnostic to the bare rule | 3 failed |
| truncate unexpected keys instead of withholding | 4 failed |
| remove the repr-safety check | 1 failed |
| raise the per-key cap | 2 failed |
| raise the count cap | 1 failed |
| drop the count from the diagnostic | 6 failed |

One parity case was removed with the reason recorded inline: `test_a_malformed_reply_is_rejected_on_the_channel_exactly_as_in_prose` parametrised `body=""`, which does **not** encode the same model behaviour on both paths — in prose it means the model emitted nothing; on the channel it means the model *selected* the channel and sent empty arguments. Forcing one diagnostic to cover both would push the silent case back to "not valid JSON". Both halves keep direct coverage.

## Blast radius

Nothing outside `evaluation/runner` imports either module. The TUI, CLI and mobile paths are bit-for-bit unaffected.

## Gates

flake8, black, pyright clean. `tests/unit/evaluation`: **1327 passed, 1 skipped**.

## Known follow-up, not fixed here

After both fixes, MiniMax still cannot complete an episode — and the reason is a **third, larger** finding recorded in a comment below: the harness's own 6078-char reply contract degrades protocol compliance from 10/10 to 3/10 on the same model and task. The `schema` blob is the culprit; the prose keys are harmless. That needs its own change and its own evidence.