### PR TITLE
chore(release): bump version to 0.54.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.0"
+version = "0.54.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
One-line version bump for the post-v0.54.0 window.

Window (plain `git log v0.54.0..origin/main`):
- #907 7ad53a5e1 chore(extension): bump version to 0.1.10 and add store publishing guidance
- #893 7db7738da fix(session): keep a degraded canonical delta from killing the attach socket

Bump class PATCH: #893 is a crash fix on an existing surface (an oversized `frontend_update` degraded into a frame that failed `FrontendUpdate` validation on the follower and dropped the attach socket); #907 is an extension version bump plus docs. Neither clears the step-function bar; materiality does not aggregate.

Lock PR for the window owned by pid 39411; peers 5214 and 88791 confirmed no competing claim.