### PR TITLE
fix(tui): mask a TYPED credential in the composer, not only a pasted one

### DIFF
--- a/docs/design/secret-store.md
+++ b/docs/design/secret-store.md
@@ -952,6 +952,19 @@ the `--persist` advice both name the inline gesture and the generated
 `LOP_SECRET_` name instead. Usage text and behaviour have to agree (QA round 1,
 Q1).
 
+**The arm stays on its own token while that token is being typed out.** `/cred`
+is a token and `/credential` is a token, but the five spellings between them are
+not — so an operator re-arming on the same line (the state the now-working Esc
+leaves them in) walked the latched arm through a window where it matched nothing
+at its own anchor, and the nearest-match tie-break migrated it back onto the
+FIRST token earlier in the line. The migration is one-way, because the anchor
+moves with it: the arm never came home, the caret-at-span-end gate never fired,
+and the secret typed next was painted in the clear and then parsed as a
+credential NAME — the half the model does learn on a later turn (UX round 2,
+U6). `_token_being_typed_at` answers the anchor's own word first, and the test
+is PREFIX-OF the token rather than starts-with, so `/credentials` cannot inherit
+an arm and a word shortened past `/cred` still reads as withdrawing the gesture.
+
 **A leading `-` escapes the mask**, so `--forget-all` stays typable. The
 credential verbs are flag-shaped precisely so they cannot collide with a key
 (keys normalize to `[A-Z0-9_]`), which is the same partition `CREDENTIAL_ARGUMENT`

--- a/docs/design/secret-store.md
+++ b/docs/design/secret-store.md
@@ -861,6 +861,88 @@ event, arms the next paste for capture. Because `consumes_prompt` and
 command, the inline form is an editor-level concern, not a slash-command one —
 the existing `/credential` command keeps working unchanged for the leading case.
 
+### 11.1 The TYPED capture
+
+The paste path above shipped in v0.53.0 and was, for two releases, the **only**
+path. Typing the secret — `/credential 12345`, the obvious human gesture —
+produced no chip at all: the line fell through to the legacy `/credential <KEY>`
+command with the secret as its **key argument**, so the app answered "Paste the
+value for 12345" and the secret sat in the transcript in plaintext. No chip, no
+error, no warning. That is a security defect rather than a missing convenience,
+and it is what this section closes.
+
+**The state machine.**
+
+```
+token typed or completed  ──▶ ARMED
+ARMED + SPACE             ──▶ TYPING   (characters masked as typed)
+TYPING + printable        ──▶ held out of the document, one mask cell painted
+TYPING + Enter            ──▶ chip minted; composer keeps the draft
+TYPING + Esc              ──▶ unredacted: the characters come back as text
+ARMED + paste             ──▶ chip in place, instantly (unchanged)
+```
+
+**The space is the boundary, and it arms from both routes.** A hand-typed space
+and the trailing space `_apply_command` inserts when a picker row is accepted
+are the same character at the same offset, so the capture opens on the shared
+edit funnel rather than at either call site — the two routes are identical *by
+construction* instead of by two code paths agreeing. The space is a delimiter
+and is **not** part of the secret, so `K` in `[Credential #N, K chars]` counts
+the value alone.
+
+**Two different Enters, separated by state, not by timing.** While the picker is
+open Enter accepts the completion; once a capture is open Enter mints the chip.
+Exactly one of those states holds at any instant, which is what makes them
+impossible to confuse. Accepting the row therefore must not *run* the command —
+`Editor.arms_a_capture` is the predicate that suppresses it, beside
+`opens_a_list` and for the same reason.
+
+**Enter ends the secret; it does not submit.** The gesture is specified as "hand
+over a secret and then describe it", so an Enter that also sent the message
+would make the description impossible to write. The operator presses Enter a
+second time to send.
+
+**The secret is held out of the document.** Characters typed while a capture is
+open never enter `self.text`; they accumulate in `Editor._credential_typed`
+while the buffer receives `CREDENTIAL_MASK_CHAR` cells. This is the whole safety
+property, and it is why the mask is *not* a render-time effect over real
+characters: every disclosure seam (history, the draft store, undo, `ctrl+o`,
+the submit path) reads the buffer, so a document that never held the secret
+closes all of them at once rather than one at a time.
+
+**Esc unredacts rather than discards.** Retyping a secret from memory is exactly
+what an operator cannot do, so the recoverable reading is the only safe one. Esc
+also ends the arm: the operator has visibly backed out, so the next paste must
+not still be swallowed.
+
+**The masked span is positional.** It is open exactly while the caret is inside
+it, asked on `watch_selection` — `move_cursor`, a mouse click and an app-set
+selection all move the caret without a caret key being pressed, and a capture
+left open after the caret moved would append to the value in one place while
+painting its cell in another.
+
+**A leading `-` escapes the mask**, so `--forget-all` stays typable. The
+credential verbs are flag-shaped precisely so they cannot collide with a key
+(keys normalize to `[A-Z0-9_]`), which is the same partition `CREDENTIAL_ARGUMENT`
+already draws on the pasted path. Only the *first* character is tested: `-` is
+common inside real keys.
+
+**A trap worth recording.** Textual spells punctuation keys as words (`minus`,
+`full_stop`), so a handler gated on `len(event.key) == 1` masks letters and
+digits while every punctuation character falls through into the document.
+Measured, the canary `zQ7-TYPED-LEAK-CANARY-4417` rendered as
+`•••-TYPED-LEAK-CANARY-4417` — the first hyphen ended the masking and the rest
+was typed in plaintext and submitted. Real credentials are mostly punctuation,
+so that gate leaks nearly every actual secret while passing against an
+alphanumeric test value. Gate on `event.is_printable`, never on the key name.
+
+**Cost accepted.** Prose typed after the token — `fix the /credential command` —
+is masked, because no rule keyed on the buffer can separate it from
+`deploy with /credential the prod key`, which must stay armed (design round 1,
+D2). The mask is loud and immediate and Esc restores the text in one keystroke,
+which is the false-positive direction; the alternative fails toward a plaintext
+secret in scrollback that nothing can recall.
+
 **Random naming.** The operator does not invent a name; the store does:
 
 ```

--- a/docs/design/secret-store.md
+++ b/docs/design/secret-store.md
@@ -910,16 +910,47 @@ characters: every disclosure seam (history, the draft store, undo, `ctrl+o`,
 the submit path) reads the buffer, so a document that never held the secret
 closes all of them at once rather than one at a time.
 
-**Esc unredacts rather than discards.** Retyping a secret from memory is exactly
-what an operator cannot do, so the recoverable reading is the only safe one. Esc
-also ends the arm: the operator has visibly backed out, so the next paste must
-not still be swallowed.
+**Esc unredacts rather than discards, and says so.** Retyping a secret from
+memory is exactly what an operator cannot do, so the recoverable reading is the
+only safe one. Esc also ends the arm: the operator has visibly backed out, so
+the next paste must not still be swallowed. But the unredact is the one exit
+that *ends with the secret in the buffer*, and the frame after it looks entirely
+ordinary — the amber marker reverts, the masking notice goes — while the next
+Enter re-commits the original leak; measured, the post-Esc-then-Enter outcome
+was byte-identical to the pre-fix base. So it posts `CredentialUnredacted` and
+the app warns that N characters are now plain text (design round 1, D1).
 
-**The masked span is positional.** It is open exactly while the caret is inside
-it, asked on `watch_selection` — `move_cursor`, a mouse click and an app-set
-selection all move the caret without a caret key being pressed, and a capture
-left open after the caret moved would append to the value in one place while
-painting its cell in another.
+**Esc works on an EMPTY span too**, which took a mechanism rather than a
+comment. The cancel's own `replace()` re-enters the edit funnel, which
+re-derived the arm from a buffer still ending in `/credential ` and re-opened
+the capture the cancel had just closed — so Esc was inert before any character
+was typed, on the exact key the on-screen notice advertises, and the prose typed
+next was captured as a secret. `_suspend_credential_sync` scopes the
+re-derivation out across the widget's own edit, the same idiom
+`_suspend_picker_sync` uses (review round 1, R1; UX round 1, U2).
+
+**The masked span is positional — and so is the held value.** The span is open
+exactly while the caret is inside it, asked on `watch_selection` — `move_cursor`,
+a mouse click and an app-set selection all move the caret without a caret key
+being pressed. Because the capture deliberately stays open *anywhere* in the
+span ("the operator may be mid-word"), the interaction invites an edit inside it,
+so `_credential_typed` is a **positional mirror** of the mask cells rather than
+an append-only buffer: `Editor.edit` maps every insertion, deletion and
+selection-replacement onto the held value at the same index. An append-only
+value beside a caret-positioned cell is the one arrangement that fails
+*silently* — the count stays right while the order goes wrong, so the chip's
+length (documented as an integrity check) passes on a value that is wrong and
+can never be displayed again to catch it. Measured before the fix: `ABCDEFGH`,
+`←←`, `xy` stored `ABCDEFGHxy` for an intended `ABCDEFxyGH` (UX round 1, U1).
+
+**The typed `/credential <KEY>` form is retired.** The space always opens a
+masked capture, so a hand-typed key name is minted as a short secret rather than
+reaching the `<KEY>` prompt. The command is still *parsed* — a pasted whole line
+reaches it, and it stays the route a viewer session uses to hand a secret to its
+owner — but nothing advertises it as typable any more: `CREDENTIAL_USAGE` and
+the `--persist` advice both name the inline gesture and the generated
+`LOP_SECRET_` name instead. Usage text and behaviour have to agree (QA round 1,
+Q1).
 
 **A leading `-` escapes the mask**, so `--forget-all` stays typable. The
 credential verbs are flag-shaped precisely so they cannot collide with a key

--- a/local_operator/secrets/promote.py
+++ b/local_operator/secrets/promote.py
@@ -84,10 +84,19 @@ def promote_session_credential(
         return PromotionResult(False, key, "This session's credential store could not be read.")
     value = values.get(key)
     if not value:
+        # NAMES THE GESTURE THAT STILL WORKS. This used to advise
+        # `/credential {key}`, which the typed capture retired: the space after
+        # the token opens a masked span, so typing a key name mints it as a short
+        # secret instead of reaching the `<KEY>` prompt (QA round 1, Q1). Advice
+        # an operator cannot follow is worse than none — they would have typed it
+        # and watched their key name become a credential. The inline gesture
+        # generates the name, so the way to persist is to hand the secret over
+        # and then persist the name the chip reports.
         return PromotionResult(
             False,
             key,
-            f"No session credential named {key}. Hand it over with /credential {key} first.",
+            f"No session credential named {key}. Hand one over with /credential "
+            "followed by a space and the secret, then --persist the name its chip reports.",
         )
     try:
         target = open_store(base, create=True)

--- a/local_operator/slash_commands.py
+++ b/local_operator/slash_commands.py
@@ -501,7 +501,18 @@ SLASH_COMMANDS: list[SlashCommand] = [
         # own verb. So the two words that tell the operator the mode exists
         # ("Type or") have to come before the guarantee, because the guarantee is
         # the half that survives cropping either way.
-        "Type or paste a secret the agent can use but never reads",
+        #
+        # AND IT IS SHORT ENOUGH TO SURVIVE. The first attempt at this copy still
+        # cropped before its own promise at EVERY width measured, 120 included
+        # ("…can use but never rea…" — a truncated reassurance dangling mid-word,
+        # which an operator completes wrongly). Measured, not estimated: the row
+        # keeps ~31 cells at 60 columns and ~47 at 100, and the budget is not
+        # monotonic in width because the transcript gutter indents it more as the
+        # terminal grows (design round 1, D5; QA round 1, Q2). At 44 cells this
+        # one paints whole from 80 columns up and still leads with the gesture
+        # everywhere below that. The SPACE is named because it is what arms the
+        # mode and nothing else on screen says so (UX round 1, U5).
+        "Type or paste a secret after a space; masked",
         aliases=("cred",),
         arguments=ArgumentMode.OPTIONAL,
         desktop_destination="session.credential",

--- a/local_operator/slash_commands.py
+++ b/local_operator/slash_commands.py
@@ -488,7 +488,20 @@ SLASH_COMMANDS: list[SlashCommand] = [
     # notice that already names what was stored or forgotten.
     SlashCommand(
         "credential",
-        "Hand the agent a secret it can use but never read; paste is masked",
+        # Describes the GESTURE, and describes it FIRST. The old copy ("paste is
+        # masked") named only the clipboard route, so the operator who TYPED the
+        # secret — the obvious human gesture — had no reason to expect it to
+        # work, and in fact it did not: the line fell through to this command
+        # with the secret as its argument.
+        #
+        # THE LEAD IS LOAD-BEARING, not a style choice. The picker ellipsizes the
+        # description's TAIL, and measured on the real app it keeps ~47
+        # characters at 100 columns and fewer at 80 — the previous copy rendered
+        # as "Hand the agent a secret it can use but never re…", dropping its
+        # own verb. So the two words that tell the operator the mode exists
+        # ("Type or") have to come before the guarantee, because the guarantee is
+        # the half that survives cropping either way.
+        "Type or paste a secret the agent can use but never reads",
         aliases=("cred",),
         arguments=ArgumentMode.OPTIONAL,
         desktop_destination="session.credential",

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1620,11 +1620,22 @@ CREDENTIAL_ARMED_NOTICE = "armed — add a space, then type or paste the secret"
 #: geometry. Prose asserting an invariant is not a mechanism enforcing it.
 #:
 #: So the rungs below are tried WIDEST-FIRST against the row's real budget by
-#: :func:`credential_typing_notice`, which is the same overflow-ladder idiom the
-#: status band and the info panel use. Every rung names BOTH keys; what degrades
-#: is the description of the mode, which the amber marker and the visible mask
-#: cells already carry. The narrowest rung is 22 cells, so the exit survives
-#: every width the picker paints at.
+#: :meth:`~local_operator.tui.widgets.command_picker.CommandPicker.set_notice_rungs`
+#: and resolved at paint time by ``CommandPicker._fitted_notice``, which is the
+#: same overflow-ladder idiom the status band and the info panel use. Every rung
+#: names BOTH keys; what degrades is the description of the mode, which the
+#: amber marker and the visible mask cells already carry.
+#:
+#: THE NARROWEST RUNG IS 25 CELLS, and with the row's own gutter and margin
+#: (``_GUTTER_CELLS=3``, ``_EDGE_MARGIN=2``) that needs 30 screen columns to
+#: paint at all — but ``truncate_cells`` takes the exit apart word by word
+#: below 34, so the honest claim is that the exit survives every width AT OR
+#: ABOVE 34 COLUMNS and the backstop truncate applies under it (design round 2,
+#: D8). The previous wording said 22 cells and "every width the picker paints
+#: at"; both were false, which is the D2 defect — prose asserting an invariant
+#: the code does not enforce — reappearing in the very docstring that names it.
+#: 24-33 columns is not a real terminal, so no rung is added for it; the
+#: guard test pins the range from 45 up.
 CREDENTIAL_TYPING_NOTICE_RUNGS: tuple[str, ...] = (
     "masked as you type — Enter turns it into a chip, Esc cancels",
     "masked as you type — Enter chips it, Esc cancels",
@@ -1650,13 +1661,25 @@ CREDENTIAL_TYPING_NOTICE = CREDENTIAL_TYPING_NOTICE_RUNGS[0]
 #: because the operator's hand is already moving toward Enter. The length comes
 #: from the message and never the value.
 #:
+#: "EXPOSE" RATHER THAN "SEND", because the consequence is SHAPE-DEPENDENT and
+#: the warning must be true for both. Mid-prose (``deploy with /credential …``)
+#: Enter genuinely sends the line to the model. But when the capture was the
+#: WHOLE line, Enter re-dispatches to the legacy ``<KEY>`` prompt instead, which
+#: puts the NORMALISED secret (``HUNTER2_TYPED_TEST``) in the transcript as a
+#: credential name — nothing reaches the model that turn, so "Enter will send
+#: them" read as false there, and it also understated the case: a name in the
+#: transcript is what the model is documented to learn on a later turn. That
+#: second behaviour is pre-existing and identical on base (QA round 2, Q6); this
+#: string is only what makes it visible, so the copy is what changes here and
+#: not the route.
+#:
 #: One line at every ordinary width. The notice block FOLDS rather than crops
 #: (``NoticeBlock.body_budget``), so nothing is lost when it does wrap — but the
 #: sentence is kept inside ~78 cells so the warning reads as one statement on a
 #: single row at 80 columns and up, which is where an operator scanning for what
 #: just happened will find it.
 CREDENTIAL_UNREDACTED_NOTICE = (
-    "{length} characters are now PLAIN TEXT in the composer — Enter will send them"
+    "{length} characters are now PLAIN TEXT in the composer — Enter will expose them"
 )
 
 
@@ -29019,12 +29042,26 @@ class OperatorApp(App[None]):
             # locally (a key no tool could read: the exact leak
             # `_FRONTEND_LOCAL_SLASHES` documents) the capture DEGRADES
             # LOUDLY: the secret is dropped here, the operator is told, and the
-            # model is told nothing was stored. `/credential <KEY>` still
-            # routes to the owner over the dedicated op and remains the
-            # supported way to hand a secret over from a viewer.
+            # model is told nothing was stored. The `/credential <KEY>` command
+            # still routes to the owner over the dedicated op and remains the
+            # supported way to hand a secret over from a viewer — but it is
+            # only reachable by PASTING the whole line, which is what the
+            # notice below has to say.
+            #
+            # IT MUST NAME THE PASTE, NOT THE TYPING. Typing `/credential KEY`
+            # cannot reach that command any more: the space after the token
+            # opens a masked capture, so the KEY NAME is minted as a short
+            # secret and nothing is handed to the owner. Advice that cannot be
+            # followed is worse than none here, because this notice fires on
+            # the submit seam — the chip the retyping mints is itself a
+            # payload, so the next submit re-enters this branch and reprints
+            # the same advice, and the operator LOOPS (review round 2, R5; QA
+            # round 2, Q5). A pasted whole line arms no capture and does reach
+            # the owner's prompt, so that is the route named.
             self._system_notice(
                 "inline /credential needs the session that runs the tools; "
-                "use /credential <KEY> here and the secret is stored on the owner",
+                "paste the whole line /credential <KEY> here "
+                "and the secret is stored on the owner",
                 "warning",
             )
             return self._mark_credentials_unstored(text, attachments)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1564,13 +1564,28 @@ COMPOSER_CREDENTIAL_CLASS = "-composer-credential"
 #: and the amber ink on the token itself, plus the picker's own notice row
 #: while its list is open. Anything counting channels here must count what
 #: PAINTS — the attribute being set correctly is not the same claim.
-CREDENTIAL_PLACEHOLDER = "Paste the secret… — it is captured, not shown"
+CREDENTIAL_PLACEHOLDER = "Type or paste the secret… — masked; Enter chips it"
 
 #: Shown where ``/credential``'s argument rows would be while a capture is
 #: armed. The rows are suppressed there (see ``_credential_choices``), and a
 #: list that simply vanished would read as the gesture having been dropped —
 #: so the row says what the composer is waiting for instead.
-CREDENTIAL_ARMED_NOTICE = "armed — paste the secret; it is captured, never shown"
+CREDENTIAL_ARMED_NOTICE = "armed — type or paste the secret; it is never shown"
+
+#: Shown in the same row once the operator has STARTED TYPING a secret and the
+#: composer is masking their keystrokes.
+#:
+#: A separate string from :data:`CREDENTIAL_ARMED_NOTICE` because the two states
+#: owe different words, and this is the state where the operator most needs
+#: them: their keystrokes are producing bullets instead of characters, which is
+#: alarming rather than reassuring unless something says it is deliberate AND
+#: says how it ends. So this names the mask, the key that finishes the entry and
+#: the key that backs out — the three facts that cannot be read off the frame.
+#:
+#: Same width budget as the held notice (~82 cells at 120 columns, and the row
+#: ellipsizes its TAIL): the tail here is "Esc cancels", the way out, which is
+#: exactly the half that must not be the part that crops.
+CREDENTIAL_TYPING_NOTICE = "masked as you type — Enter turns it into a chip, Esc cancels"
 
 #: Shown where those same rows would be once a capture has LANDED and the
 #: buffer still cites it (design round 3, D9). The armed notice cannot be
@@ -14283,11 +14298,18 @@ class OperatorApp(App[None]):
         # only ever narrows what the list offers, so no disarm can hand back a
         # destructive row the fill above withheld.
         if editor.argument_command in ("credential", "cred"):
-            editor.picker.set_notice(
-                CREDENTIAL_ARMED_NOTICE
-                if message.active
-                else (CREDENTIAL_HELD_NOTICE if editor.credential_cited() else "")
-            )
+            # THREE states, three strings. `message.typing` is read from the
+            # message rather than from the editor because this handler runs a
+            # message-loop tick after the transition, by which time the widget
+            # may already have moved on — the row would then describe a state
+            # the operator has left. See `CredentialArmChanged.typing`.
+            if message.typing:
+                notice = CREDENTIAL_TYPING_NOTICE
+            elif message.active:
+                notice = CREDENTIAL_ARMED_NOTICE
+            else:
+                notice = CREDENTIAL_HELD_NOTICE if editor.credential_cited() else ""
+            editor.picker.set_notice(notice)
         if not message.active and message.reason == "argument":
             self._notice(
                 "credential capture disarmed — that is an argument to "
@@ -28085,9 +28107,19 @@ class OperatorApp(App[None]):
             armed = editor.credential_armed()
             cited = editor.credential_cited()
             picker.set_choices(self._credential_choices(armed=armed, cited=cited))
-            picker.set_notice(
-                CREDENTIAL_ARMED_NOTICE if armed else (CREDENTIAL_HELD_NOTICE if cited else "")
-            )
+            # TYPING outranks ARMED here for the same reason ARMED outranks
+            # CITED: it is the state the operator is currently IN, and it is the
+            # one whose keys they need told. Asked off the editor rather than
+            # off a message because this is the list-OPENING path — there is no
+            # transition being reported, only a list being filled over whatever
+            # state already holds, so the widget is the authority.
+            if editor.credential_typing():
+                notice = CREDENTIAL_TYPING_NOTICE
+            elif armed:
+                notice = CREDENTIAL_ARMED_NOTICE
+            else:
+                notice = CREDENTIAL_HELD_NOTICE if cited else ""
+            picker.set_notice(notice)
             return
         if message.command in ("team", "teams", "agent", "agents"):
             # Rows and the render-time name snapshot are one fill operation. The

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -212,6 +212,7 @@ from local_operator.tui.widgets.editor import (
     ArgumentHighlightChanged,
     ArgumentQueryOpened,
     CredentialArmChanged,
+    CredentialUnredacted,
     Editor,
     EditorCopied,
     EditorCopyStale,
@@ -1564,13 +1565,40 @@ COMPOSER_CREDENTIAL_CLASS = "-composer-credential"
 #: and the amber ink on the token itself, plus the picker's own notice row
 #: while its list is open. Anything counting channels here must count what
 #: PAINTS — the attribute being set correctly is not the same claim.
+#:
+#: STILL UNREACHABLE after the typed capture, re-measured rather than assumed:
+#: every route drives ``PLACEHOLDER=0`` (design round 1, D4). Retained for the
+#: reason above — it is the armed STATE's field and the swap is what keeps the
+#: aside's placeholder restore correct — and NOT counted as guidance anywhere.
 CREDENTIAL_PLACEHOLDER = "Type or paste the secret… — masked; Enter chips it"
 
 #: Shown where ``/credential``'s argument rows would be while a capture is
 #: armed. The rows are suppressed there (see ``_credential_choices``), and a
 #: list that simply vanished would read as the gesture having been dropped —
 #: so the row says what the composer is waiting for instead.
-CREDENTIAL_ARMED_NOTICE = "armed — type or paste the secret; it is never shown"
+#:
+#: UNREACHABLE SINCE THE TYPED CAPTURE, and retained deliberately. Recorded here
+#: because a later round would otherwise 'fix' this copy and see no change on
+#: screen (design round 1, D4). The row it paints in is the ARGUMENT list's, and
+#: that list only opens once the buffer reaches the argument phase — which takes
+#: the space, and the space now opens a TYPING capture in the same edit. So the
+#: two conditions are mutually exclusive by construction: before the space
+#: ``argument_command`` is ``None`` and no list exists to carry a notice; from
+#: the space onward :data:`CREDENTIAL_TYPING_NOTICE_RUNGS` wins the row.
+#: Re-measured on six routes rather than inferred — including the flag disarm,
+#: a caret move out of the span, a backspace back to the token, and a re-arm
+#: after a chip — and this string painted on none of them.
+#:
+#: Kept rather than deleted for the reason its sibling
+#: :data:`CREDENTIAL_PLACEHOLDER` is: it belongs to the ARMED state, the
+#: three-way branch that selects it is what keeps the row's states exhaustive,
+#: and it would begin painting again the day an arming route reaches the
+#: argument list without opening a capture. It must NOT be counted as a
+#: guidance channel while it does not paint — count what PAINTS.
+#:
+#: The space is named in the PICKER DESCRIPTION instead, which is the row that
+#: does paint in the deciding frame (UX round 1, U5).
+CREDENTIAL_ARMED_NOTICE = "armed — add a space, then type or paste the secret"
 
 #: Shown in the same row once the operator has STARTED TYPING a secret and the
 #: composer is masking their keystrokes.
@@ -1582,10 +1610,55 @@ CREDENTIAL_ARMED_NOTICE = "armed — type or paste the secret; it is never shown
 #: says how it ends. So this names the mask, the key that finishes the entry and
 #: the key that backs out — the three facts that cannot be read off the frame.
 #:
-#: Same width budget as the held notice (~82 cells at 120 columns, and the row
-#: ellipsizes its TAIL): the tail here is "Esc cancels", the way out, which is
-#: exactly the half that must not be the part that crops.
-CREDENTIAL_TYPING_NOTICE = "masked as you type — Enter turns it into a chip, Esc cancels"
+#: THE WAY OUT IS KEPT BY A MECHANISM, NOT BY A COMMENT. The previous single
+#: string asserted in this very docstring that "Esc cancels" was the half that
+#: must not crop, and it was the FIRST thing to crop: the picker's notice row
+#: ellipsizes its tail, so measured on the real app `Esc cancels` was lost at 68
+#: columns and `chip` at 56, and at 45 the row read `masked as you type — Enter
+#: turns it…` — a row that names neither key (design round 1, D2; UX round 1,
+#: U3; review round 1, R3). 68-80 columns is a split pane, not an exotic
+#: geometry. Prose asserting an invariant is not a mechanism enforcing it.
+#:
+#: So the rungs below are tried WIDEST-FIRST against the row's real budget by
+#: :func:`credential_typing_notice`, which is the same overflow-ladder idiom the
+#: status band and the info panel use. Every rung names BOTH keys; what degrades
+#: is the description of the mode, which the amber marker and the visible mask
+#: cells already carry. The narrowest rung is 22 cells, so the exit survives
+#: every width the picker paints at.
+CREDENTIAL_TYPING_NOTICE_RUNGS: tuple[str, ...] = (
+    "masked as you type — Enter turns it into a chip, Esc cancels",
+    "masked as you type — Enter chips it, Esc cancels",
+    "masked — Enter chips it, Esc cancels",
+    "Enter chips it, Esc cancels",
+    "Enter chips · Esc cancels",
+)
+
+#: The widest rung, which is what the notice reads at any ordinary width. Named
+#: separately because tests and callers that mean "the full string" should not
+#: index into the ladder.
+CREDENTIAL_TYPING_NOTICE = CREDENTIAL_TYPING_NOTICE_RUNGS[0]
+
+#: Said after Esc unredacts a typed secret back into the composer as plaintext.
+#:
+#: The unredact is the only exit that leaves the secret IN the buffer, and the
+#: frame cannot say so on its own — the amber marker reverts and the masking
+#: notice goes, so the composer looks ordinary while holding a credential, and
+#: the next Enter re-commits the exact leak this feature closes (measured
+#: byte-identical to the pre-fix base; design round 1, D1).
+#:
+#: Names what is true NOW and what the next keystroke does, in that order,
+#: because the operator's hand is already moving toward Enter. The length comes
+#: from the message and never the value.
+#:
+#: One line at every ordinary width. The notice block FOLDS rather than crops
+#: (``NoticeBlock.body_budget``), so nothing is lost when it does wrap — but the
+#: sentence is kept inside ~78 cells so the warning reads as one statement on a
+#: single row at 80 columns and up, which is where an operator scanning for what
+#: just happened will find it.
+CREDENTIAL_UNREDACTED_NOTICE = (
+    "{length} characters are now PLAIN TEXT in the composer — Enter will send them"
+)
+
 
 #: Shown where those same rows would be once a capture has LANDED and the
 #: buffer still cites it (design round 3, D9). The armed notice cannot be
