### PR TITLE
fix(oauth): correct OpenAI endpoint drift and pin Anthropic's loopback port

### DIFF
--- a/local_operator/providers/oauth/anthropic.py
+++ b/local_operator/providers/oauth/anthropic.py
@@ -13,6 +13,19 @@ Anthropic OAuth port. Traps preserved:
 - Expiry skew is 5 minutes at mint.
 - The refresh-token family dies **30 days after authorization** regardless
   of rotation — the deadline is surfaced in the identity payload.
+
+What this flow is, recorded so it does not get re-litigated from scratch:
+it is a first-party-style, device-local sign-in. The user authenticates
+directly with Anthropic through Anthropic's own flow; the resulting
+credential is stored on that user's own device, exactly as Claude Code
+stores it, and is used only for that same user's own inference.
+local-operator does not proxy, resell, or intermediate the subscription, and
+no Local Operator or Radient service sits between the user and Anthropic.
+That distinction is the substance of the terms at
+https://code.claude.com/docs/en/legal-and-compliance (verified 2026-09-09),
+which address offering Claude.ai login inside a third-party product and
+routing other users' requests through plan credentials — neither of which
+this does.
 """
 
 from __future__ import annotations
@@ -79,6 +92,17 @@ class AnthropicOAuthFlow(OAuthCallbackFlow):
             CallbackFlowOptions(
                 preferred_port=CALLBACK_PORT,
                 callback_path=CALLBACK_PATH,
+                # Anthropic allowlists this exact redirect URI, so 54545 is a
+                # requirement and not a preference. Inheriting the default
+                # `allow_port_fallback=True` meant a busy 54545 bound a random
+                # OS port and cheerfully advertised it — which the allowlist
+                # rejects, at the IdP, after the browser has already opened,
+                # with an error the user cannot act on ("Redirect URI
+                # http://localhost:<port>/callback is not supported by
+                # client"). Failing locally instead is the whole point: the
+                # module docstring has always claimed 54545 is required, and
+                # this is the line that makes that true.
+                allow_port_fallback=False,
                 manual_input_only=manual_input_only,
                 provider_label="Anthropic",
             ),
@@ -101,7 +125,15 @@ class AnthropicOAuthFlow(OAuthCallbackFlow):
             "code_challenge": challenge,
             "code_challenge_method": "S256",
             "scope": SCOPES,
-            # The IdP uses this to select the code flow variant.
+            # Makes Anthropic render the authorization code as a `code#state`
+            # copy target on the page, which is what the paste fallback
+            # consumes when the browser cannot reach this machine's loopback
+            # port (remote/SSH/WSL sessions, and the reported case where the
+            # browser lands in the claude.ai portal instead of redirecting).
+            # It does NOT select a flow variant — the flow is already pinned by
+            # `response_type=code` above. See `_parse_pasted_callback` in
+            # callback_server.py, which parses exactly that `code#state` shape
+            # alongside a bare code and a full pasted redirect URL.
             "code": "true",
         }
         return f"{AUTHORIZE_URL}?{urllib.parse.urlencode(params)}"

--- a/local_operator/providers/oauth/callback_server.py
+++ b/local_operator/providers/oauth/callback_server.py
@@ -12,9 +12,12 @@ preserving (they are scar tissue from real provider behaviour):
   only ports the provider accepts) without weakening it: an OS-assigned port
   is still never advertised to such a provider.
 - A busy port is retried briefly before it is believed. The common cause is a
-  sibling login of ours still tearing down, not a permanent squatter, so the
-  ladder pokes ``GET /cancel`` at the incumbent once and retries — matching
-  upstream Codex's ``bind_server``.
+  sibling login of ours still parked on its timeout, not a permanent squatter,
+  so the ladder pokes ``GET /cancel`` at the incumbent once and retries —
+  matching upstream Codex's ``bind_server``. **That poke only works because
+  this server also ANSWERS ``/cancel``** (see ``_handle_connection``): sending
+  it without implementing it, as this did at first, leaves the sibling holding
+  the port and the retry waiting for something that will never happen.
 - Two routes on one server: the callback path and ``/launch`` (302 to the
   pending auth URL) so a TUI can hand the user a short copy target.
 - The paste-code prompt may only race the HTTP callback for providers that
@@ -112,8 +115,29 @@ def _parse_pasted_callback(pasted: str) -> tuple[str, str]:
     # Providers hand users "code#state" in the redirect URL fragment.
     if "#" in pasted:
         code, _, frag_state = pasted.partition("#")
-        return code.strip(), frag_state.strip()
-    return pasted, ""
+        return _require_code(code.strip()), frag_state.strip()
+    return _require_code(pasted), ""
+
+
+def _require_code(code: str) -> str:
+    """Reject a paste that yields no authorization code.
+
+    A stray Enter at the prompt, or a fragment-only paste like ``#state``,
+    otherwise reaches the token endpoint AS the code: the login is spent on a
+    round trip that must fail, and the user gets an opaque provider error in
+    the one place this flow exists to help people whose browser cannot reach
+    the loopback port. Raising instead re-offers the prompt, which is what
+    every other unusable shape in this parser already does.
+
+    Checks the RESULT rather than the input's shape, so every branch that can
+    produce an empty code is covered by construction.
+    """
+    if not code.strip():
+        raise LoginError(
+            "That paste carried no authorization code. Paste the code itself, "
+            "or the whole redirect URL from your browser's address bar."
+        )
+    return code
 
 
 def _describe_port_holders(ports: tuple[int, ...]) -> str:
@@ -137,8 +161,11 @@ def _describe_port_holders(ports: tuple[int, ...]) -> str:
     for port in ports:
         try:
             # Ports are ints from our own config, so there is no shell and no
-            # interpolation risk; -F pn asks for a stable machine-readable
-            # (pid, name) stream rather than the localised table layout.
+            # interpolation risk; -F pcn asks for a stable machine-readable
+            # stream of p(id), c(ommand) and n(ame) fields rather than the
+            # localised table layout. The parse below reads the `c` field, so
+            # dropping it from this argv silently removes the "X (pid N) is
+            # holding it" clause from every message.
             completed = subprocess.run(  # noqa: S603 - fixed argv, no shell
                 [binary, "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-F", "pcn"],
                 capture_output=True,
@@ -540,6 +567,11 @@ class OAuthCallbackFlow(ABC):
         self._pending_auth_url: str | None = None
         self._captured: asyncio.Future[tuple[str, str]] | None = None
         self._capture_error: asyncio.Future[str] | None = None
+        #: Resolved when a newer login asks this one to stand down over
+        #: ``/cancel``. Separate from ``_capture_error`` because the outcome is
+        #: a CANCELLATION, not a failure: hosts report the two differently, and
+        #: a superseded login is not an error the user did anything about.
+        self._cancelled: asyncio.Future[str] | None = None
         self._sent_state: str | None = None
 
     # -- subclass hooks ----------------------------------------------------
@@ -577,6 +609,13 @@ class OAuthCallbackFlow(ABC):
         Upstream Codex handles it by poking ``/cancel`` on the incumbent before
         retrying (`server.rs::send_cancel_request`), and this mirrors it.
 
+        The other half of this is the ``/cancel`` ROUTE in
+        ``_handle_connection``. Without it this method is theatre: the request
+        is sent, our sibling answers 404, the port stays held, and the retry
+        budget is spent waiting for a release that never comes. That was the
+        state this code shipped in first, and it mattered most for Anthropic
+        and Z.AI, which have no second rung to fall back to.
+
         Strictly best-effort: an unrelated server on that port answers 404 or
         garbage and nothing changes, so every failure here is swallowed and the
         retry ladder proceeds either way. It is deliberately a raw request
@@ -607,7 +646,7 @@ class OAuthCallbackFlow(ABC):
                 except Exception:
                     pass
 
-    async def _try_bind(self, port: int, *, required: bool) -> bool:
+    async def _try_bind(self, port: int, *, required: bool, may_cancel: bool = True) -> bool:
         """Bind ``port``. Returns True on success.
 
         ``required`` says whether this port is the only acceptable answer, and
@@ -636,7 +675,7 @@ class OAuthCallbackFlow(ABC):
             except OSError:
                 if not required:
                     return False
-                if not cancel_attempted:
+                if may_cancel and not cancel_attempted:
                     cancel_attempted = True
                     await self._cancel_stale_server(port)
                 if attempt < attempts - 1:
@@ -653,8 +692,13 @@ class OAuthCallbackFlow(ABC):
         pinned = opts.redirect_uri is not None or not opts.allow_port_fallback
         candidates = opts.candidate_ports if pinned else (opts.preferred_port,)
 
-        for port in candidates:
-            if await self._try_bind(port, required=pinned):
+        for index, port in enumerate(candidates):
+            # Only the PREFERRED rung is poked, matching upstream's
+            # `!using_fallback_port` guard. A fallback rung is a port we merely
+            # may use, so an incumbent there has at least as much claim to it
+            # as we do; standing one down to save ourselves a rung we do not
+            # need would be taking someone else's login for our convenience.
+            if await self._try_bind(port, required=pinned, may_cancel=index == 0):
                 return
 
         if pinned:
@@ -689,13 +733,29 @@ class OAuthCallbackFlow(ABC):
             where = f"The {provider} login can only use port {listed}, and all are"
         busy = " but is already in use." if len(candidates) == 1 else " in use."
         detail = f" {holders}" if holders else ""
-        probe = " ".join(f"lsof -nP -iTCP:{port} -sTCP:LISTEN" for port in candidates[:1])
-        return (
+        # `lsof` takes a comma list, so one command covers every candidate --
+        # naming only the first left the second port's holder unfindable in
+        # exactly the two-port case this message exists for.
+        probe = f"lsof -nP -iTCP:{','.join(str(port) for port in candidates)} -sTCP:LISTEN"
+        message = (
             f"{where}{busy}{detail} {provider} only accepts redirect URIs on "
             f"{'that port' if len(candidates) == 1 else 'those ports'}, so the login "
             "cannot fall back to another one. Quit the process holding it and run the "
             f"login again — `{probe}` shows what it is."
         )
+        # This failure happens BEFORE the server starts, so the paste prompt --
+        # the fallback this flow otherwise leans on -- is never offered. That
+        # left the only stated remedy "kill the other process", which a user
+        # who does not own that process cannot do. Naming the paste route makes
+        # the hard failure recoverable, and it is only mentioned where a host
+        # has actually attached a prompt.
+        if self.callbacks.on_manual_code_input is not None:
+            message += (
+                " If you cannot free the port, run the login again and use the "
+                "paste option: approve the sign-in in your browser, then paste "
+                "the code or the whole redirect URL at the prompt."
+            )
+        return message
 
     def _socket_port(self) -> int | None:
         """The actually-bound port — the one that lands in redirect_uri."""
@@ -817,6 +877,31 @@ class OAuthCallbackFlow(ABC):
                         tone="danger",
                     )
                     await self._respond(writer, 200, body)
