### PR TITLE
refactor(session): retire `is_remote` for the declared runtime-role predicates

### DIFF
--- a/docs/design-runtime-autorefresh.md
+++ b/docs/design-runtime-autorefresh.md
@@ -375,7 +375,8 @@ that in the test) and calls a new `_refresh_callback` instead of
 `_went_cold_callback`. `set_refresh_callback` follows the
 `set_went_cold_callback` shape (`remote.py:2011-2017`).
 
-`tui/app.py`: in `_adopt_session`'s `is_remote` block (`:2812-2830`) install
+`tui/app.py`: in `_adopt_session`'s viewer block (the `_is_viewer(session)`
+branch that installs the takeover/stopped callbacks) install
 `set_refresh(self._on_runtime_refreshed)`:
 
 ```python

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -1678,6 +1678,23 @@ class SessionRow(NamedTuple):
     #: session was deliberately stopped.
     wakes: int = 0
     wakes_dormant: bool = False
+    #: The live record's ``kind`` — ``"tui"``, ``"exec"``, ``"daemon"`` — or
+    #: ``""`` for a cold session with no record.
+    #:
+    #: Carried so the picker can SAY what is behind a row rather than implying
+    #: it. Since #804 every ``lop exec`` publishes an ordinary attachable
+    #: record, so exec runs have been appearing in this list (via
+    #: ``decorate_rows(include_live=True)``) rendered identically to a terminal
+    #: conversation — an idle one-shot and a session the user was sitting in
+    #: both read as "Ready". They are not interchangeable: an exec record is
+    #: deliberately ephemeral and can vanish between the paint and the Enter,
+    #: which is a row the user picked disappearing rather than a session they
+    #: lost. Naming the kind is what makes that predictable instead of a
+    #: glitch.
+    #:
+    #: Empty for every construction site but the live-decorating one, exactly
+    #: like the live-state fields above.
+    kind: str = ""
     #: Immutable conversation birth, not transcript activity or runtime start.
     #: Unknown legacy dates tie at zero and are ordered by session id.
     created_at: float = 0.0

--- a/local_operator/session/catalog.py
+++ b/local_operator/session/catalog.py
@@ -272,7 +272,13 @@ class CatalogEntry:
             count = self.row.wakes
             return f"Scheduled ({count} wake{'s' if count != 1 else ''})"
         if self.row.live_state == "idle":
-            return "Ready"
+            # An exec run is named by what it IS rather than by "Ready", which
+            # invites the user to treat a supervisor's one-shot as their own
+            # idle conversation. Only at THIS rung: a busy or needs-you exec run
+            # says so above, because what it is doing outranks what kind it is —
+            # the same precedence ``row_state_mark`` follows, so the words and
+            # the glyph still cannot disagree.
+            return "Running headless (exec)" if self.row.kind == "exec" else "Ready"
         if self.row.wakes:
             # Dormant: the schedule exists but the session was stopped, so it is
             # not going to fire. Named rather than hidden — a user who sees the
@@ -367,6 +373,7 @@ def decorate_rows(
         record_state = live.get(row.id)
         live_state = ""
         pending: str | None = None
+        kind = ""
         if record_state is not None:
             record, state = record_state
             if state == "wedged":
@@ -378,6 +385,10 @@ def decorate_rows(
             else:
                 live_state = "idle"
             pending = getattr(record, "pending", None) or None
+            # Only a LIVE record has a kind. A cold row keeps "" so the picker
+            # says nothing rather than claiming a session is still an exec run
+            # after the process that made it that has gone.
+            kind = str(getattr(record, "kind", "") or "")
         entry = wake_index.get(row.id) or {}
         schedules = entry.get("schedules") or () if isinstance(entry, dict) else ()
         updated.append(
@@ -386,6 +397,7 @@ def decorate_rows(
                 pending=pending,
                 wakes=len(schedules),
                 wakes_dormant=bool(isinstance(entry, dict) and entry.get("stopped_at")),
+                kind=kind,
             )
         )
     return sorted(updated, key=lambda row: 0 if row.pending else 1)

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -512,29 +512,49 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
     paint path.
 
     It is deliberately not used for dispatch, and the reason is measured rather
-    than stylistic. This protocol carries 79 public members and a POSITIVE
+    than stylistic. This protocol carries 84 public members and a POSITIVE
     ``isinstance`` walks every one of them; measured on an arm64 host, CPython
-    3.12.13, best-of-five per run:
+    3.12.13, min-of-seven over 2,000 iterations:
 
     ====================================================  ==================
-    ``isinstance(viewer, RemoteSession)`` (what it was)    0.027-0.029 us
-    ``isinstance(viewer, ViewerSessionProtocol)``            60-136 us
-    ``not session.owns_runtime`` (what it is now)          0.044-0.058 us
+    ``isinstance(viewer, RemoteSession)`` (what it was)    0.014-0.015 us
+    ``isinstance(viewer, ViewerSessionProtocol)``            55-58 us
+    ``not session.owns_runtime`` (what it is now)          0.021-0.024 us
     ====================================================  ==================
 
-    The protocol figure is quoted as a RANGE because it genuinely varies that
-    much run to run — a single number here would be a lucky sample presented as
-    a constant. The ratio is stable at ~1,300-3,000x against the predicate and
-    the conclusion does not depend on where in the range it lands. (The negative
-    case is cheap, ~1.3 us: it fails on the first missing member. Only the
-    positive path pays, and the sites below are overwhelmingly positive.)
+    The ratio is what the decision rests on and it is stable at ~2,400-2,700x
+    against the predicate; the absolute figures move with the host, so
+    re-measure them rather than inheriting them. (The negative case is cheap,
+    ~1-3 us: it fails on the first missing member. Only the positive path pays,
+    and the sites below are overwhelmingly positive.)
+
+    **HOW to re-measure, because the obvious method silently measures the wrong
+    path.** Only a FULLY CONSTRUCTED ``RemoteSession`` is a positive here — the
+    cost is 84 property getters actually executing, so anything cheaper to build
+    is cheaper to check for the wrong reason:
+
+    ==========================================  =========  ==========
+    construction                                positive?  measured
+    ==========================================  =========  ==========
+    ``RemoteSession(config_dir=..., ...)``       **yes**    ~55 us
+    ``RemoteSession.__new__(RemoteSession)``     no         ~15 us
+    ``MagicMock(spec=RemoteSession)``            no         ~3 us
+    a synthetic class from ``__protocol_attrs__``  no       ~1-2 us
+    ==========================================  =========  ==========
+
+    Each of the bottom three looks like a viewer and reports a figure one to two
+    orders of magnitude low, because it is timing the negative path that exits
+    on the first missing member. So **assert the positive before timing it** —
+    ``assert isinstance(v, ViewerSessionProtocol)`` — or the number produced is
+    an answer to a different question. This cost a round-1 reviewer three
+    attempts and produced one re-measurement (~7.5 us) that could not be
+    reproduced by two others; the earlier 60-136 us figure quoted here was
+    likewise never reproduced and has been replaced by the measurement above.
 
     Three of the converted sites are hot — the sidebar release sweep runs per
     source per pass, ``_relaunch_refusal`` loops every interaction — so
     dispatching on the type would put three orders of magnitude on a paint path
-    to buy a guarantee the ``TypeGuard`` already provides statically. If you
-    reach for ``isinstance`` against this protocol, these are the numbers to
-    weigh, and re-measure rather than inheriting them.
+    to buy a guarantee the ``TypeGuard`` already provides statically.
 
     Headless hosts need this surface too, which is why it lives here rather
     than in the TUI: ``server/utils/desktop_sessions.py`` already imports,

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Callable, Literal, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Callable, Literal, Protocol, runtime_checkable
 
 from local_operator.harness.approval import ApprovalGate
 from local_operator.harness.types import (
@@ -30,6 +30,14 @@ from local_operator.harness.types import (
     Usage,
 )
 from local_operator.session.naming import ConversationName
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    # Deferred: ``frontend_state`` imports ``tui.costs``, whose package
+    # ``__init__`` imports THIS module, so a runtime import here is a cycle.
+    # The annotation is all that is needed — ``from __future__ import
+    # annotations`` above makes every annotation in this file a string, and a
+    # Protocol member's type is never evaluated at runtime.
+    from local_operator.session.frontend_state import FrontendSessionState
 
 
 @dataclass(frozen=True, slots=True)
@@ -95,22 +103,23 @@ class SessionProtocol(Protocol):
     # --- runtime role -----------------------------------------------------
     # Three predicates that name what hosts actually need to know about the
     # relationship between this process and the session's runtime. They exist
-    # because the undeclared ``is_remote`` attribute conflated them: it is
+    # because an undeclared ``is_remote`` attribute conflated them: it was
     # written in exactly one place (``remote.py``), was never declared on this
-    # protocol, and is read through ``getattr(session, "is_remote", False)`` at
-    # every call site, where the default silently means "in-process" and a typo
-    # in the string is invisible to pyright.
+    # protocol, and was read through ``getattr(session, "is_remote", False)`` at
+    # every call site, where the default silently meant "in-process" and a typo
+    # in the string was invisible to pyright.
     #
-    # Since 0.46.0 `lop` builds a viewer for every local user, so that flag is
+    # Since 0.46.0 `lop` builds a viewer for every local user, so that flag was
     # constant-True for every TUI session and the transport question it named
-    # is dead. The same conflation has been fixed site-locally four times
+    # was dead. The same conflation was fixed site-locally four times
     # (#576, #609, #624, #625) and guarded a fifth
     # (``tests/unit/tui/test_noop_consumers.py``). A predicate that has been
     # wrong five times is a missing type, not a naming problem — so the three
     # surviving questions are declared here, separately, and checked.
     #
-    # Stage 2 declares and implements them; no call site reads them yet. The
-    # substitutions and the deletion of ``is_remote`` are Stage 3.
+    # The flag itself is GONE. Every host now asks one of these three by name,
+    # and ``tests/unit/session/test_viewer_protocol.py`` fails if a new
+    # undeclared session flag of that shape is introduced.
 
     @property
     def owns_runtime(self) -> bool:
@@ -486,11 +495,46 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
     than an absent attribute, because the caller cannot tell "nothing to show"
     from "not this kind of session".
 
-    **Why the TUI is not migrated onto it here.** The probes have graceful
-    fallbacks that also cover an owner too OLD to have a member (see
-    ``_leave_runtime_running``, which keeps a session running when
-    ``request_stop`` is absent). Substituting the type for the probes is
-    Stage 3; this declaration is what makes those substitutions checkable.
+    **How the TUI reaches it.** Through ``tui/app.py::_is_viewer``, a
+    ``TypeGuard[ViewerSessionProtocol]`` over the declared ``owns_runtime``
+    predicate — NOT through ``isinstance`` against this class. The sixteen
+    ``isinstance(session, RemoteSession)`` checks that preceded it became one
+    predicate, and pyright narrows to this type inside every true branch, so
+    the members below are statically checked at each of those call sites.
+
+    **Why ``runtime_checkable`` is still on this class**, even though no
+    production path performs an ``isinstance`` against it. The decorator is not
+    here to be used at runtime by the app; it is what lets
+    ``tests/unit/session/test_viewer_protocol.py`` assert conformance
+    STRUCTURALLY — that ``RemoteSession`` satisfies this protocol and that
+    ``Session`` does not, which is the property making the split meaningful
+    rather than decorative. Those assertions run once per test, never on a
+    paint path.
+
+    It is deliberately not used for dispatch, and the reason is measured rather
+    than stylistic. This protocol carries 79 public members and a POSITIVE
+    ``isinstance`` walks every one of them; measured on an arm64 host, CPython
+    3.12.13, best-of-five per run:
+
+    ====================================================  ==================
+    ``isinstance(viewer, RemoteSession)`` (what it was)    0.027-0.029 us
+    ``isinstance(viewer, ViewerSessionProtocol)``            60-136 us
+    ``not session.owns_runtime`` (what it is now)          0.044-0.058 us
+    ====================================================  ==================
+
+    The protocol figure is quoted as a RANGE because it genuinely varies that
+    much run to run — a single number here would be a lucky sample presented as
+    a constant. The ratio is stable at ~1,300-3,000x against the predicate and
+    the conclusion does not depend on where in the range it lands. (The negative
+    case is cheap, ~1.3 us: it fails on the first missing member. Only the
+    positive path pays, and the sites below are overwhelmingly positive.)
+
+    Three of the converted sites are hot — the sidebar release sweep runs per
+    source per pass, ``_relaunch_refusal`` loops every interaction — so
+    dispatching on the type would put three orders of magnitude on a paint path
+    to buy a guarantee the ``TypeGuard`` already provides statically. If you
+    reach for ``isinstance`` against this protocol, these are the numbers to
+    weigh, and re-measure rather than inheriting them.
 
     Headless hosts need this surface too, which is why it lives here rather
     than in the TUI: ``server/utils/desktop_sessions.py`` already imports,
@@ -584,6 +628,31 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
         Desktop-surface viewers only; the host recomputes visibility and
         notifiability from its live subscribers and pushes the result so a
         bare proxy socket is not mistaken for a watching human.
+        """
+        ...
+
+    @property
+    def frontend_state(self) -> "FrontendSessionState":
+        """The canonical snapshot this viewer renders from.
+
+        Declared HERE rather than on :class:`SessionProtocol`, even though both
+        session classes implement it, and the reason is measured rather than
+        stylistic: ``SessionProtocol`` is what every test double and reduced
+        host is checked against, so adding a member there made **1,871** pyright
+        errors across the suite for doubles that legitimately do not carry
+        canonical state. The viewer protocol is narrower — only the real facade
+        and the desktop bridge satisfy it — so the declaration lands exactly
+        where the hard accesses are.
+
+        Undeclared debt (``_UNDECLARED_ON_BOTH_CLASSES``) until Stage 3's
+        type-narrowing made pyright ask for it at three TUI sites. That is the
+        guard working: the member was always reachable and always unchecked.
+
+        **Raises until the first sync.** ``RemoteSession.frontend_state`` raises
+        ``RuntimeError`` while ``_frontend_store`` is None, so a caller on a
+        paint path that cannot tolerate a raise probes defensively instead —
+        several in ``app.py`` deliberately do, and ``_session_subject`` records
+        what a raise there costs.
         """
         ...
 

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -522,11 +522,18 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
     ``not session.owns_runtime`` (what it is now)          0.021-0.024 us
     ====================================================  ==================
 
-    The ratio is what the decision rests on and it is stable at ~2,400-2,700x
-    against the predicate; the absolute figures move with the host, so
-    re-measure them rather than inheriting them. (The negative case is cheap,
-    ~1-3 us: it fails on the first missing member. Only the positive path pays,
-    and the sites below are overwhelmingly positive.)
+    THE ABSOLUTE IS THE PORTABLE FACT; the ratio is an order of magnitude and
+    should be quoted as one (~10^3x). The positive reproduced across three
+    independent hosts at 55-58 us, but the same three computed ratios of
+    ~2,400x, ~1,500-1,690x and ~930-1,054x from it — because the sub-100 ns
+    denominator is dominated by the timing loop rather than by the work. One
+    host measured an empty-lambda floor of 0.018 us, 34% of its own predicate
+    reading, and floor-subtracting moved its ratio to ~1,641x. So a narrow band
+    here is a property of whoever last ran it: state the microseconds, which
+    travel, and let the ratio carry only the magnitude, which is all the
+    decision needs. (The negative case is cheap, ~1-3 us: it fails on the first
+    missing member. Only the positive path pays, and the sites below are
+    overwhelmingly positive.)
 
     **HOW to re-measure, because the obvious method silently measures the wrong
     path.** Only a FULLY CONSTRUCTED ``RemoteSession`` is a positive here — the

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -496,9 +496,16 @@ def _restored_job_rows(jobs: Sequence[Any]) -> list[Any]:
 
 
 class RemoteSession:
-    """A SessionProtocol facade backed by one owner's v5 attach socket."""
+    """A SessionProtocol facade backed by one owner's v5 attach socket.
 
-    is_remote = True
+    Satisfies :class:`ViewerSessionProtocol`; hosts ask ``owns_runtime`` /
+    ``outcome_is_synchronous`` / ``runtime_locality`` rather than testing for
+    this class. The ``is_remote`` flag that used to live here is gone: it named
+    a transport axis that collapsed in 0.46.0 when `lop` began building a
+    viewer for every local user, leaving it constant-True for every TUI session
+    and unable to distinguish the four questions its readers were really
+    asking. See :class:`SessionProtocol`'s runtime-role block.
+    """
 
     def __init__(
         self,
@@ -4320,8 +4327,8 @@ class RemoteSession:
     # -- SessionProtocol runtime role --------------------------------------
     # This facade owns no loop: turns execute in the runtime process on the
     # other end of the attach socket. See ``SessionProtocol.owns_runtime`` for
-    # why these are three predicates rather than the single ``is_remote`` flag
-    # above, which Stage 3 removes.
+    # why these are three predicates rather than the one transport flag they
+    # replaced.
 
     @property
     def owns_runtime(self) -> bool:
@@ -4690,7 +4697,8 @@ class RemoteSession:
         """Whether replacing this viewer leaves execution in another process.
 
         Legacy owner recovery can install an in-process takeover target behind
-        this facade, so ``is_remote`` alone is not a survival guarantee.
+        this facade, so being a viewer is not on its own a survival guarantee —
+        the takeover target is what decides it.
         """
         return self._takeover_target is None
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -34433,10 +34433,10 @@ def _is_viewer(session: Any) -> TypeGuard[ViewerSessionProtocol]:
     whose ``False`` default silently meant "in-process".
 
     **Why a predicate and not ``isinstance(session, ViewerSessionProtocol)``.**
-    The obvious conversion is the honest-looking one and it is ~2,400-2,700x
-    slower: that protocol is ``runtime_checkable`` with 84 public members, and a
-    positive ``isinstance`` walks every one of them. Measured on an arm64 host,
-    CPython 3.12.13, min-of-seven over 2,000 iterations:
+    The obvious conversion is the honest-looking one and it costs three orders
+    of magnitude (~10^3x): that protocol is ``runtime_checkable`` with 84 public
+    members, and a positive ``isinstance`` walks every one of them. Measured on
+    an arm64 host, CPython 3.12.13, min-of-seven over 2,000 iterations:
 
     ==============================================  ===============
     ``isinstance(viewer, RemoteSession)``            0.014-0.015 us
@@ -34444,8 +34444,12 @@ def _is_viewer(session: Any) -> TypeGuard[ViewerSessionProtocol]:
     ``not session.owns_runtime``                     0.021-0.024 us
     ==============================================  ===============
 
-    The RATIO is the stable quantity and the decision rests on it; the absolute
-    figures move with the host. Re-measuring needs a fully constructed
+    THE ABSOLUTE is the quantity that travels: the positive reproduced at 55-58
+    us on three independent hosts, while the ratio computed from it ranged
+    ~930x-2,700x across those same hosts because the sub-100 ns denominator is
+    mostly timing-loop overhead (one host measured its empty-lambda floor at 34%
+    of the reading). Quote the microseconds and treat the ratio as ~10^3x, which
+    is all the decision needs. Re-measuring needs a fully constructed
     ``RemoteSession`` — a ``MagicMock(spec=…)`` or a bare ``__new__`` instance is
     NOT a positive and times the cheap negative path instead, which is how the
     same row has now been "re-measured" to three different values. See

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -127,7 +127,7 @@ from local_operator.session.goal_loop import (
     _parse_loop_verdict,
 )
 from local_operator.session.peer import PEER_MESSAGE_MESSAGE_TYPE
-from local_operator.session.protocol import SessionProtocol
+from local_operator.session.protocol import SessionProtocol, ViewerSessionProtocol
 from local_operator.slash_commands import (
     PERSIST_HINT,
     SLASH_COMMANDS,
@@ -4218,7 +4218,14 @@ class OperatorApp(App[None]):
             source.turn.epoch,
             aborted=aborted,
             error=error,
-            outcome_known=not bool(getattr(source.session, "is_remote", False)),
+            # The caller holds an outcome only where ``prompt()`` returned
+            # after the turn's terminal state. A viewer's returns on the
+            # owner's admission ACK, mid-turn, so there is nothing to report.
+            #
+            # No session keeps the True the absent flag used to default to:
+            # there is no viewer to withhold an outcome on, and the message's
+            # own default for this field is True.
+            outcome_known=source.session is None or source.session.outcome_is_synchronous,
         )
         message.origin = source.controller
         message.operation = operation
@@ -4393,7 +4400,7 @@ class OperatorApp(App[None]):
                 takeover_factory=no_takeover,
                 display_window=True,
             )
-        if not isinstance(remote, RemoteSession):
+        if not _is_viewer(remote):
             raise RuntimeError("Sidebar navigation requires an owner-backed session")
         try:
             if remote.session_id != session_id:
@@ -4443,7 +4450,6 @@ class OperatorApp(App[None]):
     async def _prepare_sidebar_session(
         self, session_id: str, *, speculative: bool = False, refresh: bool = False
     ) -> tuple[SessionInteraction, SessionPresentation]:
-        from local_operator.session.remote import RemoteSession
         from local_operator.tui.session_catalog import session_directory_name
 
         if not session_directory_name(session_id):
@@ -4457,7 +4463,7 @@ class OperatorApp(App[None]):
         succeeded = False
         try:
             session = source.session
-            if not isinstance(session, RemoteSession):
+            if not _is_viewer(session):
                 raise RuntimeError("Sidebar navigation requires an owner-backed session")
             # Canonical synchronization belongs to the source connection task,
             # never to a click waiting for its first useful viewport.
@@ -4676,10 +4682,9 @@ class OperatorApp(App[None]):
             card.restore_state(saved[1])
 
     def _suspend_sidebar_gates(self, source: SessionInteraction) -> None:
-        from local_operator.session.remote import RemoteSession
 
         session = source.session
-        if not isinstance(session, RemoteSession):
+        if not _is_viewer(session):
             return
         view_generation = source.gate_view_generation
         source.gate_view_generation += 1
@@ -4931,12 +4936,11 @@ class OperatorApp(App[None]):
             self.screen.refresh(layout=True)
 
     def _sidebar_navigation_pending(self, session_id: str) -> None:
-        from local_operator.session.remote import RemoteSession
 
         current = self._session
         if session_id:
             self._sidebar_displayed_frame = None
-        if isinstance(current, RemoteSession):
+        if _is_viewer(current):
             if session_id:
                 self._suspend_sidebar_gates(self._interaction)
             elif not self._interaction.display_only:
@@ -5125,13 +5129,11 @@ class OperatorApp(App[None]):
         clauses below exist for the opposite concern: not "is the RUNTIME
         busy", but "is this VIEWER still doing something for the user".
         """
-        from local_operator.session.remote import RemoteSession
-
         retained = source.retained_for_local_work or (
             reason != "closed" and source.retained_for_auto_work
         )
         return (
-            isinstance(source.session, RemoteSession)
+            _is_viewer(source.session)
             and source is not self._interaction
             and not source.retired
             and not retained
@@ -5459,7 +5461,6 @@ class OperatorApp(App[None]):
         prepared: tuple[SessionInteraction, SessionPresentation],
         generation: int,
     ) -> asyncio.Future[None] | None:
-        from local_operator.session.remote import RemoteSession
 
         source, incoming = prepared
         session = source.session
@@ -5467,7 +5468,7 @@ class OperatorApp(App[None]):
             raise RuntimeError("The prepared conversation identity changed")
         if source is self._interaction and incoming.replay.view is self._transcript_view():
             return
-        if not isinstance(session, RemoteSession):
+        if not _is_viewer(session):
             raise RuntimeError("The conversation is not owner-backed")
         if not source.display_only and (
             not session.display_history_current
@@ -5480,7 +5481,7 @@ class OperatorApp(App[None]):
         refreshing = outgoing is source
         focused_before_refresh = self.focused if refreshing else None
         previous = outgoing.session
-        if previous is not None and not isinstance(previous, RemoteSession):
+        if previous is not None and not _is_viewer(previous):
             raise RuntimeError("Sidebar navigation requires an owner-backed current session")
         if not refreshing:
             self._close_subagent_view()
@@ -5533,7 +5534,7 @@ class OperatorApp(App[None]):
         outgoing.parked_at = time.monotonic()
         source.parked_at = None
         self._park_sidebar_aside(outgoing)
-        if isinstance(previous, RemoteSession):
+        if _is_viewer(previous):
             self._suspend_sidebar_gates(outgoing)
         # Detach the old projection without fabricating a deny/empty answer or
         # poisoning the source's turn-scoped denial latch for its next visit.
@@ -5933,7 +5934,6 @@ class OperatorApp(App[None]):
         released before each backoff and why `command_frame_pending` is
         published false around the wait instead of only in `finally`.
         """
-        from local_operator.session.remote import RemoteSession
         from local_operator.tui.session_navigation import (
             PreparationInvalidated,
             SurfaceNotReady,
@@ -5944,12 +5944,17 @@ class OperatorApp(App[None]):
         cancelled = False
         try:
             session = source.session
-            if not isinstance(session, RemoteSession):
+            if not _is_viewer(session):
                 return
-            await session._ensure_bound()
+            # ``bind_runtime`` rather than the private ``_ensure_bound`` it
+            # forwards to: this is a sidebar source being connected on the
+            # user's behalf, which is exactly the "explicitly requested owner
+            # operation" the declared member exists for, and reaching past it
+            # into a private one is what kept this call invisible to pyright.
+            await session.bind_runtime()
             if session.is_cold:
-                # A BIND THAT DID NOT BIND IS A FAILURE. `_ensure_bound` has
-                # two silent returns that look identical here — "already bound,
+                # A BIND THAT DID NOT BIND IS A FAILURE. The bind has two
+                # silent returns that look identical here — "already bound,
                 # nothing to do" and "cannot bind right now" (the facade is
                 # `_recovering`, remote.py) — and only the second leaves the
                 # session cold. Committing on that second one publishes a COLD
@@ -5961,10 +5966,13 @@ class OperatorApp(App[None]):
                 # requesting a full relayout, under a transcript the user had
                 # every reason to believe was live.
                 #
-                # Checked here rather than by giving `_ensure_bound` a
+                # Checked here rather than by giving the bind a
                 # `require_bound=True`: its other callers deliberately tolerate
                 # the silent return (a prompt waits on `_owner_ready` instead),
                 # so the postcondition is this call site's, not the method's.
+                # `is_cold` is a declared `ViewerSessionProtocol` member, so
+                # this postcondition reads through the same declared surface as
+                # the bind above and stays statically checked under `_is_viewer`.
                 #
                 # The message is the sentence the sync-failure path already
                 # uses, so the two ways a connect can fail read identically to
@@ -6914,7 +6922,7 @@ class OperatorApp(App[None]):
         # the lease-winning real Session after owner death. The callback uses
         # the preserving swap below: ownership is backend plumbing, so takeover
         # cannot clear/replay the transcript or flash a different screen.
-        if bool(getattr(session, "is_remote", False)):
+        if _is_viewer(session):
             set_takeover = getattr(session, "set_takeover_callback", None)
             if callable(set_takeover):
                 set_takeover(partial(self._adopt_takeover_session, source=source))
@@ -8674,9 +8682,8 @@ class OperatorApp(App[None]):
             return self._paging_leases.get(lease.source_token) is lease
 
         try:
-            from local_operator.session.remote import RemoteSession
 
-            if not isinstance(session, RemoteSession):
+            if not _is_viewer(session):
                 return
             rows = await session.load_older_display_page()
             completed = True
@@ -10002,8 +10009,6 @@ class OperatorApp(App[None]):
 
     def _relaunch_refusal(self) -> str:
         """Only out-of-process work survives replacing the terminal image."""
-        from local_operator.session.remote import RemoteSession
-
         for source in self._interactions.values():
             worker = source.shell.worker
             if worker is not None and not worker.is_finished:
@@ -10012,7 +10017,7 @@ class OperatorApp(App[None]):
             if (
                 session is not None
                 and session is not self._session
-                and (not isinstance(session, RemoteSession) or not session.can_detach_runtime)
+                and (not _is_viewer(session) or not session.can_detach_runtime)
                 and (
                     getattr(session, "is_streaming", False)
                     or source.loop.running
@@ -10023,7 +10028,7 @@ class OperatorApp(App[None]):
         if not self._turn_is_live():
             return ""
         session = self._session
-        if not isinstance(session, RemoteSession) or not session.can_detach_runtime:
+        if not _is_viewer(session) or not session.can_detach_runtime:
             return self._live_turn_refuse_copy()
         if not self._resumable_session_id():
             return "wait for this conversation to be saved before relaunching"
@@ -10053,9 +10058,8 @@ class OperatorApp(App[None]):
         # carries no ``--resume`` and comes back as a cold launch. The
         # completed-upgrade path already painted ``restarting…`` on the
         # same tick, so it does not get a second line.
-        from local_operator.session.remote import RemoteSession
 
-        if isinstance(self._session, RemoteSession) and self._session.can_detach_runtime:
+        if _is_viewer(self._session) and self._session.can_detach_runtime:
             self._system_notice(
                 "relaunching terminal; runtime work continues. "
                 "New runtime code waits until all work is safely idle."
@@ -10400,8 +10404,9 @@ class OperatorApp(App[None]):
         user actually asked for.
         """
         session = self._session
-        if session is None or not bool(getattr(session, "is_remote", False)):
-            # Nothing was left running: there was no runtime to leave.
+        if session is None or session.owns_runtime:
+            # Nothing was left running: there was no runtime to leave. An
+            # owner IS the runtime, so leaving it leaves nothing behind.
             return False
         try:
             from local_operator.session.runtime.control import (
@@ -10439,17 +10444,23 @@ class OperatorApp(App[None]):
         return False
 
     def _session_runs_elsewhere(self) -> bool:
-        """Whether this session's runtime is on another machine.
+        """Whether this session's runtime is somewhere a config write misses.
 
-        Under the viewer model a local session is ALSO reached over a socket,
-        so ``is_remote`` no longer distinguishes "someone else's session" from
-        "my own session, one process away". The question that still matters for
-        a config write is narrower: would writing this machine's config govern
-        the runtime? A runtime whose record this machine published is local,
-        whatever transport reaches it.
+        The question a config write actually asks. Transport does not answer
+        it: under the viewer model a local session is ALSO reached over a
+        socket, so "is there a socket" stopped distinguishing "someone else's
+        session" from "my own session, one process away". A runtime whose
+        record this machine published is local, whatever transport reaches it.
+
+        Reads ``runtime_locality`` rather than deriving locality itself for the
+        cases the session can answer, and keeps the registry scan below for the
+        one it cannot: a facade reports where it is BOUND, not whether a record
+        for this id exists on this machine.
         """
         session = self._session
-        if session is None or not bool(getattr(session, "is_remote", False)):
+        if session is None or session.runtime_locality == "this-process":
+            # The loop runs on this event loop, so this machine's config is
+            # unambiguously the one that governs it.
             return False
         # A local runtime publishes a discovery record here; a genuinely
         # foreign one does not.
@@ -16420,9 +16431,8 @@ class OperatorApp(App[None]):
 
     @staticmethod
     def _preserve_source_gate_reply(source: SessionInteraction) -> None:
-        from local_operator.session.remote import RemoteSession
 
-        if isinstance(source.session, RemoteSession):
+        if _is_viewer(source.session):
             source.session.preserve_viewer_gate_reply()
 
     def _latch_approval_answer(self, answer: str) -> None:
@@ -18800,7 +18810,9 @@ class OperatorApp(App[None]):
         # that is the whole point of it being process-scoped, and it is what the
         # teardown below would otherwise take away in the normal sidebar state.
         self._viewer_adopted(session)
-        if bool(getattr(session, "is_remote", False)):
+        # Publication rights follow OWNERSHIP, not transport: the process that
+        # runs the loop is the one whose registrant may speak for the session.
+        if not session.owns_runtime:
             self._mobile_teardown()
             return
         if self._mobile_handle is None:
@@ -18918,18 +18930,12 @@ class OperatorApp(App[None]):
         the next viewer receives the unanswered gate from canonical state.
         Sidebar sources can hold gates too, not just the visible conversation.
         """
-        from local_operator.session.remote import RemoteSession
-
         sessions = [source.session for source in self._interactions.values()]
         sessions.append(self._session)
         seen: set[int] = set()
         pending = []
         for session in sessions:
-            if (
-                isinstance(session, RemoteSession)
-                and session.can_detach_runtime
-                and id(session) not in seen
-            ):
+            if _is_viewer(session) and session.can_detach_runtime and id(session) not in seen:
                 seen.add(id(session))
                 pending.append(session.detach_viewer_gates(preserve_answers=True))
         # Suspend every source before waiting on any one reply, so a background
@@ -18965,14 +18971,13 @@ class OperatorApp(App[None]):
         await self._sidebar_drafts.close()
         if self._sidebar_timer is not None:
             self._sidebar_timer.stop()
-        from local_operator.session.remote import RemoteSession
 
         for source in tuple(self._interactions.values()):
             source.gate_draft = None
             if source.unsubscribe_frontend is not None:
                 source.unsubscribe_frontend()
                 source.unsubscribe_frontend = None
-            if source.session is not self._session and isinstance(source.session, RemoteSession):
+            if source.session is not self._session and _is_viewer(source.session):
                 if source.controller is not None:
                     source.controller.dispose()
                 await source.session.dispose()
@@ -19672,7 +19677,7 @@ class OperatorApp(App[None]):
                 # `is_streaming` False and clears the band — a working→idle→
                 # working blip bounded by the owner's prompt preparation, not by
                 # the relay of the OUTCOME. That is not the flash this closes.
-                knows_outcome = not bool(getattr(session, "is_remote", False))
+                knows_outcome = session.outcome_is_synchronous
                 if self._is_current(source):
                     self._retire_turn_band(
                         session,
@@ -19717,17 +19722,15 @@ class OperatorApp(App[None]):
         resolves the title to `idle` — "finished cleanly" — for a turn whose
         outcome this viewer has not been told. The band is released by the
         relayed `agent_end` through `_finalize_turn`, or by a locally
-        synthesised one (owner death, `/stop`, go-cold). In-process
-        (`is_remote` False) the write is unconditional and unchanged.
+        synthesised one (owner death, `/stop`, go-cold). Where the outcome IS
+        synchronous the write is unconditional and unchanged.
 
         ``failed`` carries the outcome where the caller HAS it (the composer's
         worker does, in-process); `None` means "leave the mark alone".
         """
         if self._status is None:
             return
-        if bool(getattr(session, "is_remote", False)) and bool(
-            getattr(session, "is_streaming", False)
-        ):
+        if not session.outcome_is_synchronous and bool(getattr(session, "is_streaming", False)):
             return
         self._status.update(streaming=False, failed=failed)
 
@@ -19798,7 +19801,7 @@ class OperatorApp(App[None]):
             # that is the re-title path, which has its own throttle.
             self._maybe_retitle_conversation(text)
             return
-        if bool(getattr(session, "is_remote", False)):
+        if not session.owns_runtime:
             # NAMING BELONGS TO THE RUNTIME NOW.
             # ``OwnedSessionHandle.prompt`` calls its own
             # ``_maybe_name_conversation``, so the title is generated beside
@@ -22581,8 +22584,13 @@ class OperatorApp(App[None]):
         round 1, D1). This app's own ``_approve_all`` still tracks the mode —
         it governs this process's widgets and the band — but it is not the
         thing the engine consults, so it is not the thing that gets to speak.
+
+        The gate follows the LOOP: whichever process runs the turn is the one
+        whose gate the engine asks, so this is the ownership question rather
+        than a transport one.
         """
-        return bool(getattr(self._session, "is_remote", False))
+        session = self._session
+        return session is not None and not session.owns_runtime
 
     def _note_approvals_on_parked_prompt(self) -> None:
         """Tell a card already on screen why it still asks (UX round 1, U6).
@@ -22744,7 +22752,9 @@ class OperatorApp(App[None]):
 
         # --- C: is the bound runtime a different build than this terminal? --
         session = self._session
-        if session is None or not bool(getattr(session, "is_remote", False)):
+        # An owner IS this process, so there is no second build to compare
+        # against: the skew this announces is viewer-versus-runtime.
+        if not _is_viewer(session):
             return
         # Only a BOUND follower has an owner to compare against. A cold viewer
         # has not dialled anything yet, and reading its empty stamp would
@@ -23765,7 +23775,7 @@ class OperatorApp(App[None]):
                 body, kind = self._no_session_notice()
                 self._system_notice(body, kind)
                 return
-            if bool(getattr(session, "is_remote", False)):
+            if not session.owns_runtime:
                 # A follower does not own its session; the owner ends it.
                 # Routed rather than run locally, the way every
                 # authoritative-scope command on a follower is.
@@ -23789,7 +23799,7 @@ class OperatorApp(App[None]):
         session's schedules never fire while nobody is driving it.
         """
         session = self._session
-        if session is None or bool(getattr(session, "is_remote", False)):
+        if session is None or not session.owns_runtime:
             return
         # Detach the session FIRST, before any await: this coroutine can be
         # entered twice for one session (a peer's ``stop`` op through
@@ -24219,8 +24229,17 @@ class OperatorApp(App[None]):
         # a test host), and the listing must promise exactly what the second
         # press will do — every other session through the ladder, then this
         # one in-process, last.
+        #
+        # ``own_local`` is FALSE for every `lop` TUI, and the row below is
+        # therefore never appended there. That is correct rather than a gap:
+        # the TUI's runtime is a separate spawned process which publishes its
+        # own record, so this session already reaches the listing through
+        # ``_stop_targets``, and adding it here would list it twice. The
+        # branch survives for a host that genuinely owns its session in
+        # process — the headless REPL and the server build a real ``Session``
+        # — which is why it is a predicate rather than a deletion.
         own = self._session
-        own_local = own is not None and not bool(getattr(own, "is_remote", False))
+        own_local = own is not None and own.owns_runtime
         total = len(targets) + (1 if own_local else 0)
         if not total:
             self._stop_all_armed_at = None
@@ -24286,9 +24305,14 @@ class OperatorApp(App[None]):
         # Own session LAST, through the in-process branch, which paints its
         # own receipt naming the way back; the report folds it into the
         # total so the numbers reconcile with the listing's promise.
+        #
+        # Not taken by the `lop` TUI, for the reason the listing above states:
+        # its runtime is a separate pid already stopped through the ladder.
+        # This mirrors that listing exactly — both ask ``owns_runtime`` — so
+        # the count the user was shown is the count that gets acted on.
         own_outcome: control.StopOutcome | None = None
         session = self._session
-        if session is not None and not bool(getattr(session, "is_remote", False)):
+        if session is not None and session.owns_runtime:
             own_outcome = control.StopOutcome(
                 pid=os.getpid(),
                 session_id=getattr(session, "session_id", "") or "",
@@ -24428,13 +24452,15 @@ class OperatorApp(App[None]):
             # Persisting writes THIS machine's config, so it only makes sense
             # where the launches it governs happen.
             #
-            # The test was `is_remote` until the viewer model landed, and that
-            # became wrong the moment EVERY session became remote: a user on
-            # their own machine, whose runtime is a child process on that same
-            # machine, was told to "run it on the terminal whose launches it
-            # should govern" — which is the terminal they were already sitting
-            # at. The refusal now asks the question it always meant: is the
-            # runtime somewhere this config write would not reach?
+            # The test was a transport flag until the viewer model landed, and
+            # that became wrong the moment EVERY session was reached over a
+            # socket: a user on their own machine, whose runtime is a child
+            # process on that same machine, was told to "run it on the terminal
+            # whose launches it should govern" — which is the terminal they
+            # were already sitting at. The refusal now asks the question it
+            # always meant: is the runtime somewhere this config write would
+            # not reach? That flag is gone; ``runtime_locality`` is the type
+            # that replaced it.
             self._system_notice(
                 "/model default persists to the local machine's config — run it "
                 "on the terminal whose launches it should govern; /model <p>/<id> "
@@ -34395,6 +34421,57 @@ def slot_rows(slot: Any) -> int:
     # slot, so the larger is the safe one: it can only ever withhold the inset,
     # which costs a blank row, where the smaller costs a scrollable screen.
     return max(measured, predicted, 1)
+
+
+def _is_viewer(session: Any) -> TypeGuard[ViewerSessionProtocol]:
+    """Whether this session is a VIEWER, and narrow it to the viewer surface.
+
+    The one place the TUI decides "may I reach the viewer members on this
+    object". Sixteen sites asked it as ``isinstance(session, RemoteSession)``,
+    which coupled the front end to a concrete class, and a further seventeen
+    asked ``getattr(session, "is_remote", False)`` — an undeclared attribute
+    whose ``False`` default silently meant "in-process".
+
+    **Why a predicate and not ``isinstance(session, ViewerSessionProtocol)``.**
+    The obvious conversion is the honest-looking one and it is ~1,300-3,000x
+    slower: that protocol is ``runtime_checkable`` with 79 public members, and a
+    positive ``isinstance`` walks every one of them. Measured on an arm64 host,
+    CPython 3.12.13, best-of-five per run:
+
+    ==============================================  ===============
+    ``isinstance(viewer, RemoteSession)``            0.027-0.029 us
+    ``isinstance(viewer, ViewerSessionProtocol)``      60-136 us
+    ``not session.owns_runtime``                     0.044-0.058 us
+    ==============================================  ===============
+
+    The middle row is a RANGE because it varies that much between runs; the
+    ratio is stable and the conclusion does not turn on where it lands. See
+    ``ViewerSessionProtocol`` for the full note, including why the decorator
+    stays even though nothing dispatches on it.
+
+    Three of the converted sites are hot — the sidebar release sweep runs this
+    per source per pass, ``_relaunch_refusal`` loops every interaction, and the
+    gate-answer path runs it per reply — so the protocol form would have put
+    tens of microseconds per source per sweep on a paint path to buy a type the
+    ``TypeGuard`` already supplies statically. AGENTS.md's "prefer a structural
+    invariant to a numeric one" is about assertions, not about paying three
+    orders of magnitude at runtime for one.
+
+    **What makes it sound.** ``owns_runtime`` is DECLARED on ``SessionProtocol``
+    and implemented as a constant on both classes (``Session`` True,
+    ``RemoteSession`` False), so pyright checks the read and the two classes
+    partition exactly — asserted as a pair by
+    ``tests/unit/session/test_viewer_protocol.py``. The ``TypeGuard`` return is
+    what keeps the viewer members statically checked at all sixteen call sites:
+    inside the true branch pyright sees ``ViewerSessionProtocol``, so a renamed
+    or deleted viewer member is an error here exactly as it would be under
+    ``isinstance``.
+
+    ``None`` is False rather than an error: every call site already handles a
+    session-less app, and a helper that raised would push a null check into
+    sixteen places to say the same thing.
+    """
+    return session is not None and not session.owns_runtime
 
 
 def _canonical_frontend(session: Any) -> bool:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -34433,21 +34433,25 @@ def _is_viewer(session: Any) -> TypeGuard[ViewerSessionProtocol]:
     whose ``False`` default silently meant "in-process".
 
     **Why a predicate and not ``isinstance(session, ViewerSessionProtocol)``.**
-    The obvious conversion is the honest-looking one and it is ~1,300-3,000x
-    slower: that protocol is ``runtime_checkable`` with 79 public members, and a
+    The obvious conversion is the honest-looking one and it is ~2,400-2,700x
+    slower: that protocol is ``runtime_checkable`` with 84 public members, and a
     positive ``isinstance`` walks every one of them. Measured on an arm64 host,
-    CPython 3.12.13, best-of-five per run:
+    CPython 3.12.13, min-of-seven over 2,000 iterations:
 
     ==============================================  ===============
-    ``isinstance(viewer, RemoteSession)``            0.027-0.029 us
-    ``isinstance(viewer, ViewerSessionProtocol)``      60-136 us
-    ``not session.owns_runtime``                     0.044-0.058 us
+    ``isinstance(viewer, RemoteSession)``            0.014-0.015 us
+    ``isinstance(viewer, ViewerSessionProtocol)``      55-58 us
+    ``not session.owns_runtime``                     0.021-0.024 us
     ==============================================  ===============
 
-    The middle row is a RANGE because it varies that much between runs; the
-    ratio is stable and the conclusion does not turn on where it lands. See
-    ``ViewerSessionProtocol`` for the full note, including why the decorator
-    stays even though nothing dispatches on it.
+    The RATIO is the stable quantity and the decision rests on it; the absolute
+    figures move with the host. Re-measuring needs a fully constructed
+    ``RemoteSession`` — a ``MagicMock(spec=…)`` or a bare ``__new__`` instance is
+    NOT a positive and times the cheap negative path instead, which is how the
+    same row has now been "re-measured" to three different values. See
+    ``ViewerSessionProtocol`` for the method, the table of what each stand-in
+    actually measures, and why the decorator stays even though nothing
+    dispatches on it.
 
     Three of the converted sites are hot — the sidebar release sweep runs this
     per source per pass, ``_relaunch_refusal`` loops every interaction, and the

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -1461,6 +1461,15 @@ class SessionPickerScreen(ModalScreen[str | None]):
     # field must be classified as either signature or documented exclusion.
     # A new `SessionRow` field therefore fails HERE, at the moment it is added,
     # rather than in a frame someone has to notice is stale.
+    #
+    # THIS ASSERTION AND THE PINNED TESTS ARE BOTH LOAD-BEARING; neither
+    # subsumes the other, so do not simplify one away as redundant. This one
+    # catches an UNCLASSIFIED field — the omission — at import. It cannot catch
+    # a MISCLASSIFIED one: moving `kind` into `_SIGNATURE_EXCLUDED` keeps the
+    # union equal and passes here, and only `tests/unit/tui/test_session_picker.py`
+    # (which asserts `kind` drives a repaint, and that the exclusions are the
+    # two fields whose immutability is argued above) fails. Verified by making
+    # exactly that mutation: import succeeds, two tests go red.
     assert set(_SIGNATURE_FIELDS) | set(_SIGNATURE_EXCLUDED) == set(SessionRow._fields), (
         "picker signature is out of step with SessionRow — "
         f"unknown names: {sorted(set(_SIGNATURE_FIELDS) - set(SessionRow._fields))}; "
@@ -1617,28 +1626,14 @@ class SessionPickerScreen(ModalScreen[str | None]):
                     len(rows),
                 )
 
-        # Body, then one quiet row, then the card's META — the position and the
-        # key hints, which are the same KIND of row (statements ABOUT the list,
-        # not entries in it) and so travel together at the bottom. This is the
-        # usage card's grammar; the two overlays differ only by whether the
-        # position row is there at all. The counter is EMITTED only when the
-        # list scrolls: printing an empty line in its place left two blank rows
-        # and pushed the keys away from the block they belong to.
+        # Body, then one quiet row, then the card's META — the position, the
+        # legends and the key hints, which are the same KIND of row (statements
+        # ABOUT the list, not entries in it) and so travel together at the
+        # bottom. This is the usage card's grammar; the two overlays differ only
+        # by whether the position row is there at all. The counter is EMITTED
+        # only when the list scrolls: printing an empty line in its place left
+        # two blank rows and pushed the keys away from the block they belong to.
         out.append("\n\n")
-        if counter is not None:
-            # Numerals carry the fact at the readable ``dim`` step; grammar can
-            # stay quiet at ``faint`` because it is adjacent to those anchors.
-            first, last, total = counter
-            out.append("showing ", style=faint)
-            out.append(f"{first:,}–{last:,}", style=dim)
-            out.append(" of ", style=faint)
-            out.append(f"{total:,}", style=dim)
-            out.append("\n")
-        # Key NAMES at `dim` and their labels at `faint`, matching the usage
-        # card: at `faint` on this ground the keys themselves were 1.49:1.
-        # Hints DROP to fit, in reverse order of need — the same discipline the
-        # columns use. A footer that overflowed the card was the one row that
-        # could not afford to: it is the only statement of how to get out.
         # The marker legend appears only when a marked row is actually on
         # screen, so an empty query or a pure name match never advertises a mark
         # the user cannot see (D2: teach the glyph where it is used, not always).
@@ -1648,15 +1643,70 @@ class SessionPickerScreen(ModalScreen[str | None]):
         # with no legend, is the footer and the list disagreeing about what the
         # user is looking at. One source, so they cannot.
         has_exec = self._exec_column_latched(rows)
+        # LEGENDS SHARE THE COUNTER'S ROW, and that placement is the fix for
+        # design round 2's D2 rather than a tidier arrangement. They used to sit
+        # at the front of the key row, where the arithmetic made three of the
+        # four list shapes unreachable: the full key row is 69 cells against a
+        # card capped at PICKER_MAX_WIDTH = 74, so a 24-cell `[exec]` legend
+        # could only appear by evicting a key — and the shed order rightly makes
+        # the keys win, because keys OPERATE the card and a legend only teaches.
+        # The result was a legend that painted only on a list short enough not to
+        # scroll, i.e. never on this repo's own store of ~500 sessions, at any
+        # terminal width including 200 columns.
+        #
+        # This row is the one place with the width to spare and it costs no
+        # height: CARD_CHROME_ROWS reserves it UNCONDITIONALLY (so the card
+        # cannot change height as the user types, which is why the reservation
+        # is unconditional in the first place), and it is drawn empty on a list
+        # that fits one page. The counter is ~19 cells when present, leaving
+        # ~52 for legends against the 43 both together need.
+        #
+        # It is also the better home on the merits: a legend states what a mark
+        # in the list MEANS, which is a statement about the list — exactly what
+        # this row already carries — while the row below it is how the card is
+        # driven. The two kinds no longer compete for the same cells.
+        legends = _meta_legends(
+            width,
+            has_marked=has_marked,
+            has_exec=has_exec,
+            counter_cells=_counter_cells(counter),
+        )
+        if counter is not None or legends:
+            if counter is not None:
+                # Numerals carry the fact at the readable ``dim`` step; grammar
+                # can stay quiet at ``faint`` because it is adjacent to those
+                # anchors.
+                first, last, total = counter
+                out.append("showing ", style=faint)
+                out.append(f"{first:,}–{last:,}", style=dim)
+                out.append(" of ", style=faint)
+                out.append(f"{total:,}", style=dim)
+            for index, (glyph, meaning) in enumerate(legends):
+                if index or counter is not None:
+                    out.append(" · ", style=faint)
+                # The GLYPH at `dim` and its gloss at `faint`, the same split
+                # the keys below use: the thing being explained is the anchor,
+                # the explanation is subordinate to it.
+                out.append(glyph, style=dim)
+                out.append(f" {meaning}", style=faint)
+            out.append("\n")
+        # Key NAMES at `dim` and their labels at `faint`, matching the usage
+        # card: at `faint` on this ground the keys themselves were 1.49:1.
+        # Hints DROP to fit, in reverse order of need — the same discipline the
+        # columns use. A footer that overflowed the card was the one row that
+        # could not afford to: it is the only statement of how to get out.
+        #
+        # This row carries KEYS ONLY since D2 — the legends moved up to the
+        # counter's row. ``scrolls`` still matters here because it reorders the
+        # shed between ``pgup/pgdn`` and ``type``: paging must not be the first
+        # thing sacrificed on a list that actually pages (round 1, D3).
         # ``counter`` is set exactly when the list is longer than a page, so it
         # is already the "does this scroll" fact the shed order needs.
         for index, (key, what) in enumerate(
             _footer_hints(
                 width,
-                has_marked=has_marked,
                 scrolls=counter is not None,
                 empty=not rows and bool(self._query),
-                has_exec=has_exec,
             )
         ):
             if index:
@@ -1696,24 +1746,16 @@ _FOOTER_DROP_ORDER_SCROLLING = ("type", "pgup/pgdn", "↑↓")
 #: so the legend and the mark are unmistakably the same thing.
 _MARKER_LEGEND: tuple[str, str] = (BODY_MATCH_MARKER.strip(), "matched inside")
 
-#: Drop priority once the legend is in play. The full key-hint row is ~69 cells
-#: against a ~74-cell card, so a legend can only appear by DISPLACING a hint —
-#: dropping it "first" would make it never show, i.e. no fix at all. So it
-#: outranks the two genuinely disposable hints (``pgup/pgdn``, ``type``, which
-#: describe conveniences a user discovers anyway) and is shed BEFORE the
-#: movement and action keys. Because it is dropped before the bare-key stage,
-#: it never survives as an unlabelled glyph — a lone ``"`` in the footer would
-#: be exactly the artifact-looking mark D2 flagged.
-_FOOTER_DROP_ORDER_MARKED = ("pgup/pgdn", "type", _MARKER_LEGEND[0], "↑↓")
-
-#: Drop order once the list actually SCROLLS: the marker legend goes before the
-#: paging keys. With the fixed order above, a list that grew past one page shed
-#: ``pgup/pgdn`` to make room for the legend — so the picker advertised paging
-#: in the state where paging does nothing and withdrew it in the state where it
-#: is the fastest way through the list (design round 1, D3). Uncapping the store
-#: is what made scrolling the normal case rather than the rare one, so the shed
-#: order has to know whether there is anything to page through.
-_FOOTER_DROP_ORDER_MARKED_SCROLLING = ("type", _MARKER_LEGEND[0], "pgup/pgdn", "↑↓")
+#: Where the legends do NOT live: the key row below. The full key-hint row is 69
+#: cells against a card capped at :data:`PICKER_MAX_WIDTH` (74), so a 24-cell
+#: legend could only appear there by evicting a key — and the keys must win,
+#: because they OPERATE the card while a legend teaches. Design round 1 resolved
+#: that by ranking the legend above the two disposable hints, which made it
+#: paint on a list that FITS one page and never on one that scrolls; with
+#: :data:`PAGE_ROWS_MAX` at 10 and real stores in the hundreds, that is the
+#: ordinary case, at any terminal width (design round 2, D2). The legends
+#: therefore share the position counter's row and shed against their own budget
+#: — see :func:`_meta_legends`.
 
 #: The same treatment for :data:`EXEC_MARKER`, and for a sharper reason than the
 #: body-match mark needed. `[exec]` is legible as a WORD — nobody mistakes it for
@@ -1740,50 +1782,34 @@ _FOOTER_DROP_ORDER_MARKED_SCROLLING = ("type", _MARKER_LEGEND[0], "pgup/pgdn", "
 _EXEC_LEGEND: tuple[str, str] = (EXEC_MARKER.strip(), "one-shot, may end")
 
 
-def _footer_drop_order(*, legends: Sequence[str], scrolls: bool) -> tuple[str, ...]:
-    """The shed order for whichever legends are in play.
+def _footer_drop_order(*, scrolls: bool) -> tuple[str, ...]:
+    """The shed order for the key hints, which is the only thing this row holds.
 
-    DERIVED rather than enumerated because a second legend turns four hand-kept
-    constants into eight, and the eighth is the one that gets it wrong. The four
-    above stay as the documentation of the rule — and the assertion below proves
-    this function still reproduces them byte for byte, so the prose and the code
-    cannot drift apart.
+    DERIVED rather than enumerated so the two documented constants above cannot
+    drift from the rule they state; the assertion below proves this function
+    still reproduces them byte for byte.
 
-    The rule they encode, stated once:
+    The rule, stated once:
 
     * the genuinely disposable hints shed first (``pgup/pgdn`` and ``type``,
-      conveniences a user discovers anyway), EXCEPT that a scrolling list moves
-      ``pgup/pgdn`` below the legends — paging is the fastest way through a list
-      that has more than one page, so it must not be the first thing sacrificed
-      to explain a mark;
-    * legends shed next, since a legend teaches and the keys OPERATE;
+      conveniences a user discovers anyway), EXCEPT that a scrolling list drops
+      ``type`` first instead — paging is the fastest way through a list that has
+      more than one page, so it must not be the first thing sacrificed;
     * ``↑↓`` last of all the droppable hints;
     * ``enter``/``esc`` never appear here — they are how the card is used and
       how it is left.
 
-    ``legends`` arrives in SHED order, which is the REVERSE of display order,
-    and the difference is deliberate. Displayed, the body mark comes first
-    because that is the order the marks appear in a row. Shed, ``[exec]`` goes
-    first: it is a readable word that still means something without its gloss,
-    while a lone right-quote with nothing explaining it is exactly the rendering
-    artifact the marker legend was added to prevent. So under width pressure the
-    picker gives up the explanation that is least needed, which is the same
-    judgement every other rank here makes.
+    Legends are NOT shed here any more. They live on the counter's row and shed
+    against their own budget in :func:`_meta_legends`, which is what made them
+    reachable at all — see that function and the call site.
     """
-    leading = ("type",) if scrolls else ("pgup/pgdn", "type")
-    trailing = ("pgup/pgdn", "↑↓") if scrolls else ("↑↓",)
-    return (*leading, *legends, *trailing)
+    return ("type", "pgup/pgdn", "↑↓") if scrolls else ("pgup/pgdn", "type", "↑↓")
 
 
-# The derivation must reproduce the four documented constants exactly, or the
+# The derivation must reproduce the documented constants exactly, or the
 # comments above them are describing a policy the code no longer follows.
-assert _footer_drop_order(legends=(), scrolls=False) == _FOOTER_DROP_ORDER
-assert _footer_drop_order(legends=(), scrolls=True) == _FOOTER_DROP_ORDER_SCROLLING
-assert _footer_drop_order(legends=(_MARKER_LEGEND[0],), scrolls=False) == _FOOTER_DROP_ORDER_MARKED
-assert (
-    _footer_drop_order(legends=(_MARKER_LEGEND[0],), scrolls=True)
-    == _FOOTER_DROP_ORDER_MARKED_SCROLLING
-)
+assert _footer_drop_order(scrolls=False) == _FOOTER_DROP_ORDER
+assert _footer_drop_order(scrolls=True) == _FOOTER_DROP_ORDER_SCROLLING
 
 
 #: The footer for a filter that matched nothing. Movement, paging and `enter
