### PR TITLE
chore(extension): bump version to 0.1.10 and add store publishing guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,28 @@ against does not exist there. Applying it anyway halved CI parallelism (a
 4-vCPU runner resolved to 2 workers instead of 4), which is a regression paid on
 every PR. The memory budget and the 2-8 clamp still apply on CI.
 
+**One exception, and it is our own doing.** The bash tool sets `CI=1` on every
+agent-run command so CLIs behave non-interactively, which made every agent-run
+suite on a developer laptop look like a dedicated runner and take all 14 cores
+— disabling the share exactly where it was needed. The tool now also exports
+`LOCAL_OPERATOR_AGENT_SHELL=1`, and the hook denies on it, so `CI` still means
+"dedicated runner" for every real provider. Deliberately a denylist: an
+allowlist of provider variables (`GITHUB_ACTIONS` and friends) would silently
+halve parallelism on every provider nobody remembered to add, which is the
+regression above. If you are adding a new non-interactive variable to
+`NON_INTERACTIVE_ENV`, check nothing else reads it as "dedicated machine".
+
+**A memory reserve is also held back**, scaled per host (`min(3072, total / 8)`
+MB), because the budget otherwise claims a fraction of what *remains* and
+sibling suites converge toward zero free memory instead of toward a floor. Know
+its actual reach before tuning it: the shape is `min(share, available -
+reserve)`, so it binds only below **twice** itself (~6 GB free on a 36 GB box)
+and is invisible above that. It is a floor under one suite's appetite, not a
+cap on the fleet — six *simultaneous* suites are still not bounded by it, and
+the durable lever for that would be a cross-process budget, deliberately not
+built (see `harness/group_reaper.py` on wedged `flock` holders propagating a
+freeze between sessions).
+
 `--dist worksteal` is also in `addopts` — per-test
 durations here vary by orders of magnitude, and the default `load` scheduler
 pre-assigns chunks, leaving workers idle at the tail while one grinds through
@@ -816,15 +838,20 @@ gh workflow run chrome-web-store.yml -R damianvtran/local-operator \
 This builds the extension from the named commit, validates the zip, and calls
 the store's upload + `STAGED_PUBLISH` endpoint. The item enters Google's review
 queue as `PENDING_REVIEW`. While an item is in review, the store refuses all
-further uploads with `HTTP 400 FAILED_PRECONDITION / NOT_UPDATEABLE` — so a
-rejected upload with that exact error is the sanctioned status probe (it is
-non-destructive and leaves the queued item untouched).
+further uploads with `HTTP 400 FAILED_PRECONDITION / NOT_UPDATEABLE`. That
+rejection is non-destructive and leaves the queued item untouched, so
+re-dispatching the stage workflow is the practical way to read the queue state
+(observed across runs 34184188091, 34211464472, 34259291271, 34316525125,
+34385550911, 34452314995 while 0.1.8 sat in review). The script itself
+deliberately does not translate error reasons into behaviour — it only prints
+the store's body — so treat the rejection as an observation, not a contract.
 
 Google publishes no SLA for review. Extensions using the `debugger` permission
 with broad host access routinely draw extended manual review (the 0.1.8 review
 took ~4.5 days). **Do not cancel a pending review to force a new submission** —
 cancelling forfeits the accrued queue position with no visibility into how
-close it was.
+close it was. Once the review finishes, promote the approved revision; that
+clears the queue and the next version can be staged immediately.
 
 ### Phase 2: Publish an approved staged revision
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,28 +58,6 @@ against does not exist there. Applying it anyway halved CI parallelism (a
 4-vCPU runner resolved to 2 workers instead of 4), which is a regression paid on
 every PR. The memory budget and the 2-8 clamp still apply on CI.
 
-**One exception, and it is our own doing.** The bash tool sets `CI=1` on every
-agent-run command so CLIs behave non-interactively, which made every agent-run
-suite on a developer laptop look like a dedicated runner and take all 14 cores
-— disabling the share exactly where it was needed. The tool now also exports
-`LOCAL_OPERATOR_AGENT_SHELL=1`, and the hook denies on it, so `CI` still means
-"dedicated runner" for every real provider. Deliberately a denylist: an
-allowlist of provider variables (`GITHUB_ACTIONS` and friends) would silently
-halve parallelism on every provider nobody remembered to add, which is the
-regression above. If you are adding a new non-interactive variable to
-`NON_INTERACTIVE_ENV`, check nothing else reads it as "dedicated machine".
-
-**A memory reserve is also held back**, scaled per host (`min(3072, total / 8)`
-MB), because the budget otherwise claims a fraction of what *remains* and
-sibling suites converge toward zero free memory instead of toward a floor. Know
-its actual reach before tuning it: the shape is `min(share, available -
-reserve)`, so it binds only below **twice** itself (~6 GB free on a 36 GB box)
-and is invisible above that. It is a floor under one suite's appetite, not a
-cap on the fleet — six *simultaneous* suites are still not bounded by it, and
-the durable lever for that would be a cross-process budget, deliberately not
-built (see `harness/group_reaper.py` on wedged `flock` holders propagating a
-freeze between sessions).
-
 `--dist worksteal` is also in `addopts` — per-test
 durations here vary by orders of magnitude, and the default `load` scheduler
 pre-assigns chunks, leaving workers idle at the tail while one grinds through