+        elif path == "/cancel" and method == "GET":
+            # A NEWER login of ours found this port busy and is asking this
+            # one to stand down so it can have it. Without this route the poke
+            # in `_cancel_stale_server` lands on the 404 below and the
+            # incumbent keeps the port -- which made the retry ladder's whole
+            # premise ("the usual holder is a sibling still parked on its
+            # timeout") false for our own servers. Upstream Codex implements
+            # the same route for the same reason (`server.rs` `"/cancel" =>
+            # ResponseAndExit`).
+            #
+            # Safe to honour unauthenticated: it is reachable only from
+            # loopback, it destroys no credential, and the worst a local
+            # process can do with it is end a login the user can simply run
+            # again. It deliberately carries NO state check -- the caller is a
+            # sibling process that never saw our `state`, which is the whole
+            # point.
+            self._finish_cancelled("Login superseded by a newer sign-in that needed this port.")
+            body = self._page(
+                "Sign-in cancelled",
+                "Another sign-in started and took over this address, so this "
+                "one was stopped. Nothing was connected. Continue in the "
+                "window where you started the newer sign-in.",
+                closable=False,
+            )
+            await self._respond(writer, 200, body)
         elif path == "/launch" and method == "GET":
             if self._pending_auth_url:
                 await self._respond(
@@ -913,6 +998,10 @@ class OAuthCallbackFlow(ABC):
         if self._capture_error and not self._capture_error.done():
             self._capture_error.set_result(message)
 
+    def _finish_cancelled(self, message: str) -> None:
+        if self._cancelled and not self._cancelled.done():
+            self._cancelled.set_result(message)
+
     def _launch_url(self) -> str | None:
         """Short 302 alias for the auth URL; only safe for loopback http(s)."""
         if self.options.manual_input_only or self._server is None or self._bound_port is None:
@@ -998,6 +1087,7 @@ class OAuthCallbackFlow(ABC):
         loop = asyncio.get_running_loop()
         self._captured = loop.create_future()
         self._capture_error = loop.create_future()
+        self._cancelled = loop.create_future()
         state = secrets.token_hex(16)
         self._sent_state = state
         try:
@@ -1024,6 +1114,12 @@ class OAuthCallbackFlow(ABC):
 
     async def _await_code(self) -> tuple[str, str]:
         assert self._captured is not None and self._capture_error is not None
+        # `run()` creates this, but `_await_code` is also driven directly (by
+        # tests, and by any caller that owns its own server lifecycle). A
+        # future added to this class must not become a precondition existing
+        # callers have to learn about, so it is created on demand here.
+        if self._cancelled is None:
+            self._cancelled = asyncio.get_running_loop().create_future()
         waiters: list[asyncio.Future[Any]] = []
         loop = asyncio.get_running_loop()
 
@@ -1108,6 +1204,7 @@ class OAuthCallbackFlow(ABC):
 
         waiters.append(self._captured)
         waiters.append(self._capture_error)
+        waiters.append(self._cancelled)
         waiters.append(loop.create_task(_manual()))
         if self._signal is not None:
             waiters.append(loop.create_task(_abort_watch()))
@@ -1129,7 +1226,13 @@ class OAuthCallbackFlow(ABC):
             if exc is not None:
                 raise exc
             result = task.result()
-            if isinstance(result, str):  # capture_error path
+            if isinstance(result, str):
+                # Both string-valued futures land here, and which one resolved
+                # decides the EXCEPTION TYPE: a superseded login is a
+                # cancellation (hosts report it quietly and offer no remedy),
+                # while `_capture_error` is a real failure worth surfacing.
+                if task is self._cancelled:
+                    raise LoginCancelledError(result)
                 raise LoginError(result)
             return result
         raise LoginTimeoutError()  # unreachable

--- a/local_operator/providers/oauth/callback_server.py
+++ b/local_operator/providers/oauth/callback_server.py
@@ -607,16 +607,26 @@ class OAuthCallbackFlow(ABC):
                 except Exception:
                     pass
 
-    async def _try_bind(self, port: int) -> bool:
-        """Bind ``port``, retrying briefly while it is merely in teardown.
+    async def _try_bind(self, port: int, *, required: bool) -> bool:
+        """Bind ``port``. Returns True on success.
 
-        Returns True on success. The first failure triggers one best-effort
-        ``/cancel`` at the incumbent, then the attempts play out; a port still
-        busy at the end of the budget is reported as unavailable so the caller
-        can move to the next rung or fail.
+        ``required`` says whether this port is the only acceptable answer, and
+        it decides whether waiting is worth anything. When the provider
+        validates the redirect URI, a busy port is the difference between a
+        login and no login, so it is worth ~2 s of retries to outlast a sibling
+        login still tearing down. When ANY port will do, that same wait buys
+        nothing: an OS-assigned port is one syscall away and just as valid, so
+        retrying only delays every login that happens to find the preferred
+        port occupied. Spending the budget there was a straight regression --
+        3.8 s added to a case that used to be instant.
+
+        The ``/cancel`` poke follows the same rule for a subtler reason: it is
+        aimed at a stale login server of OURS, and standing one down is only
+        justified when we actually need its port.
         """
+        attempts = PORT_RETRY_ATTEMPTS if required else 1
         cancel_attempted = False
-        for attempt in range(PORT_RETRY_ATTEMPTS):
+        for attempt in range(attempts):
             try:
                 self._server = await asyncio.start_server(
                     self._handle_connection, "127.0.0.1", port
@@ -624,10 +634,12 @@ class OAuthCallbackFlow(ABC):
                 self._bound_port = self._socket_port()
                 return True
             except OSError:
+                if not required:
+                    return False
                 if not cancel_attempted:
                     cancel_attempted = True
                     await self._cancel_stale_server(port)
-                if attempt < PORT_RETRY_ATTEMPTS - 1:
+                if attempt < attempts - 1:
                     await asyncio.sleep(PORT_RETRY_DELAY_SECONDS)
         return False
 
@@ -642,7 +654,7 @@ class OAuthCallbackFlow(ABC):
         candidates = opts.candidate_ports if pinned else (opts.preferred_port,)
 
         for port in candidates:
-            if await self._try_bind(port):
+            if await self._try_bind(port, required=pinned):
                 return
 
         if pinned:

--- a/local_operator/providers/oauth/callback_server.py
+++ b/local_operator/providers/oauth/callback_server.py
@@ -1221,18 +1221,59 @@ class OAuthCallbackFlow(ABC):
 
         if not done:
             raise LoginTimeoutError(self._timeout_message())
-        for task in done:
+
+        # ``done`` is a SET, and more than one waiter can land in it: futures
+        # that resolve in the same event-loop pass are all reported together,
+        # so iterating it directly lets HASH ORDER pick the outcome. That is
+        # not a theoretical concern -- a browser callback arriving as a sibling
+        # login pokes ``/cancel`` co-resolves ``_captured`` with ``_cancelled``
+        # and discarded an authorization code we already held (28% of
+        # concurrent trials), and it downgraded a genuine
+        # ``_capture_error`` -- the forged-redirect/state-mismatch check -- to a
+        # cancellation that hosts render as a quiet "login cancelled" with no
+        # remedy offered.
+        #
+        # So the outcomes are ranked and the most significant one wins,
+        # regardless of which future the set happens to yield first:
+        #
+        #   0 success -- we hold a code. NEVER lose one that was captured:
+        #     the user already approved in the browser, and a cancellation
+        #     racing it does not un-approve it.
+        #   1 failure -- a real error the user must see.
+        #   2 cancellation -- correct only when nothing better happened.
+        #
+        # A cancelled waiter carries no outcome at all (the ``finally`` above
+        # cancels every waiter, and ``.exception()`` on one raises rather than
+        # returning), so it is ranked last and skipped.
+        def _outcome_rank(task: asyncio.Future[Any]) -> int:
+            if task.cancelled():
+                return 3
+            exc = task.exception()
+            if exc is not None:
+                # ``_abort_watch`` signals ctrl+C by RAISING; every other
+                # exception is a real failure and outranks a cancellation.
+                return 2 if isinstance(exc, LoginCancelledError) else 1
+            # ``_captured`` and the manual-paste task both resolve to a
+            # ``(code, state)`` tuple; only the string-valued futures below
+            # describe a non-success.
+            if isinstance(task.result(), str):
+                return 2 if task is self._cancelled else 1
+            return 0
+
+        for task in sorted(done, key=_outcome_rank):
+            if task.cancelled():
+                continue
             exc = task.exception()
             if exc is not None:
                 raise exc
             result = task.result()
             if isinstance(result, str):
-                # Both string-valued futures land here, and which one resolved
-                # decides the EXCEPTION TYPE: a superseded login is a
-                # cancellation (hosts report it quietly and offer no remedy),
-                # while `_capture_error` is a real failure worth surfacing.
+                # Which future resolved decides the EXCEPTION TYPE: a
+                # superseded login is a cancellation (hosts report it quietly
+                # and offer no remedy), while `_capture_error` is a real
+                # failure worth surfacing.
                 if task is self._cancelled:
                     raise LoginCancelledError(result)
                 raise LoginError(result)
             return result
-        raise LoginTimeoutError()  # unreachable
+        raise LoginTimeoutError()  # every waiter was cancelled during teardown

--- a/local_operator/providers/oauth/callback_server.py
+++ b/local_operator/providers/oauth/callback_server.py
@@ -8,7 +8,13 @@ preserving (they are scar tissue from real provider behaviour):
 - When the provider validates redirect URIs (``redirect_uri`` pinned or
   ``allow_port_fallback=False``), a busy port MUST fail before the browser
   opens — otherwise the user gets an opaque 500 at the IdP and a 5-minute
-  hang locally.
+  hang locally. ``fallback_ports`` widens this to a BOUNDED allowlist (the
+  only ports the provider accepts) without weakening it: an OS-assigned port
+  is still never advertised to such a provider.
+- A busy port is retried briefly before it is believed. The common cause is a
+  sibling login of ours still tearing down, not a permanent squatter, so the
+  ladder pokes ``GET /cancel`` at the incumbent once and retries — matching
+  upstream Codex's ``bind_server``.
 - Two routes on one server: the callback path and ``/launch`` (302 to the
   pending auth URL) so a TUI can hand the user a short copy target.
 - The paste-code prompt may only race the HTTP callback for providers that
@@ -23,6 +29,8 @@ import inspect
 import json
 import logging
 import secrets
+import shutil
+import subprocess
 import urllib.parse
 import webbrowser
 from abc import ABC, abstractmethod
@@ -32,6 +40,20 @@ from local_operator.callback_page import Tone, render_callback_page
 from local_operator.harness.types import AbortSignal
 
 DEFAULT_TIMEOUT_SECONDS = 300.0
+
+#: Retry budget for a busy loopback port, per candidate port. Mirrors upstream
+#: Codex (`codex-rs/login/src/server.rs::bind_server`, MAX_ATTEMPTS/RETRY_DELAY)
+#: because the thing being waited out is the same: a just-exited sibling login
+#: whose listening socket is still in the kernel's teardown path. Ten attempts
+#: at 200 ms is ~2 s per port -- long enough to outlast that teardown, short
+#: enough that a genuinely occupied port still fails before the browser opens.
+PORT_RETRY_ATTEMPTS = 10
+PORT_RETRY_DELAY_SECONDS = 0.2
+
+#: How long the best-effort `GET /cancel` to a stale login server may take.
+#: It is a courtesy shove, not a dependency: everything after it works whether
+#: or not anything answered, so the budget is small on purpose.
+STALE_CANCEL_TIMEOUT_SECONDS = 2.0
 
 
 def _parse_pasted_callback(pasted: str) -> tuple[str, str]:
@@ -92,6 +114,55 @@ def _parse_pasted_callback(pasted: str) -> tuple[str, str]:
         code, _, frag_state = pasted.partition("#")
         return code.strip(), frag_state.strip()
     return pasted, ""
+
+
+def _describe_port_holders(ports: tuple[int, ...]) -> str:
+    """Name the processes listening on ``ports``, or return "" if we cannot.
+
+    "Port 1455 is in use" is true and useless; "Cursor (pid 4711) is holding
+    it" is the same fact with the next action attached. `lsof` is the only
+    portable-enough way to get it without taking a dependency (psutil is
+    deliberately not one here -- see AGENTS.md), and it is absent or
+    permission-limited often enough that this must degrade to silence rather
+    than to a wrong answer: an empty string simply omits the clause.
+
+    Never raises, and never blocks the failure path for long -- the login has
+    already failed by the time this runs, and a hung diagnostic would turn a
+    clear error into a hang.
+    """
+    binary = shutil.which("lsof")
+    if binary is None:
+        return ""
+    holders: list[str] = []
+    for port in ports:
+        try:
+            # Ports are ints from our own config, so there is no shell and no
+            # interpolation risk; -F pn asks for a stable machine-readable
+            # (pid, name) stream rather than the localised table layout.
+            completed = subprocess.run(  # noqa: S603 - fixed argv, no shell
+                [binary, "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-F", "pcn"],
+                capture_output=True,
+                text=True,
+                timeout=2.0,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        pid = ""
+        for line in completed.stdout.splitlines():
+            tag, value = line[:1], line[1:].strip()
+            if tag == "p":
+                pid = value
+            elif tag == "c" and value:
+                label = f"{value} (pid {pid})" if pid else value
+                entry = f"{label} on port {port}" if len(ports) > 1 else label
+                if entry not in holders:
+                    holders.append(entry)
+    if not holders:
+        return ""
+    if len(holders) == 1:
+        return f"{holders[0]} is holding it."
+    return f"Held by {', '.join(holders)}."
 
 
 class LoginError(Exception):
@@ -371,6 +442,22 @@ class CallbackFlowOptions:
     ``redirect_uri`` pins the exact URI and disables port fallback (provider
     allowlist). ``manual_input_only`` skips the server entirely; the user
     pastes the code from the provider page.
+
+    Three port policies are expressible, and the difference matters because a
+    provider that validates redirect URIs rejects anything not on ITS
+    allowlist -- with an opaque error raised at the IdP, after the browser has
+    already opened:
+
+    - ``allow_port_fallback=True`` (default): any OS-assigned port is fine.
+      For providers that do not validate the redirect URI.
+    - ``allow_port_fallback=False`` with no ``fallback_ports``: exactly one
+      port, and a busy port fails locally before the browser opens.
+    - ``fallback_ports`` non-empty: a BOUNDED allowlist -- ``preferred_port``
+      first, then each fallback in order, and nothing else. This exists
+      because a boolean cannot express "these two ports and no others", which
+      is precisely OpenAI's situation: 1455 and 1457 are both server-side
+      allowlisted for the Codex client id, and an OS-assigned third port is
+      still a hard failure.
     """
 
     preferred_port: int
@@ -378,6 +465,14 @@ class CallbackFlowOptions:
     callback_hostname: str = "localhost"
     redirect_uri: str | None = None
     allow_port_fallback: bool = True
+    #: Additional provider-allowlisted ports tried, in order, after
+    #: ``preferred_port``. Only meaningful with ``allow_port_fallback=False``
+    #: and ``redirect_uri=None``: the advertised URI is built from the port
+    #: actually bound, so pinning a literal URI and then binding a different
+    #: port from this ladder would advertise an address nothing is listening
+    #: on. ``__post_init__`` rejects that combination rather than letting it
+    #: reach a provider as an opaque redirect-mismatch.
+    fallback_ports: tuple[int, ...] = ()
     manual_input_only: bool = False
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS
     #: Display name of the provider being signed into ("Anthropic", "OpenAI"),
@@ -386,6 +481,37 @@ class CallbackFlowOptions:
     #: without it — the trough is omitted rather than faked (mirrors how the
     #: MCP flow treats its server URL).
     provider_label: str | None = None
+
+    def __post_init__(self) -> None:
+        # A port ladder and a pinned literal URI are mutually exclusive by
+        # construction: `redirect_uri()` returns the pinned string verbatim, so
+        # binding the second rung would advertise the first rung's port and the
+        # provider would redirect the browser to a closed socket. Refusing here
+        # turns a subtle, provider-side, post-browser failure into an obvious
+        # local one at construction time.
+        if self.fallback_ports and self.redirect_uri is not None:
+            raise ValueError(
+                "fallback_ports cannot be combined with a pinned redirect_uri: the "
+                "advertised URI must name the port actually bound."
+            )
+        if self.fallback_ports and self.allow_port_fallback:
+            raise ValueError(
+                "fallback_ports requires allow_port_fallback=False: the ladder IS the "
+                "allowlist, and an OS-assigned port would defeat it."
+            )
+
+    @property
+    def candidate_ports(self) -> tuple[int, ...]:
+        """Every port this flow may bind, in the order they are tried.
+
+        Deduplicated so a provider that lists its preferred port again among
+        the fallbacks does not spend a second retry budget on it.
+        """
+        ordered = (self.preferred_port, *self.fallback_ports)
+        seen: dict[int, None] = {}
+        for port in ordered:
+            seen.setdefault(port, None)
+        return tuple(seen)
 
 
 class OAuthCallbackFlow(ABC):
@@ -442,29 +568,122 @@ class OAuthCallbackFlow(ABC):
         port = self._bound_port if self._bound_port is not None else opts.preferred_port
         return f"http://{opts.callback_hostname}:{port}{opts.callback_path}"
 
+    async def _cancel_stale_server(self, port: int) -> None:
+        """Ask whatever holds ``port`` to shut down, if it is one of ours.
+
+        A previous login of ours that is still parked on its timeout keeps the
+        port for up to five minutes, and the user experiences that as "login is
+        broken" with no way to tell it apart from Cursor squatting on 1455.
+        Upstream Codex handles it by poking ``/cancel`` on the incumbent before
+        retrying (`server.rs::send_cancel_request`), and this mirrors it.
+
+        Strictly best-effort: an unrelated server on that port answers 404 or
+        garbage and nothing changes, so every failure here is swallowed and the
+        retry ladder proceeds either way. It is deliberately a raw request
+        rather than an httpx call -- the target may not speak HTTP at all.
+        """
+        writer: asyncio.StreamWriter | None = None
+        try:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection("127.0.0.1", port),
+                timeout=STALE_CANCEL_TIMEOUT_SECONDS,
+            )
+            writer.write(
+                b"GET /cancel HTTP/1.1\r\n"
+                + f"Host: 127.0.0.1:{port}\r\n".encode("ascii")
+                + b"Connection: close\r\n\r\n"
+            )
+            await asyncio.wait_for(writer.drain(), timeout=STALE_CANCEL_TIMEOUT_SECONDS)
+            # Read the reply only to give the peer a chance to act on the
+            # request before the socket closes; the content is irrelevant.
+            await asyncio.wait_for(reader.read(64), timeout=STALE_CANCEL_TIMEOUT_SECONDS)
+        except Exception:
+            logger.debug("stale-login cancel on port %s did not complete", port, exc_info=True)
+        finally:
+            if writer is not None:
+                try:
+                    writer.close()
+                    await writer.wait_closed()
+                except Exception:
+                    pass
+
+    async def _try_bind(self, port: int) -> bool:
+        """Bind ``port``, retrying briefly while it is merely in teardown.
+
+        Returns True on success. The first failure triggers one best-effort
+        ``/cancel`` at the incumbent, then the attempts play out; a port still
+        busy at the end of the budget is reported as unavailable so the caller
+        can move to the next rung or fail.
+        """
+        cancel_attempted = False
+        for attempt in range(PORT_RETRY_ATTEMPTS):
+            try:
+                self._server = await asyncio.start_server(
+                    self._handle_connection, "127.0.0.1", port
+                )
+                self._bound_port = self._socket_port()
+                return True
+            except OSError:
+                if not cancel_attempted:
+                    cancel_attempted = True
+                    await self._cancel_stale_server(port)
+                if attempt < PORT_RETRY_ATTEMPTS - 1:
+                    await asyncio.sleep(PORT_RETRY_DELAY_SECONDS)
+        return False
+
     async def _start_server(self) -> None:
         opts = self.options