@@ -1794,13 +1820,75 @@ assert (
 _EMPTY_HINT: tuple[str, str] = ("backspace", "to widen")
 
 
+def _counter_cells(counter: tuple[int, int, int] | None) -> int:
+    """Cells the position counter will occupy, or 0 when it is not drawn.
+
+    Measured from the FORMATTED string rather than estimated, because the
+    numerals are thousands-grouped and the width therefore depends on the store
+    size: "showing 1–10 of 40" is 18 cells and "of 24,310" is 22. The legends
+    share this row, so an estimate here is a legend that overflows the card on
+    exactly the large stores that made the picker scroll in the first place.
+    """
+    if counter is None:
+        return 0
+    first, last, total = counter
+    return cell_len(f"showing {first:,}–{last:,} of {total:,}")
+
+
+def _meta_legends(
+    width: int,
+    *,
+    has_marked: bool,
+    has_exec: bool,
+    counter_cells: int = 0,
+) -> list[tuple[str, str]]:
+    """The mark legends that fit beside the counter, dropping the least needed.
+
+    Legends explain what a mark in the LIST means, which is a statement about
+    the list — the same kind of statement the position counter makes — so they
+    share its row. They used to lead the key row below and were unreachable
+    there: see the call site, where the 69-vs-74 cell arithmetic is set out.
+
+    Order and shed are unchanged from that row and keep their round-1 reasoning.
+    DISPLAYED, the body mark leads because that is the order the marks appear in
+    a row (body column, then the kind column to its right). SHED, ``[exec]`` goes
+    first: it is a readable word that still means something without its gloss,
+    while a lone right-quote with nothing explaining it is exactly the rendering
+    artifact :data:`_MARKER_LEGEND` exists to prevent.
+
+    A legend never survives as a bare glyph. Dropping the gloss would leave the
+    unexplained mark the legend was added for, so the whole pair goes.
+    """
+    legends = [
+        legend
+        for legend, present in ((_MARKER_LEGEND, has_marked), (_EXEC_LEGEND, has_exec))
+        if present
+    ]
+    # The counter's own cells plus the separator that would join it to the
+    # first legend: the budget is what is LEFT of the row, not the row.
+    room = width - counter_cells - (3 if counter_cells else 0)
+    while legends and _row_cells(legends) > room:
+        # Shed the readable word first — reverse of display order, per above.
+        legends.pop()
+    return legends
+
+
+def _row_cells(pairs: Sequence[tuple[str, str]]) -> int:
+    """Cells ``pairs`` occupy when joined by the card's ``" · "`` separator.
+
+    One definition for both meta rows, so a legend and a key hint can never
+    disagree about what a row costs.
+    """
+    return sum(cell_len(f"{key} {what}".strip()) for key, what in pairs) + 3 * max(
+        0, len(pairs) - 1
+    )
+
+
 def _footer_hints(
     width: int,
     *,
-    has_marked: bool = False,
     scrolls: bool = False,
     empty: bool = False,
-    has_exec: bool = False,
 ) -> list[tuple[str, str]]:
     """The key hints that fit in ``width`` cells, dropping the least needed.
 
@@ -1810,50 +1898,24 @@ def _footer_hints(
     LABELS and keep the keys. Two bare keys still say which keys exist, which
     is more than a clipped row says.
 
-    ``has_marked`` adds the ``"``-marker legend (see :data:`_MARKER_LEGEND`)
-    so the glyph the list is drawing is explained where the reader already
-    looks for meaning. It sits at the FRONT (adjacent to nothing that could be
-    read as a key) and is shed under width pressure per
-    :data:`_FOOTER_DROP_ORDER_MARKED` — above the disposable hints so it can
-    actually appear on a normal card, below the movement and action keys.
+    KEYS ONLY. The mark legends moved to the counter's row in design round 2 —
+    see :func:`_meta_legends` — because the full key row is 69 cells against a
+    card capped at :data:`PICKER_MAX_WIDTH`, so a legend could only appear here
+    by evicting a key. This function no longer has to choose between teaching a
+    mark and stating how to leave the card.
 
-    ``scrolls`` says the list is longer than one page, which REORDERS the shed
-    rather than adding a hint: the paging keys outrank the legend exactly when
-    there is something to page through (see
-    :data:`_FOOTER_DROP_ORDER_MARKED_SCROLLING`). Without it the two features
-    fought — a list long enough to scroll is also long enough to contain a
-    marked row, so the legend evicted the very hint the reader needed.
-
-    ``has_exec`` adds :data:`_EXEC_LEGEND` on the same terms and for the reason
-    given there: the tag's grammar says "provenance" and its meaning is
-    "lifetime", and this footer is the picker's own established place for
-    explaining a mark. Both legends may be present at once; the shed order for
-    every combination comes from :func:`_footer_drop_order`.
+    ``scrolls`` says the list is longer than one page, which REORDERS the shed:
+    ``pgup/pgdn`` sheds first on a list that fits one page (paging there is a
+    no-op) and ``type`` sheds first on one that does not, because paging is then
+    the fastest way through the list (round 1, D3).
     """
     if empty:
         # Nothing to move through, page, or resume: offering those keys for an
-        # empty list advertises actions that do nothing, and the marker legend
-        # explains a glyph no row is drawing. `esc` stays because leaving is
-        # still available and is the other thing a user wants here.
+        # empty list advertises actions that do nothing. `esc` stays because
+        # leaving is still available and is the other thing a user wants here.
         return _shed_to_width([_EMPTY_HINT, ("esc", "cancel")], (_EMPTY_HINT[0],), width)
 
-    # Legends lead the row, ahead of anything that could be read as a key, and
-    # in the order the marks themselves appear in a row: the body mark sits in
-    # the body column, `[exec]` in the kind column to its right.
-    legends = [
-        legend
-        for legend, present in ((_MARKER_LEGEND, has_marked), (_EXEC_LEGEND, has_exec))
-        if present
-    ]
-    hints = [*legends, *_FOOTER_HINTS]
-    # Shed in the REVERSE of display order — see `_footer_drop_order`: the
-    # cryptic glyph keeps its explanation longer than the readable word does.
-    drop_order = _footer_drop_order(
-        legends=[legend[0] for legend in reversed(legends)],
-        scrolls=scrolls,
-    )
-
-    return _shed_to_width(hints, drop_order, width)
+    return _shed_to_width(list(_FOOTER_HINTS), _footer_drop_order(scrolls=scrolls), width)
 
 
 def _shed_to_width(

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -203,6 +203,43 @@ BODY_MATCH_MARKER = "” "
 #: and for the identical reason — see ``plan_columns``.
 FORK_MARKER = "[fork] "
 
+#: A live ``lop exec`` run: a machine-driven session, not a terminal someone is
+#: sitting at.
+#:
+#: These rows are not new — since #804 every ``lop exec`` publishes an ordinary
+#: attachable record, and ``decorate_rows(include_live=True)`` has been folding
+#: them into this list ever since. What was missing is that they rendered
+#: IDENTICALLY to a conversation the user started: same glyph, same "Ready".
+#: Two facts make that worth a tag rather than leaving it implicit.
+#:
+#: * **They are somebody else's work**, in the same sense a subagent directory
+#:   is — a supervisor composed the prompt. Resuming one is legitimate (that is
+#:   what an attachable record IS) but it is a deliberate reach, not the row a
+#:   user means when scanning for the conversation they had this morning.
+#: * **They are ephemeral by design.** ``exec_control`` calls its records
+#:   "deliberately ephemeral": a fast one-shot can be published and reaped
+#:   between the paint and the Enter. A row vanishing under the cursor reads as
+#:   a bug unless the row said what it was.
+#:
+#: Follows :data:`FORK_MARKER`'s form exactly — a bracketed word before the
+#: name, reserved as fixed chrome for the whole result set, painted `dim` as
+#: metadata about the row rather than part of the title — because it makes the
+#: same kind of statement about the same column, and a second visual vocabulary
+#: for "this row is qualified" would be the defect that pattern exists to avoid.
+#:
+#: Deliberately NOT a state glyph: the state column answers "what is it doing",
+#: which an exec run answers exactly like any other session (busy, idle, needs
+#: you). This answers "what KIND of thing is it", which is orthogonal, and
+#: folding it into the glyph would make the two unaskable at once.
+EXEC_MARKER = "[exec] "
+
+#: The record kinds this picker TAGS. ``"tui"`` is the unmarked default — the
+#: overwhelming majority, and tagging it would put a badge on every row to say
+#: "normal" — and ``"daemon"`` is deliberately absent for now: the phone daemon
+#: does not publish per-session records this list reads, so a tag for it would
+#: be untested chrome. Adding a kind here is one entry plus its marker.
+TAGGED_KINDS = frozenset({"exec"})
+
 #: The needs-you mark: this session has parked a question and is holding a
 #: runtime resident until somebody answers it. The one marker here that is
 #: about the USER's attention rather than the session's state, which is why it
@@ -560,6 +597,7 @@ def plan_columns(
     marked: bool = False,
     forked: bool = False,
     stated: bool = False,
+    tagged: bool = False,
 ) -> tuple[int, int, int]:
     """``(name, age, id)`` cell budgets for ``width``, dropping before cutting.
 
@@ -589,6 +627,11 @@ def plan_columns(
     appears as a forked row scrolls into view and disappears as it scrolls out
     makes every name on the list jump sideways on one arrow press.
 
+    ``tagged`` reserves :data:`EXEC_MARKER`'s cells identically. It is a
+    SEPARATE budget from ``forked`` rather than one shared "qualifier" column
+    because the two facts are independent — a forked session can be running
+    under exec — and sharing the cells would make one tag hide the other.
+
     Reserved as FIXED CHROME rather than subtracted from the name afterwards,
     which is what keeps the drop ladder honest — the id surrenders its cells
     before the age, and the age before the name, and a marker that helped
@@ -597,6 +640,7 @@ def plan_columns(
     """
     marker_col = cell_len(BODY_MATCH_MARKER) if marked else 0
     marker_col += cell_len(FORK_MARKER) if forked else 0
+    marker_col += cell_len(EXEC_MARKER) if tagged else 0
     # The live-state column follows the same reserve-for-the-RESULT-SET rule as
     # the two above, and for the same reason: a column that appears as a
     # running row scrolls into view makes every name jump sideways on one
@@ -660,10 +704,19 @@ def render_rows(
         getattr(row, "live_state", "") or getattr(row, "pending", None) or getattr(row, "wakes", 0)
         for row in rows
     )
-    name_col, age_col, id_col = plan_columns(rows, width, ages, marked, any_forked, any_stated)
+    # And again for the kind tag. Asked of the result set, not the page, for the
+    # third time and the same reason — but it matters MORE here than for a fork:
+    # an exec record is ephemeral, so this column would otherwise appear and
+    # vanish on its own as a one-shot is reaped, moving every name sideways
+    # without the user touching anything.
+    any_tagged = any(getattr(row, "kind", "") in TAGGED_KINDS for row in rows)
+    name_col, age_col, id_col = plan_columns(
+        rows, width, ages, marked, any_forked, any_stated, any_tagged
+    )
     marker_col = cell_len(BODY_MATCH_MARKER) if marked else 0
     fork_col = cell_len(FORK_MARKER) if any_forked else 0
     state_col = STATE_COL_CELLS if any_stated else 0
+    exec_col = cell_len(EXEC_MARKER) if any_tagged else 0
 
     lines: list[Text] = []
     for index, (row, age) in enumerate(zip(rows, ages)):
@@ -748,6 +801,16 @@ def render_rows(
         if fork_col:
             line.append(
                 _pad_cells(FORK_MARKER if getattr(row, "forked", False) else "", fork_col),
+                style=row_bg + Style(color=dim),
+            )
+        # Beside the fork tag and painted the same `dim`, for the reason given
+        # there: this is metadata ABOUT the row, and at name weight it would
+        # read as part of the conversation's title.
+        if exec_col:
+            line.append(
+                _pad_cells(
+                    EXEC_MARKER if getattr(row, "kind", "") in TAGGED_KINDS else "", exec_col
+                ),
                 style=row_bg + Style(color=dim),
             )
         # The live-state mark sits immediately before the name, where the eye

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -668,6 +668,7 @@ def render_rows(
     body_matched: AbstractSet[str] = frozenset(),
     forked: bool | None = None,
     frame: int = 0,
+    tagged: bool | None = None,
 ) -> list[Text]:
     """One line per session: cursor, name, age, id.
 
@@ -709,7 +710,25 @@ def render_rows(
     # an exec record is ephemeral, so this column would otherwise appear and
     # vanish on its own as a one-shot is reaped, moving every name sideways
     # without the user touching anything.
-    any_tagged = any(getattr(row, "kind", "") in TAGGED_KINDS for row in rows)
+    #
+    # Result-set scoping alone is NOT ENOUGH here, and that is the difference
+    # from `forked`. It stabilises the column against SCROLLING, because the
+    # result set does not change as the page moves. It cannot stabilise it
+    # against REAPING: when the one-shot ends, the result set itself loses the
+    # tagged row, `any_tagged` flips to False, and every name shifts 7 cells
+    # left with no keystroke (round 1, D1 — measured `(67,6,12) → (76,6,12)`).
+    # That fires on the NORMAL END OF EVERY ONE-SHOT, so the first time a user
+    # observes the ephemerality this tag exists to explain, the feedback is the
+    # whole list lurching — the exact "reads as a bug" reaction `EXEC_MARKER`
+    # was added to prevent. So the SCREEN latches the fact for the lifetime of
+    # the open picker and passes it here; `None` keeps the derive-from-rows
+    # behaviour for callers with no paging and no lifetime to latch against
+    # (tests, a one-page list), exactly as `forked` above does.
+    any_tagged = (
+        bool(tagged)
+        if tagged is not None
+        else any(getattr(row, "kind", "") in TAGGED_KINDS for row in rows)
+    )
     name_col, age_col, id_col = plan_columns(
         rows, width, ages, marked, any_forked, any_stated, any_tagged
     )
@@ -910,6 +929,10 @@ class SessionPickerScreen(ModalScreen[str | None]):
         self._body: Static
         #: Spinner phase for the running marker, advanced by ``_tick``.
         self._frame = 0
+        #: Has this picker EVER shown an exec row? Latched, never cleared while
+        #: the screen lives — see :meth:`_exec_column_latched` for why the
+        #: column may widen but must not narrow.
+        self._saw_tagged = False
         #: Re-reads each row's live state, supplied by the host that knows how
         #: (``OperatorApp._overlay_live_state``). Optional: a host that does
         #: not pass one gets the pre-refresh behaviour — markers from open,
@@ -1256,6 +1279,37 @@ class SessionPickerScreen(ModalScreen[str | None]):
         """Rows above the first session row: the header and its rule."""
         return 2
 
+    def _exec_column_latched(self, rows: Sequence[SessionRow]) -> bool:
+        """Should the exec column be reserved? Once yes, yes until the picker closes.
+
+        The column may WIDEN during a picker's life and must never NARROW, and
+        the asymmetry is the whole point. Widening is caused by the user's own
+        act — typing a filter that admits an exec row — so the movement has an
+        author and reads as a response. Narrowing is caused by a one-shot
+        ENDING, which nobody in front of the terminal did, and which happens on
+        the normal completion of every ``lop exec`` run rather than in some edge
+        case. Round 1 (D1) measured the result: `any_tagged` flips false,
+        `exec_col` goes 7 → 0, `plan_columns` `(67,6,12) → (76,6,12)`, and every
+        name on screen jumps 7 cells left with no keystroke — under the cursor,
+        on a timer. A list that lurches when a row quietly stops being special
+        reads as a glitch, which is precisely the reaction `EXEC_MARKER` exists
+        to prevent ("a row vanishing under the cursor reads as a bug unless the
+        row said what it was"). The reaped row still loses its own 7 characters
+        of tag, so the change that actually happened is still visible; what it
+        no longer does is move everything else.
+
+        Latched on the SCREEN, not on the row set, because "the result set for
+        one open picker" is the span the fixed-chrome rule is really about, and
+        a closed-and-reopened picker legitimately starts over from what is live
+        then. The cost is one reserved column of 7 cells persisting after the
+        last exec row is gone, which is the same tax the column charged a moment
+        earlier and which the drop ladder already knows how to shed at narrow
+        widths (round 1, D4 — accepted deliberately).
+        """
+        if any(getattr(row, "kind", "") in TAGGED_KINDS for row in rows):
+            self._saw_tagged = True
+        return self._saw_tagged
+
     # -- internals -----------------------------------------------------------
     def set_query(self, query: str) -> None:
         """Apply a filter and put the cursor on the FIRST match.
@@ -1374,17 +1428,45 @@ class SessionPickerScreen(ModalScreen[str | None]):
     #: is D10, unfixed by its own fix, through 83 green picker tests
     #: (round 4, D10).
     #:
-    #: `mtime` is deliberately absent: it changes constantly and is rendered
-    #: as a coarse "when", so including it would repaint ten times a second
-    #: for nothing.
-    _SIGNATURE_FIELDS = ("id", "name", "forked", "live_state", "pending", "wakes", "wakes_dormant")
-    # A NAME THAT IS NOT A FIELD READS AS A CONSTANT. That is how the D10 fix
-    # shipped broken, so the names are checked against the row type itself
-    # rather than trusted: a rename in `resume.SessionRow` fails here loudly
-    # instead of silently dropping a column out of the comparison.
-    assert not set(_SIGNATURE_FIELDS) - set(SessionRow._fields), (
-        f"picker signature names unknown SessionRow fields: "
-        f"{sorted(set(_SIGNATURE_FIELDS) - set(SessionRow._fields))}"
+    _SIGNATURE_FIELDS = (
+        "id",
+        "name",
+        "forked",
+        "live_state",
+        "pending",
+        "wakes",
+        "wakes_dormant",
+        "kind",
+    )
+
+    #: Fields deliberately OUTSIDE the signature, each with the reason it is
+    #: safe to omit. Stated as data rather than as prose because the assertion
+    #: below consumes it — an exclusion nobody can name is not an exclusion.
+    #:
+    #: * `mtime` changes constantly and renders as a coarse "when", so
+    #:   including it would repaint ten times a second for nothing.
+    #: * `created_at` is immutable for the life of a session (#800 makes it the
+    #:   ordering key precisely because it never moves), so it cannot differ
+    #:   between two ticks of one open picker.
+    _SIGNATURE_EXCLUDED = ("mtime", "created_at")
+
+    # BIDIRECTIONAL, and that is the whole point of it. The previous form
+    # checked only that every signature NAME is a real field, which catches a
+    # rename but is blind to the opposite and more common error: a field ADDED
+    # to `SessionRow`, rendered by this widget, and never added here. `kind`
+    # shipped exactly that way (round 1, MAJOR-1/Q1) — the row painted `[exec]`,
+    # `_tick` compared two kinds equal, and the frame stayed stale. Both earlier
+    # D10 escapes are the same defect in the other direction, so the guard now
+    # answers both questions at once: every name must be a field, AND every
+    # field must be classified as either signature or documented exclusion.
+    # A new `SessionRow` field therefore fails HERE, at the moment it is added,
+    # rather than in a frame someone has to notice is stale.
+    assert set(_SIGNATURE_FIELDS) | set(_SIGNATURE_EXCLUDED) == set(SessionRow._fields), (
+        "picker signature is out of step with SessionRow — "
+        f"unknown names: {sorted(set(_SIGNATURE_FIELDS) - set(SessionRow._fields))}; "
+        "unclassified fields (add to _SIGNATURE_FIELDS, or to _SIGNATURE_EXCLUDED "
+        "with the reason it cannot change under an open picker): "
+        f"{sorted(set(SessionRow._fields) - set(_SIGNATURE_FIELDS) - set(_SIGNATURE_EXCLUDED))}"
     )
 
     def _marker_signature(self) -> tuple[tuple[object, ...], ...]:
@@ -1515,6 +1597,14 @@ class SessionPickerScreen(ModalScreen[str | None]):
                     # The animated phase. Without it every call took the
                     # default 0 and the running marker never moved (D1).
                     self._frame,
+                    # The LATCHED exec fact, for the reason `_exec_column_latched`
+                    # states. Passing it here also gives the exec column the
+                    # result-set scoping its own docstring claims and did not
+                    # have: `window` is one PAGE, so leaving this to derive from
+                    # `rows` made the column appear and vanish as the one-shot
+                    # scrolled in and out of view — the very jump the fork
+                    # argument above exists to prevent, measured at 7 cells.
+                    self._exec_column_latched(rows),
                 )
             ):
                 if index:
@@ -1553,6 +1643,11 @@ class SessionPickerScreen(ModalScreen[str | None]):
         # screen, so an empty query or a pure name match never advertises a mark
         # the user cannot see (D2: teach the glyph where it is used, not always).
         has_marked = bool(self.body_matched_ids)
+        # The SAME latched fact the column reserves on, deliberately: a legend
+        # explaining a column that is no longer reserved, or a reserved column
+        # with no legend, is the footer and the list disagreeing about what the
+        # user is looking at. One source, so they cannot.
+        has_exec = self._exec_column_latched(rows)
         # ``counter`` is set exactly when the list is longer than a page, so it
         # is already the "does this scroll" fact the shed order needs.
         for index, (key, what) in enumerate(
@@ -1561,6 +1656,7 @@ class SessionPickerScreen(ModalScreen[str | None]):
                 has_marked=has_marked,
                 scrolls=counter is not None,
                 empty=not rows and bool(self._query),
+                has_exec=has_exec,
             )
         ):
             if index:
@@ -1619,6 +1715,76 @@ _FOOTER_DROP_ORDER_MARKED = ("pgup/pgdn", "type", _MARKER_LEGEND[0], "↑↓")
 #: order has to know whether there is anything to page through.
 _FOOTER_DROP_ORDER_MARKED_SCROLLING = ("type", _MARKER_LEGEND[0], "pgup/pgdn", "↑↓")
 
+#: The same treatment for :data:`EXEC_MARKER`, and for a sharper reason than the
+#: body-match mark needed. `[exec]` is legible as a WORD — nobody mistakes it for
+#: a rendering artifact the way a lone `”` is mistaken — but legibility is not
+#: the problem it has. Its grammar is byte-identical to `[fork]`'s, deliberately,
+#: and `[fork]` states a permanent fact about ancestry: a row that will still be
+#: there tomorrow. An identical treatment therefore files the two under one
+#: class, and the user learns "this row came from somewhere else" — true, and the
+#: LESS important of the two things the tag means. What it does not tell them is
+#: that the row may be gone by the time they press Enter (design round 1, D2).
+#:
+#: The words that do carry lifetime already exist and are well judged
+#: (`CatalogEntry.status`'s "Running headless (exec)"), but they render only in
+#: the sidebar's hover tooltip — a surface the picker never shows, and they
+#: appeared in zero of nine captured picker frames. So the ephemerality is said
+#: HERE, in the one place the picker already reserves for explaining a mark.
+#:
+#: "one-shot" rather than "headless": both are established (`cli.py` calls exec a
+#: "one-shot headless task"), but headless describes HOW it runs and one-shot
+#: describes how long it lasts, which is the fact the legend exists to add
+#: (design round 1, D5). No new visual grammar, no third ink — an amber `[exec]`
+#: was the other candidate and is rejected on the record, because `warning` is
+#: already a two-member class this file's own comments call "at its capacity".
+_EXEC_LEGEND: tuple[str, str] = (EXEC_MARKER.strip(), "one-shot, may end")
+
+
+def _footer_drop_order(*, legends: Sequence[str], scrolls: bool) -> tuple[str, ...]:
+    """The shed order for whichever legends are in play.
+
+    DERIVED rather than enumerated because a second legend turns four hand-kept
+    constants into eight, and the eighth is the one that gets it wrong. The four
+    above stay as the documentation of the rule — and the assertion below proves
+    this function still reproduces them byte for byte, so the prose and the code
+    cannot drift apart.
+
+    The rule they encode, stated once:
+
+    * the genuinely disposable hints shed first (``pgup/pgdn`` and ``type``,
+      conveniences a user discovers anyway), EXCEPT that a scrolling list moves
+      ``pgup/pgdn`` below the legends — paging is the fastest way through a list
+      that has more than one page, so it must not be the first thing sacrificed
+      to explain a mark;
+    * legends shed next, since a legend teaches and the keys OPERATE;
+    * ``↑↓`` last of all the droppable hints;
+    * ``enter``/``esc`` never appear here — they are how the card is used and
+      how it is left.
+
+    ``legends`` arrives in SHED order, which is the REVERSE of display order,
+    and the difference is deliberate. Displayed, the body mark comes first
+    because that is the order the marks appear in a row. Shed, ``[exec]`` goes
+    first: it is a readable word that still means something without its gloss,
+    while a lone right-quote with nothing explaining it is exactly the rendering
+    artifact the marker legend was added to prevent. So under width pressure the
+    picker gives up the explanation that is least needed, which is the same
+    judgement every other rank here makes.
+    """
+    leading = ("type",) if scrolls else ("pgup/pgdn", "type")
+    trailing = ("pgup/pgdn", "↑↓") if scrolls else ("↑↓",)
+    return (*leading, *legends, *trailing)
+
+
+# The derivation must reproduce the four documented constants exactly, or the
+# comments above them are describing a policy the code no longer follows.
+assert _footer_drop_order(legends=(), scrolls=False) == _FOOTER_DROP_ORDER
+assert _footer_drop_order(legends=(), scrolls=True) == _FOOTER_DROP_ORDER_SCROLLING
+assert _footer_drop_order(legends=(_MARKER_LEGEND[0],), scrolls=False) == _FOOTER_DROP_ORDER_MARKED
+assert (
+    _footer_drop_order(legends=(_MARKER_LEGEND[0],), scrolls=True)
+    == _FOOTER_DROP_ORDER_MARKED_SCROLLING
+)
+
 
 #: The footer for a filter that matched nothing. Movement, paging and `enter
 #: resume` all describe a list that is not there, so the only honest thing the
@@ -1629,7 +1795,12 @@ _EMPTY_HINT: tuple[str, str] = ("backspace", "to widen")
 
 
 def _footer_hints(
-    width: int, *, has_marked: bool = False, scrolls: bool = False, empty: bool = False
+    width: int,
+    *,
+    has_marked: bool = False,
+    scrolls: bool = False,
+    empty: bool = False,
+    has_exec: bool = False,
 ) -> list[tuple[str, str]]:
     """The key hints that fit in ``width`` cells, dropping the least needed.
 
@@ -1652,6 +1823,12 @@ def _footer_hints(
     :data:`_FOOTER_DROP_ORDER_MARKED_SCROLLING`). Without it the two features
     fought — a list long enough to scroll is also long enough to contain a
     marked row, so the legend evicted the very hint the reader needed.
+
+    ``has_exec`` adds :data:`_EXEC_LEGEND` on the same terms and for the reason
+    given there: the tag's grammar says "provenance" and its meaning is
+    "lifetime", and this footer is the picker's own established place for
+    explaining a mark. Both legends may be present at once; the shed order for
+    every combination comes from :func:`_footer_drop_order`.
     """
     if empty:
         # Nothing to move through, page, or resume: offering those keys for an
@@ -1660,12 +1837,21 @@ def _footer_hints(
         # still available and is the other thing a user wants here.
         return _shed_to_width([_EMPTY_HINT, ("esc", "cancel")], (_EMPTY_HINT[0],), width)
 
-    hints = list(_FOOTER_HINTS)
-    if has_marked:
-        hints = [_MARKER_LEGEND, *hints]
-        drop_order = _FOOTER_DROP_ORDER_MARKED_SCROLLING if scrolls else _FOOTER_DROP_ORDER_MARKED
-    else:
-        drop_order = _FOOTER_DROP_ORDER_SCROLLING if scrolls else _FOOTER_DROP_ORDER
+    # Legends lead the row, ahead of anything that could be read as a key, and
+    # in the order the marks themselves appear in a row: the body mark sits in
+    # the body column, `[exec]` in the kind column to its right.
+    legends = [
+        legend
+        for legend, present in ((_MARKER_LEGEND, has_marked), (_EXEC_LEGEND, has_exec))
+        if present
+    ]
+    hints = [*legends, *_FOOTER_HINTS]
+    # Shed in the REVERSE of display order — see `_footer_drop_order`: the
+    # cryptic glyph keeps its explanation longer than the readable word does.
+    drop_order = _footer_drop_order(
+        legends=[legend[0] for legend in reversed(legends)],
+        scrolls=scrolls,
+    )
 
     return _shed_to_width(hints, drop_order, width)
 

--- a/scripts/exec_picker_shot.py
+++ b/scripts/exec_picker_shot.py
@@ -1,0 +1,136 @@
+"""Capture the /resume picker listing a live ``lop exec`` run beside terminal work.
+
+Why this shot exists. Since #804 every ``lop exec`` publishes an ordinary
+attachable record, so exec runs have been appearing in this picker via
+``decorate_rows(include_live=True)`` — rendered identically to a conversation
+the user started. An idle one-shot and the session they were sitting in half an
+hour ago both read as "Ready", and an exec record is deliberately ephemeral, so
+the indistinguishable row is also the one that can vanish under the cursor.
+
+The frame is the evidence for the tag that fixes it: run this on the branch and
+on its base, and the pair shows what the user gains. A test asserting the string
+is present cannot show that the column lines up, that the tag reads as metadata
+rather than as part of the title, or that untagged rows still align.
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/exec_picker_shot.py out.svg [COLSxROWS]
+
+Rows are seeded through the real transcript writer and the real record
+publisher, so the picker's own scan/decorate path fills the live state — the
+same code the app runs. Nothing here fabricates a ``SessionRow``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Literal
+
+import scripts.probe_isolation  # noqa: F401 — isolate HOME/config before app imports
+from local_operator.harness.types import Message
+from local_operator.session.runtime import registry
+from local_operator.session.runtime.types import SessionRecord
+from local_operator.session.transcript import Transcript
+from local_operator.tui.app import OperatorApp
+from scripts.visual_capture import save_capture
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+#: (session id, title, record kind, busy). ``kind=None`` means no live record —
+#: an ordinary cold conversation, which is most of anyone's list.
+SEEDED: list[tuple[str, str, Literal["tui", "exec", "daemon"] | None, bool]] = [
+    ("aaaaaaaaaaaa", "Refactor the YAML loader", None, False),
+    ("bbbbbbbbbbbb", "nightly release audit", "exec", False),
+    ("cccccccccccc", "Draft the migration notes", None, False),
+    ("dddddddddddd", "enrichment backfill sweep", "exec", True),
+    ("eeeeeeeeeeee", "Debug the flaky pilot test", "tui", False),
+]
+
+
+async def main() -> None:
+    out = Path(sys.argv[1])
+    size = sys.argv[2] if len(sys.argv) > 2 else "100x30"
+    cols, rows = (int(part) for part in size.lower().split("x"))
+    cfg = Path(os.environ["LOCAL_OPERATOR_CONFIG_DIR"])
+
+    # One sleeping child per live record, so each record names a pid that is
+    # really alive and really distinct. Reaped in the finally below; they are
+    # bounded by a short sleep as well, so an abandoned run cannot leak them.
+    holders = [
+        subprocess.Popen([sys.executable, "-c", "import time; time.sleep(120)"]) for _ in SEEDED
+    ]
+    try:
+        await _seed_and_shoot(cfg, holders, out, cols, rows)
+    finally:
+        for holder in holders:
+            holder.terminate()
+        for holder in holders:
+            try:
+                holder.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                holder.kill()
+
+
+async def _seed_and_shoot(cfg, holders, out, cols, rows) -> None:
+    for index, (sid, title, kind, busy) in enumerate(SEEDED):
+        directory = cfg / "sessions" / sid
+        transcript = Transcript(directory)
+        await transcript.append_message(Message.user(title))
+        stamp = 1_700_000_000 - index * 900
+        (directory / "created_at.json").write_text(str(stamp))
+        os.utime(transcript.path, (stamp, stamp))
+        if kind is None:
+            continue
+        # A REAL record through the real publisher: this is what makes the
+        # picker's own decorate_rows fill live_state and kind, rather than the
+        # script asserting the state it wants to draw.
+        #
+        # A DISTINCT pid per record, and it is load-bearing rather than tidy:
+        # ``registry.publish`` keys the file by pid (``<pid>.json``), so three
+        # records published under ``os.getpid()`` overwrite each other and the
+        # scan returns exactly one. The first version of this script did that
+        # and captured a picker with no tag on any row — a plausible frame of
+        # the feature apparently not working.
+        #
+        # The pid must also be ALIVE, because ``registry.scan`` reaps records
+        # whose pid is gone. Long-lived helper processes give us real pids we
+        # are allowed to point at without inventing liveness.
+        registry.publish(
+            SessionRecord(
+                pid=holders[index].pid,
+                kind=kind,
+                session_id=sid,
+                conversation_name=title,
+                cwd=str(cfg),
+                model_label="anthropic/claude-opus-5",
+                control_port=40000 + index,
+                control_key="k",
+                busy=busy,
+                detached=True,
+            ),
+            cfg,
+        )
+
+    # A resume factory is REQUIRED, not decoration: ``_cmd_resume`` refuses with
+    # "resume requires a resume-capable launcher" when it is absent, and the
+    # refusal renders as an ordinary notice — so a shot without one captures a
+    # plausible frame of the picker never having opened. Both frames of the
+    # first before/after pair for this change were exactly that.
+    async def resume_factory(resume_id: str | None) -> FakeSession:
+        return FakeSession()
+
+    app = OperatorApp(lambda: _factory(FakeSession()), resume_factory=resume_factory)
+    async with app.run_test(size=(cols, rows)) as pilot:
+        await pilot.pause()
+        # Through the real slash command, so the frame comes from the path a
+        # user takes — including ``_overlay_live_state``, which is what fills
+        # the live state and the kind this shot exists to show.
+        app._cmd_resume("", app._system_notice)
+        for _ in range(8):
+            await pilot.pause()
+        save_capture(app, str(out))
+
+
+asyncio.run(main())

--- a/scripts/exec_picker_shot.py
+++ b/scripts/exec_picker_shot.py
@@ -21,6 +21,15 @@ gone from the scan, and shoots the frame the user actually sees when a one-shot
 ends underneath them. It also prints ``plan_columns`` before and after, because
 the stills show the symptom and only the numbers show whether the column moved.
 
+``--scroll`` seeds enough cold conversations to push the list past
+``PAGE_ROWS_MAX``, which is the ORDINARY shape rather than a stress case: the
+picker scrolls at eleven sessions and this repo's author has ~500 of them, so
+every picker they open is in this state. It exists because design round 2 (D2)
+found the exec legend structurally unreachable there while every short-list
+frame showed it painting — the five-row default this script shipped with was
+itself an instrument that could not observe the common case. It prints the
+footer row and whether the legend survived, so a frame is backed by the string.
+
 Rows are seeded through the real transcript writer and the real record
 publisher, so the picker's own scan/decorate path fills the live state — the
 same code the app runs. Nothing here fabricates a ``SessionRow``.
@@ -41,7 +50,11 @@ from local_operator.session.runtime import registry
 from local_operator.session.runtime.types import SessionRecord
 from local_operator.session.transcript import Transcript
 from local_operator.tui.app import OperatorApp
-from local_operator.tui.widgets.session_picker import SessionPickerScreen, plan_columns
+from local_operator.tui.widgets.session_picker import (
+    EXEC_MARKER,
+    SessionPickerScreen,
+    plan_columns,
+)
 from scripts.visual_capture import save_capture
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
@@ -57,8 +70,10 @@ SEEDED: list[tuple[str, str, Literal["tui", "exec", "daemon"] | None, bool]] = [
 
 
 async def main() -> None:
-    argv = [arg for arg in sys.argv[1:] if arg != "--reap"]
+    flags = {"--reap", "--scroll"}
+    argv = [arg for arg in sys.argv[1:] if arg not in flags]
     reap = "--reap" in sys.argv
+    scroll = "--scroll" in sys.argv
     out = Path(argv[0])
     size = argv[1] if len(argv) > 1 else "100x30"
     cols, rows = (int(part) for part in size.lower().split("x"))
@@ -71,7 +86,7 @@ async def main() -> None:
         subprocess.Popen([sys.executable, "-c", "import time; time.sleep(120)"]) for _ in SEEDED
     ]
     try:
-        await _seed_and_shoot(cfg, holders, out, cols, rows, reap=reap)
+        await _seed_and_shoot(cfg, holders, out, cols, rows, reap=reap, scroll=scroll)
     finally:
         for holder in holders:
             holder.terminate()
@@ -82,7 +97,22 @@ async def main() -> None:
                 holder.kill()
 
 
-async def _seed_and_shoot(cfg, holders, out, cols, rows, *, reap: bool = False) -> None:
+async def _seed_and_shoot(
+    cfg, holders, out, cols, rows, *, reap: bool = False, scroll: bool = False
+) -> None:
+    if scroll:
+        # Plain cold conversations, seeded through the same real transcript
+        # writer: they need no live record, and their only job is to make the
+        # list longer than one page so `scrolls=True` reaches the footer.
+        for filler in range(12):
+            sid = f"f{filler:011d}"
+            directory = cfg / "sessions" / sid
+            transcript = Transcript(directory)
+            await transcript.append_message(Message.user(f"routine follow-up {filler}"))
+            stamp = 1_700_000_000 - (len(SEEDED) + filler) * 900
+            (directory / "created_at.json").write_text(str(stamp))
+            os.utime(transcript.path, (stamp, stamp))
+
     for index, (sid, title, kind, busy) in enumerate(SEEDED):
         directory = cfg / "sessions" / sid
         transcript = Transcript(directory)
@@ -155,6 +185,37 @@ async def _seed_and_shoot(cfg, holders, out, cols, rows, *, reap: bool = False) 
                 seeded_kinds.get(sid) == expected
             ), f"{sid} scanned back as {seeded_kinds.get(sid)!r}, expected {expected!r}"
         print(f"precondition OK: {seeded_kinds}")
+
+        if scroll:
+            # ASSERT THE SHAPE, not just the screen. A scrolling frame is only
+            # evidence about the scrolling shed order if the list actually
+            # scrolls, and the whole point of D2 is that the short-list frame
+            # looks correct while the common one does not. So state the shape
+            # and read the footer BACK off the painted card — the legend's
+            # presence is the finding, and a grep over the whole frame would
+            # match the `[exec]` in the LIST rather than the one in the footer
+            # (a false pass QA hit this round with exactly that instrument).
+            page = screen._page_rows()
+            assert len(screen.visible_rows) > page, (
+                f"list does not scroll: {len(screen.visible_rows)} rows against page={page} "
+                "— this frame cannot show the scrolling shed order"
+            )
+            lines = screen.render_lines_for_test()
+            # The legend lives on the META row (the counter's), NOT the key row
+            # below it — that placement is the D2 fix. Read the exact row rather
+            # than grepping the frame: the list is drawing `[exec]` too, so a
+            # whole-frame search reports a legend that is not there.
+            meta, keys = lines[-2], lines[-1]
+            assert any(
+                EXEC_MARKER.strip() in line for line in lines[:-2]
+            ), "no [exec] row in the list: the legend has nothing to explain"
+            print(
+                f"shape: rows={len(screen.visible_rows)} page={page} "
+                f"scrolls=True width={screen._card_width()}"
+            )
+            print(f"meta : {meta}")
+            print(f"keys : {keys}")
+            print(f"LEGEND ON META ROW: {EXEC_MARKER.strip() in meta}")
 
         if not reap:
             save_capture(app, str(out))

--- a/scripts/exec_picker_shot.py
+++ b/scripts/exec_picker_shot.py
@@ -13,7 +13,13 @@ is present cannot show that the column lines up, that the tag reads as metadata
 rather than as part of the title, or that untagged rows still align.
 
     env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
-        scripts/exec_picker_shot.py out.svg [COLSxROWS]
+        scripts/exec_picker_shot.py out.svg [COLSxROWS] [--reap]
+
+``--reap`` captures the SECOND half of the D1 evidence: it opens the picker,
+kills the exec run's pid, drives the picker's own ``_tick`` until the record is
+gone from the scan, and shoots the frame the user actually sees when a one-shot
+ends underneath them. It also prints ``plan_columns`` before and after, because
+the stills show the symptom and only the numbers show whether the column moved.
 
 Rows are seeded through the real transcript writer and the real record
 publisher, so the picker's own scan/decorate path fills the live state — the
@@ -35,6 +41,7 @@ from local_operator.session.runtime import registry
 from local_operator.session.runtime.types import SessionRecord
 from local_operator.session.transcript import Transcript
 from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.session_picker import SessionPickerScreen, plan_columns
 from scripts.visual_capture import save_capture
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
@@ -50,8 +57,10 @@ SEEDED: list[tuple[str, str, Literal["tui", "exec", "daemon"] | None, bool]] = [
 
 
 async def main() -> None:
-    out = Path(sys.argv[1])
-    size = sys.argv[2] if len(sys.argv) > 2 else "100x30"
+    argv = [arg for arg in sys.argv[1:] if arg != "--reap"]
+    reap = "--reap" in sys.argv
+    out = Path(argv[0])
+    size = argv[1] if len(argv) > 1 else "100x30"
     cols, rows = (int(part) for part in size.lower().split("x"))
     cfg = Path(os.environ["LOCAL_OPERATOR_CONFIG_DIR"])
 
@@ -62,7 +71,7 @@ async def main() -> None:
         subprocess.Popen([sys.executable, "-c", "import time; time.sleep(120)"]) for _ in SEEDED
     ]
     try:
-        await _seed_and_shoot(cfg, holders, out, cols, rows)
+        await _seed_and_shoot(cfg, holders, out, cols, rows, reap=reap)
     finally:
         for holder in holders:
             holder.terminate()
@@ -73,7 +82,7 @@ async def main() -> None:
                 holder.kill()
 
 
-async def _seed_and_shoot(cfg, holders, out, cols, rows) -> None:
+async def _seed_and_shoot(cfg, holders, out, cols, rows, *, reap: bool = False) -> None:
     for index, (sid, title, kind, busy) in enumerate(SEEDED):
         directory = cfg / "sessions" / sid
         transcript = Transcript(directory)
@@ -130,7 +139,73 @@ async def _seed_and_shoot(cfg, holders, out, cols, rows) -> None:
         app._cmd_resume("", app._system_notice)
         for _ in range(8):
             await pilot.pause()
+
+        # ASSERT THE PRECONDITION BEFORE TRUSTING A PIXEL. Both of this
+        # script's own earlier bugs produced convincing frames of nothing:
+        # without a resume factory `_cmd_resume` refuses and the refusal
+        # renders as an ordinary notice, and under one shared pid the records
+        # collapsed to one. A frame is only evidence once the screen it claims
+        # to show is the screen that is up.
+        screen = app.screen
+        assert isinstance(screen, SessionPickerScreen), f"picker never opened: {type(screen)}"
+        seeded_kinds = {row.id: row.kind for row in screen._all}
+        for sid, _title, kind, _busy in SEEDED:
+            expected = kind or ""
+            assert (
+                seeded_kinds.get(sid) == expected
+            ), f"{sid} scanned back as {seeded_kinds.get(sid)!r}, expected {expected!r}"
+        print(f"precondition OK: {seeded_kinds}")
+
+        if not reap:
+            save_capture(app, str(out))
+            return
+
+        # -- D1: the one-shot ends while the picker is open ------------------
+        # The measurement that matters is the COLUMN, not the tag: the reaped
+        # row is supposed to lose its own 7 characters. What must not happen is
+        # every other name moving because of it.
+        before = _columns(screen, cols)
+        # EVERY exec record, not just one: the column is reserved for the
+        # result set, so it only collapses once the LAST tagged row is gone.
+        # Killing one of two leaves the reservation legitimately standing and
+        # would capture a frame that proves nothing either way.
+        for index, (_sid, _title, kind, _busy) in enumerate(SEEDED):
+            if kind != "exec":
+                continue
+            holders[index].kill()
+            holders[index].wait(timeout=5)
+
+        # Drive the picker's OWN timer rather than mutating its rows: `_tick`
+        # captures its `before` snapshot as its first statement, so a mutation
+        # applied from outside makes the tick compare the new state against
+        # itself and the repaint decision under test never runs.
+        for _ in range(40):
+            screen._tick()
+            await pilot.pause()
+            if all(row.kind != "exec" for row in screen._all):
+                break
+        assert all(row.kind != "exec" for row in screen._all), "the record was never reaped"
+
+        after = _columns(screen, cols)
+        print(f"plan_columns before reap : {before}")
+        print(f"plan_columns after  reap : {after}")
+        print(f"COLUMNS UNCHANGED        : {before == after}")
         save_capture(app, str(out))
+
+
+def _columns(screen, cols: int) -> tuple[int, int, int]:
+    """``plan_columns`` as the open picker would compute it right now."""
+    rows = screen.visible_rows
+    ages = ["1m ago"] * len(rows)
+    return plan_columns(
+        rows,
+        min(cols - 4, 74),
+        ages,
+        bool(screen.body_matched_ids),
+        any(getattr(row, "forked", False) for row in rows),
+        True,
+        screen._exec_column_latched(rows),
+    )
 
 
 asyncio.run(main())

--- a/tests/unit/session/test_catalog_scan_cost.py
+++ b/tests/unit/session/test_catalog_scan_cost.py
@@ -831,3 +831,60 @@ class TestTheHiddenSkipCannotHideRealWork:
         sidebar = {entry.id for entry in load_catalog(tmp_path)}
         assert sidebar == picker
         assert len(picker) == 20, "every subagent session must stay hidden from both"
+
+
+def test_a_live_exec_record_labels_its_row_as_an_exec_run(tmp_path) -> None:
+    """``kind`` reaches the row from the RECORD, through the real scan.
+
+    The picker's tag is only as honest as this plumbing: it reads
+    ``SessionRow.kind``, which nothing but ``decorate_rows`` sets. Asserted
+    against a published record and the real ``registry.scan`` rather than a
+    hand-built row, because the defect this guards is the two disagreeing.
+    """
+    from local_operator.resume import SessionRow
+    from local_operator.session.catalog import decorate_rows
+    from local_operator.session.runtime import registry
+    from local_operator.session.runtime.types import SessionRecord
+
+    (tmp_path / "run" / "mobile").mkdir(parents=True)
+    registry.publish(
+        SessionRecord(
+            pid=os.getpid(),
+            kind="exec",
+            session_id="bbbbbbbbbbbb",
+            conversation_name="nightly audit",
+            cwd=str(tmp_path),
+            model_label="p/m",
+            control_port=1234,
+            control_key="k",
+            detached=True,
+        ),
+        tmp_path,
+    )
+    rows = [
+        SessionRow(id="bbbbbbbbbbbb", mtime=0.0, name="nightly audit"),
+        SessionRow(id="cccccccccccc", mtime=0.0, name="no record at all"),
+    ]
+    by_id = {row.id: row for row in decorate_rows(tmp_path, rows)}
+    assert by_id["bbbbbbbbbbbb"].kind == "exec"
+    assert by_id["bbbbbbbbbbbb"].live_state == "idle"
+    # A row with no live record must not inherit a kind from anywhere.
+    assert by_id["cccccccccccc"].kind == ""
+
+
+def test_an_idle_exec_row_says_what_it_is_instead_of_ready(tmp_path) -> None:
+    """The words and the glyph may not disagree.
+
+    ``CatalogEntry.status`` mirrors ``row_state_mark``'s precedence exactly, so
+    the kind is allowed to speak only at the ``idle`` rung — a BUSY exec run
+    still reports "Working", because what it is doing outranks what kind it is.
+    """
+    from local_operator.resume import SessionRow
+    from local_operator.session.catalog import CatalogEntry
+
+    idle = CatalogEntry(SessionRow("b", 0.0, "audit", live_state="idle", kind="exec"))
+    busy = CatalogEntry(SessionRow("c", 0.0, "audit", live_state="busy", kind="exec"))
+    mine = CatalogEntry(SessionRow("d", 0.0, "mine", live_state="idle"))
+    assert idle.status == "Running headless (exec)"
+    assert busy.status == "Working"
+    assert mine.status == "Ready"

--- a/tests/unit/session/test_remote_cold.py
+++ b/tests/unit/session/test_remote_cold.py
@@ -358,8 +358,8 @@ async def test_a_draft_warms_the_runtime_before_the_message_is_sent(
 async def test_model_default_persists_for_a_local_runtime(tmp_path: Path, monkeypatch) -> None:
     """`/model … d` must keep working once EVERY session is remote.
 
-    The refusal was keyed on ``is_remote``, which meant "somebody else's
-    session" before the viewer model and means "any session at all" after it.
+    The refusal was keyed on a transport flag, which meant "somebody else's
+    session" before the viewer model and "any session at all" after it.
     Left as it was, a user on their own machine \u2014 whose runtime is a child
     process on that same machine \u2014 was told to run the command "on the
     terminal whose launches it should govern", which was the terminal they

--- a/tests/unit/session/test_viewer_protocol.py
+++ b/tests/unit/session/test_viewer_protocol.py
@@ -317,7 +317,6 @@ _UNDECLARED_ON_BOTH_CLASSES = frozenset(
         "context_breakdown",
         "epoch",
         "fork_snapshot",
-        "frontend_state",
         "jobs",
         "mcp_manager",
         "mcp_startup",
@@ -356,7 +355,32 @@ _UNDECLARED_ON_BOTH_CLASSES = frozenset(
 #: and gets promoted rather than lingering as a false claim.
 _KNOWN_MISSING_ON_BOTH_CLASSES = frozenset({"cwd"})
 
-#: Removed by Stage 3; declaring it would entrench the flag this work retires.
+#: Names that MUST NOT come back — neither read by a host nor defined on a class.
+#:
+#: This set changed meaning in Stage 3 and the inversion is the point. While
+#: ``is_remote`` still existed it was an EXCLUSION: the guard skipped it so the
+#: flag's own call sites did not read as undeclared members. The flag is now
+#: deleted, so the same name in the same set now means the opposite — reading it
+#: or defining it is a FAILURE, enforced by
+#: ``test_a_retired_session_flag_cannot_be_reintroduced`` below.
+#:
+#: Why a set rather than one assertion about one name. The defect is a SHAPE,
+#: not a spelling: an undeclared boolean on one session class, duck-probed
+#: through ``getattr(session, "...", False)`` at every call site, whose default
+#: silently means the common case. That shape was fixed site-locally five times
+#: (#576, #609, #624, #625, and the ``_cmd_model`` guard) before anyone removed
+#: the flag, because each fix addressed a call site and none addressed the
+#: attribute. A named set is what makes "this axis is closed" checkable instead
+#: of remembered — the next agent who reaches for a transport boolean adds a
+#: line here to argue for it, rather than reintroducing it silently.
+#:
+#: Three things are asserted for every name, because catching only one of them
+#: leaves the other two routes open: it is absent from BOTH classes (so it
+#: cannot be re-added to ``RemoteSession`` and duck-probed), absent from BOTH
+#: protocols (so it cannot be laundered by declaring it), and read by NO scanned
+#: host (so a probe against a name that exists nowhere cannot sit there
+#: returning its default forever, which is the ``cwd`` defect in
+#: ``_KNOWN_MISSING_ON_BOTH_CLASSES``).
 _RETIRED = frozenset({"is_remote"})
 
 
@@ -480,12 +504,18 @@ def test_every_session_member_a_host_touches_is_declared() -> None:
     """
     touched = _all_touched()
     declared = _declared()
+    # ``_RETIRED`` is deliberately NOT in this union. It was, while the flag it
+    # names still existed and its call sites had to be tolerated; now that the
+    # flag is deleted, tolerating a read of it here is exactly the laundering
+    # route this guard exists to close — a host could reintroduce the probe and
+    # this test would pass. Reads of a retired name are failed by
+    # ``test_a_retired_session_flag_cannot_be_reintroduced`` instead, with a
+    # message that says why the name is gone rather than "declare it".
     known = (
         declared
         | _OWNER_ONLY_CAPABILITY_PROBES
         | _UNDECLARED_ON_BOTH_CLASSES
         | _KNOWN_MISSING_ON_BOTH_CLASSES
-        | _RETIRED
     )
 
     offenders = {
@@ -775,6 +805,78 @@ def test_owner_only_probes_are_all_optional_capability_probes() -> None:
         f"a default: {hard_accesses}. Absence is an AttributeError at that site, "
         "not a supported state, so the name must be declared on a protocol "
         "rather than excluded here."
+    )
+
+
+def test_a_retired_session_flag_cannot_be_reintroduced() -> None:
+    """A retired name may not come back as an attribute, a declaration, or a probe.
+
+    The anti-regression half of Stage 3, and the reason the deletion is worth
+    more than the seventeen substitutions that preceded it. ``is_remote`` was
+    fixed site-locally FIVE times over four PRs (#576, #609, #624, #625, plus
+    the ``_cmd_model`` guard in ``tests/unit/tui/test_noop_consumers.py``) and
+    survived every one of them, because each fix corrected a call site while the
+    attribute stayed on the class — free for the next author to read.
+
+    So this asserts the axis is closed rather than that one call site is
+    correct, and it closes all three routes back in. Any one left open makes the
+    other two decorative:
+
+    * **On a class.** ``RemoteSession.is_remote = True`` reappearing is enough
+      on its own — every historical read was ``getattr(session, "...", False)``
+      against an attribute no protocol declared, so nothing else has to change
+      for the defect to be back.
+    * **On a protocol.** Declaring it would satisfy
+      ``test_every_session_member_a_host_touches_is_declared`` and make the
+      probes legitimate, which is the laundering route that test's ``known``
+      union no longer offers.
+    * **In a host.** A probe against a name that exists nowhere does not raise:
+      it returns the ``False`` default forever, silently, which is the exact
+      shape of the ``cwd`` defect recorded in
+      ``_KNOWN_MISSING_ON_BOTH_CLASSES``. A green suite is what that failure
+      looks like.
+
+    This is deliberately an extension of the existing derivation rather than a
+    parallel mechanism: it reuses ``_all_touched``/``_members``/``_declared``,
+    so widening ``_SCANNED`` or ``_SESSION_EXPRS`` widens this too, and a future
+    retirement is one entry in ``_RETIRED`` rather than a new test.
+    """
+    owner_members = _members(Session, "session.py", "Session")
+    viewer_members = _members(RemoteSession, "remote.py", "RemoteSession")
+    declared = _declared()
+    touched = _all_touched()
+
+    on_classes = sorted(
+        f"{name} (on {klass})"
+        for name in _RETIRED
+        for klass, members in (("Session", owner_members), ("RemoteSession", viewer_members))
+        if name in members
+    )
+    assert not on_classes, (
+        f"a retired session flag is back on a class: {on_classes}. The attribute "
+        "is what made the defect recur — five site-local fixes did not stop it "
+        "because the flag stayed readable. If a genuine need for this axis has "
+        "appeared, argue it in the PR and remove the name from _RETIRED "
+        "deliberately; do not re-add the attribute and leave the set stale."
+    )
+
+    on_protocols = sorted(name for name in _RETIRED if name in declared)
+    assert not on_protocols, (
+        f"a retired session flag is declared on a protocol: {on_protocols}. "
+        "Declaring it would make every duck-probe legitimate and silently "
+        "reopen the conflation — the four questions it merged are answered by "
+        "owns_runtime, outcome_is_synchronous, runtime_locality and the "
+        "registry scan in app.py::_session_runs_elsewhere."
+    )
+
+    read_by_hosts = sorted(
+        f"{name} ({', '.join(touched[name])})" for name in _RETIRED if name in touched
+    )
+    assert not read_by_hosts, (
+        f"a host reads a retired session flag: {read_by_hosts}. The name exists "
+        "on no class, so this probe does not raise — it returns its default "
+        "forever, which is a silent wrong answer rather than a failure. Ask the "
+        "predicate that names the question actually being asked."
     )
 
 

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -1762,9 +1762,8 @@ async def test_a_failed_remote_cancel_never_prints_a_confirmed_success() -> None
     from local_operator.tui.widgets.transcript import NoticeBlock
 
     class RemoteishSession(FakeSession):
-        is_remote = True
         # Runtime role (SessionProtocol): this fake emulates an ATTACHED
-        # viewer, so the predicates must agree with `is_remote` above.
+        # viewer: it owns no loop and learns outcomes over the wire.
         owns_runtime = False
         outcome_is_synchronous = False
         runtime_locality: RuntimeLocality = "this-machine"
@@ -1976,9 +1975,8 @@ async def test_takeover_preserves_the_status_band_verbatim() -> None:
             return self._st.conversation_title
 
     class Remoteish(StatefulSession):
-        is_remote = True
         # Runtime role (SessionProtocol): this fake emulates an ATTACHED
-        # viewer, so the predicates must agree with `is_remote` above.
+        # viewer: it owns no loop and learns outcomes over the wire.
         owns_runtime = False
         outcome_is_synchronous = False
         runtime_locality: RuntimeLocality = "this-machine"
@@ -2126,9 +2124,8 @@ async def test_resume_owned_session_adopts_remote_in_standard_app(monkeypatch, t
     session = FakeSession()
 
     class _RemoteFake(FakeSession):
-        is_remote = True
         # Runtime role (SessionProtocol): this fake emulates an ATTACHED
-        # viewer, so the predicates must agree with `is_remote` above.
+        # viewer: it owns no loop and learns outcomes over the wire.
         owns_runtime = False
         outcome_is_synchronous = False
         runtime_locality: RuntimeLocality = "this-machine"

--- a/tests/unit/tui/test_build_skew.py
+++ b/tests/unit/tui/test_build_skew.py
@@ -76,16 +76,15 @@ MOVES_OVER = "will switch to the new version when it is next idle"
 class _BoundViewer(FakeSession):
     """A follower facade that has already bound to a runtime.
 
-    ``is_remote`` plus a resolved ``owner_version`` is what a real
+    Not owning the runtime, plus a resolved ``owner_version``, is what a real
     ``RemoteSession`` looks like after ``_dial``; ``is_cold`` False is what
     makes the owner comparison meaningful, since a cold viewer has not dialled
     anything and its empty stamp would otherwise read as a prehistoric
     runtime.
     """
 
-    is_remote = True
     # Runtime role (SessionProtocol): this fake emulates an ATTACHED
-    # viewer, so the predicates must agree with `is_remote` above.
+    # viewer: it owns no loop and learns outcomes over the wire.
     owns_runtime = False
     outcome_is_synchronous = False
     runtime_locality: RuntimeLocality = "this-machine"

--- a/tests/unit/tui/test_config_change_notice.py
+++ b/tests/unit/tui/test_config_change_notice.py
@@ -811,9 +811,8 @@ async def test_only_the_owning_process_prints_the_keep_notice(monkeypatch, tmp_p
     _write_elsewhere(tmp_path, "tool_approval_mode", "ask")
 
     class AttachedSession(FakeSession):
-        is_remote = True
         # Runtime role (SessionProtocol): this fake emulates an ATTACHED
-        # viewer, so the predicates must agree with `is_remote` above.
+        # viewer: it owns no loop and learns outcomes over the wire.
         owns_runtime = False
         outcome_is_synchronous = False
         runtime_locality: RuntimeLocality = "this-machine"
@@ -955,9 +954,8 @@ async def test_only_the_process_that_owns_the_gate_prints_the_value(monkeypatch,
     ConfigManager(tmp_path).set_config_value("hosting", "")
 
     class AttachedSession(FakeSession):
-        is_remote = True
         # Runtime role (SessionProtocol): this fake emulates an ATTACHED
-        # viewer, so the predicates must agree with `is_remote` above.
+        # viewer: it owns no loop and learns outcomes over the wire.
         owns_runtime = False
         outcome_is_synchronous = False
         runtime_locality: RuntimeLocality = "this-machine"

--- a/tests/unit/tui/test_noop_consumers.py
+++ b/tests/unit/tui/test_noop_consumers.py
@@ -494,7 +494,11 @@ async def test_a_cold_viewer_may_still_set_its_default_model(tmp_path, monkeypat
     try:
         assert viewer.session_id, "the production cold viewer always carries an id"
         assert viewer.is_cold is True
-        assert viewer.is_remote is True
+        # The production viewer's runtime role: it owns no loop, and a COLD one
+        # reports "this-machine" rather than "unknown" — which is precisely why
+        # the write below is allowed.
+        assert viewer.owns_runtime is False
+        assert viewer.runtime_locality == "this-machine"
         app = OperatorApp.__new__(OperatorApp)
         app._session = viewer  # type: ignore[attr-defined]
         assert app._session_runs_elsewhere() is False, (

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -39,6 +39,7 @@ from local_operator.tui.widgets.session_picker import (
     PICKER_MIN_WIDTH,
     SessionPickerScreen,
     _footer_hints,
+    _meta_legends,
     filter_rows,
     matched_in_body,
     plan_columns,
@@ -421,15 +422,30 @@ def test_the_footer_explains_the_exec_tag_where_the_picker_can_show_it() -> None
     lands there — and only when an exec row is actually present, on the same
     "teach the mark where it is used" rule the body-match legend follows.
     """
-    with_exec = _footer_hints(74, has_exec=True)
+    with_exec = _meta_legends(74, has_marked=False, has_exec=True)
     assert _EXEC_LEGEND in with_exec
-    assert _EXEC_LEGEND not in _footer_hints(74, has_exec=False)
+    assert _EXEC_LEGEND not in _meta_legends(74, has_marked=False, has_exec=False)
     # It says how long the row lasts, not merely what it is.
     assert "one-shot" in _EXEC_LEGEND[1]
-    # Legends teach; keys operate. The legend sheds before either.
-    narrow = [key for key, _ in _footer_hints(40, has_exec=True)]
-    assert _EXEC_LEGEND[0] not in narrow
-    assert "enter" in narrow and "esc" in narrow
+
+    # AT THE WIDTHS THE CARD CAN ACTUALLY PASS, and in the shape the user is
+    # overwhelmingly in. Design round 2 (D2) found this legend structurally
+    # unreachable because the tests asserted it at `_footer_hints(100, ...)` —
+    # a width `_card_width()` caps at PICKER_MAX_WIDTH = 74 and can never
+    # produce — and because `scrolls` defaulted to False while a real store
+    # (PAGE_ROWS_MAX = 10 against hundreds of sessions) always scrolls. A check
+    # that cannot observe the case it exists for certifies nothing.
+    for counter_cells in (0, len("showing 1–10 of 501")):
+        legends = _meta_legends(74, has_marked=False, has_exec=True, counter_cells=counter_cells)
+        assert _EXEC_LEGEND in legends, f"unreachable at counter_cells={counter_cells}"
+
+    # Legends teach; keys operate. On a card too narrow for both, the legend
+    # goes and never survives as a bare unlabelled glyph.
+    narrow = _meta_legends(30, has_marked=False, has_exec=True, counter_cells=19)
+    assert _EXEC_LEGEND not in narrow
+    assert (_EXEC_LEGEND[0], "") not in narrow
+    keys = [key for key, _ in _footer_hints(30)]
+    assert "enter" in keys and "esc" in keys
 
 
 def test_both_legends_coexist_and_the_cryptic_one_survives_longer() -> None:
@@ -440,13 +456,62 @@ def test_both_legends_coexist_and_the_cryptic_one_survives_longer() -> None:
     something without its gloss, while a lone right-quote with nothing
     explaining it is the rendering artifact its legend exists to prevent.
     """
-    wide = [key for key, _ in _footer_hints(100, has_marked=True, has_exec=True)]
+    wide = [key for key, _ in _meta_legends(74, has_marked=True, has_exec=True)]
     assert wide.index(_MARKER_LEGEND[0]) < wide.index(_EXEC_LEGEND[0])
 
-    # Under pressure the readable word gives up its gloss first.
-    squeezed = [key for key, _ in _footer_hints(80, has_marked=True, has_exec=True)]
+    # Under pressure the readable word gives up its gloss first. Squeezed by a
+    # REAL constraint — the counter sharing the row on a narrow card — rather
+    # than by a width the card cannot pass.
+    squeezed = [
+        key for key, _ in _meta_legends(58, has_marked=True, has_exec=True, counter_cells=19)
+    ]
     assert _EXEC_LEGEND[0] not in squeezed
     assert _MARKER_LEGEND[0] in squeezed
+
+
+def test_the_exec_legend_paints_on_a_scrolling_list_which_is_the_ordinary_case() -> None:
+    """Design round 2, D2: the legend was unreachable in the shape users are in.
+
+    Driven through the REAL card rather than the shed helper, because that is
+    exactly the gap the finding exploited: `_footer_hints` was correct about its
+    own inputs while the card could never supply the width those tests used.
+    `_card_width()` caps at PICKER_MAX_WIDTH, so the assertion below fails on
+    the pre-fix tree at every terminal size, including 200 columns.
+
+    The legend is read off the META row specifically. A grep over the whole
+    frame would match the `[exec]` tag in the LIST and pass without the legend
+    existing at all — a false pass this PR's QA round hit with that instrument.
+    """
+    rows = [
+        SessionRow(
+            id=f"{index:012d}",
+            name=f"session number {index}",
+            mtime=NOW - index * 60,
+            created_at=NOW - index * 60,
+            forked=False,
+            live_state="",
+            pending=0,
+            wakes=0,
+            wakes_dormant=False,
+            kind="exec" if index == 1 else "",
+        )
+        for index in range(PAGE_ROWS_MAX * 3)
+    ]
+    screen = SessionPickerScreen(rows, NOW)
+    screen._screen_size = lambda: (100, 30)  # type: ignore[method-assign]
+
+    assert len(rows) > screen._page_rows(), "this list must scroll or it tests the wrong shape"
+    lines = screen.render_lines_for_test()
+    meta = lines[-2]
+
+    assert EXEC_MARKER.strip() in meta, f"legend absent from the meta row: {meta!r}"
+    assert "one-shot" in meta
+    # The keys kept their whole row: the legend no longer buys its place by
+    # evicting a hint, which is what made it unreachable when it did.
+    assert "pgup/pgdn" in lines[-1]
+    # CANARY: the list really is drawing the tag, so the legend has something to
+    # explain and this is not a frame that would pass with no exec row at all.
+    assert any(EXEC_MARKER.strip() in line for line in lines[:-2])
 
 
 def test_a_cold_row_carries_no_kind_so_a_reaped_exec_run_stops_claiming_to_be_one() -> None:
@@ -1378,33 +1443,44 @@ async def test_a_row_matched_only_by_a_past_name_is_shown_and_marked() -> None:
 def test_footer_legend_appears_only_when_a_row_is_marked() -> None:
     """D2: the ``"`` marker is meaningless without a legend, but advertising it
     when nothing is marked would explain a glyph the user cannot see. So the
-    legend is present exactly when the footer has room AND a marked row exists,
+    legend is present exactly when the row has room AND a marked row exists,
     and absent otherwise."""
-    # A card wide enough to hold the legend beside the essential keys.
-    with_legend = _footer_hints(74, has_marked=True)
-    assert _MARKER_LEGEND in with_legend
-    # Same width, nothing marked: no legend, and the full key row is intact.
-    without = _footer_hints(74, has_marked=False)
-    assert _MARKER_LEGEND not in without
-    assert ("pgup/pgdn", "page") in without
+    # A card at its widest, in BOTH list shapes: the counter shares this row on
+    # a scrolling list, and a legend that only fits when it is absent is the
+    # unreachable-in-the-ordinary-case defect of round 2 (D2).
+    for counter_cells in (0, len("showing 1–10 of 501")):
+        with_legend = _meta_legends(
+            74, has_marked=True, has_exec=False, counter_cells=counter_cells
+        )
+        assert _MARKER_LEGEND in with_legend, f"unreachable at counter_cells={counter_cells}"
+        # Same width, nothing marked: no legend.
+        without = _meta_legends(74, has_marked=False, has_exec=False, counter_cells=counter_cells)
+        assert _MARKER_LEGEND not in without
+    # The key row is untouched either way — legends no longer buy space from it.
+    assert ("pgup/pgdn", "page") in _footer_hints(74)
 
 
 def test_footer_legend_drops_before_the_movement_and_action_keys() -> None:
-    """The legend teaches; it must never crowd out the keys that OPERATE the
-    card. Under width pressure it sheds after the two disposable hints but
-    before movement/resume/cancel, and it never survives as a bare unlabelled
-    glyph (which would be the very artifact-looking mark D2 flagged)."""
-    # Wide: legend shown, and it displaced only a disposable hint (pgup/pgdn).
-    wide = _footer_hints(74, has_marked=True)
+    """The legend teaches; the keys OPERATE the card, so they never compete.
+
+    Since round 2 (D2) they do not even share a row: a legend sheds against the
+    counter's row and cannot evict a key at all. What must still hold is that a
+    card too narrow for a legend keeps every essential key, and that a legend
+    never survives as a bare unlabelled glyph (the artifact-looking mark D2
+    flagged in round 1).
+    """
+    # Wide: legend shown, and the full key row survives beside it.
+    wide = _meta_legends(74, has_marked=True, has_exec=False)
     assert _MARKER_LEGEND in wide
-    assert ("pgup/pgdn", "page") not in wide
-    # Narrow: the essential keys survive and the legend is gone entirely — not
-    # reduced to a lone glyph.
-    narrow = _footer_hints(40, has_marked=True)
+    assert ("pgup/pgdn", "page") in _footer_hints(74)
+    # Narrow: the legend is gone entirely — not reduced to a lone glyph — and
+    # the essential keys survive.
+    narrow = _meta_legends(30, has_marked=True, has_exec=False, counter_cells=19)
     assert _MARKER_LEGEND not in narrow
     assert (_MARKER_LEGEND[0], "") not in narrow
-    assert ("enter", "resume") in narrow
-    assert ("esc", "cancel") in narrow
+    keys = _footer_hints(40)
+    assert ("enter", "resume") in keys
+    assert ("esc", "cancel") in keys
 
 
 @pytest.mark.asyncio
@@ -1693,29 +1769,28 @@ async def test_the_soft_tier_runs_only_when_the_exact_tiers_are_empty() -> None:
                 assert typed in ran, f"soft tier did not run at {typed!r} with no name/id hit"
 
 
-def test_the_paging_hint_outranks_the_marker_legend_once_the_list_scrolls() -> None:
+def test_the_paging_hint_outranks_the_filter_hint_once_the_list_scrolls() -> None:
     """The paging hint was offered where paging does nothing and withdrawn where
-    it is the fastest way through the list.
+    it is the fastest way through the list (design round 1, D3).
 
-    A scrolling list is also long enough to contain a marked row, so the legend
-    shed `pgup/pgdn` to make room for itself. Uncapping the store made that the
-    normal case rather than the rare one (design round 1, D3).
+    Round 2 moved the legends off this row, so the competition `pgup/pgdn` now
+    survives is against `type to filter` — the genuinely disposable hint, since
+    a user who is filtering already knows they can type and the query is echoed
+    in the header regardless.
     """
-    width = 62  # narrow enough that legend and paging cannot both fit
+    width = 56  # narrow enough that both disposable hints cannot fit
 
-    not_scrolling = [key for key, _ in _footer_hints(width, has_marked=True, scrolls=False)]
-    scrolling = [key for key, _ in _footer_hints(width, has_marked=True, scrolls=True)]
+    not_scrolling = [key for key, _ in _footer_hints(width, scrolls=False)]
+    scrolling = [key for key, _ in _footer_hints(width, scrolls=True)]
 
-    assert _MARKER_LEGEND[0] in not_scrolling, "the legend should win when nothing scrolls"
-    assert "pgup/pgdn" not in not_scrolling
-
+    assert "pgup/pgdn" not in not_scrolling, "paging is a no-op on a list that fits"
     assert "pgup/pgdn" in scrolling, "paging must survive when the list actually pages"
-    assert _MARKER_LEGEND[0] not in scrolling
+    assert "type" not in scrolling
 
-    # A wide card keeps both regardless: the reorder is a shed policy, not a
+    # A card at its widest keeps both: the reorder is a shed policy, not a
     # removal, so nothing is lost when there is room for everything.
-    wide = [key for key, _ in _footer_hints(100, has_marked=True, scrolls=True)]
-    assert "pgup/pgdn" in wide and _MARKER_LEGEND[0] in wide
+    wide = [key for key, _ in _footer_hints(74, scrolls=True)]
+    assert "pgup/pgdn" in wide and "type" in wide
 
 
 def test_the_paging_hint_survives_on_a_plain_scrolling_list() -> None:
@@ -1727,12 +1802,12 @@ def test_the_paging_hint_survives_on_a_plain_scrolling_list() -> None:
     picker the DEFAULT state, so that was the usual case rather than an edge.
     """
     for width in (56, 60, 66):
-        scrolling = [key for key, _ in _footer_hints(width, has_marked=False, scrolls=True)]
+        scrolling = [key for key, _ in _footer_hints(width, scrolls=True)]
         assert "pgup/pgdn" in scrolling, f"paging hint dropped at width {width}: {scrolling}"
 
     # A list that fits on one page may still shed it first: there is nothing to
     # page through, so the hint is the least useful thing on the row.
-    settled = [key for key, _ in _footer_hints(60, has_marked=False, scrolls=False)]
+    settled = [key for key, _ in _footer_hints(60, scrolls=False)]
     assert "pgup/pgdn" not in settled
 
 
@@ -1743,7 +1818,7 @@ def test_the_empty_state_footer_offers_only_what_works() -> None:
     `backspace` is what widens the query and is the key a user in this state is
     already reaching for; `esc` stays because leaving is still available.
     """
-    hints = _footer_hints(100, empty=True)
+    hints = _footer_hints(74, empty=True)
     keys = [key for key, _ in hints]
     assert keys == ["backspace", "esc"], keys
 
@@ -1752,7 +1827,7 @@ def test_the_empty_state_footer_offers_only_what_works() -> None:
         assert [key for key, _ in _footer_hints(width, empty=True)] == ["backspace", "esc"]
 
     # And the populated footer is untouched.
-    populated = [key for key, _ in _footer_hints(100, empty=False)]
+    populated = [key for key, _ in _footer_hints(74, empty=False)]
     assert "↑↓" in populated and "enter" in populated
 
 

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -31,6 +31,7 @@ from local_operator.tui.widgets.session_picker import (
     BODY_MATCH_MARKER,
     CARD_MAX_HEIGHT_FRACTION,
     CARD_PADDING_ROWS,
+    EXEC_MARKER,
     GUTTER_CELLS,
     NAME_MIN_CELLS,
     PAGE_ROWS_MAX,
@@ -289,6 +290,58 @@ def test_the_cursor_marks_exactly_one_row() -> None:
     rows = [_row("a1", "one"), _row("b2", "two"), _row("c3", "three")]
     lines = [line.plain for line in render_rows(rows, 1, 74, NOW)]
     assert [line.startswith("❯") for line in lines] == [False, True, False]
+
+
+def test_a_live_exec_run_is_named_as_one_rather_than_passing_as_a_conversation() -> None:
+    """The discoverability gap this tag closes.
+
+    Since #804 every ``lop exec`` publishes an ordinary attachable record, and
+    ``decorate_rows(include_live=True)`` has been folding those into this list
+    ever since — rendered identically to a conversation the user started. An
+    idle one-shot and a session they were sitting in both read as a bare ``●``.
+    """
+    rows = [
+        _row("aaaaaaaaaaaa", "my own conversation")._replace(live_state="idle"),
+        _row("bbbbbbbbbbbb", "nightly audit")._replace(live_state="idle", kind="exec"),
+    ]
+    mine, execrun = (line.plain for line in render_rows(rows, 0, 74, NOW))
+    assert EXEC_MARKER.strip() in execrun
+    assert EXEC_MARKER.strip() not in mine
+
+
+def test_the_exec_column_is_reserved_for_every_row_so_names_stay_flush() -> None:
+    """The same fixed-chrome rule ``FORK_MARKER`` follows, and for its reason.
+
+    Painting the tag only on tagged rows moves the start of the name between
+    rows, ragging the left edge of the one field the user reads down the list.
+    Asserted as a column position rather than as a substring because that is
+    the property the eye actually reads.
+    """
+    rows = [
+        _row("aaaaaaaaaaaa", "alpha")._replace(live_state="idle"),
+        _row("bbbbbbbbbbbb", "beta")._replace(live_state="idle", kind="exec"),
+    ]
+    plain = [line.plain for line in render_rows(rows, 0, 74, NOW)]
+    assert plain[0].index("alpha") == plain[1].index("beta")
+
+
+def test_a_list_with_no_exec_run_reserves_no_exec_column() -> None:
+    """A column nobody needs costs the name its cells on every row."""
+    rows = [_row("aaaaaaaaaaaa", "alpha")._replace(live_state="idle")]
+    with_exec = plan_columns(rows, 74, ["1m ago"], False, False, True, True)
+    without = plan_columns(rows, 74, ["1m ago"], False, False, True, False)
+    assert without[0] == with_exec[0] + cell_len(EXEC_MARKER)
+
+
+def test_a_cold_row_carries_no_kind_so_a_reaped_exec_run_stops_claiming_to_be_one() -> None:
+    """``kind`` comes off the LIVE record, so it must vanish with the record.
+
+    An exec record is deliberately ephemeral. If the tag outlived it the picker
+    would keep labelling a plain cold transcript as a running headless job.
+    """
+    cold = _row("bbbbbbbbbbbb", "nightly audit")
+    assert cold.kind == ""
+    assert EXEC_MARKER.strip() not in render_rows([cold], 0, 74, NOW)[0].plain
 
 
 def test_an_unnamed_session_says_so_rather_than_rendering_a_blank() -> None:

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -27,6 +27,7 @@ from local_operator.resume import (
 )
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.widgets.session_picker import (
+    _EXEC_LEGEND,
     _MARKER_LEGEND,
     BODY_MATCH_MARKER,
     CARD_MAX_HEIGHT_FRACTION,
@@ -331,6 +332,121 @@ def test_a_list_with_no_exec_run_reserves_no_exec_column() -> None:
     with_exec = plan_columns(rows, 74, ["1m ago"], False, False, True, True)
     without = plan_columns(rows, 74, ["1m ago"], False, False, True, False)
     assert without[0] == with_exec[0] + cell_len(EXEC_MARKER)
+
+
+def test_the_repaint_signature_covers_every_field_the_rows_render() -> None:
+    """The guard that failed to catch `kind` (agent review round 1, MAJOR-1/Q1).
+
+    The previous assertion only checked that every signature NAME is a real
+    ``SessionRow`` field, which catches a rename and is blind to the error that
+    actually shipped: a field ADDED to the row, rendered by the picker, and
+    never added to the signature. ``_tick`` then compares two different rows
+    equal and leaves stale pixels on screen.
+
+    Asserted as the partition rather than as a membership test, so a future
+    field must be classified one way or the other and cannot simply be
+    forgotten.
+    """
+    covered = set(SessionPickerScreen._SIGNATURE_FIELDS)
+    excluded = set(SessionPickerScreen._SIGNATURE_EXCLUDED)
+    assert covered.isdisjoint(excluded), "a field cannot be both compared and excluded"
+    assert covered | excluded == set(SessionRow._fields)
+    # The specific escape, pinned by name: `kind` drives EXEC_MARKER and the
+    # reserved column, so it must be compared.
+    assert "kind" in covered
+
+
+def test_a_kind_only_change_is_visible_to_the_repaint_decision() -> None:
+    """Two rows identical but for ``kind`` must not compare equal.
+
+    The rendered proof that the signature fix matters: these two rows paint
+    differently, so a repaint decision that called them equal would show the
+    first row's `[exec]` for a session that is no longer one.
+    """
+    was_exec = _row("bbbbbbbbbbbb", "nightly audit")._replace(live_state="idle", kind="exec")
+    now_tui = was_exec._replace(kind="tui")
+
+    def signature(row: SessionRow) -> tuple[object, ...]:
+        return tuple(getattr(row, f, None) for f in SessionPickerScreen._SIGNATURE_FIELDS)
+
+    assert signature(was_exec) != signature(now_tui)
+    # ... and they really do render differently, so the comparison is load-bearing.
+    painted_exec = render_rows([was_exec], 0, 74, NOW)[0].plain
+    painted_tui = render_rows([now_tui], 0, 74, NOW)[0].plain
+    assert EXEC_MARKER.strip() in painted_exec
+    assert EXEC_MARKER.strip() not in painted_tui
+
+
+def test_the_exec_column_does_not_collapse_when_the_one_shot_is_reaped() -> None:
+    """Design round 1, D1: the reserved column may widen, never narrow.
+
+    A reap is not a user action, and it happens at the NORMAL END of every
+    one-shot. Letting the column collapse then moved every name 7 cells left
+    with no keystroke — the list lurching at exactly the moment the tag exists
+    to explain. The reaped row loses its own tag (that change is real and must
+    stay visible); nothing else moves.
+    """
+    live = [
+        _row("aaaaaaaaaaaa", "alpha")._replace(live_state="idle"),
+        _row("bbbbbbbbbbbb", "nightly audit")._replace(live_state="idle", kind="exec"),
+    ]
+    # The same rows after the one-shot ends: the record is gone, so is the kind.
+    reaped = [live[0], live[1]._replace(live_state="", kind="")]
+
+    screen = SessionPickerScreen(live, NOW)
+    assert screen._exec_column_latched(live) is True
+    before = plan_columns(live, 74, ["1m ago"] * 2, False, False, True, True)
+
+    # The reap: the result set itself no longer carries a tagged row.
+    assert not any(row.kind == "exec" for row in reaped)
+    assert screen._exec_column_latched(reaped) is True, "the column must stay reserved"
+    after = plan_columns(reaped, 74, ["1m ago"] * 2, False, False, True, True)
+    assert before == after, "no column may move because a one-shot ended"
+
+    # Without the latch the same reap collapses the column — the defect, pinned.
+    unlatched = plan_columns(reaped, 74, ["1m ago"] * 2, False, False, True, False)
+    assert unlatched[0] == after[0] + cell_len(EXEC_MARKER)
+
+    # A picker that has never seen an exec row still pays nothing.
+    fresh = SessionPickerScreen([live[0]], NOW)
+    assert fresh._exec_column_latched([live[0]]) is False
+
+
+def test_the_footer_explains_the_exec_tag_where_the_picker_can_show_it() -> None:
+    """Design round 1, D2: `[exec]` states provenance; the legend states lifetime.
+
+    The words that carry ephemerality ("Running headless (exec)") render only in
+    the sidebar's hover tooltip, a surface the picker never shows. The legend is
+    the picker's own established mechanism for explaining a mark, so the fact
+    lands there — and only when an exec row is actually present, on the same
+    "teach the mark where it is used" rule the body-match legend follows.
+    """
+    with_exec = _footer_hints(74, has_exec=True)
+    assert _EXEC_LEGEND in with_exec
+    assert _EXEC_LEGEND not in _footer_hints(74, has_exec=False)
+    # It says how long the row lasts, not merely what it is.
+    assert "one-shot" in _EXEC_LEGEND[1]
+    # Legends teach; keys operate. The legend sheds before either.
+    narrow = [key for key, _ in _footer_hints(40, has_exec=True)]
+    assert _EXEC_LEGEND[0] not in narrow
+    assert "enter" in narrow and "esc" in narrow
+
+
+def test_both_legends_coexist_and_the_cryptic_one_survives_longer() -> None:
+    """Two marks, one footer, and a deliberate order.
+
+    Displayed, the body mark leads because that is the order the marks appear
+    in a row. Shed, `[exec]` goes first: it is a readable word that still means
+    something without its gloss, while a lone right-quote with nothing
+    explaining it is the rendering artifact its legend exists to prevent.
+    """
+    wide = [key for key, _ in _footer_hints(100, has_marked=True, has_exec=True)]
+    assert wide.index(_MARKER_LEGEND[0]) < wide.index(_EXEC_LEGEND[0])
+
+    # Under pressure the readable word gives up its gloss first.
+    squeezed = [key for key, _ in _footer_hints(80, has_marked=True, has_exec=True)]
+    assert _EXEC_LEGEND[0] not in squeezed
+    assert _MARKER_LEGEND[0] in squeezed
 
 
 def test_a_cold_row_carries_no_kind_so_a_reaped_exec_run_stops_claiming_to_be_one() -> None:

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -490,7 +490,7 @@ def test_the_exec_legend_paints_on_a_scrolling_list_which_is_the_ordinary_case()
             created_at=NOW - index * 60,
             forked=False,
             live_state="",
-            pending=0,
+            pending=None,
             wakes=0,
             wakes_dormant=False,
             kind="exec" if index == 1 else "",

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -593,6 +593,17 @@ async def test_speculative_prepare_does_not_ensure_bound_on_a_cold_owner():
 
     bound = AsyncMock()
     remote = MagicMock(spec=RemoteSession)
+    # STATED, not inherited from the spec. ``owns_runtime`` is a property, and
+    # ``spec=`` only constrains which names exist — it does not run them, so a
+    # spec'd mock auto-fabricates a truthy ``Mock`` for it and therefore claims
+    # to OWN its runtime, which is the exact opposite of the viewer this stands
+    # in for. That was invisible while the sidebar tested ``isinstance(...,
+    # RemoteSession)`` (a spec'd mock passes that) and became visible the moment
+    # it started asking the declared predicate. The fake must answer the
+    # question the production object answers.
+    remote.owns_runtime = False
+    remote.outcome_is_synchronous = False
+    remote.runtime_locality = "this-machine"
     remote.session_id = "other"
     remote.is_cold = True
     remote._ensure_bound = bound
@@ -685,6 +696,14 @@ async def test_closing_the_sidebar_drains_leased_sources_but_keeps_local_work():
 
     def lease(app, session_id: str, *, kind: str) -> SessionInteraction:
         remote = MagicMock(spec=RemoteSession)
+        # See the note in ``test_speculative_prepare_does_not_ensure_bound_on_a
+        # _cold_owner``: a spec'd mock fabricates a TRUTHY ``owns_runtime``, so
+        # without this the drain treats every leased viewer as an owner and
+        # skips it — which is the leak this test exists to catch, reported as a
+        # failure of the fix rather than of the fake.
+        remote.owns_runtime = False
+        remote.outcome_is_synchronous = False
+        remote.runtime_locality = "this-machine"
         remote.session_id = session_id
         remote.is_cold = False
         remote.has_pending_gate_reply = False

--- a/tests/unit/tui/test_sidebar_source_state.py
+++ b/tests/unit/tui/test_sidebar_source_state.py
@@ -207,9 +207,8 @@ async def test_pending_choice_snapshot_restores_typed_and_checked_state():
 @pytest.mark.parametrize("gate_kind", ["approval", "ask"])
 async def test_hidden_stopped_callback_cannot_answer_selected_sources_gate(gate_kind):
     class Watched(FakeSession):
-        is_remote = True
         # Runtime role (SessionProtocol): this fake emulates an ATTACHED
-        # viewer, so the predicates must agree with `is_remote` above.
+        # viewer: it owns no loop and learns outcomes over the wire.
         owns_runtime = False
         outcome_is_synchronous = False
         runtime_locality: RuntimeLocality = "this-machine"

--- a/tests/unit/tui/test_sidebar_swap_reset.py
+++ b/tests/unit/tui/test_sidebar_swap_reset.py
@@ -67,9 +67,8 @@ class SidebarRemote(FakeSession):
     regression turns on.
     """
 
-    is_remote = True
     # Runtime role (SessionProtocol): this fake emulates an ATTACHED
-    # viewer, so the predicates must agree with `is_remote` above.
+    # viewer: it owns no loop and learns outcomes over the wire.
     owns_runtime = False
     outcome_is_synchronous = False
     runtime_locality: RuntimeLocality = "this-machine"

--- a/tests/unit/tui/test_stop_command.py
+++ b/tests/unit/tui/test_stop_command.py
@@ -122,9 +122,8 @@ async def test_follower_stop_sends_the_op_to_the_owner() -> None:
     from local_operator.session.frontend_state import FrontendSessionState
 
     class Remoteish(FakeSession):
-        is_remote = True
         # Runtime role (SessionProtocol): this fake emulates an ATTACHED
-        # viewer, so the predicates must agree with `is_remote` above.
+        # viewer: it owns no loop and learns outcomes over the wire.
         owns_runtime = False
         outcome_is_synchronous = False
         runtime_locality: RuntimeLocality = "this-machine"

--- a/tests/unit/tui/test_subagent_scope.py
+++ b/tests/unit/tui/test_subagent_scope.py
@@ -76,7 +76,7 @@ def scoped_state() -> FrontendSessionState:
 
 
 def install(session: Any, state: FrontendSessionState) -> None:
-    session.is_remote = True
+    session.owns_runtime = False
     session.frontend_state = state
     session.jobs = SnapshotJobs(state.jobs)
     session._subagent_comms = SnapshotSubagentComms(state.jobs)

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -4778,9 +4778,10 @@ async def test_follower_pages_durable_history_from_the_projected_session_dir(
             session_dir=str(directory) if shape == "wired" else None,
         )
         session = FakeSession()
-        # What the production ``RemoteSession`` says of itself; it keeps the
-        # app from standing up an owner-side mobile registrant over a fake.
-        session.is_remote = True  # type: ignore[attr-defined]
+        # A VIEWER, as the production ``RemoteSession`` reports itself: this is
+        # what keeps the app from standing up an owner-side mobile registrant
+        # over a fake, since publication rights follow runtime ownership.
+        session.owns_runtime = False  # type: ignore[attr-defined]
         session.jobs = SnapshotJobs([row])
         session._subagent_comms = SnapshotSubagentComms([row])
         app = OperatorApp(_async_factory(session))
@@ -4899,7 +4900,7 @@ async def test_a_restored_swept_child_pages_its_transcript_on_a_follower(
         session_id=session_id,
     )
     session = FakeSession()
-    session.is_remote = True  # type: ignore[attr-defined]
+    session.owns_runtime = False  # type: ignore[attr-defined]
     session.jobs = SnapshotJobs([row])
     session._subagent_comms = SnapshotSubagentComms([row])
     app = OperatorApp(_async_factory(session))
@@ -4991,7 +4992,7 @@ async def test_a_swept_child_with_no_directory_anywhere_keeps_the_note(tmp_path)
         trajectory=[],
     )
     session = FakeSession()
-    session.is_remote = True  # type: ignore[attr-defined]
+    session.owns_runtime = False  # type: ignore[attr-defined]
     session.jobs = SnapshotJobs([row])
     comms = SnapshotSubagentComms([row])
     assert comms.session_dir_of("never-started") is None
@@ -5071,7 +5072,7 @@ async def test_a_follower_renders_the_delegated_brief_once_not_twice(tmp_path, m
     row = JobState.model_validate(json.loads(row.model_dump_json()))
 
     session = FakeSession()
-    session.is_remote = True  # type: ignore[attr-defined]
+    session.owns_runtime = False  # type: ignore[attr-defined]
     session.jobs = SnapshotJobs([row])
     session._subagent_comms = SnapshotSubagentComms([row])
     app = OperatorApp(_async_factory(session))

--- a/tests/unit/tui/test_turn_abandoned.py
+++ b/tests/unit/tui/test_turn_abandoned.py
@@ -118,9 +118,8 @@ class HangingFollowerSession(JobsSession):
     #: know this worker's `error=None` means "the owner did not tell me" rather
     #: than "the turn succeeded". A follower fake without it models the wire
     #: ORDER while claiming the authority of an in-process session.
-    is_remote = True
     # Runtime role (SessionProtocol): this fake emulates an ATTACHED
-    # viewer, so the predicates must agree with `is_remote` above.
+    # viewer: it owns no loop and learns outcomes over the wire.
     owns_runtime = False
     outcome_is_synchronous = False
     runtime_locality: RuntimeLocality = "this-machine"
@@ -152,9 +151,8 @@ class OwnerEndRacingFollowerSession(JobsSession):
     #: See :class:`HangingFollowerSession`. Load-bearing here: it is what makes
     #: this fallback decline to announce an outcome it was never told, so the
     #: owner's real end behind it is what speaks.
-    is_remote = True
     # Runtime role (SessionProtocol): this fake emulates an ATTACHED
-    # viewer, so the predicates must agree with `is_remote` above.
+    # viewer: it owns no loop and learns outcomes over the wire.
     owns_runtime = False
     outcome_is_synchronous = False
     runtime_locality: RuntimeLocality = "this-machine"
@@ -1493,14 +1491,14 @@ async def test_a_follower_whose_prompt_is_refused_before_start_still_clears_the_
     owner (disposed session, queue full, owner reconnecting). `is_streaming`
     is False, no `TurnStarted` ever arrives, and the worker's `finally` is the
     only thing that clears the band `_start_turn` lit — exactly the "KEPT"
-    case the in-process refusal test pins. Gating the write on `is_remote`
-    alone would have left THIS band lit forever.
+    case the in-process refusal test pins. Gating the write on the session's
+    kind alone — rather than on whether its outcome is synchronous AND it is
+    still streaming — would have left THIS band lit forever.
     """
 
     class RefusingFollowerSession(JobsSession):
-        is_remote = True
         # Runtime role (SessionProtocol): this fake emulates an ATTACHED
-        # viewer, so the predicates must agree with `is_remote` above.
+        # viewer: it owns no loop and learns outcomes over the wire.
         owns_runtime = False
         outcome_is_synchronous = False
         runtime_locality: RuntimeLocality = "this-machine"
@@ -1582,9 +1580,8 @@ async def test_a_followers_loop_turn_holds_working_between_iterations() -> None:
     class CapabilitylessFollowerSession(JobsSession):
         """A follower whose owner advertised nothing — every cold viewer."""
 
-        is_remote = True
         # Runtime role (SessionProtocol): this fake emulates an ATTACHED
-        # viewer, so the predicates must agree with `is_remote` above.
+        # viewer: it owns no loop and learns outcomes over the wire.
         owns_runtime = False
         outcome_is_synchronous = False
         runtime_locality: RuntimeLocality = "this-machine"


### PR DESCRIPTION
## What

Stage 3 of the session consolidation: **retire `is_remote`.** It is the payoff Stage 2 (#861) was built to make safe.

1. All **17 reads** substituted with the predicate that names the question the site was actually asking.
2. The **16 `isinstance(session, RemoteSession)`** checks became one `TypeGuard[ViewerSessionProtocol]`.
3. **`is_remote` deleted**, with the prose describing its old semantics rewritten rather than left to mislead.
4. The **AST guard widened** so the same shape cannot come back.
5. Live `kind == "exec"` records **labelled** in the session picker.

## Why

`is_remote` named a transport axis that collapsed in 0.46.0, when `lop` began building a viewer for every local user. It had exactly one writer, was never declared on any protocol, and was read as `getattr(session, "is_remote", False)` at every site — where the `False` default silently means "in-process" and a typo in the string is invisible to pyright.

It has been constant-`True` for every TUI session ever since, and the same conflation was fixed **site-locally five times** (#576, #609, #624, #625, plus the `_cmd_model` guard) without anyone removing the attribute. That is why there was always a next one: each fix corrected a call site while the flag stayed readable. The codebase already said so in writing — `app.py` notes the test "became wrong the moment EVERY session became remote", and `_session_runs_elsewhere` notes the flag "no longer distinguishes 'someone else's session' from 'my own session, one process away'".

## Per-site classification

Every read, the question it was really asking, and what it became. Questions: **(i)** would a config write reach this runtime · **(ii)** can I know this call's outcome synchronously · **(iii)** do I own this session's lifecycle · **(v)** may this process publish a registrant. *(Question (iv), "is the transport a socket", is asked by nothing — it is always true.)*

| # | Site | Q | Became | Why |
|---|---|---|---|---|
| 1 | `_post_turn_abandoned_for` `outcome_known` | ii | `outcome_is_synchronous` | The caller holds an outcome only where `prompt()` returned after the terminal state. |
| 2 | `_adopt_session` takeover/stopped install | v | `_is_viewer(...)` | A viewer must not publish a second record for the owner's transcript. |
| 3 | `_detach_or_stop_outgoing` early return | iii | `owns_runtime` | "Nothing was left running" is true precisely when this process *is* the runtime. |
| 4 | `_session_runs_elsewhere` first guard | i | `runtime_locality == "this-process"` | Locality is the question; the registry scan below still answers what the facade cannot. |
| 5 | `_mobile_adopted` teardown | v | `owns_runtime` | Publication rights follow ownership, not transport. |
| 6 | `knows_outcome` | ii | `outcome_is_synchronous` | Same as #1, on the worker's `finally`. |
| 7 | `_retire_turn_band` withhold | ii | `outcome_is_synchronous` | Genuinely needs "outcome not yet known **and** still streaming". |
| 8 | skip local auto-naming | iii | `owns_runtime` | Naming belongs to the process that owns the provider and the transcript. |
| 9 | `_gate_is_owned_elsewhere` | iii | `owns_runtime` | The gate follows the loop: whoever runs the turn owns the gate the engine asks. |
| 10 | build-skew comparison | iii | `_is_viewer(...)` | An owner *is* this process, so there is no second build to compare against. |
| 11 | `/stop` routes to owner | iii | `owns_runtime` | A follower does not own its session; the owner ends it. |
| 12 | `_stop_local_session` early return | iii | `owns_runtime` | The in-process branch may only run where the loop is in-process. |
| 13 | `/stop all` listing `own_local` | iii | `owns_runtime` | **Dead in `lop` and correctly so** — see below. |
| 14 | `/stop all` own-session execution | iii | `owns_runtime` | Mirrors #13 exactly, so the count shown is the count acted on. |
| 15 | `/model default` refusal | i | *(already `_session_runs_elsewhere()`)* | Worked example; only its stale prose changed. |
| 16–17 | doc comments (`_session_runs_elsewhere`, `_retire_turn_band`) | — | prose | Rewritten to describe the predicates, not the flag. |

**Nothing in the taxonomy failed to fit**, with one clarification. Sites #13/#14 are dead branches in the shipped TUI — `own_local` is always `False` — and that is **correct, not a bug**: the TUI's runtime is a separate spawned process publishing its own record, so this session already reaches the listing through `_stop_targets`, and appending it here would list it twice. The branch survives for hosts that genuinely own a session in-process (the headless REPL, the server), which is why it is a predicate substitution rather than a deletion. The surrounding comments described a path the shipped TUI never takes and now say so.

`publishes_registrant` (question v) still is not a declared member — #861 deferred it for being a property of the *host* rather than of the session. Read in context, sites #2 and #5 are both answered by `owns_runtime`: publication rights follow the loop. No new type was needed.

## The 16 `isinstance` checks → one predicate

`_is_viewer()` is a module-level `TypeGuard[ViewerSessionProtocol]` over the declared `owns_runtime`, following app.py's own convention (`_skill_body_has_content`). pyright narrows to the viewer surface inside every true branch, so the members stay statically checked, and `RemoteSession` leaves the TUI's imports.

**I did not convert them to `isinstance(session, ViewerSessionProtocol)`, and that is a deliberate override of the brief.** The honest-looking conversion is ~1,300–3,000x slower. That protocol is `runtime_checkable` with **79 public members**, and a positive `isinstance` walks every one. Measured on this tree — arm64, CPython 3.12.13, best-of-five per run:

| expression | cost |
|---|---|
| `isinstance(viewer, RemoteSession)` *(what it was)* | 0.027–0.029 us |
| `isinstance(viewer, ViewerSessionProtocol)` | **60–136 us** |
| `not session.owns_runtime` *(what it is)* | 0.044–0.058 us |

The protocol row is a **range** because it genuinely varies that much between runs; a single number would be a lucky sample presented as a constant. The ratio is stable and the conclusion does not turn on where it lands. Re-measure rather than inheriting these. The negative case is cheap (~1.3 us — it fails on the first missing member); only the positive path pays, and these sites are overwhelmingly positive.

Three of the converted sites are hot: `_sidebar_source_releasable` runs per source per sweep, `_relaunch_refusal` loops every interaction, `_preserve_source_gate_reply` runs per gate reply. Putting tens of microseconds per source per sweep on a paint path to buy a type the `TypeGuard` already supplies statically is the wrong trade. AGENTS.md's "prefer a structural invariant to a numeric one" is about assertions, not about paying three orders of magnitude at runtime for one.

**`runtime_checkable` stays on the protocol**, and the docstring now says why so nobody deletes it as unused: it is what lets the conformance tests assert *structurally* that `RemoteSession` satisfies the protocol and `Session` does not — the property that makes the split meaningful. Those run once per test, never on a paint path. `app.py` has zero `isinstance` against either protocol.

## `app.py`'s raising branch, handled deliberately

The brief flagged `The conversation is not owner-backed` as raising on the negative branch. There are four such raises (`_lease_sidebar_source`, `_prepare_sidebar_session`, and two in `_commit_sidebar_session`). **All four keep raising, unchanged.** They are assertions that sidebar navigation got a viewer, and under the viewer model `lop` never builds anything else — `cli.py`'s takeover factory raises rather than returning an owner. Converting a raise into a silent return there would turn a structural invariant into a swallowed bug. Only the *test* changed, from concrete class to declared predicate.

## `desktop_sessions.py`

**Left typed against `RemoteSession`, deliberately.** I tried the protocol and measured what it costs: pyright reports `Cannot access attribute "frontend_state" for class "ViewerSessionProtocol"` at `:296`, because that host reaches two members (`frontend_state`, `subscribe_frontend`) that were undeclared debt. Declaring `frontend_state` on `SessionProtocol` — where it belongs, since both classes have it — produces **1,871 pyright errors**, because every test double and reduced host is checked against that protocol.

So `frontend_state` is declared on `ViewerSessionProtocol` (narrow enough that only the real facade and the desktop bridge satisfy it), which is what the three TUI sites the narrowing exposed actually needed. Retyping the desktop host would additionally require `subscribe_frontend`; that is a Stage-5 concern about host composition, not this stage's, and it is recorded rather than half-done.

## Scope item 5: the premise was stale — exec rows already appear

The brief says exec records are not offered by the picker and this is a discoverability gap. **Half right, and I checked before building.** I published a synthetic live `kind=="exec"` record plus a session dir into an isolated config dir and asked the real `load_catalog()`:

```
catalog ids: ['aaaaaaaaaaaa'(tui), 'bbbbbbbbbbbb'(exec)]
exec listed: True    live_state='idle'  status='Ready'
```

`catalog.py`'s `decorate_rows(include_live=True)` already injects any live record whose session dir passes `is_user_session`, and exec dirs carry no origin marker, so they pass. **Exec runs have been listed and attachable since #804.**

The real gap is that the row was **indistinguishable from a terminal session**: `SessionRow` carried no `kind`, so an idle one-shot rendered exactly like the conversation you were sitting in half an hour ago. That also hides the hazard the architecture report itself flagged — an exec record is deliberately ephemeral, so the indistinguishable row is the one that can vanish between the paint and the Enter.

So the one-screen change is **labelling**, not surfacing. `SessionRow` carries the live record's `kind`; the picker tags exec rows and the status line says `Running headless (exec)` at the idle rung only — a busy or needs-you exec run still reports what it is *doing*, because that outranks what kind it is, and the words mirror `row_state_mark`'s precedence exactly so the glyph and the tooltip cannot disagree.

### Before / after

Same seeded store, same code path (`/resume` → `_overlay_live_state` → `decorate_rows`), 100x30.

**Before** — `nightly release audit` (exec) and `Debug the flaky pilot test` (tui) both render a bare `●`:

<img width="820" alt="before" src="https://gist.githubusercontent.com/damianvtran/b2c6ae00ad99e1d7ccf8e3e23e52521b/raw/dd1934aae47017309d7414b56395075018782867/pr-exec-picker-before.svg" />

**After** — the exec runs are named; everything else is untouched:

<img width="820" alt="after" src="https://gist.githubusercontent.com/damianvtran/b2c6ae00ad99e1d7ccf8e3e23e52521b/raw/11f4b8d71e76dac3127e533dcd122defe90b6dd3/pr-exec-picker-after.svg" />

Backed by the geometry rather than by eye: every name sits at **x=192** whether its row is tagged or not (tags at x=120), so the left edge of the field being read down the list stays flush. At 70 and 80 columns the drop ladder still truncates the *name* with an ellipsis rather than collapsing the tag column.

Captured with `scripts/exec_picker_shot.py` (new, reusable). Two harness bugs were caught by *looking at the frame* rather than by any test: the first pair rendered the picker never having opened (no resume factory → `_cmd_resume` refuses, and the refusal renders as an ordinary notice), and the second published every record under `os.getpid()` — records are keyed `<pid>.json`, so three collapsed into one and the frame showed the feature apparently not working. Both are recorded in the script.

## Widening the guard

`_RETIRED` **inverts**: while the flag existed it was an *exclusion* so its own call sites did not read as undeclared; now it is a *rejection* set, and it is out of `test_every_session_member_a_host_touches_is_declared`'s `known` union — leaving it there was the laundering route, since a host could reintroduce the probe against a green guard.

`test_a_retired_session_flag_cannot_be_reintroduced` closes all three routes back in, because any one left open makes the other two decorative: **on a class** (enough on its own — every historical read was a `getattr` against an undeclared attribute), **on a protocol** (declaring it would make the probes legitimate), and **read by a host** (a probe against a name that exists nowhere does not raise, it returns `False` forever — the `cwd` defect's exact shape). It reuses `_all_touched`/`_members`/`_declared`, so widening `_SCANNED` widens this too, and a future retirement is one entry rather than a new test.

### Planted-violation harness — every mutation asserted to have LANDED

Three agents on #861 had harnesses silently no-op and report false passes; one "catch" was a `SyntaxError`. So each cell verifies the bytes changed **and** the mutated file still parses before it will believe a FAIL, checks the *expected* test fires, and asserts byte-identical restoration afterwards. Baseline is asserted green first, or every result below would be uninterpretable.

```
[baseline] test_a_retired_session_flag_cannot_be_reintroduced: PASS
[baseline] test_every_session_member_a_host_touches_is_declared: PASS
[reintroduce is_remote on RemoteSession]   landed=True parses=True guard=FAIL (caught)
[declare is_remote on SessionProtocol]     landed=True parses=True guard=FAIL (caught)
[host re-reads is_remote via getattr]      landed=True parses=True guard=FAIL (caught)
[host reaches an undeclared session member] landed=True parses=True guard=FAIL (caught)
```

## Evidence: behaviour is identical at every substituted site

This is a behaviour-preserving refactor across 17 semantic sites, so a green suite is not evidence — three duration bugs shipped from this subsystem on paths nobody exercised. Every old expression was evaluated against the new one in every state that matters, **including a viewer that has watched turns run**, which is the state that hid the original bug (checked at `streaming=False` *and* `True`):

```
SITE                                          owner        viewer_cold  viewer_attached viewer_watched viewer_postdisc exec_published none
1  _post_turn_abandoned_for outcome_known     = True/True   = False/False = False/False   = False/False  = False/False   = False/False  = True/True
...
14 /stop all own-session execution            = True/True   = False/False = False/False   = False/False  = False/False   = False/False  = False/False
ISINSTANCE x16 -> _is_viewer                  = False/False = True/True   = True/True     = True/True    = True/True     = True/True    = False/False

All 15 substituted expressions agree with the originals across all 7 states.
```

Then re-verified against the **real objects** rather than stand-ins, so the table's assumed states are the states production has:

```
REAL RemoteSession.cold (what `lop` builds at boot):
   owns_runtime = False | outcome_is_synchronous = False | runtime_locality = 'this-machine'
   hasattr is_remote = False | _is_viewer = True | isinstance ViewerProto = True
REAL Session (owner hosts: exec/REPL/server):
   owns_runtime = True  | outcome_is_synchronous = True  | runtime_locality = 'this-process'
   hasattr is_remote = False | _is_viewer = False
```

## Two mock doubles had to state their runtime role

`MagicMock(spec=RemoteSession)` **passes `isinstance(..., RemoteSession)` but fabricates a truthy `owns_runtime`** — `spec=` constrains which names exist, it does not run properties — so the mock claimed to own its runtime, the opposite of the viewer it stands in for. The failure was structurally invisible while the sidebar tested the concrete class and surfaced the instant it asked the declared predicate.

This is the *test* having encoded the old conflated meaning, not a behaviour change: the production object answers `owns_runtime = False`, and the fakes now answer the same. The codebase already records this exact hazard at `test_sidebar_swap_reset.SidebarRemote` ("a `MagicMock(spec=RemoteSession)` cannot stand in here"). Both are commented so the next author does not rediscover it.

## Gates

```
$ .venv/bin/python -m flake8 .                                    # clean
$ uvx --from black==26.1.0 black --check .                        # 1188 files unchanged
$ uvx isort==5.13.2 --check .                                     # clean
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .     # 0 errors
```

Targeted suites over the delta and its regression surfaces (`-n 4`; the whole tree is CI's job):

```
tests/unit/session + tui/{session_sidebar,session_picker,noop_consumers,subagent_view,
  subagent_scope,turn_abandoned,config_change_notice,sidebar_swap_reset,
  sidebar_source_state,build_skew,app_pilot}          2675 passed
tests/unit/tui/{stop_command,events,session_order} + tests/unit/server   415 passed, 2 skipped
```

New picker tests were proven able to fail: disabling the tag (`any_tagged = False`) fails `test_a_live_exec_run_is_named_as_one_rather_than_passing_as_a_conversation` with the exact rendered row, rather than passing vacuously.

## Not done, deliberately

- **`desktop_sessions.py` retyping** — deferred, with the cost measured above rather than asserted.
- **`_stop_local_session` / mobile-handle branch deletion** — they are unreachable from `lop` but live for in-process hosts. Substituted and documented, not deleted, per the architecture report's own risk note.
- **No version bump.**
