### PR TITLE
chore(release): bump version to 0.53.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.53.6"
+version = "0.53.7"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Version bump for the v0.53.7 release window. Owner session pid: **26368**.

Window (`git log v0.53.6..origin/main`, plain log — never `--merges`, which is blind to squashed PRs):
- [x] #890 (`61518e2a9`) — fix(providers): let ctrl+C cancel a pending OAuth login
- [x] #882 (`bb6038813`) — fix(mcp): keep OAuth capability evidence across a credential delete

**Bump: PATCH → 0.53.7.** Two bug fixes on existing surfaces. No new capability, no API addition, no wire/protocol change, no migration. Neither clears the step-function bar on its own, and materiality does not aggregate — several patches in one window remain one patch.

Scope: `pyproject.toml` only, one line, `0.53.6` → `0.53.7`. Verified `git diff v0.53.6..origin/main -- pyproject.toml` is empty, so no merged PR consumed this number.

C0 change, but still agent-authored, so it takes an independent scope-check round before merge.