-        try:
-            self._server = await asyncio.start_server(
-                self._handle_connection, "127.0.0.1", opts.preferred_port
-            )
-            self._bound_port = self._socket_port()
-            return
-        except OSError:
-            pass
-        # Preferred port busy: fall back to an OS-assigned port only when the
-        # provider does not pin the redirect URI.
+        # A provider that validates redirect URIs gets a BOUNDED ladder of
+        # allowlisted ports and nothing else; everyone else keeps the single
+        # preferred port plus an OS-assigned fallback. Either way a port we
+        # cannot use must fail HERE -- before the browser opens -- which is the
+        # invariant this module's docstring states.
         pinned = opts.redirect_uri is not None or not opts.allow_port_fallback
+        candidates = opts.candidate_ports if pinned else (opts.preferred_port,)
+
+        for port in candidates:
+            if await self._try_bind(port):
+                return
+
         if pinned:
-            raise ConfigurationError(
-                f"Port {opts.preferred_port} is required for this login flow but is already "
-                "in use. Stop the process holding it and retry."
-            )
+            # `lsof` is a blocking subprocess, and this runs on the event loop
+            # that a TUI is drawing from. Off-thread so the failure message
+            # costs a thread rather than a visible freeze.
+            holders = await asyncio.to_thread(_describe_port_holders, candidates)
+            raise ConfigurationError(self._port_unavailable_message(candidates, holders))
+
         try:
             self._server = await asyncio.start_server(self._handle_connection, "127.0.0.1", 0)
         except OSError as exc:
             raise ConfigurationError(f"Could not bind a loopback callback server: {exc}") from exc
         self._bound_port = self._socket_port()
+
+    def _port_unavailable_message(self, candidates: tuple[int, ...], holders: str = "") -> str:
+        """Explain a failed bind in terms the user can act on.
+
+        This message is the entire user-visible surface of the failure, and the
+        opaque version of it ("Port N is required ... Stop the process holding
+        it") sent users to search engines: it named no way to FIND the process,
+        and it did not say why an arbitrary port could not simply be used
+        instead. So it names the port, names what is holding it when the OS will
+        tell us, and gives the command to look for oneself.
+        """
+        provider = self.options.provider_label or "This provider"
+        if len(candidates) == 1:
+            port = candidates[0]
+            where = f"Port {port} is required for the {provider} login"
+        else:
+            listed = ", ".join(str(port) for port in candidates)
+            where = f"The {provider} login can only use port {listed}, and all are"
+        busy = " but is already in use." if len(candidates) == 1 else " in use."
+        detail = f" {holders}" if holders else ""
+        probe = " ".join(f"lsof -nP -iTCP:{port} -sTCP:LISTEN" for port in candidates[:1])
+        return (
+            f"{where}{busy}{detail} {provider} only accepts redirect URIs on "
+            f"{'that port' if len(candidates) == 1 else 'those ports'}, so the login "
+            "cannot fall back to another one. Quit the process holding it and run the "
+            f"login again — `{probe}` shows what it is."
+        )
 
     def _socket_port(self) -> int | None:
         """The actually-bound port — the one that lands in redirect_uri."""
@@ -512,7 +731,14 @@ class OAuthCallbackFlow(ABC):
             error = query.get("error")
             if error:
                 desc = query.get("error_description", "")