@@ -14304,18 +14377,38 @@ class OperatorApp(App[None]):
             # may already have moved on — the row would then describe a state
             # the operator has left. See `CredentialArmChanged.typing`.
             if message.typing:
-                notice = CREDENTIAL_TYPING_NOTICE
-            elif message.active:
-                notice = CREDENTIAL_ARMED_NOTICE
+                # LADDERED, not a fixed string: the row resolves which phrasing
+                # fits at paint time, so the way out is named at every width and
+                # survives a resize mid-capture (design round 1, D2).
+                editor.picker.set_notice_rungs(CREDENTIAL_TYPING_NOTICE_RUNGS)
             else:
-                notice = CREDENTIAL_HELD_NOTICE if editor.credential_cited() else ""
-            editor.picker.set_notice(notice)
+                if message.active:
+                    notice = CREDENTIAL_ARMED_NOTICE
+                else:
+                    notice = CREDENTIAL_HELD_NOTICE if editor.credential_cited() else ""
+                editor.picker.set_notice(notice)
         if not message.active and message.reason == "argument":
             self._notice(
                 "credential capture disarmed — that is an argument to "
                 "/credential, so the next paste is NOT captured",
                 "warning",
             )
+
+    def on_credential_unredacted(self, message: CredentialUnredacted) -> None:
+        """Say that Esc put the secret back in the composer as PLAIN TEXT.
+
+        The exit that needs words, because the frame after it carries none. The
+        unredact reverts the amber marker and drops the masking notice, leaving
+        a composer that looks entirely ordinary while holding a credential the
+        next Enter will send — measured on this branch, that Enter reproduced the
+        pre-fix leak byte for byte (design round 1, D1).
+
+        Warning rather than info, and for the same reason the ``argument`` disarm
+        above is: this is a state the operator did not ask to be IN (they asked
+        to cancel), and it is the one where the next keystroke discloses a
+        secret. The length comes off the message; the value is never seen here.
+        """
+        self._notice(CREDENTIAL_UNREDACTED_NOTICE.format(length=message.length), "warning")
 
     def session_credential_names(self) -> tuple[str, ...]:
         """Names the session store already holds, for the composer's key guard.
@@ -28114,8 +28207,13 @@ class OperatorApp(App[None]):
             # transition being reported, only a list being filled over whatever
             # state already holds, so the widget is the authority.
             if editor.credential_typing():
-                notice = CREDENTIAL_TYPING_NOTICE
-            elif armed:
+                # Laddered here too, and for the same reason: this route reaches
+                # the row independently of the transition route above, so a fixed
+                # string here would crop the exit away at exactly the widths D2
+                # measured.
+                picker.set_notice_rungs(CREDENTIAL_TYPING_NOTICE_RUNGS)
+                return
+            if armed:
                 notice = CREDENTIAL_ARMED_NOTICE
             else:
                 notice = CREDENTIAL_HELD_NOTICE if cited else ""

--- a/local_operator/tui/widgets/command_picker.py
+++ b/local_operator/tui/widgets/command_picker.py
@@ -1063,6 +1063,10 @@ class CommandPicker(Static):
         # Not a match: it is never selectable, so it lives beside the rows rather
         # than among them (see set_notice).
         self._notice = ""
+        # Widest-first phrasings for a notice whose TAIL must not crop, resolved
+        # at paint time so the choice survives a resize (see set_notice_rungs).
+        # Empty for every ordinary notice, which is cropped by `truncate_cells`.
+        self._notice_rungs: tuple[str, ...] = ()
         # True only while the one notice row is a TRANSIENT loading reserve —
         # rows are expected to replace it (see set_loading_reserve). Kept as explicit
         # state rather than inferred from the notice text, because the editor
@@ -1189,6 +1193,48 @@ class CommandPicker(Static):
         """
         return self._loading
 
+    def set_notice_rungs(self, rungs: Sequence[str]) -> None:
+        """Set a notice that DEGRADES with width instead of being cropped.
+
+        ``rungs`` is widest-first; the row paints the first one that fits its own
+        measured width and falls back to the narrowest rather than to a
+        truncation. Passing an empty sequence withdraws the notice.
+
+        Resolved HERE, at paint time, rather than by the caller choosing a string
+        up front — which is what makes the choice survive a resize. A capture
+        that opens at 120 columns and is then dragged to 60 mid-secret re-fits on
+        the ``Resize`` the row already re-truncates on; a caller-chosen string
+        would keep painting the wide rung and crop it, which is the defect this
+        replaces (design round 1, D2).
+
+        The credential typing notice is the caller this exists for: its tail
+        names the way OUT of a mode, so it is the one notice whose degradation
+        cannot be left to ``truncate_cells``.
+        """
+        fitted = tuple(text.strip() for text in rungs if text.strip())
+        if fitted == self._notice_rungs:
+            return
+        # `set_notice` clears the rungs (every other caller means a plain
+        # notice), so it is called FIRST and the rungs are installed after it.
+        self.set_notice(fitted[0] if fitted else "")
+        self._notice_rungs = fitted
+        if fitted:
+            self._repaint()
+
+    def _fitted_notice(self, width: int) -> str:
+        """The notice as it should paint at ``width`` cells of row.
+
+        A laddered notice picks its widest fitting rung; a plain one is returned
+        as-is for ``truncate_cells`` to crop, which is correct for every notice
+        whose tail is not load-bearing.
+        """
+        if not self._notice_rungs:
+            return self._notice
+        for rung in self._notice_rungs:
+            if cell_len(rung) <= width:
+                return rung
+        return self._notice_rungs[-1]
+
     def set_notice(self, text: str) -> None:
         """Say why an ARGUMENT list is empty, IN THE LIST'S OWN PLACE.
 
@@ -1206,6 +1252,11 @@ class CommandPicker(Static):
         an open picker still goes to the buffer. Passing ``""`` withdraws it.
         """
         text = text.strip()
+        # The rungs phrase THIS notice; a plain notice replacing it is not
+        # laddered, and leaving them set would degrade an unrelated string.
+        # Cleared before the early return so a repeat of the same text still
+        # drops a stale ladder.
+        self._notice_rungs = ()
         if text == self._notice:
             return
         self._notice = text
@@ -1398,6 +1449,8 @@ class CommandPicker(Static):
             self._window_start = 0
             self._chosen_by_hand = False
             self._notice = ""
+            # The rungs go with the notice they phrase, for the same reason.
+            self._notice_rungs = ()
             # The loading reserve goes with the notice it was riding: it
             # described THAT list's transient window (see set_loading_reserve).
             self._loading = False
@@ -1898,10 +1951,10 @@ class CommandPicker(Static):
         )
         row = Text()
         row.append(" " * _GUTTER_CELLS, style=dim)
-        row.append(
-            truncate_cells(self._notice, max(1, width - _GUTTER_CELLS - _EDGE_MARGIN)),
-            style=dim,
-        )
+        budget = max(1, width - _GUTTER_CELLS - _EDGE_MARGIN)
+        # `_fitted_notice` FIRST, so a laddered notice sheds whole clauses; the
+        # truncate stays as the backstop every other notice relies on.
+        row.append(truncate_cells(self._fitted_notice(budget), budget), style=dim)
         return _pad_to(row, width, dim)
 
     def _primary_column(self) -> int:
@@ -2054,6 +2107,7 @@ class CommandPicker(Static):
         # The notice belonged to the list that is now gone. Esc, a completion and a
         # submission all arrive here, and each one is the user done with it.
         self._notice = ""
