### PR TITLE
fix(session): stop an attention token conflict bricking a session forever

### DIFF
--- a/local_operator/server/models/desktop_sessions.py
+++ b/local_operator/server/models/desktop_sessions.py
@@ -125,8 +125,16 @@ class AttentionState(BaseModel):
     anchor_id: str | None
     kind: Literal["complete", "error", "interrupted"] | None
     unseen: bool
-    #: ``[published, acknowledged]`` -- monotonic, and independent of the owner
-    #: epoch, which is why a client merges on it rather than on arrival order.
+    #: ``[published, acknowledged]`` -- monotonic per conversation, and
+    #: independent of the owner epoch, so it orders a conversation's own states
+    #: rather than depending on arrival order.
+    #:
+    #: NOT a merge key: a heal deliberately REPUBLISHES a corrected state under
+    #: the SAME pair, so a client that dropped an update whose revision did not
+    #: advance would discard exactly the correction the heal exists to deliver.
+    #: The bridge republishes on full-state inequality, and no client currently
+    #: reads this field; it is a diagnostic ordering hint, and any future
+    #: consumer must treat an equal pair as "possibly changed", never as stale.
     revision: list[int]
     #: Absent on the cold list path; only a live owner can answer it.
     supported: bool | None = None

--- a/local_operator/server/utils/desktop_sessions.py
+++ b/local_operator/server/utils/desktop_sessions.py
@@ -85,7 +85,7 @@ class DesktopSessionBridge:
         self.watch_task: asyncio.Task[None] | None = None
         self.attention_task: asyncio.Task[None] | None = None
         self.attention: dict[str, Any] = {}
-        self.attention_poll_key: tuple[tuple[int, int], bool] | None = None
+        self.attention_poll_key: tuple[tuple[int, int, int], bool] | None = None
 
     async def acquire(self) -> RemoteSession:
         async with self.lock:

--- a/local_operator/session/attention.py
+++ b/local_operator/session/attention.py
@@ -34,6 +34,12 @@ logger = logging.getLogger(__name__)
 ATTENTION_CAPABILITY = "completion-ack-v1"
 ATTENTION_CUSTOM_TYPE = "completion_attention"
 
+#: Named once because BOTH the minting side (`provisional_anchor`) and the
+#: recognising side (`_supersedes_provisional`, on the stored AND the incoming
+#: anchor) key on this exact shape; a literal in one of them drifting from the
+#: other silently turns supersession off.
+_PROVISIONAL_PREFIX = "completion-"
+
 #: The delivery watermark. `delivered` is a highwater mark on the SAME
 #: `completions.sequence` that `receipts.acknowledged` uses, which is what makes
 #: the two comparable and the arbitration clock-free: sequence is assigned by
@@ -58,6 +64,33 @@ _BASELINE_DELIVERIES = (
     "GROUP BY conversation"
 )
 
+#: THE THIRD TERM OF `revision()`, and the reason it exists: a supersede is the
+#: one durable change that moves NEITHER `completions.sequence` NOR
+#: `receipts.acknowledged`, so without a counter it is invisible to every
+#: consumer that gates on `revision()` (review round 1, major-1).
+#:
+#: The obvious alternative -- mint a new completions row so `sequence` moves --
+#: is ruled out by the no-flood rule: `sequence` IS the receipt watermark, so a
+#: new row resurrects an already-acknowledged turn as unread and re-fires a
+#: notification for a result the human has read. Correcting a record is not a
+#: new completion. The counter is therefore how a heal stays sequence-preserving
+#: and still DETECTABLE.
+#:
+#: A single row by construction (`CHECK(id=1)`): this counts machine-global
+#: mutations, exactly like the rest of `revision()`, not per-conversation ones.
+_CREATE_MUTATIONS = (
+    "CREATE TABLE mutations (id INTEGER PRIMARY KEY CHECK(id=1), supersedes INTEGER NOT NULL)"
+)
+
+#: Upsert rather than UPDATE so the counter cannot silently stick at its seed on
+#: a database whose additive migration never ran -- a no-op UPDATE would leave
+#: every heal undetectable again, which is the defect this table exists to fix.
+#: Same self-healing form `acknowledge` already uses for `receipts`.
+_BUMP_SUPERSEDES = (
+    "INSERT INTO mutations(id,supersedes) VALUES(1,1) "
+    "ON CONFLICT(id) DO UPDATE SET supersedes=mutations.supersedes+1"
+)
+
 
 def conversation_identity(directory: Path) -> str:
     """Use the durable namespace, never the currently selected agent profile."""
@@ -73,13 +106,14 @@ def provisional_anchor(token: str) -> str:
     lets :meth:`AttentionStore.publish` recognise a record as provisional and
     therefore safe to replace once the real outcome lands.
     """
-    return f"completion-{token}"
+    return f"{_PROVISIONAL_PREFIX}{token}"
 
 
 def _supersedes_provisional(
     existing: Any,
     conversation: str,
     token: str,
+    anchor: str,
 ) -> bool:
     """May the incoming outcome overwrite the stored one for this token?
 
