### PR TITLE
perf(tui): stop delivering discarded deltas to parked sidebar sources

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -5466,6 +5466,70 @@ class OperatorApp(App[None]):
             editor.set_commands(SLASH_COMMANDS)
             editor.set_records_history(True)
 
+    def _park_switched_away_source(self, outgoing: SessionInteraction) -> None:
+        """Start the idle clock of a source that has just left the screen, and mute it.
+
+        THE INVARIANT THIS EXISTS TO MAKE STRUCTURAL: **a source that is
+        VISIBLE must never be parked.** A parked controller drops delta-grade
+        events (see :meth:`EventController.set_parked`), so parking the
+        conversation the user is looking at paints its boundaries and none of
+        its streaming tokens -- silently, for the whole turn. That is the worst
+        failure this feature can produce, and it must not be reachable by a
+        caller forgetting a guard.
+
+        So the visibility test is made HERE, against ``self._interaction`` --
+        the single authority on which source is on screen -- rather than at
+        each call site against whatever local happens to be in scope. Two
+        cases collapse into that one test:
+
+        * the REFRESH commit, where the switch re-lands the session already on
+          screen (``outgoing is source``), and
+        * a commit that RAISES before ownership moves, where the switch is
+          abandoned by ``SessionNavigation._prepare_and_commit`` and the
+          outgoing conversation stays on screen (review round 2, MAJOR).
+
+        The second is why this is called only AFTER :meth:`_adopt_session` has
+        returned. A mute applied before the transfer is a mute with no unwind:
+        the failure path shows a warning notice and abandons the switch, and
+        nothing there would lift it. Applied after, the mute simply never
+        happens unless the switch actually completed -- which needs no
+        ``try``/``finally`` and cannot be defeated by a future exception
+        somewhere in the ~66 lines of widget work the commit does.
+
+        ``parked_at`` moves with the mute for the same reason. It is the idle
+        sweep's deadline (:meth:`_sweep_idle_sidebar_sources`), and stamping it
+        on a session that is still current advertises a reapable source that
+        the user is in fact looking at.
+        """
+        # `self._interaction` is the incoming source by now, so this is false
+        # exactly when the switch really moved the screen somewhere else.
+        if outgoing is self._interaction:
+            return
+        # Attention is the only thing this stamp records: `outgoing` has just
+        # stopped being on screen. A source that is current has no deadline at
+        # all, which is what makes "the displayed conversation is never reaped"
+        # a structural property rather than a clause someone must remember.
+        outgoing.parked_at = time.monotonic()
+        # SYMMETRIC WITH THE STAMP ABOVE, and for the same reason: from here
+        # every delta `outgoing` receives is discarded by
+        # `_reduce_hidden_session_event` exactly as a never-visited prewarmed
+        # source's is. Without this the mute is a ONE-WAY LATCH --
+        # `_lease_sidebar_source` parks at birth and `_adopt_session` unparks
+        # on commit, and nothing ever re-parks -- so every session the user
+        # actually clicks into stays exempt for the rest of its
+        # `SIDEBAR_IDLE_RELEASE_S` retention and keeps paying full per-token
+        # delivery while hidden. That decays the saving with exactly the
+        # behaviour the sidebar exists to support (review round 1, R1).
+        #
+        # Safe with respect to the reveal, because the return trip either
+        # rebuilds the presentation (the cache misses whenever the source is
+        # `streaming`, so an in-flight answer is never served from it) or
+        # replays the owner's `live_events` seed through
+        # `restore_live_projection`, which bypasses the mute. The buffer this
+        # drops is per-token text already superseded by that seed.
+        if outgoing.controller is not None:
+            outgoing.controller.set_parked(True)
+
     def _commit_sidebar_session(
         self,
         session_id: str,
@@ -5536,38 +5600,16 @@ class OperatorApp(App[None]):
             ):
                 self._sidebar_presentations[previous.session_id] = outgoing_presentation
                 outgoing_presentation = None
-        # Start the outgoing source's idle clock, and stop the incoming one's.
-        # This is the single place the two transitions happen together, and
-        # attention is the only thing either stamp records: `outgoing` has just
-        # stopped being on screen, `source` has just become the session the
-        # user is looking at. A source that is current has no deadline at all,
-        # which is what makes "the displayed conversation is never reaped" a
-        # structural property rather than a clause someone must remember.
-        outgoing.parked_at = time.monotonic()
+        # Stop the incoming source's idle clock: it is about to be the session
+        # the user is looking at, and a current source has no deadline at all.
+        # Its counterpart -- starting the OUTGOING source's clock, and muting
+        # it -- deliberately does NOT happen here. It runs after
+        # `_adopt_session` via `_park_switched_away_source`, because a mute
+        # applied before ownership moves is a mute with no unwind: a commit
+        # that raises in the widget work below is caught by
+        # `SessionNavigation._prepare_and_commit`, which abandons the switch
+        # and leaves this conversation on screen (review round 2, MAJOR).
         source.parked_at = None
-        # SYMMETRIC WITH THE STAMP ABOVE, and for the same reason: `outgoing`
-        # has just stopped being on screen, so from here every delta it
-        # receives is discarded by `_reduce_hidden_session_event` exactly as a
-        # never-visited prewarmed source's is. Without this the mute is a
-        # ONE-WAY LATCH -- `_lease_sidebar_source` parks at birth and
-        # `_adopt_session` unparks on commit, and nothing ever re-parks -- so
-        # every session the user actually clicks into stays exempt for the rest
-        # of its `SIDEBAR_IDLE_RELEASE_S` retention and keeps paying full
-        # per-token delivery while hidden. That decays the saving with exactly
-        # the behaviour the sidebar exists to support (review round 1, R1).
-        #
-        # `outgoing is not source` guards the REFRESH case, where the commit
-        # re-lands the session already on screen: parking that controller would
-        # mute the conversation the user is looking at.
-        #
-        # Safe with respect to the reveal, because the return trip either
-        # rebuilds the presentation (the cache misses whenever the source is
-        # `streaming`, so an in-flight answer is never served from it) or
-        # replays the owner's `live_events` seed through
-        # `restore_live_projection`, which bypasses the mute. The buffer this
-        # drops is per-token text already superseded by that seed.
-        if outgoing.controller is not None and outgoing is not source:
-            outgoing.controller.set_parked(True)
         self._park_sidebar_aside(outgoing)
         if isinstance(previous, RemoteSession):
             self._suspend_sidebar_gates(outgoing)
@@ -5634,6 +5676,16 @@ class OperatorApp(App[None]):
             # straight back to.
             self._reset_band_for_swap(retire=False)
             self._adopt_session(session, replay_history=False, reuse_controller=True)
+            # IMMEDIATELY AFTER the adopt, and never before it. `_adopt_session`
+            # is the single place a source becomes current: it has just moved
+            # `self._interaction` to the incoming source and lifted ITS mute, so
+            # from this line the helper's `outgoing is self._interaction` test
+            # can tell a completed switch from an abandoned one. Ordering the
+            # pair this way is what makes "a VISIBLE source is never parked"
+            # hold without an unwind path -- an exception anywhere above simply
+            # never reaches this line, leaving the outgoing conversation live on
+            # the screen it never left (review round 2, MAJOR).
+            self._park_switched_away_source(outgoing)
             # Re-derive the fork indicator from the session now in front of the
             # user. `fork_pending` is app-scoped with no `FrontendSessionState`
             # field, so no snapshot repaints it and the park leg deliberately

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -5545,6 +5545,29 @@ class OperatorApp(App[None]):
         # structural property rather than a clause someone must remember.
         outgoing.parked_at = time.monotonic()
         source.parked_at = None
+        # SYMMETRIC WITH THE STAMP ABOVE, and for the same reason: `outgoing`
+        # has just stopped being on screen, so from here every delta it
+        # receives is discarded by `_reduce_hidden_session_event` exactly as a
+        # never-visited prewarmed source's is. Without this the mute is a
+        # ONE-WAY LATCH -- `_lease_sidebar_source` parks at birth and
+        # `_adopt_session` unparks on commit, and nothing ever re-parks -- so
+        # every session the user actually clicks into stays exempt for the rest
+        # of its `SIDEBAR_IDLE_RELEASE_S` retention and keeps paying full
+        # per-token delivery while hidden. That decays the saving with exactly
+        # the behaviour the sidebar exists to support (review round 1, R1).
+        #
+        # `outgoing is not source` guards the REFRESH case, where the commit
+        # re-lands the session already on screen: parking that controller would
+        # mute the conversation the user is looking at.
+        #
+        # Safe with respect to the reveal, because the return trip either
+        # rebuilds the presentation (the cache misses whenever the source is
+        # `streaming`, so an in-flight answer is never served from it) or
+        # replays the owner's `live_events` seed through
+        # `restore_live_projection`, which bypasses the mute. The buffer this
+        # drops is per-token text already superseded by that seed.
+        if outgoing.controller is not None and outgoing is not source:
+            outgoing.controller.set_parked(True)
         self._park_sidebar_aside(outgoing)
         if isinstance(previous, RemoteSession):
             self._suspend_sidebar_gates(outgoing)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -5496,6 +5496,20 @@ class OperatorApp(App[None]):
         ``try``/``finally`` and cannot be defeated by a future exception
         somewhere in the ~66 lines of widget work the commit does.
 
+        THE POST-SWAP WINDOW IS NOT A LEAK, stated here because it reads like
+        one. A raise after :meth:`_apply_sidebar_presentation` but before this
+        line leaves the INCOMING transcript mounted on screen while
+        ``self._interaction`` still points at the OUTGOING source, and that
+        incoming source is still parked from its birth in
+        :meth:`_lease_sidebar_source`. Both halves are correct. The outgoing
+        source is the one the app considers current, and it is left unmuted and
+        unstamped -- this line never ran -- so the conversation the app is
+        driving still paints. The incoming one stays muted because no commit
+        ever claimed it: the navigation failed, and the retry prepares it again
+        through the same seam that unparks it. Verified by injecting a raise in
+        exactly that window: current source unparked and painting deltas,
+        ``parked_at`` None, incoming still parked.
+
         ``parked_at`` moves with the mute for the same reason. It is the idle
         sweep's deadline (:meth:`_sweep_idle_sidebar_sources`), and stamping it
         on a session that is still current advertises a reapable source that

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -4418,6 +4418,19 @@ class OperatorApp(App[None]):
             self._sidebar_sources[session_id] = source
             source.controller = EventController(remote, self)
             self._event_sources[source.controller] = source
