### PR TITLE
chore(release): bump version to 0.53.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.53.3"
+version = "0.53.4"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release lock for the post-v0.53.3 window. `pyproject.toml` only, one line.

## Window

Re-derived from `origin/main` after a second PR landed, and this PR was rebased onto it:

- Last tag: **v0.53.3**
- `git log v0.53.3..origin/main` → two commits, merged 26 minutes apart, so both are in the same ~60-minute window

| PR | Merge SHA | Impact |
|---|---|---|
| [#861](https://github.com/damianvtran/local-operator/pull/861) | `1e595859f` | declares the viewer surface and the runtime-role predicates the TUI was duck-typing against, plus an AST guard that fails when a host reaches an undeclared session member |
| [#873](https://github.com/damianvtran/local-operator/pull/873) | `273e8d1fd` | `/analytics` no longer freezes on open and on every terminal resize against a large ledger; subagent rows collapse behind a per-session disclosure |

Verified that `273e8d1fd` does not touch `pyproject.toml` (`git show 273e8d1fd --stat` returns no match) — its branch carried a stale base at `0.52.15`, so the check mattered: a squash that *had* touched the file could have rolled main's version backwards. `origin/main` reads `0.53.3` immediately before this bump.

## Bump class: PATCH

**#861** is additive declarations only: no call-site substitution, no behaviour change, nothing a consumer observes differently on upgrade. QA proved it at AST level — three predicates added per class, zero removed, zero existing method bodies changed, and the only removed production lines are two in-place import widenings. Its `feat:` prefix describes the commit's shape, not its blast radius; letting the prefix decide the bump would make the version number a restatement of the commit message rather than an independent signal.

**#873** is a perf fix plus a keyboard affordance on one existing overlay: no API, no schema, no wire or protocol change, no migration.

Neither clears the step-function bar. Sixteen peers were asked to argue MINOR if they disagreed; every reply reached PATCH independently, and #873's owner argued PATCH for its own change unprompted.

## What rides in it

**#861** — the operator asked whether `Session` (11,567 lines) and `RemoteSession` (5,028) should be unified, since "remote" lost its meaning once every interface runs on a detached runtime. Two independent architects said **no**, with measurements: of 46 shared method names only 2 have structurally identical bodies; `Session` has 0 lines of socket code and `RemoteSession` 0 lines of compaction; genuinely-shared-concern-implemented-twice is ~0.3% of 16,595 lines.

What *was* wrong is that the TUI programs against a viewer surface that was never declared — reached by `getattr` duck-probes and 16 `isinstance(RemoteSession)` checks, one of which raises. This declares it as `ViewerSessionProtocol`, declares the three predicates replacing `is_remote`'s four conflated meanings, and adds an AST guard.

**The guard is the point, and it took four rounds to make honest.** It pins scanned paths, bindings, *and* per-(host, binding) pairs, and asserts owner-presence so a member existing on neither class cannot be laundered through an exclusion set. The rounds found five undeclared members escaping in live code — including two hard accesses from `server/utils/desktop_sessions.py` that would raise `AttributeError` on rename, and `subagent_comms` in `/info`, the very host whose past outage motivated the work.

**If you add a session member a host calls, declare it on `SessionProtocol` or `ViewerSessionProtocol` or the guard will fail your PR.** That is deliberate: three duration-rendering bugs shipped from this subsystem, each surviving review because the broken path was one nobody exercised.

**#873** — the "By session" table flattened the whole forest into ~2,300 lines and ~11,500 style spans in one `Static`, rebuilt on every repaint, with `on_resize` repainting unconditionally. On the operator's real ledger that was 2,240 rows, of which 1,637 were subagent children while only 103 of 595 roots had any children at all. Interleaved A/B: first paint ~3-4x faster, resize ~4x, toggle ~2.6x. Root rows already carried subtree totals, so collapsing loses no cost information.

## Gate on the released content

- **#861:** agent review rounds 1–4 and QA rounds 1–4, both TERMINAL/CLEAN and fresh on the merged head `9d949ea6b`, 17/17 CI green.
- **#873:** four independent streams — agent review, QA, design and UX — all TERMINAL/CLEAN and fresh on the merged head `a16bb2fdd`, 16/16 CI green (the paths-gated `mobile-web.yml` correctly did not fire for a Python-only diff).

Both had reviewers independent of the author.

## Ownership

Announced to sixteen live peers before cutting; all who replied yielded and none contested PATCH. #873's owner reported its merge into this window with its SHA and bump class rather than tagging separately.

## Scope check

One line in `pyproject.toml` (`0.53.3` → `0.53.4`). No source, test, or workflow file touched, so the C0 one-file scope check is the appropriate gate.

Note on flaky shards: five tests on `main` are clock/PID-registry races unreachable from a version diff — `test_word_caret.py`, two in `test_stop_command.py`, `test_resume_subagents_todos.py::test_snapshot_entry_is_written_for_a_launched_child`, and `test_provider_client.py::…session_names` (which failed once on this PR and passed on re-run). A single red shard warrants a re-run, not an investigation.