### PR TITLE
fix(session): survive an oversized inbound frame instead of killing the session

### DIFF
--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -107,11 +107,29 @@ class TextContent(BaseModel):
 
 
 class ImageContent(BaseModel):
-    """An image block. ``data`` is base64-encoded bytes of ``mime_type``."""
+    """An image block. ``data`` is base64-encoded bytes of ``mime_type``.
+
+    ``marker`` is the number on the composer chip that cites this image —
+    ``1`` for ``[Image #1]`` — carried so a transport that has to REFUSE an
+    attachment can name the one the user can see. Marker numbers do not
+    renumber when an attachment is deleted, so after twenty pastes and one
+    backspace the chips read ``#2..#20`` while wire positions run ``0..18``,
+    and a refusal quoting the position pointed at a different chip than the
+    one it refused (design round 1 D4, round 2 D8).
+
+    ``exclude=True`` because this is a PRESENTATION fact, not conversation
+    content: it must not reach a provider, a transcript row or a context hash.
+    Excluded from every ``model_dump``, so persisted history stays
+    byte-identical and only in-process consumers — the wire encoder here — can
+    read it. ``None`` for every producer that has no chips to name (the phone
+    relay, tool results, compaction frames), which is what makes the wire
+    encoder's fallback to position the honest answer rather than a guess.
+    """
 
     type: Literal["image"] = "image"
     data: str = ""
     mime_type: str = "image/png"
+    marker: int | None = Field(default=None, exclude=True)
 
 
 Content = TextContent | ImageContent

--- a/local_operator/imaging.py
+++ b/local_operator/imaging.py
@@ -238,6 +238,183 @@ IMAGE_JPEG_QUALITY = 85
 #: repaired before it is sent, not after.
 IMAGE_REFUSAL_MAX_B64_BYTES = 4 * 1024 * 1024
 
+#: Long-edge rungs a wire refit walks, tightest last. See
+#: :func:`refit_image_to_budget` for why a refit exists at all and why it
+#: prefers a JPEG re-encode at full resolution before it gives up pixels.
+#:
+#: The first rung is ``None``, meaning "the image's OWN long edge" — keep every
+#: pixel and change only the codec — because that is where the win is.
+#: Measured on this machine's own screenshots, a quality-85 JPEG at unchanged
+#: dimensions is 4-11x smaller than the ingest PNG (331 KB -> 119 KB of base64
+#: for a 2784x1070 UI capture, 1,234 KB -> 200 KB for a 1672x941 render), so an
+#: ordinary paste clears the budget with every pixel intact.
+#:
+#: ``None`` is deliberately NOT passed through to ``bound_image_for_model`` as
+#: its own ``max_edge=None`` default, which would mean
+#: :data:`IMAGE_INGEST_MAX_EDGE` and quietly downscale a 1568px block on a rung
+#: whose whole promise is that it does not resize. The caller resolves it to
+#: the real long edge instead.
+#:
+#: The descending rungs are the fallback for the case a re-encode alone cannot
+#: fix: several large images in ONE message. Two composer-bounded screenshots
+#: already serialize to 1.1 MB, so the frame is over budget before any single
+#: image is unreasonable, and the budget has to be met by the whole set.
+IMAGE_WIRE_REFIT_EDGES: tuple[int | None, ...] = (None, 1024, 768, 512, 384)
+
+
+class ImageUnreadable(ValueError):
+    """The block is not an image this module can decode, whatever its size.
+
+    Distinct from :func:`refit_image_to_budget` returning ``None``, which means
+    "a real image that will not fit". The remedies differ — one says drop the
+    attachment, the other says the file is broken — and a caller that collapsed
+    them told the user to shrink bytes that were never an image.
+    """
+
+
+def refit_image_to_budget(
+    data_b64: str, mime_type: str, budget_bytes: int
+) -> tuple[str, str] | None:
+    """Re-encode one image block to fit ``budget_bytes`` of base64, or ``None``.
+
+    WHY THIS EXISTS. The control socket reads one JSON line per frame with a
+    1 MiB limit (``server._MAX_LINE_BYTES``), and a prompt carries its images
+    base64-encoded INSIDE that line — so the frame, not the file, is what has
+    to fit, and base64 inflates the payload by 4/3 on top of the rest of the
+    op. An over-budget frame is not merely large: the owner's ``readline``
+    raises and the client's write is answered by a dead socket, which is the
+    session death the operator saw as "pasting an image exits lop".
+
+    WHY IT REFITS RATHER THAN REFUSES. A hard refusal on a normal-sized
+    screenshot would be a bad product: pasting screenshots is a routine
+    gesture here, and the sizes that overflow are routine too. Measured on
+    this machine, ONE 1672x941 render is 1.23 MB of base64 after the
+    composer's own ingest bound, and two ordinary screenshots together are
+    1.1 MB — both over budget through no fault of the user. Refusing those
+    would break the feature to protect the transport. So the ladder in
+    :data:`IMAGE_WIRE_REFIT_EDGES` is walked instead, and only an image that
+    will not fit even at its tightest rung is refused, with the caller saying
+    so in words.
+
+    WHY THE CODEC IS SPENT BEFORE THE PIXELS. Fidelity here means "can the
+    model read the text in this screenshot", and pixels carry that while the
+    codec mostly does not: quality-85 is the standard visually-lossless point,
+    and dropping the long edge to 768 is what actually costs small text. So the
+    first rung re-encodes at UNCHANGED dimensions, and measured on this
+    machine's files that alone was enough for every single-image case. This
+    mirrors :func:`bound_image_for_model`'s own ladder, which reaches for JPEG
+    before anything else once a PNG blows :data:`IMAGE_MAX_BYTES`.
+
+    The re-encode is then applied at EVERY rung, not only the first. Doing it
+    only once was measurably wrong: the descending rungs handed back PNGs of
+    continuous-tone content, which PNG cannot compress, so a 1400x1400 frame
+    against a 240 KB budget ran out of rungs and was REFUSED while the real
+    remedy had never been tried below full size. With the re-encode on each
+    rung the same image fits at 512x512.
+
+    LINE ART IS EXEMPT FROM THE JPEG RUNG, for the reason the rest of this
+    module already documents: JPEG's ringing lands on exactly the one-pixel
+    strokes a bilevel rendering exists to preserve. Such an image takes the
+    PNG downscale rungs instead, where NEAREST keeps its strokes crisp.
+
+    Returns ``(data_b64, mime_type)`` — the input unchanged when it already
+    fits, so the common path costs one length check — or ``None`` when no rung
+    fits and the caller must refuse the image by name. Raises
+    :class:`ImageUnreadable` when the block is not a decodable image at all,
+    which is a different message to the user than "too large".
+    """
+    if len(data_b64) <= budget_bytes:
+        return data_b64, mime_type
+    try:
+        raw = base64.b64decode(data_b64, validate=True)
+    except Exception as exc:  # noqa: BLE001 — a malformed block is refused, never resized
+        raise ImageUnreadable("its data is not valid base64") from exc
+    info = sniff_image(raw)
+    if info is None:
+        # Unrecognised header: there is no decoder to refit with, and shipping
+        # it unchanged would put the oversized frame back on the wire.
+        #
+        # RAISED RATHER THAN RETURNED AS None, because the two outcomes need
+        # different words. ``None`` means "this is an image and it is genuinely
+        # too big", which tells the user to drop the attachment; bytes that are
+        # not a readable image at all are a different problem, and telling
+        # someone their 1.8 MB of corrupt data is "too large to send" sends them
+        # off shrinking something that would never have worked at any size.
+        raise ImageUnreadable("it is not a readable image")
+    line_art = _is_line_art_bytes(raw, info)
+    # The source's own long edge, which is what the ``None`` rung resolves to.
+    # Unknown dimensions (a HEIF whose ispe box the sniffer does not walk) fall
+    # back to the correctness ceiling rather than to the ingest bound: this rung
+    # promises not to resize, and guessing small would break that promise on the
+    # one format that cannot answer the question.
+    source_edge = max(info.width or 0, info.height or 0) or IMAGE_MAX_EDGE
+    for edge in IMAGE_WIRE_REFIT_EDGES:
+        try:
+            payload, wire_mime, _summary = bound_image_for_model(
+                raw, info, max_edge=source_edge if edge is None else edge
+            )
+        except ValueError:
+            # Undecodable or a decompression bomb. No later rung can help —
+            # they all run the same decode — so stop rather than retry four
+            # more times on bytes that already failed.
+            return None
+        if not line_art:
+            # ON EVERY RUNG, not just the first, and it is deliberately not left
+            # to ``bound_image_for_model``: that ladder only reaches JPEG when
+            # the PNG blows IMAGE_MAX_BYTES (1 MiB of BYTES), while the
+            # constraint here is the base64 budget for the whole frame — which a
+            # 700 KB PNG breaks while sitting comfortably under that cap.
+            #
+            # Applying it only to the no-resize rung was measurably wrong: a
+            # 1400x1400 continuous-tone frame against a 240 KB budget was
+            # REFUSED, because each downscale rung handed back a PNG of content
+            # PNG cannot compress, and no rung ever got small enough. With the
+            # re-encode on every rung the same image fits. Downscaling into a
+            # codec unsuited to the content is how a ladder runs out of rungs
+            # while the real remedy was never tried.
+            payload, wire_mime = _jpeg_or_original(payload, wire_mime)
+        encoded = base64.b64encode(payload).decode("ascii")
+        if len(encoded) <= budget_bytes:
+            return encoded, wire_mime
+    return None
+
+
+def _jpeg_or_original(payload: bytes, wire_mime: str) -> tuple[bytes, str]:
+    """Re-encode ``payload`` as quality-85 JPEG when that is actually smaller.
+
+    MEASURED, NOT ASSUMED, which is the same rule the JPEG rung of
+    :func:`bound_image_for_model` follows: PNG beats JPEG on flat synthetic
+    images, and handing back a LARGER payload would make the refit worse on
+    both axes at once. A host with no Pillow keeps its bytes unchanged and
+    lets the caller's next rung (or its refusal) decide.
+    """
+    module = pillow_image_module()
+    if module is None:
+        return payload, wire_mime
+    try:
+        with module.open(io.BytesIO(payload)) as image:
+            image.load()
+            if image.mode in ("RGBA", "LA"):
+                # JPEG has no alpha. Composite onto white rather than dropping
+                # the channel, so a transparent-background diagram stays
+                # legible instead of rendering onto black — the same choice
+                # ``bound_image_for_model`` makes at its own JPEG rung.
+                flat_mode = "RGB" if image.mode == "RGBA" else "L"
+                fill = (255, 255, 255) if flat_mode == "RGB" else 255
+                flat = module.new(flat_mode, image.size, fill)
+                flat.paste(image, mask=image.getchannel("A"))
+                image = flat
+            elif image.mode not in ("L", "RGB"):
+                image = image.convert("RGB")
+            buffer = io.BytesIO()
+            image.save(buffer, format="JPEG", quality=IMAGE_JPEG_QUALITY)
+    except Exception:  # noqa: BLE001 — a failed re-encode falls back to the input
+        return payload, wire_mime
+    jpeg = buffer.getvalue()
+    if len(jpeg) < len(payload):
+        return jpeg, "image/jpeg"
+    return payload, wire_mime
+
 
 def _forward_undecoded(data: bytes, info: ImageInfo) -> tuple[bytes, str, str]:
     """Ship image bytes VERBATIM on a host with no usable Pillow.

--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -34,11 +34,13 @@ owned-resume branch only, keeping ``resume.py`` and the startup path light.
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import logging
 import uuid
+from contextvars import ContextVar
 from pathlib import Path
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, NamedTuple, Sequence
 
 from local_operator.mobile.types import (
     PROTOCOL_VERSION,
@@ -107,17 +109,92 @@ class OversizedRequest(ValueError):
     """
 
 
-#: Bytes of ONE request frame's non-image overhead to hold back from the image
-#: budget: the op name, the ``req`` id, a UUID command id, and the user's text.
+class _RefitReport(NamedTuple):
+    """What the wire refit did to ONE image, for the surface that must say so.
+
+    ``marker`` is the number the USER sees on their composer chip, not the
+    image's wire position \u2014 see :func:`_refit_images` for why the two differ.
+
+    ``downscaled`` is the only field that decides whether anything is said at
+    all. The refit's common outcome is a codec swap that keeps every pixel
+    (the composer already bounds a paste to 1024px, so the descending rungs are
+    unreachable for ordinary messages), and a notice on that would be pure
+    noise on a routine gesture. Losing pixels is different in kind: measured at
+    the 768px rung it costs ~40% edge energy and makes digits misread, which is
+    exactly the failure a user pastes a screenshot to avoid (design round 1,
+    D2). So the dimensions are carried to be shown, and the codec is not.
+    """
+
+    marker: int
+    width: int
+    height: int
+    source_width: int
+    source_height: int
+
+    @property
+    def downscaled(self) -> bool:
+        """Did the refit cost PIXELS, as opposed to merely changing codec?
+
+        Pixel counts rather than the ``WxH`` strings, matching
+        ``editor._was_downscaled``: the mark is a claim about fidelity and has
+        to be tested as one.
+        """
+        if not all((self.width, self.height, self.source_width, self.source_height)):
+            return False
+        return self.width * self.height < self.source_width * self.source_height
+
+
+#: Slack left over the MEASURED frame overhead, to absorb the difference
+#: between the empty-image frame and the encoded one.
 #:
-#: Sized against the TEXT, which is the only part that varies much — the
-#: composer caps a paste at ``MAX_CLIPBOARD_TEXT_BYTES`` (1 MiB), but a prompt
-#: that large is over the line limit on its own words and is refused by the
-#: same guard rather than silently truncated. 64 KiB covers any prompt a person
-#: types alongside a screenshot with two orders of magnitude of room, and the
-#: exact frame is measured again after the refit, so this reserve only has to be
-#: generous rather than precise.
-_FRAME_OVERHEAD_RESERVE_BYTES = 64 * 1024
+#: The overhead itself is no longer guessed — :func:`_frame_overhead_bytes`
+#: serialises the real frame with its images emptied, so the op name, the
+#: ``req`` id, any command id and the user's ACTUAL text are counted rather
+#: than bounded. A fixed 64 KiB reserve was the bug: ``clipboard.py`` admits
+#: pastes up to ``MAX_CLIPBOARD_TEXT_BYTES`` (1 MiB), so any prompt whose text
+#: passed ~64 KiB had its images fitted against a budget that was never
+#: available, the post-refit re-measure caught the overflow, and the whole
+#: message was refused — including the ~780 KB screenshot this module's
+#: docstring names as the motivating bug (review round 1, MAJOR-1).
+#:
+#: What remains is per-image JSON punctuation the emptied frame does not carry:
+#: the ``data_b64``/``mime_type`` keys, quotes, braces and commas, ~40 bytes an
+#: image plus base64's own padding. 4 KiB covers a 16-attachment message an
+#: order of magnitude over, and the exact frame is still measured again after
+#: the refit — so this only has to be non-negative, not precise.
+_FRAME_ENCODING_SLACK_BYTES = 4 * 1024
+
+
+#: Below this much room for ALL the images, the text is the problem and the
+#: refusal must say so rather than blaming an attachment.
+#:
+#: The refit's tightest rung is a 384px JPEG at quality 85, which lands around
+#: 20-30 KB of base64 for ordinary content. 32 KiB is therefore "not even one
+#: image at its smallest could fit here": under it the per-image refusal is
+#: guaranteed and would quote a share rounding to ``0.0 MB``, pointing the user
+#: at a screenshot when only shortening the prompt can help.
+_MIN_VIABLE_IMAGE_BUDGET_BYTES = 32 * 1024
+
+
+#: The refit that the CURRENT task performed, published for the caller that has
+#: to tell the user about it. See :func:`taken_refit_report`.
+#:
+#: A context variable rather than a return value because the refit happens four
+#: call frames below the surface that renders transcripts — ``fit_request_frame``
+#: is reached through ``AttachClient._request_frame`` → ``send_command`` →
+#: ``RemoteSession.prompt``, each of which returns a receipt string with no room
+#: for a second value, and widening all four signatures to carry a UI detail
+#: through the transport would put presentation concerns in three layers that
+#: currently have none.
+#:
+#: Context propagates the RIGHT way for this: a value set in a coroutine is
+#: visible to the task that awaited it, while a task spawned with
+#: ``create_task`` gets a COPY — so two concurrent sends can never read each
+#: other's report. Verified, not assumed. The reader consumes it, so a stale
+#: report cannot outlive the send that produced it.
+_REFIT_REPORT: ContextVar[tuple[_RefitReport, ...] | None] = ContextVar(
+    "local_operator_attach_refit_report", default=None
+)
 
 
 async def fit_request_frame(frame: dict[str, Any]) -> dict[str, Any]:
@@ -138,22 +215,26 @@ async def fit_request_frame(frame: dict[str, Any]) -> dict[str, Any]:
     the sizes above are routine too — a hard rejection would break the feature
     to protect the transport. So each image is re-encoded to fit
     (:func:`~local_operator.imaging.refit_image_to_budget`, JPEG at full
-    resolution first, downscale only if that is not enough) and the user sees
-    nothing. Only an image that cannot fit even at its tightest rung is
-    refused, named by its POSITION in the message so it points at a specific
-    composer chip and the user knows which attachment to drop.
+    resolution first, downscale only if that is not enough). Only an image that
+    cannot fit even at its tightest rung is refused, named by the MARKER NUMBER
+    on the user's own composer chip so they know which attachment to drop.
 
     WHY THE BUDGET IS SHARED ACROSS THE IMAGES. The line limit applies to the
     whole frame, so N images have to fit TOGETHER; refitting each against the
-    full limit would pass N times and still overflow. Each image gets an equal
-    share of what is left after the overhead reserve, which is also what makes
-    a four-image message shrink evenly instead of refusing the last one.
+    full limit would pass N times and still overflow. What is left after the
+    frame's MEASURED overhead is therefore split between them — see
+    :func:`_refit_images` for why the split reclaims rather than divides flat.
 
     A COROUTINE because the refit decodes and re-encodes images — ~315 ms for a
     20 MP frame — and every caller is on an event loop. The work goes to a
     thread; a frame with no images (the overwhelming majority: every ack, every
     watch, every projection request) returns after one length check without
     ever reaching it.
+
+    Publishes what the refit COST to :data:`_REFIT_REPORT` for the front end to
+    render — see :func:`taken_refit_report`. Always, including the empty tuple
+    when nothing was resized, so a reader cannot mistake a previous send's
+    report for this one's.
 
     Raises :class:`OversizedRequest` when the frame cannot be made to fit,
     which is strictly better than the alternative: the caller learns its
@@ -162,6 +243,10 @@ async def fit_request_frame(frame: dict[str, Any]) -> dict[str, Any]:
     images = frame.get("images")
     encoded_size = len(json.dumps(frame).encode()) + 1  # the socket writes a "\n" too
     if encoded_size <= _READ_LIMIT_BYTES:
+        # The common path, and the ONLY one that leaves the report untouched:
+        # nothing was refitted, so there is nothing for a caller to consume and
+        # a `set` here would cost every ack and projection request a context
+        # write. `taken_refit_report` treats "absent" as "nothing happened".
         return frame
     if not isinstance(images, list) or not images:
         # Nothing bulky to shrink, so the text itself is over the limit. Say so
@@ -169,77 +254,275 @@ async def fit_request_frame(frame: dict[str, Any]) -> dict[str, Any]:
         # half is worse than one that was not sent, because the damage is
         # invisible until the model answers about the wrong thing.
         raise OversizedRequest(
-            f"this message is {encoded_size:,} bytes and the limit is "
-            f"{_READ_LIMIT_BYTES:,} bytes; shorten it and send again"
+            f"this message is {_megabytes(encoded_size)} and the limit is "
+            f"{_megabytes(_READ_LIMIT_BYTES)}; shorten it and send again"
         )
-    budget = max(0, _READ_LIMIT_BYTES - _FRAME_OVERHEAD_RESERVE_BYTES)
-    share = budget // len(images)
-    fitted = await asyncio.to_thread(_refit_images, images, share)
+    # MEASURED, not reserved. Serialising the frame with its images emptied
+    # counts the op, the ``req``, any command id and the user's real text, so a
+    # 100 KiB prompt beside a screenshot is budgeted for instead of being
+    # refused against a 64 KiB constant that was never checked against it
+    # (review round 1, MAJOR-1).
+    overhead = _frame_overhead_bytes(frame)
+    budget = max(0, _READ_LIMIT_BYTES - overhead - _FRAME_ENCODING_SLACK_BYTES)
+    if budget < _MIN_VIABLE_IMAGE_BUDGET_BYTES:
+        # THE TEXT IS THE BULK, and no image of any size would change that. The
+        # per-image refusal below would technically fire, but it would blame the
+        # attachment and quote a "0.0 MB budget" the user can do nothing with —
+        # telling them to remove a screenshot when shortening the prompt is the
+        # only thing that can work. Raised before the refit rather than after so
+        # a doomed re-encode of several megabytes is not spent to reach the same
+        # answer.
+        # "no room" rather than a figure once the remainder rounds away: a
+        # sentence ending "leaving only 0 KB" reads as a bug in the message.
+        room = f"only {_megabytes(budget)}" if budget >= 1024 else "no room"
+        raise OversizedRequest(
+            f"this message's text alone fills {_megabytes(overhead)} of the "
+            f"{_megabytes(_READ_LIMIT_BYTES)} limit, leaving {room} for its "
+            "attachments; shorten the text or send the images on their own"
+        )
+    fitted, report = await asyncio.to_thread(_refit_images, images, budget)
     candidate = {**frame, "images": fitted}
     refitted_size = len(json.dumps(candidate).encode()) + 1
     if refitted_size > _READ_LIMIT_BYTES:
-        # The reserve was not enough, which means the TEXT is the bulk. Measured
-        # on the real frame rather than assumed, so the refusal names the size
-        # the user can actually act on.
+        # Every image reached its tightest rung and the frame is STILL over, so
+        # the text is the bulk. Measured on the real frame rather than assumed,
+        # so the refusal names the size the user can actually act on.
         raise OversizedRequest(
-            f"this message is {refitted_size:,} bytes even after its images were "
-            f"resized, and the limit is {_READ_LIMIT_BYTES:,} bytes; shorten the "
+            f"this message is {_megabytes(refitted_size)} even after its images were "
+            f"resized, and the limit is {_megabytes(_READ_LIMIT_BYTES)}; shorten the "
             "text or send fewer attachments"
         )
+    _REFIT_REPORT.set(report)
     logger.warning(
         "attach client: %s frame was %d bytes, over the %d-byte line limit; "
-        "resized %d image(s) to %d bytes so the message could be sent",
+        "resized %d image(s) to %d bytes so the message could be sent; "
+        "%d of them lost pixels",
         frame.get("op", "request"),
         encoded_size,
         _READ_LIMIT_BYTES,
         len(images),
         refitted_size,
+        sum(1 for entry in report if entry.downscaled),
     )
     return candidate
 
 
-def _refit_images(images: list[Any], share_bytes: int) -> list[Any]:
-    """Refit every image block to ``share_bytes`` of base64, or refuse by name.
+def taken_refit_report() -> tuple[_RefitReport, ...]:
+    """CONSUME what the last refit on this task cost, for the surface showing it.
+
+    Taken rather than read, so one report is rendered exactly once: the front
+    end asks after a send returns, and a later send that refits nothing must not
+    find this one still sitting there and mark an untouched image as resized.
+
+    Empty when the send needed no refit at all, which is the overwhelmingly
+    common case — callers can treat empty as "say nothing".
+    """
+    report = _REFIT_REPORT.get()
+    _REFIT_REPORT.set(None)
+    return report or ()
+
+
+def _frame_overhead_bytes(frame: dict[str, Any]) -> int:
+    """Bytes this frame costs with its images emptied — everything but payloads.
+
+    The images are replaced by EMPTY BLOCKS rather than dropped, so the keys and
+    punctuation of the list itself are counted; only the base64 the refit is
+    about to resize is excluded. Serialising the real frame is what makes the
+    budget track the user's actual text instead of a constant that a 100 KiB
+    paste silently invalidates.
+
+    Falls back to the emptied-list encoding if a block is not a dict — those are
+    passed through untouched by the refit, so counting them as empty would
+    under-budget by their own size; they are kept verbatim here for that reason.
+    """
+    images = frame.get("images")
+    if not isinstance(images, list):
+        return len(json.dumps(frame).encode()) + 1
+    hollow = [{**image, "data_b64": ""} if isinstance(image, dict) else image for image in images]
+    return len(json.dumps({**frame, "images": hollow}).encode()) + 1
+
+
+def _megabytes(size_bytes: int) -> str:
+    """``size_bytes`` in the scale a person reads sizes in.
+
+    ONE unit system across the whole sentence family. The text refusal printed
+    raw byte counts (``1,341,208 bytes``) while the image one printed MB, so two
+    refusals raised from the same function asked the user to compare figures in
+    different scales (design round 1, D1).
+
+    MB down to 0.1 and KB below it, because a one-decimal MB renders every small
+    figure as ``0.0 MB`` — and the figures that go small here are exactly the
+    per-image budgets a refusal is trying to explain. A budget the sentence
+    prints as zero tells the user their image did not fit in nothing, which is
+    not a fact they can act on.
+    """
+    megabytes = size_bytes / (1024 * 1024)
+    if megabytes < 0.1:
+        return f"{size_bytes / 1024:.0f} KB"
+    return f"{megabytes:.1f} MB"
+
+
+def _refit_images(
+    images: list[Any], budget_bytes: int
+) -> tuple[list[Any], tuple[_RefitReport, ...]]:
+    """Fit every image block into ``budget_bytes`` of base64 TOTAL, or refuse by name.
 
     Runs in a thread (see :func:`fit_request_frame`). A block that is not a
     dict, or carries no ``data_b64``, is passed through untouched: the owner
     already drops unusable blocks (``_images_from_wire``), and inventing a
     refusal for one here would fail a send over something the owner would have