+            # PARKED BEFORE SUBSCRIBING, never after. A lease reached from
+            # prewarm is speculative by construction -- it exists to make a
+            # future CLICK fast, and until that click every delta it receives
+            # is discarded by `_reduce_hidden_session_event`. Parking first
+            # means the very first relayed token is already declined rather
+            # than paid for in the window between the two calls.
+            #
+            # The subscription itself STAYS: `_emit_or_buffer` buffers rather
+            # than drops when no handler is registered, so an unsubscribed
+            # parked source silently accumulates its owner's whole stream (8k+
+            # events in 25 s across 12 sources, measured) and then delivers it
+            # in one drain at commit. See `EventController.set_parked`.
+            source.controller.set_parked(True)
             source.controller.subscribe()
             self._watch_source_frontend(source)
             return source
@@ -6819,6 +6832,14 @@ class OperatorApp(App[None]):
         # a source leased by prewarm and later adopted would otherwise keep the
         # stamp it was born with and be swept while on screen.
         source.parked_at = None
+        # THE SINGLE PLACE A SOURCE BECOMES CURRENT, and therefore the one
+        # place its event stream must go live again. A prewarmed source was
+        # muted for delta-grade events while speculative (see
+        # `_lease_sidebar_source` and `EventController.set_parked`); from here
+        # its tokens are painted, so the mute has to lift BEFORE the commit
+        # path below replays the owner's live seed through the same controller.
+        if source.controller is not None:
+            source.controller.set_parked(False)
         self._watch_source_frontend(source)
         self._set_approve_all(self._approve_all)
         if getattr(session, "session_id", ""):

--- a/local_operator/tui/events.py
+++ b/local_operator/tui/events.py
@@ -526,9 +526,24 @@ class EventController:
         dispatched, posted as a Textual message, and dequeued by the app --
         which discarded it, because ``_reduce_hidden_session_event`` paints
         nothing for a hidden source. Measured on 12 background sessions: ~229
-        such events/s, every one hidden-source, +9 points of a core, and
-        keystroke latency 1.46x worse at the median / 2.2-3.3x at p99. The full
+        such events/s, every one hidden-source, +9 points of a core. The full
         delivery cost of a result thrown away.
+
+        WHAT THIS DOES *NOT* FIX, stated here because this is where the next
+        investigator lands. Typing is measurably slower with the sidebar open
+        than closed, and THIS PATH IS NOT THE CAUSE -- do not re-derive the
+        retracted attribution from the numbers above. An ABBA A/B put this
+        change at 153.8 ms against 143.1 ms without it (within noise) while
+        closed sat at 121.1 ms; an independent QA replication measured
+        109.5 ms with / 100.3 ms without / 86.7 ms closed and reached the same
+        conclusion. A CEILING ARM that dropped the identical events at the
+        owner's ``_relay_on_loop`` -- i.e. before they ever reach a viewer --
+        did not close the gap either, which retires viewer-side gating on the
+        event path as a CLASS: no filter placed here can recover it, however
+        aggressive. The leading open suspect is ``_prepare_sidebar_session``
+        (93 ms median, on the event loop, two per prewarm refresh), not event
+        fan-in. The justification for this mode is the discarded work above,
+        and nothing else.
 
         WHY IT IS A MODE HERE, AND NOT A DEFERRED ``subscribe()``. The obvious
         fix -- do not subscribe a speculative source at all -- does not work,
@@ -639,28 +654,6 @@ class EventController:
         return self._pending_tool_ends
 
     # -- event dispatch -----------------------------------------------------
-    #: Event types a PARKED source drops outright (see :meth:`set_parked`).
-    #:
-    #: The membership rule is "carries a fragment of something in flight, and
-    #: the owner's ``live_events`` seed already accumulates it", so a reveal
-    #: rebuilds the same viewport from ``restore_live_projection`` without
-    #: this terminal having paid per token for it. Deliberately NOT here:
-    #: ``message_start``/``message_end`` (row identity and the settled row the
-    #: dedupe and card pairing key on), every turn/agent boundary, tool
-    #: start/end, compaction, retry, model change, and every delivery notice --
-    #: those change state a parked source is still expected to have right.
-    #:
-    #: These three ARE the volume: at 12 streaming sessions they were ~229
-    #: events/s of the traffic measured, against a handful per turn for
-    #: everything above.
-    _PARKED_DROP_TYPES: frozenset[str] = frozenset(
-        {
-            "message_update",  # one per assistant token
-            "tool_execution_update",  # one per streamed tool-output chunk
-            "subagent_progress",  # one per child progress beat
-        }
-    )
-
     def _on_event(self, event: AgentEvent) -> None:
         """Route one engine event to its handler (sync or async-safe)."""
         event_type = event.type
@@ -983,6 +976,39 @@ class EventController:
         "subagent_progress": _handle_subagent_progress,
         "subagent_end": _handle_subagent_end,
     }
+
+    #: Event types a PARKED source drops outright (see :meth:`set_parked`).
+    #: Grouped with ``_HANDLERS`` because both are class-level dispatch tables
+    #: read by ``_on_event``, and this file keeps its class constants together.
+    #:
+    #: MEMBERSHIP RULE, all three clauses required: the event carries a
+    #: fragment of something in flight, the owner's ``live_events`` seed
+    #: already accumulates it (so a reveal rebuilds the same viewport through
+    #: ``restore_live_projection``), AND it is emitted UNTHROTTLED, once per
+    #: token or chunk. The third clause is what makes the set finite, and it is
+    #: why ``tool_call_compose`` is DELIBERATELY EXCLUDED despite satisfying
+    #: the first two: it carries partial argument bytes of an in-flight call,
+    #: but ``harness/loop.py`` already rate-limits it to one per
+    #: ``COMPOSE_NOTICE_INTERVAL_S`` (0.2 s), so it is not volume traffic and
+    #: dropping it would buy nothing while costing a compose preview on reveal.
+    #: Do not "complete" this set by adding it.
+    #:
+    #: Also deliberately absent: ``message_start``/``message_end`` (row
+    #: identity and the settled row the dedupe and card pairing key on), every
+    #: turn/agent boundary, tool start/end, compaction, retry, model change,
+    #: and every delivery notice -- those change state a parked source is still
+    #: expected to have right.
+    #:
+    #: These three ARE the volume: at 12 streaming sessions they were ~229
+    #: events/s of the traffic measured, against a handful per turn for
+    #: everything above.
+    _PARKED_DROP_TYPES: frozenset[str] = frozenset(
+        {
+            "message_update",  # one per assistant token
+            "tool_execution_update",  # one per streamed tool-output chunk
+            "subagent_progress",  # one per child progress beat
+        }
+    )
 
     # -- flush timer --------------------------------------------------------
     def _request_flush_timer(self) -> None:

--- a/local_operator/tui/events.py
+++ b/local_operator/tui/events.py
@@ -513,8 +513,65 @@ class EventController:
         self._flush_timer = None
         self._unsubscribe: Callable[[], Any] | None = None
         self._restoring_projection = False
+        self._parked = False
 
     # -- lifecycle ----------------------------------------------------------
+    def set_parked(self, parked: bool) -> None:
+        """Mute delta-grade traffic for a source nobody is looking at.
+
+        WHY THIS EXISTS. The sidebar prewarms every live session it can see, so
+        opening it attaches up to ``RETAINED_PRESENTATIONS`` real subscriptions
+        held for ``SIDEBAR_IDLE_RELEASE_S``. Each streaming delta of each of
+        those OTHER conversations was then decoded, deserialized, deduped,
+        dispatched, posted as a Textual message, and dequeued by the app --
+        which discarded it, because ``_reduce_hidden_session_event`` paints
+        nothing for a hidden source. Measured on 12 background sessions: ~229
+        such events/s, every one hidden-source, +9 points of a core, and
+        keystroke latency 1.46x worse at the median / 2.2-3.3x at p99. The full
+        delivery cost of a result thrown away.
+
+        WHY IT IS A MODE HERE, AND NOT A DEFERRED ``subscribe()``. The obvious
+        fix -- do not subscribe a speculative source at all -- does not work,
+        and it fails silently. ``RemoteSession._emit_or_buffer`` does not DROP
+        an event when nobody is subscribed, it BUFFERS it (``remote.py``: ``if
+        not self._ready_for_events or not self._handlers: ...append``). A
+        parked source is ready-for-events with zero handlers, which is exactly
+        that branch, so deferring the subscribe trades CPU for an unbounded
+        list: measured at 8,169 events parked across 12 sources in 25 s (327/s
+        and climbing), which the commit path would then hand over in ONE drain
+        -- an avalanche landing on the click, i.e. on precisely the switch
+        latency the retention tuning exists to protect. Staying subscribed and
+        declining the work HERE keeps the drop where the events are already
+        known to be discardable.
+
+        WHAT SURVIVES THE MUTE. Only per-token/per-chunk traffic is dropped
+        (see ``_PARKED_DROP_TYPES``). Everything that changes a parked
+        conversation's OBSERVABLE state still flows: turn/agent boundaries keep
+        ``source.turn`` honest (a turn that starts or ends while parked is
+        still noticed, which is what the notifier, the abandon path and the
+        commit-time gate read), tool starts/ends keep card pairing intact so a
+        revealed view does not paint a succeeded call as interrupted,
+        compaction boundaries still release input held for the source, and
+        notices/wakes/peer deliveries are session facts a viewer must not miss.
+        The dropped events are recoverable by construction: the owner folds
+        them into ``live_events`` and ``restore_live_projection`` replays that
+        seed at commit, which is the same path a mid-turn join already uses.
+        """
+        if parked == self._parked:
+            return
+        self._parked = parked
+        if parked:
+            # A parked controller must not hold a 30 Hz timer for text nobody
+            # can see; the buffer it would flush is dropped below anyway.
+            self._stop_flush_timer()
+            self._assistant_buffer = ""
+            self._assistant_seen = ""
+
+    @property
+    def parked(self) -> bool:
+        """Whether delta-grade events are being dropped (test/inspection hook)."""
+        return self._parked
+
     def restore_live_projection(
         self, state: Any, rendered_ids: set[str], settled_tools: set[str]
     ) -> None:
@@ -582,9 +639,41 @@ class EventController:
         return self._pending_tool_ends
 
     # -- event dispatch -----------------------------------------------------
