### PR TITLE
chore(release): bump version to 0.53.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.53.7"
+version = "0.53.8"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window claimed and decided. Owner session pid: 35567.

Bump: **patch** → `0.53.8` (last tag `v0.53.7`).

Window (one PR, derived with plain `git log v0.53.7..origin/main` — never `--merges`, every commit here is a squash):

- [x] #883 — `712288f62` — `fix(tui): retry a sidebar reconnect instead of publishing a cold session`
  `Release: patch — selecting a session in the sidebar no longer latches on "Connection unavailable" or reverts to it ~15s after appearing connected while the runtime is healthy; a transient reconnect failure now retries itself.`

Bump class argument: a single bug fix on an existing surface. No API addition, no wire/protocol change, no migration. It does not clear the step-function bar, and per the versioning section of AGENTS.md materiality does not aggregate — a minor needs a single PR to clear the bar on its own.

Scope: `pyproject.toml` only, one line, `version = "0.53.7"` → `version = "0.53.8"`. `git diff v0.53.7..origin/main -- pyproject.toml` was empty before this commit, so no merged PR consumed the number.
