### PR TITLE
chore(release): bump version to 0.54.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.2"
+version = "0.54.3"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release lock for the post-v0.54.2 window. `pyproject.toml` only, one line.

## Window

Derived from `origin/main` immediately before opening this PR:

- Last tag: **v0.54.2**
- `git log v0.54.2..origin/main` (plain, never `--merges`) → one commit

| PR | Merge SHA | Impact |
|---|---|---|
| [#909](https://github.com/damianvtran/local-operator/pull/909) | `8304297d4` | a typed/pasted `/credential` in the composer on a viewer now stores into the runtime that runs the tools, instead of degrading to un-followable "stored on the owner" advice |

## Bump class: PATCH

One bug fix on an existing surface. No API addition, no wire/protocol change, no migration. Does not clear the step-function bar.

## What shipped in #909

The production TUI always holds a `RemoteSession`. The composer submit seam read `getattr(session, "variables", None)`, found nothing, and painted a warning ending "the secret is stored on the owner" plus advice to paste `/credential <KEY>` — advice the code's own comment documents as un-followable (the space after the token opens a masked capture). The operator looped.

Now `credential_op` is a `SessionProtocol` member with two implementations: execute against the local store, or route to the runtime. `on_editor_submitted` is async so Textual's pump awaits it to completion. A lost runtime degrades loudly with copy naming the failure, not a privileged process.

This is Stage 4 PR 1 of retiring the "owner" concept (plan: `~/workspace/lop-session-consolidation/stage4-owner-retirement.md`). Mechanism and initial implementation by pid 1184's coder; conformance doubles and gate by this session.

## Gate on the released content

Agent review, QA, and design rounds 1 all TERMINAL/CLEAN and fresh on the merged head `45c019c44`, reviewers independent of the author. Two CI reds on the PR were the known pre-existing shard-4 sidebar flake and the #895 teardown-tail cap; a second run on the same head was green.

## Ownership

Announced to ten live peers before cutting. Later claimant yields.

## Scope check

One line in `pyproject.toml` (`0.54.2` → `0.54.3`). No source, test, or workflow file touched.