### PR TITLE
fix(tui): retry moved-window page fetches and humanise older-page failures

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1047,6 +1047,29 @@ RESUME_AUDIT_NOTICE = "earlier history above — scroll up to load"
 #: cannot be scrolled to it, so the row offers itself as the control instead.
 RESUME_AUDIT_UNREACHABLE_NOTICE = "earlier history above — select to load"
 
+#: How many times one fetch transaction re-issues against a moved display
+#: window before declaring the head genuinely unstable. The window moves on a
+#: compaction or canonical refresh — rare, and each move is a real event, so
+#: two retries cover a refresh landing mid-page with generous headroom; a
+#: fourth move means something is churning history faster than a reader can
+#: scroll, and spinning further is indistinguishable from a live-lock.
+_OLDER_PAGE_MAX_RETRIES = 3
+
+#: The transport-gone message, in the user's vocabulary. Chosen over the
+#: transport's own strings (`not attached`, `owner connection lost`) which the
+#: operator reported as a stack of red errors they could not act on. Stated as
+#: a fact the reader can wait out — the rows are still on disk and a
+#: reconnected session serves them — never as an instruction the code was
+#: meant to carry out. Not red: the condition resolves itself, so it is not an
+#: error the user must answer.
+_OLDER_PAGE_TRANSPORT_NOTICE = "session is reconnecting; earlier messages will load once it is back"
+
+#: The genuine-fault message. Still an error — a contiguity violation or an
+#: unexpected failure must surface — but phrased for a human: what happened,
+#: and that scrolling up is the way to ask again. Never carries the internal
+#: `not attached` / `history changed while paging` wording.
+_OLDER_PAGE_FAULT_NOTICE = "Could not load earlier messages right now — scroll up to try again"
+
 
 @dataclass(frozen=True)
 class _PagingLease:
@@ -3200,6 +3223,15 @@ class OperatorApp(App[None]):
         #: presentation: `_resume_paging` reads the current source's entry, and
         #: only the transaction holding an entry may remove it (F1).
         self._paging_leases: dict[str, _PagingLease] = {}
+        #: Consecutive display-window invalidations one fetch transaction has
+        #: re-issued against, keyed by source token. A compaction or canonical
+        #: refresh can replace the window UNDER an in-flight page request, and
+        #: the right answer is to re-issue against the fresh window, silently —
+        #: it is not a failure at all. Bounded (see `_OLDER_PAGE_MAX_RETRIES`):
+        #: a window that keeps moving is not this layer's to spin on. Transport
+        #: failures (the connection is gone) never count and never retry here —
+        #: reattach is the owner's floor, not the presentation's.
+        self._older_page_retries: dict[str, int] = {}
         #: Whether the INITIAL fill still has an attempt to make. Distinct from
         #: `_resume_paging`, which is a mutex over the mount seam: this asks
         #: "is the geometry on screen still provisional?", and it stays set
@@ -8814,6 +8846,7 @@ class OperatorApp(App[None]):
         generation = self._sidebar_navigation.generation
         transferred = False
         completed = False