@@ -87,8 +121,22 @@ def _supersedes_provisional(
     provisional shape. Cross-conversation reuse and overwrites of an already
     authoritative record both stay refusals — see :meth:`AttentionStore.publish`
     for why each half of that is load-bearing.
+
+    THE INCOMING ANCHOR IS CHECKED TOO, not just the stored one (review round 1,
+    minor-2). A publish for token T carrying `provisional_anchor(U)` — some
+    OTHER token's synthetic anchor — otherwise superseded happily, and the row
+    it left behind wore an anchor matching no token: unviewable, and permanently
+    unhealable, because no later real outcome could ever supersede a record
+    whose stored anchor is not `provisional_anchor(T)`. A one-way trip into a
+    dead state. Reachability is low (`_publish_attention_outcome` always mints
+    the anchor for the same token, and the journal path is gated on conversation
+    identity), which is why the guard is cheap rather than elaborate: an
+    incoming provisional anchor is legitimate only when it belongs to the token
+    being published.
     """
     stored_conversation, stored_anchor, stored_kind = tuple(existing)
+    if anchor.startswith(_PROVISIONAL_PREFIX) and anchor != provisional_anchor(token):
+        return False
     return (
         stored_conversation == conversation
         and stored_kind == "interrupted"
@@ -120,6 +168,12 @@ def bootstrap_transcript(transcript: Any, store: AttentionStore | None = None) -
             "attention: skipping outcome import for %s (%r)",
             getattr(directory, "name", directory),
             exc,
+            # An arbitrary unknown exception is being swallowed here, and `%r`
+            # names its type but not the frame that raised it. The destination
+            # is a real file (a spawned runtime's `log_dir()/mobile.log`), so
+            # the traceback is what makes the next novel failure recoverable
+            # from disk instead of only reproducible.
+            exc_info=True,
         )
 
 
@@ -215,6 +269,7 @@ class AttentionStore:
                     # there is no backlog to baseline against — an empty
                     # delivery watermark IS the correct starting point.
                     conn.execute(_CREATE_DELIVERIES)
+                    conn.execute(_CREATE_MUTATIONS)
                 else:
                     # Missing tables/columns in an established database are
                     # corruption, not permission to rebuild an empty watermark.
@@ -250,6 +305,21 @@ class AttentionStore:
                     ).fetchone():
                         conn.execute(_CREATE_DELIVERIES)
                         conn.execute(_BASELINE_DELIVERIES, (time.time(),))
+                    # `mutations` is additive for the SAME reason and stays out
+                    # of the probe above for the same reason: every database
+                    # written before this fix legitimately lacks it, and
+                    # probing for it would read all of them as corrupt.
+                    #
+                    # NO BASELINE, unlike `deliveries`. That table baselines
+                    # because `unseen` is a LEVEL and an unbaselined watermark
+                    # would re-announce history. A change detector is an EDGE:
+                    # it only has to move when something changes AFTER this
+                    # point, so seeding at 0 is correct and a historical
+                    # supersede count would be meaningless anyway.
+                    if not conn.execute(
+                        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='mutations'"
+                    ).fetchone():
+                        conn.execute(_CREATE_MUTATIONS)
             return conn
         except BaseException:
             conn.close()
@@ -385,6 +455,20 @@ class AttentionStore:
         not a new completion. Holding the sequence also means a corrected old
         turn stays where it belongs in the order instead of jumping ahead of
         newer ones.
+
+        THAT CHOICE HAS A COST, and it is paid explicitly rather than left
+        implicit (review round 1, major-1). Holding ``sequence`` means the heal
+        moves neither term of the OLD ``revision()``, and two consumers gate on
+        that value: the desktop bridge skips ``refresh_attention`` and keeps
+        serving the stale ``interrupted`` record with its synthetic anchor to
+        phone and desktop subscribers, and the TUI's background notifier skips
+        its catalog scan. On a quiet machine a phone could show "Interrupted"
+        for a turn that completed successfully, until some unrelated session
+        happened to publish. So a supersede bumps ``mutations.supersedes``,
+        which ``revision()`` folds into its tuple: the heal moves the change
+        detector WITHOUT moving the watermark, and an acknowledged turn stays
+        read. Detectable and flood-free are not in tension once they are
+        separate counters.
         """
         if kind not in {"complete", "error", "interrupted"} or not anchor:
             raise ValueError("invalid completion")
@@ -403,12 +487,17 @@ class AttentionStore:
                 "SELECT conversation, anchor, kind FROM completions WHERE token=?", (token,)
             ).fetchone()
             if existing and tuple(existing) != (conversation, anchor, kind):
-                if not _supersedes_provisional(existing, conversation, token):
+                if not _supersedes_provisional(existing, conversation, token, anchor):
                     raise ValueError("completion token belongs to another outcome")
                 conn.execute(
                     "UPDATE completions SET anchor=?, kind=? WHERE token=?",
                     (anchor, kind, token),
                 )
+                # Inside the SAME transaction as the UPDATE: a reader must
+                # never observe a healed row whose change the detector has not
+                # yet counted, or it would cache the new state under the old
+                # revision and then ignore the next real change.
+                conn.execute(_BUMP_SUPERSEDES)
             conn.execute(
                 "INSERT OR IGNORE INTO completions(conversation,token,anchor,kind) VALUES(?,?,?,?)",
                 (conversation, token, anchor, kind),
@@ -423,21 +512,43 @@ class AttentionStore:
                 )
             return self._state(conn, conversation)
 
-    def revision(self) -> tuple[int, int]:
-        """Cheap process-independent change detector for existing polling loops."""
+    def revision(self) -> tuple[int, int, int]:
+        """Cheap process-independent change detector for existing polling loops.
+
+        Three terms, because there are three kinds of durable change and the
+        first two do not cover the third: ``MAX(sequence)`` moves on a publish,
+        ``SUM(acknowledged)`` on a read, and ``supersedes`` on a heal that
+        deliberately moves NEITHER of the others (see :meth:`publish`). Callers
+        compare the tuple for equality and never interpret the terms, so widening
+        it is safe for them; the per-conversation ``state()["revision"]`` pair is
+        a separate, unchanged wire contract (``AttentionState.revision``, mirrored
+        by the mobile client) and deliberately does not grow a third element.
+        """
         if not self.path.exists():
-            return (0, 0)
+            return (0, 0, 0)
         with closing(
             sqlite3.connect(f"{self.path.as_uri()}?mode=ro", uri=True, timeout=2.0)
         ) as conn:
             conn.execute("BEGIN")
             if self._uninitialized(conn):
-                return (0, 0)
+                return (0, 0, 0)
+            # This connection is READ-ONLY, so it cannot run the additive
+            # migration itself: a database written before this fix, whose owner
+            # has not reconnected yet, legitimately has no `mutations` table and
+            # must read as 0 rather than raising. A poller that raised here
+            # would lose cross-process read sync for the life of the loop.
             row = conn.execute(
                 "SELECT COALESCE(MAX(sequence),0), "
-                "(SELECT COALESCE(SUM(acknowledged),0) FROM receipts) FROM completions"
+                "(SELECT COALESCE(SUM(acknowledged),0) FROM receipts), "
+                "(SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='mutations') "
+                "FROM completions"
             ).fetchone()
-            return (row[0], row[1])
+            supersedes = 0
+            if row[2]:
+                supersedes = conn.execute(
+                    "SELECT COALESCE(MAX(supersedes),0) FROM mutations"
+                ).fetchone()[0]
+            return (row[0], row[1], supersedes)
 
     def acknowledge(self, conversation: str, token: str) -> dict[str, Any]:
         """Advance only through the observed token, never through server 'now'."""

--- a/local_operator/session/attention.py
+++ b/local_operator/session/attention.py
@@ -82,10 +82,13 @@ _CREATE_MUTATIONS = (
     "CREATE TABLE mutations (id INTEGER PRIMARY KEY CHECK(id=1), supersedes INTEGER NOT NULL)"
 )
 