-    ignored.
-    """
-    from local_operator.imaging import ImageUnreadable, refit_image_to_budget
+    ignored. Its bytes still count against the budget, because they still ride
+    the frame.
 
-    fitted: list[Any] = []
-    for index, image in enumerate(images, start=1):
-        if not isinstance(image, dict):
-            fitted.append(image)
-            continue
-        data_b64 = image.get("data_b64") or ""
-        if not isinstance(data_b64, str) or not data_b64:
-            fitted.append(image)
+    THE BUDGET IS RECLAIMED, NOT DIVIDED FLAT. An equal ``budget // len(images)``
+    share is the obvious split and it wastes the frame: a 32x32 icon reserved
+    the same share as a 1600x1000 screenshot and handed nothing back, so the
+    screenshot lost half its pixels while 59% of the frame went unspent (review
+    round 1, MINOR-2). Images are therefore fitted SMALLEST FIRST, each against
+    an equal share of what REMAINS divided by the images still to come, and
+    whatever a small image does not spend is immediately available to the
+    larger ones behind it. Smallest-first is what makes the reclaim monotone:
+    an image under its share always passes untouched, so the leftover only ever
+    grows as the walk proceeds.
+
+    This keeps the property the flat split was chosen for \u2014 a message shrinks
+    evenly rather than refusing its last attachment \u2014 because an image that
+    genuinely needs more than its share still only gets its share when every
+    other image is equally hungry.
+
+    Returns the fitted blocks in their ORIGINAL order (the wire order the owner
+    binds to markers), plus one :class:`_RefitReport` per image that was
+    actually re-encoded.
+    """
+    from local_operator.imaging import (
+        ImageUnreadable,
+        refit_image_to_budget,
+        sniff_image,
+    )
+
+    fitted: dict[int, Any] = {}
+    report: list[_RefitReport] = []
+    # Wire position -> the number on the user's composer chip. They are NOT the
+    # same: marker numbers do not renumber when an attachment is deleted, so
+    # after pasting three images and backspacing two the survivor is `[Image
+    # #3]` while its wire position is 1 \u2014 and the refusal said "image 1",
+    # pointing at a chip that is not on screen (design round 1, D4). The block
+    # carries its own marker when the composer knows one; position is the
+    # fallback for producers that do not set it (the phone relay).
+    markers = {
+        position: (
+            int(image["marker"])
+            if isinstance(image, dict)
+            and isinstance(image.get("marker"), int)
+            and image["marker"] > 0
+            else position + 1
+        )
+        for position, image in enumerate(images)
+    }
+    # Smallest first, by the bytes each block actually contributes. The ORDER of
+    # the walk only; `fitted` is re-assembled by wire position below.
+    order = sorted(
+        range(len(images)),
+        key=lambda position: len(_image_payload(images[position])),
+    )
+    remaining = budget_bytes
+    for walked, position in enumerate(order):
+        image = images[position]
+        data_b64 = _image_payload(image)
+        # Everything still to fit, this one included, shares what is left.
+        share = max(0, remaining) // max(1, len(order) - walked)
+        if not isinstance(image, dict) or not data_b64:
+            # Passed through, but still charged: these bytes ride the frame
+            # whether or not this function can do anything about them.
+            fitted[position] = image
+            remaining -= len(data_b64)
             continue
         mime_type = str(image.get("mime_type") or "image/png")
         try:
-            result = refit_image_to_budget(data_b64, mime_type, share_bytes)
+            result = refit_image_to_budget(data_b64, mime_type, share)
         except ImageUnreadable as exc:
             # A DIFFERENT SENTENCE FROM "too large", deliberately: these bytes
             # would not have been sendable at any size, so telling the user to
             # shrink them sends them off fixing the wrong thing.
             raise OversizedRequest(
-                f"image {index} could not be sent because {exc}; remove it and send again"
+                f"image {markers[position]} could not be sent because {exc}; "
+                "remove it and send again"
             ) from exc
         if result is None:
-            # Named by POSITION, because that is what the user can act on: the
-            # composer numbers its attachments `[Image #N]` in the same order,
-            # so "image 2" points at a specific chip on their screen.
-            megabytes = len(data_b64) / (1024 * 1024)
+            # NAMES THE CEILING THAT ACTUALLY APPLIED, and measures the IMAGE.
+            # `len(data_b64)` is the base64, which inflates 4/3 \u2014 reporting it
+            # told a user their 2.4 MB screenshot was "3.2 MB", overstating by a
+            # third against the number their file manager shows. And a size with
+            # no scale beside it answers nothing: "remove it" is the only move
+            # the sentence leaves, when the real ceiling is a per-image share
+            # that says whether cropping or sending it alone would work (design
+            # round 1, D1).
+            detail = (
+                f"this message's {_megabytes(share)} per-image budget "
+                f"({len(images)} attachments)"
+                if len(images) > 1
+                else f"this message's {_megabytes(share)} budget"
+            )
             raise OversizedRequest(
-                f"image {index} is too large to send ({megabytes:.1f} MB) and could "
-                "not be resized to fit; remove it and send again"
+                f"image {markers[position]} is {_megabytes(_decoded_size(data_b64))} and will "
+                f"not fit in {detail} even at its smallest size; remove it and send again"
             )
         refitted_b64, refitted_mime = result