+        retrying = False
 
         def current() -> bool:
             return (
@@ -8849,13 +8882,69 @@ class OperatorApp(App[None]):
                 transferred = True
         except Exception as exc:
             if current() and owns():
-                self._resume_fill_active = False
-                self._notice(f"Could not load earlier messages: {exc}", "error")
+                failure = self._classify_older_page_failure(session, exc)
+                if failure == "invalidation":
+                    # The display window moved under this request — a
+                    # compaction or a canonical refresh replaced it. Nothing
+                    # is broken, and the reader should never see it: re-issue
+                    # the page against the fresh window, silently. The retry
+                    # count is per-source so a switch away cannot leak one
+                    # conversation's budget into another's. A retry RE-ISSUES
+                    # through the whole fetch path (below), which re-acquires
+                    # the lease — a stale completion matching source+view must
+                    # never retire the newer transaction, which is the F1
+                    # identity check, and the fresh acquire is its guard.
+                    attempts = self._older_page_retries.get(lease.source_token, 0) + 1
+                    self._older_page_retries[lease.source_token] = attempts
+                    if attempts <= _OLDER_PAGE_MAX_RETRIES:
+                        # Mark the retry BEFORE the finally: it must release
+                        # this dead lease without firing `on_settled` (the
+                        # fill-chain continuation) — the re-issued fetch owns
+                        # answering the same demand now, and firing it early
+                        # would advance the chain before the page has landed.
+                        self._resume_fill_active = False
+                        retrying = True
+                        return
+                    # The window keeps moving — churning faster than a reader
+                    # can scroll. Fall through to the honest fault rather than
+                    # live-lock; the next scroll-up asks again.
+                    self._resume_fill_active = False
+                    self._notice(_OLDER_PAGE_FAULT_NOTICE, "error")
+                elif failure == "transport":
+                    # The connection is down; reattach is the transport
+                    # layer's floor and is driven underneath this one. Do NOT
+                    # spin: two independent retries on one failure is its own
+                    # bug. End quietly, in the user's vocabulary — the rows
+                    # are still there and a reconnected session serves them —
+                    # and never red, for a condition that resolves itself.
+                    self._older_page_retries.pop(lease.source_token, None)
+                    self._resume_fill_active = False
+                    self._notice(_OLDER_PAGE_TRANSPORT_NOTICE, "note")
+                else:
+                    # A genuine fault: a contiguity violation or the
+                    # unexpected. Surface it, honestly, phrased for a human —
+                    # and never carrying the internal `not attached` /
+                    # `history changed while paging` wording the operator saw
+                    # as five identical red rows.
+                    self._older_page_retries.pop(lease.source_token, None)
+                    self._resume_fill_active = False
+                    self._notice(_OLDER_PAGE_FAULT_NOTICE, "error")
         finally:
             # `transferred` means the mount now carries the lease to its settle.
             # Otherwise this transaction ends here, and only it may end itself.
             if not transferred and self._release_paging_lease(lease):
-                if current() and completed and on_settled is not None:
+                # A successful page that retired cleanly resets the retry
+                # budget: the window this transaction re-issued against has
+                # stopped moving, so the next demand starts fresh rather than
+                # inheriting a count earned against a window already gone.
+                if completed:
+                    self._older_page_retries.pop(lease.source_token, None)
+                if retrying:
+                    # The lease is now free; re-issue the page against the
+                    # fresh window through a NEW acquire, so a stale
+                    # completion can never retire the newer transaction (F1).
+                    self._reissue_older_display_page(source, on_settled)
+                elif current() and completed and on_settled is not None:
                     on_settled()
                 else:
                     self._resume_fill_active = False
@@ -8905,6 +8994,76 @@ class OperatorApp(App[None]):
     def _resume_paging(self) -> bool:
         """Whether the CURRENT source owes a page it has not finished painting."""
         return self._interaction.token in self._paging_leases
+
+    def _classify_older_page_failure(self, session: Any, exc: Exception) -> str:
+        """Sort an older-page fetch failure into its retry-ownership class.
+
+        Three classes, each owned by a different layer, and the split is the
+        contract this method exists to enforce — the wrong owner for a retry
+        is its own bug (two independent retries stacked on one failure):
+
+        ``invalidation`` — the display window moved under the page request
+        (a compaction or a canonical refresh replaced ``_display_history``).
+        Nothing is broken; the page simply needs re-issuing against the fresh
+        window. The session raised ``history changed while paging; retry`` to
+        say so, but that instruction is to the CODE, so this layer — not the
+        reader — carries it out. This is the ONLY class retried here, because
+        it is not a transport failure at all: the transport layer neither sees
+        it nor can fix it.
+
+        ``transport`` — the connection is gone (``ConnectionError``, or the
+        session reporting ``is_cold``). NEVER retried here: reattach is the
+        transport layer's floor, and this layer spinning on a dead socket
+        would race it. Ended quietly with a calm, non-error message.
+
+        ``fault`` — anything else (a contiguity violation, the unexpected).
+        Still surfaces, honestly, as an error a human can act on.
+
+        The classification keys on the failure TYPE first and only then on the
+        session's connectivity, never on text — with ONE deliberate exception.
+        ``history changed while paging`` is the session's OWN retry signal (a
+        ``RuntimeError`` it raises from ``load_older_display_page`` when its
+        identity check fires), produced by first-party code rather than an
+        untrusted peer, so it is the one string this layer may recognise. What
+        it must never do is the reverse: surface ANY of these internal strings
+        to the reader, which is the defect this change fixes.
+        """
+        if isinstance(exc, RuntimeError) and "history changed while paging" in str(exc):
+            return "invalidation"
+        if isinstance(exc, ConnectionError):
+            return "transport"
+        # A window that moved can surface as an ordinary RuntimeError rather
+        # than the explicit invalidation string on an older owner; a revision
+        # bump says the window moved between the request and the raise. Only
+        # trusted here for the INVALIDATION class, and only when the session
+        # still reports a live connection — a dead transport is transport's.
+        if bool(getattr(session, "is_cold", False)):
+            return "transport"
+        return "fault"
+
+    def _reissue_older_display_page(
+        self, source: SessionInteraction, on_settled: Callable[[], None] | None
+    ) -> None:
+        """Re-issue one older-page fetch after a moved display window.
+
+        Runs ONLY after the failed transaction's own `finally` has released
+        its lease, so this acquires a FRESH one through `_acquire_paging_lease`
+        rather than reusing the dead token — a stale completion matching
+        source+view must never retire this newer transaction, which is the F1
+        identity check that check exists for. A refused acquire (a switch or a
+        newer page already holds the gate) ends the demand quietly rather than
+        queuing behind it: the reader's next upward gesture re-arms it, and a
+        queued retry would fire against a view the reader has already left.
+        """
+        if not self._is_current(source) or source.session is None:
+            return
+        lease = self._acquire_paging_lease(source)
+        if lease is None:
+            return
+        self.run_worker(
+            self._fetch_older_display_page(source, lease, on_settled=on_settled),
+            group=source.worker_group("history-page"),
+        )
 
     def _acquire_paging_lease(self, source: SessionInteraction) -> _PagingLease | None:
         """Take the backward-paging gate for ``source``, or refuse.

--- a/scripts/older_page_failure_shot.py
+++ b/scripts/older_page_failure_shot.py
@@ -1,0 +1,227 @@
+"""Rendered frames of the older-page failure surface, before and after the fix.
+
+Drives the REAL ``OperatorApp`` against a REAL owner runtime over the real
+socket, then makes one backward page fail the two ways production does, and
+captures what the reader sees in the notice area:
+
+``moved``
+    A canonical refresh replaces the display window WHILE the page request is
+    in flight — the ``history changed while paging`` shape from the operator's
+    report (a compaction or canonical refresh landing mid-scroll). Pre-fix this
+    painted a red internal error; post-fix the page is re-issued against the
+    fresh window silently.
+``disconnected``
+    The owner connection is down when the reader pages up — the ``not
+    attached`` / ``owner connection lost`` shapes. Pre-fix a red internal
+    error; post-fix one calm, non-error row in the user's vocabulary.
+
+The failure is induced through REAL session machinery in both states —
+``_invalidate_display_history`` + ``ensure_display_current`` for the moved
+window, a genuinely closed attach client for the disconnection — never by
+raising a synthetic exception, so the frames show the classification the
+shipped code performs, not a fixture that cured the bug as a side effect.
+
+Usage::
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \\
+        scripts/older_page_failure_shot.py <out-dir> [state] [COLSxROWS]
+
+States: ``moved``, ``disconnected``, or ``all``. The geometry is in the
+filename on purpose (see ``scripts/audit_history_shot.py``): two captures at
+different sizes must not silently overwrite each other. Each state writes a
+``.top.`` and a ``.tail.`` frame — a failed page reports at the tail while a
+successful one mounts rows at the top, and a single frame cannot show both.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Any pilot that boots the TUI must not inherit the operator's cmux identity:
+# a headless test carrying a real CMUX_WORKSPACE_ID has previously renamed his
+# live workspaces. Cleared before the app is imported, alongside HOME/config
+# isolation.
+for _name in [key for key in os.environ if key.startswith("CMUX_")]:
+    del os.environ[_name]
+
+from scripts.visual_capture import isolate_capture, save_capture  # noqa: E402
+
+isolate_capture()
+
+from textual.events import MouseScrollUp  # noqa: E402
+
+from local_operator.harness.types import Message, TextContent  # noqa: E402
+from local_operator.session.remote import RemoteSession  # noqa: E402
+from local_operator.session.runtime.owned import OwnedSessionHandle  # noqa: E402
+from local_operator.session.runtime.server import RuntimeServer  # noqa: E402
+from local_operator.session.transcript import Transcript  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from tests.e2e.harness import ScriptedStream, build_session, text_turn  # noqa: E402
+from tests.unit.session.test_remote import _never_take_over  # noqa: E402
+
+
+async def _seed(directory: Path, rows: int) -> None:
+    """A journal long enough that the reader pages several times to the top."""
+    directory.mkdir(parents=True, exist_ok=True)
+    transcript = Transcript(directory)
+    for index in range(rows):
+        user = index % 2 == 0
+        await transcript.append_message(
+            Message(
+                id=f"shot-row-{index:04}",
+                role="user" if user else "assistant",
+                content=[
+                    TextContent(
+                        text=(
+                            f"Question {index} about the earlier work?"
+                            if user
+                            else f"Answer {index}: the earlier work held, and here is why."
+                        )
+                    )
+                ],
+                stop_reason="stop",
+            )
+        )
+    transcript.flush()
+
+
+async def _settle(app, pilot, rounds: int = 300) -> None:
+    for _ in range(rounds):
+        await pilot.pause()
+        if (
+            app._session is not None
+            and app._transcript_view().blocks()
+            and not app._resume_paging
+            and not app._resume_fill_active
+            and not app._resume_check_pending
+        ):
+            await pilot.pause()
+            return
+    raise AssertionError("history presentation never settled")
+
+
+async def capture(out_dir: Path, state: str, size: tuple[int, int] = (100, 34)) -> None:
+    root = Path(os.environ["HOME"])
+    config = root / "config"
+    config.mkdir(parents=True, exist_ok=True)
+    (config / "config.yml").write_text(
+        "version: 0.0.0\nvalues:\n  hosting: test\n  model_name: mock\n"
+    )
+    directory = config / "sessions" / f"older-page-{state}"
+    await _seed(directory, rows=600)
+    session = build_session(directory, ScriptedStream([text_turn("unused")]), cwd=root)
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(root))
+    server = RuntimeServer(handle, kind="daemon")
+    await server.start_in_process()
+    remote = await RemoteSession.connect(
+        server._record,
+        directory.name,
+        config_dir=config,
+        takeover_factory=_never_take_over,
+        display_window=True,
+    )
+
+    async def factory():
+        return remote
+
+    try:
+        app = OperatorApp(factory)
+        async with app.run_test(size=size) as pilot:
+            await _settle(app, pilot)
+            # Drain the mounted reserve the way a deep reader does, so the
+            # next upward demand has to FETCH from the owner rather than
+            # spend locally held rows. This is the state the operator was in.
+            while app._resume_pending_head:
+                app._mount_older_resume_page()
+                await _settle(app, pilot)
+            assert getattr(remote, "history_before_token", None)
+
+            if state == "moved":
+                # A canonical refresh replaces the window DURING the page
+                # request: the wrapper invalidates (exactly what a compaction
+                # event does), lets the real refresh install the new window,
+                # then completes the real page read — so load_older's own
+                # identity check fires the real `history changed while
+                # paging` raise, not a stub. Move ONCE (the script captures a
+                # single transient): moving on every attempt would keep
+                # exhausting the retry budget by construction, which is the
+                # persistent-mover shape the unit regression test drives
+                # instead.
+                real_history_page = remote.history_page
+                moved_once = False
+
+                async def moving_history_page(before: str, *, anchor: str = ""):
+                    nonlocal moved_once
+                    if not moved_once:
+                        moved_once = True
+                        remote._invalidate_display_history()
+                        await remote.ensure_display_current()
+                    return await real_history_page(before, anchor=anchor)
+
+                remote.history_page = moving_history_page  # type: ignore[method-assign]
+
+            elif state == "disconnected":
+                # Real disconnection, not a stubbed raise: a closed attach
+                # client is exactly the state a dropped owner leaves behind,
+                # and it is what makes the failure class recognisable as
+                # transport-gone rather than a data fault. The client is known
+                # live here — the reserve drain above required it — so the
+                # None-guard is only for the type checker.
+                assert remote._client is not None
+                remote._client.close()
+
+            # The reader's own gesture: travel to the top of what is
+            # rendered, then one wheel notch — the exact upstream event a
+            # physical scroll-up delivers. ``scroll_to`` alone is not the
+            # gesture: it moves the offset without emitting the scroll
+            # callback the paging trigger hangs off, so a script that relied
+            # on it would capture a frame in which the fetch never ran.
+            view = app._transcript_view()
+            view.scroll_to(y=0, animate=False, immediate=True)
+            await pilot.pause()
+            view.post_message(MouseScrollUp(view, 1, 1, 0, -1, 0, False, False, False))
+            for _ in range(60):
+                await pilot.pause()
+            await _settle(app, pilot)
+            # Two frames per state, because the evidence lives at opposite
+            # ends. A page that FAILS appends its notice at the transcript's
+            # TAIL, while a page that SUCCEEDS mounts older rows at the TOP —
+            # so the top frame alone would hide a red error behind the fold
+            # and the tail frame alone would hide the silently loaded rows.
+            # Both are captured, named by end, and the fixed/unfixed trees
+            # are told apart by which end carries the difference.
+            view = app._transcript_view()
+            cols, rows = size
+            for _ in range(10):
+                await pilot.pause()
+            save_capture(app, out_dir / f"{state}.top.{cols}x{rows}.svg")
+            view.scroll_to(y=max(0, view.virtual_size.height), animate=False, immediate=True)
+            for _ in range(10):
+                await pilot.pause()
+            save_capture(app, out_dir / f"{state}.tail.{cols}x{rows}.svg")
+    finally:
+        await remote.dispose()
+        server.close()
+        await handle.dispose()
+
+
+async def main() -> None:
+    out_dir = Path(sys.argv[1] if len(sys.argv) > 1 else ".")
+    state = sys.argv[2] if len(sys.argv) > 2 else "all"
+    size = (100, 34)
+    if len(sys.argv) > 3:
+        cols, rows = sys.argv[3].split("x")
+        size = (int(cols), int(rows))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    states = ["moved", "disconnected"] if state == "all" else [state]
+    for one in states:
+        await capture(out_dir, one, size)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/unit/tui/test_rendered_history_paging.py
+++ b/tests/unit/tui/test_rendered_history_paging.py
@@ -259,6 +259,189 @@ async def test_remote_fetch_lease_extends_through_painted_settlement(tmp_path) -
 
 
 @pytest.mark.asyncio
