### PR TITLE
docs(agents): canary dead instruments before trusting their readings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1619,6 +1619,84 @@ forced your hand.
 Then check the other direction: run the file several times under load
 (`for i in $(seq 1 5)` with a few CPU spinners) and confirm it stays green.
 
+### A dead instrument returns a reading, not an error
+
+"Prove the test can still fail" covers the guard. This is the half underneath
+it: the instrument reading the guard can be dead too, and a dead instrument
+does not raise, warn, or emit garbage — it emits a well-formed answer to a
+question nobody asked. Its null result is indistinguishable from a real
+reading in **both** directions, and care does not defend against that. A
+canary does: before trusting anything an instrument says about the case you
+actually care about, push a **known-positive and a known-negative through the
+same instrument** — the tracer, the log parser, the grep, the render probe —
+and watch it tell them apart.
+
+Every instrument below succeeded, in the sense that none of it errored:
+
+- A syscall tracer blind to `stat`/`lstat` on CPython 3.14, used to verify a
+  gate whose entire purpose was preventing an existence oracle.
+- "Zero network calls", reported from a port collision that meant the request
+  log was never written.
+- A mutation harness that scored every mutant CAUGHT against a suite that
+  never ran — `pytest-timeout` was absent, the run exited `rc=4`, and the
+  harness read the exit code as the mutant dying. Two sessions hit this
+  independently.
+- A mutation that silently no-op'd because a formatter had rewrapped the
+  anchor line it patched, so the score measured an unmutated file.
+- Fifteen planted-violation cells reporting PASS without their mutation ever
+  landing; the one apparent catch was a `SyntaxError`.
+- A containment grep reporting "canary absent, len=2" — the `2` was `[]`,
+  serialised. An empty container greps clean.
+
+The reciprocal is equally real, and just as invisible — the instrument is dead
+*to the thing you changed*, so it fails what should pass:
+
+- A stale regex expecting a symbol a later round had renamed, reporting a
+  correctly-released binary as MISSING ITS OWN FIX — a hunt for a publishing
+  failure that never happened.
+- A `MagicMock(spec=...)` that measured the negative branch, producing a
+  "cheap" figure for an expensive operation.
+- A capture run under an env var that disabled the very effect being measured,
+  showing a defect "reproducing" after it was fixed.
+- A UI frame captured with no factory wired: the command refused, the refusal
+  rendered as an ordinary notice, and the still showed a plausible frame of
+  the feature never opening.
+- A `screen.render_line(y)` probe read outside a paint cycle returns blank
+  strips — 22 non-blank rows read as blank, a false BLOCKER against a correct
+  implementation.
+
+Name the asymmetry, because it decides where your paranoia goes: a false pass
+ships a defect; a false failure sends someone hunting a bug that does not
+exist. The second is cheaper, but it is not free — and the reading itself
+looks identical either way, which is exactly why the canary is the only
+defence.
+
+Two rules sit beside this one, each earned the hard way:
+
+**When you fix something that raises or refuses, verify it still raises where
+it should** — otherwise you have proven only that you removed a check. A
+reauth fix correctly fell through when nothing was stored, but also fired when
+the DELETE itself failed: it logged in over a surviving credential and
+reported success for an account switch that never happened. The reviewer then
+narrowed the fix to break it again, and all 520 tests still passed — the suite
+was structurally blind to the distinction the fix depended on. A separate
+session converged on the same rule from the opposite direction: an integrity
+refusal that survived a heal.
+
+**Quote the query, not just the result.** A `df` against `/` — a sealed,
+read-only APFS system volume whose percentage cannot move — and a
+`dict.get()` against the wrong nesting level both return clean, confident,
+wrong answers. State the basis alongside the number so a reader can check the
+*question*, not just the digit. A disk figure taken against the wrong mount
+propagated through a dozen sessions, each one confirming it back against the
+same wrong basis; every confirmation strengthened a number that was never
+right.
+
+And the corollary, for when the canary finally catches your own earlier
+finding: **withdraw it, do not defer it.** A deferred wrong finding is a
+landmine — the next reader treats it as unresolved-but-real and "corrects" a
+correct value into a wrong one.
+
 ### When a test is already flaking
 
 Reproduce and classify before touching a threshold. A single failure out of

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1647,6 +1647,11 @@ Every instrument below succeeded, in the sense that none of it errored:
   landing; the one apparent catch was a `SyntaxError`.
 - A containment grep reporting "canary absent, len=2" — the `2` was `[]`,
   serialised. An empty container greps clean.
