### PR TITLE
fix(tui): store an inline credential through the session, not a viewer-only probe

### DIFF
--- a/local_operator/session/credential_ops.py
+++ b/local_operator/session/credential_ops.py
@@ -1,0 +1,113 @@
+"""The one ``/credential`` verb table, shared by every session shape.
+
+Storing a credential is a SESSION capability, not a viewer one: the store
+exists so the environment of the ``bash`` commands the agent runs can carry
+the secret, and those commands run wherever the session's turn loop runs. A
+session that runs its tools in this process therefore executes the verbs
+against its own store (``Session.credential_op``); a session that is a window
+onto a runtime routes them there
+(``RemoteSession.credential_op`` → the runtime's
+``OwnedSessionHandle.credential_op`` → this same table).
+
+Before this module existed, the table lived only on the runtime's handle, and
+the capability was declared on the viewer protocol alone — so the codebase
+asserted "storing a credential is a viewer capability", the in-process session
+never implemented it, and the TUI's submit seam (which cannot know which shape
+it holds) degraded on the only branch the shipping product can reach. Keeping
+ONE table is what prevents that drift from coming back: the verbs cannot
+diverge between the two shapes if there is only one copy.
+
+The value crosses into this function and never leaves it: it is written to the
+store, never logged, never journalled, never echoed in the answer. Only the
+key name and the outcome cross back.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+#: The journal half of the table's contract: ``(key, action=..., replaced=...)``.
+#: Named so the parameter reads as behaviour rather than as a bare callable.
+CredentialJournal = Callable[..., None]
+
+
+async def run_credential_verb(
+    store: Any,
+    journal: CredentialJournal | None,
+    action: str,
+    key: str,
+    value: str,
+) -> dict[str, Any]:
+    """Run one ``/credential`` verb against ``store``; announce through ``journal``.
+
+    ``store`` is a :class:`~local_operator.variables.VariableStore`; ``journal``
+    is the session's credential-change announcer (a callable with the
+    ``journal_credential_change`` shape) or ``None`` to skip announcing — the
+    announcement is best-effort by design, so a missing or raising journal must
+    never fail a store that already succeeded.
+
+    Returns plain data rather than a receipt object because the callers need
+    the FACTS (did it replace, what was removed) to build their own notices,
+    and because the store verb's receipt has to name the key that was actually
+    normalized and stored, not the one that was typed.
+    """
+    if store is None or not hasattr(store, "store_credential"):
+        return {"ok": False, "reason": "unavailable"}
+    if action == "list":
+        return {
+            "ok": True,
+            "credentials": [
+                {"key": item.key, "source": item.source} for item in store.list_credentials()
+            ],
+        }
+    if action == "names":
+        return {"ok": True, "names": list(store.credential_names())}
+    if action == "forget":
+        removed = bool(store.forget_credential(key))
+        if removed:
+            _announce(journal, key, action="forgot")
+        return {"ok": True, "removed": removed, "key": key}
+    if action == "forget-all":
+        # Names BEFORE the clear: the store is empty afterwards, so reading
+        # them after would announce nothing to the model.
+        names = list(store.credential_names())
+        count = int(store.clear_credentials())
+        for name in names:
+            _announce(journal, name, action="forgot")
+        return {"ok": True, "count": count, "names": names}
+    if action == "persist":
+        # The promotion route: both stores that matter are the session's own —
+        # the in-memory store holding the value and the config dir holding the
+        # encrypted long-term one. Only a name and an outcome sentence cross
+        # back; never the value.
+        from local_operator.secrets.promote import promote_session_credential_guarded
+
+        outcome = promote_session_credential_guarded(store, key)
+        return {"ok": True, "promoted": outcome.ok, "key": key, "message": outcome.message}
+    if action == "store":
+        result = store.store_credential(key, value, "command")
+        credential = getattr(result, "credential", None)
+        if not getattr(result, "ok", False) or credential is None:
+            return {"ok": False, "reason": getattr(result, "reason", "") or "empty-value"}
+        replaced = bool(getattr(result, "replaced", False))
+        # The announcement is what makes the key findable on LATER turns, so it
+        # belongs on the side that owns the context, immediately after the
+        # write it reports — never before it, and never on a refusal.
+        _announce(journal, credential.key, replaced=replaced)
+        return {"ok": True, "key": credential.key, "replaced": replaced}
+    return {"ok": False, "reason": "unknown-action"}
+
+
+def _announce(
+    journal: CredentialJournal | None, key: str, *, action: str = "stored", replaced: bool = False
+) -> None:
+    """Best-effort announcement; a failed one must not fail the store."""
+    if journal is None:
+        return
+    try:
+        journal(key, action=action, replaced=replaced)
+    except Exception:  # noqa: BLE001 — the credential is already stored
+        logger.warning("could not announce credential change", exc_info=True)

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -458,6 +458,23 @@ class SessionProtocol(Protocol):
         """
         ...
 
+    # --- credentials ------------------------------------------------------
+    async def credential_op(self, action: str, key: str = "", value: str = "") -> dict[str, Any]:
+        """Run one ``/credential`` verb against the session's store.
+
+        A SESSION capability, declared here so it is declared once for every
+        session shape: a session that runs its tools in this process executes
+        the verb against its own store, and a session that is a window onto a
+        runtime routes it there, because the store the tools' environment is
+        built from lives beside the turn loop — on the wrong side of that
+        split, a stored key would be advertised to the model while no
+        executing tool could read it.
+
+        The value is never logged, never journalled, and never returned —
+        only the key name and the outcome cross back.
+        """
+        ...
+
     # --- events -----------------------------------------------------------
     def subscribe(self, handler: EventHandler) -> Callable[[], None]:
         """Register an event handler; returns an unsubscribe callable."""
@@ -881,15 +898,6 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
 
     async def set_working_directory(self, cwd: str) -> str:
         """Change the OWNER's working directory; returns its receipt."""
-        ...
-
-    async def credential_op(self, action: str, key: str = "", value: str = "") -> dict[str, Any]:
-        """Run a credential verb on the runtime.
-
-        Routed rather than executed locally because the store lives beside the
-        runtime: a viewer that answered from this machine would report the
-        wrong secrets and, worse, refuse a write the user is entitled to make.
-        """
         ...
 
     async def route_shared_slash(

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -2364,14 +2364,20 @@ class OwnedSessionHandle(SessionHandle):
         result = await self.run_slash_authoritative(command, args, images)
         return str(result.get("text") or f"ran /{command}")
 
-    def credential_op(self, action: str, key: str, value: str) -> dict[str, Any]:
-        """Run one ``/credential`` verb against the OWNER's variable store.
+    async def credential_op(self, action: str, key: str, value: str) -> dict[str, Any]:
+        """Run one ``/credential`` verb against the session's variable store.
 
-        The store is session state and its whole purpose is to be injected into
-        the environment of the bash commands the agent runs — which run in this
-        process. A follower holding its own copy would advertise a key to the
-        model that no executing tool could read, so every verb lands here and
-        the follower only paints the receipt.
+        The runtime's half of a capability the base protocol declares for every
+        session: the agent's ``bash`` commands run in THIS process and read
+        ``credential_env()`` from this store, so the verb executes here and a
+        front end holding its own copy would advertise a key no executing tool
+        could read. The front end keeps the masked paste (the user is sitting
+        there); only the resulting value crosses, over the dedicated op.
+
+        The verb table itself is shared with the in-process shape
+        (:func:`local_operator.session.credential_ops.run_credential_verb`) so
+        the two implementations cannot drift — a verb added for one shape is a
+        verb added for both.
 
         Returns plain data rather than a ``SlashResult`` because the caller
         needs the FACTS (did it replace, what was removed) to build its own
@@ -2381,59 +2387,15 @@ class OwnedSessionHandle(SessionHandle):
         The value is never logged, never journalled, and never returned — only
         the key name and the outcome cross back.
         """
-        store = getattr(self._session, "variables", None)
-        if store is None or not hasattr(store, "store_credential"):
-            return {"ok": False, "reason": "unavailable"}
-        if action == "list":
-            return {
-                "ok": True,
-                "credentials": [
-                    {"key": item.key, "source": item.source} for item in store.list_credentials()
-                ],
-            }
-        if action == "names":
-            return {"ok": True, "names": list(store.credential_names())}
-        if action == "forget":
-            removed = bool(store.forget_credential(key))
-            if removed:
-                self._journal_credential(key, action="forgot")
-            return {"ok": True, "removed": removed, "key": key}
-        if action == "forget-all":
-            # Names BEFORE the clear: the store is empty afterwards, so reading
-            # them after would announce nothing to the model.
-            names = list(store.credential_names())
-            count = int(store.clear_credentials())
-            for name in names:
-                self._journal_credential(name, action="forgot")
-            return {"ok": True, "count": count, "names": names}
-        if action == "persist":
-            # §5.4's promotion route, executed on the OWNER because both stores
-            # that matter are the owner's: the session memory holding the value
-            # and the config dir holding the encrypted long-term store. Only a
-            # name and an outcome sentence cross back — never the value.
-            from local_operator.secrets.promote import (
-                promote_session_credential_guarded,
-            )
+        from local_operator.session.credential_ops import run_credential_verb
 
-            outcome = promote_session_credential_guarded(store, key)
-            return {
-                "ok": True,
-                "promoted": outcome.ok,
-                "key": key,
-                "message": outcome.message,
-            }
-        if action == "store":
-            result = store.store_credential(key, value, "command")
-            credential = getattr(result, "credential", None)
-            if not getattr(result, "ok", False) or credential is None:
-                return {"ok": False, "reason": getattr(result, "reason", "") or "empty-value"}
-            replaced = bool(getattr(result, "replaced", False))
-            # The announcement is what makes the key findable on LATER turns,
-            # so it belongs on the side that owns the context — same reason
-            # `_cmd_credential` journals rather than writing a transcript row.
-            self._journal_credential(credential.key, replaced=replaced)
-            return {"ok": True, "key": credential.key, "replaced": replaced}
-        return {"ok": False, "reason": "unknown-action"}
+        return await run_credential_verb(
+            getattr(self._session, "variables", None),
+            self._journal_credential,
+            action,
+            key,
+            value,
+        )
 
     def _journal_credential(
         self, key: str, *, action: str = "stored", replaced: bool = False

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -4256,6 +4256,32 @@ class Session:
         """
         return self._variables
 
+    async def credential_op(self, action: str, key: str = "", value: str = "") -> dict[str, Any]:
+        """Run one ``/credential`` verb against this session's own store.
+
+        The in-process half of a capability the base protocol declares for
+        every session: this class runs its own turn loop, so its ``bash``
+        commands read ``credential_env()`` from THIS store and a store held
+        anywhere else would advertise a key no executing tool could read.
+        A session attached to a runtime routes the same verb there instead;
+        both shapes share ONE verb table
+        (:func:`local_operator.session.credential_ops.run_credential_verb`) so
+        the verbs cannot drift between them.
+
+        ``async`` for signature parity with the routed implementation, not
+        because the work awaits: the callers sit on an event loop and must not
+        care which shape they hold.
+
+        The value is never logged, never journalled, and never returned — only
+        the key name and the outcome cross back (the journal record names the
+        KEY only, exactly as the masked-paste flow journals).
+        """
+        from local_operator.session.credential_ops import run_credential_verb
+
+        return await run_credential_verb(
+            self._variables, self.journal_credential_change, action, key, value
+        )
+
     @property
     def conversation_name(self) -> str:
         """The conversation's title ("" until one is set or generated)."""

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1737,6 +1737,15 @@ CREDENTIAL_PLACEHOLDER = "Type or paste the secret… — masked; Enter chips it
 #: does paint in the deciding frame (UX round 1, U5).
 CREDENTIAL_ARMED_NOTICE = "armed — add a space, then type or paste the secret"
 
+#: How long the submit seam will wait for one inline-credential store to
+#: answer. A live round-trip is milliseconds (an in-memory store write behind
+#: a loopback socket), so anything that takes this long is a hung or dead
+#: connection — and because this wait sits on the submit seam, the honest
+#: answer to a hung one is the loud degrade, not a parked composer. Generous
+#: relative to the real cost for the same reason the connect envelope is: it
+#: is a backstop, not a target.
+CREDENTIAL_STORE_TIMEOUT_S = 5.0
+
 #: Shown in the same row once the operator has STARTED TYPING a secret and the
 #: composer is masking their keystrokes.
 #:
@@ -14387,8 +14396,22 @@ class OperatorApp(App[None]):
         del message
         self._warm_runtime_for_draft()
 
-    def on_editor_submitted(self, message: EditorSubmitted) -> None:
-        """Slash commands run synchronously BEFORE any prompt is sent."""
+    async def on_editor_submitted(self, message: EditorSubmitted) -> None:
+        """Slash commands run synchronously BEFORE any prompt is sent.
+
+        ASYNC, and deliberately so. The one seam that must await is the
+        inline-credential store: the verb belongs to the session, and for an
+        attached session it crosses a socket to the runtime that runs the
+        tools. Textual's App pump awaits each message handler to completion
+        before dispatching the next message (verified by probe in this repo's
+        e2e suite, not assumed), so the await preserves the ordering of every
+        branch below: a keystroke or a second submit that arrives during the
+        round-trip queues behind this handler exactly as it queued behind the
+        synchronous version. The alternative — keeping this sync and parking
+        the rest of submit in a spawned task — would NOT hold that property:
+        a task yields the pump, and the aside/shell/slash branches would
+        interleave with the next message.
+        """
         if self.composer_submission_blocked(message.text, shell=message.shell):
             # Enter is normally intercepted inside Editor before it clears. Keep
             # this second boundary for mouse/programmatic submits: the event may
@@ -14422,7 +14445,7 @@ class OperatorApp(App[None]):
         # credential citation any further than the name — the transcript row,
         # the history entry, the journal and the model all read the substituted
         # form, and the value exists only in the store.
-        text = self._capture_inline_credentials(text, message.attachments)
+        text = await self._capture_inline_credentials(text, message.attachments)
         # The aside owns the composer while it is up. EVERYTHING goes to it,
         # slash-shaped lines included: the card is a MODE, its footer says so
         # (`esc close · enter ask again`) and its placeholder says so, and a
@@ -29746,7 +29769,9 @@ class OperatorApp(App[None]):
             "as an environment variable; the agent cannot read the value."
         )
 
