### PR TITLE
chore(release): bump version to 0.54.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.1"
+version = "0.54.2"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
One-line version bump for the post-v0.54.1 window.

Window (plain `git log v0.54.1..origin/main`):
- #908 036d9e766 / 046a1d52e fix(tui): retry moved-window page fetches and humanise older-page failures

Release: patch — scrolling up for earlier messages no longer paints raw transport errors; a moved window retries silently and a dropped owner shows a calm reconnect note.

Bump class PATCH: #908 is notice-wording + bounded local retry on an existing surface. Does not clear the step-function bar.

Lock PR for the window owned by pid 5214; pid 39411 (previous owner) and pid 5843 confirmed no competing claim. #896 is still OPEN and is not in this window.

C0: one line in pyproject.toml. Independent reviewer must confirm the diff is exactly that line, version is last-tag + patch, and no other PR in the window touched pyproject.toml.