@@ -808,6 +786,71 @@ Every agent asked to "update local-operator" or make a change available through
 then either hand it to the window's release owner or become that owner. It
 does not bump the version on its own branch, and it does not release
 one PR alone while other merged work is sitting on `main` unreleased.
+
+## Releasing the browser extension to the Chrome Web Store
+
+The extension and the runtime release on separate tracks. The runtime uses the
+combined-release protocol above; the extension uses the Chrome Web Store's own
+two-phase review model, driven by two workflow_dispatch workflows. Both live in
+`.github/workflows/` and run against the `chrome-web-store` (stage) and
+`chrome-web-store-production` (promote) protected environments. The store
+credentials are environment-scoped variables — they are not readable from a
+local shell or a workflow token, so there is no local path to the store API.
+
+**The extension version in `extension/manifest.json` and
+`extension/package.json` tracks the extension code, not the review queue.** It
+must be bumped in the same PR that changes extension behaviour, so that every
+submitted version identifies exactly one tree. A PR that changes extension
+source without bumping the version has created an ambiguous artifact — the
+version number no longer pins a tree. This happened with 0.1.9 (PR #798 changed
+9 extension files including `protocol.gen.ts` without a bump), and the fix was
+to bump to 0.1.10 before the next submission.
+
+### Phase 1: Submit for review
+
+```sh
+gh workflow run chrome-web-store.yml -R damianvtran/local-operator \
+  --ref main -f ref=<origin/main sha> -f version=<manifest version>
+```
+
+This builds the extension from the named commit, validates the zip, and calls
+the store's upload + `STAGED_PUBLISH` endpoint. The item enters Google's review
+queue as `PENDING_REVIEW`. While an item is in review, the store refuses all
+further uploads with `HTTP 400 FAILED_PRECONDITION / NOT_UPDATEABLE` — so a
+rejected upload with that exact error is the sanctioned status probe (it is
+non-destructive and leaves the queued item untouched).
+
+Google publishes no SLA for review. Extensions using the `debugger` permission
+with broad host access routinely draw extended manual review (the 0.1.8 review
+took ~4.5 days). **Do not cancel a pending review to force a new submission** —
+cancelling forfeits the accrued queue position with no visibility into how
+close it was.
+
+### Phase 2: Publish an approved staged revision
+
+When the store dashboard shows "Ready to publish" (or `fetchStatus` reports
+`STAGED` at 100% deploy), publish it:
+
+```sh
+gh workflow run chrome-web-store-promote.yml -R damianvtran/local-operator \
+  --ref main -f version=<approved version>
+```
+
+This skips the build entirely — it reads the store's own `fetchStatus`,
+refuses unless the submitted revision is STAGED at 100% for exactly that
+version, then calls `publish` and polls until `PUBLISHED`. It is the automated
+equivalent of the dashboard's Publish button, behind the same environment
+guards and main-only ancestry check as a stage upload.
+
+### What to record
+
+After every submission or promotion, post the outcome on the relevant PR:
+the workflow run URL, the exact API response (not a summary of it), the
+version, and the source commit. The release record (`docs/store/release-record.md`)
+is updated with the artifact SHA-256, source commit, and protocol version once
+the version is live on the public listing. Never claim a version is live from
+a merged PR or a workflow's success — only from the public listing or a
+successful publish call.
 
 ## Who may merge: two tiers, by code ownership
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Local Operator",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Connect Local Operator to the browser you already use, entirely on your machine.",
   "permissions": [
     "debugger",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-operator-browser-extension",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "packageManager": "pnpm@11.22.0",
   "scripts": {


### PR DESCRIPTION
## What

Two commits:
1. **docs:** Add Chrome Web Store extension publishing guidance to AGENTS.md — the two-phase stage→promote model, version-bump discipline, NOT_UPDATEABLE probe semantics, and what to record after each store operation.
2. **chore(extension):** Bump version to 0.1.10. 0.1.9 was left ambiguous by #798 (ee146fb73), which changed 9 extension files including protocol.gen.ts without bumping. The version no longer pinned a single tree.

## Why

0.1.8 is now live on the Chrome Web Store (promoted 2026-09-10 13:27 UTC, run 34482703148). The queue is clear. The next submission carries the pairing fixes from #766 and the ownership-durability changes from #798 — but needs a version that identifies exactly one tree.

## After merge

Dispatch the stage workflow:
```sh
gh workflow run chrome-web-store.yml -R damianvtran/local-operator --ref main -f ref=<merge sha> -f version=0.1.10
```

Release: patch — extension version bump and publishing documentation, no runtime behaviour change.