-    def _capture_inline_credentials(self, text: str, attachments: Mapping[int, Marked]) -> str:
+    async def _capture_inline_credentials(
+        self, text: str, attachments: Mapping[int, Marked]
+    ) -> str:
         """Store every credential ``text`` cites; return the text to send on.
 
         The submit-side half of the inline ``/credential`` gesture. The
@@ -29758,86 +29783,60 @@ class OperatorApp(App[None]):
         Returns ``text`` unchanged when nothing was captured, which is the
         overwhelmingly common case and costs one dict scan.
 
+        ASYNC because storing is a session capability that may ROUTE: the
+        store the agent's tools read from lives with the turn loop, which for
+        this product is another process, and the verb crosses a socket
+        (``credential_op``). This method runs inside the awaited message
+        handler (``on_editor_submitted``), and the Textual App pump awaits each
+        handler to completion before dispatching the next message — a property
+        this repo verified by probe rather than assumed — so the await cannot
+        let a second submit or keystroke interleave ahead of the six
+        early-return branches below it.
+
         WHY THE SUBSTITUTION HAPPENS EVEN WHEN THE STORE REFUSES: a marker left
         in the outgoing text would tell the model a credential exists that
         nothing holds. Every failure path below therefore rewrites the citation
         too — to an explicit "not stored" phrase — so the model is never handed
         a name it cannot use, which is the silent failure the viewer split in
-        ``_FRONTEND_LOCAL_SLASHES`` exists to prevent.
-
-        PER CREDENTIAL, not per submit. That invariant is only true if each
-        citation reflects ITS OWN payload's outcome, and an aggregate guard
-        cannot deliver it: guarding on "did anything store" rewrote every
-        citation to the confident form whenever ONE payload landed, so a
-        message carrying a refused credential beside a stored one advertised
-        ``$LOP_SECRET_…`` for a key ``credential_env()`` does not contain
-        (review round 1 R1, QA round 1 Q1 — two independent derivations of the
-        same defect).
+        ``_FRONTEND_LOCAL_SLASHES`` documents and review round 1 R1/Q1 pinned:
+        the rewrite has to be able to say "this one did not land" for a
+        SPECIFIC marker, so the outcomes below are keyed by the payload's own
+        key.
 
         That mixed case is REACHABLE through shipped components: a draft spilled
         to the sidebar's temp JSON comes back with ``value=""`` by design (the
-        encoder deliberately does not persist secrets), ``store_credential``
-        refuses a blank, and one restored credential beside one freshly pasted
-        one is exactly the shape. The docstring above asserted the invariant
-        twice while the code held it only in the all-or-nothing case.
+        encoder deliberately does not persist secrets), ``store`` refuses a
+        blank, and one restored credential beside one freshly pasted one is
+        exactly the shape. The docstring above asserted the invariant twice
+        while the code held it only in the all-or-nothing case.
         """
         payloads = credential_payloads(text, attachments)
         if not payloads:
             return text
-        session = self._session
-        store = getattr(session, "variables", None)
-        if store is None or not hasattr(store, "store_credential"):
-            # A VIEWER (or a session still starting). The store that matters is
-            # the OWNER's — `credential_env()` is read by the `bash` tool in
-            # the owner's process — and this path is synchronous, on the submit
-            # seam, with no place to await the remote op. Rather than store
-            # locally (a key no tool could read: the exact leak
-            # `_FRONTEND_LOCAL_SLASHES` documents) the capture DEGRADES
-            # LOUDLY: the secret is dropped here, the operator is told, and the
-            # model is told nothing was stored. The `/credential <KEY>` command
-            # still routes to the owner over the dedicated op and remains the
-            # supported way to hand a secret over from a viewer — but it is
-            # only reachable by PASTING the whole line, which is what the
-            # notice below has to say.
+        stored, refused, unreachable = await self._store_inline_credentials(payloads)
+        if unreachable:
+            # THE HONEST DEGRADE. The round-trip to the session's store
+            # genuinely failed — the runtime is gone, still starting, or a
+            # reduced double with no credential surface — and a key promised
+            # here would name an env var no tool can read. The secret is
+            # dropped, the operator is told, and the model is told nothing was
+            # stored. This path EXISTS on purpose; removing the wrong
+            # degradation did not remove the ability to fail.
             #
-            # IT MUST NAME THE PASTE, NOT THE TYPING. Typing `/credential KEY`
-            # cannot reach that command any more: the space after the token
-            # opens a masked capture, so the KEY NAME is minted as a short
-            # secret and nothing is handed to the owner. Advice that cannot be
-            # followed is worse than none here, because this notice fires on
-            # the submit seam — the chip the retyping mints is itself a
-            # payload, so the next submit re-enters this branch and reprints
-            # the same advice, and the operator LOOPS (review round 2, R5; QA
-            # round 2, Q5). A pasted whole line arms no capture and does reach
-            # the owner's prompt, so that is the route named.
+            # The advice must be FOLLOWABLE, unlike the notice this replaced:
+            # typing `/credential <KEY>` cannot reach any store (the space
+            # after the token opens a masked capture, so the KEY NAME is minted
+            # as a short secret), and the retired notice sent the operator
+            # into exactly that loop. Arming `/credential` and pasting the
+            # value again is the one gesture that retries a store.
+            noun = "credential" if len(payloads) == 1 else "credentials"
             self._system_notice(
-                "inline /credential needs the session that runs the tools; "
-                "paste the whole line /credential <KEY> here "
-                "and the secret is stored on the owner",
+                f"the {noun} could not be stored — the session could not be "
+                "reached; the agent has been told so. "
+                "Paste the value again after /credential to retry.",
                 "warning",
             )
             return self._mark_credentials_unstored(text, attachments)
-        stored: list[str] = []
-        # Keyed by the payload's OWN key, so the citation rewrite below can ask
-        # about each credential individually. A list of successes is not enough:
-        # the rewrite has to be able to say "this one did not land" for a
-        # specific marker, which is the whole of R1/Q1.
-        refused: dict[str, CredentialStoreFailure] = {}
-        for payload in payloads:
-            result = store.store_credential(payload.key, payload.value, "command")
-            if not result.ok or result.credential is None:
-                # `empty-value` is the reachable one (a restored spilled draft
-                # carries no bytes); `empty-key` cannot happen for a generated
-                # name, but the reason is carried through rather than assumed so
-                # the model is told what actually refused.
-                refused[payload.key] = result.reason or "empty-value"
-                continue
-            stored.append(result.credential.key)
-            # Journalled exactly as the masked-paste flow journals, so a
-            # credential handed over inline is visible to the next turn and to
-            # a resume. The record names the KEY only; `journal_credential_
-            # change` never sees the value.
-            self._journal_credential_change(result.credential.key, replaced=bool(result.replaced))
         if refused:
             # THE OPERATOR HEARS IT TOO, on every refusal and not only the
             # all-failed one. The composer has already cleared and the marker is
