### PR TITLE
chore(release): bump version to 0.53.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.53.5"
+version = "0.53.6"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Version bump only for the post-v0.53.5 release window.

## Window

`git log v0.53.5..main` — four commits:

- #886 (ab49b0c4c) fix(skills): resolve a skill authored mid-session without a restart
- #889 (68dd42d55) fix(session): stop an attention token conflict bricking a session forever
- #881 (ec89d811d) perf(sidebar): make the catalog poll's per-directory syscalls O(user sessions) — **also fixes a data-loss defect**: during the stale-verdict window an un-hidden session lost `session.cleanup`'s recent-N guard, so an enabled cleanup policy could delete it. Cleanup is off by default, so exposure was narrow, but it was irreversible where it applied.
- #888 (781d0ae8b) fix(evaluation): recover when a model selects the tool channel and emits nothing

Rebased onto `ab49b0c4c`: #886 merged after this lock was first opened against a three-commit window, so the window was re-derived and this body re-states it rather than leaving stale prose on a release lock.

## Bump class: PATCH

All four are bug/perf fixes on existing surfaces. No API addition, no wire or protocol change, no migration a user acts on. Bug severity and change materiality are different axes: #881 and #889 are both serious fixes, and neither is a materially breaking change.

Two items could argue for a minor, and neither clears the bar:

- **#889** adds a `mutations` table to `attention.db`. Additive and self-migrating, with back-compat verified in both directions — an old-schema store is read without raising and without writing over the read-only connection, the first subsequent write migrates while preserving `receipts.acknowledged`, and old writers still work against a migrated store. The per-conversation `state()["revision"]` wire pair is deliberately unchanged because `mobile/web/src/types.ts:190` pins `[number, number]`.
- **#881** is a measured complexity-class change on a hot path, but there is no API, wire format, schema, config or CLI surface change; the listing is byte-identical before and after (independently verified for both the sidebar and `/resume`). Its only persisted change is `ORIGIN_CACHE_VERSION` 1 → 2, and an unknown version already degrades to a clean rebuild, so no user performs or notices a migration. One bounded semantic change: hand-deleting `origin.json` to un-hide a session now repairs at the ~5 min revalidation epoch rather than the next poll; hiding stays immediate.

#886 is likewise the same `read skill://<name>` path it always was; it just stops being wrong when the skill was authored after session start.

## Scope

`pyproject.toml` only, one line, 0.53.5 -> 0.53.6.

Each of the four commits was checked against its own parent (`git diff <sha>^ <sha> -- pyproject.toml`) — none touches the version file, so no stale-base squash can roll the version backward under this lock. Verified independently by two sessions.
