### PR TITLE
fix(info): skip capacity probes on a follower's SnapshotJobs facade

### DIFF
--- a/local_operator/info/collect.py
+++ b/local_operator/info/collect.py
@@ -941,8 +941,18 @@ def collect_live(
 
     jobs = _attr(session, "jobs", None) if session is not None else None
     if jobs is not None:
-        max_running = _safe("live.max_running", lambda: int(jobs.max_running), None, errors)
-        at_capacity = _safe("live.at_capacity", lambda: bool(jobs.at_capacity()), False, errors)
+        # A follower's ``jobs`` is ``SnapshotJobs`` — a minimal facade that only
+        # knows the roster, NOT the capacity fields the owner's
+        # ``AsyncJobManager`` carries. Probing them unconditionally on a follower
+        # surfaced two "Could not read: AttributeError" rows on a HEALTHY
+        # screen, which is exactly the false alarm this collector exists to
+        # prevent. Leaving both at their defaults instead keeps the panel
+        # honest: ``max_running=None`` hides the "Subagent capacity" row rather
+        # than asserting the built-in cap the owner may have overridden, and
+        # ``at_capacity=False`` simply declines to warn.
+        if hasattr(jobs, "max_running"):
+            max_running = _safe("live.max_running", lambda: int(jobs.max_running), None, errors)
+            at_capacity = _safe("live.at_capacity", lambda: bool(jobs.at_capacity()), False, errors)
 
     startup = _attr(session, "mcp_startup", None) if session is not None else None
     failures: dict[str, str] = dict(_attr(startup, "failures", {}) or {})

--- a/tests/unit/info/test_collect.py
+++ b/tests/unit/info/test_collect.py
@@ -362,6 +362,28 @@ def test_live_capture_of_none_is_a_full_default_state() -> None:
     assert live.running == 0 and live.tree == () and live.max_running is None
 
 
+def test_live_capture_of_a_snapshot_jobs_facade_records_no_capacity_errors() -> None:
+    """A follower's ``jobs`` is ``SnapshotJobs`` — roster only, no
+    ``max_running``/``at_capacity``. The probes must SKIP the capacity row and
+    record NOTHING in ``errors``, rather than two AttributeError entries that
+    render as "Could not read" on a healthy screen."""
+    from local_operator.session.frontend_state import SnapshotJobs
+
+    class _Follower:
+        jobs = SnapshotJobs()
+        subagent_comms = None
+        mcp_startup = None
+        session_id = "s"
+        conversation_name = ""
+        model_label = ""
+        effective_model_label = ""
+
+    live = collect_live(_Follower())
+    assert live.max_running is None and live.at_capacity is False
+    # No capacity probe name may appear among the recorded probe failures.
+    assert not any("max_running" in name or "at_capacity" in name for name, _ in live.errors)
+
+
 @pytest.mark.parametrize("failing", ["sessions", "agents", "env", "install"])
 def test_each_block_degrades_independently(failing: str, monkeypatch: pytest.MonkeyPatch) -> None:
     """Make exactly ONE collector raise; every other block must still populate.


### PR DESCRIPTION
## Summary of Changes

Fixes the false "Could not read / 2 probes" errors that appear at the bottom of the `/info` panel when the session is a **follower** (a viewer attached to another runtime's session):

```
live.max_running: AttributeError: 'SnapshotJobs' object has no attribute 'max_running'
live.at_capacity: AttributeError: 'SnapshotJobs' object has no attribute 'at_capacity'
```

**Root cause:** a follower's `session.jobs` is `SnapshotJobs` (`session/frontend_state.py`) — a minimal roster-only facade that deliberately does NOT carry the `max_running`/`at_capacity` fields the owner's `AsyncJobManager` has. `collect_live` probed both attributes unconditionally inside `_safe`, so every follower rendered two `AttributeError` rows in the "Could not read" degraded block on a perfectly healthy screen — the exact false alarm this screen exists to prevent.

**Fix:** gate the two probes on `hasattr(jobs, "max_running")`. On a follower both stay at their defaults:
- `max_running=None` → the "Subagent capacity" row is hidden rather than asserting the built-in cap the owner may have overridden (the follower cannot see the owner's live cap).
- `at_capacity=False` → simply declines to warn.

An **owner** is completely unchanged — its `AsyncJobManager` has the attribute, so both probes run exactly as before.

## Related Issue(s)

- User-reported: `/info` showed 2 spurious probe errors on a follower session.

## Impact

- No breaking changes; no dependency updates; no perf/security implications.
- Purely a diagnostic-screen accuracy fix. Owner behaviour identical; follower stops reporting phantom probe failures.

## Testing Details

- Added `test_live_capture_of_a_snapshot_jobs_facade_records_no_capacity_errors`: drives `collect_live` with a session whose `jobs` is a real `SnapshotJobs`, asserting `max_running is None`, `at_capacity is False`, and that no capacity probe name lands in `live.errors`.
- Full `tests/unit/info/test_collect.py`: **52 passed**.
- Gates: `flake8` clean, `black --check` clean, `isort --check-only` clean, `pyright` **0 errors**.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required. (inline why-comment added; no doc changes needed)
- [x] Security considerations are addressed.
- [x] I have linked all related issues.