@@ -29859,10 +29858,10 @@ class OperatorApp(App[None]):
         # SCRUB THE MAP once the store owns the value. The same attachments map
         # rides on past this point into `SessionDraft` (the accepted-draft and
         # `/reload` hand-back), the compaction hold and the aside stash — all
-        # in-memory, none of which needs the bytes now that
-        # `VariableStore._credentials` holds them. Emptying the payload here
-        # means those seams are safe BY CONSTRUCTION rather than by an argument
-        # about which of them re-expands.
+        # in-memory, none of which needs the bytes now that the store the tools
+        # read from holds them. Emptying the payload here means those seams are
+        # safe BY CONSTRUCTION rather than by an argument about which of them
+        # re-expands.
         #
         # WHAT THIS SCRUB DOES NOT REACH, stated exactly, because an earlier
         # version of this comment claimed it bounded a secret's lifetime to the
@@ -29880,27 +29879,107 @@ class OperatorApp(App[None]):
         # field is absent from `_encode_draft`'s list (`session_drafts.py`), so
         # it never reaches disk, and nothing re-expands it into a prompt. It is
         # the operator's own unsubmitted draft, and scrubbing it would hand them
-        # back a credential marker with no value behind it, which
-        # `store_credential` then refuses — destroying unsubmitted work to
-        # shorten the lifetime of a secret that never leaves memory. The
-        # narrower claim is the true one: this bounds what the SUBMITTED turn's
-        # downstream holders carry, not what a parked draft retains.
+        # back a credential marker with no value behind it, which the store
+        # then refuses — destroying unsubmitted work to shorten the lifetime of
+        # a secret that never leaves memory. The narrower claim is the true one:
+        # this bounds what the SUBMITTED turn's downstream holders carry, not
+        # what a parked draft retains.
         #
         # The key and marker stay so a restored draft still paints its receipt.
-        # A restore that re-submits finds an empty value, which
-        # `store_credential` refuses, and the operator is told it was not
-        # stored rather than the model being promised a key twice.
+        # A restore that re-submits finds an empty value, which the store
+        # refuses, and the operator is told it was not stored rather than the
+        # model being promised a key twice.
         if isinstance(attachments, MutableMapping):
             for index, payload in list(attachments.items()):
                 if isinstance(payload, PastedCredential):
                     attachments[index] = PastedCredential("", payload.key, payload.marker)
         # The receipt names what the agent can now use. Plural-safe because two
         # pastes while armed capture two credentials (see `_capture_credential`).
+        # The stored keys are announced to the MODEL on the session side, by the
+        # same verb that stored them, so this notice is the operator's half.
         self._notice(
             f"Stored {', '.join(stored)}. Injected into every bash command "
             "as an environment variable; the agent cannot read the value."
         )
         return substituted
