### PR TITLE
chore(release): bump version to 0.53.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.53.4"
+version = "0.53.5"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## What

Bump `pyproject.toml` from 0.53.4 to 0.53.5. One line, one file.

## Window

`v0.53.4..main` — one commit:

- #859 (3b84c0554) `fix(tui): keep a still-running tool card live across a sidebar switch`

## Bump class: PATCH

A rendering bug fix on an existing surface plus per-slot start-time bookkeeping in the tool loop. No API addition, no wire/protocol change, no migration. The one added public member (`executing_display_tool_ids`) is additive and declared on `ViewerSessionProtocol`; nothing calls anything differently. Does not clear the step-function bar for a minor.

## Scope check

This branch modifies exactly one file and exactly one line. `git diff origin/main` is the version string and nothing else.
