### PR TITLE
feat(tui): click-to-expand and hover highlight on the /analytics session table

### DIFF
--- a/local_operator/tui/widgets/analytics_panel.py
+++ b/local_operator/tui/widgets/analytics_panel.py
@@ -2576,6 +2576,17 @@ class AnalyticsScreen(ModalScreen[None]):
             self._repaint()
         if anchored:
             self._scroll_cursor_into_view()
+        # Same re-resolve as ``_set_expanded``, for the case it exists to
+        # close: ``e`` moves rows under a resting pointer even when the
+        # viewport does not. Children appear below every expandable root (or
+        # vanish on collapse), sliding the table under the pointer — but the
+        # ``scroll_y`` watch only fires when the cursor reveal above happens
+        # to scroll, and with the cursor row already visible the reveal is a
+        # no-op. No notification, no re-resolve, and the highlight stays
+        # painted on a row the pointer is not over: the wheel-gotcha defect
+        # via a keypress (review R1). ``_viewport_moved`` coalesces this with
+        # any watch callback the reveal did fire.
+        self.call_after_refresh(self._viewport_moved)
         self.call_after_refresh(self._sync_hint)
 
     def _forest(self) -> list["SessionNode"]:

--- a/local_operator/tui/widgets/analytics_panel.py
+++ b/local_operator/tui/widgets/analytics_panel.py
@@ -29,7 +29,7 @@ it is the right way to pin what the screen SAYS.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Collection, Mapping, Protocol, Sequence
+from typing import Collection, Mapping, NamedTuple, Protocol, Sequence
 
 from rich.cells import cell_len
 from rich.style import Style
@@ -489,6 +489,7 @@ def build_report(
     metric: str = METRIC_COST,
     expanded: "Collection[str] | None" = None,
     cursor: str | None = None,
+    hover: str | None = None,
     layout: ReportLayout | None = None,
     forest: list["SessionNode"] | None = None,
 ) -> list[Text]:
@@ -517,6 +518,11 @@ def build_report(
     for the same reason the expansion set is: expanding a row inserts rows above
     every later index, so an index-keyed cursor would slide onto a different
     session on the very keypress that is supposed to leave it where it is.
+
+    ``hover`` is the SESSION ID the POINTER is over, keyed by id for that same
+    reason, and it is independent of ``cursor``: the two selection models are
+    allowed to sit on different rows, and the report paints both marks at once.
+
     ``layout``, if given, receives which rows were painted and where, which the
     interactive screen needs to scroll the cursor into view; recomputing that
     outside this function would be a second, possibly disagreeing, notion of
@@ -899,6 +905,16 @@ def build_report(
             cursor_index = next(
                 (i for i, row in enumerate(structure) if row.session_id == cursor), None
             )
+        # Resolved to an index the same way, and by SESSION ID for the same
+        # reason: expanding a row inserts rows above every later index, so an
+        # index carried across a rebuild would land on a different session. A
+        # hovered id no longer on screen (its parent was collapsed) simply finds
+        # nothing and paints no highlight, which is the honest answer.
+        hover_index = None
+        if hover is not None:
+            hover_index = next(
+                (i for i, row in enumerate(structure) if row.session_id == hover), None
+            )
         lines.append(
             _session_section(
                 session_rows,
@@ -906,6 +922,7 @@ def build_report(
                 name_col,
                 meta,
                 cursor=cursor_index,
+                hover=hover_index,
                 suffixes=[suffixes[row.session_id] for row in structure],
             )
         )
@@ -1050,6 +1067,21 @@ _DISCLOSURE_CELLS = 2
 #: not as the position they are on). It is painted into the two leading indent
 #: cells every row already spends, so a cursor costs the label budget nothing.
 _ROW_CURSOR = "❯"
+
+
+class _PointerAt(NamedTuple):
+    """A bare screen coordinate with the two attributes the hit-test reads.
+
+    :meth:`AnalyticsScreen._row_at` takes an "event" but uses only
+    ``screen_x``/``screen_y``. Re-resolving the hover after the viewport moved
+    has a coordinate and NO event: synthesising a real ``events.MouseMove`` for
+    it would mean inventing a widget, a button state and deltas that no hit-test
+    reads, and posting it would re-enter the handler. This is the coordinate,
+    and nothing else — the same shape ``copy_picker`` uses for the same case.
+    """
+
+    screen_x: int
+    screen_y: int
 
 
 @dataclass(frozen=True)
@@ -1299,6 +1331,7 @@ def _session_section(
     meta: str = "",
     *,
     cursor: int | None = None,
+    hover: int | None = None,
     suffixes: Sequence[str] | None = None,
 ) -> Text:
     """The per-session table, pre-ordered and pre-indented by the forest walk.
@@ -1328,6 +1361,23 @@ def _session_section(
     cursor at all, which keeps the plain-text renderers and the scripts on the
     same output they had before the row cursor existed.
 
+    ``hover`` is the index the POINTER is over, and it is deliberately a second
+    and independent index from ``cursor``: the mouse and the keyboard are two
+    selection models that must be able to sit on different rows without either
+    dragging the other. It is painted as a background tint across the row's full
+    cell width and nothing else — no inserted glyph, no changed indent — because
+    this table's "no reflow on interaction" property is load-bearing (three
+    review rounds of #873 pinned it), and a hover that reflowed the table under
+    a moving pointer would move the very row the user is aiming at.
+
+    The tint is ``tint-select``, the same ground the ``/copy`` picker's hover
+    uses, so a highlighted row means one thing across the app. The caret is what
+    DISCRIMINATES hover from the keyboard cursor: on the cursor row the ground
+    is ``tint-select-hi`` (a step up, so "the pointer is on the row the keyboard
+    is also on" is its own visible state) and the ``❯`` is present either way.
+    Hover alone never paints a caret — two carets would be two claims about
+    where ``enter`` acts.
+
     ``suffixes`` is the ``+N subagents`` tail already composed into each label,
     handed over separately ONLY so it can be painted ``dim`` (review D3). It is
     metadata about the row, not part of the session's name, and at full
@@ -1351,11 +1401,17 @@ def _session_section(
     calls_col = _calls_col(pairs)
     for index, (label, depth, agg) in enumerate(rows):
         block.append("\n")
+        # Where this row's cells begin, so the hover tint can be laid over the
+        # WHOLE row once it is composed. Taken after the newline, which belongs
+        # to the row above: tinting it would paint a notch into the previous
+        # row's right edge.
+        row_start = len(block.plain)
         # A nested row is dimmed as well as indented: its dollars are already
         # inside the root above it, so it must not compete visually with the
         # rows that actually partition the total.
         style = fg if depth == 0 else dim
         on_cursor = cursor is not None and index == cursor
+        on_hover = hover is not None and index == hover
         if on_cursor:
             block.append(f"{_ROW_CURSOR} ", style=accent)
         else:
@@ -1383,6 +1439,24 @@ def _session_section(
         block.append(f"   {agg.calls:>{calls_col}} calls", style=dim)
         if show_cache:
             block.append(f"   {format_percent(agg.cache_hit_rate):>4} cache", style=dim)
+        if on_hover:
+            # A BACKGROUND laid over the finished row, never a re-styling of it:
+            # `Text.stylize` adds a span, so every foreground the row already
+            # chose (dim suffix, dim calls, accent caret) survives underneath and
+            # only the ground changes. Re-composing the row in a "hover style"
+            # would flatten those distinctions exactly on the row the user is
+            # looking at hardest.
+            #
+            # Spanned to the row's own composed cells rather than padded out to
+            # ``width``: the table is narrower than the card whenever the name
+            # column hits its cap (100 cells inside a 134-cell box), and a tint
+            # run to the box edge would highlight a band of empty margin that is
+            # not part of the table. Every row composes to the same cell count,
+            # so the tint is a clean rectangle down the table.
+            ground = "tint-select-hi" if on_cursor else "tint-select"
+            block.stylize(
+                Style(bgcolor=theme_mod.semantic_color(ground)), row_start, len(block.plain)
+            )
     return block
 
 
@@ -1541,6 +1615,19 @@ class AnalyticsScreen(ModalScreen[None]):
         #: Session ID the row cursor is on, or ``None`` before the first paint
         #: has told us which rows exist. Same keying rule, same reasons.
         self._cursor: str | None = None
+        #: Session ID the POINTER is over, or ``None``. A SECOND selection model
+        #: beside ``_cursor`` and deliberately independent of it: the pointer can
+        #: rest on one row while the keyboard cursor sits on another, and neither
+        #: may drag the other around. Same id-keying rule as ``_cursor``.
+        self._hover: str | None = None
+        #: Last known pointer position, in SCREEN coordinates. Kept because the
+        #: viewport moves under a resting pointer — a real terminal sends no
+        #: ``MouseMove`` while only the wheel turns — so the highlight has to be
+        #: re-resolved from a coordinate that has no event behind it. See
+        #: ``_refresh_hover``; this is ``copy_picker``'s ``_pointer_at`` and it
+        #: exists here for the identical reason, on a surface that scrolls much
+        #: further.
+        self._pointer_at: tuple[int, int] | None = None
         #: What the last paint put where — the rows it drew and the body line the
         #: first of them landed on. Written by ``build_report`` through the
         #: ``ReportLayout`` receiver so cursor movement and scroll-to-cursor read
@@ -1556,6 +1643,11 @@ class AnalyticsScreen(ModalScreen[None]):
         #: unchanged width cannot produce different output. So the width is the
         #: repaint's cache key.
         self._painted_width: int | None = None
+        #: Whether a hover re-resolve is already queued for after the next
+        #: refresh. ``scroll_y`` is an ANIMATED value — one ``pagedown`` fired 28
+        #: notifications — so the re-resolve is coalesced to one per frame rather
+        #: than run per notification at 12 ms a repaint. See ``_viewport_moved``.
+        self._hover_refresh_pending = False
         #: Lazily built by ``_forest()``; see there for why it is cached.
         self._forest_cache: list["SessionNode"] | None = None
         self._title: Static
@@ -1581,6 +1673,21 @@ class AnalyticsScreen(ModalScreen[None]):
         # body has been measured against the viewport.
         self.call_after_refresh(self._sync_hint)
         self.call_after_refresh(self._place_initial_cursor)
+        # THE WHEEL GOTCHA, covered at its source. A real terminal sends no
+        # ``MouseMove`` while only the wheel turns, so the rows slide under a
+        # resting pointer and the highlight stays painted on a row the pointer
+        # is no longer over. Watching the container's own ``scroll_y`` catches
+        # every way the viewport can move — wheel, scrollbar drag, page/home/end
+        # keys, and ``_scroll_cursor_into_view`` — as one hook, instead of a
+        # ``_refresh_hover()`` call bolted onto each of those paths that the
+        # next new one would forget.
+        #
+        # A wheel notch measurably never reaches a screen-level handler: Textual
+        # stops the event on the container while it can still scroll, so a
+        # ``on_mouse_scroll_*`` override here would run only at the ends of the
+        # travel (the trap AGENTS.md records for ``/settings``). The watcher sees
+        # all of them.
+        self.watch(self._scroll, "scroll_y", self._viewport_moved, init=False)
 
     def _place_initial_cursor(self) -> None:
         """Draw the caret from frame 1, without moving the viewport.
@@ -1622,6 +1729,10 @@ class AnalyticsScreen(ModalScreen[None]):
         # enter ``_card_width`` at all.
         self._repaint(force=False)
         self.call_after_refresh(self._sync_hint)
+        # A resize relays the rows under a pointer that did not move, so the
+        # highlight has to be re-resolved for the same reason a scroll does.
+        # After the refresh, because it reads the new geometry.
+        self.call_after_refresh(self._refresh_hover)
 
     def _card_width(self) -> int:
         # Track the CSS card (90% of the terminal, capped at 140 — see the
@@ -1804,6 +1915,7 @@ class AnalyticsScreen(ModalScreen[None]):
             metric=self._metric,
             expanded=self._expanded,
             cursor=self._cursor,
+            hover=self._hover,
             layout=self._layout,
             # Every arrow key repaints, and rebuilding the forest each time was
             # 34 ms of the ~0.25 s that made the cursor feel laggy rather than
@@ -1998,6 +2110,191 @@ class AnalyticsScreen(ModalScreen[None]):
         line = self._layout.session_first_line + index
         return top <= line <= top + height - 1
 
+    # -- mouse ----------------------------------------------------------------
+    # Public handler names on purpose: Textual dispatches ``_on_<event>`` and
+    # then ``on_<event>``, so overriding the PRIVATE name shadows the base
+    # ``Widget``'s own ``mouse_hover`` bookkeeping — the thing that drives every
+    # ``:hover`` rule — and silently latches it on. ``command_picker`` documents
+    # the same trap at its own mouse block.
+
+    def _row_at(self, event) -> int | None:  # type: ignore[no-untyped-def]
+        """Index of the session row under a mouse event, or ``None``.
+
+        Resolved against the VIEWPORT plus the scroll offset, and deliberately
+        NOT against ``_body.region``. The two are arithmetically identical — the
+        body is ``height: auto`` inside the container, so ``body.y ==
+        viewport.y - scroll_offset.y`` held exactly at every offset measured —
+        but they are not equally CURRENT. ``body.region`` is recomputed by
+        layout and lags a scroll by a frame, while ``scroll_y`` is the reactive
+        whose change notifies ``_viewport_moved`` in the first place. Basing the
+        hit-test on the body read a stale ``body.y`` of -9 against an already
+        settled offset of 0 (measured), resolving the pointer 16 rows away from
+        the truth and leaving the highlight stuck on a row it had scrolled past.
+        This basis is correct at the instant the watcher runs.
+
+        Two guards, and the FIRST is mandatory rather than defensive:
+
+        - the point must be inside the SCROLL VIEWPORT, not merely inside the
+          body's region. The body overhangs the viewport by however much of the
+          report is scrolled out of sight — measured at 27 rows on a 40-row
+          frame — so ``body.region.contains`` alone resolves coordinates that
+          are clipped, including the hint line below the card (measured: the
+          hint at y=33 is inside ``body.region`` and outside the viewport). This
+          is a modal over the transcript, so the backdrop also bubbles events
+          from well outside the panel, which the same guard rejects;
+        - and the resulting index must be a row that EXISTS. The table is one
+          section of a long report: everything above it (totals, both charts,
+          the input attribution, the provider table) and the legend below it
+          resolve to indices outside ``session_rows`` and must be inert.
+
+        Rows are addressable by their whole width. Every row composes ``no_wrap``
+        to the same cell count, so the row is a clean rectangle and the ``x``
+        coordinate carries no information the ``y`` does not already have.
+        """
+        scroll = getattr(self, "_scroll", None)
+        if scroll is None or not scroll.is_mounted:
+            return None
+        viewport = scroll.scrollable_content_region
+        if not viewport.contains(event.screen_x, event.screen_y):
+            return None
+        line = event.screen_y - viewport.y + int(scroll.scroll_offset.y)
+        index = line - self._layout.session_first_line
+        return index if 0 <= index < len(self._layout.session_rows) else None
+
+    def on_mouse_move(self, event) -> None:  # type: ignore[no-untyped-def]
+        self._pointer_at = (event.screen_x, event.screen_y)
+        self._apply_hover(self._row_at(event))
+
+    def on_leave(self, event) -> None:  # type: ignore[no-untyped-def]
+        """Drop the highlight when the pointer leaves the rows.
+
+        ``Leave`` bubbles from the body ``Static``, and its ORDERING relative to
+        the ``MouseMove`` that lands somewhere else was measured before relying
+        on it: moving row -> hint delivers ``move`` and then ``leave``, and hint
+        -> row delivers ``leave`` (of the hint) and then ``move``. In neither
+        direction does a stale ``leave`` arrive after the move that set a new
+        hover, so this cannot erase a highlight that was just correctly placed.
+        """
+        self._pointer_at = None
+        self._apply_hover(None)
+
+    def _apply_hover(self, index: int | None) -> None:
+        """Move the highlight to visible row ``index`` and set the pointer shape.
+
+        One place, because every path that resolves a hover — a real pointer
+        event and the eventless re-resolve after the viewport moved — must agree
+        about what a hover DOES, including the pointer shape. Splitting them is
+        how the shape ends up correct on one path and latched on the other.
+
+        The hand appears over EXPANDABLE rows only. A childless row still takes
+        the highlight — it is genuinely the row under the pointer and saying so
+        is honest — but its click does nothing, and a hand over it would promise
+        a click it does not keep. That is the majority case, not an edge one:
+        492 of the operator's 595 roots are childless.
+        """
+        rows = self._layout.session_rows
+        row = rows[index] if index is not None else None
+        session_id = row.session_id if row is not None else None
+        self.styles.pointer = "pointer" if row is not None and row.expandable else "default"
+        if session_id == self._hover:
+            return
+        self._hover = session_id
+        self._repaint()
+
+    def _refresh_hover(self) -> None:
+        """Re-resolve the highlight against the LAST KNOWN pointer position.
+
+        The rows move under a resting pointer — the wheel scrolls the report,
+        the scrollbar drags it, ``_scroll_cursor_into_view`` moves it for a key
+        — and a real terminal sends NO ``MouseMove`` for any of that. Without
+        this the highlight stays painted on a row the pointer is not over, and
+        on a report this tall it scrolls off the viewport entirely while the
+        hand cursor stays (the defect ``copy_picker._refresh_hover`` was written
+        for, on a surface that scrolls much further).
+
+        Takes a coordinate with no event behind it, which is what
+        ``_PointerAt`` is for: synthesising a ``MouseMove`` would mean inventing
+        a widget, a button state and deltas no hit-test reads, and POSTING one
+        would re-enter the handler.
+        """
+        if self._pointer_at is None:
+            return
+        self._apply_hover(self._row_at(_PointerAt(*self._pointer_at)))
+
+    def _viewport_moved(self) -> None:
+        """Re-resolve the hover after the viewport moved, at most once a frame.
+
+        ``scroll_y`` is watched rather than each mover being patched, but it is
+        an ANIMATED value: one ``pagedown`` on a real ledger fired 28 separate
+        notifications as the scroll eased to its target. A repaint per
+        notification is 12 ms each measured against the operator's 2,779-session
+        ledger — a third of a second of rebuilds for one keypress, which is the
+        freeze this panel's width cache already exists to prevent.
+
+        So the work is coalesced: the flag marks the viewport dirty and
+        ``call_after_refresh`` resolves it once, after the whole burst has been
+        applied and the geometry it reads is final.
+        """
+        if self._hover is None and self._pointer_at is None:
+            # Nothing to re-resolve and nothing painted: the common case (no
+            # pointer has ever been over this screen) costs one attribute read.
+            return
+        if self._hover_refresh_pending:
+            return
+        self._hover_refresh_pending = True
+        self.call_after_refresh(self._resolve_pending_hover)
+
+    def _resolve_pending_hover(self) -> None:
+        self._hover_refresh_pending = False
+        self._refresh_hover()
+
+    def on_click(self, event) -> None:  # type: ignore[no-untyped-def]
+        """Click a row to expand or collapse it.
+
+        **The WHOLE row is the target, not just the ``\u25b8`` glyph.** The glyph is
+        two cells against a hundred-cell row, and a two-cell target is a
+        precision the mouse was invited in to avoid — the sibling pickers
+        (`command_picker`, `copy_picker`, `session_picker`, `model_picker`) all
+        make the whole row clickable and a user who learned that here would find
+        this one screen demanding aim. The usual argument for the narrow target
+        is accidental toggles, and it does not apply: the rows carry no other
+        click action to collide with, and the mistake is instantly visible and
+        undone by clicking again. The cost of the wide target is one wrong
+        expand; the cost of the narrow one is a control most users never find.
+
+        **The click also moves the keyboard cursor to the row.** The two
+        selection models may sit apart while the pointer merely HOVERS — that is
+        what makes hover a preview — but an ACT is different: after clicking row
+        7 open, an ``enter`` that collapsed row 2 instead (because the caret
+        never left it) would be the two models visibly disagreeing about which
+        row is "current". Moving the caret on the acting gesture is what
+        `copy_picker` does for the same reason, and it keeps the hint honest:
+        ``enter expand`` names the row the user just acted on.
+
+        A click on a CHILDLESS row is a clean no-op — no cursor move, no
+        viewport move, no repaint. Not merely "toggling nothing": moving the
+        caret there would scroll the view for a gesture the user experienced as
+        doing nothing, and 492 of 595 real roots are childless, so this is the
+        majority click.
+
+        ``event.stop()`` because this is a modal over the transcript and a
+        bubbled click hands the gesture to a parent — one gesture must not move
+        two surfaces. Button 1 only, and the button is tested BEFORE any state
+        changes: a right-click asking for a context menu must not toggle a row
+        on its way to being ignored.
+        """
+        if getattr(event, "button", 1) != 1:
+            return
+        index = self._row_at(event)
+        if index is None:
+            return
+        event.stop()
+        row = self._layout.session_rows[index]
+        if not row.expandable:
+            return
+        self._cursor = row.session_id
+        self.action_toggle_row()
+
     def _move_cursor(self, delta: int) -> None:
         rows = self._layout.session_rows
         if not rows:
@@ -2157,6 +2454,16 @@ class AnalyticsScreen(ModalScreen[None]):
             self._rehome_to_ancestor(chain)
             self._repaint()
         self._scroll_cursor_into_view()
+        # An expand/collapse is the one mover the ``scroll_y`` watch does not
+        # see: it changes the body's height, and only moves the viewport when
+        # the cursor reveal above happens to scroll. Either way rows slide
+        # under a resting pointer — 30 children appearing below the cursor
+        # pushes every row beneath it down by 30 — so the highlight is
+        # re-resolved here too. Deferred rather than run in place: the new
+        # geometry is only settled after the refresh that paints it, and
+        # ``_viewport_moved`` already coalesces this with any watch callback
+        # the reveal fired, so one repaint carries both.
+        self.call_after_refresh(self._viewport_moved)
         # Expanding changes the body's height, so whether it overflows its
         # viewport — and therefore whether the scroll hint is honest — can change
         # with it. Deferred, because the new height is only known after the

--- a/scripts/analytics_mouse_shot.py
+++ b/scripts/analytics_mouse_shot.py
@@ -1,0 +1,291 @@
+"""Capture what the MOUSE does to the ``/analytics`` session table.
+
+Sibling of ``analytics_cursor_shot.py`` (where is the KEYBOARD cursor) and
+``analytics_collapse_shot.py`` (how much of the table is on screen). This one
+is about the pointer: the hover highlight, the pointer shape, and what a click
+does to a row — the three things a rendered frame can settle and an assertion
+about ``_hovered`` cannot.
+
+Four states, each named after what it shows and each ASSERTED before the
+capture rather than reached by a fixed number of gestures:
+
+1. ``hover-expandable`` — the pointer on a row with children. The highlight has
+   to be visible AND distinguishable from the caret.
+2. ``hover-childless`` — the pointer on a row with none. It still highlights
+   (the row is under the pointer and saying so is honest), but the pointer
+   SHAPE stays ``default`` and a click does nothing.
+3. ``hover-vs-cursor`` — hover and caret on DIFFERENT rows, which is the frame
+   that proves the two selection models are visually separable. If hover
+   painted like the caret a reader would see two cursors and not know which one
+   ``enter`` acts on.
+4. ``after-click`` — the same row after a click expanded it.
+
+**Captured at three geometries, not one.** The most expensive defect in #873
+got through because every frame was taken at 120x40 — the one size where the
+table is on screen at mount. 120x30 and 110x20 put the table below the fold and
+force the scroll-then-hover path, which is where the coordinate arithmetic is
+easiest to get wrong.
+
+Usage: ``python -m scripts.analytics_mouse_shot <out-dir>``
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+# Clear every multiplexer identifier BEFORE any application import: a headless
+# pilot that inherits ``CMUX_WORKSPACE_ID`` renames the operator's real cmux
+# workspaces (the incident ``analytics_collapse_shot`` records).
+for _key in tuple(os.environ):
+    if _key.startswith("CMUX_"):
+        os.environ.pop(_key)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import scripts.probe_isolation  # noqa: E402, F401  — isolates HOME and the config dir
+from local_operator.analytics.store import AnalyticsStore  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.analytics_panel import AnalyticsScreen  # noqa: E402
+from scripts.analytics_collapse_shot import (  # noqa: E402
+    _factory_for,
+    _make_session,
+    seed,
+)
+from scripts.visual_capture import save_capture  # noqa: E402
+from tests.unit.tui.test_slash_echo import _submit  # noqa: E402
+
+#: Geometries. 120x40 is the size the collapse PR's frames used; the other two
+#: are the sizes it never looked at, where the table starts below the fold.
+SIZES = ((120, 40), (120, 30), (110, 20))
+
+
+async def _open(pilot, app) -> AnalyticsScreen:
+    await pilot.pause()
+    await _submit(pilot, app, "/analytics")
+    await app.workers.wait_for_complete()
+    await pilot.pause()
+    screen = app.screen
+    assert isinstance(screen, AnalyticsScreen), f"expected /analytics, got {type(screen)}"
+    return screen
+
+
+def _scroll_table_into_view(screen: AnalyticsScreen) -> None:
+    """Put the first session row on screen, whatever the terminal height.
+
+    The table sits below the totals and both charts, so on a short frame it is
+    simply not painted until the viewport moves. Scrolled directly rather than
+    by counting ``pagedown`` presses: how many pages reach the table depends on
+    the height, which is exactly what varies across ``SIZES``.
+    """
+    scroll = screen._scroll
+    first = screen._layout.session_first_line
+    scroll.scroll_to(y=max(0, first - 1), animate=False)
+
+
+def _row_y(screen: AnalyticsScreen, index: int) -> int:
+    """Screen row of visible session row ``index``.
+
+    Resolved from the VIEWPORT and the scroll offset, the same basis
+    ``AnalyticsScreen._row_at`` uses — ``_body.region`` is arithmetically
+    equivalent but lags a scroll by a frame, so a capture aiming by the body
+    can shoot at a row the screen no longer thinks is there. Spelled here
+    rather than calling the screen's own helper so the capture and the code
+    under test agree only if BOTH are right.
+    """
+    scroll = screen._scroll
+    viewport = scroll.scrollable_content_region
+    line = screen._layout.session_first_line + index
+    return viewport.y + line - int(scroll.scroll_offset.y)
+
+
+def _find_row(screen: AnalyticsScreen, *, expandable: bool) -> int:
+    """Index of the first VISIBLE row of the asked-for kind, or raise.
+
+    Frames are named after the state they show, so the state is asserted rather
+    than assumed — round 1 of #873 shipped a frame called ``cursor-expandable``
+    holding the cursor on a childless root because press count was used as a
+    proxy for row kind.
+    """
+    scroll = screen._scroll
+    top = scroll.scroll_offset.y
+    height = scroll.size.height
+    first = screen._layout.session_first_line
+    for index, row in enumerate(screen._layout.session_rows):
+        line = first + index
+        if row.expandable is expandable and top <= line <= top + height - 1:
+            return index
+    raise AssertionError(f"no visible row with expandable={expandable}")
+
+
+def _hovered(screen: AnalyticsScreen) -> int | None:
+    """Index of the hovered row, or ``None`` when nothing is hovered.
+
+    The screen stores the hover as a SESSION ID (``_hover``) for the same
+    reason it stores the cursor as one — an index slides when a row above it
+    expands — so the index a frame is checked against is resolved here against
+    the layout that was actually painted.
+
+    Read through ``getattr`` so this SAME script runs unchanged against the
+    pre-change code, where the attribute does not exist: the before-frames then
+    come out of the identical harness as the after-frames, which is what makes
+    the pair comparable (``analytics_collapse_shot`` does this for the expand
+    keys for the same reason).
+    """
+    session_id = getattr(screen, "_hover", None)
+    if session_id is None:
+        return None
+    return next(
+        (i for i, row in enumerate(screen._layout.session_rows) if row.session_id == session_id),
+        None,
+    )
+
+
+async def _capture(app, pilot, out: Path, name: str, state: dict[str, object]) -> dict[str, object]:
+    path = out / f"{name}.svg"
+    save_capture(app, str(path))
+    await pilot.pause()
+    return {"state": name, "svg": path.name, **state}
+
+
+async def _states_for(width: int, height: int, out: Path) -> list[dict[str, object]]:
+    tag = f"{width}x{height}"
+    states: list[dict[str, object]] = []
+    app = OperatorApp(lambda: _factory_for(_make_session()))
+    async with app.run_test(size=(width, height)) as pilot:
+        screen = await _open(pilot, app)
+        _scroll_table_into_view(screen)
+        await pilot.pause()
+
+        body_x = screen._body.region.x + 6
+
+        # 1. Hover an EXPANDABLE row.
+        index = _find_row(screen, expandable=True)
+        row = screen._layout.session_rows[index]
+        await pilot.hover(screen, offset=(body_x, _row_y(screen, index)))
+        await pilot.pause()
+        states.append(
+            await _capture(
+                app,
+                pilot,
+                out,
+                f"hover-expandable-{tag}",
+                {
+                    "hovered_index": _hovered(screen),
+                    "aimed_at": index,
+                    "session_id": row.session_id,
+                    "expandable": row.expandable,
+                    "pointer_shape": str(screen.styles.pointer),
+                    "cursor_index": screen._cursor_index(),
+                },
+            )
+        )
+
+        # 2. Hover a CHILDLESS row — highlighted, but no hand and no action.
+        childless = _find_row(screen, expandable=False)
+        await pilot.hover(screen, offset=(body_x, _row_y(screen, childless)))
+        await pilot.pause()
+        before = "\n".join(screen.render_lines_for_test())
+        states.append(
+            await _capture(
+                app,
+                pilot,
+                out,
+                f"hover-childless-{tag}",
+                {
+                    "hovered_index": _hovered(screen),
+                    "aimed_at": childless,
+                    "session_id": screen._layout.session_rows[childless].session_id,
+                    "expandable": False,
+                    "pointer_shape": str(screen.styles.pointer),
+                },
+            )
+        )
+
+        # 3. Hover and CARET on different rows. The caret is moved with the
+        #    keyboard to a row the pointer is not on, so the frame carries both
+        #    marks at once and their difference is what the reader checks.
+        target = index if index != screen._cursor_index() else childless
+        hover_on = childless if target == index else index
+        screen._cursor = screen._layout.session_rows[target].session_id
+        screen._repaint()
+        await pilot.hover(screen, offset=(body_x, _row_y(screen, hover_on)))
+        await pilot.pause()
+        states.append(
+            await _capture(
+                app,
+                pilot,
+                out,
+                f"hover-vs-cursor-{tag}",
+                {
+                    "hovered_index": _hovered(screen),
+                    "cursor_index": screen._cursor_index(),
+                    "distinct_rows": _hovered(screen) != screen._cursor_index(),
+                },
+            )
+        )
+
+        # 4. CLICK the expandable row and capture what it opened.
+        rows_before = len(screen._layout.session_rows)
+        await pilot.click(screen, offset=(body_x, _row_y(screen, index)))
+        await pilot.pause()
+        await pilot.pause()
+        rows_after = len(screen._layout.session_rows)
+        states.append(
+            await _capture(
+                app,
+                pilot,
+                out,
+                f"after-click-{tag}",
+                {
+                    "rows_before": rows_before,
+                    "rows_after": rows_after,
+                    "expanded_by_click": rows_after > rows_before,
+                    "cursor_followed_click": screen._cursor == row.session_id,
+                    "hovered_index": _hovered(screen),
+                },
+            )
+        )
+
+        # 5. A click on a CHILDLESS row must be inert: same rows, same viewport.
+        offset_before = screen._scroll.scroll_offset.y
+        text_before = "\n".join(screen.render_lines_for_test())
+        childless = _find_row(screen, expandable=False)
+        await pilot.click(screen, offset=(body_x, _row_y(screen, childless)))
+        await pilot.pause()
+        states.append(
+            {
+                "state": f"childless-click-inert-{tag}",
+                "viewport_unmoved": screen._scroll.scroll_offset.y == offset_before,
+                "row_count_unchanged": len(screen._layout.session_rows) == rows_after,
+                "frame_changed": "\n".join(screen.render_lines_for_test()) != text_before,
+            }
+        )
+        assert before  # the childless hover frame was captured above
+
+    for state in states:
+        state["size"] = tag
+    return states
+
+
+async def main() -> None:
+    out = Path(sys.argv[1]).resolve()
+    out.mkdir(parents=True, exist_ok=True)
+
+    store = AnalyticsStore()
+    seed(store)
+    store.close()
+
+    states: list[dict[str, object]] = []
+    for width, height in SIZES:
+        states.extend(await _states_for(width, height, out))
+
+    (out / "mouse-states.json").write_text(json.dumps(states, indent=2) + "\n")
+    for state in states:
+        print(json.dumps(state))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/unit/tui/test_analytics_mouse.py
+++ b/tests/unit/tui/test_analytics_mouse.py
@@ -1,0 +1,693 @@
+"""The ``/analytics`` session table driven by a POINTER.
+
+Separate from ``test_analytics_panel.py`` (what the report says, and its
+keyboard) for the reason ``test_copy_picker_mouse.py`` is separate from its
+own sibling: this file asks whether the surface behaves when it is DRIVEN
+rather than merely drawn. Everything here runs against the real ``OperatorApp``
+under the production stylesheet — the lightweight hosts elsewhere in this suite
+declare no ``CSS_PATH``, so a card sized by percentage rules is not sized at
+all under one, and a mouse coordinate against an unsized card means nothing.
+
+The hit-test geometry these tests pin was MEASURED before it was written, and
+two of the measurements are why the guards exist:
+
+* ``_body`` is ``height: auto`` inside the scroll container, so its region
+  tracks the scroll offset (measured: ``region.y`` 8 -> 4 for an offset of 3).
+  The body line under a screen row is therefore a plain subtraction.
+* the body OVERHANGS the viewport by everything scrolled out of sight
+  (measured: 27 rows on a 40-row frame), and ``body.region`` contains the hint
+  line below the card. A hit-test guarded by the body alone resolves clipped
+  coordinates to real rows, which is what ``test_a_click_below_the_viewport_
+  is_not_a_row`` pins.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from textual import events
+
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.analytics_panel import AnalyticsScreen
+from tests.unit.tui.test_analytics_panel import (
+    _nested_screen_agg,
+    _push,
+    _tall_report_agg,
+)
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+def _app() -> OperatorApp:
+    return OperatorApp(lambda: _factory(FakeSession()))
+
+
+def _row_y(screen: AnalyticsScreen, index: int) -> int:
+    """Screen row of visible session row ``index``.
+
+    Deliberately NOT a call to the screen's own ``_row_at`` inverted: a test
+    that aims with the code under test cannot catch that code aiming wrongly.
+    This is the arithmetic spelled from the widget geometry — the viewport
+    plus the scroll offset, since the body's region lags a scroll by a frame —
+    so the two agree only if both are right.
+    """
+    scroll = screen._scroll
+    line = screen._layout.session_first_line + index
+    return scroll.scrollable_content_region.y + line - int(scroll.scroll_offset.y)
+
+
+def _row_x(screen: AnalyticsScreen) -> int:
+    return screen._body.region.x + 6
+
+
+def _move(screen: AnalyticsScreen, x: int, y: int) -> events.MouseMove:
+    return events.MouseMove(
+        widget=screen._body,
+        x=0,
+        y=0,
+        delta_x=0,
+        delta_y=0,
+        button=0,
+        shift=False,
+        meta=False,
+        ctrl=False,
+        screen_x=x,
+        screen_y=y,
+    )
+
+
+def _click(screen: AnalyticsScreen, x: int, y: int, button: int = 1) -> events.Click:
+    return events.Click(
+        widget=screen._body,
+        x=0,
+        y=0,
+        delta_x=0,
+        delta_y=0,
+        button=button,
+        shift=False,
+        meta=False,
+        ctrl=False,
+        screen_x=x,
+        screen_y=y,
+        chain=1,
+    )
+
+
+def _hover_index(screen: AnalyticsScreen) -> int | None:
+    """The hovered row as an INDEX, resolved against the painted layout.
+
+    The screen stores a session id (an index slides when a row above it
+    expands), and the tests are about which row the reader sees highlighted.
+    """
+    if screen._hover is None:
+        return None
+    return next(
+        (i for i, row in enumerate(screen._layout.session_rows) if row.session_id == screen._hover),
+        None,
+    )
+
+
+def _first_row(screen: AnalyticsScreen, *, expandable: bool) -> int:
+    return next(
+        i for i, row in enumerate(screen._layout.session_rows) if row.expandable is expandable
+    )
+
+
+def _show_table(screen: AnalyticsScreen) -> None:
+    """Scroll the session table into view, whatever the terminal height.
+
+    Scrolled directly rather than by counting ``pagedown`` presses: how many
+    pages reach the table depends on the height, which varies across these
+    tests.
+    """
+    screen._scroll.scroll_to(y=max(0, screen._layout.session_first_line - 1), animate=False)
+
+
+# -- clicking -----------------------------------------------------------------
+
+
+def test_clicking_an_expandable_row_expands_it():
+    """The operator's ask: "make it so you can also click to expand"."""
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _nested_screen_agg())
+            _show_table(screen)
+            await pilot.pause()
+            index = _first_row(screen, expandable=True)
+            row = screen._layout.session_rows[index]
+            assert "kid1session" not in "\n".join(screen.render_lines_for_test())
+
+            await pilot.click(screen, offset=(_row_x(screen), _row_y(screen, index)))
+            await pilot.pause()
+            assert "kid1session" in "\n".join(screen.render_lines_for_test())
+            assert row.session_id in screen._expanded
+
+            # And clicking it again closes it: one gesture, both directions,
+            # exactly like the ``enter`` it mirrors.
+            await pilot.click(screen, offset=(_row_x(screen), _row_y(screen, index)))
+            await pilot.pause()
+            assert "kid1session" not in "\n".join(screen.render_lines_for_test())
+
+    asyncio.run(run())
+
+
+def test_a_click_moves_the_keyboard_cursor_to_the_clicked_row():
+    """The two selection models must not visibly disagree after an ACT.
+
+    Hover alone may sit apart from the caret — that is what makes hover a
+    preview — but once a click has expanded row N, an ``enter`` that collapsed
+    some other row (because the caret never left it) would be the screen
+    holding two different opinions about which row is current.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            _show_table(screen)
+            await pilot.pause()
+            index = _first_row(screen, expandable=True)
+            target = screen._layout.session_rows[index].session_id
+            screen._cursor = screen._layout.session_rows[-1].session_id
+            screen._repaint()
+
+            await pilot.click(screen, offset=(_row_x(screen), _row_y(screen, index)))
+            await pilot.pause()
+            assert screen._cursor == target
+
+            # The caret really does act there now: ``enter`` closes the row the
+            # click opened rather than some row the mouse never visited.
+            await pilot.press("enter")
+            await pilot.pause()
+            assert target not in screen._expanded
+
+    asyncio.run(run())
+
+
+def test_clicking_a_childless_row_is_a_clean_no_op():
+    """492 of the operator's 595 roots are childless: this is the MAJORITY click.
+
+    "Toggling nothing" is not enough. Moving the caret there would scroll the
+    viewport for a gesture the user experienced as doing nothing, so the row
+    count, the cursor, the viewport and the painted frame must all be untouched.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _nested_screen_agg())
+            _show_table(screen)
+            await pilot.pause()
+            index = _first_row(screen, expandable=False)
+            cursor_before = screen._cursor
+            offset_before = screen._scroll.scroll_offset.y
+            frame_before = "\n".join(screen.render_lines_for_test())
+            expanded_before = set(screen._expanded)
+
+            await pilot.click(screen, offset=(_row_x(screen), _row_y(screen, index)))
+            await pilot.pause()
+
+            assert screen._cursor == cursor_before, "a dead click moved the keyboard cursor"
+            assert screen._scroll.scroll_offset.y == offset_before, "a dead click moved the view"
+            assert "\n".join(screen.render_lines_for_test()) == frame_before
+            assert screen._expanded == expanded_before
+
+    asyncio.run(run())
+
+
+def test_clicking_a_depth_one_child_toggles_that_child():
+    """A child with children of its own is expandable like any other row.
+
+    The nesting is not two kinds of row with two kinds of click; depth only
+    changes the indent.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _nested_screen_agg())
+            _show_table(screen)
+            await pilot.pause()
+            # Open the root so its child is on screen to be clicked.
+            root = _first_row(screen, expandable=True)
+            await pilot.click(screen, offset=(_row_x(screen), _row_y(screen, root)))
+            await pilot.pause()
+
+            child = next(
+                i
+                for i, row in enumerate(screen._layout.session_rows)
+                if row.depth == 1 and row.expandable
+            )
+            child_id = screen._layout.session_rows[child].session_id
+            assert "grandkidses" not in "\n".join(screen.render_lines_for_test())
+
+            await pilot.click(screen, offset=(_row_x(screen), _row_y(screen, child)))
+            await pilot.pause()
+            assert child_id in screen._expanded
+            assert "grandkidses" in "\n".join(screen.render_lines_for_test())
+
+    asyncio.run(run())
+
+
+def _painted_y(app, needle: str) -> int:
+    """Screen row that actually PAINTS ``needle``, from the compositor.
+
+    Read out of the finished frame rather than re-derived from the geometry the
+    hit-test uses: a test that aims with the same arithmetic it is checking
+    cannot catch that arithmetic aiming wrongly (both move together). This is
+    the independent reading — where the row IS, as the terminal shows it.
+    """
+    strips = app.screen._compositor.render_strips()
+    for y, strip in enumerate(strips):
+        if needle in "".join(segment.text for segment in strip):
+            return y
+    raise AssertionError(f"{needle!r} is not painted anywhere")
+
+
+def test_the_hit_test_aims_where_the_row_is_painted():
+    """A click on the pixel a row is PAINTED on must hit that row.
+
+    This is the test the arithmetic-derived ones cannot be: they compute the
+    target from the same geometry ``_row_at`` reads, so a wrong basis moves
+    both and nothing trips. Here the coordinate comes from the compositor, so
+    the hit-test and the paint agree only if both are right. It exists because
+    two mutations survived the rest of the suite — pointing the hit-test at the
+    scroll region instead of the viewport, and off the compositor's row — both
+    of which this catches.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 24)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            _show_table(screen)
+            await pilot.pause()
+
+            # Aim at a row by where it actually PAINTED, not by re-deriving it.
+            index = _first_row(screen, expandable=True)
+            target = screen._layout.session_rows[index].session_id
+            text = screen.render_lines_for_test()[screen._layout.session_first_line + index]
+            y = _painted_y(app, text.strip()[:16])
+
+            await pilot.click(screen, offset=(_row_x(screen), y))
+            await pilot.pause()
+            assert (
+                target in screen._expanded
+            ), "the click landed on a different row than the one it was painted on"
+
+    asyncio.run(run())
+
+
+def test_a_right_click_does_not_toggle_a_row():
+    """A context-menu click must not act on its way to being ignored.
+
+    The button is tested BEFORE any state changes, which is why this asserts the
+    expansion set rather than merely that nothing crashed.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _nested_screen_agg())
+            _show_table(screen)
+            await pilot.pause()
+            index = _first_row(screen, expandable=True)
+            before = set(screen._expanded)
+            screen.on_click(_click(screen, _row_x(screen), _row_y(screen, index), button=3))
+            await pilot.pause()
+            assert screen._expanded == before
+
+    asyncio.run(run())
+
+
+def test_a_click_below_the_viewport_is_not_a_row():
+    """The body overhangs the viewport, so ``body.region`` alone is not a guard.
+
+    Measured on this fixture: the body extends well past the scroll viewport
+    and its region CONTAINS the hint line under the card. Clicking there must
+    not resolve to whatever table row happens to sit at that body line.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 24)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            _show_table(screen)
+            await pilot.pause()
+            body = screen._body.region
+            hint_y = screen._hint.region.y
+            # The precondition this test exists for: the coordinate really is
+            # inside the body and outside the viewport, so the guard is being
+            # exercised rather than trivially satisfied.
+            assert body.contains(_row_x(screen), hint_y), "fixture no longer reproduces overhang"
+            assert not screen._scroll.scrollable_content_region.contains(_row_x(screen), hint_y)
+
+            before = set(screen._expanded)
+            assert screen._row_at(_click(screen, _row_x(screen), hint_y)) is None
+            screen.on_click(_click(screen, _row_x(screen), hint_y))
+            await pilot.pause()
+            assert screen._expanded == before
+
+    asyncio.run(run())
+
+
+# -- hovering -----------------------------------------------------------------
+
+
+def test_the_hover_follows_the_pointer_between_rows():
+    """The highlight names the row under the pointer, and only that row."""
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            _show_table(screen)
+            await pilot.pause()
+
+            for index in (0, 1, 2):
+                await pilot.hover(screen, offset=(_row_x(screen), _row_y(screen, index)))
+                await pilot.pause()
+                assert _hover_index(screen) == index
+
+    asyncio.run(run())
+
+
+def test_the_hover_clears_when_the_pointer_leaves_the_rows():
+    """A highlight left painted after the pointer is gone is a lie about aim."""
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            _show_table(screen)
+            await pilot.pause()
+            await pilot.hover(screen, offset=(_row_x(screen), _row_y(screen, 0)))
+            await pilot.pause()
+            assert _hover_index(screen) == 0
+
+            # Onto the hint line, which is outside the scroll viewport.
+            await pilot.hover(screen, offset=(_row_x(screen), screen._hint.region.y))
+            await pilot.pause()
+            assert screen._hover is None
+            assert str(screen.styles.pointer) == "default"
+
+    asyncio.run(run())
+
+
+def test_the_pointer_is_a_hand_only_over_an_expandable_row():
+    """A hand over a dead row promises a click it does not keep."""
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _nested_screen_agg())
+            _show_table(screen)
+            await pilot.pause()
+
+            await pilot.hover(
+                screen, offset=(_row_x(screen), _row_y(screen, _first_row(screen, expandable=True)))
+            )
+            await pilot.pause()
+            assert str(screen.styles.pointer) == "pointer"
+
+            childless = _first_row(screen, expandable=False)
+            await pilot.hover(screen, offset=(_row_x(screen), _row_y(screen, childless)))
+            await pilot.pause()
+            # Still highlighted — it IS the row under the pointer — but no hand.
+            assert _hover_index(screen) == childless
+            assert str(screen.styles.pointer) == "default"
+
+    asyncio.run(run())
+
+
+def test_the_totals_block_above_the_table_takes_no_hover():
+    """Only table rows are live. The report above them is text, not targets."""
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _nested_screen_agg())
+            await pilot.pause()
+            # Frame 1, table not scrolled to: aim at the totals block near the
+            # top of the body.
+            await pilot.hover(screen, offset=(_row_x(screen), screen._body.region.y + 2))
+            await pilot.pause()
+            assert screen._hover is None
+            assert str(screen.styles.pointer) == "default"
+
+    asyncio.run(run())
+
+
+def test_the_hover_and_the_cursor_can_sit_on_different_rows():
+    """Two selection models, two marks, and they must not merge.
+
+    If hover painted like the caret the reader would see two cursors and could
+    not tell which row ``enter`` acts on.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            _show_table(screen)
+            await pilot.pause()
+            screen._cursor = screen._layout.session_rows[2].session_id
+            screen._repaint()
+            await pilot.hover(screen, offset=(_row_x(screen), _row_y(screen, 0)))
+            await pilot.pause()
+
+            assert _hover_index(screen) == 0
+            assert screen._cursor_index() == 2
+            # The caret is on the CURSOR row and nowhere else: the hovered row
+            # is marked by its ground, not by a second caret.
+            lines = screen.render_lines_for_test()
+            first = screen._layout.session_first_line
+            assert "❯" in lines[first + 2]
+            assert "❯" not in lines[first]
+
+    asyncio.run(run())
+
+
+def test_the_hover_does_not_reflow_the_row():
+    """No reflow on interaction — three review rounds of #873 pinned this.
+
+    The highlight is a background span, so the row's TEXT is identical hovered
+    and not. A hover that inserted a marker would shift the row under a moving
+    pointer, which is the one place a layout shift is least forgivable. The
+    colour half is pinned too: the hovered row's segments must carry a
+    background, because a highlight that costs the text nothing and paints
+    nothing is not a highlight.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            _show_table(screen)
+            await pilot.pause()
+            before = screen.render_lines_for_test()
+
+            await pilot.hover(screen, offset=(_row_x(screen), _row_y(screen, 1)))
+            await pilot.pause()
+            after = screen.render_lines_for_test()
+
+            assert _hover_index(screen) == 1, "the fixture did not actually hover a row"
+            assert after == before, "the hover changed the table's text, not just its colour"
+
+            # And the paint DID change on exactly that row: the hover ground was
+            # laid over it. The panel background itself has a bgcolor, so this
+            # must name the tint specifically rather than merely "a background".
+            from local_operator.tui import theme as theme_mod
+
+            tint = theme_mod.semantic_color("tint-select")
+            y = _painted_y(app, after[screen._layout.session_first_line + 1].strip()[:16])
+            strip = app.screen._compositor.render_strips()[y]
+            hexes = {
+                s.style.bgcolor.triplet.hex
+                for s in strip
+                if s.style is not None
+                and s.style.bgcolor is not None
+                and s.style.bgcolor.triplet is not None
+            }
+            assert tint in hexes, f"the hovered row did not paint the tint-select ground; {hexes}"
+
+    asyncio.run(run())
+
+
+def test_hover_on_the_cursor_row_is_a_distinct_state():
+    """Hover + caret on the same row paints a THIRD ground, not either alone.
+
+    The pointer landing on the row the keyboard is already on is its own
+    visible state: ``tint-select-hi`` against the hover's ``tint-select``, so a
+    reader can tell "the mouse is on the caret row" from "the mouse is on some
+    other row" at a glance.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            _show_table(screen)
+            await pilot.pause()
+            cursor = screen._cursor_index()
+            assert cursor is not None
+
+            await pilot.hover(screen, offset=(_row_x(screen), _row_y(screen, cursor)))
+            await pilot.pause()
+            assert _hover_index(screen) == cursor, "hover and cursor did not coincide"
+
+            y = _painted_y(
+                app,
+                screen.render_lines_for_test()[screen._layout.session_first_line + cursor].strip()[
+                    :16
+                ],
+            )
+            strip = app.screen._compositor.render_strips()[y]
+            grounds = {
+                segment.style.bgcolor
+                for segment in strip
+                if segment.style is not None and segment.style.bgcolor is not None
+            }
+            from local_operator.tui import theme as theme_mod
+
+            hi = theme_mod.semantic_color("tint-select-hi")
+            lo = theme_mod.semantic_color("tint-select")
+            hexes = {g.triplet.hex for g in grounds if g is not None and g.triplet is not None}
+            assert (
+                hi in hexes
+            ), f"the cursor row under the pointer did not step up to tint-select-hi; {hexes}"
+            assert lo not in hexes, "the coincide state painted the plain hover ground"
+
+    asyncio.run(run())
+
+
+# -- the wheel gotcha ---------------------------------------------------------
+
+
+def test_the_wheel_moves_the_highlight_under_a_resting_pointer():
+    """THE WHEEL CASE. A real terminal sends NO ``MouseMove`` while only the
+    wheel turns, so the rows slide under a pointer that never moved and the
+    highlight would stay painted on a row the pointer is no longer over.
+
+    The pointer is placed once and then NEVER moved again: every subsequent
+    event is a wheel notch. The highlight must track the row that is now under
+    that fixed coordinate.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 24)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            _show_table(screen)
+            await pilot.pause()
+
+            x, y = _row_x(screen), _row_y(screen, 3)
+            await pilot.hover(screen, offset=(x, y))
+            await pilot.pause()
+            before = _hover_index(screen)
+            assert before is not None
+            hovered_before = screen._hover
+
+            # Wheel notches through ``App.on_event``, the path a terminal uses.
+            # Textual stops the event on the container while it can still
+            # scroll, so these never reach a screen-level handler at all — the
+            # highlight can only follow via the scroll watcher.
+            offset_before = screen._scroll.scroll_offset.y
+            for _ in range(3):
+                await app.on_event(
+                    events.MouseScrollDown(
+                        widget=None,
+                        x=x,
+                        y=y,
+                        delta_x=0,
+                        delta_y=1,
+                        button=0,
+                        shift=False,
+                        meta=False,
+                        ctrl=False,
+                        screen_x=x,
+                        screen_y=y,
+                    )
+                )
+                await pilot.pause()
+            await pilot.pause()
+
+            moved = screen._scroll.scroll_offset.y - offset_before
+            assert moved > 0, "the wheel did not scroll, so this test proves nothing"
+
+            # The rows moved UP by ``moved`` lines under a fixed pointer, so the
+            # row now under it is ``before + moved``. Asserted as the exact row
+            # rather than merely "it changed": a highlight that cleared, or one
+            # that jumped somewhere arbitrary, would both pass a weaker check.
+            assert _hover_index(screen) == before + moved
+            assert screen._hover != hovered_before
+
+    asyncio.run(run())
+
+
+def test_scrolling_the_rows_out_from_under_the_pointer_clears_the_highlight():
+    """Scrolled far enough, the pointer is over the report ABOVE the table.
+
+    The highlight must go out with them rather than staying painted on the last
+    row it saw — the failure ``copy_picker`` records as the highlight surviving
+    six notches off the pane.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 24)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            _show_table(screen)
+            await pilot.pause()
+            x, y = _row_x(screen), _row_y(screen, 1)
+            await pilot.hover(screen, offset=(x, y))
+            await pilot.pause()
+            assert _hover_index(screen) is not None
+
+            # Back to the top of the report: the table is now far below, and the
+            # pointer's coordinate is over the totals block.
+            screen._scroll.scroll_to(y=0, animate=False)
+            await pilot.pause()
+            await pilot.pause()
+            assert screen._hover is None
+            assert str(screen.styles.pointer) == "default"
+
+    asyncio.run(run())
+
+
+def test_expanding_a_row_re_resolves_the_highlight_under_a_still_pointer():
+    """A click inserts rows BELOW the pointer, moving the table under it.
+
+    The gesture that changes the row count is itself a way to move rows under a
+    resting pointer, so the highlight has to be re-resolved from it too — and
+    the row under the pointer after an expand is not the row that was there.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg(kids=30))
+            _show_table(screen)
+            await pilot.pause()
+            root = _first_row(screen, expandable=True)
+
+            # Rest the pointer a few rows BELOW the expandable root, so opening
+            # it pushes different sessions under the fixed coordinate.
+            x, y = _row_x(screen), _row_y(screen, root + 2)
+            await pilot.hover(screen, offset=(x, y))
+            await pilot.pause()
+            before_id = screen._hover
+            assert before_id is not None
+
+            # Expand with the KEYBOARD so the pointer genuinely never moves.
+            screen._cursor = screen._layout.session_rows[root].session_id
+            screen._repaint()
+            await pilot.press("enter")
+            await pilot.pause()
+            await pilot.pause()
+
+            assert _hover_index(screen) == root + 2, "the highlight did not follow the coordinate"
+            assert screen._hover != before_id, "30 rows were inserted above it and it did not move"
+
+    asyncio.run(run())