+- A footer legend certified at a width no caller can produce: the picker's
+  content box is capped at 74 cells and the hint row carrying the legend
+  wants 88, so the legend could only ever appear by displacing another hint.
+  Passing the function a width the terminal cannot reach tests a code path
+  that does not exist.
 
 The reciprocal is equally real, and just as invisible — the instrument is dead
 *to the thing you changed*, so it fails what should pass:
@@ -1671,6 +1676,29 @@ exist. The second is cheaper, but it is not free — and the reading itself
 looks identical either way, which is exactly why the canary is the only
 defence.
 
+One species sits off that axis, being about what the instrument does to the
+subject rather than which way it errs: **the instrument cures it.** A fixture
+pinned `history_generation=1` against a snapshot at state 0, permanently
+invalidating the follower, so every ordinary delta restarted a refresh — and
+that refresh serviced the orphaned debt the test existed to catch. It passed
+because the harness was broken in a way that repaired the defect.
+
+That beats all three defences above: the instrument is live and
+discriminating, the mutation does land, and the pre-fix tree goes green too,
+because the harness cures the old tree as readily as the new one. A
+both-sides green reads as "already fixed" or "the test does not
+discriminate", never as "my fixture is repairing the bug".
+
+The defence is a precondition on the precondition: **assert the fixture's
+starting state is one the system can actually reach**, not merely that it is
+set. `history_generation=1` over snapshot state 0 is a state production never
+produces. It can drift there rather than be mis-set, too — a "known-bad"
+session artifact kept as a reproduction had healed past its failure mode
+(15,171 entries against the 14,905 it was captured at) and binds happily on
+the unfixed tree. This is the query rule below applied to fixtures: a
+fixture's state is part of its basis, so assert it at use time rather than
+inheriting it from when it was captured.
+
 Two rules sit beside this one, each earned the hard way:
 
 **When you fix something that raises or refuses, verify it still raises where
@@ -1683,14 +1711,14 @@ was structurally blind to the distinction the fix depended on. A separate
 session converged on the same rule from the opposite direction: an integrity
 refusal that survived a heal.
 
-**Quote the query, not just the result.** A `df` against `/` — a sealed,
-read-only APFS system volume whose percentage cannot move — and a
-`dict.get()` against the wrong nesting level both return clean, confident,
-wrong answers. State the basis alongside the number so a reader can check the
-*question*, not just the digit. A disk figure taken against the wrong mount
-propagated through a dozen sessions, each one confirming it back against the
-same wrong basis; every confirmation strengthened a number that was never
-right.
+**Quote the query, not just the result.** A `df` against `/` — which reports
+how full the sealed system volume is, not the writable `/System/Volumes/Data`
+that every byte you write lands on — and a `dict.get()` against the wrong
+nesting level both return clean, confident, wrong answers. State the basis
+alongside the number so a reader can check the *question*, not just the
+digit. A disk figure taken against the wrong mount propagated through a dozen
+sessions, each one confirming it back against the same wrong basis; every
+confirmation strengthened a number that was never right.
 
 And the corollary, for when the canary finally catches your own earlier
 finding: **withdraw it, do not defer it.** A deferred wrong finding is a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1684,20 +1684,14 @@ that refresh serviced the orphaned debt the test existed to catch. It passed
 because the harness was broken in a way that repaired the defect.
 
 That beats all three defences above: the instrument is live and
-discriminating, the mutation does land, and the pre-fix tree goes green too,
-because the harness cures the old tree as readily as the new one. A
-both-sides green reads as "already fixed" or "the test does not
-discriminate", never as "my fixture is repairing the bug".
+discriminating, the mutation lands, and the pre-fix tree goes green because
+the cure operates there too. Both sides green reads as "already fixed" or "the
+test does not discriminate", never "my fixture is repairing the bug".
 
 The defence is a precondition on the precondition: **assert the fixture's