+    #: Event types a PARKED source drops outright (see :meth:`set_parked`).
+    #:
+    #: The membership rule is "carries a fragment of something in flight, and
+    #: the owner's ``live_events`` seed already accumulates it", so a reveal
+    #: rebuilds the same viewport from ``restore_live_projection`` without
+    #: this terminal having paid per token for it. Deliberately NOT here:
+    #: ``message_start``/``message_end`` (row identity and the settled row the
+    #: dedupe and card pairing key on), every turn/agent boundary, tool
+    #: start/end, compaction, retry, model change, and every delivery notice --
+    #: those change state a parked source is still expected to have right.
+    #:
+    #: These three ARE the volume: at 12 streaming sessions they were ~229
+    #: events/s of the traffic measured, against a handful per turn for
+    #: everything above.
+    _PARKED_DROP_TYPES: frozenset[str] = frozenset(
+        {
+            "message_update",  # one per assistant token
+            "tool_execution_update",  # one per streamed tool-output chunk
+            "subagent_progress",  # one per child progress beat
+        }
+    )
+
     def _on_event(self, event: AgentEvent) -> None:
         """Route one engine event to its handler (sync or async-safe)."""
-        handler = self._HANDLERS.get(event.type)
+        event_type = event.type
+        # The drop is FIRST, before the handler lookup and before anything can
+        # mint a Textual message: the cost this closes is the delivery, not the
+        # handler (the reduction the app finally runs is 1.1 us/call, 0.025% of
+        # a core -- the ~9 points sat in getting there). Guarded on the restore
+        # path too, which replays the seed through this same entry point while
+        # the source is being revealed and must NOT be muted.
+        if self._parked and not self._restoring_projection:
+            if event_type in self._PARKED_DROP_TYPES:
+                return
+        handler = self._HANDLERS.get(event_type)
         if handler is not None:
             handler(self, event)
 

--- a/tests/unit/tui/test_events.py
+++ b/tests/unit/tui/test_events.py
@@ -15,6 +15,7 @@ import pytest
 from local_operator.harness.types import (
     AgentEndEvent,
     AgentStartEvent,
+    AgentToolUpdate,
     ImageContent,
     Message,
     MessageEndEvent,
@@ -23,6 +24,7 @@ from local_operator.harness.types import (
     NoticeEvent,
     ToolExecutionEndEvent,
     ToolExecutionStartEvent,
+    ToolExecutionUpdateEvent,
     ToolResult,
     Usage,
 )
@@ -534,3 +536,125 @@ async def test_controller_async_handler_compat() -> None:
     controller, session, app = _controller()
     session.emit(AgentStartEvent())
     assert controller.generation == 1
+
+
+# -- parked sources: delta-grade traffic is declined, state is not ----------
+#
+# Guards the N-way fan-in fix. Opening the sidebar prewarms every live session
+# it can see and holds a REAL subscription to each, so without a mute every
+# streaming delta of every other conversation is decoded, dispatched, posted as
+# a Textual message and dequeued by the app -- which discards it. Measured at 12
+# streaming sessions: ~229 discarded events/s and keystroke latency 1.46x worse
+# at the median, 2.2-3.3x at p99.
+#
+# Each of these fails on the pre-fix tree: without `set_parked` the controller
+# posts for every event regardless of whether anyone is looking.
+
+
+def test_parked_source_drops_delta_grade_events() -> None:
+    """The volume traffic -- one event per token -- must not reach the app."""
+    controller, session, app = _controller()
+    controller.set_parked(True)
+    session.emit(AgentStartEvent())
+    app.posted.clear()
+
+    message = Message.assistant("partial")
+    message.id = "m1"
+    for _ in range(50):
+        session.emit(MessageUpdateEvent(message=message, delta="tok"))
+    session.emit(
+        ToolExecutionUpdateEvent(
+            tool_call_id="call-1",
+            tool_name="read",
+            partial_result=AgentToolUpdate(),
+        )
+    )
+
+    assert app.posted == []
+
+
+def test_parked_source_still_reports_turn_boundaries() -> None:
+    """A turn that STARTS or ENDS while parked is still an observable fact.
+
+    `_reduce_hidden_session_event` maintains `source.turn` from these, and the
+    sidebar row, the abandon path and the commit-time gate all read it. Muting
+    them would leave a parked session showing the wrong live state.
+    """
+    controller, session, app = _controller()
+    controller.set_parked(True)
+
+    session.emit(AgentStartEvent(generation=7))
+    session.emit(AgentEndEvent(generation=7))
+
+    assert [type(m) for m in app.posted] == [TurnStarted, TurnEnded]
+    assert controller.generation == 7
+
+
+def test_parked_source_keeps_tool_and_message_boundaries() -> None:
+    """Row identity and card pairing survive the mute.
+
+    A dropped tool START would leave its END unmatched and the revealed view
+    would paint a call that SUCCEEDED as interrupted -- so only the per-chunk
+    `tool_execution_update` is in the drop set, never the boundaries.
+    """
+    controller, session, app = _controller()
+    controller.set_parked(True)
+    session.emit(AgentStartEvent())
+    app.posted.clear()
+
+    session.emit(ToolExecutionStartEvent(tool_call_id="call-1", tool_name="read"))
+    session.emit(
+        ToolExecutionEndEvent(
+            tool_call_id="call-1",
+            tool_name="read",
+            result=ToolResult(tool_call_id="call-1", tool_name="read"),
+        )
+    )
+    message = Message.assistant("final")
+    message.id = "m2"
+    session.emit(MessageEndEvent(message=message))
+    session.emit(NoticeEvent(text="owner said something", kind="info"))
+
+    kinds = [type(m) for m in app.posted]
+    assert ToolStarted in kinds
+    assert ToolEnded in kinds
+    assert AssistantMessageEnd in kinds
+    assert NoticePosted in kinds
+
+
+def test_unparking_restores_delta_delivery() -> None:
+    """Committing a parked source makes it current: its tokens paint again."""
+    controller, session, app = _controller()
+    controller.set_parked(True)
+    session.emit(AgentStartEvent())
+    controller.set_parked(False)
+    app.posted.clear()
+
+    message = Message.assistant("live")
+    message.id = "m3"
+    session.emit(MessageUpdateEvent(message=message, delta="tok"))
+    app.flush()
+
+    assert any(isinstance(m, AssistantDelta) for m in app.posted)
+
+
+def test_restoring_projection_is_never_muted() -> None:
+    """The reveal replays the owner's live seed through this same entry point.
+
+    `restore_live_projection` runs BEFORE the app clears the parked flag in
+    some orderings, so the restore path must bypass the mute or a revealed
+    conversation loses the in-flight answer it is supposed to show.
+    """
+    controller, session, app = _controller()
+    controller.set_parked(True)
+    message = Message.assistant("seeded")
+    message.id = "m4"
+
+    class _State:
+        streaming = True
+        generation = 3
+        live_events = [MessageUpdateEvent(message=message, delta="seeded").model_dump(mode="json")]
+
+    controller.restore_live_projection(_State(), set(), set())
+
+    assert any(isinstance(m, AssistantDelta) for m in app.posted)

--- a/tests/unit/tui/test_events.py
+++ b/tests/unit/tui/test_events.py
@@ -544,8 +544,14 @@ async def test_controller_async_handler_compat() -> None:
 # it can see and holds a REAL subscription to each, so without a mute every
 # streaming delta of every other conversation is decoded, dispatched, posted as
 # a Textual message and dequeued by the app -- which discards it. Measured at 12
-# streaming sessions: ~229 discarded events/s and keystroke latency 1.46x worse
-# at the median, 2.2-3.3x at p99.
+# streaming sessions: ~229 discarded events/s, +9 points of a core.
+#
+# What these guard is the removal of PROVABLY DISCARDED work, NOT keystroke
+# latency: the open/closed typing gap is real but survives this change (ABBA:
+# 153.8 ms with / 143.1 ms without / 121.1 ms closed), and a ceiling arm
+# dropping the same events at the owner did not close it either. See
+# `EventController.set_parked` for the full disproof before attributing any
+# latency result to this path.
 #
 # Each of these fails on the pre-fix tree: without `set_parked` the controller
 # posts for every event regardless of whether anyone is looking.

--- a/tests/unit/tui/test_events.py
+++ b/tests/unit/tui/test_events.py
@@ -39,6 +39,7 @@ from local_operator.tui.costs import turn_cost
 from local_operator.tui.events import (
     AssistantDelta,
     AssistantMessageEnd,
+    AssistantMessageStart,
     EventController,
     NoticePosted,
     StartFlushTimer,
@@ -618,12 +619,21 @@ def test_parked_source_keeps_tool_and_message_boundaries() -> None:
     )
     message = Message.assistant("final")
     message.id = "m2"
+    session.emit(MessageStartEvent(message=message))
     session.emit(MessageEndEvent(message=message))
     session.emit(NoticeEvent(text="owner said something", kind="info"))
 
     kinds = [type(m) for m in app.posted]
     assert ToolStarted in kinds
     assert ToolEnded in kinds
+    # `message_start` is ROW IDENTITY. Adding it to `_PARKED_DROP_TYPES` was a
+    # mutation that survived every suite (review round 2, MINOR): membership
+    # was asserted only positively, so the set could silently grow to include
+    # the one boundary the docstring names as un-droppable. A parked source
+    # that loses its starts has no row to key the dedupe and card pairing on,
+    # and QA's residual histogram on the real seam is 100% `message_start` --
+    # i.e. this is exactly the traffic the mute is supposed to let through.
+    assert AssistantMessageStart in kinds
     assert AssistantMessageEnd in kinds
     assert NoticePosted in kinds
 

--- a/tests/unit/tui/test_parked_source_seam.py
+++ b/tests/unit/tui/test_parked_source_seam.py
@@ -340,3 +340,237 @@ async def test_returning_to_a_reparked_source_paints_its_stream_again(tmp_path) 
                 "a source parked a SECOND time by the switch-away re-park never "
                 "came back: returning to it paints no tokens"
             )