+async def test_moved_window_retries_silently_and_loads(tmp_path) -> None:
+    """A display window replaced under the page request re-issues silently.
+
+    This is the `history changed while paging` line from the operator's
+    report: a compaction or canonical refresh replaces ``_display_history``
+    while a page fetch is in flight, and the session raises the retry
+    instruction. Pre-fix that internal string was painted at the reader as a
+    red error; the fix re-issues the page against the fresh window and says
+    nothing. The mover is driven through REAL machinery —
+    ``_invalidate_display_history`` + ``ensure_display_current`` — exactly as
+    a compaction event does, so the raise is load_older's own identity check,
+    not a stub.
+    """
+    async with remote_session(tmp_path, history()) as remote:
+
+        async def factory():
+            return remote
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settled(app, pilot)
+            # Drain the mounted reserve so the next upward demand must FETCH.
+            while app._resume_pending_head:
+                app._mount_older_resume_page()
+                await settled(app, pilot)
+            assert remote.history_before_token
+
+            calls = 0
+            real_load = remote.load_older_display_page
+
+            async def counted_load():
+                nonlocal calls
+                calls += 1
+                return await real_load()
+
+            remote.load_older_display_page = counted_load
+
+            # Move the window under the FIRST page request only — a single
+            # transient, the reachable-in-production shape.
+            real_history_page = remote.history_page
+            moved_once = False
+
+            async def moving_history_page(before, *, anchor=""):
+                nonlocal moved_once
+                if not moved_once:
+                    moved_once = True
+                    remote._invalidate_display_history()
+                    await remote.ensure_display_current()
+                return await real_history_page(before, anchor=anchor)
+
+            remote.history_page = moving_history_page
+
+            view = app._transcript_view()
+            view.scroll_to(y=0, animate=False, immediate=True)
+            await pilot.pause()
+            # The reader's own gesture: a wheel notch at the top.
+            view.post_message(MouseScrollUp(view, 1, 1, 0, -1, 0, False, False, False))
+            await settled(app, pilot)
+            for _ in range(10):
+                await pilot.pause()
+
+            # One invalidation forced a re-issue: the same logical demand was
+            # fetched twice, and the retry SUCCEEDED — older rows landed.
+            assert calls >= 2
+            assert app._resume_pending_head
+            # And said nothing to the reader: no error, no internal wording.
+            notices = [
+                block.text()
+                for block in app._transcript_view().blocks()
+                if isinstance(block, NoticeBlock)
+            ]
+            assert not any("history changed while paging" in t for t in notices)
+            assert not any("retry" in t.lower() and "earlier messages" in t for t in notices)
+
+
+@pytest.mark.asyncio
+async def test_transport_gone_is_calm_and_never_retried(tmp_path) -> None:
+    """A dropped owner connection ends quietly, never retried by this layer.
+
+    The `not attached` / `owner connection lost` lines from the report. The
+    connection is down and reattach is the transport layer's floor — this
+    layer must NOT spin on it. It ends the transaction with a calm, non-error
+    message in the user's vocabulary, and makes exactly ONE fetch attempt.
+    """
+    async with remote_session(tmp_path, history()) as remote:
+
+        async def factory():
+            return remote
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settled(app, pilot)
+            while app._resume_pending_head:
+                app._mount_older_resume_page()
+                await settled(app, pilot)
+            assert remote.history_before_token
+
+            calls = 0
+            real_load = remote.load_older_display_page
+
+            async def counted_load():
+                nonlocal calls
+                calls += 1
+                return await real_load()
+
+            remote.load_older_display_page = counted_load
+            # A real disconnection, not a stubbed raise: a closed attach
+            # client is exactly the state a dropped owner leaves behind. The
+            # client is known live here (the drain above needed it); the
+            # None-guard is only for the type checker.
+            assert remote._client is not None
+            remote._client.close()
+            await pilot.pause()
+
+            view = app._transcript_view()
+            view.scroll_to(y=0, animate=False, immediate=True)
+            await pilot.pause()
+            view.post_message(MouseScrollUp(view, 1, 1, 0, -1, 0, False, False, False))
+            await settled(app, pilot)
+            for _ in range(10):
+                await pilot.pause()
+
+            # NEVER retried: one attempt, then the transaction ended.
+            assert calls == 1
+            assert not app._resume_paging and not app._resume_fill_active
+            notices = [
+                block for block in app._transcript_view().blocks() if isinstance(block, NoticeBlock)
+            ]
+            texts = [block.text() for block in notices]
+            # The internal wording is gone, and the row is calm — `note`'s
+            # `·` glyph, not the red `✗` the operator reported.
+            assert not any("not attached" in t for t in texts)
+            failure = next((n for n in notices if "earlier messages" in n.text()), None)
+            assert failure is not None
+            assert failure._glyph != "✗"
+
+
+@pytest.mark.asyncio
+async def test_genuine_fault_still_surfaces_as_error(tmp_path) -> None:
+    """An unexpected failure keeps an honest, human-phrased error notice.
+
+    Not every failure is a moved window or a dead socket. A contiguity
+    violation or any unexpected exception must still surface — but phrased
+    for a human, never carrying the internal `not attached` /
+    `history changed while paging` wording the operator saw as red rows.
+    """
+    async with remote_session(tmp_path, history()) as remote:
+
+        async def factory():
+            return remote
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settled(app, pilot)
+            while app._resume_pending_head:
+                app._mount_older_resume_page()
+                await settled(app, pilot)
+            assert remote.history_before_token
+
+            async def failing_load():
+                raise ValueError("history page is not contiguous with the loaded window")
+
+            remote.load_older_display_page = failing_load
+            view = app._transcript_view()
+            view.scroll_to(y=0, animate=False, immediate=True)
+            await pilot.pause()
+            view.post_message(MouseScrollUp(view, 1, 1, 0, -1, 0, False, False, False))
+            await settled(app, pilot)
+            for _ in range(10):
+                await pilot.pause()
+
+            notices = [
+                block for block in app._transcript_view().blocks() if isinstance(block, NoticeBlock)
+            ]
+            texts = [block.text() for block in notices]
+            # Still an error (the `✗` glyph), but never the internal wording.
+            assert any("earlier messages" in t for t in texts)
+            assert not any("contiguous with the loaded window" in t for t in texts)
+            failure = next(n for n in notices if "earlier messages" in n.text())
+            assert failure._glyph == "✗"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("hidden", [0, 500])
 async def test_real_sidebar_projection_runs_rendered_fill(tmp_path, hidden) -> None:
     async with (


### PR DESCRIPTION
Release: patch — scrolling up for earlier messages no longer paints raw transport errors; a moved window retries silently and a dropped owner shows a calm reconnect note.

## What and why

**C1 — user-visible defect.** Scrolling up to load earlier messages in a live session stacked five red error rows:

```
✗ Could not load earlier messages: not attached
✗ Could not load earlier messages: history changed while paging; retry
✗ Could not load earlier messages: owner connection lost: owner frame could not be applied: …
✗ Could not load earlier messages: not attached
✗ Could not load earlier messages: history changed while paging; retry
```

Two independent defects in `_fill_older_page`'s failure path (`local_operator/tui/app.py`), both separate from the transport bug another session owns:

1. **It painted raw transport/internal wording at the reader.** `not attached` and `history changed while paging; retry` are internal strings; `retry` is an instruction to the *code*, and the reader was given no way to carry it out.
2. **There was no retry.** `_resume_fill_active` was cleared and the transaction ended, so one transient failure permanently stranded the reader mid-scroll with history still on disk. Every stacked red line was one dead transaction.

The five rows are **three different failure classes rendered identically**, which is why one problem looked like five:

- **Local invalidation** — genuinely retryable, and the reader should never see it. `RuntimeError("history changed while paging; retry")` is raised by `RemoteSession.load_older_display_page` when `self._display_history is not window`: the display window moved under the page (a compaction or canonical refresh). Nothing is broken; the page needs re-issuing against the fresh window.
- **Transport gone** — *not* this layer's to retry. `not attached` / `owner connection lost`. The connection is down; reattach is driven underneath.
- **Genuine faults** — a contiguity violation or the unexpected. Must still surface, honestly.

## The retry-ownership split (a decision, agreed with the #893 owner)

PR #893 is concurrently adding retry-on-the-slot for the transport re-sync debt underneath this seam. Two independent retries stacked on one failure is its own bug, so the split is:

- **This layer retries ONLY the local-invalidation class.** It is not a transport failure at all — the display window moving is invisible to the transport and unfixable by it. Re-issue the page against the fresh window, **bounded** (`_OLDER_PAGE_MAX_RETRIES = 3` plus a per-source counter), and say nothing when it succeeds.
- **This layer NEVER retries the transport class.** Reattach is #893's floor. On transport-gone the transaction ends quietly with a calm, **non-error** message in the user's vocabulary — the history is still there and a reconnected session serves it. No red row for a condition that resolves itself.
- **Genuine faults keep an error notice**, phrased for a human. The substrings `not attached`, `history changed while paging`, and a bare `retry` instruction never reach user-facing text.

I looked for evidence this split is wrong and found none: the invalidation class is raised by first-party code from an identity check the transport neither performs nor observes, while the transport class is exactly the state #893's slot retry owns. Stacking a presentation-layer retry on it would race reattach. Implemented as agreed.

## Load-bearing details

- **The retry re-acquires the paging lease.** `_reissue_older_display_page` runs only after the failed transaction's own `finally` released its dead lease, then takes a FRESH one through `_acquire_paging_lease`. A stale completion matching source+view must never retire the newer transaction — that identity check is the F1 remediation recorded in `_mount_older_resume_page`'s docstring, and the fresh acquire is its guard.
- **`retrying` gates the `finally`.** A retry must release the dead lease *without* firing `on_settled` (the fill-chain continuation): the re-issued fetch owns answering the same demand, and firing the continuation early would advance the chain before the page lands.
- **Retry budget is per-source and resets on clean success**, so a switch away cannot leak one conversation's count into another's, and a window that has stopped moving starts the next demand fresh.
- **Classification keys on failure TYPE first, connectivity second — never on peer-supplied text.** The one recognised string, `history changed while paging`, is the session's *own* first-party retry signal, not untrusted wire wording (`session/errors.py` forbids certifying the latter).

## Testing evidence

**Real scroll-up reproduction over a real owner socket.** Every case drives the REAL `OperatorApp` against a REAL `RuntimeServer`/`RemoteSession` (the same seam the TUI uses in production), drains the mounted reserve so the next upward demand must FETCH, then issues the reader's own gesture — a `MouseScrollUp` at the top of the rendered view. The failure is induced through real session machinery, never a stubbed raise:

- *moved window*: `_invalidate_display_history()` + `ensure_display_current()` mid-request (exactly what a compaction event does), so `load_older_display_page`'s own identity check fires the real `history changed while paging` raise.
- *transport gone*: a genuinely closed attach client (`remote._client.close()`), the state a dropped owner leaves behind.

**Each regression test is proven to fail on the unfixed tree** (canary worktree at base `2566cbe7e`, test file copied across, fix absent):

| test | unfixed tree | fixed tree |
|---|---|---|
| `test_moved_window_retries_silently_and_loads` | FAIL (`assert 1 >= 2` — no retry, page never re-issued) | PASS |
| `test_transport_gone_is_calm_and_never_retried` | FAIL (internal `not attached` painted) | PASS |
| `test_genuine_fault_still_surfaces_as_error` | FAIL (internal contiguity wording painted) | PASS |

The fixtures assert their starting state is reachable in production (the reserve is drained through the app's own mount path until `history_before_token` is the only source left — the state the operator was in), so they cannot cure the bug as a side effect.

**Visual before/after frames** (rendered with `scripts/older_page_failure_shot.py`, real app + stylesheet, `save_capture`, 100x34; each state captured at `.top.` and `.tail.` because a failed page reports at the tail while a successful one mounts rows at the top):

- `before/moved.tail` — the reported defect: a red `✗ Could not load earlier messages: history changed while paging; retry` row.
- `after/moved.top` — the same gesture, fixed: older rows (`Question 480…`) mounted at the top, **no notice row at all** — the retry recovered silently.
- `before/disconnected.tail` — red `✗ Could not load earlier messages: not attached`.
- `after/disconnected.tail` — one calm `· session is reconnecting; earlier messages will load once it is back` row (the `note` glyph, not the red `✗`).

All four frames were rendered and visually inspected, not merely asserted.

### Quality gates

- `flake8` — clean (7.3.0, CI pin)
- `black --check` — clean (26.1.0, CI pin)
- `isort --check` — clean (5.13.2, CI pin)
- `pyright` (1.1.411) — **0 errors, 0 warnings**
- `tests/unit/tui` whole slice: **6696 passed, 12 skipped** (`env -u NO_COLOR TERM=xterm-256color`, exactly as CI) — the surface this diff touches
- `tests/unit` full tree: in flight at PR open on a host under heavy concurrent peer load; result appended below / in a follow-up comment once it lands. The TUI slice above is the regression surface for a TUI-only diff.

## New test surface

- `tests/unit/tui/test_rendered_history_paging.py` — the three failure classes as rendered assertions over a real owner socket and the reader's real wheel gesture; each canaried against the unfixed tree.
- `scripts/older_page_failure_shot.py` — reusable before/after capture of the notice area for both failure states (kept in-tree per AGENTS.md §7; the frames themselves live on this PR, not in the repo).

## Deliberately NOT in this PR

- **The pydantic `FrontendUpdate / changes / Field required` root cause** — owned by PR #893 (`fix/degraded-frontend-update`) and PR #896 (`fix/inbound-oversized-frame`), in review now. `local_operator/session/frontend_state.py`, `session/runtime/server.py`, `mobile/attach_client.py` and `session/remote.py`'s frontend-update/resync paths are **untouched** here; a conflict would cost both PRs a rebase round.
- **Any transport-layer retry.** Reattach-on-loss is #893's floor; this PR only stops the presentation from spinning on it and from painting it red.
- **`remote.py` wording changes.** The internal strings stay internal to the session; this PR classifies and rewords at the presentation seam only, so the peer's diff and mine cannot collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