--- a/tests/unit/tui/test_analytics_mouse.py
+++ b/tests/unit/tui/test_analytics_mouse.py
@@ -691,3 +691,173 @@ def test_expanding_a_row_re_resolves_the_highlight_under_a_still_pointer():
             assert screen._hover != before_id, "30 rows were inserted above it and it did not move"
 
     asyncio.run(run())
+
+
+def test_expand_all_re_resolves_the_highlight_without_moving_the_viewport():
+    """``e`` moves rows under a resting pointer EVEN WHEN THE VIEWPORT DOES NOT.
+
+    This is the case the wheel test cannot be and QA's round-1 expand-all row
+    (M5c) did not cover: their geometry scrolled the viewport, so the ``scroll_y``
+    watch fired and re-resolved the highlight for them. Here the cursor row stays
+    visible across ``e`` — mount parks the cursor on table row 0, expanding root 0
+    inserts its children BELOW it, and the reveal inside ``action_toggle_all`` is
+    therefore a no-op — so ``scroll_y`` never notifies and the ONLY thing that can
+    re-resolve the highlight is the action's own deferred ``_viewport_moved``.
+    Without it the highlight stays painted on a row the pointer is not over: the
+    wheel-gotcha defect via a keypress (review R1).
+
+    The ``scroll_offset`` assertion is the pin, not a comment. A test that let the
+    viewport move would pass against the broken code exactly like M5c did, because
+    the watch would do the re-resolve the action failed to schedule.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg(kids=30))
+            _show_table(screen)
+            await pilot.pause()
+
+            scroll = screen._scroll
+            # Precondition: the cursor is on table row 0 and ON SCREEN, so the
+            # reveal inside ``action_toggle_all`` has nothing to scroll and no
+            # ``scroll_y`` notification can fire.
+            assert screen._cursor == screen._layout.session_rows[0].session_id
+            assert screen._cursor_on_screen(), "fixture: cursor row is not visible"
+
+            # Rest the pointer two rows below the expandable root. Expand-all
+            # inserts 30 children at indices 1..30, so the row under this FIXED
+            # coordinate changes from a root to a child.
+            x, y = _row_x(screen), _row_y(screen, 2)
+            await pilot.hover(screen, offset=(x, y))
+            await pilot.pause()
+            before_id = screen._hover
+            assert before_id == screen._layout.session_rows[2].session_id
+            assert screen._layout.session_rows[2].depth == 0, "fixture: index 2 is not a root"
+            scroll_y_before = scroll.scroll_offset.y
+
+            await pilot.press("e")
+            await pilot.pause()
+            await pilot.pause()
+            await pilot.pause()
+
+            # THE PIN: the viewport did not move, so no watch fired and nothing
+            # but the action's own deferred re-resolve could have moved the
+            # highlight. If this assertion ever fails the test has silently
+            # degraded into the M5c case and no longer pins R1.
+            assert scroll.scroll_offset.y == scroll_y_before, (
+                "the viewport moved, so this no longer pins the no-scroll path — "
+                "the scroll_y watch would re-resolve the highlight on its own"
+            )
+            # The highlight followed the COORDINATE into the inserted block.
+            assert _hover_index(screen) == 2, "the highlight did not follow the coordinate"
+            assert screen._hover != before_id, "30 rows were inserted above it and it did not move"
+            assert screen._layout.session_rows[2].depth == 1, "fixture: index 2 is not a child"
+
+    asyncio.run(run())
+
+
+def test_collapse_all_re_resolves_the_highlight_without_moving_the_viewport():
+    """The other direction of R1: collapsing every row also moves them.
+
+    Staged so the pointer rests on a CHILD that collapse-all removes: the row
+    under the fixed coordinate changes from a child back to a root, and — as in
+    the expand direction — the cursor row stays visible so ``scroll_y`` never
+    notifies. The re-resolve can only come from ``action_toggle_all`` itself.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg(kids=30))
+            _show_table(screen)
+            await pilot.pause()
+
+            scroll = screen._scroll
+            # Expand everything first, so the second ``e`` is a collapse-all.
+            await pilot.press("e")
+            await pilot.pause()
+            await pilot.pause()
+            await pilot.pause()
+            assert len(screen._layout.session_rows) > 41, "fixture: expand-all did not expand"
+            assert screen._cursor_on_screen(), "fixture: cursor row is not visible after expand"
+
+            x, y = _row_x(screen), _row_y(screen, 2)
+            await pilot.hover(screen, offset=(x, y))
+            await pilot.pause()
+            before_id = screen._hover
+            assert screen._layout.session_rows[2].depth == 1, "fixture: index 2 is not a child"
+            assert before_id == screen._layout.session_rows[2].session_id
+            scroll_y_before = scroll.scroll_offset.y
+
+            await pilot.press("e")
+            await pilot.pause()
+            await pilot.pause()
+            await pilot.pause()
+
+            assert (
+                scroll.scroll_offset.y == scroll_y_before
+            ), "the viewport moved, so this no longer pins the no-scroll path"
+            assert _hover_index(screen) == 2, "the highlight did not follow the coordinate"
+            assert screen._hover != before_id, "the children vanished and it did not move"
+            assert screen._layout.session_rows[2].depth == 0, "fixture: index 2 is not a root"
+
+    asyncio.run(run())
+
+
+def test_the_empty_scrollbar_gutter_takes_no_hover_and_no_click():
+    """The stable gutter is RESERVED space, not a row — even when it is empty.
+
+    ``#analytics-scroll`` sets ``scrollbar-gutter: stable``, so the column is
+    there whether or not a bar is drawn. On a frame whose body does NOT overflow
+    there is no bar widget to capture events, so gutter coordinates really reach
+    the screen — and the viewport guard in ``_row_at`` is the only thing standing
+    between them and a row. Review R2 measured exactly that: under a
+    ``scroll.region.contains`` mutant a gutter hover highlights a row and a
+    gutter click on the root line TOGGLES it. The shipped guard is correct; this
+    is the pin that was missing.
+
+    The preconditions ARE the test. Without asserting that the frame does not
+    overflow and that the gutter column sits inside ``scroll.region`` but outside
+    the viewport, a passing run cannot distinguish "the guard rejected it" from
+    "nothing was ever delivered".
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _nested_screen_agg())
+            _show_table(screen)
+            await pilot.pause()
+
+            scroll = screen._scroll
+            viewport = scroll.scrollable_content_region
+            gutter_x = viewport.x + viewport.width
+            row_y = _row_y(screen, 0)
+
+            # Precondition 1: the body does NOT overflow, so no bar is drawn and
+            # the gutter is empty — events there really reach the screen.
+            assert (
+                scroll.max_scroll_y == 0
+            ), "fixture overflows: a drawn bar would capture the gutter"
+            # Precondition 2: the gutter column is inside the container's region
+            # (what the R2 mutant guards with) but outside the viewport (what the
+            # shipped guard uses), so the guard is genuinely exercised rather
+            # than trivially satisfied.
+            assert scroll.region.contains(gutter_x, row_y), "gutter is not inside scroll.region"
+            assert not viewport.contains(gutter_x, row_y), "gutter is inside the viewport"
+            # Precondition 3: the coordinate is over a visible, EXPANDABLE row,
+            # so a click there would toggle it under the mutant.
+            assert screen._layout.session_rows[0].expandable, "fixture: row 0 is not expandable"
+
+            await pilot.hover(screen, offset=(gutter_x, row_y))
+            await pilot.pause()
+            assert screen._hover is None, "the empty gutter took a hover"
+            assert str(screen.styles.pointer) == "default", "the gutter promised a click"
+
+            before = set(screen._expanded)
+            await pilot.click(screen, offset=(gutter_x, row_y))
+            await pilot.pause()
+            assert screen._expanded == before, "the empty gutter took a click"
+
+    asyncio.run(run())


### PR DESCRIPTION
## What and why

The collapsible `/analytics` session table from #873 was keyboard-only. The operator asked directly: *"make it so you can also click to expand with hover UX."* This adds the mouse half. The deferred note on #873 said `ReportLayout` was built to carry the row→line mapping "precisely so click can land later" — this is that landing.

## Design decisions (each made deliberately, rationale inline in the diff)

- **Whole row is the click target, not just the `▸` glyph.** The glyph is 2 cells against a ~100-cell row; a 2-cell target is precision the mouse was invited in to avoid. Every sibling picker (`command_picker`, `copy_picker`, `session_picker`, `model_picker`) makes the whole row clickable, so a user who learned that would find this one screen demanding aim. The counter-argument (accidental toggles) does not apply: rows carry no other click action to collide with, and a wrong toggle is instantly visible and one click from undone.
- **A click also moves the keyboard cursor to the row.** Hover may sit apart from the caret (that is what makes hover a *preview*), but after an *act* the two selection models must not visibly disagree — clicking row 7 open and having `enter` collapse row 2 would be two opinions about which row is current. Matches `copy_picker`. Kept the hint honest: `enter expand` names the row just acted on.
- **Clicking a childless row is a clean no-op** — no cursor move, no viewport move, no repaint. 492 of the operator's 595 roots are childless, so this is the *majority* click; moving the caret there would scroll the view for a gesture the user experienced as doing nothing.
- **Pointer shape: hand over expandable rows only.** A hand over a dead row promises a click it does not keep (`default` over the totals block, charts, provider table, and childless rows).
- **The hint line does NOT advertise the click.** Follows `copy_picker`, which treats the hover highlight as "the ENTIRE affordance for the mouse" — mouse affordances are discovered by hovering, and the hint already carries the keyboard ladder; adding `click` would repeat it.

## The wheel gotcha (the load-bearing part)

A real terminal sends **no `MouseMove` while only the wheel turns**, so the rows slide under a resting pointer and the highlight would stay painted on a row it is no longer over. This is what `copy_picker._refresh_hover` exists for, and `/analytics` scrolls much further. The fix watches the scroll container's `scroll_y` and re-resolves the hover from the last known pointer coordinate (`_PointerAt`, no synthetic event) — one hook covering wheel, scrollbar drag, page/home/end, and `_scroll_cursor_into_view`. `scroll_y` is **animated** (one `pagedown` fired 28 notifications), so the re-resolve is coalesced to once per frame — a repaint is 12 ms on the real 2,779-session ledger, and 28 of them would be the freeze the width cache already exists to prevent. Expanding a row re-resolves too (it changes the row count under a still pointer without touching `scroll_y` when no reveal scroll happens).

**Hit-test basis:** the viewport + live `scroll_offset`, not `_body.region`. Arithmetically identical (`body.y == viewport.y - scroll_offset.y` held at every measured offset), but `body.region` is recomputed by layout and **lags a scroll by a frame** — read mid-settle it resolved a pointer 16 rows from the truth and left the highlight stuck. The viewport `contains` guard is *mandatory*: the body overhangs the viewport by every scrolled-out row (measured 27) and its region contains the hint line below the card.

## Testing evidence

Real pilot tests (`pilot.click`/`pilot.hover`, wheel via `App.on_event`) in `tests/unit/tui/test_analytics_mouse.py`, 17 tests, all on the real `OperatorApp` under the production stylesheet. Covers: click expand/collapse, click-on-childless inert, click depth-1 child, right-click inert, click below viewport not a row, hit-test aimed by painted pixel, hover between rows, hover leaving the widget, hand-only-over-expandable, totals block inert, hover-vs-cursor separability, no reflow, cursor+hover distinct ground, wheel under a resting pointer, scroll clearing the highlight, and expand re-resolving the highlight.

**Mutation-checked** (`/tmp/an-mouse/probes/mutate.py`, every mutation asserted to have LANDED before its result was read):

| Mutation | Result |
|---|---|
| click-on-childless-toggles | CAUGHT |
| click-does-not-move-cursor | CAUGHT |
| hand-over-every-row | CAUGHT |
| no-hover-refresh-on-viewport-move | CAUGHT |
| no-hover-refresh-on-expand | CAUGHT |
| basis-ignores-scroll-offset | CAUGHT |
| basis-uses-stale-body-region | CAUGHT |
| hover-tint-always-tint-select (coincide state) | CAUGHT |
| drop-hover-span | CAUGHT |
| guard-uses-container-region-not-viewport | SURVIVED round 1 — **row corrected in round 2 (review R2)**: the round-1 name and reason were both wrong. The mutant actually run guards with `scroll.region.contains`, not `_body.region`; and it is NOT a no-op — on a non-overflowing frame the empty stable gutter delivers events to the screen, so a gutter hover highlights a row and a gutter click on the root line toggles it. Now CAUGHT by `test_the_empty_scrollbar_gutter_takes_no_hover_and_no_click`. The variant the row originally *named* (`_body.region.contains`) was always CAUGHT by `test_a_click_below_the_viewport_is_not_a_row`. |

**Suites** (`-n 2`, `CMUX_*` unset, isolated config dir): `test_analytics_panel.py` + `test_analytics_mouse.py` + `tests/unit/analytics` = **248 passed**. Full unit tree left to CI (shared machine near capacity).

**Gates:** flake8, `black --check`, `isort --check-only`, `pyright --pythonpath .venv/bin/python` — all clean.

## Visual evidence

Before/after frames captured with `scripts/analytics_mouse_shot.py` at **120x40, 120x30 and 110x20** (the #873 defect got through because every frame was 120x40, the one size where the table is on screen at mount). Each state is asserted before capture, not reached by gesture count. Rendered and inspected:

- **hover-expandable** — tint on the row, no caret duplication
- **hover-childless** — row highlighted, pointer stays `default`, click inert
- **hover-vs-cursor** — tint on the hovered row, `❯` on a different row; the two marks are visibly distinct
- **after-click** — glyph flipped `▸`→`▾`, children revealed (6→18 rows), caret followed the click, `tint-select-hi` on the coincide row

Before-frames (same script, pre-change tree): no hover (`hovered_index: null`), `default` pointer everywhere, `expanded_by_click: false`. Ledger untouched by capture.

SVG + geometry in `/tmp/an-mouse/frames/{before,after,final}/`; rasterized in `/tmp/an-mouse/png/`.

## Out of scope (recorded, not fixed)

- No version bump (`pyproject.toml` stays 0.53.9) per the release rule.
- Keyboard behaviour, collapse defaults, rollup arithmetic, and the hint ladder are untouched. The per-session column still sums to the headline total (root rows carry subtree totals; the rollup invariant is load-bearing).
