### PR TITLE
chore(release): bump version to 0.54.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.53.9"
+version = "0.54.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release-window lock for the post-v0.53.9 window. Owner: this session.

**Window RE-DERIVED three times after late merges** (`git log v0.53.9..origin/main`, plain — never `--merges`, every commit here is a squash): FOUR PRs.

- #894 `74827a6d4` perf(tui): stop delivering discarded deltas to parked sidebar sources
- #885 `98e6f8eae` feat(desktop): serve durable session attachments by digest
- #899 `2566cbe7e` fix(session): make pre-compaction history reachable for audit
- #898 `59cd1b04b` refactor(session): retire `is_remote` for the declared runtime-role predicates

**Bump class: MINOR -> 0.54.0** (this PR was originally created as PATCH/0.53.10; the branch name is a leftover of that draft, the target is deliberately 0.54.0).

#885 adds `GET /v1/desktop/sessions/{session_id}/attachments/{digest}` — a NEW public HTTP route. That is an API addition, not a fix to an existing surface, and per AGENTS.md a MINOR needs a SINGLE PR to clear the step-function bar: **#885 clears it on its own.** This is not aggregation — #894 (waste-removal perf), #899 (defect repair on an existing surface; its `display-history-audit-v1` string is a compatibility gate, not a user-facing feature), and #898 (behaviour-preserving refactor with additive declarations and a one-row picker label, per its author's own PATCH argument) all stay patch-class and contribute nothing to the class. The window takes the class of its largest member.

The alternative at each late merge was to tag on less and let the rest ride the next window. Rejected each time because each was already reachable from `origin/main`, so any tag cut then ships them whether or not the notes name them — the v0.51.4 failure mode. Shipping a new public route unlisted under a PATCH label would understate the release to every reader. All three other authors sent PR#/merge-SHA/impact at merge time per protocol; the clock beat the handoff twice and the re-derivation caught both.

**Compatibility, verified rather than assumed** (confirmed by #885's author against the merged SHA): #885 is purely additive — one new route, no existing route's path/method/request schema/response schema/status codes changed, no wire or protocol change, no migration, no config key, no default flipped. A UI client older than local-operator-ui #104 never calls it. MINOR promises it is safe to take, and it is.

**Desktop auth confirmed intact on the merged commit.** A concurrent session's uncommitted edit in the shared worktree transiently removed `dependencies=[Depends(require_desktop)]` from the router; it never reached a commit. Verified independently from `git show 98e6f8eae:local_operator/server/routes/desktop_sessions.py` (line 51 carries it), corroborated by that PR's round-2 QA live probing on the same head: no bearer -> 401, wrong bearer -> 401, evil Origin -> 403.

**Scope:** `pyproject.toml` only, one line, 0.53.9 -> 0.54.0. Rebased onto `59cd1b04b`.

I re-derive immediately before `gh release create` — which is how #885, #899 and #898 were all caught.

**Known CI condition, pre-existing on `main` and NOT caused by this bump.** A shard caps at ~20m with zero pytest failures: no FAILURES section, all dots to [97-99%], sole error `The operation was canceled`, and a stall in the coverage/teardown tail rather than in a test.

The identifying signature is that teardown-tail stall, **not a shard number** — `scripts/shard_tests.py` balances by DURATION, not `i % 5`, so indices move as the file set changes. Observed on shards 1, 2, 3 and 4 across six sessions. Anyone checking a fixed shard number will see green and wrongly conclude it is unreproducible.

Bisect: `main` is green on `4dc303eda`/`4ee3e6735` and red from `a71eae1ad` (#895) onward, which adds `tests/unit/providers/test_oauth_flows.py`. **But the commit-level bisect is where the certainty ends.** Two independent agents could NOT reproduce that file hanging locally (116 passed in 39.7s and 116 in 10s, bare and under CI coverage flags), a peer reproduced the cap on a **one-line pyproject bump that cannot influence any test**, and another observed a capped job terminating **6 orphan processes (1 pytest, 4 python, 1 named `Local Operator`)**. A leaked child outliving its test fits the teardown stall, the migration, and the version-bump reproduction; a non-terminating test does not. Best current reading: #895 is a real inflection point that plausibly introduced or worsened a **process leak** (OAuth work: loopback listeners on 1455/1457, a `/cancel` route, device-code polling) rather than a hanging test, and the fix should start from the orphan list in a capped job's `Complete job` section. A one-line version bump reproducing it makes this PR a controlled confirmation that the fault is not diff-borne.