+        self._notice_rungs = ()
         self._loading = False
         self.display = False
         self._report_highlight()

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -578,6 +578,37 @@ CREDENTIAL_ARM = re.compile(r"(?:^|(?<=\s))/(?:credential|cred)[ \t]*$", re.IGNO
 #: draws: ``/credential`` and ``/cred`` are the token, ``/credentials`` is not.
 CREDENTIAL_TOKEN = re.compile(r"(?:^|(?<=\s))/(?:credential|cred)(?!\S)", re.IGNORECASE)
 
+#: The word at a latched anchor, used ONLY to ask "is the operator still typing
+#: this same token?" — never to arm.
+#:
+#: ``/cred`` is a token and ``/credential`` is a token, but the five spellings
+#: BETWEEN them are not: an operator typing a second ``/credential`` passes
+#: through ``/crede``, ``/creden``, ``/credent``, ``/credenti``, ``/credentia``,
+#: none of which match :data:`CREDENTIAL_TOKEN`. During that window the latched
+#: arm had no match at its own anchor, so the nearest-match tie-break handed it
+#: to a DIFFERENT token earlier on the line — and it never came back, because
+#: from then on the anchor was the earlier token and "nearest" kept choosing it.
+#: The caret-at-span-end gate in :meth:`Editor._open_credential_typing` then
+#: could not fire (the arm covered a span the caret was not in), the opening
+#: space was just a space, and the secret typed next landed in the CLEAR
+#: (UX round 2, U6).
+#:
+#: The rule is a PREFIX-OF relation, not a starts-with one, and the difference
+#: is the whole containment argument. ``/credentials`` starts with the token but
+#: is NOT a prefix of it, so it stays disarmed exactly as it is today — a
+#: starts-with test would have widened the armed set onto a word the gesture
+#: has never covered. ``/cre`` is below the token floor and also fails, which is
+#: correct: shortening past ``/cred`` is the operator deleting the gesture, the
+#: visible way to withdraw it.
+CREDENTIAL_TOKEN_WORD = re.compile(r"(?:^|(?<=\s))(/[A-Za-z]*)", re.IGNORECASE)
+
+#: The shortest spelling that still reads as the token (``/cred``). Below this,
+#: a word at the anchor is a deletion rather than a gesture in progress.
+CREDENTIAL_TOKEN_FLOOR = "/cred"
+
+#: The full spelling the typed-through window walks toward.
+CREDENTIAL_TOKEN_FULL = "/credential"
+
 #: What DISARMS a latched capture: a flag-shaped argument on the token's own
 #: line. Nothing else does — see :meth:`Editor._sync_credential_arm`.
 #:
@@ -5904,6 +5935,18 @@ class Editor(TextArea):
         (review round 2, R6b/R6c).
         """
         anchor = self._credential_arm[0] if self._credential_arm is not None else 0
+        # THE ANCHOR'S OWN WORD WINS BEFORE ANY TIE-BREAK RUNS. While the
+        # operator types the token out — `/cred` -> `/crede` -> … ->
+        # `/credential` — the middle spellings do not match CREDENTIAL_TOKEN,
+        # so without this the latched arm found no match at its anchor and the
+        # nearest-match tie-break below migrated it onto a different token
+        # earlier in the line. That migration is one-way: the anchor moved with
+        # it, so "nearest" kept choosing the earlier token and the arm never
+        # came home. Held in place instead, the arm re-anchors normally on the
+        # very next keystroke that completes the token (UX round 2, U6).
+        typed_through = self._token_being_typed_at(anchor)
+        if typed_through is not None:
+            return typed_through
         nearest: tuple[int, int] | None = None
         best = -1
         for match in CREDENTIAL_TOKEN.finditer(self.text):
@@ -5916,6 +5959,36 @@ class Editor(TextArea):
                 # shrinking every later match is further away still.
                 break
         return nearest
+
+    def _token_being_typed_at(self, anchor: int) -> tuple[int, int] | None:
+        """The word at ``anchor`` when it is this token MID-TYPING, else ``None``.
+
+        Answers one question for :meth:`_relocate_armed_token`: is the word
+        sitting at the latched offset the operator's own gesture, caught partly
+        typed? ``/crede`` is — it is a prefix of ``/credential`` and at or above
+        the ``/cred`` floor — so the arm stays on it rather than migrating.
+
+        DELIBERATELY NOT AN ARMING RULE. Arming still asks
+        :data:`CREDENTIAL_ARM` at the caret and nothing else, so this cannot
+        arm a token that merely arrived in the buffer; it only keeps an arm the
+        operator already made. It also cannot widen the armed set sideways: the
+        test is PREFIX-OF the token, so ``/credentials`` (a longer word that
+        merely starts with it) fails here exactly as it fails
+        ``CREDENTIAL_TOKEN``, and a word shortened past ``/cred`` fails too
+        because that is the operator deleting the gesture.
+        """
+        if self._credential_arm is None:
+            return None
+        match = CREDENTIAL_TOKEN_WORD.match(self.text, anchor)
+        if match is None:
+            return None
+        word = match.group(1)
+        lowered = word.lower()
+        if len(lowered) < len(CREDENTIAL_TOKEN_FLOOR):
+            return None
+        if not CREDENTIAL_TOKEN_FULL.startswith(lowered):
+            return None
+        return match.start(1), match.end(1)
 
     def _credential_arm_span(self) -> tuple[int, int] | None:
         """Buffer offsets of the ``/credential`` token arming the next paste.
@@ -5963,9 +6036,13 @@ class Editor(TextArea):
           submitted text beginning with ``/credential``, which
           ``_dispatchable_slash`` routes to the masked-paste command with the
           marker as its KEY argument. Consuming the token means the leading and
-          the mid-line gestures behave identically, and bare
-          ``/credential <KEY>`` (no paste, so no capture) still dispatches
-          exactly as it always has.
+          the mid-line gestures behave identically, and a bare
+          ``/credential <KEY>`` line that arrives with no capture open — a
+          PASTED whole line, a recalled prompt, a restored draft — still
+          dispatches exactly as it always has. TYPING that line no longer
+          reaches the command: the space after the token opens a capture, so
+          the key name is minted as a short secret instead (QA round 1, Q1).
+          The form is retired for typing, not removed.
         """
         offset = self._caret_offset()
         before = self.text[:offset]
@@ -6126,11 +6203,27 @@ class Editor(TextArea):
         """The held secret after ``edit``, or ``None`` to leave it alone.
 
         THE HELD VALUE IS A MIRROR OF THE MASK CELLS, and this is the one place
-        the two are kept in step. Every buffer mutation funnels through
-        :meth:`edit`, so an edit that moves, removes or splits mask cells is
-        applied to :attr:`_credential_typed` at the SAME index — which makes
-        arrow-then-type, backspace, delete and select-and-replace all correct by
-        one rule instead of four agreeing key handlers.
+        the two are kept in step. Every buffer mutation the OPERATOR makes
+        funnels through :meth:`edit`, so an edit that moves, removes or splits
+        mask cells is applied to :attr:`_credential_typed` at the SAME index —
+        which makes arrow-then-type, backspace, delete and select-and-replace
+        all correct by one rule instead of four agreeing key handlers.
+
+        UNDO AND REDO ARE THE FUNNEL'S ONE EXCEPTION, and the claim is stated
+        with it rather than without it. Textual's ``undo()``/``redo()`` call
+        ``edit.undo(self)``/``edit.do(self)`` DIRECTLY (``_text_area.py``), so
+        they bypass this override and the mirror never runs for them — measured
+        with a positive control: eight typed characters produce eight ``edit()``
+        calls and eight mirror calls, while ``ctrl+z``/``ctrl+y`` produce zero
+        of each. The reachable outcome is inert (``ctrl+z`` mid-capture empties
+        buffer and value together; ``ctrl+y`` repaints mask cells with an empty
+        held value — bullets that stand for nothing), nothing leaks and no
+        payload is minted, and the behaviour is byte-identical on the
+        pre-remediation tree, so this is pre-existing rather than introduced by
+        the mirror. It is named here because this codebase's own standard is
+        that prose asserting an invariant is not a mechanism enforcing it, and
+        the mirror's correctness argument should not rest on a funnel claim with
+        an unstated exception (review round 2, R6).
 
         Why a mirror and not an append (UX round 1, U1). The mask cell was
         always inserted AT THE CARET while the value appended to the END, and
@@ -6718,14 +6811,22 @@ class Editor(TextArea):
 
     # -- command completion -------------------------------------------------
     def edit(self, edit: Edit) -> EditResult:
-        """Every buffer mutation funnels through here — resync the picker.
+        """Every operator buffer mutation funnels through here — resync the picker.
 
-        Hooking the two mutation funnels (:meth:`edit` for inserts/deletes/
-        undo, :meth:`load_text` for whole-buffer replacement) keeps the picker
-        exact for keystrokes, pastes, and history navigation alike, and does
-        it synchronously. Listening for ``TextArea.Changed`` instead would put
-        the picker one message-loop tick behind the buffer, which is the tick
-        in which Enter decides whether to complete.
+        Hooking the two mutation funnels (:meth:`edit` for inserts and deletes,
+        :meth:`load_text` for whole-buffer replacement) keeps the picker exact
+        for keystrokes, pastes, and history navigation alike, and does it
+        synchronously.
+
+        NOT undo/redo: Textual calls ``edit.undo``/``edit.do`` directly and
+        never reaches this override, so neither the picker nor the credential
+        mirror runs for them. Measured, not assumed, and unchanged from before
+        the credential work (review round 2, R6). This docstring previously
+        listed ``undo`` as one of the things it hooks, which was never true.
+
+        Listening for ``TextArea.Changed`` instead would put the picker one
+        message-loop tick behind the buffer, which is the tick in which Enter
+        decides whether to complete.
         """
         # Only a REMOVAL can uncite an attachment, and only the attachments it
         # touched. Both halves are measured BEFORE the edit, because afterwards

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -1436,6 +1436,33 @@ class CredentialArmChanged(Message):
         self.typing = typing
 
 
+class CredentialUnredacted(Message):
+    """Posted when Esc restored a typed secret into the composer as plaintext.
+
+    The one exit that ENDS with the secret in the document. Every other way out
+    of a capture either mints a chip or leaves inert mask cells, so this is the
+    only transition after which the buffer holds something the operator must be
+    told is now visible and sendable.
+
+    It exists because the frame cannot say it on its own: the unredact reverts
+    the amber marker and drops the masking notice, so the composer looks
+    ORDINARY at exactly the moment it is holding a plaintext credential — and
+    the next Enter, the single most likely keystroke, submits it. Measured on
+    this branch, that Enter reproduced the pre-fix leak byte for byte (design
+    round 1, D1).
+
+    Carries the LENGTH and never the value, the same discipline the chip label
+    and the journal follow: the app needs to say how much came back, not what.
+
+    Editor owns the state, app owns the voice — the split
+    :class:`CredentialArmChanged` and :class:`ShellModeChanged` already draw.
+    """
+
+    def __init__(self, length: int) -> None:
+        super().__init__()
+        self.length = length
+
+
 class ShellModeChanged(Message):
     """Posted when bang-mode is entered or left.
 
@@ -2162,7 +2189,32 @@ class Editor(TextArea):
         self._credential_typing: int | None = None
         #: The characters typed into the open masked span, in order. The ONLY
         #: place a typed secret lives before it becomes a `PastedCredential`.
+        #:
+        #: POSITIONALLY MIRRORED against the mask cells by :meth:`edit`, not
+        #: appended to. An append-only value plus a caret-positioned mask is the
+        #: one arrangement that can disagree SILENTLY: the count stays right
+        #: while the order goes wrong, so the chip's length — documented as an
+        #: integrity check — passes on a value that is not what was typed, and
+        #: the value can never be shown again to catch it (UX round 1, U1).
         self._credential_typed: str = ""
+        #: The true character a mask cell about to be inserted stands for.
+        #:
+        #: Set by :meth:`_type_credential_char` for exactly the length of one
+        #: edit and read by the mirror in :meth:`edit`, because the buffer edit
+        #: carries :data:`CREDENTIAL_MASK_CHAR` and the mirror needs the
+        #: character it replaced. A field rather than a parameter because the
+        #: edit funnel is Textual's, reached through ``insert``/``replace``.
+        self._credential_pending_char: str | None = None
+        #: Set while a credential exit is performing its OWN buffer edit.
+        #:
+        #: The cancel replaces the mask cells with the restored plaintext, and
+        #: that replacement re-enters the edit funnel — which re-derived the arm
+        #: from a buffer still ending in ``/credential `` and re-opened the
+        #: capture the cancel had just closed, making Esc inert on an empty span
+        #: (review round 1, R1; UX round 1, U2). The same suspend idiom
+        #: ``_suspend_picker_sync`` uses, and for the same reason: a handler's
+        #: own edit must not be read as the operator's.
+        self._suspend_credential_sync: bool = False
         self.set_commands(commands or [])
 
     def render_line(self, y: int) -> Strip:
@@ -2807,11 +2859,14 @@ class Editor(TextArea):
                 # the draft already held, not a silent disarm.
             elif key in ("backspace", "ctrl+h"):
                 if self._credential_typed:
-                    # Backspace inside the span retracts the last character from
-                    # the held value AND removes its mask cell, so the two can
-                    # never disagree about how long the secret is. Falls through
-                    # to TextArea's own delete for the cell itself.
-                    self._credential_typed = self._credential_typed[:-1]
+                    # Falls through to TextArea's own delete, and the MIRROR in
+                    # `edit` retracts the held character the deleted cell stood
+                    # for. It used to drop the LAST character here regardless of
+                    # where the caret was, so a backspace mid-span removed the
+                    # wrong one silently (UX round 1, U1) — the mirror answers
+                    # positionally and covers `delete` and select-and-replace by
+                    # the same rule.
+                    pass
                 else:
                     # Backspace at the START of the span deletes the delimiting
                     # space, which un-terminates the token — the operator is
@@ -5975,7 +6030,25 @@ class Editor(TextArea):
     #                                           in the composer (state: ARMED
     #                                           ends, composer keeps the draft)
     #     (5) Esc while TYPING              ->  CANCEL: the typed characters are
-    #                                           restored as ordinary text
+    #                                           restored as ordinary text, and
+    #                                           the app SAYS SO (they are now
+    #                                           plaintext in the composer)
+    #     (5a) Esc on an EMPTY span         ->  the same cancel, ending the mode
+    #                                           with `/credential ` left inert.
+    #                                           Called out because it is the case
+    #                                           the table's prose covered and the
+    #                                           code did not: with no characters
+    #                                           to restore, the cancel's own
+    #                                           `replace()` re-entered the edit
+    #                                           funnel and re-armed, so Esc was
+    #                                           INERT and the prose typed next
+    #                                           became a credential (R1/U2).
+    #     (5b) an EDIT INSIDE the span      ->  applied POSITIONALLY to the held
+    #                                           value by the mirror in `edit()`:
+    #                                           arrow-then-type, backspace,
+    #                                           delete and select-and-replace all
+    #                                           land where the operator sees them
+    #                                           land (U1)
     #     (6) Paste while ARMED             ->  chip in place, unchanged
     #
     # (1), (2) and (6) already existed or are one predicate each; (3), (4) and
@@ -6049,6 +6122,73 @@ class Editor(TextArea):
         self.post_message(CredentialArmChanged(True, typing=True))
         return True
 
+    def _credential_edit_mirror(self, edit: Edit) -> str | None:
+        """The held secret after ``edit``, or ``None`` to leave it alone.
+
+        THE HELD VALUE IS A MIRROR OF THE MASK CELLS, and this is the one place
+        the two are kept in step. Every buffer mutation funnels through
+        :meth:`edit`, so an edit that moves, removes or splits mask cells is
+        applied to :attr:`_credential_typed` at the SAME index — which makes
+        arrow-then-type, backspace, delete and select-and-replace all correct by
+        one rule instead of four agreeing key handlers.
+
+        Why a mirror and not an append (UX round 1, U1). The mask cell was
+        always inserted AT THE CARET while the value appended to the END, and
+        `_credential_caret_left_span` deliberately keeps the capture open
+        anywhere inside the span — so the interaction INVITES the edit that the
+        value then mis-applies. Measured: typed ``ABCDEFGH``, ``←←``, typed
+        ``xy`` stored ``ABCDEFGHxy`` for an intended ``ABCDEFxyGH``. The chip
+        reported the right LENGTH with the wrong ORDER, so the documented
+        integrity check passed on a wrong value that can never be displayed
+        again to catch it; it surfaces days later as an auth failure with
+        nothing tying it to the keystroke. Ending the capture on any caret move
+        was the other acceptable fix and is rejected here: mid-secret typo
+        correction is exactly what an operator does with a 40-character token,
+        and taking the mask away mid-value fails toward plaintext.
+
+        Computed from OLD offsets, before ``super().edit()`` runs, because the
+        mapping from a buffer position to an index in the held value only exists
+        while the buffer still holds the cells the value stands for.
+
+        ``None`` for every edit that cannot touch the span — no capture open, an
+        edit entirely outside it — so the common keystroke pays one comparison.
+        """
+        start = self._credential_typing
+        if start is None:
+            return None
+        held = self._credential_typed
+        end = start + len(held)
+        top = self._offset_at(*edit.top)
+        bottom = self._offset_at(*edit.bottom)
+        # Wholly outside the span, on either side. `>` and `<` rather than `>=`
+        # and `<=`: an edit that merely ABUTS the span (a character typed at its
+        # end, the commonest keystroke of all) does touch it.
+        if top > end or bottom < start:
+            return None
+        inserted = edit.text
+        # What the inserted text stands for in the HELD value. A mask cell being
+        # painted carries its true character in `_credential_pending_char`;
+        # anything else reaching the span is literal text, which only happens on
+        # a route that has already closed the capture.
+        pending = self._credential_pending_char
+        if pending is not None and inserted == CREDENTIAL_MASK_CHAR:
+            replacement = pending
+        elif inserted == "":
+            replacement = ""
+        else:
+            # Text arriving into an open span that is NOT a mask cell would put
+            # real characters among the bullets and desynchronise the two. No
+            # such route exists (every printable key is masked, and the exits
+            # close the capture first), so this is a guard rather than a case:
+            # leave the value untouched rather than silently corrupting it.
+            return None
+        # Clamped into the span, so an edit STRADDLING its edge (a selection
+        # begun in the token and dragged into the secret) removes only the part
+        # that was actually held.
+        cut_from = max(top, start) - start
+        cut_to = min(bottom, end) - start
+        return held[:cut_from] + replacement + held[cut_to:]
+
     def _type_credential_char(self, char: str) -> None:
         """Absorb one typed character into the secret; paint one mask cell.
 
@@ -6061,13 +6201,33 @@ class Editor(TextArea):
         ``text``, so the mask cells participate in the document exactly as typed
         text does — the caret advances, the width recomputes, and the arm
         re-syncs — while the value itself accumulates out of band.
+
+        THE VALUE IS NOT APPENDED HERE. ``char`` is handed to the mirror in
+        :meth:`edit` through :attr:`_credential_pending_char`, which splices it
+        in at the position the mask cell lands — so a character typed after an
+        arrow key goes where the operator watched it appear, not on the end (UX
+        round 1, U1). ``finally`` because the value must not survive the edit:
+        a stale pending character would be spliced in by an unrelated later
+        edit.
         """
-        self._credential_typed += char
-        # Insertion at the caret, which is by construction the end of the masked
-        # span: `_credential_typing` + len(typed) is where the caret must be, and
-        # any key that could have moved it away has already closed the capture
-        # (see `_credential_caret_left_span`).
-        self.insert(CREDENTIAL_MASK_CHAR)
+        self._credential_pending_char = char
+        try:
+            # REPLACES THE SELECTION when there is one, exactly as TextArea's own
+            # printable-key path does (`_replace_via_keyboard(insert, *selection)`).
+            # `insert()` alone ignores the selection, so selecting two mask cells
+            # and typing left them in the buffer and appended a third — the
+            # buffer and the held value then disagreed on the secret's LENGTH,
+            # not merely its order. The span the caret sits in is the one the
+            # mirror maps, so a replacement inside it is spliced positionally.
+            start, end = self.selection
+            self.replace(
+                CREDENTIAL_MASK_CHAR,
+                start,
+                end,
+                maintain_selection_offset=False,
+            )
+        finally:
+            self._credential_pending_char = None
 
     def _mint_typed_credential(self) -> bool:
         """Enter while TYPING: turn token + masked span into a chip.
@@ -6144,6 +6304,16 @@ class Editor(TextArea):
         is still swallowed as a credential after the operator has visibly backed
         out. That is the false-POSITIVE direction, which costs one backspace;
         the alternative (staying armed) is the direction D2 calls unrecoverable.
+
+        AND IT WORKS ON AN EMPTY SPAN, which it did not. The `replace()` below
+        re-entered the edit funnel, which re-derived the arm from a buffer still
+        ending in ``/credential `` with the caret still at its end and RE-OPENED
+        the capture this method had just closed — so Esc was inert before any
+        character was typed, on the exact key the on-screen notice advertises,
+        and the prose the operator then wrote was captured as a secret (review
+        round 1, R1; UX round 1, U2). Every one of the file's 95 tests passed
+        with that live, because the Esc test typed characters first. The suspend
+        below is the mechanism; the empty-span regression test is the guard.
         """
         if self._credential_typing is None:
             return False
@@ -6156,28 +6326,55 @@ class Editor(TextArea):
         # is the ONLY route by which the typed secret enters the document, and
         # it is the operator explicitly asking for it — at which point it is
         # their prose, not a credential.
-        self.replace(
-            secret,
-            self._offset_to_location(start),
-            self._offset_to_location(end),
-            maintain_selection_offset=False,
-        )
-        self.move_cursor(self._offset_to_location(start + len(secret)))
+        #
+        # Suspended across THIS WIDGET'S OWN edit so the cancel cannot re-arm
+        # itself. Restored in `finally`: an exception mid-replace that left the
+        # flag set would silently stop every later keystroke from arming, which
+        # is the unrecoverable direction (a paste landing in plaintext).
+        self._suspend_credential_sync = True
+        try:
+            self.replace(
+                secret,
+                self._offset_to_location(start),
+                self._offset_to_location(end),
+                maintain_selection_offset=False,
+            )
+            self.move_cursor(self._offset_to_location(start + len(secret)))
+        finally:
+            self._suspend_credential_sync = False
+        # THE EXIT ANNOUNCES ITSELF, because it is the one exit that puts a
+        # plaintext secret in the composer. After the unredact the frame looks
+        # completely ordinary — the amber marker reverts, the masking notice
+        # goes — while the buffer now holds the secret and the very next Enter
+        # re-commits the original leak this feature exists to close; measured,
+        # HEAD-after-Esc-then-Enter was byte-identical to BASE-after-Enter
+        # (design round 1, D1). The word `cancels` promises the gesture is off,
+        # so the state it actually leaves has to be said out loud. Only when
+        # there were characters to restore: an empty cancel puts nothing in the
+        # buffer and owes no warning.
+        if secret:
+            self.post_message(CredentialUnredacted(len(secret)))
         return True
 
-    def _close_credential_typing(self) -> None:
+    def _close_credential_typing(self, reason: str = "") -> None:
         """Drop the typed-capture state and the secret it held.
 
         Called by every exit from the TYPING state. The value is cleared here
         and nowhere else, so there is exactly one place a secret stops being
         held — a second clearing site is how one path comes to leave it behind.
+
+        ``reason`` rides the message, matching the sibling
+        :meth:`_disarm_credential`. It used to stop at
+        :meth:`_abandon_credential_typing`'s signature, which accepted four
+        distinct reasons from four call sites and read none of them — a channel
+        that existed only in the parameter list (review round 1, R4).
         """
         if self._credential_typing is None:
             return
         self._credential_typing = None
         self._credential_typed = ""
         self._invalidate_slash_runs()
-        self.post_message(CredentialArmChanged(self._credential_arm is not None))
+        self.post_message(CredentialArmChanged(self._credential_arm is not None, reason=reason))
 
     def _abandon_credential_typing(self, reason: str) -> None:
         """End a typed capture WITHOUT restoring the secret, leaving the mask.
@@ -6212,7 +6409,8 @@ class Editor(TextArea):
         # the same answer.
         if getattr(self, "_credential_typing", None) is None:
             return
-        self._close_credential_typing()
+        # `reason` reaches the message rather than stopping here (R4).
+        self._close_credential_typing(reason)
 
     async def _attach_pasted_images(self, pasted: str) -> str | None:
         """Load every path in ``pasted`` as an attachment; return the markers.
@@ -6549,6 +6747,19 @@ class Editor(TextArea):
         # Measured BEFORE the edit for the same reason the citation spans are:
         # afterwards there is no way to tell a first keystroke from the tenth.
         was_empty = not self.text.strip()
+        # THE HELD SECRET IS MIRRORED ON THE SAME EDIT THAT MOVES ITS MASK
+        # CELLS. Computed from OLD offsets (the mapping only exists while the
+        # buffer still holds the cells the value stands for) and applied BEFORE
+        # the edit runs, which is load-bearing rather than tidy: `super().edit()`
+        # sets the selection inside `edit.after()`, which fires
+        # `_credential_caret_left_span` — so a value updated afterwards would be
+        # measured against the NEW caret while still the OLD length, and the
+        # watcher would read the caret as having left the span and abandon the
+        # capture. Measured when this was ordered the other way: every character
+        # after the first landed in the buffer as PLAINTEXT.
+        mirror = self._credential_edit_mirror(edit)
+        if mirror is not None:
+            self._credential_typed = mirror
         result = super().edit(edit)
         if stale_receipt:
             self._copied = False
@@ -6562,20 +6773,28 @@ class Editor(TextArea):
         # is derived from the buffer, so deriving it anywhere but here would
         # leave it a message-loop tick behind the text — and that tick is the
         # one in which a paste decides whether it is a secret.
-        self._sync_credential_arm()
-        # THE OPENING SPACE, asked on the funnel BOTH routes converge on. The
-        # hand-typed space and the trailing space `_apply_command` appends when
-        # a picker row is accepted are the same insertion at the same offset, so
-        # asking here is what makes the two routes identical by construction
-        # rather than by two call sites agreeing. Asking in `_on_key` instead
-        # would have covered only the typed route and left the completion route
-        # silently unmasked — which is exactly the shape of the defect being
-        # fixed, one level down.
         #
-        # After `_sync_credential_arm`, because the arm's span is what the open
-        # is checked against and the space is the character that just extended it.
-        if self._credential_typing is None and self._credential_arm is not None:
-            self._open_credential_typing()
+        # SUSPENDED while a credential exit performs its own edit: the cancel's
+        # `replace()` funnels through here, and re-deriving from the buffer it
+        # is halfway through rewriting re-armed and re-opened the capture the
+        # cancel had just closed (R1/U2). Skipped rather than reordered, because
+        # the arm must still be derived on the operator's own edits.
+        if not self._suspend_credential_sync:
+            self._sync_credential_arm()
+            # THE OPENING SPACE, asked on the funnel BOTH routes converge on. The
+            # hand-typed space and the trailing space `_apply_command` appends when
+            # a picker row is accepted are the same insertion at the same offset, so
+            # asking here is what makes the two routes identical by construction
+            # rather than by two call sites agreeing. Asking in `_on_key` instead
+            # would have covered only the typed route and left the completion route
+            # silently unmasked — which is exactly the shape of the defect being
+            # fixed, one level down.
+            #
+            # After `_sync_credential_arm`, because the arm's span is what the
+            # open is checked against and the space is the character that just
+            # extended it.
+            if self._credential_typing is None and self._credential_arm is not None:
+                self._open_credential_typing()
         if touched:
             self._release_uncited(touched)
         return result

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -598,6 +598,47 @@ CREDENTIAL_TOKEN = re.compile(r"(?:^|(?<=\s))/(?:credential|cred)(?!\S)", re.IGN
 #: the operator writing ``deploy with /credential the prod key`` stays armed.
 CREDENTIAL_ARGUMENT = re.compile(r"[ \t]+-", re.IGNORECASE)
 
+#: The cell painted in place of each character of a TYPED secret.
+#:
+#: One mask cell per typed character, so the operator can see their typing is
+#: being received and can count what they have entered — the same feedback a
+#: password field gives, and the reason a fixed-width blob was rejected: an
+#: operator who cannot see the count cannot tell a swallowed keystroke from a
+#: registered one, and the whole point of the length in the chip label is that
+#: a capture is verifiable without being visible.
+#:
+#: U+2022 BULLET rather than ``*``: it is the idiom every password field in
+#: this app and outside it already uses, and it is visually distinct from the
+#: prose around it so the masked span reads as a distinct region rather than as
+#: typed punctuation. It is a single-width cell in every font the composer is
+#: rendered in, which matters because the mask must be a 1:1 substitution for
+#: the character it hides — a wide glyph would make the span's width disagree
+#: with the count the chip later reports.
+CREDENTIAL_MASK_CHAR = "•"
+
+#: What OPENS a typed capture: a single space typed at the end of an armed
+#: token. Space rather than the token itself because the operator must be able
+#: to type ``/credential`` as prose, to reach the picker, and to complete the
+#: word — none of which should start swallowing keystrokes. The space is the
+#: operator committing to the gesture, and it is the same separator the command
+#: has always taken its argument after, so nothing new has to be learned.
+#:
+#: BOTH ROUTES INTO IT ARE THE SAME KEYSTROKE by construction: a hand-typed
+#: space and the trailing space `_apply_command` inserts when a picker row is
+#: accepted are the same character at the same place, so the capture opens from
+#: the completion route without that route knowing anything about credentials.
+#: See :meth:`_open_credential_typing` for why that equivalence is enforced at
+#: the buffer rather than at the two call sites.
+CREDENTIAL_OPEN_SPACE = " "
+
+#: The command words whose completion ARMS a capture rather than running the
+#: command. The same two spellings ``CREDENTIAL_ARM`` matches, kept beside it so
+#: the completion route and the typing route can never come to disagree about
+#: what the token is — they are two doors into one mode, and a mode reachable by
+#: one spelling through one door is the kind of asymmetry this feature's history
+#: is made of.
+CREDENTIAL_COMMAND_NAMES = frozenset({"credential", "cred"})
+
 #: Random-name alphabet: Crockford-ish base32 WITHOUT the letters that read as
 #: digits. The name is quoted back to the operator in a notice and may be typed
 #: into a shell by hand, so ``0/O`` and ``1/I/L`` confusions are worth the
@@ -1378,12 +1419,21 @@ class CredentialArmChanged(Message):
     needs no words (the marker is the receipt) and ``"gone"`` was the operator
     deleting the token, but ``"argument"`` is the one where they typed on and
     the mode changed under them.
+
+    ``typing`` distinguishes the TWO armed states, which owe the operator
+    different words: merely armed is "the next paste is captured", while typing
+    is "the keys you are pressing right now are being masked". Carried on the
+    message rather than read back off the editor because the app's handler is
+    where the hint is chosen, and a handler that asked the widget would race the
+    next keystroke — the state it painted would be the one after the transition
+    it was told about.
     """
 
-    def __init__(self, active: bool, *, reason: str = "") -> None:
+    def __init__(self, active: bool, *, reason: str = "", typing: bool = False) -> None:
         super().__init__()
         self.active = active
         self.reason = reason
+        self.typing = typing
 
 
 class ShellModeChanged(Message):
@@ -2089,6 +2139,30 @@ class Editor(TextArea):
         #: the secret on screen (design round 1, D2). The app follows via
         #: :class:`CredentialArmChanged`, exactly as it follows bang-mode.
         self._credential_arm: tuple[int, int] | None = None
+        #: WHERE the typed secret begins, once the operator has opened the
+        #: masked span by pressing SPACE after an armed token — or ``None``
+        #: while no typed capture is open.
+        #:
+        #: This is the TYPED half of the gesture, and it needs its own state
+        #: because the armed span cannot express it. ``_credential_arm`` covers
+        #: the TOKEN (the range spliced out at capture time); this covers the
+        #: SECRET being typed after it. An offset rather than a span because
+        #: only the START is stable — the end is implied by how much has been
+        #: typed, so there are never two values to disagree.
+        #:
+        #: THE SECRET IS HELD OUT OF THE DOCUMENT. Characters typed while this
+        #: is open never enter ``self.text``; they accumulate in
+        #: :attr:`_credential_typed` and the buffer gets mask cells in their
+        #: place. That is the whole safety property, and it is why the mask is
+        #: not a render-time effect painted over real characters: a buffer that
+        #: HELD the secret would leak it through every seam that reads the
+        #: buffer — history, the draft store, undo, ``ctrl+o``, and the submit
+        #: path that leaked it in the first place. Nothing can read a secret
+        #: out of a document that never contained it.
+        self._credential_typing: int | None = None
+        #: The characters typed into the open masked span, in order. The ONLY
+        #: place a typed secret lives before it becomes a `PastedCredential`.
+        self._credential_typed: str = ""
         self.set_commands(commands or [])
 
     def render_line(self, y: int) -> Strip:
@@ -2411,6 +2485,25 @@ class Editor(TextArea):
         lowered = name.lower()
         return lowered in self.MODEL_COMMANDS or lowered in self._required_argument_commands
 
+    def arms_a_capture(self, name: str) -> bool:
+        """Whether completing ``name`` opens a credential capture instead of running.
+
+        The same shape as :meth:`opens_a_list` and for the same reason: for these
+        commands, completing the word IS the outcome of the keystroke, so an
+        Enter that also submitted would run a command the operator was in the
+        middle of using as a gesture.
+
+        THIS IS WHAT SEPARATES THE TWO ENTERS. Accepting the row inserts
+        ``/credential `` and that trailing space opens the masked span; the NEXT
+        Enter mints the chip, and it reaches a completely different handler
+        because a capture is open by then. Without this predicate the accepting
+        Enter fell through to `_run_command_from_buffer`, which submitted
+        ``/credential `` on the spot — so the operator's very next keystrokes
+        were typed into an ordinary, unmasked composer and the secret went to the
+        model in plaintext. That was one of the three reproduced leaks.
+        """
+        return name.lower() in CREDENTIAL_COMMAND_NAMES
+
     def _is_name_argument_command(self, name: str | None) -> bool:
         """Whether ``name``'s argument is a NAME followed by a free-text message.
 
@@ -2667,6 +2760,146 @@ class Editor(TextArea):
         # then a typed character must stop the turn, then type the character).
         if self._pending_escape is not None:
             self._flush_escape()
+        # A LIVE TYPED CAPTURE OWNS THE KEYBOARD, ahead of the prompt router,
+        # both pickers, history and submit. It has to be first, and the reason
+        # is the defect this whole mode exists to close rather than a matter of
+        # precedence: every branch below can put the pressed character somewhere
+        # the operator can read it — the prompt router answers a question with
+        # it, a picker completes on it, `_submit` sends the line. While the mask
+        # is up the ONLY safe default is that no other handler sees the key at
+        # all, so this block returns on every key it recognises and falls
+        # through only for the ones it has deliberately decided to allow.
+        if self._credential_typing is not None:
+            if key == "escape":
+                # NOT deferred, unlike every other Esc in this handler. The
+                # deferral exists so an Esc-prefixed `⌥←` is not read as a bare
+                # Escape, and it costs a message-loop tick — during which, here,
+                # the operator would keep typing INTO A CAPTURE THEY HAVE ALREADY
+                # CANCELLED, and those keystrokes would be masked and then
+                # restored in the wrong order. Cancelling synchronously is also
+                # what makes the unredaction land on the frame the operator
+                # pressed the key for. The chord risk is accepted knowingly: the
+                # worst case is that `⌥←` cancels a capture and returns the
+                # operator's own text, which is visible and one keystroke from
+                # being redone, whereas a tick of ambiguity while masking is a
+                # keystroke landing in the wrong buffer.
+                self._cancel_credential_typing()
+                event.stop()
+                event.prevent_default()
+                return
+            if key == "enter":
+                # THE SECOND OF THE TWO ENTERS (see `_mint_typed_credential`).
+                # The first is the picker's accept, which cannot reach here: a
+                # capture is only open once the completion has been applied and
+                # the picker closed, so the two Enters are separated by STATE,
+                # not by timing or by a flag. That is what makes them impossible
+                # to confuse — at any instant exactly one of "a picker is open"
+                # and "a capture is typing" is true, and each owns Enter in its
+                # own state. `_open_credential_typing` closes the picker as it
+                # opens the capture precisely so this stays an invariant rather
+                # than an ordering accident.
+                if self._mint_typed_credential():
+                    event.stop()
+                    event.prevent_default()
+                    return
+                # Empty secret: fall through to the ordinary Enter. The capture
+                # stays open (see the method), so this is a submit of whatever
+                # the draft already held, not a silent disarm.
+            elif key in ("backspace", "ctrl+h"):
+                if self._credential_typed:
+                    # Backspace inside the span retracts the last character from
+                    # the held value AND removes its mask cell, so the two can
+                    # never disagree about how long the secret is. Falls through
+                    # to TextArea's own delete for the cell itself.
+                    self._credential_typed = self._credential_typed[:-1]
+                else:
+                    # Backspace at the START of the span deletes the delimiting
+                    # space, which un-terminates the token — the operator is
+                    # backing out of the gesture, so the capture closes and the
+                    # ordinary delete takes the space. `_sync_credential_arm`
+                    # then re-derives the arm from the shortened buffer.
+                    self._abandon_credential_typing("gone")
+            elif event.is_printable and event.character is not None:
+                # `event.is_printable`/`event.character` and NEVER the key NAME.
+                # Textual spells punctuation keys as words — `minus`,
+                # `full_stop`, `plus`, `equals_sign` — so a `len(key) == 1` gate
+                # masks letters and digits while every punctuation character
+                # falls straight through into the document. MEASURED: the canary
+                # `zQ7-TYPED-LEAK-CANARY-4417` rendered as `•••-TYPED-LEAK-
+                # CANARY-4417`, i.e. the first hyphen ended the masking and the
+                # rest of the secret was typed in PLAINTEXT and submitted. Real
+                # credentials are full of `-`, `_`, `.` and `/`, so that gate
+                # leaked almost every actual secret while looking correct
+                # against an alphanumeric test value.
+                if not self._credential_typed and event.character == "-":
+                    # A LEADING ``-`` IS THE COMMAND, NOT A SECRET, and it must
+                    # escape the mask before it is masked. This is the same
+                    # partition `CREDENTIAL_ARGUMENT` already draws for the
+                    # pasted path, honoured here so the two agree: the credential
+                    # verbs are flag-shaped (`--forget`, `--forget-all`)
+                    # PRECISELY so they can never collide with a key, because
+                    # keys normalize to `[A-Z0-9_]` and cannot begin with `-`
+                    # (see variables.py).
+                    #
+                    # Without this the destructive verbs became untypable: the
+                    # opening space starts masking, so `/credential --forget-all`
+                    # went in as a masked eight-character "secret" and Enter
+                    # minted a chip instead of forgetting anything. That is a
+                    # regression of the shipped command, which the brief requires
+                    # stay reachable exactly as it was.
+                    #
+                    # Only the FIRST character is tested. A `-` inside a secret is
+                    # an ordinary character (and common in base64url), so once any
+                    # character has been typed the operator is entering a value
+                    # and the flag reading is gone.
+                    self._abandon_credential_typing("argument")
+                    self._disarm_credential("argument")
+                    # Falls through: the `-` is inserted as ordinary text.
+                else:
+                    # THE MASKING ITSELF. One printable character is held out of
+                    # the document and a mask cell takes its place.
+                    #
+                    # THIS INCLUDES THE SPACE, which is deliberate: a space
+                    # inside the span is part of the SECRET, not a terminator.
+                    # Passphrases contain spaces, and the operator has an
+                    # explicit, advertised Enter to end the entry, so there is no
+                    # need to overload the space with a second meaning.
+                    # Overloading it would fail in the unrecoverable direction —
+                    # a passphrase would be truncated at its first space and the
+                    # remainder typed in PLAINTEXT, which is this feature's
+                    # original defect reappearing inside its own fix.
+                    self._type_credential_char(event.character)
+                    event.stop()
+                    event.prevent_default()
+                    return
+            elif key == "tab":
+                # Tab has no completion meaning inside a secret (no list is
+                # open), and a literal tab in the middle of a masked span is far
+                # more likely to be a reach for a picker that is not there.
+                # Swallowed so it can neither insert whitespace into the value
+                # nor move focus out of the composer mid-capture.
+                event.stop()
+                event.prevent_default()
+                return
+            elif key == "shift+enter":
+                # AN EXPLICIT NEWLINE ENDS THE CAPTURE, and this is a
+                # correctness requirement rather than a preference. The masked
+                # span is a CONTIGUOUS run of cells starting at
+                # `_credential_typing`, and the mint splices
+                # ``[token_start, _credential_typing + len(typed))``. A newline
+                # inserted mid-capture occupies an offset that is NOT a mask
+                # cell, so every character typed after it puts the computed end
+                # one further out of step with the cells actually on screen —
+                # measured: the splice then left an orphaned bullet in the
+                # buffer and mis-reported the span.
+                #
+                # Ending it is also the honest reading of the gesture: a secret
+                # is a single-line value, Enter already terminates it, and an
+                # operator pressing shift+enter is composing the prose around the
+                # chip. Abandoned rather than cancelled, for the same reason a
+                # caret move is — they did not ask for the plaintext back.
+                self._abandon_credential_typing("moved")
+                # Falls through: the newline is inserted as usual.
         # An advertised answer key, while a question is up and the buffer is
         # empty, answers the question instead of being typed.
         #
@@ -2892,7 +3125,18 @@ class Editor(TextArea):
                         # argument phase — `_apply_command` moved the caret to the
                         # end of the completed word, so the run path re-parses at
                         # that caret and finds this token.
-                        if key == "enter" and not self.opens_a_list(name):
+                        #
+                        # `arms_a_capture` joins `opens_a_list` for the same
+                        # reason it exists: completing `/credential` OPENS the
+                        # masked span (the trailing space does it), so running
+                        # the command as well would submit the bare word and
+                        # drop the operator into an unmasked composer with a
+                        # secret half-typed. See that predicate for the leak.
+                        if (
+                            key == "enter"
+                            and not self.opens_a_list(name)
+                            and not self.arms_a_capture(name)
+                        ):
                             self._run_command_from_buffer()
                     elif key == "tab":
                         # Tab never sends, so it can safely take the highlighted
@@ -3885,6 +4129,14 @@ class Editor(TextArea):
         # captured or lands in plaintext.
         if self._credential_arm is not None:
             start, end = self._credential_arm
+            # The masked span is painted as ONE run with the token, so the
+            # amber ink covers the whole gesture rather than stopping at the
+            # command word. The bullets are the part the operator is actually
+            # looking at while they type, and leaving them in ordinary prose
+            # colour made the mask read as characters that had simply come out
+            # wrong — the ink is what says "this region is the mode".
+            if self._credential_typing is not None:
+                end = max(end, self._credential_typing + len(self._credential_typed))
             before = self.text[:start]
             line_index = before.count("\n")
             line_start = len(before) - len(before.rpartition("\n")[2])
@@ -4681,6 +4933,42 @@ class Editor(TextArea):
         claim = getattr(self, "_click_selection", None)
         if claim is not None and claim != selection:
             self._click_selection = None
+        # THE CARET LEAVING A MASKED SPAN ENDS THE CAPTURE, and the question is
+        # asked HERE — at the reactive that every caret move funnels through —
+        # rather than on the caret KEYS. Key-level checks covered only the keys
+        # they enumerated: `move_cursor` from a completion, a mouse click, a
+        # selection set by the app and `ctrl+u`-style edits all moved the caret
+        # without pressing one, leaving the capture open with its span no longer
+        # under the caret. The next typed character was then appended to the
+        # secret while its mask cell was inserted somewhere else entirely, and
+        # the mint spliced a range that did not match what was on screen.
+        #
+        # The span is contiguous and ends at `_credential_typing + len(typed)`,
+        # so "still inside" is a position test: anywhere from the start of the
+        # secret to its end is fine (the operator may be mid-word), anything
+        # outside is a departure. Abandoned, never cancelled — a caret move is
+        # not a request for the plaintext back, so the value is dropped rather
+        # than written into the buffer behind them.
+        start = getattr(self, "_credential_typing", None)
+        if start is not None:
+            end = start + len(self._credential_typed)
+            caret = self._offset_at(*selection.end)
+            if not start <= caret <= end:
+                self._abandon_credential_typing("moved")
+        elif getattr(self, "_credential_arm", None) is not None:
+            # AND THE CARET RETURNING RE-OPENS IT. The pair makes the masked
+            # span POSITIONAL — it is open exactly while the caret is in it —
+            # which is the only rule that behaves the same however the caret
+            # got there. Without the reopen, leaving and coming back left an
+            # armed token whose next typed character landed in PLAINTEXT: the
+            # capture only ever opened on the edit that inserted the space, and
+            # that space had already been typed.
+            #
+            # Cheap and safe to ask on every caret move: `_open_credential_typing`
+            # re-derives from the buffer and refuses unless the caret is exactly
+            # at the end of the armed token's trailing space, so a caret parked
+            # anywhere else is a no-op.
+            self._open_credential_typing()
         # A caret move changes the ghost's answer: it renders AT the caret, so
         # one set while the caret sat at the end of `/mcp login` renders
         # mid-word once the caret moves back into it (`/mcp loGHOSTgin notion`,
@@ -4793,6 +5081,37 @@ class Editor(TextArea):
         """
         arm = self._credential_arm
         if arm is not None:
+            if self._credential_typing is not None and self._credential_typed:
+                # PASTING INTO A SPAN THE OPERATOR HAS ALREADY TYPED INTO appends
+                # to the secret rather than minting beside it. Typing a prefix
+                # and pasting the rest is an ordinary way to enter a key that is
+                # partly memorised, and two chips would split one credential into
+                # two values the model cannot recombine. Masked through the same
+                # path as typing, so the pasted characters never enter the
+                # document either.
+                #
+                # Scoped to a NON-EMPTY typed value on purpose. The opening space
+                # now starts a capture immediately, so a plain `/credential ` +
+                # paste — the gesture that shipped in v0.53.0 and the one most
+                # operators have in their fingers — arrives here with an OPEN but
+                # EMPTY span. That must still mint instantly in place, so it
+                # falls through to `_capture_credential` below exactly as it did
+                # before this mode existed. Appending there instead would have
+                # left the paste masked and unchipped until a further Enter,
+                # which is a regression of the paste path dressed up as
+                # consistency.
+                pasted = event.text
+                if pasted:
+                    event.prevent_default()
+                    event.stop()
+                    for char in pasted:
+                        self._type_credential_char(char)
+                    return
+            if self._credential_typing is not None:
+                # An empty open span is closed before the paste mints, so the
+                # capture state cannot outlive the chip that supersedes it and
+                # leave the composer masking keystrokes after a visible receipt.
+                self._close_credential_typing()
             captured = self._capture_credential(event.text)
             if captured is not None:
                 event.prevent_default()
@@ -5643,6 +5962,258 @@ class Editor(TextArea):
         # the operator keeps typing inline.
         return marker + " "
 
+    # -- the TYPED capture ----------------------------------------------------
+    #
+    # THE STATE MACHINE, written down once here because a future agent has to be
+    # able to reconstruct why each key does what it does:
+    #
+    #     (1) token typed / completed      ->  ARMED      (`_credential_arm`)
+    #     (2) SPACE at the end of the token ->  TYPING     (`_credential_typing`)
+    #     (3) printable key while TYPING    ->  held in `_credential_typed`,
+    #                                           one mask cell into the buffer
+    #     (4) Enter while TYPING            ->  MINT the chip, leave the caret
+    #                                           in the composer (state: ARMED
+    #                                           ends, composer keeps the draft)
+    #     (5) Esc while TYPING              ->  CANCEL: the typed characters are
+    #                                           restored as ordinary text
+    #     (6) Paste while ARMED             ->  chip in place, unchanged
+    #
+    # (1), (2) and (6) already existed or are one predicate each; (3), (4) and
+    # (5) are what this feature adds. The invariant that makes the whole thing
+    # safe is stated at `_credential_typing`: BETWEEN (2) AND (4) THE SECRET IS
+    # NEVER IN THE DOCUMENT. Every seam that could disclose it reads the
+    # document, so holding it outside closes all of them at once rather than one
+    # at a time — which is the failure mode the pasted path had to be audited
+    # for across six separate expansion seams.
+
+    def credential_typing(self) -> bool:
+        """True while a TYPED secret is open and being masked.
+
+        The third public read of credential state, beside
+        :meth:`credential_armed` and :meth:`credential_cited`, and it is a
+        distinct question from both: "armed" is *before* the secret arrives,
+        "typing" is *while it arrives*, "cited" is *after*. The app paints a
+        different hint for each, so collapsing any two would make the composer
+        say the wrong thing about what the next keystroke means.
+        """
+        return self._credential_typing is not None
+
+    def _open_credential_typing(self) -> bool:
+        """Turn the space just typed after an armed token into a masked span.
+
+        Returns whether the capture opened, so the caller knows whether the
+        space was consumed as the mode's opening delimiter.
+
+        THE SPACE IS A DELIMITER, NOT PART OF THE SECRET. It stays in the
+        buffer (the token still needs terminating, and the picker closes on it)
+        and the masked span begins at the offset AFTER it. That is what keeps
+        the chip's reported length honest: ``K`` counts the characters of the
+        secret, and a leading space silently included would make the receipt
+        disagree with the value by one — precisely the kind of off-by-one an
+        operator cannot check, because they can never see the value again.
+
+        ONE OPENING RULE FOR BOTH ROUTES, and it is enforced HERE rather than at
+        the two call sites, which is the reason this reads the buffer instead of
+        taking a flag. The hand-typed route arrives as a `space` keystroke; the
+        accepted-completion route arrives as the trailing space
+        :meth:`_apply_command` appends. Those are the same character at the same
+        offset, so a rule stated about the BUFFER cannot treat them differently
+        — whereas two call-site flags would be two rules that drift, and the
+        divergence would be invisible until one route silently stopped masking.
+        """
+        arm = self._credential_arm
+        if arm is None or self._credential_typing is not None:
+            return False
+        offset = self._caret_offset()
+        # The space must be the character the caret just passed, and it must sit
+        # at the END of the armed token: `/credential ` opens, but a caret parked
+        # mid-line after an unrelated space does not. `_sync_credential_arm` has
+        # already extended the arm over the token's trailing whitespace, so the
+        # armed span's own end IS the offset after the space.
+        if offset != arm[1] or not self.text[:offset].endswith(CREDENTIAL_OPEN_SPACE):
+            return False
+        self._credential_typing = offset
+        self._credential_typed = ""
+        # THE PICKER IS DELIBERATELY LEFT OPEN. It is the surface that says what
+        # the mode is doing — its notice row carries
+        # `CREDENTIAL_TYPING_NOTICE` — and closing it would remove the guidance
+        # at the exact moment the composer starts turning keystrokes into
+        # bullets, which is when the operator most needs telling why.
+        #
+        # It cannot claim the keys that matter: `_on_key` routes a live capture
+        # AHEAD of the picker, so Enter mints and Esc cancels regardless of what
+        # the list is showing. And the rows it would offer are already withheld
+        # while armed (`_credential_choices`), so there is no highlighted row for
+        # a stray key to act on either.
+        self._invalidate_slash_runs()
+        self.post_message(CredentialArmChanged(True, typing=True))
+        return True
+
+    def _type_credential_char(self, char: str) -> None:
+        """Absorb one typed character into the secret; paint one mask cell.
+
+        The buffer receives :data:`CREDENTIAL_MASK_CHAR`, never ``char``. The
+        substitution is 1:1 so the span's width tracks the secret's length,
+        which is what lets the operator verify the count against the chip label
+        the mint produces.
+
+        Inserted through the ordinary edit funnel rather than by assigning to
+        ``text``, so the mask cells participate in the document exactly as typed
+        text does — the caret advances, the width recomputes, and the arm
+        re-syncs — while the value itself accumulates out of band.
+        """
+        self._credential_typed += char
+        # Insertion at the caret, which is by construction the end of the masked
+        # span: `_credential_typing` + len(typed) is where the caret must be, and
+        # any key that could have moved it away has already closed the capture
+        # (see `_credential_caret_left_span`).
+        self.insert(CREDENTIAL_MASK_CHAR)
+
+    def _mint_typed_credential(self) -> bool:
+        """Enter while TYPING: turn token + masked span into a chip.
+
+        Returns whether a chip was minted, so the caller knows whether Enter was
+        consumed by the capture or should fall through to submit.
+
+        ENTER ENDS THE SECRET; IT DOES NOT SUBMIT THE MESSAGE. The gesture is
+        specified as "hand over a secret and then describe it" — the operator
+        types ``/credential``, the secret, Enter, and then keeps typing prose
+        around the chip. An Enter that also submitted would make that
+        description impossible to write: the message would leave the moment the
+        secret ended, so the only reachable prompt would be a bare chip with no
+        explanation of what the credential is for. The operator presses Enter a
+        SECOND time to send, which is the same shape as every other completion
+        in this composer (a picker row, a name argument) — Enter finishes the
+        thing you are in the middle of, and sends only when you are in the
+        middle of nothing.
+
+        AN EMPTY SECRET MINTS NOTHING. ``/credential `` + Enter with no
+        characters typed falls through as an ordinary Enter, matching the empty
+        PASTE decision at :meth:`_capture_credential`: a zero-length credential
+        would advertise a key to the model that can never hold anything, and
+        `store_credential` refuses a blank value regardless. The capture stays
+        open rather than closing, so the operator who simply has not typed yet
+        is not silently disarmed by a stray keypress.
+        """
+        if self._credential_typing is None:
+            return False
+        secret = self._credential_typed
+        if not secret:
+            return False
+        arm = self._credential_arm
+        start = arm[0] if arm is not None else self._credential_typing
+        end = self._credential_typing + len(secret)
+        marker = self._capture_credential(secret)
+        self._close_credential_typing()
+        if marker is None:
+            return False
+        # ONE edit replaces the token, the delimiting space AND every mask cell.
+        # Doing it as a single `replace` (rather than a delete plus an insert)
+        # keeps it a single undoable step, and there is no intermediate document
+        # state in which some of the mask cells have been resolved — an undo
+        # therefore returns the operator to the buffer as it was before the
+        # gesture, never to one holding a partially revealed secret. It cannot
+        # reveal the secret in any case: the document never held it.
+        self.replace(
+            marker,
+            self._offset_to_location(start),
+            self._offset_to_location(end),
+            maintain_selection_offset=False,
+        )
+        self.move_cursor(self._offset_to_location(start + len(marker)))
+        return True
+
+    def _cancel_credential_typing(self) -> bool:
+        """Esc while TYPING: give the operator their characters back.
+
+        Returns whether a capture was cancelled, so Esc falls through to its
+        other meanings (dismiss a list, leave shell mode, stop the turn) when no
+        capture is open.
+
+        UNREDACTS RATHER THAN DISCARDS. The spec says Esc "unredacts and/or
+        cancels", and restoring the text is the reading that cannot lose work:
+        an operator who typed a long secret and pressed Esc because they meant
+        it as prose gets exactly what they typed, while an operator who wanted
+        it gone deletes it with the keystrokes they would use for any other
+        text. Discarding silently would be unrecoverable in the one direction
+        that matters — retyping a secret is precisely what an operator cannot do
+        from memory.
+
+        THE ARM ENDS TOO. Esc means "I am not handing over a secret", so leaving
+        the token armed would put the composer in a state where the next paste
+        is still swallowed as a credential after the operator has visibly backed
+        out. That is the false-POSITIVE direction, which costs one backspace;
+        the alternative (staying armed) is the direction D2 calls unrecoverable.
+        """
+        if self._credential_typing is None:
+            return False
+        secret = self._credential_typed
+        start = self._credential_typing
+        end = start + len(secret)
+        self._close_credential_typing()
+        self._disarm_credential("cancelled")
+        # The mask cells become the characters they were standing in for. This
+        # is the ONLY route by which the typed secret enters the document, and
+        # it is the operator explicitly asking for it — at which point it is
+        # their prose, not a credential.
+        self.replace(
+            secret,
+            self._offset_to_location(start),
+            self._offset_to_location(end),
+            maintain_selection_offset=False,
+        )
+        self.move_cursor(self._offset_to_location(start + len(secret)))
+        return True
+
+    def _close_credential_typing(self) -> None:
+        """Drop the typed-capture state and the secret it held.
+
+        Called by every exit from the TYPING state. The value is cleared here
+        and nowhere else, so there is exactly one place a secret stops being
+        held — a second clearing site is how one path comes to leave it behind.
+        """
+        if self._credential_typing is None:
+            return
+        self._credential_typing = None
+        self._credential_typed = ""
+        self._invalidate_slash_runs()
+        self.post_message(CredentialArmChanged(self._credential_arm is not None))
+
+    def _abandon_credential_typing(self, reason: str) -> None:
+        """End a typed capture WITHOUT restoring the secret, leaving the mask.
+
+        The exit for the states where the operator has moved on rather than
+        cancelled: the caret left the masked span, the buffer was replaced, the
+        draft was submitted. Restoring the plaintext there would push a secret
+        into the document behind the operator's back, at a moment they are not
+        looking at the span — the opposite of what Esc does, and deliberately
+        so, because Esc is an explicit request and these are not.
+
+        The mask cells are LEFT IN THE BUFFER as ordinary bullets. They are not
+        the secret and carry no way back to it: the value is dropped here, so
+        what remains is a visible run of ``•`` the operator can see and delete.
+        Silently deleting them instead would make a caret movement erase text
+        the operator watched themselves type, which reads as data loss even
+        though the characters were never real.
+
+        THE ARM IS LEFT ALONE, which is the whole difference between this and
+        :meth:`_cancel_credential_typing`. The token is still in the buffer and
+        the operator has not withdrawn it, so disarming here would silently
+        revoke the safety property while the gesture is still on screen — the
+        false-NEGATIVE direction D2 calls unrecoverable, and it is reachable by
+        something as ordinary as clicking elsewhere in the draft and clicking
+        back. The routes that genuinely end the gesture (the buffer being
+        replaced, a submit) disarm on their own account at their own call site.
+        """
+        # `getattr`, because `load_text` calls this and TextArea's constructor
+        # calls `load_text` BEFORE this widget's own `__init__` body has run —
+        # the same ordering `_picker` is built ahead of `super().__init__()` for.
+        # A capture cannot be open at that point, so "absent" and "closed" are
+        # the same answer.
+        if getattr(self, "_credential_typing", None) is None:
+            return
+        self._close_credential_typing()
+
     async def _attach_pasted_images(self, pasted: str) -> str | None:
         """Load every path in ``pasted`` as an attachment; return the markers.
 
@@ -5992,6 +6563,19 @@ class Editor(TextArea):
         # leave it a message-loop tick behind the text — and that tick is the
         # one in which a paste decides whether it is a secret.
         self._sync_credential_arm()
+        # THE OPENING SPACE, asked on the funnel BOTH routes converge on. The
+        # hand-typed space and the trailing space `_apply_command` appends when
+        # a picker row is accepted are the same insertion at the same offset, so
+        # asking here is what makes the two routes identical by construction
+        # rather than by two call sites agreeing. Asking in `_on_key` instead
+        # would have covered only the typed route and left the completion route
+        # silently unmasked — which is exactly the shape of the defect being
+        # fixed, one level down.
+        #
+        # After `_sync_credential_arm`, because the arm's span is what the open
+        # is checked against and the space is the character that just extended it.
+        if self._credential_typing is None and self._credential_arm is not None:
+            self._open_credential_typing()
         if touched:
             self._release_uncited(touched)
         return result
@@ -6142,6 +6726,15 @@ class Editor(TextArea):
         # which replace the buffer for `/team`, `/model` and friends; a
         # completion is not the arming gesture either, and letting one preserve
         # an arm would reopen the migration route through a second door.
+        #
+        # A TYPED CAPTURE ENDS HERE TOO, and it is ABANDONED rather than
+        # cancelled: the buffer is being replaced wholesale, so restoring the
+        # plaintext would write a secret into a document the operator is in the
+        # middle of navigating away from — into a recalled prompt, or a draft
+        # about to be stored. The held value is dropped instead, which is the
+        # only outcome that cannot disclose it. This must run BEFORE the text is
+        # gone, and it does: the state is closed here on the same call.
+        self._abandon_credential_typing("gone")
         self._disarm_credential("gone")
 
     def _caret_offset(self) -> int:
@@ -6180,6 +6773,29 @@ class Editor(TextArea):
         finally:
             self._suspend_picker_sync = False
         self._sync_picker()
+        # THE ARM IS RE-DERIVED AT THE SETTLED CARET, and only here, for exactly
+        # the reason the picker is: `load_text` DISARMS (deliberately — arriving
+        # text must never inherit an arm), and it runs with the caret still at
+        # the origin, so a completion that just wrote `/credential ` ended with
+        # no arm at all. That is why accepting the picker row produced no chip
+        # and leaked: the gesture was complete on screen and the state said
+        # otherwise.
+        #
+        # Safe against the migration route `load_text`'s disarm exists to close.
+        # That route is about an arm SURVIVING a buffer swap and re-anchoring
+        # onto a token the operator never typed; this re-derives from scratch at
+        # the caret the completion just placed, using the same `CREDENTIAL_ARM`
+        # end-of-line rule a hand-typed token must satisfy. So a recalled prompt
+        # or a restored draft still cannot arm — neither routes through here, and
+        # neither leaves the caret at the end of a `/credential` token.
+        self._sync_credential_arm()
+        # The completion's own trailing space is the opening delimiter, and it
+        # was inserted by the buffer replacement above rather than by `edit()`,
+        # so the funnel that normally opens the capture never saw it. Asking here
+        # is what makes the accepted-completion route land in the SAME masked
+        # state as the hand-typed one.
+        if self._credential_typing is None and self._credential_arm is not None:
+            self._open_credential_typing()
 
     def _location_at_offset(self, offset: int) -> tuple[int, int]:
         """A whole-buffer ``offset`` as a ``(row, column)`` document location.

--- a/local_operator/tui/widgets/key_prompt.py
+++ b/local_operator/tui/widgets/key_prompt.py
@@ -183,7 +183,10 @@ class KeyPromptBlock(TranscriptBlock):
         "a login is already in progress".
 
         ``credential`` is the ``/credential <KEY>`` prompt, which reuses this
-        block for its masked paste. The value is a session secret named by the
+        block for its masked paste. It is reached by a PASTED whole line rather
+        than a typed one — typing the form opens the inline masked capture
+        instead (QA round 1, Q1) — and is the route a viewer hands a secret to
+        its owner on. The value is a session secret named by the
         user — a database password, a deploy token — not a provider's API key,
         and nothing about it is a LOGIN. The label is the key name, so the
         prompt says "paste the value for DB_PASSWORD" and the cancel receipt

--- a/local_operator/variables.py
+++ b/local_operator/variables.py
@@ -126,17 +126,42 @@ class CredentialCommand:
 #:
 #: The INLINE gesture leads, because it is the one an operator reaches for and
 #: the one that used to fail silently: typing `/credential <secret>` fell
-#: through to the `<KEY>` form below with the secret as its key argument, and
-#: the value landed in the transcript in plaintext. Naming the space and the
+#: through to the `<KEY>` form with the secret as its key argument, and the
+#: value landed in the transcript in plaintext. Naming the space and the
 #: terminating Enter here is what makes the mode discoverable from the error an
 #: operator sees when they get it wrong.
+#:
+#: THE TYPED ``<KEY>`` FORM IS NOT LISTED, because it can no longer be TYPED and
+#: help that cannot be followed is worse than help that is missing. The space
+#: after the token now always opens a masked capture, so a hand-typed key name
+#: is minted as a short secret rather than reaching the prompt — measured on
+#: this branch, ``/credential MYKEY`` produced ``[Credential #1, 5 chars]`` (QA
+#: round 1, Q1). The form itself still EXISTS and is still parsed: a pasted
+#: whole line reaches it, and it is the route a viewer session uses to hand a
+#: secret to its owner. It is simply not something to advertise as typable.
+#: Naming a credential yourself is what was lost; the generated ``LOP_SECRET_``
+#: name in the chip is what ``--persist`` and ``--forget`` take instead.
+#:
+#: ONE ALIGNED COMMENT COLUMN, and a lead short enough not to wrap. The previous
+#: first line was 74 cells and folded in the notice column, splitting
+#: ``# masked; Enter`` from ``chips it`` and leaving the rest of the block at a
+#: different indent, with the ``#`` column unaligned across three different
+#: offsets (design round 1, D6).
+#:
+#: THE FIRST LINE IS BUDGETED FOR ITS CALLER'S PREFIX, which is what the earlier
+#: attempt missed. ``format_credential_list`` prepends
+#: ``No credentials stored for this session. `` (40 cells) before this string, so
+#: the lead is measured against that too: ``NoticeBlock.body_budget(100)`` is 94
+#: cells, leaving ~54 for line one. Measured in a rendered frame rather than
+#: counted in the source — the first version of this block still wrapped at 100
+#: columns because only the bare string was checked.
 CREDENTIAL_USAGE = (
-    "Usage: /credential <space> then type or paste it  # masked; Enter chips it\n"
-    "       /credential <KEY>         # name it yourself, value via a prompt\n"
-    "       /credential                # list\n"
-    "       /credential --persist <KEY>  # also save to the encrypted long-term store\n"
-    "       /credential --forget <KEY>\n"
-    "       /credential --forget-all"
+    "Usage: /credential <space> then the secret\n"
+    "       Enter chips it, Esc cancels     # it never enters the line\n"
+    "       /credential                     # list\n"
+    "       /credential --persist <KEY>     # also save it long-term\n"
+    "       /credential --forget <KEY>      # forget one\n"
+    "       /credential --forget-all        # forget every one"
 )
 
 

--- a/local_operator/variables.py
+++ b/local_operator/variables.py
@@ -122,8 +122,17 @@ class CredentialCommand:
     message: str = ""
 
 
+#: The operator-facing help for the command, shown on every parse error.
+#:
+#: The INLINE gesture leads, because it is the one an operator reaches for and
+#: the one that used to fail silently: typing `/credential <secret>` fell
+#: through to the `<KEY>` form below with the secret as its key argument, and
+#: the value landed in the transcript in plaintext. Naming the space and the
+#: terminating Enter here is what makes the mode discoverable from the error an
+#: operator sees when they get it wrong.
 CREDENTIAL_USAGE = (
-    "Usage: /credential <KEY>\n"
+    "Usage: /credential <space> then type or paste it  # masked; Enter chips it\n"
+    "       /credential <KEY>         # name it yourself, value via a prompt\n"
     "       /credential                # list\n"
     "       /credential --persist <KEY>  # also save to the encrypted long-term store\n"
     "       /credential --forget <KEY>\n"

--- a/tests/unit/secrets/test_agent_surfaces.py
+++ b/tests/unit/secrets/test_agent_surfaces.py
@@ -625,10 +625,22 @@ def test_promote_refuses_to_clobber_an_existing_long_term_secret(isolated: Path)
     assert open_store().get("SHARED") == b"the-original", "promotion overwrote a secret"
 
 
-def test_promote_of_an_unknown_key_says_what_to_do(isolated: Path) -> None:
+def test_promote_of_an_unknown_key_advises_a_gesture_that_still_works(isolated: Path) -> None:
+    """The advice must name something the operator can actually DO.
+
+    It used to say ``/credential NOPE``, which the typed capture retired: the
+    space after the token opens a masked span, so typing a key name mints it as
+    a short secret instead of reaching the ``<KEY>`` prompt (QA round 1, Q1).
+    Advice that cannot be followed is worse than none — the operator would have
+    typed it and watched their key name become a credential. So this pins the
+    property (the message routes them to a working gesture) rather than the old
+    literal, and explicitly refuses the retired one.
+    """
     result = promote_session_credential(VariableStore(), "NOPE")
     assert not result.ok
-    assert "/credential NOPE" in result.message
+    assert "NOPE" in result.message, "it still names the key they asked for"
+    assert "/credential" in result.message, "and the command that hands one over"
+    assert "/credential NOPE" not in result.message, "but never the untypable form"
 
 
 def test_credential_command_parses_the_persist_verb() -> None:

--- a/tests/unit/secrets/test_agent_surfaces.py
+++ b/tests/unit/secrets/test_agent_surfaces.py
@@ -8,8 +8,10 @@ worthless, and this series has produced false-passing harnesses repeatedly.
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import contextlib
+import re
 import shlex
 import sys
 import threading
@@ -18,6 +20,7 @@ from typing import Any
 
 import pytest
 
+import local_operator
 from local_operator.harness.types import AbortSignal, ToolContext
 from local_operator.secrets.promote import promote_session_credential
 from local_operator.secrets.protocol import PROTOCOL_VERSION
@@ -641,6 +644,75 @@ def test_promote_of_an_unknown_key_advises_a_gesture_that_still_works(isolated: 
     assert "NOPE" in result.message, "it still names the key they asked for"
     assert "/credential" in result.message, "and the command that hands one over"
     assert "/credential NOPE" not in result.message, "but never the untypable form"
+
+
+#: Advice that tells the operator to TYPE the retired ``/credential <KEY>``
+#: form. The verb is what makes it advice rather than a description, and the
+#: argument is what makes it the RETIRED form rather than the live gesture.
+#:
+#: THE KEY HALF IS DELIBERATELY CASE-SENSITIVE. Compiling the whole pattern
+#: with ``re.IGNORECASE`` makes ``[A-Z]`` match lowercase too, and the rule then
+#: fires on ordinary prose like "run /credential from the owner session" — which
+#: it did on the first draft of this guard. Only the VERBS are spelled both
+#: ways.
+_TYPE_THE_RETIRED_FORM = re.compile(
+    r"(?:[Uu]se|[Tt]ype|[Rr]un|[Ee]nter|[Tt]ry|[Ss]ay)\s+(?:the\s+)?[`'\"]*"
+    r"/credential\s+(?!--)(?:<[A-Za-z_]+>|[A-Z][A-Z0-9_]{2,})"
+)
+
+
+def test_no_shipped_string_tells_the_operator_to_type_the_retired_form() -> None:
+    """The RETIREMENT SWEEP itself, as a mechanism rather than a grep somebody ran.
+
+    Q1 retired the typed ``/credential <KEY>`` form and corrected the usage
+    text, the ``--persist`` advice and the design doc. A live viewer notice was
+    missed, and the miss was found INDEPENDENTLY by the reviewer and by QA on
+    the same line (review round 2, R5; QA round 2, Q5) — two agents finding one
+    site means the sweep was the defect, not just the site. So the sweep is
+    pinned here and runs on every commit.
+
+    Why it matters more than a stale string usually would: following that advice
+    mints the operator's KEY NAME as a short secret, and on the viewer path it
+    fires on the submit seam, so the chip the retyping mints re-enters the same
+    branch and reprints the same advice — the operator LOOPS.
+
+    Scoped to shipped strings under ``local_operator/`` — tests and design docs
+    describe the retired form deliberately, and a guard that forbade naming it
+    would forbid explaining why it was retired.
+    """
+    package = Path(local_operator.__file__).parent
+    offenders: list[str] = []
+    scanned = 0
+    for path in sorted(package.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (OSError, SyntaxError):  # pragma: no cover - unreadable file
+            continue
+        scanned += 1
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+                continue
+            found = _TYPE_THE_RETIRED_FORM.search(node.value)
+            if found is not None:
+                offenders.append(
+                    f"{path.relative_to(package.parent)}:{node.lineno}: {found.group(0)!r}"
+                )
+
+    # A ZERO FROM A DEAD INSTRUMENT READS EXACTLY LIKE A PASS, and this rule is
+    # narrow enough to break silently, so the detector is proven live in the
+    # same run against the exact string that was missed.
+    missed = (
+        "inline /credential needs the session that runs the tools; "
+        "use /credential <KEY> here and the secret is stored on the owner"
+    )
+    assert _TYPE_THE_RETIRED_FORM.search(missed), "the detector is dead; its zero means nothing"
+    assert scanned > 100, f"the sweep only reached {scanned} modules"
+
+    assert not offenders, (
+        "these shipped strings tell the operator to TYPE the retired "
+        "`/credential <KEY>` form, which mints their key name as a secret:\n  "
+        + "\n  ".join(offenders)
+    )
 
 
 def test_credential_command_parses_the_persist_verb() -> None:

--- a/tests/unit/tui/test_inline_credential.py
+++ b/tests/unit/tui/test_inline_credential.py
@@ -2281,6 +2281,103 @@ async def test_escape_with_characters_typed_announces_the_plaintext() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "retry",
+    [
+        # The shape UX walked: the operator explains themselves, then re-arms.
+        "actually /credential",
+        # Straight back to the gesture with nothing in between.
+        "/credential",
+        # Words first, token last — the commonest mid-prose arm.
+        "ok now /credential",
+    ],
+)
+async def test_retrying_the_gesture_after_an_escape_masks_again(retry: str) -> None:
+    """U6 — the cancel's OWN flow: retry on the same line and it must mask.
+
+    Making Esc real (R1/U2) created the state this fails in, so it is the
+    remediation's own regression. Typing a SECOND token walks through spellings
+    (`/crede`, `/creden`, …) that are not tokens, so the latched arm found no
+    match at its anchor and the nearest-match tie-break MIGRATED it back onto
+    the first token earlier in the line. The migration is one-way — the anchor
+    moved with it — so the arm never came home, the caret-at-span-end gate never
+    fired, and the secret typed next was painted in the CLEAR and then parsed as
+    a credential NAME, which is the half the model does learn (UX round 2, U6).
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type_secret(pilot, editor, "")
+        await pilot.press("escape")
+        await pilot.pause()
+        assert not editor.credential_typing(), "precondition: the cancel landed"
+
+        for char in retry:
+            await pilot.press("space" if char == " " else char)
+        await pilot.pause()
+        await pilot.press("space")
+        await pilot.pause()
+        assert editor.credential_typing(), f"the retry re-opens the capture after {retry!r}"
+
+        for char in SECRET:
+            await pilot.press(char)
+        await pilot.pause()
+        assert SECRET not in editor.text, "the retyped secret is masked, not painted"
+        assert editor.text.count(CREDENTIAL_MASK_CHAR) == len(SECRET), "one cell per character"
+        assert editor._credential_typed == SECRET, "and the held value is the one typed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "word",
+    [
+        # Longer words that merely START WITH the token must stay prose. The
+        # typed-through rule is PREFIX-OF, not starts-with, precisely so these
+        # cannot inherit an arm.
+        "/credentials",
+        "/credentialx",
+        # Shortened BELOW the `/cred` floor is the operator withdrawing the
+        # gesture, which is the visible way out and must keep working.
+        "/cre",
+        "/credx",
+        # An unrelated command, and ordinary prose.
+        "/help",
+        "notes about the deploy",
+    ],
+)
+async def test_the_retry_rule_does_not_arm_anything_but_the_token(word: str) -> None:
+    """U6's fix must widen the masked set ONLY onto the operator's own gesture.
+
+    The counterpart to the test above, and the one that stops it being satisfied
+    by masking everything: a rule that re-armed on any word at the anchor would
+    swallow prose as a secret, which is the unrecoverable direction. So each
+    word here is typed into exactly the post-cancel state U6 lives in and must
+    leave the following text as PLAIN TEXT.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type_secret(pilot, editor, "")
+        await pilot.press("escape")
+        await pilot.pause()
+
+        for char in word:
+            await pilot.press("space" if char == " " else char)
+        await pilot.pause()
+        await pilot.press("space")
+        await pilot.pause()
+        assert not editor.credential_typing(), f"{word!r} must not arm a capture"
+
+        for char in "PLAINTEXT_STAYS_VISIBLE":
+            await pilot.press(char)
+        await pilot.pause()
+        assert "PLAINTEXT_STAYS_VISIBLE" in editor.text, "it stays readable"
+        assert CREDENTIAL_MASK_CHAR not in editor.text, "and nothing was masked"
+
+
+@pytest.mark.asyncio
 async def test_an_empty_escape_announces_nothing() -> None:
     """No characters restored, no warning owed — the notice must not cry wolf."""
     app = Host()

--- a/tests/unit/tui/test_inline_credential.py
+++ b/tests/unit/tui/test_inline_credential.py
@@ -28,14 +28,17 @@ from local_operator.tui.app import (
     CREDENTIAL_ARMED_NOTICE,
     CREDENTIAL_HELD_NOTICE,
     CREDENTIAL_PLACEHOLDER,
+    CREDENTIAL_TYPING_NOTICE,
     OperatorApp,
 )
 from local_operator.tui.widgets.editor import (
     ASIDE_PLACEHOLDER,
     ATTACHMENT_MARKER,
     CREDENTIAL_KEY_PREFIX,
+    CREDENTIAL_MASK_CHAR,
     Attachment,
     Editor,
+    EditorSubmitted,
     Marked,
     PastedCredential,
     PastedText,
@@ -1371,13 +1374,20 @@ async def test_a_flag_disarm_clears_the_pickers_armed_notice() -> None:
         for _ in range(4):
             await pilot.pause()
         assert editor.credential_armed()
-        assert CREDENTIAL_ARMED_NOTICE in _painted(app), "precondition: the row is up"
+        # Typed through the space, so the capture is open and the row carries
+        # the masking notice rather than the bare armed one.
+        assert CREDENTIAL_TYPING_NOTICE in _painted(app), "precondition: the row is up"
 
         await pilot.press("-")
         for _ in range(8):
             await pilot.pause()
         assert not editor.credential_armed()
-        assert CREDENTIAL_ARMED_NOTICE not in _painted(app), "the promise went with the state"
+        painted = _painted(app)
+        assert CREDENTIAL_ARMED_NOTICE not in painted, "the promise went with the state"
+        # The typed-capture promise must go with it for the same reason: a `-`
+        # means the operator is addressing the COMMAND, so nothing may still
+        # claim their keystrokes are being masked.
+        assert CREDENTIAL_TYPING_NOTICE not in painted, "nor the masking promise"
 
         # And it STAYS cleared: the operator pastes into the disarmed composer,
         # which is the moment the stale row would have lied about.
@@ -1399,9 +1409,27 @@ async def _capture_leaving_a_leftover_token(pilot, app, editor) -> None:
     therefore sits on the EARLIER token, the marker splices there, and the
     token the operator typed at the caret is left in the buffer, unarmed and
     with an empty argument slot.
+
+    THE ``escape`` IS THE PROSE AUTHOR'S KEYSTROKE, and it is what the typed
+    capture makes necessary. The space after that first mention now opens a
+    masked span, so ``command`` is taken as a secret and rendered as bullets —
+    loudly and immediately, which is the point. Esc unredacts it back to the
+    word the operator typed and ends the capture, leaving exactly the prose
+    draft this helper is about. That is the intended cost of the mode: a false
+    positive is visible on the frame and one keystroke to undo, where the false
+    negative it replaces put a plaintext secret in scrollback for good.
     """
-    for char in "fix the /credential command /credential ":
+    for char in "fix the /credential command":
         await pilot.press(char)
+    for _ in range(4):
+        await pilot.pause()
+    # Back out of the capture the prose opened; the masked word returns as text.
+    await pilot.press("escape")
+    for _ in range(4):
+        await pilot.pause()
+    assert "command" in editor.text, "Esc gave the prose back"
+    for char in " /credential ":
+        await pilot.press("space" if char == " " else char)
     for _ in range(4):
         await pilot.pause()
     app.post_message(events.Paste(SECRET))
@@ -1613,7 +1641,12 @@ async def test_a_second_capture_still_arms_while_the_first_chip_is_held() -> Non
             await pilot.pause()
         assert editor.credential_armed(), "the second gesture still arms"
         painted = _painted(app)
-        assert CREDENTIAL_ARMED_NOTICE in painted, "mid-gesture, the armed notice wins"
+        # The separating space also OPENS the typed capture, so the row shows
+        # the more specific of the two mid-gesture notices: the operator's next
+        # keystroke is being masked, which is what they need told. The HELD
+        # notice is what must not win here, and that is the property this line
+        # has always guarded.
+        assert CREDENTIAL_TYPING_NOTICE in painted, "mid-gesture, the capture notice wins"
         assert CREDENTIAL_HELD_NOTICE not in painted, "and the two do not both show"
 
         app.post_message(events.Paste("second-secret-value"))
@@ -1621,3 +1654,541 @@ async def test_a_second_capture_still_arms_while_the_first_chip_is_held() -> Non
             await pilot.pause()
         assert editor.text.count("[Credential #") == 2, "both captures are chipped"
         assert "second-secret-value" not in _painted(app)
+
+
+# ---------------------------------------------------------------------------
+# THE TYPED capture.
+#
+# Everything above this line is about the PASTED gesture. `/credential` shipped
+# in v0.53.0 with a clipboard path and no typed path at all, so the obvious
+# human gesture — typing `/credential 12345` — fell through to the legacy
+# `/credential <KEY>` command with the SECRET as its key argument, and landed in
+# the transcript in plaintext with no chip and no warning. These tests pin the
+# typed path and, more importantly, the several ways it can silently stop
+# masking. Each one is a reproduced failure, not a hypothetical.
+# ---------------------------------------------------------------------------
+
+#: A value shaped like a REAL credential: punctuation, mixed case, digits. The
+#: alphanumeric secrets used above cannot catch the punctuation leak below,
+#: which is exactly how that bug survived its first implementation.
+TYPED_SECRET = "zQ7-TYPED.canary_4417/x+y"
+
+
+async def _type_secret(pilot, editor: Editor, secret: str, prefix: str = "") -> None:
+    """Type ``prefix``, the token, the opening SPACE, then ``secret``.
+
+    No paste anywhere — this is the gesture the operator actually made. The
+    picker is dismissed the way a user does it, so the hand-typed route is
+    measured rather than the completion route.
+    """
+    for char in f"{prefix}/credential":
+        await pilot.press("space" if char == " " else char)
+    await pilot.pause()
+    if editor._picker.is_open():
+        await pilot.press("escape")
+        await pilot.pause()
+    await pilot.press("space")
+    await pilot.pause()
+    for char in secret:
+        await pilot.press("space" if char == " " else char)
+    await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_a_typed_secret_never_enters_the_document() -> None:
+    """THE HEADLINE. Typing the secret masks it and mints the same chip a paste does.
+
+    The reproduction of the reported defect: `/credential 12345` typed by hand
+    produced no chip and put the secret in the submitted text.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type_secret(pilot, editor, TYPED_SECRET)
+        assert TYPED_SECRET not in editor.text, "the buffer must never hold it"
+        assert editor.text == "/credential " + CREDENTIAL_MASK_CHAR * len(TYPED_SECRET)
+        assert editor.credential_typing(), "the capture is open"
+
+        await pilot.press("enter")
+        await pilot.pause()
+        assert editor.text == f"[Credential #1, {len(TYPED_SECRET)} chars] "
+        payloads = credential_payloads(editor.text, editor._attachments)
+        assert len(payloads) == 1
+        assert payloads[0].value == TYPED_SECRET, "the stored value is exactly what was typed"
+
+
+@pytest.mark.asyncio
+async def test_every_printable_character_is_masked_not_only_alphanumerics() -> None:
+    """The punctuation leak, pinned.
+
+    Textual spells punctuation keys as WORDS (`minus`, `full_stop`), so a
+    handler gated on ``len(event.key) == 1`` masks letters and digits and lets
+    every punctuation character fall through into the document. Measured, the
+    canary rendered as ``•••-TYPED-LEAK-CANARY-4417``: the first hyphen ended
+    the masking and the rest of the secret was typed in plaintext and submitted.
+    Real credentials are mostly punctuation, so that gate leaked nearly every
+    actual secret while passing against an alphanumeric test value.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        # Deliberately not LEADING with `-`: that is the documented flag
+        # escape (`--forget-all`). Every other punctuation character, and a
+        # hyphen in a non-leading position, must be masked.
+        punctuation = "a-_.+/=:@!~"
+        await _type_secret(pilot, editor, punctuation)
+        assert editor.text == "/credential " + CREDENTIAL_MASK_CHAR * len(punctuation)
+        for char in punctuation:
+            assert char not in editor.text[len("/credential ") :], f"{char!r} reached the buffer"
+
+
+@pytest.mark.asyncio
+async def test_the_separating_space_is_not_counted_in_the_length() -> None:
+    """``K`` counts the secret, never the delimiter that opened the span.
+
+    The operator can never see the value again, so a length that disagreed with
+    it by one is a receipt they cannot check.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type_secret(pilot, editor, "12345")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert "[Credential #1, 5 chars]" in editor.text, "5, not 6"
+        payloads = credential_payloads(editor.text, editor._attachments)
+        assert payloads[0].value == "12345"
+        assert not payloads[0].value.startswith(" ")
+
+
+@pytest.mark.asyncio
+async def test_a_space_inside_the_span_is_part_of_the_secret() -> None:
+    """Passphrases contain spaces; Enter is the terminator, not the space.
+
+    Terminating on the space would truncate a passphrase and type its remainder
+    in PLAINTEXT — this feature's own defect, reappearing inside its fix.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        phrase = "correct horse battery staple"
+        await _type_secret(pilot, editor, phrase)
+        assert phrase not in editor.text
+        await pilot.press("enter")
+        await pilot.pause()
+        payloads = credential_payloads(editor.text, editor._attachments)
+        assert payloads[0].value == phrase, "every space was kept"
+        assert f"{len(phrase)} chars" in editor.text
+
+
+@pytest.mark.asyncio
+async def test_enter_ends_the_secret_and_leaves_the_operator_in_the_composer() -> None:
+    """Enter mints the chip; it does NOT submit.
+
+    The gesture is specified as "hand over a secret and then describe it", so an
+    Enter that also sent the message would make the description impossible to
+    write.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        submitted: list[str] = []
+        original = editor.post_message
+
+        def _spy(message):  # type: ignore[no-untyped-def]
+            if isinstance(message, EditorSubmitted):
+                submitted.append(message.text)
+            return original(message)
+
+        editor.post_message = _spy  # type: ignore[method-assign]
+        await _type_secret(pilot, editor, "12345")
+        await pilot.press("enter")
+        await pilot.pause()
+        assert not submitted, "the first Enter must not send the message"
+        for char in "the staging key":
+            await pilot.press("space" if char == " " else char)
+        await pilot.pause()
+        assert editor.text == "[Credential #1, 5 chars] the staging key"
+
+
+@pytest.mark.asyncio
+async def test_escape_unredacts_the_typed_characters() -> None:
+    """Esc gives the operator their text back rather than discarding it.
+
+    Retyping a secret from memory is precisely what an operator cannot do, so
+    the recoverable reading is the only safe one. It also ENDS the arm: the
+    operator has visibly backed out, so the next paste must not still be
+    swallowed.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type_secret(pilot, editor, "12345")
+        assert "12345" not in editor.text
+        await pilot.press("escape")
+        await pilot.pause()
+        assert editor.text == "/credential 12345", "the characters came back"
+        assert not editor.credential_typing()
+        assert not editor.credential_armed(), "Esc ends the gesture too"
+
+
+@pytest.mark.asyncio
+async def test_a_typed_capture_never_routes_to_the_legacy_command() -> None:
+    """The reported defect, at the seam where it did its damage.
+
+    The typed line used to reach `_dispatchable_slash` as
+    ``/credential <secret>``, which the legacy command reads as a KEY NAME — so
+    the app prompted "Paste the value for 12345" with the secret rendered as the
+    key, in the transcript, in plaintext.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        submitted: list[str] = []
+        original = editor.post_message
+
+        def _spy(message):  # type: ignore[no-untyped-def]
+            if isinstance(message, EditorSubmitted):
+                submitted.append(message.text)
+            return original(message)
+
+        editor.post_message = _spy  # type: ignore[method-assign]
+        await _type_secret(pilot, editor, TYPED_SECRET)
+        await pilot.press("enter")  # mints the chip
+        await pilot.pause()
+        await pilot.press("enter")  # sends the message
+        for _ in range(8):
+            await pilot.pause()
+        assert submitted, "the second Enter sends"
+        assert TYPED_SECRET not in " ".join(submitted)
+        assert "[Credential #1," in " ".join(submitted), "the chip goes instead"
+        assert TYPED_SECRET not in _painted(app), "and nothing paints it"
+
+
+@pytest.mark.asyncio
+async def test_bare_credential_with_a_key_still_dispatches_as_the_command() -> None:
+    """The shipped command is untouched when no capture is open.
+
+    ``/credential MY_API_KEY`` arriving as TEXT (a recalled prompt, a restored
+    draft) has passed through no arming gesture, so it must still reach the
+    legacy handler exactly as it always has.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        submitted: list[str] = []
+        original = editor.post_message
+
+        def _spy(message):  # type: ignore[no-untyped-def]
+            if isinstance(message, EditorSubmitted):
+                submitted.append(message.text)
+            return original(message)
+
+        editor.post_message = _spy  # type: ignore[method-assign]
+        editor.load_text("/credential MY_API_KEY")
+        editor.move_cursor(editor._end_of_buffer())
+        await pilot.pause()
+        assert not editor.credential_armed(), "arriving text never arms"
+        assert not editor.credential_typing()
+        if editor._picker.is_open():
+            await pilot.press("escape")
+            await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert submitted == ["/credential MY_API_KEY"], "dispatched unchanged"
+
+
+@pytest.mark.asyncio
+async def test_a_leading_flag_escapes_the_mask_so_the_verbs_stay_typable() -> None:
+    """``--forget-all`` must survive the opening space.
+
+    The credential verbs are flag-shaped precisely so they cannot collide with a
+    key (keys normalize to ``[A-Z0-9_]``). Without the escape the opening space
+    masked them and Enter minted a chip instead of forgetting anything, which
+    regresses the shipped command.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        for char in "/credential":
+            await pilot.press(char)
+        await pilot.pause()
+        if editor._picker.is_open():
+            await pilot.press("escape")
+            await pilot.pause()
+        await pilot.press("space")
+        for char in "--forget-all":
+            await pilot.press(char)
+        await pilot.pause()
+        assert editor.text == "/credential --forget-all", "typed verbatim"
+        assert not editor.credential_typing(), "a flag is the command, not a secret"
+        assert not editor.credential_armed()
+
+
+@pytest.mark.asyncio
+async def test_a_hyphen_inside_a_secret_is_masked_like_any_character() -> None:
+    """The flag escape is scoped to the FIRST character only.
+
+    ``-`` is common inside real keys (base64url), so once any character has been
+    typed the operator is entering a value and the flag reading is gone.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type_secret(pilot, editor, "abc-def")
+        assert editor.text == "/credential " + CREDENTIAL_MASK_CHAR * len("abc-def")
+        await pilot.press("enter")
+        await pilot.pause()
+        payloads = credential_payloads(editor.text, editor._attachments)
+        assert payloads[0].value == "abc-def"
+
+
+@pytest.mark.asyncio
+async def test_the_caret_leaving_the_span_ends_the_capture_without_disclosing() -> None:
+    """A caret move is not a request for the plaintext back.
+
+    The mask is positional, so a capture left open after the caret moved would
+    append to the value in one place while inserting its cell in another. Asked
+    on ``watch_selection`` because `move_cursor`, a mouse click and an
+    app-set selection all move the caret WITHOUT a caret key being pressed.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type_secret(pilot, editor, "12345")
+        editor.move_cursor((0, 0))
+        await pilot.pause()
+        assert not editor.credential_typing(), "the capture ended"
+        assert "12345" not in editor.text, "and did not write the secret out"
+
+
+@pytest.mark.asyncio
+async def test_the_caret_returning_to_the_token_re_opens_the_capture() -> None:
+    """The span is POSITIONAL: open exactly while the caret is in it.
+
+    Without the reopen, leaving and coming back left an armed token whose next
+    typed character landed in PLAINTEXT — the capture only ever opened on the
+    edit that inserted the space, and that space had already been typed.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        for char in "/credential":
+            await pilot.press(char)
+        await pilot.pause()
+        if editor._picker.is_open():
+            await pilot.press("escape")
+            await pilot.pause()
+        await pilot.press("space")
+        await pilot.pause()
+        editor.move_cursor((0, 0))
+        await pilot.pause()
+        assert not editor.credential_typing()
+        editor.move_cursor(editor._end_of_buffer())
+        await pilot.pause()
+        assert editor.credential_typing(), "back in the span, masking again"
+        for char in "9999":
+            await pilot.press(char)
+        await pilot.pause()
+        assert "9999" not in editor.text
+
+
+@pytest.mark.asyncio
+async def test_an_empty_secret_mints_nothing() -> None:
+    """``/credential `` + Enter advertises no key.
+
+    A zero-length credential would name a key to the model that can never hold
+    anything, and `store_credential` refuses a blank value regardless.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        for char in "/credential":
+            await pilot.press(char)
+        await pilot.pause()
+        if editor._picker.is_open():
+            await pilot.press("escape")
+            await pilot.pause()
+        await pilot.press("space")
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert "[Credential #" not in editor.text
+        assert not credential_payloads(editor.text, editor._attachments)
+
+
+@pytest.mark.asyncio
+async def test_backspacing_the_delimiting_space_backs_out_of_the_gesture() -> None:
+    """Erasing the span and then the space un-terminates the token.
+
+    The two counters cannot disagree about the length: a backspace inside the
+    span retracts the held character AND its cell together.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type_secret(pilot, editor, "12345")
+        for _ in range(5):
+            await pilot.press("backspace")
+        await pilot.pause()
+        assert editor.text == "/credential ", "the cells went with the characters"
+        assert editor.credential_typing(), "still open, just empty"
+        await pilot.press("backspace")
+        await pilot.pause()
+        assert editor.text == "/credential"
+        assert not editor.credential_typing(), "the gesture is withdrawn"
+
+
+@pytest.mark.asyncio
+async def test_a_typed_capture_is_dropped_when_the_buffer_is_replaced() -> None:
+    """History recall, a restored draft and `/clear` must not reveal it.
+
+    Abandoned rather than cancelled: restoring the plaintext into a buffer the
+    operator is navigating AWAY from is the one thing that must never happen.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type_secret(pilot, editor, TYPED_SECRET)
+        editor.clear_content()
+        await pilot.pause()
+        assert not editor.credential_typing()
+        assert TYPED_SECRET not in editor.text
+        assert TYPED_SECRET not in repr(getattr(editor, "_history", []))
+
+
+@pytest.mark.asyncio
+async def test_accepting_the_picker_row_with_enter_arms_and_masks() -> None:
+    """Route 2: Enter accepts the completion; it must not submit the command.
+
+    TWO DIFFERENT ENTERS in one gesture, separated by STATE rather than timing:
+    the picker's accept can only happen while no capture is open, and the mint
+    only once one is. Before this, the accepting Enter ran the command, cleared
+    the buffer, and the operator's next keystrokes were typed into an ordinary
+    unmasked composer.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        submitted: list[str] = []
+        original = editor.post_message
+
+        def _spy(message):  # type: ignore[no-untyped-def]
+            if isinstance(message, EditorSubmitted):
+                submitted.append(message.text)
+            return original(message)
+
+        editor.post_message = _spy  # type: ignore[method-assign]
+        for char in "/credential":
+            await pilot.press(char)
+        for _ in range(4):
+            await pilot.pause()
+        assert editor._picker.is_open(), "precondition: the row is offered"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert not submitted, "accepting a completion must not send"
+        assert editor.text == "/credential ", "the token and its space are inserted"
+        assert editor.credential_typing(), "and that space armed the mask"
+        for char in "12345":
+            await pilot.press(char)
+        await pilot.pause()
+        assert "12345" not in editor.text
+        await pilot.press("enter")
+        await pilot.pause()
+        assert editor.text == "[Credential #1, 5 chars] "
+        assert not submitted, "the mint Enter does not send either"
+
+
+@pytest.mark.asyncio
+async def test_accepting_the_picker_row_with_tab_arms_and_masks() -> None:
+    """Route 2, Tab. Both keys insert the same completion, so both must arm."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        for char in "/credential":
+            await pilot.press(char)
+        for _ in range(4):
+            await pilot.pause()
+        assert editor._picker.is_open()
+        await pilot.press("tab")
+        await pilot.pause()
+        assert editor.text == "/credential "
+        assert editor.credential_typing(), "Tab arms identically to Enter"
+        for char in "12345":
+            await pilot.press(char)
+        await pilot.pause()
+        assert "12345" not in editor.text
+        await pilot.press("enter")
+        await pilot.pause()
+        assert editor.text == "[Credential #1, 5 chars] "
+
+
+@pytest.mark.asyncio
+async def test_pasting_while_armed_still_chips_instantly_in_place() -> None:
+    """The v0.53.0 gesture must not regress.
+
+    The opening space now starts a capture immediately, so a plain
+    ``/credential `` + paste arrives with an OPEN but EMPTY span. That still
+    mints in place rather than being appended and left masked until a further
+    Enter.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        for char in "/credential":
+            await pilot.press(char)
+        await pilot.pause()
+        if editor._picker.is_open():
+            await pilot.press("escape")
+            await pilot.pause()
+        await pilot.press("space")
+        await pilot.pause()
+        app.post_message(events.Paste(SECRET))
+        await pilot.pause()
+        await pilot.pause()
+        assert editor.text == f"[Credential #1, {len(SECRET)} chars] ", "chipped in place"
+        assert SECRET not in editor.text
+
+
+@pytest.mark.asyncio
+async def test_pasting_into_a_partly_typed_span_appends_to_the_same_secret() -> None:
+    """One value, one chip: typing a prefix and pasting the rest is ordinary.
+
+    Two chips would split one credential into two the model cannot recombine.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type_secret(pilot, editor, "abc")
+        app.post_message(events.Paste("def"))
+        await pilot.pause()
+        await pilot.pause()
+        assert editor.text == "/credential " + CREDENTIAL_MASK_CHAR * 6
+        await pilot.press("enter")
+        await pilot.pause()
+        payloads = credential_payloads(editor.text, editor._attachments)
+        assert len(payloads) == 1, "one credential, not two"
+        assert payloads[0].value == "abcdef"

--- a/tests/unit/tui/test_inline_credential.py
+++ b/tests/unit/tui/test_inline_credential.py
@@ -37,6 +37,7 @@ from local_operator.tui.widgets.editor import (
     CREDENTIAL_KEY_PREFIX,
     CREDENTIAL_MASK_CHAR,
     Attachment,
+    CredentialUnredacted,
     Editor,
     EditorSubmitted,
     Marked,
@@ -2192,3 +2193,250 @@ async def test_pasting_into_a_partly_typed_span_appends_to_the_same_secret() -> 
         payloads = credential_payloads(editor.text, editor._attachments)
         assert len(payloads) == 1, "one credential, not two"
         assert payloads[0].value == "abcdef"
+
+
+# -- the exits, and editing inside the span -----------------------------------
+#
+# Every test below covers a state the 95 tests above passed straight through.
+# The empty-span Esc is the sharpest instance: `test_escape_unredacts_the_typed_
+# characters` types "12345" FIRST, so the zero-character case — the one where
+# the cancel had nothing to replace and re-armed itself — was never reached
+# (review round 1, R1). A guard that cannot go red is worse than no guard.
+
+
+@pytest.mark.asyncio
+async def test_escape_on_an_empty_span_actually_ends_the_capture() -> None:
+    """Esc BEFORE any character is typed must exit, not silently re-arm.
+
+    The regression: `_cancel_credential_typing`'s own `replace()` re-entered the
+    edit funnel, which re-derived the arm from a buffer still ending in
+    `/credential ` with the caret still at its end, and re-opened the capture the
+    cancel had just closed. Esc was inert on the exact key the on-screen notice
+    advertises — measured, three presses changed nothing.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type_secret(pilot, editor, "")
+        assert editor.credential_typing(), "precondition: the span is open and empty"
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert not editor.credential_typing(), "Esc ends the capture"
+        assert not editor.credential_armed(), "and the arm with it"
+        assert editor.text == "/credential ", "the token is left as inert text"
+
+
+@pytest.mark.asyncio
+async def test_prose_after_an_empty_span_escape_is_not_captured() -> None:
+    """The consequence the inert Esc had, pinned at the seam it did damage.
+
+    An operator who armed the mode, changed their mind and pressed Esc had their
+    next sentence swallowed: `is broken please fix` became a stored credential
+    and the message never reached the model.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type_secret(pilot, editor, "")
+        await pilot.press("escape")
+        await pilot.pause()
+        for char in "is broken please fix":
+            await pilot.press("space" if char == " " else char)
+        await pilot.pause()
+        assert editor.text == "/credential is broken please fix", "typed as ordinary prose"
+        assert CREDENTIAL_MASK_CHAR not in editor.text, "nothing was masked"
+        assert not credential_payloads(editor.text, editor._attachments), "and nothing minted"
+
+
+@pytest.mark.asyncio
+async def test_escape_with_characters_typed_announces_the_plaintext() -> None:
+    """The unredact is the one exit that ENDS with the secret in the buffer.
+
+    It restores by design (retyping a secret from memory is what an operator
+    cannot do), but the frame after it looks completely ordinary — the amber
+    marker reverts, the masking notice goes — while the next Enter re-commits the
+    original leak. So the exit has to say what it did (design round 1, D1).
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        announced: list[int] = []
+        original = editor.post_message
+
+        def _spy(message):  # type: ignore[no-untyped-def]
+            if isinstance(message, CredentialUnredacted):
+                announced.append(message.length)
+            return original(message)
+
+        editor.post_message = _spy  # type: ignore[method-assign]
+        await _type_secret(pilot, editor, "12345")
+        await pilot.press("escape")
+        await pilot.pause()
+        assert editor.text == "/credential 12345", "the characters came back"
+        assert announced == [5], "and the operator is told they are now plaintext"
+
+
+@pytest.mark.asyncio
+async def test_an_empty_escape_announces_nothing() -> None:
+    """No characters restored, no warning owed — the notice must not cry wolf."""
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        announced: list[int] = []
+        original = editor.post_message
+
+        def _spy(message):  # type: ignore[no-untyped-def]
+            if isinstance(message, CredentialUnredacted):
+                announced.append(message.length)
+            return original(message)
+
+        editor.post_message = _spy  # type: ignore[method-assign]
+        await _type_secret(pilot, editor, "")
+        await pilot.press("escape")
+        await pilot.pause()
+        assert announced == [], "nothing came back, so nothing is announced"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "keys, typed, expected",
+    [
+        # Arrow back two, type two: the obvious way to fix a typo mid-token.
+        (("left", "left"), "xy", "ABCDEFxyGH"),
+        # One arrow back, one character.
+        (("left",), "z", "ABCDEFGzH"),
+        # Home, then a character: the whole span jumped, not one cell.
+        (("home",), "0", None),
+    ],
+)
+async def test_typing_inside_the_span_lands_where_the_operator_sees_it(
+    keys: tuple[str, ...], typed: str, expected: str | None
+) -> None:
+    """The held value is a POSITIONAL MIRROR of the mask cells, not an append.
+
+    The regression (UX round 1, U1): the bullet was inserted AT THE CARET while
+    the value appended to the END, and the capture deliberately stays open
+    anywhere inside the span — so the interaction invited the edit and then
+    mis-applied it. Measured, typed `ABCDEFGH` + `←←` + `xy` stored
+    `ABCDEFGHxy` for an intended `ABCDEFxyGH`: the chip reported the RIGHT
+    length with the WRONG order, so the documented integrity check passed on a
+    value that can never be displayed again to catch it.
+
+    ``expected`` is ``None`` where the caret leaves the span entirely: that is a
+    departure, and the capture closes rather than mis-applying the edit.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type_secret(pilot, editor, "ABCDEFGH")
+        for key in keys:
+            await pilot.press(key)
+        await pilot.pause()
+        if expected is None:
+            assert not editor.credential_typing(), "leaving the span ends the capture"
+            return
+        for char in typed:
+            await pilot.press(char)
+        await pilot.pause()
+        assert editor.text == "/credential " + CREDENTIAL_MASK_CHAR * len(expected)
+        await pilot.press("enter")
+        await pilot.pause()
+        payloads = credential_payloads(editor.text, editor._attachments)
+        assert payloads[0].value == expected, "the stored value is the one typed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "keys, expected",
+    [
+        # Backspace mid-span drops the character BEFORE the caret, not the last.
+        (("left", "left", "backspace"), "ABCDEGH"),
+        # Forward delete drops the one UNDER it.
+        (("left", "left", "delete"), "ABCDEFH"),
+        # Backspace at the end is the ordinary case, and still works.
+        (("backspace",), "ABCDEFG"),
+        # A selection dragged over two cells and deleted takes exactly those two.
+        (("shift+left", "shift+left", "backspace"), "ABCDEF"),
+    ],
+)
+async def test_deleting_inside_the_span_removes_the_character_under_the_caret(
+    keys: tuple[str, ...], expected: str
+) -> None:
+    """Deletion is positional too, by the same mirror and not a second rule.
+
+    Backspace used to drop the LAST held character wherever the caret was, so a
+    backspace between F and G removed H. `delete` and select-and-delete had no
+    handler at all: the mask cell went and the held value did not, leaving the
+    buffer and the value disagreeing about the secret's LENGTH.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type_secret(pilot, editor, "ABCDEFGH")
+        for key in keys:
+            await pilot.press(key)
+        await pilot.pause()
+        assert editor.text == "/credential " + CREDENTIAL_MASK_CHAR * len(expected)
+        await pilot.press("enter")
+        await pilot.pause()
+        payloads = credential_payloads(editor.text, editor._attachments)
+        assert payloads[0].value == expected, "the stored value is the one left on screen"
+
+
+@pytest.mark.asyncio
+async def test_selecting_inside_the_span_and_typing_replaces_those_characters() -> None:
+    """Select-and-replace is one edit, and the mirror applies it as one.
+
+    `insert()` ignores the selection, so a printable key over a selection left
+    the selected mask cells in the buffer and appended a third — the buffer and
+    the held value then disagreed on LENGTH, not merely order.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _type_secret(pilot, editor, "ABCDEFGH")
+        await pilot.press("shift+left")
+        await pilot.press("shift+left")
+        await pilot.press("Z")
+        await pilot.pause()
+        assert editor.text == "/credential " + CREDENTIAL_MASK_CHAR * 7
+        await pilot.press("enter")
+        await pilot.pause()
+        payloads = credential_payloads(editor.text, editor._attachments)
+        assert payloads[0].value == "ABCDEFZ", "GH was replaced by Z, in place"
+
+
+@pytest.mark.asyncio
+async def test_the_typing_notice_keeps_its_way_out_at_every_width() -> None:
+    """The exit is kept by a LADDER, not by a comment asserting it must be.
+
+    `CREDENTIAL_TYPING_NOTICE`'s own docstring said "Esc cancels" was "exactly
+    the half that must not be the part that crops" — and measured on the real
+    app it was the FIRST thing to crop, lost at 68 columns while `chip` went at
+    56 (design round 1, D2; UX round 1, U3; review round 1, R3). Prose asserting
+    an invariant is not a mechanism enforcing it, so this pins the mechanism at
+    the widths the sweep named.
+    """
+    session = FakeSession()
+    for width in (45, 56, 60, 66, 68, 69, 80, 120):
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(width, 24)) as pilot:
+            await _boot(pilot, app)
+            editor = app._editor()
+            editor.focus()
+            await _type_secret(pilot, editor, "hunter2-typed-test")
+            for _ in range(3):
+                await pilot.pause()
+            painted = _painted(app).replace("\xa0", " ")
+            assert "Esc cancels" in painted, f"the way out crops at {width} columns"
+            assert (
+                "Enter chips" in painted or "Enter turns it into a chip" in painted
+            ), f"and the key that ENDS the entry is gone at {width} columns"


### PR DESCRIPTION
# PR Description

## Summary of Changes

**`/credential` shipped in v0.53.0 with a clipboard path and no typed path at all.** `Editor._capture_credential` had exactly one call site — inside `_on_paste`. So typing the obvious human gesture:

```
/credential 12345
```

produced **no chip**. The line fell through to the legacy `/credential <KEY>` slash command with the **secret as its key argument**, and the app answered *"Paste the value for 12345"* — with the secret rendered into the transcript in plaintext. No chip, no error, no warning.

That is the exact outcome the feature was built to prevent, and it happened silently. This PR treats it as a **security defect**, not a UX gap.

### The state machine

The space after the token is the boundary that opens the masked span:

```
token typed or completed   ──▶  ARMED
ARMED + SPACE              ──▶  TYPING   (characters masked as typed)
TYPING + printable         ──▶  held out of the document, one mask cell painted
TYPING + Enter             ──▶  chip minted; operator stays in the composer
TYPING + Esc               ──▶  unredacted: the characters come back as text
ARMED + paste              ──▶  chip in place, instantly (unchanged)
```

**Both entry routes are the same keystroke by construction.** A hand-typed space and the trailing space `_apply_command` inserts when a picker row is accepted are the same character at the same offset, so the capture opens on the **shared edit funnel** rather than at either call site — the two routes are identical structurally instead of by two code paths agreeing. The separating space is a delimiter, so `K` counts the secret alone.

**Two different Enters, separated by STATE rather than timing.** While the picker is open, Enter accepts the completion; once a capture is open, Enter mints the chip. Exactly one of those states holds at any instant, which is what makes them impossible to confuse. `Editor.arms_a_capture` stops the accepting Enter from *also* running the command — before this, it ran `/credential`, cleared the buffer, and dropped the operator into an unmasked composer mid-secret.

**Enter ends the secret; it does not submit.** The gesture is "hand over a secret and then describe it", so an Enter that also sent the message would make the description impossible to write. A second Enter sends.

### The core safety property

**The secret is held out of the document.** Characters typed while a capture is open never enter `self.text`; they accumulate in `Editor._credential_typed` while the buffer receives `CREDENTIAL_MASK_CHAR` cells. The mask is deliberately **not** a render-time effect over real characters: every disclosure seam (history, the draft store, undo, `ctrl+o`, the submit path) reads the buffer, so a document that never held the secret closes all of them at once rather than one at a time.

## Related Issue(s)

- Related: the inline `/credential` capture shipped in v0.53.0; this closes the typed half of §11 in `docs/design/secret-store.md` (new §11.1).

## Impact

**Security: closes a plaintext secret disclosure.** Three reproduced leaking routes, not one.

**One behaviour change, corrected in remediation round 1.** The typed
`/credential <KEY>` form is **retired**: the space now always opens a masked
capture, so a hand-typed key name is minted as a short secret rather than
reaching the `<KEY>` prompt. This PR originally claimed the bare form "still
dispatches exactly as it always has" — QA measured that to be true only of the
**pasted** route, so the claim was wrong and is withdrawn (QA round 1, Q1). The
command is still *parsed*, so a pasted whole line and the viewer→owner route
work unchanged; nothing advertises it as typable any more. A leading `-` escapes
the mask so `--forget-all` stays typable. The paste path is unchanged and still
chips instantly in place.

**No dependency updates. No version bump** — `pyproject.toml` stays at the last released version for the window owner.

### A trap worth recording

Found by a leak audit, **not** by a test — and this is the reason the audit exists. Textual spells punctuation keys as *words* (`minus`, `full_stop`, `plus`), so a handler gated on `len(event.key) == 1` masks letters and digits while **every punctuation character falls straight through into the document**. Measured, the canary `zQ7-TYPED-LEAK-CANARY-4417` rendered as:

```
•••-TYPED-LEAK-CANARY-4417
```

The first hyphen ended the masking and the rest of the secret was typed in plaintext and submitted. Real credentials are mostly punctuation, so that gate leaked nearly every *actual* secret while passing against an alphanumeric test value. The fix gates on `event.is_printable`; `test_every_printable_character_is_masked_not_only_alphanumerics` pins it.

### Guidance surfaces

The operator asked for the tooltips to reflect the real gesture. Updated: the command-picker description, the composer placeholder, the armed notice, a new typing notice, and `CREDENTIAL_USAGE`.

The picker description **leads with the gesture** because that row ellipsizes its
**tail** at ~47 cells — the old copy rendered as `Hand the agent a secret it can
use but never re…`, dropping its own verb. The "verified at 80 and 100 columns"
claim first made here was **too strong** and is withdrawn: design and QA both
measured the replacement still cropping before its own promise at *every* width
including 120, and the budget is not monotonic in width because the transcript
gutter indents the row more as the terminal grows (D5/Q2). Shortened in
remediation round 1 to `Type or paste a secret after a space; masked`, which
paints whole from 80 columns up and names the SPACE (U5).

## Testing Details

> A green test is not evidence here. **Every red was proven before any green was trusted**, by reverting the behaviour and confirming the test fails.

### RED — reproduced by TYPING on `origin/main`, before any change

Driving the real `OperatorApp` with keystrokes (no paste on the typed routes):

| Route | `origin/main` result | Secret in submitted text? |
|---|---|---|
| `/credential` + space + `12345` + Enter | no chip; `'/credential 12345'` submitted | **YES — LEAK** |
| `/credential` + **Enter** (accept row) + `12345` | ran the command, then `'12345'` submitted | **YES — LEAK** |
| `/credential` + **Tab** (accept row) + `12345` | `'/credential 12345'` submitted | **YES — LEAK** |
| paste while armed | `[Credential #1, 5 chars]` | no (already worked) |

### GREEN — the same gestures after the change

| Route | Armed frame | After Enter | Verdict |
|---|---|---|---|
| hand-typed space | `/credential •••••` | `[Credential #1, 5 chars] ` | clean |
| Enter-accepted completion | `/credential •••••` | `[Credential #1, 5 chars] ` | clean |
| Tab-accepted completion | `/credential •••••` | `[Credential #1, 5 chars] ` | clean |
| Esc after typing | `/credential •••••` | restores `/credential 12345` | clean (unredacts by design) |
| paste while armed | — | `[Credential #1, 5 chars] ` | clean (no regression) |

### Leak audit — every artifact, grepped for the literal value

Canary `zQ7-TYPED-LEAK-CANARY-4417`, typed, chipped, described and **submitted**:

```
masked frame : '/credential ••••••••••••••••••••••••••'
submitted    : ['[Credential #1, 26 chars] this is the staging key']

  clean  armed composer frame        clean  prompt history
  clean  composer after submit       clean  editor draft stash
  clean  submitted text              clean  transcript rows
  clean  session messages
  (6 files scanned under an isolated HOME — none contained it)

chip reached the model instead: True
stored under generated key(s) : ['LOP_SECRET_4ZNA7JWW']
=> PASS
```

This audit is what caught the punctuation leak: an earlier build reported `PASS` on an alphanumeric secret and `FAIL` here.

### Edge states — each decided deliberately, driven on the real app

| State | Decision | Verified |
|---|---|---|
| `K` vs the delimiting space | space is a delimiter, not the secret | `5 chars`, value `12345` |
| space **inside** the span | part of the secret (passphrases) | `correct horse battery staple` round-trips |
| bare `/credential <KEY>` | retired for TYPING; still reached by a pasted line | pasted: line intact, no chip minted; typed: `[Credential #1, 5 chars]` |
| Enter semantics | ends the secret only | prose typed around the chip, nothing sent |
| empty secret + Enter | mints nothing | no chip, no zero-length key |
| backspace past the token | backs out of the gesture | cells retract with the characters |
| caret leaves the span | capture ends, **no** disclosure | asked on `watch_selection` |
| caret returns | capture **re-opens** (positional) | next char masked again |
| edit INSIDE the span | held value spliced **positionally** (r1: U1) | `ABCDEFGH` `←←` `xy` stores `ABCDEFxyGH` |
| Esc on an EMPTY span | ends the mode; prose after is **not** captured (r1: R1/U2) | `typing=False`, `armed=False` |
| Esc after typing | unredacts **and warns** it is now plaintext (r1: D1) | `18 characters are now PLAIN TEXT…` |
| history recall while typing | value dropped, never written out | secret absent |
| second `/credential` | two distinct captures | 2 keys, both chipped |
| `shift+enter` | ends the capture | offsets stay coherent |
| `--forget-all` | leading `-` escapes the mask | typed verbatim |
| prose after the token | masks; **Esc restores in one keystroke** | accepted cost, argued below |

**The one accepted cost.** Prose typed after the token — `fix the /credential command` — is masked, because no rule keyed on the buffer can separate it from `deploy with /credential the prod key`, which **must** stay armed (design round 1, D2 — the existing code says so explicitly and I have not contradicted it). The mask is loud, immediate, and Esc restores the text in one keystroke: the false-positive direction. The alternative fails toward a plaintext secret in scrollback that nothing can recall.

### Automated tests

**19 new tests** in `tests/unit/tui/test_inline_credential.py`, all typed-path. Each was **proven RED first**: with the masking branch neutered, 7 of the headline tests fail; with the punctuation bug reintroduced verbatim, the 2 punctuation tests fail.

```
tests/unit/tui/test_inline_credential.py .... 95 passed
tests/unit/tui/test_credential_command.py ..  9 passed
```

Three **existing** tests were updated rather than worked around: they asserted the ARMED notice in a state that is now legitimately TYPING (which has its own, more specific string), and one helper now presses Esc where prose-after-token masks. Each change is commented with why.

### Gates

```
flake8                     clean
black --check (26.1.0)     clean
isort --check-only         clean
pyright (1.1.411)          0 errors, 0 warnings
```

Whole-tree unit run reached `[100%]` with no failures. **Note for the reviewer:** that run's summary was replaced by `conftest.py`'s real-store tripwire (`REAL SESSION STORE SHRANK…`), which fired on a directory snapshot while 16 other `lop` sessions were live on this machine. It is **not** attributable to this change — the guard monkeypatches every deletion primitive to *raise* in-process (no such error occurred), and this diff contains no deletion call of any kind. Reported separately.

### Visual validation

Frames captured from the **real `OperatorApp`** via `scripts.visual_capture.save_capture` (the host that loads the stylesheet), rendered and inspected — not eyeballed as markup. Before-frames taken from a throwaway `origin/main` worktree. Attached in a follow-up comment: before/after for the masked state, the chip, the picker description, plus the Esc cancel, both completion routes, the paste path, and an 80-column narrow check.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.