-                self._finish_error(f"Authorization failed: {error} {desc}".strip())
+                # The raw error code is preserved verbatim (it is the string a
+                # user searches for), but a bare `access_denied` left the
+                # terminal with a verdict and no next step. Naming the remedy
+                # matches the paste-fallback path's message above.
+                self._finish_error(
+                    f"Authorization failed: {error} {desc}".strip()
+                    + ". Nothing was connected — run the login again to retry."
+                )
                 # The provider's words go in their own labelled trough rather
                 # than into our sentence — same voice boundary the MCP flow
                 # draws, and where a bare `access_denied` reads as data rather
@@ -689,6 +915,66 @@ class OAuthCallbackFlow(ABC):
             return None
         return f"http://{self.options.callback_hostname}:{self._bound_port}/launch"
 
+    def _timeout_message(self) -> str | None:
+        """Timeout copy that names the recovery, when there is one.
+
+        A timeout has two quite different causes and the generic message serves
+        only the rarer one. Either the user walked away — nothing to say beyond
+        "try again" — or the browser DID complete the sign-in but its redirect
+        never reached this machine, which is the remote/SSH case and the
+        reported claude.ai-portal case. In the second, the user has been
+        staring at a page carrying the code all along; the default message
+        ("check that the system clock is in sync") sends them nowhere useful.
+
+        Returning None keeps :class:`LoginTimeoutError`'s existing default,
+        including the WSL/VM clock-drift note, for flows with no paste path.
+        """
+        if self.callbacks.on_manual_code_input is None:
+            return None
+        provider = self.options.provider_label or "the provider"
+        return (
+            f"Timed out waiting for the {provider} login callback. If your browser "
+            "finished the sign-in but showed you a login code — or stayed on the "
+            f"{provider} website instead of returning here — its redirect never "
+            "reached this machine. Run the login again and paste that code, or the "
+            "whole redirect URL from the address bar, at the prompt. If you run "
+            "inside WSL/a VM, check that the system clock is in sync."
+        )
+
+    def _instructions(self) -> str | None:
+        """The line shown under the auth URL while the login is pending.
+
+        Two affordances, and the second one is why this method exists. The
+        ``/launch`` URL is a convenience. The PASTE fallback is the escape
+        hatch for the failure users actually hit — a browser that never reaches
+        this machine's loopback port (a remote/SSH/WSL session, or the reported
+        case where the provider leaves the user sitting in its own web portal
+        instead of redirecting). Anthropic's own documentation points at it:
+        if the browser shows a login code instead of redirecting back, paste
+        the code into the terminal.
+
+        It used to be invisible. The prompt was attached and functional, but
+        nothing on screen said it existed, so a user watching a browser that
+        was never going to redirect had no way to learn there was anything to
+        do but wait out the five-minute timeout. Announcing it up front costs
+        one line and turns a dead end into a recovery.
+
+        Only announced when a prompt is actually attached
+        (``on_manual_code_input``): promising a paste target that no host will
+        offer is worse than saying nothing.
+        """
+        parts: list[str] = []
+        launch_url = self._launch_url()
+        if launch_url:
+            parts.append(f"Or open: {launch_url}")
+        if self.callbacks.on_manual_code_input is not None:
+            parts.append(
+                "If your browser shows a login code instead of returning here, "
+                "paste that code — or the whole redirect URL from the address "
+                "bar — at the prompt below."
+            )
+        return "\n".join(parts) if parts else None
+
     # -- driver ------------------------------------------------------------
 
     async def run(self) -> dict[str, Any]:
@@ -709,10 +995,10 @@ class OAuthCallbackFlow(ABC):
             auth_url = await self.generate_auth_url(state, redirect_uri)
             self._pending_auth_url = auth_url
 
-            launch_url = self._launch_url()
             if self.callbacks.on_auth_url is not None:
-                instructions = f"Or open: {launch_url}" if launch_url else None
-                await maybe_await(self.callbacks.on_auth_url(auth_url, instructions=instructions))
+                await maybe_await(
+                    self.callbacks.on_auth_url(auth_url, instructions=self._instructions())
+                )
             if not self.options.manual_input_only:
                 try:
                     self._open_browser(auth_url)
@@ -825,7 +1111,7 @@ class OAuthCallbackFlow(ABC):
                 task.cancel()
 
         if not done:
-            raise LoginTimeoutError()
+            raise LoginTimeoutError(self._timeout_message())
         for task in done:
             exc = task.exception()
             if exc is not None:

--- a/local_operator/providers/oauth/openai.py
+++ b/local_operator/providers/oauth/openai.py
@@ -3,11 +3,14 @@
 OpenAI Codex OAuth port:
 
 - **Browser flow** (provider id ``openai``): authorization code + PKCE,
-  loopback port **1455** pinned (``/auth/callback``). OpenAI allowlists the
-  redirect URI, so there is NO port fallback — a busy port must fail before
-  the browser opens.
+  loopback ``/auth/callback`` on port **1455**, falling back to **1457** when
+  1455 is busy. Those two ports and no others: OpenAI allowlists the redirect
+  URI server-side, so an OS-assigned port must still fail before the browser
+  opens. The advertised URI names whichever of the two actually bound.
 - **Device flow** (provider id ``openai-device``): OpenAI-private
-  ``deviceauth`` endpoints (NOT RFC 8628). Both store under ``openai``.
+  ``deviceauth`` endpoints (NOT RFC 8628) — JSON-encoded, and the poll body
+  carries ``user_code``; a bare 403/404 means "still pending". Both store
+  under ``openai``.
 - Identity comes from **JWT claims decoded without signature verification**
   (no PyJWT — the IdP already validated it): ``https://api.openai.com/auth``
   → ``chatgpt_account_id``/``chatgpt_plan_type``, ``.../profile`` → email.
@@ -51,14 +54,33 @@ SCOPES = "openid profile email offline_access api.connectors.read api.connectors
 ORIGINATOR = "local-operator"
 
 CALLBACK_PORT = 1455
+# Second server-side allowlisted port for this client id. Upstream Codex added
+# it (commit 8d5da3f, 2026-04-29) because Cursor and Codex Desktop squat on
+# 1455, which made an otherwise-correct login fail intermittently with nothing
+# the user could act on. Its E2E asserts the exchanged
+# redirect_uri=http%3A%2F%2Flocalhost%3A1457%2Fauth%2Fcallback, so 1457 is
+# known-good against the live IdP rather than merely plausible.
+#
+# This is an ALLOWLIST, not a fallback range: OpenAI validates the redirect URI
+# exactly, so a third, OS-assigned port would be rejected at the IdP after the
+# browser had already opened. 1455 and 1457, in that order, and nothing else.
+CALLBACK_FALLBACK_PORT = 1457
 CALLBACK_PATH = "/auth/callback"
+#: The redirect URI of the PREFERRED port. No longer the pinned value the flow
+#: advertises — the live one is built from whichever allowlisted port actually
+#: bound (see `OpenAIOAuthFlow`), so read `flow.redirect_uri()` for that.
+#: Retained because it is the canonical form of the allowlist entry and is
+#: what tests and docs quote.
 REDIRECT_URI = f"http://localhost:{CALLBACK_PORT}{CALLBACK_PATH}"
 
 AUTH_CLAIM_KEY = "https://api.openai.com/auth"
 PROFILE_CLAIM_KEY = "https://api.openai.com/profile"
 
-DEVICE_MAX_POLLS = 120
-DEVICE_SAFETY_MARGIN_SECONDS = 3
+#: Hard cap on the device flow, matching upstream Codex's `max_wait`
+#: (`device_code_auth.rs`) and the 15-minute expiry the device page prints to
+#: the user. Bounding in time rather than in poll count keeps our deadline and
+#: the code's real lifetime in step when the provider changes `interval`.
+DEVICE_EXPIRY_SECONDS = 15 * 60
 
 
 def _b64url_decode(segment: str) -> bytes:
@@ -141,7 +163,7 @@ def _credentials_from_token(token: dict[str, Any]) -> dict[str, Any]:
 
 
 class OpenAIOAuthFlow(OAuthCallbackFlow):