-starting state is one the system can actually reach**, not merely that it is
-set. `history_generation=1` over snapshot state 0 is a state production never
-produces. It can drift there rather than be mis-set, too — a "known-bad"
-session artifact kept as a reproduction had healed past its failure mode
-(15,171 entries against the 14,905 it was captured at) and binds happily on
-the unfixed tree. This is the query rule below applied to fixtures: a
-fixture's state is part of its basis, so assert it at use time rather than
-inheriting it from when it was captured.
+starting state is production-reachable**, at use time rather than at capture —
+state drifts out of a failure condition as readily as it is mis-set into one
+production never produces.
 
 Two rules sit beside this one, each earned the hard way:
 


### PR DESCRIPTION
## What

One new AGENTS.md subsection: **A dead instrument returns a reading, not an error**, placed directly after `Prove the test can still fail` (inside `## Timing, flakes, and how to assert that something is fast`) and before `When a test is already flaking` — its closest relative.

`Prove the test can still fail` says a guard that cannot go red is worse than no guard. The new section is the generalisation: the **instrument that reads the guard can also be dead**, and a dead instrument's null result is indistinguishable from a real reading in *both* directions. The defence is a canary — push a known-positive and a known-negative through the same instrument before trusting anything it says about the case you actually care about.

## Content

Every instance cited is real and every instrument in them **succeeded** — no raise, no warning, a well-formed reading of a question nobody asked:

- **False passes:** a syscall tracer blind to `stat`/`lstat` on CPython 3.14 verifying an existence-oracle gate; "zero network calls" from a request log a port collision meant was never written; a mutation harness scoring every mutant CAUGHT against a suite that never ran (`pytest-timeout` absent → `rc=4` misread — two sessions independently); a mutation no-op'd by a formatter rewrapping its anchor line; fifteen planted-violation cells passing without their mutation landing (the one "catch" was a `SyntaxError`); a containment grep whose "len=2" was `[]` serialised — an empty container greps clean.
- **False failures:** a stale regex reporting a correctly-released binary as missing its own fix; a `MagicMock(spec=...)` measuring the negative branch; a capture run under an env var that disabled the effect being measured; a UI frame captured with no factory wired; a `screen.render_line(y)` probe outside a paint cycle reading 22 non-blank rows as blank.
- **The asymmetry, named:** a false pass ships a defect, a false failure sends someone hunting a bug that does not exist — cheaper, but not free, and the reading looks identical either way.
- **Two adjacent rules:** verify a fix that raises/refuses *still raises where it should* (the reauth case where all 520 tests stayed green through a reviewer mutation — the suite was structurally blind to the distinction the fix depended on; converged on independently from an integrity-refusal-survives-a-heal case); *quote the query, not just the result* (`df` against a sealed read-only APFS system volume, `dict.get()` at the wrong nesting level, and a wrong-mount disk figure a dozen sessions kept confirming).
- **Withdrawal corollary:** withdraw a wrong finding rather than deferring it — a deferred wrong finding is a landmine the next reader treats as unresolved-but-real.

## Verification

- Docs-only change: `AGENTS.md` +78 lines, nothing else touched. No version bump (per release-window rules).
- Placement verified on `origin/main` head: level-3 heading between `Prove the test can still fail` and `When a test is already flaking`, still inside the Timing chapter.
- Rendered with a real Markdown parser (python-markdown + toc): heading nests at `h3` beside its siblings, 2 `<ul>` blocks with 11 `<li>` items, all `**strong**` markers balanced, no stray markup. Max line length 82 chars, in family with the rest of the file.
- Unit suite deliberately not run locally (docs change; machine at ~92% disk / load ~9) — CI carries it.
- Worktree: fresh `~/worktrees/lop-docs-dead-instruments` from `origin/main` (`d77239876`), own bare venv, no symlink. Reclaimed after the PR opened.