+
+    async def _store_inline_credentials(
+        self, payloads: Sequence[PastedCredential]
+    ) -> tuple[list[str], dict[str, CredentialStoreFailure], bool]:
+        """Send each captured credential through the session's ``credential_op``.
+
+        The I/O half of the inline gesture, split from the citation rewrite so
+        the rewrite stays pure and per-credential. Every session shape offers
+        the same verb (``SessionProtocol.credential_op``): an in-process
+        session executes it against its own store, an attached one routes it to
+        the runtime — this seam must not care which, because the TUI cannot
+        know.
+
+        Returns ``(stored, refused, unreachable)``: the keys that landed, the
+        keys the store itself refused (with the reason the citation rewrite
+        needs), and whether the round-trip failed in a way that says nothing
+        about any individual credential — a dropped runtime, a session still
+        starting, or a hung socket.
+
+        THE JOURNAL HAPPENS ON THE SESSION SIDE, not here: the routed store is
+        journalled where the live context lives (the runtime), and the local
+        store by ``Session.credential_op`` — journalling here as well would
+        announce every stored key twice.
+
+        BOUNDED, because this runs on the submit seam: a live round-trip is
+        milliseconds, and an answer that never comes is a dead or hung
+        connection, which is the degrade below and not a reason to park the
+        composer indefinitely.
+        """
+        # Probed and cast exactly as ``_credential_remote_flow`` probes and
+        # casts the same verb: the session may be either shape, the protocol
+        # declares the verb for both, and a probe with a default is the
+        # established way this file reaches an optional capability.
+        route = cast(
+            "Callable[..., Awaitable[Mapping[str, Any]]] | None",
+            getattr(self._session, "credential_op", None),
+        )
+        if route is None or not callable(route):
+            # No credential surface at all: a session still starting, or a
+            # reduced double. Indistinguishable in effect from a lost runtime
+            # and degraded identically — loudly, with nothing promised.
+            return [], {}, True
+        stored: list[str] = []
+        refused: dict[str, CredentialStoreFailure] = {}
+        for payload in payloads:
+            try:
+                answer = await asyncio.wait_for(
+                    route("store", payload.key, payload.value),
+                    timeout=CREDENTIAL_STORE_TIMEOUT_S,
+                )
+            except TimeoutError:
+                logger.warning(
+                    "inline credential store timed out after %ss", CREDENTIAL_STORE_TIMEOUT_S
+                )
+                return stored, refused, True
+            except Exception:  # noqa: BLE001 — a failed route is a notice, not a crash
+                logger.warning("inline credential store failed", exc_info=True)
+                return stored, refused, True
+            if not isinstance(answer, Mapping):
+                answer = {}
+            if answer.get("ok"):
+                stored.append(str(answer.get("key") or payload.key))
+                continue
+            reason = str(answer.get("reason") or "")
+            if reason in ("empty-key", "empty-value"):
+                # The store itself said no to THIS credential — the reachable
+                # case is a restored spilled draft, which carries no bytes.
+                # Per-key, so a refused credential beside a stored one cites
+                # individually (review round 1 R1 / QA round 1 Q1).
+                refused[payload.key] = reason  # type: ignore[assignment]
+                continue
+            # disconnected / unavailable / remote-client / unknown-action (or
+            # anything unrecognised): the failure is about the ROUND-TRIP, not
+            # the credential, so the whole gesture degrades rather than
+            # pretending a per-key verdict exists. Same rule the paste route
+            # applies to the same reasons.
+            return stored, refused, True
+        return stored, refused, False
 
     def _mark_credentials_unstored(
         self,
@@ -29915,12 +29994,13 @@ class OperatorApp(App[None]):
         the secret is missing, and the agent would go looking for an env var
         nobody set.
 
-        ``refused`` names why each key was refused, when a store was present and
-        said no. Without it the phrase is the viewer case — there is no store on
-        this side at all. The distinction is the whole of QA finding Q3: the
-        sentence used to hard-code "no session store available" for both, so a
-        store that WAS present and refused an empty value told the model the
-        store was unavailable, pointing any diagnosis at the wrong subsystem.
+        ``refused`` names why each key was refused, when the store was reached
+        and said no. Without it the phrase is the round-trip case — the store
+        could not be reached at all. The distinction is the whole of QA finding
+        Q3: the sentence used to hard-code "no session store available" for
+        both, so a store that WAS reached and refused an empty value told the
+        model the store was unavailable, pointing any diagnosis at the wrong
+        subsystem.
         """
         from local_operator.tui.widgets.editor import cite, describe_unstored
 

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -748,21 +748,24 @@ def describe_unstored(reason: str | None) -> str:
     per-credential rewrite below — and a model reading two different sentences
     for one outcome would have to guess whether they mean different things.
 
-    ``reason`` is ``None`` when there is no store on this side at all (a viewer,
-    or a session still starting) and a
-    :data:`~local_operator.variables.CredentialStoreFailure` when a store was
-    present and refused the write. Naming which is not cosmetic: the phrase used
-    to hard-code "no session store available" for both, so a present store
-    refusing an empty value told the model the store was unavailable and sent
-    any diagnosis after the wrong subsystem (QA round 1, Q3).
+    ``reason`` is ``None`` when the round-trip to the session failed — the
+    runtime was lost or could not be reached between the paste and the submit —
+    and a :data:`~local_operator.variables.CredentialStoreFailure` when the
+    store was reached and refused the write. Naming which is not cosmetic: the
+    sentence used to hard-code "no session store available" for both, so a
+    store that WAS reached and refused an empty value told the model the store
+    was unavailable and sent any diagnosis after the wrong subsystem (QA round
+    1, Q3).
 
     In every form the sentence states the OUTCOME the agent must act on — there
     is no usable credential here — before it explains the cause, because an
     agent that reads only the first clause must still not go hunting an env var
-    nobody set.
+    nobody set. And no form names a privileged process: the failure is stated
+    as what happened (the store could not be reached), never as a topology the
+    operator is invited to think about.
     """
     if reason is None:
-        return "[credential NOT stored — no session store available]"
+        return "[credential NOT stored — the session could not be reached; try again]"
     if reason == "empty-key":
         return "[credential NOT stored — the store rejected its name]"
     # `empty-value`, the reachable one: a draft that spilled to disk comes back

--- a/tests/e2e/test_inline_credential_e2e.py
+++ b/tests/e2e/test_inline_credential_e2e.py
@@ -1,0 +1,429 @@
+"""Inline ``/credential`` over the session class the shipping product uses.
+
+**This file exists because a green four-stream review shipped a half-feature.**
+The inline-credential submit seam was built primarily against
+:class:`~local_operator.session.session.Session` — and `lop`'s TUI never builds
+one. ``cli.py``'s ``viewer_factory`` returns a ``RemoteSession`` on every path
+and its takeover closure raises outright, so the branch the tests certified was
+unreachable in the product and the branch that actually ran was written as the
+"degradation". The operator hit it on his first use: he typed a secret and was
+told no store was available, with advice to paste ``/credential <KEY>``
+instead.
+
+So the rule here is the one ``test_viewer_attach_e2e`` states and for the same
+reason: **the production handle class, the production server, a real loopback
+socket, the production ``RemoteSession`` client, and the real ``OperatorApp``
+driven by keystrokes.** A test that constructs a ``Session`` and hands it to
+the app proves nothing about `lop` — that substitution IS the defect this file
+guards. ``test_the_app_under_test_holds_the_class_the_product_builds`` asserts
+the harness has not quietly drifted back to the reachable-looking-but-wrong
+shape.
+
+The value asserted here is synthetic and its bytes are never printed: length is
+proof enough, and a canary that reached a log would be a leak of the same shape
+the feature exists to prevent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from textual import events
+
+from local_operator.session.runtime import registry
+from local_operator.session.runtime.owned import OwnedSessionHandle
+from local_operator.session.runtime.server import RuntimeServer
+from tests.e2e.harness import ScriptedStream, build_session, text_turn
+
+pytestmark = pytest.mark.e2e
+
+#: A synthetic 52-character secret. Never printed, never asserted by value into
+#: a message a human reads — only its LENGTH crosses into an assertion, which
+#: is the same discipline ``test_viewer_attach_e2e`` follows.
+CANARY = "lopcanary" + "Z" * 39 + "END"
+
+
+async def _never_take_over() -> Any:
+    raise AssertionError("a viewer never takes over a session")
+
+
+async def _wait_for_record(config_dir: Path, session_id: str, timeout: float = 15.0) -> Any:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        for record, _state in registry.scan(config_dir):
+            if getattr(record, "session_id", "") == session_id:
+                return record
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"no record published for {session_id} within {timeout}s")
+
+
+async def _pump(pilot: Any, predicate: Any, tries: int = 400) -> bool:
+    for _ in range(tries):
+        await pilot.pause()
+        if predicate():
+            return True
+    return False
+
+
+class _Runtime:
+    """A real ``Session`` behind the production handle behind the real server."""
+
+    def __init__(self, config_dir: Path) -> None:
+        self.config_dir = config_dir
+        # The id is DERIVED from the directory name, exactly as a real
+        # runtime's is — `Session.session_id` is read-only for that reason.
+        self.session_id = uuid.uuid4().hex[:12]
+        self.directory = config_dir / "sessions" / self.session_id
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self.session: Any = None
+        self.server: RuntimeServer | None = None
+        #: The scripted provider itself, held directly: the recorded requests
+        #: are the evidence for "the model was told the NAME", and reaching
+        #: them through the session's private provider plumbing would couple
+        #: the test to it.
+        self.stream = ScriptedStream([text_turn("ack"), text_turn("ack")])
+
+    async def start(self) -> None:
+        stream = self.stream
+        self.session = build_session(self.directory, stream)
+        assert self.session.session_id == self.session_id, (
+            "the session must publish under the directory's id, which is what " "the app dials"
+        )
+        handle = OwnedSessionHandle(
+            self.session, asyncio.get_running_loop(), cwd=str(self.directory)
+        )
+        self.server = RuntimeServer(handle, kind="daemon")
+        await self.server.start_in_process()
+        (self.directory / ".session.pid").write_text(str(os.getpid()), encoding="utf-8")
+        await _wait_for_record(self.config_dir, self.session_id)
+
+    async def stop(self) -> None:
+        if self.server is not None:
+            self.server.close()
+        if self.session is not None:
+            await self.session.dispose()
+
+
+async def _viewer_app(runtime: _Runtime) -> Any:
+    """The real ``OperatorApp`` over a real attached ``RemoteSession``.
+
+    ``cli.viewer_factory`` in miniature and deliberately no smaller: a live
+    record exists, so the production ``RemoteSession.connect`` is what the app
+    adopts — the exact object `lop` gives it.
+    """
+    from local_operator.session.remote import RemoteSession
+    from local_operator.tui.app import OperatorApp
+
+    record = await _wait_for_record(runtime.config_dir, runtime.session_id)
+
+    async def factory() -> RemoteSession:
+        return await RemoteSession.connect(
+            record,
+            runtime.session_id,
+            config_dir=runtime.config_dir,
+            takeover_factory=_never_take_over,
+        )
+
+    OperatorApp._check_for_update = lambda self: None  # type: ignore[method-assign]
+    return OperatorApp(factory)
+
+
+async def _arm_and_paste(pilot: Any, app: Any, prefix: str, secret: str = CANARY) -> None:
+    """The reported gesture: type ``/credential ``, paste, describe, Enter.
+
+    Keystrokes rather than a direct call into the handler, because the whole
+    defect lived between the composer and the submit seam.
+    """
+    from local_operator.tui.widgets.editor import Editor
+
+    editor = app.query_one(Editor)
+    editor.focus()
+    await pilot.pause()
+    for char in f"{prefix}/credential ":
+        await pilot.press(char)
+    await pilot.pause()
+    app.post_message(events.Paste(secret))
+    await pilot.pause()
+    await pilot.pause()
+
+
+def _credential_keys(app: Any) -> list[str]:
+    from local_operator.tui.widgets.editor import Editor, PastedCredential
+
+    editor = app.query_one(Editor)
+    return [
+        payload.key
+        for payload in editor._attachments.values()
+        if isinstance(payload, PastedCredential)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_the_app_under_test_holds_the_class_the_product_builds(
+    headless_tui_env: Path, workspace: Path
+) -> None:
+    """The harness canary: assert the SHAPE before trusting any result from it.
+
+    Every other test in this file is only evidence about `lop` if the app it
+    drives holds what `lop`'s factory hands it. This asserts that directly —
+    and it is not ceremony: the substitution it forbids (an in-process
+    ``Session`` injected into ``OperatorApp``) is exactly what let the inline
+    ``/credential`` half-feature pass four review streams.
+    """
+    from local_operator.session.remote import RemoteSession
+    from local_operator.session.session import Session
+
+    runtime = _Runtime(headless_tui_env)
+    await runtime.start()
+    app = await _viewer_app(runtime)
+    try:
+        async with app.run_test(size=(120, 40)) as pilot:
+            assert await _pump(pilot, lambda: app._session is not None), "the app never adopted"
+            assert isinstance(app._session, RemoteSession), (
+                "this harness must drive the class cli.viewer_factory returns; "
+                f"it holds {type(app._session).__name__}"
+            )
+            assert not isinstance(app._session, Session)
+            # The store the value must reach is the RUNTIME's, and the viewer
+            # must not have grown one of its own — a local store would satisfy
+            # a naive round-trip and leave every bash command unable to read it.
+            assert getattr(app._session, "variables", None) is None
+    finally:
+        await runtime.stop()
+
+
+@pytest.mark.asyncio
+async def test_a_typed_credential_reaches_the_runtime_store_and_the_agents_tools(
+    headless_tui_env: Path, workspace: Path
+) -> None:
+    """RED before this change, GREEN after: the gesture on the REACHABLE path.
+
+    The four assertions are the feature, in order: the value lands in the
+    store that ``credential_env()`` reads, a real child process can use it,
+    the model is told the NAME (never the bytes), and the operator's own words
+    survive around the citation.
+    """
+    from local_operator.tools.builtin import execute_bash
+
+    runtime = _Runtime(headless_tui_env)
+    await runtime.start()
+    app = await _viewer_app(runtime)
+    try:
+        async with app.run_test(size=(120, 40)) as pilot:
+            assert await _pump(pilot, lambda: app._session is not None)
+            await _arm_and_paste(pilot, app, "deploy with ")
+            keys = _credential_keys(app)
+            assert len(keys) == 1, f"the chip must be minted before submit: {keys}"
+            key = keys[0]
+            for char in " for the staging deploy":
+                await pilot.press(char)
+            await pilot.press("enter")
+
+            store = runtime.session.variables
+            landed = await _pump(pilot, lambda: key in store.credential_names())
+            assert landed, (
+                "the typed credential never reached the runtime's store; "
+                f"it holds {store.credential_names()}"
+            )
+            # ASSERT THE MUTATION LANDED, by the value's LENGTH rather than by
+            # its bytes: a store that held a truncated or empty value would
+            # otherwise be indistinguishable from a correct one.
+            assert len(store.credential_env()[key]) == len(CANARY)
+
+            # USABLE, not merely present: the whole point of the store is the
+            # environment of the commands the agent runs.
+            class _Ctx:
+                variables = store
+                cwd = str(runtime.directory)
+
+            result = await execute_bash(
+                "e2e-inline-cred",
+                {"command": f'test -n "${key}" && echo LEN=${{#{key}}}'},
+                None,
+                None,
+                cast("Any", _Ctx()),
+            )
+            rendered = str(getattr(result, "content", result))
+            assert f"LEN={len(CANARY)}" in rendered, rendered
+            assert CANARY not in rendered, "the value must not appear in tool output"
+
+            # The model is handed the NAME and the operator's description.
+            sent = " ".join(
+                str(getattr(request, "messages", "")) for request in runtime.stream.requests
+            )
+            assert CANARY not in sent
+            assert key in sent, "the model must be told the key it can use"
+            assert "NOT stored" not in sent, "the degradation must not fire on a live runtime"
+            assert "for the staging deploy" in sent
+    finally:
+        await runtime.stop()
+
+
+@pytest.mark.asyncio
+async def test_the_secret_reaches_no_transcript_history_or_draft(
+    headless_tui_env: Path, workspace: Path
+) -> None:
+    """Containment, over the same real submit — with the grep canaried.
+
+    The value now lives across an await it did not cross before, so this is
+    the invariant most at risk from the change and least visible when broken.
+
+    **The grep is canaried in both directions**: a file known to contain the
+    canary must be found, or an "absent everywhere" result would be
+    indistinguishable from a scanner that reads nothing. Both the literal form
+    and the normalised (``-``→``_``, upper-cased) form are searched, since a
+    key-shaped rewrite of the value would evade a literal-only scan.
+    """
+    normalised = CANARY.replace("-", "_").upper()
+
+    runtime = _Runtime(headless_tui_env)
+    await runtime.start()
+    app = await _viewer_app(runtime)
+    try:
+        async with app.run_test(size=(120, 40)) as pilot:
+            assert await _pump(pilot, lambda: app._session is not None)
+            await _arm_and_paste(pilot, app, "token ")
+            key = _credential_keys(app)[0]
+            for char in " is the deploy key":
+                await pilot.press(char)
+            await pilot.press("enter")
+            store = runtime.session.variables
+            assert await _pump(pilot, lambda: key in store.credential_names())
+            await pilot.pause()
+
+            # POSITIVE CONTROL for the scanner. Without it, "no hits anywhere"
+            # is exactly what a scanner pointed at an empty tree reports.
+            planted = headless_tui_env / "planted-canary.txt"
+            planted.write_text(f"prefix {CANARY} suffix\n{normalised}\n", encoding="utf-8")
+
+            scanned: list[Path] = []
+            hits: list[str] = []
+            for path in headless_tui_env.rglob("*"):
+                if not path.is_file():
+                    continue
+                try:
+                    blob = path.read_text(encoding="utf-8", errors="ignore")
+                except OSError:
+                    continue
+                scanned.append(path)
+                if CANARY in blob or normalised in blob:
+                    hits.append(str(path.relative_to(headless_tui_env)))
+
+            assert "planted-canary.txt" in hits, (
+                "the scanner never found the planted canary, so its silence "
+                f"about every other file means nothing (scanned {len(scanned)})"
+            )
+            assert hits == ["planted-canary.txt"], f"the secret reached disk: {hits}"
+
+            # In-memory holders the scanner cannot see.
+            from local_operator.tui.widgets.editor import Editor
+
+            editor = app.query_one(Editor)
+            assert CANARY not in editor.text
+            assert CANARY not in "\n".join(editor._history)
+            painted = "\n".join(strip.text for strip in app.screen._compositor.render_strips())
+            assert CANARY not in painted and normalised not in painted
+    finally:
+        await runtime.stop()
+
+
+@pytest.mark.asyncio
+async def test_a_lost_runtime_still_refuses_loudly_instead_of_promising_a_key(
+    headless_tui_env: Path, workspace: Path
+) -> None:
+    """The refusal must SURVIVE the fix — otherwise only a check was removed.
+
+    Round-tripping to the runtime replaces a wrong degradation, not the
+    ability to degrade. With the runtime gone between the chip and Enter,
+    ``credential_op`` answers ``disconnected`` and the model must be told the
+    credential did NOT land — never handed a key nothing holds.
+    """
+    runtime = _Runtime(headless_tui_env)
+    await runtime.start()
+    app = await _viewer_app(runtime)
+    try:
+        async with app.run_test(size=(120, 40)) as pilot:
+            assert await _pump(pilot, lambda: app._session is not None)
+            await _arm_and_paste(pilot, app, "deploy with ")
+            key = _credential_keys(app)[0]
+
+            # The runtime goes away AFTER the chip is minted and BEFORE Enter:
+            # the exact window the honest-failure invariant is about.
+            await runtime.stop()
+            await pilot.pause()
+
+            await pilot.press("enter")
+            await _pump(
+                pilot,
+                lambda: "NOT stored"
+                in "\n".join(strip.text for strip in app.screen._compositor.render_strips()),
+            )
+            painted = "\n".join(strip.text for strip in app.screen._compositor.render_strips())
+            assert CANARY not in painted
+            assert "NOT stored" in painted, (
+                "a failed round-trip must say so; a silent drop is the one "
+                f"belief this feature must never create. screen: {painted[-800:]!r}"
+            )
+            # And the copy must not send the operator after a privileged
+            # process that does not exist.
+            for forbidden in ("owner", "viewer"):
+                assert forbidden not in painted.lower(), (
+                    f"the failure copy names {forbidden!r}, which is the model "
+                    "that produced this defect"
+                )
+            assert key not in painted or "NOT stored" in painted
+    finally:
+        await runtime.stop()
+
+
+@pytest.mark.asyncio
+async def test_the_paste_route_still_stores_on_the_runtime(
+    headless_tui_env: Path, workspace: Path
+) -> None:
+    """``/credential <KEY>`` pasted whole — the route that already worked.
+
+    It now shares ``credential_op`` with the typed route, so it is exercised
+    against the same live runtime to prove the shared verb did not regress the
+    one path the operator has been relying on.
+    """
+    runtime = _Runtime(headless_tui_env)
+    await runtime.start()
+    app = await _viewer_app(runtime)
+    try:
+        async with app.run_test(size=(120, 40)) as pilot:
+            assert await _pump(pilot, lambda: app._session is not None)
+            from local_operator.tui.widgets.editor import Editor
+
+            editor = app.query_one(Editor)
+            editor.focus()
+            await pilot.pause()
+            app.post_message(events.Paste("/credential PASTED_TOKEN"))
+            await pilot.pause()
+            await pilot.press("enter")
+
+            # The command opens a masked prompt card; the value is TYPED into
+            # it, which is the paste route's own gesture (the card is the
+            # masked-paste surface, not the composer).
+            def _card_up() -> bool:
+                try:
+                    return bool(app.query("KeyPromptBlock"))
+                except Exception:
+                    return False
+
+            assert await _pump(pilot, _card_up), "the store verb must open the masked paste"
+            for char in CANARY:
+                await pilot.press(char)
+            await pilot.pause()
+            await pilot.press("enter")
+
+            store = runtime.session.variables
+            landed = await _pump(pilot, lambda: "PASTED_TOKEN" in store.credential_names())
+            assert landed, f"the paste route regressed: {store.credential_names()}"
+            assert len(store.credential_env()["PASTED_TOKEN"]) == len(CANARY)
+    finally:
+        await runtime.stop()

--- a/tests/unit/info/test_collect.py
+++ b/tests/unit/info/test_collect.py
@@ -813,6 +813,29 @@ def test_nested_subagents_are_counted_once() -> None:
 
         subagent_comms = _Comms()
 
+        # ``SessionProtocol.credential_op``: the REAL verb table against a
+        # memory-only store (the ``test_app_pilot.FakeSession`` pattern), so a
+        # credential probe of this double answers the way the owner session it
+        # stands in for does instead of silently refusing — a double that
+        # swallows the verb is how #891 passed review on an unreachable path.
+        @property
+        def variables(self) -> Any:
+            store = getattr(self, "_variables", None)
+            if store is None:
+                from local_operator.variables import VariableStore
+
+                store = self._variables = VariableStore(cwd="/tmp", env={})
+            return store
+
+        async def credential_op(
+            self, action: str, key: str = "", value: str = ""
+        ) -> dict[str, Any]:
+            from local_operator.session.credential_ops import run_credential_verb
+
+            return await run_credential_verb(
+                self.variables, getattr(self, "journal_credential_change", None), action, key, value
+            )
+
     live = collect_live(_Session())
     assert live.running == 3, "one per roster entry, not per path through the tree"
     assert len(live.tree) == 3
@@ -895,6 +918,29 @@ def test_a_comms_object_without_nodes_degrades_instead_of_raising() -> None:
         runtime_locality: RuntimeLocality = "this-process"
 
         subagent_comms = _NoNodes()
+
+        # ``SessionProtocol.credential_op``: the REAL verb table against a
+        # memory-only store (the ``test_app_pilot.FakeSession`` pattern), so a
+        # credential probe of this double answers the way the owner session it
+        # stands in for does instead of silently refusing — a double that
+        # swallows the verb is how #891 passed review on an unreachable path.
+        @property
+        def variables(self) -> Any:
+            store = getattr(self, "_variables", None)
+            if store is None:
+                from local_operator.variables import VariableStore
+
+                store = self._variables = VariableStore(cwd="/tmp", env={})
+            return store
+
+        async def credential_op(
+            self, action: str, key: str = "", value: str = ""
+        ) -> dict[str, Any]:
+            from local_operator.session.credential_ops import run_credential_verb
+
+            return await run_credential_verb(
+                self.variables, getattr(self, "journal_credential_change", None), action, key, value
+            )
 
     live = collect_live(_Session())  # must not raise
     assert live.roster_unread is True

--- a/tests/unit/mcp/test_grants.py
+++ b/tests/unit/mcp/test_grants.py
@@ -89,6 +89,34 @@ class _Session:
     def __init__(self, manager: Any) -> None:
         self.mcp_manager = manager
 
+    @property
+    def variables(self) -> Any:
+        """Memory-only store for ``/credential``. Created on first use so
+        tests that never touch credentials pay nothing for the property."""
+        store = getattr(self, "_variables", None)
+        if store is None:
+            from local_operator.variables import VariableStore
+
+            store = self._variables = VariableStore(cwd="/tmp", env={})
+        return store
+
+    async def credential_op(self, action: str, key: str = "", value: str = "") -> dict[str, Any]:
+        """The REAL verb table against this fake's store, not a stub of it.
+
+        ``SessionProtocol`` declares this verb for every session shape, and
+        the TUI's submit seam probes it BY NAME — a double lacking it
+        silently degrades every credential gesture driven through it to
+        "this session cannot hold credentials", and a fake that swallows the
+        verb is how #891 passed four review streams on an unreachable path.
+        The canonical delegation rationale lives on
+        ``test_app_pilot.FakeSession.credential_op``.
+        """
+        from local_operator.session.credential_ops import run_credential_verb
+
+        return await run_credential_verb(
+            self.variables, getattr(self, "journal_credential_change", None), action, key, value
+        )
+
 
 @pytest.fixture(autouse=True)
 def _no_real_credential_writes(monkeypatch: pytest.MonkeyPatch) -> list[str]:

--- a/tests/unit/session/runtime/test_capability_surface.py
+++ b/tests/unit/session/runtime/test_capability_surface.py
@@ -375,6 +375,29 @@ def test_the_runtime_applies_fast_mode_to_the_spec_it_builds_requests_from() -> 
         def set_model(self, spec, *, explicit: bool = False) -> None:  # noqa: ANN001
             self.model = spec
 
+        # ``SessionProtocol.credential_op``: the REAL verb table against a
+        # memory-only store (the ``test_app_pilot.FakeSession`` pattern), so a
+        # credential probe of this double answers the way the owner session it
+        # stands in for does instead of silently refusing — a double that
+        # swallows the verb is how #891 passed review on an unreachable path.
+        @property
+        def variables(self) -> Any:
+            store = getattr(self, "_variables", None)
+            if store is None:
+                from local_operator.variables import VariableStore
+
+                store = self._variables = VariableStore(cwd="/tmp", env={})
+            return store
+
+        async def credential_op(
+            self, action: str, key: str = "", value: str = ""
+        ) -> dict[str, Any]:
+            from local_operator.session.credential_ops import run_credential_verb
+
+            return await run_credential_verb(
+                self.variables, getattr(self, "journal_credential_change", None), action, key, value
+            )
+
     handle = OwnedSessionHandle.__new__(OwnedSessionHandle)
     handle._notify = lambda: None  # type: ignore[method-assign]
     session = _Session()

--- a/tests/unit/session/runtime/test_eager_runtime.py
+++ b/tests/unit/session/runtime/test_eager_runtime.py
@@ -251,6 +251,29 @@ async def test_is_pristine_reads_the_attachment_sidecar(tmp_path: Path, monkeypa
         def history(self):  # noqa: ANN202
             return []
 
+        # ``SessionProtocol.credential_op``: the REAL verb table against a
+        # memory-only store (the ``test_app_pilot.FakeSession`` pattern), so a
+        # credential probe of this double answers the way the owner session it
+        # stands in for does instead of silently refusing — a double that
+        # swallows the verb is how #891 passed review on an unreachable path.
+        @property
+        def variables(self) -> Any:
+            store = getattr(self, "_variables", None)
+            if store is None:
+                from local_operator.variables import VariableStore
+
+                store = self._variables = VariableStore(cwd="/tmp", env={})
+            return store
+
+        async def credential_op(
+            self, action: str, key: str = "", value: str = ""
+        ) -> dict[str, Any]:
+            from local_operator.session.credential_ops import run_credential_verb
+
+            return await run_credential_verb(
+                self.variables, getattr(self, "journal_credential_change", None), action, key, value
+            )
+
     handle = object.__new__(OwnedSessionHandle)
     handle._session = _Session()  # type: ignore[attr-defined]
     object.__setattr__(handle, "is_busy", lambda: False)
@@ -294,6 +317,29 @@ async def test_is_pristine_reads_durable_rows_not_the_model_window(
 
         def history(self):  # noqa: ANN202 — compaction emptied the window
             return []
+
+        # ``SessionProtocol.credential_op``: the REAL verb table against a
+        # memory-only store (the ``test_app_pilot.FakeSession`` pattern), so a
+        # credential probe of this double answers the way the owner session it
+        # stands in for does instead of silently refusing — a double that
+        # swallows the verb is how #891 passed review on an unreachable path.
+        @property
+        def variables(self) -> Any:
+            store = getattr(self, "_variables", None)
+            if store is None:
+                from local_operator.variables import VariableStore
+
+                store = self._variables = VariableStore(cwd="/tmp", env={})
+            return store
+
+        async def credential_op(
+            self, action: str, key: str = "", value: str = ""
+        ) -> dict[str, Any]:
+            from local_operator.session.credential_ops import run_credential_verb
+
+            return await run_credential_verb(
+                self.variables, getattr(self, "journal_credential_change", None), action, key, value
+            )
 
     handle = object.__new__(OwnedSessionHandle)
     handle._session = _Session()  # type: ignore[attr-defined]
@@ -613,6 +659,29 @@ async def test_is_pristine_reads_the_wake_index_not_only_the_live_scheduler(
 
         def history(self):  # noqa: ANN202
             return []
+
+        # ``SessionProtocol.credential_op``: the REAL verb table against a
+        # memory-only store (the ``test_app_pilot.FakeSession`` pattern), so a
+        # credential probe of this double answers the way the owner session it
+        # stands in for does instead of silently refusing — a double that
+        # swallows the verb is how #891 passed review on an unreachable path.
+        @property
+        def variables(self) -> Any:
+            store = getattr(self, "_variables", None)
+            if store is None:
+                from local_operator.variables import VariableStore
+
+                store = self._variables = VariableStore(cwd="/tmp", env={})
+            return store
+
+        async def credential_op(
+            self, action: str, key: str = "", value: str = ""
+        ) -> dict[str, Any]:
+            from local_operator.session.credential_ops import run_credential_verb
+
+            return await run_credential_verb(
+                self.variables, getattr(self, "journal_credential_change", None), action, key, value
+            )
 
     handle = object.__new__(OwnedSessionHandle)
     handle._session = _Session()  # type: ignore[attr-defined]

--- a/tests/unit/session/runtime/test_exec_control.py
+++ b/tests/unit/session/runtime/test_exec_control.py
@@ -84,6 +84,36 @@ class FakeSession:
     async def dispose(self) -> None:
         self.disposed = True
 
+    @property
+    def variables(self) -> Any:
+        """Memory-only store for ``/credential``, created on first use. The
+        handle's own ``credential_op`` probes this attribute BY NAME on the
+        session it wraps, so the double carries the real store the probe
+        expects instead of answering ``None`` (the table's refusal)."""
+        store = getattr(self, "_variables", None)
+        if store is None:
+            from local_operator.variables import VariableStore
+
+            store = self._variables = VariableStore(cwd="/tmp", env={})
+        return store
+
+    async def credential_op(self, action: str, key: str = "", value: str = "") -> dict[str, Any]:
+        """The REAL verb table against this fake's store, not a stub of it.
+
+        ``SessionProtocol`` declares this verb for every session shape, and
+        the TUI's submit seam probes it BY NAME — a double lacking it
+        silently degrades every credential gesture driven through it to
+        "this session cannot hold credentials", and a fake that swallows the
+        verb is how #891 passed four review streams on an unreachable path.
+        The canonical delegation rationale lives on
+        ``test_app_pilot.FakeSession.credential_op``.
+        """
+        from local_operator.session.credential_ops import run_credential_verb
+
+        return await run_credential_verb(
+            self.variables, getattr(self, "journal_credential_change", None), action, key, value
+        )
+
 
 @pytest.fixture()
 def isolated_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:

--- a/tests/unit/session/runtime/test_inbox.py
+++ b/tests/unit/session/runtime/test_inbox.py
@@ -204,7 +204,28 @@ def test_the_drain_reads_a_property_the_session_exposes(tmp_path: Path) -> None:
         outcome_is_synchronous = True
         runtime_locality: RuntimeLocality = "this-process"
 
-        pass
+        # ``SessionProtocol.credential_op``: the REAL verb table against a
+        # memory-only store (the ``test_app_pilot.FakeSession`` pattern), so a
+        # credential probe of this double answers the way the owner session it
+        # stands in for does instead of silently refusing — a double that
+        # swallows the verb is how #891 passed review on an unreachable path.
+        @property
+        def variables(self) -> Any:
+            store = getattr(self, "_variables", None)
+            if store is None:
+                from local_operator.variables import VariableStore
+
+                store = self._variables = VariableStore(cwd="/tmp", env={})
+            return store
+
+        async def credential_op(
+            self, action: str, key: str = "", value: str = ""
+        ) -> dict[str, Any]:
+            from local_operator.session.credential_ops import run_credential_verb
+
+            return await run_credential_verb(
+                self.variables, getattr(self, "journal_credential_change", None), action, key, value
+            )
 
     # A bare stand-in would re-create the defect's blind spot; the point is
     # that the PRODUCTION attribute name resolves. Use the real Session's

--- a/tests/unit/session/runtime/test_owned.py
+++ b/tests/unit/session/runtime/test_owned.py
@@ -176,6 +176,36 @@ class FakeSession:
     def reasoning_effort(self):  # pragma: no cover
         return "auto"
 
+    @property
+    def variables(self) -> Any:
+        """Memory-only store for ``/credential``, created on first use. The
+        handle's own ``credential_op`` probes this attribute BY NAME on the
+        session it wraps, so the double carries the real store the probe
+        expects instead of answering ``None`` (the table's refusal)."""
+        store = getattr(self, "_variables", None)
+        if store is None:
+            from local_operator.variables import VariableStore
+
+            store = self._variables = VariableStore(cwd="/tmp", env={})
+        return store
+
+    async def credential_op(self, action: str, key: str = "", value: str = "") -> dict[str, Any]:
+        """The REAL verb table against this fake's store, not a stub of it.
+
+        ``SessionProtocol`` declares this verb for every session shape, and
+        the TUI's submit seam probes it BY NAME — a double lacking it
+        silently degrades every credential gesture driven through it to
+        "this session cannot hold credentials", and a fake that swallows the
+        verb is how #891 passed four review streams on an unreachable path.
+        The canonical delegation rationale lives on
+        ``test_app_pilot.FakeSession.credential_op``.
+        """
+        from local_operator.session.credential_ops import run_credential_verb
+
+        return await run_credential_verb(
+            self.variables, getattr(self, "journal_credential_change", None), action, key, value
+        )
+
 
 def make_handle(auto_approve: bool = False) -> tuple[OwnedSessionHandle, FakeSession]:
     # The handle records whichever loop it is built on; inside an async test

--- a/tests/unit/session/test_viewer_protocol.py
+++ b/tests/unit/session/test_viewer_protocol.py
@@ -753,9 +753,16 @@ def test_app_py_dominates_the_derivation_so_a_global_floor_cannot_work() -> None
     # An exact pin, unlike the ratio above: this is the population the aggregate
     # floor of 40 is set against, so a drop here is the decay that floor exists
     # to catch rather than ordinary churn.
-    assert len(viewer_only) == 50, (
+    #
+    # 50 → 49 is a DELIBERATE removal, not decay: ``credential_op`` moved from
+    # ``ViewerSessionProtocol`` to ``SessionProtocol`` (the capability is a
+    # session capability — execute locally or route — not a viewer one), so it
+    # left the viewer-only population by becoming declared for both shapes.
+    # That move is the fix for the inline ``/credential`` half-feature; a
+    # LATER drop back to this figure would mean the word crept home again.
+    assert len(viewer_only) == 49, (
         f"there are {len(viewer_only)} viewer-only members; _SCANNED's comment "
-        "says 50, and the aggregate floor is set at 40 against that number. A "
+        "says 49, and the aggregate floor is set at 40 against that number. A "
         "drop here is the decay that floor exists to catch, so check it is "
         "genuinely a removal before editing this figure."
     )

--- a/tests/unit/test_exec_mode.py
+++ b/tests/unit/test_exec_mode.py
@@ -127,6 +127,34 @@ class FakeSession:
     def set_conversation_name(self, text: str, *, user_set: bool = True) -> str:
         return self.conversation_name_state.set(text, user_set=user_set)
 
+    @property
+    def variables(self) -> Any:
+        """Memory-only store for ``/credential``. Created on first use so
+        tests that never touch credentials pay nothing for the property."""
+        store = getattr(self, "_variables", None)
+        if store is None:
+            from local_operator.variables import VariableStore
+
+            store = self._variables = VariableStore(cwd="/tmp", env={})
+        return store
+
+    async def credential_op(self, action: str, key: str = "", value: str = "") -> dict[str, Any]:
+        """The REAL verb table against this fake's store, not a stub of it.
+
+        ``SessionProtocol`` declares this verb for every session shape, and
+        the TUI's submit seam probes it BY NAME — a double lacking it
+        silently degrades every credential gesture driven through it to
+        "this session cannot hold credentials", and a fake that swallows the
+        verb is how #891 passed four review streams on an unreachable path.
+        The canonical delegation rationale lives on
+        ``test_app_pilot.FakeSession.credential_op``.
+        """
+        from local_operator.session.credential_ops import run_credential_verb
+
+        return await run_credential_verb(
+            self.variables, getattr(self, "journal_credential_change", None), action, key, value
+        )
+
     async def complete_once(self, system: str, prompt: str) -> str:
         return ""
 

--- a/tests/unit/test_scheduler_new.py
+++ b/tests/unit/test_scheduler_new.py
@@ -98,6 +98,34 @@ class FakeSession:
     async def dispose(self) -> None:
         self.disposed = True
 
+    @property
+    def variables(self) -> Any:
+        """Memory-only store for ``/credential``. Created on first use so
+        tests that never touch credentials pay nothing for the property."""
+        store = getattr(self, "_variables", None)
+        if store is None:
+            from local_operator.variables import VariableStore
+
+            store = self._variables = VariableStore(cwd="/tmp", env={})
+        return store
+
+    async def credential_op(self, action: str, key: str = "", value: str = "") -> dict[str, Any]:
+        """The REAL verb table against this fake's store, not a stub of it.
+
+        ``SessionProtocol`` declares this verb for every session shape, and
+        the TUI's submit seam probes it BY NAME — a double lacking it
+        silently degrades every credential gesture driven through it to
+        "this session cannot hold credentials", and a fake that swallows the
+        verb is how #891 passed four review streams on an unreachable path.
+        The canonical delegation rationale lives on
+        ``test_app_pilot.FakeSession.credential_op``.
+        """
+        from local_operator.session.credential_ops import run_credential_verb
+
+        return await run_credential_verb(
+            self.variables, getattr(self, "journal_credential_change", None), action, key, value
+        )
+
 
 class FakeSessionFactory:
     """Async stand-in for ``session_factory.create_session``."""

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -522,6 +522,26 @@ class FakeSession:
             store = self._variables = VariableStore(cwd="/tmp", env={})
         return store
 
+    async def credential_op(self, action: str, key: str = "", value: str = "") -> dict[str, Any]:
+        """The REAL verb table against this fake's store, not a stub of it.
+
+        The TUI's submit seam stores through ``credential_op`` now, so the
+        double must answer it the way the session it stands in for does —
+        otherwise every unit test below certifies a branch `lop` cannot reach,
+        which is exactly how the inline half-feature shipped. Delegating to the
+        shared table (rather than hand-writing a ``store``-only answer) also
+        keeps the double honest when a test drives the read or forget verbs,
+        and — because the journal is passed through exactly as the real
+        ``Session.credential_op`` passes it — an announcement a test stages on
+        ``journal_credential_change`` still fires, on the session side where
+        the live context lives.
+        """
+        from local_operator.session.credential_ops import run_credential_verb
+
+        return await run_credential_verb(
+            self.variables, getattr(self, "journal_credential_change", None), action, key, value
+        )
+
     async def seed_history(self, messages: list[Any]) -> None:
         pass
 

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -144,6 +144,34 @@ class FakeSession:
         self._goal = (text or "").strip()
         return self._goal
 
+    @property
+    def variables(self) -> Any:
+        """Memory-only store for ``/credential``. Created on first use so
+        tests that never touch credentials pay nothing for the property."""
+        store = getattr(self, "_variables", None)
+        if store is None:
+            from local_operator.variables import VariableStore
+
+            store = self._variables = VariableStore(cwd="/tmp", env={})
+        return store
+
+    async def credential_op(self, action: str, key: str = "", value: str = "") -> dict[str, Any]:
+        """The REAL verb table against this fake's store, not a stub of it.
+
+        ``SessionProtocol`` declares this verb for every session shape, and
+        the TUI's submit seam probes it BY NAME — a double lacking it
+        silently degrades every credential gesture driven through it to
+        "this session cannot hold credentials", and a fake that swallows the
+        verb is how #891 passed four review streams on an unreachable path.
+        The canonical delegation rationale lives on
+        ``test_app_pilot.FakeSession.credential_op``.
+        """
+        from local_operator.session.credential_ops import run_credential_verb
+
+        return await run_credential_verb(
+            self.variables, getattr(self, "journal_credential_change", None), action, key, value
+        )
+
     async def seed_history(self, messages: list[Any]) -> None:
         pass
 

--- a/tests/unit/tui/test_boot_layout.py
+++ b/tests/unit/tui/test_boot_layout.py
@@ -141,6 +141,34 @@ class FakeSession:
     def set_goal(self, text: str) -> str:
         return text
 
+    @property
+    def variables(self) -> Any:
+        """Memory-only store for ``/credential``. Created on first use so
+        tests that never touch credentials pay nothing for the property."""
+        store = getattr(self, "_variables", None)
+        if store is None:
+            from local_operator.variables import VariableStore
+
+            store = self._variables = VariableStore(cwd="/tmp", env={})
+        return store
+
+    async def credential_op(self, action: str, key: str = "", value: str = "") -> dict[str, Any]:
+        """The REAL verb table against this fake's store, not a stub of it.
+
+        ``SessionProtocol`` declares this verb for every session shape, and
+        the TUI's submit seam probes it BY NAME — a double lacking it
+        silently degrades every credential gesture driven through it to
+        "this session cannot hold credentials", and a fake that swallows the
+        verb is how #891 passed four review streams on an unreachable path.
+        The canonical delegation rationale lives on
+        ``test_app_pilot.FakeSession.credential_op``.
+        """
+        from local_operator.session.credential_ops import run_credential_verb
+
+        return await run_credential_verb(
+            self.variables, getattr(self, "journal_credential_change", None), action, key, value
+        )
+
     async def seed_history(self, messages: list[Any]) -> None:
         pass
 

--- a/tests/unit/tui/test_events.py
+++ b/tests/unit/tui/test_events.py
@@ -152,6 +152,23 @@ class FakeSession:
             store = self._variables = VariableStore(cwd="/tmp", env={})
         return store
 
+    async def credential_op(self, action: str, key: str = "", value: str = "") -> dict[str, Any]:
+        """The REAL verb table against this fake's store, not a stub of it.
+
+        ``SessionProtocol`` declares this verb for every session shape, and
+        the TUI's submit seam probes it BY NAME — a double lacking it
+        silently degrades every credential gesture driven through it to
+        "this session cannot hold credentials", and a fake that swallows the
+        verb is how #891 passed four review streams on an unreachable path.
+        The canonical delegation rationale lives on
+        ``test_app_pilot.FakeSession.credential_op``.
+        """
+        from local_operator.session.credential_ops import run_credential_verb
+
+        return await run_credential_verb(
+            self.variables, getattr(self, "journal_credential_change", None), action, key, value
+        )
+
     async def prompt(self, text: str, images: Sequence[ImageContent] | None = None) -> None:
         pass
 

--- a/tests/unit/tui/test_inline_credential.py
+++ b/tests/unit/tui/test_inline_credential.py
@@ -16,8 +16,10 @@ can never be recalled from.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 from textual import events
@@ -934,6 +936,64 @@ def test_the_store_key_is_usable_by_a_real_variable_store() -> None:
     assert store.credential_names() == [key]
 
 
+class _SlowRouteSession(FakeSession):
+    """A credential route that answers LATE, to open the await window.
+
+    The submit seam now awaits the store round-trip inside the message
+    handler. Whether that is safe is a property of the Textual App pump (it
+    awaits each handler to completion before the next dispatch — verified by
+    probe in ``tests/e2e/test_inline_credential_e2e.py``'s companion probe),
+    and this double is how that property is pinned at the seam it protects:
+    an Enter that arrives DURING the round-trip must queue behind the handler,
+    not interleave with it.
+    """
+
+    def __init__(self, delay_s: float = 0.25) -> None:
+        super().__init__()
+        self._delay_s = delay_s
+
+    async def credential_op(self, action: str, key: str = "", value: str = "") -> dict[str, Any]:
+        await asyncio.sleep(self._delay_s)
+        return await super().credential_op(action, key, value)
+
+
+@pytest.mark.asyncio
+async def test_an_enter_arriving_during_the_store_await_queues_behind_it() -> None:
+    """No double-send and no interleave: the await holds the pump (plan §4.3).
+
+    Enter ends the secret; a second Enter sends the next message. If the
+    handler's await let the second submit interleave, the model could receive
+    the second message BEFORE the first — or the first turn could start with a
+    citation the store had not answered yet. Both orders are asserted against.
+    """
+    session = _SlowRouteSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        await _armed_capture(pilot, editor, "deploy with ")
+        await pilot.press("enter")
+        # The round-trip is now open (0.25s). A second line submitted while it
+        # runs must NOT pass the first handler mid-flight.
+        await pilot.pause()
+        for char in "second message":
+            await pilot.press(char)
+        await pilot.press("enter")
+        for _ in range(60):
+            await pilot.pause()
+
+        # Exactly two prompts, in order, and no double-send of either.
+        assert len(session.prompts) == 2, session.prompts
+        first = str(session.prompts[0])
+        assert "credential" in first and "deploy with" in first
+        assert "second message" == str(session.prompts[1])
+        # The store answered before the first prompt left the seam: the first
+        # message names the stored key, never a NOT-stored citation.
+        assert "NOT stored" not in first
+        assert SECRET not in first and SECRET not in str(session.prompts[1])
+
+
 class _ViewerSession(FakeSession):
     """A follower: no local variable store, exactly as a real viewer has none.
 
@@ -1085,12 +1145,27 @@ async def test_a_store_refusal_is_reported_to_the_operator_not_only_the_model() 
 
 
 def test_the_refusal_phrase_names_the_cause_that_actually_applied() -> None:
-    """Q3: "no session store available" is false when a store refused the write."""
-    assert "no session store available" in describe_unstored(None)
-    # A present store that refused must not blame an absent one.
+    """Q3: the phrase must blame what actually happened.
+
+    The ``None`` arm is the ROUND-TRIP failure — the session's store could not
+    be reached — which is what the submit seam degrades to when the runtime is
+    gone. It used to read "no session store available", copy that described a
+    topology rather than an outcome; a store that WAS reached and refused an
+    empty value was told apart from it by the ``reason`` arm, and that half is
+    unchanged.
+    """
+    unreachable = describe_unstored(None)
+    assert "NOT stored" in unreachable, "the outcome leads, whatever the cause"
+    assert "could not be reached" in unreachable
+    # A reached store that refused must not blame an unreachable one.
     refused = describe_unstored("empty-value")
-    assert "no session store available" not in refused
+    assert "could not be reached" not in refused
     assert "NOT stored" in refused, "the outcome leads, whatever the cause"
+    # Neither arm may name a privileged process: the failure is an event, not
+    # a topology the operator is invited to reason about.
+    for phrase in (unreachable, refused):
+        low = phrase.lower()
+        assert "owner" not in low and "viewer" not in low, phrase
 
 
 # -- the armed state is legible and cannot be disarmed by accident (D1/D2) ----

--- a/tests/unit/tui/test_snapshot.py
+++ b/tests/unit/tui/test_snapshot.py
@@ -132,6 +132,34 @@ class FakeSession:
         self._goal = (text or "").strip()
         return self._goal
 
+    @property
+    def variables(self) -> Any:
+        """Memory-only store for ``/credential``. Created on first use so
+        tests that never touch credentials pay nothing for the property."""
+        store = getattr(self, "_variables", None)
+        if store is None:
+            from local_operator.variables import VariableStore
+
+            store = self._variables = VariableStore(cwd="/tmp", env={})
+        return store
+
+    async def credential_op(self, action: str, key: str = "", value: str = "") -> dict[str, Any]:
+        """The REAL verb table against this fake's store, not a stub of it.
+
+        ``SessionProtocol`` declares this verb for every session shape, and
+        the TUI's submit seam probes it BY NAME — a double lacking it
+        silently degrades every credential gesture driven through it to
+        "this session cannot hold credentials", and a fake that swallows the
+        verb is how #891 passed four review streams on an unreachable path.
+        The canonical delegation rationale lives on
+        ``test_app_pilot.FakeSession.credential_op``.
+        """
+        from local_operator.session.credential_ops import run_credential_verb
+
+        return await run_credential_verb(
+            self.variables, getattr(self, "journal_credential_change", None), action, key, value
+        )
+
     async def seed_history(self, messages: list[Any]) -> None:
         pass
 

--- a/tests/unit/tui/test_welcome.py
+++ b/tests/unit/tui/test_welcome.py
@@ -573,6 +573,34 @@ class FakeSession:
     def set_goal(self, text: str) -> str:
         return text
 
+    @property
+    def variables(self) -> Any:
+        """Memory-only store for ``/credential``. Created on first use so
+        tests that never touch credentials pay nothing for the property."""
+        store = getattr(self, "_variables", None)
+        if store is None:
+            from local_operator.variables import VariableStore
+
+            store = self._variables = VariableStore(cwd="/tmp", env={})
+        return store
+
+    async def credential_op(self, action: str, key: str = "", value: str = "") -> dict[str, Any]:
+        """The REAL verb table against this fake's store, not a stub of it.
+
+        ``SessionProtocol`` declares this verb for every session shape, and
+        the TUI's submit seam probes it BY NAME — a double lacking it
+        silently degrades every credential gesture driven through it to
+        "this session cannot hold credentials", and a fake that swallows the
+        verb is how #891 passed four review streams on an unreachable path.
+        The canonical delegation rationale lives on
+        ``test_app_pilot.FakeSession.credential_op``.
+        """
+        from local_operator.session.credential_ops import run_credential_verb
+
+        return await run_credential_verb(
+            self.variables, getattr(self, "journal_credential_change", None), action, key, value
+        )
+
     async def seed_history(self, messages: list[Any]) -> None:
         pass
 


### PR DESCRIPTION
# PR Description

## Summary of Changes

The inline `/credential` gesture — typing or pasting `KEY=value` after the
command token in the composer — never stored anything on the session the
shipping product actually holds. This PR makes it store, through the
session, on both session shapes, and completes the test-double conformance
the protocol move left behind.

**The defect.** On a viewer (`RemoteSession` — what `cli.py`'s
`viewer_factory` returns on every path, with its takeover closure raising
outright), a typed/pasted credential in the composer degraded to a warning
ending *"…paste the whole line /credential <KEY> here and the secret is
stored on the owner"* plus `[credential NOT stored — no session store
available]`. The code's own comment documents that advice as un-followable:
the space in `/credential <KEY>` opens the masked capture, so the line the
operator was told to paste cannot be pasted as a line. The operator loops.
This is the operator-reported confusion in its finished form: the
vocabulary ("owner", a capability declared viewer-only) taught a competent
implementer to build a half-feature — the submit seam read
`getattr(session, "variables", None)`, found nothing on the only class the
product builds, and the branch that actually ran was written up as the
"degradation".

**The mechanism.**

- `credential_op` is declared on `SessionProtocol`: a SESSION capability
  with two implementations — a session that runs its tools in this process
  executes the verb against its own store; a session that is a window onto a
  runtime routes it there, because the store the tools' environment is
  built from lives beside the turn loop. On the wrong side of that split, a
  stored key would be advertised to the model while no executing tool could
  read it.
- The verb table is extracted to `local_operator/session/credential_ops.py`
  (`run_credential_verb`), which both implementations call, so the verbs
  cannot drift between the two shapes.
- `on_editor_submitted` becomes async so Textual's App pump awaits it to
  completion before the next dispatch (verified by probe): the six
  early-return branches behind it cannot interleave. The await is bounded;
  a lost runtime still degrades loudly, with copy that names the failure
  ("the session could not be reached") rather than a privileged process.

**Deliberate divergence from the Stage 4 plan.**
`~/workspace/lop-session-consolidation/stage4-owner-retirement.md` briefs
this work as its PR-1: a viewer-only copy rewrite ("stop telling the
operator secrets are 'stored on the owner'") — reword the ~60
user/agent-visible strings, leave the capability viewer-only. The
implementing session (pid 1184's coder) diverged on purpose, and the
rationale is the defect above: the copy is a symptom. Rewording the notice
leaves the inline gesture still unable to store, because the seam probed
for a local store that never exists on the class the product builds — the
operator's loop survives any wording. Declaring the verb on the base
protocol gives the seam one capability to call whichever shape it holds,
and one shared verb table keeps the two implementations from drifting. The
vocabulary lesson still lands: no notice names an "owner" any more, and the
degradation copy names the failure with a followable retry instead of a
privileged host.

**Follow-up commit (second commit on this branch).** The protocol move left
every other protocol-claiming double without the new member: 211 whole-tree
pyright errors in 19 files (16 test + 3 script doubles), zero on base main
with the same pinned analyzer — CI's `type-check` runs exactly that
whole-tree command, so the head was red on arrival. The second commit
completes the conformance doubles the way #861 completed its 34-fake
addition when `ViewerSessionProtocol` gained members: every double carrying
the runtime-role marker now mirrors `test_app_pilot.FakeSession`'s
real-table delegation (lazy memory-only `VariableStore` + the shared verb
table), following each file's own convention; no double no-ops the verb,
because a fake that swallows it is how #891 passed four review streams on an
unreachable path. Scope of that commit is test doubles only — no production
code, no protocol change, and the first commit stays byte-identical as its
parent.

## Related Issue(s)

- Related: #891 — the half-feature this fixes (green four-stream review on
  a substitution the product cannot reach)
- Refs: `~/workspace/OWNER-REMOVAL-PLAN.md` §4 (Stage 1);
  `~/workspace/lop-session-consolidation/stage4-owner-retirement.md` PR-1
  (diverged, see above)

## Impact

- No breaking changes; no dependency updates.
- Behaviour: the inline `/credential` gesture stores on both session
  shapes; a lost runtime refuses loudly with followable copy instead of
  promising a key or naming a privileged host.
- Security: the value crosses into `run_credential_verb` and never leaves
  it — never logged, never journalled, never returned; only the key name
  and the outcome cross back. The e2e canary secret is synthetic and
  asserted by length only, never printed.
- Second commit is test-only: the doubles conform to `SessionProtocol`
  again and whole-tree pyright returns to 0 errors.

## Testing Details

Reproduced RED before the fix over the **real** `OperatorApp` + **real**
`RemoteSession` + **real** runtime — production handle class, production
server, real loopback socket, production client, keystroke-driven app (the
substitution a `Session`-based test would make is itself the defect):

- **Before** (`before/typed.png`): the typed credential reaches no store;
  the screen says *"inline /credential needs the session that runs the
  tools; paste the whole line /credential <KEY> here and the secret is
  stored on the owner"* and `[credential NOT stored — no session store
  available]`.
- **After, runtime alive** (`after/typed-alive.png`): *"Stored
  LOP_SECRET_FDE8K2BE. Injected into every bash command as an environment
  variable; the agent cannot read the value."* The value was read back
  through the runtime's store and used from a real `bash` child —
  `test_a_typed_credential_reaches_the_runtime_store_and_the_agents_tools`.
- **After, runtime dead** (`after/typed-dead.png`): refuses loudly with
  followable copy — *"the credential could not be stored — the session
  could not be reached; the agent has been told so. Paste the value again
  after /credential to retry."* —
  `test_a_lost_runtime_still_refuses_loudly_instead_of_promising_a_key`.
- **Negative cases:** empty value and malformed shape are refused by the
  store's own `reason` arms with distinct copy that blames the cause that
  actually applied (`test_the_refusal_phrase_names_the_cause_that_actually_applied`,
  `test_an_empty_paste_while_armed_creates_no_zero_length_credential`); the
  paste route still stores on the runtime
  (`test_the_paste_route_still_stores_on_the_runtime`); the secret reaches
  no transcript, history or draft
  (`test_the_secret_reaches_no_transcript_history_or_draft`).
- **Harness canary:** `test_the_app_under_test_holds_the_class_the_product_builds`
  asserts the e2e harness holds the class `cli.viewer_factory` actually
  returns. It exists because a test on the `Session` branch is exactly how
  #891 passed four review streams on a path the product cannot reach — the
  substitution IS the defect, so the harness pins itself against drifting
  back to the reachable-looking-but-wrong shape.
- **Suites:** targeted unit suites (`tests/unit/tui`, `tests/unit/session`,
  `tests/unit/mcp`, `tests/unit/info`, `test_exec_mode`, `test_scheduler_new`,
  `test_imaging`) at `-n 4`: **9220 passed**, 2 failed, both classified and
  neither in this branch's diff scope — `test_transcript_selection.py::
  test_a_double_click_that_drifts_one_cell_does_not_clear_the_draft` passes
  isolated (load-flaky under a 23-minute run with three sibling suites on
  the host), and `test_session_sidebar.py::
  test_a_speculatively_leased_source_is_parked_and_stays_subscribed` fails
  identically and deterministically at base main `0ba02790c`, at the first
  commit `699f40cf5`, and at this head (real-`RemoteSession` connect path,
  no double involved) — pre-existing, not chased here.
  `tests/e2e/test_inline_credential_e2e.py` at `-n0`: **5 passed** including
  the harness canary. Follow-up-commit gates: pyright whole-tree with
  `--pythonpath .venv/bin/python` **0 errors** (was 211 in 19 files), flake8
  clean, `black --check` (pinned 26.1.0) clean, `isort --check-only` (pinned
  5.13.2) clean. A functional canary drove store/names/forget plus the
  unknown-action refusal through all ten top-level doubles in both
  directions (asserting no value crosses back), and asserted the
  runtime-side doubles' `variables` is a real store for the handle's
  by-name probe.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.

## Screenshots (Optional)

Rendered frames live on a separate, never-merged branch:
[`evidence/pr-909`](https://github.com/damianvtran/local-operator/tree/evidence/pr-909).

| state | frame |
|---|---|
| before — typed credential reaches no store, copy names "the owner" | [before/typed.png](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-909/before/typed.png) |
| after, runtime alive — stored, injected into bash, value unreadable | [after/typed-alive.png](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-909/after/typed-alive.png) |
| after, runtime dead — loud refusal with followable retry | [after/typed-dead.png](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-909/after/typed-dead.png) |