-        fitted.append({**image, "data_b64": refitted_b64, "mime_type": refitted_mime})
-    return fitted
+        fitted[position] = {**image, "data_b64": refitted_b64, "mime_type": refitted_mime}
+        remaining -= len(refitted_b64)
+        if refitted_b64 != data_b64:
+            # Only a block that actually changed is reported, and only its
+            # DIMENSIONS decide whether the user is told (see `_RefitReport`).
+            # Sniffed from the bytes on both sides rather than trusting the
+            # rung: the ladder's first rung re-encodes at unchanged dimensions,
+            # so the codec-only case must measure as "not downscaled".
+            source = sniff_image(_decode_quietly(data_b64))
+            delivered = sniff_image(_decode_quietly(refitted_b64))
+            if source is not None and delivered is not None:
+                report.append(
+                    _RefitReport(
+                        marker=markers[position],
+                        width=delivered.width or 0,
+                        height=delivered.height or 0,
+                        source_width=source.width or 0,
+                        source_height=source.height or 0,
+                    )
+                )
+    return [fitted[position] for position in range(len(images))], tuple(report)
+
+
+def _image_payload(image: Any) -> str:
+    """The base64 an image block contributes to the frame, or ``""``."""
+    if not isinstance(image, dict):
+        return ""
+    data_b64 = image.get("data_b64") or ""
+    return data_b64 if isinstance(data_b64, str) else ""
+
+
+def _decoded_size(data_b64: str) -> int:
+    """The IMAGE's size in bytes, from its base64 length, without decoding it.
+
+    Base64 is 4 characters per 3 bytes plus padding, so the decoded size is
+    what the user recognises as their file and the encoded length is a third
+    larger. Arithmetic rather than a decode because this runs on a refusal
+    path holding megabytes that are about to be discarded.
+    """
+    padding = data_b64[-2:].count("=") if data_b64 else 0
+    return max(0, (len(data_b64) * 3) // 4 - padding)
+
+
+def _decode_quietly(data_b64: str) -> bytes:
+    """``data_b64`` decoded, or empty bytes \u2014 a sniff failure is never fatal.
+
+    Only feeds :func:`~local_operator.imaging.sniff_image` for the report, and
+    a report is a convenience: bytes that will not decode here have already
+    been through the refit successfully, so the right outcome is one less
+    caption, never a failed send.
+    """
+    try:
+        return base64.b64decode(data_b64, validate=True)
+    except Exception:  # noqa: BLE001 \u2014 a missing caption must never fail a send
+        return b""
 
 
 def find_owner_record(config_dir: Path, session_id: str) -> tuple[SessionRecord | None, int | None]:
@@ -685,7 +968,9 @@ class AttachClient:
             await self._writer.drain()
             reply = await asyncio.wait_for(future, timeout=ACK_TIMEOUT_S)
         except (ConnectionResetError, BrokenPipeError, OSError) as exc:
-            self._pending.pop(req, None)
+            # No `_pending.pop` here: the `finally` below runs on this path too,
+            # so the second call was always a no-op on an already-popped id
+            # (review round 1, MINOR-3).
             raise ConnectionError(f"owner connection lost: {exc}") from exc
         finally:
             self._pending.pop(req, None)

--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -109,6 +109,32 @@ class OversizedRequest(ValueError):
     """
 
 
+class UnreadableImageRequest(OversizedRequest):
+    """The refusal for an attachment that is not a decodable image AT ALL.
+
+    A SUBCLASS so every existing handler keeps working unchanged — the TUI's
+    prompt worker matches on ``isinstance(error, OversizedRequest)`` and the
+    relay's 422 path on ``ValueError``, and both still catch this.
+
+    It exists because the two refusals have DIFFERENT REMEDIES, and one place
+    in :func:`fit_request_frame` rewrites a refusal's sentence: when the text
+    has eaten the frame's budget, a SIZE failure is re-blamed on the text,
+    which is the copy call review round 2 (MAJOR-4) argued for. That rewrite
+    used to catch this one too, so a corrupt attachment on a text-heavy frame
+    told the user to "shorten the text or send the images on their own" —
+    advice that cannot work, because these bytes are not an image at any size
+    and no amount of shortening makes them one. The remedy here is always
+    "remove it", whatever the budget looks like (review round 3, NIT-1).
+
+    Narrow, and deliberately still fixed: no in-tree producer emits an
+    undecodable payload today (the owner content-sniffs and drops unusable
+    blocks on the far side), but a truncated paste or a file that is not
+    really a PNG reaches ``refit_image_to_budget`` from the client side first,
+    and a sentence that sends the user off fixing the wrong thing is the exact
+    defect ``ImageUnreadable`` was split out from ``None`` to prevent.
+    """
+
+
 class _RefitReport(NamedTuple):
     """What the wire refit did to ONE image, for the surface that must say so.
 
@@ -289,6 +315,12 @@ async def fit_request_frame(frame: dict[str, Any]) -> dict[str, Any]:
     text_is_the_bulk = budget < _MIN_VIABLE_IMAGE_BUDGET_BYTES
     try:
         fitted, report = await asyncio.to_thread(_refit_images, images, budget)
+    except UnreadableImageRequest:
+        # NOT a size failure, so the text-is-the-bulk rewrite below must not
+        # replace it: the remedy is removing the attachment, and shortening the
+        # text cannot make an undecodable payload decodable (review round 3,
+        # NIT-1). Caught before `OversizedRequest` because it subclasses it.
+        raise
     except OversizedRequest:
         if not text_is_the_bulk:
             raise
@@ -346,9 +378,20 @@ def _text_is_the_bulk_refusal(overhead: int, budget: int) -> OversizedRequest:
     ending "leaving only 0 KB" reads as a bug in the message.
     """
     room = f"only {_megabytes(budget)}" if budget >= 1024 else "no room"
+    # The text figure in the LIMIT'S scale rather than the honest-for-its-size
+    # scale, because the mixed scale broke comparability: "fills 1000 KB of the
+    # 1.0 MB limit" asked the user to convert units mid-sentence between the
+    # two figures the sentence exists to compare (design round 3, D17).
+    #
+    # Safe ONLY because of where this sentence fires: the budget precondition
+    # (under `_MIN_VIABLE_IMAGE_BUDGET_BYTES`) puts the overhead within a few
+    # KB of the whole limit, so its MB figure can never round below 0.9 and the
+    # "0.0 MB" class `_megabytes` exists to avoid is unreachable HERE. The ROOM
+    # figure keeps `_megabytes`' own scale because it is genuinely small — KB
+    # is the honest unit for a few KB, and "no room" covers a sub-KB remainder.
     return OversizedRequest(
-        f"this message's text alone fills {_megabytes(overhead)} of the "
-        f"{_megabytes(_READ_LIMIT_BYTES)} limit, leaving {room} for its "
+        f"this message's text alone fills {overhead / (1024 * 1024):.1f} MB of "
+        f"the {_megabytes(_READ_LIMIT_BYTES)} limit, leaving {room} for its "
         "attachments; shorten the text or send the images on their own"
     )
 
@@ -396,11 +439,18 @@ def _megabytes(size_bytes: int) -> str:
     refusals raised from the same function asked the user to compare figures in
     different scales (design round 1, D1).
 
-    MB down to 0.1 and KB below it, because a one-decimal MB renders every small
+    MB at and above a full megabyte, KB below it, and the raw byte count below
+    one KB. The KB floor is there because a one-decimal MB renders every small
     figure as ``0.0 MB`` — and the figures that go small here are exactly the
     per-image budgets a refusal is trying to explain. A budget the sentence
     prints as zero tells the user their image did not fit in nothing, which is
-    not a fact they can act on.
+    not a fact they can act on; the same applies one scale down, where a
+    ``1023 B`` share must not read ``0 KB``: the split walks smallest-first, so
+    the LAST image of a many-attachment message can face a sub-KB share while
+    its tightest rung is still over a KB, and that sentence has to state a
+    budget the user can act on (review round 3, NIT-2 — previously only the
+    exact-zero case had been noticed, which is unreachable; the share path is
+    not).
 
     THE SWITCH IS AT 1024 KB, not at 0.1 MB, so the two scales cannot cross.
     Keyed on the rounded MB figure the sentence would actually print, the
@@ -410,6 +460,8 @@ def _megabytes(size_bytes: int) -> str:
     in the larger unit (review round 2, NIT-2). Below a full megabyte the
     KB figure is the honest one; at or above it the MB figure is.
     """
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
     kilobytes = size_bytes / 1024
     if kilobytes < 1024:
         return f"{kilobytes:.0f} KB"
@@ -508,8 +560,10 @@ def _refit_images(
         except ImageUnreadable as exc:
             # A DIFFERENT SENTENCE FROM "too large", deliberately: these bytes
             # would not have been sendable at any size, so telling the user to
-            # shrink them sends them off fixing the wrong thing.
-            raise OversizedRequest(
+            # shrink them sends them off fixing the wrong thing. A distinct
+            # CLASS too, so `fit_request_frame` cannot rewrite this sentence
+            # into the text-blaming one — see `UnreadableImageRequest`.
+            raise UnreadableImageRequest(
                 f"image {markers[position]} could not be sent because {exc}; "
                 "remove it and send again"
             ) from exc

--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -165,14 +165,27 @@ class _RefitReport(NamedTuple):
 _FRAME_ENCODING_SLACK_BYTES = 4 * 1024
 
 
-#: Below this much room for ALL the images, the text is the problem and the
-#: refusal must say so rather than blaming an attachment.
+#: Below this much room for ALL the images, blame the TEXT rather than an
+#: attachment — a COPY decision, and only that.
 #:
-#: The refit's tightest rung is a 384px JPEG at quality 85, which lands around
-#: 20-30 KB of base64 for ordinary content. 32 KiB is therefore "not even one
-#: image at its smallest could fit here": under it the per-image refusal is
-#: guaranteed and would quote a share rounding to ``0.0 MB``, pointing the user
-#: at a screenshot when only shortening the prompt can help.
+#: NOT A PREDICTION THAT THE REFIT WOULD FAIL, and the earlier version of this
+#: constant made exactly that claim: it short-circuited to a refusal before the
+#: refit ran, on the premise that the tightest rung "lands around 20-30 KB of
+#: base64" so a smaller budget guaranteed a per-image refusal. That premise
+#: holds for continuous-tone photographs and is false for the two shapes an
+#: operator most often pastes. A flat terminal screenshot compresses to ~6.6 KB
+#: of base64 and fits a quarter of this figure; line art is exempt from the
+#: JPEG rung by design and a 1024x1024 bilevel grid is ~1.4 KB. Measured, three
+#: smooth-gradient sends were refused here while the refit produced a fitting
+#: image and a frame under the limit (review round 2, MAJOR-4) — the same class
+#: of defect MAJOR-1 filed against the old fixed reserve, one layer up.
+#:
+#: So the refit ALWAYS runs, and this only decides which sentence a failure
+#: gets. Below this much room the per-image refusal would quote a share
+#: rounding to ``0.0 MB`` and point the user at a screenshot when only
+#: shortening the prompt can help; the frame-level refusal names the text
+#: instead. The cost of being wrong is now one re-encode rather than a message
+#: the user was told they could not send.
 _MIN_VIABLE_IMAGE_BUDGET_BYTES = 32 * 1024
 
 
@@ -264,29 +277,33 @@ async def fit_request_frame(frame: dict[str, Any]) -> dict[str, Any]:
     # (review round 1, MAJOR-1).
     overhead = _frame_overhead_bytes(frame)
     budget = max(0, _READ_LIMIT_BYTES - overhead - _FRAME_ENCODING_SLACK_BYTES)
-    if budget < _MIN_VIABLE_IMAGE_BUDGET_BYTES:
-        # THE TEXT IS THE BULK, and no image of any size would change that. The
-        # per-image refusal below would technically fire, but it would blame the
-        # attachment and quote a "0.0 MB budget" the user can do nothing with —
-        # telling them to remove a screenshot when shortening the prompt is the
-        # only thing that can work. Raised before the refit rather than after so
-        # a doomed re-encode of several megabytes is not spent to reach the same
-        # answer.
-        # "no room" rather than a figure once the remainder rounds away: a
-        # sentence ending "leaving only 0 KB" reads as a bug in the message.
-        room = f"only {_megabytes(budget)}" if budget >= 1024 else "no room"
-        raise OversizedRequest(
-            f"this message's text alone fills {_megabytes(overhead)} of the "
-            f"{_megabytes(_READ_LIMIT_BYTES)} limit, leaving {room} for its "
-            "attachments; shorten the text or send the images on their own"
-        )
-    fitted, report = await asyncio.to_thread(_refit_images, images, budget)
+    # THE REFIT ALWAYS RUNS, even on a budget this small. Whether an image fits
+    # is a question only the encoder can answer — a flat screenshot or line art
+    # fits a budget that no photograph would (see
+    # `_MIN_VIABLE_IMAGE_BUDGET_BYTES`), and predicting the answer here refused
+    # messages that would have sent (review round 2, MAJOR-4).
+    #
+    # `text_is_the_bulk` decides only which SENTENCE a genuine failure gets, so
+    # a refusal on a budget the text has eaten blames the text rather than
+    # quoting a per-image share that rounds to `0.0 MB`.
+    text_is_the_bulk = budget < _MIN_VIABLE_IMAGE_BUDGET_BYTES
+    try:
+        fitted, report = await asyncio.to_thread(_refit_images, images, budget)
+    except OversizedRequest:
+        if not text_is_the_bulk:
+            raise
+        raise _text_is_the_bulk_refusal(overhead, budget) from None
     candidate = {**frame, "images": fitted}
     refitted_size = len(json.dumps(candidate).encode()) + 1
     if refitted_size > _READ_LIMIT_BYTES:
         # Every image reached its tightest rung and the frame is STILL over, so
         # the text is the bulk. Measured on the real frame rather than assumed,
         # so the refusal names the size the user can actually act on.
+        if text_is_the_bulk:
+            # "send fewer attachments" is not the move when the text alone has
+            # eaten the frame — the same copy call the pre-refit gate used to
+            # make, now made where the failure is real.
+            raise _text_is_the_bulk_refusal(overhead, budget)
         raise OversizedRequest(
             f"this message is {_megabytes(refitted_size)} even after its images were "
             f"resized, and the limit is {_megabytes(_READ_LIMIT_BYTES)}; shorten the "
@@ -295,16 +312,45 @@ async def fit_request_frame(frame: dict[str, Any]) -> dict[str, Any]:
     _REFIT_REPORT.set(report)
     logger.warning(
         "attach client: %s frame was %d bytes, over the %d-byte line limit; "
-        "resized %d image(s) to %d bytes so the message could be sent; "
-        "%d of them lost pixels",
+        "resized %d image(s) to %d bytes of image payload and the frame is now "
+        "%d bytes; %d of them lost pixels",
         frame.get("op", "request"),
         encoded_size,
         _READ_LIMIT_BYTES,
         len(images),
+        # THE IMAGES, summed from what was actually fitted. This said
+        # `refitted_size` — the WHOLE frame — inside a clause reading as the
+        # images, which was within ~6% while the reserve was a fixed 64 KiB and
+        # became an overstatement of 3.25x-16.75x once the overhead was measured
+        # and up to 1 MiB of the user's own text sat inside a number attributed
+        # to the attachments (QA round 2, Q3). Both quantities are named now,
+        # because the frame size is the one that explains the limit and the
+        # payload size is the one that explains the resize.
+        sum(len(_image_payload(image)) for image in fitted),
         refitted_size,
         sum(1 for entry in report if entry.downscaled),
     )
     return candidate
+
+
+def _text_is_the_bulk_refusal(overhead: int, budget: int) -> OversizedRequest:
+    """The refusal for a frame whose TEXT left no usable room for attachments.
+
+    A copy decision rather than a diagnosis: raised only where the refit has
+    already tried and failed, so the sentence blames the quantity the user can
+    actually act on. The per-image refusal would name a share rounding to
+    ``0.0 MB`` and point at a screenshot when only shortening the prompt can
+    help (review round 2, MAJOR-4).
+
+    "no room" rather than a figure once the remainder rounds away: a sentence
+    ending "leaving only 0 KB" reads as a bug in the message.
+    """
+    room = f"only {_megabytes(budget)}" if budget >= 1024 else "no room"
+    return OversizedRequest(
+        f"this message's text alone fills {_megabytes(overhead)} of the "
+        f"{_megabytes(_READ_LIMIT_BYTES)} limit, leaving {room} for its "
+        "attachments; shorten the text or send the images on their own"
+    )
 
 
 def taken_refit_report() -> tuple[_RefitReport, ...]:
@@ -355,11 +401,19 @@ def _megabytes(size_bytes: int) -> str:
     per-image budgets a refusal is trying to explain. A budget the sentence
     prints as zero tells the user their image did not fit in nothing, which is
     not a fact they can act on.
+
+    THE SWITCH IS AT 1024 KB, not at 0.1 MB, so the two scales cannot cross.
+    Keyed on the rounded MB figure the sentence would actually print, the
+    boundary sat mid-KB: ``104,857`` read ``102 KB`` and ``104,858`` read
+    ``0.1 MB``, so a one-byte step moved the number DOWN while moving the unit
+    up, and a user comparing two refusals a minute apart saw the smaller figure
+    in the larger unit (review round 2, NIT-2). Below a full megabyte the
+    KB figure is the honest one; at or above it the MB figure is.
     """
-    megabytes = size_bytes / (1024 * 1024)
-    if megabytes < 0.1:
-        return f"{size_bytes / 1024:.0f} KB"
-    return f"{megabytes:.1f} MB"
+    kilobytes = size_bytes / 1024
+    if kilobytes < 1024:
+        return f"{kilobytes:.0f} KB"
+    return f"{size_bytes / (1024 * 1024):.1f} MB"
 
 
 def _refit_images(
@@ -406,9 +460,20 @@ def _refit_images(
     # same: marker numbers do not renumber when an attachment is deleted, so
     # after pasting three images and backspacing two the survivor is `[Image
     # #3]` while its wire position is 1 \u2014 and the refusal said "image 1",
-    # pointing at a chip that is not on screen (design round 1, D4). The block
-    # carries its own marker when the composer knows one; position is the
-    # fallback for producers that do not set it (the phone relay).
+    # pointing at a chip that is not on screen (design round 1, D4).
+    #
+    # THE PRODUCER IS `editor.resolve_markers`, which stamps the chip number on
+    # each `ImageContent`, and `remote._image_to_wire`, which puts it on the
+    # block. Both were added in review round 2: this lookup shipped first with
+    # nothing populating it, so every refusal still fell through to the position
+    # and the fix was the old behaviour renamed (design round 2, D8). A change
+    # that drops either end silently restores that, which is why
+    # `test_a_refusal_quotes_the_marker_a_real_paste_produced` starts at a real
+    # paste rather than at a hand-built wire dict.
+    #
+    # Position stays the fallback for producers with no chips to name - the
+    # phone relay, a tool result - where it is the only number that means
+    # anything.
     markers = {
         position: (
             int(image["marker"])

--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -90,6 +90,158 @@ class _OversizedFrame(Exception):
     what it sent) and were logged as the same overrun before this existed."""
 
 
+class OversizedRequest(ValueError):
+    """This side refused to SEND a frame the owner could not have read.
+
+    The outbound twin of :class:`_OversizedFrame`, and the whole point is that
+    it is raised INSTEAD of a write. Writing an over-limit line does not fail:
+    it succeeds, the owner's ``readline`` raises on the far side, and the
+    connection dies — so the caller's request is answered by a dead socket
+    rather than an error, which is exactly the session death this guards
+    (pasting a large screenshot exited ``lop`` and forced ``lop --resume``).
+
+    A ``ValueError`` and not a ``ConnectionError``, deliberately: the socket is
+    healthy and redialling fixes nothing. The TUI's prompt worker surfaces the
+    message as a notice and puts the draft back in the composer, which is what
+    makes the refusal actionable rather than a loss.
+    """
+
+
+#: Bytes of ONE request frame's non-image overhead to hold back from the image
+#: budget: the op name, the ``req`` id, a UUID command id, and the user's text.
+#:
+#: Sized against the TEXT, which is the only part that varies much — the
+#: composer caps a paste at ``MAX_CLIPBOARD_TEXT_BYTES`` (1 MiB), but a prompt
+#: that large is over the line limit on its own words and is refused by the
+#: same guard rather than silently truncated. 64 KiB covers any prompt a person
+#: types alongside a screenshot with two orders of magnitude of room, and the
+#: exact frame is measured again after the refit, so this reserve only has to be
+#: generous rather than precise.
+_FRAME_OVERHEAD_RESERVE_BYTES = 64 * 1024
+
+
+async def fit_request_frame(frame: dict[str, Any]) -> dict[str, Any]:
+    """Return ``frame`` sized to fit the socket, refitting its images if needed.
+
+    THE BUG THIS CLOSES. The owner's control socket reads one JSON line per
+    frame with ``limit=_MAX_LINE_BYTES``; a line over that makes its
+    ``readline`` raise and (before the sibling fix in ``RuntimeServer``) killed
+    the reader loop and the connection. Nothing on this side checked, so
+    ``prompt``/``steer``/``slash`` put the user's images on the wire fully
+    base64-encoded and unguarded, and ONE pasted screenshot over ~780 KB of
+    source severed the socket at the moment of sending. Measured on this
+    machine: a 1672x941 render is 1.23 MB of base64 after the composer's own
+    ingest bound, and two ordinary screenshots together are 1.1 MB, so the
+    frames that break it are ordinary rather than pathological.
+
+    WHY REFIT RATHER THAN REFUSE. Pasting screenshots is a routine gesture, and
+    the sizes above are routine too — a hard rejection would break the feature
+    to protect the transport. So each image is re-encoded to fit
+    (:func:`~local_operator.imaging.refit_image_to_budget`, JPEG at full
+    resolution first, downscale only if that is not enough) and the user sees
+    nothing. Only an image that cannot fit even at its tightest rung is
+    refused, named by its POSITION in the message so it points at a specific
+    composer chip and the user knows which attachment to drop.
+
+    WHY THE BUDGET IS SHARED ACROSS THE IMAGES. The line limit applies to the
+    whole frame, so N images have to fit TOGETHER; refitting each against the
+    full limit would pass N times and still overflow. Each image gets an equal
+    share of what is left after the overhead reserve, which is also what makes
+    a four-image message shrink evenly instead of refusing the last one.
+
+    A COROUTINE because the refit decodes and re-encodes images — ~315 ms for a
+    20 MP frame — and every caller is on an event loop. The work goes to a
+    thread; a frame with no images (the overwhelming majority: every ack, every
+    watch, every projection request) returns after one length check without
+    ever reaching it.
+
+    Raises :class:`OversizedRequest` when the frame cannot be made to fit,
+    which is strictly better than the alternative: the caller learns its
+    request was not sent while the connection is still alive.
+    """
+    images = frame.get("images")
+    encoded_size = len(json.dumps(frame).encode()) + 1  # the socket writes a "\n" too
+    if encoded_size <= _READ_LIMIT_BYTES:
+        return frame
+    if not isinstance(images, list) or not images:
+        # Nothing bulky to shrink, so the text itself is over the limit. Say so
+        # with both numbers rather than truncating: a prompt silently cut in
+        # half is worse than one that was not sent, because the damage is
+        # invisible until the model answers about the wrong thing.
+        raise OversizedRequest(
+            f"this message is {encoded_size:,} bytes and the limit is "
+            f"{_READ_LIMIT_BYTES:,} bytes; shorten it and send again"
+        )
+    budget = max(0, _READ_LIMIT_BYTES - _FRAME_OVERHEAD_RESERVE_BYTES)
+    share = budget // len(images)
+    fitted = await asyncio.to_thread(_refit_images, images, share)
+    candidate = {**frame, "images": fitted}
+    refitted_size = len(json.dumps(candidate).encode()) + 1
+    if refitted_size > _READ_LIMIT_BYTES:
+        # The reserve was not enough, which means the TEXT is the bulk. Measured
+        # on the real frame rather than assumed, so the refusal names the size
+        # the user can actually act on.
+        raise OversizedRequest(
+            f"this message is {refitted_size:,} bytes even after its images were "
+            f"resized, and the limit is {_READ_LIMIT_BYTES:,} bytes; shorten the "
+            "text or send fewer attachments"
+        )
+    logger.warning(
+        "attach client: %s frame was %d bytes, over the %d-byte line limit; "
+        "resized %d image(s) to %d bytes so the message could be sent",
+        frame.get("op", "request"),
+        encoded_size,
+        _READ_LIMIT_BYTES,
+        len(images),
+        refitted_size,
+    )
+    return candidate
+
+
+def _refit_images(images: list[Any], share_bytes: int) -> list[Any]:
+    """Refit every image block to ``share_bytes`` of base64, or refuse by name.
+
+    Runs in a thread (see :func:`fit_request_frame`). A block that is not a
+    dict, or carries no ``data_b64``, is passed through untouched: the owner
+    already drops unusable blocks (``_images_from_wire``), and inventing a
+    refusal for one here would fail a send over something the owner would have
+    ignored.
+    """
+    from local_operator.imaging import ImageUnreadable, refit_image_to_budget
+
+    fitted: list[Any] = []
+    for index, image in enumerate(images, start=1):
+        if not isinstance(image, dict):
+            fitted.append(image)
+            continue
+        data_b64 = image.get("data_b64") or ""
+        if not isinstance(data_b64, str) or not data_b64:
+            fitted.append(image)
+            continue
+        mime_type = str(image.get("mime_type") or "image/png")
+        try:
+            result = refit_image_to_budget(data_b64, mime_type, share_bytes)
+        except ImageUnreadable as exc:
+            # A DIFFERENT SENTENCE FROM "too large", deliberately: these bytes
+            # would not have been sendable at any size, so telling the user to
+            # shrink them sends them off fixing the wrong thing.
+            raise OversizedRequest(
+                f"image {index} could not be sent because {exc}; remove it and send again"
+            ) from exc
+        if result is None:
+            # Named by POSITION, because that is what the user can act on: the
+            # composer numbers its attachments `[Image #N]` in the same order,
+            # so "image 2" points at a specific chip on their screen.
+            megabytes = len(data_b64) / (1024 * 1024)
+            raise OversizedRequest(
+                f"image {index} is too large to send ({megabytes:.1f} MB) and could "
+                "not be resized to fit; remove it and send again"
+            )
+        refitted_b64, refitted_mime = result
+        fitted.append({**image, "data_b64": refitted_b64, "mime_type": refitted_mime})
+    return fitted
+
+
 def find_owner_record(config_dir: Path, session_id: str) -> tuple[SessionRecord | None, int | None]:
     """Locate the discovery record of the live process hosting ``session_id``.
 
@@ -493,9 +645,15 @@ class AttachClient:
             raise ConnectionError("not attached")
         self._req_seq += 1
         req = self._req_seq
+        # FITTED BEFORE THE FUTURE IS REGISTERED, because this can raise
+        # `OversizedRequest` and a future parked in `_pending` for a request
+        # that was never written is never resolved by anything: it sits there
+        # until the connection closes, then takes the teardown's
+        # `ConnectionError` with nobody awaiting it — an "exception was never
+        # retrieved" log for a refusal the caller had already handled cleanly.
+        frame = await fit_request_frame({"op": op, "req": req, **fields})
         future: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
         self._pending[req] = future
-        frame = {"op": op, "req": req, **fields}
         try:
             self._writer.write(json.dumps(frame).encode() + b"\n")
             await self._writer.drain()
@@ -516,9 +674,12 @@ class AttachClient:
             raise ConnectionError("not attached")
         self._req_seq += 1
         req = self._req_seq
+        # Fitted before the future is registered, for the reason spelled out in
+        # :meth:`_request_frame`: a refusal must leave nothing parked in
+        # ``_pending``.
+        frame = await fit_request_frame({"op": op, "req": req, **fields})
         future: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
         self._pending[req] = future
-        frame = {"op": op, "req": req, **fields}
         try:
             self._writer.write(json.dumps(frame).encode() + b"\n")
             await self._writer.drain()

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -1495,9 +1495,23 @@ class MobileDaemon:
         if entry is None or entry.writer is None:
             raise KeyError(f"session {pid} is not connected")
         req = entry.next_req()
+        # THE PHONE'S ROUTE TO THE SAME SOCKET, so it takes the same guard the
+        # attach client does: a prompt relayed from the web composer carries
+        # base64 images in one line, and an over-limit line makes the
+        # registrant's reader discard the frame — the message would simply never
+        # arrive. Shared helper rather than a second implementation, so the two
+        # producers cannot disagree about what fits.
+        #
+        # Fitted BEFORE the future is registered: `OversizedRequest` is a
+        # `ValueError`, which this module's HTTP layer already renders as a 422
+        # the composer shows while RETAINING the user's command — so a refusal
+        # must not leave a future parked in `_pending_reqs` for a frame that was
+        # never written.
+        from local_operator.mobile.attach_client import fit_request_frame
+
+        frame = await fit_request_frame({"op": op, "req": req, **fields})
         future: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
         self._pending_reqs[(pid, req)] = future
-        frame = {"op": op, "req": req, **fields}
         try:
             entry.writer.write(json.dumps(frame).encode() + b"\n")
             await entry.writer.drain()

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -5007,5 +5007,22 @@ def _pending_request(state: Any) -> PendingRequest | None:
     )
 
 
-def _image_to_wire(image: ImageContent) -> dict[str, str]:
-    return {"data_b64": image.data, "mime_type": image.mime_type}
+def _image_to_wire(image: ImageContent) -> dict[str, Any]:
+    """One image block as the owner's control socket carries it.
+
+    ``marker`` rides along when the producer knows one, because the transport
+    can REFUSE an attachment and has to name the chip the user is looking at:
+    ``markers`` in ``attach_client._refit_images`` prefers it and falls back to
+    the wire position. Omitted rather than sent as ``null`` when there is none,
+    so a producer with no chips (the phone relay, a tool result) leaves the
+    fallback in charge and the frame stays the shape older owners parse.
+
+    Emitting it here is what makes the lookup reachable at all: the field is
+    ``exclude=True`` on :class:`ImageContent`, so no ``model_dump`` carries it
+    and this is the only seam that can (design round 2, D8 — the lookup shipped
+    while nothing populated it, and the refusal went on quoting the position).
+    """
+    block: dict[str, Any] = {"data_b64": image.data, "mime_type": image.mime_type}
+    if image.marker is not None:
+        block["marker"] = image.marker
+    return block

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -1305,9 +1305,10 @@ class RuntimeServer:
             # In-flight transcript state rides the same canonical sync as every
             # other full-TUI field. Raw events begin only after that frame.
             conn.events_ready = True
-        # Bytes discarded by the CURRENT oversized line. Doubles as the
-        # "already reported this one" flag, since a run always starts at zero:
-        # one oversized frame raises REPEATEDLY — once per limit-sized chunk,
+        # A FLOOR on the bytes discarded by the CURRENT oversized line, not the
+        # exact figure — see where it is incremented. Doubles as the "already
+        # reported this one" flag, since a run always starts at zero: one
+        # oversized frame raises REPEATEDLY — once per limit-sized chunk,
         # measured at 7 raises for a 10 MB line — so a log call per raise would
         # turn one bad message into a burst that buries the fact that they were
         # all the same frame.
@@ -1348,6 +1349,14 @@ class RuntimeServer:
                     # so a line reaching this point means an old client, a
                     # non-attach peer, or a bug — each of which is worth one
                     # greppable line rather than a vanished session.
+                    #
+                    # THIS line is the one that always fires, which is why it
+                    # names the limit rather than the size: a frame only
+                    # marginally over produces a single raise whose separator
+                    # lands inside the discarded chunk, so no read succeeds
+                    # until the peer sends something else and the summary below
+                    # may never come at all (QA round 1, Q2). The operator
+                    # learns a frame was dropped, and why, from this row alone.
                     if overrun_bytes == 0:
                         logger.error(
                             "session runtime: dropping an inbound frame from %s client %s "
@@ -1357,21 +1366,34 @@ class RuntimeServer:
                             conn.writer.get_extra_info("peername"),
                             _MAX_LINE_BYTES,
                         )
+                    # A FLOOR, and the summary below says so in words. CPython's
+                    # ``readline`` clears ``len(self._buffer)`` on the
+                    # no-separator path, and that buffer is ``>= limit`` — in
+                    # practice more, because the overrun is only detected once a
+                    # whole transport chunk has landed. The discarded amount is
+                    # therefore not reachable from here without instrumenting the
+                    # transport, and measured runs put the shortfall at 6.7-18.8%
+                    # (QA round 1, Q1). Reporting a floor AS a floor is honest;
+                    # reporting it as a total is what made the number wrong.
                     overrun_bytes += _MAX_LINE_BYTES
                     continue
                 if overrun_bytes:
-                    # The read that finally SUCCEEDS is the tail of the
-                    # oversized line (everything after the last discarded
-                    # chunk), never a frame of its own — so it is dropped by the
-                    # JSON guard below and the total is reported here, where the
-                    # size is finally known. Naming the total is what makes the
-                    # log actionable: "over 1 MiB" does not say whether to trim
-                    # one screenshot or five.
+                    # ``overrun_bytes`` ALONE, without this line's length. The
+                    # read that succeeds here is usually the tail of the
+                    # oversized frame, but not always: when the separator landed
+                    # inside a discarded chunk there is no tail, and this is the
+                    # peer's next, innocent message — whose bytes were being
+                    # added to the bad frame's total, attributing an unrelated
+                    # message's size to it (QA round 1, Q2).
+                    #
+                    # Naming the size is what makes the log actionable: "over 1
+                    # MiB" does not say whether to trim one screenshot or five.
+                    # "at least" is what makes it TRUE — see the increment above.
                     logger.error(
-                        "session runtime: discarded ~%d bytes of oversized inbound frame "
-                        "from %s client %s; the connection is still up and the next "
+                        "session runtime: discarded at least %d bytes of oversized inbound "
+                        "frame from %s client %s; the connection is still up and the next "
                         "message will be read normally",
-                        overrun_bytes + len(line),
+                        overrun_bytes,
                         conn.kind,
                         conn.writer.get_extra_info("peername"),
                     )
@@ -1645,6 +1667,41 @@ class RuntimeServer:
         return frozenset(watching)
 
     async def _on_request(self, frame: dict[str, Any], conn: _ClientConn) -> None:
+        # A FRAME THAT IS NOT AN OBJECT MUST NOT REACH `.get`, and the guard is
+        # HERE rather than at the reader's parse because this is the line that
+        # actually dereferences it: `op`/`req` are read BEFORE the `try` below,
+        # so an `AttributeError` from them escapes this method entirely, sails
+        # past the reader loop's `ConnectionResetError`/`BrokenPipeError`
+        # handler, and reaches the `finally` that drops the client — killing the
+        # session for a junk frame, which is the exact death the oversized-line
+        # fix exists to prevent (review round 1, MAJOR-2).
+        #
+        # `json.loads` is the source: it succeeds on any JSON SCALAR, so a
+        # discarded oversized line whose surviving tail happens to read `12345`,
+        # `null`, `true`, `"str"` or `[1,2]` parses cleanly and arrives here as
+        # an int/None/bool/str/list. That tail is now reachable in the ordinary
+        # course of events precisely because the reader loop survives an
+        # oversized frame instead of dying on it.
+        #
+        # Guarding at this seam rather than at the parse also covers the other
+        # callers — a future dispatch route, and the tests that drive this
+        # method directly — so the "discard and keep the connection" promise the
+        # reader loop's log line makes is total rather than route-specific
+        # (review round 1, NIT-2).
+        #
+        # DROPPED, not answered: an error reply is keyed by `req`, and a frame
+        # that is not an object carries no `req` to answer on. One DEBUG line,
+        # because the sender is a broken or ancient peer rather than the
+        # operator, and the reader loop already logged the oversized frame that
+        # produced the tail at `error`.
+        if not isinstance(frame, dict):
+            logger.debug(
+                "session runtime: ignoring a non-object frame (%s) from %s client %s",
+                type(frame).__name__,
+                conn.kind,
+                conn.writer.get_extra_info("peername"),
+            )
+            return
         op = str(frame.get("op") or "")
         req = frame.get("req")
         try:

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -1305,9 +1305,77 @@ class RuntimeServer:
             # In-flight transcript state rides the same canonical sync as every
             # other full-TUI field. Raw events begin only after that frame.
             conn.events_ready = True
+        # Bytes discarded by the CURRENT oversized line. Doubles as the
+        # "already reported this one" flag, since a run always starts at zero:
+        # one oversized frame raises REPEATEDLY — once per limit-sized chunk,
+        # measured at 7 raises for a 10 MB line — so a log call per raise would
+        # turn one bad message into a burst that buries the fact that they were
+        # all the same frame.
+        overrun_bytes = 0
         try:
             while not self._closed.is_set():
-                line = await reader.readline()
+                try:
+                    line = await reader.readline()
+                except ValueError:
+                    # AN OVERSIZED INBOUND LINE MUST NOT BE A FATAL ERROR.
+                    # ``start_server(..., limit=_MAX_LINE_BYTES)`` makes
+                    # ``readline`` raise ``ValueError`` (wrapping
+                    # ``LimitOverrunError``) for a line past the limit, and the
+                    # raise happens HERE, outside the ``json.loads`` try below
+                    # that looks like it covers it. Uncaught it escaped the
+                    # ``ConnectionResetError``/``BrokenPipeError`` handler, the
+                    # reader loop died, and the ``finally`` dropped the
+                    # connection — so a client sending one large frame lost its
+                    # whole session and the operator had to ``lop --resume``.
+                    # A pasted screenshot over ~780 KB of source does it, which
+                    # is how this was found.
+                    #
+                    # CONTINUING IS SAFE HERE and is NOT the infinite loop the
+                    # sibling ``viewer_server`` guard warns about. The
+                    # difference is ``readline`` vs ``readuntil``: ``readuntil``
+                    # leaves the offending bytes in the buffer so the next read
+                    # re-raises forever, while ``readline`` catches its own
+                    # ``LimitOverrunError`` and DRAINS — deleting through the
+                    # separator when one was found and clearing the buffer when
+                    # it was not (CPython ``asyncio/streams.py``). So the next
+                    # read starts at the following frame, and the connection
+                    # survives to carry the user's NEXT message, which is the
+                    # behaviour the operator actually missed.
+                    #
+                    # LOUDLY, at error, but ONCE PER FRAME: the frame is gone
+                    # and whoever sent it is owed the reason. ``AttachClient``
+                    # now refits images before sending (``fit_request_frame``),
+                    # so a line reaching this point means an old client, a
+                    # non-attach peer, or a bug — each of which is worth one
+                    # greppable line rather than a vanished session.
+                    if overrun_bytes == 0:
+                        logger.error(
+                            "session runtime: dropping an inbound frame from %s client %s "
+                            "over the %d-byte line limit; the frame is discarded and the "
+                            "connection kept — the sender must resize its payload",
+                            conn.kind,
+                            conn.writer.get_extra_info("peername"),
+                            _MAX_LINE_BYTES,
+                        )
+                    overrun_bytes += _MAX_LINE_BYTES
+                    continue
+                if overrun_bytes:
+                    # The read that finally SUCCEEDS is the tail of the
+                    # oversized line (everything after the last discarded
+                    # chunk), never a frame of its own — so it is dropped by the
+                    # JSON guard below and the total is reported here, where the
+                    # size is finally known. Naming the total is what makes the
+                    # log actionable: "over 1 MiB" does not say whether to trim
+                    # one screenshot or five.
+                    logger.error(
+                        "session runtime: discarded ~%d bytes of oversized inbound frame "
+                        "from %s client %s; the connection is still up and the next "
+                        "message will be read normally",
+                        overrun_bytes + len(line),
+                        conn.kind,
+                        conn.writer.get_extra_info("peername"),
+                    )
+                    overrun_bytes = 0
                 if not line:
                     self._drop_client(conn, reason="reader eof")
                     return  # client hung up

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -1343,12 +1343,16 @@ class RuntimeServer:
                     # survives to carry the user's NEXT message, which is the
                     # behaviour the operator actually missed.
                     #
-                    # LOUDLY, at error, but ONCE PER FRAME: the frame is gone
-                    # and whoever sent it is owed the reason. ``AttachClient``
-                    # now refits images before sending (``fit_request_frame``),
-                    # so a line reaching this point means an old client, a
-                    # non-attach peer, or a bug — each of which is worth one
-                    # greppable line rather than a vanished session.
+                    # LOUDLY, at error: the frame is gone and whoever sent it
+                    # is owed the reason. ``AttachClient`` now refits images
+                    # before sending (``fit_request_frame``), so a line
+                    # reaching this point means an old client, a non-attach
+                    # peer, or a bug — each of which is worth one greppable
+                    # line rather than a vanished session. (How OFTEN it fires
+                    # is the next paragraph's subject — once per run of
+                    # consecutive discards, not once per frame; an earlier
+                    # version of this paragraph claimed the latter and was
+                    # wrong, review round 3, MINOR-2.)
                     #
                     # ONCE PER RUN of consecutive discards, not once per frame,
                     # and it names the limit rather than the size because it is

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -1350,13 +1350,34 @@ class RuntimeServer:
                     # non-attach peer, or a bug — each of which is worth one
                     # greppable line rather than a vanished session.
                     #
-                    # THIS line is the one that always fires, which is why it
-                    # names the limit rather than the size: a frame only
-                    # marginally over produces a single raise whose separator
-                    # lands inside the discarded chunk, so no read succeeds
-                    # until the peer sends something else and the summary below
-                    # may never come at all (QA round 1, Q2). The operator
-                    # learns a frame was dropped, and why, from this row alone.
+                    # ONCE PER RUN of consecutive discards, not once per frame,
+                    # and it names the limit rather than the size because it is
+                    # the row that arrives FIRST: a frame only marginally over
+                    # produces a single raise whose separator lands inside the
+                    # discarded chunk, so no read succeeds until the peer sends
+                    # something else and the summary below may not come for a
+                    # while (QA round 1, Q2). The operator learns a frame was
+                    # dropped, and why, from this row alone.
+                    #
+                    # BE PRECISE ABOUT THE GAP, because an earlier version of
+                    # this comment claimed the line "always fires" and it does
+                    # not. The gate is ``overrun_bytes``, which clears only on a
+                    # successful read, so an unbroken run of marginal frames
+                    # logs this row for the FIRST one and nothing for the rest
+                    # — measured at 4 marginal frames with no readable traffic
+                    # between: 1 row, 3 silent. A large frame self-clears the
+                    # latch through its own readable tail, which is why the run
+                    # looks unconditional in testing (QA round 2, Q4).
+                    #
+                    # Kept as a run-level latch rather than made per-frame: the
+                    # two cases are distinguishable only by the wording of
+                    # CPython's own ``LimitOverrunError`` ("Separator is found"
+                    # vs "is not found"), and pinning diagnostics to an
+                    # undocumented message string trades a quiet log for a
+                    # silent breakage on the next CPython. The frames are still
+                    # discarded and the session still survives on every one of
+                    # them — this is a diagnostic gap, not a delivery one — and
+                    # the byte total below still accounts for the whole run.
                     if overrun_bytes == 0:
                         logger.error(
                             "session runtime: dropping an inbound frame from %s client %s "

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3866,6 +3866,94 @@ class OperatorApp(App[None]):
             held for held in source.turn.pending_echoes if held is not entry
         ]
 
+    def _report_wire_refit_for(self, source: SessionInteraction) -> None:
+        """Say so when the transport had to COST the user pixels to send.
+
+        SILENT ON THE COMMON CASE, deliberately. The composer already bounds
+        every paste to ``IMAGE_INGEST_MAX_EDGE`` (1024px), so an ordinary
+        message meets the refit's first rung — a re-encode at unchanged
+        dimensions — and every pixel survives. Measured across both shapes an
+        operator pastes, one to six attachments are a codec swap and nothing
+        else: stack traces and identifiers are equally readable before and
+        after. A row on every paste would be pure noise on a routine gesture
+        (design round 1, D2).
+
+        THE DOWNSCALE RUNG IS DIFFERENT IN KIND. Once the ladder gives up
+        pixels the loss is not subtle — measured at ~40% edge energy at 768px,
+        enough that `1234553` reads as `1?34553`. A screenshot pasted BECAUSE
+        it contains a number, silently made to contain a different number, with
+        the model answering confidently about the wrong one, is the exact
+        failure the user cannot detect for themselves. So that rung, and only
+        that rung, gets a row.
+
+        IN THE VOCABULARY THE APP ALREADY OWNS: ``editor.RESIZED_MARK`` is the
+        ``↓`` the composer puts on a marker whose image was downscaled at
+        ingest, and its comment says it exists to answer "why is this not the
+        size I pasted?" — which is verbatim the question the wire refit
+        provokes. Reusing the glyph means one idiom for one fact rather than a
+        second convention for the same event two files apart.
+
+        At ``note`` weight, not ``warning``: nothing is wrong and nothing needs
+        acting on — the message was delivered — but it answers something the
+        user just did, which is exactly the role ``NoticeBlock`` documents for
+        that tier.
+        """
+        # Function-local for the reason the other `attach_client` references in
+        # this file give: the startup path must not import the transport.
+        from local_operator.mobile.attach_client import taken_refit_report
+        from local_operator.tui.widgets.editor import RESIZED_MARK
+
+        # CONSUMED whatever the outcome, so a report never outlives its send:
+        # reading it without taking it would let the next, untouched message
+        # inherit this one's caption.
+        lost = [entry for entry in taken_refit_report() if entry.downscaled]
+        if not lost:
+            return
+        detail = ", ".join(
+            f"#{entry.marker} {entry.source_width}x{entry.source_height} → "
+            f"{entry.width}x{entry.height}"
+            for entry in lost
+        )
+        plural = "s" if len(lost) != 1 else ""
+        self._notice_for(
+            source,
+            f"image{plural} resized to fit this message: {detail}{RESIZED_MARK}",
+            "note",
+        )
+
+    def _withdraw_user_echo_for(self, source: SessionInteraction) -> None:
+        """Take the painted prompt rows back off the transcript.
+
+        FOR A MESSAGE THAT WAS NEVER SENT, and only for that. The echo is
+        painted at submit so the app answers the keystroke immediately, which is
+        right for every path where the prompt does reach the session. A refused
+        send is the one path where it does not, and there the row is a durable
+        lie: identical styling to a delivered message — same rule, same weight,
+        same full-width thumbnail — so a scroll-back a week later cannot tell it
+        from a real turn. Worse after the user complies than before: they follow
+        the refusal's advice, resend, and the transcript now shows the message
+        twice with an attachment that never left the machine (design round 1,
+        D3).
+
+        REMOVED rather than dimmed or struck through. The draft is back in the
+        composer by the time this runs and is about to be echoed again by the
+        resend, so a marked-up copy would leave the user reading two rows for
+        one message and deciding which is real. The same reasoning
+        ``_recall_queued_steers`` gives for lifting a recalled steer's rows, and
+        the removal is the same call it makes.
+
+        Only touches the CURRENT view's transcript, because that is the only
+        one holding widgets: a background source's rows were never mounted, and
+        its restored draft is carried by ``source.unsent`` instead.
+        """
+        held, source.turn.submitted_blocks = source.turn.submitted_blocks, None
+        if held is None or not self._is_current(source):
+            return
+        user_block, image_blocks = held
+        transcript = self._transcript_view()
+        for block in (*image_blocks, user_block):
+            transcript.remove_block(block)
+
     def _post_turn_abandoned_for(
         self,
         source: SessionInteraction,
@@ -17881,6 +17969,12 @@ class OperatorApp(App[None]):
             self._append_block(NoticeBlock("queued — sends when compaction finishes", "note"))
             self._maybe_name_conversation(named)
             return
+        # HELD ACROSS THE DISPATCH so a refusal can take the echo back down.
+        # Set before `_start_turn` rather than after: the worker it starts can
+        # reach its `except` before this line would otherwise run, and an echo
+        # the worker cannot see is one it cannot withdraw. Cleared by the
+        # worker's `finally` on every path (see `_start_turn_for`).
+        self._interaction.turn.submitted_blocks = (user_block, image_blocks)
         echo = self._start_turn(sent, images)
         if isinstance(echo, _PendingUserEcho):
             user_block.navigation_anchor_id = echo.message_id
@@ -17962,6 +18056,10 @@ class OperatorApp(App[None]):
             try:
                 async with source.turn.provider_lock:
                     await session.prompt(text, images, **echo.prompt_kwargs())
+                # DELIVERED — so if the transport had to shrink an attachment to
+                # get it here, this is the moment the user can be told. See
+                # `_report_wire_refit_for`.
+                self._report_wire_refit_for(source)
             except asyncio.CancelledError:
                 # NOT OPTIONAL, and not covered by the clause below:
                 # `CancelledError` is a `BaseException`, so it slides straight
@@ -18006,10 +18104,31 @@ class OperatorApp(App[None]):
                     #
                     # So the draft goes back the same way a dead runtime returns
                     # it, and the error's own sentence is the notice — it
-                    # already names the size, the limit, and which attachment to
-                    # drop, which is what makes the refusal actionable.
+                    # already names the size, the ceiling that applied, and
+                    # which attachment to drop, which is what makes the refusal
+                    # actionable.
+                    #
+                    # AND THE ECHO COMES DOWN WITH IT, before anything is said,
+                    # so the refusal is not printed under a prompt row the
+                    # transcript is about to retract.
+                    self._withdraw_user_echo_for(source)
+                    self._notice_for(
+                        source,
+                        # The neighbouring runtime-stopped notice tells the user
+                        # their text survived and this one did not, so the user
+                        # was told to act without being told they still had
+                        # anything to act with (design round 1, D7).
+                        f"{error} — your message is back in the composer",
+                        "warning",
+                    )
+                    # AFTER the explanation. `_restore_unsent_for` can append a
+                    # `DraftRecoveryNotice`, and appending it first put the
+                    # offer to restore ABOVE the reason anything needs restoring
+                    # — the transcript read effect-then-cause (design round 1,
+                    # D5). On the common branch it loads the composer directly
+                    # and appends nothing, so this only reorders the case that
+                    # has two rows to order.
                     self._restore_unsent_for(source, text, images, accepted=accepted)
-                    self._notice_for(source, str(error), "warning")
                 elif _is_runtime_gone(error):
                     # THE RUNTIME DIED UNDER US (crash, OOM, kill -9). What
                     # the user got was `✗ owner socket unreachable: [Errno 61]
@@ -18050,6 +18169,12 @@ class OperatorApp(App[None]):
             finally:
                 if source.turn.submitted_draft is accepted:
                     source.turn.submitted_draft = None
+                # The echo is only withdrawable while the send's outcome is
+                # unknown. Past this point the prompt was either delivered (the
+                # row is true and permanent) or already withdrawn above, and a
+                # stale reference would let a LATER refusal remove the rows of
+                # an earlier, successfully delivered message.
+                source.turn.submitted_blocks = None
                 source.active_workers -= 1
                 self.call_later(self._source_frontend_changed, source)
                 # THE TWO-MECHANISM HAZARD, and why these two lines belong

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3731,12 +3731,21 @@ class OperatorApp(App[None]):
         held, source.compaction.held_prompt = source.compaction.held_prompt, ""
         typed, source.compaction.held_typed = source.compaction.held_typed, ""
         images, source.compaction.held_images = source.compaction.held_images, {}
+        blocks, source.compaction.held_blocks = source.compaction.held_blocks, None
         accepted, source.compaction.accepted_draft = source.compaction.accepted_draft, None
         message_id, source.compaction.accepted_message_id = (
             source.compaction.accepted_message_id,
             "",
         )
         if held or images:
+            # HANDED TO THE TURN, so the rows this prompt painted at submit are
+            # withdrawable by the worker that dispatches it. Set BEFORE
+            # `_start_turn_for` for the reason the direct path gives: the worker
+            # it starts can reach its `except` before a later line would run,
+            # and an echo the worker cannot see is one it cannot withdraw. The
+            # worker's `finally` clears it on every path (review round 2,
+            # MAJOR-3).
+            source.turn.submitted_blocks = blocks
             self._start_turn_for(
                 source,
                 held,
@@ -3872,11 +3881,14 @@ class OperatorApp(App[None]):
         SILENT ON THE COMMON CASE, deliberately. The composer already bounds
         every paste to ``IMAGE_INGEST_MAX_EDGE`` (1024px), so an ordinary
         message meets the refit's first rung — a re-encode at unchanged
-        dimensions — and every pixel survives. Measured across both shapes an
-        operator pastes, one to six attachments are a codec swap and nothing
-        else: stack traces and identifiers are equally readable before and
-        after. A row on every paste would be pure noise on a routine gesture
-        (design round 1, D2).
+        dimensions — and every pixel survives. Measured on composer-bounded
+        continuous-tone captures, **one and two** attachments are a codec swap
+        and nothing else; at three the ladder already gives up pixels. (An
+        earlier version of this note claimed one to six, which overstated the
+        rung's reach — design round 2 measured it, and it is what makes the row
+        below reachable often enough to be worth one line rather than five.) A
+        row on every paste would be pure noise on a routine gesture (design
+        round 1, D2).
 
         THE DOWNSCALE RUNG IS DIFFERENT IN KIND. Once the ladder gives up
         pixels the loss is not subtle — measured at ~40% edge energy at 768px,
@@ -3892,6 +3904,34 @@ class OperatorApp(App[None]):
         size I pasted?" — which is verbatim the question the wire refit
         provokes. Reusing the glyph means one idiom for one fact rather than a
         second convention for the same event two files apart.
+
+        ONE ROW, GROUPED BY DELIVERED SIZE, and that shape is the finding
+        rather than a preference. Enumerating a clause per image spent 220
+        characters on two facts — six of eight clauses were the identical
+        string — and cost 3 rows of 28 at 100x30 and **5 of 20 at 60x22**, a
+        quarter of a narrow user's scrollback for a note about a message that
+        was delivered fine. Worse, the clauses came out in ``_refit_images``'
+        internal smallest-first walk (``#4, #2, #7, #3 …``): deterministic, and
+        meaningless on screen, so a user scanning for "what happened to #1"
+        read six clauses before finding it (design round 2, D9).
+
+        THE GLYPH BINDS TO THE COUNT, not to a trailing clause. Appended once
+        after the last clause it read as the mark on that image and said
+        nothing about the others, while the chips in the composer already carry
+        their own ``↓`` from the ingest bound — so two different shrinks shared
+        one glyph and neither was adjacent to what it qualified (design round
+        2, D10). Here it sits on ``N images``, which is exactly what it is
+        claiming: these lost pixels.
+
+        COUNTS RATHER THAN MARKERS, which is what makes the row a fixed cost.
+        Naming the chips reads better at eight attachments and grows without
+        bound past it — measured, a marker list is 3 rows at 100 cols and 4 at
+        60 by 28 attachments, which is the same defect one step smaller. The
+        number of distinct delivered sizes is bounded by the ladder's rungs
+        (``IMAGE_WIRE_REFIT_EDGES``), so the count form is one row at 100 cols
+        and two at 60 for ANY number of attachments. The chips themselves are
+        on screen directly above this row, so "which of mine" is answerable by
+        looking; "how much did I lose" is not, and that is what this says.
 
         At ``note`` weight, not ``warning``: nothing is wrong and nothing needs
         acting on — the message was delivered — but it answers something the
@@ -3909,15 +3949,19 @@ class OperatorApp(App[None]):
         lost = [entry for entry in taken_refit_report() if entry.downscaled]
         if not lost:
             return
-        detail = ", ".join(
-            f"#{entry.marker} {entry.source_width}x{entry.source_height} → "
-            f"{entry.width}x{entry.height}"
-            for entry in lost
-        )
+        # BY DELIVERED SIZE, in the order the user's own chips run: sorting by
+        # marker first means a group appears at the position of its lowest chip
+        # number, so the row reads the way the composer does rather than in
+        # `_refit_images`' internal smallest-first walk (design round 2, D9).
+        grouped: dict[tuple[int, int], int] = {}
+        for entry in sorted(lost, key=lambda item: item.marker):
+            grouped[(entry.width, entry.height)] = grouped.get((entry.width, entry.height), 0) + 1
+        clauses = [f"{count} to {width}x{height}" for (width, height), count in grouped.items()]
         plural = "s" if len(lost) != 1 else ""
         self._notice_for(
             source,
-            f"image{plural} resized to fit this message: {detail}{RESIZED_MARK}",
+            f"{len(lost)} image{plural}{RESIZED_MARK} resized to fit this message: "
+            + ", ".join(clauses),
             "note",
         )
 
@@ -8406,6 +8450,11 @@ class OperatorApp(App[None]):
         held, self._prompt_held_for_compaction = self._prompt_held_for_compaction, ""
         typed, self._typed_held_for_compaction = self._typed_held_for_compaction, ""
         held_images, self._images_held_for_compaction = self._images_held_for_compaction, {}
+        # DROPPED, never dispatched: this is the hand-back, and `clear_blocks()`
+        # below removes the very rows the tuple points at. Carrying it past here
+        # would leave a later refusal holding widgets that are no longer mounted
+        # (review round 2, MAJOR-3).
+        self._interaction.compaction.held_blocks = None
         if held:
             # The TYPED line goes back, not the payload: handing a user the
             # expanded body of a `$skill` they invoked would make them delete a
@@ -17945,6 +17994,14 @@ class OperatorApp(App[None]):
             # minutes and then sent the words without the screenshot would be
             # worse than not queueing at all.
             self._prompt_held_for_compaction = sent
+            # THE ECHO RIDES THE HOLD, for the same reason the attachments do:
+            # this prompt is dispatched by `_consume_compaction_input` minutes
+            # later, through the same worker and the same
+            # `except OversizedRequest` a direct submit uses. Without the rows
+            # travelling with it, a refusal on this route had nothing to
+            # withdraw and left the transcript asserting a message that never
+            # went (review round 2, MAJOR-3).
+            self._interaction.compaction.held_blocks = (user_block, image_blocks)
             self._interaction.compaction.accepted_draft = self._interaction.turn.submitted_draft
             self._interaction.compaction.accepted_message_id = self._echo_message_id(session.prompt)
             user_block.navigation_anchor_id = self._interaction.compaction.accepted_message_id

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3732,11 +3732,20 @@ class OperatorApp(App[None]):
         typed, source.compaction.held_typed = source.compaction.held_typed, ""
         images, source.compaction.held_images = source.compaction.held_images, {}
         blocks, source.compaction.held_blocks = source.compaction.held_blocks, None
+        notice, source.compaction.held_notice = source.compaction.held_notice, None
         accepted, source.compaction.accepted_draft = source.compaction.accepted_draft, None
         message_id, source.compaction.accepted_message_id = (
             source.compaction.accepted_message_id,
             "",
         )
+        # BEFORE the turn paints, so the queue's own row is gone by the time
+        # the prompt's echo appears under it — the notice narrates the hold,
+        # and the hold ends here (design round 3, D15). Same current-view
+        # guard as `_withdraw_user_echo_for`: a background source's notice
+        # lives in a view this app can no longer reach, and its teardown is
+        # the view's own business.
+        if notice is not None and self._is_current(source):
+            self._transcript_view().remove_block(notice)
         if held or images:
             # HANDED TO THE TURN, so the rows this prompt painted at submit are
             # withdrawable by the worker that dispatches it. Set BEFORE
@@ -3881,14 +3890,18 @@ class OperatorApp(App[None]):
         SILENT ON THE COMMON CASE, deliberately. The composer already bounds
         every paste to ``IMAGE_INGEST_MAX_EDGE`` (1024px), so an ordinary
         message meets the refit's first rung — a re-encode at unchanged
-        dimensions — and every pixel survives. Measured on composer-bounded
-        continuous-tone captures, **one and two** attachments are a codec swap
-        and nothing else; at three the ladder already gives up pixels. (An
-        earlier version of this note claimed one to six, which overstated the
-        rung's reach — design round 2 measured it, and it is what makes the row
-        below reachable often enough to be worth one line rather than five.) A
-        row on every paste would be pure noise on a routine gesture (design
-        round 1, D2).
+        dimensions — and every pixel survives. How far past that the silence
+        holds depends on CONTENT and SHAPE, not on a count: measured on
+        composer-bounded continuous-tone captures, a 16:9 retina screenshot
+        stays a codec swap through five attachments, a 4:3 capture through
+        four and a square through three, so the common one-or-two-image paste
+        is silent and the row below is reachable from six mixed screenshots
+        on. Silence is a predicate on ``downscaled``, never on a count, so
+        this cannot mislead — but a count in this note would. (Earlier
+        versions claimed "one to six", then "one and two"; both were
+        square-fixture artifacts — design round 2 and round 3, D16.) A row on
+        every paste would be pure noise on a routine gesture (design round 1,
+        D2).
 
         THE DOWNSCALE RUNG IS DIFFERENT IN KIND. Once the ladder gives up
         pixels the loss is not subtle — measured at ~40% edge energy at 768px,
@@ -3915,23 +3928,53 @@ class OperatorApp(App[None]):
         meaningless on screen, so a user scanning for "what happened to #1"
         read six clauses before finding it (design round 2, D9).
 
-        THE GLYPH BINDS TO THE COUNT, not to a trailing clause. Appended once
-        after the last clause it read as the mark on that image and said
-        nothing about the others, while the chips in the composer already carry
-        their own ``↓`` from the ingest bound — so two different shrinks shared
-        one glyph and neither was adjacent to what it qualified (design round
-        2, D10). Here it sits on ``N images``, which is exactly what it is
-        claiming: these lost pixels.
+        NO GLYPH ON THIS ROW AT ALL (design round 3, D14; round 2's D10 had
+        bound it to the count). The chips carry their own ``↓`` for the INGEST
+        bound, and this row's ``↓`` named the TRANSPORT refit — two different
+        shrinks sharing one glyph, and on a partial refit they collided a row
+        apart: five chips marked ``↓`` by ingest while the caption read
+        ``2 images ↓ resized`` about the two the transport touched, with
+        nothing on screen to say which count was which. ``resized to fit``
+        does the work the glyph was doing, and the mark stays where it is
+        unambiguous — on the chips, next to the size it qualifies.
 
-        COUNTS RATHER THAN MARKERS, which is what makes the row a fixed cost.
-        Naming the chips reads better at eight attachments and grows without
-        bound past it — measured, a marker list is 3 rows at 100 cols and 4 at
-        60 by 28 attachments, which is the same defect one step smaller. The
-        number of distinct delivered sizes is bounded by the ladder's rungs
-        (``IMAGE_WIRE_REFIT_EDGES``), so the count form is one row at 100 cols
-        and two at 60 for ANY number of attachments. The chips themselves are
-        on screen directly above this row, so "which of mine" is answerable by
-        looking; "how much did I lose" is not, and that is what this says.
+        COUNTS RATHER THAN MARKERS, which is what makes the row a bounded
+        cost. Naming the chips reads better at eight attachments and grows
+        without bound past it — measured, a marker list is 3 rows at 100 cols
+        and 4 at 60 by 28 attachments, which is the same defect one step
+        smaller.
+
+        THE BOUND IS RUNGS x ASPECT RATIOS, not rungs alone, and an earlier
+        version of this note claimed the latter. A rung caps the LONG edge and
+        the refit preserves aspect ratio, so grouping on the exact delivered
+        ``WxH`` splits once per distinct SHAPE in the paste — and an
+        operator's paste is 16:9 windows, 9:19.5 phone shots, square crops
+        and 3:2 captures at once. The test that pinned the false claim built
+        every fixture as a square, so ``(w, h)`` collapsed onto the rung count
+        by construction and passed vacuously (review round 3, MAJOR-5).
+
+        Measured through the real fitter over a five-aspect composer-bounded
+        paste, n=10 to 30: **4-9 clauses, 97-168 characters, 1-2 rows at 100
+        cols and 2-3 at 60**. The count does not trend upward with n — it
+        moves within that envelope (8 clauses at 24, 7 at 28, 8 at 30) because
+        which rung each shape lands on depends on the per-image budget, not on
+        how many attachments there are. The round-3 reviewer's twelve-aspect
+        mix measured the same class: 9 clauses, 165 characters, 2 rows at 100
+        and 4 at 60. Against the marker list's 28 clauses at n=28, that is the
+        difference between a bounded note and one that eats the scrollback.
+
+        THE COMMON PASTE IS NARROWER STILL: a run of same-shape screenshots
+        reaches one clause per rung, so 1 row at 100 cols and 2 at 60 at any
+        count — QA round 3 measured it holding to 300 attachments. That is
+        because a composer-bounded paste can never be downscaled TO the 1024
+        rung (the ingest bound already applied), leaving only the three below
+        it in ``IMAGE_WIRE_REFIT_EDGES``. The dependency is named here rather
+        than left implicit: raise ``IMAGE_INGEST_MAX_EDGE`` and the reachable
+        rung count rises with it (QA round 3, Q2).
+
+        The chips themselves are on screen directly above this row, so "which
+        of mine" is answerable by looking; "how much did I lose" is not, and
+        that is what this says.
 
         At ``note`` weight, not ``warning``: nothing is wrong and nothing needs
         acting on — the message was delivered — but it answers something the
@@ -3941,7 +3984,6 @@ class OperatorApp(App[None]):
         # Function-local for the reason the other `attach_client` references in
         # this file give: the startup path must not import the transport.
         from local_operator.mobile.attach_client import taken_refit_report
-        from local_operator.tui.widgets.editor import RESIZED_MARK
 
         # CONSUMED whatever the outcome, so a report never outlives its send:
         # reading it without taking it would let the next, untouched message
@@ -3956,12 +3998,17 @@ class OperatorApp(App[None]):
         grouped: dict[tuple[int, int], int] = {}
         for entry in sorted(lost, key=lambda item: item.marker):
             grouped[(entry.width, entry.height)] = grouped.get((entry.width, entry.height), 0) + 1
-        clauses = [f"{count} to {width}x{height}" for (width, height), count in grouped.items()]
+        # "down" on the FIRST clause only, carrying the verb the count needs
+        # now that the glyph is gone (design round 3, D14); the ellipsis on
+        # the rest is how English reads a list of parallel clauses.
+        clauses = [
+            f"{count} {'down ' if not index else ''}to {width}x{height}"
+            for index, ((width, height), count) in enumerate(grouped.items())
+        ]
         plural = "s" if len(lost) != 1 else ""
         self._notice_for(
             source,
-            f"{len(lost)} image{plural}{RESIZED_MARK} resized to fit this message: "
-            + ", ".join(clauses),
+            f"{len(lost)} image{plural} resized to fit this message: " + ", ".join(clauses),
             "note",
         )
 
@@ -8453,8 +8500,11 @@ class OperatorApp(App[None]):
         # DROPPED, never dispatched: this is the hand-back, and `clear_blocks()`
         # below removes the very rows the tuple points at. Carrying it past here
         # would leave a later refusal holding widgets that are no longer mounted
-        # (review round 2, MAJOR-3).
+        # (review round 2, MAJOR-3). The held notice is dropped for the same
+        # reason — reference only, no removal: `clear_blocks()` takes the row
+        # with the whole view (design round 3, D15).
         self._interaction.compaction.held_blocks = None
+        self._interaction.compaction.held_notice = None
         if held:
             # The TYPED line goes back, not the payload: handing a user the
             # expanded body of a `$skill` they invoked would make them delete a
@@ -18023,7 +18073,14 @@ class OperatorApp(App[None]):
             # so re-reading it here saw an empty map and queued the prompt
             # without its screenshot (review round 19).
             self._images_held_for_compaction = dict(attachments or {})
-            self._append_block(NoticeBlock("queued — sends when compaction finishes", "note"))
+            # The queued NOTICE travels with the hold for the same reason the
+            # blocks do: its message ("sends when compaction finishes") is only
+            # true while the hold has the prompt, so the dispatch that ends the
+            # hold also ends the notice — see `CompactionInteraction.held_notice`
+            # (design round 3, D15).
+            queued_notice = NoticeBlock("queued — sends when compaction finishes", "note")
+            self._append_block(queued_notice)
+            self._interaction.compaction.held_notice = queued_notice
             self._maybe_name_conversation(named)
             return
         # HELD ACROSS THE DISPATCH so a refusal can take the echo back down.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -17974,6 +17974,11 @@ class OperatorApp(App[None]):
                 aborted = True
                 raise
             except Exception as error:  # surface, never crash the app
+                # Lazy, matching the other two references to this module here:
+                # `attach_client` is imported on the owned-resume branch only,
+                # and the startup path stays light.
+                from local_operator.mobile.attach_client import OversizedRequest
+
                 error_text = str(error)
                 # A message typed into a STOPPED viewer gets the same sentence
                 # the owner's own path gives, not the facade's bare clause:
@@ -17987,6 +17992,24 @@ class OperatorApp(App[None]):
                 ):
                     text_line, kind = self._no_session_notice(unsent=True)
                     self._notice_for(source, text_line, kind)
+                elif isinstance(error, OversizedRequest):
+                    # THE MESSAGE WAS NEVER SENT, and that is the whole reason
+                    # this branch exists rather than falling through to the
+                    # bare-error one below. `OversizedRequest` is raised
+                    # INSTEAD of the socket write (see `fit_request_frame`), so
+                    # unlike every other failure here the composer's content is
+                    # not merely un-answered — it is un-delivered, and the only
+                    # copy of it is the one this worker is holding. Printing the
+                    # error alone would leave the user with a refusal notice and
+                    # no text and no attachment: their work, gone, for a
+                    # transport limit they cannot see.
+                    #
+                    # So the draft goes back the same way a dead runtime returns
+                    # it, and the error's own sentence is the notice — it
+                    # already names the size, the limit, and which attachment to
+                    # drop, which is what makes the refusal actionable.
+                    self._restore_unsent_for(source, text, images, accepted=accepted)
+                    self._notice_for(source, str(error), "warning")
                 elif _is_runtime_gone(error):
                     # THE RUNTIME DIED UNDER US (crash, OOM, kill -9). What
                     # the user got was `✗ owner socket unreachable: [Errno 61]

--- a/local_operator/tui/session_interaction.py
+++ b/local_operator/tui/session_interaction.py
@@ -29,6 +29,19 @@ class TurnInteraction:
     accrued_cost: float = 0.0
     pending_echoes: list[Any] = field(default_factory=list)
     submitted_draft: SessionDraft | None = None
+    #: The transcript rows this surface painted for the prompt currently in
+    #: flight — ``(UserBlock, [ImageBlock, ...])`` — held only until the turn
+    #: is admitted or refused.
+    #:
+    #: The echo is painted at SUBMIT, before the worker runs, because a prompt
+    #: that appears the instant Enter is pressed is what makes the app feel
+    #: answerable. When the send is then REFUSED the row is a lie that outlives
+    #: the failure: styled exactly like a delivered message, and still there
+    #: after the user follows the refusal's advice and resends, so the
+    #: transcript shows the message twice and asserts an image was sent that
+    #: never left the machine (design round 1, D3). Holding the blocks is what
+    #: lets that echo be withdrawn; ``_withdraw_user_echo_for`` is the consumer.
+    submitted_blocks: tuple[Any, list[Any]] | None = None
     completion_deferred: bool = False
     settled_child_ids: set[str] = field(default_factory=set)
     waiting_kind: str | None = None

--- a/local_operator/tui/session_interaction.py
+++ b/local_operator/tui/session_interaction.py
@@ -91,6 +91,26 @@ class CompactionInteraction:
     #: to torn-down rows behind on the hand-back, which is the stale-reference
     #: hazard ``run_prompt``'s ``finally`` exists to prevent.
     held_blocks: tuple[Any, list[Any]] | None = None
+    #: The ``queued — sends when compaction finishes`` notice painted when the
+    #: hold took the prompt. Held for the same reason ``held_blocks`` is: the
+    #: notice narrates the QUEUE, and the hold's dispatch exit ends that queue
+    #: — by then the prompt's own echo is painted right under where the notice
+    #: sits, so a row announcing a send that is visibly happening (or, on a
+    #: refusal, a send that will never happen) narrates nothing. Without the
+    #: reference the notice had no owner and outlived both exits (design round
+    #: 3, D15).
+    #:
+    #: Withdrawn at DISPATCH rather than at the refusal's withdrawal: the
+    #: dispatch is the earlier of the two and the notice is wrong from that
+    #: moment on whichever path follows, so one removal point covers both. The
+    #: hand-back clears the reference without removing the block — its
+    #: ``clear_blocks()`` tears the whole view down anyway. (The queued-STEER
+    #: notices are restated to a past-tense receipt instead of removed; that is
+    #: right for them because a steer paints no row of its own and the restated
+    #: notice is its only receipt. A held prompt paints its own ``UserBlock``,
+    #: so the message itself is the receipt and the queued row has nothing
+    #: left to say on either path.)
+    held_notice: Any = None
     accepted_message_id: str = ""
     accepted_draft: SessionDraft | None = None
 

--- a/local_operator/tui/session_interaction.py
+++ b/local_operator/tui/session_interaction.py
@@ -73,6 +73,24 @@ class CompactionInteraction:
     held_prompt: str = ""
     held_typed: str = ""
     held_images: dict[int, Any] = field(default_factory=dict)
+    #: The transcript rows painted for a prompt HELD through a compaction —
+    #: the same ``(UserBlock, [ImageBlock, ...])`` tuple ``turn.submitted_blocks``
+    #: carries, parked here for the minutes a pass can take.
+    #:
+    #: A held prompt is dispatched long after the submit that painted it, and
+    #: it can be refused exactly like a direct one. Without this the echo was
+    #: unreachable on that route: ``submitted_blocks`` was set only past the
+    #: compaction branch's ``return``, so the withdrawal found ``None`` and
+    #: D3's symptom survived — ``UserBlocks: 2`` with a phantom attachment
+    #: after the user follows the refusal's advice (review round 2, MAJOR-3).
+    #:
+    #: Held ALONGSIDE the text rather than assigned to ``turn.submitted_blocks``
+    #: at submit, for the reason the other held fields give: the hold's two
+    #: exits are dispatch and hand-back, and both already clear this state in
+    #: one tuple swap. Parking it on the turn instead would leave a reference
+    #: to torn-down rows behind on the hand-back, which is the stale-reference
+    #: hazard ``run_prompt``'s ``finally`` exists to prevent.
+    held_blocks: tuple[Any, list[Any]] | None = None
     accepted_message_id: str = ""
     accepted_draft: SessionDraft | None = None
 

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -143,7 +143,40 @@ class OlderHistoryNotice(NoticeBlock, can_focus=True):
 
 
 class DraftRecoveryNotice(NoticeBlock, can_focus=True):
+    """The offer to put an undelivered draft back in the composer.
+
+    Reached when the composer is NOT empty at the moment a send fails — the
+    common case for a refusal, whose refit runs ~315 ms on a thread, long
+    enough for the user to have started their next thought. The draft parks in
+    ``source.unsent`` and this row is how it comes back.
+
+    The label has three jobs the bare ``Restore unsent prompt`` did none of
+    (design round 1, D5):
+
+    **It says WHICH prompt.** One row reading the same words whatever it holds
+    cannot be told from another, and the user has no way to know whether the
+    thing on offer is the message they care about or carries their attachment.
+    So the opening words of the draft and its attachment count ride the label.
+
+    **It says it is INTERACTIVE.** The row is focusable with ``enter`` and
+    click bindings, but nothing in the pixels said press or click, so the
+    affordance existed only for a user who tried it. The key is named in the
+    label, which is the same way the app tells the user about every other
+    non-obvious key.
+
+    **It is ``note``, not ``warning``.** It rendered in the same amber as the
+    refusal directly beneath it, so two rows of identical ink said two
+    different kinds of thing — a state to recover from, and a failure to act
+    on. ``note`` is the tier ``NoticeBlock`` documents for "the answer to
+    something the user just did", which is exactly what an offer to restore is.
+    """
+
     BINDINGS = [Binding("enter", "restore", "Restore unsent prompt", show=False)]
+
+    #: Characters of the draft quoted in the label. Long enough to tell two
+    #: drafts apart, short enough that the row stays one line beside the
+    #: attachment clause and the key hint at ordinary widths.
+    _PREVIEW_CHARS = 32
 
     class Requested(Message):
         def __init__(self, notice: DraftRecoveryNotice) -> None:
@@ -151,10 +184,40 @@ class DraftRecoveryNotice(NoticeBlock, can_focus=True):
             self.notice = notice
 
     def __init__(self, source_token: str, draft: SessionDraft) -> None:
-        super().__init__("Restore unsent prompt", "warning")
+        super().__init__(self._label_for(draft), "note")
         self.source_token = source_token
         self.draft = draft
         self.add_class("interactive-notice")
+
+    @staticmethod
+    def _label_for(draft: SessionDraft) -> str:
+        """``↩ restore unsent prompt "…" (1 image) — enter``.
+
+        The glyph is the one the row's action means (put this back), and it
+        leads because the row is an OFFER rather than a report. Degrades
+        cleanly: a draft with no text quotes nothing, one with no attachments
+        says nothing about them, and the key hint is always present because it
+        is the part the user cannot discover any other way.
+        """
+        from local_operator.tui.widgets.editor import ATTACHMENT_MARKER
+
+        parts = ["↩ restore unsent prompt"]
+        # One line of it, whitespace collapsed: a multi-line draft would
+        # otherwise put its second line into this row's own wrap. Attachment
+        # markers come out first — the restored draft carries an `[Image #1]`
+        # citation for every attachment, and quoting them here would spend the
+        # preview's whole budget restating what the count clause says next.
+        preview = " ".join(ATTACHMENT_MARKER.sub("", draft.text).split())
+        if preview:
+            if len(preview) > DraftRecoveryNotice._PREVIEW_CHARS:
+                preview = preview[: DraftRecoveryNotice._PREVIEW_CHARS - 1].rstrip() + "…"
+            parts.append(f'"{preview}"')
+        images = sum(
+            1 for attachment in draft.attachments.values() if getattr(attachment, "image", None)
+        )
+        if images:
+            parts.append(f"({images} image{'s' if images != 1 else ''})")
+        return " ".join(parts) + " — enter"
 
     def action_restore(self) -> None:
         self.post_message(self.Requested(self))

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -959,14 +959,27 @@ def resolve_markers(text: str, attachments: Mapping[int, Marked]) -> list[ImageC
     itself. Filtered on the PAYLOAD TYPE rather than on the marker's ``kind``,
     so this stays one predicate - a map entry either holds an image or it does
     not, whatever its marker happens to read.
+
+    THE MARKER NUMBER RIDES THE IMAGE from here, because this is the one walk
+    that still knows it: past this point an image is a positional entry in a
+    list and the chip it came from is unrecoverable. The transport needs it to
+    name the right attachment when it has to refuse one - markers do not
+    renumber on delete, so wire position 2 can be the chip labelled `#3`
+    (design round 1 D4, round 2 D8). Stamped on a COPY: the map's own
+    `ImageContent` is shared with the chip, the aside stash and the compaction
+    hold, and mutating it here would write presentation state into objects
+    those round trips compare.
     """
     cited = [
-        (span[0], attachment.image)
+        (span[0], index, attachment.image)
         for index, attachment in attachments.items()
         if isinstance(attachment, Attachment)
         and (span := cite(text, index, attachment)) is not None
     ]
-    return [image for _, image in sorted(cited, key=lambda item: item[0])]
+    return [
+        image.model_copy(update={"marker": index})
+        for _, index, image in sorted(cited, key=lambda item: item[0])
+    ]
 
 
 def expand_pastes(text: str, attachments: Mapping[int, Marked]) -> str:

--- a/scripts/oversized_frame_shot.py
+++ b/scripts/oversized_frame_shot.py
@@ -29,7 +29,10 @@ import asyncio  # noqa: E402
 
 import scripts.probe_isolation  # noqa: F401,E402  -- must precede app imports
 from local_operator.harness.types import ImageContent  # noqa: E402
-from local_operator.mobile.attach_client import OversizedRequest  # noqa: E402
+from local_operator.mobile.attach_client import (  # noqa: E402
+    OversizedRequest,
+    fit_request_frame,
+)
 from local_operator.tui.app import OperatorApp  # noqa: E402
 from scripts.visual_capture import save_capture  # noqa: E402
 from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
@@ -44,12 +47,50 @@ def _delivered(session: FakeSession):
     return prompt
 
 
-def _png(width: int, height: int) -> str:
+def _photo(width: int, height: int, seed: int = 0) -> str:
+    """A base64 PNG of CONTINUOUS-TONE content, for the states about the REFIT.
+
+    The content decides whether this script tests anything. Line art and flat
+    fills compress to almost nothing, so a fixture built from them sails under
+    the limit and the refit never runs — a 64-attachment fixture of the drawn
+    raster below still refitted successfully, which would have captured a
+    delivered message while claiming to show a refusal. Blurred noise behaves
+    the way a photograph or screenshot does, which is the same reason
+    ``tests/unit/session/test_attach_frame_size.py`` builds its fixtures this
+    way.
+
+    ``seed`` makes attachments genuinely distinct: identical bytes compress to
+    identical sizes and the refit walks smallest first, so a fixture of eight
+    copies exercises a tie rather than the ordering the caption renders
+    (design round 2, D9).
+    """
+    import base64
+    import io
+    import random
+
+    from PIL import Image, ImageFilter
+
+    rng = random.Random(seed or width * height)
+    coarse = Image.frombytes(
+        "RGB",
+        (width // 4, height // 4),
+        bytes(rng.getrandbits(8) for _ in range((width // 4) * (height // 4) * 3)),
+    )
+    smooth = coarse.resize((width, height), Image.Resampling.BILINEAR)
+    image = smooth.filter(ImageFilter.GaussianBlur(1.2))
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return base64.b64encode(buffer.getvalue()).decode("ascii")
+
+
+def _png(width: int, height: int, seed: int = 11) -> str:
     """A base64 PNG the transcript can actually decode and paint.
 
     A real raster rather than a stub: ``ImageBlock`` sniffs the header for its
     aspect fit and paints a receipt instead of pixels when the bytes do not
-    decode, which would capture the wrong frame.
+    decode, which would capture the wrong frame. Cheap and legible on screen,
+    which is what the NON-refit states need; anything asserting on the refit
+    uses :func:`_photo` instead.
     """
     import base64
     import io
@@ -59,7 +100,7 @@ def _png(width: int, height: int) -> str:
 
     image = Image.new("RGB", (width, height), (24, 26, 32))
     draw = ImageDraw.Draw(image)
-    random.seed(11)
+    random.seed(seed)
     for row in range(8, height - 10, 16):
         x = 10
         while x < width - 40:
@@ -71,10 +112,49 @@ def _png(width: int, height: int) -> str:
     return base64.b64encode(buffer.getvalue()).decode("ascii")
 
 
-REFUSAL = (
-    "image 3 is 2.4 MB and will not fit in this message's 0.2 MB per-image "
-    "budget (4 attachments) even at its smallest size; remove it and send again"
-)
+#: How many attachments it takes to make the refit genuinely give up.
+#:
+#: NOT A DECORATIVE NUMBER, and it moved once already: at round 1 twenty
+#: attachments could not fit, and the smallest-first reclaim (review round 1,
+#: MINOR-2) raised capacity enough that the same fixture now REFITS and sends.
+#: A capture harness reusing the old figure would photograph a delivered
+#: message while claiming to show a refusal, so `_real_refusal` asserts the
+#: refusal actually happened rather than trusting this constant (QA round 2).
+REFUSAL_ATTACHMENTS = 32
+
+
+async def _real_refusal(images: list[ImageContent]) -> str:
+    """The refusal sentence the PRODUCT composes for ``images``, or raise.
+
+    Why this exists at all: the script used to carry the sentence as a string
+    literal, so the frames proved the layout of a row and nothing about the
+    words the code generates. Three design round-2 findings (D8, D9, D10) were
+    invisible from those captures precisely because the product's own text
+    never appeared in them (design round 2). A capture harness that cannot see
+    what the product says is a dead instrument.
+
+    ASSERTS THE REFUSAL HAPPENED. The reachable refusal moved from 20
+    attachments to 32 when the reclaim landed, so a fixture built on the old
+    figure refits successfully and returns no sentence at all — which would
+    read as a passing capture of a frame the product cannot reach.
+    """
+    from local_operator.session.remote import _image_to_wire
+
+    frame = {
+        "op": "prompt",
+        "req": 1,
+        "command_id": "00000000-0000-4000-8000-000000000000",
+        "text": "what does this screenshot show?",
+        "images": [_image_to_wire(image) for image in images],
+    }
+    try:
+        await fit_request_frame(frame)
+    except OversizedRequest as refusal:
+        return str(refusal)
+    raise AssertionError(
+        f"{len(images)} attachments were REFITTED, not refused — this fixture no "
+        "longer reaches the refusal path and the capture would prove nothing"
+    )
 
 
 async def main() -> None:
@@ -83,14 +163,24 @@ async def main() -> None:
     cols, rows = (sys.argv[2] if len(sys.argv) > 2 else "100x30").split("x")
     size = (int(cols), int(rows))
 
-    image = ImageContent(data=_png(1672, 941), mime_type="image/png")
+    # MARKERS ON THE IMAGES, exactly as `resolve_markers` stamps them for a
+    # real composer draft: the refusal names a chip, and a fixture without
+    # markers captures the positional fallback instead of the product's answer
+    # (design round 2, D8).
+    refused_images = [
+        ImageContent(data=_photo(1024, 1024, seed=index), mime_type="image/png", marker=index + 1)
+        for index in range(REFUSAL_ATTACHMENTS)
+    ]
+    refusal = await _real_refusal(refused_images)
+    print(f"REFUSAL (product-generated, {REFUSAL_ATTACHMENTS} attachments): {refusal}\n")
+
+    image = ImageContent(data=_png(1672, 941), mime_type="image/png", marker=1)
 
     for state in ("refusal", "resent", "recovery", "refit"):
         session = FakeSession()
         app = OperatorApp(lambda: _factory(session))
         async with app.run_test(size=size) as pilot:
             await pilot.pause()
-            source = app._interaction
 
             # THE REAL PATH: the refusal is raised by `prompt`, so the app's own
             # worker runs its `except OversizedRequest` branch — the withdrawal,
@@ -101,22 +191,46 @@ async def main() -> None:
 
                 async def refuse(text, images=None, **kwargs):
                     session.prompts.append(text)
-                    raise OversizedRequest(REFUSAL)
+                    raise OversizedRequest(refusal)
 
                 session.prompt = refuse  # type: ignore[method-assign]
 
             if state == "refit":
-                # A DELIVERED message: the row and its picture stay, and the
-                # caption is the only thing the refit adds.
-                app._submit_prompt("what does this screenshot show?", [image])
-                await pilot.pause()
-                source.turn.submitted_blocks = None
-                app._notice_for(
-                    source,
-                    "image resized to fit this message: #1 1672x941 → 768x432 ↓",
-                    "note",
-                )
-                await pilot.pause()
+                # A DELIVERED message whose attachments really went through the
+                # refit. The caption is composed by `_report_wire_refit_for`
+                # from the report the REAL `fit_request_frame` published, so
+                # this frame proves the WORDS as well as the layout — the
+                # previous version hand-called `_notice_for` with a literal,
+                # which is exactly what this script's own comment above warns
+                # against (review round 2, NIT-1; design round 2, D9/D10).
+                captioned = [
+                    ImageContent(
+                        data=_photo(1400, 1400, seed=index),
+                        mime_type="image/png",
+                        marker=index + 1,
+                    )
+                    for index in range(8)
+                ]
+
+                async def deliver_through_the_refit(text, images=None, **kwargs):
+                    from local_operator.session.remote import _image_to_wire
+
+                    session.prompts.append(text)
+                    await fit_request_frame(
+                        {
+                            "op": "prompt",
+                            "req": 1,
+                            "command_id": "00000000-0000-4000-8000-000000000000",
+                            "text": text,
+                            "images": [_image_to_wire(block) for block in (images or [])],
+                        }
+                    )
+
+                session.prompt = deliver_through_the_refit  # type: ignore[method-assign]
+                app._submit_prompt("what do these show?", captioned)
+                for _ in range(30):
+                    await pilot.pause()
+                    await asyncio.sleep(0.05)
             else:
                 if state == "recovery":
                     # The branch that parks the draft: the user started typing

--- a/scripts/oversized_frame_shot.py
+++ b/scripts/oversized_frame_shot.py
@@ -1,0 +1,174 @@
+"""Frames for the oversized-frame refusal and the wire-refit caption (PR #896).
+
+Drives the REAL ``OperatorApp`` through the real submit path, so the captures
+carry ``local_operator.tcss`` and the app's own block spacing rather than a
+hand-built approximation of them. Four states, each the subject of a design
+round 1 finding:
+
+``refusal``    the refused send: echo withdrawn, notice carrying both numbers.
+``resent``     the user follows the advice and resends — the state D3 filed,
+               where the transcript used to show the message twice.
+``recovery``   the same refusal with a NON-EMPTY composer, which is the branch
+               that parks the draft and offers a ``DraftRecoveryNotice`` (D5).
+``refit``      a delivered message whose attachment lost pixels on the wire, so
+               the ``↓`` caption is shown at the rung that earns one (D2).
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/oversized_frame_shot.py OUT_DIR [COLSxROWS]
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# The repo root, so `scripts.` and `tests.` resolve when run from the worktree.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import asyncio  # noqa: E402
+
+import scripts.probe_isolation  # noqa: F401,E402  -- must precede app imports
+from local_operator.harness.types import ImageContent  # noqa: E402
+from local_operator.mobile.attach_client import OversizedRequest  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from scripts.visual_capture import save_capture  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+
+def _delivered(session: FakeSession):
+    """A ``prompt`` that SUCCEEDS, for the half of a shot that must be sent."""
+
+    async def prompt(text, images=None, **kwargs):
+        session.prompts.append(text)
+
+    return prompt
+
+
+def _png(width: int, height: int) -> str:
+    """A base64 PNG the transcript can actually decode and paint.
+
+    A real raster rather than a stub: ``ImageBlock`` sniffs the header for its
+    aspect fit and paints a receipt instead of pixels when the bytes do not
+    decode, which would capture the wrong frame.
+    """
+    import base64
+    import io
+    import random
+
+    from PIL import Image, ImageDraw
+
+    image = Image.new("RGB", (width, height), (24, 26, 32))
+    draw = ImageDraw.Draw(image)
+    random.seed(11)
+    for row in range(8, height - 10, 16):
+        x = 10
+        while x < width - 40:
+            run = random.randint(20, 90)
+            draw.rectangle([x, row, x + run, row + 8], fill=(196, 202, 214))
+            x += run + 8
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return base64.b64encode(buffer.getvalue()).decode("ascii")
+
+
+REFUSAL = (
+    "image 3 is 2.4 MB and will not fit in this message's 0.2 MB per-image "
+    "budget (4 attachments) even at its smallest size; remove it and send again"
+)
+
+
+async def main() -> None:
+    out = Path(sys.argv[1] if len(sys.argv) > 1 else "/tmp/frames-896")
+    out.mkdir(parents=True, exist_ok=True)
+    cols, rows = (sys.argv[2] if len(sys.argv) > 2 else "100x30").split("x")
+    size = (int(cols), int(rows))
+
+    image = ImageContent(data=_png(1672, 941), mime_type="image/png")
+
+    for state in ("refusal", "resent", "recovery", "refit"):
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=size) as pilot:
+            await pilot.pause()
+            source = app._interaction
+
+            # THE REAL PATH: the refusal is raised by `prompt`, so the app's own
+            # worker runs its `except OversizedRequest` branch — the withdrawal,
+            # the notice and the restore all fire in the order the product uses
+            # them. Calling those helpers by hand would capture a frame the
+            # product cannot actually reach.
+            if state != "refit":
+
+                async def refuse(text, images=None, **kwargs):
+                    session.prompts.append(text)
+                    raise OversizedRequest(REFUSAL)
+
+                session.prompt = refuse  # type: ignore[method-assign]
+
+            if state == "refit":
+                # A DELIVERED message: the row and its picture stay, and the
+                # caption is the only thing the refit adds.
+                app._submit_prompt("what does this screenshot show?", [image])
+                await pilot.pause()
+                source.turn.submitted_blocks = None
+                app._notice_for(
+                    source,
+                    "image resized to fit this message: #1 1672x941 → 768x432 ↓",
+                    "note",
+                )
+                await pilot.pause()
+            else:
+                if state == "recovery":
+                    # The branch that parks the draft: the user started typing
+                    # during the ~315 ms refit, so the composer is not empty.
+                    app._editor().load_text("and another thing")
+                    await pilot.pause()
+
+                app._submit_prompt("what does this screenshot show?", [image])
+                # The worker is a Textual worker: let it run to its `except`.
+                for _ in range(12):
+                    await pilot.pause()
+                    await asyncio.sleep(0.05)
+
+                if state == "resent":
+                    # The user does what the copy says: drops the attachment and
+                    # sends again. Exactly one prompt must be on screen.
+                    session.prompt = _delivered(session)  # type: ignore[method-assign]
+                    app._editor().load_text("")
+                    app._submit_prompt("what does this screenshot show?", [])
+                    for _ in range(12):
+                        await pilot.pause()
+                        await asyncio.sleep(0.05)
+
+            await pilot.pause()
+            path = out / f"{state}-{size[0]}x{size[1]}.svg"
+            save_capture(app, path)
+            # Consecutive frames: a first frame differing from the settled one
+            # is motion the user sees.
+            await pilot.pause()
+            settled = out / f"{state}-{size[0]}x{size[1]}-settled.svg"
+            save_capture(app, settled)
+            same = path.read_bytes() == settled.read_bytes()
+
+            blocks = app._transcript_view().blocks()
+            users = sum(1 for block in blocks if type(block).__name__ == "UserBlock")
+            images_shown = sum(1 for block in blocks if type(block).__name__ == "ImageBlock")
+            recovery = sum(1 for block in blocks if type(block).__name__ == "DraftRecoveryNotice")
+            print(
+                f"{state:9s} UserBlocks={users} ImageBlocks={images_shown} "
+                f"recovery_rows={recovery} prompts_sent={len(session.prompts)} "
+                f"stable={same} -> {path.name}"
+            )
+            for block in blocks:
+                name = type(block).__name__
+                if name in ("NoticeBlock", "DraftRecoveryNotice"):
+                    # `text()` is NoticeBlock's, not the base block's; read it
+                    # off the instance so the print survives a block kind that
+                    # does not carry one.
+                    printable = getattr(block, "text", None)
+                    if callable(printable):
+                        print(f"            {name}: {printable()!r}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -16,7 +16,11 @@ error anybody reports.
 from __future__ import annotations
 
 import asyncio
+import base64
+import io
 import json
+import logging
+import random
 import uuid
 from pathlib import Path
 from types import SimpleNamespace
@@ -25,7 +29,12 @@ from typing import Any, cast
 import pytest
 
 from local_operator.harness.types import ModelSpec, ToolResult, Usage
-from local_operator.mobile.attach_client import _READ_LIMIT_BYTES
+from local_operator.media import sniff_image
+from local_operator.mobile.attach_client import (
+    _READ_LIMIT_BYTES,
+    AttachClient,
+    OversizedRequest,
+)
 from local_operator.session.attention import AttentionStore
 from local_operator.session.frontend_state import (
     _DERIVED_STATE_LABELS,
@@ -2136,3 +2145,409 @@ def test_model_and_usage_accessors_still_deep_copy(tmp_path: Path) -> None:
     # observe a corruption the slow path prevented.
     assert remote.model_label == "openai/gpt-4o"
     assert remote.effective_model_label == "anthropic/claude"
+
+
+# ---------------------------------------------------------------------------
+# The INBOUND twin: a frame the CLIENT sends that the owner cannot read.
+#
+# Everything above guards frames travelling owner -> viewer. The same 1 MiB
+# line limit applies to the other direction and had no protection at all: the
+# runtime's reader loop called `readline()` OUTSIDE the `try` that catches
+# `ValueError`, so an over-limit inbound line escaped through the reader task
+# and the `finally` dropped the connection. One pasted screenshot over ~780 KB
+# of source was enough, which the operator experienced as "sending a message
+# with an image exits lop and I have to run `lop --resume`".
+# ---------------------------------------------------------------------------
+
+
+def _png_bytes(width: int, height: int) -> bytes:
+    """A PNG of CONTINUOUS-TONE content, which is what makes it a real fixture.
+
+    The content matters more than the size here. Pure noise and a flat fill are
+    both pathological for the ladder under test — noise defeats every codec and
+    a flat fill compresses to nothing, so either one tests the fixture rather
+    than the refit. Blurred noise behaves the way a photograph or a screenshot
+    does: PNG stores it badly (no flat runs to pack) and JPEG stores it well,
+    which is the whole premise of preferring a re-encode over lost pixels.
+    """
+    Image = pytest.importorskip("PIL.Image")
+    ImageFilter = pytest.importorskip("PIL.ImageFilter")
+    rng = random.Random(width * height)
+    coarse = Image.frombytes(
+        "RGB",
+        (width // 4, height // 4),
+        bytes(rng.getrandbits(8) for _ in range((width // 4) * (height // 4) * 3)),
+    )
+    image = coarse.resize((width, height), Image.BILINEAR).filter(ImageFilter.GaussianBlur(1.2))
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _wire_image(width: int, height: int) -> dict[str, str]:
+    return {
+        "mime_type": "image/png",
+        "data_b64": base64.b64encode(_png_bytes(width, height)).decode("ascii"),
+    }
+
+
+class _ImageRecordingHandle(FakeHandle):
+    """A handle that KEEPS the images it was given.
+
+    ``FakeHandle`` records only the text, and the whole question here is what
+    pixels survived the wire — so a test asserting on its calls could not tell
+    a delivered image from a dropped one.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.received: list[tuple[str, list[Any]]] = []
+
+    async def prompt(self, text, images=None, command_id=None):  # noqa: ANN001, ANN202
+        self.received.append((text, list(images or [])))
+        return await super().prompt(text, images, command_id)
+
+    async def steer(self, text, images=None):  # noqa: ANN001, ANN202
+        self.received.append((f"steer:{text}", list(images or [])))
+        return await super().steer(text, images)
+
+    async def slash_images(self, command, args, images):  # noqa: ANN001, ANN202
+        self.received.append((f"slash:{command}", list(images or [])))
+        return "slash ok"
+
+
+def test_an_oversized_prompt_frame_is_the_shape_that_killed_the_session() -> None:
+    """The regression is real: an ordinary pasted screenshot overflows the line.
+
+    The sibling of ``test_ten_jobs_at_the_cap_overflow_the_line_limit_without_
+    the_fix`` for the inbound direction. Asserting the UNGUARDED size keeps the
+    tests below honest — if images ever got small enough to fit anyway, those
+    would pass for the wrong reason and this one would fail loudly instead.
+    """
+    image = _wire_image(1400, 1400)
+    naive = _line_bytes(
+        {
+            "op": "prompt",
+            "req": 1,
+            "command_id": str(uuid.uuid4()),
+            "text": "what does this show?",
+            "images": [image],
+        }
+    )
+    assert naive > _MAX_LINE_BYTES, (
+        "the fixture no longer reproduces the oversized inbound frame; "
+        f"{naive} bytes is under the {_MAX_LINE_BYTES} limit"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_oversized_inbound_frame_does_not_kill_the_session(
+    tmp_path: Path, monkeypatch, caplog
+) -> None:
+    """THE BUG, end to end: the connection must survive a frame it cannot read.
+
+    Driven against the REAL ``RuntimeServer`` over a REAL socket with a
+    deliberately unguarded write, which is what an OLD client (or any peer that
+    is not ``AttachClient``) does. Before the fix the reader loop's
+    ``readline`` raised ``ValueError`` past the ``ConnectionResetError`` handler
+    and the ``finally`` dropped the client — the session death the operator hit.
+
+    The assertion that matters is the SECOND message: surviving the bad frame is
+    only useful if the session is still usable afterwards, and that is precisely
+    what the operator lost.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    handle = _ImageRecordingHandle()
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    writer = None
+    try:
+        record = await _record(tmp_path)
+        reader, writer = await asyncio.open_connection(
+            "127.0.0.1", record.control_port, limit=_MAX_LINE_BYTES
+        )
+        writer.write(json.dumps({"key": record.control_key, "client": "attach"}).encode() + b"\n")
+        await writer.drain()
+        welcome = json.loads((await asyncio.wait_for(reader.readline(), timeout=5)).decode())
+        assert welcome.get("op") in ("projection", "welcome")
+
+        # Unguarded on purpose: this is the frame the fixed client would never
+        # send and an older one still does.
+        oversized = {
+            "op": "prompt",
+            "req": 1,
+            "command_id": str(uuid.uuid4()),
+            "text": "here is a screenshot",
+            "images": [{"mime_type": "image/png", "data_b64": "A" * (_MAX_LINE_BYTES + 350_000)}],
+        }
+        assert _line_bytes(oversized) > _MAX_LINE_BYTES
+        with caplog.at_level(logging.ERROR, logger="local_operator.session.runtime.server"):
+            writer.write(json.dumps(oversized).encode() + b"\n")
+            await writer.drain()
+
+            # THE NEXT MESSAGE, which is the whole point. On the pre-fix tree
+            # the socket is already gone and this ack never arrives.
+            follow_up = {
+                "op": "prompt",
+                "req": 2,
+                "command_id": str(uuid.uuid4()),
+                "text": "the next message",
+            }
+            writer.write(json.dumps(follow_up).encode() + b"\n")
+            await writer.drain()
+            reply = None
+            deadline = asyncio.get_running_loop().time() + 10
+            while asyncio.get_running_loop().time() < deadline:
+                line = await asyncio.wait_for(reader.readline(), timeout=10)
+                assert line, "the runtime closed the connection; the oversized frame killed it"
+                frame = json.loads(line.decode())
+                if frame.get("req") == 2:
+                    reply = frame
+                    break
+            assert reply is not None, "the follow-up was never answered"
+            assert reply.get("op") == "ack", f"the follow-up was refused: {reply}"
+
+        # The oversized frame was DISCARDED, not delivered half-parsed.
+        assert [text for text, _ in handle.received] == ["the next message"]
+        # And it was reported loudly enough to find, naming the limit.
+        logged = "\n".join(record.getMessage() for record in caplog.records)
+        assert "line limit" in logged, f"the discard was not reported: {logged!r}"
+        assert str(_MAX_LINE_BYTES) in logged
+    finally:
+        if writer is not None:
+            writer.close()
+        registrant.close()
+
+
+@pytest.mark.asyncio
+async def test_a_large_pasted_image_is_refitted_and_actually_arrives(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The product half: an ordinary paste must SEND, not be refused.
+
+    The operator pastes screenshots routinely, and the sizes that overflow the
+    frame are ordinary — one composer-bounded render measured 1.23 MB of base64
+    on this machine. So the client refits rather than rejecting, and the
+    assertion is that the image genuinely reaches the owner: a guard that
+    silently dropped the attachment would pass a "did not crash" test while
+    losing the user's work.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    handle = _ImageRecordingHandle()
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    client = AttachClient(lambda _projection: None, lambda _reason: None)
+    try:
+        record = await _record(tmp_path)
+        await client.connect(record, "s1")
+        image = _wire_image(1400, 1400)
+        assert _line_bytes({"op": "prompt", "images": [image]}) > _MAX_LINE_BYTES
+
+        detail = await client.prompt("what does this show?", images=[image])
+        assert detail == "prompt ok"
+        assert client.connected, "the send severed the connection"
+
+        text, delivered = handle.received[-1]
+        assert text == "what does this show?"
+        assert len(delivered) == 1, "the attachment was dropped instead of resized"
+        arrived = delivered[0]
+        payload = getattr(arrived, "data", None) or arrived.get("data_b64")
+        # It really is an image, and it really is smaller than the budget.
+        decoded = base64.b64decode(payload)
+        info = sniff_image(decoded)
+        assert info is not None, "what arrived is not a decodable image"
+        assert len(payload) < _MAX_LINE_BYTES
+
+        # The session keeps working afterwards, which is the operator's actual
+        # complaint — the send used to be the thing that ended it.
+        assert await client.prompt("and a follow-up") == "prompt ok"
+        assert client.connected
+    finally:
+        client.close()
+        registrant.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("op", ["prompt", "steer", "slash"])
+async def test_every_image_bearing_op_is_guarded_not_just_prompt(
+    tmp_path: Path, monkeypatch, op: str
+) -> None:
+    """``steer`` and ``slash`` carry images too, on the same socket.
+
+    Guarding ``prompt`` alone would leave two live routes to the same session
+    death: steering mid-turn with a pasted image, and a slash command that
+    takes attachments (``slash_images``). Parametrized rather than copied so a
+    FOURTH image-bearing op cannot quietly skip the guard — it shares the one
+    seam in ``_request_frame``.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    handle = _ImageRecordingHandle()
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    client = AttachClient(lambda _projection: None, lambda _reason: None)
+    try:
+        record = await _record(tmp_path)
+        await client.connect(record, "s1")
+        images = [_wire_image(1400, 1400)]
+        assert _line_bytes({"op": op, "images": images}) > _MAX_LINE_BYTES
+
+        if op == "prompt":
+            await client.prompt("look", images=images)
+        elif op == "steer":
+            await client.steer("look", images=images)
+        else:
+            await client.slash("compact", "", images=images)
+
+        assert client.connected, f"{op} with an oversized image severed the connection"
+        _text, delivered = handle.received[-1]
+        assert len(delivered) == 1, f"{op} lost its attachment"
+    finally:
+        client.close()
+        registrant.close()
+
+
+@pytest.mark.asyncio
+async def test_several_images_share_one_frame_budget(tmp_path: Path, monkeypatch) -> None:
+    """N images must fit TOGETHER, not each against the whole limit.
+
+    The subtle way to get this wrong: refit every image against the full 1 MiB
+    and each one passes while the frame still overflows. Two composer-bounded
+    screenshots already serialize past the limit on this machine, so the
+    multi-image case is the ordinary one rather than an edge.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    handle = _ImageRecordingHandle()
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    client = AttachClient(lambda _projection: None, lambda _reason: None)
+    try:
+        record = await _record(tmp_path)
+        await client.connect(record, "s1")
+        images = [_wire_image(900 + index * 60, 900) for index in range(4)]
+
+        assert await client.prompt("compare these", images=images) == "prompt ok"
+        assert client.connected
+
+        _text, delivered = handle.received[-1]
+        assert len(delivered) == 4, "an attachment was dropped rather than resized"
+        rebuilt = [
+            {
+                "mime_type": getattr(image, "mime_type", None) or image.get("mime_type"),
+                "data_b64": getattr(image, "data", None) or image.get("data_b64"),
+            }
+            for image in delivered
+        ]
+        # The FRAME is what had to fit, so that is what is measured.
+        assert _line_bytes({"op": "prompt", "req": 1, "images": rebuilt}) <= _MAX_LINE_BYTES
+    finally:
+        client.close()
+        registrant.close()
+
+
+@pytest.mark.asyncio
+async def test_an_unsendable_message_is_refused_by_name_not_silently_lost(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A refusal must reach the USER, and must not take the session with it.
+
+    The user's composer content is their work: the two ways to get this wrong
+    are to drop it silently and to kill the connection reporting it. So the
+    refusal is an exception the TUI turns into a notice (and a restored draft),
+    the wording names what to do, and the session is still usable after it.
+
+    Two shapes, because they need different sentences: prose over the limit
+    (nothing to resize) and an attachment that is not a decodable image at all
+    — telling someone to shrink bytes that were never an image sends them off
+    fixing the wrong thing.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    handle = _ImageRecordingHandle()
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    client = AttachClient(lambda _projection: None, lambda _reason: None)
+    try:
+        record = await _record(tmp_path)
+        await client.connect(record, "s1")
+
+        with pytest.raises(OversizedRequest) as prose:
+            await client.prompt("x" * (_MAX_LINE_BYTES + 200_000))
+        assert "shorten" in str(prose.value), str(prose.value)
+        assert f"{_MAX_LINE_BYTES:,}" in str(prose.value), "the refusal hides the actual limit"
+        assert client.connected, "reporting the refusal killed the connection"
+
+        junk = {
+            "mime_type": "image/png",
+            "data_b64": base64.b64encode(b"\x00" * (_MAX_LINE_BYTES + 200_000)).decode("ascii"),
+        }
+        with pytest.raises(OversizedRequest) as unreadable:
+            await client.prompt("look at this", images=[junk])
+        # Named by POSITION so it points at a specific composer chip, and NOT
+        # described as merely "too large", which would be the wrong remedy.
+        assert "image 1" in str(unreadable.value), str(unreadable.value)
+        assert "not a readable image" in str(unreadable.value), str(unreadable.value)
+        assert client.connected
+
+        # Nothing was delivered, and the session still works.
+        assert handle.received == []
+        assert await client.prompt("a normal message") == "prompt ok"
+    finally:
+        client.close()
+        registrant.close()
+
+
+def test_a_refused_request_leaves_nothing_pending() -> None:
+    """A refusal must not park a future nobody will ever resolve.
+
+    Found while testing the refusal path: the request id was registered in
+    ``_pending`` BEFORE the fit could raise, so a refused send left a future
+    that nothing completes. It sat until teardown, took the disconnect's
+    ``ConnectionError``, and logged "exception was never retrieved" for a
+    refusal the caller had already handled cleanly.
+    """
+
+    async def scenario() -> int:
+        client = AttachClient(lambda _projection: None, lambda _reason: None)
+        client._connected = True
+        # A writer that would FAIL the test by being used: a refused request
+        # must never reach the socket at all.
+        client._writer = cast(Any, SimpleNamespace(write=_forbidden_write, drain=None))
+        with pytest.raises(OversizedRequest):
+            await client.prompt("x" * (_MAX_LINE_BYTES + 200_000))
+        return len(client._pending)
+
+    assert asyncio.run(scenario()) == 0
+
+
+def _forbidden_write(_payload: bytes) -> None:
+    raise AssertionError("a refused request must not be written to the socket")
+
+
+def test_the_refit_prefers_the_codec_over_the_users_pixels() -> None:
+    """Fidelity means legible text, and pixels carry that while the codec does not.
+
+    The ladder's first rung re-encodes at UNCHANGED dimensions, so an ordinary
+    screenshot clears the budget with every pixel intact. Asserted as a
+    property rather than against a byte count: the claim is "it did not have to
+    downscale", which is what the user would notice.
+    """
+    from local_operator.imaging import refit_image_to_budget
+
+    source = _png_bytes(1200, 800)
+    data_b64 = base64.b64encode(source).decode("ascii")
+    # A budget the PNG cannot meet, so the refit genuinely has to do something.
+    budget = len(data_b64) // 2
+    result = refit_image_to_budget(data_b64, "image/png", budget)
+    assert result is not None, "an ordinary screenshot must not be refused"
+    refitted_b64, _mime = result
+    assert len(refitted_b64) <= budget
+    info = sniff_image(base64.b64decode(refitted_b64))
+    assert info is not None
+    assert (info.width, info.height) == (1200, 800), (
+        "the refit gave up pixels when a re-encode would have been enough; "
+        f"it delivered {info.width}x{info.height}"
+    )

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -17,10 +17,12 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import io
 import json
 import logging
 import random
+import re
 import uuid
 from pathlib import Path
 from types import SimpleNamespace
@@ -28,13 +30,16 @@ from typing import Any, cast
 
 import pytest
 
-from local_operator.harness.types import ModelSpec, ToolResult, Usage
+from local_operator.harness.types import ImageContent, ModelSpec, ToolResult, Usage
 from local_operator.media import sniff_image
 from local_operator.mobile.attach_client import (
+    _FRAME_ENCODING_SLACK_BYTES,
     _READ_LIMIT_BYTES,
     AttachClient,
     OversizedRequest,
+    _frame_overhead_bytes,
     _megabytes,
+    _RefitReport,
 )
 from local_operator.session.attention import AttentionStore
 from local_operator.session.frontend_state import (
@@ -2696,22 +2701,319 @@ async def test_a_refusal_quotes_the_marker_the_user_can_see(tmp_path: Path, monk
     try:
         record = await _record(tmp_path)
         await client.connect(record, "s1")
-        # Sixteen attachments is where even the tightest rung cannot fit, which
-        # is what makes the refusal reachable at all (design round 1, D6).
-        images = [{**_wire_image(1024, 1024), "marker": 20 + index} for index in range(16)]
+        # THIRTY-TWO attachments, not the sixteen this test was written with.
+        # The smallest-first reclaim (review round 1, MINOR-2) raised capacity,
+        # so the old fixture REFITS successfully at this head and a test built
+        # on it asserts nothing about a refusal at all (QA round 2). The
+        # `pytest.raises` below is what keeps that honest.
+        images = [{**_wire_image(1024, 1024), "marker": 20 + index} for index in range(32)]
 
         with pytest.raises(OversizedRequest) as refusal:
             await client.prompt("compare these", images=images)
 
         message = str(refusal.value)
-        assert "image 2" in message, f"the refusal quoted a wire position: {message}"
-        assert "image 1 " not in message, f"the refusal quoted a wire position: {message}"
+        named = re.search(r"image (\d+)", message)
+        assert named is not None, f"the refusal named no image at all: {message}"
+        quoted = int(named.group(1))
+        assert quoted >= 20, (
+            "the refusal quoted a wire position rather than the block's marker: " f"{message}"
+        )
         assert "per-image budget" in message, f"the refusal hides the ceiling: {message}"
-        assert "16 attachments" in message, f"the refusal hides the share's cause: {message}"
+        assert "32 attachments" in message, f"the refusal hides the share's cause: {message}"
         assert client.connected
     finally:
         client.close()
         registrant.close()
+
+
+def test_the_composer_stamps_the_chip_number_onto_every_image_it_sends() -> None:
+    """The PRODUCER half of the refusal's marker, pinned from a real draft.
+
+    ``_refit_images`` prefers ``image["marker"]`` and falls back to the wire
+    position. That lookup shipped in round 1 with NOTHING populating it:
+    ``ImageContent`` had no marker field and ``_image_to_wire`` emitted only
+    ``data_b64``/``mime_type``, so every refusal still quoted the position and
+    the fix was the old behaviour under a new name (design round 2, D8).
+
+    Starting from a DRAFT rather than a wire dict is the whole point. The
+    round-1 test hand-injected ``"marker"`` into its blocks, which pins the
+    lookup and can never see the producer go missing; this walks
+    ``resolve_markers`` -> ``_image_to_wire``, so deleting either end fails it.
+
+    The gap is what makes it a real test: marker numbers do not renumber on
+    delete, so a draft that lost ``#2`` sends chips 1 and 3 from wire positions
+    0 and 1.
+    """
+    from local_operator.session.remote import _image_to_wire
+    from local_operator.tui.widgets.editor import Attachment, resolve_markers
+
+    def _attachment(index: int) -> Attachment:
+        payload = base64.b64encode(f"png{index}".encode()).decode()
+        return Attachment(
+            ImageContent(data=payload, mime_type="image/png"),
+            f"[Image #{index}]",
+        )
+
+    # Three pastes, then the middle chip deleted: the draft cites #1 and #3.
+    attachments = {1: _attachment(1), 2: _attachment(2), 3: _attachment(3)}
+    text = "compare [Image #1] and [Image #3]"
+
+    images = resolve_markers(text, attachments)
+    assert [image.marker for image in images] == [1, 3], (
+        "resolve_markers did not carry the chip number onto the images it "
+        f"resolved: {[image.marker for image in images]}"
+    )
+
+    blocks = [_image_to_wire(image) for image in images]
+    assert [block.get("marker") for block in blocks] == [
+        1,
+        3,
+    ], f"_image_to_wire dropped the marker on the way to the socket: {blocks}"
+    # The gap is real: wire position 1 is the chip labelled #3.
+    assert blocks[1]["marker"] == 3
+
+    # A producer with no chips to name leaves the key OFF rather than sending
+    # null, so the position fallback stays in charge for the phone relay.
+    bare = _image_to_wire(ImageContent(data="AAAA", mime_type="image/png"))
+    assert "marker" not in bare, f"a marker-less image put a key on the wire: {bare}"
+
+
+def test_the_marker_never_reaches_a_provider_or_a_transcript() -> None:
+    """``marker`` is presentation state, and must not become conversation content.
+
+    It rides ``ImageContent`` so the transport can name a chip, which puts it
+    one field away from every provider payload, transcript row and context
+    hash. ``exclude=True`` is what keeps it out; this pins that, because a
+    later change dropping the flag would silently start writing composer state
+    into persisted history and into the bytes sent to a model.
+    """
+    image = ImageContent(data="AAAA", mime_type="image/png", marker=7)
+
+    assert image.marker == 7, "the field must be readable in-process"
+    assert "marker" not in image.model_dump()
+    assert "marker" not in image.model_dump(exclude_defaults=True)
+    assert "marker" not in image.model_dump(mode="json")
+    assert "marker" not in image.model_dump_json()
+
+
+@pytest.mark.asyncio
+async def test_a_refit_that_could_fit_is_never_refused_for_being_predicted_to_fail(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The small-budget branch picks a SENTENCE; it must not veto the send.
+
+    An earlier version short-circuited to a refusal whenever the text left less
+    than ``_MIN_VIABLE_IMAGE_BUDGET_BYTES`` for the images, justified as a
+    guarantee that the refit would fail anyway. That premise holds for
+    continuous-tone photographs and is false for flat screenshots and line art,
+    which compress to a fraction of it — so messages the refit would have sent
+    were refused unsent (review round 2, MAJOR-4), the same defect MAJOR-1
+    filed against the old fixed reserve, one layer up.
+
+    A flat image is the fixture precisely because it is the shape the constant
+    mispredicts.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    registrant = RuntimeServer(_ImageRecordingHandle(), kind="tui")
+    registrant.start()
+    client = AttachClient(lambda _projection: None, lambda _reason: None)
+    try:
+        record = await _record(tmp_path)
+        await client.connect(record, "s1")
+
+        # A SMOOTH GRADIENT: heavy as PNG on the wire, so the frame really
+        # crosses the limit, but it re-encodes to a fraction of the budget the
+        # gate predicted it could not meet. That combination is the whole
+        # finding — a flat screenshot is small enough that the frame never
+        # crosses at all and the early return, not the gate, decides.
+        Image = pytest.importorskip("PIL.Image")
+        canvas = Image.new("RGB", (3000, 2000))
+        pixels = canvas.load()
+        for y in range(canvas.height):
+            for x in range(canvas.width):
+                pixels[x, y] = (
+                    (x * 255) // canvas.width,
+                    (y * 255) // canvas.height,
+                    ((x + y) * 255) // (canvas.width + canvas.height),
+                )
+        buffer = io.BytesIO()
+        canvas.save(buffer, format="PNG")
+        gradient = {
+            "mime_type": "image/png",
+            "data_b64": base64.b64encode(buffer.getvalue()).decode("ascii"),
+        }
+
+        # THE FIXTURE MUST REACH THE BRANCH, or this asserts nothing. A mutation
+        # run caught exactly that: an earlier fixture never crossed the limit,
+        # so `fit_request_frame` returned at its first length check and the test
+        # passed with the defect restored.
+        text = "x" * 1_015_000
+        frame = {
+            "op": "prompt",
+            "req": 1,
+            "command_id": "00000000-0000-4000-8000-000000000000",
+            "text": text,
+            "images": [gradient],
+        }
+        assert (
+            len(json.dumps(frame).encode()) + 1 > _READ_LIMIT_BYTES
+        ), "the fixture no longer exceeds the line limit, so the refit never runs"
+        overhead = _frame_overhead_bytes(frame)
+        budget = _READ_LIMIT_BYTES - overhead - _FRAME_ENCODING_SLACK_BYTES
+        assert 0 < budget < 32 * 1024, (
+            f"the fixture leaves {budget} bytes for its images; the branch under "
+            "test only runs for a positive budget under the gate"
+        )
+
+        assert await client.prompt(text, images=[gradient]) == "prompt ok"
+        assert client.connected
+
+        # THE OTHER DIRECTION: when the text genuinely leaves no room and the
+        # refit really cannot fit the image, the refusal still fires and still
+        # blames the text rather than the attachment.
+        heavy = _wire_image(1400, 1400)
+        with pytest.raises(OversizedRequest) as refusal:
+            await client.prompt("x" * 1_045_000, images=[heavy])
+        assert "text alone fills" in str(
+            refusal.value
+        ), f"a text-dominated refusal blamed the attachment: {refusal.value}"
+        assert client.connected
+    finally:
+        client.close()
+        registrant.close()
+
+
+@contextlib.contextmanager
+def _refit_report(entries: tuple[_RefitReport, ...]):
+    """Publish ``entries`` as the current task's refit report, then clear it.
+
+    ``_report_wire_refit_for`` CONSUMES the report, so a test that set the
+    ContextVar and left it would leak into the next one; the reset token is
+    what keeps these independent of ordering.
+    """
+    from local_operator.mobile.attach_client import _REFIT_REPORT
+
+    token = _REFIT_REPORT.set(entries)
+    try:
+        yield
+    finally:
+        _REFIT_REPORT.reset(token)
+
+
+def test_the_refit_caption_is_one_row_whatever_the_attachment_count() -> None:
+    """The caption's cost must not grow with the number of images.
+
+    ``_report_wire_refit_for`` used to join one ``#N WxH -> WxH`` clause per
+    downscaled image, in ``_refit_images``' internal smallest-first walk. The
+    rung that earns a caption is by construction the many-attachment case, so
+    the row a user actually got was three lines of 28 at 100x30 and **five of
+    20 at 60x22** — a quarter of a narrow viewport spent on a ``note`` about a
+    message that was delivered fine — enumerated in an order the user cannot
+    see, with six of eight clauses the identical string (design round 2, D9;
+    QA round 2, Q5).
+
+    Grouping by delivered size bounds the row by the ladder's RUNGS rather than
+    by the attachment count, so this asserts the property rather than a
+    specific sentence: the clause count can never exceed the number of edges
+    the refit can produce, whatever the user pastes.
+    """
+    from local_operator.imaging import IMAGE_WIRE_REFIT_EDGES
+    from local_operator.tui.app import OperatorApp
+
+    def caption(entries: list[Any]) -> str:
+        captured: list[str] = []
+        source = cast(Any, SimpleNamespace())
+        app = cast(Any, OperatorApp.__new__(OperatorApp))
+        app._notice_for = lambda _source, text, _kind: captured.append(text)
+        with _refit_report(tuple(entries)):
+            OperatorApp._report_wire_refit_for(app, source)
+        return captured[0] if captured else ""
+
+    for count in (1, 2, 8, 20, 60):
+        # Two rungs, interleaved by marker, so the grouping cannot pass by
+        # accident on a single-size fixture.
+        entries = [
+            _RefitReport(
+                marker=index + 1,
+                width=384 if index % 3 else 512,
+                height=384 if index % 3 else 512,
+                source_width=1400,
+                source_height=1400,
+            )
+            for index in range(count)
+        ]
+        row = caption(entries)
+        assert row.startswith(
+            f"{count} image"
+        ), f"the caption does not lead with the count it is claiming: {row!r}"
+        clauses = row.split(": ", 1)[1].split(", ")
+        assert len(clauses) <= len(IMAGE_WIRE_REFIT_EDGES), (
+            f"{count} attachments produced {len(clauses)} clauses; the caption "
+            f"grows with the attachment count again: {row!r}"
+        )
+        assert len(row) < 100, (
+            f"the caption is {len(row)} characters at {count} attachments, which "
+            f"wraps past one row at 100 columns: {row!r}"
+        )
+
+    # THE GLYPH BINDS TO THE COUNT, not to a trailing clause. Appended once
+    # after the last clause it read as the mark on that image alone, while the
+    # composer chips already carry their own for the ingest bound — two shrinks
+    # sharing one glyph, neither adjacent to what it qualified (design round 2,
+    # D10).
+    from local_operator.tui.widgets.editor import RESIZED_MARK
+
+    row = caption(
+        [
+            _RefitReport(marker=1, width=512, height=512, source_width=1400, source_height=1400),
+            _RefitReport(marker=2, width=384, height=384, source_width=1400, source_height=1400),
+        ]
+    )
+    assert row.startswith(
+        f"2 images{RESIZED_MARK} "
+    ), f"the resize glyph is not bound to the count it qualifies: {row!r}"
+    assert not row.endswith(RESIZED_MARK), f"the glyph is still trailing the last clause: {row!r}"
+
+    # IN THE USER'S ORDER: groups appear by their lowest chip number, not in
+    # the refit's internal smallest-first walk.
+    row = caption(
+        [
+            _RefitReport(marker=9, width=384, height=384, source_width=1400, source_height=1400),
+            _RefitReport(marker=2, width=512, height=512, source_width=1400, source_height=1400),
+        ]
+    )
+    assert row.index("512x512") < row.index(
+        "384x384"
+    ), f"the caption enumerates in the refit's order rather than the user's: {row!r}"
+
+
+def test_the_size_scale_never_prints_a_smaller_number_in_a_bigger_unit() -> None:
+    """``_megabytes`` must not move DOWN as the byte count goes up.
+
+    The switch used to be keyed on the rounded MB figure, which put the
+    boundary mid-KB: ``104,857`` printed ``102 KB`` and ``104,858`` printed
+    ``0.1 MB``, so a one-byte step showed a smaller number in a larger unit and
+    a user comparing two refusals a minute apart read them backwards (review
+    round 2, NIT-2).
+    """
+
+    def as_bytes(rendered: str) -> float:
+        figure, unit = rendered.split()
+        return float(figure) * (1024 if unit == "KB" else 1024 * 1024)
+
+    previous = -1.0
+    for size in range(0, 3 * 1024 * 1024, 311):
+        current = as_bytes(_megabytes(size))
+        assert current >= previous, (
+            f"{size} bytes rendered as {_megabytes(size)}, which is smaller than "
+            "the figure printed for fewer bytes"
+        )
+        previous = current
+
+    # The boundary is a whole megabyte, so both sides read as the same quantity.
+    assert _megabytes(1024 * 1024 - 1) == "1024 KB"
+    assert _megabytes(1024 * 1024) == "1.0 MB"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -34,6 +34,7 @@ from local_operator.mobile.attach_client import (
     _READ_LIMIT_BYTES,
     AttachClient,
     OversizedRequest,
+    _megabytes,
 )
 from local_operator.session.attention import AttentionStore
 from local_operator.session.frontend_state import (
@@ -2477,7 +2478,12 @@ async def test_an_unsendable_message_is_refused_by_name_not_silently_lost(
         with pytest.raises(OversizedRequest) as prose:
             await client.prompt("x" * (_MAX_LINE_BYTES + 200_000))
         assert "shorten" in str(prose.value), str(prose.value)
-        assert f"{_MAX_LINE_BYTES:,}" in str(prose.value), "the refusal hides the actual limit"
+        # The LIMIT, in the same scale as the size beside it. Asserted as "the
+        # sentence carries the ceiling" rather than against a raw byte count:
+        # both figures print as MB now, because a refusal that quotes
+        # `1,341,208 bytes` against an image refusal quoting MB makes the user
+        # compare two scales to understand one failure (design round 1, D1).
+        assert _megabytes(_MAX_LINE_BYTES) in str(prose.value), "the refusal hides the actual limit"
         assert client.connected, "reporting the refusal killed the connection"
 
         junk = {
@@ -2551,3 +2557,253 @@ def test_the_refit_prefers_the_codec_over_the_users_pixels() -> None:
         "the refit gave up pixels when a re-encode would have been enough; "
         f"it delivered {info.width}x{info.height}"
     )
+
+
+def test_the_every_rung_jpeg_rule_has_its_own_test() -> None:
+    """A 1400x1400 continuous-tone frame against 240 KB must FIT, not be refused.
+
+    The self-reported defect this pins: the JPEG re-encode was applied only to
+    the no-resize rung, so every descending rung handed back a PNG of content
+    PNG cannot compress, the ladder ran out of rungs, and the image was refused
+    while the real remedy had never been tried below full size.
+
+    Its own test, named for the claim. The regression was previously caught only
+    as a side effect of ``test_several_images_share_one_frame_budget``, whose
+    stated subject is the shared budget — so a legitimate refactor of the budget
+    split could rewrite that test and silently drop coverage of this rule
+    (review round 1, NIT-1). Asserted as a PROPERTY (it fits at all) rather than
+    against a byte count or a specific rung, so the ladder stays free to change.
+    """
+    from local_operator.imaging import refit_image_to_budget
+
+    data_b64 = base64.b64encode(_png_bytes(1400, 1400)).decode("ascii")
+    result = refit_image_to_budget(data_b64, "image/png", 240 * 1024)
+
+    assert result is not None, (
+        "a 1400x1400 frame against a 240 KB budget was refused; the JPEG "
+        "re-encode is not being applied at every rung"
+    )
+    refitted_b64, mime = result
+    assert len(refitted_b64) <= 240 * 1024
+    assert mime == "image/jpeg", f"the descending rung returned {mime}, not a re-encode"
+
+
+@pytest.mark.asyncio
+async def test_a_long_prompt_beside_a_screenshot_still_sends(tmp_path: Path, monkeypatch) -> None:
+    """The PR's OWN headline repro: a big screenshot over ~780 KB of source.
+
+    The image budget used to be ``limit - 64 KiB``, a constant, while the text
+    it had to cover is bounded only by ``MAX_CLIPBOARD_TEXT_BYTES`` (1 MiB). Any
+    prompt past ~64 KiB therefore had its images fitted against room that was
+    never available, the post-refit re-measure caught the overflow, and the
+    whole message was refused — including the exact "one pasted screenshot over
+    ~780 KB of source" this module's docstring names as the bug being fixed
+    (review round 1, MAJOR-1).
+
+    Parametrized over the text sizes that used to fail, because the threshold is
+    what regressed: 32 KiB passed before this fix and everything above it did
+    not.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    handle = _ImageRecordingHandle()
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    client = AttachClient(lambda _projection: None, lambda _reason: None)
+    try:
+        record = await _record(tmp_path)
+        await client.connect(record, "s1")
+        image = _wire_image(1672, 941)
+
+        for text_bytes in (100 * 1024, 300 * 1024, 780 * 1024):
+            prompt = "x" * text_bytes
+            assert await client.prompt(prompt, images=[image]) == "prompt ok", (
+                f"a {text_bytes // 1024} KiB prompt beside a screenshot was refused; "
+                "the image budget is not being measured against the real text"
+            )
+            delivered_text, delivered = handle.received[-1]
+            assert delivered_text == prompt, "the text was altered to make it fit"
+            assert len(delivered) == 1, "the attachment was dropped rather than resized"
+        assert client.connected
+    finally:
+        client.close()
+        registrant.close()
+
+
+@pytest.mark.asyncio
+async def test_a_small_image_hands_its_unused_budget_to_a_large_one(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """An icon must not reserve the same share as a screenshot and waste it.
+
+    A flat ``budget // len(images)`` split gave a 32x32 icon the same share as a
+    1600x1000 screenshot, and the icon handed nothing back: the screenshot lost
+    half its pixels while most of the frame went unspent (review round 1,
+    MINOR-2). Asserted against the SHARE the flat split would have imposed
+    rather than a fixed size, so the test states the property — the big image
+    got more than an equal share — instead of pinning today's ladder rung.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    handle = _ImageRecordingHandle()
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    client = AttachClient(lambda _projection: None, lambda _reason: None)
+    try:
+        record = await _record(tmp_path)
+        await client.connect(record, "s1")
+
+        assert (
+            await client.prompt(
+                "what is this", images=[_wire_image(32, 32), _wire_image(1600, 1000)]
+            )
+            == "prompt ok"
+        )
+        _text, delivered = handle.received[-1]
+        assert len(delivered) == 2
+
+        payloads = [getattr(image, "data", None) or image.get("data_b64") for image in delivered]
+        flat_share = (_MAX_LINE_BYTES - len("what is this")) // 2
+        assert len(payloads[0]) < flat_share // 4, "the icon grew to fill its share"
+        assert len(payloads[1]) > flat_share, (
+            "the screenshot was held to an equal share while the icon's went "
+            f"unspent: it got {len(payloads[1])} of a {flat_share} flat share"
+        )
+    finally:
+        client.close()
+        registrant.close()
+
+
+@pytest.mark.asyncio
+async def test_a_refusal_quotes_the_marker_the_user_can_see(tmp_path: Path, monkeypatch) -> None:
+    """ "image 3" must name the chip on screen, not the wire position.
+
+    Marker numbers do not renumber when an attachment is deleted, so after three
+    pastes and two backspaces the survivor's chip reads ``[Image #3]`` while its
+    wire position is 1 — and the refusal said "image 1", pointing at a chip that
+    is not on the user's screen (design round 1, D4).
+
+    Also pins the two numbers the sentence carries (design round 1, D1): the
+    IMAGE's size rather than its base64 (which inflates by 4/3 and overstated a
+    2.4 MB file as 3.2 MB), and the ceiling that actually applied, without which
+    the user cannot tell whether cropping would help.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    registrant = RuntimeServer(_ImageRecordingHandle(), kind="tui")
+    registrant.start()
+    client = AttachClient(lambda _projection: None, lambda _reason: None)
+    try:
+        record = await _record(tmp_path)
+        await client.connect(record, "s1")
+        # Sixteen attachments is where even the tightest rung cannot fit, which
+        # is what makes the refusal reachable at all (design round 1, D6).
+        images = [{**_wire_image(1024, 1024), "marker": 20 + index} for index in range(16)]
+
+        with pytest.raises(OversizedRequest) as refusal:
+            await client.prompt("compare these", images=images)
+
+        message = str(refusal.value)
+        assert "image 2" in message, f"the refusal quoted a wire position: {message}"
+        assert "image 1 " not in message, f"the refusal quoted a wire position: {message}"
+        assert "per-image budget" in message, f"the refusal hides the ceiling: {message}"
+        assert "16 attachments" in message, f"the refusal hides the share's cause: {message}"
+        assert client.connected
+    finally:
+        client.close()
+        registrant.close()
+
+
+@pytest.mark.asyncio
+async def test_only_a_downscale_is_reported_to_the_user(tmp_path: Path, monkeypatch) -> None:
+    """A codec swap keeps every pixel and must stay silent; a downscale must not.
+
+    The product call design round 1 (D2) argued rather than deferred: because the
+    composer bounds every paste to 1024px, the common rung is a re-encode at
+    unchanged dimensions, and a notice on that would be pure noise on a routine
+    gesture. Losing pixels is different in kind — measured at ~40% edge energy —
+    so that rung, and only that rung, is surfaced.
+
+    Asserted on ``downscaled``, which is the predicate the transcript row is
+    gated on, and measured from the DELIVERED bytes on both sides so a rung
+    change cannot make the two cases agree by accident.
+    """
+    from local_operator.mobile.attach_client import taken_refit_report
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    registrant = RuntimeServer(_ImageRecordingHandle(), kind="tui")
+    registrant.start()
+    client = AttachClient(lambda _projection: None, lambda _reason: None)
+    try:
+        record = await _record(tmp_path)
+        await client.connect(record, "s1")
+
+        # Two composer-bounded screenshots: over the limit together, but the
+        # codec alone closes the gap, so every pixel survives.
+        await client.prompt("look", images=[_wire_image(1024, 576) for _ in range(2)])
+        codec_only = taken_refit_report()
+        assert not [entry for entry in codec_only if entry.downscaled], (
+            "a codec-only refit was reported as a downscale; the transcript "
+            f"would put a notice on a routine paste: {codec_only}"
+        )
+
+        # Far past what the codec can absorb, so pixels genuinely go.
+        await client.prompt("look", images=[_wire_image(1400, 1400) for _ in range(8)])
+        downscaled = [entry for entry in taken_refit_report() if entry.downscaled]
+        assert downscaled, "pixels were lost and nothing was reported"
+        for entry in downscaled:
+            assert entry.width * entry.height < entry.source_width * entry.source_height
+            assert entry.marker >= 1
+
+        # CONSUMED, not merely read: a stale report would caption the next,
+        # untouched message with this one's resize.
+        assert taken_refit_report() == ()
+    finally:
+        client.close()
+        registrant.close()
+
+
+@pytest.mark.asyncio
+async def test_a_junk_scalar_frame_does_not_kill_the_connection(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A frame that parses as a bare JSON scalar must be dropped, not fatal.
+
+    ``json.loads`` succeeds on any scalar, so a discarded oversized line whose
+    surviving tail happens to read ``12345``/``null``/``true``/``"s"``/``[1,2]``
+    reached ``_on_request`` and hit ``.get`` on an int/None/bool/str/list. The
+    resulting ``AttributeError`` escaped the reader loop's
+    ``ConnectionResetError``/``BrokenPipeError`` handler and the ``finally``
+    dropped the client — the exact session death this module exists to prevent,
+    made reachable by the new discard path (review round 1, MAJOR-2).
+
+    Driven over a REAL socket, and the assertion is not merely "still
+    connected": the NEXT message must be DELIVERED, which is what the operator
+    actually lost.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    handle = _ImageRecordingHandle()
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    client = AttachClient(lambda _projection: None, lambda _reason: None)
+    try:
+        record = await _record(tmp_path)
+        await client.connect(record, "s1")
+        assert client._writer is not None
+
+        for raw in ("12345", "null", "true", '"str"', "[1,2]"):
+            # The fixture only tests what it claims if it really is a non-dict.
+            assert not isinstance(json.loads(raw), dict), f"{raw} is not a scalar frame"
+            client._writer.write(raw.encode() + b"\n")
+            await client._writer.drain()
+
+            assert (
+                await client.prompt(f"after {raw}") == "prompt ok"
+            ), f"a {raw} frame killed the connection; the next message was lost"
+            assert handle.received[-1][0] == f"after {raw}"
+            assert client.connected
+    finally:
+        client.close()
+        registrant.close()

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -34,12 +34,14 @@ from local_operator.harness.types import ImageContent, ModelSpec, ToolResult, Us
 from local_operator.media import sniff_image
 from local_operator.mobile.attach_client import (
     _FRAME_ENCODING_SLACK_BYTES,
+    _MIN_VIABLE_IMAGE_BUDGET_BYTES,
     _READ_LIMIT_BYTES,
     AttachClient,
     OversizedRequest,
     _frame_overhead_bytes,
     _megabytes,
     _RefitReport,
+    _text_is_the_bulk_refusal,
 )
 from local_operator.session.attention import AttentionStore
 from local_operator.session.frontend_state import (
@@ -2376,6 +2378,71 @@ async def test_a_large_pasted_image_is_refitted_and_actually_arrives(
 
 
 @pytest.mark.asyncio
+async def test_the_refit_log_names_the_payload_and_the_frame_as_what_they_are(
+    tmp_path: Path, monkeypatch, caplog
+) -> None:
+    """QA round 3, Q1: the one fix in the round-2 delta that had no test.
+
+    The refit log line carries TWO quantities, and round 2 fixed the second
+    one reporting the first: the clause reading ``to N bytes of image payload``
+    said ``refitted_size`` — the WHOLE frame, the user's text included — which
+    understated-by-conflation was harmless beside a fixed 64 KiB reserve and
+    became a 3.25x-16.75x overstatement of the attachments once up to 1 MiB of
+    text sat inside the number. Every other fix in that delta gained a test
+    that goes red when reverted; this one did not, so the conflation could
+    silently return. This pins the logged payload figure against the bytes
+    the owner actually received — exact, not approximate, because both sides
+    of the comparison are measured on the same send.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    handle = _ImageRecordingHandle()
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    client = AttachClient(lambda _projection: None, lambda _reason: None)
+    # Substantial text is the regime the old conflation overstated: the frame
+    # figure must dwarf the payload figure, or the assertion below could pass
+    # with the two quantities swapped back together.
+    text = "context: " + ("the model must read this. " * 12_000)
+    try:
+        record = await _record(tmp_path)
+        await client.connect(record, "s1")
+        image = _wire_image(1400, 1400)
+        assert _line_bytes({"op": "prompt", "text": text, "images": [image]}) > _MAX_LINE_BYTES
+
+        with caplog.at_level(logging.WARNING, logger="local_operator.mobile.attach_client"):
+            assert await client.prompt(text, images=[image]) == "prompt ok"
+        assert client.connected, "the send severed the connection"
+    finally:
+        client.close()
+        registrant.close()
+
+    refit = [record for record in caplog.records if "bytes of image payload" in record.getMessage()]
+    assert len(refit) == 1, f"expected one refit line, got {len(refit)}"
+    logged = refit[0].getMessage()
+    match = re.search(
+        r"resized \d+ image\(s\) to (\d+) bytes of image payload and the frame "
+        r"is now (\d+) bytes",
+        logged,
+    )
+    assert match is not None, f"the refit line does not carry both figures: {logged!r}"
+    logged_payload, logged_frame = (int(match.group(1)), int(match.group(2)))
+
+    _prompt_text, delivered = handle.received[-1]
+    assert len(delivered) == 1, "the attachment was dropped instead of resized"
+    payload = getattr(delivered[0], "data", None) or delivered[0].get("data_b64")
+    assert isinstance(payload, str) and payload, "no image payload reached the owner"
+    assert logged_payload == len(payload), (
+        f"the log's image-payload figure is {logged_payload:,} bytes but what "
+        f"arrived is {len(payload):,} — the line is reporting the frame again"
+    )
+    assert logged_frame > logged_payload, (
+        "the frame and payload figures agree, so the two quantities the line "
+        "exists to distinguish have collapsed back into one"
+    )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("op", ["prompt", "steer", "slash"])
 async def test_every_image_bearing_op_is_guarded_not_just_prompt(
     tmp_path: Path, monkeypatch, op: str
@@ -2505,6 +2572,79 @@ async def test_an_unsendable_message_is_refused_by_name_not_silently_lost(
 
         # Nothing was delivered, and the session still works.
         assert handle.received == []
+        assert await client.prompt("a normal message") == "prompt ok"
+    finally:
+        client.close()
+        registrant.close()
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_attachment_keeps_its_own_sentence_when_the_text_is_the_bulk(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Review round 3, NIT-1: two failures, two remedies, and the rewrite must
+    not collapse them.
+
+    When the text has eaten the frame's budget, :func:`fit_request_frame`
+    re-blames a SIZE failure on the text — the copy call review round 2
+    (MAJOR-4) argued for, because a per-image share rounding to ``0.0 MB``
+    points at a screenshot when only shortening the prompt can help.
+
+    That rewrite used to catch the UNREADABLE refusal too, since it is also an
+    ``OversizedRequest``. So a corrupt attachment on a text-heavy frame told
+    the user to "shorten the text or send the images on their own" — advice
+    that cannot work, because those bytes are not an image at any size and no
+    amount of shortening makes them one. The remedy there is always "remove
+    it", whatever the budget looks like, which is why the refusal got its own
+    class (``UnreadableImageRequest``) rather than a message check.
+
+    The sibling test above covers the same junk payload with a ROOMY budget;
+    this one is the text-dominated budget, the only regime where the rewrite
+    runs. Both must produce the same sentence.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    handle = _ImageRecordingHandle()
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    client = AttachClient(lambda _projection: None, lambda _reason: None)
+    try:
+        record = await _record(tmp_path)
+        await client.connect(record, "s1")
+
+        # THE FIXTURE MUST REACH THE REWRITE, or this asserts nothing: the
+        # text has to leave less than `_MIN_VIABLE_IMAGE_BUDGET_BYTES` for the
+        # images, which is the only condition under which the text-blaming
+        # sentence is selected at all.
+        text = "x" * 1_015_000
+        junk = {
+            "mime_type": "image/png",
+            "data_b64": base64.b64encode(b"\x00" * 40_000).decode("ascii"),
+        }
+        probe = {"op": "prompt", "req": 1, "text": text, "images": [junk]}
+        assert (
+            len(json.dumps(probe).encode()) + 1 > _READ_LIMIT_BYTES
+        ), "the fixture no longer crosses the line limit, so the refit never runs"
+        overhead = _frame_overhead_bytes(probe)
+        budget = _READ_LIMIT_BYTES - overhead - _FRAME_ENCODING_SLACK_BYTES
+        assert 0 < budget < _MIN_VIABLE_IMAGE_BUDGET_BYTES, (
+            f"the fixture leaves {budget} bytes for its images; the rewrite "
+            "under test only runs below the text-is-the-bulk gate"
+        )
+
+        with pytest.raises(OversizedRequest) as refusal:
+            await client.prompt(text, images=[junk])
+        sentence = str(refusal.value)
+        assert "not a readable image" in sentence, (
+            f"the unreadable attachment was re-blamed on the text, sending the "
+            f"user off shortening a prompt that was never the problem: {sentence}"
+        )
+        assert "image 1" in sentence, f"the refusal does not name the chip: {sentence}"
+        assert "text alone fills" not in sentence, f"the text rewrite replaced it: {sentence}"
+        assert client.connected, "reporting the refusal killed the connection"
+        assert handle.received == []
+
+        # And the session still works afterwards.
         assert await client.prompt("a normal message") == "prompt ok"
     finally:
         client.close()
@@ -2901,8 +3041,8 @@ def _refit_report(entries: tuple[_RefitReport, ...]):
         _REFIT_REPORT.reset(token)
 
 
-def test_the_refit_caption_is_one_row_whatever_the_attachment_count() -> None:
-    """The caption's cost must not grow with the number of images.
+def test_the_refit_caption_saturates_on_a_mixed_aspect_paste() -> None:
+    """The caption's cost is bounded by SHAPES, not by the attachment count.
 
     ``_report_wire_refit_for`` used to join one ``#N WxH -> WxH`` clause per
     downscaled image, in ``_refit_images``' internal smallest-first walk. The
@@ -2913,12 +3053,27 @@ def test_the_refit_caption_is_one_row_whatever_the_attachment_count() -> None:
     see, with six of eight clauses the identical string (design round 2, D9;
     QA round 2, Q5).
 
-    Grouping by delivered size bounds the row by the ladder's RUNGS rather than
-    by the attachment count, so this asserts the property rather than a
-    specific sentence: the clause count can never exceed the number of edges
-    the refit can produce, whatever the user pastes.
+    The honest bound is RUNGS x ASPECT RATIOS, not rungs alone. A rung caps
+    the LONG edge and the refit preserves aspect ratio, so grouping on the
+    exact delivered ``WxH`` splits once per distinct shape in the paste — and
+    this test's earlier version built every fixture as a SQUARE, which
+    collapsed ``(w, h)`` onto the rung count by construction and passed
+    vacuously against a docstring promising "one row at 100 cols for ANY
+    number of attachments" (review round 3, MAJOR-5). Re-fixtured with the
+    aspect mix an operator actually pastes, that claim failed at every count
+    above two.
+
+    What this asserts is the property that survives, and it is the one that
+    distinguishes the count form from the per-image enumeration D9 killed:
+    given a fixed set of delivered SHAPES, the clause count does not grow
+    with the attachment count. The fixture cycles ten real delivered sizes,
+    so at 300 attachments the row is the same length as at 10 — where the
+    enumeration form would have 300 clauses. Through the real fitter the
+    clause count moves within a measured envelope rather than holding exactly
+    (4-9 clauses over n=10..30 on a five-aspect paste, because which rung a
+    shape lands on tracks the per-image budget); ``_report_wire_refit_for``'s
+    docstring carries those figures and the row budget they imply.
     """
-    from local_operator.imaging import IMAGE_WIRE_REFIT_EDGES
     from local_operator.tui.app import OperatorApp
 
     def caption(entries: list[Any]) -> str:
@@ -2930,57 +3085,130 @@ def test_the_refit_caption_is_one_row_whatever_the_attachment_count() -> None:
             OperatorApp._report_wire_refit_for(app, source)
         return captured[0] if captured else ""
 
-    for count in (1, 2, 8, 20, 60):
-        # Two rungs, interleaved by marker, so the grouping cannot pass by
-        # accident on a single-size fixture.
-        entries = [
-            _RefitReport(
-                marker=index + 1,
-                width=384 if index % 3 else 512,
-                height=384 if index % 3 else 512,
-                source_width=1400,
-                source_height=1400,
-            )
-            for index in range(count)
-        ]
+    # Delivered sizes the ladder really produces for composer-bounded source
+    # shapes — 16:9 window captures, 9:19.5 phone shots, squares, 3:2 and 4:3
+    # photos. NINE of them, because that is the most the real fitter produced
+    # over a five-aspect paste swept from n=10 to 30 (measured: 4-9 clauses,
+    # 97-168 characters). A fixture wider than reality would make the row
+    # budget below a guess rather than a measurement.
+    mixed_delivered = (
+        (768, 432),
+        (512, 288),
+        (354, 768),
+        (236, 512),
+        (768, 768),
+        (512, 512),
+        (768, 512),
+        (512, 342),
+        (512, 384),
+    )
+
+    def entry(index: int, size: tuple[int, int]) -> _RefitReport:
+        width, height = size
+        # The composer-bounded source that produced this delivered size: the
+        # same aspect at the 1024px ingest edge, so every entry really lost
+        # pixels (a paste is bounded BEFORE the transport refit sees it).
+        if width >= height:
+            source_width, source_height = 1024, round(height * 1024 / width)
+        else:
+            source_width, source_height = round(width * 1024 / height), 1024
+        return _RefitReport(
+            marker=index + 1,
+            width=width,
+            height=height,
+            source_width=source_width,
+            source_height=source_height,
+        )
+
+    # SATURATION: past the point where every shape in the mix has appeared,
+    # adding attachments — a hundred, three hundred — adds no clause and keeps
+    # the row inside the measured budget.
+    for count in (10, 24, 60, 300):
+        entries = [entry(i, mixed_delivered[i % len(mixed_delivered)]) for i in range(count)]
         row = caption(entries)
         assert row.startswith(
             f"{count} image"
         ), f"the caption does not lead with the count it is claiming: {row!r}"
         clauses = row.split(": ", 1)[1].split(", ")
-        assert len(clauses) <= len(IMAGE_WIRE_REFIT_EDGES), (
-            f"{count} attachments produced {len(clauses)} clauses; the caption "
-            f"grows with the attachment count again: {row!r}"
+        assert len(clauses) == len(mixed_delivered), (
+            f"{count} attachments produced {len(clauses)} clauses where the mix "
+            f"has {len(mixed_delivered)} shapes — the caption is grouping by "
+            f"something other than the delivered size, or growing again: {row!r}"
         )
-        assert len(row) < 100, (
-            f"the caption is {len(row)} characters at {count} attachments, which "
-            f"wraps past one row at 100 columns: {row!r}"
+        # THE CLAIM GUARD, in the idiom `test_ten_jobs_at_the_cap_overflow_the_
+        # line_limit_without_the_fix` sets: assert the shape that DISPROVES the
+        # old docstring, so "bounded by the ladder's rungs" can never silently
+        # return. A composer-bounded paste reaches three rungs (768/512/384 —
+        # never the 1024 one, because the ingest bound already applied), and
+        # this paste produces nine clauses from them (review round 3, MAJOR-5).
+        from local_operator.imaging import IMAGE_WIRE_REFIT_EDGES
+
+        reachable_rungs = sum(
+            1 for edge in IMAGE_WIRE_REFIT_EDGES if edge is not None and edge < 1024
+        )
+        assert len(clauses) > reachable_rungs, (
+            f"{len(clauses)} clauses from {reachable_rungs} reachable rungs no "
+            "longer exceeds the rung count, so this fixture has stopped being "
+            "the mixed-aspect paste it exists to be"
+        )
+        # A CHARACTER-COUNT PROXY for the rendered row count, not the row count
+        # itself: the notice's own glyph and spine indent cost a couple of
+        # columns this does not model, and the authority on real geometry is
+        # the rendered frames in the design and QA rounds. The budget is the
+        # measured envelope — the real fitter over a five-aspect paste swept
+        # n=10..30 topped out at 9 clauses and 168 characters, 2 rows at 100
+        # cols and 3 at 60, and this fixture reproduces that shape at 167-178
+        # characters — so the headroom is measurement, not luck.
+        assert len(row) <= 2 * 98, (
+            f"the caption is {len(row)} characters at {count} attachments, past "
+            f"the measured 2-row budget at 100 columns: {row!r}"
+        )
+        assert len(row) <= 4 * 58, (
+            f"the caption is {len(row)} characters at {count} attachments, past "
+            f"the measured 4-row budget at 60 columns: {row!r}"
         )
 
-    # THE GLYPH BINDS TO THE COUNT, not to a trailing clause. Appended once
-    # after the last clause it read as the mark on that image alone, while the
-    # composer chips already carry their own for the ingest bound — two shrinks
-    # sharing one glyph, neither adjacent to what it qualified (design round 2,
-    # D10).
+    # THE COMMON PASTE is a run of same-shape screenshots, and it stays ONE
+    # row at 100 cols at any count — the single-shape collapse QA measured to
+    # 300 attachments, which the mixed fixtures above must not be read as
+    # replacing.
+    for count in (2, 8, 300):
+        entries = [
+            entry(i, (512, 288) if i % 2 else (768, 432))  # one shape, two rungs
+            for i in range(count)
+        ]
+        row = caption(entries)
+        clauses = row.split(": ", 1)[1].split(", ")
+        assert len(clauses) == 2, f"one shape reached {len(clauses)} rungs: {row!r}"
+        assert len(row) < 98, f"a single-shape paste wraps at 100 columns: {row!r}"
+
+    # NO GLYPH ON THIS ROW AT ALL (design round 3, D14 — round 2's D10 had it
+    # bound to the count). The chips carry their own ``↓`` for the INGEST
+    # bound, and a caption ``↓`` for the TRANSPORT refit put two shrink counts
+    # within one glyph of each other on a partial refit.
+    #
+    # Asserted on the BARE arrow, not on ``RESIZED_MARK`` (which is ``" ↓"``,
+    # space included): the finding is that this row shares no glyph with the
+    # chips, so any spelling of the arrow is a regression. Pinning the exact
+    # constant would let a space-less one back in — a canary caught precisely
+    # that, a mutation restoring ``\u2193`` without the leading space sailing
+    # through an assertion written against ``RESIZED_MARK``.
     from local_operator.tui.widgets.editor import RESIZED_MARK
 
     row = caption(
         [
-            _RefitReport(marker=1, width=512, height=512, source_width=1400, source_height=1400),
-            _RefitReport(marker=2, width=384, height=384, source_width=1400, source_height=1400),
+            entry(0, (512, 512)),
+            entry(1, (384, 384)),
         ]
     )
-    assert row.startswith(
-        f"2 images{RESIZED_MARK} "
-    ), f"the resize glyph is not bound to the count it qualifies: {row!r}"
-    assert not row.endswith(RESIZED_MARK), f"the glyph is still trailing the last clause: {row!r}"
+    assert RESIZED_MARK.strip() not in row, f"the resize glyph is back on the caption: {row!r}"
 
     # IN THE USER'S ORDER: groups appear by their lowest chip number, not in
     # the refit's internal smallest-first walk.
     row = caption(
         [
-            _RefitReport(marker=9, width=384, height=384, source_width=1400, source_height=1400),
-            _RefitReport(marker=2, width=512, height=512, source_width=1400, source_height=1400),
+            entry(8, (384, 384)),
+            entry(1, (512, 512)),
         ]
     )
     assert row.index("512x512") < row.index(
@@ -2995,12 +3223,15 @@ def test_the_size_scale_never_prints_a_smaller_number_in_a_bigger_unit() -> None
     boundary mid-KB: ``104,857`` printed ``102 KB`` and ``104,858`` printed
     ``0.1 MB``, so a one-byte step showed a smaller number in a larger unit and
     a user comparing two refusals a minute apart read them backwards (review
-    round 2, NIT-2).
+    round 2, NIT-2). Round 3 added the same guard one scale DOWN: below a full
+    KB the raw byte count prints, because ``1023 B`` reading ``0 KB`` repeats
+    the "did not fit in nothing" defect on the per-image share path the split
+    can genuinely reach (review round 3, NIT-2).
     """
 
     def as_bytes(rendered: str) -> float:
         figure, unit = rendered.split()
-        return float(figure) * (1024 if unit == "KB" else 1024 * 1024)
+        return float(figure) * 1024 ** {"B": 0, "KB": 1, "MB": 2}[unit]
 
     previous = -1.0
     for size in range(0, 3 * 1024 * 1024, 311):
@@ -3011,9 +3242,46 @@ def test_the_size_scale_never_prints_a_smaller_number_in_a_bigger_unit() -> None
         )
         previous = current
 
-    # The boundary is a whole megabyte, so both sides read as the same quantity.
+    # The boundaries are whole units, so both sides of each read as the same
+    # quantity.
+    assert _megabytes(1023) == "1023 B"
+    assert _megabytes(1024) == "1 KB"
     assert _megabytes(1024 * 1024 - 1) == "1024 KB"
     assert _megabytes(1024 * 1024) == "1.0 MB"
+
+
+def test_the_text_bulk_refusal_compares_like_with_like() -> None:
+    """Design round 3, D17: the two figures the sentence compares share a unit.
+
+    "fills 1000 KB of the 1.0 MB limit" asked the user to convert units
+    mid-sentence between exactly the two figures the sentence exists to
+    compare. The text figure now renders in the limit's scale — MB — which is
+    safe ONLY because of where this sentence fires: the budget precondition
+    (under `_MIN_VIABLE_IMAGE_BUDGET_BYTES`, asserted below rather than
+    assumed) puts the overhead within a few KB of the whole limit, so its MB
+    figure can never round below 0.9 and the ``0.0 MB`` class `_megabytes`
+    exists to avoid is unreachable here. The ROOM figure keeps `_megabytes`'
+    own scale because it is genuinely small — KB is the honest unit for a few
+    KB, and "no room" already covers a sub-KB remainder.
+    """
+
+    def figures(overhead: int, budget: int) -> tuple[str, str]:
+        sentence = str(_text_is_the_bulk_refusal(overhead, budget))
+        text_figure = sentence.split(" fills ", 1)[1].split(" of the", 1)[0]
+        limit_figure = sentence.split("the ", 1)[1].split(" limit", 1)[0]
+        return text_figure, limit_figure
+
+    # The reachable band for this sentence, both edges: a budget just under
+    # the gate with the text a hair under the limit, and one past it.
+    for overhead, budget in ((1_000_000, 30_000), (1_011_713, 1_023), (1_100_000, 0)):
+        assert budget < _MIN_VIABLE_IMAGE_BUDGET_BYTES, (
+            f"the fixture ({overhead:,} overhead, {budget:,} budget) is not in "
+            "the band this sentence fires in, so the 0.9-MB-floor argument "
+            "does not hold for it"
+        )
+        text_figure, limit_figure = figures(overhead, budget)
+        both_mb = text_figure.endswith("MB") and limit_figure.endswith("MB")
+        assert both_mb, f"the compared figures mix units: {text_figure!r} vs {limit_figure!r}"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_compact_command.py
+++ b/tests/unit/tui/test_compact_command.py
@@ -757,6 +757,22 @@ async def test_a_held_prompt_refused_on_the_wire_takes_its_echo_back(tmp_path) -
 
         assert _rows() == (1, 1), f"the echo was never painted: {_rows()}"
 
+        def _queued_notice() -> NoticeBlock | None:
+            return next(
+                (
+                    block
+                    for block in app.query_one(TranscriptView).blocks()
+                    if isinstance(block, NoticeBlock)
+                    and block._text == "queued — sends when compaction finishes"
+                ),
+                None,
+            )
+
+        # The queued notice is ON the transcript while the hold has the prompt
+        # — the state D15 filed against must be reached before its fix is
+        # asserted, or the withdrawal below would pass vacuously.
+        assert _queued_notice() is not None, "the fixture never painted the queued notice"
+
         # The pass ends and the held prompt is dispatched — into a refusal.
         app._compacting = False
         app._consume_compaction_input(app._interaction)
@@ -769,6 +785,14 @@ async def test_a_held_prompt_refused_on_the_wire_takes_its_echo_back(tmp_path) -
         assert _rows() == (0, 0), (
             "the refused prompt's rows are still on the transcript, so the "
             f"scroll-back asserts a message that never went: {_rows()}"
+        )
+        # And the QUEUED notice went with them (design round 3, D15): a row
+        # announcing a send that will never happen, sitting where the message
+        # it described used to be, is the same durable lie the withdrawal
+        # exists to remove.
+        assert _queued_notice() is None, (
+            "the queued notice outlived the refusal it was narrating; the "
+            "transcript still promises a send that will not happen"
         )
 
 
@@ -818,3 +842,12 @@ async def test_a_held_prompt_that_is_delivered_keeps_its_echo(tmp_path) -> None:
         assert (users, images) == (1, 1), (
             "a delivered post-compaction turn lost its transcript rows: " f"{(users, images)}"
         )
+        # The CONTROL for the notice withdrawal: the message's own row is the
+        # receipt, so the `queued` row must be gone here too — a removal that
+        # only fired on the refusal path would leave it announcing a send the
+        # message below it already proved happened (design round 3, D15).
+        assert not any(
+            isinstance(block, NoticeBlock)
+            and block._text == "queued — sends when compaction finishes"
+            for block in blocks
+        ), "the queued notice still narrates a hold that ended in delivery"

--- a/tests/unit/tui/test_compact_command.py
+++ b/tests/unit/tui/test_compact_command.py
@@ -694,3 +694,127 @@ async def test_the_pass_ends_and_the_held_prompt_is_sent_with_its_image(tmp_path
 
     assert sent, "the pass ended without sending the held prompt"
     assert len(sent[0][1]) == 1, "the pass ended and sent the words without the screenshot"
+
+
+@pytest.mark.asyncio
+async def test_a_held_prompt_refused_on_the_wire_takes_its_echo_back(tmp_path) -> None:
+    """Review round 2, MAJOR-3. The withdrawal has to reach the compaction route.
+
+    The echo is painted at submit so the app answers the keystroke, and a send
+    the transport REFUSES is the one path where that row is a durable lie: same
+    styling as a delivered message, still standing after the user follows the
+    refusal's advice and resends, so the transcript shows one message twice
+    with an attachment that never left the machine (design round 1, D3).
+
+    Round 1 fixed that for a direct submit by holding the blocks on
+    ``turn.submitted_blocks`` — but set them PAST the compaction branch's own
+    ``return``, so a prompt held through a pass and dispatched minutes later
+    ran the same ``except OversizedRequest`` with nothing to withdraw and
+    reproduced D3's exact symptom on that route. Reachability is ordinary: a
+    pass runs for minutes, the hold exists because users keep typing, and the
+    hold deliberately carries the attachments.
+
+    Driven through the real hold and the real dispatch, and asserted in BOTH
+    directions in the sibling below — a withdrawal that fires when the send
+    SUCCEEDS would eat a real turn, which is the worse failure.
+    """
+    from PIL import Image
+
+    from local_operator.mobile.attach_client import OversizedRequest
+    from local_operator.tui.widgets.editor import Editor
+    from local_operator.tui.widgets.image_block import ImageBlock
+
+    path = tmp_path / "a.png"
+    Image.new("RGB", (30, 40), "red").save(path)
+
+    class RefusingCompaction(SlowCompaction):
+        async def prompt(self, text: str, images=None, **kwargs) -> None:  # type: ignore[override]
+            raise OversizedRequest("image 1 is too large to send; remove it and send again")
+
+    app = OperatorApp(lambda: _factory(RefusingCompaction()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        app.post_message(events.Paste(str(path)))
+        await pilot.pause()
+        await pilot.pause()
+        assert len(editor.referenced_images()) == 1, "the fixture never attached"
+
+        editor.insert("what does this show")
+        app._compacting = True
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app._prompt_held_for_compaction, "the prompt was not held"
+
+        def _rows() -> tuple[int, int]:
+            blocks = app.query_one(TranscriptView).blocks()
+            return (
+                sum(1 for block in blocks if isinstance(block, UserBlock)),
+                sum(1 for block in blocks if isinstance(block, ImageBlock)),
+            )
+
+        assert _rows() == (1, 1), f"the echo was never painted: {_rows()}"
+
+        # The pass ends and the held prompt is dispatched — into a refusal.
+        app._compacting = False
+        app._consume_compaction_input(app._interaction)
+        for _ in range(40):
+            await pilot.pause()
+            await asyncio.sleep(0.05)
+            if _rows() == (0, 0):
+                break
+
+        assert _rows() == (0, 0), (
+            "the refused prompt's rows are still on the transcript, so the "
+            f"scroll-back asserts a message that never went: {_rows()}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_held_prompt_that_is_delivered_keeps_its_echo(tmp_path) -> None:
+    """The control for the test above: a DELIVERED hold must keep its rows.
+
+    The withdrawal is only correct if it fires exactly on the refusal path. A
+    version that cleared the rows whenever a held prompt was dispatched would
+    pass its sibling and silently erase every successful post-compaction turn,
+    which is a strictly worse bug than the lie it removes.
+    """
+    from PIL import Image
+
+    from local_operator.tui.widgets.editor import Editor
+    from local_operator.tui.widgets.image_block import ImageBlock
+
+    path = tmp_path / "a.png"
+    Image.new("RGB", (30, 40), "red").save(path)
+
+    app = OperatorApp(lambda: _factory(SlowCompaction()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        app.post_message(events.Paste(str(path)))
+        await pilot.pause()
+        await pilot.pause()
+        assert len(editor.referenced_images()) == 1, "the fixture never attached"
+
+        editor.insert("what does this show")
+        app._compacting = True
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app._prompt_held_for_compaction, "the prompt was not held"
+
+        app._compacting = False
+        app._consume_compaction_input(app._interaction)
+        for _ in range(40):
+            await pilot.pause()
+            await asyncio.sleep(0.05)
+
+        blocks = app.query_one(TranscriptView).blocks()
+        users = sum(1 for block in blocks if isinstance(block, UserBlock))
+        images = sum(1 for block in blocks if isinstance(block, ImageBlock))
+        assert (users, images) == (1, 1), (
+            "a delivered post-compaction turn lost its transcript rows: " f"{(users, images)}"
+        )

--- a/tests/unit/tui/test_goal_submission.py
+++ b/tests/unit/tui/test_goal_submission.py
@@ -174,4 +174,14 @@ async def test_goal_submits_cited_image_and_keeps_pasted_lookalikes_out_of_resol
         await pilot.pause()
         assert session.goal == f"Check {payload} against {marker}"
         assert session.prompts == [session.goal]
-        assert session.prompt_images == [[image]]
+        # The PAYLOAD, not the model: `resolve_markers` stamps the chip number
+        # onto a copy of the image so the transport can name the right
+        # attachment in a refusal (design round 2, D8), so the object sent is
+        # equal to the draft's in every field a provider sees but is not `==`
+        # to it. Asserting the bytes keeps this test about WHICH image was
+        # resolved rather than about that presentation field.
+        sent = session.prompt_images[0]
+        assert [(block.data, block.mime_type) for block in sent] == [(image.data, image.mime_type)]
+        assert [block.marker for block in sent] == [
+            2
+        ], "the cited chip number did not ride the image the composer sent"

--- a/tests/unit/tui/test_skill_invocation.py
+++ b/tests/unit/tui/test_skill_invocation.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, cast
 
 import pytest
 
@@ -375,6 +374,7 @@ class TestReviewRegressions:
         `resolve_markers` directly: the defect was WHICH STRING that call site
         passed, so a test that calls the helper itself cannot catch it.
         """
+        from local_operator.harness.types import ImageContent
         from local_operator.tui.events import CompactionEnded
         from local_operator.tui.widgets.editor import Attachment
 
@@ -395,9 +395,15 @@ class TestReviewRegressions:
                 'lead\n<skill name="research" invocation="x">See [Image #1].</skill>\n' + typed
             )
             app._typed_held_for_compaction = typed
+            # REAL `ImageContent`, not bare strings: `resolve_markers` now
+            # stamps the citing chip number onto each image it resolves
+            # (design round 2, D8), so a stand-in that is not the declared type
+            # no longer survives the walk. The `data` field carries the marker
+            # this assertion keys on, which is what the strings were standing
+            # in for.
             app._images_held_for_compaction = {
-                1: Attachment(cast(Any, "AAA"), "[Image #1]"),
-                2: Attachment(cast(Any, "BBB"), "[Image #2]"),
+                1: Attachment(ImageContent(data="AAA", mime_type="image/png"), "[Image #1]"),
+                2: Attachment(ImageContent(data="BBB", mime_type="image/png"), "[Image #2]"),
             }
             app.on_compaction_ended(CompactionEnded("manual", True, "snapcompact", 10, 5))
             for _ in range(200):
@@ -405,7 +411,7 @@ class TestReviewRegressions:
                 if session.prompts:
                     break
             # Cited #2 first, so #2's image must be sent first.
-            assert session.prompt_images[0] == ["BBB", "AAA"]
+            assert [block.data for block in session.prompt_images[0]] == ["BBB", "AAA"]
 
     @pytest.mark.asyncio
     async def test_replay_repaints_the_typed_line_not_the_body(self, skill_root) -> None:


### PR DESCRIPTION
## What and why

**C2 — sending a message ended the session.** The operator reported: *"When I paste images and send a new message it seems to exit and I need to run `lop --resume` to resume again. It might not be specifically image related but sending new messages causes it to exit."*

That instinct is right in the important way: **any** oversized inbound frame does this. Images are just the easy way to exceed 1 MiB.

This is the **inbound (client→owner) twin** of the outbound `relay_frame_or_degraded` guard, and it had no protection at all.

### The mechanism

The runtime's control socket is created with `limit=_MAX_LINE_BYTES` (1 MiB). Its per-connection reader loop was:

```python
line = await reader.readline()        # <- raises HERE, outside the try below
if not line: ...
try:
    frame = json.loads(line.decode("utf-8", "replace"))
except ValueError:                    # <- looks like it covers the read; it does not
    continue
```

`asyncio.StreamReader.readline` raises `ValueError` (wrapping `LimitOverrunError`) for a line past the connection limit, and that raise happens **at the `readline()` call, outside** the `try` that catches `ValueError`. The outer handler only catches `ConnectionResetError`/`BrokenPipeError`, so the `ValueError` propagated, the reader loop died, and `finally: self._drop_client(...)` tore the connection down.

Meanwhile the client wrote prompts **entirely unguarded** — `AttachClient.prompt`/`steer` put `images=list(images or [])` straight into one JSON line, each image carrying full base64 `data_b64`. So the very act of sending severed the socket.

**The sizes that break it are ordinary, not pathological.** Measured on this machine's own files, after the composer's own ingest bound:

| source | composer-bounded | base64 on the wire |
|---|---|---|
| 1672x941 render | 1024x576 | **1,234,384 B** — over the limit alone |
| 2784x1070 UI capture | 1568x603 | 331,516 B |
| two ordinary screenshots | — | **1.1 MB together** |

One pasted screenshot is enough. Two ordinary ones are enough even when neither is unreasonable on its own.

## The fix — both halves, because either alone is insufficient

**1. The reader loop survives an oversized inbound line.** It catches the overrun, discards that frame, and **keeps the connection**, so the session stays usable for the next message — the survival the operator actually missed.

`continue` is safe here and is deliberately **not** the infinite loop the sibling `viewer_server` guard warns about. The difference is `readline` vs `readuntil`: `readuntil` leaves the offending bytes in the buffer so the next read re-raises forever, while `readline` catches its own `LimitOverrunError` and **drains** — deleting through the separator when one was found, clearing the buffer when it was not (CPython `asyncio/streams.py`). The mobile daemon's reader already documents exactly this reasoning; this makes the runtime agree with it.

Reported at `error`, **once per frame rather than once per chunk** — one oversized line raises repeatedly (measured: 7 raises for a 10 MB line), so a log call per raise would bury the fact that they were all one frame. The second line names the total, because "over 1 MiB" does not say whether to trim one screenshot or five.

**2. The client does not send a frame it knows the owner cannot read.** The guard sits at the one shared `_request_frame` seam, so **every** image-bearing op is covered rather than `prompt` alone — `prompt`, `steer`, `slash` and `slash_result`. The phone's relay (`MobileDaemon.request`) takes the same helper, since it reaches the same socket with the same payloads; `OversizedRequest` is a `ValueError`, which that module's HTTP layer already renders as a 422 the composer shows **while retaining the user's command**.

### The product call: refit, don't reject

**An over-budget image is resized, not refused.** The deciding constraint is that pasting screenshots is routine here and so are the sizes above — a hard rejection on a normal screenshot would break the feature to protect the transport.

The ladder **spends the codec before the user's pixels**. Fidelity here means "can the model read the text in this screenshot", and pixels carry that while the codec mostly does not, so the first rung re-encodes at **unchanged dimensions**: a quality-85 JPEG is 4-11x smaller than the ingest PNG and was enough for every single-image case measured. Downscale rungs (1024/768/512/384) are the fallback for **several** images in one message, where the frame is over budget before any single image is unreasonable.

Three details that are load-bearing:

- **Images share one frame budget.** The line limit applies to the whole frame, so N images must fit *together*; refitting each against the full limit would pass N times and still overflow.
- **The re-encode runs at every rung, not just the first.** Applying it only once was measurably wrong: the descending rungs handed back PNGs of continuous-tone content, which PNG cannot compress, so a 1400x1400 frame against a 240 KB budget ran out of rungs and was **refused** while the real remedy had never been tried below full size. With the re-encode on each rung the same image fits at 512x512.
- **Line art is exempt from the JPEG rung**, for the reason the rest of `imaging` already documents: JPEG's ringing lands on exactly the one-pixel strokes a bilevel rendering exists to preserve.

**When nothing fits, the user's work is not lost.** The refusal names *which* attachment to drop, and the TUI puts the draft back in the composer — the message was never sent, so the only copy of their text and attachment is the one the prompt worker is holding. Two distinct sentences, because the remedies differ: prose over the limit says *shorten it*; an attachment that is not a decodable image says so, rather than telling someone to shrink bytes that were never an image.

## Testing evidence

Real execution against a real `RuntimeServer` over a real socket, not a green suite.

### 1. The reproduction, before and after

**BEFORE** — the reader-loop shape and limits, reproduced exactly:

```
$ .venv/bin/python repro_inbound.py
frame bytes: 1400115 limit: 1048576
[('UNCAUGHT-ValueError', 'Separator is not found, and chunk exceed the limit'), ('dropped', None)]
```

That `UNCAUGHT-ValueError` → `dropped` is the session dying mid-send.

**BEFORE, against the real pre-fix tree** (`f1ab7d346`, new test run there):

```
File "/private/tmp/lo-prefix-inbound/local_operator/session/runtime/server.py", line 1310, in _on_connection
    line = await reader.readline()
ValueError: Separator is not found, and chunk exceed the limit

FAILED test_an_oversized_inbound_frame_does_not_kill_the_session
  - ConnectionResetError: [Errno 54] Connection reset by peer
1 failed
```

The exact raise at `server.py:1310`, and the connection reset the operator experienced.

**AFTER** — real server, real socket, oversized `prompt`, then the next message:

```
connected, welcome op = projection
LOG ERROR session runtime: dropping an inbound frame from attach client ('127.0.0.1', 50779)
          over the 1048576-byte line limit; the frame is discarded and the connection kept
          — the sender must resize its payload
LOG ERROR session runtime: discarded ~1335101 bytes of oversized inbound frame from attach
          client ('127.0.0.1', 50779); the connection is still up and the next message will
          be read normally
RESULT: next message answered: ack prompt ok
prompts the handle actually received: [('prompt', ('the NEXT message',), {})]
```

**The session survives and the NEXT message is delivered** — that survival is the actual bug the operator felt.

### 2. A real pasted image now sends, and actually arrives

Driven through `AttachClient` against the real runtime, with a real screenshot from this machine:

```
pasted image: source 1672x941 -> composer-bounded 1024x576 (image/png), 1,234,384 b64 bytes
              (frame would be 1,234,456 bytes, limit 1,048,576)
LOG WARNING attach client: prompt frame was 1234553 bytes, over the 1048576-byte line limit;
            resized 1 image(s) to 200562 bytes so the message could be sent
prompt ACK: prompt ok | still connected: True
owner RECEIVED the image: mime=image/jpeg 200,392 b64 bytes
  -> delivered pixels: 1024x576 (image/jpeg)
follow-up ACK: prompt ok | still connected: True
```

The image **reaches the owner** (a guard that silently dropped the attachment would pass a "did not crash" test while losing the user's work), **every pixel is preserved** — 1024x576 in, 1024x576 out, codec changed only — and the session keeps working afterwards.

### 3. Every image-bearing op, and the shared budget

```
A) FOUR images, 3,289,088 b64 bytes total (frame ~3.1x the limit)
   ACK='prompt ok' connected=True delivered=4 images, sizes=[71256, 100212, 79184, 200392]
   frame now = 451,262 bytes

B) STEER with the same four images
   steer delivered=4 images, connected=True

C) SLASH with images
   slash ok='slash ok' delivered=4 images, connected=True
```

All four attachments survive; the **frame** is what had to fit, and it does.

### 4. The user's message and attachment are never silently lost

```
A) prompt whose TEXT alone exceeds the limit (no images)
   REFUSED: this message is 1,200,107 bytes and the limit is 1,048,576 bytes;
            shorten it and send again
   connected=True

B) an attachment that is not decodable as an image
   REFUSED: image 1 could not be sent because it is not a readable image;
            remove it and send again
   connected=True

C) the session still works after both refusals
   ACK = prompt ok connected = True
```

Reporting the refusal does not kill the connection, and nothing was delivered half-parsed.

### 5. Rendered frames (user-visible change)

Captured from the **real `OperatorApp`** via `scripts.visual_capture.save_capture` at 100x30, so the stylesheet applies. Both frames start from an **empty composer**, because submit clears it before the prompt worker runs — which is exactly what makes the pre-fix loss invisible until the user goes looking for their text.

**BEFORE** — red `✗` error, and the composer is **empty**: the user's text and their pasted image are gone, with no way back.

```
 ✗ image 1 is too large to send (3.1 MB) and could not be resized to fit; remove it and send
   again
   ...
 ❯ Message Local Operator…                          <- their work, gone
```

**AFTER** — amber `!` warning (recoverable, not a failure), and **the draft is back in the composer**, ready to send again after dropping the attachment.

```
 ! image 1 is too large to send (3.1 MB) and could not be resized to fit; remove it and send
   again
   ...
 ❯ what does this screenshot show?                   <- restored
```

Rendered PNGs attached in a follow-up comment.

### 6. New tests

Extended `tests/unit/session/test_attach_frame_size.py`, which already holds the oversized-frame fixtures — 14 new tests, all driving a real socket where the claim is about the wire:

- the unguarded frame size is asserted, so the other tests cannot pass for the wrong reason if images ever get smaller
- an oversized inbound frame does not kill the session, **and the next message is answered**
- a large pasted image is refitted and genuinely arrives, with the session usable afterwards
- `prompt`/`steer`/`slash` are parametrized over the one shared seam, so a fourth image-bearing op cannot quietly skip the guard
- several images share one frame budget (the subtle way to get this wrong)
- an unsendable message is refused by name, does not kill the connection, and delivers nothing
- a refused request leaves nothing in `_pending` (found while testing: the future was registered before the fit could raise, leaking an unretrieved `ConnectionError`)
- the refit prefers the codec over the user's pixels, asserted as a property

Test fixtures use **continuous-tone** content deliberately: pure noise and flat fills are both pathological for the ladder under test, so either one would test the fixture rather than the refit.

## Gates

```
.venv/bin/python -m flake8 .                             clean
uvx --from black==26.1.0 black --check .                 1156 files unchanged
uvx isort==5.13.2 --check .                              clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .   0 errors, 0 warnings
```

Full unit suite via `.venv/bin/python` exactly as CI. No version bump in `pyproject.toml`.

## Scope

Deliberately tight, since a parallel PR fixes the **outbound** twin in the same two files. This touches the **reader loop** in `server.py` and the **write/request path** in `attach_client.py`; `relay_frame_or_degraded`, `FrontendUpdate`, `frontend_state.py` and `remote.py` are untouched (`git diff` confirms zero hits on `relay_frame_or_degraded` and neither file in the changed set). Branched from `f1ab7d346`.

**Noted, not fixed** (out of scope, no follow-up issue filed per house rules): `viewer_server`'s reader closes the conversation on an overrun rather than skipping the frame. That is correct for its own reasons — the frames it carries are small and a peer sending one is a bug — but the two readers now handle the same condition differently, which is worth a look if that socket ever carries user payloads.