-    """ChatGPT browser login; pinned port 1455, no fallback."""
+    """ChatGPT browser login; bounded port allowlist 1455 then 1457."""
 
     def __init__(
         self,
@@ -154,9 +176,19 @@ class OpenAIOAuthFlow(OAuthCallbackFlow):
         super().__init__(
             CallbackFlowOptions(
                 preferred_port=CALLBACK_PORT,
+                fallback_ports=(CALLBACK_FALLBACK_PORT,),
                 callback_path=CALLBACK_PATH,
-                # Pinned: OpenAI allowlists this exact URI.
-                redirect_uri=REDIRECT_URI,
+                # `redirect_uri` is deliberately NOT pinned to a literal here,
+                # even though OpenAI allowlists the URI exactly. Both ports are
+                # on that allowlist, so the URI has to name whichever one we
+                # actually bound; the base class builds it from the bound port.
+                # Pinning the 1455 string would advertise a closed socket on
+                # every 1457 login. `allow_port_fallback=False` still forbids
+                # an OS-assigned port, which is what the allowlist cares about.
+                #
+                # The advertised host stays `localhost` (not `127.0.0.1`) to
+                # match the allowlist entry and upstream; the socket itself
+                # binds the IP literal, which is what RFC 8252 §8.3 requires.
                 allow_port_fallback=False,
                 provider_label="OpenAI",
             ),
@@ -239,14 +271,34 @@ async def login_openai_device(
 
     1. ``POST deviceauth/usercode`` → ``{device_auth_id, user_code, interval}``.
     2. User opens the device page and types the code.
-    3. Poll ``POST deviceauth/token`` (≤120 polls, interval + 3 s margin).
+    3. Poll ``POST deviceauth/token`` until authorized (15-minute cap).
     4. Success returns ``{authorization_code, code_verifier}``, exchanged
        against ``redirect_uri = https://auth.openai.com/deviceauth/callback``.
+
+    These are OpenAI-PRIVATE endpoints, so RFC 8628 is not the specification
+    they follow — upstream Codex
+    (`codex-rs/login/src/device_code_auth.rs`) is, and the shapes below are
+    matched to it field by field:
+
+    - **JSON, not form-encoded.** Both requests set
+      `Content-Type: application/json` upstream (`UserCodeReq`,
+      `TokenPollReq`). Form-encoding was silently wrong here.
+    - **The poll carries `user_code`.** Upstream's `TokenPollReq` is
+      `{device_auth_id, user_code}`; omitting `user_code` cannot identify the
+      pending authorization.
+    - **403/404 means "still waiting", not "failed".** This endpoint signals
+      pending authorization with a bare status and no OAuth error body, so the
+      RFC 8628 `authorization_pending` classification never matched and the
+      FIRST poll — always pending, since the user has not typed the code yet —
+      aborted the login. That defect made this flow unusable end to end.
+
+    oh-my-pi's `packages/ai/src/registry/oauth/openai-codex.ts` agrees
+    independently on all three.
     """
     owns_client = http_client is None
     http = http_client or httpx.AsyncClient(timeout=30.0)
     try:
-        start = await http.post(DEVICE_USERCODE_URL, data={"client_id": CLIENT_ID})
+        start = await http.post(DEVICE_USERCODE_URL, json={"client_id": CLIENT_ID})
         if start.status_code != 200:
             raise LoginError(f"OpenAI device auth start failed ({start.status_code}): {start.text}")
         device = start.json()
@@ -264,12 +316,21 @@ async def login_openai_device(
         async def _poll() -> DevicePollResult[dict[str, Any]]:
             response = await http.post(
                 DEVICE_TOKEN_URL,
-                data={"client_id": CLIENT_ID, "device_auth_id": device_auth_id},
+                # `user_code` is REQUIRED (upstream `TokenPollReq`); the
+                # endpoint identifies the pending authorization by the pair.
+                # `client_id` is not part of that struct and is not sent.
+                json={"device_auth_id": device_auth_id, "user_code": user_code},
             )
             if response.status_code == 200:
                 payload = response.json()
                 if payload.get("authorization_code"):
                     return DevicePollResult.complete(payload)
+                return DevicePollResult.pending()
+            # A bare 403/404 is how this endpoint says "not authorized yet" —
+            # there is no OAuth error body to classify. Treating it as terminal
+            # meant the first poll ended the login before the user could
+            # possibly have entered the code.
+            if response.status_code in (403, 404):
                 return DevicePollResult.pending()
             try:
                 payload = response.json()
@@ -285,7 +346,12 @@ async def login_openai_device(
                 or f"Device authorization failed ({response.status_code})"
             )
 
-        expires_in = DEVICE_MAX_POLLS * (interval + DEVICE_SAFETY_MARGIN_SECONDS)
+        # Bound the wait in TIME, matching upstream's 15-minute cap, rather
+        # than in poll count: the server-provided `interval` sets the cadence,
+        # so a count-based budget silently changes the deadline whenever the
+        # provider changes the interval. The user-facing code expires in 15
+        # minutes, so that is the honest deadline to hold ourselves to.
+        expires_in = DEVICE_EXPIRY_SECONDS
         token = await poll_device_code_flow(
             _poll,
             interval_seconds=interval,
@@ -317,13 +383,25 @@ async def login_openai_device(
 async def refresh_openai_token(
     creds: dict[str, Any], *, http_client: httpx.AsyncClient | None = None
 ) -> dict[str, Any]:
-    """Form-encoded refresh; org fields are never rewritten."""
+    """JSON-encoded refresh; org fields are never rewritten.
+
+    **The encoding asymmetry here is deliberate: do not "tidy" it.** The
+    authorization-code exchange above posts FORM-encoded to this same URL,
+    while refresh posts JSON. That looks like an inconsistency and is not one —
+    it is what upstream Codex does (`codex-rs/login/src/auth/manager.rs`
+    `request_chatgpt_token_refresh`, which sets `Content-Type: application/json`
+    and `.json(&RefreshRequest)`, against the same
+    `https://auth.openai.com/oauth/token` the form-encoded exchange uses).
+    Matching the client the endpoint is actually built around is the whole
+    point; making the two calls consistent with each other would make both of
+    them inconsistent with the server.
+    """
     owns_client = http_client is None
     http = http_client or httpx.AsyncClient(timeout=30.0)
     try:
         response = await http.post(
             TOKEN_URL,
-            data={
+            json={
                 "grant_type": "refresh_token",
                 "refresh_token": creds.get("refresh"),
                 "client_id": CLIENT_ID,

--- a/tests/unit/providers/test_oauth_flows.py
+++ b/tests/unit/providers/test_oauth_flows.py
@@ -8,6 +8,7 @@ import base64
 import hashlib
 import inspect
 import json
+import socket
 import urllib.parse
 from datetime import datetime, timezone
 from typing import Any
@@ -1960,3 +1961,475 @@ class TestABadPasteDoesNotEndTheLogin:
         )
         got, _ = result[0]
         assert got == ("browser-code", "browser-state")
+
+
+# ---------------------------------------------------------------------------
+# Bounded port allowlist (OpenAI 1455 -> /cancel -> retry -> 1457)
+# ---------------------------------------------------------------------------
+
+
+async def _occupy(port: int = 0) -> asyncio.base_events.Server:
+    """Bind 127.0.0.1:port with a server that never answers /cancel.
+
+    Stands in for the real squatters (Cursor, Codex Desktop): something that
+    holds the port and is NOT a login server of ours, so the cancel poke is
+    correctly ignored and the ladder has to move on.
+
+    Port 0 asks the OS for a free one. These tests deliberately do NOT bind the
+    real 1455/1457/54545: this repo is worked through many concurrent
+    worktrees, and a developer running Cursor, Codex Desktop or Claude Code has
+    those ports legitimately occupied — a test that needs them is a test that
+    fails for reasons that have nothing to do with the code. The ladder logic
+    is port-agnostic, so it is exercised on ephemeral ports; that the LITERAL
+    ports are the right ones is a separate, binding-free assertion (see
+    ``test_openai_uses_the_allowlisted_port_pair``).
+    """
+
+    async def _sink(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            await reader.read(1024)
+        finally:
+            writer.close()
+
+    return await asyncio.start_server(_sink, "127.0.0.1", port)
+
+
+def _port_of(server: asyncio.base_events.Server) -> int:
+    assert server.sockets
+    return int(server.sockets[0].getsockname()[1])
+
+
+def _free_port() -> int:
+    """An ephemeral port that is free right now (racy by nature, adequate here)."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
+def test_fallback_ports_reject_pinned_redirect_uri() -> None:
+    """A ladder plus a literal URI would advertise a port we did not bind."""
+    with pytest.raises(ValueError, match="pinned redirect_uri"):
+        CallbackFlowOptions(
+            preferred_port=1455,
+            fallback_ports=(1457,),
+            allow_port_fallback=False,
+            redirect_uri="http://localhost:1455/auth/callback",
+        )
+
+
+def test_fallback_ports_reject_os_assigned_fallback() -> None:
+    """The ladder IS the allowlist; an OS-assigned port would defeat it."""
+    with pytest.raises(ValueError, match="allow_port_fallback=False"):
+        CallbackFlowOptions(preferred_port=1455, fallback_ports=(1457,))
+
+
+def test_candidate_ports_dedupe_preserving_order() -> None:
+    opts = CallbackFlowOptions(
+        preferred_port=1455, fallback_ports=(1457, 1455), allow_port_fallback=False
+    )
+    assert opts.candidate_ports == (1455, 1457)
+
+
+def test_openai_uses_the_allowlisted_port_pair() -> None:
+    """The literal ports are the contract: 1455 then 1457, both server-side
+    allowlisted for this client id (upstream commit 8d5da3f). Asserted without
+    binding anything, so a developer running Cursor cannot fail it."""
+    from local_operator.providers.oauth.openai import OpenAIOAuthFlow
+
+    flow = OpenAIOAuthFlow(LoginCallbacks(), open_browser=lambda url: None)
+    assert flow.options.candidate_ports == (1455, 1457)
+    assert flow.options.allow_port_fallback is False
+    # No literal redirect_uri: it must name whichever of the two we bound.
+    assert flow.options.redirect_uri is None
+
+
+async def test_port_ladder_falls_back_to_second_allowlisted_port() -> None:
+    """Preferred busy => bind the fallback rung and ADVERTISE it. The
+    redirect_uri must name the port actually bound, or the IdP sends the
+    browser to a closed socket."""
+    squatter = await _occupy()
+    busy = _port_of(squatter)
+    spare = _free_port()
+    try:
+        flow = _EchoFlow(
+            CallbackFlowOptions(
+                preferred_port=busy,
+                fallback_ports=(spare,),
+                allow_port_fallback=False,
+                callback_path="/auth/callback",
+                provider_label="OpenAI",
+            ),
+            LoginCallbacks(),
+        )
+        await flow._start_server()
+        try:
+            assert flow.bound_port == spare
+            assert flow.redirect_uri() == f"http://localhost:{spare}/auth/callback"
+        finally:
+            await flow._stop_server()
+    finally:
+        squatter.close()
+        await squatter.wait_closed()
+
+
+async def test_port_ladder_fails_when_every_allowlisted_port_is_busy() -> None:
+    """Both busy => fail BEFORE the browser opens, naming both ports. An
+    OS-assigned port is never substituted for a validated redirect URI."""
+    held = [await _occupy(), await _occupy()]
+    first, second = (_port_of(server) for server in held)
+    try:
+        flow = _EchoFlow(
+            CallbackFlowOptions(
+                preferred_port=first,
+                fallback_ports=(second,),
+                allow_port_fallback=False,
+                callback_path="/auth/callback",
+                provider_label="OpenAI",
+            ),
+            LoginCallbacks(),
+        )
+        with pytest.raises(ConfigurationError) as excinfo:
+            await flow._start_server()
+        message = str(excinfo.value)
+        assert str(first) in message and str(second) in message
+        assert "OpenAI" in message
+        # The message must give the user a way to find the squatter.
+        assert "lsof" in message
+        assert flow.bound_port is None
+    finally:
+        for server in held:
+            server.close()
+            await server.wait_closed()
+
+
+async def test_port_ladder_pokes_cancel_at_a_stale_login_server() -> None:
+    """A busy port is retried, and the incumbent is asked to stand down first
+    -- the common cause is a sibling login of ours still parked on its
+    timeout, not a permanent squatter."""
+    seen: list[str] = []
+    holder: list[asyncio.base_events.Server] = []
+
+    async def _stale(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        raw = await reader.read(256)
+        seen.append(raw.decode("latin-1").split("\r\n", 1)[0])
+        writer.write(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+        try:
+            await writer.drain()
+        except Exception:
+            pass
+        writer.close()
+        # Release the port, as a real login server does when cancelled.
+        holder[0].close()
+
+    holder.append(await asyncio.start_server(_stale, "127.0.0.1", 0))
+    preferred = _port_of(holder[0])
+    try:
+        flow = _EchoFlow(
+            CallbackFlowOptions(
+                preferred_port=preferred,
+                fallback_ports=(_free_port(),),
+                allow_port_fallback=False,
+                callback_path="/auth/callback",
+            ),
+            LoginCallbacks(),
+        )
+        await flow._start_server()
+        try:
+            assert seen and seen[0] == "GET /cancel HTTP/1.1"
+            # Having stood the incumbent down, the retry wins the PREFERRED
+            # port rather than burning the fallback.
+            assert flow.bound_port == preferred
+        finally:
+            await flow._stop_server()
+    finally:
+        try:
+            holder[0].close()
+            await holder[0].wait_closed()
+        except Exception:
+            pass
+
+
+async def test_single_pinned_port_message_names_the_port() -> None:
+    """Anthropic's case: one port, no ladder, and a message worth reading."""
+    squatter = await _occupy()
+    port = _port_of(squatter)
+    try:
+        flow = _EchoFlow(
+            CallbackFlowOptions(
+                preferred_port=port,
+                allow_port_fallback=False,
+                provider_label="Anthropic",
+            ),
+            LoginCallbacks(),
+        )
+        with pytest.raises(ConfigurationError) as excinfo:
+            await flow._start_server()
+        message = str(excinfo.value)
+        assert str(port) in message
+        assert "Anthropic" in message
+        assert "lsof" in message
+    finally:
+        squatter.close()
+        await squatter.wait_closed()
+
+
+# ---------------------------------------------------------------------------
+# OpenAI device flow + refresh encoding (first tests for the device path)
+# ---------------------------------------------------------------------------
+
+
+class _BodyRecorder:
+    """Captures the RAW request bytes and Content-Type of every call.
+
+    Encoding claims are the point of these tests, so nothing here inspects a
+    parsed convenience view: JSON vs form-encoded is a property of the wire
+    bytes, and asserting on `request.content` is what makes the claim checkable
+    rather than assumed.
+    """
+
+    def __init__(self, responses: list[httpx.Response]) -> None:
+        self._responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    async def handler(self, request: httpx.Request) -> httpx.Response:
+        self.calls.append(
+            {
+                "url": str(request.url),
+                "content_type": request.headers.get("content-type", ""),
+                "body": request.content.decode(),
+            }
+        )
+        return self._responses[min(len(self.calls) - 1, len(self._responses) - 1)]
+
+    def client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(transport=httpx.MockTransport(self.handler))
+
+
+def _id_token(account_id: str = "acct_1") -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').decode().rstrip("=")
+    payload = {
+        "https://api.openai.com/auth": {
+            "chatgpt_account_id": account_id,
+            "chatgpt_plan_type": "plus",
+        },
+        "https://api.openai.com/profile": {"email": "user@example.com"},
+    }
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    return f"{header}.{body}.sig"
+
+
+async def test_openai_refresh_sends_json_not_form() -> None:
+    """Upstream refreshes with JSON (auth/manager.rs request_chatgpt_token_refresh)
+    while the code exchange stays form-encoded. The asymmetry is the server's,
+    not ours -- assert the wire bytes so nobody 'tidies' it into consistency."""
+    from local_operator.providers.oauth.openai import refresh_openai_token
+
+    recorder = _BodyRecorder(
+        [httpx.Response(200, json={"access_token": "at_new", "expires_in": 3600})]
+    )
+    async with recorder.client() as client:
+        merged = await refresh_openai_token(
+            {"refresh": "rt_old", "access": "at_old", "org_id": "org_keep"},
+            http_client=client,
+        )
+
+    call = recorder.calls[0]
+    assert call["content_type"].startswith("application/json")
+    assert json.loads(call["body"]) == {
+        "grant_type": "refresh_token",
+        "refresh_token": "rt_old",
+        "client_id": "app_EMoamEEZ73f0CkXaXp7hrann",
+    }
+    assert "grant_type=refresh_token" not in call["body"]  # not form-encoded
+    assert merged["access"] == "at_new"
+    assert merged["org_id"] == "org_keep"  # org fields are never rewritten
+
+
+async def test_openai_device_flow_sends_json_with_user_code() -> None:
+    """The three device-flow defects at once: JSON encoding on both requests,
+    `user_code` present in the poll body (upstream TokenPollReq), and a bare
+    403 treated as 'keep polling' rather than as a hard failure."""
+    from local_operator.providers.oauth.openai import login_openai_device
+
+    recorder = _BodyRecorder([])
+    responses = iter(
+        [
+            # 1. usercode
+            httpx.Response(
+                200, json={"device_auth_id": "dev_1", "user_code": "ABCD-1234", "interval": 0}
+            ),
+            # 2/3. pending -- the statuses that used to abort the login on the
+            # very first poll, before the user could have typed anything.
+            httpx.Response(403),
+            httpx.Response(404),
+            # 4. authorized
+            httpx.Response(200, json={"authorization_code": "ac_1", "code_verifier": "cv_1"}),
+            # 5. token exchange
+            httpx.Response(
+                200,
+                json={
+                    "access_token": "at_1",
+                    "refresh_token": "rt_1",
+                    "id_token": _id_token(),
+                    "expires_in": 3600,
+                },
+            ),
+        ]
+    )
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        recorder.calls.append(
+            {
+                "url": str(request.url),
+                "content_type": request.headers.get("content-type", ""),
+                "body": request.content.decode(),
+            }
+        )
+        return next(responses)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        creds = await asyncio.wait_for(
+            login_openai_device(LoginCallbacks(), http_client=client), timeout=30
+        )
+
+    usercode, first_poll, second_poll, third_poll, exchange = recorder.calls
+
+    # (a) JSON, not form-encoded, on the OpenAI-private endpoints.
+    assert usercode["content_type"].startswith("application/json")
+    assert json.loads(usercode["body"]) == {"client_id": "app_EMoamEEZ73f0CkXaXp7hrann"}
+
+    # (b) the poll carries user_code -- upstream TokenPollReq{device_auth_id,
+    # user_code}. client_id is NOT part of that struct.
+    for poll in (first_poll, second_poll, third_poll):
+        assert poll["content_type"].startswith("application/json")
+        assert json.loads(poll["body"]) == {
+            "device_auth_id": "dev_1",
+            "user_code": "ABCD-1234",
+        }
+
+    # (c) 403 and 404 kept the flow polling instead of ending it.
+    assert len([c for c in recorder.calls if c["url"].endswith("deviceauth/token")]) == 3
+
+    # The code exchange stays FORM-encoded (upstream exchange_code_for_tokens).
+    assert exchange["content_type"].startswith("application/x-www-form-urlencoded")
+    exchanged = dict(urllib.parse.parse_qsl(exchange["body"]))
+    assert exchanged["grant_type"] == "authorization_code"
+    assert exchanged["code"] == "ac_1"
+    assert exchanged["redirect_uri"] == "https://auth.openai.com/deviceauth/callback"
+    assert exchanged["code_verifier"] == "cv_1"
+
+    assert creds["access"] == "at_1"
+    assert creds["account_id"] == "acct_1"
+
+
+async def test_openai_device_flow_still_fails_on_a_real_error() -> None:
+    """403/404 meaning 'pending' must not swallow genuine failures."""
+    from local_operator.providers.oauth.openai import login_openai_device
+
+    responses = iter(
+        [
+            httpx.Response(
+                200, json={"device_auth_id": "dev_1", "user_code": "ABCD-1234", "interval": 0}
+            ),
+            httpx.Response(400, json={"error": "expired_token", "error_description": "gone"}),
+        ]
+    )
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return next(responses)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(LoginError, match="gone"):
+            await asyncio.wait_for(
+                login_openai_device(LoginCallbacks(), http_client=client), timeout=30
+            )
+
+
+# ---------------------------------------------------------------------------
+# Paste fallback: reachable, announced, and honest about failure
+# ---------------------------------------------------------------------------
+
+
+# NOTE: the shapes `_parse_pasted_callback` accepts (bare code, `code#state`,
+# full redirect URL, state-in-fragment) are already pinned by
+# TestPastedCallbackParsing above; re-verified against this change, unchanged.
+
+
+async def test_pending_login_announces_the_paste_fallback() -> None:
+    """A user watching a browser that will never redirect must be able to SEE
+    that pasting is available, without hunting. The prompt was always attached;
+    nothing on screen said so."""
+    seen: dict[str, Any] = {}
+
+    def on_auth_url(url: str, instructions: str | None = None) -> None:
+        seen["url"] = url
+        seen["instructions"] = instructions
+
+    callbacks = LoginCallbacks(
+        on_auth_url=on_auth_url,
+        on_manual_code_input=lambda: None,  # attached, declines -> parks
+    )
+    flow = _EchoFlow(
+        CallbackFlowOptions(preferred_port=0, timeout_seconds=0.2, provider_label="Anthropic"),
+        callbacks,
+    )
+    with pytest.raises(LoginError):
+        await asyncio.wait_for(flow.run(), timeout=10)
+
+    instructions = seen["instructions"]
+    assert instructions is not None
+    assert "paste" in instructions.lower()
+    assert "redirect URL" in instructions
+
+
+async def test_no_paste_prompt_means_no_paste_promise() -> None:
+    """Loopback-only providers get no prompt, so promising one would lie."""
+    seen: dict[str, Any] = {}
+
+    def on_auth_url(url: str, instructions: str | None = None) -> None:
+        seen["instructions"] = instructions
+
+    flow = _EchoFlow(
+        CallbackFlowOptions(preferred_port=0, timeout_seconds=0.2),
+        LoginCallbacks(on_auth_url=on_auth_url),
+    )
+    with pytest.raises(LoginError):
+        await asyncio.wait_for(flow.run(), timeout=10)
+
+    assert "paste" not in (seen["instructions"] or "").lower()
+
+
+async def test_timeout_with_a_paste_path_names_the_recovery() -> None:
+    """The reported symptom -- browser stays on the provider's site -- times out
+    here. The generic 'check your system clock' message serves the wrong cause."""
+    from local_operator.providers.oauth.callback_server import LoginTimeoutError
+
+    flow = _EchoFlow(
+        CallbackFlowOptions(preferred_port=0, timeout_seconds=0.2, provider_label="Anthropic"),
+        LoginCallbacks(on_manual_code_input=lambda: None),
+    )
+    with pytest.raises(LoginTimeoutError) as excinfo:
+        await asyncio.wait_for(flow.run(), timeout=10)
+
+    message = str(excinfo.value)
+    assert "Anthropic" in message
+    assert "paste" in message.lower()
+    assert "clock" in message  # the WSL/VM note is kept, not replaced
+
+
+def test_anthropic_pins_its_callback_port() -> None:
+    """54545 is allowlisted by Anthropic; inheriting the default port fallback
+    meant a busy 54545 minted a random-port redirect_uri that the allowlist
+    rejects at the IdP, after the browser had opened, with an error the user
+    cannot act on. The pin is what makes the module docstring's claim true.
+
+    Asserted on configuration rather than by binding 54545: the operator may
+    well have a real Claude login open, and the busy-port BEHAVIOUR is covered
+    on an ephemeral port by test_single_pinned_port_message_names_the_port.
+    """
+    from local_operator.providers.oauth.anthropic import AnthropicOAuthFlow
+
+    flow = AnthropicOAuthFlow(LoginCallbacks(), open_browser=lambda url: None)
+    assert flow.options.allow_port_fallback is False
+    assert flow.options.candidate_ports == (54545,)
+    assert flow.options.redirect_uri is None  # built from the bound port

--- a/tests/unit/providers/test_oauth_flows.py
+++ b/tests/unit/providers/test_oauth_flows.py
@@ -2167,6 +2167,87 @@ async def test_a_real_sibling_login_stands_down_when_poked() -> None:
             await sibling_run
 
 
+async def _await_outcome(flow: OAuthCallbackFlow, resolve: list[tuple[str, Any]]) -> str:
+    """Drive `_await_code` with several futures resolving in ONE event-loop pass.
+
+    The race this guards is co-resolution: `asyncio.wait` reports every future
+    that settled before the waiter was rescheduled, and `done` is a SET, so
+    iterating it lets hash order pick the outcome. Resolving without awaiting
+    in between is what actually holds that window open — a test that yields
+    between the two resolutions can never lose the race and therefore proves
+    nothing about it.
+    """
+    loop = asyncio.get_running_loop()
+    flow._captured = loop.create_future()
+    flow._capture_error = loop.create_future()
+    flow._cancelled = loop.create_future()
+    task = asyncio.create_task(flow._await_code())
+    await asyncio.sleep(0)  # let `_await_code` reach `asyncio.wait`
+    for which, value in resolve:  # deliberately no await between these
+        getattr(flow, which).set_result(value)
+    try:
+        got = await asyncio.wait_for(task, timeout=5)
+        return "SUCCESS" if got == ("real-code", "st") else f"UNEXPECTED:{got}"
+    except LoginCancelledError:
+        return "CANCELLED"
+    except LoginError:
+        return "ERROR"
+
+
+@pytest.mark.parametrize(
+    "resolve",
+    [
+        [("_captured", ("real-code", "st")), ("_cancelled", "superseded")],
+        [("_cancelled", "superseded"), ("_captured", ("real-code", "st"))],
+    ],
+    ids=["code-first", "cancel-first"],
+)
+async def test_a_captured_code_survives_a_concurrent_cancel(
+    resolve: list[tuple[str, Any]],
+) -> None:
+    """A `/cancel` racing a successful callback must NOT discard the code.
+
+    The user already approved in the browser and the provider already issued a
+    code; a sibling login wanting the port does not un-approve that. Losing it
+    here would be worse than the bug the `/cancel` route fixes, so this is
+    asserted over repeated trials in BOTH resolution orders — a single trial
+    can pass on set order alone.
+    """
+    flow = _EchoFlow(CallbackFlowOptions(preferred_port=0, timeout_seconds=5.0), LoginCallbacks())
+    outcomes = {await _await_outcome(flow, resolve) for _ in range(40)}
+    assert outcomes == {"SUCCESS"}, f"a captured code was lost to a cancel: {outcomes}"
+
+
+@pytest.mark.parametrize(
+    "resolve",
+    [
+        [("_capture_error", "state mismatch"), ("_cancelled", "superseded")],
+        [("_cancelled", "superseded"), ("_capture_error", "state mismatch")],
+    ],
+    ids=["error-first", "cancel-first"],
+)
+async def test_a_real_error_is_not_downgraded_to_a_cancellation(
+    resolve: list[tuple[str, Any]],
+) -> None:
+    """A genuine failure racing a cancel must still surface AS a failure.
+
+    Distinct from the code-loss case above and tested separately: hosts render
+    `LoginCancelledError` as a quiet outcome offering no remedy, so a
+    forged-redirect/state-mismatch silently downgraded to "login cancelled"
+    tells the user nothing about a security-relevant event.
+    """
+    flow = _EchoFlow(CallbackFlowOptions(preferred_port=0, timeout_seconds=5.0), LoginCallbacks())
+    outcomes = {await _await_outcome(flow, resolve) for _ in range(40)}
+    assert outcomes == {"ERROR"}, f"a real error was silenced as a cancel: {outcomes}"
+
+
+async def test_a_cancel_alone_is_still_a_cancellation() -> None:
+    """The control: ranking outcomes must not have broken the plain cancel."""
+    flow = _EchoFlow(CallbackFlowOptions(preferred_port=0, timeout_seconds=5.0), LoginCallbacks())
+    outcomes = {await _await_outcome(flow, [("_cancelled", "superseded")]) for _ in range(20)}
+    assert outcomes == {"CANCELLED"}
+
+
 async def test_cancel_route_answers_200_not_404() -> None:
     """The route itself: our server must ANSWER `/cancel`, not 404 it.
 

--- a/tests/unit/providers/test_oauth_flows.py
+++ b/tests/unit/providers/test_oauth_flows.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import hashlib
 import inspect
 import json
@@ -2006,7 +2007,7 @@ def _free_port() -> int:
         return int(probe.getsockname()[1])
 
 
-def test_fallback_ports_reject_pinned_redirect_uri() -> None:
+async def test_fallback_ports_reject_pinned_redirect_uri() -> None:
     """A ladder plus a literal URI would advertise a port we did not bind."""
     with pytest.raises(ValueError, match="pinned redirect_uri"):
         CallbackFlowOptions(
@@ -2017,20 +2018,20 @@ def test_fallback_ports_reject_pinned_redirect_uri() -> None:
         )
 
 
-def test_fallback_ports_reject_os_assigned_fallback() -> None:
+async def test_fallback_ports_reject_os_assigned_fallback() -> None:
     """The ladder IS the allowlist; an OS-assigned port would defeat it."""
     with pytest.raises(ValueError, match="allow_port_fallback=False"):
         CallbackFlowOptions(preferred_port=1455, fallback_ports=(1457,))
 
 
-def test_candidate_ports_dedupe_preserving_order() -> None:
+async def test_candidate_ports_dedupe_preserving_order() -> None:
     opts = CallbackFlowOptions(
         preferred_port=1455, fallback_ports=(1457, 1455), allow_port_fallback=False
     )
     assert opts.candidate_ports == (1455, 1457)
 
 
-def test_openai_uses_the_allowlisted_port_pair() -> None:
+async def test_openai_uses_the_allowlisted_port_pair() -> None:
     """The literal ports are the contract: 1455 then 1457, both server-side
     allowlisted for this client id (upstream commit 8d5da3f). Asserted without
     binding anything, so a developer running Cursor cannot fail it."""
@@ -2102,51 +2103,131 @@ async def test_port_ladder_fails_when_every_allowlisted_port_is_busy() -> None:
             await server.wait_closed()
 
 
-async def test_port_ladder_pokes_cancel_at_a_stale_login_server() -> None:
-    """A busy port is retried, and the incumbent is asked to stand down first
-    -- the common cause is a sibling login of ours still parked on its
-    timeout, not a permanent squatter."""
-    seen: list[str] = []
-    holder: list[asyncio.base_events.Server] = []
+async def test_a_real_sibling_login_stands_down_when_poked() -> None:
+    """The claim the retry ladder is built on, tested against a REAL sibling.
 
-    async def _stale(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-        raw = await reader.read(256)
-        seen.append(raw.decode("latin-1").split("\r\n", 1)[0])
-        writer.write(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
-        try:
-            await writer.drain()
-        except Exception:
-            pass
-        writer.close()
-        # Release the port, as a real login server does when cancelled.
-        holder[0].close()
+    This must not use a hand-written responder that closes its own listener:
+    such a stand-in asserts only that we SEND `/cancel`, which was true even
+    when our server answered it with a 404 and kept the port. The regression
+    that hid behind exactly that shape is what this test exists to catch, so
+    the incumbent here is a genuine OAuthCallbackFlow with `run()` pending.
+    """
+    port = _free_port()
+    sibling = _EchoFlow(
+        CallbackFlowOptions(
+            preferred_port=port,
+            allow_port_fallback=False,
+            callback_path="/auth/callback",
+            timeout_seconds=30.0,
+        ),
+        LoginCallbacks(),
+    )
+    sibling_run = asyncio.create_task(sibling.run())
+    for _ in range(400):  # let the sibling actually bind before we compete
+        if sibling.bound_port is not None and sibling.generated:
+            break
+        await asyncio.sleep(0.01)
 
-    holder.append(await asyncio.start_server(_stale, "127.0.0.1", 0))
-    preferred = _port_of(holder[0])
+    # PRECONDITION: the sibling really holds the port and its login is really
+    # pending. Without this, "the newcomer got the port" could just mean the
+    # sibling never started, which is a passing test for a broken feature.
+    assert sibling.bound_port == port
+    assert not sibling_run.done(), "sibling login should still be pending"
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
-        flow = _EchoFlow(
+        with pytest.raises(OSError):
+            probe.bind(("127.0.0.1", port))
+    finally:
+        probe.close()
+
+    try:
+        newcomer = _EchoFlow(
             CallbackFlowOptions(
-                preferred_port=preferred,
-                fallback_ports=(_free_port(),),
+                preferred_port=port,
                 allow_port_fallback=False,
                 callback_path="/auth/callback",
             ),
             LoginCallbacks(),
         )
-        await flow._start_server()
+        await newcomer._start_server()
         try:
-            assert seen and seen[0] == "GET /cancel HTTP/1.1"
-            # Having stood the incumbent down, the retry wins the PREFERRED
-            # port rather than burning the fallback.
-            assert flow.bound_port == preferred
+            # The newcomer won the PREFERRED port, which is only possible if
+            # the sibling honoured `/cancel` and released it.
+            assert newcomer.bound_port == port
         finally:
-            await flow._stop_server()
+            await newcomer._stop_server()
+
+        # And the sibling ended as a CANCELLATION, not as a generic failure:
+        # it was superseded, which is not something the user did wrong.
+        with pytest.raises(LoginCancelledError):
+            await asyncio.wait_for(sibling_run, timeout=10)
     finally:
-        try:
-            holder[0].close()
-            await holder[0].wait_closed()
-        except Exception:
-            pass
+        sibling_run.cancel()
+        with contextlib.suppress(asyncio.CancelledError, LoginError):
+            await sibling_run
+
+
+async def test_cancel_route_answers_200_not_404() -> None:
+    """The route itself: our server must ANSWER `/cancel`, not 404 it.
+
+    Pinned directly because the 404 is what made the poke a no-op, and a 404
+    here is indistinguishable from "route missing" at the ladder's call site.
+    """
+    flow = _EchoFlow(CallbackFlowOptions(preferred_port=0, timeout_seconds=30.0), LoginCallbacks())
+    run = asyncio.create_task(flow.run())
+    for _ in range(400):
+        if flow.bound_port is not None and flow.generated:
+            break
+        await asyncio.sleep(0.01)
+    assert flow.bound_port is not None
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(f"http://127.0.0.1:{flow.bound_port}/cancel")
+        assert response.status_code == 200
+        with pytest.raises(LoginCancelledError):
+            await asyncio.wait_for(run, timeout=10)
+    finally:
+        run.cancel()
+        with contextlib.suppress(asyncio.CancelledError, LoginError):
+            await run
+
+
+async def test_the_fallback_rung_is_never_poked() -> None:
+    """Upstream gates the poke on `!using_fallback_port`; so do we.
+
+    An incumbent on a rung we merely MAY use has as much claim to it as we do,
+    so standing it down to save ourselves a fallback would be taking someone
+    else's login for our own convenience.
+    """
+    poked: list[str] = []
+
+    async def _watch(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        raw = await reader.read(256)
+        poked.append(raw.decode("latin-1").split("\r\n", 1)[0])
+        writer.close()
+
+    preferred = await asyncio.start_server(_watch, "127.0.0.1", 0)
+    fallback = await asyncio.start_server(_watch, "127.0.0.1", 0)
+    try:
+        flow = _EchoFlow(
+            CallbackFlowOptions(
+                preferred_port=_port_of(preferred),
+                fallback_ports=(_port_of(fallback),),
+                allow_port_fallback=False,
+                callback_path="/auth/callback",
+            ),
+            LoginCallbacks(),
+        )
+        with pytest.raises(ConfigurationError):
+            await flow._start_server()
+        assert (
+            poked.count("GET /cancel HTTP/1.1") == 1
+        ), f"expected exactly one poke (the preferred rung), saw {poked}"
+    finally:
+        for server in (preferred, fallback):
+            server.close()
+            await server.wait_closed()
 
 
 async def test_single_pinned_port_message_names_the_port() -> None:
@@ -2417,7 +2498,7 @@ async def test_timeout_with_a_paste_path_names_the_recovery() -> None:
     assert "clock" in message  # the WSL/VM note is kept, not replaced
 
 
-def test_anthropic_pins_its_callback_port() -> None:
+async def test_anthropic_pins_its_callback_port() -> None:
     """54545 is allowlisted by Anthropic; inheriting the default port fallback
     meant a busy 54545 minted a random-port redirect_uri that the allowlist
     rejects at the IdP, after the browser had opened, with an error the user


### PR DESCRIPTION
## What

Four OpenAI/Anthropic OAuth defects, all of which reach the user as an **intermittent or opaque login failure**. Verified against upstream `openai/codex@main` (`codex-rs/login/src/`) and Anthropic's live docs, re-read 2026-09-09 rather than taken on trust.

| # | Defect | Symptom before |
|---|---|---|
| 1 | OpenAI pinned port 1455, no fallback | Login fails whenever Cursor/Codex Desktop holds 1455 |
| 2 | OpenAI refresh form-encoded | Drift from the client the endpoint is built around |
| 3 | OpenAI device flow: form-encoded, no `user_code`, 403/404 = fatal | **Flow was wholly non-functional** — the first poll aborted every login |
| 4 | Anthropic inherited `allow_port_fallback=True` | Busy 54545 → random-port `redirect_uri` → opaque IdP rejection |

`Release: patch — OAuth login reliability; no new surface.`

## 1. OpenAI: bounded port allowlist (1455 → 1457)

Upstream added 1457 to the **server-side allowlist for this client id** ([commit 8d5da3f](https://github.com/openai/codex/commit/8d5da3f)) precisely because Cursor and Codex Desktop squat on 1455. `bind_server` tries 1455, pokes `GET /cancel` at the incumbent, retries 10×/200 ms, then moves to 1457.

`allow_port_fallback` is a boolean and **cannot express "these two ports and no others"**, so `CallbackFlowOptions` gains `fallback_ports`. The invariant in the module docstring is preserved, not weakened:

> when the provider validates redirect URIs, a port we cannot use MUST fail **before** the browser opens.

An OS-assigned third port is still forbidden for OpenAI. `__post_init__` rejects `fallback_ports` combined with a pinned literal `redirect_uri` — that combination would advertise a port we did not bind, i.e. send the browser to a closed socket.

The `/cancel` poke matters on its own: the usual holder of 1455 is **a sibling login of ours still parked on its 5-minute timeout**, which is indistinguishable from Cursor to the user.

> Note: upstream sends `GET /cancel`, not `POST` — implemented as upstream actually does it.

## 2. OpenAI: JSON on refresh (form on exchange)

Upstream is **deliberately asymmetric** — `auth/manager.rs::request_chatgpt_token_refresh` sets `Content-Type: application/json`, while `exchange_code_for_tokens` sends `application/x-www-form-urlencoded` to the *same* URL. Matching the client the endpoint is built around is the point; making our two calls consistent with each other would make both inconsistent with the server. The docstring says so, so nobody "tidies" it later.

## 3. OpenAI device flow: three defects, first-ever tests

Against upstream `device_code_auth.rs`:

- **JSON, not form** — both `UserCodeReq` and `TokenPollReq` are JSON upstream.
- **`user_code` in the poll body** — upstream's `TokenPollReq { device_auth_id, user_code }`; we omitted it, so the pending authorization could not be identified. (`client_id` is *not* in that struct and is no longer sent.)
- **403/404 means "keep polling"** — this endpoint signals pending with a bare status and no OAuth error body, so the RFC 8628 `authorization_pending` classification never matched and **the first poll ended every login** before the user could type the code.

Bounded in **time** (15 min, upstream's `max_wait`) rather than in poll count, so the deadline stays honest when the provider changes `interval`. oh-my-pi's `openai-codex.ts` agrees independently on all three.

## 4. Anthropic: pin 54545, and make the failure legible

The module docstring always claimed 54545 was required; the code did not enforce it. A busy port bound a **random** OS port and advertised it, which the allowlist rejects at the IdP — *after* the browser opens — with `Redirect URI http://localhost:<port>/callback is not supported by client`.

Now it fails locally, before the browser opens, and the message is the whole user-visible surface of the fix:

```
Port 54545 is required for the Anthropic login but is already in use. python3.14 (pid 81598)
is holding it. Anthropic only accepts redirect URIs on that port, so the login cannot fall
back to another one. Quit the process holding it and run the login again —
`lsof -nP -iTCP:54545 -sTCP:LISTEN` shows what it is.
```

The pid in that message is read from the live OS and **matches `lsof` exactly** (see evidence). `lsof` runs off-thread — it is a blocking subprocess on an event loop a TUI draws from.

### Paste fallback: dependable and legible

The paste fallback is the escape hatch for a browser that never reaches our loopback (remote/SSH/WSL, and the reported case where the browser lands in the claude.ai portal). It **worked but was invisible** — nothing on screen said it existed, so a user watching a browser that would never redirect had no way to learn there was anything to do but wait out the timeout. It is now announced while the login is pending, and the timeout names it as the recovery:

```
Open this URL to authorize:
  https://claude.ai/oauth/authorize?...&code=true
Or open: http://localhost:54545/launch
If your browser shows a login code instead of returning here, paste that code — or the
whole redirect URL from the address bar — at the prompt below.

Error: Timed out waiting for the Anthropic login callback. If your browser finished the
sign-in but showed you a login code — or stayed on the Anthropic website instead of
returning here — its redirect never reached this machine. Run the login again and paste
that code, or the whole redirect URL from the address bar, at the prompt. If you run
inside WSL/a VM, check that the system clock is in sync.
```

Only announced when a prompt is actually attached — promising a paste target no host will offer is worse than silence (verified by a test).

Also corrects the `code=true` comment: it makes Anthropic render the `code#state` copy target that `_parse_pasted_callback` consumes; it does **not** "select the code flow variant". And a short factual note records what this flow is (device-local, first-party-style sign-in; credential stored on the user's own device and used only for that user's own inference; no proxying, reselling or intermediation), citing the [Anthropic terms](https://code.claude.com/docs/en/legal-and-compliance) verified 2026-09-09 — so the next agent does not re-litigate it from scratch.

## Evidence

A green suite is not evidence, so every claim below is the **real path**, with the **precondition asserted** and a **negative control** — a squatter that silently failed to bind would produce a green result proving nothing.

### OpenAI 1455 → 1457, against a real listener

```
CONTROL: 1455 and 1457 FREE -> flow must use the PREFERRED port
precondition asserted: 1455 free, 1457 free
  bound_port     = 1455
  CONTROL PASS: preferred port used when free

TEST: 1455 OCCUPIED by a real listener -> flow must fall back to 1457
precondition asserted: this process (pid 80880) holds 1455
  lsof says: python3.1 80880 damian 6u IPv4 ... TCP 127.0.0.1:1455 (LISTEN)
  independent re-bind of 1455 -> refused (as required)
  1457 confirmed free (so a pass means fallback, not luck)

  bound_port     = 1457
  redirect_uri() = http://localhost:1457/auth/callback
```

Raw authorize URL — carries exactly what upstream's E2E asserts:

```
https://auth.openai.com/oauth/authorize?response_type=code&client_id=app_EMoamEEZ73f0CkXaXp7hrann&redirect_uri=http%3A%2F%2Flocalhost%3A1457%2Fauth%2Fcallback&scope=openid+profile+email+offline_access+api.connectors.read+api.connectors.invoke&state=state-demo&code_challenge=N-4EUSqWSaYBWpcrguuK_WtHjVUEib5H0in9KgMrM-k&code_challenge_method=S256&id_token_add_organizations=true&codex_cli_simplified_flow=true&originator=local-operator
```

`live TCP connect to 127.0.0.1:1457 = OK` — the advertised port is genuinely serving.

### Stale-sibling `/cancel` reclaims the preferred port

```
a stale login server of ours is holding 127.0.0.1:1455
[stale server on 1455] received: 'GET /cancel HTTP/1.1' -> shutting down
bound_port     = 1455  (preferred port reclaimed, fallback not burned)
```

### Anthropic fails fast, before any browser

```
CONTROL: 54545 FREE -> bound_port = 54545; CONTROL PASS (normal operation unaffected)

TEST: 54545 OCCUPIED
precondition asserted: this process (pid 81598) holds 54545
  lsof says: python3.1 81598 damian 6u IPv4 ... TCP 127.0.0.1:54545 (LISTEN)
  independent re-bind of 54545 -> refused (as required)

  ConfigurationError after 3.87s:
    Port 54545 is required for the Anthropic login but is already in use.
    python3.14 (pid 81598) is holding it. ...

  browser opened? NO -- failed before the browser opened
  bound_port      = None (no random port was minted)
```

The pid in the message (81598) matches `lsof` — the diagnostic reads live OS state, not our bookkeeping.

### Wire bodies, diffed field-by-field against upstream's Rust structs

Capture asserts it received all 5 requests first (an empty capture would read as "no drift"):

```
precondition asserted: capture transport received 5 requests

POST .../deviceauth/usercode   application/json
  {"client_id":"app_EMoamEEZ73f0CkXaXp7hrann"}            == UserCodeReq{client_id}

POST .../deviceauth/token      application/json           (x3: 403, 404, then success)
  {"device_auth_id":"dev_evidence","user_code":"WXYZ-9876"} == TokenPollReq{device_auth_id, user_code}

POST /oauth/token              application/x-www-form-urlencoded
  grant_type=authorization_code&client_id=...&code=ac_ev&redirect_uri=...&code_verifier=cv_ev

POST /oauth/token              application/json           (refresh)
  {"grant_type":"refresh_token","refresh_token":"rt_stored","client_id":"..."}  == RefreshRequest
```

The two pending statuses (403, 404) **continued polling** and the flow completed — the defect that made this path unusable.

### Paste fallback completes a login, all three real shapes

```
bare code                -> login completed, access='at_x' org='Personal'
code#state               -> login completed, access='at_x' org='Personal'
full redirect URL        -> login completed, access='at_x' org='Personal'
```

`_parse_pasted_callback` was re-verified against every real shape (bare, `code#state`, full URL, state-in-fragment) and needed **no change** — already correct, already pinned by `TestPastedCallbackParsing`.

### Tests are real guards, not decoration

Each fix was individually reverted to confirm its test fails:

| Reverted fix | Result |
|---|---|
| 403/404 → pending | `LoginError: Device authorization failed (403)` — the original defect, reproduced |
| JSON refresh | `'application/x-www-form-urlencoded'.startswith('application/json')` → False |
| `user_code` in poll | body diff shows `- 'user_code': 'ABCD-1234'` |
| Anthropic port pin | `allow_port_fallback = True` |
| OpenAI port ladder | `candidate_ports` missing `1457` |

### What was NOT exercised

**No live provider endpoint was contacted and no stored token was touched** — token endpoints are stubbed via `httpx.MockTransport`. Invalidating the operator's real Anthropic/OpenAI grants was not an acceptable cost for this evidence. The *local* half (port binding, URL generation, request shaping) is fully real; the *remote* half is verified by field-by-field diff against upstream's structs rather than by a live call.

## Quality gate

`flake8`, `black --check`, `isort --check-only`, `pyright` (0 errors) all clean. `tests/unit/providers`: **1151 passed**. Full `tests/unit`: **0 failures**. Protocol/AST guard from #861 (in my rebased base): **167 passed** — this diff adds no session member.

Tests deliberately bind **ephemeral** ports, not the literal 1455/1457/54545: this repo is worked through many concurrent worktrees and a developer running Cursor or Claude Code has those legitimately occupied. That the *literal* ports are right is a separate, binding-free assertion.

## Notes for the reviewer

- **Shared file with PR A.** Both PRs touch `callback_server.py`. My diff is confined to **port binding** (`fallback_ports`, `_try_bind`, `_cancel_stale_server`, `_start_server`, the failure message) plus `_instructions`/`_timeout_message` and one error-copy line in the callback route. I did **not** touch the ABORT/cancel paths or add a `/cancel` *route* — PR A owns those. Sequencing should be low-risk, but the two diffs do meet in this file.
- **Not done, deliberately:** no anti-detection/impersonation/fingerprint work of any kind and existing impersonation left byte-for-byte; no speculative authorize params; `originator=local-operator` unchanged; `localhost` (not `127.0.0.1`) still advertised — we already bind the IP literal, which is what RFC 8252 §8.3 requires, and the provider's exact-match allowlist wins; authorize URL, token URL, client id, scopes, the three authorize params and the omission of `state` on exchange all verified as matching upstream and left alone.
- No version bump (`pyproject.toml` untouched).
