### PR TITLE
fix(session): keep a degraded canonical delta from killing the attach socket

### DIFF
--- a/docs/evidence/degraded-frontend-update/after.txt
+++ b/docs/evidence/degraded-frontend-update/after.txt
@@ -1,0 +1,9 @@
+attached; viewer title='fake'
+session runtime: frontend_update frame is 1528063 bytes, over the 1048576-byte socket line limit; relaying a degraded placeholder instead of killing the connection (the viewer recovers this state through frontend_sync + durable history)
+session s1: owner degraded canonical delta fake-owner/1 (A live update was too large to send and was dropped; the view refreshes from the session's own history.); re-syncing canonical state from the owner's snapshot
+connection alive        : True
+owner  title/seq        : 'post-degrade title' / 1
+viewer title/seq        : 'post-degrade title' / 1
+viewer catalogue rows   : 3426
+state matches owner     : True
+stream still live after : 'still streaming'

--- a/docs/evidence/degraded-frontend-update/before.txt
+++ b/docs/evidence/degraded-frontend-update/before.txt
@@ -1,0 +1,12 @@
+attached; viewer title='fake'
+session runtime: frontend_update frame is 1528021 bytes, over the 1048576-byte socket line limit; relaying a degraded placeholder instead of killing the connection (the viewer recovers this state through frontend_sync + durable history)
+attach client: owner frame could not be applied: 1 validation error for FrontendUpdate
+changes
+  Field required [type=missing, input_value={'epoch': 'fake-owner', '...session's own history."}, input_type=dict]
+    For further information visit https://errors.pydantic.dev/2.13/v/missing; the connection cannot continue
+connection alive        : False
+owner  title/seq        : 'post-degrade title' / 1
+viewer title/seq        : 'fake' / 0
+viewer catalogue rows   : 0
+state matches owner     : False
+stream still live after : 'fake'

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -1740,10 +1740,21 @@ class FrontendUpdate(BaseModel):
     them would leave a follower permanently stale with a gap check that stays
     happy forever, since the sequence number was consumed either way.
 
-    ``changes`` therefore defaults to empty instead of carrying a validator that
-    demands it whenever ``degraded`` is false. A stricter model would raise on
-    exactly the transport seam whose raised exception is the bug being fixed;
-    the flag carries the semantics, and the receiver decides.
+    ``changes`` is therefore OPTIONAL ON A DEGRADED FRAME AND REQUIRED ON EVERY
+    OTHER ONE, enforced by ``_changes_required_unless_degraded`` below. Relaxing
+    it unconditionally would have re-created the very defect this class is being
+    fixed for: a frame that misspells the key (``chnages``) — the model allows
+    extras — would validate as an empty change set, apply as "nothing moved",
+    consume a sequence and keep the gap check satisfied forever, with no log and
+    no ``degraded`` flag to ask about. That is silent drift from a different
+    cause, which is a strictly worse failure than the loud one it replaces.
+
+    Refusing a malformed frame is NOT the same as tearing down the socket over
+    a degraded one. The degrade path now labels its own frame, so the frame this
+    validator rejects is one claiming to be a complete delta while carrying no
+    body — which no correct owner emits. The receiver refuses it and re-syncs
+    (``RemoteSession._on_frontend_update``), which is the recovery the transport
+    already has for a gap. Staying loud is what keeps that recovery reachable.
     """
 
     model_config = ConfigDict(extra="allow")
@@ -1764,6 +1775,25 @@ class FrontendUpdate(BaseModel):
     # while duplicating rows in its click-through view.
     job_trajectory_replacements: list[str] = Field(default_factory=list)
     job_todo_updates: dict[str, list[dict[str, Any]] | None] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _changes_required_unless_degraded(cls, data: Any) -> Any:
+        """Only a DEGRADED frame may omit its body.
+
+        Scoped rather than blanket-permissive: ``model_config`` allows extras,
+        so without this a typo'd key silently becomes an empty change set that
+        consumes a sequence and drifts the follower — the same shape as the
+        defect this class is being fixed for. A normal delta always carries
+        ``changes`` (``mutate`` returns ``None`` rather than emitting an empty
+        one), so requiring it here rejects only frames no correct owner sends.
+        """
+        if isinstance(data, dict) and "changes" not in data and not data.get("degraded"):
+            raise ValueError(
+                "frontend update omits 'changes' without the 'degraded' flag; "
+                "only a degraded frame may shed its body"
+            )
+        return data
 
 
 # One watched plan must not take down the 1 MiB control stream. Larger plans

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -1723,13 +1723,39 @@ class FrontendUpdate(BaseModel):
     consumed only when canonical fields actually change, so any missing number
     is a real transport gap and forces a fresh snapshot rather than being
     mistaken for intentional coalescing.
+
+    A DEGRADED delta is the one case where the body is absent by design. The
+    runtime's ``relay_frame_or_degraded`` sheds an oversized payload and keeps
+    only the sequencing fields, because killing the socket over one delta costs
+    the session while dropping the delta costs one animation step. That frame
+    still has to VALIDATE here: ``changes`` was required, so the follower's
+    ``model_validate`` raised and ``AttachClient._pump``'s catch-all tore the
+    connection down anyway — the guard defeated one layer below itself.
+
+    ``degraded`` is an explicit field rather than an inference from an empty
+    ``changes`` because downstream code must be able to ASK whether a body was
+    shed. The two are NOT equivalent: an empty change set means "nothing moved"
+    and is safe to apply, while a shed body means canonical state has genuinely
+    drifted and the follower owes itself a fresh ``frontend_sync``. Collapsing
+    them would leave a follower permanently stale with a gap check that stays
+    happy forever, since the sequence number was consumed either way.
+
+    ``changes`` therefore defaults to empty instead of carrying a validator that
+    demands it whenever ``degraded`` is false. A stricter model would raise on
+    exactly the transport seam whose raised exception is the bug being fixed;
+    the flag carries the semantics, and the receiver decides.
     """
 
     model_config = ConfigDict(extra="allow")
 
     epoch: str
     sequence: int
-    changes: dict[str, Any]
+    changes: dict[str, Any] = Field(default_factory=dict)
+    #: The owner shed this delta's body to keep the line under the socket limit.
+    #: Sequencing is still authoritative; the FIELDS are not, so a receiver must
+    #: re-snapshot rather than treat the empty body as "nothing changed".
+    degraded: bool = False
+    degraded_reason: str = ""
     job_trajectory_appends: dict[str, list[dict[str, Any]]] = Field(default_factory=dict)
     # Jobs whose appended events are a REPLACEMENT, not a suffix. The owner's
     # ``AsyncJob.trajectory`` evicts oldest past ``subagent.TRAJECTORY_CAP``, so
@@ -2798,9 +2824,31 @@ class FrontendStateStore:
             subscriber(update.model_copy(deep=True))
 
     def apply_update(self, update: FrontendUpdate) -> FrontendSessionState:
-        """Apply one already-validated ordered delta from an owner."""
+        """Apply one already-validated ordered delta from an owner.
+
+        A DEGRADED delta advances the sequence and touches nothing else. The
+        owner shed the body to keep the line under the socket limit, so the
+        fields it carried are unknown here — not unchanged. Rebuilding the
+        payload from an empty ``changes`` would be indistinguishable from a
+        no-op delta and would leave the store quietly wrong, so the only honest
+        local action is to keep what we have and let the sequence advance in
+        step with the owner's.
+
+        The sequence MUST still advance: the owner consumed that number, and
+        refusing it here would desynchronise this store from the transport's
+        gap check and refuse every later delta. Recovering the shed fields is
+        the SUBSCRIBER's job — ``RemoteSession`` forces a fresh ``frontend_sync``
+        off the same flag — which is why the delta is still published below: an
+        in-process subscriber and the resync path must see the same event, or
+        the two disagree about whether state is trustworthy.
+        """
         if update.epoch != self._state.epoch or update.sequence != self._state.sequence + 1:
             raise ValueError("frontend update is not the next state sequence")
+        if update.degraded:
+            self._state = self._state.model_copy(update={"sequence": update.sequence})
+            for subscriber in list(self._subscribers):
+                subscriber(update.model_copy(deep=True))
+            return self.state
         changes = copy.deepcopy(update.changes)
         if "jobs" in changes:
             previous = {job.id: job for job in self._state.jobs}

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -616,6 +616,12 @@ class RemoteSession:
         self._display_revision = 0
         self._loaded_history_generation = 0
         self._display_window_supported = False
+        #: A degraded canonical delta is owed a fresh snapshot. Separate from
+        #: ``_display_invalidated`` because that flag is about display history
+        #: and is gated on a windowed-history owner; this one is about canonical
+        #: FIELDS and applies to every follower. See
+        #: ``_resync_after_degraded_delta``.
+        self._frontend_resync_pending = False
         self._frontend_refresh_cut: tuple[str, int] | None = None
         self._hydrated_once = False
         self._display_history: DisplayHistoryWindow | None = None
@@ -2619,6 +2625,53 @@ class RemoteSession:
 
             task.add_done_callback(finished)
 
+    def _resync_after_degraded_delta(self) -> None:
+        """Force a canonical re-snapshot after the owner shed a delta's body.
+
+        Deliberately NOT ``_invalidate_display_history``, even though it shares
+        that method's task and lock. That one returns early unless
+        ``_display_window_supported``, because it exists for DISPLAY history
+        drift — and a degraded delta drops canonical FIELDS (roster, usage,
+        gates), which every follower has whether or not it negotiated a windowed
+        history. Gating this on that flag would leave legacy and full-replay
+        viewers permanently stale on exactly the frame this fix is about.
+
+        It reuses ``_refresh_display_history`` rather than adding a second
+        recovery path so there is one place that captures a cut, buffers live
+        deltas and installs them in order. That method re-snapshots the whole
+        canonical state through ``frontend_sync``, which is a superset of what a
+        shed body could have carried.
+
+        A BURST OF DEGRADED FRAMES MUST NOT BECOME A REFRESH STORM. Two existing
+        mechanisms already bound it and are reused rather than duplicated: the
+        task slot is only refilled when the previous refresh has finished, and
+        ``_refresh_display_history`` loops on ``_display_invalidated`` under its
+        lock, so frames that arrive mid-refresh fold into at most one further
+        pass instead of one sync each. Deltas arriving during the refresh are
+        buffered and replayed, and the refresh cut discards those the snapshot
+        already covers.
+        """
+        self._frontend_resync_pending = True
+        self._display_revision += 1
+        task = self._display_refresh_task
+        if task is not None and not task.done():
+            # A refresh is already running; it re-reads the flag above under its
+            # lock and folds this frame into at most one further pass.
+            return
+        task = asyncio.create_task(self._refresh_display_history())
+        self._display_refresh_task = task
+
+        def finished(done: asyncio.Task[None]) -> None:
+            if not done.cancelled() and done.exception() is not None:
+                # The socket may already be gone (this runs off a frame the pump
+                # delivered). Log rather than raise into the task's context: the
+                # invalidation fence stays closed, so a reconnect re-syncs.
+                logger.warning(
+                    "canonical re-sync after a degraded delta failed: %s", done.exception()
+                )
+
+        task.add_done_callback(finished)
+
     async def ensure_display_current(self) -> None:
         task = self._display_refresh_task
         if task is not None:
@@ -2636,13 +2689,19 @@ class RemoteSession:
         """
         async with self._display_refresh_lock:
             self._display_invalidated = True
-            while self._display_invalidated:
+            while self._display_invalidated or self._frontend_resync_pending:
                 client = self._client
                 if client is None or not client.connected:
                     raise ConnectionError("history owner is unavailable")
                 self._ready_for_events = False
                 self._owner_ready.clear()
                 self._pending_frontend_updates = []
+                # Cleared BEFORE the capture, so a degraded delta that lands
+                # while this pass is in flight (buffered here, replayed by
+                # ``_install_frontend``) re-arms the flag and earns another
+                # pass. Clearing it after would swallow exactly the frame that
+                # raced the snapshot it is not covered by.
+                self._frontend_resync_pending = False
                 try:
                     frontend = FrontendSync.model_validate(await client.frontend_sync())
                     if (
@@ -2659,6 +2718,12 @@ class RemoteSession:
                         self._read_state_field("history_generation")
                         != self._loaded_history_generation
                     )
+                    # A degraded delta replayed during this pass carries a
+                    # sequence the snapshot did not cover, so its fields are
+                    # still missing. Folded into ONE further pass rather than
+                    # spawning a second task — this is the burst bound.
+                    if self._frontend_resync_pending:
+                        self._display_invalidated = True
                     self._finish_sync()
                 except BaseException:
                     # The transport remains usable even when this read fails.
@@ -3135,6 +3200,22 @@ class RemoteSession:
             raise ConnectionError("frontend update arrived before synchronization")
         state = self._frontend_store.apply_update(update)
         self._apply_frontend_facades(state)
+        if update.degraded:
+            # The owner shed this delta's body to keep the line under the socket
+            # limit. The sequence was consumed on both sides, so the gap check
+            # stays satisfied forever while our canonical fields are missing
+            # whatever that frame carried — a silent, permanent drift. The only
+            # cure is the fresh snapshot the degrade path already promises.
+            logger.warning(
+                "session %s: owner degraded canonical delta %s/%d (%s); "
+                "re-syncing canonical state from the owner's snapshot",
+                self._session_id,
+                update.epoch,
+                update.sequence,
+                update.degraded_reason or "no reason given",
+            )
+            self._resync_after_degraded_delta()
+            return
         if state.history_generation != self._loaded_history_generation:
             self._invalidate_display_history()
 

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -371,6 +371,31 @@ _BIND_RETRY_INITIAL_S = 0.1
 _BIND_RETRY_FACTOR = 1.7
 _BIND_RETRY_DELAY_CAP_S = 0.5
 
+#: Backoff for RETRYING the canonical re-sync a degraded delta owes, when that
+#: re-sync fails against a socket that is still up (the owner busy, a transient
+#: RPC error). Retrying is not optional bookkeeping: the degraded frame consumed
+#: a sequence, so the follower's gap check stays satisfied forever while its
+#: canonical fields are missing whatever that frame carried. Giving up after one
+#: attempt leaves a LIVE connection showing WRONG data with nothing on screen
+#: saying so — strictly worse than a dropped one, which at least re-syncs on
+#: reconnect.
+#:
+#: Retries continue while the socket is alive rather than stopping at a fixed
+#: attempt count, because the debt does not expire: nothing else on a non-TUI
+#: follower (``cli.py``, ``session_factory.py``, the desktop bridge) ever calls
+#: ``ensure_display_current`` to notice. The CAP is what keeps that from being a
+#: storm — a persistently failing owner is retried once per
+#: ``_DEGRADED_RESYNC_RETRY_CAP_S``, not in a tight loop — and a dead or swapped
+#: client ends it outright, since a reconnect re-syncs from scratch.
+#:
+#: The initial delay is deliberately not zero: the common cause of a failed pass
+#: is an owner too busy to answer (the nine-subagent session that produced the
+#: oversized frame in the first place), and an immediate retry asks the same
+#: overloaded loop the same question.
+_DEGRADED_RESYNC_RETRY_INITIAL_S = 0.5
+_DEGRADED_RESYNC_RETRY_FACTOR = 2.0
+_DEGRADED_RESYNC_RETRY_CAP_S = 8.0
+
 #: What a viewer says when its socket is alive, authenticated, and the owner
 #: has still not produced the canonical sync. Deliberately NOT "owner did not
 #: send frontend synchronization": the viewer cannot observe what the owner
@@ -622,6 +647,11 @@ class RemoteSession:
         #: FIELDS and applies to every follower. See
         #: ``_resync_after_degraded_delta``.
         self._frontend_resync_pending = False
+        #: The pending BACKOFF timer for a re-sync that failed against a live
+        #: socket. Held so ``dispose`` can cancel it: the debt outlives one
+        #: attempt, so without a retry a single transient RPC failure leaves the
+        #: follower permanently stale behind a satisfied gap check.
+        self._degraded_resync_retry_task: asyncio.Task[None] | None = None
         self._frontend_refresh_cut: tuple[str, int] | None = None
         self._hydrated_once = False
         self._display_history: DisplayHistoryWindow | None = None
@@ -2642,35 +2672,123 @@ class RemoteSession:
         canonical state through ``frontend_sync``, which is a superset of what a
         shed body could have carried.
 
-        A BURST OF DEGRADED FRAMES MUST NOT BECOME A REFRESH STORM. Two existing
-        mechanisms already bound it and are reused rather than duplicated: the
-        task slot is only refilled when the previous refresh has finished, and
-        ``_refresh_display_history`` loops on ``_display_invalidated`` under its
-        lock, so frames that arrive mid-refresh fold into at most one further
-        pass instead of one sync each. Deltas arriving during the refresh are
-        buffered and replayed, and the refresh cut discards those the snapshot
-        already covers.
+        DEGRADED FRAMES ARRIVING DURING A REFRESH FOLD INTO ONE FURTHER PASS.
+        Two existing mechanisms provide that and are reused rather than
+        duplicated: the task slot is only refilled when the previous refresh has
+        finished, and ``_refresh_display_history`` loops on
+        ``_display_invalidated`` under its lock. Deltas arriving during the
+        refresh are buffered and replayed, and the refresh cut discards those
+        the snapshot already covers.
+
+        That bound is IN-FLIGHT COALESCING, not a rate limit, and the difference
+        is worth stating because the docstring here used to overclaim it. Frames
+        spaced further apart than one refresh takes each get their own sync:
+        measured over a real socket, 20 oversized frames cost 1 sync back to
+        back and 20 syncs at 50 ms apart. That is the correct behaviour rather
+        than a gap — each of those frames shed state a completed snapshot did
+        not cover, so skipping its sync would leave the follower stale, which is
+        the bug this method exists for. What must never happen is one sync per
+        frame while a refresh is ALREADY running, which is what the slot
+        prevents. Cost is bounded by the refresh round trip (~2 s for the 20
+        paced frames above) on a session already shedding 1.5 MB deltas.
         """
         self._frontend_resync_pending = True
-        self._display_revision += 1
+        # NOT ``_display_revision += 1``. That counter is a TUI cache key
+        # (``app.py`` drops cached sidebar presentations and raises
+        # ``PreparationInvalidated`` on it), and its invariant is that both
+        # terms move only on DURABLE CONTENT. Bumping it per degraded frame
+        # invalidated ~20x per burst while only one history reload happened —
+        # the RPCs coalesced but the invalidation did not, moving the refresh
+        # storm one layer up instead of removing it. ``_load_frontend_history``
+        # already bumps it once per actual reload, which is the event the
+        # counter names.
+        self._cancel_degraded_resync_retry()
         task = self._display_refresh_task
         if task is not None and not task.done():
             # A refresh is already running; it re-reads the flag above under its
             # lock and folds this frame into at most one further pass.
             return
+        self._start_degraded_resync(prior_delay=0.0)
+
+    def _cancel_degraded_resync_retry(self) -> None:
+        """Drop a scheduled retry that a fresh attempt supersedes."""
+        retry = self._degraded_resync_retry_task
+        if retry is not None and not retry.done():
+            retry.cancel()
+        self._degraded_resync_retry_task = None
+
+    def _start_degraded_resync(self, *, prior_delay: float) -> None:
+        """Run one re-sync pass NOW, re-arming and scheduling a retry if it fails.
+
+        The failure path is the whole point. ``_frontend_resync_pending`` is
+        cleared BEFORE the capture inside ``_refresh_display_history`` (so a
+        frame racing the snapshot earns another pass), and that method re-raises
+        on failure — so without re-arming here, a single transient failure
+        leaves the flag false, the debt forgotten, and the follower showing
+        stale fields behind a gap check that agrees with the owner forever.
+        Reproduced: one injected ``ConnectionError`` left a live socket at
+        sequence 11/11 with the follower's title stuck at its pre-degrade value
+        through ten subsequent healthy deltas.
+
+        ``prior_delay`` is the backoff this attempt already waited out. It is
+        bookkeeping for the NEXT delay only — the pass itself never sleeps, so
+        ``_display_refresh_task`` never holds a sleeping task for
+        ``ensure_display_current`` to block a navigating TUI on.
+        """
         task = asyncio.create_task(self._refresh_display_history())
         self._display_refresh_task = task
 
         def finished(done: asyncio.Task[None]) -> None:
-            if not done.cancelled() and done.exception() is not None:
-                # The socket may already be gone (this runs off a frame the pump
-                # delivered). Log rather than raise into the task's context: the
-                # invalidation fence stays closed, so a reconnect re-syncs.
-                logger.warning(
-                    "canonical re-sync after a degraded delta failed: %s", done.exception()
-                )
+            if done.cancelled() or done.exception() is None:
+                return
+            error = done.exception()
+            client = self._client
+            if self._disposed or client is None or not client.connected:
+                # A reconnect re-syncs from scratch, so the debt dies with the
+                # socket. Log rather than raise into the task's context.
+                logger.warning("canonical re-sync after a degraded delta failed: %s", error)
+                return
+            # The socket is still up, so this follower is now the dangerous
+            # case: connected and quietly wrong. Re-arm the debt and retry.
+            self._frontend_resync_pending = True
+            next_delay = (
+                _DEGRADED_RESYNC_RETRY_INITIAL_S
+                if prior_delay <= 0
+                else min(prior_delay * _DEGRADED_RESYNC_RETRY_FACTOR, _DEGRADED_RESYNC_RETRY_CAP_S)
+            )
+            logger.warning(
+                "canonical re-sync after a degraded delta failed: %s; retrying in %.1fs",
+                error,
+                next_delay,
+            )
+            self._degraded_resync_retry_task = asyncio.create_task(
+                self._retry_degraded_resync(next_delay)
+            )
 
         task.add_done_callback(finished)
+
+    async def _retry_degraded_resync(self, delay: float) -> None:
+        """Wait out the backoff, then re-enter the pass if the debt still stands.
+
+        Separate task from the refresh itself so ``_display_refresh_task`` is not
+        left holding a sleeping task: ``ensure_display_current`` awaits that slot,
+        and a navigating TUI must not block on a backoff timer.
+        """
+        try:
+            await asyncio.sleep(delay)
+        except asyncio.CancelledError:
+            return
+        self._degraded_resync_retry_task = None
+        if self._disposed or not self._frontend_resync_pending:
+            return
+        client = self._client
+        if client is None or not client.connected:
+            return
+        task = self._display_refresh_task
+        if task is not None and not task.done():
+            # A pass is running already and re-reads the flag under its lock.
+            return
+        self._start_degraded_resync(prior_delay=delay)
 
     async def ensure_display_current(self) -> None:
         task = self._display_refresh_task
@@ -5249,6 +5367,9 @@ class RemoteSession:
     async def dispose(self) -> None:
         self._disposed = True
         self._fail_prompt_completion_waiters("viewer disposed while awaiting turn completion")
+        # A sleeping degraded-resync backoff would otherwise outlive the facade
+        # and re-enter a refresh against a client dispose is about to drop.
+        self._cancel_degraded_resync_retry()
         refresh = self._display_refresh_task
         if refresh is not None and refresh is not asyncio.current_task() and not refresh.done():
             refresh.cancel()

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -2644,16 +2644,12 @@ class RemoteSession:
         self._display_revision += 1
         task = self._display_refresh_task
         if task is None or task.done():
-            task = asyncio.create_task(self._refresh_display_history())
-            self._display_refresh_task = task
-
-            def finished(done: asyncio.Task[None]) -> None:
-                if not done.cancelled() and done.exception() is not None:
-                    # Keep the invalidation fence closed. Selection awaits this
-                    # task and reports the failure instead of painting stale rows.
-                    logger.warning("canonical display refresh failed: %s", done.exception())
-
-            task.add_done_callback(finished)
+            # Through the shared slot filler, NOT a private task with a
+            # log-only callback. This path and the degrade path share
+            # ``_display_refresh_task`` and ``_frontend_resync_pending``, so a
+            # pass started here can swallow a degrade debt (review round 2, B2)
+            # and must be able to retry it.
+            self._start_display_refresh(prior_delay=0.0)
 
     def _resync_after_degraded_delta(self) -> None:
         """Force a canonical re-snapshot after the owner shed a delta's body.
@@ -2706,9 +2702,14 @@ class RemoteSession:
         task = self._display_refresh_task
         if task is not None and not task.done():
             # A refresh is already running; it re-reads the flag above under its
-            # lock and folds this frame into at most one further pass.
+            # lock and folds this frame into at most one further pass. Dropping
+            # the timer just above is safe BECAUSE every filler of that slot now
+            # carries the debt-aware callback: whoever owns the running pass
+            # re-arms and reschedules if it fails. That was not true when only
+            # this method's own task did, which is how the debt was orphaned
+            # here (review round 2, B2).
             return
-        self._start_degraded_resync(prior_delay=0.0)
+        self._start_display_refresh(prior_delay=0.0)
 
     def _cancel_degraded_resync_retry(self) -> None:
         """Drop a scheduled retry that a fresh attempt supersedes."""
@@ -2717,18 +2718,40 @@ class RemoteSession:
             retry.cancel()
         self._degraded_resync_retry_task = None
 
-    def _start_degraded_resync(self, *, prior_delay: float) -> None:
-        """Run one re-sync pass NOW, re-arming and scheduling a retry if it fails.
+    def _start_display_refresh(self, *, prior_delay: float) -> None:
+        """Fill the refresh SLOT — always with the debt-aware failure callback.
+
+        THE RETRY BELONGS TO THE SLOT, NOT TO ONE CREATOR'S TASK (review round
+        2, B2). The first version of this attached the retrying callback only to
+        the task ``_resync_after_degraded_delta`` created, while
+        ``_invalidate_display_history`` filled the SAME slot with a log-only
+        one. A degraded frame arriving while that pass was in flight took the
+        early return above and handed its debt to a task that re-armed nothing —
+        the original defect, one route over, reachable in production from a
+        ``history_generation`` move and from ``CompactionEndEvent``. Reproduced
+        on that tree with a 1,528,060-byte delta: live socket, sequence 22/22 so
+        the gap check agrees forever, follower title stuck at its pre-degrade
+        value through 20 later healthy deltas, catalogue 0 rows against the
+        owner's 5000, and ``ensure_display_current`` re-raising the stored error
+        on every call. A cached task holding a FAILURE is not a cache, it is a
+        latch.
+
+        So every filler of ``_display_refresh_task`` goes through here, and the
+        callback READS the debt flag rather than assuming who armed it: a pass
+        started for display drift that happens to consume a degrade debt retries
+        it, and a pass with no debt outstanding still only logs, exactly as the
+        display-invalidation path always did.
 
         The failure path is the whole point. ``_frontend_resync_pending`` is
         cleared BEFORE the capture inside ``_refresh_display_history`` (so a
-        frame racing the snapshot earns another pass), and that method re-raises
-        on failure — so without re-arming here, a single transient failure
-        leaves the flag false, the debt forgotten, and the follower showing
-        stale fields behind a gap check that agrees with the owner forever.
-        Reproduced: one injected ``ConnectionError`` left a live socket at
-        sequence 11/11 with the follower's title stuck at its pre-degrade value
-        through ten subsequent healthy deltas.
+        frame racing the snapshot earns another pass), and that method restores
+        what it consumed when it re-raises — so the flag read below is an honest
+        statement of whether canonical fields are still owed. Without the retry,
+        a single transient failure leaves the debt forgotten and the follower
+        showing stale fields behind a gap check that agrees with the owner
+        forever. Reproduced: one injected ``ConnectionError`` left a live socket
+        at sequence 11/11 with the follower's title stuck at its pre-degrade
+        value through ten subsequent healthy deltas.
 
         ``prior_delay`` is the backoff this attempt already waited out. It is
         bookkeeping for the NEXT delay only — the pass itself never sleeps, so
@@ -2742,6 +2765,13 @@ class RemoteSession:
             if done.cancelled() or done.exception() is None:
                 return
             error = done.exception()
+            if not self._frontend_resync_pending:
+                # Display drift alone. Keep the invalidation fence closed:
+                # selection awaits this task and reports the failure instead of
+                # painting stale rows. Nothing canonical is owed, so a retry
+                # here would only add RPCs to a surface that already reports.
+                logger.warning("canonical display refresh failed: %s", error)
+                return
             client = self._client
             if self._disposed or client is None or not client.connected:
                 # A reconnect re-syncs from scratch, so the debt dies with the
@@ -2749,8 +2779,7 @@ class RemoteSession:
                 logger.warning("canonical re-sync after a degraded delta failed: %s", error)
                 return
             # The socket is still up, so this follower is now the dangerous
-            # case: connected and quietly wrong. Re-arm the debt and retry.
-            self._frontend_resync_pending = True
+            # case: connected and quietly wrong. Retry the outstanding debt.
             next_delay = (
                 _DEGRADED_RESYNC_RETRY_INITIAL_S
                 if prior_delay <= 0
@@ -2761,6 +2790,14 @@ class RemoteSession:
                 error,
                 next_delay,
             )
+            # AT MOST ONE TIMER, always. Now that display invalidation fills the
+            # slot too, a pass can start and fail while an older backoff is
+            # still sleeping — and that path never cancelled it the way
+            # ``_resync_after_degraded_delta`` does. Two live timers would each
+            # clear the single handle and fire their own pass, which is the
+            # double-attempt the round-1 measurements (peak 1 concurrent retry)
+            # rule out.
+            self._cancel_degraded_resync_retry()
             self._degraded_resync_retry_task = asyncio.create_task(
                 self._retry_degraded_resync(next_delay)
             )
@@ -2778,7 +2815,11 @@ class RemoteSession:
             await asyncio.sleep(delay)
         except asyncio.CancelledError:
             return
-        self._degraded_resync_retry_task = None
+        # Only clear the handle if it is still OURS. A newer timer may have
+        # replaced it while this one slept, and blanking that registration would
+        # hide a live task from ``dispose``.
+        if self._degraded_resync_retry_task is asyncio.current_task():
+            self._degraded_resync_retry_task = None
         if self._disposed or not self._frontend_resync_pending:
             return
         client = self._client
@@ -2786,9 +2827,14 @@ class RemoteSession:
             return
         task = self._display_refresh_task
         if task is not None and not task.done():
-            # A pass is running already and re-reads the flag under its lock.
+            # A pass is running already and re-reads the flag under its lock —
+            # and, if it fails, re-arms and reschedules through the same
+            # ``finished`` callback this one was started with, because the slot
+            # owns that callback rather than the caller. Yielding here without
+            # that guarantee is what dropped a quiescent follower's debt (QA
+            # round 2, Q3).
             return
-        self._start_degraded_resync(prior_delay=delay)
+        self._start_display_refresh(prior_delay=delay)
 
     async def ensure_display_current(self) -> None:
         task = self._display_refresh_task
@@ -2819,6 +2865,13 @@ class RemoteSession:
                 # ``_install_frontend``) re-arms the flag and earns another
                 # pass. Clearing it after would swallow exactly the frame that
                 # raced the snapshot it is not covered by.
+                #
+                # Remembered because clearing it makes THIS pass the only holder
+                # of the debt: a failure below must hand it back rather than
+                # consume it, whichever caller filled the slot. That is what
+                # makes the flag an honest debt marker for the done-callback in
+                # ``_start_display_refresh`` to read.
+                owed_canonical_resync = self._frontend_resync_pending
                 self._frontend_resync_pending = False
                 try:
                     frontend = FrontendSync.model_validate(await client.frontend_sync())
@@ -2844,6 +2897,14 @@ class RemoteSession:
                         self._display_invalidated = True
                     self._finish_sync()
                 except BaseException:
+                    # Hand the consumed debt back. ORed rather than assigned: a
+                    # degraded frame that landed during the capture has already
+                    # set the flag for a debt this pass did not cover, and
+                    # overwriting it with this pass's older value would drop the
+                    # newer one.
+                    self._frontend_resync_pending = (
+                        self._frontend_resync_pending or owed_canonical_resync
+                    )
                     # The transport remains usable even when this read fails.
                     # Preserve its ordered updates and surface the history error
                     # to navigation, without cancelling source work or its gates.

--- a/tests/unit/session/runtime/test_server.py
+++ b/tests/unit/session/runtime/test_server.py
@@ -74,7 +74,16 @@ class FakeHandle:
     def frontend_state_seed(self):  # noqa: ANN202
         return self._frontend.state
 
-    def subscribe_frontend(self, on_update):  # noqa: ANN001, ANN202
+    def subscribe_frontend(self, on_update, *, display_window=False):  # noqa: ANN001, ANN202
+        # `display_window` mirrors the real `Session.subscribe_frontend`, which
+        # the server calls with it both at connect time and on the
+        # `frontend_sync` RPC. This double accepted only the positional form, so
+        # every server path taking the RPC raised TypeError against it and no
+        # test could reach the canonical re-snapshot at all. Capturing a durable
+        # window needs a transcript this handle does not have, so the flag is
+        # accepted and ignored: the sync carries canonical state without a
+        # display window, which is exactly the `window is None` branch
+        # `_load_frontend_history` already handles.
         return self._frontend.subscribe(on_update)
 
     def subscribe_events(self, on_event):  # noqa: ANN001, ANN202

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -57,6 +57,7 @@ from local_operator.session.goal_loop import (
     LOOP_REASON_CHARS,
     MAX_LOOP_ITERATIONS,
 )
+from local_operator.session.history_window import DisplayHistoryWindow
 from local_operator.session.remote import RemoteSession
 from local_operator.session.runtime import registry
 from local_operator.session.runtime.server import _MAX_LINE_BYTES, RuntimeServer
@@ -1527,21 +1528,29 @@ async def test_an_oversized_delta_keeps_the_socket_and_the_follower_resyncs(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("delay", [0.0, 0.05])
 async def test_a_burst_of_degraded_deltas_coalesces_into_one_resync(
-    tmp_path: Path, monkeypatch
+    tmp_path: Path, monkeypatch, delay: float
 ) -> None:
-    """Recovery must not turn one bad minute into a snapshot storm.
+    """Frames arriving DURING a refresh fold into it rather than each buying one.
 
     The frame that degrades is by definition a frame the session is big enough
     to produce repeatedly — the operator hit this with nine subagents running —
-    so a naive "re-sync on every degraded delta" answers a 1.5 MB frame with a
-    sync RPC per frame and makes the overload worse.
+    so answering a 1.5 MB frame with a sync RPC per frame while a refresh is
+    already running would make the overload worse.
 
-    The bound is the existing refresh task slot plus ``_refresh_display_history``'s
-    own loop, not a timer: frames arriving while a refresh is in flight re-arm
-    the flag and fold into at most ONE further pass. The assertion is on the
-    number of ``frontend_sync`` round trips, and on the state still converging
-    — a coalescing bound that lost the last delta would be a worse bug.
+    THE BOUND IS IN-FLIGHT COALESCING, NOT A RATE LIMIT, and this test says so
+    because an earlier version of it did not: it asserted ``syncs <= 3`` while
+    emitting all 20 mutations without awaiting, which pins only the unpaced
+    regime. QA swept the spacing and found 1 sync back to back but 20 syncs at
+    50 ms apart. That is correct — a frame arriving after a snapshot completed
+    shed state that snapshot did not cover, so it genuinely owes another sync —
+    and the paced case is asserted below so the claim and the code agree.
+
+    What must hold at EVERY spacing is that the invalidation does not exceed the
+    work: ``_display_revision`` is a TUI cache key, so a bump per frame rather
+    than per reload moves the refresh storm from the RPC layer into the
+    presentation layer, where this test would not have seen it.
     """
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
     (tmp_path / "sessions" / "s1").mkdir(parents=True)
@@ -1566,35 +1575,382 @@ async def test_a_burst_of_degraded_deltas_coalesces_into_one_resync(
             return await original()
 
         monkeypatch.setattr(client, "frontend_sync", counting_sync)
+        assert client.frontend_sync is counting_sync, "the sync counter did not land"
+
+        # ``_load_frontend_history`` is where a reload actually happens, and it
+        # owns the one legitimate ``_display_revision`` bump. Counting it is
+        # what lets the invalidation assertion below mean "per reload" rather
+        # than "a number that looked small in the unpaced case".
+        loads = 0
+        original_load = remote._load_frontend_history
+
+        async def counting_load(frontend: Any) -> None:
+            nonlocal loads
+            loads += 1
+            return await original_load(frontend)
+
+        monkeypatch.setattr(remote, "_load_frontend_history", counting_load)
+        assert remote._load_frontend_history is counting_load, "the load counter did not land"
+
+        revision_before = remote.display_history_revision
 
         # Every delta must be GENUINELY oversized, so the catalogue has to
         # DIFFER each time: re-sending an identical list produces no field diff
         # and a small delta, which would let this pass for free.
         rounds = 20
+        oversized = 0
         for index in range(rounds):
-            handle._frontend.mutate(
+            update = handle._frontend.mutate(
                 model_catalogue=[_catalogue_row(row + index * 10_000) for row in range(5_000)],
                 conversation_title=f"title-{index}",
             )
+            assert update is not None
+            if (
+                _line_bytes({"op": "frontend_update", "data": update.model_dump(mode="json")})
+                > _MAX_LINE_BYTES
+            ):
+                oversized += 1
+            if delay:
+                await asyncio.sleep(delay)
+        # The fixture has to keep producing frames the wire cannot carry, or
+        # every assertion below passes for free against ordinary deltas.
+        assert oversized == rounds, f"only {oversized}/{rounds} frames were oversized"
 
         for _ in range(400):
-            if remote.frontend_state.conversation_title == f"title-{rounds - 1}":
+            if (
+                remote.frontend_state.conversation_title == f"title-{rounds - 1}"
+                and not remote._frontend_resync_pending
+            ):
                 break
             await asyncio.sleep(0.02)
 
         # Converged on the owner's latest, not on some intermediate the
-        # coalescing happened to stop at.
+        # coalescing happened to stop at. True at BOTH spacings.
         owner = handle._frontend.state
         assert remote.frontend_state.conversation_title == owner.conversation_title
         assert remote.frontend_state.sequence == owner.sequence
         assert client.connected
-        # The bound itself. Far below one-per-frame; exact count is scheduling
-        # dependent, so this asserts the ORDER of magnitude the design promises.
-        assert 0 < syncs <= 3, f"{rounds} degraded frames caused {syncs} snapshot round trips"
+
+        # THE INVALIDATION MUST TRACK THE WORK, NOT THE FRAMES. This is the
+        # assertion the previous version lacked: the RPCs coalesced while
+        # ``_display_revision`` was bumped once per degraded frame, so the TUI
+        # dropped its cached sidebar presentation ~20x per burst for a single
+        # reload. Tying it to ``loads`` rather than to a constant keeps it
+        # honest at any spacing, since the sync count itself is legitimately
+        # scheduling dependent.
+        assert remote.display_history_revision - revision_before == loads, (
+            f"{rounds} degraded frames bumped the display revision "
+            f"{remote.display_history_revision - revision_before} times "
+            f"for {loads} history reloads"
+        )
+        assert 0 < syncs <= rounds
+        assert loads == syncs
+        if not delay:
+            # Back to back, the in-flight slot is what does the work: the whole
+            # burst folds into a single pass.
+            assert syncs <= 3, f"{rounds} unpaced degraded frames caused {syncs} round trips"
     finally:
         if remote is not None:
             await remote.dispose()
         registrant.close()
+
+
+class _WindowedHandle(FakeHandle):
+    """A ``FakeHandle`` whose followers negotiate the WINDOWED history path.
+
+    The plain double offers no ``history_page``, so ``RuntimeServer`` never
+    advertises ``display-history-window-v1`` and every follower built on it
+    lands in ``_display_window_supported=False`` — the legacy/full-replay case.
+    That left the MODERN viewer, which is what the TUI actually builds, with no
+    coverage of the degrade path at all, and the two are not interchangeable
+    here: ``_invalidate_display_history`` returns early for the legacy follower
+    while ``_display_invalidated`` latches for the windowed one, so the blast
+    radius of a failed re-sync differs by viewer.
+
+    The window is synthesised rather than captured from a transcript (this
+    handle has none) but it is a REAL ``DisplayHistoryWindow`` that satisfies
+    ``_validate_display_window``: matching conversation/epoch/cursor and a
+    self-consistent range. That is what the follower gates on, so it is what
+    decides which path it takes.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # A cursor the window and the snapshot agree on. ``through_id`` must
+        # equal the sync's ``live_cursor`` or the follower refuses the window.
+        self._frontend.mutate(history_cursor="row-0")
+
+    def _window(self, epoch: str, cursor: str | None) -> DisplayHistoryWindow:
+        return DisplayHistoryWindow(
+            status="ok",
+            conversation_id="s1",
+            owner_epoch=epoch,
+            history_generation=1,
+            through_id=cursor,
+            messages=[],
+            total_message_count=0,
+            start=0,
+        )
+
+    def subscribe_frontend(self, on_update, *, display_window=False):  # noqa: ANN001, ANN202
+        subscription = self._frontend.subscribe(on_update)
+        if display_window:
+            sync = subscription.sync
+            sync.display_history = self._window(sync.epoch, sync.live_cursor)
+        return subscription
+
+    async def history_page(self, before: str, anchor: str = "") -> dict[str, Any]:
+        # Presence of this method is what makes the server advertise the
+        # windowed capability; the follower only calls it when paging older
+        # rows, which these tests do not do.
+        state = self._frontend.state
+        return self._window(state.epoch, state.history_cursor).model_dump(mode="json")
+
+
+@pytest.mark.asyncio
+async def test_a_windowed_follower_also_resyncs_after_a_degraded_delta(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The modern windowed viewer must recover too, not just the legacy one.
+
+    Every other test here runs against a handle with no ``history_page``, so
+    the follower negotiates full replay. The TUI negotiates the WINDOW, and the
+    two paths differ exactly where this fix lives: ``_invalidate_display_history``
+    is a no-op for the legacy follower and latches ``_display_invalidated`` for
+    the windowed one. A fix proven only on the legacy path is proven on the
+    viewer the operator was least likely to be running.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    handle = _WindowedHandle()
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    remote = None
+    try:
+        record = await _record(tmp_path)
+        assert "display-history-window-v1" in record.capabilities
+        remote = await RemoteSession.connect(
+            record,
+            "s1",
+            config_dir=tmp_path,
+            takeover_factory=_never,
+            display_window=True,
+        )
+        # The whole point of this test: without this the run silently repeats
+        # the legacy-path coverage the other tests already have.
+        assert remote._display_window_supported, "the follower did not take the windowed path"
+
+        handle._frontend.mutate(
+            model_catalogue=[_catalogue_row(index) for index in range(5_000)],
+            conversation_title="after the degrade",
+        )
+
+        for _ in range(400):
+            if remote.frontend_state.conversation_title == "after the degrade":
+                break
+            await asyncio.sleep(0.02)
+
+        client = remote._client
+        assert client is not None and client.connected, "the degraded delta killed the socket"
+        owner = handle._frontend.state
+        assert remote.frontend_state.conversation_title == owner.conversation_title
+        assert remote.frontend_state.sequence == owner.sequence
+        assert remote.frontend_state.model_catalogue
+    finally:
+        if remote is not None:
+            await remote.dispose()
+        registrant.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("windowed", [False, True])
+async def test_a_failed_resync_is_retried_rather_than_left_permanently_stale(
+    tmp_path: Path, monkeypatch, windowed: bool
+) -> None:
+    """A live socket showing WRONG data is worse than a dead one.
+
+    THE BUG THIS PINS (review round 1, B1). ``_frontend_resync_pending`` is
+    cleared before the capture and ``_refresh_display_history`` re-raises on
+    failure, so the first version of this fix dropped the debt on the floor: one
+    transient ``frontend_sync`` failure left the follower stale FOREVER behind a
+    gap check that agreed with the owner at every later sequence. Measured on
+    that tree: socket alive, sequence 11/11, follower still showing its
+    pre-degrade title through ten subsequent healthy deltas.
+
+    Recovery cannot ride on ``ensure_display_current`` either — that is a TUI
+    navigation hook the CLI, the session factory and the desktop bridge never
+    call — so the retry has to be the transport's own.
+
+    Run on BOTH follower shapes because the failure's blast radius depends on
+    which one the viewer negotiated.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    handle = _WindowedHandle() if windowed else FakeHandle()
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    remote = None
+    try:
+        record = await _record(tmp_path)
+        remote = await RemoteSession.connect(
+            record,
+            "s1",
+            config_dir=tmp_path,
+            takeover_factory=_never,
+            display_window=windowed,
+        )
+        assert remote._display_window_supported is windowed
+        client = remote._client
+        assert client is not None
+
+        failures = 0
+        original = client.frontend_sync
+
+        async def failing_sync() -> Any:
+            nonlocal failures
+            failures += 1
+            raise ConnectionError("injected sync failure")
+
+        monkeypatch.setattr(client, "frontend_sync", failing_sync)
+        # ASSERT THE INJECTION LANDED. A harness that silently fails to patch
+        # turns this test into a green run of the unmodified path.
+        assert client.frontend_sync is failing_sync
+
+        handle._frontend.mutate(
+            model_catalogue=[_catalogue_row(index) for index in range(5_000)],
+            conversation_title="after the degrade",
+        )
+
+        for _ in range(400):
+            if failures:
+                break
+            await asyncio.sleep(0.02)
+        # The failure must actually have FIRED, or the retry below proves
+        # nothing about the failure path.
+        assert failures >= 1, "the injected sync failure never fired"
+
+        # Restore a working owner: the retry, not another degraded frame, is
+        # what has to repair this. Ordinary deltas on OTHER fields keep flowing
+        # so a follower that merely applies them still fails the assertion.
+        monkeypatch.setattr(client, "frontend_sync", original)
+        for index in range(10):
+            handle._frontend.mutate(cwd=f"/tmp/normal-{index}")
+            await asyncio.sleep(0.02)
+
+        # Wait for the END STATE, never for a clock: the retry is a backoff task
+        # and the last ordinary delta can still be in flight behind it, so a
+        # poll on the title alone reads a moment mid-recovery.
+        for _ in range(600):
+            if (
+                remote.frontend_state.conversation_title == "after the degrade"
+                and remote.frontend_state.sequence == handle._frontend.state.sequence
+                and not remote._frontend_resync_pending
+                and remote._degraded_resync_retry_task is None
+            ):
+                break
+            await asyncio.sleep(0.02)
+
+        owner = handle._frontend.state
+        assert client.connected, "the retry cost the socket"
+        assert remote.frontend_state.conversation_title == owner.conversation_title, (
+            "the follower is permanently stale behind a satisfied gap check: "
+            f"{remote.frontend_state.conversation_title!r} != {owner.conversation_title!r}"
+        )
+        assert remote.frontend_state.sequence == owner.sequence
+        assert remote.frontend_state.cwd == "/tmp/normal-9"
+        # The debt is settled rather than merely quiet, and no backoff timer is
+        # left running behind it.
+        assert not remote._frontend_resync_pending
+        assert remote._degraded_resync_retry_task is None
+
+        # And the stream is still LIVE after the retry, which is what proves the
+        # recovery did not leave the sequence cursor desynced.
+        handle._frontend.mutate(conversation_title="after the retry")
+        for _ in range(400):
+            if remote.frontend_state.conversation_title == "after the retry":
+                break
+            await asyncio.sleep(0.02)
+        assert remote.frontend_state.conversation_title == "after the retry"
+        assert client.connected
+    finally:
+        if remote is not None:
+            await remote.dispose()
+        registrant.close()
+
+
+def test_a_malformed_non_degraded_update_is_refused_rather_than_silently_applied():
+    """Relaxing ``changes`` must not extend past the frame that needs it.
+
+    THE FINDING THIS PINS (review round 1, M2). ``changes`` was made optional
+    for every update, and the model allows extras — so a frame that misspelled
+    the key validated as an empty change set, applied as "nothing moved",
+    consumed a sequence and kept the gap check happy with no log and no
+    ``degraded`` flag. That is the same silent drift the degraded frame causes,
+    reintroduced from a different cause: a loud failure traded for a quiet one.
+
+    Refusing the frame is not the same as tearing down the socket over a
+    degraded one — the degrade path labels its own frames, so what is rejected
+    here is a frame claiming to be a complete delta while carrying no body,
+    which no correct owner emits.
+    """
+    from pydantic import ValidationError
+
+    # The reviewer's exact frame.
+    with pytest.raises(ValidationError, match="only a degraded frame may shed its body"):
+        FrontendUpdate.model_validate(
+            {"epoch": "e1", "sequence": 6, "chnages": {"streaming": True}}
+        )
+
+    # And the same shape with the key simply absent.
+    with pytest.raises(ValidationError, match="only a degraded frame may shed its body"):
+        FrontendUpdate.model_validate({"epoch": "e1", "sequence": 6})
+
+    # A DEGRADED frame may still omit it — the fix must survive its own guard.
+    degraded = FrontendUpdate.model_validate(
+        {"epoch": "e1", "sequence": 6, "degraded": True, "degraded_reason": "too large"}
+    )
+    assert degraded.changes == {}
+
+    # An EXPLICIT empty change set is still legal: "nothing moved" is a
+    # different statement from "the body was shed", which is why the flag
+    # exists rather than being inferred from emptiness.
+    empty = FrontendUpdate.model_validate({"epoch": "e1", "sequence": 6, "changes": {}})
+    assert empty.changes == {}
+    assert empty.degraded is False
+
+    # An ordinary delta is untouched.
+    ordinary = FrontendUpdate.model_validate(
+        {"epoch": "e1", "sequence": 7, "changes": {"conversation_title": "t"}}
+    )
+    assert ordinary.changes == {"conversation_title": "t"}
+    assert ordinary.degraded is False
+
+
+def test_a_refused_update_never_reaches_the_store_or_consumes_a_sequence():
+    """The refusal's POINT is that no sequence is spent on a frame nobody read.
+
+    A silently-applied malformed frame is worse than a rejected one precisely
+    because it advances the cursor: the follower then agrees with the owner
+    about sequencing forever while disagreeing about content. The receiver
+    refuses the frame instead, which the transport already recovers from by
+    re-syncing.
+    """
+    from pydantic import ValidationError
+
+    store = FrontendStateStore(
+        FrontendSessionState(session_id="s1", epoch="e1", conversation_title="before")
+    )
+    start = store.state.sequence
+
+    with pytest.raises(ValidationError):
+        store.apply_update(
+            FrontendUpdate.model_validate(
+                {"epoch": "e1", "sequence": start + 1, "chnages": {"conversation_title": "typo"}}
+            )
+        )
+
+    assert store.state.sequence == start
+    assert store.state.conversation_title == "before"
 
 
 def _oversized_event_frame() -> dict[str, Any]:

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -1461,6 +1461,7 @@ async def test_an_oversized_delta_keeps_the_socket_and_the_follower_resyncs(
         remote = await RemoteSession.connect(
             record, "s1", config_dir=tmp_path, takeover_factory=_never
         )
+        _assert_reachable(remote)
         assert remote.frontend_state.conversation_title == "fake"
 
         # One mutation whose DELTA cannot ride the wire. `conversation_title`
@@ -1563,6 +1564,7 @@ async def test_a_burst_of_degraded_deltas_coalesces_into_one_resync(
         remote = await RemoteSession.connect(
             record, "s1", config_dir=tmp_path, takeover_factory=_never
         )
+        _assert_reachable(remote)
         client = remote._client
         assert client is not None
 
@@ -1667,44 +1669,120 @@ class _WindowedHandle(FakeHandle):
     while ``_display_invalidated`` latches for the windowed one, so the blast
     radius of a failed re-sync differs by viewer.
 
-    The window is synthesised rather than captured from a transcript (this
-    handle has none) but it is a REAL ``DisplayHistoryWindow`` that satisfies
-    ``_validate_display_window``: matching conversation/epoch/cursor and a
-    self-consistent range. That is what the follower gates on, so it is what
-    decides which path it takes.
+    THE WINDOW IS CAPTURED FROM A REAL ``Transcript``, NOT SYNTHESISED, and the
+    reason is a fixture defect worth naming (review round 2, Q). The first
+    version hardcoded ``history_generation=1`` against a snapshot carrying 0.
+    ``_load_frontend_history`` takes ``_loaded_history_generation`` from the
+    WINDOW, so that follower was permanently invalidated: every ordinary delta
+    re-entered ``_invalidate_display_history`` and started a fresh refresh,
+    which serviced any orphaned re-sync debt AS A SIDE EFFECT. The regression
+    guard for a blocker therefore could not fail — measured green on the
+    pre-fix tree, which has no retry mechanism at all.
+
+    That species of fixture defect is immune to the usual defences: the
+    instrument is live, the mutation lands, and going green on both trees reads
+    as "already fixed" rather than "my fixture is curing the bug". The defence
+    is a precondition on the precondition — assert the starting state is one
+    PRODUCTION CAN REACH, not merely that it was set. ``_assert_reachable``
+    below is that assertion, and this handle earns it by serving
+    ``display_window(...)``, the exact function ``Session.history_page`` calls,
+    over a real transcript. Real rows also make paging genuine (the surfaced
+    symptom was "Could not load earlier messages") rather than a window whose
+    empty message list makes every paging assertion vacuous.
     """
 
-    def __init__(self) -> None:
-        super().__init__()
-        # A cursor the window and the snapshot agree on. ``through_id`` must
-        # equal the sync's ``live_cursor`` or the follower refuses the window.
-        self._frontend.mutate(history_cursor="row-0")
+    #: Enough rows to exceed ``DISPLAY_HISTORY_MESSAGES`` (120), so the first
+    #: window is a real PAGE with a ``before_token`` behind it rather than the
+    #: whole history — the shape the TUI actually pages through.
+    _ROWS = 270
 
-    def _window(self, epoch: str, cursor: str | None) -> DisplayHistoryWindow:
-        return DisplayHistoryWindow(
-            status="ok",
-            conversation_id="s1",
-            owner_epoch=epoch,
-            history_generation=1,
-            through_id=cursor,
-            messages=[],
-            total_message_count=0,
-            start=0,
+    def __init__(self, directory: Path) -> None:
+        super().__init__()
+        from local_operator.session.transcript import Transcript
+
+        self.transcript = Transcript(directory)
+        self.page_calls: list[str] = []
+
+    async def seed(self) -> None:
+        """Commit real rows and point the snapshot cursor at the last of them.
+
+        Separate from ``__init__`` because ``append_messages`` is async. The
+        cursor must equal the window's ``through_id`` or the follower refuses
+        the window and silently falls back to the legacy path.
+        """
+        from local_operator.harness.types import Message
+
+        await self.transcript.append_messages(
+            [Message.user(f"row {index}") for index in range(self._ROWS)]
+        )
+        entries = self.transcript.entries()
+        assert len(entries) == self._ROWS, "the transcript did not take the rows"
+        self._frontend.mutate(history_cursor=entries[-1].id)
+
+    def _window(self, before: str | None = None, anchor: str = "") -> DisplayHistoryWindow:
+        from local_operator.session.history_window import display_window
+
+        state = self._frontend.state
+        return display_window(
+            self.transcript,
+            conversation_id=state.session_id,
+            owner_epoch=state.epoch,
+            through_id=state.history_cursor,
+            before=before,
+            anchor=anchor,
         )
 
     def subscribe_frontend(self, on_update, *, display_window=False):  # noqa: ANN001, ANN202
         subscription = self._frontend.subscribe(on_update)
         if display_window:
-            sync = subscription.sync
-            sync.display_history = self._window(sync.epoch, sync.live_cursor)
+            subscription.sync.display_history = self._window()
         return subscription
 
     async def history_page(self, before: str, anchor: str = "") -> dict[str, Any]:
         # Presence of this method is what makes the server advertise the
-        # windowed capability; the follower only calls it when paging older
-        # rows, which these tests do not do.
-        state = self._frontend.state
-        return self._window(state.epoch, state.history_cursor).model_dump(mode="json")
+        # windowed capability. Recorded so a paging assertion can prove the RPC
+        # was actually served rather than answered from the resident window.
+        self.page_calls.append(before)
+        return self._window(before=before, anchor=anchor).model_dump(mode="json")
+
+
+async def _windowed_handle(tmp_path: Path) -> _WindowedHandle:
+    """A seeded windowed handle whose window is canaried before any test uses it.
+
+    A window that came back empty, or as ``reset``, would make every paging and
+    staleness assertion downstream pass vacuously.
+    """
+    handle = _WindowedHandle(tmp_path / "transcript")
+    await handle.seed()
+    probe = handle._window()
+    assert probe.status == "ok", f"window status {probe.status}"
+    assert probe.total_message_count == _WindowedHandle._ROWS
+    assert probe.messages, "the window carries no rows — the instrument is dead"
+    assert probe.before_token, "the window has no before_token — paging is unreachable"
+    return handle
+
+
+def _assert_reachable(remote: RemoteSession) -> None:
+    """Refuse a fixture whose starting state PRODUCTION CANNOT REACH.
+
+    Review round 2, Q. A fixture pairing a window generation with a disagreeing
+    snapshot generation leaves the follower permanently invalidated, so ordinary
+    deltas keep restarting refreshes that repair the very defect the test exists
+    to catch — an instrument that does not merely fail to observe but
+    ACCIDENTALLY REPAIRS. A real owner serves both numbers from the same
+    ``Transcript._history_generation``, so they agree at connect by
+    construction; anything else is a state that exists only in the harness.
+
+    Asserted after connect on every follower these tests build, legacy included,
+    so the pairing cannot silently drift again.
+    """
+    snapshot_generation = remote._read_state_field("history_generation")
+    assert snapshot_generation == remote._loaded_history_generation, (
+        "unreachable fixture: the follower is permanently invalidated, so ordinary "
+        f"deltas will repair the staleness under test (snapshot {snapshot_generation} "
+        f"!= loaded {remote._loaded_history_generation})"
+    )
+    assert remote.display_history_current, "unreachable fixture: invalidated at connect"
 
 
 @pytest.mark.asyncio
@@ -1722,7 +1800,7 @@ async def test_a_windowed_follower_also_resyncs_after_a_degraded_delta(
     """
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
     (tmp_path / "sessions" / "s1").mkdir(parents=True)
-    handle = _WindowedHandle()
+    handle = await _windowed_handle(tmp_path)
     registrant = RuntimeServer(handle, kind="tui")
     registrant.start()
     remote = None
@@ -1739,6 +1817,11 @@ async def test_a_windowed_follower_also_resyncs_after_a_degraded_delta(
         # The whole point of this test: without this the run silently repeats
         # the legacy-path coverage the other tests already have.
         assert remote._display_window_supported, "the follower did not take the windowed path"
+        _assert_reachable(remote)
+        # Real rows arrived, so the window under test is the paging shape the
+        # TUI builds rather than an empty envelope that satisfies the validator.
+        assert remote.display_history_window()
+        assert remote.history_before_token
 
         handle._frontend.mutate(
             model_catalogue=[_catalogue_row(index) for index in range(5_000)],
@@ -1786,7 +1869,7 @@ async def test_a_failed_resync_is_retried_rather_than_left_permanently_stale(
     """
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
     (tmp_path / "sessions" / "s1").mkdir(parents=True)
-    handle = _WindowedHandle() if windowed else FakeHandle()
+    handle = await _windowed_handle(tmp_path) if windowed else FakeHandle()
     registrant = RuntimeServer(handle, kind="tui")
     registrant.start()
     remote = None
@@ -1800,6 +1883,12 @@ async def test_a_failed_resync_is_retried_rather_than_left_permanently_stale(
             display_window=windowed,
         )
         assert remote._display_window_supported is windowed
+        # The windowed leg used to run on a fixture whose window/snapshot
+        # generations disagreed, which permanently invalidated the follower and
+        # made every ordinary delta below restart a refresh that repaired the
+        # staleness under test. This assertion is what keeps this test able to
+        # FAIL (review round 2, Q).
+        _assert_reachable(remote)
         client = remote._client
         assert client is not None
 
@@ -1872,6 +1961,381 @@ async def test_a_failed_resync_is_retried_rather_than_left_permanently_stale(
             await asyncio.sleep(0.02)
         assert remote.frontend_state.conversation_title == "after the retry"
         assert client.connected
+    finally:
+        if remote is not None:
+            await remote.dispose()
+        registrant.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("windowed", [False, True])
+async def test_a_degrade_folded_into_an_in_flight_refresh_is_still_retried(
+    tmp_path: Path, monkeypatch, windowed: bool
+) -> None:
+    """The debt survives being handed to a refresh THIS PATH DID NOT START.
+
+    THE BUG THIS PINS (review round 2, B2). ``_resync_after_degraded_delta``
+    delegates to an already-running refresh instead of starting its own, and the
+    retry used to be attached only to the task the degrade path created. A
+    refresh started by ``_invalidate_display_history`` carried a LOG-ONLY
+    callback, so a degraded frame arriving during it handed its debt to a task
+    that re-armed nothing and scheduled no retry — the round-1 defect, one route
+    over, with a live socket, a satisfied gap check and permanently stale
+    canonical fields. Reachable in production from a ``history_generation`` move
+    and from ``CompactionEndEvent``, which is exactly what a long busy session
+    (the session shape that emits oversized deltas) does.
+
+    A cached task holding a FAILURE is not a cache, it is a latch. The fix is
+    that the retry belongs to the SLOT: whatever fills ``_display_refresh_task``
+    carries the debt-aware callback.
+
+    THE TRAP THIS TEST AVOIDS. Pre-populating the slot with an already-completed
+    task would take the same early return and pass without ever exercising the
+    failure path. So the refresh here is held open on a real gate, the test
+    asserts it was genuinely IN FLIGHT when the degrade folded into it, and
+    asserts it then genuinely FAILED.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    handle = await _windowed_handle(tmp_path) if windowed else FakeHandle()
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    remote = None
+    try:
+        record = await _record(tmp_path)
+        remote = await RemoteSession.connect(
+            record,
+            "s1",
+            config_dir=tmp_path,
+            takeover_factory=_never,
+            display_window=windowed,
+        )
+        assert remote._display_window_supported is windowed
+        _assert_reachable(remote)
+        client = remote._client
+        assert client is not None
+
+        original = client.frontend_sync
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        failures = 0
+
+        async def blocking_failing_sync() -> Any:
+            nonlocal failures
+            failures += 1
+            entered.set()
+            # Hold the pass open so the degraded frame below lands while it is
+            # genuinely running, which is the whole reachability condition.
+            await release.wait()
+            raise ConnectionError("injected sync failure")
+
+        monkeypatch.setattr(client, "frontend_sync", blocking_failing_sync)
+        assert client.frontend_sync is blocking_failing_sync
+
+        # Start a refresh through the OTHER door — the one whose callback used
+        # to only log. The legacy follower's ``_invalidate_display_history``
+        # returns early by design, so the flag is lifted just long enough to
+        # fill the slot: the point of the legacy leg is the DELEGATION branch in
+        # ``_resync_after_degraded_delta``, which is shape-independent.
+        supported = remote._display_window_supported
+        remote._display_window_supported = True
+        remote._invalidate_display_history()
+        remote._display_window_supported = supported
+        await asyncio.wait_for(entered.wait(), timeout=5)
+
+        in_flight = remote._display_refresh_task
+        assert in_flight is not None and not in_flight.done(), (
+            "the refresh was not in flight, so this run never reaches the delegating "
+            "branch this test exists for"
+        )
+
+        handle._frontend.mutate(
+            model_catalogue=[_catalogue_row(index) for index in range(5_000)],
+            conversation_title="after the degrade",
+        )
+        # A frame arriving mid-pass is BUFFERED, not applied — that is how it
+        # reaches the delegating branch. It is replayed by the failure path
+        # below, at which point the failing task still occupies the slot, so
+        # ``_resync_after_degraded_delta`` hands it the debt and returns. Waiting
+        # on the buffer (never on the clock) is what makes the ordering certain
+        # rather than assumed.
+        for _ in range(400):
+            buffered = remote._pending_frontend_updates
+            if buffered and any(update.degraded for update in buffered):
+                break
+            await asyncio.sleep(0.02)
+        buffered = remote._pending_frontend_updates
+        assert buffered and any(update.degraded for update in buffered), (
+            "the degraded frame never reached the in-flight pass's buffer, so this run "
+            "does not exercise the delegating branch this test exists for"
+        )
+        assert not in_flight.done(), "the pass finished early; the fold never happened"
+
+        release.set()
+        await asyncio.gather(in_flight, return_exceptions=True)
+        # It genuinely FAILED. A pass that succeeded would settle the debt by
+        # doing the work, proving nothing about the failure path.
+        assert failures >= 1
+        assert in_flight.done() and in_flight.exception() is not None
+        # The debt landed on a task THIS PATH DID NOT START and which has now
+        # failed: the slot still holds it, so the degrade path took its early
+        # return rather than starting a pass of its own. That is the exact state
+        # in which the debt used to be orphaned — `pending=True retry=None`.
+        assert remote._display_refresh_task is in_flight, (
+            "the degrade started its own pass, so the delegating branch — where the "
+            "debt was orphaned — was never exercised"
+        )
+        assert remote._frontend_resync_pending, "the degraded frame never registered a debt"
+        assert remote._degraded_resync_retry_task is not None, (
+            "the debt was orphaned: the in-flight pass failed with a re-sync owed and "
+            "armed no retry"
+        )
+
+        # Restore a healthy owner. Nothing else touches the follower: no further
+        # deltas, so only the retry can repair this.
+        monkeypatch.setattr(client, "frontend_sync", original)
+
+        for _ in range(600):
+            if (
+                remote.frontend_state.conversation_title == "after the degrade"
+                and not remote._frontend_resync_pending
+                and remote._degraded_resync_retry_task is None
+            ):
+                break
+            await asyncio.sleep(0.02)
+
+        owner = handle._frontend.state
+        assert client.connected, "the retry cost the socket"
+        assert remote.frontend_state.conversation_title == owner.conversation_title, (
+            "the debt was orphaned in the in-flight refresh: the follower is permanently "
+            f"stale at {remote.frontend_state.conversation_title!r}"
+        )
+        assert remote.frontend_state.sequence == owner.sequence
+        # The shed BODY came back, not just the scalar that also rides the
+        # ordinary stream — a title alone is a way to misread a stale follower
+        # as converged.
+        assert remote.frontend_state.model_catalogue
+        assert not remote._frontend_resync_pending
+        assert remote._degraded_resync_retry_task is None
+
+        # Navigation is usable again rather than latched on a stored error.
+        await remote.ensure_display_current()
+        if isinstance(handle, _WindowedHandle):
+            # The surfaced symptom was "Could not load earlier messages": prove
+            # real paging still works, over real transcript rows.
+            served = len(handle.page_calls)
+            assert remote.history_before_token
+            rows = await remote.load_older_display_page()
+            assert rows, "paging returned nothing after the recovery"
+            assert len(handle.page_calls) > served, "the page was not served by the owner"
+    finally:
+        if remote is not None:
+            await remote.dispose()
+        registrant.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("windowed", [False, True])
+async def test_a_quiescent_follower_recovers_without_waiting_for_more_traffic(
+    tmp_path: Path, monkeypatch, windowed: bool
+) -> None:
+    """Recovery must not depend on a delta that may never come.
+
+    THE FINDING THIS PINS (QA round 2, Q3) — the same mechanism as B2 seen from
+    its second face. When the debt was orphaned in a refresh started by the
+    other path, a follower still LOOKED like it recovered as long as traffic
+    kept arriving: ``_display_invalidated`` stayed latched, so the next delta of
+    any kind restarted a pass that serviced the orphan as a side effect. A
+    genuinely quiet session had nothing to ride on and stayed stale — measured
+    at 45 s of quiescence with 0 of 5000 catalogue rows on a live socket at
+    sequence 3/3.
+
+    So this test sends NO traffic after the failure, and asserts the owner
+    stayed quiet. The retry timer is the only thing that can repair it, which is
+    the property Q3 asks for.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    handle = await _windowed_handle(tmp_path) if windowed else FakeHandle()
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    remote = None
+    try:
+        record = await _record(tmp_path)
+        remote = await RemoteSession.connect(
+            record,
+            "s1",
+            config_dir=tmp_path,
+            takeover_factory=_never,
+            display_window=windowed,
+        )
+        assert remote._display_window_supported is windowed
+        _assert_reachable(remote)
+        client = remote._client
+        assert client is not None
+
+        original = client.frontend_sync
+        failures = 0
+
+        async def failing_sync() -> Any:
+            nonlocal failures
+            failures += 1
+            raise ConnectionError("injected sync failure")
+
+        monkeypatch.setattr(client, "frontend_sync", failing_sync)
+        assert client.frontend_sync is failing_sync
+
+        handle._frontend.mutate(
+            model_catalogue=[_catalogue_row(index) for index in range(5_000)],
+            conversation_title="after the degrade",
+        )
+        for _ in range(400):
+            if failures:
+                break
+            await asyncio.sleep(0.02)
+        assert failures >= 1, "the injected sync failure never fired"
+
+        # THE INTERLEAVING (this is what orphans the debt, not the failure
+        # alone). Inside the backoff, an ordinary delta that MOVES
+        # ``history_generation`` re-enters ``_invalidate_display_history`` and
+        # takes over the refresh slot. When that pass carried a log-only
+        # callback, ``_retry_degraded_resync`` deferred to it, the pass failed,
+        # and the debt died there — after which only more traffic could repair
+        # it.
+        assert remote._degraded_resync_retry_task is not None, (
+            "no backoff timer to interleave with, so this run cannot reproduce the "
+            "hand-off that orphans the debt"
+        )
+        if windowed:
+            # Only the windowed follower can be interleaved with:
+            # ``_invalidate_display_history`` early-returns for the legacy one,
+            # so the generation move is a no-op there and asserting a takeover
+            # would be asserting against a path that does not exist. The legacy
+            # leg below still proves quiescent recovery, just from the simpler
+            # state where the retry is the only actor.
+            taken_over = remote._display_refresh_task
+            handle._frontend.mutate(history_generation=1, cwd="/tmp/generation-moved")
+            for _ in range(400):
+                current = remote._display_refresh_task
+                if current is not None and current is not taken_over:
+                    break
+                await asyncio.sleep(0.02)
+            current = remote._display_refresh_task
+            # The SLOT genuinely changed hands to a pass this path did not
+            # start. A count of injected failures would not prove this — the
+            # backoff's own attempts also raise, so it would go green on the
+            # broken tree for the wrong reason.
+            assert current is not None and current is not taken_over, (
+                "the generation move never took over the refresh slot, so the debt was "
+                "never handed to the other path"
+            )
+            await asyncio.gather(current, return_exceptions=True)
+            assert current.exception() is not None, (
+                "the interleaved pass succeeded, so it settled the debt by doing the "
+                "work rather than by orphaning it"
+            )
+
+        monkeypatch.setattr(client, "frontend_sync", original)
+        # Deliberately no mutations from here on. The owner is quiet, which is
+        # the condition under which the orphaned debt was never serviced.
+        quiet_sequence = handle._frontend.state.sequence
+        for _ in range(600):
+            if (
+                remote.frontend_state.conversation_title == "after the degrade"
+                and not remote._frontend_resync_pending
+                and remote._degraded_resync_retry_task is None
+            ):
+                break
+            await asyncio.sleep(0.02)
+
+        assert handle._frontend.state.sequence == quiet_sequence, (
+            "the owner emitted deltas during the quiet window, so this run cannot "
+            "distinguish the retry from a delta-driven refresh"
+        )
+        assert client.connected
+        assert remote.frontend_state.conversation_title == "after the degrade"
+        assert remote.frontend_state.model_catalogue, "the shed body never came back"
+        assert not remote._frontend_resync_pending
+        assert remote._degraded_resync_retry_task is None
+    finally:
+        if remote is not None:
+            await remote.dispose()
+        registrant.close()
+
+
+@pytest.mark.asyncio
+async def test_a_display_refresh_failure_still_reports_when_nothing_canonical_is_owed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Fixing a raise must not remove it: ``ensure_display_current`` still raises.
+
+    Moving the retry onto the slot made ``_invalidate_display_history`` share
+    the degrade path's failure callback, so the risk is the mirror of B2 — a
+    display-drift failure quietly retried into silence instead of reported to
+    navigation, which is how stale rows get painted. It must still surface (the
+    fence stays closed, the error reaches the caller) when NO canonical re-sync
+    is owed and the owner is genuinely unreachable, and it must still be a
+    reporting surface rather than a retrying one.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    handle = await _windowed_handle(tmp_path)
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    remote = None
+    try:
+        record = await _record(tmp_path)
+        remote = await RemoteSession.connect(
+            record, "s1", config_dir=tmp_path, takeover_factory=_never, display_window=True
+        )
+        assert remote._display_window_supported
+        _assert_reachable(remote)
+        client = remote._client
+        assert client is not None
+
+        # A healthy owner with nothing owed RETURNS. Without this the raise
+        # below would pass for the wrong reason.
+        await remote.ensure_display_current()
+
+        failures = 0
+        original = client.frontend_sync
+
+        async def failing_sync() -> Any:
+            nonlocal failures
+            failures += 1
+            raise ConnectionError("injected sync failure")
+
+        monkeypatch.setattr(client, "frontend_sync", failing_sync)
+        remote._invalidate_display_history()
+        task = remote._display_refresh_task
+        assert task is not None
+        await asyncio.gather(task, return_exceptions=True)
+        assert failures >= 1, "the injected sync failure never fired"
+
+        # No canonical debt was ever armed, so this is pure display drift.
+        assert not remote._frontend_resync_pending
+        # No retry timer either: this surface reports, and one timer per failed
+        # navigation would be an RPC stream the operator never asked for.
+        assert remote._degraded_resync_retry_task is None
+        assert not remote.display_history_current, "the invalidation fence was left open"
+        with pytest.raises(ConnectionError):
+            await remote.ensure_display_current()
+
+        # The raise is the CONTRACT here, so it must survive the owner coming
+        # back: `ensure_display_current` awaits the stored task first, so this
+        # surface stays latched on the failed pass until something invalidates
+        # again. That is pre-existing behaviour on the display-drift path —
+        # unchanged by moving the retry onto the slot — and it is what makes the
+        # canonical debt's own retry necessary rather than optional.
+        monkeypatch.setattr(client, "frontend_sync", original)
+        with pytest.raises(ConnectionError):
+            await remote.ensure_display_current()
+        # A fresh invalidation is the documented way out, and it works.
+        remote._invalidate_display_history()
+        refreshed = remote._display_refresh_task
+        assert refreshed is not None and refreshed is not task
+        await refreshed
+        assert remote.display_history_current
     finally:
         if remote is not None:
             await remote.dispose()

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -41,6 +41,7 @@ from local_operator.session.frontend_state import (
     FrontendSessionState,
     FrontendStateStore,
     FrontendSync,
+    FrontendUpdate,
     FrontendUsage,
     JobState,
     McpServerState,
@@ -1425,6 +1426,177 @@ async def test_attach_succeeds_against_an_owner_offering_thousands_of_models(
         registrant.close()
 
 
+@pytest.mark.asyncio
+async def test_an_oversized_delta_keeps_the_socket_and_the_follower_resyncs(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """End to end over a REAL socket: the connection survives AND state recovers.
+
+    The serialization tests above prove the frame validates. This one proves the
+    two claims that actually matter to the operator, neither of which a shape
+    assertion can reach:
+
+    1. The socket stays up. Before the fix the follower's ``model_validate``
+       raised, the pump's catch-all named it ``owner frame could not be
+       applied`` and dropped the connection — the reported failure.
+    2. The follower ends up with the owner's CANONICAL state, not silently
+       stale state. The degraded frame consumed a sequence, so the gap check
+       stays satisfied forever; without a forced re-snapshot the viewer would
+       keep a title from before the shed delta and never learn otherwise. That
+       is the difference between a fixed bug and a hidden one.
+
+    The fixture degrades a DELTA while leaving the snapshot small — a huge
+    catalogue mutation is 1.5 MB on the wire and re-syncs to ~1.2 KB — which is
+    the real shape: the snapshot the recovery rides on has to fit.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    handle = FakeHandle()
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    remote = None
+    try:
+        record = await _record(tmp_path)
+        remote = await RemoteSession.connect(
+            record, "s1", config_dir=tmp_path, takeover_factory=_never
+        )
+        assert remote.frontend_state.conversation_title == "fake"
+
+        # One mutation whose DELTA cannot ride the wire. `conversation_title`
+        # rides along in the same delta: it is the field whose loss proves the
+        # follower would otherwise be stale, because it survives into the
+        # snapshot while the catalogue is what made the frame oversized.
+        handle._frontend.mutate(
+            model_catalogue=[_catalogue_row(index) for index in range(5_000)],
+            conversation_title="after the degrade",
+        )
+
+        # The owner's delta really was over the limit, so this test cannot pass
+        # by the frame simply fitting.
+        assert (
+            _line_bytes(
+                {
+                    "op": "frontend_update",
+                    "data": {
+                        "epoch": handle._frontend.state.epoch,
+                        "sequence": handle._frontend.state.sequence,
+                        "changes": {
+                            "model_catalogue": [_catalogue_row(index) for index in range(5_000)],
+                            "conversation_title": "after the degrade",
+                        },
+                    },
+                }
+            )
+            > _MAX_LINE_BYTES
+        )
+
+        # Wait on the RESULT, never on the clock: the recovery is an async task
+        # the frame scheduled, so poll the property it repairs.
+        for _ in range(200):
+            if remote.frontend_state.conversation_title == "after the degrade":
+                break
+            await asyncio.sleep(0.02)
+
+        # 1. The connection is still up. This is the regression assertion.
+        client = remote._client
+        assert client is not None and client.connected, "the degraded delta killed the socket"
+
+        # 2. Canonical state matches the OWNER, rather than being stale at the
+        #    pre-degrade value while the sequence marches on.
+        owner = handle._frontend.state
+        assert remote.frontend_state.conversation_title == owner.conversation_title
+        assert remote.frontend_state.sequence == owner.sequence
+        # The catalogue came back too (clipped by the wire budget, as ever), so
+        # the recovery restored the shed body rather than only the scalar.
+        assert remote.frontend_state.model_catalogue
+        assert remote.frontend_state.model_catalogue[0] == _catalogue_row(0)
+
+        # And the stream is still LIVE after recovery: a later ordinary delta
+        # applies on top, proving the sequence cursor was not left desynced.
+        handle._frontend.mutate(conversation_title="still live")
+        for _ in range(200):
+            if remote.frontend_state.conversation_title == "still live":
+                break
+            await asyncio.sleep(0.02)
+        assert remote.frontend_state.conversation_title == "still live"
+        assert client.connected
+    finally:
+        if remote is not None:
+            await remote.dispose()
+        registrant.close()
+
+
+@pytest.mark.asyncio
+async def test_a_burst_of_degraded_deltas_coalesces_into_one_resync(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Recovery must not turn one bad minute into a snapshot storm.
+
+    The frame that degrades is by definition a frame the session is big enough
+    to produce repeatedly — the operator hit this with nine subagents running —
+    so a naive "re-sync on every degraded delta" answers a 1.5 MB frame with a
+    sync RPC per frame and makes the overload worse.
+
+    The bound is the existing refresh task slot plus ``_refresh_display_history``'s
+    own loop, not a timer: frames arriving while a refresh is in flight re-arm
+    the flag and fold into at most ONE further pass. The assertion is on the
+    number of ``frontend_sync`` round trips, and on the state still converging
+    — a coalescing bound that lost the last delta would be a worse bug.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    handle = FakeHandle()
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    remote = None
+    try:
+        record = await _record(tmp_path)
+        remote = await RemoteSession.connect(
+            record, "s1", config_dir=tmp_path, takeover_factory=_never
+        )
+        client = remote._client
+        assert client is not None
+
+        syncs = 0
+        original = client.frontend_sync
+
+        async def counting_sync() -> Any:
+            nonlocal syncs
+            syncs += 1
+            return await original()
+
+        monkeypatch.setattr(client, "frontend_sync", counting_sync)
+
+        # Every delta must be GENUINELY oversized, so the catalogue has to
+        # DIFFER each time: re-sending an identical list produces no field diff
+        # and a small delta, which would let this pass for free.
+        rounds = 20
+        for index in range(rounds):
+            handle._frontend.mutate(
+                model_catalogue=[_catalogue_row(row + index * 10_000) for row in range(5_000)],
+                conversation_title=f"title-{index}",
+            )
+
+        for _ in range(400):
+            if remote.frontend_state.conversation_title == f"title-{rounds - 1}":
+                break
+            await asyncio.sleep(0.02)
+
+        # Converged on the owner's latest, not on some intermediate the
+        # coalescing happened to stop at.
+        owner = handle._frontend.state
+        assert remote.frontend_state.conversation_title == owner.conversation_title
+        assert remote.frontend_state.sequence == owner.sequence
+        assert client.connected
+        # The bound itself. Far below one-per-frame; exact count is scheduling
+        # dependent, so this asserts the ORDER of magnitude the design promises.
+        assert 0 < syncs <= 3, f"{rounds} degraded frames caused {syncs} snapshot round trips"
+    finally:
+        if remote is not None:
+            await remote.dispose()
+        registrant.close()
+
+
 def _oversized_event_frame() -> dict[str, Any]:
     """An ``event`` frame the size the operator's real transcript produced.
 
@@ -1518,6 +1690,73 @@ def test_oversized_frontend_update_keeps_its_sequence():
     assert sendable["data"]["epoch"] == "epoch-1"
     assert sendable["data"]["sequence"] == 42
     assert sendable["data"]["degraded"] is True
+
+
+def test_a_degraded_frontend_update_still_validates_as_one():
+    """The degrade path's own frame must satisfy the model the follower parses.
+
+    THE BUG THIS PINS. ``changes`` was a REQUIRED field, so the stand-in built
+    by ``relay_frame_or_degraded`` — which sheds the body and keeps only
+    sequencing — raised ``ValidationError`` inside the follower's
+    ``_on_frontend_update``. ``AttachClient._pump``'s catch-all turned that into
+    ``owner frame could not be applied: ...`` and tore the socket down, so the
+    guard written specifically to avoid killing the connection killed it one
+    layer further down. The operator saw exactly this string.
+    """
+    from local_operator.session.runtime.server import (
+        _MAX_LINE_BYTES,
+        relay_frame_or_degraded,
+    )
+
+    frame = {
+        "op": "frontend_update",
+        "data": {
+            "epoch": "epoch-1",
+            "sequence": 42,
+            "changes": {"cwd": "y" * (_MAX_LINE_BYTES + 10)},
+        },
+    }
+
+    sendable = relay_frame_or_degraded(frame, _MAX_LINE_BYTES)
+
+    # The exact call the follower makes. Before the fix this raised.
+    update = FrontendUpdate.model_validate(sendable["data"])
+    assert update.degraded is True
+    assert update.degraded_reason
+    # Empty rather than absent, so `payload["changes"]` readers keep working.
+    assert update.changes == {}
+    assert update.model_dump(mode="json")["changes"] == {}
+
+
+def test_a_degraded_delta_advances_the_sequence_without_touching_fields():
+    """Applying a shed body as an empty change set would be a silent corruption.
+
+    The owner consumed the sequence, so it must advance here or every later
+    delta is refused as a gap. But the fields the frame carried are UNKNOWN,
+    not unchanged — writing an empty change set over canonical state and
+    calling it applied is what leaves a follower permanently, quietly wrong.
+    """
+    store = FrontendStateStore(
+        FrontendSessionState(session_id="s1", epoch="e1", conversation_title="before")
+    )
+    seen: list[FrontendUpdate] = []
+    store.subscribe(seen.append)
+    start = store.state.sequence
+
+    state = store.apply_update(
+        FrontendUpdate(
+            epoch="e1",
+            sequence=start + 1,
+            degraded=True,
+            degraded_reason="too large",
+        )
+    )
+
+    assert state.sequence == start + 1
+    assert state.conversation_title == "before"
+    # Published, so an in-process subscriber and the resync path agree that a
+    # delta was shed rather than one of them believing state is complete.
+    assert [u.degraded for u in seen] == [True]
 
 
 def test_ordinary_relay_frames_pass_through_untouched():


### PR DESCRIPTION
## What and why

**C2 — transport correctness fix on the attach seam.** A live session's viewer printed this and lost the connection:

```
✗ Could not load earlier messages: owner connection lost; owner frame could not be applied:
1 validation error for FrontendUpdate
changes
  Field required [type=missing, input_value={'epoch': '6ea9378813ea45...session's own history."}, input_type=dict]
```

The session had 9 subagents running, and "awaiting all in-flight rounds" then hung.

### A guard that never worked for the op it was written for

`relay_frame_or_degraded` (`session/runtime/server.py`) exists so that one oversized frame costs an animation step rather than the session. Its own docstring says so:

> **DEGRADING ONE DELTA IS SAFE; KILLING THE SOCKET IS NOT.**

For `frontend_update` it sheds the body and keeps only sequencing, because the client's gap check closes the connection on a missing sequence:

```python
return {"op": op, "data": {"epoch": ..., "sequence": ..., "degraded": True, "degraded_reason": text}}
```

But `FrontendUpdate` declared **`changes: dict[str, Any]` as required**. So the follower's `RemoteSession._on_frontend_update` called `FrontendUpdate.model_validate(data)`, pydantic raised, and `AttachClient._pump`'s catch-all turned it into `owner frame could not be applied: …` and tore the socket down. **The guard written specifically to avoid killing the connection killed it one layer below itself.**

### Validation is only half of it

Making the frame validate, on its own, converts a dropped connection into something worse: a **silently stale** one. The degraded frame **consumed a sequence number**, so the follower's gap check stays satisfied forever while its canonical state is missing whatever that frame carried. Applying an empty change set as though it were a no-op delta is a correctness bug wearing a fix's clothes.

Demonstrated, not asserted — the same script against the pre-fix runtime and the fixed one (`docs/evidence/degraded-frontend-update/`):

| | before | after |
|---|---|---|
| connection alive | **False** | **True** |
| owner title / seq | `'post-degrade title'` / 1 | `'post-degrade title'` / 1 |
| viewer title / seq | **`'fake'` / 0** | **`'post-degrade title'` / 1** |
| viewer catalogue rows | **0** | 3426 |
| state matches owner | **False** | **True** |
| stream still live after | `'fake'` | `'still streaming'` |

The `before` column is the operator's bug: the viewer keeps the pre-degrade title and never learns otherwise.

### The fix

**1. The frame validates, and says what it is.** `FrontendUpdate` gains explicit `degraded: bool = False` and `degraded_reason: str = ""`, with `changes` defaulting to empty.

An explicit flag rather than inferring "degraded" from an empty `changes`, because **the two are not equivalent**: an empty change set means *nothing moved* and is safe to apply, while a shed body means canonical state **has genuinely drifted**. Downstream code must be able to ASK. Collapsing them is exactly how a follower ends up permanently stale with a gap check that stays happy forever.

`changes` defaults to empty rather than carrying a validator demanding it whenever `degraded` is false: a stricter model would raise at precisely the transport seam whose raised exception is the bug being fixed.

**2. `apply_update` advances the sequence and mutates nothing.** The owner consumed that number, so refusing it would desync the store and reject every later delta. But the fields are **unknown, not unchanged**, so nothing is written. The delta is **still published** to subscribers, so an in-process subscriber and the resync path agree that state is untrustworthy rather than one of them believing it is complete.

**3. The follower re-syncs, through the existing path.** `RemoteSession` forces a fresh `frontend_sync`, making true the degrade path's own promise that "the viewer recovers this state through frontend_sync + durable history".

Deliberately **not** `_invalidate_display_history`, though it reuses that method's task and lock: that one returns early unless `_display_window_supported`, because it is about *display history*. A degraded delta drops canonical **fields** (roster, usage, gates), which every follower has whether or not it negotiated a windowed history — gating on that flag would leave legacy and full-replay viewers permanently stale on exactly the frame this fix is about.

**A burst must not become a refresh storm.** The frame that degrades is by definition one a busy session produces repeatedly (the operator had 9 subagents). The bound reuses two existing mechanisms rather than adding a timer: the refresh task slot, and `_refresh_display_history`'s own loop. Measured — **20 genuinely-oversized frames produce 1 `frontend_sync` round trip**, and state still converges on the last one.

One race closed while wiring it: a degraded delta landing *mid-refresh* is buffered and replayed by `_install_frontend`, so the flag is cleared **before** the capture and re-checked after, folding into one further pass instead of being swallowed by the terminal `_display_invalidated` assignment.

**4. Other consumers checked, not assumed.** `server/utils/desktop_sessions.py::_frontend` does `payload["changes"].pop("attention", None)` and indexes `payload["changes"]` — exercised directly against the real class: `changes` serializes as `{}` (present, empty), the `pop` and the `&` key-intersection both survive, and the flag is forwarded to phone/web subscribers. It recovers its own state through `replace_and_notify`'s full-snapshot republish.

**5. `AttachClient._pump`'s catch-all is untouched.** It is doing its job — a callback failure must not be silent. The bug was upstream of it, and weakening it to swallow validation failures would mask real gaps.

### A test double that hid the seam

`FakeHandle.subscribe_frontend` accepted only the positional form, while the real `Session.subscribe_frontend` takes `display_window=` — which the server passes both at connect time and **on the `frontend_sync` RPC**. So every server path taking that RPC raised `TypeError` against the double, and **no test could reach the canonical re-snapshot at all**. Fixed to match the real contract.

## Testing evidence

Real execution, not a green suite.

**The reported reproduction, before and after** (the exact command from the report):

```
$ .venv/bin/python -c "... FrontendUpdate.model_validate(relay_frame_or_degraded(big, _MAX_LINE_BYTES)['data'])"

# before
pydantic_core._pydantic_core.ValidationError: 1 validation error for FrontendUpdate
changes
  Field required [type=missing, ...]

# after
OK validated: e1 42 degraded= True changes= {}
```

**Over a REAL runtime→attach-client socket.** `RuntimeServer` on a real TCP socket, a real `RemoteSession` follower, and a delta genuinely over the 1 MiB limit (1,528,062 bytes). Against the **pre-fix runtime** the follower logs the operator's exact string and drops:

```
attach client: owner frame could not be applied: 1 validation error for FrontendUpdate
changes
  Field required [type=missing, ...]; the connection cannot continue
connection alive : False      state matches owner : False
```

After: `connection alive : True`, `state matches owner : True`, and a later ordinary delta still applies (`'still streaming'`) — proving the sequence cursor was not left desynced.

**Both halves proven load-bearing** by reverting each independently:

| reverted | result |
|---|---|
| `changes` back to required | `AssertionError: the degraded delta killed the socket` |
| the `update.degraded` resync branch | `AssertionError: assert 'fake' == 'after the degrade'` — silently stale |

The second is finding #2 failing on demand: without the resync the socket survives and the viewer is quietly wrong, which is why it is a test and not a claim.

**Tests added** to `tests/unit/session/test_attach_frame_size.py` (the file that already owns these fixtures):

- `test_a_degraded_frontend_update_still_validates_as_one` — pins the exact `model_validate` call the follower makes.
- `test_a_degraded_delta_advances_the_sequence_without_touching_fields` — sequence advances, fields untouched, delta still published.
- `test_an_oversized_delta_keeps_the_socket_and_the_follower_resyncs` — end to end over a real socket; connection survives **and** canonical state matches the owner.
- `test_a_burst_of_degraded_deltas_coalesces_into_one_resync` — 20 oversized frames, ≤3 sync round trips, state still converges.

The burst test mutates the catalogue with **different content each round**; re-sending an identical list produces no field diff and a small delta, which would let it pass for free.

## Gates

| gate | result |
|---|---|
| `flake8 .` | rc=0 |
| `black --check .` (26.1.0, pinned) | rc=0 — 1185 files unchanged |
| `isort --check .` (5.13.2) | rc=0 |
| `pyright --pythonpath .venv/bin/python .` | **0 errors, 0 warnings** |
| `pytest tests/unit/session/test_attach_frame_size.py tests/unit/session/runtime/test_server.py` | **123 passed** |
| full `pytest tests/unit` | see comment below |

Exit codes read directly, never through a pipeline (`rc=126` is swallowed by `cmd | tail`, per `AGENTS.md`).

## Scope

Inside the transport seam only. **No version bump** — `pyproject.toml` is untouched, per the release rule. The frontend state store is not refactored, and no in-flight PR is touched. Rebased onto current `main` (`6eacd91e2`, 0.53.3) since the branch point.

### Noted, not fixed (out of slice)

- `docs/evidence/` in this repo holds many uncommitted directories from prior sessions; I added one and left the rest alone.
- `FakeHandle` accepts `display_window` and ignores it (no transcript to capture a window from). Sufficient here — the sync carries canonical state and `_load_frontend_history` already handles the `window is None` branch — but a double that captured a real window would test more.
