### PR TITLE
fix(providers): let ctrl+C cancel a pending OAuth login

### DIFF
--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -5300,4 +5300,18 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    exit(main())
+    # ``sys.exit``, NOT the ``exit()`` builtin, so ``python -m local_operator.cli``
+    # ends the same way the installed console scripts do. ``exit`` is
+    # ``_sitebuiltins.Quitter``, which CLOSES ``sys.stdin`` before raising
+    # SystemExit — and that close waits on the buffered reader's lock. The
+    # interactive login reads a pasted value on a daemon thread that may still
+    # be parked in that read (it is deliberately not joined; see
+    # ``auth_cli.on_manual_code_input``), so the two together can deadlock a
+    # cancel that has already printed its receipt: the user is told the login
+    # was cancelled and the shell prompt never returns.
+    #
+    # ``sys.exit`` raises SystemExit without touching stdin, which is why the
+    # shipped entry points have never had this shape. Site builtins are also
+    # absent under ``python -S`` and in frozen builds, so this is the more
+    # portable spelling regardless (QA round 1, Q1).
+    sys.exit(main())

--- a/local_operator/providers/auth_cli.py
+++ b/local_operator/providers/auth_cli.py
@@ -10,10 +10,16 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import signal
+import threading
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
-from local_operator.providers.oauth.callback_server import LoginCallbacks, LoginError
+from local_operator.providers.oauth.callback_server import (
+    LoginCallbacks,
+    LoginCancelledError,
+    LoginError,
+)
 from local_operator.providers.registry import (
     PROVIDER_REGISTRY,
     ProviderDefinition,
@@ -97,8 +103,56 @@ def _callbacks_interactive(definition: ProviderDefinition) -> LoginCallbacks:
         return input(prompt)
 
     async def on_manual_code_input() -> str | None:
+        """Read a pasted value without making the process unkillable.
+
+        A DAEMON thread we own, deliberately NOT ``asyncio.to_thread``. The
+        difference only shows up on Ctrl+C, and there it is the whole
+        behaviour: ``to_thread`` runs on the loop's default
+        ``ThreadPoolExecutor``, and ``asyncio.run`` shuts that executor down by
+        JOINING its workers with ``THREAD_JOIN_TIMEOUT``, which is 300 s. The
+        worker is blocked in ``input()``/``getpass()`` on a terminal read that
+        nothing interrupts, so it never finishes and the join never returns.
+
+        Measured on the pre-change tree, driving the real CLI under a pty and
+        sending a real Ctrl+C: the interrupt is delivered and ``run_login``'s
+        ``except KeyboardInterrupt`` is reached, and then the process sits in
+        ``Runner.close()`` for the full five minutes. From the user's side the
+        cancel simply does not work — which is the same 300 s wait this change
+        exists to remove, arrived at from the other direction.
+
+        A daemon thread is not joined at interpreter exit, so the blocked read
+        stops being able to hold the process open. The value is handed back
+        through a loop-thread callback, and the future is checked for
+        cancellation first: by the time a late paste arrives the flow it was
+        feeding may already be gone.
+        """
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[str] = loop.create_future()
+
+        def deliver(setter: Callable[[], None]) -> None:
+            # The future is resolved from the LOOP thread; a cancelled future
+            # (the login ended while the user was still typing) is left alone
+            # rather than raising InvalidStateError into a dead flow.
+            if not future.done():
+                setter()
+
+        def worker() -> None:
+            try:
+                value = read_line()
+            except BaseException as raised:  # noqa: BLE001 — reported, not swallowed
+                # Bound to a local BEFORE the lambda closes over it: Python
+                # deletes an `except ... as` name when the clause exits, so a
+                # lambda that referenced it directly would raise NameError on
+                # the loop thread instead of delivering the error.
+                error = raised
+                loop.call_soon_threadsafe(deliver, lambda: future.set_exception(error))
+            else:
+                read = value
+                loop.call_soon_threadsafe(deliver, lambda: future.set_result(read))
+
+        threading.Thread(target=worker, daemon=True, name="lo-login-paste").start()
         try:
-            value = await asyncio.to_thread(read_line)
+            value = await future
         except (EOFError, KeyboardInterrupt):
             return None
         return value.strip() or None
@@ -107,6 +161,57 @@ def _callbacks_interactive(definition: ProviderDefinition) -> LoginCallbacks:
     return LoginCallbacks(
         on_auth_url=on_auth_url, on_progress=on_progress, on_manual_code_input=manual_input
     )
+
+
+async def _login_or_cancel(login: Any, callbacks: LoginCallbacks, aborted: Any) -> Any:
+    """Run a login, and give up on it the moment the abort signal fires.
+
+    The signal is passed down as well, because a provider that WATCHES it can
+    unwind itself cleanly — the loopback flows stop their callback server in
+    their own `finally`, which is what frees the port for a retry, and that is
+    strictly better than being cancelled from outside.
+
+    But not every login watches it. The paste-a-key providers
+    (`create_api_key_login`) are nothing but an `on_manual_code_input` await:
+    they accept `signal` through `**_kwargs` and ignore it, so an abort alone
+    would leave `local-operator login alibaba` blocked on a prompt read until
+    the user found another way out. Verified under a pty before this race
+    existed: Ctrl+C printed nothing and the process had to be SIGKILLed.
+
+    Racing here covers both shapes with one rule, and the ordering keeps the
+    better outcome when it is available: a flow that raises
+    `LoginCancelledError` for itself wins the race normally, and the losing
+    task is cancelled and reaped so no login continues detached from the
+    command that started it.
+    """
+    login_task = asyncio.ensure_future(login(callbacks, signal=aborted))
+    abort_task = asyncio.ensure_future(aborted.wait())
+    try:
+        done, _pending = await asyncio.wait(
+            {login_task, abort_task}, return_when=asyncio.FIRST_COMPLETED
+        )
+        if login_task in done:
+            return login_task.result()
+        raise LoginCancelledError(aborted.reason or "Login cancelled")
+    finally:
+        for task in (login_task, abort_task):
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(login_task, abort_task, return_exceptions=True)
+
+
+def _cancelled_message(definition: ProviderDefinition) -> str:
+    """What the terminal says when a login is cancelled.
+
+    Same sentence the TUI's notice carries, for the same reason: the user
+    cancelled because nothing appeared to happen (a browser that landed in the
+    provider's portal instead of coming back to the loopback redirect), so
+    "cancelled" alone leaves them unsure whether something is still listening
+    on the port and how to try again. The listener clause is conditional so it
+    stays true — a paste-a-key provider never started a server.
+    """
+    stopped = "local sign-in listener stopped; " if definition.callback_port is not None else ""
+    return f"\nLogin cancelled. {stopped}retry with: local-operator login {definition.id}"
 
 
 def run_login(
@@ -140,16 +245,58 @@ def run_login(
     callbacks = _callbacks_interactive(definition)
 
     async def _run() -> str | dict[str, Any]:
-        return await login(callbacks)
+        # A Ctrl+C during a PENDING login has to cancel the login, not merely
+        # unwind the interpreter. The flow is parked in `asyncio.wait` on the
+        # loopback callback, so the signal is turned into an abort the flow is
+        # already watching for -- the same AbortSignal the TUI's Ctrl+C rung
+        # feeds -- which makes it raise `LoginCancelledError` at once instead
+        # of sitting out the 300 s `DEFAULT_TIMEOUT_SECONDS`, and lets
+        # `run()`'s `finally` stop the loopback server so the port is free for
+        # an immediate retry.
+        #
+        # `add_signal_handler` and not `signal.signal`, because the default
+        # KeyboardInterrupt lands wherever the main thread happens to be and
+        # unwinds the flow WITHOUT running its cleanup; scheduling on the loop
+        # makes the cancel a normal, orderly outcome of the flow itself.
+        from local_operator.harness.types import AbortSignal
+
+        aborted = AbortSignal()
+        loop = asyncio.get_running_loop()
+        try:
+            loop.add_signal_handler(signal.SIGINT, lambda: aborted.abort("Login cancelled"))
+        except (NotImplementedError, RuntimeError):
+            # Windows event loops do not implement add_signal_handler, and it
+            # also raises off the main thread. The bare KeyboardInterrupt path
+            # below still catches the interrupt there; it just cannot be as
+            # tidy about the teardown.
+            pass
+        try:
+            return await _login_or_cancel(login, callbacks, aborted)
+        finally:
+            # The handler outlives the flow otherwise, and a later Ctrl+C would
+            # abort a signal nobody is watching instead of interrupting.
+            try:
+                loop.remove_signal_handler(signal.SIGINT)
+            except (NotImplementedError, RuntimeError):
+                pass
 
     try:
         result = asyncio.run(_run())
     except LoginError as exc:
+        # A cancel is an OUTCOME, not a failure, so it must not be reported as
+        # "Login failed:" — LoginCancelledError is a LoginError subclass and
+        # would otherwise be caught by the clause below.
+        if isinstance(exc, LoginCancelledError):
+            print(_cancelled_message(definition))
+            return 130
         print(f"Login failed: {exc}")
         return 1
     except KeyboardInterrupt:
-        print("Login cancelled.")
-        return 1
+        # The fallback for a host where the loop-level handler could not be
+        # installed (see `_run`), and for an interrupt outside the flow's own
+        # wait.
+        print(_cancelled_message(definition))
+        return 130
 
     storage_provider = credential_provider_id(definition.id)
     if isinstance(result, str):

--- a/local_operator/providers/auth_cli.py
+++ b/local_operator/providers/auth_cli.py
@@ -8,11 +8,14 @@ from an interactive terminal (exec/headless mode never calls them).
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 import signal
+import sys
 import threading
 import time
+from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Callable
 
 from local_operator.providers.oauth.callback_server import (
@@ -125,6 +128,17 @@ def _callbacks_interactive(definition: ProviderDefinition) -> LoginCallbacks:
         through a loop-thread callback, and the future is checked for
         cancellation first: by the time a late paste arrives the flow it was
         feeding may already be gone.
+
+        THE WORKER OUTLIVES THIS CALL ON EVERY PATH, not just the cancel one.
+        A successful Anthropic login finishes when the loopback callback wins
+        the race, and this reader is still parked in `input()`/`getpass()` with
+        a `read()` outstanding on the terminal until the process exits. That is
+        why the terminal's own state is snapshotted and restored by the
+        COMMAND (`_terminal_state_restored`) rather than by the reader, and why
+        anything the CLI does after a successful login would be competing for
+        stdin with this thread. Nothing does today; a future caller that wants
+        to read from the terminal after a login has to reckon with it (agent
+        review round 1, minor-3).
         """
         loop = asyncio.get_running_loop()
         future: asyncio.Future[str] = loop.create_future()
@@ -139,13 +153,24 @@ def _callbacks_interactive(definition: ProviderDefinition) -> LoginCallbacks:
         def worker() -> None:
             try:
                 value = read_line()
-            except BaseException as raised:  # noqa: BLE001 — reported, not swallowed
+            except Exception as raised:  # noqa: BLE001 — reported, not swallowed
                 # Bound to a local BEFORE the lambda closes over it: Python
                 # deletes an `except ... as` name when the clause exits, so a
                 # lambda that referenced it directly would raise NameError on
                 # the loop thread instead of delivering the error.
                 error = raised
                 loop.call_soon_threadsafe(deliver, lambda: future.set_exception(error))
+            except BaseException:
+                # `SystemExit`/`KeyboardInterrupt` raised INSIDE this reader
+                # belong to interpreter teardown on this thread, not to the
+                # awaiting flow. Delivering one into the future would re-raise
+                # it on the loop thread, in a context its author never meant —
+                # a `SystemExit` from a reader would surface as the login's
+                # outcome. The flow has its own answer for a cancel (the abort
+                # signal and the `_login_or_cancel` race), so leaving the
+                # future unresolved lets that answer win (agent review round 1,
+                # nit-1). EOF still arrives as the `EOFError` handled below.
+                logger.debug("login paste reader exited during teardown", exc_info=True)
             else:
                 read = value
                 loop.call_soon_threadsafe(deliver, lambda: future.set_result(read))
@@ -198,6 +223,67 @@ async def _login_or_cancel(login: Any, callbacks: LoginCallbacks, aborted: Any) 
             if not task.done():
                 task.cancel()
         await asyncio.gather(login_task, abort_task, return_exceptions=True)
+
+
+@contextlib.contextmanager
+def _terminal_state_restored() -> Iterator[None]:
+    """Put the terminal back the way it was found, whatever happens inside.
+
+    The paste prompt reads through ``getpass`` for an API key, which disables
+    ECHO via ``termios`` and restores it in its own ``finally`` — on the reader
+    thread. That thread is deliberately a DAEMON (see
+    ``on_manual_code_input``): not joining it is what stops a blocked terminal
+    read holding the process open for the 300 s executor join. The cost is that
+    when a cancel exits the process while the reader is still parked inside
+    ``getpass``, its ``finally`` never runs and the user is returned to a shell
+    with ECHO off — typing nothing they can see, with no way to diagnose it
+    short of blind-typing ``stty sane``.
+
+    So the restore cannot live on the reader. It belongs to whoever owns the
+    terminal for the duration of the login, which is this command. Snapshotting
+    before the flow starts and restoring on every exit makes it independent of
+    which thread was reading, whether it was interrupted, and whether
+    ``getpass`` ever ran at all.
+
+    Reproduced under a real pty with the precondition asserted (ECHO on before,
+    off at the prompt): ``alibaba`` left ECHO off after a cancel while
+    ``anthropic`` — whose ``read_line`` uses plain ``input()`` — restored it,
+    which is what isolates this to the ``getpass`` branch and its 10-11
+    ``paste_prompt_required`` providers (agent review round 1, major-1).
+
+    A no-op when stdin is not a tty (piped input, CI) or the platform has no
+    ``termios`` (Windows), and it never raises: failing to restore a terminal
+    must not turn a completed login into an error.
+    """
+    saved = None
+    # The DESCRIPTOR, captured once, not the stream object: ``sys.stdin`` can
+    # be rebound or closed while the login runs, and the restore has to name
+    # the same terminal the snapshot came from.
+    fd: int | None = None
+    try:
+        stream = sys.stdin
+        if stream is not None and stream.isatty():
+            import termios
+
+            descriptor = stream.fileno()
+            saved = termios.tcgetattr(descriptor)
+            fd = descriptor
+    except Exception:  # pragma: no cover - no tty, or a platform without termios
+        saved = None
+        fd = None
+    try:
+        yield
+    finally:
+        if saved is not None and fd is not None:
+            try:
+                import termios
+
+                # TCSADRAIN, not TCSANOW: let whatever the flow already wrote
+                # drain before the mode flips, so the restore cannot cut into
+                # the cancel receipt being printed.
+                termios.tcsetattr(fd, termios.TCSADRAIN, saved)
+            except Exception:  # pragma: no cover - terminal vanished under us
+                logger.debug("could not restore terminal attributes", exc_info=True)
 
 
 def _cancelled_message(definition: ProviderDefinition) -> str:
@@ -280,8 +366,13 @@ def run_login(
             except (NotImplementedError, RuntimeError):
                 pass
 
+    # Wraps the WHOLE flow, not just the cancel branch: the reader thread can
+    # still be parked inside `getpass` on a successful loopback login too (see
+    # `on_manual_code_input`), so every way out of here owes the user the
+    # terminal they arrived with.
     try:
-        result = asyncio.run(_run())
+        with _terminal_state_restored():
+            result = asyncio.run(_run())
     except LoginError as exc:
         # A cancel is an OUTCOME, not a failure, so it must not be reported as
         # "Login failed:" — LoginCancelledError is a LoginError subclass and

--- a/local_operator/providers/controller.py
+++ b/local_operator/providers/controller.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any, Callable, Protocol
 
 import httpx
 
-from local_operator.harness.types import ModelSpec
+from local_operator.harness.types import AbortSignal, ModelSpec
 from local_operator.model.configure import (  # noqa: F401  (used by callers)
     build_model_spec,
 )
@@ -481,7 +481,11 @@ class ProviderController:
         )
 
     async def login(
-        self, provider_id: str, *, open_browser: Callable[[str], None] | None = None
+        self,
+        provider_id: str,
+        *,
+        open_browser: Callable[[str], None] | None = None,
+        signal: AbortSignal | None = None,
     ) -> str:
         """Run the provider's login flow and report a human summary.
 
@@ -489,11 +493,31 @@ class ProviderController:
         wraps this in ``App.suspend()``). Returns a message like
         ``Logged in to 'anthropic' (you@example.com).``; raises
         ``ValueError`` / ``LoginError`` on failure.
+
+        ``signal`` makes a PENDING login cancellable. Every layer beneath this
+        one already had the machinery -- ``OAuthCallbackFlow._await_code``
+        races an abort watcher against its capture futures, the device flow
+        polls it, and the registry's lazy thunks forward it -- but nothing ever
+        constructed one, so all of it was unreachable and a user whose browser
+        never came back had no way out but the 300 s
+        ``DEFAULT_TIMEOUT_SECONDS``. This parameter is the missing end of that
+        chain, not a new mechanism.
+
+        Forwarded to EVERY login callable, including the paste-a-key providers
+        and ``local_setup``, which ignore it: they all accept ``**kwargs``, and
+        keeping the call shape uniform is what stops a host having to know
+        which flavour of provider it is talking to before it can offer a
+        cancel.
         """
         definition = get_provider_definition(provider_id)
         if definition is None:
             raise ValueError(f"Unknown provider: {provider_id}")
         if definition.local_setup:
+            # Endpoint setup has no loopback listener and no timeout to escape:
+            # it is a sequence of prompts, and its cancel is the host declining
+            # one (each `prompt` returning None raises LoginCancelledError
+            # already). The signal is accepted and dropped here rather than
+            # threaded through, so a caller can pass one to any provider.
             return await self._configure_local(definition)
         if definition.login is None:
             raise ValueError(f"Provider '{provider_id}' has no interactive login.")
@@ -506,7 +530,11 @@ class ProviderController:
         options: dict[str, Any] = {}
         if open_browser is not None and definition.callback_port is not None:
             options["open_browser"] = open_browser
-        result = await definition.login(callbacks, **options)
+        # Passed UNCONDITIONALLY, including when it is None, so there is exactly
+        # one call shape. Every login callable in the registry takes it: the
+        # lazy OAuth thunks name it explicitly, and `create_api_key_login`'s
+        # paste-only login swallows it through `**_kwargs`.
+        result = await definition.login(callbacks, signal=signal, **options)
 
         storage = definition.store_credentials_as or provider_id
         if isinstance(result, str):

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -14428,6 +14428,25 @@ class OperatorApp(App[None]):
         # rendered "ctrl+c again to exit" while the login stayed pending, so the
         # reflex was already live and already loaded.
         if self._cancel_pending_login():
+            # RETURN TO THE CONVERSATION FIRST, exactly as the exit-ladder tail
+            # below does and for its stated reason: the card floats over the
+            # transcript at one elevation step, so a notice appended behind it
+            # is drawn where it cannot be read. This rung appends precisely
+            # such a notice — the "login cancelled … retry with /login <x>"
+            # receipt — and on a LOOPBACK-ONLY provider no `KeyPromptBlock`
+            # mounts, so `_request_login_key`'s own `_close_aside()` never runs
+            # and nothing else closes the card. The user pressed ctrl+C, the
+            # login really was cancelled, and the only evidence landed out of
+            # sight: "nothing appeared to happen", which is the very state the
+            # retry wording exists to answer.
+            #
+            # Ordinary ctrl+C already closes these; a login-cancelling ctrl+C
+            # that did not would be a behavioural split with no reason a user
+            # could infer (agent review round 1, major-2).
+            self._close_subagent_view()
+            self._close_org_chart_view()
+            self._close_settings_view()
+            self._close_aside()
             # Same two lines the draft and barren-click rungs run for the same
             # reason: the press was absorbed, so a live "ctrl+c again to exit"
             # would promise an exit the next press does not make.
@@ -15465,32 +15484,55 @@ class OperatorApp(App[None]):
         pending, so the press falls through to the rungs below EXACTLY as it
         did before this rung existed.
 
-        Aborting the signal is the whole action, and everything else follows
-        from the layers that already handle it:
+        THE TWO ACTIONS BELOW ARE BOTH LOAD-BEARING, and which one actually
+        ends a given login depends on the provider. Saying "aborting the signal
+        is the whole action" was true only for the loopback flows, and a
+        docstring that names one mechanism while a second is silently required
+        is how the next change here removes the wrong line (agent review round
+        1, minor-2):
 
-        * `OAuthCallbackFlow._await_code` is racing an abort watcher against
-          its capture futures, so it raises `LoginCancelledError` immediately
-          rather than sitting out the 300 s timeout;
-        * `run()`'s `finally: await self._stop_server()` tears the loopback
-          listener down, which releases the port (54545 for Anthropic, 1455 for
-          OpenAI) so an immediately retried `/login` can bind it again;
-        * `_login_flow`'s own `finally` releases `_login_lock` and clears
-          `_login_signal`, which is what stops the retry being refused with "a
-          login is already in progress".
+        * **The abort** is what ends a LOOPBACK flow.
+          `OAuthCallbackFlow._await_code` is racing an abort watcher against
+          its capture futures, so it raises `LoginCancelledError` at once
+          rather than sitting out the 300 s timeout; `run()`'s `finally: await
+          self._stop_server()` then tears the listener down, releasing the port
+          (54545 for Anthropic, 1455 for OpenAI) so an immediately retried
+          `/login` can bind it again.
+        * **Settling the prompt** is what ends a PASTE-ONLY flow and the
+          `local_setup` path. `create_api_key_login` takes `signal` through
+          `**_kwargs` and never reads it, and `_configure_local` does not watch
+          it either — those flows are parked on the prompt future, so resolving
+          it to None is the thing that unblocks them
+          (`create_api_key_login` turns the None into `LoginCancelledError`,
+          and `_configure_local` does the same for a declined field).
 
-        The key prompt is settled here as well, and not left to `_interrupt`.
-        This rung returns before that runs, and a prompt left mounted and
-        focused for a login that has just been cancelled owns the keyboard for
-        a flow that no longer exists — which is the same class of bug as the
-        one being fixed. `_settle_key_prompt` is idempotent, so the ordinary
-        interrupt path settling it too is harmless.
+        Either way `_login_flow`'s own `finally` releases `_login_lock` and
+        clears `_login_signal`, which is what stops the retry being refused
+        with "a login is already in progress".
+
+        Settling here rather than leaving it to `_interrupt` is deliberate on
+        both counts: this rung returns before that runs, and a prompt left
+        mounted and focused for a login that has just been cancelled owns the
+        keyboard for a flow that no longer exists. `_settle_key_prompt` is
+        idempotent, so the ordinary interrupt path settling it too is harmless.
         """
         signal = self._login_signal
-        if signal is None or signal.aborted:
-            # An already-aborted signal is NOT this rung's press to take: the
-            # flow is unwinding, and claiming the key again would swallow a
-            # second press that should reach the rungs below.
+        if signal is None:
             return False
+        if signal.aborted:
+            # An abort already requested. Deliberately still TAKING the press
+            # rather than declining it, because `abort()` only asks: for the
+            # paste-only and `local_setup` flows nothing reads the signal, so
+            # between the first press and the flow actually unwinding the
+            # signal is burned while `_login_signal` is still set. Declining
+            # here handed that press to the rungs below — which would clear the
+            # user's draft, or arm the exit ladder, on a press they aimed at a
+            # login that is still on screen (agent review round 1, minor-1).
+            #
+            # Re-settling the prompt is what makes the repeat useful rather
+            # than merely absorbed, and it is idempotent.
+            self._settle_key_prompt(superseded=True)
+            return True
         # The reason travels to the user: `_await_code` raises
         # `LoginCancelledError(signal.reason)`, so this string is what a host
         # without the TUI's own notice would print.
@@ -29213,6 +29255,23 @@ class OperatorApp(App[None]):
             ]
             if instructions:
                 lines.append(Text(instructions, style=Style(color=theme_mod.semantic_color("dim"))))
+            # NAME THE ESCAPE AT THE MOMENT THE WAIT BEGINS. A rescue key
+            # nobody knows about rescues nobody, and this block is the only
+            # surface a loopback-only login puts on screen — no paste prompt
+            # mounts for it, so without this line the pending state advertises
+            # no way out at all. The user this is for is watching a browser
+            # that landed somewhere unexpected; the alternative to knowing
+            # about ctrl+C is the 300 s timeout (UX round 1, U4).
+            #
+            # `dim` and last: it is a standing affordance, not an event, and
+            # must not compete with the URL directly above it — which is still
+            # the thing the user came here to act on.
+            lines.append(
+                Text(
+                    "waiting for the browser — ctrl+c to cancel this login",
+                    style=Style(color=theme_mod.semantic_color("dim")),
+                )
+            )
             self._append_block(RichBlock(Group(*lines)))
 
         def on_progress(message: str) -> None:
@@ -29443,6 +29502,23 @@ class OperatorApp(App[None]):
         # two pieces of pending-login state are always set together.
         signal = AbortSignal()
         self._login_signal = signal
+        # RETIRE AN ALREADY-ARMED EXIT HINT, because from this moment ctrl+C
+        # means something else. If the user interrupted something just before
+        # starting the login, the transcript reads "· ctrl+c again to exit"
+        # directly above "· logging in to <provider>…" — and that line is now
+        # FALSE: the next press cancels the login and the app keeps running.
+        #
+        # It is false in the direction that does the damage. A user whose
+        # browser never came back reads "again to exit", believes the rescue
+        # key will quit their session, and does not press it — which leaves
+        # them in the 300 s wait this whole change exists to end. The rung
+        # already disarms the ladder when it TAKES a press; this is the
+        # symmetric half, disarming it when the press changes meaning (UX
+        # round 1, U3).
+        self._last_interrupt_at = 0.0
+        if self._exit_hint is not None:
+            self._transcript_view().remove_block(self._exit_hint)
+            self._exit_hint = None
         try:
             self._providers.set_login_callbacks(self._login_callbacks)
             message = await self._providers.login(provider, signal=signal)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3064,6 +3064,18 @@ class OperatorApp(App[None]):
         # Serializes interactive login flows so two /login commands can never
         # race the one suspended terminal.
         self._login_lock: Any | None = None
+        #: AbortSignal for the login `_login_flow` currently has in flight, or
+        #: None when no login is pending. Set for the WHOLE flow (from before
+        #: the provider callable is entered until its `finally`), because that
+        #: is the window in which Ctrl+C has to mean "cancel this login": a
+        #: browser that lands somewhere other than the loopback redirect leaves
+        #: the flow parked with nothing on screen to press, and the only other
+        #: way out is the 300 s `DEFAULT_TIMEOUT_SECONDS`.
+        #:
+        #: Typed loosely for the same reason `_login_lock` is: `harness.types`
+        #: is imported lazily by the paths that need it, and this attribute is
+        #: declared on a class every interactive session constructs.
+        self._login_signal: Any | None = None
         # ``/loop`` state: one loop at a time, cooperatively cancellable at
         # the turn boundary (never mid-turn, so a turn is never half-applied).
         self._loop_running = False
@@ -14385,6 +14397,45 @@ class OperatorApp(App[None]):
         if self._sidebar_navigation.requested_id:
             self._sidebar_navigation.cancel()
             return
+        # A PENDING LOGIN takes the press, ahead of the draft rung and every
+        # rung below it.
+        #
+        # Placed here because of what the state IS, not because a login is
+        # important. While `/login` is in flight the app is effectively modal on
+        # something OUTSIDE itself: a browser tab that was supposed to come back
+        # to the loopback listener. The scenario this rung exists for is that
+        # tab landing somewhere else entirely — the user closes it, returns to a
+        # terminal that is still narrating "opening your browser to authorize…",
+        # and Ctrl+C is overwhelmingly what they mean by "get me out of this".
+        # Before this rung the only exit was the 300 s
+        # `DEFAULT_TIMEOUT_SECONDS`, which is not an escape hatch, it is a wait.
+        #
+        # AHEAD OF THE DRAFT RUNG, which is the ordering that needs justifying,
+        # since the draft rung is otherwise first for good reason. Two things
+        # decide it. A draft survives this rung — the composer is untouched and
+        # the text is still there to clear with the next press — whereas a login
+        # cancelled late is a login that was never cancelled at all, so the
+        # asymmetric cost points one way. And a login flow mounts a paste prompt
+        # that TAKES FOCUS (`KeyPromptBlock`), so during the window this rung
+        # covers, the composer is not even where the user's attention is.
+        #
+        # It CONSUMES the press without arming the exit ladder, exactly as the
+        # draft rung does, and that is the load-bearing half. This area's whole
+        # history is rungs stealing each other's presses and costing users their
+        # work; here the specific hazard is a user reflex-double-tapping Ctrl+C
+        # to kill a stuck login and QUITTING THE APP on the second tap.
+        # Measured on the pre-change tree: one Ctrl+C during a pending login
+        # rendered "ctrl+c again to exit" while the login stayed pending, so the
+        # reflex was already live and already loaded.
+        if self._cancel_pending_login():
+            # Same two lines the draft and barren-click rungs run for the same
+            # reason: the press was absorbed, so a live "ctrl+c again to exit"
+            # would promise an exit the next press does not make.
+            self._last_interrupt_at = 0.0
+            if self._exit_hint is not None:
+                self._transcript_view().remove_block(self._exit_hint)
+                self._exit_hint = None
+            return
         editor = self._editor()
         # A COPY GESTURE IN FLIGHT is not a draft the user is scrapping, so
         # Ctrl+C keeps its older meaning there — the interrupt and the first
@@ -15406,6 +15457,51 @@ class OperatorApp(App[None]):
         except Exception:  # noqa: BLE001 — a phone bridge must never break naming
             logger.debug("mobile title notify failed", exc_info=True)
 
+    def _cancel_pending_login(self) -> bool:
+        """Abort the `/login` in flight, if there is one. True when it took the press.
+
+        The return value is what the Ctrl+C ladder branches on, so it must be
+        an honest "did this press do something": False when no login is
+        pending, so the press falls through to the rungs below EXACTLY as it
+        did before this rung existed.
+
+        Aborting the signal is the whole action, and everything else follows
+        from the layers that already handle it:
+
+        * `OAuthCallbackFlow._await_code` is racing an abort watcher against
+          its capture futures, so it raises `LoginCancelledError` immediately
+          rather than sitting out the 300 s timeout;
+        * `run()`'s `finally: await self._stop_server()` tears the loopback
+          listener down, which releases the port (54545 for Anthropic, 1455 for
+          OpenAI) so an immediately retried `/login` can bind it again;
+        * `_login_flow`'s own `finally` releases `_login_lock` and clears
+          `_login_signal`, which is what stops the retry being refused with "a
+          login is already in progress".
+
+        The key prompt is settled here as well, and not left to `_interrupt`.
+        This rung returns before that runs, and a prompt left mounted and
+        focused for a login that has just been cancelled owns the keyboard for
+        a flow that no longer exists — which is the same class of bug as the
+        one being fixed. `_settle_key_prompt` is idempotent, so the ordinary
+        interrupt path settling it too is harmless.
+        """
+        signal = self._login_signal
+        if signal is None or signal.aborted:
+            # An already-aborted signal is NOT this rung's press to take: the
+            # flow is unwinding, and claiming the key again would swallow a
+            # second press that should reach the rungs below.
+            return False
+        # The reason travels to the user: `_await_code` raises
+        # `LoginCancelledError(signal.reason)`, so this string is what a host
+        # without the TUI's own notice would print.
+        signal.abort("Login cancelled")
+        # `superseded`, not a plain decline: the login is over, so the optional
+        # paste did not get "skipped" while the browser carried on — it stopped
+        # being needed. The flow's own "login cancelled" notice states the
+        # outcome a line below.
+        self._settle_key_prompt(superseded=True)
+        return True
+
     def _settle_ask_picker(self) -> None:
         """Take down a live ``ask`` picker, answering with whatever was chosen.
 
@@ -15642,7 +15738,7 @@ class OperatorApp(App[None]):
         except Exception:  # pragma: no cover - no composer in reduced hosts
             logger.debug("no composer to hand focus back to", exc_info=True)
 
-    def _settle_key_prompt(self) -> None:
+    def _settle_key_prompt(self, *, superseded: bool = False) -> None:
         """Cancel a live API-key prompt, freeing the login parked on it.
 
         Called by the paths that END a turn or tear the app down, for the same
@@ -15655,6 +15751,15 @@ class OperatorApp(App[None]):
         credential row that shadows a working environment key. Unlike the ask
         picker — where a partial answer still tells the agent something — there
         is no useful partial value here.
+
+        ``superseded`` says the prompt stopped being NEEDED rather than being
+        declined, which changes the receipt it settles into. It exists because
+        the default receipt for a declined optional paste reads "paste skipped
+        — still waiting for the browser", and after a cancelled login that
+        sentence is simply false: nothing is waiting for the browser any more,
+        the loopback listener has been stopped. Callers that end the whole
+        login pass True; the turn-end and teardown paths keep the default,
+        where the flow may genuinely still be running.
         """
         block = self._key_prompt
         self._key_prompt = None
@@ -15685,7 +15790,7 @@ class OperatorApp(App[None]):
 
         if block is not None:
             try:
-                block.resolve(None)
+                block.resolve(None, superseded=superseded)
             except Exception:  # pragma: no cover - teardown races only
                 logger.debug("key prompt was already settled", exc_info=True)
 
@@ -29322,6 +29427,7 @@ class OperatorApp(App[None]):
         # own name lazily: ``callback_server`` drags in http.server, ssl and
         # email (~138 ms) for a loopback listener only a login needs, and this
         # module is what every interactive session imports.
+        from local_operator.harness.types import AbortSignal
         from local_operator.providers.oauth.callback_server import LoginCancelledError
 
         assert self._providers is not None
@@ -29331,9 +29437,15 @@ class OperatorApp(App[None]):
             await notice("a login is already in progress.", "warning")
             return
         self._login_lock.acquire()
+        # Published BEFORE the flow is entered and cleared in the `finally`, so
+        # the window in which Ctrl+C can cancel is exactly the window in which
+        # a login is actually pending. Ordered right after `acquire()` so the
+        # two pieces of pending-login state are always set together.
+        signal = AbortSignal()
+        self._login_signal = signal
         try:
             self._providers.set_login_callbacks(self._login_callbacks)
-            message = await self._providers.login(provider)
+            message = await self._providers.login(provider, signal=signal)
             await notice(message, "success")
             # Make the fresh login usable as the boot default when nothing is
             # configured yet: set hosting to this provider and model_name to its
@@ -29388,16 +29500,44 @@ class OperatorApp(App[None]):
             # painted its own "cancelled" receipt, so this stays quiet about the
             # detail and only closes the sentence the "logging in to …" notice
             # opened.
-            local = getattr(self._providers.provider(provider), "local_setup", False)
-            await notice(
-                "setup cancelled; previous configuration kept." if local else "login cancelled.",
-                "info",
-            )
+            definition = self._providers.provider(provider)
+            local = getattr(definition, "local_setup", False)
+            if local:
+                await notice("setup cancelled; previous configuration kept.", "info")
+            else:
+                # The sentence has to answer the question the user is actually
+                # holding, which is "is that thing still running, and how do I
+                # try again?". The scenario this exists for is a browser that
+                # landed somewhere other than the loopback redirect: from the
+                # user's side nothing visibly happened, so a bare "cancelled"
+                # leaves them unsure whether a half-finished login is still
+                # listening on the port. Naming the retry command spares them
+                # scrolling back for the provider id they typed.
+                #
+                # The listener clause is conditional because it must stay TRUE:
+                # a paste-a-key provider never started a server, and telling
+                # someone a port was released when none was bound is the kind
+                # of confident-and-wrong detail that costs trust in the rest of
+                # the message.
+                stopped = (
+                    "local sign-in listener stopped; "
+                    if getattr(definition, "callback_port", None) is not None
+                    else ""
+                )
+                await notice(
+                    f"login cancelled. {stopped}retry with /login {provider}",
+                    "info",
+                )
         except Exception as error:
             local = getattr(self._providers.provider(provider), "local_setup", False)
             await notice(f"{'setup' if local else 'login'} failed: {error}", "error")
         finally:
             self._login_lock.release()
+            # Cleared unconditionally and alongside the lock: a stale signal
+            # would make `_cancel_pending_login` claim a login to cancel after
+            # this one has ended, so the Ctrl+C rung would swallow a press the
+            # rungs below it should have had.
+            self._login_signal = None
 
     def _cmd_logout(self, arg: str, notice: NoticeFn) -> None:
         """``/logout [provider]`` — remove stored credentials for a provider."""

--- a/local_operator/tui/widgets/key_prompt.py
+++ b/local_operator/tui/widgets/key_prompt.py
@@ -86,6 +86,28 @@ CHOICES: tuple[tuple[str, str], ...] = (
     ("esc", "cancel"),
 )
 
+#: The hint row for a prompt whose ESC does NOT end the login (``sole_path``
+#: false — Anthropic, where the loopback callback is still listening and a
+#: declined paste re-parks by design).
+#:
+#: Two keys that do genuinely different things must not both be called
+#: "cancel". On this prompt ESC dismisses the PASTE and leaves the login
+#: running — the port stays bound and the receipt says "still waiting for the
+#: browser" — while ctrl+C ends the LOGIN. Advertising only ``esc cancel``
+#: sent the user in the reported scenario (a browser that never came back) to
+#: press the one key that does not get them out, landing them somewhere
+#: strictly worse: the prompt gone, so the only affordance on screen gone with
+#: it, and the listener still bound (UX round 1, U2).
+#:
+#: Ordered so the shed-from-the-right rule keeps the useful ones longest:
+#: ``enter`` submits, then ``ctrl+c`` — which is the escape that WORKS here —
+#: and ``esc`` sheds first because it is the narrowest in meaning.
+BROWSER_FLOW_CHOICES: tuple[tuple[str, str], ...] = (
+    ("enter", "submit"),
+    ("ctrl+c", "cancel login"),
+    ("esc", "skip paste"),
+)
+
 #: Below this width the two-cell spine indent is given up, matching
 #: ``approval.SPINE_FLOOR_WIDTH``: an alignment edge that only some blocks
 #: honour is not an edge, so the whole transcript sheds it together.
@@ -607,9 +629,15 @@ class KeyPromptBlock(TranscriptBlock):
         # what the row helper alone would do. ``CHOICES`` is ordered so the key
         # that SUBMITS survives longest: a prompt that only tells you how to
         # give up is one you cannot get past.
+        # Which keys this prompt actually offers depends on whether ESC ends
+        # the login (see ``BROWSER_FLOW_CHOICES``). Not for the ``credential``
+        # prompt, which is `/credential <KEY>` reusing this block and is not a
+        # login at all — there is no listener to cancel and no ctrl+C rung
+        # waiting for it, so advertising one would name a key that does nothing.
+        choices = BROWSER_FLOW_CHOICES if (not self.sole_path and not self.credential) else CHOICES
         hint_parts: list[tuple[str, Style]] = []
         used = 0
-        for index, (key, label) in enumerate(CHOICES):
+        for index, (key, label) in enumerate(choices):
             separator = HINT_SEPARATOR if index else ""
             width_needed = cell_len(separator) + cell_len(key) + cell_len(f" {label}")
             if used + width_needed > body:

--- a/tests/unit/providers/test_auth_cli_invalidation.py
+++ b/tests/unit/providers/test_auth_cli_invalidation.py
@@ -57,7 +57,12 @@ def _swap_login(monkeypatch, provider_id: str, answer):
     definition = get_provider_definition(provider_id)
     assert definition is not None
 
-    async def fake_login(_callbacks):
+    # ``**_kwargs`` mirrors the shape of every real login callable: the CLI and
+    # the controller pass ``signal=`` to all of them so a host can offer a
+    # cancel without knowing which flavour of provider it is talking to. A
+    # double that pins the old narrow signature fails with TypeError instead of
+    # exercising the invalidation this file is about.
+    async def fake_login(_callbacks, **_kwargs):
         return answer
 
     monkeypatch.setattr(

--- a/tests/unit/providers/test_controller.py
+++ b/tests/unit/providers/test_controller.py
@@ -27,6 +27,21 @@ from local_operator.providers.usage_cache import (
     account_backoff_ms,
 )
 
+#: Why every ``fake_login`` double in this file takes ``**_kwargs``.
+#:
+#: ``ProviderController.login`` forwards ``signal=`` to EVERY login callable so
+#: a host can offer a cancel without knowing which flavour of provider it is
+#: talking to. A double that pins the older, narrower signature therefore
+#: raises ``TypeError`` inside the controller — and the surfaces above it
+#: report that as an ordinary "login failed", so the assertion misreads as a
+#: real provider failure rather than as a stale test. Stated once here and
+#: referenced from each double (agent review round 1, nit-2).
+LOGIN_DOUBLE_SIGNATURE_NOTE = (
+    "ProviderController.login forwards signal= to every login callable; a "
+    "double with a narrower signature raises TypeError and misreads as a "
+    "provider failure."
+)
+
 
 class FakeAuthStore:
     """Minimal stand-in for the AuthStore credential surface."""
@@ -1459,8 +1474,7 @@ class TestPerAccountLastKnown:
         # The same identity logs in again: the fake's upsert appends rather
         # than replacing, so pin the fingerprint to prove the key is unchanged
         # and the drop below is the login's own doing, not a key move.
-        # ``**_kwargs``: the controller passes ``signal=`` to every login so a
-        # host can offer a cancel; a narrower double raises TypeError.
+        # ``**_kwargs``: see LOGIN_DOUBLE_SIGNATURE_NOTE.
         async def fake_login(_callbacks, **_kwargs):
             return {
                 "access_token": "t2",
@@ -1894,8 +1908,7 @@ async def test_logging_in_drops_the_cached_listing(controller, store, monkeypatc
         lambda provider_id: dropped.append(provider_id) or 1,
     )
 
-    # ``**_kwargs``: the controller passes ``signal=`` to every login so a
-    # host can offer a cancel; a narrower double raises TypeError.
+    # ``**_kwargs``: see LOGIN_DOUBLE_SIGNATURE_NOTE.
     async def fake_login(_callbacks, **_kwargs):
         return {"access_token": "t", "refresh_token": "r", "email": "you@example.com"}
 
@@ -1929,8 +1942,7 @@ async def test_an_api_key_login_drops_the_listing_under_the_storage_id(
         lambda provider_id: dropped.append(provider_id) or 1,
     )
 
-    # ``**_kwargs``: the controller passes ``signal=`` to every login so a
-    # host can offer a cancel; a narrower double raises TypeError.
+    # ``**_kwargs``: see LOGIN_DOUBLE_SIGNATURE_NOTE.
     async def fake_login(_callbacks, **_kwargs):
         return "xai-key"
 
@@ -1977,8 +1989,7 @@ async def test_a_failed_invalidation_never_fails_a_successful_login(
 
     monkeypatch.setattr("local_operator.providers.controller.invalidate_listing", boom)
 
-    # ``**_kwargs``: the controller passes ``signal=`` to every login so a
-    # host can offer a cancel; a narrower double raises TypeError.
+    # ``**_kwargs``: see LOGIN_DOUBLE_SIGNATURE_NOTE.
     async def fake_login(_callbacks, **_kwargs):
         return "sk-ant"
 
@@ -2012,8 +2023,7 @@ async def test_login_and_logout_drop_the_in_process_model_info_memo(
         lambda: cleared.append("memo"),
     )
 
-    # ``**_kwargs``: the controller passes ``signal=`` to every login so a
-    # host can offer a cancel; a narrower double raises TypeError.
+    # ``**_kwargs``: see LOGIN_DOUBLE_SIGNATURE_NOTE.
     async def fake_login(_callbacks, **_kwargs):
         return "sk-ant"
 

--- a/tests/unit/providers/test_controller.py
+++ b/tests/unit/providers/test_controller.py
@@ -1459,7 +1459,9 @@ class TestPerAccountLastKnown:
         # The same identity logs in again: the fake's upsert appends rather
         # than replacing, so pin the fingerprint to prove the key is unchanged
         # and the drop below is the login's own doing, not a key move.
-        async def fake_login(_callbacks):
+        # ``**_kwargs``: the controller passes ``signal=`` to every login so a
+        # host can offer a cancel; a narrower double raises TypeError.
+        async def fake_login(_callbacks, **_kwargs):
             return {
                 "access_token": "t2",
                 "refresh_token": "r2",
@@ -1892,7 +1894,9 @@ async def test_logging_in_drops_the_cached_listing(controller, store, monkeypatc
         lambda provider_id: dropped.append(provider_id) or 1,
     )
 
-    async def fake_login(_callbacks):
+    # ``**_kwargs``: the controller passes ``signal=`` to every login so a
+    # host can offer a cancel; a narrower double raises TypeError.
+    async def fake_login(_callbacks, **_kwargs):
         return {"access_token": "t", "refresh_token": "r", "email": "you@example.com"}
 
     # ProviderDefinition is a frozen dataclass, so the login is swapped by
@@ -1925,7 +1929,9 @@ async def test_an_api_key_login_drops_the_listing_under_the_storage_id(
         lambda provider_id: dropped.append(provider_id) or 1,
     )
 
-    async def fake_login(_callbacks):
+    # ``**_kwargs``: the controller passes ``signal=`` to every login so a
+    # host can offer a cancel; a narrower double raises TypeError.
+    async def fake_login(_callbacks, **_kwargs):
         return "xai-key"
 
     definition = controller.provider("xai-oauth")
@@ -1971,7 +1977,9 @@ async def test_a_failed_invalidation_never_fails_a_successful_login(
 
     monkeypatch.setattr("local_operator.providers.controller.invalidate_listing", boom)
 
-    async def fake_login(_callbacks):
+    # ``**_kwargs``: the controller passes ``signal=`` to every login so a
+    # host can offer a cancel; a narrower double raises TypeError.
+    async def fake_login(_callbacks, **_kwargs):
         return "sk-ant"
 
     definition = controller.provider("anthropic")
@@ -2004,7 +2012,9 @@ async def test_login_and_logout_drop_the_in_process_model_info_memo(
         lambda: cleared.append("memo"),
     )
 
-    async def fake_login(_callbacks):
+    # ``**_kwargs``: the controller passes ``signal=`` to every login so a
+    # host can offer a cancel; a narrower double raises TypeError.
+    async def fake_login(_callbacks, **_kwargs):
         return "sk-ant"
 
     definition = controller.provider("anthropic")

--- a/tests/unit/providers/test_login_cancel_cli.py
+++ b/tests/unit/providers/test_login_cancel_cli.py
@@ -359,3 +359,72 @@ def test_ctrl_c_really_exits_the_command(provider: str, tmp_path: Any) -> None:
         except (ProcessLookupError, ChildProcessError):
             pass
         os.close(fd)
+
+
+def test_the_terminal_guard_restores_attributes_it_snapshotted(monkeypatch) -> None:
+    """Agent review round 1, major-1: a cancel must not leave ECHO disabled.
+
+    The paste prompt reads through `getpass`, which turns ECHO off and restores
+    it in its own `finally` — on the daemon reader thread, which is never
+    joined (that is what fixes the 300 s executor join). So when a cancel exits
+    the process with the reader still parked, the restore never runs and the
+    user is returned to a shell where their typing is invisible.
+
+    Driven at the guard rather than through a pty here: the pty form is real
+    evidence but needs a controlling terminal, which the suite does not have.
+    The under-test property is "whatever the terminal looked like on the way in
+    is what it looks like on the way out", which is exactly what this asserts,
+    including that it survives an exception.
+    """
+    calls: list[tuple[str, Any]] = []
+    sentinel = ["saved-attrs"]
+
+    class _Termios:
+        TCSADRAIN = 2
+
+        @staticmethod
+        def tcgetattr(fd):
+            calls.append(("get", fd))
+            return sentinel
+
+        @staticmethod
+        def tcsetattr(fd, when, attrs):
+            calls.append(("set", (fd, when, attrs)))
+
+    class _Tty:
+        def isatty(self):
+            return True
+
+        def fileno(self):
+            return 7
+
+    monkeypatch.setitem(sys.modules, "termios", _Termios)
+    monkeypatch.setattr(sys, "stdin", _Tty())
+
+    with auth_cli._terminal_state_restored():
+        pass
+    assert calls[0] == ("get", 7)
+    assert calls[-1] == ("set", (7, _Termios.TCSADRAIN, sentinel)), calls
+
+    # And on the path that matters: the cancel raises through the guard.
+    calls.clear()
+    with pytest.raises(RuntimeError):
+        with auth_cli._terminal_state_restored():
+            raise RuntimeError("cancelled")
+    assert calls[-1] == ("set", (7, _Termios.TCSADRAIN, sentinel)), calls
+
+
+def test_the_terminal_guard_is_inert_without_a_tty(monkeypatch) -> None:
+    """Piped stdin and CI have no terminal to restore, and a guard that tried
+    would raise on every non-interactive login."""
+
+    class _Pipe:
+        def isatty(self):
+            return False
+
+        def fileno(self):  # pragma: no cover - must not be reached
+            raise AssertionError("fileno must not be consulted for a non-tty")
+
+    monkeypatch.setattr(sys, "stdin", _Pipe())
+    with auth_cli._terminal_state_restored():
+        pass  # no exception is the assertion

--- a/tests/unit/providers/test_login_cancel_cli.py
+++ b/tests/unit/providers/test_login_cancel_cli.py
@@ -1,0 +1,313 @@
+"""`local-operator login` must be escapable with Ctrl+C.
+
+Two defects met on this path and the tests are split by which one they can see.
+
+The IN-PROCESS tests drive `run_login` with a login that parks, and assert the
+contract: an abort ends it, the message tells the user how to retry, and the
+exit code is 130 (the shell's SIGINT convention, already used by
+`credential_update_command`).
+
+The SUBPROCESS test exists because the worse defect was invisible from inside
+the process. A real Ctrl+C was delivered, `run_login`'s `except
+KeyboardInterrupt` was reached and printed its line — and then the process sat
+for FIVE MINUTES before exiting. `asyncio.run` shuts down the loop's default
+executor by joining its workers with `THREAD_JOIN_TIMEOUT` (300 s), and the
+paste prompt's worker was blocked in a terminal read that never returns. From
+the user's side the cancel did not work at all. Nothing in-process can observe
+that: the assertion is about whether the INTERPRETER exits, so the test has to
+own a real child.
+
+It runs under a pty because that is the only way to make Ctrl+C mean what it
+means for a user: a process started in the background from a non-interactive
+shell inherits SIGINT as SIG_IGN, and writing \\x03 to a pty master goes through
+the line discipline exactly as a keypress does.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import os
+import sys
+from typing import Any
+
+import pytest
+
+from local_operator.harness.types import AbortSignal
+from local_operator.providers import auth_cli
+from local_operator.providers.oauth.callback_server import LoginCallbacks
+from local_operator.providers.registry import get_provider_definition
+
+
+class _Store:
+    """The AuthStore surface `run_login` touches, and nothing else."""
+
+    def __init__(self) -> None:
+        self.rows: dict[str, dict[str, Any]] = {}
+
+    def upsert_credential(self, provider: str, credential: dict[str, Any]) -> Any:
+        self.rows[provider] = dict(credential)
+        return dataclasses.make_dataclass("Row", ["provider"])(provider)
+
+
+def _swap_login(monkeypatch: pytest.MonkeyPatch, provider_id: str, fn: Any) -> None:
+    definition = get_provider_definition(provider_id)
+    assert definition is not None
+    monkeypatch.setattr(
+        auth_cli,
+        "get_provider_definition",
+        lambda pid: (
+            dataclasses.replace(definition, login=fn) if pid == provider_id else definition
+        ),
+    )
+
+
+def test_a_cancelled_login_exits_130_and_says_how_to_retry(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The message has to answer "is it still running, and how do I try again?".
+
+    A bare "cancelled" leaves the user of the reported scenario — a browser
+    that never came back — unsure whether something is still listening on the
+    port they were told about.
+    """
+    from local_operator.providers.oauth.callback_server import LoginCancelledError
+
+    async def cancelling_login(callbacks: Any, **kwargs: Any) -> dict[str, Any]:
+        raise LoginCancelledError("Login cancelled")
+
+    monkeypatch.setattr(auth_cli, "_apply_login_defaults", lambda provider_id: None)
+    _swap_login(monkeypatch, "anthropic", cancelling_login)
+
+    code = auth_cli.run_login("anthropic", None, _Store())  # type: ignore[arg-type]
+
+    out = capsys.readouterr().out
+    assert code == 130, "130 is the shell's SIGINT convention"
+    assert "Login cancelled" in out
+    assert "local-operator login anthropic" in out, "the retry command must be named"
+    assert "listener stopped" in out, "anthropic pins a callback port, so one was running"
+    assert "Login failed" not in out, "a cancel is an outcome, not a failure"
+
+
+def test_a_paste_only_provider_does_not_claim_a_listener_was_stopped(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The clause is conditional so it stays TRUE.
+
+    `alibaba` reads a pasted key and never starts a callback server; telling
+    the user a local listener was stopped would be a confident, wrong detail.
+    """
+    from local_operator.providers.oauth.callback_server import LoginCancelledError
+
+    async def cancelling_login(callbacks: Any, **kwargs: Any) -> str:
+        raise LoginCancelledError("Login cancelled")
+
+    monkeypatch.setattr(auth_cli, "_apply_login_defaults", lambda provider_id: None)
+    _swap_login(monkeypatch, "alibaba", cancelling_login)
+
+    code = auth_cli.run_login("alibaba", None, _Store())  # type: ignore[arg-type]
+
+    out = capsys.readouterr().out
+    assert code == 130
+    assert "local-operator login alibaba" in out
+    assert "listener stopped" not in out
+
+
+@pytest.mark.asyncio
+async def test_an_abort_ends_a_login_that_ignores_the_signal() -> None:
+    """The paste-a-key providers accept `signal` and ignore it.
+
+    Their whole flow is one `on_manual_code_input` await, so an abort alone
+    would leave the command blocked on a prompt read forever. `_login_or_cancel`
+    races the flow against the signal for exactly this shape; verified under a
+    pty before the race existed, where Ctrl+C printed nothing and the process
+    had to be SIGKILLed.
+
+    Driven at `_login_or_cancel` rather than through `run_login`, because the
+    signal is delivered by a REAL SIGINT handler there — and a test that
+    installs one fights pytest for the interpreter's signal disposition. The
+    end-to-end claim is covered by the pty test below, which uses a real
+    keypress instead of simulating one.
+    """
+    from local_operator.providers.oauth.callback_server import LoginCancelledError
+
+    entered = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def never_returns(callbacks: Any, **kwargs: Any) -> str:
+        entered.set()
+        try:
+            await asyncio.Future()  # a prompt nobody answers
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+        return "unreachable"  # pragma: no cover
+
+    aborted = AbortSignal()
+    task = asyncio.ensure_future(
+        auth_cli._login_or_cancel(never_returns, LoginCallbacks(), aborted)
+    )
+    await asyncio.wait_for(entered.wait(), timeout=10)
+
+    aborted.abort("Login cancelled")
+    with pytest.raises(LoginCancelledError, match="Login cancelled"):
+        await asyncio.wait_for(task, timeout=10)
+
+    # The losing task is reaped rather than left running detached from the
+    # command that started it.
+    await asyncio.wait_for(cancelled.wait(), timeout=10)
+
+
+@pytest.mark.asyncio
+async def test_a_login_that_finishes_first_wins_the_race() -> None:
+    """The race must not cost the ordinary path its result."""
+    aborted = AbortSignal()
+
+    async def prompt_login(callbacks: Any, **kwargs: Any) -> str:
+        return "sk-real"
+
+    result = await auth_cli._login_or_cancel(prompt_login, LoginCallbacks(), aborted)
+    assert result == "sk-real"
+
+
+def test_the_signal_reaches_the_provider_login(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CLI builds a signal and hands it down, like the TUI does."""
+    seen: dict[str, Any] = {}
+
+    async def recording_login(callbacks: Any, **kwargs: Any) -> str:
+        seen.update(kwargs)
+        return "sk-key"
+
+    monkeypatch.setattr(auth_cli, "_apply_login_defaults", lambda provider_id: None)
+    monkeypatch.setattr(auth_cli, "_invalidate_cached_listing", lambda pid: None)
+    monkeypatch.setattr(auth_cli, "_invalidate_cached_usage", lambda pid, store: None)
+    _swap_login(monkeypatch, "alibaba", recording_login)
+
+    assert auth_cli.run_login("alibaba", None, _Store()) == 0  # type: ignore[arg-type]
+    assert isinstance(seen.get("signal"), AbortSignal)
+
+
+def test_a_successful_login_is_unaffected_by_the_cancel_plumbing(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The regression guard: the ordinary path still stores and reports."""
+    store = _Store()
+
+    async def good_login(callbacks: Any, **kwargs: Any) -> str:
+        return "sk-real"
+
+    monkeypatch.setattr(auth_cli, "_apply_login_defaults", lambda provider_id: None)
+    monkeypatch.setattr(auth_cli, "_invalidate_cached_listing", lambda pid: None)
+    monkeypatch.setattr(auth_cli, "_invalidate_cached_usage", lambda pid, s: None)
+    _swap_login(monkeypatch, "alibaba", good_login)
+
+    assert auth_cli.run_login("alibaba", None, store) == 0  # type: ignore[arg-type]
+    assert store.rows["alibaba"]["key"] == "sk-real"
+    assert "Stored API key" in capsys.readouterr().out
+
+
+# -- the hang only a real process can show ----------------------------------
+
+
+_CHILD = """
+import os, sys, tempfile
+cfg = tempfile.mkdtemp(prefix="lo-cancel-test-")
+os.environ["LOCAL_OPERATOR_CONFIG_DIR"] = cfg
+os.environ["HOME"] = cfg
+sys.path.insert(0, {root!r})
+import webbrowser
+webbrowser.open = lambda *a, **k: True
+from local_operator.providers.auth_cli import run_login
+from local_operator.providers.auth_store import AuthStore
+print("READY", flush=True)
+code = run_login({provider!r}, None, AuthStore(os.path.join(cfg, "auth.db")))
+print("EXIT_CODE=%d" % code, flush=True)
+raise SystemExit(code)
+"""
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="pty is POSIX-only")
+@pytest.mark.parametrize("provider", ["anthropic", "alibaba"])
+def test_ctrl_c_really_exits_the_command(provider: str, tmp_path: Any) -> None:
+    """A REAL Ctrl+C on a REAL terminal ends the process, promptly.
+
+    Both provider shapes, because they hang for different reasons: `anthropic`
+    runs a loopback listener AND a paste prompt (the executor-join hang), while
+    `alibaba` is a bare prompt read (the flow that ignores the signal).
+
+    The 30 s bound is not a performance assertion — the measured cancel is
+    30-60 ms. It is a backstop that fails loudly against the 300 s wait this
+    replaces, chosen wide enough that a loaded CI runner cannot trip it.
+    """
+    import pty
+    import select
+    import signal as signal_module
+    import time
+
+    root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+    script = _CHILD.format(root=root, provider=provider)
+
+    env = {k: v for k, v in os.environ.items() if not k.startswith("CMUX_")}
+    env["TERM"] = "xterm-256color"
+    env.pop("NO_COLOR", None)
+
+    pid, fd = pty.fork()
+    if pid == 0:  # child
+        # A process started from a non-interactive shell inherits SIGINT as
+        # SIG_IGN and exec preserves it, so without this the test measures its
+        # own harness rather than the product.
+        signal_module.signal(signal_module.SIGINT, signal_module.SIG_DFL)
+        os.execve(sys.executable, [sys.executable, "-c", script], env)
+        os._exit(127)  # pragma: no cover
+
+    output = bytearray()
+
+    def drain(seconds: float) -> None:
+        deadline = time.monotonic() + seconds
+        while time.monotonic() < deadline:
+            ready, _, _ = select.select([fd], [], [], 0.1)
+            if not ready:
+                continue
+            try:
+                chunk = os.read(fd, 65536)
+            except OSError:
+                return
+            if not chunk:
+                return
+            output.extend(chunk)
+
+    try:
+        # Wait until the flow is genuinely pending: it has asked for input.
+        deadline = time.monotonic() + 60
+        while b"empty to cancel" not in bytes(output) and time.monotonic() < deadline:
+            drain(0.2)
+        assert b"empty to cancel" in bytes(output), bytes(output).decode(errors="replace")
+
+        started = time.monotonic()
+        os.write(fd, b"\x03")  # a real Ctrl+C keypress
+
+        status = None
+        while time.monotonic() - started < 30.0:
+            drain(0.1)
+            done, waited = os.waitpid(pid, os.WNOHANG)
+            if done:
+                status = waited
+                break
+        elapsed = time.monotonic() - started
+        text = bytes(output).decode(errors="replace")
+
+        assert status is not None, (
+            f"the command was still running {elapsed:.0f}s after Ctrl+C — "
+            f"it used to hang for 300s in the executor join. Output:\n{text}"
+        )
+        assert os.WIFEXITED(status), f"expected a clean exit, got {status}"
+        assert os.WEXITSTATUS(status) == 130, text
+        assert "Login cancelled" in text
+        assert f"local-operator login {provider}" in text
+    finally:
+        try:
+            os.kill(pid, signal_module.SIGKILL)
+            os.waitpid(pid, 0)
+        except (ProcessLookupError, ChildProcessError):
+            pass
+        os.close(fd)

--- a/tests/unit/providers/test_login_cancel_cli.py
+++ b/tests/unit/providers/test_login_cancel_cli.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import os
+import socket
 import sys
 from typing import Any
 
@@ -226,6 +227,19 @@ raise SystemExit(code)
 """
 
 
+def _listener_is_up(port: int) -> bool:
+    """True when something already holds ``port`` on loopback."""
+    probe = socket.socket()
+    probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        probe.bind(("127.0.0.1", port))
+        return False
+    except OSError:
+        return True
+    finally:
+        probe.close()
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="pty is POSIX-only")
 @pytest.mark.parametrize("provider", ["anthropic", "alibaba"])
 def test_ctrl_c_really_exits_the_command(provider: str, tmp_path: Any) -> None:
@@ -277,33 +291,67 @@ def test_ctrl_c_really_exits_the_command(provider: str, tmp_path: Any) -> None:
             output.extend(chunk)
 
     try:
-        # Wait until the flow is genuinely pending: it has asked for input.
+        # THE PRECONDITION, ASSERTED. "Cancelled in 40 ms" is worthless if the
+        # login never started — a setup that silently did not take is
+        # indistinguishable from a feature that works. So this waits for proof
+        # the flow is genuinely PARKED (it has printed its prompt) and, for a
+        # loopback provider, that the listener is really BOUND. Without both,
+        # the cancel below could be measuring an empty process exiting.
         deadline = time.monotonic() + 60
         while b"empty to cancel" not in bytes(output) and time.monotonic() < deadline:
             drain(0.2)
-        assert b"empty to cancel" in bytes(output), bytes(output).decode(errors="replace")
+        assert b"empty to cancel" in bytes(output), (
+            "the login never reached its prompt, so there was nothing pending to "
+            f"cancel:\n{bytes(output).decode(errors='replace')}"
+        )
+        if provider == "anthropic":
+            assert _listener_is_up(54545), (
+                "the loopback listener was never bound, so a fast 'cancel' would "
+                "prove nothing about releasing it"
+            )
 
         started = time.monotonic()
         os.write(fd, b"\x03")  # a real Ctrl+C keypress
 
-        status = None
+        # Wait for the CHILD to report its own exit rather than for waitpid to
+        # win a race. Under xdist the worker process has other machinery that
+        # reaps children, so `waitpid` can return ECHILD even though the
+        # command exited perfectly — observed on CI, where the captured output
+        # contained "EXIT_CODE=130" while this loop concluded the process was
+        # still running. The pty EOF and the child's own printed exit code are
+        # facts about the product; `waitpid` succeeding is a fact about the
+        # test runner.
+        status: int | None = None
         while time.monotonic() - started < 30.0:
             drain(0.1)
-            done, waited = os.waitpid(pid, os.WNOHANG)
+            if b"EXIT_CODE=" in bytes(output):
+                break
+            try:
+                done, waited = os.waitpid(pid, os.WNOHANG)
+            except ChildProcessError:
+                break  # already reaped by the runner; the output is the record
             if done:
                 status = waited
                 break
         elapsed = time.monotonic() - started
         text = bytes(output).decode(errors="replace")
 
-        assert status is not None, (
-            f"the command was still running {elapsed:.0f}s after Ctrl+C — "
+        assert "EXIT_CODE=130" in text or (
+            status is not None and os.WIFEXITED(status) and os.WEXITSTATUS(status) == 130
+        ), (
+            f"the command did not exit 130 within {elapsed:.0f}s of Ctrl+C — "
             f"it used to hang for 300s in the executor join. Output:\n{text}"
         )
-        assert os.WIFEXITED(status), f"expected a clean exit, got {status}"
-        assert os.WEXITSTATUS(status) == 130, text
+        assert elapsed < 30.0, f"the cancel took {elapsed:.0f}s"
         assert "Login cancelled" in text
         assert f"local-operator login {provider}" in text
+        if provider == "anthropic":
+            # The listener the cancel was supposed to tear down is really gone,
+            # which is what makes an immediate retry possible.
+            released_by = time.monotonic() + 10
+            while _listener_is_up(54545) and time.monotonic() < released_by:
+                time.sleep(0.1)
+            assert not _listener_is_up(54545), "the loopback listener outlived the cancel"
     finally:
         try:
             os.kill(pid, signal_module.SIGKILL)

--- a/tests/unit/providers/test_login_cancellation.py
+++ b/tests/unit/providers/test_login_cancellation.py
@@ -1,0 +1,342 @@
+"""Cancelling a PENDING login, end to end through the layers that carry it.
+
+The reported problem: a `/login` opens the browser, the browser lands somewhere
+other than the loopback redirect (Anthropic's own portal, an expired consent
+page, a tab the user closes), and the flow stays parked. The only way out was
+`DEFAULT_TIMEOUT_SECONDS`, which is 300 s.
+
+Every mechanism the cancel needs already existed and none of it was reachable:
+`OAuthCallbackFlow._await_code` races an abort watcher against its capture
+futures, the device flow polls the signal, and the registry's lazy thunks
+forward it — but `ProviderController.login` never constructed a signal, so no
+caller could ever abort a flow. These tests cover the seam that was missing and
+the properties a cancel has to leave behind: the listener stopped, the port
+free, and a retry that works immediately.
+
+The port assertions bind a real socket rather than reading a flag, because
+"the login said it stopped" and "the OS will let the next login have the port"
+are different claims and only the second one is the user's problem.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import time
+from typing import Any
+
+import pytest
+
+from local_operator.harness.types import AbortSignal
+from local_operator.providers.oauth.callback_server import (
+    DEFAULT_TIMEOUT_SECONDS,
+    CallbackFlowOptions,
+    LoginCallbacks,
+    LoginCancelledError,
+    OAuthCallbackFlow,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Flow(OAuthCallbackFlow):
+    """A real callback flow whose only fake is the token exchange."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.exchanged = False
+
+    async def generate_auth_url(self, state: str, redirect_uri: str) -> str:
+        return f"https://provider.invalid/authorize?state={state}&redirect_uri={redirect_uri}"
+
+    async def exchange_token(self, code: str, state: str, redirect_uri: str) -> dict[str, Any]:
+        self.exchanged = True
+        return {"access": "token"}
+
+
+def _free_port() -> int:
+    """A port that is free RIGHT NOW, so the test never fights the real 54545.
+
+    The suite runs under xdist with sibling worktrees on the same machine; a
+    hardcoded port here would make two unrelated runs collide and report a
+    product bug.
+    """
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    port = int(probe.getsockname()[1])
+    probe.close()
+    return port
+
+
+def _port_is_free(port: int) -> bool:
+    probe = socket.socket()
+    probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        probe.bind(("127.0.0.1", port))
+        return True
+    except OSError:
+        return False
+    finally:
+        probe.close()
+
+
+async def _await_bound(flow: OAuthCallbackFlow, limit: int = 250) -> None:
+    """Wait for the listener to come up, bounded in TURNS not seconds."""
+    for _ in range(limit):
+        await asyncio.sleep(0)
+        if flow.bound_port is not None:
+            return
+    raise AssertionError("the callback server never bound")
+
+
+async def test_aborting_a_pending_flow_raises_at_once_instead_of_waiting_out_the_timeout() -> None:
+    """The whole point of the change, as a number.
+
+    The bound is deliberately enormous relative to the work (the abort is an
+    event set on an already-parked waiter) and tiny relative to what it
+    replaces. It is a BACKSTOP against a regression that reintroduces a wait,
+    not a calibrated performance assertion — anything in the same order of
+    magnitude as 300 s fails it, and ordinary CI contention cannot.
+    """
+    port = _free_port()
+    signal = AbortSignal()
+    flow = _Flow(
+        options=CallbackFlowOptions(preferred_port=port, allow_port_fallback=False),
+        open_browser=lambda url: None,
+        signal=signal,
+    )
+    task = asyncio.create_task(flow.run())
+    await _await_bound(flow)
+
+    started = time.monotonic()
+    signal.abort("Login cancelled")
+    with pytest.raises(LoginCancelledError, match="Login cancelled"):
+        await task
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 5.0, f"cancel took {elapsed:.1f}s"
+    assert elapsed < DEFAULT_TIMEOUT_SECONDS / 10
+    assert not flow.exchanged, "a cancelled login must not exchange a token"
+
+
+async def test_a_cancelled_login_releases_the_port_for_an_immediate_retry() -> None:
+    """The property the user actually experiences after a cancel.
+
+    A cancel that raised but left the listener up would be worse than the
+    timeout it replaces: the retry the message invites would then fail with
+    "port is required for this login flow but is already in use", and the
+    provider pins these ports (54545 for Anthropic, 1455 for OpenAI) so there
+    is no fallback to hide it.
+    """
+    port = _free_port()
+    signal = AbortSignal()
+    flow = _Flow(
+        options=CallbackFlowOptions(preferred_port=port, allow_port_fallback=False),
+        open_browser=lambda url: None,
+        signal=signal,
+    )
+    task = asyncio.create_task(flow.run())
+    await _await_bound(flow)
+    assert not _port_is_free(port), "precondition: the listener holds the port"
+
+    signal.abort("Login cancelled")
+    with pytest.raises(LoginCancelledError):
+        await task
+
+    assert _port_is_free(port), "the loopback listener outlived the cancelled login"
+
+    # The retry, for real: a second flow on the SAME pinned port, which is what
+    # the cancel message tells the user to do.
+    retry = _Flow(
+        options=CallbackFlowOptions(preferred_port=port, allow_port_fallback=False),
+        open_browser=lambda url: None,
+        signal=AbortSignal(),
+    )
+    retry_task = asyncio.create_task(retry.run())
+    await _await_bound(retry)
+    assert retry.bound_port == port
+    retry_task.cancel()
+    await asyncio.gather(retry_task, return_exceptions=True)
+
+
+async def test_an_abort_beats_a_paste_prompt_that_never_answers() -> None:
+    """Anthropic's shape: a paste prompt races the loopback callback.
+
+    The prompt parks forever when the user declines, which is exactly the state
+    the reported bug leaves the app in — so the abort has to win against a
+    waiter that is never going to resolve.
+    """
+    port = _free_port()
+    signal = AbortSignal()
+    parked = asyncio.Event()
+
+    async def never_answers() -> str | None:
+        parked.set()
+        await asyncio.Future()  # the user is looking at a dead browser tab
+        return None
+
+    flow = _Flow(
+        options=CallbackFlowOptions(preferred_port=port, allow_port_fallback=False),
+        callbacks=LoginCallbacks(on_manual_code_input=never_answers),
+        open_browser=lambda url: None,
+        signal=signal,
+    )
+    task = asyncio.create_task(flow.run())
+    await asyncio.wait_for(parked.wait(), timeout=10)
+
+    signal.abort("Login cancelled")
+    with pytest.raises(LoginCancelledError):
+        await task
+    assert _port_is_free(port)
+
+
+async def test_a_signal_aborted_before_the_flow_starts_still_cancels() -> None:
+    """The race a user creates by pressing ctrl+C while the browser is opening.
+
+    `_await_code` builds its abort watcher from an already-set event here, so
+    the flow must not sail past it and park for the full timeout.
+    """
+    port = _free_port()
+    signal = AbortSignal()
+    signal.abort("Login cancelled")
+    flow = _Flow(
+        options=CallbackFlowOptions(preferred_port=port, allow_port_fallback=False),
+        open_browser=lambda url: None,
+        signal=signal,
+    )
+    with pytest.raises(LoginCancelledError):
+        await asyncio.wait_for(flow.run(), timeout=10)
+    assert _port_is_free(port)
+
+
+async def test_no_signal_means_the_flow_behaves_exactly_as_before() -> None:
+    """The regression guard for every caller that passes nothing.
+
+    `_await_code` only appends the abort watcher when a signal is present, so
+    the no-signal path must keep waiting on its capture futures rather than
+    acquiring a new way to end early.
+    """
+    port = _free_port()
+    flow = _Flow(
+        options=CallbackFlowOptions(
+            preferred_port=port, allow_port_fallback=False, timeout_seconds=0.2
+        ),
+        open_browser=lambda url: None,
+    )
+    from local_operator.providers.oauth.callback_server import LoginTimeoutError
+
+    with pytest.raises(LoginTimeoutError):
+        await flow.run()
+    assert _port_is_free(port), "the timeout path still stops the server"
+
+
+# -- the seam that was missing: ProviderController.login ---------------------
+
+
+def _controller(tmp_path: Any) -> Any:
+    from local_operator.providers.auth_store import AuthStore
+    from local_operator.providers.controller import ProviderController
+
+    return ProviderController(AuthStore(tmp_path / "auth.db"))
+
+
+async def test_the_controller_forwards_its_signal_to_the_provider(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The defect this change fixes, stated directly.
+
+    Before it, `ProviderController.login` called `definition.login(callbacks)`
+    with no signal, so every abort mechanism beneath it was unreachable code.
+    Driven through the REAL controller over a real store, with only the
+    provider's own login coroutine swapped — the seam under test is between
+    the controller and the registry, and a stub standing in for the controller
+    would be a test of the stub.
+    """
+    import dataclasses
+
+    import local_operator.providers.controller as controller_module
+    from local_operator.providers.registry import get_provider_definition
+
+    definition = get_provider_definition("anthropic")
+    assert definition is not None
+    seen: dict[str, Any] = {}
+
+    async def fake_login(callbacks: Any, **kwargs: Any) -> dict[str, Any]:
+        seen.update(kwargs)
+        return {"access": "t", "refresh": "r"}
+
+    patched = dataclasses.replace(definition, login=fake_login)
+    monkeypatch.setattr(
+        controller_module,
+        "get_provider_definition",
+        lambda pid: patched if pid == "anthropic" else get_provider_definition(pid),
+    )
+
+    controller = _controller(tmp_path)
+    signal = AbortSignal()
+    await controller.login("anthropic", signal=signal)
+
+    assert seen.get("signal") is signal, f"the signal never reached the provider: {seen}"
+
+
+async def test_the_controller_still_works_when_no_signal_is_passed(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`signal` is optional, and every existing caller omits it.
+
+    The keyword is forwarded even when it is None (one call shape for all
+    providers), so this pins that a None reaches the flow harmlessly rather
+    than the parameter being dropped for the default case.
+    """
+    import dataclasses
+
+    import local_operator.providers.controller as controller_module
+    from local_operator.providers.registry import get_provider_definition
+
+    definition = get_provider_definition("anthropic")
+    assert definition is not None
+    seen: dict[str, Any] = {}
+
+    async def fake_login(callbacks: Any, **kwargs: Any) -> dict[str, Any]:
+        seen.update(kwargs)
+        seen["called"] = True
+        return {"access": "t", "refresh": "r"}
+
+    patched = dataclasses.replace(definition, login=fake_login)
+    monkeypatch.setattr(
+        controller_module,
+        "get_provider_definition",
+        lambda pid: patched if pid == "anthropic" else get_provider_definition(pid),
+    )
+
+    controller = _controller(tmp_path)
+    await controller.login("anthropic")
+
+    assert seen.get("called") is True
+    assert seen.get("signal") is None
+
+
+async def test_the_controller_passes_a_signal_to_every_login_in_the_registry() -> None:
+    """Enumerated over the shipped registry, not checked for one provider.
+
+    The controller passes `signal=` UNCONDITIONALLY, so a login callable that
+    did not accept the keyword would raise `TypeError` for that provider only —
+    the kind of break that ships because the test named the two OAuth providers
+    someone happened to think of. The paste-a-key logins take it through
+    `**_kwargs` and ignore it; that is fine and is exactly what this asserts.
+    """
+    import inspect
+
+    from local_operator.providers.registry import PROVIDER_REGISTRY
+
+    rejects = []
+    for provider in PROVIDER_REGISTRY:
+        if provider.login is None:
+            continue
+        parameters = inspect.signature(provider.login).parameters
+        accepts = "signal" in parameters or any(
+            value.kind is inspect.Parameter.VAR_KEYWORD for value in parameters.values()
+        )
+        if not accepts:
+            rejects.append(provider.id)
+    assert rejects == [], f"these logins would raise TypeError on signal=: {rejects}"

--- a/tests/unit/server/test_desktop_controls.py
+++ b/tests/unit/server/test_desktop_controls.py
@@ -528,7 +528,11 @@ async def test_oauth_failure_is_redacted_and_browser_opener_is_per_flow(desktop,
     client, _ = desktop
     observed = []
 
-    async def login(callbacks, *, open_browser):
+    # ``**_kwargs``: the controller passes ``signal=`` to every login callable
+    # so a host can cancel a pending flow. Without it this double raises
+    # TypeError before recording anything, and the assertion below reads as
+    # "the browser opener was never injected".
+    async def login(callbacks, *, open_browser, **_kwargs):
         observed.append(open_browser)
         await asyncio.sleep(0)
         raise RuntimeError("raw-provider-access-token-do-not-return")

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -4278,7 +4278,12 @@ class FakeProviderController:
         # and reports as "login failed", which looks exactly like a real failure.
         self.login_callbacks = factory
 
-    async def login(self, provider):
+    async def login(self, provider, **_kwargs):
+        # ``**_kwargs`` mirrors the real ``ProviderController.login``, which
+        # takes ``signal=`` (and ``open_browser=``) so a host can cancel a
+        # pending login. A double pinning the older narrower signature makes
+        # the app's call raise TypeError, which the flow reports as "login
+        # failed" — indistinguishable from a real provider failure.
         self.logins.append(provider)
         return f"logged in {provider}"
 

--- a/tests/unit/tui/test_login_cancel_interrupt.py
+++ b/tests/unit/tui/test_login_cancel_interrupt.py
@@ -1,0 +1,404 @@
+"""Ctrl+C cancels a pending `/login`, and takes nothing else with it.
+
+The reported scenario: `/login anthropic` opens the browser, the browser lands
+in the provider's own portal instead of coming back to the loopback redirect,
+the user closes the tab — and the app is parked with no way out but the 300 s
+`DEFAULT_TIMEOUT_SECONDS`.
+
+Half of this file is the fix and half is the LADDER REGRESSION GUARD, which is
+the part worth reading twice. `action_interrupt` is a ladder of rungs that each
+claim Ctrl+C under some condition, and this area's entire history is rungs
+stealing each other's presses — a draft cleared when the user meant to
+interrupt, an exit ladder made unreachable, an exit ladder armed when the press
+was absorbed. So the new rung is pinned on three axes:
+
+* it takes the press when a login is pending,
+* it does NOT arm the double-tap exit ladder when it does (a user
+  reflex-double-tapping to kill a stuck login must not quit the app — measured
+  on the pre-change tree, where one press rendered "ctrl+c again to exit" while
+  the login stayed pending), and
+* with no login pending, every rung below it behaves byte-identically to
+  before.
+
+The tests drive the REAL `OperatorApp` with the real `ProviderController` over
+a throwaway store, because the defect lived in the seam between the app's key
+handling and the provider layer and a stub standing in for either end would be
+a test of the stub.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.editor import Editor
+from local_operator.tui.widgets.key_prompt import KeyPromptBlock
+from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+pytestmark = pytest.mark.asyncio
+
+
+def _controller(tmp_path: Path) -> Any:
+    from local_operator.providers.auth_store import AuthStore
+    from local_operator.providers.controller import ProviderController
+
+    return ProviderController(AuthStore(tmp_path / "auth.db"))
+
+
+def _notices(app: OperatorApp) -> list[str]:
+    return [
+        block._text
+        for block in app.query_one(TranscriptView).blocks()
+        if isinstance(block, NoticeBlock)
+    ]
+
+
+async def _boot(pilot: Any, app: OperatorApp) -> None:
+    for _ in range(60):
+        await pilot.pause()
+        if app._session is not None:
+            return
+
+
+async def _start_login(pilot: Any, app: OperatorApp, provider: str) -> None:
+    editor = app.query_one(Editor)
+    editor.text = f"/login {provider}"
+    await pilot.pause()
+    if editor.picker.is_open():
+        await pilot.press("escape")
+        await pilot.pause()
+    await pilot.press("enter")
+
+
+async def _settle(predicate: Any, limit: int = 250) -> bool:
+    """Pump until the predicate holds, bounded in TURNS rather than seconds."""
+    for _ in range(limit):
+        await asyncio.sleep(0.01)
+        if predicate():
+            return True
+    return False
+
+
+def _port_held(port: int) -> bool:
+    probe = socket.socket()
+    probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        probe.bind(("127.0.0.1", port))
+        return False
+    except OSError:
+        return True
+    finally:
+        probe.close()
+
+
+@pytest.fixture
+def no_browser(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("webbrowser.open", lambda *a, **k: True)
+
+
+async def test_ctrl_c_cancels_a_pending_login(tmp_path: Path, no_browser: None) -> None:
+    """The reported bug: a parked login now ends on one press.
+
+    `alibaba` is the provider here because its login is a pure paste prompt,
+    which parks deterministically with no port to bind — the loopback half is
+    covered separately below, where the port is the assertion.
+    """
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _start_login(pilot, app, "alibaba")
+        assert await _settle(lambda: bool(app.query(KeyPromptBlock))), _notices(app)
+        assert app._login_signal is not None, "a pending login must publish its signal"
+
+        await pilot.press("ctrl+c")
+
+        assert await _settle(
+            lambda: any("login cancelled" in note for note in _notices(app))
+        ), _notices(app)
+        notices = _notices(app)
+        assert not any("failed" in note for note in notices), notices
+        assert app._login_signal is None, "the signal must be cleared when the flow ends"
+        lock = app._login_lock
+        assert (
+            lock is not None and not lock.locked()
+        ), "a held lock refuses the retry the message invites"
+
+    assert controller.auth_store.list_credentials(provider=None) == []
+
+
+async def test_the_cancel_message_says_how_to_retry(tmp_path: Path, no_browser: None) -> None:
+    """A user who just watched their browser dump them somewhere unexpected
+    needs to know the local listener is gone and how to try again — "cancelled"
+    on its own answers neither."""
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _start_login(pilot, app, "anthropic")
+        assert await _settle(lambda: app._login_signal is not None)
+        await pilot.press("ctrl+c")
+        assert await _settle(lambda: any("login cancelled" in n for n in _notices(app)))
+
+        message = next(n for n in _notices(app) if "login cancelled" in n)
+        assert "/login anthropic" in message, message
+        assert "listener stopped" in message, message
+
+
+async def test_a_paste_only_provider_is_not_told_a_listener_stopped(
+    tmp_path: Path, no_browser: None
+) -> None:
+    """The clause is conditional so that it stays TRUE: `alibaba` never binds a
+    port, and a confident wrong detail costs trust in the rest of the line."""
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _start_login(pilot, app, "alibaba")
+        assert await _settle(lambda: app._login_signal is not None)
+        await pilot.press("ctrl+c")
+        assert await _settle(lambda: any("login cancelled" in n for n in _notices(app)))
+
+        message = next(n for n in _notices(app) if "login cancelled" in n)
+        assert "/login alibaba" in message
+        assert "listener stopped" not in message
+
+
+async def test_the_cancel_releases_the_port_and_a_retry_works(
+    tmp_path: Path, no_browser: None
+) -> None:
+    """The property the whole change is for: cancelled means GONE.
+
+    A cancel that raised but left the listener up would be worse than the
+    timeout it replaces — the retry would fail with "port is required for this
+    login flow but is already in use", and Anthropic pins 54545 so nothing
+    falls back to hide it. The port is probed with a real bind rather than read
+    off a flag: "the flow says it stopped" and "the OS will let the next login
+    have the port" are different claims.
+    """
+    port = 54545
+    if _port_held(port):
+        pytest.skip("port 54545 is already in use on this machine")
+
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _start_login(pilot, app, "anthropic")
+        assert await _settle(lambda: _port_held(port)), "the listener never came up"
+
+        await pilot.press("ctrl+c")
+        assert await _settle(lambda: not _port_held(port)), "the port was never released"
+
+        # The retry the message invites, for real.
+        await _start_login(pilot, app, "anthropic")
+        assert await _settle(lambda: _port_held(port)), "the retry could not bind the port"
+        assert not any("already in progress" in n for n in _notices(app)), _notices(app)
+        assert not any("already in use" in n for n in _notices(app)), _notices(app)
+
+        # Leave nothing listening behind for the next test.
+        await pilot.press("ctrl+c")
+        await _settle(lambda: not _port_held(port))
+
+
+# -- the ladder regression guard --------------------------------------------
+
+
+async def test_cancelling_a_login_does_not_arm_the_exit_ladder(
+    tmp_path: Path, no_browser: None
+) -> None:
+    """THE hazard of adding this rung.
+
+    A user whose login is stuck reaches for Ctrl+C and, when the first press
+    appears to do nothing, presses it again — that is the reflex the whole
+    feature is responding to. If the cancelling press also armed the double-tap
+    exit ladder, the second press would QUIT THE APP.
+
+    Measured on the pre-change tree: one Ctrl+C during a pending login rendered
+    "ctrl+c again to exit" while the login stayed pending, so the trap was
+    already loaded before this rung existed.
+
+    The ladder is ARMED FIRST, deliberately. A press on an idle app leaves
+    `_last_interrupt_at` at 0.0 anyway, so a version of this test that started
+    from rest would pass against a rung that never disarms anything —
+    confirmed by mutation, where dropping the disarm lines left the whole file
+    green. Arming it first is what makes the disarm the thing under test, and
+    it is also the real sequence: the user presses Ctrl+C once (arming the
+    ladder and showing "ctrl+c again to exit"), THEN starts a login, then
+    presses again to kill it.
+    """
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+
+        # Arm the exit ladder, exactly as an ordinary interrupt does.
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+        assert app._last_interrupt_at != 0.0, "precondition: the ladder is armed"
+        armed_at = app._last_interrupt_at
+
+        await _start_login(pilot, app, "alibaba")
+        assert await _settle(lambda: app._login_signal is not None)
+
+        await pilot.press("ctrl+c")
+        assert await _settle(lambda: any("login cancelled" in n for n in _notices(app)))
+
+        assert app._last_interrupt_at == 0.0, (
+            "the cancelling press left the exit ladder armed: the reflex second "
+            f"press would quit the app (was {armed_at}, still {app._last_interrupt_at})"
+        )
+        assert app._exit_hint is None, "a stale 'ctrl+c again to exit' hint is still on screen"
+
+        # The reflex second press, for real: the app must still be running.
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+        assert app.is_running, "a double-tap to kill a stuck login quit the app"
+
+
+async def test_with_no_login_pending_the_ladder_is_unchanged(tmp_path: Path) -> None:
+    """The other half of the guard: the rung must not claim a press it has no
+    business claiming.
+
+    With no login in flight, `_cancel_pending_login` returns False and the
+    press falls through to exactly the rungs it reached before — here, the
+    interrupt rung, which arms the double-tap exit ladder.
+    """
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        assert app._login_signal is None
+
+        app._last_interrupt_at = 0.0
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+
+        assert app._last_interrupt_at != 0.0, "the exit ladder should arm as it always did"
+
+
+async def test_the_draft_rung_still_wins_when_no_login_is_pending(tmp_path: Path) -> None:
+    """The rung sits AHEAD of the draft rung, so this pins that the draft rung
+    is still reachable — a new rung that shadowed it would silently cost users
+    the composer text this repo has repeatedly paid to protect."""
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        editor = app.query_one(Editor)
+        editor.text = "a sentence the user is still writing"
+        await pilot.pause()
+
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+
+        assert editor.text.strip() == "", "the draft rung no longer clears the composer"
+        assert any("draft cleared" in note for note in _notices(app)), _notices(app)
+
+
+async def test_a_pending_login_takes_the_press_ahead_of_the_draft(
+    tmp_path: Path, no_browser: None
+) -> None:
+    """The ordering decision, pinned.
+
+    A login is pending AND the composer holds a draft. The login wins, and the
+    draft SURVIVES — which is the asymmetry the ordering rests on: the draft is
+    still there to clear with the next press, whereas a login cancelled late is
+    a login that was never cancelled at all.
+    """
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _start_login(pilot, app, "alibaba")
+        assert await _settle(lambda: app._login_signal is not None)
+
+        editor = app.query_one(Editor)
+        editor.text = "a draft the user does not want to lose"
+        await pilot.pause()
+
+        await pilot.press("ctrl+c")
+        assert await _settle(lambda: any("login cancelled" in n for n in _notices(app)))
+
+        assert editor.text == "a draft the user does not want to lose", "the draft was destroyed"
+        assert not any("draft cleared" in note for note in _notices(app)), _notices(app)
+
+
+async def test_a_second_press_after_the_cancel_reaches_the_draft_rung(
+    tmp_path: Path, no_browser: None
+) -> None:
+    """The ladder stays MONOTONIC: the rung claims exactly one press.
+
+    A rung that could be reached twice in a row is how the exit ladder became
+    unreachable in an earlier round, so the press after a completed cancel must
+    fall through to the rung it would have reached anyway.
+    """
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _start_login(pilot, app, "alibaba")
+        assert await _settle(lambda: app._login_signal is not None)
+        editor = app.query_one(Editor)
+        editor.text = "still here"
+        await pilot.pause()
+
+        await pilot.press("ctrl+c")  # takes the login
+        assert await _settle(lambda: any("login cancelled" in n for n in _notices(app)))
+        await pilot.press("ctrl+c")  # must now reach the draft rung
+        await pilot.pause()
+
+        assert editor.text.strip() == "", "the second press did not reach the draft rung"
+
+
+async def test_the_key_prompt_does_not_swallow_the_press(tmp_path: Path, no_browser: None) -> None:
+    """The specific trap named in the brief.
+
+    A paste-code provider mounts a `KeyPromptBlock` and FOCUSES it, and that
+    block binds escape and consumes printable keys. If it also swallowed
+    Ctrl+C, the press would never reach the ladder and the login would stay
+    pending — the exact bug being fixed, reintroduced one layer down.
+
+    Ctrl+C is not printable and the block does not bind it, so it bubbles to
+    the app; this pins that rather than leaving it to the block's key handling
+    staying the way it is today.
+    """
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _start_login(pilot, app, "alibaba")
+        assert await _settle(lambda: bool(app.query(KeyPromptBlock)))
+        prompt = next(iter(app.query(KeyPromptBlock)))
+        assert prompt.has_focus, "precondition: the prompt owns the keyboard"
+
+        await pilot.press("ctrl+c")
+
+        assert await _settle(lambda: any("login cancelled" in n for n in _notices(app)))
+        assert prompt.answered, "the prompt must settle with the login it belonged to"
+
+
+async def test_escape_still_cancels_from_the_prompt(tmp_path: Path, no_browser: None) -> None:
+    """Escape keeps its existing meaning on the block that binds it.
+
+    The two keys now both end the login, by different routes — escape through
+    the prompt's own `action_cancel`, Ctrl+C through the app's ladder — and
+    this pins that adding the second did not disturb the first.
+    """
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _start_login(pilot, app, "alibaba")
+        assert await _settle(lambda: bool(app.query(KeyPromptBlock)))
+
+        await pilot.press("escape")
+
+        assert await _settle(lambda: any("cancelled" in n for n in _notices(app))), _notices(app)
+        assert not any("failed" in note for note in _notices(app)), _notices(app)

--- a/tests/unit/tui/test_login_cancel_interrupt.py
+++ b/tests/unit/tui/test_login_cancel_interrupt.py
@@ -408,3 +408,145 @@ async def test_escape_still_cancels_from_the_prompt(tmp_path: Path, no_browser: 
 
         assert await _settle(lambda: any("cancelled" in n for n in _notices(app))), _notices(app)
         assert not any("failed" in note for note in _notices(app)), _notices(app)
+
+
+# -- loopback-only providers: the state every other test here cannot reach ----
+#
+# Every ordering test above uses a provider that mounts a `KeyPromptBlock`, and
+# that block closes the aside and the floating views on mount. So none of them
+# can observe what a LOOPBACK-ONLY login does — no prompt is ever mounted for
+# one — and both majors of agent review round 1 lived in exactly that gap.
+
+
+async def test_a_loopback_login_cancels_with_no_prompt_mounted(
+    tmp_path: Path, no_browser: None
+) -> None:
+    """The baseline for the two tests below: openai mounts NO prompt.
+
+    Asserted rather than assumed, because it is the precondition that makes
+    them meaningful — if a prompt did mount, they would be re-testing the
+    paste-provider path under a different name.
+    """
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _start_login(pilot, app, "openai")
+        assert await _settle(lambda: app._login_signal is not None), "no login was pending"
+        assert not list(app.query(KeyPromptBlock)), "openai must not mount a paste prompt"
+
+        await pilot.press("ctrl+c")
+
+        assert await _settle(lambda: any("login cancelled" in n for n in _notices(app))), _notices(
+            app
+        )
+        assert app._login_signal is None
+
+
+async def test_cancelling_a_loopback_login_returns_to_the_conversation(
+    tmp_path: Path, no_browser: None
+) -> None:
+    """Agent review round 1, major-2: the receipt must not be drawn out of sight.
+
+    The aside floats over the transcript at one elevation step, so a notice
+    appended behind it is drawn where it cannot be read — the rule the exit
+    ladder's own tail states and honours. The cancel appends exactly such a
+    notice, and on a loopback-only provider nothing else closes the card, so
+    the user pressed ctrl+C, the login really cancelled, and the only evidence
+    landed behind the aside: "nothing appeared to happen".
+
+    The CONTROL is the point of the test: an ordinary ctrl+C closes the aside,
+    so a login-cancelling one that did not would be a behavioural split with no
+    reason a user could infer.
+    """
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _start_login(pilot, app, "openai")
+        assert await _settle(lambda: app._login_signal is not None), "no login was pending"
+        assert not list(app.query(KeyPromptBlock)), "precondition: no prompt closes the aside"
+
+        app._open_aside()
+        await pilot.pause()
+        assert app._aside_is_open(), "precondition: the aside is open over the transcript"
+
+        await pilot.press("ctrl+c")
+        assert await _settle(lambda: any("login cancelled" in n for n in _notices(app)))
+
+        assert not app._aside_is_open(), (
+            "the cancel receipt was appended behind the floating aside, where the "
+            "user cannot read it"
+        )
+
+        # Control: the ordinary interrupt rung closes it too, so the two presses
+        # agree.
+        app._open_aside()
+        await pilot.pause()
+        assert app._aside_is_open() and app._login_signal is None
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+        assert not app._aside_is_open(), "control: ordinary ctrl+C should close the aside"
+
+
+async def test_starting_a_login_retires_an_armed_exit_hint(
+    tmp_path: Path, no_browser: None
+) -> None:
+    """UX round 1, U3: the screen must not say ctrl+C exits while a login is up.
+
+    Interrupt something first and the transcript carries "ctrl+c again to
+    exit". Start a login and that line is now FALSE — the next press cancels
+    the login and the app keeps running. It is false in the direction that
+    costs the user the feature: they read "again to exit", believe the rescue
+    key will quit their session, and sit out the 300 s wait instead.
+    """
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+        assert app._last_interrupt_at != 0.0, "precondition: the exit ladder is armed"
+        assert app._exit_hint is not None, "precondition: the hint is on screen"
+        assert any("again to exit" in note for note in _notices(app)), _notices(app)
+
+        await _start_login(pilot, app, "openai")
+        assert await _settle(lambda: app._login_signal is not None)
+
+        assert app._exit_hint is None, "the stale exit hint survived into the pending login"
+        assert app._last_interrupt_at == 0.0
+        assert not any(
+            "again to exit" in note for note in _notices(app)
+        ), "the screen still tells the user ctrl+c exits, which is now false"
+
+        # And the press it was contradicting does the right thing.
+        await pilot.press("ctrl+c")
+        assert await _settle(lambda: any("login cancelled" in n for n in _notices(app)))
+        assert app.is_running, "the login-cancelling press must not quit the app"
+
+
+async def test_the_browser_wait_names_the_key_that_cancels_it(
+    tmp_path: Path, no_browser: None
+) -> None:
+    """UX round 1, U4: a rescue key nobody knows about rescues nobody.
+
+    For a loopback-only login this block is the ONLY surface the pending state
+    puts on screen, so without this line the frame advertises no way out at
+    all — and the user it is for is watching a browser that landed somewhere
+    unexpected.
+    """
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _start_login(pilot, app, "openai")
+        assert await _settle(lambda: app._login_signal is not None)
+
+        from tests.unit.tui.test_app_pilot import _transcript_text
+
+        rendered = _transcript_text(app)
+        assert "ctrl+c" in rendered, f"the pending frame names no escape key:\n{rendered}"
+
+        await pilot.press("ctrl+c")
+        await _settle(lambda: app._login_signal is None)

--- a/tests/unit/tui/test_login_cancel_interrupt.py
+++ b/tests/unit/tui/test_login_cancel_interrupt.py
@@ -191,6 +191,12 @@ async def test_the_cancel_releases_the_port_and_a_retry_works(
     async with app.run_test(size=(100, 30)) as pilot:
         await _boot(pilot, app)
         await _start_login(pilot, app, "anthropic")
+        # THE PRECONDITION, ASSERTED BEFORE THE CANCEL. A fast "cancelled" only
+        # means something if a login was genuinely pending and genuinely held
+        # the port: a setup that quietly did not take looks exactly like a
+        # feature that works. Both facts are checked — the flow published its
+        # signal, and the OS says the socket is taken.
+        assert await _settle(lambda: app._login_signal is not None), "no login was ever pending"
         assert await _settle(lambda: _port_held(port)), "the listener never came up"
 
         await pilot.press("ctrl+c")

--- a/tests/unit/tui/test_login_cancel_interrupt.py
+++ b/tests/unit/tui/test_login_cancel_interrupt.py
@@ -550,3 +550,97 @@ async def test_the_browser_wait_names_the_key_that_cancels_it(
 
         await pilot.press("ctrl+c")
         await _settle(lambda: app._login_signal is None)
+
+
+async def test_a_repeat_press_inside_the_aborted_but_still_pending_window(
+    tmp_path: Path, no_browser: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Agent review round 1, minor-1 — the window its own regression test could not see.
+
+    `abort()` only REQUESTS cancellation. The paste-only and `local_setup`
+    flows never read the signal (`create_api_key_login` swallows it through
+    `**_kwargs`), so they end when the prompt future resolves, not when the
+    signal fires. Between the two there is a window in which `signal.aborted`
+    is already True while `_login_signal` is still set — and the old predicate
+    (`signal is None or signal.aborted`) DECLINED the press there, handing it
+    to the rungs below, where it cleared the user's composer on a keystroke
+    they aimed at a login still on screen.
+
+    WHY THIS TEST HAS TO GATE THE FLOW. Against a real `alibaba` login the
+    abort and the unwind land in the same pump, so the window closes before a
+    second press can be delivered and the state is never observed. QA proved
+    the consequence: with the fix reverted, all fifteen other tests in this
+    file — including `test_a_second_press_after_the_cancel_reaches_the_draft_rung`,
+    which was written for this finding — stayed GREEN (QA round 2, Q5). A test
+    that cannot fail against the bug it names is not a regression guard, so the
+    login is parked on an event the test controls and the window is held open
+    deliberately.
+
+    The gate replaces only the provider's own login coroutine. Everything under
+    test — the rung, the predicate, `_login_signal`'s lifetime, the draft — is
+    the real app's.
+    """
+    import dataclasses
+
+    import local_operator.providers.controller as controller_module
+    from local_operator.providers.registry import get_provider_definition
+
+    definition = get_provider_definition("alibaba")
+    assert definition is not None
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def parked_login(callbacks: Any, **kwargs: Any) -> str:
+        # Parks exactly like a paste-only flow awaiting its prompt future, and
+        # deliberately never consults `signal`: that indifference is the whole
+        # reason the window exists.
+        entered.set()
+        await release.wait()
+        return "sk-never-reached"
+
+    patched = dataclasses.replace(definition, login=parked_login)
+    monkeypatch.setattr(
+        controller_module,
+        "get_provider_definition",
+        lambda pid: patched if pid == "alibaba" else get_provider_definition(pid),
+    )
+
+    controller = _controller(tmp_path)
+    app = OperatorApp(lambda: _factory(FakeSession()), provider_controller=controller)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _start_login(pilot, app, "alibaba")
+        assert await _settle(entered.is_set), "the gated login never started"
+        assert app._login_signal is not None
+
+        draft = "QA890 draft that must survive"
+        editor = app.query_one(Editor)
+        editor.text = draft
+        await pilot.pause()
+
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+
+        # THE PRECONDITION, asserted rather than assumed: without both halves
+        # of this the test would be exercising the ordinary already-unwound
+        # path and would pass against the bug.
+        signal = app._login_signal
+        assert signal is not None, "the flow unwound; the window was not held open"
+        assert signal.aborted, "the first press did not abort the signal"
+
+        # The press under test, delivered INSIDE that window.
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+
+        assert editor.text == draft, (
+            "a repeat press inside the aborted-but-still-pending window fell "
+            "through to the draft rung and destroyed the user's composer"
+        )
+        assert not any("draft cleared" in note for note in _notices(app)), _notices(app)
+        # Nor may it arm the exit ladder: the user is still aiming at a login.
+        assert app._last_interrupt_at == 0.0, "the repeat press armed the exit ladder"
+        assert app._exit_hint is None
+
+        # Let the gated flow finish so teardown is clean.
+        release.set()
+        await _settle(lambda: app._login_signal is None)


### PR DESCRIPTION
## What and why

**C2 — user-visible correctness fix on the login path.** A pending `/login` could not be cancelled. If the browser did not come back to the loopback redirect, the user's only way out was `DEFAULT_TIMEOUT_SECONDS` — **300 seconds** — with the local listener still holding the port the whole time.

The operator's report, verbatim:

> *"if there's an outstanding oauth waiting, if we close the browser because it doesn't work for whatever reason (redirects us into the portal instead of redirect URI for example), then we can press cmd+C/ctrl+C and if there's a waiting oauth listener then it will cancel it? Otherwise right now we have no choice but to wait the max timeout"*

### The mechanism existed. Nothing could reach it.

This is the part worth dwelling on, because it is why the bug survived. **Every layer needed for a cancel was already built and wired:**

| Layer | State on `main` |
|---|---|
| `OAuthCallbackFlow._await_code` | races `_abort_watch()` against the capture futures, raises `LoginCancelledError` |
| `poll_device_code_flow` | polls `signal.aborted` between attempts |
| `registry._lazy_login` | accepts `signal` and forwards it |
| TUI `_login_flow` | already catches `LoginCancelledError` and reports it as an INFO outcome, not an error |
| **`ProviderController.login`** | **never constructed a signal — called `definition.login(callbacks, **options)`** |

One missing argument at the top made all of it **unreachable code**. This PR closes that gap end to end; it adds no new cancellation mechanism.

## What changed

**`ProviderController.login(signal=...)`** — forwarded to *every* login callable, unconditionally, including when `None`. The paste-a-key providers and `local_setup` ignore it. One call shape means a host never has to know which flavour of provider it is talking to before offering a cancel. Enumerated over the shipped registry rather than spot-checked: **all 17 logins accept the keyword** (a test asserts this over `PROVIDER_REGISTRY`, so a new provider with a narrow signature fails there rather than at runtime for that provider only).

**TUI — a pending-login rung in `action_interrupt`, ahead of the draft rung.** Two facts decide the placement, and both are about the state rather than about logins being important: while a login is in flight the app is effectively modal on something *outside* itself, and the flow mounts a `KeyPromptBlock` that **takes focus**, so the composer is not where the user's attention is. The asymmetry settles it — the draft **survives** this rung and is still there to clear with the next press, whereas a login cancelled late is a login that was never cancelled.

**It consumes the press without arming the double-tap exit ladder.** This is the load-bearing half. Measured on the pre-change tree:

```
· paste skipped Anthropic — still waiting for the browser
· ctrl+c again to exit          ← the login is STILL PENDING
```

The trap was already loaded before this rung existed: a user reflex-double-tapping Ctrl+C to kill a stuck login **would have quit the app on the second tap**.

**CLI `run_login`** — installs a loop-level SIGINT handler that aborts the same signal, and races the flow against it. The race is not redundant: the paste-a-key logins accept `signal` and *ignore* it (their whole flow is one `on_manual_code_input` await), so an abort alone left `local-operator login alibaba` blocked on a prompt read. Exits **130**, the SIGINT convention already used by `credential_update_command`.

**CLI paste prompt — a daemon thread, not `asyncio.to_thread`.** A second, worse defect that only a real process could show:

```
>>> SIGINT HANDLER RAN in thread MainThread
  File ".../auth_cli.py", line 146, in run_login
    result = asyncio.run(_run())
```

The interrupt *was* delivered and `except KeyboardInterrupt` *was* reached — and then the process sat for **five minutes**. `asyncio.run` shuts the loop's default executor down by joining its workers with `THREAD_JOIN_TIMEOUT` (300 s), and the worker is blocked in a terminal read nothing interrupts. The same 300 s wait, reached from the other direction, and invisible from inside the process.

**The message tells the user something useful.** Someone who just watched their browser dump them into the Claude portal needs to know the local listener is gone and how to retry. The listener clause is **conditional so it stays true** — a paste-a-key provider never bound a port, and a confident wrong detail costs trust in the rest of the line.

## Evidence

### The frame, before and after

Same script, same seeded state, one Ctrl+C during a pending `/login anthropic`.

**Before** — login still pending, exit ladder armed:
```
· paste skipped Anthropic — still waiting for the browser
· ctrl+c again to exit
```

**After** — login over, receipt honest, no armed exit:
```
· no longer needed Anthropic
· login cancelled. local sign-in listener stopped; retry with /login anthropic
```

The receipt changed too: `paste skipped … still waiting for the browser` is **false** after a cancel — nothing is waiting, the listener is stopped. `_settle_key_prompt` grew a `superseded` flag for exactly that sentence.

### Driving the real TUI (Textual pilot, real `ProviderController`, isolated config, `CMUX_*` scrubbed)

```
DEFAULT_TIMEOUT_SECONDS this replaces: 300.0s

1. a pending /login binds the loopback port
  [PASS] loopback listener is up on 54545
  [PASS] a login signal is published
  [PASS] the login lock is held
2. ctrl+C cancels it
  [PASS] the transcript says the login was cancelled
  [PASS] it returned in 159 ms (budget 1000 ms) — 1892x faster than the timeout
  [PASS] the message names the retry command
  [PASS] the message says the listener stopped
3. the press did NOT arm the exit ladder
  [PASS] no 'ctrl+c again to exit' hint
  [PASS] the exit-hint block is absent
  [PASS] _last_interrupt_at was reset
4. the cancel released everything
  [PASS] port 54545 is free again
  [PASS] the login lock is released
  [PASS] the login signal is cleared
5. an immediately retried /login works
  [PASS] the retry binds 54545 again
  [PASS] the retry was not refused
6. with NO login pending, ctrl+C behaves exactly as before
  [PASS] the exit ladder arms normally
```

### The CLI, under a real pty with a real Ctrl+C

A `kill -INT` would have measured the harness, not the product: a child started in the background from a non-interactive shell inherits SIGINT as `SIG_IGN`. Writing `\x03` to a pty master goes through the line discipline exactly as a keypress does.

> **Corrected in remediation round 1.** Two numbers in the original version of this table did not survive review, and both are fixed below rather than left in the thread. (1) The `alibaba` result was quoted as "exit 130 in 56 ms" when the process in fact did **not** exit — UX could not reproduce it in any configuration and QA reproduced the hang, and they were right: that measurement came from a harness where the reader had already been unblocked, so the precondition had not landed. (2) "All three hung ≥ 20 s before" was **false for `openai`**, which never had a `getpass` reader to deadlock on. Both re-measured against the merge base (`51c71ff6f`) and this head, under a real pty with the parked-at-the-prompt precondition asserted:

| provider | shape | on the merge base | on this head |
|---|---|---|---|
| `anthropic` | loopback + paste prompt | **hung, SIGKILLed at 20 s** | exit **130** in **33 ms** |
| `openai` | loopback only | exit **1** in **26 ms** — *no hang* | exit **130** in **28 ms** |
| `alibaba` | paste only, ignores the signal | **hung, SIGKILLed at 20 s** | exit **130** in **45 ms** |

So the `openai` improvement is exit-code correctness (1 → 130) and message quality, **not** a hang that was fixed — the hang was real for the two `getpass`/paste-prompt shapes only.

```
Login cancelled. local sign-in listener stopped; retry with: local-operator login anthropic
EXIT_CODE=130
RESULT: exited with code 130 after 33 ms
```

### Retry after cancel

The property the operator specifically asked to see. Probed by **binding a real socket**, not by reading a flag — "the flow says it stopped" and "the OS will let the next login have the port" are different claims:

```
port free before:        True
bound port:              54545
port free while pending: False
LoginCancelledError(cancelled by user) after 1.1 ms
port free after cancel:  True
retry bound port:        54545      ← the same pinned port, immediately
```

### The ladder guard is mutation-tested

The brief asked for a regression guard specifically, and the first version of mine **was worthless** — I proved it rather than assuming:

| mutant | first guard | final guard |
|---|---|---|
| drop the two disarm lines | **survived** ❌ | **killed** ✅ |
| rung never fires (`if False and …`) | killed (5 tests) ✅ | killed (5 tests) ✅ |
| controller drops `signal=` | killed ✅ | killed ✅ |

A press on an idle app leaves `_last_interrupt_at` at `0.0` anyway, so a test starting from rest passes against a rung that disarms nothing. The guard now **arms the ladder first**, which is also the real sequence a user hits.

## Tests

- `tests/unit/providers/test_login_cancellation.py` — abort vs. the 300 s timeout, port release, immediate retry, abort-before-start, and the **no-signal path unchanged**; plus the controller seam and the registry-wide signature sweep.
- `tests/unit/providers/test_login_cancel_cli.py` — exit code, message shape, the race for signal-ignoring logins, and a **pty subprocess test** for the executor-join hang, which nothing in-process can observe.
- `tests/unit/tui/test_login_cancel_interrupt.py` — 11 tests: the cancel, the message, the port, **and the ladder** (does not arm the exit ladder; unchanged with no login pending; the draft rung still reachable; the draft survives; the rung claims exactly one press; the focused `KeyPromptBlock` does not swallow Ctrl+C; escape still works).

Six existing `fake_login` doubles were widened to `**_kwargs` with a note saying why — they pinned the old narrow signature and would otherwise `TypeError`.

## Gates

`flake8` ✅ · `black --check` ✅ · `isort --check` ✅ · `pyright` **0 errors** ✅

Targeted suites on this head: **1189 passed** (`tests/unit/providers` + login/TUI cancel) and **601 passed** across the ladder neighbours (`test_steering_approval`, `test_session_drafts`, `test_bindings`, `test_keymap_pilot`). The full-tree run is left to CI: this machine is at **94% disk / swap 9.8 of 11.3 GB / load ~70**, where an OOM mid-suite is indistinguishable from a test failure.

`flake8` caught a real bug in review, worth noting: `except … as exc` unbinds the name at clause exit, so the worker's `lambda: future.set_exception(exc)` would have raised `NameError` on the loop thread. Fixed by binding to a local first, and all five prompt paths (value / exception / EOF / KeyboardInterrupt / empty) were then exercised directly.

## Scope

No provider URL, param, scope, or port changes, and **no anti-detection or impersonation work** — the existing impersonation is untouched. This only makes a failure legible and cancellable.

**No overlap with PR B:** `local_operator/providers/oauth/` has a **zero diff**, `callback_server.py` included. No merge sequencing needed.

`pyproject.toml` is untouched.

---

## Follow-up commit: three CI failures, all mine, all real

The first push went red on two shards. None of it was flaky infrastructure:

**Two narrow test doubles.** `FakeProviderController.login(self, provider)` in the TUI pilot and `login(callbacks, *, open_browser)` in the desktop controls pinned the pre-change signature, so the new `signal=` made them raise `TypeError` — which the surfaces above them report as an ordinary "login failed". Widened to `**_kwargs` (the shape every real login callable already has) with a note so they are not re-narrowed. This is exactly the failure mode the registry-wide signature test exists to prevent for *product* code; these were test-local doubles it cannot see.

**One harness bug in my own pty test.** It reported "still running 30 s after Ctrl+C" while its own captured output contained:

```
Login cancelled. local sign-in listener stopped; retry with: local-operator login anthropic
EXIT_CODE=130
```

The product exited correctly in ~40 ms. Under xdist the worker process reaps children, so `waitpid` loses the race or returns `ECHILD` for a process that exited perfectly. The exit is now read from the child's **own printed exit code** — a fact about the product — with `waitpid` as a secondary path.

### Preconditions are now asserted before the cancel is measured

Per the fleet-wide evidence rule, and it applies squarely here: **"cancelled in 40 ms" proves nothing if no login was ever pending.** A setup that silently did not take is indistinguishable from a feature that works.

- pty test: asserts the flow reached its prompt **and** that 54545 was genuinely bound before Ctrl+C, then that it was **released** after.
- TUI test: asserts the signal was published **and** the port held before pressing.
- e2e evidence: opens with `PRECONDITION: port 54545 is free before we start`, so the bind that follows is a real state change rather than a pre-existing condition.

Verified the guard bites: with the child mutated to exit immediately (no login pending), the test **fails** with *"the login never reached its prompt, so there was nothing pending to cancel"* rather than passing quickly.

```
1. a pending /login binds the loopback port
  [PASS] PRECONDITION: port 54545 is free before we start
  [PASS] loopback listener is up on 54545
  [PASS] a login signal is published
2. ctrl+C cancels it
  [PASS] it returned in 145 ms (budget 1000 ms) — 2070x faster than the timeout
```

**CI on this head: all 16 checks green** — 5 test shards, both `tui-e2e` legs, `lint`, `type-check`, `pip-audit`, `cli-sanity`, `server-sanity`, `coverage-report`, `context-budget`, `filesystem-boundaries-windows`, `version-bump-guard`.

Locally re-verified across 3 consecutive xdist runs (1479 tests each) plus a 1532-test run covering every affected file.


---

## Remediation round 1

Reviewer, UX and QA all landed on one root cause and two discoverability gaps. Fixed in `ce95b6925`; full per-finding disposition is in the `### Agent review remediation — round 1` comment. Headlines:

- **Terminal state (reviewer major-1).** The daemon reader that cures the 300 s executor join is never joined, so a cancel with the reader parked in `getpass` skipped getpass's own ECHO restore and left the user blind-typing until they ran `stty sane`. The restore now belongs to the command (`_terminal_state_restored`), not the reader. Re-verified under a real pty on `alibaba`/`openrouter`, with `anthropic` (plain `input()`) as the control that isolates it to the getpass branch.
- **`cli.py` now uses `sys.exit(main())`** instead of the `exit()` builtin, which closes `sys.stdin` and can wait on a lock a parked reader holds. I could not reproduce the hang on this head (`getpass` prefers `/dev/tty` and only falls back to `sys.stdin` when that open fails — the shape QA and UX hit); taking the one-line fix regardless, since it removes the hazard class and matches the shipped console scripts.
- **Aside (reviewer major-2).** The rung returned before the tail that closes the floating views, so on a loopback-only provider the cancel receipt was drawn behind the aside where it cannot be read. Reproduced with the control that makes it a defect: ordinary ctrl+C closed the aside, the login-cancelling one did not.
- **Discoverability (UX U2/U3/U4).** The browser-flow prompt now reads `enter submit · ctrl+c cancel login · esc skip paste` — two keys that do different things must not both be called "cancel". Starting a login retires an already-armed exit hint, so the screen can no longer say "ctrl+c again to exit" above "logging in to …". The browser-wait block names the escape at the moment the wait begins, which for a loopback login is the only surface the pending state has.

Every fix is mutation-verified: reverting the aside closers, the armed-hint retirement, the wait line, or the terminal guard each fails its own test. Four new loopback-only tests cover the state every previous ordering test structurally could not reach, because they all mount a paste prompt.
