### PR TITLE
fix(session): make pre-compaction history reachable for audit

### DIFF
--- a/docs/design/full-history-audit-window.md
+++ b/docs/design/full-history-audit-window.md
@@ -260,11 +260,21 @@ the original sentence were wrong.
 frame.** The original 82-character string wrapped and orphaned its last two
 words at every compaction (D2). Arithmetic alone is not enough to settle this:
 round 1 derived a "~76 character" budget and the 71-character string it produced
-*still wrapped*. The budget is not the terminal width — an 80-column terminal
-gives a 78-column screen, the notice block's padding takes more, and the `· `
-glyph costs 2, leaving 68 columns of text and so 66 for the string. Check it
-with `scripts/audit_history_shot.py <dir> marker 80x30`, which is the only
-instrument that answers the question.
+*still wrapped*. The budget at 80 columns is **70 text columns**, and the
+mechanical check is `NoticeBlock.body_budget(76) == 70` rather than hand
+arithmetic (D6). The chain: an 80-column terminal gives a 78-column screen;
+`scrollbar-gutter: stable` on `TranscriptView` permanently reserves one more
+column whether or not the bar is visible (77); the view's own left padding takes
+one (76, the width the block is actually painted at); `_build` folds at
+`max(width - 2, 12)` (74); and the hanging glyph field is `GLYPH_COLS` =
+`SPINE_INDENT + 2` = 4, not 2 (70). The shipped string is 66, so it sits 4
+columns inside the budget. Do **not** re-derive this from the older "68 usable,
+so 66" arithmetic that earlier drafts of this document carried: it reached a safe
+number through two compensating errors — subtracting neither the reserved
+scrollbar column nor the fold clamp, and charging the glyph 2 where it costs 4 —
+so it cannot be carried to any other width. Check a copy change in a rendered
+frame with `scripts/audit_history_shot.py <dir> marker 80x30`, which is the
+instrument that settles the question.
 
 Head notice copy, by state — this is the full state table for
 `_reconcile_head_notice`:

--- a/docs/design/full-history-audit-window.md
+++ b/docs/design/full-history-audit-window.md
@@ -240,7 +240,7 @@ branch for `compaction_summary`** — verified, the custom-type branches are
 Add one branch:
 
 ```
-context compacted here — earlier history above the agent no longer sees
+context compacted — earlier history above the agent no longer sees
 ```
 
 `NoticeBlock`, kind `"note"` — same reasoning as `RESUME_UNREACHABLE_NOTICE`
@@ -256,11 +256,15 @@ a marker were 100% still in the model's context — precisely what the sentence
 claimed the agent could not see — while the rows above were 0-1%. Both halves of
 the original sentence were wrong.
 
-**Hold the string under ~76 characters.** The glyph prefix costs 2 columns, so
-82 characters needed 84 and wrapped at an 80-column terminal, orphaning the last
-two words on their own line at every compaction (D2). This is a review-time
-arithmetic check: the usual capture geometries (98 and 138 usable columns) clear
-it and so cannot show the wrap.
+**Hold the string at 66 characters or fewer, verified in a rendered 80-column
+frame.** The original 82-character string wrapped and orphaned its last two
+words at every compaction (D2). Arithmetic alone is not enough to settle this:
+round 1 derived a "~76 character" budget and the 71-character string it produced
+*still wrapped*. The budget is not the terminal width — an 80-column terminal
+gives a 78-column screen, the notice block's padding takes more, and the `· `
+glyph costs 2, leaving 68 columns of text and so 66 for the string. Check it
+with `scripts/audit_history_shot.py <dir> marker 80x30`, which is the only
+instrument that answers the question.
 
 Head notice copy, by state — this is the full state table for
 `_reconcile_head_notice`:

--- a/docs/design/full-history-audit-window.md
+++ b/docs/design/full-history-audit-window.md
@@ -1,0 +1,558 @@
+# Design brief: durable audit history behind the display window
+
+Status: proposal (architect). Not implemented. Scope: `local-operator` @ `f1ab7d346`.
+
+All line citations are against `f1ab7d346`, read in a clean worktree
+(`/private/tmp/arch-hist/wt`) because the primary checkout has uncommitted edits
+to `remote.py` and `app.py` from a sibling session.
+
+---
+
+## 1. The problem, as found
+
+### 1.1 Confirmed: the display window inherits an LLM-context cut
+
+`_capture_display_window` builds every page from the model's replay:
+
+- `history_window.py:261` — `history = transcript.build_llm_history(through_id=through_id)`
+- `transcript.py:1294-1366` — `replay_entries` finds the **latest** `ENTRY_COMPACTION`,
+  emits `[compaction_summary marker, *preserved_user_turns]`, then replays only
+  `entries[start:]` where `start` is the index of `first_kept_entry_id`.
+
+Everything downstream is therefore computed over the post-compaction replay:
+`total_message_count` (`history_window.py:351`), the `before_token` chain
+(`:341-343`, `None` once `start == 0`), and `has_more` (`:350`). The bytes are
+intact on disk; the reading surface simply cannot address them.
+
+Re-measured independently across the operator's store (`Transcript(dir)`,
+message rows on disk vs `len(build_llm_history())`):
+
+| session | MB | msg rows | compactions | replayed | unreachable |
+|---|---|---|---|---|---|
+| `bda7b76d34e0` | 231 | 17,345 | 48 | 514 | 97.0% |
+| `835fbcafdc27` | 60 | 14,324 | 26 | 630 | 95.6% |
+| `9f8e5b652ac7` | 75 | 11,344 | 22 | 411 | 96.4% |
+| `4140ee201ce1` | 78 | 10,548 | 14 | 464 | 95.6% |
+| `28a800c6a783` | 15 | 4,372 | 9 | 638 | 85.4% |
+
+Twelve of the operator's sessions exceed 80% unreachable. This is the defect.
+
+### 1.2 The head notice is a faithful reporter, not the bug
+
+`_reconcile_head_notice` (`app.py:7267-7269`) computes
+`more = bool(self._resume_pending_head) or bool(session.history_before_token)`,
+and `RemoteSession.history_before_token` (`remote.py:2603-2606`) returns the
+window's `before_token` — `None` once the truncated replay is drained. So
+`RESUME_START_NOTICE` (`app.py:1077`) is the honest rendering of a history layer
+that already discarded the older rows. **Do not fix the copy.** Fix the layer.
+
+### 1.3 The suspected second defect: not confirmed on the reported session
+
+I drove `display_window` against `59cbf6dfc63f` directly. It has 294 entries, 281
+message rows, **zero compactions**, 281 replayed. Its backward chain:
+
+```
+start=201 (80 msgs, has_more=True, total=281)
+start=199 (2)   → start=113 (86)   → start=0 (113, has_more=False)
+```
+
+It terminates at 0 correctly, and 0 is the true beginning. **On that session
+"start of conversation" was correct**, and there is no separable paging defect
+demonstrated by it. The `_resume_pending_head = []` resets (`app.py:4972`,
+`7076`, `15282`, `31546`) each guard a real transition (a snapshot that shrank, a
+fresh resume, `/clear`, a canonical reset) and each is followed by a
+re-projection of the *current* history, so none of them strands rows while
+claiming exhaustion. `load_older_display_page`'s `full_required` branch
+(`remote.py:2618-2620`) does not drop a page either — it escalates to
+`materialize_history()` and returns the id-deduped difference.
+
+What that session *does* show is a different, real, and much smaller thing worth
+recording: 281 replayed rows project to only ~216 visible blocks (149 of the 281
+are `role == "tool"` rows, skipped at `session_presentation.py:751-752`, and 11
+are `session_state` customs with no renderer). A reader on a tall viewport
+therefore drains the head faster than the message count suggests. That is
+correct behaviour, not a defect.
+
+**Conclusion for the coder: treat this as ONE defect, not two.** If the operator
+saw "start of conversation" above genuinely unseen rows on a *compacted*
+session, §1.1 explains it completely. I found no evidence for an independent
+non-compacted paging bug, and I would not have a coder chase one on suspicion.
+Evidence that would change my mind: a reproduction on a session with **zero**
+compaction entries where `display_window`'s chain terminates at `start=0` while
+`total_message_count < ` the count of message rows on disk. That comparison is
+two lines of Python and belongs in the QA matrix (§7) precisely so the question
+is settled by data rather than left open.
+
+---
+
+## 2. The seam
+
+**Stop overloading one function.** `build_llm_history` answers "what may the
+model see". Nothing should ask it "what did the conversation contain". Introduce
+a second replay mode alongside it, in the same module, sharing the same row
+rehydration.
+
+### 2.1 `transcript.py` — the new primitive
+
+```python
+def replay_entries(
+    entries, attachments, *, through_id=None, mode: Literal["context", "audit"] = "context"
+) -> list[AgentMessage]: ...
+```
+
+- `mode="context"` — today's behaviour, byte for byte. Default. Untouched.
+- `mode="audit"` — ignore the compaction cut entirely: replay **every**
+  `ENTRY_MESSAGE` from index 0 through the cut, still applying prunes, and emit
+  a `compaction_summary` `CustomMessage` **in place** at each compaction row
+  (not just the latest, and not hoisted to the front).
+
+Two consequences make audit mode strictly simpler than context mode:
+
+- `preserved_user_turns` must **not** be re-injected in audit mode. They are
+  verbatim copies of user rows that already exist before the cut
+  (`transcript.py:1316-1343`), and audit mode replays those rows. Re-injecting
+  would double every preserved turn, and would do so under the *original* ids
+  (`:1339-1341`), producing duplicate ids in one list — which the TUI's
+  `_resume_mounted_ids` dedupe (`app.py:7726`) would then silently swallow,
+  hiding a real row. Skip them; the originals are right there.
+- The `first_kept_entry_id` fallback (`:1344-1365`) is irrelevant: audit mode
+  starts at 0 unconditionally, so the "silent amnesia" hazard that comment
+  guards against cannot arise.
+
+Add a windowed reader beside it — this is what keeps the design inside budget B:
+
+```python
+def audit_slice(entries, attachments, *, end_index: int, limit: int) -> list[AgentMessage]
+```
+
+Replays only `entries[lo:end_index]`, where `lo` walks back `limit` *message*
+rows. Prunes are the only cross-row dependency and a prune is always appended
+**after** its target (`transcript.py:376-380` documents exactly this), so a
+prune targeting a row inside the slice may sit after `end_index`. Collect the
+prune map from the whole `_entries` list (a cheap `type ==` scan over
+already-parsed objects, no rehydration) and pass it in. Do not re-derive it from
+the slice.
+
+### 2.2 `history_window.py` — the field and the flag
+
+`DisplayHistoryWindow` gains:
+
+```python
+audit: bool = False          # this page is pre-compaction history
+audit_available: bool = False  # older rows exist behind the context cut
+```
+
+`display_window`/`_capture_display_window` gain `audit: bool = False`. Paging
+becomes a two-phase chain over one continuous coordinate space:
+
+1. **Context phase** — unchanged. Pages walk back through the replay to
+   `start == 0`.
+2. At `start == 0`, instead of `before_token = None`, mint a token carrying
+   `{"phase": "audit", "end_index": <journal index of the cut>}` **iff** audit
+   rows exist. Set `audit_available=True`.
+3. **Audit phase** — tokens carry a journal `end_index`. Each page replays
+   `audit_slice(...)` backward, sets `audit=True`, and mints the next token at
+   the new `end_index`. `before_token` becomes `None` only when `end_index`
+   reaches the first message row in the journal. **That is where paging
+   terminates, and it is the only place it may.**
+
+Both phases keep signing through `transcript._history_page_key` with the same
+`conversation_id`/`owner_epoch`/`history_generation` claims (`:250-257`), so
+compaction during a scroll still invalidates outstanding tokens into `reset` and
+the existing reconciliation runs. `end_index` is a **journal index, resolved to
+an entry id in the token** — sign the id, not the integer, for the same reason
+`TranscriptPage` uses ids (`transcript.py:269-272`): `compact_file` replaces the
+file and integer offsets become lies. On resolve-failure, return `status="reset"`.
+
+`total_message_count` **stays the context total.** Do not inflate it. It is read
+by `_sidebar_presentation_current` (`app.py:3922-3924`) as a monotonic growth
+signal and by `history_message_count` (`remote.py:4280-4287`); redefining it
+mid-chain would make cached presentations miss forever. Audit pages report their
+extent through `start`/`audit` only. Expose the audit depth, if it is ever
+needed, as a separate `audit_message_count` — but I would not add it until a
+surface asks.
+
+`theme_turn_count` and `opener_text` likewise stay context-derived.
+`history_theme_turn_count` feeds `should_refresh_theme` (`naming.py:703-720`),
+whose growth gate would re-fire across the board if the count jumped by 17,000.
+
+---
+
+## 3. Performance (budget B)
+
+Measured, not assumed, on the operator's real journals:
+
+| operation | `bda7b76d34e0` (231 MB) | `9f8e5b652ac7` (75 MB) |
+|---|---|---|
+| owner `Transcript` ctor (already paid) | 1.37 s | 0.34 s |
+| naive full audit replay | 0.29 s, **47 MB peak** | 0.18 s, 33 MB |
+| windowed audit slice (120 rows, tail) | **<1 ms** | 1 ms |
+| windowed audit slice (120 rows, mid-file) | **<1 ms** | <1 ms |
+| `read_transcript_page` backward page | 1.03–1.13 s | 0.31–0.42 s |
+
+Three conclusions the coder must not relitigate:
+
+1. **Serve audit pages from the owner's resident `_entries`, never from a disk
+   re-read.** `Transcript.__init__` already parses the whole file into
+   `self._entries` (`transcript.py:557-566`). The rows are in RAM before any
+   page is requested; a windowed replay over them is ~1 ms. Using
+   `read_transcript_page` instead would cost ~1 s per page on the 231 MB
+   journal — a thousandfold regression for no benefit.
+2. **Never call full audit replay.** 0.29 s and 47 MB of peak allocation per
+   call is exactly what budget B forbids. `audit_slice` is the only entry point.
+3. `read_replay_suffix` (`remote.py:99`, `transcript.py:360`) is for the
+   *attach* path and stays exactly as it is. Audit paging is a post-attach,
+   reader-driven gesture on an owner that already holds the journal. **The
+   resume path's cost does not change at all.**
+
+Page residency is bounded by the existing machinery, unchanged:
+`DISPLAY_HISTORY_MESSAGES`/`DISPLAY_HISTORY_BYTES` (`history_window.py:27-28`)
+bound each page; `_DisplayWindowCache` and `_retained_size` (`:82-162`) bound
+per-owner retention; `RESUME_RENDER_MESSAGES` (`app.py:1049`) bounds first
+paint; `SessionPresentation.retainable` (`session_presentation.py:317`) bounds a
+parked view. Audit pages flow through all four untouched — they are ordinary
+`DisplayHistoryWindow` pages carrying an extra boolean.
+
+One thing to watch (§8): audit pages enter `_resume_pending_head`, which
+`retainable()` measures directly (`session_presentation.py:386`), and its
+docstring records the retained-text figure as 127–357 KiB against a 1 MiB
+budget. A reader who scrolls far into a 17,000-row audit history will push a
+parked presentation past `RETAIN_TEXT_BYTES` and it will stop being cached.
+That is the budget **working as designed** — the presentation is re-prepared,
+not corrupted — but it will look like sidebar lag on exactly the sessions this
+feature targets. Do not "fix" it by raising the budget; that docstring records
+two prior mis-tunings in that direction.
+
+---
+
+## 4. Honest presentation (requirement C)
+
+Pre-compaction rows are real history the model can no longer see. Both facts
+must be on screen.
+
+**Reuse the existing marker.** `replay_entries` already emits a
+`compaction_summary` `CustomMessage` (`transcript.py:1308-1315`); audit mode
+emits one *per* compaction, in place. But note: `project_settled_rows` has **no
+branch for `compaction_summary`** — verified, the custom-type branches are
+`wake_prompt`, `peer_message`, `gate_timeout` and `COMPACTION_REFUSED_TYPE`
+(`session_presentation.py:613-668`), and anything else falls through to
+`role`-based handling and is dropped. So the marker renders as nothing today.
+Add one branch:
+
+```
+context compacted here — earlier history above the agent no longer sees
+```
+
+`NoticeBlock`, kind `"note"` — same reasoning as `RESUME_UNREACHABLE_NOTICE`
+(`app.py:1084-1091`): it answers "where did my history go", and `info` maps to
+`dim` at 3.77:1 on the light theme, below the AA floor. It is not an error and
+not a warning; nothing went wrong.
+
+**The direction is ABOVE.** An earlier draft of this table said "older messages
+below", and design review round 1 (D1) measured that against real mounted block
+positions: a transcript paints oldest-at-top, so the pre-compaction rows sit
+*above* the marker. Compared against `mode="context"` membership, the rows below
+a marker were 100% still in the model's context — precisely what the sentence
+claimed the agent could not see — while the rows above were 0-1%. Both halves of
+the original sentence were wrong.
+
+**Hold the string under ~76 characters.** The glyph prefix costs 2 columns, so
+82 characters needed 84 and wrapped at an 80-column terminal, orphaning the last
+two words on their own line at every compaction (D2). This is a review-time
+arithmetic check: the usual capture geometries (98 and 138 usable columns) clear
+it and so cannot show the wrap.
+
+Head notice copy, by state — this is the full state table for
+`_reconcile_head_notice`:
+
+| state | copy |
+|---|---|
+| context rows remain, scrollable | `RESUME_OLDER_NOTICE` (unchanged) |
+| context rows remain, not scrollable | `RESUME_UNREACHABLE_NOTICE` (unchanged) |
+| context drained, `audit_available` | **new:** `earlier history above — scroll up to load` |
+| audit rows remain, scrollable | same new string |
+| audit rows remain, not scrollable | **new:** `earlier history above — select to load` |
+| audit exhausted (`end_index` at first row) | `RESUME_START_NOTICE` — now *true* |
+| no compaction ever, head drained | `RESUME_START_NOTICE` (unchanged, correct) |
+
+The head notice stays interactive in every audit state and drops interactivity
+only at true exhaustion — `_restate_head_notice` (`app.py:7337-7341`) keys that
+off `text != RESUME_START_NOTICE`, which already produces the right answer for
+the new strings with no change. Keep that predicate as-is.
+
+Deliberate wording choice: **"earlier history", not "older messages"**. The two
+phases are different in kind, and a reader who crosses the compaction marker
+should see the vocabulary change with it.
+
+---
+
+## 5. Changes per file
+
+**`local_operator/session/transcript.py`**
+- `replay_entries`: add `mode` kwarg; audit path skips the compaction cut,
+  skips `preserved_user_turns`, emits an in-place marker per compaction row.
+- New `audit_slice(entries, attachments, *, end_index, limit, prunes)`.
+- New `first_message_index(entries)` helper (termination test).
+- `build_llm_history`: **unchanged signature and behaviour.**
+
+**`local_operator/session/history_window.py`**
+- `DisplayHistoryWindow`: `+audit: bool`, `+audit_available: bool`.
+- `display_window`/`_capture_display_window`: accept and thread `audit`; add the
+  audit phase to token minting and the `before_token`/`has_more` chain; add the
+  phase to the cache key tuple (`:187-198`).
+- Grouping/boundary logic (`:285-297`) applies unchanged to audit pages —
+  tool call/result groups must not split there either.
+
+**`local_operator/session/session.py`**
+- `history_page` (`:5797-5809`): pass the token's phase through. The token
+  already carries it; this is a thread-through, not a new parameter.
+
+**`local_operator/session/remote.py`**
+- `history_before_token` (`:2603-2606`): return the audit token once context is
+  drained. Today it is gated on `not self._history_hydrated`; that flag means
+  "the context replay is fully loaded" and must **not** be repurposed. Add a
+  separate `_audit_exhausted` flag, and gate on `not (self._history_hydrated and
+  self._audit_exhausted)`.
+- `load_older_display_page` (`:2608-2634`): the contiguity assertion
+  `page.start + len(page.messages) != window.start` (`:2621`) is a
+  context-coordinate check and **will fire on the first audit page**. Skip it
+  when `page.audit`; audit pages are contiguous in journal order, not in replay
+  coordinates. Set `_history_hydrated`/`_audit_exhausted` from the phase.
+- `materialize_history` (`:2659-2691`): **must not** walk into the audit phase.
+  It exists to produce the *model's* history for naming
+  (`app.py:18490`) and `history()`. Stop its loop when the context phase ends.
+  This is load-bearing: letting it drain audit pages would hand `generate_retitle`
+  17,000 rows.
+- `full_required` fallback (`:2672-2683`, requirement D): its inline `replay()`
+  builds a whole `Transcript` and calls `build_llm_history`. For an audit page
+  that must instead call `audit_slice` over the same bounded window — a
+  `full_required` audit page means *one group* exceeded the byte budget, not
+  that the reader asked for 231 MB. Concretely: retry the same `end_index` with
+  `max_messages=1` so the oversized group is delivered alone. If a single group
+  still exceeds the frame limit, surface it as a page carrying a
+  `NoticeBlock`-shaped custom row rather than escalating to a full replay.
+
+**`local_operator/tui/app.py`**
+- Three new copy constants beside `RESUME_START_NOTICE` (`:1077`).
+- `_reconcile_head_notice` (`:7220-7295`): implement the §4 table. Its
+  `more` computation (`:7267`) needs the audit token, which
+  `history_before_token` now supplies — so the shape of that expression is
+  unchanged.
+- `_mount_older_resume_page` (`:7666`): no change. Its docstring's "No disk
+  read" claim stays true — audit pages arrive through the same RPC into
+  `_resume_pending_head` (`:7493`).
+
+**`local_operator/tui/session_presentation.py`**
+- `project_settled_rows`: add the `compaction_summary` branch (§4), beside the
+  existing custom-type branches at `:613-668`.
+
+**`local_operator/mobile/durable.py`** — see §6. No change in this PR.
+
+---
+
+## 6. Capability and back-compat
+
+**Add a new capability string: `"display-history-audit-v1"`.**
+
+`DISPLAY_HISTORY_CAPABILITY = "display-history-window-v1"`
+(`history_window.py:26`) is advertised at `runtime/server.py:659` on the mere
+presence of `history_page`, and negotiated at `mobile/attach_client.py:245`.
+It is a *presence* flag with no version handshake, so it cannot express "this
+owner also pages audit history". Two ways it breaks without a new string:
+
+- **New viewer, old owner.** The viewer receives `audit_available` absent →
+  Pydantic default `False` → it never asks for an audit page. Safe by
+  construction. But `extra="forbid"` on the model means the reverse direction
+  is not safe:
+- **Old viewer, new owner.** `DisplayHistoryWindow` sets
+  `model_config = ConfigDict(extra="forbid")` (`history_window.py:39`), so an
+  old viewer validating a payload carrying `audit`/`audit_available` **raises**,
+  and `_fetch_history_page` (`remote.py:2490`) turns that into a failed attach.
+  This is a hard cross-version break, and it is the single most likely way this
+  change causes an incident during a staged rollout.
+
+So: the owner advertises `display-history-audit-v1` and **only emits the two new
+fields when the attaching viewer negotiated it**, exactly as `display_window` is
+negotiated today (`runtime/server.py:1253`, `attach_client.py:245`). Mixed
+versions on one machine are the norm here — the global `lop` runtime is a
+separate uv tool install updated only by `lop-update`, so a repo `.venv` session
+and a global session routinely run different builds against the same sessions
+directory.
+
+**Existing transcripts need no migration.** Audit mode reads rows that are
+already on disk; `compact_file` (`transcript.py:1093-1198`) only folds prune
+journals and superseded `subagent_roster` customs, so a folded transcript's
+message rows are still all present — a folded row simply replays with its notice
+text, which is the honest record of what the model saw. No backfill, no version
+stamp, no format change. **The journal format does not change at all.**
+
+**The mobile surface has the same defect and is out of scope.**
+`mobile/durable.py:122-125` and `_replay` (`:325-346`) reimplement
+`build_llm_history` semantics for the phone's fold cache, so
+`daemon._history_page` pages only post-compaction rows too. Fixing it means
+teaching the fold cache an audit mode, and the fold cache's incremental cursor
+design (offset-into-inode) is a separate problem. Record it in the PR as a
+known follow-up; do not widen this PR into it.
+
+---
+
+## 7. Test surface
+
+**Unit — `tests/unit/session/test_transcript.py`**
+- `mode="context"` output is byte-identical to today's `build_llm_history` on a
+  compacted fixture. This is the regression guard for the whole change.
+- `mode="audit"` returns every message row; count equals the on-disk message
+  row count.
+- Preserved user turns appear **exactly once** in audit mode (the duplicate-id
+  hazard, §2.1).
+- A prune targeting a row inside an `audit_slice` whose prune entry sits after
+  `end_index` still blanks that row.
+- Multi-compaction fixture: one marker per compaction, in journal position.
+
+**Unit — `tests/unit/session/test_history_window.py`**
+- Chain terminates at the first message row, not at the compaction cut.
+- Page count over a 3-compaction fixture equals `ceil(rows / page)`, and every
+  row appears exactly once across the chain (the audit-completeness assertion).
+- `total_message_count` and `theme_turn_count` are unchanged by audit paging.
+- An audit token minted at generation N returns `reset` after a compaction
+  bumps `_history_generation` (`transcript.py:841`).
+- A tool call and its result never split across an audit page boundary.
+
+**Unit — `tests/unit/session/test_display_page_cache.py`**
+- Audit pages are cached and evicted under the existing byte budget; the phase
+  is part of the cache key (a context and an audit page at the same nominal
+  position must not collide).
+
+**Unit — `tests/unit/tui/test_rendered_history_paging.py`**
+- The §4 state table, one assertion per row. Existing coverage already asserts
+  `!= "start of conversation"` (`:258`), so extend rather than duplicate.
+- A compacted session reaches `RESUME_START_NOTICE` **only** after the audit
+  chain drains.
+- The compaction marker renders as a `NoticeBlock` mid-transcript.
+
+**Cross-version — `tests/unit/session/runtime/`**
+- A viewer that did **not** negotiate `display-history-audit-v1` receives a
+  payload with no `audit` keys and validates clean under `extra="forbid"`.
+  This is the §6 break, and it needs an explicit test.
+
+**QA (independent, per the team's gate)** — on a **copy** of the operator's real
+sessions in an isolated config dir, never the live store:
+- The §1.3 comparison, run across every session: for each, assert the audit
+  chain's total row count equals the on-disk message row count. This is what
+  finally settles whether a second defect exists.
+- Page latency on `bda7b76d34e0` (231 MB): assert per-page wall time stays in
+  the single-digit-ms range and that no page allocates on the order of the
+  47 MB full replay.
+- Resume timing on that session is unchanged versus base — the attach path is
+  not supposed to move at all.
+- Visual: rendered before/after frames of the head notice in each state and of
+  the compaction marker row, per AGENTS.md "Visual validation".
+
+**Quality gates** before the PR: flake8, `black --check`, `isort --check-only`,
+pyright, and the unit suite via `.venv/bin/python` over the whole tree; TUI
+tests under `env -u NO_COLOR TERM=xterm-256color`.
+
+---
+
+## 8. Risks to watch during rollout
+
+1. **Cross-version payload rejection (§6)** — the `extra="forbid"` break. Highest
+   severity, and entirely preventable by gating the fields on the negotiated
+   capability. Verify with a real old-binary viewer against a new owner, not
+   only with a unit test.
+2. **`materialize_history` walking into audit** — would feed 17,000 rows to the
+   retitle sampler and to `history()`. Guard it explicitly (§5) and assert it.
+3. **Parked-presentation cache eviction (§3)** — deep audit scrolling pushes
+   `retainable()` over budget and re-prepares the presentation on each sidebar
+   poll. Expected, but it presents as UI lag. Watch for it; do not raise the
+   budget.
+4. **`total_message_count` drift** — any future contributor "fixing" it to
+   include audit rows breaks `_sidebar_presentation_current`'s monotonic growth
+   check (`app.py:3922-3924`). Put the reason in a comment at the field, not
+   only in this document.
+5. **Contiguity assertion** (`remote.py:2621`) — if the audit exemption is
+   missed, the first audit page raises `ConnectionError` and the reader sees a
+   failed page rather than history. Cheap to get wrong, loud when it happens.
+
+---
+
+## 9. Explicitly NOT changing
+
+- **LLM context.** `build_llm_history` keeps its signature and its semantics;
+  compaction keeps bounding what the model sees. `mode="context"` is the
+  default and every existing caller keeps it.
+- **The transcript file format.** No new row types, no migration, no backfill.
+- **The attach/resume path.** `read_replay_suffix`, `_read_transcript`,
+  `_load_frontend_history` and `RESUME_RENDER_MESSAGES` are untouched; resume
+  cost does not move.
+- **The head-notice mechanism.** `_restate_head_notice`, `OlderHistoryNotice`
+  and the interactivity rule stay as-is; only the copy table grows.
+- **`compact_file`.** Its folding rules are correct and orthogonal.
+- **The mobile fold cache** (§6) — same defect, deliberate follow-up.
+- **`RESUME_START_NOTICE` itself.** It stays exactly as worded. After this
+  change it is finally always true, which is the point.
+
+---
+
+## 10. Choices I made where two options were reasonable
+
+**Second replay mode vs. a second index.** A parallel display index (a
+`display.jsonl` or a sidecar offset map) would make audit paging O(1) instead of
+O(window). Rejected: it is a second source of truth for the same bytes, it needs
+a migration and a backfill for every existing transcript, and it must be kept
+consistent with `compact_file`'s atomic replacement. The measured cost of the
+windowed replay is ~1 ms against a resident entry list, so the index buys
+nothing that matters. Fix the existing function; do not add a second one beside
+it.
+
+**Extending the existing paging chain vs. a separate audit RPC.** A separate
+`audit_page` op would keep the two concerns visibly apart. Rejected: the TUI
+would need a second cursor, a second pending buffer, and a second dedupe path,
+and the reader's gesture is *identical* — scroll up. One chain with a phase flag
+means `load_older_display_page`, `_resume_pending_head`, the lease machinery and
+the cache all work unmodified. The seam belongs in the replay layer, which is
+where the two semantics actually diverge, not in the transport.
+
+**Emitting one marker per compaction vs. only the boundary the reader crosses.**
+Chose per-compaction. `bda7b76d34e0` has 48 of them; a reader auditing that
+session needs to see where each one fell, and a single marker at the context
+boundary would misrepresent 47 others as ordinary history.
+
+*Per-compaction means per surviving boundary, not per compaction ROW.* Repeated
+compaction against a short kept suffix leaves earlier compaction rows sitting at
+or above the current cut, and those describe boundaries the latest compaction has
+already moved — the seam they name no longer exists in the rendered transcript.
+Every compaction row below the cut is emitted in place by the audit phase, and
+the latest is emitted at the context head as the live seam; on `2f95e374dd22`
+that is 56 markers for 56 surviving boundaries out of 61 compaction rows.
+
+Review round 1 (R2) read the remaining 5 as unreachable markers and suggested
+emitting them. Rejected on measurement, and recorded here because it is the
+natural thing to try:
+
+- They would be **false where they landed.** Each sits 3-15 live context rows
+  below the seam, so its notice would claim the rows above it are outside the
+  model's context while the model can still see them — the D1 inversion, back
+  again.
+- Emitting them from the **context phase** breaks this change's central
+  regression guard (`mode="context"` byte-identical to `build_llm_history`) and
+  pushes each marker's `preserve_data` into the model's own context: measured
+  +3,380,677 bytes, roughly 845k tokens, on that one journal.
+- Extending the audit window's first `end_index` **past the cut** re-delivers 16
+  message rows the context page already sent.
+
+Both routes are pinned by tests in `tests/unit/session/test_history_window.py`
+so the argument does not have to be rediscovered from this document.
+
+**Keeping `total_message_count` context-scoped.** The alternative — making it
+the true total — is arguably the more honest field name. Rejected on evidence:
+two consumers read it as a monotonic context-growth signal (`app.py:3922`,
+`remote.py:4287`), and redefining it silently breaks presentation caching. A
+separate `audit_message_count` is available if a surface ever needs it; I did
+not add it speculatively.
+
+**One defect, not two (§1.3).** I chose to report the second defect as *not
+demonstrated* rather than hedge. The session named in the report has no
+compaction and pages correctly to a true zero. I have specified the exact
+measurement that would prove me wrong and put it in the QA matrix rather than
+leaving it as a suspicion for the coder to chase.

--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -244,6 +244,12 @@ class AttachClient:
             auth["frontend_state"] = True
         if self._display_window and "display-history-window-v1" in record.capabilities:
             auth["display_window"] = True
+            # Declared separately from the window itself: this build can READ
+            # the audit fields, and an owner that does not advertise the
+            # capability simply never sends them. Announcing it is what makes
+            # the owner's strip decision a negotiation rather than a guess.
+            if "display-history-audit-v1" in record.capabilities:
+                auth["display_history_audit"] = True
         if self._slash_consumers is not None:
             # Additive and advisory, exactly the shape ``events`` and
             # ``frontend_state`` are: an older owner ignores the unknown auth

--- a/local_operator/session/history_window.py
+++ b/local_operator/session/history_window.py
@@ -97,10 +97,19 @@ def strip_audit_fields(payload: dict[str, Any], *, audit_capable: bool) -> dict[
 
     THE one place that decision is implemented, mutating in place and returning
     the same dict so it composes with either kind of caller. A page reaches the
-    wire by two routes — the attach sync frame and the ``history_page`` RPC —
-    and stripping in only one of them yields a viewer that attaches cleanly and
-    then fails on its first scroll up, which is a worse failure than either
-    route breaking on its own.
+    wire by THREE routes, and every one of them must strip:
+
+    * the attach sync push frame (``server.py``, ``_handle_auth``),
+    * the ``history_page`` RPC (``_dispatch_payload``),
+    * the ``frontend_sync`` RPC (``_dispatch_payload``), which an older viewer
+      calls on every history refresh.
+
+    Stripping in only some of them yields a viewer that attaches cleanly and
+    then fails later — on its first scroll up, or on the first refresh after
+    the owner appends a row — which is a worse failure than any single route
+    breaking on its own. Round 1 review found the third route unstripped after
+    this docstring had asserted there were two: if a fourth is ever added,
+    update this list in the same commit.
     """
     if not audit_capable:
         for name in AUDIT_WIRE_FIELDS:

--- a/local_operator/session/history_window.py
+++ b/local_operator/session/history_window.py
@@ -19,11 +19,30 @@ from typing import TYPE_CHECKING, Any, Literal
 from pydantic import BaseModel, ConfigDict, Field
 
 from local_operator.harness.types import AgentMessage, Message
+from local_operator.session.transcript import (
+    audit_slice,
+    collect_prunes,
+    context_cut_index,
+    context_preserved_turn_ids,
+    first_message_index,
+)
 
 if TYPE_CHECKING:
     from local_operator.session.transcript import Transcript
 
 DISPLAY_HISTORY_CAPABILITY = "display-history-window-v1"
+
+#: Separate from the capability above, and it MUST stay separate. That one is a
+#: presence flag with no version handshake, so it cannot express "this owner
+#: also pages pre-compaction history". :class:`DisplayHistoryWindow` forbids
+#: extra fields, so an owner that emitted ``audit``/``audit_available`` to a
+#: viewer built before those fields existed would fail that viewer's validation
+#: and turn into a FAILED ATTACH — not a degraded one. Mixed builds against one
+#: sessions directory are routine here (the global uv-tool runtime is updated
+#: independently of a repo checkout's venv), so this is a live rollout hazard
+#: rather than a theoretical one. The owner emits the new fields only to a
+#: viewer that negotiated this string.
+DISPLAY_HISTORY_AUDIT_CAPABILITY = "display-history-audit-v1"
 DISPLAY_HISTORY_MESSAGES = 120
 DISPLAY_HISTORY_BYTES = 512 * 1024
 
@@ -55,6 +74,43 @@ class DisplayHistoryWindow(BaseModel):
     # IDs: older unseen messages must remain pageable without being suppressed.
     durable_seed_ids: list[str] = Field(default_factory=list)
     durable_seed_tool_ids: list[str] = Field(default_factory=list)
+    #: This page carries PRE-COMPACTION rows: real history the model can no
+    #: longer see. Its ``start`` is a journal coordinate, not a position in the
+    #: context replay, so a consumer must not compare the two (see
+    #: ``RemoteSession.load_older_display_page``, whose contiguity check is a
+    #: context-coordinate assertion and is skipped for these pages).
+    audit: bool = False
+    #: Older rows exist behind the context cut and are reachable by paging.
+    #: Lets the viewer say "earlier history above" at the moment the context
+    #: phase drains, rather than claiming the conversation starts there.
+    audit_available: bool = False
+
+
+#: Fields the audit capability introduced. Stripped for a viewer that did not
+#: negotiate :data:`DISPLAY_HISTORY_AUDIT_CAPABILITY`; see its comment for why
+#: emitting them unconditionally is an attach failure rather than noise.
+AUDIT_WIRE_FIELDS = ("audit", "audit_available")
+
+
+def strip_audit_fields(payload: dict[str, Any], *, audit_capable: bool) -> dict[str, Any]:
+    """Drop the audit fields from a serialized page for an older viewer.
+
+    THE one place that decision is implemented, mutating in place and returning
+    the same dict so it composes with either kind of caller. A page reaches the
+    wire by two routes — the attach sync frame and the ``history_page`` RPC —
+    and stripping in only one of them yields a viewer that attaches cleanly and
+    then fails on its first scroll up, which is a worse failure than either
+    route breaking on its own.
+    """
+    if not audit_capable:
+        for name in AUDIT_WIRE_FIELDS:
+            payload.pop(name, None)
+    return payload
+
+
+def wire_payload(window: DisplayHistoryWindow, *, audit_capable: bool) -> dict[str, Any]:
+    """Serialize a page for one viewer, honouring what that viewer negotiated."""
+    return strip_audit_fields(window.model_dump(mode="json"), audit_capable=audit_capable)
 
 
 def _sign(payload: dict[str, Any], key: bytes) -> str:
@@ -190,6 +246,12 @@ def display_window(
         transcript._history_generation,
         transcript._history_page_key,
         None if before is not None else through_id,
+        # The paging PHASE needs no key term of its own: it is carried inside
+        # the signed ``before`` token, which is already keyed here, and the two
+        # phases mint structurally different token payloads. So a context page
+        # and an audit page can never collide on one key, and — because the
+        # phase is only ever read from a signature this owner minted — a viewer
+        # cannot ask for audit rows without having been handed a cursor to them.
         before,
         anchor,
         max_messages,
@@ -218,6 +280,194 @@ def display_window(
     if page.status != "reset":
         cache.put(key, page)
     return page
+
+
+#: Marks a backward cursor as belonging to the audit phase rather than to the
+#: context replay. Carried inside the SIGNED token, so a viewer cannot ask for
+#: an audit page it was not handed a cursor for.
+_AUDIT_PHASE = "audit"
+
+
+def _audit_entry_cursor(transcript: Transcript) -> str | None:
+    """Entry id the audit phase resumes from, or ``None`` if nothing precedes.
+
+    Returns an ENTRY ID, never a journal index, and the token signs that id for
+    the same reason ``TranscriptPage`` addresses rows by id: ``compact_file``
+    rewrites the journal in place, so an integer offset minted before a
+    compaction points at a different row afterwards \u2014 it does not fail, it
+    silently lies. An id that no longer resolves is detectable, and the resolve
+    failure is answered with ``status="reset"`` so the viewer re-syncs.
+    """
+    entries = transcript._entries
+    cut = context_cut_index(entries, quiet=True)
+    first = first_message_index(entries)
+    # Nothing precedes the context replay: this conversation really does begin
+    # where the context phase ends, and the chain terminates there as before.
+    if first is None or first >= cut:
+        return None
+    return entries[cut].id if cut < len(entries) else _AUDIT_TAIL_CURSOR
+
+
+#: The audit window's first cursor when the context cut sits past the last
+#: journal row (an empty kept suffix). Distinct from an entry id so it cannot
+#: collide with one.
+_AUDIT_TAIL_CURSOR = "\x00audit-tail"
+
+
+def _hoisted_turn_ids(transcript: Transcript) -> frozenset[str]:
+    """Cached :func:`context_preserved_turn_ids` for the current journal state.
+
+    Cached because it is asked once per audit page and is not cheap: it runs the
+    same shed/cap filter the context replay does, over a scan of the whole entry
+    list, and measured 88 ms on the 231 MB reference journal — which would have
+    dominated a page that otherwise costs ~8 ms and put this feature outside its
+    budget on exactly the sessions it exists for.
+
+    Keyed on ``_history_generation``, which the transcript already bumps on
+    every compaction and prune — the only events that can change which turns are
+    hoisted. An append cannot, because only the LATEST compaction's payload is
+    read and appending does not create one.
+    """
+    generation = transcript._history_generation
+    cached = transcript._audit_hoisted_cache
+    if cached is not None and cached[0] == generation:
+        return cached[1]
+    resolved = frozenset(context_preserved_turn_ids(transcript._entries))
+    transcript._audit_hoisted_cache = (generation, resolved)
+    return resolved
+
+
+def _capture_audit_window(
+    transcript: Transcript,
+    *,
+    envelope: dict[str, Any],
+    claims: dict[str, Any],
+    max_messages: int,
+    max_wire_bytes: int,
+) -> DisplayHistoryWindow:
+    """One backward page of PRE-COMPACTION history.
+
+    Deliberately a separate function from :func:`_capture_display_window`
+    rather than a branch inside it, mirroring the split in
+    :func:`~local_operator.session.transcript.replay_entries`: the two phases
+    answer different questions ("what may the model see" vs "what did the
+    conversation contain") and share no coordinate space. This one's ``start``
+    is a JOURNAL index; that one's is a position in the context replay. Fusing
+    them would make every later edit have to remember which coordinate it is
+    holding, and the first one to forget reintroduces the unreachable-history
+    defect from the other side.
+
+    The counts this page does NOT touch are as load-bearing as the rows it
+    returns. ``total_message_count``, ``theme_turn_count`` and ``opener_text``
+    stay CONTEXT-derived and are left at their defaults here, because the TUI
+    reads the first as a monotonic context-growth signal for its presentation
+    cache and the second as the growth gate for conversation retitling.
+    Inflating them by an audit depth of 17,000 rows would invalidate every
+    cached presentation and re-fire the retitle gate across every session on
+    the machine.
+    """
+    entries = transcript._entries
+    cursor = str(claims.get("end_entry_id") or "")
+    if cursor == _AUDIT_TAIL_CURSOR:
+        end_index = len(entries)
+    else:
+        end_index = next((i for i, entry in enumerate(entries) if entry.id == cursor), -1)
+        # The signed id no longer resolves: ``compact_file`` replaced the file
+        # under an outstanding cursor. Reset is the honest answer — the viewer
+        # re-syncs and re-pages rather than being handed rows from a coordinate
+        # space that no longer exists.
+        if end_index < 0:
+            return DisplayHistoryWindow(status="reset", **envelope)
+    first = first_message_index(entries)
+    if first is None or end_index <= first:
+        return DisplayHistoryWindow(
+            **envelope,
+            messages=[],
+            before_token=None,
+            has_more=False,
+            start=end_index,
+            audit=True,
+            audit_available=False,
+        )
+    prunes = collect_prunes(entries)
+    # The one place the two phases can OVERLAP. The context page re-emits the
+    # latest compaction's ``preserved_user_turns`` at its head, under the
+    # ORIGINAL row ids — and those same rows sit below the cut, where this
+    # phase replays them in place. Delivered twice, the TUI's mount-time id
+    # dedupe drops the second, so the visible symptom is a row that is silently
+    # MISSING from the audit page rather than one shown twice. Suppress the
+    # audit copy: the reader has already been shown that row by the context
+    # page it scrolled through to get here.
+    hoisted = _hoisted_turn_ids(transcript)
+    messages, indices, window_start = audit_slice(
+        entries,
+        transcript._attachments,
+        end_index=end_index,
+        limit=max_messages,
+        prunes=prunes,
+    )
+    if hoisted:
+        kept = [
+            (message, index)
+            for message, index in zip(messages, indices)
+            if message.id not in hoisted
+        ]
+        messages = [message for message, _ in kept]
+        indices = [index for _, index in kept]
+    # Trim from the LEFT to fit the frame budget, so the page stays contiguous
+    # with the cursor it was fetched for and the next cursor is simply the row
+    # this page begins at. Matches the context phase, which also drops whole
+    # groups off its left edge rather than truncating prose.
+    used = 0
+    keep = 0
+    for offset in range(len(messages) - 1, -1, -1):
+        cost = len(json.dumps(messages[offset].model_dump(mode="json")).encode()) + 1
+        if used + cost > max_wire_bytes - 8192 and keep:
+            break
+        used += cost
+        keep += 1
+    if not keep and messages:
+        # A single row exceeds the whole frame budget. The context phase
+        # answers this with ``full_required``, which escalates to a local
+        # replay; that escalation is meaningless here (it would rebuild the
+        # model's history, which does not contain this row at all). Return the
+        # oversized row alone instead — one row over budget is a frame the
+        # transport will refuse, but returning nothing strands the chain.
+        keep = 1
+    trimmed = bool(keep) and keep < len(messages)
+    if keep:
+        messages = messages[len(messages) - keep :]
+        indices = indices[len(indices) - keep :]
+    # Where the NEXT page resumes. Normally the window's own left edge, so the
+    # chain advances by a whole window even when this page delivered nothing —
+    # which happens for real, when every row in the window was a hoisted
+    # preserved turn the context phase already showed. Minting the cursor from
+    # the surviving rows instead would re-mint the cursor this page was fetched
+    # with, and the chain would spin on one window forever: a hang, not a wrong
+    # answer.
+    #
+    # The exception is a page the BYTE budget trimmed. There the rows below the
+    # kept ones were dropped for size, not because they were already shown, so
+    # the next page must resume at the first row kept or they are skipped.
+    start = indices[0] if (trimmed and indices) else window_start
+    more = start > first
+    before_token = (
+        _sign(
+            dict(envelope, phase=_AUDIT_PHASE, end_entry_id=entries[start].id),
+            transcript._history_page_key,
+        )
+        if more
+        else None
+    )
+    return DisplayHistoryWindow(
+        **envelope,
+        messages=messages,
+        before_token=before_token,
+        has_more=more,
+        start=start,
+        audit=True,
+        audit_available=more,
+    )
 
 
 def _capture_display_window(
@@ -257,6 +507,14 @@ def _capture_display_window(
             return DisplayHistoryWindow(status="reset", **envelope)
         through_id = claims.get("through_id")
         envelope["through_id"] = through_id
+        if claims.get("phase") == _AUDIT_PHASE:
+            return _capture_audit_window(
+                transcript,
+                envelope=envelope,
+                claims=claims,
+                max_messages=max_messages,
+                max_wire_bytes=max_wire_bytes,
+            )
     try:
         history = transcript.build_llm_history(through_id=through_id) if through_id else []
     except ValueError:
@@ -327,8 +585,28 @@ def _capture_display_window(
                     for m in selected
                 )
             ):
+                # One group is larger than the whole frame budget, so the
+                # reader escalates to a local replay of the model's history.
+                # That replay reaches the start of the CONTEXT phase and stops
+                # there — so hand it the audit cursor on the way out, or the
+                # pre-compaction rows become unreachable for exactly the
+                # sessions most likely to contain an oversized group. The
+                # cursor stays valid across the escalation because it names an
+                # entry id, not a position in the chain being abandoned.
+                audit_entry = _audit_entry_cursor(transcript)
                 return DisplayHistoryWindow(
-                    status="full_required", durable_seed_tool_ids=seed_tool_ids, **envelope
+                    status="full_required",
+                    durable_seed_tool_ids=seed_tool_ids,
+                    before_token=(
+                        _sign(
+                            dict(envelope, phase=_AUDIT_PHASE, end_entry_id=audit_entry),
+                            transcript._history_page_key,
+                        )
+                        if audit_entry is not None
+                        else None
+                    ),
+                    audit_available=audit_entry is not None,
+                    **envelope,
                 )
             break
         selected[0:0] = group
@@ -338,18 +616,32 @@ def _capture_display_window(
             break
     token_fields = dict(envelope)
     snapshot_token = _sign(dict(token_fields, position=total), transcript._history_page_key)
-    before_token = (
-        _sign(dict(token_fields, position=start), transcript._history_page_key) if start else None
-    )
+    # The audit handoff. When the context replay is drained, the conversation
+    # does NOT necessarily begin here: everything before the compaction cut is
+    # still on disk, and before this it was simply unaddressable (measured on
+    # the reference journal: 327 of 17,349 rows reachable). Mint a cursor into
+    # the audit phase instead of terminating the chain.
+    audit_entry = _audit_entry_cursor(transcript) if not start else None
+    audit_available = audit_entry is not None
+    if start:
+        before_token = _sign(dict(token_fields, position=start), transcript._history_page_key)
+    elif audit_entry is not None:
+        before_token = _sign(
+            dict(token_fields, phase=_AUDIT_PHASE, end_entry_id=audit_entry),
+            transcript._history_page_key,
+        )
+    else:
+        before_token = None
     return DisplayHistoryWindow(
         **envelope,
         messages=selected,
         durable_seed_tool_ids=seed_tool_ids,
         before_token=before_token,
         snapshot_token=snapshot_token,
-        has_more=start > 0,
+        has_more=before_token is not None,
         total_message_count=total,
         start=start,
+        audit_available=audit_available,
         theme_turn_count=sum(getattr(m, "role", "") in ("user", "assistant") for m in history),
         opener_text=next(
             (m.text[:256] for m in history if isinstance(m, Message) and m.role == "user"), ""

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -625,6 +625,18 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
         ...
 
     @property
+    def history_is_audit(self) -> bool:
+        """Whether the rows still above the reader are PRE-COMPACTION history.
+
+        The head notice branches its copy on this: rows behind the compaction
+        cut are real history the model can no longer see, which is a different
+        kind of row from "older messages" rather than merely an earlier one.
+        ``False`` on an owner too old to page them, so that viewer keeps the
+        copy it always had.
+        """
+        ...
+
+    @property
     def history_opener_text(self) -> str:
         """The first user message's text, for the session's title row."""
         ...

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -620,6 +620,11 @@ class RemoteSession:
         self._hydrated_once = False
         self._display_history: DisplayHistoryWindow | None = None
         self._history_hydrated = True
+        #: Whether the PRE-COMPACTION rows behind the context replay are
+        #: loaded (or absent). Separate from ``_history_hydrated`` on purpose;
+        #: see :attr:`history_before_token`. Starts ``True`` so a session with
+        #: no owner window behaves exactly as it did before this existed.
+        self._audit_exhausted = True
         self._durable_seed_ids: set[str] = set()
         self._durable_seed_tool_ids: set[str] = set()
         self._history_ids: set[str] = set()
@@ -2490,6 +2495,7 @@ class RemoteSession:
             # Legacy owners and oversized prose keep the honest full replay.
             self._display_history = None
             self._history_hydrated = True
+            self._audit_exhausted = True
             self._durable_seed_ids.clear()
             self._durable_seed_tool_ids.clear()
             await self._load_history(frontend.live_cursor, strict_cut=window is not None)
@@ -2527,6 +2533,9 @@ class RemoteSession:
         self._history = rows
         self._live_history.clear()
         self._history_hydrated = page.start == 0 and len(rows) == window.total_message_count
+        # An owner too old to know about audit paging reports neither field, so
+        # this stays True and the chain terminates exactly where it used to.
+        self._audit_exhausted = not (page.audit_available or page.audit)
         self._history_ids = {m.id for m in rows}
         self._durable_seed_ids = set(window.durable_seed_ids)
         self._durable_seed_tool_ids = set(window.durable_seed_tool_ids)
@@ -2551,7 +2560,16 @@ class RemoteSession:
             or window.through_id != cursor
         ):
             raise ConnectionError("display history does not match canonical sync")
-        if window.start < 0 or window.start + len(window.messages) > window.total_message_count:
+        if window.start < 0:
+            raise ConnectionError("invalid display history range")
+        # The range check is a CONTEXT-coordinate check: it bounds a page
+        # against ``total_message_count``, which is deliberately the size of
+        # the model's replay. An audit page's ``start`` is a JOURNAL index and
+        # its rows sit BELOW that replay entirely, so it exceeds the bound by
+        # construction and this would reject every one of them. Audit pages are
+        # bounded by their own phase instead: the owner mints their cursor from
+        # its resident entry list and refuses one it cannot resolve.
+        if not window.audit and window.start + len(window.messages) > window.total_message_count:
             raise ConnectionError("invalid display history range")
 
     async def _fetch_history_page(
@@ -2721,7 +2739,31 @@ class RemoteSession:
     @property
     def history_before_token(self) -> str | None:
         window = self._display_history
-        return window.before_token if window is not None and not self._history_hydrated else None
+        if window is None:
+            return None
+        # Two independent exhaustion facts, and they must NOT be folded into
+        # one flag. ``_history_hydrated`` means "the model's replay is fully
+        # loaded" and is what ``history()`` and ``materialize_history()`` gate
+        # on; ``_audit_exhausted`` means "the pre-compaction rows behind that
+        # replay are loaded too". Reusing the first for both would either let
+        # the retitle sampler drain 17,000 audit rows or stop the reader at the
+        # compaction cut, which is the defect this feature exists to fix.
+        if self._history_hydrated and self._audit_exhausted:
+            return None
+        return window.before_token
+
+    @property
+    def history_is_audit(self) -> bool:
+        """Whether the rows still above the reader are PRE-COMPACTION history.
+
+        Read by the head notice to choose its vocabulary. False on an owner
+        that cannot page audit rows, so an older owner keeps the copy it always
+        had rather than promising history it cannot serve.
+        """
+        window = self._display_history
+        if window is None:
+            return False
+        return bool(window.audit or window.audit_available)
 
     async def load_older_display_page(self) -> list[Any]:
         window = self._display_history
@@ -2735,21 +2777,58 @@ class RemoteSession:
             return []
         if page.status == "full_required":
             old_ids = set(self._history_ids)
-            return [m for m in await self.materialize_history() if m.id not in old_ids]
-        if page.start + len(page.messages) != window.start:
+            rows = [m for m in await self.materialize_history() if m.id not in old_ids]
+            # ``materialize_history`` deliberately stops at the end of the
+            # context phase, so the audit cursor the owner returned alongside
+            # the escalation is the only way back into the older rows. Keep it.
+            if page.before_token:
+                self._adopt_audit_cursor(page.before_token)
+            return rows
+        if not page.audit and page.start + len(page.messages) != window.start:
+            # Context-phase contiguity only. An audit page's ``start`` is a
+            # JOURNAL index while the loaded window's is a position in the
+            # context replay, so comparing them is a category error that fires
+            # on the very first audit page and surfaces to the reader as a
+            # failed fetch instead of history.
             raise ConnectionError("history page is not contiguous with the loaded window")
         self._history[:0] = page.messages
         self._history_ids.update(m.id for m in page.messages)
         self._display_history = window.model_copy(
             update={
-                "start": page.start,
+                # An audit page must not move the window's context coordinate:
+                # ``start`` is read against ``total_message_count``, which stays
+                # context-scoped. It is already 0 by the time audit begins.
+                "start": window.start if page.audit else page.start,
                 "before_token": page.before_token,
                 "has_more": page.has_more,
                 "messages": list(self._history),
+                "audit": page.audit,
+                "audit_available": page.audit_available,
             }
         )
-        self._history_hydrated = page.start == 0
+        if page.audit:
+            self._audit_exhausted = not page.before_token
+        else:
+            self._history_hydrated = page.start == 0
+            # Context drained with audit rows behind it: the chain continues.
+            self._audit_exhausted = not (page.start == 0 and page.before_token)
         return list(page.messages)
+
+    def _adopt_audit_cursor(self, token: str) -> None:
+        """Keep paging alive at the audit cursor after a full-replay escalation.
+
+        ``full_required`` hands the reader the model's whole history and would
+        otherwise end the chain there, stranding every pre-compaction row on a
+        session whose oversized group triggered the escalation — the sessions
+        most likely to have one.
+        """
+        window = self._display_history
+        if window is None:
+            return
+        self._display_history = window.model_copy(
+            update={"before_token": token, "has_more": True, "audit_available": True}
+        )
+        self._audit_exhausted = False
 
     async def ensure_display_anchor(self, anchor: str) -> bool:
         window = self._display_history
@@ -2775,7 +2854,15 @@ class RemoteSession:
         return True
 
     async def materialize_history(self) -> list[Any]:
-        """Explicit full replay, off the click path, at the captured sync cut."""
+        """Explicit full replay, off the click path, at the captured sync cut.
+
+        Produces the MODEL's history and stops at the end of the context phase.
+        It must never walk into the audit phase: its consumers are
+        ``history()`` and the conversation-retitle sampler, and draining audit
+        here would hand the retitle model every row of a 17,000-row journal on
+        an ordinary message submit. Audit rows are reached only by the reader's
+        own backward scroll, one bounded page at a time.
+        """
         if self._history_hydrated:
             return self.history()
         window = self._display_history
@@ -2800,7 +2887,9 @@ class RemoteSession:
                 rows = await asyncio.to_thread(replay)
                 break
             rows[:0] = page.messages
-            token = page.before_token
+            # The context phase ends here; the audit cursor is left for the
+            # reader (see this method's docstring).
+            token = None if page.audit_available or page.audit else page.before_token
         if self._display_history is not window:
             raise RuntimeError("history changed while materializing; retry")
         self._history = rows

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -1318,10 +1318,11 @@ class RuntimeServer:
             # cannot carry them.
             sync_payload = sync_wire_payload(sync)
             # The sync frame carries the FIRST display page, so it is one of
-            # the two places the audit fields reach the wire (the other is the
-            # ``history_page`` RPC below). Both strip through the same helper;
-            # stripping in only one would produce a viewer that attaches
-            # cleanly and then fails on its first scroll.
+            # the THREE places the audit fields reach the wire (the others are
+            # the ``history_page`` and ``frontend_sync`` RPCs). All three strip
+            # through the same helper; stripping in only some would produce a
+            # viewer that attaches cleanly and then fails on its first scroll
+            # or on its first post-append refresh.
             if isinstance(sync_payload.get("display_history"), dict):
                 strip_audit_fields(
                     sync_payload["display_history"], audit_capable=conn.audit_history
@@ -2403,6 +2404,7 @@ class RuntimeServer:
                 oversized_frame_report,
                 sync_wire_payload,
             )
+            from local_operator.session.history_window import strip_audit_fields
 
             capture = getattr(h, "subscribe_frontend", None)
             if not callable(capture):
@@ -2413,22 +2415,38 @@ class RuntimeServer:
             )
             try:
                 payload = sync_wire_payload(subscription.sync)
+                # The THIRD wire route, and the one an old viewer uses most:
+                # ``RemoteSession._refresh_display_history`` calls this op on
+                # every history refresh, which fires whenever the frontend's
+                # ``history_generation`` moves — i.e. as soon as a new owner
+                # appends a row. ``audit``/``audit_available`` are ordinary
+                # model fields, so they serialize on an UNCOMPACTED page too;
+                # missing the strip here is a hard ValidationError on the
+                # viewer's nested ``DisplayHistoryWindow`` (``extra='forbid'``)
+                # rather than a compaction-only or a racy failure.
+                if isinstance(payload.get("display_history"), dict):
+                    strip_audit_fields(payload["display_history"], audit_capable=audit_capable)
                 # Keep the existing live subscription. This temporary capture
                 # only supplies an atomic cut; it must not multiply observers.
                 response = {"op": "result", "req": frame.get("req"), "data": payload}
                 if oversized_frame_report(response, _MAX_LINE_BYTES) is not None:
                     window = subscription.sync.display_history
                     if window is not None:
-                        payload["display_history"] = window.model_copy(
-                            update={
-                                "status": "full_required",
-                                "messages": [],
-                                "durable_seed_ids": [],
-                                "durable_seed_tool_ids": [],
-                                "before_token": None,
-                                "snapshot_token": None,
-                            }
-                        ).model_dump(mode="json")
+                        # Re-serialized from the model, so it needs the same
+                        # strip as the page above rather than inheriting it.
+                        payload["display_history"] = strip_audit_fields(
+                            window.model_copy(
+                                update={
+                                    "status": "full_required",
+                                    "messages": [],
+                                    "durable_seed_ids": [],
+                                    "durable_seed_tool_ids": [],
+                                    "before_token": None,
+                                    "snapshot_token": None,
+                                }
+                            ).model_dump(mode="json"),
+                            audit_capable=audit_capable,
+                        )
                     if oversized_frame_report(response, _MAX_LINE_BYTES) is not None:
                         raise ValueError("canonical refresh exceeds the transport frame limit")
                 return payload

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -434,6 +434,12 @@ class _ClientConn:
     # v5 canonical state is attach-only and independently negotiated so daemon
     # projection bytes never gain frontend frames.
     wants_frontend: bool = False
+    #: This viewer negotiated ``display-history-audit-v1`` and can therefore be
+    #: sent the audit fields on a display page. A property of the CONNECTION,
+    #: so it is read where the connection is known and never inferred from the
+    #: frame; see ``DISPLAY_HISTORY_AUDIT_CAPABILITY`` for what emitting them
+    #: to a viewer that did not negotiate would do.
+    audit_history: bool = False
     frontend_ready: bool = False
     # Updates can be scheduled back to this loop while the owner-loop
     # subscription call is returning. Hold them until the sync frame is queued;
@@ -664,6 +670,14 @@ class RuntimeServer:
                 + ([FRONTEND_CAPABILITY] if hasattr(handle, "subscribe_frontend") else [])
                 + (["completion-ack-v1"] if hasattr(handle, "acknowledge_attention") else [])
                 + (["display-history-window-v1"] if hasattr(handle, "history_page") else [])
+                # A SECOND string for the same op, because the one above is a
+                # bare presence flag with no version handshake and cannot say
+                # "this owner also pages pre-compaction history". The page
+                # model forbids extra fields, so emitting the audit fields to a
+                # viewer built before them fails that viewer's validation and
+                # breaks the attach outright. See
+                # ``DISPLAY_HISTORY_AUDIT_CAPABILITY``.
+                + (["display-history-audit-v1"] if hasattr(handle, "history_page") else [])
             ),
             # A runtime is born with no terminal watching it. Stamped at
             # construction rather than left to the first transition, because
@@ -1276,9 +1290,19 @@ class RuntimeServer:
                 oversized_frame_report,
                 sync_wire_payload,
             )
+            from local_operator.session.history_window import (
+                strip_audit_fields,
+                wire_payload,
+            )
 
             window_requested = bool(frame.get("display_window")) and (
                 "display-history-window-v1" in self._record.capabilities
+            )
+            # Negotiated exactly like ``display_window``: the viewer opts in by
+            # declaring the flag, and an older viewer that cannot name it never
+            # receives the fields it would reject.
+            conn.audit_history = bool(frame.get("display_history_audit")) and (
+                "display-history-audit-v1" in self._record.capabilities
             )
             outcome = (
                 subscribe_frontend(on_update, display_window=True)
@@ -1293,6 +1317,15 @@ class RuntimeServer:
             # ``job_trajectory``; see ``sync_wire_payload`` for why the frame
             # cannot carry them.
             sync_payload = sync_wire_payload(sync)
+            # The sync frame carries the FIRST display page, so it is one of
+            # the two places the audit fields reach the wire (the other is the
+            # ``history_page`` RPC below). Both strip through the same helper;
+            # stripping in only one would produce a viewer that attaches
+            # cleanly and then fails on its first scroll.
+            if isinstance(sync_payload.get("display_history"), dict):
+                strip_audit_fields(
+                    sync_payload["display_history"], audit_capable=conn.audit_history
+                )
             conn.frontend_unsubscribe = subscription.unsubscribe
             # Registration and snapshot capture happened synchronously on the
             # authoritative loop. Mark ready only after queuing that snapshot;
@@ -1319,7 +1352,9 @@ class RuntimeServer:
                         "snapshot_token": None,
                     }
                 )
-                sync_payload["display_history"] = fallback.model_dump(mode="json")
+                sync_payload["display_history"] = wire_payload(
+                    fallback, audit_capable=conn.audit_history
+                )
                 oversize = oversized_frame_report(sync_frame, _MAX_LINE_BYTES)
             if oversize is not None:
                 logger.error("session runtime: frontend_sync will not fit — %s", oversize)
@@ -1790,7 +1825,13 @@ class RuntimeServer:
                 # ``data`` the invoker renders locally (a slash command's typed
                 # outcome, a cancel's authoritative count) rather than a
                 # one-line receipt that would paint in the owner's transcript.
-                data = await self._dispatch_payload(op, frame, conn.locality, conn.slash_consumers)
+                data = await self._dispatch_payload(
+                    op,
+                    frame,
+                    conn.locality,
+                    conn.slash_consumers,
+                    audit_capable=conn.audit_history,
+                )
                 await self._send_to(conn, {"op": "result", "req": req, "data": data})
                 await self._handle.refresh()
                 await self._push()
@@ -2220,6 +2261,7 @@ class RuntimeServer:
         frame: dict[str, Any],
         locality: ClientLocality = "local",
         consumers: frozenset[str] | None = None,
+        audit_capable: bool = False,
     ) -> Any:
         """Structured-answer ops: the return value becomes the ``result`` data.
 
@@ -2227,6 +2269,9 @@ class RuntimeServer:
         ``slash_consumers`` set (``None`` when the auth frame omitted it),
         carried here for the same reason ``locality`` is: it is a property of
         the CONNECTION, not of the frame, and only the handle can act on it.
+        ``audit_capable`` is a third of the same kind — whether this viewer
+        negotiated ``display-history-audit-v1`` — and it decides whether a
+        display page may carry the audit fields at all.
         """
         h = self._handle
         if op == "fork_snapshot":
@@ -2398,7 +2443,15 @@ class RuntimeServer:
             if len(before) > 4096 or len(anchor) > 512:
                 raise ValueError("invalid history page request")
             result = fetch(before, anchor)
-            return await result if inspect.isawaitable(result) else result
+            payload = await result if inspect.isawaitable(result) else result
+            # Same contract as the sync frame: a viewer that did not negotiate
+            # the audit capability must not be handed fields its page model
+            # forbids.
+            if isinstance(payload, dict):
+                from local_operator.session.history_window import strip_audit_fields
+
+                strip_audit_fields(payload, audit_capable=audit_capable)
+            return payload
         if op == "job_trajectory":
             # The other half of the frame-size fix: the attach snapshot omits
             # trajectories, so a viewer opening a child page pulls that one

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -43,7 +43,7 @@ import uuid
 from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence
 
 from local_operator.harness.types import (
     AgentMessage,
@@ -536,6 +536,11 @@ class Transcript:
         self._history_generation = 0
         self._history_page_key = os.urandom(32)
         self._display_window_cache: _DisplayWindowCache | None = None
+        #: Memo for the audit pager's hoisted-turn lookup, keyed by
+        #: ``_history_generation``. See ``history_window._hoisted_turn_ids``:
+        #: the answer costs a filtered whole-journal scan and is asked once per
+        #: audit page, so it is cached rather than recomputed per scroll.
+        self._audit_hoisted_cache: tuple[int, frozenset[str]] | None = None
         # Derived indexes only describe durable rows. They are updated after
         # fsync, rebuilt after a file fold, and never published from a worker.
         self._entry_ids: set[str] = set()
@@ -1319,11 +1324,224 @@ def _journal_injection_ids(entries: Sequence[TranscriptEntry]) -> set[str]:
     }
 
 
+def _compaction_marker(entry: TranscriptEntry) -> CustomMessage:
+    """The in-band row that says a compaction happened here.
+
+    Shared by both replay modes so the marker a reader sees mid-transcript in
+    audit mode is the same object shape the model's replay puts at its head —
+    one renderer, one payload contract, no second definition to drift.
+    """
+    details: dict[str, Any] = {"summary": entry.payload.get("summary", "")}
+    preserve_data = entry.payload.get("preserve_data")
+    if preserve_data is not None:
+        details["preserve_data"] = preserve_data
+    return CustomMessage(
+        id=entry.id,
+        custom_type="compaction_summary",
+        attribution="system",
+        details=details,
+    )
+
+
+def collect_prunes(entries: Sequence[TranscriptEntry]) -> dict[str, str]:
+    """Map pruned message id -> notice, over the WHOLE journal.
+
+    Exported because :func:`audit_slice` must not re-derive this from its own
+    window. A prune is always appended AFTER the row it targets (see
+    :meth:`Transcript.append_prune`), so a prune for a row inside the slice can
+    sit arbitrarily far past its end — deriving the map from the slice would
+    silently replay pruned tool output the compaction pass already decided was
+    dead weight, which is a privacy and a size regression at once. The scan is
+    a ``type ==`` test over already-parsed objects, so it costs no rehydration.
+    """
+    return {
+        str(entry.payload.get("target")): str(entry.payload.get("notice", ""))
+        for entry in entries
+        if entry.type == ENTRY_PRUNE and entry.payload.get("target")
+    }
+
+
+def context_cut_index(entries: Sequence[TranscriptEntry], *, quiet: bool = False) -> int:
+    """Journal index where the CONTEXT replay begins — the compaction cut.
+
+    Extracted so the audit phase starts exactly where the context phase starts,
+    from ONE implementation of the rule. The audit chain hands this index to
+    :func:`audit_slice` as its first ``end_index``: rows below it are what the
+    context replay dropped, rows at and above it are what the model still sees,
+    and the two phases therefore tile the journal with no gap and no overlap.
+    A second copy of this scan would put a hole or a duplicate at that seam the
+    first time either side was edited.
+
+    ``quiet`` suppresses the unresolved-cut error, because the audit pager asks
+    this question once per page and a corrupt journal would otherwise log on
+    every scroll; the context replay still reports it once per replay.
+    """
+    compaction_index: int | None = None
+    for i in range(len(entries) - 1, -1, -1):
+        if entries[i].type == ENTRY_COMPACTION:
+            compaction_index = i
+            break
+    if compaction_index is None:
+        return 0
+    first_kept_id = entries[compaction_index].payload.get("first_kept_entry_id")
+    if first_kept_id is None:
+        return compaction_index + 1
+    for i in range(len(entries)):
+        if entries[i].id == first_kept_id:
+            return i
+    if not quiet:
+        logger.error(
+            "first_kept_entry_id %s not found in transcript; replaying full history",
+            first_kept_id,
+        )
+    return 0
+
+
+def context_preserved_turn_ids(entries: Sequence[TranscriptEntry]) -> set[str]:
+    """Ids the CONTEXT replay re-emits at its head from the latest compaction.
+
+    Only the latest compaction's, because only that one's ``preserved_user_turns``
+    are hoisted into the model's replay (see :func:`replay_entries`). They carry
+    the ORIGINAL row ids, so a two-phase reading chain would deliver each of
+    them twice: once hoisted by the context page, once in place by the audit
+    page that replays the row it was copied from.
+
+    Used by the audit PAGER to suppress its copy, and deliberately not by
+    :func:`replay_entries` in audit mode \u2014 a standalone audit replay is not
+    chained with a context replay, so suppressing there would drop a real row
+    rather than de-duplicate one.
+    """
+    for i in range(len(entries) - 1, -1, -1):
+        if entries[i].type == ENTRY_COMPACTION:
+            if not entries[i].payload.get("preserved_user_turns"):
+                return set()
+            # Resolved through the SAME shed/cap filter the context replay
+            # applies, never off the raw payload. The stored block is not what
+            # gets emitted: ``replay_preserved_turns`` drops journalled
+            # injections and enforces the cap, so on a real journal the payload
+            # held 295 turns while the replay emitted 104. Suppressing the raw
+            # 295 would have hidden 191 rows that no phase then delivered —
+            # measured, and exactly the class of silent loss this whole change
+            # exists to end.
+            from local_operator.compaction.cutpoint import replay_preserved_turns
+
+            return {
+                str(turn.get("id"))
+                for turn in replay_preserved_turns(
+                    entries[i].payload,
+                    injection_ids=_journal_injection_ids(entries),
+                )
+                if turn.get("id")
+            }
+    return set()
+
+
+def first_message_index(entries: Sequence[TranscriptEntry]) -> int | None:
+    """Index of the journal's first message row, or ``None`` if it has none.
+
+    The audit chain's termination test. Paging stops when a page's window
+    reaches this index and NOT before — that is the whole point of the audit
+    phase, so the test lives in one named function rather than as an inline
+    ``start == 0`` that a later edit can quietly redefine.
+    """
+    for index, entry in enumerate(entries):
+        if entry.type == ENTRY_MESSAGE:
+            return index
+    return None
+
+
+def audit_slice(
+    entries: Sequence[TranscriptEntry],
+    attachments: AttachmentStore | None,
+    *,
+    end_index: int,
+    limit: int,
+    prunes: dict[str, str] | None = None,
+) -> tuple[list[AgentMessage], list[int], int]:
+    """Replay a bounded backward window of the FULL journal, for audit reading.
+
+    Returns ``(messages, journal_indices, start_index)``. The per-row journal
+    indices are returned rather than recomputed by the caller because the pager
+    mints its next backward cursor from the index of the first row it actually
+    KEPT after applying its byte budget — which is not necessarily the start of
+    this window — and that index must be the same one this replay used or the
+    chain skips or repeats rows at the page seam.
+
+    Windowed rather than a full audit replay because the cost difference is the
+    whole design: measured on the operator's 231 MB / 17,345-row journal, a
+    naive full audit replay is 0.29 s and 47 MB of peak allocation per call,
+    while this walks back ``limit`` message rows over the owner's already
+    resident ``_entries`` in under a millisecond. Reading the page off disk
+    instead (``read_transcript_page``) measured ~1.03 s on the same journal.
+    Serve audit pages from RAM the owner already holds.
+
+    ``prunes`` is passed in deliberately; see :func:`collect_prunes`.
+    """
+    entries = list(entries)
+    end_index = max(0, min(end_index, len(entries)))
+    if prunes is None:
+        prunes = collect_prunes(entries)
+    # Walk back over journal rows until ``limit`` MESSAGE rows are in hand.
+    # Non-message rows (customs, prunes, checkpoints) are free to include: they
+    # cost nothing to skip and stopping on them would make the window's size
+    # depend on journal noise rather than on rows the reader sees.
+    start = end_index
+    counted = 0
+    while start > 0 and counted < limit:
+        start -= 1
+        if entries[start].type == ENTRY_MESSAGE:
+            counted += 1
+    # Never BEGIN a window inside a tool group. A tool result row is rendered
+    # on the card of the call above it, so a window whose first row is a result
+    # renders a settled call as interrupted until some unrelated scroll happens
+    # to fetch the call. The context replay avoids this by computing its group
+    # boundaries over the whole history; a bounded window has to extend its own
+    # left edge instead. Cheap: results sit immediately after their call, so
+    # this walks a handful of rows.
+    while start > 0 and start < end_index:
+        row = entries[start]
+        if row.type != ENTRY_MESSAGE or str(row.payload.get("role", "")) != "tool":
+            break
+        start -= 1
+    out: list[AgentMessage] = []
+    indices: list[int] = []
+    for offset in range(start, end_index):
+        message = _replay_row(entries[offset], attachments, prunes)
+        if message is not None:
+            out.append(message)
+            indices.append(offset)
+    return out, indices, start
+
+
+def _replay_row(
+    entry: TranscriptEntry,
+    attachments: AttachmentStore | None,
+    prunes: dict[str, str],
+) -> AgentMessage | None:
+    """Rehydrate one journal row for either replay mode.
+
+    Compaction rows become an in-place marker; message rows rehydrate and pick
+    up their prune notice. Everything else is not conversation content.
+    """
+    if entry.type == ENTRY_COMPACTION:
+        return _compaction_marker(entry)
+    if entry.type != ENTRY_MESSAGE:
+        return None
+    message = _entry_to_message(entry, attachments)
+    if message is None:
+        return None
+    notice = prunes.get(entry.id)
+    if notice is not None and isinstance(message, Message):
+        _apply_prune(message, notice)
+    return message
+
+
 def replay_entries(
     entries: Sequence[TranscriptEntry],
     attachments: AttachmentStore | None,
     *,
     through_id: str | None = None,
+    mode: Literal["context", "audit"] = "context",
 ) -> list[AgentMessage]:
     """The replay semantics behind :meth:`Transcript.build_llm_history`.
 
@@ -1332,6 +1550,36 @@ def replay_entries(
     same code path as the whole-file parse, and equivalence between the two is
     a property of one function applied to two inputs rather than two
     implementations kept in step by hand.
+
+    Two MODES, and the separation is load-bearing rather than tidy:
+
+    * ``"context"`` answers *what may the model see* — the latest compaction
+      wins and replay starts at its ``first_kept_entry_id``. This is the
+      default and it is byte-for-byte what this function has always done;
+      every existing caller keeps it, and compaction keeps bounding the model's
+      context exactly as before.
+    * ``"audit"`` answers *what did the conversation contain* — every message
+      row from the journal's start, with a marker in place at each compaction.
+
+    They were ONE function once, and that is precisely the defect this mode
+    exists to fix: the display window built its pages from the context replay,
+    so on a compacted session the reader could not address rows that were still
+    on disk (measured: 97% of a 17,345-row journal unreachable). Do not
+    re-merge them, and do not make either one call the other. A future change
+    to what the model sees must not become a change to what the audit reader
+    can reach, and the reverse would silently grow the model's context.
+
+    Audit mode is strictly simpler than context mode, in two ways worth stating
+    because both look like omissions:
+
+    * ``preserved_user_turns`` are NOT re-injected. They are verbatim copies of
+      user rows that already sit before the cut, and audit mode replays those
+      rows — re-injecting would double every preserved turn AND do so under the
+      original ids, which the TUI's mount-time id dedupe would then swallow,
+      hiding a real row rather than showing a duplicate.
+    * the ``first_kept_entry_id`` fallback is irrelevant: audit mode starts at
+      index 0 unconditionally, so the silent-amnesia hazard that fallback
+      guards against cannot arise here.
     """
     entries = list(entries)
     if through_id is not None:
@@ -1344,6 +1592,14 @@ def replay_entries(
                 break
         else:
             raise ValueError("history cursor is no longer retained")
+    if mode == "audit":
+        prunes = collect_prunes(entries)
+        audited: list[AgentMessage] = []
+        for entry in entries:
+            message = _replay_row(entry, attachments, prunes)
+            if message is not None:
+                audited.append(message)
+        return audited
     compaction_index: int | None = None
     for i in range(len(entries) - 1, -1, -1):
         if entries[i].type == ENTRY_COMPACTION:
@@ -1354,18 +1610,7 @@ def replay_entries(
     prefix: list[AgentMessage] = []
     if compaction_index is not None:
         compaction = entries[compaction_index]
-        details: dict[str, Any] = {"summary": compaction.payload.get("summary", "")}
-        preserve_data = compaction.payload.get("preserve_data")
-        if preserve_data is not None:
-            details["preserve_data"] = preserve_data
-        prefix.append(
-            CustomMessage(
-                id=compaction.id,
-                custom_type="compaction_summary",
-                attribution="system",
-                details=details,
-            )
-        )
+        prefix.append(_compaction_marker(compaction))
         # User-authored turns that fell into the summarized partition are
         # re-injected VERBATIM right after the marker, so the user's own
         # words survive the pass byte for byte instead of being paraphrased
@@ -1417,34 +1662,18 @@ def replay_entries(
                     message.id = turn_id
                 message.provider_payload = preserved_turn_payload(turn)
                 prefix.append(message)
-        first_kept_id = compaction.payload.get("first_kept_entry_id")
         # The first kept entry normally sits BEFORE the compaction marker
         # (messages are persisted as they happen; the marker comes last),
-        # so scan the whole transcript. If the id no longer resolves (a
-        # dropped malformed line, a converter-minted id), replaying from
-        # compaction_index + 1 would point PAST the kept window and lose
-        # every message compaction promised to preserve. Replaying too
-        # much is recoverable at the next compaction; silent amnesia is
-        # not, so fall back to the full history with an error.
-        start = 0
-        if first_kept_id is None:
-            start = compaction_index + 1
-        else:
-            for i in range(len(entries)):
-                if entries[i].id == first_kept_id:
-                    start = i
-                    break
-            else:
-                logger.error(
-                    "first_kept_entry_id %s not found in transcript; " "replaying full history",
-                    first_kept_id,
-                )
+        # so the scan covers the whole transcript. If the id no longer
+        # resolves (a dropped malformed line, a converter-minted id),
+        # replaying from compaction_index + 1 would point PAST the kept
+        # window and lose every message compaction promised to preserve.
+        # Replaying too much is recoverable at the next compaction; silent
+        # amnesia is not, so that case falls back to the full history with
+        # an error. See :func:`context_cut_index`, which owns that rule.
+        start = context_cut_index(entries)
 
-    prunes = {
-        str(entry.payload.get("target")): str(entry.payload.get("notice", ""))
-        for entry in entries
-        if entry.type == ENTRY_PRUNE and entry.payload.get("target")
-    }
+    prunes = collect_prunes(entries)
     out: list[AgentMessage] = list(prefix)
     for entry in entries[start:]:
         if entry.type != ENTRY_MESSAGE:

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -1375,6 +1375,30 @@ def context_cut_index(entries: Sequence[TranscriptEntry], *, quiet: bool = False
     ``quiet`` suppresses the unresolved-cut error, because the audit pager asks
     this question once per page and a corrupt journal would otherwise log on
     every scroll; the context replay still reports it once per replay.
+
+    COMPACTION ROWS AT OR ABOVE THE CUT ARE DELIBERATELY NOT RENDERED, and the
+    asymmetry is not a gap in the tiling. Review round 1 (R2) read the omission
+    as unreachable markers; measured in RENDERED order on ``2f95e374dd22`` (61
+    compaction rows, cut 1626) it is the opposite. Repeated compaction leaves
+    several *superseded* compaction rows inside the kept suffix: each describes
+    a boundary the latest compaction has already moved, so the seam it names no
+    longer exists in the transcript the reader is looking at. Every compaction
+    row BELOW the cut is emitted in place by the audit phase (55 of 55 there),
+    and the latest one is emitted at the context head as the live seam — 56
+    markers for 56 boundaries that still exist.
+
+    Emitting the remaining 5 would make the marker copy FALSE at each of them.
+    ``COMPACTION_MARKER_NOTICE`` claims the history above it is outside the
+    model's context; those rows land 3-15 LIVE context rows below the seam, so
+    each would sit above rows the agent can still see and assert the reverse —
+    reintroducing the inversion D1 was raised to fix. The two suggested routes
+    are worse than the symptom: emitting them from the CONTEXT phase breaks
+    this PR's central regression guard (``mode="context"`` byte-identical to
+    ``build_llm_history`` on 8/8 journals) and pushes the markers' 680 KB
+    ``preserve_data`` blocks into the model's own context — measured at
+    +3,380,677 bytes, roughly 845k tokens, on this one journal — while
+    extending the audit window's first ``end_index`` past the cut re-delivers
+    16 message rows the context page already sent.
     """
     compaction_index: int | None = None
     for i in range(len(entries) - 1, -1, -1):
@@ -1418,11 +1442,15 @@ def context_preserved_turn_ids(entries: Sequence[TranscriptEntry]) -> set[str]:
             # Resolved through the SAME shed/cap filter the context replay
             # applies, never off the raw payload. The stored block is not what
             # gets emitted: ``replay_preserved_turns`` drops journalled
-            # injections and enforces the cap, so on a real journal the payload
-            # held 295 turns while the replay emitted 104. Suppressing the raw
-            # 295 would have hidden 191 rows that no phase then delivered —
-            # measured, and exactly the class of silent loss this whole change
-            # exists to end.
+            # injections and enforces the cap, so on the reference journal
+            # (``bda7b76d34e0``) the payload held 295 turns while the replay
+            # emitted 105. Suppressing the raw 295 would have hidden 190 rows
+            # that no phase then delivered — measured, and exactly the class of
+            # silent loss this whole change exists to end. The three figures
+            # track a live journal that keeps growing, so treat them as an
+            # order-of-magnitude illustration of the gap rather than a pin;
+            # what is invariant is that the payload count EXCEEDS the emitted
+            # count, which is the whole reason this filter cannot be skipped.
             from local_operator.compaction.cutpoint import replay_preserved_turns
 
             return {

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -1398,7 +1398,7 @@ def context_cut_index(entries: Sequence[TranscriptEntry], *, quiet: bool = False
     ``preserve_data`` blocks into the model's own context — measured at
     +3,380,677 bytes, roughly 845k tokens, on this one journal — while
     extending the audit window's first ``end_index`` past the cut re-delivers
-    16 message rows the context page already sent.
+    15 message rows the context page already sent.
     """
     compaction_index: int | None = None
     for i in range(len(entries) - 1, -1, -1):
@@ -1444,13 +1444,19 @@ def context_preserved_turn_ids(entries: Sequence[TranscriptEntry]) -> set[str]:
             # gets emitted: ``replay_preserved_turns`` drops journalled
             # injections and enforces the cap, so on the reference journal
             # (``bda7b76d34e0``) the payload held 295 turns while the replay
-            # emitted 105. Suppressing the raw 295 would have hidden 190 rows
-            # that no phase then delivered — measured, and exactly the class of
-            # silent loss this whole change exists to end. The three figures
-            # track a live journal that keeps growing, so treat them as an
-            # order-of-magnitude illustration of the gap rather than a pin;
-            # what is invariant is that the payload count EXCEEDS the emitted
-            # count, which is the whole reason this filter cannot be skipped.
+            # emitted 149 rows — which dedupe to the 105 DISTINCT ids this
+            # function returns. Those last two are different quantities and
+            # are worth keeping apart: the emitted count is what the reader
+            # sees, the id set is what suppression is matched against, and one
+            # turn can be emitted under more than one row. Suppressing off the
+            # raw payload instead would have matched 295 ids against those
+            # 105, hiding 190 that no phase then delivered — measured, and
+            # exactly the class of silent loss this whole change exists to
+            # end. All of these figures track a live journal that keeps
+            # growing, so treat them as an order-of-magnitude illustration of
+            # the gap rather than a pin; what is invariant is that the payload
+            # count EXCEEDS both the emitted count and the id set, which is
+            # the whole reason this filter cannot be skipped.
             from local_operator.compaction.cutpoint import replay_preserved_turns
 
             return {

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -7983,7 +7983,16 @@ class OperatorApp(App[None]):
         # is still the correct thing to say.
         audit = bool(session is not None and getattr(session, "history_is_audit", False))
         if not more:
-            self._restate_head_notice(notice, RESUME_START_NOTICE, "info")
+            # `note` for the same reason the two states below use it, and this
+            # is the state the audit phase made load-bearing: before audit
+            # paging, "start of conversation" appeared at the compaction cut
+            # and was simply false, so its quietness cost nothing. It now
+            # appears only when the journal's first message row has genuinely
+            # been reached, which makes it the definitive answer to "where did
+            # my history go" — and it was the one state of the six still
+            # rendered at `info`/`dim`, 3.77:1 on the light theme against the
+            # 4.5:1 AA floor (design review round 1, D4).
+            self._restate_head_notice(notice, RESUME_START_NOTICE, "note")
         elif not scrollable and self._resume_fill_active:
             # A fill attempt is still in flight, and the frame it is about to
             # produce is the one worth describing. Stating "unreachable" from

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1026,6 +1026,26 @@ RESUME_START_NOTICE = "start of conversation"
 #: keyboard chord the product documents nowhere else.
 RESUME_UNREACHABLE_NOTICE = "older messages above — select to load"
 
+#: The audit-phase twins of the two notices above, shown once the reader has
+#: drained everything the model can still see and the rows above are
+#: PRE-COMPACTION history.
+#:
+#: "earlier history", deliberately not "older messages": the two phases differ
+#: in kind, not merely in age, and a reader who has just crossed the compaction
+#: marker should see the vocabulary change with it rather than be told the same
+#: sentence about materially different rows.
+#:
+#: These are what make ``RESUME_START_NOTICE`` honest. Before audit paging
+#: existed the head notice went straight to "start of conversation" at the
+#: compaction cut — a faithful report of a history layer that had discarded the
+#: rows, and still a false statement about the conversation. It now appears
+#: only when the journal's first message row has actually been reached.
+RESUME_AUDIT_NOTICE = "earlier history above — scroll up to load"
+
+#: The unreachable twin: more pre-compaction history exists but this frame
+#: cannot be scrolled to it, so the row offers itself as the control instead.
+RESUME_AUDIT_UNREACHABLE_NOTICE = "earlier history above — select to load"
+
 
 @dataclass(frozen=True)
 class _PagingLease:
@@ -7955,6 +7975,13 @@ class OperatorApp(App[None]):
         more = bool(self._resume_pending_head) or bool(
             session is not None and getattr(session, "history_before_token", None)
         )
+        # Which VOCABULARY the two "more exists" states use. Once the context
+        # replay is drained, what remains above is pre-compaction history — a
+        # different kind of row, not merely an older one — so the copy says
+        # "earlier history" rather than "older messages". Absent on an owner
+        # too old to page audit rows, which is exactly when the pre-audit copy
+        # is still the correct thing to say.
+        audit = bool(session is not None and getattr(session, "history_is_audit", False))
         if not more:
             self._restate_head_notice(notice, RESUME_START_NOTICE, "info")
         elif not scrollable and self._resume_fill_active:
@@ -7975,12 +8002,18 @@ class OperatorApp(App[None]):
             # on. `info` maps to `dim`, which measures 3.77:1 on the light
             # theme — below the 4.5:1 AA floor — so the row got quieter
             # exactly as it got more important.
-            self._restate_head_notice(notice, RESUME_UNREACHABLE_NOTICE, "note")
+            self._restate_head_notice(
+                notice,
+                RESUME_AUDIT_UNREACHABLE_NOTICE if audit else RESUME_UNREACHABLE_NOTICE,
+                "note",
+            )
         else:
             # The way BACK. More history exists and the frame can now reach it,
             # so the instruction is followable again and the notice returns to
             # stating the promise it can keep.
-            self._restate_head_notice(notice, RESUME_OLDER_NOTICE, "note")
+            self._restate_head_notice(
+                notice, RESUME_AUDIT_NOTICE if audit else RESUME_OLDER_NOTICE, "note"
+            )
 
     @staticmethod
     def _restate_head_notice(notice: NoticeBlock, text: str, kind: NoticeKind) -> None:

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -35,6 +35,15 @@ from local_operator.tui.widgets.transcript import (
 #: to measure a real presentation against it before changing it.
 RETAIN_TEXT_BYTES = 1024 * 1024
 
+#: The in-transcript seam between what the agent still sees and what it does
+#: not. Both halves of that sentence have to be on screen: the rows below the
+#: marker are REAL history (so the reader is not being told anything was lost)
+#: and they are outside the model's context (so the reader is not misled into
+#: thinking the agent can still refer to them).
+COMPACTION_MARKER_NOTICE = (
+    "context compacted here — older messages below are history the agent no longer sees"
+)
+
 
 class HistoryPageNotice(NoticeBlock, can_focus=True):
     BINDINGS = [Binding("enter", "more", "More recent messages", show=False)]
@@ -497,7 +506,10 @@ def project_settled_rows(
     """
     from contextlib import nullcontext
 
-    from local_operator.compaction.marker import COMPACTION_REFUSED_TYPE
+    from local_operator.compaction.marker import (
+        COMPACTION_MARKER_TYPE,
+        COMPACTION_REFUSED_TYPE,
+    )
     from local_operator.harness.approval import GATE_TIMEOUT_CUSTOM_TYPE
 
     # The row DECISIONS this fold shares with the phone's. Held outside both
@@ -667,6 +679,26 @@ def project_settled_rows(
                 details = getattr(message, "details", None) or {}
                 text, kind = compaction_refused_notice(details)
                 self._append_block(NoticeBlock(text, kind=kind))
+                appended = True
+                continue
+            # The compaction boundary itself. The replay layer has always
+            # emitted this row, and it rendered as NOTHING: it is a custom
+            # message, so it fell past every branch above and then past the
+            # role-based handling below, which drops what it does not
+            # recognise. That was survivable while the row only ever sat at the
+            # very top of the model's replay; it is not survivable now that
+            # audit paging puts one at each compaction MID-transcript, because
+            # the reader would scroll from live conversation into
+            # pre-compaction history with no sign of the seam.
+            #
+            # `note`, not `info`, for the reason `RESUME_UNREACHABLE_NOTICE`
+            # is: this answers "where did my history go", and `info` maps to
+            # `dim`, which measures below the AA contrast floor on the light
+            # theme. Nothing went wrong here, so it is neither a warning nor an
+            # error — the rows below are real history, they are simply outside
+            # what the agent can still see.
+            if getattr(message, "custom_type", None) == COMPACTION_MARKER_TYPE:
+                self._append_block(NoticeBlock(COMPACTION_MARKER_NOTICE, kind="note"))
                 appended = True
                 continue
             role = getattr(message, "role", None)

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -53,13 +53,42 @@ RETAIN_TEXT_BYTES = 1024 * 1024
 #: the wrong way is worse for a trusting reader than the silent nothing it
 #: replaced.
 #:
-#: Keep it UNDER ~76 characters. The glyph prefix costs 2 columns, so a longer
-#: string wraps at an 80-column terminal and orphans its last words on a second
-#: line — at every compaction, 48 times in the reference journal (D2). The
-#: captured evidence geometries (98 and 138 usable columns) cannot show that,
-#: so width is a review-time arithmetic check rather than something a frame
-#: will catch.
-COMPACTION_MARKER_NOTICE = "context compacted here — earlier history above the agent no longer sees"
+#: Keep it at 66 characters or fewer, and CHECK THAT IN A RENDERED 80-COLUMN
+#: FRAME rather than by counting. A longer string wraps and orphans its last
+#: word on a second line, at every compaction — 48 times in the reference
+#: journal (D2). The budget is not the terminal width: an 80-column terminal
+#: leaves a 78-column screen, the notice block's own padding takes more, and
+#: the ``· `` glyph costs 2, which measured out to 68 columns of text and so
+#: 66 for this string. Round 1 suggested "under ~76" from arithmetic alone and
+#: the 71-character string it produced still wrapped in the frame; the only
+#: instrument that settles it is ``scripts/audit_history_shot.py marker
+#: 80x30``.
+COMPACTION_MARKER_NOTICE = "context compacted — earlier history above the agent no longer sees"
+
+
+class CompactionMarkerBlock(NoticeBlock):
+    """The compaction seam, spaced apart from whatever it lands beside.
+
+    A plain ``NoticeBlock`` would be right in every respect but one. In the
+    audit state the head notice sits directly above this row, and the two share
+    a ``SPACING_KIND`` of ``notice``, so the adaptive rule stacks them flush
+    (see :func:`needs_gap_above`: same kind, previous is one row, no gap). They
+    also share the ``·`` glyph and the ``note`` ink, and after the round-1 copy
+    fix they open with nearly the same words — "earlier history above — scroll
+    up to load" over "context compacted — earlier history above …". Design
+    review round 1 (D3) flagged the pair as indistinguishable, and the D1 fix
+    alone did not resolve it: verified in a rendered 80x30 frame, the two rows
+    still read as one wrapped block, with nothing to say that the first is a
+    CONTROL (focusable, clickable, `enter`-bound) and this one is inert.
+
+    ``SPACING_AIRY`` is the mechanism the tool ledger already uses for exactly
+    this — "each row is a separate thing, not a paragraph of one" — so the seam
+    takes a blank row above itself rather than earning a second glyph or a
+    second ink. The designer's own preference, and it keeps ``NOTICE_GLYPHS``'
+    deliberate sharing of ``·`` between ``info`` and ``note`` intact.
+    """
+
+    SPACING_AIRY = True
 
 
 class HistoryPageNotice(NoticeBlock, can_focus=True):
@@ -715,7 +744,7 @@ def project_settled_rows(
             # error — the rows below are real history, they are simply outside
             # what the agent can still see.
             if getattr(message, "custom_type", None) == COMPACTION_MARKER_TYPE:
-                self._append_block(NoticeBlock(COMPACTION_MARKER_NOTICE, kind="note"))
+                self._append_block(CompactionMarkerBlock(COMPACTION_MARKER_NOTICE, kind="note"))
                 appended = True
                 continue
             role = getattr(message, "role", None)

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -53,16 +53,30 @@ RETAIN_TEXT_BYTES = 1024 * 1024
 #: the wrong way is worse for a trusting reader than the silent nothing it
 #: replaced.
 #:
-#: Keep it at 66 characters or fewer, and CHECK THAT IN A RENDERED 80-COLUMN
-#: FRAME rather than by counting. A longer string wraps and orphans its last
-#: word on a second line, at every compaction — 48 times in the reference
-#: journal (D2). The budget is not the terminal width: an 80-column terminal
-#: leaves a 78-column screen, the notice block's own padding takes more, and
-#: the ``· `` glyph costs 2, which measured out to 68 columns of text and so
-#: 66 for this string. Round 1 suggested "under ~76" from arithmetic alone and
-#: the 71-character string it produced still wrapped in the frame; the only
-#: instrument that settles it is ``scripts/audit_history_shot.py marker
-#: 80x30``.
+#: The wrap budget at 80 columns is 70 text columns, and the MECHANICAL check
+#: is ``NoticeBlock.body_budget(76) == 70`` rather than hand arithmetic (design
+#: review round 2, D6). The chain, measured on a block mounted in an 80x30
+#: pilot rather than reasoned on paper: an 80-column terminal gives a 78-column
+#: screen; ``scrollbar-gutter: stable`` on ``TranscriptView`` permanently
+#: reserves one more column whether or not the bar is visible (77); the view's
+#: own left padding takes one (76, which is the width the block is actually
+#: painted); ``_build`` folds at ``max(width - 2, 12)`` (74); and the hanging
+#: glyph field is ``GLYPH_COLS`` = ``SPINE_INDENT + 2`` = 4, not 2 (70).
+#: Corroborated by rendered block height at that geometry: a 70-character
+#: string is one row, a 71-character string is two.
+#:
+#: This string is 66, so it sits 4 columns inside the budget, and the unit
+#: guard pins 66 rather than 70 — a copy change that wants the headroom has to
+#: move that guard deliberately. Do NOT re-derive the budget from the older
+#: "68 usable, so 66" arithmetic: it landed on a safe number through two
+#: COMPENSATING errors — it subtracted neither the reserved scrollbar column
+#: nor the fold clamp, and charged the glyph 2 where it costs 4 — so it cannot
+#: be carried to any other width. Round 1's "under ~76", also derived on
+#: paper, produced a 71-character string that still wrapped in the frame. That
+#: is why a longer string is checked in a RENDERED frame rather than counted:
+#: it orphans its last word on a second line at every compaction, 48 times in
+#: the reference journal (D2). Capture one with
+#: ``scripts/audit_history_shot.py <dir> marker 80x30``.
 COMPACTION_MARKER_NOTICE = "context compacted — earlier history above the agent no longer sees"
 
 

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -36,13 +36,30 @@ from local_operator.tui.widgets.transcript import (
 RETAIN_TEXT_BYTES = 1024 * 1024
 
 #: The in-transcript seam between what the agent still sees and what it does
-#: not. Both halves of that sentence have to be on screen: the rows below the
-#: marker are REAL history (so the reader is not being told anything was lost)
-#: and they are outside the model's context (so the reader is not misled into
+#: not. Both halves of that sentence have to be on screen: the rows it points
+#: at are REAL history (so the reader is not being told anything was lost) and
+#: they are outside the model's context (so the reader is not misled into
 #: thinking the agent can still refer to them).
-COMPACTION_MARKER_NOTICE = (
-    "context compacted here — older messages below are history the agent no longer sees"
-)
+#:
+#: The direction is ABOVE, and it is not interchangeable with "below". A
+#: transcript paints oldest-at-top, so the pre-compaction rows sit above this
+#: marker and the rows below it are the newer ones the model still sees.
+#: Design review round 1 (D1) measured both halves of the original "older
+#: messages below" wording against real mounted block positions and against
+#: ``mode="context"`` membership: rows BELOW a marker were 100% still in
+#: context — exactly what the sentence claimed the agent could not see — while
+#: the rows above were 0-1%. Audit reading is the one task where someone is
+#: reasoning about which rows the agent could have used, so a marker pointing
+#: the wrong way is worse for a trusting reader than the silent nothing it
+#: replaced.
+#:
+#: Keep it UNDER ~76 characters. The glyph prefix costs 2 columns, so a longer
+#: string wraps at an 80-column terminal and orphans its last words on a second
+#: line — at every compaction, 48 times in the reference journal (D2). The
+#: captured evidence geometries (98 and 138 usable columns) cannot show that,
+#: so width is a review-time arithmetic check rather than something a frame
+#: will catch.
+COMPACTION_MARKER_NOTICE = "context compacted here — earlier history above the agent no longer sees"
 
 
 class HistoryPageNotice(NoticeBlock, can_focus=True):

--- a/scripts/audit_history_shot.py
+++ b/scripts/audit_history_shot.py
@@ -9,11 +9,22 @@ lightweight test host declares no ``CSS_PATH`` and would show none of this.
 Usage::
 
     env -u NO_COLOR TERM=xterm-256color .venv/bin/python \\
-        scripts/audit_history_shot.py <out-dir> [state]
+        scripts/audit_history_shot.py <out-dir> [state] [COLSxROWS]
 
 States: ``context`` (rows the model still sees), ``audit`` (pre-compaction
 rows), ``exhausted`` (the journal's first row reached), ``marker`` (the
 compaction boundary mid-transcript), or ``all``.
+
+The geometry argument is not decoration. A head-notice state is a function of
+the VIEWPORT as well as the history: ``_reconcile_head_notice`` chooses between
+its scrollable and not-scrollable copy from ``virtual_size`` against
+``container_size``, so a frame captured at one size can show a state that does
+not reproduce at another. Capture the states you are claiming at more than one
+geometry, and say in the evidence which one each frame is.
+
+Two frames are written per capture, ``<state>.svg`` and ``<state>.settled.svg``,
+taken before and after a further settle. They must be identical for a static
+state; a difference is a reflow the reader sees as motion.
 """
 
 from __future__ import annotations
@@ -95,7 +106,7 @@ async def _seed(directory: Path, *, compactions: int, rows_each: int) -> None:
     transcript.flush()
 
 
-async def capture(out_dir: Path, state: str) -> None:
+async def capture(out_dir: Path, state: str, size: tuple[int, int] = (100, 34)) -> None:
     root = Path(os.environ["HOME"])
     config = root / "config"
     config.mkdir(parents=True, exist_ok=True)
@@ -122,7 +133,7 @@ async def capture(out_dir: Path, state: str) -> None:
 
     try:
         app = OperatorApp(factory)
-        async with app.run_test(size=(100, 34)) as pilot:
+        async with app.run_test(size=size) as pilot:
             for _ in range(300):
                 await pilot.pause()
                 if app._session is not None and app._transcript_view().blocks():
@@ -230,6 +241,12 @@ async def capture(out_dir: Path, state: str) -> None:
             )
             out_dir.mkdir(parents=True, exist_ok=True)
             save_capture(app, str(out_dir / f"{state}.svg"))
+            # Second frame after a further settle. A static state must produce
+            # a byte-identical pair; a difference is a reflow the reader sees
+            # as motion, and the evidence has to be able to show that.
+            for _ in range(30):
+                await pilot.pause()
+            save_capture(app, str(out_dir / f"{state}.settled.svg"))
     finally:
         await remote.dispose()
         server.close()
@@ -239,9 +256,12 @@ async def capture(out_dir: Path, state: str) -> None:
 async def main() -> None:
     out_dir = Path(sys.argv[1])
     requested = sys.argv[2] if len(sys.argv) > 2 else "all"
+    geometry = sys.argv[3] if len(sys.argv) > 3 else "100x34"
+    columns, _, rows = geometry.partition("x")
+    size = (int(columns), int(rows))
     states = ["context", "audit", "exhausted", "marker"] if requested == "all" else [requested]
     for state in states:
-        await capture(out_dir, state)
+        await capture(out_dir, state, size)
 
 
 if __name__ == "__main__":

--- a/scripts/audit_history_shot.py
+++ b/scripts/audit_history_shot.py
@@ -1,10 +1,11 @@
 """Rendered frames of the durable audit-history surface.
 
-Captures the head notice in each state of the §4 copy table, plus the
-compaction marker as it renders mid-transcript. Drives the REAL ``OperatorApp``
-against a REAL owner runtime over the real socket, so the stylesheet is applied
-and the pages come back through the same RPC the TUI uses in production — a
-lightweight test host declares no ``CSS_PATH`` and would show none of this.
+Captures the head notice in each state of the §4 copy table in
+``docs/design/full-history-audit-window.md``, plus the compaction marker as it
+renders mid-transcript. Drives the REAL ``OperatorApp`` against a REAL owner
+runtime over the real socket, so the stylesheet is applied and the pages come
+back through the same RPC the TUI uses in production — a lightweight test host
+declares no ``CSS_PATH`` and would show none of this.
 
 Usage::
 
@@ -22,9 +23,17 @@ its scrollable and not-scrollable copy from ``virtual_size`` against
 not reproduce at another. Capture the states you are claiming at more than one
 geometry, and say in the evidence which one each frame is.
 
-Two frames are written per capture, ``<state>.svg`` and ``<state>.settled.svg``,
-taken before and after a further settle. They must be identical for a static
-state; a difference is a reflow the reader sees as motion.
+Two frames are written per capture, ``<state>.<COLS>x<ROWS>.svg`` and
+``<state>.<COLS>x<ROWS>.settled.svg``, taken before and after a further settle.
+They must be identical for a static state; a difference is a reflow the reader
+sees as motion.
+
+The GEOMETRY is in the filename deliberately. It used to name frames by state
+alone, so capturing two geometries into one directory left files that were
+silently all the second run — a design reviewer's settle check "passed" over
+four such overwritten files before the collision was spotted. Since the whole
+point of the geometry argument is to compare sizes, the output names have to
+distinguish them or the script quietly destroys the comparison it exists for.
 """
 
 from __future__ import annotations
@@ -240,13 +249,14 @@ async def capture(out_dir: Path, state: str, size: tuple[int, int] = (100, 34)) 
                 f"| more={bool(remote.history_before_token)}"
             )
             out_dir.mkdir(parents=True, exist_ok=True)
-            save_capture(app, str(out_dir / f"{state}.svg"))
+            stem = f"{state}.{size[0]}x{size[1]}"
+            save_capture(app, str(out_dir / f"{stem}.svg"))
             # Second frame after a further settle. A static state must produce
             # a byte-identical pair; a difference is a reflow the reader sees
             # as motion, and the evidence has to be able to show that.
             for _ in range(30):
                 await pilot.pause()
-            save_capture(app, str(out_dir / f"{state}.settled.svg"))
+            save_capture(app, str(out_dir / f"{stem}.settled.svg"))
     finally:
         await remote.dispose()
         server.close()

--- a/scripts/audit_history_shot.py
+++ b/scripts/audit_history_shot.py
@@ -1,0 +1,248 @@
+"""Rendered frames of the durable audit-history surface.
+
+Captures the head notice in each state of the §4 copy table, plus the
+compaction marker as it renders mid-transcript. Drives the REAL ``OperatorApp``
+against a REAL owner runtime over the real socket, so the stylesheet is applied
+and the pages come back through the same RPC the TUI uses in production — a
+lightweight test host declares no ``CSS_PATH`` and would show none of this.
+
+Usage::
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \\
+        scripts/audit_history_shot.py <out-dir> [state]
+
+States: ``context`` (rows the model still sees), ``audit`` (pre-compaction
+rows), ``exhausted`` (the journal's first row reached), ``marker`` (the
+compaction boundary mid-transcript), or ``all``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Any pilot that boots the TUI must not inherit the operator's cmux identity:
+# a headless test carrying a real CMUX_WORKSPACE_ID has previously renamed his
+# live workspaces. Cleared before the app is imported, alongside HOME/config
+# isolation.
+for _name in [key for key in os.environ if key.startswith("CMUX_")]:
+    del os.environ[_name]
+
+from scripts.visual_capture import isolate_capture, save_capture  # noqa: E402
+
+isolate_capture()
+
+from local_operator.harness.types import Message, TextContent  # noqa: E402
+from local_operator.session.remote import RemoteSession  # noqa: E402
+from local_operator.session.runtime.owned import OwnedSessionHandle  # noqa: E402
+from local_operator.session.runtime.server import RuntimeServer  # noqa: E402
+from local_operator.session.transcript import Transcript  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from tests.e2e.harness import ScriptedStream, build_session, text_turn  # noqa: E402
+from tests.unit.session.test_remote import _never_take_over  # noqa: E402
+
+
+async def _seed(directory: Path, *, compactions: int, rows_each: int) -> None:
+    """A journal with real compaction cuts, as a long-running session has."""
+    directory.mkdir(parents=True, exist_ok=True)
+    transcript = Transcript(directory)
+    for cut in range(compactions):
+        batch = []
+        for index in range(rows_each):
+            user = index % 2 == 0
+            batch.append(
+                Message(
+                    id=f"cut{cut}-row-{index:04}",
+                    role="user" if user else "assistant",
+                    content=[
+                        TextContent(
+                            text=(
+                                f"What did we decide about phase {cut}, item {index}?"
+                                if user
+                                else f"In phase {cut} we settled item {index} by "
+                                "recording the constraint and moving on."
+                            )
+                        )
+                    ],
+                    stop_reason="stop",
+                )
+            )
+        for message in batch:
+            await transcript.append_message(message)
+        await transcript.append_compaction(f"phase {cut} summary", batch[-1].id, 500)
+    for index in range(rows_each):
+        user = index % 2 == 0
+        await transcript.append_message(
+            Message(
+                id=f"tail-row-{index:04}",
+                role="user" if user else "assistant",
+                content=[
+                    TextContent(
+                        text=(
+                            f"And the current question {index}?"
+                            if user
+                            else f"Currently we are on question {index}, still in context."
+                        )
+                    )
+                ],
+                stop_reason="stop",
+            )
+        )
+    transcript.flush()
+
+
+async def capture(out_dir: Path, state: str) -> None:
+    root = Path(os.environ["HOME"])
+    config = root / "config"
+    config.mkdir(parents=True, exist_ok=True)
+    (config / "config.yml").write_text(
+        "version: 0.0.0\nvalues:\n  hosting: test\n  model_name: mock\n"
+    )
+    directory = config / "sessions" / f"shot-{state}"
+    rows_each = 30 if state == "marker" else 400
+    await _seed(directory, compactions=6 if state != "marker" else 3, rows_each=rows_each)
+    session = build_session(directory, ScriptedStream([text_turn("unused")]), cwd=root)
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(root))
+    server = RuntimeServer(handle, kind="daemon")
+    await server.start_in_process()
+    remote = await RemoteSession.connect(
+        server._record,
+        directory.name,
+        config_dir=config,
+        takeover_factory=_never_take_over,
+        display_window=True,
+    )
+
+    async def factory():
+        return remote
+
+    try:
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 34)) as pilot:
+            for _ in range(300):
+                await pilot.pause()
+                if app._session is not None and app._transcript_view().blocks():
+                    break
+            for _ in range(40):
+                await pilot.pause()
+
+            async def page_once() -> bool:
+                """Fetch one older page INTO the app's deferred-head buffer.
+
+                Mirrors what ``_fetch_older_resume_page`` does on the reader's
+                scroll: rows fetched straight off the session would never enter
+                the frame, which is how an earlier version of this script
+                captured a tail while claiming to show the head.
+                """
+                if not remote.history_before_token:
+                    return False
+                rows = await remote.load_older_display_page()
+                if not rows:
+                    return False
+                app._resume_pending_head = rows + app._resume_pending_head
+                for message in rows:
+                    if getattr(message, "role", "") == "tool" and getattr(
+                        message, "tool_call_id", None
+                    ):
+                        app._resume_results[message.tool_call_id] = message
+                await pilot.pause()
+                return True
+
+            if state in ("audit", "exhausted", "marker"):
+                # Walk into the pre-compaction phase the way a reader does.
+                for _ in range(1200):
+                    if state == "audit" and remote.history_is_audit:
+                        break
+                    if not await page_once():
+                        break
+
+            if state == "marker":
+                # Mount pages until the compaction boundary is on screen.
+                from local_operator.tui.session_presentation import (
+                    COMPACTION_MARKER_NOTICE,
+                )
+                from local_operator.tui.widgets.transcript import NoticeBlock
+
+                # Drive the reader's OWN gesture rather than the transport:
+                # rows only enter the view through the app's paging path, so
+                # calling the session directly would fetch pages the frame
+                # never shows.
+                marker = None
+                for _ in range(600):
+                    blocks = app._transcript_view().blocks()
+                    marker = next(
+                        (
+                            block
+                            for block in blocks
+                            if isinstance(block, NoticeBlock)
+                            and getattr(block, "text", None)
+                            and block.text() == COMPACTION_MARKER_NOTICE
+                        ),
+                        None,
+                    )
+                    if marker is not None or not app._resume_pending_head:
+                        break
+                    app._mount_older_resume_page()
+                    await pilot.pause()
+                if marker is None:
+                    raise SystemExit("no compaction marker mounted")
+                # Put the boundary a few rows below the top of the frame, so
+                # the shot shows what a reader crossing it actually sees: live
+                # conversation above, the marker, pre-compaction rows below.
+                view = app._transcript_view()
+                for _ in range(10):
+                    await pilot.pause()
+                # A few rows ABOVE the boundary, so the frame shows both sides
+                # of it: pre-compaction history, the marker, then rows the
+                # agent can still see.
+                view.scroll_to(
+                    y=max(0, marker.virtual_region.y - 10), animate=False, immediate=True
+                )
+                for _ in range(10):
+                    await pilot.pause()
+            else:
+                # "exhausted" is the claim that the reader reached the JOURNAL's
+                # first row, so mount everything and show that row. The other
+                # states keep one page pending, because the head notice only
+                # exists while rows are still deferred.
+                floor = 0 if state == "exhausted" else 1
+                while len(app._resume_pending_head) > floor:
+                    app._mount_older_resume_page()
+                    await pilot.pause()
+                app._transcript_view().scroll_to(y=0, animate=False, immediate=True)
+                for _ in range(10):
+                    await pilot.pause()
+
+            app._reconcile_head_notice()
+            for _ in range(10):
+                await pilot.pause()
+
+            notice = app._resume_head_notice
+            print(
+                f"[{state}] head notice: "
+                f"{notice.text() if notice is not None else '<none>'!r} "
+                f"| audit={remote.history_is_audit} "
+                f"| more={bool(remote.history_before_token)}"
+            )
+            out_dir.mkdir(parents=True, exist_ok=True)
+            save_capture(app, str(out_dir / f"{state}.svg"))
+    finally:
+        await remote.dispose()
+        server.close()
+        await handle.dispose()
+
+
+async def main() -> None:
+    out_dir = Path(sys.argv[1])
+    requested = sys.argv[2] if len(sys.argv) > 2 else "all"
+    states = ["context", "audit", "exhausted", "marker"] if requested == "all" else [requested]
+    for state in states:
+        await capture(out_dir, state)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/unit/session/runtime/test_display_history_audit_capability.py
+++ b/tests/unit/session/runtime/test_display_history_audit_capability.py
@@ -1,0 +1,203 @@
+"""Cross-version safety for the audit fields on a display page.
+
+The hazard this file exists for is a HARD attach break, not a degradation.
+:class:`DisplayHistoryWindow` sets ``extra="forbid"``, so a viewer built before
+the audit fields existed RAISES when it validates a payload carrying them, and
+the viewer turns that into a failed attach — no history, no session. Mixed
+builds against one sessions directory are routine on a development machine: the
+global runtime is a separate uv-tool install updated on its own schedule, so a
+repo checkout's venv and the global binary regularly attach to each other.
+
+``display-history-window-v1`` cannot express this. It is advertised on the mere
+PRESENCE of ``history_page`` and carries no version, so a second capability
+string is the only thing that can distinguish "pages history" from "pages
+pre-compaction history too".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.harness.types import Message
+from local_operator.session.history_window import (
+    AUDIT_WIRE_FIELDS,
+    DISPLAY_HISTORY_AUDIT_CAPABILITY,
+    DisplayHistoryWindow,
+    display_window,
+)
+from local_operator.session.runtime.owned import OwnedSessionHandle
+from local_operator.session.runtime.server import RuntimeServer
+from local_operator.session.transcript import Transcript
+from tests.e2e.harness import ScriptedStream, build_session, seed_transcript, text_turn
+
+
+async def _server(tmp_path: Path, rows: list[Message]):
+    directory = tmp_path / "sessions" / "audit-capability"
+    await seed_transcript(directory, rows)
+    session = build_session(directory, ScriptedStream([text_turn("unused")]), cwd=tmp_path)
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(tmp_path))
+    server = RuntimeServer(handle, kind="daemon")
+    await server.start_in_process()
+    return server
+
+
+async def _attach(server: RuntimeServer, *, announce_audit: bool) -> dict[str, Any]:
+    """Attach as a viewer that does or does not know the audit capability.
+
+    Speaks the wire protocol directly rather than through ``AttachClient``,
+    because the point is to reproduce a viewer whose BUILD predates the field —
+    which the current client can no longer be talked into being.
+    """
+    record = server._record
+    reader, writer = await asyncio.open_connection("127.0.0.1", record.control_port)
+    auth = {
+        "key": record.control_key,
+        "client": "attach",
+        "locality": "local",
+        "frontend_state": True,
+        "display_window": True,
+    }
+    if announce_audit:
+        auth["display_history_audit"] = True
+    writer.write(json.dumps(auth).encode() + b"\n")
+    await writer.drain()
+    frames = []
+    try:
+        while True:
+            line = await asyncio.wait_for(reader.readline(), timeout=10)
+            if not line:
+                break
+            frame = json.loads(line)
+            frames.append(frame)
+            if frame.get("op") == "frontend_sync":
+                return frame["data"]
+    finally:
+        writer.close()
+    raise AssertionError(f"no frontend_sync frame arrived: {frames}")
+
+
+@pytest.mark.asyncio
+async def test_owner_advertises_the_audit_capability_beside_the_window_one(tmp_path) -> None:
+    server = await _server(tmp_path, [Message.user("row")])
+    try:
+        assert DISPLAY_HISTORY_AUDIT_CAPABILITY in server._record.capabilities
+        assert "display-history-window-v1" in server._record.capabilities
+    finally:
+        server.close()
+
+
+@pytest.mark.asyncio
+async def test_a_viewer_that_did_not_negotiate_receives_no_audit_keys(tmp_path) -> None:
+    """The §6 break, asserted end to end.
+
+    An old viewer's page model forbids extra keys, so the payload it receives
+    must not contain them — and the proof is that the page model validates it.
+    """
+    server = await _server(tmp_path, [Message.user(f"row {i}") for i in range(5)])
+    try:
+        payload = await _attach(server, announce_audit=False)
+        window = payload["display_history"]
+        assert window is not None
+        for name in AUDIT_WIRE_FIELDS:
+            assert name not in window, f"{name} leaked to a viewer that cannot accept it"
+
+        # An old viewer would validate exactly this dict under extra="forbid".
+        # Rebuilt from the model with the new fields removed, so the assertion
+        # is about the WIRE payload rather than about a hand-written schema.
+        legacy_fields = {
+            name: field
+            for name, field in DisplayHistoryWindow.model_fields.items()
+            if name not in AUDIT_WIRE_FIELDS
+        }
+        assert set(window) <= set(legacy_fields)
+    finally:
+        server.close()
+
+
+@pytest.mark.asyncio
+async def test_a_viewer_that_negotiated_receives_the_audit_keys(tmp_path) -> None:
+    server = await _server(tmp_path, [Message.user(f"row {i}") for i in range(5)])
+    try:
+        payload = await _attach(server, announce_audit=True)
+        window = payload["display_history"]
+        for name in AUDIT_WIRE_FIELDS:
+            assert name in window
+        DisplayHistoryWindow.model_validate(window)
+    finally:
+        server.close()
+
+
+@pytest.mark.asyncio
+async def test_a_history_page_rpc_strips_the_keys_for_an_old_viewer(tmp_path) -> None:
+    """The second emission point. Stripping only the sync frame would produce a
+    viewer that attaches cleanly and then fails on its first scroll up."""
+    rows = [Message.user(f"row {index}") for index in range(300)]
+    server = await _server(tmp_path, rows)
+    try:
+        record = server._record
+        reader, writer = await asyncio.open_connection("127.0.0.1", record.control_port)
+        writer.write(
+            json.dumps(
+                {
+                    "key": record.control_key,
+                    "client": "attach",
+                    "locality": "local",
+                    "frontend_state": True,
+                    "display_window": True,
+                }
+            ).encode()
+            + b"\n"
+        )
+        await writer.drain()
+        sync = None
+        while sync is None:
+            line = await asyncio.wait_for(reader.readline(), timeout=10)
+            frame = json.loads(line)
+            if frame.get("op") == "frontend_sync":
+                sync = frame["data"]
+        token = sync["display_history"]["before_token"]
+        assert token, "the fixture must be long enough to page"
+        writer.write(
+            json.dumps({"op": "history_page", "req": "r1", "before": token}).encode() + b"\n"
+        )
+        await writer.drain()
+        page = None
+        while page is None:
+            line = await asyncio.wait_for(reader.readline(), timeout=10)
+            frame = json.loads(line)
+            if frame.get("req") == "r1":
+                assert frame.get("op") == "result", frame
+                page = frame["data"]
+        for name in AUDIT_WIRE_FIELDS:
+            assert name not in page
+        writer.close()
+    finally:
+        server.close()
+
+
+@pytest.mark.asyncio
+async def test_a_new_viewer_against_an_owner_without_the_capability_is_safe(tmp_path) -> None:
+    """The reverse direction, which is safe by construction and worth pinning.
+
+    The fields are absent from the payload, Pydantic supplies ``False``, and the
+    viewer therefore never asks for an audit page it cannot be served.
+    """
+    transcript = Transcript(tmp_path / "s")
+    await transcript.append_messages([Message.user("row")])
+    page = display_window(
+        transcript,
+        conversation_id="c",
+        owner_epoch="e",
+        through_id=transcript.entries()[-1].id,
+    )
+    payload = page.model_dump(mode="json")
+    for name in AUDIT_WIRE_FIELDS:
+        payload.pop(name)
+    restored = DisplayHistoryWindow.model_validate(payload)
+    assert restored.audit is False
+    assert restored.audit_available is False

--- a/tests/unit/session/runtime/test_display_history_audit_capability.py
+++ b/tests/unit/session/runtime/test_display_history_audit_capability.py
@@ -132,6 +132,97 @@ async def test_a_viewer_that_negotiated_receives_the_audit_keys(tmp_path) -> Non
         server.close()
 
 
+async def _rpc_frontend_sync(server: RuntimeServer, *, announce_audit: bool) -> dict[str, Any]:
+    """Attach, drain the push frames, then CALL the frontend_sync RPC op.
+
+    Deliberately NOT the pushed ``frontend_sync`` FRAME that ``_attach`` above
+    reads. The frame and the op are different code paths, and covering only the
+    frame is why the unstripped op shipped green through round 1 (QA Q1 /
+    review R1).
+    """
+    record = server._record
+    reader, writer = await asyncio.open_connection("127.0.0.1", record.control_port)
+    auth = {
+        "key": record.control_key,
+        "client": "attach",
+        "locality": "local",
+        "frontend_state": True,
+        "display_window": True,
+    }
+    if announce_audit:
+        auth["display_history_audit"] = True
+    writer.write(json.dumps(auth).encode() + b"\n")
+    await writer.drain()
+
+    # Wait for the pushed sync so the connection is fully established, exactly
+    # as a real viewer does before it ever issues a refresh.
+    while True:
+        line = await asyncio.wait_for(reader.readline(), timeout=10)
+        if not line:
+            raise AssertionError("connection closed before the push frame")
+        if json.loads(line).get("op") == "frontend_sync":
+            break
+
+    # The RPC under test.
+    writer.write(json.dumps({"op": "frontend_sync", "req": 1}).encode() + b"\n")
+    await writer.drain()
+    try:
+        while True:
+            line = await asyncio.wait_for(reader.readline(), timeout=10)
+            if not line:
+                raise AssertionError("connection closed before the result frame")
+            frame = json.loads(line)
+            if frame.get("op") == "result" and frame.get("req") == 1:
+                return frame["data"]
+    finally:
+        writer.close()
+
+
+@pytest.mark.asyncio
+async def test_frontend_sync_rpc_strips_the_keys_for_an_old_viewer(tmp_path) -> None:
+    """An old viewer's history REFRESH must not receive fields it forbids.
+
+    The steady-state path, not a race: ``_refresh_display_history`` calls this
+    op whenever the frontend's ``history_generation`` moves, so an old viewer
+    attached to a new owner hits it as soon as the owner appends a row. The
+    fields serialize on an UNCOMPACTED page too, so a single-row fixture is
+    enough to reproduce it.
+    """
+    server = await _server(tmp_path, [Message.user("row")])
+    try:
+        data = await _rpc_frontend_sync(server, announce_audit=False)
+    finally:
+        server.close()
+    window = data.get("display_history")
+    assert isinstance(window, dict), "the RPC returned no display page"
+    leaked = [field for field in AUDIT_WIRE_FIELDS if field in window]
+    assert not leaked, (
+        f"the frontend_sync RPC leaked {leaked} to a viewer that did not "
+        f"negotiate display-history-audit-v1; its DisplayHistoryWindow sets "
+        f"extra='forbid', so its refresh raises"
+    )
+
+
+@pytest.mark.asyncio
+async def test_frontend_sync_rpc_keeps_the_keys_for_a_new_viewer(tmp_path) -> None:
+    """CANARY (known-positive): the same probe must SEE the fields when the
+    viewer did negotiate. Without this, a pass above could mean the fields are
+    simply never emitted on this route and the test would prove nothing."""
+    server = await _server(tmp_path, [Message.user("row")])
+    try:
+        data = await _rpc_frontend_sync(server, announce_audit=True)
+    finally:
+        server.close()
+    window = data.get("display_history")
+    assert isinstance(window, dict), "the RPC returned no display page"
+    present = [field for field in AUDIT_WIRE_FIELDS if field in window]
+    assert present == list(AUDIT_WIRE_FIELDS), (
+        f"probe is dead: a negotiating viewer saw {present}, so the "
+        f"stripped-case assertion above cannot distinguish a fix from a "
+        f"route that never carries these fields at all"
+    )
+
+
 @pytest.mark.asyncio
 async def test_a_history_page_rpc_strips_the_keys_for_an_old_viewer(tmp_path) -> None:
     """The second emission point. Stripping only the sync frame would produce a

--- a/tests/unit/session/test_history_window.py
+++ b/tests/unit/session/test_history_window.py
@@ -342,3 +342,222 @@ async def test_prompt_and_wait_does_not_complete_on_admission(tmp_path, monkeypa
             await remote.dispose()
         server.close()
         await handle.dispose()
+
+
+# --- Audit paging ------------------------------------------------------------
+#
+# The chain must reach the journal's FIRST message row. Before this, it stopped
+# at the compaction cut and told the reader that was the start of the
+# conversation — measured at 97% of rows unreachable on a real 17,345-row
+# session.
+
+
+async def _compacted_journal(directory: Path, *, compactions: int, rows_each: int):
+    transcript = Transcript(directory)
+    written = []
+    for cut in range(compactions):
+        batch = [Message.user(f"cut {cut} row {index}") for index in range(rows_each)]
+        await transcript.append_messages(batch)
+        written.extend(batch)
+        await transcript.append_compaction(
+            f"summary {cut}",
+            batch[-1].id,
+            500,
+            preserved_user_turns=[{"id": batch[0].id, "text": batch[0].text}],
+        )
+    tail = [Message.assistant(f"tail {index}") for index in range(rows_each)]
+    await transcript.append_messages(tail)
+    written.extend(tail)
+    return transcript, written
+
+
+def _walk(transcript: Transcript, **kwargs):
+    """Follow the whole backward chain, returning (rows, pages, audit_pages)."""
+    page = window(transcript, **kwargs)
+    rows = list(page.messages)
+    pages = [page]
+    while page.before_token:
+        page = window(transcript, before=page.before_token, **kwargs)
+        assert page.status == "ok", page.status
+        rows[0:0] = list(page.messages)
+        pages.append(page)
+    return rows, pages
+
+
+@pytest.mark.asyncio
+async def test_chain_terminates_at_the_first_message_row_not_the_compaction_cut(tmp_path):
+    """The defect, stated as a test.
+
+    ``before_token`` may become ``None`` only when the journal's first message
+    row has been delivered. Terminating at the compaction cut is what made the
+    TUI print "start of conversation" above thousands of real rows.
+    """
+    transcript, written = await _compacted_journal(tmp_path / "s", compactions=3, rows_each=40)
+    rows, pages = _walk(transcript, max_messages=30)
+    message_rows = [r for r in rows if getattr(r, "custom_type", None) != "compaction_summary"]
+    assert message_rows[0].id == written[0].id
+    assert pages[-1].before_token is None
+    assert any(p.audit for p in pages), "the chain never entered the audit phase"
+
+
+@pytest.mark.asyncio
+async def test_every_row_appears_exactly_once_across_the_chain(tmp_path):
+    """Audit completeness: the chain tiles the journal with no gap and no repeat.
+
+    This is the assertion that proves the two phases meet exactly at the
+    compaction cut — a page-seam off-by-one shows up here as a missing row or a
+    duplicated one rather than as a subtly short transcript nobody notices.
+    """
+    transcript, written = await _compacted_journal(tmp_path / "s", compactions=3, rows_each=25)
+    rows, pages = _walk(transcript, max_messages=20)
+    delivered = [r.id for r in rows if getattr(r, "custom_type", None) != "compaction_summary"]
+    # Completeness and exactly-once are the contract.
+    assert set(delivered) == {m.id for m in written}
+    assert len(delivered) == len(set(delivered)) == len(written)
+
+    # Global order is NOT asserted, and the reason is a pre-existing property
+    # of the context phase rather than a concession: the latest compaction's
+    # ``preserved_user_turns`` are re-emitted at the HEAD of the model's replay
+    # under their original ids, so that one row is displayed where compaction
+    # put it rather than at its journal position. The audit phase suppresses
+    # its own in-place copy so the row is delivered once instead of twice (the
+    # duplicate-id hazard). Within the audit phase itself, order is journal
+    # order, and that IS asserted.
+    # ``_walk`` collects pages newest-first, so reverse to read the audit phase
+    # in the order a reader scrolling upward actually assembles it.
+    audit_rows = [
+        r.id
+        for page in reversed(pages)
+        if page.audit
+        for r in page.messages
+        if getattr(r, "custom_type", None) != "compaction_summary"
+    ]
+    order = {m.id: index for index, m in enumerate(written)}
+    positions = [order[row_id] for row_id in audit_rows]
+    assert positions == sorted(positions)
+
+
+@pytest.mark.asyncio
+async def test_audit_paging_does_not_move_the_context_derived_counts(tmp_path):
+    """``total_message_count``/``theme_turn_count`` stay CONTEXT-scoped.
+
+    The TUI reads the first as a monotonic context-growth signal for its
+    presentation cache and the second as the retitle growth gate. Inflating
+    either by the audit depth would invalidate every cached presentation and
+    re-fire retitling across every session on the machine.
+    """
+    transcript, _ = await _compacted_journal(tmp_path / "s", compactions=2, rows_each=20)
+    first = window(transcript, max_messages=15)
+    _rows, pages = _walk(transcript, max_messages=15)
+    audit_pages = [p for p in pages if p.audit]
+    assert audit_pages
+    for page in audit_pages:
+        assert page.total_message_count == 0
+        assert page.theme_turn_count == 0
+        assert page.opener_text == ""
+    # And the context page's own counts are untouched by the audit phase.
+    assert first.total_message_count == len(transcript.build_llm_history())
+
+
+@pytest.mark.asyncio
+async def test_an_audit_token_resets_after_a_compaction_bumps_the_generation(tmp_path):
+    """An outstanding audit cursor must not survive the journal changing.
+
+    The cursor names an entry id rather than an offset precisely because
+    ``compact_file`` rewrites the file; a generation bump invalidates it into
+    ``reset`` so the viewer re-syncs instead of paging a stale coordinate space.
+    """
+    transcript, written = await _compacted_journal(tmp_path / "s", compactions=2, rows_each=20)
+    page = window(transcript, max_messages=15)
+    while page.before_token and not page.audit:
+        page = window(transcript, before=page.before_token, max_messages=15)
+    assert page.audit and page.before_token
+    await transcript.append_compaction("later cut", written[-1].id, 500)
+    assert window(transcript, before=page.before_token, max_messages=15).status == "reset"
+
+
+@pytest.mark.asyncio
+async def test_a_tool_call_and_its_result_never_split_across_an_audit_page(tmp_path):
+    """A result is drawn on its call's card; a page may not open on one."""
+    directory = tmp_path / "s"
+    transcript = Transcript(directory)
+    rows = []
+    for index in range(12):
+        call = Message.assistant(
+            f"calling {index}",
+            tool_calls=[ToolCall(id=f"call-{index}", name="probe", arguments={})],
+        )
+        result = Message.tool_result(
+            ToolResult(
+                tool_call_id=f"call-{index}",
+                tool_name="probe",
+                content=[TextContent(text=f"done {index}")],
+            )
+        )
+        rows.extend([Message.user(f"ask {index}"), call, result])
+    await transcript.append_messages(rows)
+    await transcript.append_compaction("cut", rows[-1].id, 500)
+    await transcript.append_messages([Message.user("after")])
+
+    _all_rows, pages = _walk(transcript, max_messages=4)
+    for page in pages:
+        if not page.messages:
+            continue
+        first = page.messages[0]
+        assert getattr(first, "role", None) != "tool", f"page opens on a tool result: {first.id}"
+
+
+@pytest.mark.asyncio
+async def test_a_journal_without_compaction_still_terminates_where_it_always_did(tmp_path):
+    """No compaction means no audit phase: unchanged behaviour, unchanged copy."""
+    transcript = Transcript(tmp_path / "s")
+    messages = [Message.user(f"row {index}") for index in range(50)]
+    await transcript.append_messages(messages)
+    rows, pages = _walk(transcript, max_messages=20)
+    assert [r.id for r in rows] == [m.id for m in messages]
+    assert not any(p.audit for p in pages)
+    assert not any(p.audit_available for p in pages)
+
+
+@pytest.mark.asyncio
+async def test_the_audit_chain_advances_even_when_a_page_delivers_no_rows(tmp_path):
+    """Forward progress is a property of the WINDOW, not of the rows kept.
+
+    An audit page can legitimately deliver nothing: every row in its window was
+    a preserved user turn the context phase already re-emitted at its head, so
+    the audit copy is suppressed to avoid a duplicate id. If the next cursor
+    were minted from the surviving rows, such a page would re-mint the cursor
+    it was fetched with and the chain would spin on one window forever.
+
+    Found on a real 231 MB journal, where it presented as a hang rather than as
+    a wrong answer — which is why the assertion is a bounded loop.
+    """
+    directory = tmp_path / "s"
+    transcript = Transcript(directory)
+    # A run of user turns, ALL of which the compaction preserves. Their audit
+    # copies are therefore all suppressed, so some audit window is empty.
+    preserved = [Message.user(f"preserved {index}") for index in range(12)]
+    await transcript.append_messages(preserved)
+    later = [Message.assistant(f"later {index}") for index in range(30)]
+    await transcript.append_messages(later)
+    await transcript.append_compaction(
+        "summary",
+        later[-1].id,
+        500,
+        preserved_user_turns=[{"id": m.id, "text": m.text} for m in preserved],
+    )
+    await transcript.append_messages([Message.user("after the cut")])
+
+    page = window(transcript, max_messages=4)
+    seen_cursors = set()
+    for _ in range(200):  # bounded: a stalled chain must fail, not hang
+        token = page.before_token
+        if not token:
+            break
+        assert token not in seen_cursors, "the audit chain re-issued a cursor"
+        seen_cursors.add(token)
+        page = window(transcript, before=token, max_messages=4)
+        assert page.status == "ok"
+    else:
+        raise AssertionError("the audit chain did not terminate")
+    assert page.before_token is None

--- a/tests/unit/session/test_history_window.py
+++ b/tests/unit/session/test_history_window.py
@@ -13,11 +13,20 @@ from local_operator.harness.types import (
     ToolCall,
     ToolResult,
 )
-from local_operator.session.history_window import display_window
+from local_operator.session.history_window import (
+    _AUDIT_TAIL_CURSOR,
+    _audit_entry_cursor,
+    display_window,
+)
 from local_operator.session.remote import RemoteSession
 from local_operator.session.runtime.owned import OwnedSessionHandle
 from local_operator.session.runtime.server import RuntimeServer
-from local_operator.session.transcript import Transcript
+from local_operator.session.transcript import (
+    ENTRY_COMPACTION,
+    Transcript,
+    context_cut_index,
+    replay_entries,
+)
 from tests.e2e.harness import ScriptedStream, build_session, seed_transcript, text_turn
 from tests.unit.session.test_remote import _never_take_over
 
@@ -561,3 +570,176 @@ async def test_the_audit_chain_advances_even_when_a_page_delivers_no_rows(tmp_pa
     else:
         raise AssertionError("the audit chain did not terminate")
     assert page.before_token is None
+
+
+@pytest.mark.asyncio
+async def test_a_superseded_compaction_row_above_the_cut_renders_no_marker(tmp_path):
+    """Repeated compaction leaves compaction rows INSIDE the kept suffix.
+
+    Review round 1 (R2) read the omission of these as unreachable markers. It is
+    the opposite: each names a boundary the latest compaction already moved, so
+    the seam it describes no longer exists in the rendered transcript. Rendering
+    them would place ``COMPACTION_MARKER_NOTICE`` — which claims the history
+    above it is outside the model's context — above rows the model can still
+    see, reintroducing the inversion D1 fixed.
+
+    Pinned because the tempting "fix" (emit them from the context phase) also
+    breaks the byte-identical guard below and pushes each marker's
+    ``preserve_data`` into the model's own context.
+    """
+    directory = tmp_path / "s"
+    transcript = Transcript(directory)
+    rows = [Message.user(f"row {index}") for index in range(40)]
+    await transcript.append_messages(rows)
+    # Two compactions whose kept windows OVERLAP, so the earlier compaction row
+    # ends up at or above the later one's cut — the shape the real journal
+    # reaches by compacting repeatedly against a short kept suffix.
+    superseded = await transcript.append_compaction("older summary", rows[20].id, 500)
+    latest = await transcript.append_compaction("latest summary", rows[30].id, 500)
+
+    entries = transcript.entries()
+    cut = context_cut_index(entries, quiet=True)
+    positions = {entry.id: index for index, entry in enumerate(entries)}
+    # THE STARTING STATE MUST BE REACHABLE, not merely arranged: assert the
+    # superseded row really does sit at/above the cut, or this test passes
+    # while exercising nothing.
+    assert positions[superseded.id] >= cut, "fixture did not reproduce a superseded marker"
+    assert positions[latest.id] >= cut
+
+    _, pages = _walk(transcript, max_messages=15)
+    marker_ids = [
+        row.id
+        for page in pages
+        for row in page.messages
+        if getattr(row, "custom_type", None) == "compaction_summary"
+    ]
+    assert latest.id in marker_ids, "the live seam must still be rendered"
+    assert superseded.id not in marker_ids, (
+        "a superseded compaction row was rendered as a seam; its notice would "
+        "claim the rows above it are outside the model's context, but they are "
+        "still in the kept window"
+    )
+
+
+@pytest.mark.asyncio
+async def test_emitting_superseded_markers_would_break_the_context_replay_guard(tmp_path):
+    """Why R2's suggested route is rejected, asserted rather than argued.
+
+    The PR's central regression guard is that ``mode="context"`` stays
+    byte-for-byte what ``build_llm_history`` always produced. A context phase
+    that also emitted the superseded markers would violate exactly that.
+    """
+    directory = tmp_path / "s"
+    transcript = Transcript(directory)
+    rows = [Message.user(f"row {index}") for index in range(40)]
+    await transcript.append_messages(rows)
+    superseded = await transcript.append_compaction("older summary", rows[20].id, 500)
+    await transcript.append_compaction("latest summary", rows[30].id, 500)
+
+    entries = transcript.entries()
+    assert {e.id for e in entries} >= {superseded.id}
+    replayed = replay_entries(entries, None, mode="context")
+    assert [m.model_dump() for m in replayed] == [
+        m.model_dump() for m in transcript.build_llm_history()
+    ]
+    # Exactly ONE marker at the head: the live seam.
+    markers = [m for m in replayed if getattr(m, "custom_type", None) == "compaction_summary"]
+    assert len(markers) == 1 and markers[0].id != superseded.id
+
+
+@pytest.mark.asyncio
+async def test_full_required_hands_back_an_audit_cursor_and_the_reader_adopts_it(tmp_path):
+    """The DOMINANT real path into the audit phase, which had no coverage.
+
+    All eight reference journals reach audit through this escalation rather
+    than through a plain context drain: a group larger than the frame budget
+    returns ``full_required``, the reader replays the model's history locally,
+    and that replay stops at the context cut. The audit cursor returned
+    alongside the escalation is the only way back to the pre-compaction rows,
+    so a regression here silently restores the original defect for every
+    compacted session while every other test stays green (review round 1, R3).
+    """
+    directory = tmp_path / "s"
+    transcript = Transcript(directory)
+    early = [Message.user(f"early {index}") for index in range(6)]
+    await transcript.append_messages(early)
+    cut_row = Message.user("cut row")
+    await transcript.append_message(cut_row)
+    await transcript.append_compaction("summary", cut_row.id, 500)
+    # One group larger than the whole frame budget, which is what forces the
+    # escalation rather than an ordinary page.
+    await transcript.append_message(Message.assistant("oversized prose " * 100_000))
+
+    page = window(transcript)
+    # Reachability of the starting state, again asserted rather than assumed:
+    # this must be the REAL escalation, carrying a REAL audit cursor.
+    assert page.status == "full_required", page.status
+    assert page.audit_available is True
+    assert page.before_token, "the escalation dropped the audit cursor"
+
+    # The reader's half: adopting that cursor must leave the chain live.
+    remote = RemoteSession.__new__(RemoteSession)
+    remote._display_history = page
+    # The state a reader is REALLY in at this moment, not a convenient one:
+    # ``materialize_history`` has just replayed the model's history in full, so
+    # the context half is hydrated and only the audit half is outstanding.
+    # ``history_before_token`` returns None unless BOTH are set, so getting
+    # either wrong would hide the regression this test exists to catch.
+    remote._history_hydrated = True
+    remote._audit_exhausted = True
+    assert remote.history_before_token is None, (
+        "fixture is not in the post-escalation state: the chain must look "
+        "exhausted BEFORE the cursor is adopted, or adopting it proves nothing"
+    )
+    remote._adopt_audit_cursor(page.before_token)
+    assert remote.history_before_token == page.before_token
+    assert remote._audit_exhausted is False
+    assert remote._display_history.has_more is True
+    assert remote._display_history.audit_available is True
+
+    # And the adopted cursor actually fetches pre-compaction rows.
+    resumed = window(transcript, before=page.before_token)
+    assert resumed.status == "ok"
+    assert resumed.audit is True
+    assert {row.id for row in resumed.messages} & {row.id for row in early}
+
+
+@pytest.mark.asyncio
+async def test_an_empty_kept_suffix_pages_the_audit_tail_and_terminates(tmp_path):
+    """``_AUDIT_TAIL_CURSOR``: the cut lands PAST the journal's last row.
+
+    ``context_cut_index`` returns ``len(entries)`` when the newest compaction
+    row carries no ``first_kept_entry_id``, so there is no entry id at the cut
+    for the first audit cursor to name and the sentinel stands in for one. A
+    regression here is a HUNG chain rather than a wrong answer (review round 1,
+    R5).
+
+    REACHABILITY, stated honestly because it decides what this test is worth:
+    the CURRENT writer cannot produce this row. ``append_compaction`` takes
+    ``first_kept_entry_id: str`` as a required argument and always records it,
+    and a scan of 401 real session journals found 280 compaction rows with the
+    field and none without. So the sentinel is defensive — it covers a journal
+    written by a build predating the field, which is exactly the mixed-build
+    situation this PR's capability negotiation exists for. The row is therefore
+    appended through ``_append``, the same primitive ``append_compaction`` uses,
+    rather than by passing a bogus id to the public writer: an unresolvable id
+    is a DIFFERENT branch (it returns 0 and replays everything), and using it
+    here would silently test the wrong path.
+    """
+    directory = tmp_path / "s"
+    transcript = Transcript(directory)
+    rows = [Message.user(f"row {index}") for index in range(8)]
+    await transcript.append_messages(rows)
+    await transcript._append(ENTRY_COMPACTION, {"summary": "summary", "tokens_before": 500})
+
+    entries = transcript.entries()
+    cut = context_cut_index(entries, quiet=True)
+    assert cut == len(entries), "fixture did not reproduce an empty kept suffix"
+    # And the sentinel is genuinely the cursor in play, not merely the state.
+    assert _audit_entry_cursor(transcript) == _AUDIT_TAIL_CURSOR
+
+    walked, pages = _walk(transcript, max_messages=30)
+    assert any(p.audit for p in pages), "the tail cursor never entered the audit phase"
+    assert pages[-1].before_token is None, "the chain did not terminate"
+    delivered = {row.id for row in walked}
+    assert delivered >= {row.id for row in rows}, "audit tail paging lost rows"

--- a/tests/unit/session/test_transcript.py
+++ b/tests/unit/session/test_transcript.py
@@ -12,7 +12,9 @@ from local_operator.harness.types import (
     CustomMessage,
     Message,
     TextContent,
+    ToolCall,
     ToolContext,
+    ToolResult,
     Usage,
 )
 from local_operator.mcp.tool_bridge import format_mcp_result
@@ -722,3 +724,161 @@ def test_replay_suffix_absent_journal_is_empty_history(tmp_path):
     assert (
         replay_entries(suffix.entries, None) == Transcript(tmp_path / "absent").build_llm_history()
     )
+
+
+# --- Audit replay mode -------------------------------------------------------
+#
+# The seam these tests guard: ``replay_entries`` answers two different
+# questions, and the first one must not move. ``mode="context"`` is what the
+# MODEL sees and is bounded by compaction; ``mode="audit"`` is what the
+# CONVERSATION contained and is bounded by nothing. Fusing them is how the
+# display window came to page only post-compaction rows.
+
+
+async def _compacted(directory: Path, *, compactions: int = 1, rows_each: int = 4):
+    """Journal with ``compactions`` cuts, each preserving the turn before it."""
+    transcript = Transcript(directory)
+    written: list[Message] = []
+    for cut in range(compactions):
+        batch = [Message.user(f"cut {cut} row {i}") for i in range(rows_each)]
+        await transcript.append_messages(batch)
+        written.extend(batch)
+        await transcript.append_compaction(
+            f"summary {cut}",
+            batch[-1].id,
+            500,
+            preserved_user_turns=[{"id": batch[0].id, "text": batch[0].text}],
+        )
+    tail = [Message.assistant("after the last cut")]
+    await transcript.append_messages(tail)
+    written.extend(tail)
+    return transcript, written
+
+
+@pytest.mark.asyncio
+async def test_context_mode_is_byte_identical_to_build_llm_history(tmp_path):
+    """The regression guard for the entire audit change.
+
+    ``mode="context"`` is the default and must remain what this function has
+    always produced, compaction cut and preserved turns included. If this ever
+    fails, the model's context has changed — which the audit feature is
+    explicitly not allowed to do.
+    """
+    transcript, _ = await _compacted(tmp_path / "sess", compactions=3)
+    expected = transcript.build_llm_history()
+    replayed = replay_entries(transcript.entries(), transcript._attachments, mode="context")
+    assert [m.model_dump(mode="json") for m in replayed] == [
+        m.model_dump(mode="json") for m in expected
+    ]
+    # And the default is context, so no existing caller changed behaviour.
+    default = replay_entries(transcript.entries(), transcript._attachments)
+    assert [m.model_dump(mode="json") for m in default] == [
+        m.model_dump(mode="json") for m in expected
+    ]
+
+
+@pytest.mark.asyncio
+async def test_audit_mode_returns_every_message_row_on_disk(tmp_path):
+    """Audit mode's contract: nothing the journal holds is unreachable."""
+    transcript, written = await _compacted(tmp_path / "sess", compactions=3)
+    audited = replay_entries(transcript.entries(), transcript._attachments, mode="audit")
+    rows = [m for m in audited if getattr(m, "custom_type", None) != "compaction_summary"]
+    assert [m.id for m in rows] == [m.id for m in written]
+    # Context mode, on the same journal, reaches almost none of them — which is
+    # the defect that made this mode necessary.
+    assert len(transcript.build_llm_history()) < len(rows)
+
+
+@pytest.mark.asyncio
+async def test_audit_mode_does_not_reinject_preserved_user_turns(tmp_path):
+    """Preserved turns are COPIES of rows audit mode already replays.
+
+    Re-injecting them would duplicate every preserved turn under its ORIGINAL
+    id, and the TUI's mount-time id dedupe would then swallow the second — so
+    the visible symptom is a MISSING row, not a doubled one.
+    """
+    transcript, written = await _compacted(tmp_path / "sess", compactions=3)
+    audited = replay_entries(transcript.entries(), transcript._attachments, mode="audit")
+    ids = [m.id for m in audited]
+    assert len(ids) == len(set(ids))
+    for message in written:
+        assert ids.count(message.id) == 1
+
+
+@pytest.mark.asyncio
+async def test_audit_mode_emits_one_marker_per_compaction_in_place(tmp_path):
+    """Every cut is shown where it happened, not hoisted to the front.
+
+    Context mode keeps only the latest cut and puts its marker at the head. A
+    reader auditing a session with 48 compactions needs to see where each one
+    fell; one marker at the boundary would misrepresent the other 47 as
+    ordinary history.
+    """
+    transcript, _ = await _compacted(tmp_path / "sess", compactions=3, rows_each=2)
+    audited = replay_entries(transcript.entries(), transcript._attachments, mode="audit")
+    positions = [
+        index
+        for index, m in enumerate(audited)
+        if getattr(m, "custom_type", None) == "compaction_summary"
+    ]
+    assert len(positions) == 3
+    assert positions != sorted(positions)[:1] * 3  # not all hoisted to one spot
+    assert positions[0] > 0, "the first marker sits after the rows it followed"
+    assert positions == sorted(positions)
+
+
+@pytest.mark.asyncio
+async def test_audit_slice_applies_a_prune_journalled_after_its_window(tmp_path):
+    """The one cross-row dependency a bounded window can miss.
+
+    A prune is always appended AFTER the row it targets, so a prune for a row
+    inside the slice can sit past ``end_index``. Deriving the prune map from
+    the slice would replay tool output compaction already blanked.
+    """
+    from local_operator.session.transcript import audit_slice
+
+    directory = tmp_path / "sess"
+    transcript = Transcript(directory)
+    target = Message.assistant("secret tool output")
+    await transcript.append_message(target)
+    filler = [Message.user(f"later {i}") for i in range(30)]
+    await transcript.append_messages(filler)
+    # The prune lands at the very END of the journal, far past the window.
+    await transcript.append_prune(target.id, "[pruned]")
+
+    entries = transcript.entries()
+    end = next(i for i, e in enumerate(entries) if e.id == filler[0].id)
+    rows, _indices, _start = audit_slice(entries, transcript._attachments, end_index=end, limit=50)
+    replayed = next(m for m in rows if m.id == target.id)
+    assert isinstance(replayed, Message)
+    assert replayed.text == "[pruned]"
+    assert (replayed.provider_payload or {}).get("pruned") is True
+
+
+@pytest.mark.asyncio
+async def test_audit_slice_never_begins_inside_a_tool_group(tmp_path):
+    """A window opening on a tool RESULT renders a settled call as interrupted.
+
+    The result row is drawn on the card of the call above it, so a page whose
+    first row is a result would show a card with no call until some unrelated
+    scroll happened to fetch it.
+    """
+    from local_operator.session.transcript import audit_slice
+
+    transcript = Transcript(tmp_path / "sess")
+    call = Message.assistant(
+        "calling", tool_calls=[ToolCall(id="call-1", name="probe", arguments={})]
+    )
+    result = Message.tool_result(
+        ToolResult(tool_call_id="call-1", tool_name="probe", content=[TextContent(text="done")])
+    )
+    rows = [Message.user("before"), call, result, Message.user("after")]
+    await transcript.append_messages(rows)
+    entries = transcript.entries()
+    end = next(i for i, e in enumerate(entries) if e.id == rows[-1].id)
+    # limit=1 would otherwise land the window exactly on the result row.
+    messages, _indices, _start = audit_slice(
+        entries, transcript._attachments, end_index=end, limit=1
+    )
+    assert messages[0].id == call.id
+    assert [m.id for m in messages] == [call.id, result.id]

--- a/tests/unit/session/test_viewer_protocol.py
+++ b/tests/unit/session/test_viewer_protocol.py
@@ -723,9 +723,9 @@ def test_app_py_dominates_the_derivation_so_a_global_floor_cannot_work() -> None
     # An exact pin, unlike the ratio above: this is the population the aggregate
     # floor of 40 is set against, so a drop here is the decay that floor exists
     # to catch rather than ordinary churn.
-    assert len(viewer_only) == 49, (
+    assert len(viewer_only) == 50, (
         f"there are {len(viewer_only)} viewer-only members; _SCANNED's comment "
-        "says 49, and the aggregate floor is set at 40 against that number. A "
+        "says 50, and the aggregate floor is set at 40 against that number. A "
         "drop here is the decay that floor exists to catch, so check it is "
         "genuinely a removal before editing this figure."
     )

--- a/tests/unit/tui/test_rendered_history_paging.py
+++ b/tests/unit/tui/test_rendered_history_paging.py
@@ -842,3 +842,185 @@ async def test_explicit_anchor_offset_outranks_a_tail_following_view() -> None:
         assert abs(view.scroll_y - held.virtual_region.y) < 1.0
         assert view.max_scroll_y > inserted_at, "the page did not mount above"
         assert view.blocks()[:40] == page, "the page is not above the retained rows"
+
+
+# --- Audit history, rendered -------------------------------------------------
+
+
+async def compacted_history(directory: Path, *, compactions: int, rows_each: int):
+    """Seed a journal with real compaction cuts, as a resumed session has."""
+    from local_operator.session.transcript import Transcript
+
+    directory.mkdir(parents=True, exist_ok=True)
+    transcript = Transcript(directory)
+    written: list[Message] = []
+    for cut in range(compactions):
+        batch = [
+            Message(
+                id=f"cut{cut}-row-{index:04}",
+                role="user" if index % 2 else "assistant",
+                content=[TextContent(text=f"cut {cut} row {index:04}")],
+                stop_reason="stop",
+            )
+            for index in range(rows_each)
+        ]
+        for message in batch:
+            await transcript.append_message(message)
+        written.extend(batch)
+        await transcript.append_compaction(f"summary {cut}", batch[-1].id, 500)
+    tail = [
+        Message(
+            id=f"tail-row-{index:04}",
+            role="assistant",
+            content=[TextContent(text=f"tail row {index:04}")],
+            stop_reason="stop",
+        )
+        for index in range(rows_each)
+    ]
+    for message in tail:
+        await transcript.append_message(message)
+    written.extend(tail)
+    transcript.flush()
+    return written
+
+
+@asynccontextmanager
+async def compacted_session(tmp_path: Path, *, compactions: int = 3, rows_each: int = 40):
+    config = tmp_path / "config"
+    config.mkdir(exist_ok=True)
+    (config / "config.yml").write_text(
+        "version: 0.0.0\nvalues:\n  hosting: test\n  model_name: mock\n"
+    )
+    directory = config / "sessions" / "synthetic-compacted"
+    await compacted_history(directory, compactions=compactions, rows_each=rows_each)
+    session = build_session(directory, ScriptedStream([text_turn("unused")]), cwd=tmp_path)
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(tmp_path))
+    server = RuntimeServer(handle, kind="daemon")
+    await server.start_in_process()
+    remote = await RemoteSession.connect(
+        server._record,
+        directory.name,
+        config_dir=config,
+        takeover_factory=_never_take_over,
+        display_window=True,
+    )
+    try:
+        yield remote
+    finally:
+        await remote.dispose()
+        server.close()
+        await handle.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_compacted_session_does_not_claim_the_conversation_starts_at_the_cut(
+    tmp_path,
+) -> None:
+    """The operator's report, as a rendered assertion.
+
+    He resumed a long conversation, scrolled up, and the top row said "start of
+    conversation" above real messages. It was the honest rendering of a history
+    layer that had already discarded them — so the fix is that the layer now
+    reaches them, and this asserts the rendered consequence.
+    """
+    from local_operator.tui.app import (
+        RESUME_AUDIT_NOTICE,
+        RESUME_AUDIT_UNREACHABLE_NOTICE,
+    )
+
+    # Large enough that the reader does NOT reach the head in one fill, which
+    # is the situation the operator was in: a long conversation whose top he
+    # had to scroll toward.
+    async with compacted_session(tmp_path, compactions=6, rows_each=400) as remote:
+
+        async def factory():
+            return remote
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settled(app, pilot)
+            # Drain everything the model can still see, and STOP at the
+            # boundary: this asserts the state the operator was in — context
+            # exhausted, pre-compaction rows still above — not the state after
+            # the whole journal has been read back.
+            for _ in range(40):
+                if not remote.history_before_token or remote.history_is_audit:
+                    break
+                await remote.load_older_display_page()
+                await pilot.pause()
+            assert remote.history_is_audit, "the chain never offered the audit phase"
+            app._reconcile_head_notice()
+            await pilot.pause()
+            notice = app._resume_head_notice
+            assert notice is not None, "the audit phase left no head notice to read"
+            # The defect, precisely: this row used to say "start of
+            # conversation" while pre-compaction rows sat unread on disk.
+            assert notice.text() != "start of conversation"
+            assert notice.text() in (RESUME_AUDIT_NOTICE, RESUME_AUDIT_UNREACHABLE_NOTICE)
+            assert notice.can_focus, "the audit head notice stays actionable"
+
+
+@pytest.mark.asyncio
+async def test_start_of_conversation_appears_only_once_the_audit_chain_drains(tmp_path) -> None:
+    """``RESUME_START_NOTICE`` is now a TRUE statement, and only then."""
+    from local_operator.tui.app import RESUME_START_NOTICE
+
+    async with compacted_session(tmp_path) as remote:
+
+        async def factory():
+            return remote
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settled(app, pilot)
+            for _ in range(200):
+                if not remote.history_before_token:
+                    break
+                await remote.load_older_display_page()
+                await pilot.pause()
+            assert not remote.history_before_token
+            app._reconcile_head_notice()
+            await pilot.pause()
+            notice = app._resume_head_notice
+            # Head fully drained: the notice may be removed entirely or state
+            # the (now true) start of the conversation.
+            if notice is not None and not app._resume_pending_head:
+                assert notice.text() == RESUME_START_NOTICE
+                assert not notice.can_focus, "true exhaustion drops interactivity"
+
+
+@pytest.mark.asyncio
+async def test_the_compaction_marker_renders_as_a_notice_mid_transcript(tmp_path) -> None:
+    """The marker had NO renderer and painted as nothing.
+
+    Harmless while it only ever sat at the very top of the model's replay;
+    not harmless now that audit paging puts one at each compaction inside the
+    transcript, where it is the only thing telling the reader they have crossed
+    out of what the agent can still see.
+    """
+    from local_operator.tui.session_presentation import COMPACTION_MARKER_NOTICE
+
+    async with compacted_session(tmp_path) as remote:
+
+        async def factory():
+            return remote
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settled(app, pilot)
+            for _ in range(200):
+                if not remote.history_before_token:
+                    break
+                await remote.load_older_display_page()
+                await pilot.pause()
+            for _ in range(60):
+                if not app._resume_pending_head:
+                    break
+                app._mount_older_resume_page()
+                await pilot.pause()
+            texts = [
+                block.text()
+                for block in app._transcript_view().blocks()
+                if isinstance(block, NoticeBlock) and hasattr(block, "text")
+            ]
+            assert COMPACTION_MARKER_NOTICE in texts

--- a/tests/unit/tui/test_rendered_history_paging.py
+++ b/tests/unit/tui/test_rendered_history_paging.py
@@ -1034,12 +1034,21 @@ def test_the_compaction_marker_fits_an_80_column_terminal() -> None:
     once per seam on exactly the sessions audit paging exists for.
 
     The budget is NOT the terminal width, which is why round 1's arithmetic
-    ("under ~76") produced a 71-character string that still wrapped. An
-    80-column terminal yields a 78-column screen, the notice block's padding
-    takes more, and the `· ` glyph costs 2 — measured at 68 columns of text in
-    a rendered frame, so 66 for the string. Kept as a cheap unit guard beside
-    the frame capture (`scripts/audit_history_shot.py <dir> marker 80x30`),
-    which is the instrument that established the number.
+    ("under ~76") produced a 71-character string that still wrapped. At 80
+    columns the budget is 70 text columns, and the mechanical check is
+    ``NoticeBlock.body_budget(76) == 70`` rather than hand arithmetic (D6): an
+    80-column terminal gives a 78-column screen, ``scrollbar-gutter: stable``
+    reserves one more (77), the view's left padding one (76, the painted block
+    width), ``_build`` folds at ``max(width - 2, 12)`` (74), and ``GLYPH_COLS``
+    is 4 rather than 2 (70). Do not re-derive it from the superseded "68
+    usable, so 66" arithmetic, which reached a safe number through compensating
+    errors and does not transfer to any other width.
+
+    This guard pins 66, not the 70 budget, so a copy change that wants the
+    4 columns of headroom has to move the number here deliberately. Kept as a
+    cheap unit guard beside the frame capture
+    (`scripts/audit_history_shot.py <dir> marker 80x30`), which is the
+    instrument that established the number.
     """
     from local_operator.tui.session_presentation import COMPACTION_MARKER_NOTICE
 

--- a/tests/unit/tui/test_rendered_history_paging.py
+++ b/tests/unit/tui/test_rendered_history_paging.py
@@ -1024,3 +1024,57 @@ async def test_the_compaction_marker_renders_as_a_notice_mid_transcript(tmp_path
                 if isinstance(block, NoticeBlock) and hasattr(block, "text")
             ]
             assert COMPACTION_MARKER_NOTICE in texts
+
+
+def test_the_compaction_marker_fits_an_80_column_terminal() -> None:
+    """D2: the marker must not wrap and orphan its last word.
+
+    80x24 is the oldest default terminal size there is, and this row repeats at
+    every compaction — 48 times in the reference journal — so a wrap is paid
+    once per seam on exactly the sessions audit paging exists for.
+
+    The budget is NOT the terminal width, which is why round 1's arithmetic
+    ("under ~76") produced a 71-character string that still wrapped. An
+    80-column terminal yields a 78-column screen, the notice block's padding
+    takes more, and the `· ` glyph costs 2 — measured at 68 columns of text in
+    a rendered frame, so 66 for the string. Kept as a cheap unit guard beside
+    the frame capture (`scripts/audit_history_shot.py <dir> marker 80x30`),
+    which is the instrument that established the number.
+    """
+    from local_operator.tui.session_presentation import COMPACTION_MARKER_NOTICE
+
+    assert len(COMPACTION_MARKER_NOTICE) <= 66, (
+        f"the marker is {len(COMPACTION_MARKER_NOTICE)} chars; it wraps at 80 "
+        f"columns and orphans its last word at every compaction"
+    )
+
+
+def test_the_compaction_marker_is_spaced_apart_from_the_head_notice() -> None:
+    """D3: the seam and the head notice must not read as one block.
+
+    In the audit state they land on adjacent rows sharing the `·` glyph, the
+    `note` ink, and — after the D1 copy fix — nearly the same opening words.
+    One is a CONTROL (focusable, clickable) and the other is inert, with
+    nothing else to tell them apart, so the separation has to come from
+    spacing. `SPACING_AIRY` is the mechanism the tool ledger already uses for
+    "each row is a separate thing"; asserting it here keeps a future edit from
+    dropping the class and silently restacking the two rows flush.
+    """
+    from local_operator.tui.app import RESUME_AUDIT_NOTICE
+    from local_operator.tui.session_presentation import (
+        COMPACTION_MARKER_NOTICE,
+        CompactionMarkerBlock,
+        OlderHistoryNotice,
+    )
+    from local_operator.tui.widgets.transcript import needs_gap_above
+
+    marker = CompactionMarkerBlock(COMPACTION_MARKER_NOTICE, kind="note")
+    # The real audit-state pairing: this exact copy sits directly above it.
+    head = OlderHistoryNotice(RESUME_AUDIT_NOTICE)
+    # Same SPACING_KIND is precisely why the default rule stacked them flush.
+    assert marker.SPACING_KIND == head.SPACING_KIND == "notice"
+    assert needs_gap_above(head, marker), (
+        "the compaction marker stacks flush against the head notice; the two "
+        "share a glyph, an ink and their opening words, and one is clickable "
+        "while the other is not"
+    )


### PR DESCRIPTION
## What and why

**C2 — data-reachability defect.** The operator resumed a long conversation, scrolled up, and the top row said **"start of conversation"** above messages he could still remember having. The bytes were never lost; the reading surface could not name them.

`_capture_display_window` builds every page from `transcript.build_llm_history()`, which implements **LLM-CONTEXT** semantics: the latest compaction wins and replay starts at `first_kept_entry_id`. So every display page, `total_message_count`, the `before_token` chain and `has_more` were computed over the post-compaction replay. The head notice was a *faithful reporter* of a history layer that had already discarded the rows — which is why fixing the copy would have been the wrong fix.

Measured on the operator's own store (message rows on disk vs `len(build_llm_history())`), sandbox copies, never the live store:

| session | MB | msg rows | compactions | reachable before | unreachable |
|---|---|---|---|---|---|
| `bda7b76d34e0` | 231 | 17,349 | 48 | 328 | **98.1%** |
| `9f8e5b652ac7` | 75 | 11,344 | 22 | 366 | **96.8%** |

Twelve of his sessions exceed 80% unreachable.

## The seam

**Stop overloading one function.** `build_llm_history` answers *"what may the model see"*. Nothing should ask it *"what did the conversation contain"*.

`replay_entries` gains a `mode`:

- **`mode="context"`** — today's behaviour, byte for byte. Still the default; every existing caller keeps it, and compaction keeps bounding the model's context exactly as before. This is the regression guard for the whole change and it is asserted directly against `build_llm_history` output.
- **`mode="audit"`** — every message row from index 0, with a `compaction_summary` marker **in place** at each compaction (not just the latest, and not hoisted to the front).

They stay **two functions, deliberately**, and the code says why: a future change to what the model sees must not silently become a change to what an audit reader can reach, and the reverse would grow the model's context.

Paging becomes two phases over one continuous chain. At `start == 0` the owner mints a cursor into the audit phase instead of terminating; `before_token` becomes `None` **only** at the journal's first message row. That is now the only place paging may end.

### Load-bearing details

- **The cursor signs an entry ID, never a journal offset.** `compact_file` replaces the file, so an integer offset minted before a compaction silently points at a different row afterwards — it does not fail, it lies. An id that no longer resolves is detectable and answers `status="reset"`.
- **Audit mode does not re-inject `preserved_user_turns`.** They are verbatim copies of rows that already exist before the cut, under their **original ids**. Re-injecting would duplicate them, and the TUI's mount-time id dedupe would then swallow the second — so the visible symptom would be a **missing** row, not a doubled one.
- **Counts stay context-derived.** `total_message_count`, `theme_turn_count` and `opener_text` are read as monotonic context-growth signals by `_sidebar_presentation_current` and by the retitle gate. Inflating them by an audit depth of 17,000 rows would invalidate every cached presentation and re-fire retitling across every session on the machine.
- **`materialize_history` stops at the end of the context phase.** It feeds `generate_retitle`; draining audit would hand the retitle model 17,000 rows on an ordinary message submit.
- **Two context-coordinate checks are exempted for audit pages.** `load_older_display_page`'s contiguity assertion *and* `_validate_display_window`'s range check both bound a page against context coordinates and fire on the first audit page. The second was **found by running it**, not by reading the brief — it surfaced as `ConnectionError: invalid display history range`.

## Capability negotiation (the rollout hazard)

`DisplayHistoryWindow` sets `extra="forbid"`, so an owner emitting `audit`/`audit_available` to a viewer built before those fields **raises** in that viewer and `_fetch_history_page` turns it into a **failed attach** — not a degraded one. `display-history-window-v1` is a bare presence flag with no version handshake and cannot express the difference.

So the owner advertises **`display-history-audit-v1`** and emits the two fields **only** to a viewer that negotiated it, gated exactly the way `display_window` is. Mixed builds against one sessions directory are the norm on this machine (the global uv-tool runtime updates independently of a repo `.venv`). Both wire routes — the attach sync frame and the `history_page` RPC — strip through **one** helper, because stripping in only one produces a viewer that attaches cleanly and then fails on its first scroll.

## Honest presentation

`project_settled_rows` had **no branch** for `compaction_summary`, so the marker rendered as *nothing*. Survivable while it only ever sat atop the model's replay; not survivable once audit paging puts one at each compaction mid-transcript. Added as a `NoticeBlock` kind `"note"` (not `info`, which maps to `dim` at 3.77:1 on the light theme, below the AA floor):

> context compacted here — older messages below are history the agent no longer sees

Head-notice copy, by state. **"earlier history", deliberately not "older messages"** — the two phases differ in kind, and a reader crossing the marker should see the vocabulary change with it:

| state | copy |
|---|---|
| context rows remain, scrollable | `older messages above — scroll up to load` (unchanged) |
| context rows remain, not scrollable | `older messages above — select to load` (unchanged) |
| context drained, audit available | **new:** `earlier history above — scroll up to load` |
| audit rows remain, not scrollable | **new:** `earlier history above — select to load` |
| audit exhausted | `start of conversation` — **now finally true** |
| no compaction ever | `start of conversation` (unchanged, always was correct) |

`RESUME_START_NOTICE` is unchanged in wording. The point is that it is now only ever shown when it is true.

## Two defects found by running it, not by reading

Both were invisible to the unit suite and only appeared against the operator's real journals.

**1. Over-broad suppression hid 191 real rows.** The audit pager suppresses its copy of turns the context phase hoists. Reading `preserved_user_turns` off the raw payload was wrong: `replay_preserved_turns` sheds journalled injections and enforces a cap, so the payload held **295** turns while the replay emitted only **104**. Suppressing the raw 295 hid 191 rows that no phase then delivered — the exact class of silent loss this change exists to end. Now resolved through the same filter the context replay uses.

**2. An empty audit page hung the chain.** A page can legitimately deliver zero rows (every row in its window was a hoisted preserved turn). Minting the next cursor from the *surviving rows* re-minted the cursor the page was fetched with, and the chain spun on one window forever — a **hang**, not a wrong answer. The cursor now advances by the **window**, except when the byte budget trimmed the page, where it must resume at the first row kept. Both cases are pinned by a bounded-loop test that fails (not hangs) on regression.

## Testing evidence

### 1. Every on-disk row is reachable — real journals, isolated sandbox

Sandbox copies of two of the operator's real sessions under a redirected `HOME` **and** `LOCAL_OPERATOR_CONFIG_DIR`; `~/.local-operator/sessions` was never opened. Script walks the full backward chain exactly as the reader does (context phase, `full_required` escalation, then audit) and compares the delivered id set against the message rows physically in the journal:

```
session bda7b76d34e0
  message rows on disk: 17349  compactions: 48
  context replay reaches: 328 rows          <- what a reader could address BEFORE
  chain delivered: 17677 rows (17350 unique)
  audit pages: 214   markers rendered: 47
  MISSING (on disk, never delivered): 0
  >>> every on-disk message row reachable: True

session 9f8e5b652ac7
  message rows on disk: 11344  compactions: 22
  context replay reaches: 366 rows
  chain delivered: 11710 rows (11345 unique)
  audit pages: 122   markers rendered: 21
  MISSING (on disk, never delivered): 0
  >>> every on-disk message row reachable: True
```

The one "extra" id in each is `compaction-elision`, the pre-existing synthetic elision notice — not a journal row. Before this change the same walk terminated at `compaction-elision` with 327/17,349 rows.

### 2. Budget B holds — audit pages are *faster* than existing context pages

Same 231 MB journal, no instrumentation overhead:

| operation | measured |
|---|---|
| **audit page** (`bda7b76d34e0`) | **median 8.20 ms**, p95 59 ms |
| context page (baseline, unchanged path) | median 12.56 ms |
| **audit page** (`9f8e5b652ac7`) | **median 7.48 ms** |
| naive full audit replay (**never called**) | 0.29 s / 47 MB peak |
| `read_transcript_page` disk pager (**not used**) | ~1.03 s |

No full-journal parse and no pin: pages are served from the owner's already-resident `_entries`.

**Attach path unmoved** — same journals, base vs branch, `read_replay_suffix` + replay:

```
base   bda7b76d34e0: median 37.9ms  rows=372
branch bda7b76d34e0: median 38.1ms  rows=372
base   9f8e5b652ac7: median 21.3ms  rows=411
branch 9f8e5b652ac7: median 22.4ms  rows=411
```

One cost this change introduced and then removed: the hoisted-turn lookup runs the shed/cap filter over the whole entry list and measured **88 ms**, once per page. Memoised on `_history_generation` (the counter the transcript already bumps on compaction/prune — the only events that change the answer), which is what keeps the page at ~8 ms.

### 3. Rendered frames — the real app, real owner, real RPC

**Frames live on a separate, never-merged branch: [`evidence/pr-899`](https://github.com/damianvtran/local-operator/tree/evidence/pr-899)** ([README](https://github.com/damianvtran/local-operator/blob/evidence/pr-899/README.md)). GitHub renders committed SVGs, so each frame opens directly from that branch's file list.

Kept out of this PR's tree deliberately: `AGENTS.md` §7 ("Evidence goes on the PR, never into the repository") bans committing frames into the merged history and names `docs/evidence/<change>/` specifically. The orphan branch keeps them reviewable without ever entering `main`; it is **deleted when this PR merges**. The reusable part — `scripts/audit_history_shot.py` — is in the tree here, which is what §7 says belongs there.

| state | before (`main`) | after (this branch) |
|---|---|---|
| context rows remain | [100x34](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-899/before/context.100x34.svg) · [140x50](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-899/before/context.140x50.svg) | [100x34](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-899/after/context.100x34.svg) · [140x50](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-899/after/context.140x50.svg) |
| context drained, audit rows behind it | [100x34](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-899/before/audit.100x34.svg) · [140x50](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-899/before/audit.140x50.svg) — **the defect** | [100x34](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-899/after/audit.100x34.svg) · [140x50](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-899/after/audit.140x50.svg) |
| chain fully drained | [100x34](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-899/before/exhausted.100x34.svg) · [140x50](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-899/before/exhausted.140x50.svg) | [100x34](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-899/after/exhausted.100x34.svg) · [140x50](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-899/after/exhausted.140x50.svg) |
| compaction marker mid-transcript | *(rendered as nothing before this fix — no twin exists)* | [100x34](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-899/after/marker.100x34.svg) · [140x50](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-899/after/marker.140x50.svg) |

Captured by driving the **real `OperatorApp`** against a **real `RuntimeServer`** over the actual control socket, so the stylesheet is applied and pages arrive through the same `history_page` RPC production uses. A lightweight test host declares no `CSS_PATH` and would show none of this. Every `CMUX_*` variable is cleared before app import, and HOME/config are isolated via `isolate_capture()`. The fixture is synthetic — no real session data is in any frame.

**Exact commands.** `after/` frames, on this branch:

```sh
env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
    scripts/audit_history_shot.py <out-dir> all 100x34
env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
    scripts/audit_history_shot.py <out-dir> all 140x50
```

`before/` frames, from a detached worktree at `origin/main`, same script and same fixture:

```sh
env -u NO_COLOR TERM=xterm-256color PYTHONPATH=<base-worktree> \
    .venv/bin/python scripts/audit_history_shot.py <out-dir> <state> <geometry>
```

**Capture geometry, stated because a head-notice state depends on it.** `_reconcile_head_notice` chooses between its scrollable and not-scrollable copy from `virtual_size` against `container_size`, so a frame captured at one viewport can show a state that does not reproduce at another. Every claimed state is therefore captured at **two**:

| geometry | `run_test(size=...)` | screen size | region | scrollbars |
|---|---|---|---|---|
| `100x34` | `(100, 34)` | `98 x 32` | `[0, 0, 100, 34]` | none |
| `140x50` | `(140, 50)` | `138 x 48` | `[0, 0, 140, 50]` | none |

**Result: every state renders the same copy at both geometries** — no claimed state is geometry-dependent, and the defect reproduces at both.

**Settle check.** Each state was captured twice, before and after a further settle, and all 8 pairs came back **byte-identical** (`cmp`), so there is no reflow between first paint and settled frame and one frame per state is sufficient. The script still writes the `.settled.svg` twin so this is re-checkable.

**Head-notice strings, verbatim, as printed by the capture at the moment of each frame** — the numbers behind the pixels:

| state | `main` (before) | this branch (after) |
|---|---|---|
| context rows remain | `older messages above — scroll up to load` | `older messages above — scroll up to load` (unmoved) |
| context drained, audit rows behind it | `start of conversation` — **false** | `earlier history above — scroll up to load` |
| chain fully drained | `start of conversation` | `start of conversation` — **now true** |

Raw capture output, both builds at `100x34`:

```
main    [context]   'older messages above — scroll up to load'  | audit=False | more=True
main    [audit]     'start of conversation'                     | audit=False | more=False
main    [exhausted] 'start of conversation'                     | audit=False | more=False

branch  [context]   'older messages above — scroll up to load'  | audit=False | more=True
branch  [audit]     'earlier history above — scroll up to load' | audit=True  | more=True
branch  [exhausted] 'start of conversation'                     | audit=True  | more=False
```

`audit=` is `RemoteSession.history_is_audit` and `more=` is `bool(history_before_token)` — the two values the notice actually branches on. On `main` the audit state is unreachable, which is why its `[audit]` row is identical to `[exhausted]`.

What the frames show: `before/audit` is the reported defect — `start of conversation` sitting above `question 280` with ~2,400 rows still on disk. `after/exhausted` is the same notice above **phase 0, item 0**, the journal's genuine first row. `after/marker` is the compaction boundary mid-transcript with pre-compaction rows above it and live context below; it has no `before/` twin because that marker rendered as **nothing** before this fix.

### 4. Quality gates

- `flake8` — clean
- `black --check` (26.1.0, pinned) — clean
- `isort --check` (5.13.2, pinned) — clean
- `pyright` (1.1.411) — **0 errors, 0 warnings**
- **`tests/unit` whole tree: 17,518 passed, 18 skipped** (`env -u NO_COLOR TERM=xterm-256color`, exactly as CI)

**Both critical new tests were verified to fail against the pre-fix behaviour**, not merely to pass:
- reverting audit-cursor minting ⇒ 4 failures including chain termination and audit completeness;
- disabling the wire strip ⇒ `audit leaked to a viewer that cannot accept it`;
- reverting the cursor advance ⇒ `the audit chain re-issued a cursor`.

**One note for the reviewer, investigated and cleared:** an earlier full-suite run tripped the repo's real-store tripwire (`21a02fea39a2`, `dfa8034012f8` vanished). It is **not this branch**. Those ids appear nowhere in the tree; every new test uses `tmp_path` only; my tests run with the guard silent; and a run of the **unmodified base tree** saw the store *grow* 426→428 while 15 peer sessions were live. It is the guard's own documented "or running alongside it" case.

## New test surface

- `test_transcript.py` — context mode byte-identical to `build_llm_history`; audit returns every row; preserved turns appear **exactly once**; a prune journalled *after* an `audit_slice` window still blanks its target; one marker per compaction, in journal position; a window never begins on a tool result.
- `test_history_window.py` — chain terminates at the first message row, not the cut; **every row appears exactly once across the chain**; context counts unmoved by audit paging; an audit token resets after a generation bump; tool call/result never split across a page; a non-compacted journal is unchanged; **the chain advances even when a page delivers no rows**.
- `runtime/test_display_history_audit_capability.py` — the `extra="forbid"` break, end to end over a real socket, in both directions and on **both** wire routes. Speaks the wire protocol directly, because the current client can no longer be talked into being an old build.
- `tui/test_rendered_history_paging.py` — the operator's report as a rendered assertion; `start of conversation` only after the audit chain drains; the marker renders as a `NoticeBlock` mid-transcript.

## Deliberately NOT in this PR

- **`mobile/durable.py` has the same defect** — its fold cache reimplements the truncating semantics, so `daemon._history_page` also pages only post-compaction rows. Fixing it means teaching an incremental offset-into-inode cursor an audit mode, which is a separate problem. **Known follow-up.**
- **`build_llm_history`'s signature and semantics** — unchanged. LLM context stays exactly as bounded as it is today.
- **The transcript file format** — no new row types, no migration, no backfill. Audit mode reads rows already on disk.
- **The attach/resume path** — `read_replay_suffix`, `_load_frontend_history` and `RESUME_RENDER_MESSAGES` untouched.
- **`audit_message_count`** — not added speculatively; no surface asks for it yet.
- **The retain budget** — deep audit scrolling will push a parked presentation past `RETAIN_TEXT_BYTES` and it will stop being cached. That is the budget working as designed; the docstring there records two prior mis-tunings in the direction of raising it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