+
+
+@pytest.mark.asyncio
+async def test_an_abandoned_switch_leaves_the_still_visible_source_live(tmp_path) -> None:
+    """A commit that RAISES must not leave the conversation on screen muted.
+
+    ``SessionNavigation._prepare_and_commit`` catches ``Exception``
+    unconditionally, shows a warning notice and abandons the switch -- so the
+    OUTGOING conversation stays on screen. If the switch-away re-park has
+    already run by then, that visible conversation is muted with nothing to
+    lift it: it paints its boundaries and no streaming tokens for the rest of
+    the turn (review round 2, MAJOR).
+
+    The fix is ordering rather than an unwind: the re-park runs after
+    ``_adopt_session``, so an exception in the widget work above it never
+    reaches the mute at all. This test drives the REAL ``nav.select()`` entry
+    point rather than calling ``_commit_sidebar_session`` directly, because the
+    failure only exists on the path that catches.
+
+    THE ORACLE IS PER-TOKEN, deliberately. ``message_end`` is NOT in the drop
+    set, so a parked source still paints the full text off a settled row --
+    a settled-row oracle passes whether or not the source is muted (QA round 2
+    found exactly that vacuous cell in its own rig). Only ``message_update`` is
+    dropped, so the sensitive shape is start + update + flush with NO end.
+    """
+    async with (
+        _remote(tmp_path, "abandon-origin") as origin,
+        _remote(tmp_path, "abandon-first") as first,
+        _remote(tmp_path, "abandon-second") as second,
+    ):
+
+        async def factory():
+            return origin
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(100):
+                await pilot.pause()
+                if app._session is origin:
+                    break
+
+            sources: dict[str, SessionInteraction] = {}
+            for remote in (first, second):
+                source = SessionInteraction(remote)
+                sources[remote.session_id] = source
+                app._sidebar_sources[remote.session_id] = source
+
+            async def lease(session_id, *, speculative=False):
+                source = sources[session_id]
+                source.preparations += 1
+                if source.controller is None:
+                    from local_operator.tui.events import EventController
+
+                    app._interactions[id(source.session)] = source
+                    source.controller = EventController(source.session, app)
+                    app._event_sources[source.controller] = source
+                    source.controller.set_parked(True)
+                    source.controller.subscribe()
+                return source
+
+            app._lease_sidebar_source = lease  # type: ignore[method-assign]
+
+            failures: list[tuple[str, str]] = []
+            original_failed = app._sidebar_navigation_failed
+
+            def record_failure(session_id: str, error: Exception) -> None:
+                failures.append((session_id, repr(error)))
+                original_failed(session_id, error)
+
+            app._sidebar_navigation_failed = record_failure  # type: ignore[method-assign]
+            app._sidebar_navigation._failed = record_failure
+
+            # Visit `first` normally: it becomes the visible conversation.
+            await asyncio.wait_for(app._sidebar_navigation.select(first.session_id), 30)
+            await _pump(pilot, 12)
+            first_source = sources[first.session_id]
+            assert app._interaction is first_source, "the ordinary switch did not commit"
+            assert first_source.controller is not None
+            assert not first_source.controller.parked
+
+            # Now fail the NEXT commit inside its window. `_apply_sidebar_
+            # presentation` is a real step of the commit that sits after the
+            # point the re-park used to run and before `_adopt_session`, which
+            # is exactly the span the MAJOR was about. Patched on the class so
+            # the production bound method is what raises.
+            injected = {"count": 0}
+            original_apply = type(app)._apply_sidebar_presentation
+
+            def exploding_apply(self, presentation):  # type: ignore[no-untyped-def]
+                injected["count"] += 1
+                raise RuntimeError("synthetic failure inside the commit window")
+
+            type(app)._apply_sidebar_presentation = exploding_apply  # type: ignore[assignment]
+            try:
+                await asyncio.wait_for(app._sidebar_navigation.select(second.session_id), 30)
+                await _pump(pilot, 12)
+            finally:
+                type(app)._apply_sidebar_presentation = original_apply  # type: ignore[assignment]
+
+            # Canary: a null result from an injection that never fired would be
+            # indistinguishable from a pass.
+            assert injected["count"] > 0, "the injected failure never ran; the cell is vacuous"
+            assert failures, "the navigation did not report a failure: nothing was abandoned"
+            assert app._interaction is first_source, (
+                "the abandoned switch moved the current source anyway; this test "
+                "no longer exercises the still-visible case"
+            )
+
+            controller = first_source.controller
+            assert not controller.parked, (
+                "the conversation STILL ON SCREEN was left parked by an abandoned "
+                "switch: the mute outlived the failed commit and nothing lifts it"
+            )
+
+            posted: list[object] = []
+            original_post = controller._post
+            controller._post = posted.append  # type: ignore[method-assign]
+            try:
+                controller._on_event(MessageStartEvent(message=Message.assistant("")))
+                for event in _delta_grade(4):
+                    controller._on_event(event)
+                controller._flush_assistant()
+            finally:
+                controller._post = original_post  # type: ignore[method-assign]
+
+            assert any(isinstance(message, AssistantDelta) for message in posted), (
+                "the visible conversation painted NO streaming tokens after a "
+                "failed switch: a mute with no unwind, silent for the whole turn"
+            )
+
+            # `parked_at` is the idle sweep's deadline, and the same window
+            # stamped it. A session that is still current must carry none, or
+            # the sweep can reap the conversation the user is looking at.
+            assert first_source.parked_at is None, (
+                "the still-visible source was left with an idle deadline by the " "abandoned switch"
+            )
+
+
+@pytest.mark.asyncio
+async def test_a_refresh_commit_does_not_mute_the_visible_conversation(tmp_path) -> None:
+    """A commit that re-lands the session ALREADY on screen must not park it.
+
+    ``_start_sidebar_connection`` re-commits the current source to swap a cold
+    display-only projection for a live one. On that path the outgoing and
+    incoming source are the SAME object, so an unguarded switch-away re-park
+    would mute the conversation the user is looking at -- the same blank stream
+    as the abandoned switch above, on a path that runs routinely.
+
+    Review round 2 (MINOR) found this guard was load-bearing but untested:
+    dropping it survived all three suites. The guard now lives in
+    ``_park_switched_away_source`` as the ``outgoing is self._interaction``
+    test, and this is what fails if it goes.
+
+    Per-token oracle, not a settled row, for the reason given above:
+    ``message_end`` is not dropped, so a settled row paints either way.
+    """
+    async with (
+        _remote(tmp_path, "refresh-origin") as origin,
+        _remote(tmp_path, "refresh-target") as target,
+    ):
+
+        async def factory():
+            return origin
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(100):
+                await pilot.pause()
+                if app._session is origin:
+                    break
+
+            source = SessionInteraction(target)
+            app._sidebar_sources[target.session_id] = source
+
+            async def lease(session_id, *, speculative=False):
+                source.preparations += 1
+                if source.controller is None:
+                    from local_operator.tui.events import EventController
+
+                    app._interactions[id(source.session)] = source
+                    source.controller = EventController(source.session, app)
+                    app._event_sources[source.controller] = source
+                    source.controller.set_parked(True)
+                    source.controller.subscribe()
+                return source
+
+            app._lease_sidebar_source = lease  # type: ignore[method-assign]
+
+            async def commit(prepared) -> None:
+                ready = app._commit_sidebar_session(
+                    target.session_id, prepared, app._sidebar_navigation.generation
+                )
+                await _pump(pilot, 12)
+                if ready is not None and not ready.done():
+                    ready.cancel()
+
+            # Become the visible conversation, then REFRESH it: `refresh=True`
+            # is what `_start_sidebar_connection` passes, and it is the only
+            # way to reach a commit whose outgoing source is its incoming one.
+            await commit(await app._prepare_sidebar_session(target.session_id))
+            assert app._interaction is source, "the source under test is not on screen"
+
+            refreshed = await app._prepare_sidebar_session(target.session_id, refresh=True)
+            await commit(refreshed)
+
+            # Canary in the other direction: if the refresh silently failed to
+            # re-commit, "not muted" would be true for the wrong reason.
+            assert app._interaction is source, "the refresh commit did not re-land the source"
+
+            controller = source.controller
+            assert controller is not None
+            assert not controller.parked, (
+                "a refresh commit parked the conversation the user is LOOKING AT: "
+                "the outgoing-is-current guard is gone"
+            )
+
+            posted: list[object] = []
+            original_post = controller._post
+            controller._post = posted.append  # type: ignore[method-assign]
+            try:
+                controller._on_event(MessageStartEvent(message=Message.assistant("")))
+                for event in _delta_grade(5):
+                    controller._on_event(event)
+                controller._flush_assistant()
+            finally:
+                controller._post = original_post  # type: ignore[method-assign]
+
+            assert any(isinstance(message, AssistantDelta) for message in posted), (
+                "the visible conversation paints no streaming tokens after a "
+                "refresh commit muted it"
+            )
+            assert (
+                source.parked_at is None
+            ), "the visible conversation was given an idle deadline by a refresh"