-#: Upsert rather than UPDATE so the counter cannot silently stick at its seed on
-#: a database whose additive migration never ran -- a no-op UPDATE would leave
-#: every heal undetectable again, which is the defect this table exists to fix.
-#: Same self-healing form `acknowledge` already uses for `receipts`.
+#: Upsert rather than UPDATE because the table is created with NO row: both
+#: `_CREATE_MUTATIONS` sites above create it empty and nothing seeds it, so the
+#: first bump has nothing to update. A plain UPDATE would match zero rows and
+#: silently succeed with rowcount 0, leaving every heal undetectable again --
+#: the exact defect this table exists to fix. The `INSERT ... ON CONFLICT`
+#: writes the seed and the increment in one statement, so the first caller and
+#: every later one take the same path.
 _BUMP_SUPERSEDES = (
     "INSERT INTO mutations(id,supersedes) VALUES(1,1) "
     "ON CONFLICT(id) DO UPDATE SET supersedes=mutations.supersedes+1"
@@ -163,6 +166,15 @@ def bootstrap_transcript(transcript: Any, store: AttentionStore | None = None) -
     try:
         _import_transcript_outcome(transcript, store)
     except Exception as exc:  # noqa: BLE001 — attention must never block a boot
+        # `getattr` so the handler cannot itself raise on a transcript that
+        # never grew a `.directory` (a stub, a partially constructed instance)
+        # and turn a swallowed failure back into a fatal one. It survives a
+        # MISSING attribute only: `getattr` suppresses `AttributeError` and
+        # nothing else, so a `.directory` raising `OSError` would still escape.
+        # That case is unreachable — `Transcript.directory` is a plain instance
+        # attribute, `transcript.py` defines no `@property`, `Path.name` does
+        # not raise — so the read stays as-is rather than growing a third guard.
+        # `session.py` mirrors this same defensive read.
         directory = getattr(transcript, "directory", None)
         logger.warning(
             "attention: skipping outcome import for %s (%r)",

--- a/local_operator/session/attention.py
+++ b/local_operator/session/attention.py
@@ -18,6 +18,7 @@ forever, which is correct — the sidebar's checkmark stays until it is opened.
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 import time
 import uuid
@@ -27,6 +28,8 @@ from pathlib import Path
 from typing import Any
 
 from local_operator.paths import config_dir
+
+logger = logging.getLogger(__name__)
 
 ATTENTION_CAPABILITY = "completion-ack-v1"
 ATTENTION_CUSTOM_TYPE = "completion_attention"
@@ -62,7 +65,65 @@ def conversation_identity(directory: Path) -> str:
     return f"{namespace}/{directory.name}"
 
 
+def provisional_anchor(token: str) -> str:
+    """The anchor a run wears before it has a viewable result entry.
+
+    A failed or interrupted run may have no assistant message to point at, so
+    its outcome marker anchors to the run itself. The synthetic shape is what
+    lets :meth:`AttentionStore.publish` recognise a record as provisional and
+    therefore safe to replace once the real outcome lands.
+    """
+    return f"completion-{token}"
+
+
+def _supersedes_provisional(
+    existing: Any,
+    conversation: str,
+    token: str,
+) -> bool:
+    """May the incoming outcome overwrite the stored one for this token?
+
+    Only for the SAME conversation, and only over a record still wearing the
+    provisional shape. Cross-conversation reuse and overwrites of an already
+    authoritative record both stay refusals — see :meth:`AttentionStore.publish`
+    for why each half of that is load-bearing.
+    """
+    stored_conversation, stored_anchor, stored_kind = tuple(existing)
+    return (
+        stored_conversation == conversation
+        and stored_kind == "interrupted"
+        and stored_anchor == provisional_anchor(token)
+    )
+
+
 def bootstrap_transcript(transcript: Any, store: AttentionStore | None = None) -> None:
+    """Import a conversation's durable outcome; NEVER fatal to the caller.
+
+    Both call sites are boot paths that must survive a bad conversation:
+    ``Session.__init__`` constructs the runtime process, and the mobile daemon
+    sweeps up to 100 session directories in one loop. A raise here used to be
+    unrecoverable rather than transient — the runtime failed to spawn on EVERY
+    attach, so the session could never be opened again and the TUI showed only
+    "Saved excerpt · Connection unavailable". An attention record is an
+    observability nicety (who has an unread result); it may never outrank the
+    ability to READ the conversation, and one poisoned session may never take
+    the daemon's remaining 99 down with it.
+
+    The failure is logged with the identity and the exception so a swallowed
+    problem is still diagnosable from the log rather than silently invisible.
+    """
+    try:
+        _import_transcript_outcome(transcript, store)
+    except Exception as exc:  # noqa: BLE001 — attention must never block a boot
+        directory = getattr(transcript, "directory", None)
+        logger.warning(
+            "attention: skipping outcome import for %s (%r)",
+            getattr(directory, "name", directory),
+            exc,
+        )
+
+
+def _import_transcript_outcome(transcript: Any, store: AttentionStore | None = None) -> None:
     """Explicit one-time import; never called by GET, SSE or focus observation.
 
     Old baselines were memory-only. Unknown historical work keeps that no-flood
@@ -79,7 +140,10 @@ def bootstrap_transcript(transcript: Any, store: AttentionStore | None = None) -
         and (not isinstance(saved, dict) or saved.get("token") != started.get("token"))
     ):
         token = started["token"]
-        store.publish(identity, token, f"completion-{token}", "interrupted")
+        # Provisional by construction: the turn may still be in flight, so this
+        # marker is explicitly the kind `publish` will let the real outcome
+        # supersede once the journal proves how the run actually ended.
+        store.publish(identity, token, provisional_anchor(token), "interrupted")
         return
     if isinstance(saved, dict) and saved.get("conversation_id") == identity:
         if saved.get("eligible", True):
@@ -282,7 +346,46 @@ class AttentionStore:
         *,
         baseline_seen: bool | None = None,
     ) -> dict[str, Any]:
-        """Import a durable outcome idempotently, including after owner restart."""
+        """Import a durable outcome idempotently, including after owner restart.
+
+        A TOKEN MAY LEGITIMATELY ADVANCE OUT OF ITS PROVISIONAL RECORD, and
+        refusing that used to brick a session permanently. One turn writes
+        ``attention_started`` with token T and, on completion, writes the SAME T
+        with the real anchor and kind. Anything that bootstraps while that turn
+        is in flight — a mobile daemon sweep, a resume attempt, a killed owner —
+        publishes the provisional ``(completion-T, interrupted)`` marker first.
+        When the turn then finishes and the conversation is next opened, the
+        journal's authoritative ``(<entry id>, complete)`` arrives for the same
+        T: not a conflict, just the same turn described exactly. Rejecting it
+        raised out of ``bootstrap_transcript`` on every single spawn, so the
+        runtime could never start and the conversation was unopenable forever.
+
+        Supersession is deliberately narrow: same conversation, and the stored
+        record must still wear the provisional shape — anchor
+        ``completion-<token>`` with kind ``interrupted``. Two refusals it does
+        NOT relax. A token appearing under a DIFFERENT conversation stays an
+        error, which is the integrity property this check exists for: a forked
+        transcript carrying its parent's journal must not capture the parent's
+        receipt. And a record already anchored to a real entry is never
+        replaced, so a late bootstrap racing a finished turn cannot drag a real
+        outcome back to a synthetic one.
+
+        A genuinely interrupted turn is stored in that same provisional shape,
+        and that is intended rather than an ambiguity to resolve: the only
+        writer that can present a different outcome for an existing token is
+        this conversation's own journal replaying that same run, so the record
+        it supersedes is by construction a description of the run that the
+        journal now describes better. An unrelated turn always carries its own
+        freshly minted token.
+
+        The supersede is an UPDATE IN PLACE, which is what keeps it idempotent
+        and flood-free: ``sequence`` is the receipt watermark, so minting a new
+        row would resurrect an ALREADY-ACKNOWLEDGED turn as unread and re-fire
+        a notification for a result the human has read. Correcting a record is
+        not a new completion. Holding the sequence also means a corrected old
+        turn stays where it belongs in the order instead of jumping ahead of
+        newer ones.
+        """
         if kind not in {"complete", "error", "interrupted"} or not anchor:
             raise ValueError("invalid completion")
         if str(uuid.UUID(token)) != token:
@@ -300,7 +403,12 @@ class AttentionStore:
                 "SELECT conversation, anchor, kind FROM completions WHERE token=?", (token,)
             ).fetchone()
             if existing and tuple(existing) != (conversation, anchor, kind):
-                raise ValueError("completion token belongs to another outcome")
+                if not _supersedes_provisional(existing, conversation, token):
+                    raise ValueError("completion token belongs to another outcome")
+                conn.execute(
+                    "UPDATE completions SET anchor=?, kind=? WHERE token=?",
+                    (anchor, kind, token),
+                )
             conn.execute(
                 "INSERT OR IGNORE INTO completions(conversation,token,anchor,kind) VALUES(?,?,?,?)",
                 (conversation, token, anchor, kind),

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1792,9 +1792,19 @@ class Session:
             logger.warning(
                 "attention bootstrap failed for %s (%r); continuing without it",
                 # `getattr` because a handler that can itself raise is not a
-                # guard: a transcript whose `.directory` raises would be
-                # survived by the inner guard and then killed by this one,
-                # which is the exact failure this block exists to prevent.
+                # guard: a transcript object that never grew a `.directory` —
+                # a stub, a partially constructed instance — would be survived
+                # by the inner guard and then killed by this one, which is the
+                # exact failure this block exists to prevent.
+                #
+                # Precisely: this survives a MISSING `.directory`, not a
+                # raising one. `getattr(obj, name, default)` suppresses
+                # `AttributeError` and nothing else, so a `.directory` that
+                # raised `OSError` would still propagate out of this handler.
+                # No third guard for that, because it is unreachable on every
+                # real path: `Transcript.directory` is a plain instance
+                # attribute, `transcript.py` defines no `@property`, and
+                # `Path.name` does not raise.
                 # Mirrors the same defensive read in `attention.py`.
                 getattr(getattr(transcript, "directory", None), "name", None),
                 exc,

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1774,6 +1774,16 @@ class Session:
         # "Connection unavailable". Knowing whether a result is unread can
         # never be worth losing the conversation, so the import is attempted
         # and its failure is logged rather than propagated.
+        #
+        # DO NOT DELETE THIS AS "COVERED BY THE INNER GUARD" (review round 1,
+        # minor-4). The inner guard catches everything the import CALL can
+        # raise, so the live coverage unique to this half is the `import`
+        # STATEMENT itself failing — a circular import, a partially installed
+        # package, a broken .pyc — which would brick boot exactly as the
+        # original defect did. That is why the import sits inside the `try`
+        # rather than above it, and it is the path
+        # `test_a_broken_attention_import_cannot_stop_a_session_from_loading`
+        # exercises.
         try:
             from local_operator.session.attention import bootstrap_transcript
 
@@ -1781,8 +1791,17 @@ class Session:
         except Exception as exc:  # noqa: BLE001 — must not break session boot
             logger.warning(
                 "attention bootstrap failed for %s (%r); continuing without it",
-                transcript.directory.name,
+                # `getattr` because a handler that can itself raise is not a
+                # guard: a transcript whose `.directory` raises would be
+                # survived by the inner guard and then killed by this one,
+                # which is the exact failure this block exists to prevent.
+                # Mirrors the same defensive read in `attention.py`.
+                getattr(getattr(transcript, "directory", None), "name", None),
                 exc,
+                # The traceback, because this swallows an ARBITRARY unknown
+                # exception: `%r` alone names the type but not the frame, and
+                # the next novel failure here is diagnosed from a log file.
+                exc_info=True,
             )
         self._session_id = session_id or transcript.directory.name
         self._attention: dict[str, Any] = {}

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1766,9 +1766,24 @@ class Session:
         # the session's direct calls stamp ``_context_tokens_hint`` themselves.
         self._tools = list(tools)
         self._transcript = transcript
-        from local_operator.session.attention import bootstrap_transcript
+        # Attention bookkeeping is DELIBERATELY NON-FATAL to construction, and
+        # this guard is the outer half of a pair (`bootstrap_transcript` holds
+        # its own). Anything raising here kills the runtime process before it
+        # can serve, on every spawn — so the session is not merely slow to
+        # attach, it is permanently unopenable and the TUI reports only
+        # "Connection unavailable". Knowing whether a result is unread can
+        # never be worth losing the conversation, so the import is attempted
+        # and its failure is logged rather than propagated.
+        try:
+            from local_operator.session.attention import bootstrap_transcript
 
-        bootstrap_transcript(transcript)
+            bootstrap_transcript(transcript)
+        except Exception as exc:  # noqa: BLE001 — must not break session boot
+            logger.warning(
+                "attention bootstrap failed for %s (%r); continuing without it",
+                transcript.directory.name,
+                exc,
+            )
         self._session_id = session_id or transcript.directory.name
         self._attention: dict[str, Any] = {}
         self._attention_outcome: AgentEndEvent | None = None
@@ -5742,6 +5757,7 @@ class Session:
             ATTENTION_CUSTOM_TYPE,
             AttentionStore,
             conversation_identity,
+            provisional_anchor,
         )
 
         outcome = self._attention_outcome
@@ -5771,7 +5787,7 @@ class Session:
             return
         # Failure may precede the first assistant message. Its durable outcome
         # marker, not an unrelated previous answer, is the viewable anchor.
-        anchor = messages[-1].id if kind == "complete" else f"completion-{token}"
+        anchor = messages[-1].id if kind == "complete" else provisional_anchor(token)
         # The journal precedes publication: owner death between these writes is
         # repaired idempotently on resume, without fabricating a new token.
         await self._transcript.append_custom(

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2436,14 +2436,18 @@ class OperatorApp(App[None]):
         #: one that announces OTHER sessions finishing (see
         #: `_notify_background_completions`). The latch keeps one off-loop scan
         #: in flight at a time; the revision is the attention store's own cheap
-        #: `(max_sequence, sum_acknowledged)` detector, so the 1 s poll does a
-        #: catalog scan only when something actually changed. ``None`` rather
-        #: than ``(0, 0)`` so the FIRST tick always scans: an empty store
-        #: genuinely reads ``(0, 0)``, and seeding with it would make a
+        #: `(max_sequence, sum_acknowledged, supersedes)` detector, so the 1 s
+        #: poll does a catalog scan only when something actually changed. The
+        #: third term is what makes a record HEALED in place visible here at
+        #: all: a supersede deliberately holds `sequence` so an acknowledged
+        #: turn is not resurrected as unread, so without it the scan is skipped
+        #: for exactly the row that changed. ``None`` rather
+        #: than ``(0, 0, 0)`` so the FIRST tick always scans: an empty store
+        #: genuinely reads ``(0, 0, 0)``, and seeding with it would make a
         #: completion published before this app started invisible until the
         #: next unrelated change.
         self._background_notify_pending = False
-        self._background_notify_revision: tuple[int, int] | None = None
+        self._background_notify_revision: tuple[int, int, int] | None = None
         #: Retry backoff for a delivery that failed: how many ticks to wait
         #: before the next attempt, and how many of those are still owed. The
         #: interval doubles per barren attempt so the revision-forgetting retry
@@ -2458,7 +2462,7 @@ class OperatorApp(App[None]):
         #: publish or acknowledgement apart from the observer's own retry coming
         #: back round — without it, a real completion arriving mid-backoff would
         #: be made to wait out the backoff it had nothing to do with.
-        self._background_notify_seen_revision: tuple[int, int] | None = None
+        self._background_notify_seen_revision: tuple[int, int, int] | None = None
         #: Desktop notifications for the user who is looking at another app —
         #: the surface one step beyond the window title (see `tui/notify.py`).
         #: Held by the app rather than by the band because, unlike the title,

--- a/tests/unit/mobile/test_attention.py
+++ b/tests/unit/mobile/test_attention.py
@@ -145,7 +145,9 @@ async def test_first_publication_is_safe_for_batch_revision_and_authenticated_li
         try:
             assert created.wait(10)
             assert store.state_many([f"session/{sid}"])[f"session/{sid}"]["unseen"] is False
-            assert store.revision() == (0, 0)
+            # Three terms since supersession became detectable: the third is a
+            # heal counter that a store this empty has never bumped.
+            assert store.revision() == (0, 0, 0)
             response = client.get("/api/sessions")
             assert response.status_code == 200
             assert response.json()["sessions"][0]["unseen"] is False

--- a/tests/unit/session/test_attention.py
+++ b/tests/unit/session/test_attention.py
@@ -12,6 +12,34 @@ import pytest
 from local_operator.session.attention import AttentionStore, conversation_identity
 
 
+def _provisional_anchor(token: str) -> str:
+    """The provisional shape, spelled out rather than imported from the product.
+
+    DELIBERATE DUPLICATION. Importing `provisional_anchor` here made these tests
+    fail against pre-fix code with `ImportError` — which proves only that the
+    symbol is new, not that the behaviour changed, and would fail identically
+    against a tree where supersession was implemented WRONGLY (QA round 1, Q2).
+    Writing the literal makes every assertion below discriminate on behaviour.
+    `test_the_provisional_shape_is_what_the_product_actually_writes` pins this
+    against the product's own writer so the duplication cannot drift silently.
+    """
+    return f"completion-{token}"
+
+
+def test_the_provisional_shape_is_what_the_product_actually_writes() -> None:
+    """Anchor the test-local literal to the product, so it cannot rot.
+
+    This is the ONE test allowed to import the helper, and it is a shape
+    assertion rather than a behaviour one: if the product ever changes the
+    provisional anchor format, this fails loudly instead of letting the
+    duplicated literal above quietly stop matching anything.
+    """
+    from local_operator.session.attention import provisional_anchor
+
+    token = str(uuid.uuid4())
+    assert provisional_anchor(token) == _provisional_anchor(token)
+
+
 def test_delayed_duplicate_and_foreign_acknowledgements(tmp_path: Path) -> None:
     path = tmp_path / "attention.db"
     store = AttentionStore(path)
@@ -379,7 +407,6 @@ async def test_a_completed_turn_supersedes_its_own_interrupted_marker(tmp_path: 
     from local_operator.session.attention import (
         ATTENTION_CUSTOM_TYPE,
         bootstrap_transcript,
-        provisional_anchor,
     )
     from local_operator.session.transcript import Transcript
 
@@ -401,7 +428,7 @@ async def test_a_completed_turn_supersedes_its_own_interrupted_marker(tmp_path: 
 
     store = AttentionStore(tmp_path / "attention.db")
     # What a bootstrap observing the turn in flight leaves behind.
-    store.publish(identity, token, provisional_anchor(token), "interrupted")
+    store.publish(identity, token, _provisional_anchor(token), "interrupted")
     assert store.state(identity)["kind"] == "interrupted"
 
     # SELF-HEALING: an already-poisoned store reconciles on next load, with no
@@ -428,11 +455,9 @@ def test_supersession_never_relaxes_the_cross_conversation_refusal(tmp_path: Pat
     stored record looks. Nor may an authoritative record be dragged back to a
     synthetic anchor by a late bootstrap racing a finished turn.
     """
-    from local_operator.session.attention import provisional_anchor
-
     store = AttentionStore(tmp_path / "attention.db")
     token = str(uuid.uuid4())
-    store.publish("session/owner", token, provisional_anchor(token), "interrupted")
+    store.publish("session/owner", token, _provisional_anchor(token), "interrupted")
     # Same provisional shape, different conversation: still a hard error.
     with pytest.raises(ValueError):
         store.publish("session/fork", token, "message-1", "complete")
@@ -442,7 +467,7 @@ def test_supersession_never_relaxes_the_cross_conversation_refusal(tmp_path: Pat
     store.publish("session/owner", token, "message-1", "complete")
     # No downgrade: a real outcome is not replaced by a provisional one.
     with pytest.raises(ValueError):
-        store.publish("session/owner", token, provisional_anchor(token), "interrupted")
+        store.publish("session/owner", token, _provisional_anchor(token), "interrupted")
     assert store.state("session/owner")["anchor_id"] == "message-1"
     # Nor by a different real outcome under the same token.
     with pytest.raises(ValueError):
@@ -458,11 +483,9 @@ def test_superseding_does_not_resurrect_an_acknowledged_turn_as_unread(
     row would sort above the acknowledgement and re-announce a result the human
     has already read — the exact flood `_BASELINE_DELIVERIES` exists to prevent.
     """
-    from local_operator.session.attention import provisional_anchor
-
     store = AttentionStore(tmp_path / "attention.db")
     token = str(uuid.uuid4())
-    store.publish("session/a", token, provisional_anchor(token), "interrupted")
+    store.publish("session/a", token, _provisional_anchor(token), "interrupted")
     before = store.state("session/a")["revision"][0]
     store.acknowledge("session/a", token)
     assert store.state("session/a")["unseen"] is False
@@ -533,3 +556,119 @@ def test_bootstrap_swallows_and_logs_a_broken_conversation(
         bootstrap_transcript(Unreadable(), AttentionStore(tmp_path / "attention.db"))
     assert "broken" in caplog.text
     assert "transcript is unreadable" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_a_broken_attention_import_cannot_stop_a_session_from_loading(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The path the OUTER guard uniquely exists for: the import itself failing.
+
+    `test_a_failing_attention_bootstrap_cannot_stop_a_session_from_loading`
+    monkeypatches `bootstrap_transcript`, so it exercises a failure the INNER
+    guard in `attention.py` would have absorbed anyway — it proves the pair
+    works, not that the outer half is load-bearing (review round 1, minor-4).
+    The outer guard's own coverage is the `from ... import bootstrap_transcript`
+    STATEMENT raising: a circular import, a half-installed package, a broken
+    .pyc. There is no inner guard to fall back on there, because the module
+    holding it never loads, and an unguarded ImportError would brick boot
+    exactly as the original defect did.
+
+    Simulated by making the import machinery itself raise for that one module,
+    which is what a genuinely broken install looks like from inside `__init__`.
+    """
+    import builtins
+
+    from tests.unit.session.test_session import ScriptedStream, make_session
+
+    real_import = builtins.__import__
+    attempted: list[str] = []
+
+    def broken_import(  # type: ignore[no-untyped-def]
+        name, globals=None, locals=None, fromlist=(), level=0
+    ):
+        if name == "local_operator.session.attention" and "bootstrap_transcript" in (
+            fromlist or ()
+        ):
+            attempted.append(name)
+            raise ImportError("cannot import name 'bootstrap_transcript'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", broken_import)
+    session = make_session(tmp_path, ScriptedStream([]))
+    monkeypatch.setattr(builtins, "__import__", real_import)
+    try:
+        assert attempted, "the import must actually have been attempted and failed"
+        # Boot survived an ImportError with no inner guard available.
+        assert session._transcript.directory.name == "sess"
+        assert session.session_id
+    finally:
+        await session.dispose()
+
+
+def test_a_heal_moves_the_change_detector_without_moving_the_watermark(
+    tmp_path: Path,
+) -> None:
+    """A supersede must be DETECTABLE, or the phone keeps serving the stale row.
+
+    `revision()` is the store's cheap change detector and two consumers gate on
+    it: the desktop bridge skips `refresh_attention` when it is unchanged, and
+    the TUI's background notifier skips its catalog scan. An in-place UPDATE
+    moves neither `MAX(sequence)` nor `SUM(acknowledged)`, so a healed record
+    reached neither of them — a phone could show "Interrupted" for a turn that
+    completed successfully until some unrelated session happened to publish
+    (review round 1, major-1).
+
+    The two properties are in tension only if they share a counter, so they do
+    not: `sequence` stays pinned (no resurrected unread, no re-fired toast) and
+    a third term moves. This test pins BOTH halves — the fix is wrong if either
+    the revision fails to move or the watermark does move.
+    """
+    store = AttentionStore(tmp_path / "attention.db")
+    token = str(uuid.uuid4())
+    store.publish("session/a", token, _provisional_anchor(token), "interrupted")
+    store.acknowledge("session/a", token)
+    # Announced already, so a re-claim after the heal would be a SECOND toast
+    # for one turn — the flood the pinned sequence exists to prevent.
+    assert store.claim_delivery("session/a", token, "test") is True
+    before = store.revision()
+    sequence_before = store.state("session/a")["revision"][0]
+
+    store.publish("session/a", token, "message-real", "complete")
+
+    after = store.revision()
+    assert after != before, "a heal must be visible to the change detector"
+    # The watermark terms specifically must NOT be what moved.
+    assert after[0] == before[0]
+    assert after[1] == before[1]
+    assert store.state("session/a")["revision"][0] == sequence_before
+    assert store.state("session/a")["unseen"] is False
+    assert store.claim_delivery("session/a", token, "test") is False
+    # Read cross-process, since the consumers gating on this are other processes.
+    assert AttentionStore(store.path).revision() == after
+
+
+def test_a_mismatched_provisional_anchor_cannot_supersede(tmp_path: Path) -> None:
+    """An incoming anchor belonging to ANOTHER token is not a heal.
+
+    `_supersedes_provisional` checked the STORED anchor's shape but nothing
+    checked the incoming one, so a publish for T carrying `completion-<U>`
+    superseded successfully and left a row wearing an anchor matching no token:
+    unviewable, and permanently unhealable, because no later real outcome could
+    supersede a record whose stored anchor is no longer `completion-<T>` — a
+    one-way trip into a dead state (review round 1, minor-2).
+    """
+    store = AttentionStore(tmp_path / "attention.db")
+    token, other = str(uuid.uuid4()), str(uuid.uuid4())
+    store.publish("session/a", token, _provisional_anchor(token), "interrupted")
+
+    with pytest.raises(ValueError):
+        store.publish("session/a", token, _provisional_anchor(other), "complete")
+
+    # Refused, and — the point of the finding — still healable afterwards.
+    with sqlite3.connect(store.path) as conn:
+        stored = conn.execute("SELECT anchor FROM completions WHERE token=?", (token,)).fetchone()
+    assert stored[0] == _provisional_anchor(token)
+    store.publish("session/a", token, "message-real", "complete")
+    assert store.state("session/a")["kind"] == "complete"
+    assert store.state("session/a")["anchor_id"] == "message-real"

--- a/tests/unit/session/test_attention.py
+++ b/tests/unit/session/test_attention.py
@@ -358,3 +358,178 @@ def test_a_missing_deliveries_table_is_not_read_as_corruption(tmp_path: Path) ->
         conn.execute("DROP TABLE receipts")
     with pytest.raises(sqlite3.DatabaseError):
         AttentionStore(path).publish("session/a", str(uuid.uuid4()), "result", "complete")
+
+
+@pytest.mark.asyncio
+async def test_a_completed_turn_supersedes_its_own_interrupted_marker(tmp_path: Path) -> None:
+    """The permanent-brick regression: a session that could never be opened again.
+
+    The operator lost a 65 MB, 14,905-entry conversation to this. A turn writes
+    `attention_started` with token T; anything that bootstraps while that turn
+    is still in flight publishes the provisional `(completion-T, interrupted)`
+    marker. The turn then finishes and journals the SAME T with its real anchor
+    and kind `complete`, so the next open published a second outcome for T,
+    `publish` called it a conflict, and the raise propagated out of
+    `Session.__init__` — killing the runtime process on EVERY spawn attempt.
+    Not a timeout and not corruption: the normal turn lifecycle, unopenable
+    forever. A long-running session is the one that gets hit, because it has
+    the most turns and the widest window to be observed mid-turn.
+    """
+    from local_operator.harness.types import Message, TextContent
+    from local_operator.session.attention import (
+        ATTENTION_CUSTOM_TYPE,
+        bootstrap_transcript,
+        provisional_anchor,
+    )
+    from local_operator.session.transcript import Transcript
+
+    directory = tmp_path / "sessions" / "long-running"
+    transcript = Transcript(directory)
+    identity = conversation_identity(directory)
+    token = str(uuid.uuid4())
+    await transcript.append_custom(
+        "attention_started", {"conversation_id": identity, "token": token}
+    )
+    await transcript.append_message(
+        Message(role="assistant", content=[TextContent(text="the finished answer")])
+    )
+    anchor = transcript.entries()[-1].id
+    await transcript.append_custom(
+        ATTENTION_CUSTOM_TYPE,
+        {"conversation_id": identity, "token": token, "anchor": anchor, "kind": "complete"},
+    )
+
+    store = AttentionStore(tmp_path / "attention.db")
+    # What a bootstrap observing the turn in flight leaves behind.
+    store.publish(identity, token, provisional_anchor(token), "interrupted")
+    assert store.state(identity)["kind"] == "interrupted"
+
+    # SELF-HEALING: an already-poisoned store reconciles on next load, with no
+    # manual SQL. Users bricked by an older release are repaired by opening.
+    bootstrap_transcript(transcript, AttentionStore(store.path))
+    state = store.state(identity)
+    assert state["kind"] == "complete"
+    assert state["anchor_id"] == anchor
+    assert state["completion_token"] == token
+    # Corrected in place, never minted: a second row would re-fire a
+    # notification for a result the human may already have read.
+    with sqlite3.connect(store.path) as conn:
+        assert conn.execute("SELECT count(*) FROM completions").fetchone()[0] == 1
+    # Still idempotent once healed.
+    bootstrap_transcript(transcript, AttentionStore(store.path))
+    assert store.state(identity)["anchor_id"] == anchor
+
+
+def test_supersession_never_relaxes_the_cross_conversation_refusal(tmp_path: Path) -> None:
+    """The integrity property the conflict check exists for, unchanged.
+
+    A forked transcript carries its parent's journal, so a token presented
+    under a DIFFERENT conversation must stay an error however provisional the
+    stored record looks. Nor may an authoritative record be dragged back to a
+    synthetic anchor by a late bootstrap racing a finished turn.
+    """
+    from local_operator.session.attention import provisional_anchor
+
+    store = AttentionStore(tmp_path / "attention.db")
+    token = str(uuid.uuid4())
+    store.publish("session/owner", token, provisional_anchor(token), "interrupted")
+    # Same provisional shape, different conversation: still a hard error.
+    with pytest.raises(ValueError):
+        store.publish("session/fork", token, "message-1", "complete")
+    assert store.state("session/fork")["completion_token"] is None
+    assert store.state("session/owner")["kind"] == "interrupted"
+
+    store.publish("session/owner", token, "message-1", "complete")
+    # No downgrade: a real outcome is not replaced by a provisional one.
+    with pytest.raises(ValueError):
+        store.publish("session/owner", token, provisional_anchor(token), "interrupted")
+    assert store.state("session/owner")["anchor_id"] == "message-1"
+    # Nor by a different real outcome under the same token.
+    with pytest.raises(ValueError):
+        store.publish("session/owner", token, "message-2", "complete")
+
+
+def test_superseding_does_not_resurrect_an_acknowledged_turn_as_unread(
+    tmp_path: Path,
+) -> None:
+    """Correcting a record is not a new completion.
+
+    `sequence` is the receipt watermark, so healing must update in place. A new
+    row would sort above the acknowledgement and re-announce a result the human
+    has already read — the exact flood `_BASELINE_DELIVERIES` exists to prevent.
+    """
+    from local_operator.session.attention import provisional_anchor
+
+    store = AttentionStore(tmp_path / "attention.db")
+    token = str(uuid.uuid4())
+    store.publish("session/a", token, provisional_anchor(token), "interrupted")
+    before = store.state("session/a")["revision"][0]
+    store.acknowledge("session/a", token)
+    assert store.state("session/a")["unseen"] is False
+    # Somebody already announced this run, per the no-flood rule.
+    assert store.claim_delivery("session/a", token, "test") is True
+
+    store.publish("session/a", token, "message-1", "complete")
+    healed = store.state("session/a")
+    assert healed["kind"] == "complete"
+    assert healed["revision"][0] == before
+    assert healed["unseen"] is False
+    # And the delivery watermark is likewise not rewound into a second toast.
+    assert store.claim_delivery("session/a", token, "test") is False
+
+
+@pytest.mark.asyncio
+async def test_a_failing_attention_bootstrap_cannot_stop_a_session_from_loading(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Attention bookkeeping is an observability nicety; boot outranks it.
+
+    The severity of the brick came from `Session.__init__` calling the
+    bootstrap unguarded: a raise there kills the runtime process before it can
+    serve, on every attach, so no retry ever helps. Whatever else goes wrong in
+    attention, the conversation must still open.
+    """
+    import local_operator.session.attention as attention_module
+    from tests.unit.session.test_session import ScriptedStream, make_session
+
+    calls: list[str] = []
+
+    def exploding(transcript, store=None):  # type: ignore[no-untyped-def]
+        calls.append(transcript.directory.name)
+        raise RuntimeError("attention store is unreachable")
+
+    monkeypatch.setattr(attention_module, "bootstrap_transcript", exploding)
+    session = make_session(tmp_path, ScriptedStream([]))
+    try:
+        assert calls, "the guard must not skip the import, only survive it"
+        # The session is fully constructed and usable.
+        assert session._transcript.directory.name == "sess"
+        assert session.session_id
+    finally:
+        await session.dispose()
+
+
+def test_bootstrap_swallows_and_logs_a_broken_conversation(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """One poisoned session may not take the mobile daemon's other 99 with it.
+
+    The daemon sweeps up to 100 session directories in one loop, so the guard
+    lives in `bootstrap_transcript` itself rather than only at its callers. The
+    failure is logged with the conversation and the exception: swallowed is not
+    the same as invisible.
+    """
+    import logging
+
+    from local_operator.session.attention import bootstrap_transcript
+
+    class Unreadable:
+        directory = tmp_path / "sessions" / "broken"
+
+        def latest_custom(self, _type: str) -> dict[str, object]:
+            raise OSError("transcript is unreadable")
+
+    with caplog.at_level(logging.WARNING, logger="local_operator.session.attention"):
+        bootstrap_transcript(Unreadable(), AttentionStore(tmp_path / "attention.db"))
+    assert "broken" in caplog.text
+    assert "transcript is unreadable" in caplog.text


### PR DESCRIPTION
## What and why

**C3 — an unrecoverable data-access defect.** A long-running conversation became **permanently unopenable**. Every attach failed, the runtime process never started, and the TUI showed only `Saved excerpt · Connection unavailable · Reselect to retry`. There is no retry that helps and no user-facing recovery: the session is simply lost.

It hit the operator's real "OSWorld benchmark evaluation and agent optimization" session — 65 MB, 14,905 entries, 256 subagent records.

```
ConnectionError: session owner is reconnecting
engage failed for 835fbcafdc27: could not start a runtime for session 835fbcafdc27:
  builtins.ValueError: completion token belongs to another outcome
```

**Not a timeout and not a size problem.** The journal parses in 0.6 s and engage takes ~2 s. The runtime failed to *spawn*, on every single attempt.

### The mechanism

A token legitimately advances, and `publish` called that a conflict.

One turn writes `attention_started` with token `T`, and on completion writes the **same** `T` with its real anchor and kind. Verified in the affected journal — one turn, 373 entries apart:

```
line=14531 attention_started    tok=6b156608 anchor=None                (turn starts)
line=14904 completion_attention tok=6b156608 anchor=416aa134… complete  (same turn ends)
```

Anything that bootstraps **while that turn is in flight** — a mobile daemon sweep, a resume attempt, a killed owner — takes the interrupted arm and publishes the provisional `(completion-T, interrupted)` marker. When the turn later finishes and the session is next opened, the saved arm publishes the journal's authoritative `(<entry id>, complete)` for the same `T`. Different outcome, same token → `ValueError`. The stored row matched exactly:

```
db:   token=6b156608… anchor='completion-6b156608-…'          kind='interrupted'
want: token=6b156608… anchor='416aa134800949208dbd6ac459bb943a' kind='complete'
```

This is the **normal turn lifecycle**, not corruption — which is why a *long-running* session is the one that got hit. More turns means a wider window in which a bootstrap can observe one in flight.

### Why it was permanent rather than transient

`Session.__init__` called `bootstrap_transcript(transcript)` **unguarded**. The raise therefore killed the runtime process *before it could serve*, on every spawn. An attention record is an observability nicety — who has an unread result — and it was outranking the ability to read the conversation at all.

## The fix — two independent defects, both needed

**1. Attention bookkeeping is now non-fatal to a boot.** Guards sit at **both** layers: `bootstrap_transcript` holds its own, and `Session.__init__` holds the outer half. The daemon path matters as much as the session path — it sweeps up to 100 session directories in one loop, and one poisoned session must not take the other 99 down with it. Failures are **logged with the conversation and the exception**, following the codebase's existing `# noqa: BLE001` convention: swallowed is not the same as invisible.

**2. A token may advance out of its provisional record.** `publish` now lets a later, more authoritative outcome supersede one that is still **provisional** — anchor `completion-<token>`, kind `interrupted` — for the **same conversation**.

Deliberately narrow. Both integrity refusals are **preserved**:

| Case | Behaviour |
|---|---|
| Same conversation, stored record provisional | **superseded** (the fix) |
| Token under a **different** conversation | **still `ValueError`** — a forked transcript must not capture its parent's receipt |
| Stored record already anchored to a real entry | **still `ValueError`** — a late bootstrap cannot drag a real outcome back to a synthetic one |
| Genuinely interrupted turn, journal agrees | **stays `interrupted`** |

The supersede is an **`UPDATE` in place**, not a new row, and that is load-bearing: `sequence` is the receipt watermark, so minting a row would resurrect an **already-acknowledged** turn as unread and re-fire a notification for a result the human has read — the exact flood `_BASELINE_DELIVERIES` exists to prevent. Correcting a record is not a new completion.

**3. Self-healing.** A store already poisoned by an older release reconciles to the journal's truth **on next load**, with no manual SQL.

`provisional_anchor()` replaces the two hand-built `f"completion-{token}"` sites so the shape the supersede rule recognises has exactly one definition.

## Testing evidence

### Before → after on the actual failing path

Isolated fixture (fresh `HOME` + `LOCAL_OPERATOR_CONFIG_DIR`), synthetic session whose transcript carries the normal lifecycle, DB poisoned with the provisional row:

**BEFORE** — the defect, reproduced:
```
poisoned row: kind=interrupted anchor=completion-a6fc162f-0ff7-4486-84b2-a4399fcbe5dd
transcript truth: kind=complete anchor=231e165aa1ac400998867e2a9f2e9399

bootstrap_transcript RAISED (session is bricked):
Traceback (most recent call last):
  File "/tmp/attn-brick/repro.py", line 67, in main
    bootstrap_transcript(transcript, AttentionStore(config / "attention.db"))
  File ".../local_operator/session/attention.py", line 86, in bootstrap_transcript
    store.publish(identity, saved["token"], saved["anchor"], saved["kind"])
  File ".../local_operator/session/attention.py", line 303, in publish
    raise ValueError("completion token belongs to another outcome")
ValueError: completion token belongs to another outcome
EXIT=1
```

**AFTER** — same fixture, this branch:
```
poisoned row: kind=interrupted anchor=completion-79decb3f-c4f4-464d-9c3c-81ff8e1039c8
transcript truth: kind=complete anchor=58976f8458c34a3a919074ccaa6ef328

bootstrap_transcript OK -> kind=complete anchor=58976f8458c34a3a919074ccaa6ef328
SELF-HEALED: store now reflects the completed outcome
EXIT=0
```

### End-to-end attach against the real 65 MB session

A **copy** of the operator's bricked session, with an isolated config dir **re-poisoned** with the exact row that bricked it (the live DB has already been hand-repaired, and was never touched by this work — the scan below reads it `mode=ro`). This drives the real attach path, `RemoteSession.saved_preview` → `_ensure_bound` → `ensure_display_current`, with `CMUX_*` scrubbed:

**BEFORE**
```
journal entries: 14905
journal completion_attention: token=6b156608 kind=complete
POISONED: kind=interrupted anchor=completion-6b156608-eb72-4416-9cfe-7fe2e
saved_preview      0.14s partial=True
engage failed for 835fbcafdc27: could not start a runtime for session 835fbcafdc27:
  builtins.ValueError: completion token belongs to another outcome
_ensure_bound      4.71s FAILED ConnectionError: session owner is reconnecting
AFTER ATTACH: kind=interrupted anchor=completion-6b156608-eb72-4416-9cfe-7fe2e
self-healed to journal truth: False
```

**AFTER**
```
journal entries: 14905
journal completion_attention: token=6b156608 kind=complete
POISONED: kind=interrupted anchor=completion-6b156608-eb72-4416-9cfe-7fe2e
saved_preview      0.10s partial=True
_ensure_bound      2.37s cold=False  BOUND
display_current    0.00s
TOTAL              2.47s
AFTER ATTACH: kind=complete anchor=416aa134800949208dbd6ac459bb943a
self-healed to journal truth: True
```

**`engage failed` → `BOUND` in 2.37 s**, and the store healed to the journal's real anchor `416aa134…` with no manual SQL.

### Fleet-wide scan

Replays the bootstrap decision for every session with a journal and classifies it under the old rule vs the new one. Against the operator's **pre-repair** DB backup — the genuinely bricked state:

```
sessions with journals checked: 321
OLD rule — bricked (boot raises, session unopenable forever): 1
NEW rule — self-healed on next load: 1
NEW rule — still a hard refusal (genuine integrity violation): 0
  835fbcafdc27 tok=6b156608
    db=('session/835fbcafdc27', 'completion-6b156608-…', 'interrupted')
    want=('session/835fbcafdc27', '416aa134800949208dbd6ac459bb943a', 'complete')
```

Low incidence, catastrophic and unrecoverable impact. **Every** brick in the fleet is repaired by the self-healing path, and **no** case that previously raised for a genuine integrity reason stops raising.

### Semantic edge cases, executed

```
interrupted turn stays interrupted: True (kind=interrupted)
error supersedes provisional: True
error record is authoritative: True
```

### Regression tests

Five new tests in `tests/unit/session/test_attention.py` covering the reproduction, the preserved cross-conversation refusal, the no-downgrade rule, the watermark/no-flood property, and both guard layers.

**Proved they can still fail.** Against the pre-fix code (supersede reverted, `provisional_anchor` shimmed so the imports resolve), all four fail with exactly the defect's own errors:

```
FAILED test_a_completed_turn_supersedes_its_own_interrupted_marker
       - ValueError: completion token belongs to another outcome
FAILED test_superseding_does_not_resurrect_an_acknowledged_turn_as_unread
       - ValueError: completion token belongs to another outcome
FAILED test_a_failing_attention_bootstrap_cannot_stop_a_session_from_loading
       - RuntimeError: attention store is unreachable
FAILED test_bootstrap_swallows_and_logs_a_broken_conversation
       - OSError: transcript is unreadable
4 failed, 24 deselected
```

## Quality gates

Run on the rebased head, in a worktree venv verified to resolve this tree.

| Gate | Result |
|---|---|
| `flake8 .` | clean |
| `black --check .` | 1185 files unchanged |
| `isort --check-only .` | clean |
| `pyright --pythonpath .venv/bin/python .` | **0 errors, 0 warnings** |
| `tests/unit/session/test_attention.py` | **28 passed** |
| `test_creation` + `test_remote_cold` + `test_remote_disconnect` + `test_frontend_state` + `tests/unit/mobile` | **379 passed** |

**On the whole-tree unit suite: I did not complete one locally, and am not claiming it.** A run on the pre-rebase head reached **85% with zero failures** and then stopped advancing for ~30 minutes — that is a **partial run**, and it is the host, not the diff: this machine is at 96% disk on `/System/Volumes/Data` (~21 GiB left), ~64 MB RAM free, swap 12.4/13.3 GB, load peaking ~261 across a large agent fleet. Continuing risked an ENOSPC death that would read as a failure in this diff. CI runs the full suite on hardware that is not swapping, and is the authoritative gate on this head.

## Scope

`local_operator/session/attention.py`, `local_operator/session/session.py`, `tests/unit/session/test_attention.py`. No version bump — `pyproject.toml` stays at the released `0.53.3`. No user-visible surface, so no design or UX round is required; reviewer + QA apply.

Rebased onto `origin/main` at `6eacd91e2` (v0.53.3).
