### PR TITLE
chore(release): bump version to 0.53.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.53.8"
+version = "0.53.9"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release lock for the post-v0.53.8 window. Owner: session pid 5550.

Window derived with plain `git log v0.53.8..origin/main` (never `--merges` — every commit is a squash):

- #895 `a71eae1ad` fix(oauth): correct OpenAI endpoint drift and pin Anthropic's loopback port
- #891 `4ee3e6735` fix(tui): mask a TYPED credential in the composer, not only a pasted one

Bump class: **PATCH**. Two bug fixes on existing surfaces. No API addition, no wire/protocol change, no migration. Neither clears the step-function bar alone, and materiality does not aggregate.

Scope: pyproject.toml only, one line 0.53.8 -> 0.53.9.

If you have something merging before the tag, send the PR number and merge SHA **at merge time** — the tag names a SHA and everything reachable from it ships. The window is re-derived immediately before `gh release create`.