--- a/tests/unit/tui/test_parked_source_seam.py
+++ b/tests/unit/tui/test_parked_source_seam.py
@@ -1,0 +1,342 @@
+"""The parked-source latch, driven through the REAL app seam.
+
+The controller-level behaviour of ``EventController.set_parked`` is covered in
+``tests/unit/tui/test_events.py``. What is covered HERE is the thing that
+module structurally cannot see: whether the app actually *drives* the mode at
+the two transitions that own it.
+
+Why a separate, heavier file. Mutation testing during review round 1 deleted
+the ``set_parked(False)`` call from ``_adopt_session`` and both existing suites
+stayed green (26 passed + 62 passed), because the unpark test calls the setter
+directly instead of exercising the seam that is supposed to invoke it. That is
+the single worst failure this feature can produce -- a conversation the user
+clicked into renders its boundaries but paints **no streaming tokens at all**,
+silently, for the whole turn -- and nothing observed it. A test that drives the
+production prepare/commit path is the only shape that can.
+
+Both directions are asserted, because the mute is a two-sided latch and each
+side has its own failure:
+
+* commit must UNPARK the incoming source, or the visible conversation goes
+  blank mid-turn (review R2);
+* commit must RE-PARK the outgoing source, or the mute is a one-way latch and
+  every session the user visits stays exempt for the rest of its
+  ``SIDEBAR_IDLE_RELEASE_S`` retention, still paying full per-token delivery
+  while hidden (review R1).
+
+The assertions are on DELIVERED DELTAS -- real events pushed through a real
+``RemoteSession`` subscription into the real controller -- not on the ``parked``
+flag alone. A flag is the API; the delta count is the mechanism, and review
+round 1 found the guard density on the mechanism thinner than the test count
+suggested (QA Q1). Each assertion below fails if the corresponding
+``set_parked`` call is removed from ``app.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+
+from local_operator.harness.types import (
+    AgentToolUpdate,
+    Message,
+    MessageStartEvent,
+    MessageUpdateEvent,
+    SubagentProgressEvent,
+    TextContent,
+    ToolExecutionUpdateEvent,
+)
+from local_operator.session.remote import RemoteSession
+from local_operator.session.runtime.owned import OwnedSessionHandle
+from local_operator.session.runtime.server import RuntimeServer
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.events import AssistantDelta
+from local_operator.tui.session_interaction import SessionInteraction
+from tests.e2e.harness import ScriptedStream, build_session, seed_transcript, text_turn
+from tests.unit.session.test_remote import _never_take_over
+
+
+def _rows(count: int = 3) -> list[Message]:
+    return [
+        Message(
+            id=f"seam-row-{index:04}",
+            role="assistant",
+            content=[TextContent(text=f"Saved row {index:04}")],
+            stop_reason="stop",
+        )
+        for index in range(count)
+    ]
+
+
+@asynccontextmanager
+async def _remote(tmp_path: Path, name: str):
+    """A real owner runtime plus a real ``RemoteSession`` viewer over it.
+
+    Mirrors ``test_rendered_history_paging.remote_session``; kept local so this
+    module does not import a neighbour's private fixture, and because the
+    sessions here need no history paging at all.
+    """
+    config = tmp_path / "config"
+    config.mkdir(exist_ok=True)
+    (config / "config.yml").write_text(
+        "version: 0.0.0\nvalues:\n  hosting: test\n  model_name: mock\n"
+    )
+    directory = config / "sessions" / f"synthetic-{name}"
+    await seed_transcript(directory, _rows())
+    session = build_session(directory, ScriptedStream([text_turn("unused")]), cwd=tmp_path)
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(tmp_path))
+    server = RuntimeServer(handle, kind="daemon")
+    await server.start_in_process()
+    remote = await RemoteSession.connect(
+        server._record,
+        directory.name,
+        config_dir=config,
+        takeover_factory=_never_take_over,
+        display_window=True,
+    )
+    try:
+        yield remote
+    finally:
+        await remote.dispose()
+        server.close()
+        await handle.dispose()
+
+
+def _delta_grade(index: int) -> list[object]:
+    """One of EACH type in ``_PARKED_DROP_TYPES``, not just ``message_update``.
+
+    QA round 1 (Q2) observed 100% ``message_update`` in its load generator, so
+    ``tool_execution_update`` and ``subagent_progress`` were covered by unit
+    test only. Emitting all three here puts every member of the drop set
+    through the real subscription at the real seam.
+    """
+    message = Message.assistant(f"token {index}")
+    message.id = f"seam-live-{index}"
+    return [
+        MessageUpdateEvent(message=message, delta=f"tok{index}"),
+        ToolExecutionUpdateEvent(
+            tool_call_id=f"seam-call-{index}",
+            tool_name="read",
+            partial_result=AgentToolUpdate(),
+        ),
+        SubagentProgressEvent(job_id=f"seam-job-{index}", label="child", progress="working"),
+    ]
+
+
+async def _pump(pilot, count: int = 6) -> None:
+    for _ in range(count):
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_commit_unparks_the_incoming_source_and_reparks_the_outgoing(tmp_path) -> None:
+    """The two-sided latch, at the seam, measured in delivered deltas.
+
+    Deleting either ``set_parked`` call from ``app.py`` fails this test; the
+    round-1 mutation that survived both existing suites is the ``False`` half.
+    """
+    async with (
+        _remote(tmp_path, "home") as home,
+        _remote(tmp_path, "first") as first,
+        _remote(tmp_path, "second") as second,
+    ):
+        # The app boots on a REAL owner-backed session: `_commit_sidebar_session`
+        # refuses to switch away from anything else, so a `FakeSession` current
+        # session cannot reach the seam under test at all.
+        async def factory():
+            return home
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(100):
+                await pilot.pause()
+                if app._session is home:
+                    break
+
+            sources: dict[str, SessionInteraction] = {}
+            for remote in (first, second):
+                source = SessionInteraction(remote)
+                sources[remote.session_id] = source
+                app._sidebar_sources[remote.session_id] = source
+
+            async def lease(session_id, *, speculative=False):
+                # Only external discovery is redirected: the lease body's own
+                # park-at-birth is what the first assertion reads, so it is
+                # reproduced here exactly as `_lease_sidebar_source` does it
+                # rather than being skipped.
+                source = sources[session_id]
+                source.preparations += 1
+                if source.controller is None:
+                    from local_operator.tui.events import EventController
+
+                    # `_interactions` keyed by id(session) is what `_adopt_session`
+                    # resolves the incoming source through: without it the adopt
+                    # builds a FRESH SessionInteraction and unparks that instead,
+                    # which is the production wiring `_lease_sidebar_source` does.
+                    app._interactions[id(source.session)] = source
+                    source.controller = EventController(source.session, app)
+                    app._event_sources[source.controller] = source
+                    source.controller.set_parked(True)
+                    source.controller.subscribe()
+                return source
+
+            app._lease_sidebar_source = lease  # type: ignore[method-assign]
+
+            first_source = sources[first.session_id]
+            second_source = sources[second.session_id]
+
+            # --- commit the FIRST session: it must come off the mute --------
+            prepared = await app._prepare_sidebar_session(first.session_id)
+            ready = app._commit_sidebar_session(
+                first.session_id, prepared, app._sidebar_navigation.generation
+            )
+            await _pump(pilot, 12)
+            if ready is not None and not ready.done():
+                ready.cancel()
+
+            assert first_source.controller is not None
+            assert not first_source.controller.parked, (
+                "the committed source is the conversation on screen: leaving it "
+                "parked paints no streaming tokens at all for the whole turn"
+            )
+
+            # The mechanism, not the flag: a real delta must reach the app.
+            controller = first_source.controller
+            posted: list[object] = []
+            original_post = controller._post
+            controller._post = posted.append  # type: ignore[method-assign]
+            try:
+                for event in _delta_grade(1):
+                    controller._on_event(event)
+                controller._flush_assistant()
+            finally:
+                controller._post = original_post  # type: ignore[method-assign]
+            assert any(isinstance(message, AssistantDelta) for message in posted), (
+                "a committed source delivered no assistant delta: the unpark at "
+                "the commit seam is missing and the visible stream is blank"
+            )
+
+            # --- switch AWAY: the outgoing source must go back on the mute --
+            prepared = await app._prepare_sidebar_session(second.session_id)
+            ready = app._commit_sidebar_session(
+                second.session_id, prepared, app._sidebar_navigation.generation
+            )
+            await _pump(pilot, 12)
+            if ready is not None and not ready.done():
+                ready.cancel()
+
+            assert second_source.controller is not None
+            assert not second_source.controller.parked, "the newly visible source must paint"
+            assert first_source.controller.parked, (
+                "a source the user switched AWAY from stays unparked forever: the "
+                "mute is a one-way latch, so every visited session keeps paying "
+                "full per-token delivery for the rest of its retention (R1)"
+            )
+
+            # And again as delivered traffic, for every member of the drop set.
+            controller = first_source.controller
+            posted = []
+            original_post = controller._post
+            controller._post = posted.append  # type: ignore[method-assign]
+            try:
+                for event in _delta_grade(2):
+                    controller._on_event(event)
+            finally:
+                controller._post = original_post  # type: ignore[method-assign]
+            assert posted == [], (
+                "the re-parked outgoing source still minted Textual messages for "
+                f"delta-grade events: {posted!r}"
+            )
+
+            # A re-parked source must remain SUBSCRIBED, or its owner's stream
+            # buffers in `_emit_or_buffer` and lands in one drain at the next
+            # click -- the failure mode the rejected deferred-subscribe design
+            # had, arriving one seam later.
+            assert first._handlers, "a re-parked source must stay subscribed"
+
+
+@pytest.mark.asyncio
+async def test_returning_to_a_reparked_source_paints_its_stream_again(tmp_path) -> None:
+    """The round trip: park -> visit -> leave -> RETURN must not stay muted.
+
+    Re-parking on switch-away (R1) creates a state the one-way latch never
+    could: a source that is parked for the SECOND time. If the unpark did not
+    re-run on the return commit, the fix for R1 would itself produce the blank
+    stream R2 is about -- so the round trip is asserted, not assumed.
+    """
+    async with (
+        _remote(tmp_path, "origin") as origin,
+        _remote(tmp_path, "alpha") as alpha,
+        _remote(tmp_path, "beta") as beta,
+    ):
+
+        async def factory():
+            return origin
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(100):
+                await pilot.pause()
+                if app._session is origin:
+                    break
+
+            sources: dict[str, SessionInteraction] = {}
+            for remote in (alpha, beta):
+                source = SessionInteraction(remote)
+                sources[remote.session_id] = source
+                app._sidebar_sources[remote.session_id] = source
+
+            async def lease(session_id, *, speculative=False):
+                source = sources[session_id]
+                source.preparations += 1
+                if source.controller is None:
+                    from local_operator.tui.events import EventController
+
+                    # `_interactions` keyed by id(session) is what `_adopt_session`
+                    # resolves the incoming source through: without it the adopt
+                    # builds a FRESH SessionInteraction and unparks that instead,
+                    # which is the production wiring `_lease_sidebar_source` does.
+                    app._interactions[id(source.session)] = source
+                    source.controller = EventController(source.session, app)
+                    app._event_sources[source.controller] = source
+                    source.controller.set_parked(True)
+                    source.controller.subscribe()
+                return source
+
+            app._lease_sidebar_source = lease  # type: ignore[method-assign]
+
+            async def visit(session_id: str) -> None:
+                prepared = await app._prepare_sidebar_session(session_id)
+                ready = app._commit_sidebar_session(
+                    session_id, prepared, app._sidebar_navigation.generation
+                )
+                await _pump(pilot, 12)
+                if ready is not None and not ready.done():
+                    ready.cancel()
+
+            await visit(alpha.session_id)
+            await visit(beta.session_id)
+            await visit(alpha.session_id)
+
+            controller = sources[alpha.session_id].controller
+            assert controller is not None
+            assert not controller.parked, "the returned-to source must be live again"
+
+            posted: list[object] = []
+            original_post = controller._post
+            controller._post = posted.append  # type: ignore[method-assign]
+            try:
+                controller._on_event(MessageStartEvent(message=Message.assistant("")))
+                for event in _delta_grade(3):
+                    controller._on_event(event)
+                controller._flush_assistant()
+            finally:
+                controller._post = original_post  # type: ignore[method-assign]
+
+            assert any(isinstance(message, AssistantDelta) for message in posted), (
+                "a source parked a SECOND time by the switch-away re-park never "
+                "came back: returning to it paints no tokens"
+            )

--- a/tests/unit/tui/test_parked_source_seam.py
+++ b/tests/unit/tui/test_parked_source_seam.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -52,6 +53,7 @@ from local_operator.harness.types import (
 from local_operator.session.remote import RemoteSession
 from local_operator.session.runtime.owned import OwnedSessionHandle
 from local_operator.session.runtime.server import RuntimeServer
+from local_operator.tui import app as app_module
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.events import AssistantDelta
 from local_operator.tui.session_interaction import SessionInteraction
@@ -574,3 +576,137 @@ async def test_a_refresh_commit_does_not_mute_the_visible_conversation(tmp_path)
             assert (
                 source.parked_at is None
             ), "the visible conversation was given an idle deadline by a refresh"
+
+
+@pytest.mark.asyncio
+async def test_switching_away_stamps_the_deadline_the_idle_sweep_reaps_on(tmp_path) -> None:
+    """The switch-away must STAMP ``parked_at``, or the source leaks forever.
+
+    The mute and the stamp are one act -- both say "nobody is looking at this
+    any more" -- but only the mute was guarded. Deleting
+    ``outgoing.parked_at = time.monotonic()`` left every test in the tree green
+    (review round 3, MINOR-1), and the consequence is silent and delayed: the
+    sweep's first clause is ``parked_at is None -> continue``, so an unstamped
+    source is skipped on EVERY tick forever. That is the original runtime leak
+    this area exists to bound -- one attach socket and one runtime child per
+    conversation the user ever clicked -- and it would not surface for five
+    minutes, with nothing on screen to suggest it.
+
+    So the assertion is the CONSEQUENCE, not just the field. A stamp that is
+    written but never acted on would satisfy ``is not None`` while leaking just
+    as badly, so this drives the real ``_sweep_idle_sidebar_sources`` across the
+    real deadline and asserts the source is actually handed to a release
+    worker. ``time.monotonic`` is patched on the app module rather than slept
+    through, matching ``test_sidebar_idle_reap.py``: the seam reads the module
+    attribute per tick precisely so a test can compress the window.
+    """
+    async with (
+        _remote(tmp_path, "stamp-origin") as origin,
+        _remote(tmp_path, "stamp-first") as first,
+        _remote(tmp_path, "stamp-second") as second,
+    ):
+
+        async def factory():
+            return origin
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(100):
+                await pilot.pause()
+                if app._session is origin:
+                    break
+
+            sources: dict[str, SessionInteraction] = {}
+            for remote in (first, second):
+                source = SessionInteraction(remote)
+                sources[remote.session_id] = source
+                app._sidebar_sources[remote.session_id] = source
+
+            async def lease(session_id, *, speculative=False):
+                source = sources[session_id]
+                source.preparations += 1
+                if source.controller is None:
+                    from local_operator.tui.events import EventController
+
+                    app._interactions[id(source.session)] = source
+                    source.controller = EventController(source.session, app)
+                    app._event_sources[source.controller] = source
+                    source.controller.set_parked(True)
+                    source.controller.subscribe()
+                return source
+
+            app._lease_sidebar_source = lease  # type: ignore[method-assign]
+
+            first_source = sources[first.session_id]
+
+            async def visit(session_id: str) -> None:
+                prepared = await app._prepare_sidebar_session(session_id)
+                ready = app._commit_sidebar_session(
+                    session_id, prepared, app._sidebar_navigation.generation
+                )
+                await _pump(pilot, 12)
+                if ready is not None and not ready.done():
+                    ready.cancel()
+
+            await visit(first.session_id)
+            # PRECONDITION: while it is the visible conversation it must carry
+            # NO deadline, or "was stamped on the way out" cannot be told from
+            # "was stamped all along" and the assertion below passes vacuously.
+            assert app._interaction is first_source, "the first switch did not commit"
+            assert first_source.parked_at is None, (
+                "the VISIBLE conversation already carries an idle deadline; the "
+                "stamp assertion below would not prove the switch-away wrote it"
+            )
+
+            await visit(second.session_id)
+
+            assert first_source.parked_at is not None, (
+                "switching away left `parked_at` unset: the idle sweep skips this "
+                "source on every tick forever, so its socket and runtime child "
+                "leak for the life of the process"
+            )
+
+            # The consequence, not just the field: drive the real sweep across
+            # the real deadline and require an actual release.
+            released: list[Any] = []
+
+            def capture_release(coro: Any, **kwargs: Any) -> Any:
+                # Close the coroutine rather than running it: the assertion is
+                # that the sweep HANDED the source to a release worker, and
+                # actually retiring it would tear down the live RemoteSession
+                # this test still owns. Mirrors `test_sidebar_idle_reap.py`.
+                released.append(coro)
+                coro.close()
+
+            app.run_worker = capture_release  # type: ignore[method-assign,assignment]
+            # `preparations` is decremented by the prepare path's `finally`; the
+            # releasable predicate refuses any source still counted as preparing,
+            # which would make a null result here mean nothing about the stamp.
+            first_source.preparations = 0
+            app._sidebar_presentations.pop(first.session_id, None)
+
+            # COMPRESS THE WINDOW, never move the clock. `test_sidebar_idle_
+            # reap.py` patches `time.monotonic` because it drives a bare app
+            # with no running loop; this test is inside `run_test`, so a live
+            # asyncio/Textual loop is scheduling on that same clock and jumping
+            # it forward by the window would fire every pending timer at once.
+            # The sweep re-reads `SIDEBAR_IDLE_RELEASE_S` per tick precisely so
+            # a test can inject the window instead (see its comment).
+            deadline = app_module.SIDEBAR_IDLE_RELEASE_S
+            try:
+                # Sub-window first: the sweep must SKIP it. Without this arm a
+                # release below would not prove the deadline was read at all.
+                app_module.SIDEBAR_IDLE_RELEASE_S = 10_000.0
+                app._sweep_idle_sidebar_sources()
+                assert not released, "a source parked under the window was released early"
+
+                app_module.SIDEBAR_IDLE_RELEASE_S = 0.0
+                app._sweep_idle_sidebar_sources()
+            finally:
+                app_module.SIDEBAR_IDLE_RELEASE_S = deadline
+
+            assert released, (
+                "the sweep did not release a source parked past the deadline: the "
+                "stamp the switch-away wrote is never acted on, which leaks the "
+                "viewer exactly as an absent stamp would"
+            )

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -2419,7 +2419,9 @@ async def test_a_speculatively_leased_source_is_parked_and_stays_subscribed():
     `_prewarm_sidebar` leases a real, subscribed source for every live session
     the sidebar can see. Those sources are speculative: nothing they receive is
     painted until the user clicks one, and at 12 streaming sessions delivering
-    them anyway cost ~229 discarded events/s and 1.46x median keystroke latency.
+    them anyway cost ~229 discarded events/s and +9 points of a core -- work
+    whose result is thrown away. It is NOT a keystroke-latency fix; see
+    `EventController.set_parked` for the measurements that retired that claim.
 
     Two halves, and BOTH are load-bearing:
 

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -2410,3 +2410,55 @@ async def test_a_click_superseded_by_a_click_for_the_same_session_does_not_spawn
         assert committed and set(committed) == {"target-session"}, (
             "every switch that landed must be the session the clicks asked " f"for: {committed!r}"
         )
+
+
+@pytest.mark.asyncio
+async def test_a_speculatively_leased_source_is_parked_and_stays_subscribed():
+    """The N-way fan-in guard, at the seam that creates the attachments.
+
+    `_prewarm_sidebar` leases a real, subscribed source for every live session
+    the sidebar can see. Those sources are speculative: nothing they receive is
+    painted until the user clicks one, and at 12 streaming sessions delivering
+    them anyway cost ~229 discarded events/s and 1.46x median keystroke latency.
+
+    Two halves, and BOTH are load-bearing:
+
+    * the controller must be PARKED, so per-token traffic is declined; and
+    * it must still be SUBSCRIBED, because `RemoteSession._emit_or_buffer`
+      buffers rather than drops when no handler is registered -- an
+      unsubscribed parked source silently accumulates its owner's entire
+      stream (measured: 8,169 events across 12 sources in 25 s) and dumps it
+      in one drain at commit, landing on the click this whole cache exists to
+      make fast.
+    """
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from local_operator.session.remote import RemoteSession
+
+    remote = MagicMock(spec=RemoteSession)
+    remote.session_id = "spec"
+    remote.is_cold = False
+    remote.frontend_state = SimpleNamespace(pending_gate=None)
+    handlers: list[object] = []
+    remote.subscribe = lambda handler: handlers.append(handler) or (lambda: None)
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+
+        async def connect(*_args, **_kwargs):
+            return remote
+
+        with (
+            patch("local_operator.session.remote.RemoteSession.connect", side_effect=connect),
+            patch(
+                "local_operator.mobile.attach_client.find_owner_record",
+                return_value=(SimpleNamespace(pid=1), SimpleNamespace()),
+            ),
+        ):
+            source = await app._lease_sidebar_source("spec", speculative=True)
+
+        assert source.controller is not None
+        assert source.controller.parked, "a speculative lease must not paint deltas"
+        assert handlers, "a parked source must stay subscribed or its owner's stream buffers"


### PR DESCRIPTION
## What and why

**C2 — waste removal on the TUI event path. This is not a latency fix, and the disproof is in this description.**

Opening the sidebar makes `_prewarm_sidebar` lease a real, subscribed `EventController` for every live session it can see — up to `RETAINED_PRESENTATIONS` (12), held for `SIDEBAR_IDLE_RELEASE_S` (300 s). Every streaming delta from every one of those **other** conversations was then read off a socket, JSON-decoded, deserialized, duplicate-checked, tracked, dispatched through the controller, posted as a Textual message, and dequeued by `app._on_message` — which **discarded it**, because `_reduce_hidden_session_event` paints nothing for a hidden source.

Measured with 12 background sessions streaming: **215.7–222.4 SessionEvent/s, 5,403 and 5,595 events per 25 s cell, 100 % hidden-source, zero from the current conversation.** The full delivery cost of a result thrown away, scaling linearly with live-session count.

This PR stops that traffic. It removes ~220 events/s and ~5,400 pointless Textual messages per 25 s of provably-discarded work. **It does not improve keystroke latency**, and §"What this does NOT fix" below shows why nothing on this path can.

## The change

A parked source's controller declines the three delta-grade event types at the top of dispatch, before a Textual message can be minted:

```python
if self._parked and not self._restoring_projection:
    if event_type in self._PARKED_DROP_TYPES:   # message_update,
        return                                   # tool_execution_update,
                                                 # subagent_progress
```

`_lease_sidebar_source` parks a speculative lease **before** subscribing; `_adopt_session` — the single place a source becomes current — unparks it, ahead of the commit path's live-seed replay.

**Every boundary event still flows.** Turn/agent start and end, tool start and end, message start and end, compaction, retry, model change, notices, wakes, peer deliveries. That is the care point the QA report named: `source.turn`, tool-card pairing and the sidebar row all read those, so a parked session that starts or ends a turn must still surface correctly. Dropping a tool *start* would leave its end unmatched and paint a call that **succeeded** as `⊘ interrupted`. The dropped events are recoverable by construction — the owner folds them into `live_events` and `restore_live_projection` replays that seed at commit, the same path a mid-turn join already uses. `_sidebar_presentation_current` refuses any cached presentation whose session is streaming, so a streaming parked source always rebuilds through that replay rather than being revealed stale.

### QA's option 1, as written, is a trap — corrected here with measurement

The QA report's preferred fix is *"defer `subscribe()` to the commit path"*. **That does not drop the events; it buffers them,** and it fails silently. `RemoteSession._emit_or_buffer`:

```python
if not self._ready_for_events or not self._handlers:
    self._buffered_events.append(event)   # parked, not dropped
    return
```

A speculative source is `_ready_for_events` (its sync completed at connect) with zero handlers — exactly that branch. Measured on a monkeypatched build of that exact proposal:

| | value |
|---|---|
| events buffered across 12 parked sources | **8,169 in 25.0 s** |
| growth rate | **326.6/s, still climbing at cell end** |
| per-source | 583–775 events each |

`_drain_buffered_events` would then hand that entire backlog over in **one** delivery at commit — an avalanche landing on precisely the click that the presentation cache and the 4→12 retention tuning exist to make fast. So the source here **stays subscribed** and the controller declines the work instead. Nothing accumulates.

Neither `RETAINED_PRESENTATIONS` nor `SIDEBAR_IDLE_RELEASE_S` is touched.

## Before / after — fan-in counts

`qa_fanin.py`, 12 background sessions streaming in **every** cell (so the closed control streams just as hard; the TUI simply never receives it), 25 s per cell, interleaved open/closed, 2 reps.

| | cell | attached | cache | busy | **SessionEvent/s** | **hidden-source events** | CPU % core |
|---|---|---|---|---|---|---|---|
| **before** | open rep0 | 13 | 12 | 12 | **215.72** | **5,403** | 21.2 |
| **before** | closed rep0 | 1 | 0 | 0 | 0.00 | 0 | 13.1 |
| **before** | open rep1 | 13 | 12 | 12 | **222.35** | **5,595** | 21.9 |
| **before** | closed rep1 | 1 | 0 | 0 | 0.00 | 0 | 13.7 |
| **after** | open rep0 | 13 | 12 | 12 | **0.00** | **0** | 21.9 |
| **after** | closed rep0 | 1 | 0 | 0 | 0.00 | 0 | 10.0 |
| **after** | open rep1 | 13 | 12 | 12 | **0.00** | **0** | 20.4 |
| **after** | closed rep1 | 1 | 0 | 0 | 0.00 | 0 | 9.7 |

Hidden-source events reach **exactly zero**. Attached sources stay at 13 and the presentation cache stays at 12 — the prewarm behaviour and the retention tuning are untouched, which is the point: the sources still exist and a click still finds them warm.

**These cells are the NEVER-VISITED case**, and at the time they were measured that was the only case the fix covered. Review round 1 (R1) found parking was a one-way latch — `_lease_sidebar_source` parked at birth, `_adopt_session` unparked on commit, and nothing re-parked — so every session the user actually clicked into stayed exempt for the rest of its 300 s retention. Remediation round 1 re-parks the outgoing source at the commit seam; the visited-then-left numbers are below.

### After remediation — the VISITED-then-left case (R1)

The case a sidebar in use actually produces: all 12 sources prewarmed, **each one visited and then left**, then streamed while hidden. ABBA, one sitting, 20 s per cell, 12 sessions streaming throughout. The `latch` arm reproduces the pre-remediation behaviour by neutralising only the re-park, leaving every other path identical.

| arm | parked after leaving | deltas emitted | discarded by the app | **rate** | Textual messages minted |
|---|---|---|---|---|---|
| latch (pre-remediation) | **0 / 12** | 3,060 | 3,072 | **153.60/s** | 3,072 |
| reparked (head) | **12 / 12** | 3,060 | 12 | **0.60/s** | 12 |
| reparked (head) | **12 / 12** | 3,036 | 12 | **0.60/s** | 12 |
| latch (pre-remediation) | **0 / 12** | 3,060 | 3,072 | **153.60/s** | 3,072 |

Delta-grade work goes **3,060 → 0**. The residual 12 is exactly the 12 `message_start` boundaries the generator emits once per session — boundary events are deliberately never dropped — so the delta traffic of a visited-then-left source returns to zero, not merely to a lower number. `_buffered_events` is 0 on both arms, so nothing moved into the buffer instead.

So the fix now covers both populations: the never-visited sources above (0.00/s) and the visited-then-left sources here (153.6/s → 0.6/s, all of the residual being boundaries).

## What this does NOT fix — the open/closed latency gap, and why no gate on this path closes it

**The gap is real, reproducible, and unresolved. This PR does not address it.**

### Interleaved ABBA A/B — sidebar OPEN in both arms

`qa_seam.py`, 4 reps, **arm order reversed on odd reps** (host load drifted 51→114 during an earlier fixed-order run and would otherwise be charged entirely to whichever arm went first). Both arms are the same binary in the same process pool; the fix-off arm neuters `set_parked` rather than checking out an old tree.

| cell | CPU % core | median | p90 | p99 | keys in 20 s |
|---|---|---|---|---|---|
| none_rep0 (pre-fix) | 18.6 | 146.49 | 380.36 | 771.67 | 80 |
| ctrl_rep0 (this PR) | 18.3 | 162.12 | 360.73 | 781.77 | 81 |
| closed_rep0 | 11.4 | 116.25 | 232.17 | 770.17 | 96 |
| closed_rep1 | 12.6 | 110.11 | 228.62 | 318.57 | 109 |
| ctrl_rep1 | 20.9 | 136.17 | 266.60 | 791.36 | 91 |
| none_rep1 | 21.1 | 139.75 | 225.80 | 680.19 | 100 |
| none_rep2 | 21.4 | 116.07 | 263.59 | 795.30 | 96 |
| ctrl_rep2 | 20.9 | 145.39 | 272.22 | 609.33 | 91 |
| closed_rep2 | 13.9 | 149.63 | 350.39 | 758.12 | 88 |
| closed_rep3 | 12.3 | 125.97 | 271.14 | 419.88 | 97 |
| ctrl_rep3 | 18.2 | 209.72 | 430.79 | 1359.17 | 62 |
| none_rep3 | 17.5 | 235.57 | 628.22 | 1099.47 | 53 |

| arm | median-of-medians | the four medians |
|---|---|---|
| **none** (pre-fix) | **143.1 ms** | 146.5 / 139.8 / 116.1 / 235.6 |
| **ctrl** (this PR) | **153.8 ms** | 162.1 / 136.2 / 145.4 / 209.7 |
| **closed** (control) | **121.1 ms** | 116.3 / 110.1 / 149.6 / 126.0 |

Fix-on is within noise of fix-off and nominally **worse**; closed remains clearly better. Zeroing 220 events/s moved keystroke latency by nothing.

### The ceiling arm — the general result

`qa_seam.py` also cuts the chain at three greater depths, in one sitting. The last one is the ceiling: **`relay` drops the same events at the OWNER's `RuntimeServer._relay_on_loop`, so they are never serialized, never cross the socket, and the viewer's pump never wakes.**

| arm | cut point | median | p90 | p99 | events suppressed |
|---|---|---|---|---|---|
| none_rep0 | — | 122.51 | 266.13 | 845.07 | 0 |
| ctrl_rep0 | `EventController._on_event` (this PR) | 119.72 | 209.10 | 291.06 | — |
| wire_rep0 | `_on_wire_event`, pre-`deserialize_event` (**QA option 2**) | 112.80 | 205.62 | 365.73 | 4,655 |
| **relay_rep0** | **owner `_relay_on_loop` (ceiling)** | **117.33** | 215.01 | 352.27 | **8,831** |
| closed_rep0 | sidebar shut, 1 attachment | **88.16** | 116.90 | 196.78 | 0 |
| none_rep1 | — | 137.04 | 323.96 | 931.63 | 0 |
| ctrl_rep1 | this PR | 112.95 | 209.76 | 327.77 | — |
| wire_rep1 | QA option 2 | 110.46 | 161.28 | 371.63 | 4,632 |
| **relay_rep1** | **ceiling** | **98.84** | 158.19 | 269.36 | **8,808** |
| closed_rep1 | control | **92.55** | 191.47 | 372.83 | 0 |

**Even the ceiling arm does not close the gap to `closed`.** Killing the traffic at the producer — before serialization, before the socket, before the pump wakes — still leaves open ≫ closed.

**The general result, stated so it retires the class:** *no viewer-side gate on the event path can recover the sidebar-open latency gap, because removing the traffic entirely at the producer does not recover it either.* A wire-level filter (QA option 2) is measured here and is **not** worth its risk to the shared path the current session uses; that proposal should not come back without new evidence that defeats the `relay` arm.

### Where the cost is not

Per-segment CPU **self**-time (nested time subtracted), no cProfile — the QA report correctly flags cProfile as confounded here, since the background runtimes share this process and its overhead roughly doubled measured CPU:

| segment | rate | µs/call | self, % of one core |
|---|---|---|---|
| `deserialize_event` (pydantic) | 223.4/s | 6.77 | 0.151 % |
| `app._on_message` | 239.5/s | 5.58 | 0.134 % |
| `_deliver` → handlers | 223.4/s | 5.11 | 0.114 % |
| `EventController._post` | 223.4/s | 2.31 | 0.052 % |
| `_is_duplicate` | 223.4/s | 1.51 | 0.034 % |
| `_track` | 223.4/s | 1.29 | 0.029 % |
| **whole Python delivery chain** | | | **0.51 %** |
| process CPU that cell | | | **19.2 %** |

The entire chain the static analysis points at is **half a point of a core** against a ~7–9 point open/closed delta. It was never going to be the latency. Wire attribution agrees: all frames the viewer's pump reads are `op: "event"` (205.0/s open, 0.0/s closed, `frontend_update` never appears), and the pump's own `json.loads` is 0.156 % of a core.

### The leading suspect

**`_prepare_sidebar_session`: 93 ms median, on the event loop, 2 per prewarm refresh.** That is the shape that produces a ~150 ms keystroke median and a near-second p99 tail. It is in the prewarm/prepare path, not the event path.

That figure is **from QA's own Matrix B** — the datum that reframes this was already in the evidence, just not connected to the latency question. Deliberately not touched here: it is a different slice, and `resume.py` / `session/catalog.py` / `session/retention.py` are owned by the in-flight `perf/catalog-scan-users` PR.

### On the causal step

QA's measurements are sound and its A/B was clean — I reproduced its counts closely (215.7–222.4 ev/s here against its 228.0/228.0, 13 attached, 100 % hidden-source). The inference from *"fan-in is 100 % correlated with sidebar-open"* to *"fan-in causes the latency"* is the one step that does not hold: **everything** the sidebar switches on co-varies with sidebar-open, including the prepare path. That is a normal failure mode, it was caught by exactly the right method — an interleaved A/B with a ceiling arm — and the investigation is what made this correction cheap to reach.

## Regression tests

Six new tests. All six fail on the pre-fix tree (verified by stashing the two production files and re-running, not asserted):

- `test_parked_source_drops_delta_grade_events` — 50 `message_update`s + a `tool_execution_update` reach the app as **nothing**.
- `test_parked_source_still_reports_turn_boundaries` — a turn that starts and ends while parked still posts `TurnStarted`/`TurnEnded` and adopts the stamped generation. **This is the guard for the care point.**
- `test_parked_source_keeps_tool_and_message_boundaries` — tool start/end, message end and notices survive the mute, so card pairing cannot paint a succeeded call as interrupted.
- `test_unparking_restores_delta_delivery` — a committed source paints its tokens again.
- `test_restoring_projection_is_never_muted` — the reveal's seed replay bypasses the mute.
- `test_a_speculatively_leased_source_is_parked_and_stays_subscribed` — app-level, at the seam that creates the attachments; asserts **both** halves, that the controller is parked **and** still subscribed, because dropping the second is the buffering trap above.

### Added in remediation round 1 — `tests/unit/tui/test_parked_source_seam.py` (R2, Q1, Q2)

Review round 1 showed the mute's worst failure mode was unguarded: deleting the unpark from `_adopt_session` left **both** existing suites green (26 passed + 62 passed), because `test_unparking_restores_delta_delivery` calls the setter directly rather than exercising the app seam that is supposed to invoke it. Two new tests drive the **production** `_prepare_sidebar_session` → `_commit_sidebar_session` path over real `RemoteSession`s against real in-process `RuntimeServer`s, and assert on **delivered deltas**, not on the `parked` flag:

- `test_commit_unparks_the_incoming_source_and_reparks_the_outgoing` — both sides of the latch at the real seam.
- `test_returning_to_a_reparked_source_paints_its_stream_again` — the round trip that re-parking newly makes reachable (park → visit → leave → return), so the R1 fix cannot itself produce the blank stream R2 is about.

**Mutation evidence**, with each mutation asserted live in the *imported* module via `inspect.getsource` before any verdict was trusted — a mutation that silently fails to apply is indistinguishable from a test correctly passing:

| mutation | old suites | new seam tests |
|---|---|---|
| M3: `set_parked(False)` deleted from `_adopt_session` | `VERIFIED LIVE` → **88 passed, SURVIVED** | `VERIFIED LIVE` → **2 failed, CAUGHT** |
| re-park deleted from `_commit_sidebar_session` (R1's own guard) | — | `VERIFIED LIVE` → **2 failed, CAUGHT** |

That is QA's Q1 answered as well: guard density now pins the mechanism, not just the API. **Q2** is answered too — `_delta_grade()` emits one of *each* member of `_PARKED_DROP_TYPES`, so `tool_execution_update` and `subagent_progress` go through the real subscription at the real seam rather than being covered by unit test alone.

## Gates

| gate | result |
|---|---|
| `flake8` (whole tree) | clean |
| `black --check` (26.1.0, pinned as CI) | clean, 1026 files |
| `isort --check` (5.13.2, pinned as CI) | clean |
| `pyright --pythonpath .venv/bin/python .` | **0 errors, 0 warnings** |
| unit suite, whole tree, `.venv/bin/python` | reached 100 %, **0 FAILED, 0 ERROR** (twice) |
| targeted: `test_events.py` + `test_session_sidebar.py` `-n0` | **88 passed** |
| `tests/e2e -m e2e -n0` | **95 passed, 7 skipped** in 128.59 s |

**Remediation round 1 re-ran as CI on head `afee7f953`** (scoped to the affected suites: CI is green on this exact head and the host is at 92–94 % disk with swap near capacity, so the whole tree was deliberately *not* re-run locally rather than implying coverage):

| gate | result |
|---|---|
| `flake8 .` (7.3.0, pinned as CI) | clean |
| `black --check .` (26.1.0, pinned as CI) | clean, 1,195 files |
| `isort --check .` (5.13.2, pinned as CI) | clean |
| `pyright --pythonpath .venv/bin/python` | **0 errors, 0 warnings, 0 informations** |
| `test_events.py` + `test_session_sidebar.py` + `test_parked_source_seam.py` + `test_sidebar_idle_reap.py` + `test_rendered_history_paging.py` `-n0` | **126 passed** |
| `tests/e2e -m e2e -n0` | **99 passed, 7 skipped** in 122.67 s |
| #861 AST session-member guard + `test_no_session_deletion.py` | **196 passed** |

Rebased onto `origin/main` at `ec89d811d` (#881). `git range-diff` reports `=` — content identical across the move — and the two diffs share **no file**: #881 touches `resume.py` / `session/catalog.py` / `session/cleanup.py`, this one touches `tui/app.py` / `tui/events.py` and TUI tests.

Both full-tree unit runs reached 100 % with zero test failures and were then aborted at `pytest_sessionfinish` by the repo's real-store tripwires (`REAL CONFIG CHANGED` / `REAL SESSION STORE SHRANK`). Those guards are whole-machine by design — their own text says *"or running alongside it"* — and this host is running many concurrent worktrees, one of which is actively changing `session/retention.py`. Confirmed not attributable here: this diff contains no deletion, prune or config-write code (`git diff` for `unlink|rmtree|remove|prune|delete` matches only a prose comment), and running the two touched test files against a snapshot of the real config left it **byte-identical**.

## Independently confirmed by QA round 1 (verdict: **PASS**, 30/30 rows, 0 FAIL, 0 BLOCKED)

QA reproduced the waste-removal claim with its own instrumentation and its own worktrees, and added three checks this description did not have:

- **The zero is real, not a broken subscription.** A head count of 0 is equally consistent with "events arrive and are declined" and "the subscription silently broke and the stream is accumulating elsewhere" — the rejected design's failure mode. Counted at three depths: arrivals at `EventController._on_event` **5,880 base / 5,868 head** (equal within noise), declined as delta-grade at dispatch **0 → 5,868**, Textual messages minted **5,880 → 0**, `RemoteSession._buffered_events` **0 on both**. The subscription is fully intact and the work is declined at dispatch — the claimed mechanism, measured.
- **A correctness oracle on the production `write` tool.** QA's first card-pairing scenarios used a gated fake tool that never reached success on *either* tree, so they proved head == base but not the property this PR rests on. Re-run with the real `write` tool and real arguments, the **whole call executing while the source was parked**: card state after reveal **`success`** on head and base, artifact written with correct content on both, no card `interrupted`. The failure mode the docstring names does not occur.
- **Switch latency does not regress.** The concrete risk was that a parked source discards deltas, so commit replays the owner's seed instead of having painted incrementally. n = 48/arm, per-switch alternation with symmetric cold treatment: median **33.4 ms fix-on vs 30.3 ms fix-off**, permutation test on the median difference (200 k relabellings) **p = 0.461**; the +3.1 ms gap shrinks to +1.8 ms under a 20 % trim — a fat tail on a contended host, not an effect. QA caught and discarded a cache-warmth confound in its own first design before reporting this.

QA also independently reproduced the ABBA **disproof**, not just the claim: pooled medians open-fix 109.5 ms / open-nofix 100.3 ms / closed 86.7 ms, with the `set_parked` neutralisation asserted to have landed before any cell was trusted. Fix-on is not better than fix-off; closed is still clearly better than either. Its ABBA counts were 231.54/234.44 SessionEvent/s → **0.00/0.00**, hidden-source 5,798/5,868 → **0/0**, attached still 12 — slightly above this description's 215.7–222.4/s on different host load, with the before/after structure reproducing exactly.

## Measurement discipline

The host is heavily oversubscribed (load 13–114 across these runs, swap near capacity), so **counts are the primary evidence** and every timing is interleaved A/B in one sitting with `uptime` recorded per cell. No wall-clock absolute is a headline. Isolated `LOCAL_OPERATOR_CONFIG_DIR` with `HOME` repointed into the scratch dir, every `CMUX_*` unset then replaced with synthetic ids, `ulimit -n 8192`; `~/.local-operator` never read or written. Real assembled `OperatorApp` under a Textual `run_test()` pilot, real `RuntimeServer`s, real `RemoteSession.connect`, real `EventController.subscribe` — nothing mocked. The two harness bugs the QA report documents (transcript envelope, `registry.record_path` pid collision) are carried forward fixed, not reintroduced.

## Stated honestly, since they could not be determined

- **The function-level split of the ~9 CPU points.** Now partly answered: the whole Python delivery chain is 0.51 % of a core (table above), so the points are **not** there. Where they *are* is not claimed — the in-process background runtimes mean this process's CPU mixes producer and consumer, which is also why the `relay` arm is an **upper bound** on what a viewer-side fix could achieve rather than a production estimate.
- **Real-world delta sizes.** The harness emits ~30 chars every 50 ms per session. Real tool-call payloads move the per-event cost but not the mechanism or the counts.
- ~~**Behaviour past the 5-minute release window.**~~ **CLOSED by QA round 1 (Q3).** This caveat is stale. QA ran a 330 s cell, sampled every 15 s with 12 sessions streaming throughout: the genuine unpatched `SIDEBAR_IDLE_RELEASE_S` sweep fired at **t≈315 s and released all 12 parked sources cleanly** (attached 12 → 0), with every accumulation candidate flat at zero across all 21 samples (`_buffered_events` 0, queue depth 0, `pending_tool_ends` 0) and RSS growth equivalent to base (+9.1 MB head vs +9.3 MB base, i.e. not a parked-mode leak).

## Not addressed

- The open/closed keystroke-latency gap (see above) — real, reproducible, unresolved, evidence points at `_prepare_sidebar_session`.
- The prewarm/prepare path, and `resume.py` / `session/catalog.py` / `session/retention.py` — owned by the in-flight `perf/catalog-scan-users` PR; deliberately untouched so both stay reviewable.
- No version bump: `pyproject.toml` stays at the last released version (0.53.5).

