### PR TITLE
refactor(session): rename viewer-side owner identifiers to runtime

### DIFF
--- a/docs/design-build-skew.md
+++ b/docs/design-build-skew.md
@@ -280,7 +280,7 @@ incident.
 ### 4.2 C — version exchange over the existing record
 
 The discovery record **is** the version channel: an attach client reads it
-before dial (`find_owner_record`) and holds it at bind
+before dial (`find_runtime_record`) and holds it at bind
 (`RemoteSession._bind_to(record)`, remote.py:1002); the daemon reads records
 the same way. No frame change is needed — the "ready/hello" for a v5 attach
 client effectively arrives with the record. (The task suggested the frontend

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -4804,13 +4804,13 @@ def main() -> int:
             # transcript another process owns is the corruption case. The
             # refusal IS the feature; no new flag.
             if getattr(args, "resume", None) is not None:
-                from local_operator.resume import live_session_owner, resolve_resume_id
+                from local_operator.resume import live_runtime_pid, resolve_resume_id
 
                 try:
                     exec_resume_id = resolve_resume_id(config_dir(), str(args.resume))
                 except Exception:
                     exec_resume_id = str(args.resume)
-                exec_owner = live_session_owner(config_dir(), exec_resume_id)
+                exec_owner = live_runtime_pid(config_dir(), exec_resume_id)
                 if exec_owner is not None and exec_owner != os.getpid():
                     print(
                         f"\033[31msession {exec_resume_id} is already open in "
@@ -5094,7 +5094,7 @@ def main() -> int:
                 import uuid as _uuid
 
                 from local_operator.harness.types import ModelSpec
-                from local_operator.mobile.attach_client import find_owner_record
+                from local_operator.mobile.attach_client import find_runtime_record
                 from local_operator.session.remote import RemoteSession
                 from local_operator.session_factory import resolve_hosting_model
 
@@ -5154,7 +5154,7 @@ def main() -> int:
                 record = None
                 if resume_id:
                     record, _owner = await asyncio.to_thread(
-                        find_owner_record, config_directory, session_id
+                        find_runtime_record, config_directory, session_id
                     )
                 degraded_reason = ""
                 if record is not None:

--- a/local_operator/fork.py
+++ b/local_operator/fork.py
@@ -27,7 +27,7 @@ THE COPY IS AN EXPLICIT ALLOW-LIST, NEVER A DIRECTORY COPY
 ----------------------------------------------------------
 :data:`COPIED_SIDECARS` names every file a fork inherits. A ``shutil.copytree``
 would be one line shorter and would copy ``.session.pid`` — the liveness marker
-— which makes ``live_session_owner`` report the fork as owned by the PARENT's
+— which makes ``live_runtime_pid`` report the fork as owned by the PARENT's
 pid, so the fork's own boot takes the *attach* path instead of opening its
 conversation. That failure is spectacular and silent, so the allow-list is
 pinned by a set-equality test rather than by review attention.
@@ -268,14 +268,14 @@ def fork_session(
     # spectacular one. ``claim_session`` stamps ``os.getpid()``, and this
     # function runs inside the PARENT's TUI process, so the marker left behind
     # names the parent as the fork's live owner. The fork's own boot then reads
-    # it through ``live_session_owner`` and either refuses outright ("session
+    # it through ``live_runtime_pid`` and either refuses outright ("session
     # <id> is open in an older Local Operator process") or, when a discovery
     # record exists, attaches the new window as a FOLLOWER of its parent
     # instead of opening the branched conversation. That is exactly the failure
     # the sidecar allow-list exists to prevent, arriving through a different
     # door than ``copytree`` — the module docstring above describes the
     # consequence, and the claim reintroduced the cause. Guarded by
-    # ``live_session_owner(config_dir, fork_id) is None`` in the tests, which is
+    # ``live_runtime_pid(config_dir, fork_id) is None`` in the tests, which is
     # the property that actually matters; asserting the file's absence alone
     # would not survive a future claim written by some other path.
     release_session(fork_dir)

--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -17,7 +17,7 @@ Design constraints baked in:
   loop (re-discover the owner, or become it through the normal resume
   factory) instead of showing a decision card, but each loop iteration still
   builds a FRESH client against a freshly discovered record.
-- **Identity over pid trust.** ``live_session_owner`` cannot probe pids on
+- **Identity over pid trust.** ``live_runtime_pid`` cannot probe pids on
   Windows, and a recycled pid anywhere defeats pid trust. After auth the
   registrant sends a full projection unprompted; the client requires that
   projection's ``session_id`` to match the one the user asked for before
@@ -644,7 +644,9 @@ def _decode_quietly(data_b64: str) -> bytes:
         return b""
 
 
-def find_owner_record(config_dir: Path, session_id: str) -> tuple[SessionRecord | None, int | None]:
+def find_runtime_record(
+    config_dir: Path, session_id: str
+) -> tuple[SessionRecord | None, int | None]:
     """Locate the discovery record of the live process hosting ``session_id``.
 
     Returns ``(record, owner_pid)``. The normal case matches a record whose
@@ -659,9 +661,9 @@ def find_owner_record(config_dir: Path, session_id: str) -> tuple[SessionRecord 
     binary, registrant failed to start): the caller degrades gracefully.
     ``(None, None)`` means no owner at all.
     """
-    from local_operator.resume import live_session_owner
+    from local_operator.resume import live_runtime_pid
 
-    owner = live_session_owner(config_dir, session_id)
+    owner = live_runtime_pid(config_dir, session_id)
     if owner is None:
         return None, None
     best: SessionRecord | None = None
@@ -1429,7 +1431,7 @@ async def continue_command(
     # turn it started. A record must exist now (engage_runtime only returns
     # once one answered), so a miss here is a runtime that died in the gap and
     # is reported as the same timeout the caller already handles.
-    record, _ = await asyncio.to_thread(find_owner_record, config_dir, command.session_id)
+    record, _ = await asyncio.to_thread(find_runtime_record, config_dir, command.session_id)
     if record is None:
         raise TimeoutError("Couldn’t continue this conversation. Try again.")
     client = AttachClient(

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -1725,13 +1725,13 @@ class MobileDaemon:
             # so a spawned child would be orphaned from its own control plane.
             raise RuntimeError("observer daemon cannot start sessions")
         from local_operator.interpreter import python_argv
-        from local_operator.mobile.attach_client import find_owner_record
+        from local_operator.mobile.attach_client import find_runtime_record
         from local_operator.paths import config_dir
 
         # A durable resume can already have an owner (including one started
         # by another surface). Acknowledge that verified owner, never the PID
         # of a losing speculative constructor.
-        existing, _ = await asyncio.to_thread(find_owner_record, config_dir(), session_id)
+        existing, _ = await asyncio.to_thread(find_runtime_record, config_dir(), session_id)
         if existing is not None:
             try:
                 async with asyncio.timeout(SESSION_START_TIMEOUT_S):
@@ -1782,7 +1782,7 @@ class MobileDaemon:
 
         async def ready() -> None:
             while True:
-                record, _ = await asyncio.to_thread(find_owner_record, config_dir(), session_id)
+                record, _ = await asyncio.to_thread(find_runtime_record, config_dir(), session_id)
                 if record is not None:
                     if record.pid != process.pid:
                         raise RuntimeError("another runtime acquired this session; retry resume")
@@ -1817,7 +1817,9 @@ class MobileDaemon:
                 async def retire_if_pristine() -> None:
                     from local_operator.mobile.attach_client import AttachClient
 
-                    record, _ = await asyncio.to_thread(find_owner_record, config_dir(), session_id)
+                    record, _ = await asyncio.to_thread(
+                        find_runtime_record, config_dir(), session_id
+                    )
                     if record is None or record.pid != process.pid:
                         return
                     client = AttachClient(

--- a/local_operator/resume.py
+++ b/local_operator/resume.py
@@ -1105,7 +1105,7 @@ def resolve_resume_id(config_dir: Path, requested: str) -> str:
     return resume_dir(config_dir, requested).name
 
 
-def live_session_owner(config_dir: Path, session_id: str) -> int | None:
+def live_runtime_pid(config_dir: Path, session_id: str) -> int | None:
     """Pid of the process currently hosting ``session_id``, or ``None``.
 
     Two writers on one transcript is how a TUI ``/resume`` of a phone-started

--- a/local_operator/session/cleanup.py
+++ b/local_operator/session/cleanup.py
@@ -435,7 +435,7 @@ def _claimed(directory: Path, now: float) -> bool:
     return _is_claimed(directory, now)
 
 
-def _lease_owner_alive(directory: Path) -> bool | None:
+def _lease_runtime_alive(directory: Path) -> bool | None:
     """Whether the ``.execution-lease`` names a live pid; ``None`` = no lease."""
     lease = directory / ".execution-lease"
     try:
@@ -484,7 +484,7 @@ def _guard(directory: Path, config_dir: Path, now: float) -> str | None:
     try:
         if _claimed(directory, now):
             return "claimed by a live process"
-        if _lease_owner_alive(directory):
+        if _lease_runtime_alive(directory):
             return "leased by a live process"
         if _has_wake(config_dir, directory.name):
             return "has an armed wake"

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -69,7 +69,7 @@ from local_operator.mobile.attach_client import (
     RETIRING_REASON,
     STOPPED_REASON,
     AttachClient,
-    find_owner_record,
+    find_runtime_record,
 )
 from local_operator.mobile.types import (
     SLASH_ACTION_RECEIPTS,
@@ -143,7 +143,7 @@ COLD_FALLBACK_S = 8.0
 #: cosmetic flag: it is the state that REFUSES ``/model``, ``/goal``,
 #: ``/rename``, ``/effort``, ``/compact``, ``/fork`` and ``/credential`` with
 #: ``_RECONNECTING_SLASH_NOTICE``, and that PARKS ``prompt`` silently on
-#: ``_owner_ready`` with no message and no spinner resolution. Reported from
+#: ``_runtime_ready`` with no message and no spinner resolution. Reported from
 #: the field as a session whose model could not be switched by any number of
 #: retries or ``/resume``s.
 #:
@@ -161,13 +161,13 @@ COLD_FALLBACK_S = 8.0
 #: SCOPED TO A RECORD HAVING BEEN SEEN. This bound answers "an owner is there
 #: and will not answer", never "no owner is there": the latter is the DEAD
 #: shape, whose contract is to keep chasing a successor through the takeover
-#: arm, and it keeps that contract unchanged. ``_recover_owner`` tracks the
+#: arm, and it keeps that contract unchanged. ``_recover_runtime`` tracks the
 #: sighting across passes (``record_seen``) because the deadline is necessarily
 #: evaluated before the pass reads a record.
 #:
 #: The terminal state is COLD AND REBINDABLE, not failed: the exit sets
-#: ``_can_go_cold`` before ``_go_cold`` (see ``_recover_owner``), so the
-#: transcript stays on screen, ``_owner_ready`` is set, and the next prompt
+#: ``_can_go_cold`` before ``_go_cold`` (see ``_recover_runtime``), so the
+#: transcript stays on screen, ``_runtime_ready`` is set, and the next prompt
 #: re-engages through ``_ensure_bound`` against this very same live record.
 #: That rebind is the whole repair, and it is why no user-facing copy was added
 #: for this state: a typed ``/model p/id`` on the resulting facade is diverted
@@ -175,7 +175,7 @@ COLD_FALLBACK_S = 8.0
 #: performs exactly that retry and reports its outcome.
 RECOVERY_GIVE_UP_S = 2 * HEARTBEAT_TIMEOUT_S
 
-#: Backoff ceiling for ``_recover_owner``'s DIAL-FAILURE arm specifically.
+#: Backoff ceiling for ``_recover_runtime``'s DIAL-FAILURE arm specifically.
 #:
 #: That arm ``continue``s, which skips the sleep at the bottom of the loop, so
 #: its own ``sleep(delay)`` is the only pacing on the path — the ceiling has to
@@ -246,7 +246,7 @@ FRONTEND_SYNC_BACKSTOP_S = 120.0
 FRONTEND_SYNC_FOREGROUND_S = 15.0
 
 #: The envelope for a wait that BLOCKS the facade while it runs. Today that is
-#: ``_recover_owner``, whose ``_recovering`` flag refuses prompts, `/fork`,
+#: ``_recover_runtime``, whose ``_recovering`` flag refuses prompts, `/fork`,
 #: `/model` and every other mutation for as long as the wait lasts, and which
 #: is itself bounded by ``COLD_FALLBACK_S`` — going cold is its designed,
 #: non-failing outcome, after which the next prompt re-engages through
@@ -357,10 +357,10 @@ _MODEL_INTENT_PENDING = (
 #: ``_discard_rejected_client`` (see its docstring for the half-bound facade
 #: and the 272-eviction burst that discipline exists to prevent), so every
 #: attempt starts from a clean facade and no attach slot leaks against
-#: ``ATTACH_MAX_CLIENTS``. ``find_owner_record`` is re-run per attempt so a
+#: ``ATTACH_MAX_CLIENTS``. ``find_runtime_record`` is re-run per attempt so a
 #: runtime that retired and respawned between attempts is picked up rather
 #: than redialled at its dead pid. The backoff shape was originally copied from
-#: ``_recover_owner`` so the two redial loops behaved the same way; the CEILINGS
+#: ``_recover_runtime`` so the two redial loops behaved the same way; the CEILINGS
 #: have since deliberately diverged (``_RECOVERY_DIAL_CAP_S`` is 2.0 s) and this
 #: one is deliberately LEFT at 0.5. This loop is bounded to
 #: ``_BIND_RETRY_ATTEMPTS`` inside a wall-clock budget, so it cannot storm attach
@@ -613,7 +613,7 @@ class RemoteSession:
         #: (``request_stop`` acked) or the wire evidence says the session was
         #: deliberately ended (the owner served the stop and unpublished).
         #: Owner loss after THAT is the request landing, not a death:
-        #: ``_recover_owner`` must not take over the conversation a stop
+        #: ``_recover_runtime`` must not take over the conversation a stop
         #: just ended (it would republish a live record for a stopped
         #: session, and its next prompt would be refused against the
         #: ``stopped_at`` marker the stop stamped).
@@ -639,7 +639,7 @@ class RemoteSession:
         self._live_history: dict[str, Any] = {}
         self._display_window_requested = False
         self.saved_preview_partial = False
-        self._owner_record: SessionRecord | None = None
+        self._runtime_record: SessionRecord | None = None
         self._display_refresh_lock = asyncio.Lock()
         self._display_refresh_task: asyncio.Task[None] | None = None
         self._prompt_completion_waiters: set[asyncio.Future[AgentEndEvent]] = set()
@@ -734,7 +734,7 @@ class RemoteSession:
         # socket; on takeover it goes straight to the real Session after the
         # preserving adoption callback completes. Keystrokes remain editable in
         # the standard composer throughout — no attach/recovery UI state.
-        self._owner_ready = asyncio.Event()
+        self._runtime_ready = asyncio.Event()
         # Socket delivery can outrun the coroutine installing its initial sync.
         # Buffer that suffix until its epoch, rather than the cold disk epoch,
         # is authoritative. None means the canonical boundary is installed.
@@ -959,12 +959,12 @@ class RemoteSession:
                 read_saved_preview, config_dir / "sessions" / session_id
             )
         except FileNotFoundError:
-            from local_operator.mobile.attach_client import find_owner_record
+            from local_operator.mobile.attach_client import find_runtime_record
 
             # A speculative live owner can deliberately defer creating its
             # journal until its first write. Only an actual discoverable owner
             # proves that empty state; a stale catalog row proves nothing.
-            record, owner = await asyncio.to_thread(find_owner_record, config_dir, session_id)
+            record, owner = await asyncio.to_thread(find_runtime_record, config_dir, session_id)
             if record is None or owner is None:
                 raise FileNotFoundError("This conversation is no longer available") from None
             preview = SavedPreview([], False, record.cwd or cwd)
@@ -985,7 +985,7 @@ class RemoteSession:
             )
         )
         self._finish_sync()
-        self._owner_ready.set()
+        self._runtime_ready.set()
         return self
 
     @classmethod
@@ -1047,7 +1047,7 @@ class RemoteSession:
         # Nothing is queued behind an owner that will never arrive: a cold
         # viewer is READY, and it is _ensure_bound that supplies the runtime
         # when one is actually needed.
-        self._owner_ready.set()
+        self._runtime_ready.set()
         return self
 
     def _restore_cold_details(self, state: FrontendSessionState) -> FrontendSessionState:
@@ -1496,7 +1496,7 @@ class RemoteSession:
         even when an owner is already live: losing that owner must never move
         execution into the HTTP worker or start a replacement just for a reader.
         """
-        from local_operator.mobile.attach_client import find_owner_record
+        from local_operator.mobile.attach_client import find_runtime_record
 
         # FOREGROUND: an HTTP request is waiting on this acquisition, so it
         # announces itself rather than silently inheriting whatever envelope a
@@ -1508,7 +1508,7 @@ class RemoteSession:
             if self._disposed or not self.is_cold:
                 return not self.is_cold
             record, _ = await asyncio.to_thread(
-                find_owner_record, self._config_dir, self._session_id
+                find_runtime_record, self._config_dir, self._session_id
             )
             if record is None or self._disposed:
                 return False
@@ -1685,7 +1685,7 @@ class RemoteSession:
 
         DURING OWNER RECOVERY it refuses, in the same words and for the same
         reason as ``route_shared_slash`` one seam over. A recovering viewer is
-        chasing a successor that ``_recover_owner`` will bind at whatever cwd
+        chasing a successor that ``_recover_runtime`` will bind at whatever cwd
         the owner's record names, so a "cold move" reported here is silently
         undone the moment that bind lands — the viewer would say it moved and
         then work somewhere else, which is the one divergence this method
@@ -1915,7 +1915,7 @@ class RemoteSession:
         rather than the lock: handing over the lock would discard an
         authenticated dial and risk a second engage for one session's lease.
         """
-        # Recovery already owns its dial/sync and signals _owner_ready. A
+        # Recovery already owns its dial/sync and signals _runtime_ready. A
         # prompt or steer must wait on that promise, not start a competing
         # initial attachment merely because its connected socket is not ready.
         if not self._can_go_cold or self._disposed:
@@ -1984,7 +1984,7 @@ class RemoteSession:
             return
         if not self.is_cold:
             return
-        from local_operator.mobile.attach_client import find_owner_record
+        from local_operator.mobile.attach_client import find_runtime_record
         from local_operator.session.runtime.launch import (
             ActionableConnectionError,
             RuntimeStartupError,
@@ -2093,7 +2093,7 @@ class RemoteSession:
             # under a new pid, and redialling the dead one would burn every
             # remaining attempt on a socket that cannot answer.
             record, _owner = await asyncio.to_thread(
-                find_owner_record, self._config_dir, self._session_id
+                find_runtime_record, self._config_dir, self._session_id
             )
             if self._disposed:
                 # Same rule as the guard at the top of the loop: never
@@ -2221,13 +2221,13 @@ class RemoteSession:
             self._finish_sync()
             self._deliberate_stop = False
             self._stopped_announced = False
-            self._owner_ready.set()
+            self._runtime_ready.set()
         except BaseException:
             # A failed/cancelled sync is not an attached viewer. Retrying must
             # not leak the half-open socket or inherit its queued epoch suffix.
             self._discard_rejected_client()
             if not self._recovering:
-                self._owner_ready.set()
+                self._runtime_ready.set()
             raise
 
     def _discard_rejected_client(self) -> None:
@@ -2246,7 +2246,7 @@ class RemoteSession:
         Closing the client makes ``is_cold`` honest again — the next
         ``_ensure_bound`` retries the whole engage and the TUI's own failure
         path can say why — and it releases the runtime's attach slot. Without
-        the release each retry of ``_recover_owner`` opened another connection
+        the release each retry of ``_recover_runtime`` opened another connection
         on top of the last, and the runtime's LRU cap evicted them in a burst
         (272 evictions logged in the minutes after one fork booted).
 
@@ -2283,11 +2283,11 @@ class RemoteSession:
         closes. The attribute is still assigned because ``_on_frontend_sync``
         resolves through it from the pump.
         """
-        self._owner_record = record
+        self._runtime_record = record
         # Freeze relay delivery until the canonical sync is installed ahead of
         # raw event frames that follow it on the same socket.
         self._ready_for_events = False
-        self._owner_ready.clear()
+        self._runtime_ready.clear()
         self._pending_frontend_updates = []
         self._runtime_pid = record.pid
         loop = asyncio.get_running_loop()
@@ -2400,7 +2400,7 @@ class RemoteSession:
         not start frontend synchronization" refusal for a dial that was fine)
         and a concurrent redial replaces it, so the caller could end up awaiting
         a DIFFERENT dial's future. ``_ensure_bound`` holds ``_bind_lock`` but
-        ``_recover_owner`` never takes it, so the two are ordered only by the
+        ``_recover_runtime`` never takes it, so the two are ordered only by the
         ``_recovering`` flag — not by a lock. Threading the future through the
         call closes that seam by construction, which is why the ``None`` case
         below is an internal invariant rather than an owner fault.
@@ -2928,7 +2928,7 @@ class RemoteSession:
                 if client is None or not client.connected:
                     raise ConnectionError("history owner is unavailable")
                 self._ready_for_events = False
-                self._owner_ready.clear()
+                self._runtime_ready.clear()
                 self._pending_frontend_updates = []
                 # Cleared BEFORE the capture, so a degraded delta that lands
                 # while this pass is in flight (buffered here, replayed by
@@ -2985,7 +2985,7 @@ class RemoteSession:
                     self._drain_buffered_events()
                     raise
                 finally:
-                    self._owner_ready.set()
+                    self._runtime_ready.set()
 
     @property
     def history_before_token(self) -> str | None:
@@ -3331,7 +3331,7 @@ class RemoteSession:
             insert_at += 1
         self._buffered_events[insert_at:insert_at] = seeded
         self._ready_for_events = True
-        self._owner_ready.set()
+        self._runtime_ready.set()
         self._drain_buffered_events()
         self._maybe_start_gate()
 
@@ -3840,7 +3840,7 @@ class RemoteSession:
         # session ended on purpose, so there is no owner to recover and no
         # transcript lease to win. Stay a viewer showing the cold session —
         # the same shape bare /stop leaves an owner in. The record scan in
-        # `_recover_owner` would otherwise rediscover nothing and take over.
+        # `_recover_runtime` would otherwise rediscover nothing and take over.
         # The owner announced the stop on the wire before closing (the
         # ``stopping`` frame the client turns into this reason). That covers
         # the cases the local flag cannot: another TUI's /stop all, or a shell
@@ -3859,7 +3859,7 @@ class RemoteSession:
         if _reason == STOPPED_REASON:
             self._deliberate_stop = True
         if self._deliberate_stop:
-            self._owner_ready.set()  # prompts route to the stopped notice
+            self._runtime_ready.set()  # prompts route to the stopped notice
             # A stop ENDS the turn, exactly as a death does. Without this the
             # facade reports is_streaming forever — nothing else can clear it,
             # because every other writer of that flag is fed by the owner
@@ -3872,13 +3872,13 @@ class RemoteSession:
             self._notify_stopped()
             return
         self._recovering = True
-        self._owner_ready.clear()
+        self._runtime_ready.clear()
         # Do NOT end the turn here. A dropped socket says nothing about the
         # turn: the runtime is usually still running it (a send timeout under
         # a stalled TUI loop is the common cause). Recovery decides — see
         # ``_settle_suspect_turn``.
         self._suspect_generation = self._generation if self._streaming else None
-        self._recovery_task = asyncio.create_task(self._recover_owner())
+        self._recovery_task = asyncio.create_task(self._recover_runtime())
 
     def _end_turn_locally(
         self,
@@ -4028,7 +4028,7 @@ class RemoteSession:
         # The marker says stopped; confirm nobody re-opened it in the
         # meantime (an open clears ``stopped_at``). If an owner is live and
         # reachable, this is a re-open — recover normally.
-        record, _ = await asyncio.to_thread(find_owner_record, self._config_dir, self._session_id)
+        record, _ = await asyncio.to_thread(find_runtime_record, self._config_dir, self._session_id)
         return record is None
 
     def _unavailable_reason(self) -> str:
@@ -4048,7 +4048,7 @@ class RemoteSession:
         """Unbind from a runtime that is gone, keeping the conversation.
 
         The viewer stays exactly as it is on screen; only its binding drops.
-        ``_owner_ready`` is SET rather than left clear because a cold viewer is
+        ``_runtime_ready`` is SET rather than left clear because a cold viewer is
         ready — the next prompt engages a runtime through ``_ensure_bound``
         instead of waiting for one that is never coming back.
 
@@ -4088,7 +4088,7 @@ class RemoteSession:
         # Guarded like the two teardown steps that bracket it (the client
         # close above, the went-cold callback below): a handler that raises —
         # `EventController._handle_agent_end` flushes, prices usage and sums
-        # cost — must not propagate out of teardown and skip `_owner_ready`,
+        # cost — must not propagate out of teardown and skip `_runtime_ready`,
         # which would leave the prompt path waiting on an event nothing else
         # will set (review round 1, MINOR-1).
         if refresh:
@@ -4121,7 +4121,7 @@ class RemoteSession:
             # ``not _streaming``: a suspect recorded at the drop must not
             # outlive the verdict that the runtime is gone.
             self._suspect_generation = None
-        self._owner_ready.set()
+        self._runtime_ready.set()
         callback = self._refresh_callback if refresh else self._went_cold_callback
         if callback is None:
             return
@@ -4205,7 +4205,7 @@ class RemoteSession:
         # ``_end_turn_locally()`` immediately before this, so the call here is
         # a no-op for it (no ``force``, and ``_streaming`` is already False).
         # The path this exists for is the wake-marker inference inside
-        # ``_recover_owner``, which never passed through that branch and would
+        # ``_recover_runtime``, which never passed through that branch and would
         # otherwise leave the suspect turn open forever. Do NOT add ``force``
         # here without splitting the two callers: it would double-end the
         # first one (review round 1, MINOR-1).
@@ -4218,7 +4218,7 @@ class RemoteSession:
         except Exception:  # noqa: BLE001 — a viewer notice must not break teardown
             logger.debug("stopped-session callback failed", exc_info=True)
 
-    async def _recover_owner(self) -> None:
+    async def _recover_runtime(self) -> None:
         if self._deliberate_stop:
             # The disconnect came from the stop this follower issued (or that
             # landed while it watched): the session is cold, not orphaned.
@@ -4227,7 +4227,7 @@ class RemoteSession:
             # would win the lease, republish a live record for a session the
             # user just stopped, and let a later `lop stop --all` SIGTERM
             # this terminal for a record it never made.
-            self._owner_ready.set()  # prompts route to the stopped notice
+            self._runtime_ready.set()  # prompts route to the stopped notice
             return
         delay = 0.1
         # Under the viewer model, owner loss has a THIRD outcome beside
@@ -4259,7 +4259,7 @@ class RemoteSession:
         # chasing a successor through the takeover arm. The check has to sit at
         # the top of the pass (that is where a deadline can be evaluated before
         # the pass spends its time on a dial that may block), which is BEFORE
-        # ``find_owner_record`` runs, so the exit cannot consult this pass's
+        # ``find_runtime_record`` runs, so the exit cannot consult this pass's
         # record. It consults the previous passes' instead: one sighting is
         # enough, because a record seen at all is what distinguishes "an owner
         # is there and silent" from "nothing is there". Without this the exit
@@ -4309,12 +4309,12 @@ class RemoteSession:
                     # LIVE BUT SILENT owner never reaches, because a record is
                     # found on every pass. So the chase had no terminal state:
                     # ``/model`` and every other mutation seam refused forever
-                    # and ``prompt`` parked silently on ``_owner_ready``.
+                    # and ``prompt`` parked silently on ``_runtime_ready``.
                     #
                     # SCOPED TO ``record_seen``, which is what makes the
                     # paragraph below true rather than merely intended. The
                     # condition cannot be "this pass found a record" — the
-                    # deadline is evaluated before ``find_owner_record`` runs —
+                    # deadline is evaluated before ``find_runtime_record`` runs —
                     # so it is "some pass did", which selects the same class:
                     # an owner that is discoverable at all is the live-but-
                     # silent shape, and one that never was is the dead shape the
@@ -4385,7 +4385,7 @@ class RemoteSession:
                         # latch again the next time an exit is added.
                         self._go_cold()
                         # ``finally`` clears ``_recovering``: the refusals lift
-                        # and the parked prompt is released by ``_owner_ready``.
+                        # and the parked prompt is released by ``_runtime_ready``.
                         return
                 # A stop by someone else while we watched: the transcript's
                 # ``stopped_at`` marker plus no live owner is the deliberate
@@ -4394,11 +4394,11 @@ class RemoteSession:
                 # from resurrecting a session a kill switch just ended.
                 if not self._deliberate_stop and await self._session_was_stopped():
                     self._deliberate_stop = True
-                    self._owner_ready.set()  # prompts route to the stopped notice
+                    self._runtime_ready.set()  # prompts route to the stopped notice
                     self._notify_stopped()
                     return
                 record, _ = await asyncio.to_thread(
-                    find_owner_record, self._config_dir, self._session_id
+                    find_runtime_record, self._config_dir, self._session_id
                 )
                 if (
                     record is not None
@@ -4532,7 +4532,7 @@ class RemoteSession:
                             if inspect.isawaitable(result):
                                 await result
                             self._takeover_target = local
-                            self._owner_ready.set()
+                            self._runtime_ready.set()
                             return
                         # Adoption normally installed the callback before a
                         # disconnect can happen; if it did not, avoid leaking
@@ -5222,7 +5222,7 @@ class RemoteSession:
         generation contract, without a new scheduler or longer RPC timeout.
         """
         await self._ensure_bound()
-        await self._owner_ready.wait()
+        await self._runtime_ready.wait()
         if self._takeover_target is not None:
             await self.prompt(text, images=images, message_id=message_id)
             return
@@ -5309,7 +5309,7 @@ class RemoteSession:
         # session starts working in it here, which is the first moment a
         # runtime is actually owed. A no-op once attached.
         await self._ensure_bound()
-        await self._owner_ready.wait()
+        await self._runtime_ready.wait()
         target = self._takeover_target
         if target is not None:
             # A takeover means a real in-process Session now owns the
@@ -5351,7 +5351,7 @@ class RemoteSession:
     async def _send_steer_when_ready(self, message: Message) -> None:
         await self._ensure_bound()
         """Retain a queued steer across silent reattach/takeover."""
-        await self._owner_ready.wait()
+        await self._runtime_ready.wait()
         target = self._takeover_target
         if target is not None:
             target.steer_message(message)

--- a/local_operator/session/runtime/launch.py
+++ b/local_operator/session/runtime/launch.py
@@ -30,7 +30,7 @@ an error (``process.py`` logs the loss and returns 0 for that reason).
    now covers it — and would just be another loser to reap.
 
 **What the parent's dead time is NOT.** Two other suspects were measured and
-acquitted, so nobody re-derives them. (1) The first ``find_owner_record``
+acquitted, so nobody re-derives them. (1) The first ``find_runtime_record``
 scan is a guaranteed miss for a freshly minted ``/new`` session, which looks
 like serialized latency ahead of the spawn — but in the warm parent that
 actually runs ``/new`` (a long-lived TUI) engage-entry to fork measures a
@@ -517,7 +517,7 @@ async def engage_runtime(
     existing expiry path unlinks the capture file and reports the child's own
     reason, where a cancelled task would leak that tempfile and lose it.
     """
-    from local_operator.mobile.attach_client import find_owner_record
+    from local_operator.mobile.attach_client import find_runtime_record
 
     if not getattr(work, "command_id", ""):
         # Identity is what makes a retry safe. A caller that did not supply one
@@ -571,7 +571,7 @@ async def engage_runtime(
     defer = isinstance(work, WarmErrand)
 
     while time.monotonic() < _deadline():
-        record, _owner = await asyncio.to_thread(find_owner_record, config_dir, session_id)
+        record, _owner = await asyncio.to_thread(find_runtime_record, config_dir, session_id)
         if record is not None:
             try:
                 detail, duplicate = await _deliver(record, session_id, work)
@@ -706,7 +706,7 @@ async def engage_runtime(
         # dialable is open-ended and belongs on the backoff.
         #
         # It also bounds the scan cost the dense interval assumes. A quiet
-        # record makes `scan()` fork `ps`, but `find_owner_record` only reaches
+        # record makes `scan()` fork `ps`, but `find_runtime_record` only reaches
         # `scan()` once an owner marker exists; requiring `record is None`
         # keeps the dense regime off the marker-plus-record case entirely. See
         # `_poll_delay` for the measured table and the one overlap that
@@ -791,10 +791,10 @@ def _poll_delay(backoff: float, constructing_for_s: float | None) -> tuple[float
     WHY DENSE POLLING IS AFFORDABLE HERE
     ====================================
     The backoff was protecting against a cost that does not exist at these
-    timescales. One full poll iteration — ``find_owner_record`` (a miss scan),
+    timescales. One full poll iteration — ``find_runtime_record`` (a miss scan),
     ``_lease_holder``, and ``Popen.poll`` — measures 23-30 µs against a run
     directory of 200 real records, and is FLAT from 0 to 200 because
-    ``find_owner_record`` returns before ``scan()`` when there is no owner
+    ``find_runtime_record`` returns before ``scan()`` when there is no owner
     marker (QA round 1, Q3; an earlier author estimate of 339 µs on an
     11-record dir was pessimistic). At a 10 ms interval that is a 0.2-0.3%
     duty cycle on one thread, for at most ``_CONSTRUCTING_WINDOW_S``, and only
@@ -815,7 +815,7 @@ def _poll_delay(backoff: float, constructing_for_s: float | None) -> tuple[float
     so it pays that fork on every scan (review round 1, MINOR-1).
 
     Where that lands is narrower than it first appears, because
-    ``find_owner_record`` returns BEFORE ``scan()`` when the session has no
+    ``find_runtime_record`` returns BEFORE ``scan()`` when the session has no
     ``.session.pid`` owner marker. Measured on this host, 8 fresh records plus
     N quiet ones:
 

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -820,7 +820,7 @@ class RuntimeServer:
         if loop is None or loop.is_closed():
             return
         frame = {"op": "stopping", "session_id": self._record.session_id}
-        if self._on_owner_loop():
+        if self._on_runtime_loop():
             # An in-process runtime shares the TUI's loop, so the owner's own
             # /stop arrives HERE, from a synchronous caller whose very next
             # statement tears the sockets down. Awaiting a drain is therefore
@@ -934,7 +934,7 @@ class RuntimeServer:
             return
         if loop is None or loop.is_closed():
             return
-        if self._on_owner_loop():
+        if self._on_runtime_loop():
             self._ensure_shutdown_task()
             return
         shutdown = self._shutdown_on_loop()
@@ -955,7 +955,7 @@ class RuntimeServer:
         the cross-thread closed flag is not proof that loop-owned work ended.
         """
         self._request_close()
-        if not self._on_owner_loop():
+        if not self._on_runtime_loop():
             raise RuntimeError("RuntimeServer.aclose() must run on its owning event loop")
         await self._shutdown_on_loop()
 
@@ -977,7 +977,7 @@ class RuntimeServer:
                 logger.debug("runtime event unsubscribe failed", exc_info=True)
             self._unsubscribe_events = None
 
-    def _on_owner_loop(self) -> bool:
+    def _on_runtime_loop(self) -> bool:
         try:
             return asyncio.get_running_loop() is self._loop
         except RuntimeError:

--- a/local_operator/session/runtime/types.py
+++ b/local_operator/session/runtime/types.py
@@ -228,7 +228,7 @@ class SessionRecord:
     # is required to read.
     #
     # The record IS the version channel between a viewer and a runtime. An
-    # attach client reads it before dialing (``find_owner_record``) and holds
+    # attach client reads it before dialing (``find_runtime_record``) and holds
     # it at bind, so one comparison there is complete — a runtime's build
     # cannot change while the process lives.
 

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -2651,11 +2651,11 @@ async def create_session(
     # get the existing refusal: they have no full front end to host the facade.
     resume_id = getattr(args, "resume", None)
     if has_ui and resume_id is not None and not _force_local_takeover:
-        from local_operator.mobile.attach_client import find_owner_record
+        from local_operator.mobile.attach_client import find_runtime_record
         from local_operator.session.remote import RemoteSession
 
         root = Path(agent_registry.config_dir)
-        record, owner = await asyncio.to_thread(find_owner_record, root, str(resume_id))
+        record, owner = await asyncio.to_thread(find_runtime_record, root, str(resume_id))
         if owner is not None and owner != os.getpid():
             if record is None or record.protocol < 4:
                 raise ValueError(

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -4607,7 +4607,7 @@ class OperatorApp(App[None]):
     async def _lease_sidebar_source(
         self, session_id: str, *, speculative: bool
     ) -> SessionInteraction:
-        from local_operator.mobile.attach_client import find_owner_record
+        from local_operator.mobile.attach_client import find_runtime_record
         from local_operator.paths import config_dir
         from local_operator.session.remote import RemoteSession
 
@@ -4630,7 +4630,7 @@ class OperatorApp(App[None]):
                 takeover_factory=no_takeover,
             )
         else:
-            record, owner = await asyncio.to_thread(find_owner_record, directory, session_id)
+            record, owner = await asyncio.to_thread(find_runtime_record, directory, session_id)
             if record is None or owner is None:
                 raise RuntimeError("The prepared owner is no longer active")
             remote = await RemoteSession.connect(
@@ -4722,7 +4722,7 @@ class OperatorApp(App[None]):
             # never to a click waiting for its first useful viewport.
             #
             # THIS CAN NOW FIRE WHERE IT PREVIOUSLY COULD NOT, and it is benign.
-            # v0.52.16 (#849) bounds `_recover_owner` at 90s, so a
+            # v0.52.16 (#849) bounds `_recover_runtime` at 90s, so a
             # `RemoteSession` can reach a TERMINAL cold state on a path that
             # used to retry forever; a speculative prepare can therefore meet
             # `is_cold` for real rather than only in transit. Verified by
@@ -6310,7 +6310,7 @@ class OperatorApp(App[None]):
                 #
                 # Checked here rather than by giving the bind a
                 # `require_bound=True`: its other callers deliberately tolerate
-                # the silent return (a prompt waits on `_owner_ready` instead),
+                # the silent return (a prompt waits on `_runtime_ready` instead),
                 # so the postcondition is this call site's, not the method's.
                 # `is_cold` is a declared `ViewerSessionProtocol` member, so
                 # this postcondition reads through the same declared surface as
@@ -10849,7 +10849,7 @@ class OperatorApp(App[None]):
         from local_operator.paths import config_dir
         from local_operator.resume import (
             RESUME_LATEST,
-            live_session_owner,
+            live_runtime_pid,
             resolve_resume_id,
         )
 
@@ -10861,7 +10861,7 @@ class OperatorApp(App[None]):
         except Exception:
             concrete = resume_id
         if concrete != RESUME_LATEST:
-            owner = live_session_owner(config_dir(), concrete)
+            owner = live_runtime_pid(config_dir(), concrete)
             if owner is not None and owner != os.getpid():
                 # Discovery scans the filesystem; run it as a worker so the
                 # UI thread never blocks on it, and settle attach-vs-refuse
@@ -11005,7 +11005,7 @@ class OperatorApp(App[None]):
                 # No id at all is the same known-local fact by another route:
                 # nothing could have published a record for it.
                 return False
-            # ``registry.scan`` rather than ``find_owner_record``: the latter
+            # ``registry.scan`` rather than ``find_runtime_record``: the latter
             # deliberately excludes the CALLING process, which is the right
             # answer for "who else owns this" and the wrong one here — the
             # question is whether a record exists on this machine at all.
@@ -11177,10 +11177,10 @@ class OperatorApp(App[None]):
         deliberately deleted, so a mixed-version owner gets a precise upgrade
         refusal rather than silently falling back to a divergent UI.
         """
-        from local_operator.mobile.attach_client import find_owner_record
+        from local_operator.mobile.attach_client import find_runtime_record
         from local_operator.session.remote import RemoteSession
 
-        record, found_owner = await asyncio.to_thread(find_owner_record, config_root, concrete)
+        record, found_owner = await asyncio.to_thread(find_runtime_record, config_root, concrete)
         if record is None or found_owner != owner or record.protocol < 4:
             self._system_notice(
                 f"session {concrete} is open in an older Local Operator process "
@@ -14554,7 +14554,7 @@ class OperatorApp(App[None]):
                 self._warm_engage_started = False
                 # "could not start a runtime for this session" was wrong on
                 # both halves for the common case: a runtime very likely DID
-                # start (``engage_runtime`` returned, ``find_owner_record``
+                # start (``engage_runtime`` returned, ``find_runtime_record``
                 # found it, the socket authenticated) and the session is not
                 # broken — the bind ran out of its envelope while the owner's
                 # authoritative loop was busy. Reporting that as a boot failure
@@ -23358,7 +23358,7 @@ class OperatorApp(App[None]):
         if bool(getattr(session, "is_cold", False)):
             return
         owner_version = str(getattr(session, "owner_version", "") or "")
-        owner_ref = str(getattr(session, "owner_source_ref", "") or "")
+        runtime_ref = str(getattr(session, "owner_source_ref", "") or "")
         # The subject of an owner notice is the SESSION, so the debounce is
         # keyed by it: "once per session per process", which is what design
         # §6.7 and this method's own contract say. Keyed on the session id
@@ -23376,7 +23376,7 @@ class OperatorApp(App[None]):
         subject = _session_subject(session)
         from local_operator.update import BuildStamp
 
-        owner = BuildStamp(version=owner_version, source_ref=owner_ref) if owner_version else None
+        owner = BuildStamp(version=owner_version, source_ref=runtime_ref) if owner_version else None
         if owner is not None and owner == loaded:
             return
         # WHICH SIDE IS STALE? A difference alone does not say, and this branch
@@ -27016,14 +27016,14 @@ class OperatorApp(App[None]):
         session = self._session
         owner_catalogue = getattr(session, "owner_model_catalogue", None)
         if callable(owner_catalogue):
-            owner_rows: list[dict[str, Any]] = []
+            runtime_rows: list[dict[str, Any]] = []
             try:
                 fetched = owner_catalogue()
                 if isinstance(fetched, list):
-                    owner_rows = fetched
+                    runtime_rows = fetched
             except Exception:
-                owner_rows = []
-            if owner_rows:
+                runtime_rows = []
+            if runtime_rows:
                 from local_operator.providers.controller import CatalogueEntry
 
                 known = {entry.selector for entry in entries}
@@ -27046,16 +27046,18 @@ class OperatorApp(App[None]):
                         # router reaches a follower through this path at all.
                         routed=bool(row.get("routed", False)),
                     )
-                    for row in owner_rows
+                    for row in runtime_rows
                     if f"{row.get('provider', '')}/{row.get('model_id', '')}" not in known
                 ]
-                owner_usable = {
-                    str(row.get("provider", "") or "") for row in owner_rows if row.get("connected")
+                runtime_usable = {
+                    str(row.get("provider", "") or "")
+                    for row in runtime_rows
+                    if row.get("connected")
                 }
                 # The owner's usable set EXTENDS, never replaces: the local
                 # store may name providers the owner's static catalogue did
                 # not (aggregators enumerate only live).
-                usable = owner_usable | (usable or set())
+                usable = runtime_usable | (usable or set())
         rows = [
             ModelRow(
                 provider=entry.provider,
@@ -35236,11 +35238,11 @@ def _owner_is_not_behind_this_window(owner: Any, loaded: Any, on_disk: Any) -> b
         return True
     from local_operator.update import parse_version
 
-    owner_parsed = parse_version(owner.version)
+    runtime_parsed = parse_version(owner.version)
     loaded_parsed = parse_version(loaded.version)
-    if owner_parsed is None or loaded_parsed is None:
+    if runtime_parsed is None or loaded_parsed is None:
         return False
-    return owner_parsed > loaded_parsed
+    return runtime_parsed > loaded_parsed
 
 
 def _skew_direction_is_knowable(owner: Any, loaded: Any, on_disk: Any) -> bool:
@@ -35272,7 +35274,7 @@ def _skew_direction_is_knowable(owner: Any, loaded: Any, on_disk: Any) -> bool:
     """
     from local_operator.update import parse_version
 
-    owner_parsed = parse_version(owner.version)
+    runtime_parsed = parse_version(owner.version)
     loaded_parsed = parse_version(loaded.version)
     # An unparseable side whose string DIFFERS from the other is unrankable
     # outright: ``0.51.31rc1`` vs ``0.51.30`` can be compared only by ordering,
@@ -35282,9 +35284,9 @@ def _skew_direction_is_knowable(owner: Any, loaded: Any, on_disk: Any) -> bool:
     # same-version ref drift, which disk can rank below.) Without this early
     # exit the equal-ref term promoted an unparseable rc to rankable (R2-3,
     # second shape).
-    if owner.version != loaded.version and (owner_parsed is None or loaded_parsed is None):
+    if owner.version != loaded.version and (runtime_parsed is None or loaded_parsed is None):
         return False
-    if owner_parsed is not None and loaded_parsed is not None and owner_parsed != loaded_parsed:
+    if runtime_parsed is not None and loaded_parsed is not None and runtime_parsed != loaded_parsed:
         return True
     if owner.source_ref == loaded.source_ref:
         return True

--- a/local_operator/wakes/supervisor.py
+++ b/local_operator/wakes/supervisor.py
@@ -125,9 +125,9 @@ async def _has_live_runtime(config_dir: Path, session_id: str) -> bool:
     The no-live-record rule's implementation. Off the loop: it walks the
     record directory.
     """
-    from local_operator.mobile.attach_client import find_owner_record
+    from local_operator.mobile.attach_client import find_runtime_record
 
-    record, _owner = await asyncio.to_thread(find_owner_record, config_dir, session_id)
+    record, _owner = await asyncio.to_thread(find_runtime_record, config_dir, session_id)
     return record is not None
 
 

--- a/scripts/bench_runtime_attach.py
+++ b/scripts/bench_runtime_attach.py
@@ -13,15 +13,15 @@ returns, so the number a user actually feels is exactly the wall time of
       └─ child: import           the composition root's import graph
       └─ child: spawn_owned_session()  build the session
       └─ child: RuntimeServer.start_in_process()  bind + publish record
-      └─ parent poll loop        find_owner_record() every _POLL_* seconds
-    find_owner_record()         one more scan once the errand is delivered
+      └─ parent poll loop        find_runtime_record() every _POLL_* seconds
+    find_runtime_record()         one more scan once the errand is delivered
     _bind_to(record)            dial the socket, await the frontend snapshot,
                                 load history, install state
 
 Two of those phases are pure latency the parent adds on top of the child's
 real work: the **poll grid** (the parent only notices the record on a poll
 boundary, so up to one full backoff step is dead time) and the **serialized
-spawn** (nothing is started until the first `find_owner_record` scan has
+spawn** (nothing is started until the first `find_runtime_record` scan has
 already come back empty). This benchmark reports every phase separately so a
 change can be shown to move the phase it claims to move, rather than showing
 one aggregate number that improved for unknown reasons.
@@ -89,7 +89,7 @@ async def _one_run(config_dir: Path) -> dict[str, float]:
     Returns a mapping of phase name to milliseconds. `total` is the number the
     user feels — the whole of `_ensure_bound`.
     """
-    from local_operator.mobile.attach_client import find_owner_record
+    from local_operator.mobile.attach_client import find_runtime_record
     from local_operator.session.runtime.launch import WarmErrand, engage_runtime
 
     session_id = f"bench-{uuid.uuid4().hex[:12]}"
@@ -103,7 +103,7 @@ async def _one_run(config_dir: Path) -> dict[str, float]:
     out["engage_ms"] = engage.stop()
 
     lookup = Phase("lookup")
-    record, _owner = await asyncio.to_thread(find_owner_record, config_dir, session_id)
+    record, _owner = await asyncio.to_thread(find_runtime_record, config_dir, session_id)
     out["lookup_ms"] = lookup.stop()
 
     out["total_ms"] = total.stop()

--- a/scripts/bench_state_field_reads.py
+++ b/scripts/bench_state_field_reads.py
@@ -189,7 +189,7 @@ def build_remote(state: FrontendSessionState) -> RemoteSession:
     """A viewer bound to a real store and nothing else.
 
     The accessors under measurement read only the store, so a socket would add
-    setup without changing a single number. ``find_owner_record`` is patched to
+    setup without changing a single number. ``find_runtime_record`` is patched to
     find nothing so construction does no disk work.
     """
 
@@ -197,7 +197,7 @@ def build_remote(state: FrontendSessionState) -> RemoteSession:
         raise AssertionError("the benchmark never takes a session over")
 
     with (
-        patch("local_operator.session.remote.find_owner_record", lambda *a, **k: (None, None)),
+        patch("local_operator.session.remote.find_runtime_record", lambda *a, **k: (None, None)),
         tempfile.TemporaryDirectory() as config_dir,
     ):
         remote = RemoteSession(

--- a/scripts/diag/tui_growth.py
+++ b/scripts/diag/tui_growth.py
@@ -789,7 +789,7 @@ async def run_switches(fixture: Fixture) -> list[dict[str, Any]]:
     profiler_early = cProfile.Profile() if ARGS.profile else None
     profiler_late = cProfile.Profile() if ARGS.profile else None
     with (
-        patch("local_operator.mobile.attach_client.find_owner_record", fixture.find),
+        patch("local_operator.mobile.attach_client.find_runtime_record", fixture.find),
         patch.object(OperatorApp, "_check_for_update", lambda self: None),
     ):
         async with app.run_test(size=(140, 40)) as pilot:
@@ -861,7 +861,7 @@ async def run_uptime(fixture: Fixture) -> list[dict[str, Any]]:
     records: list[dict[str, Any]] = []
     app = OperatorApp(lambda: fixture.resume(fixture.ids[0]), resume_factory=fixture.resume)
     with (
-        patch("local_operator.mobile.attach_client.find_owner_record", fixture.find),
+        patch("local_operator.mobile.attach_client.find_runtime_record", fixture.find),
         patch.object(OperatorApp, "_check_for_update", lambda self: None),
     ):
         async with app.run_test(size=(140, 40)) as pilot:

--- a/tests/e2e/test_desktop_controls.py
+++ b/tests/e2e/test_desktop_controls.py
@@ -412,10 +412,10 @@ async def test_desktop_control_surface(headless_tui_env: Path, workspace: Path, 
         if spawned_child is not None:
             from local_operator.mobile.attach_client import (
                 AttachClient,
-                find_owner_record,
+                find_runtime_record,
             )
 
-            record, _ = await asyncio.to_thread(find_owner_record, root, spawned_child)
+            record, _ = await asyncio.to_thread(find_runtime_record, root, spawned_child)
             if record is not None:
                 child_client = AttachClient(lambda _: None, lambda _: None)
                 await child_client.connect(record, spawned_child)

--- a/tests/e2e/test_desktop_sessions.py
+++ b/tests/e2e/test_desktop_sessions.py
@@ -116,9 +116,9 @@ async def test_canonical_desktop_over_http(headless_tui_env: Path, workspace: Pa
             # The assembled test owns this in-process Session; production's
             # process launcher writes the same claim marker before publishing.
             (root / "sessions" / sid / ".session.pid").write_text(str(os.getpid()))
-            from local_operator.mobile.attach_client import find_owner_record
+            from local_operator.mobile.attach_client import find_runtime_record
 
-            record, _ = find_owner_record(root, sid)
+            record, _ = find_runtime_record(root, sid)
             assert record is not None
             terminal = AttachClient(lambda _: None, lambda _: None)
             await terminal.connect(record, sid)

--- a/tests/e2e/test_desktop_spawn.py
+++ b/tests/e2e/test_desktop_spawn.py
@@ -16,7 +16,7 @@ import httpx
 import pytest
 import uvicorn
 
-from local_operator.mobile.attach_client import AttachClient, find_owner_record
+from local_operator.mobile.attach_client import AttachClient, find_runtime_record
 from local_operator.server.app import app
 from tests.e2e.test_desktop_sessions import next_frame
 
@@ -97,7 +97,7 @@ async def test_spawn_and_reopen_after_http_restart(
                     },
                 )
                 assert renamed.status_code == 200, renamed.text
-                record, _ = await asyncio.to_thread(find_owner_record, root, sid)
+                record, _ = await asyncio.to_thread(find_runtime_record, root, sid)
                 assert record is not None and record.pid != os.getpid()
                 owner_pid = record.pid
                 body = {
@@ -159,7 +159,7 @@ async def test_spawn_and_reopen_after_http_restart(
             )
     finally:
         if sid is not None:
-            record, _ = await asyncio.to_thread(find_owner_record, root, sid)
+            record, _ = await asyncio.to_thread(find_runtime_record, root, sid)
             if record is not None:
                 client = AttachClient(lambda _: None, lambda _: None)
                 await client.connect(record, sid)

--- a/tests/e2e/test_fork_checkpoint_e2e.py
+++ b/tests/e2e/test_fork_checkpoint_e2e.py
@@ -143,7 +143,7 @@ def _kill_runtime_children(config: Path) -> None:
 async def test_a_fork_with_an_inherited_checkpoint_binds_switches_and_admits_followers(
     headless_tui_env: Path, workspace: Path, monkeypatch
 ) -> None:
-    from local_operator.mobile.attach_client import find_owner_record
+    from local_operator.mobile.attach_client import find_runtime_record
     from local_operator.providers.auth_store import AuthStore
     from local_operator.providers.controller import ProviderController
     from local_operator.spawn import registry as spawn_registry
@@ -172,7 +172,7 @@ async def test_a_fork_with_an_inherited_checkpoint_binds_switches_and_admits_fol
         session_id = resume_id or "newsession01"
         record = None
         if resume_id:
-            record, _ = await asyncio.to_thread(find_owner_record, config, session_id)
+            record, _ = await asyncio.to_thread(find_runtime_record, config, session_id)
         if record is not None:
             return await RemoteSession.connect(
                 record, session_id, config_dir=config, takeover_factory=take_over
@@ -259,7 +259,7 @@ async def test_a_fork_with_an_inherited_checkpoint_binds_switches_and_admits_fol
                 ), "the switch never reached the owner"
 
                 # A SECOND terminal attaches as a follower (#573's report).
-                record, _ = await asyncio.to_thread(find_owner_record, config, fork_id)
+                record, _ = await asyncio.to_thread(find_runtime_record, config, fork_id)
                 assert record is not None
                 follower = await RemoteSession.connect(
                     record, fork_id, config_dir=config, takeover_factory=_never_take_over
@@ -279,7 +279,7 @@ async def test_a_fork_of_a_fork_serves_its_own_id(headless_tui_env: Path, worksp
     """#573 observed the GRANDPARENT's id two hops down. Chain two forks on
     disk and boot a real runtime for the second: its sync names itself."""
     from local_operator.fork import fork_session
-    from local_operator.mobile.attach_client import find_owner_record
+    from local_operator.mobile.attach_client import find_runtime_record
     from local_operator.session.runtime import registry
 
     config = headless_tui_env
@@ -315,8 +315,8 @@ async def test_a_fork_of_a_fork_serves_its_own_id(headless_tui_env: Path, worksp
                         record = candidate
                 await asyncio.sleep(0.1)
             assert record is not None, "the fork-of-a-fork runtime never published"
-            # ``find_owner_record`` needs the liveness marker the child wrote.
-            found, _ = await asyncio.to_thread(find_owner_record, config, second)
+            # ``find_runtime_record`` needs the liveness marker the child wrote.
+            found, _ = await asyncio.to_thread(find_runtime_record, config, second)
             assert found is not None
             viewer = await RemoteSession.connect(
                 found, second, config_dir=config, takeover_factory=_never_take_over

--- a/tests/e2e/test_fork_cold_e2e.py
+++ b/tests/e2e/test_fork_cold_e2e.py
@@ -49,7 +49,7 @@ async def test_cold_snapshot_live_preferences_overrides_and_cancel(
     # Real process discovery deliberately excludes our own PID. This owner is
     # hosted in the test's process; only that discovery boundary is supplied.
     monkeypatch.setattr(
-        "local_operator.mobile.attach_client.find_owner_record",
+        "local_operator.mobile.attach_client.find_runtime_record",
         lambda *_: (server._record, server._record.pid),
     )
     launches = []

--- a/tests/e2e/test_sidebar_display_e2e.py
+++ b/tests/e2e/test_sidebar_display_e2e.py
@@ -141,7 +141,7 @@ async def test_saved_view_switches_while_authenticated_owner_sync_is_held(
 
         app = OperatorApp(lambda: resume("origin"), resume_factory=resume)
         with (
-            patch("local_operator.mobile.attach_client.find_owner_record", find),
+            patch("local_operator.mobile.attach_client.find_runtime_record", find),
             patch.object(OperatorApp, "_check_for_update", lambda self: None),
         ):
             async with app.run_test(size=(120, 36)) as pilot:

--- a/tests/e2e/test_sidebar_reconnect_e2e.py
+++ b/tests/e2e/test_sidebar_reconnect_e2e.py
@@ -165,7 +165,7 @@ async def test_an_evicted_viewer_reconnects_without_ever_looking_connected(
         )
 
     app = OperatorApp(lambda: resume("origin"), resume_factory=resume)
-    with patch("local_operator.mobile.attach_client.find_owner_record", find_owner):
+    with patch("local_operator.mobile.attach_client.find_runtime_record", find_owner):
         async with app.run_test(size=(120, 36)) as pilot:
             await wait_for_adoption(app, pilot)
             await asyncio.wait_for(app._sidebar_navigation.select("target"), 30)
@@ -276,7 +276,7 @@ async def test_a_plain_socket_loss_reconnects_with_no_attach_pressure(
     def find_owner(_config_dir, requested):
         return (server._record, server._record.pid) if requested == session_id else (None, None)
 
-    with patch("local_operator.mobile.attach_client.find_owner_record", find_owner):
+    with patch("local_operator.mobile.attach_client.find_runtime_record", find_owner):
         viewer = await RemoteSession.saved_preview(
             session_id,
             config_dir=config,

--- a/tests/e2e/test_sidebar_runtime_reap_e2e.py
+++ b/tests/e2e/test_sidebar_runtime_reap_e2e.py
@@ -111,7 +111,7 @@ async def test_visited_conversations_do_not_hold_their_runtimes_open(
     app = OperatorApp(lambda: resume("origin"), resume_factory=resume)
     try:
         with (
-            patch("local_operator.mobile.attach_client.find_owner_record", find),
+            patch("local_operator.mobile.attach_client.find_runtime_record", find),
             patch.object(OperatorApp, "_check_for_update", lambda self: None),
         ):
             async with app.run_test(size=(120, 36)) as pilot:
@@ -195,7 +195,7 @@ async def test_an_empty_conversation_visited_and_left_retires_its_runtime(
     app = OperatorApp(lambda: resume("origin"), resume_factory=resume)
     try:
         with (
-            patch("local_operator.mobile.attach_client.find_owner_record", find),
+            patch("local_operator.mobile.attach_client.find_runtime_record", find),
             patch.object(OperatorApp, "_check_for_update", lambda self: None),
         ):
             async with app.run_test(size=(120, 36)) as pilot:

--- a/tests/e2e/test_viewer_attach_e2e.py
+++ b/tests/e2e/test_viewer_attach_e2e.py
@@ -929,11 +929,11 @@ async def test_a_tool_started_during_the_gap_paints_and_completes_after_rebind(
 
     (directory / ".session.pid").write_text(str(os.getpid()), encoding="utf-8")
 
-    # The recovery hold (step 4). ``find_owner_record`` answering "no record
+    # The recovery hold (step 4). ``find_runtime_record`` answering "no record
     # yet" is a real transient the viewer already handles — the recovery loop
     # polls until one appears — so this delays the rebind without touching the
     # code under test.
-    real_find = remote_module.find_owner_record
+    real_find = remote_module.find_runtime_record
 
     def gated_find(*args: Any, **kwargs: Any) -> Any:
         if not second_running.is_set():
@@ -978,7 +978,7 @@ async def test_a_tool_started_during_the_gap_paints_and_completes_after_rebind(
             assert conns, "no full-TUI client to drop"
             # Arm the hold BEFORE the drop, so the very first recovery poll
             # already sees "no record yet".
-            remote_module.find_owner_record = gated_find
+            remote_module.find_runtime_record = gated_find
             server._drop_client(conns[0], reason="test")
             drop_done.set()
 
@@ -991,7 +991,7 @@ async def test_a_tool_started_during_the_gap_paints_and_completes_after_rebind(
             assert second_running.is_set(), "the gap step never started"
             # B's start is now in the owner's ``live_events``; releasing the
             # hold lets recovery re-bind and take that snapshot.
-            remote_module.find_owner_record = real_find
+            remote_module.find_runtime_record = real_find
 
             # Let recovery rebind; B exists only in the snapshot seed.
             rebound = False
@@ -1032,7 +1032,7 @@ async def test_a_tool_started_during_the_gap_paints_and_completes_after_rebind(
                 gap_cards[0]._state == "success"
             ), f"the gap tool settled as {gap_cards[0]._state!r}, not success"
     finally:
-        remote_module.find_owner_record = real_find
+        remote_module.find_runtime_record = real_find
         drop_done.set()
         release_second.set()
         if viewer is not None:
@@ -1197,7 +1197,7 @@ async def test_a_joiner_after_the_tools_end_paints_no_interrupted_card(
     handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(workspace))
     server = RuntimeServer(handle, kind="daemon")
     await server.start_in_process()
-    # A real runtime process writes this; without it `find_owner_record` cannot
+    # A real runtime process writes this; without it `find_runtime_record` cannot
     # see a perfectly healthy runtime and the viewer goes cold, faking an abort.
     (directory / ".session.pid").write_text(str(os.getpid()), encoding="utf-8")
 

--- a/tests/unit/mobile/test_attach_client.py
+++ b/tests/unit/mobile/test_attach_client.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from local_operator.mobile.attach_client import AttachClient, find_owner_record
+from local_operator.mobile.attach_client import AttachClient, find_runtime_record
 from local_operator.mobile.types import SessionProjection, TranscriptEntry
 from local_operator.session.runtime import registry
 from local_operator.session.runtime.server import RuntimeServer
@@ -103,7 +103,7 @@ async def test_discovery_finds_the_live_owner(config: Path) -> None:
     try:
         record = await _wait_record()
         _marker(config, "sess-a", os.getpid())
-        found, owner = find_owner_record(config, "sess-a")
+        found, owner = find_runtime_record(config, "sess-a")
         assert found is not None
         assert found.pid == record.pid
         assert owner == os.getpid()
@@ -113,7 +113,7 @@ async def test_discovery_finds_the_live_owner(config: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_discovery_without_owner_returns_none(config: Path) -> None:
-    found, owner = find_owner_record(config, "never-started")
+    found, owner = find_runtime_record(config, "never-started")
     assert found is None
     assert owner is None
 
@@ -123,7 +123,7 @@ async def test_discovery_owner_without_record_reports_pid_only(config: Path) -> 
     # A live pid holds the claim but publishes nothing (old binary,
     # registrant failed): the caller needs the pid for the refusal copy.
     _marker(config, "sess-x", os.getpid())
-    found, owner = find_owner_record(config, "sess-x")
+    found, owner = find_runtime_record(config, "sess-x")
     assert found is None
     assert owner == os.getpid()
 
@@ -139,7 +139,7 @@ async def test_protocol_gate_refuses_v1_records(config: Path) -> None:
         # Degrade the published record to protocol 1, as an old binary would.
         record.protocol = 1
         registry.publish(record, root=config)
-        found, owner = find_owner_record(config, "sess-old")
+        found, owner = find_runtime_record(config, "sess-old")
         # The gate reports the owner (refusal copy needs the pid) but no
         # dialable record.
         assert found is None

--- a/tests/unit/mobile/test_phone_startup.py
+++ b/tests/unit/mobile/test_phone_startup.py
@@ -304,7 +304,7 @@ async def test_different_owner_is_never_acknowledged_as_spawned_pid(
             1,
         )
 
-    monkeypatch.setattr(attach_client, "find_owner_record", swapped_owner)
+    monkeypatch.setattr(attach_client, "find_runtime_record", swapped_owner)
     daemon = MobileDaemon(password="pw")
     try:
         async with asyncio.timeout(10):

--- a/tests/unit/session/runtime/test_eager_runtime.py
+++ b/tests/unit/session/runtime/test_eager_runtime.py
@@ -487,7 +487,7 @@ async def test_an_engage_that_lands_after_dispose_does_not_bind(
         return None, None
 
     monkeypatch.setattr("local_operator.session.runtime.launch.engage_runtime", fake_engage)
-    monkeypatch.setattr("local_operator.mobile.attach_client.find_owner_record", fake_find)
+    monkeypatch.setattr("local_operator.mobile.attach_client.find_runtime_record", fake_find)
 
     async def _never():
         raise AssertionError

--- a/tests/unit/session/runtime/test_launch_arbitration.py
+++ b/tests/unit/session/runtime/test_launch_arbitration.py
@@ -941,10 +941,10 @@ async def test_a_published_record_that_refuses_the_dial_is_not_polled_densely(
         control_key="k" * 16,
     )
     # A record IS present and the lease IS held by a live pid: construction is
-    # over and this runtime is simply unreachable. `find_owner_record` is a
+    # over and this runtime is simply unreachable. `find_runtime_record` is a
     # function-local import in the loop, so it is patched at its source module.
     monkeypatch.setattr(
-        "local_operator.mobile.attach_client.find_owner_record",
+        "local_operator.mobile.attach_client.find_runtime_record",
         lambda config_dir, session_id: (record, os.getpid()),
     )
     monkeypatch.setattr(launch_module, "_lease_holder", lambda config_dir, session_id: os.getpid())

--- a/tests/unit/session/test_cleanup.py
+++ b/tests/unit/session/test_cleanup.py
@@ -865,7 +865,7 @@ def _aggressive_store(tmp_path: Path, count: int = 15) -> None:
 
 @pytest.mark.parametrize(
     "target",
-    ["_claimed", "_lease_owner_alive", "_has_wake", "_has_spooled_mail"],
+    ["_claimed", "_lease_runtime_alive", "_has_wake", "_has_spooled_mail"],
 )
 def test_a_guard_that_raises_keeps_the_directory(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, target: str

--- a/tests/unit/session/test_frontend_sync_liveness.py
+++ b/tests/unit/session/test_frontend_sync_liveness.py
@@ -56,9 +56,9 @@ async def _never():
 
 
 def _claim(tmp_path: Path) -> None:
-    """Make ``find_owner_record`` resolve this test's in-process server.
+    """Make ``find_runtime_record`` resolve this test's in-process server.
 
-    ``find_owner_record`` starts from ``live_session_owner``, which reads the
+    ``find_runtime_record`` starts from ``live_runtime_pid``, which reads the
     session directory's ``.session.pid`` marker — a real TUI writes it when it
     claims the directory. The tests below run the ``RuntimeServer`` inside the
     test process, so this process IS the owner.
@@ -357,7 +357,7 @@ async def test_the_wait_uses_the_dials_own_future_not_the_current_attribute(
     make a healthy wait fail with "owner did not start frontend
     synchronization" (the reported sentence's sibling) or silently await a
     DIFFERENT dial's future. ``_ensure_bound`` holds ``_bind_lock`` and
-    ``_recover_owner`` does not take it at all, so nothing else orders them.
+    ``_recover_runtime`` does not take it at all, so nothing else orders them.
 
     This is a fact about DATA FLOW, not about timing.
     """
@@ -533,7 +533,9 @@ async def test_a_vanished_record_does_not_discard_an_earlier_attempts_reason(
             lookups += 1
             return (record, None) if lookups == 1 else (None, None)
 
-        monkeypatch.setattr("local_operator.mobile.attach_client.find_owner_record", vanishing_find)
+        monkeypatch.setattr(
+            "local_operator.mobile.attach_client.find_runtime_record", vanishing_find
+        )
 
         async def fail_with_reason(record, *, sync_timeout, preempt=None):
             raise ConnectionError("the pump's own words")
@@ -581,7 +583,9 @@ async def test_the_retry_rediscovers_the_record_each_attempt(tmp_path: Path, mon
             lookups += 1
             return record, None
 
-        monkeypatch.setattr("local_operator.mobile.attach_client.find_owner_record", counting_find)
+        monkeypatch.setattr(
+            "local_operator.mobile.attach_client.find_runtime_record", counting_find
+        )
 
         async def always_fail(record, *, sync_timeout, preempt=None):
             raise ConnectionError(remote_module._SYNC_UNRESPONSIVE_REASON)

--- a/tests/unit/session/test_remote.py
+++ b/tests/unit/session/test_remote.py
@@ -435,11 +435,11 @@ async def test_a_failed_redial_in_recovery_leaves_no_stale_runtime_identity(
         # Feed the loop that unreachable record instead of the registry, then
         # let it take a few passes and go cold on its own deadline.
         monkeypatch.setattr(
-            "local_operator.session.remote.find_owner_record",
+            "local_operator.session.remote.find_runtime_record",
             lambda *_a, **_k: (dead, None),
         )
         monkeypatch.setattr("local_operator.session.remote.COLD_FALLBACK_S", 0.4)
-        await viewer._recover_owner()
+        await viewer._recover_runtime()
 
         assert viewer._client is None, "a failed dial installs no client"
         assert viewer.is_cold is True

--- a/tests/unit/session/test_remote_cold.py
+++ b/tests/unit/session/test_remote_cold.py
@@ -169,7 +169,7 @@ async def test_the_first_prompt_binds_the_viewer_to_a_runtime(tmp_path: Path, mo
         nonlocal engagements
         engagements += 1
         server.start()
-        # A real runtime claims the transcript, and ``find_owner_record``
+        # A real runtime claims the transcript, and ``find_runtime_record``
         # consults that liveness marker before trusting any record. Writing it
         # is part of standing in for the process, not test scaffolding.
         marker = config_dir / "sessions" / session_id / ".session.pid"
@@ -226,7 +226,7 @@ async def test_concurrent_first_writes_engage_exactly_one_runtime(
         # actually contended and the test would prove nothing.
         await asyncio.sleep(0.2)
         server.start()
-        # A real runtime claims the transcript, and ``find_owner_record``
+        # A real runtime claims the transcript, and ``find_runtime_record``
         # consults that liveness marker before trusting any record. Writing it
         # is part of standing in for the process, not test scaffolding.
         marker = config_dir / "sessions" / session_id / ".session.pid"

--- a/tests/unit/session/test_remote_disconnect.py
+++ b/tests/unit/session/test_remote_disconnect.py
@@ -20,7 +20,7 @@ from local_operator.session.remote import RemoteSession
 
 
 def _facade(tmp_path, monkeypatch, *, can_go_cold: bool = False) -> RemoteSession:
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(
         config_dir=tmp_path,
         session_id="s1",
@@ -264,7 +264,7 @@ async def test_the_real_recovery_loop_bounds_the_turn_on_a_terminal_viewer(
     THIS TEST LETS THE REAL LOOP RUN. Every other verdict test here hand-calls
     ``_settle_suspect_turn`` / ``_go_cold``, and that test shape is what let
     the blocker through — ``_facade`` defaults ``can_go_cold=False`` and no
-    test ever drove ``_recover_owner`` itself on that surface.
+    test ever drove ``_recover_runtime`` itself on that surface.
 
     ``COLD_FALLBACK_S`` is monkeypatched so the bound is exercised in
     milliseconds; the assertion is on the VERDICT, never on elapsed time.
@@ -276,7 +276,7 @@ async def test_the_real_recovery_loop_bounds_the_turn_on_a_terminal_viewer(
         takeover_attempts.append(1)
         raise RuntimeError("the lease is held by another follower")
 
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(
         config_dir=tmp_path,
         session_id="s1",
@@ -327,7 +327,7 @@ async def test_the_terminal_bound_does_not_fire_when_no_turn_was_live(
     async def failing_takeover() -> Any:
         raise RuntimeError("no successor yet")
 
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(
         config_dir=tmp_path,
         session_id="s1",
@@ -479,7 +479,7 @@ def _silent_owner_facade(tmp_path, monkeypatch) -> tuple[RemoteSession, list[flo
     monkeypatch.setattr(remote_module, "COLD_FALLBACK_S", 0.05)
     monkeypatch.setattr(remote_module, "FRONTEND_SYNC_BLOCKED_S", 0.05)
     monkeypatch.setattr(remote_module, "RECOVERY_GIVE_UP_S", 0.3)
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *a: (_live_record(), None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *a: (_live_record(), None))
 
     remote = RemoteSession(
         config_dir=tmp_path,
@@ -586,7 +586,7 @@ async def test_the_refusal_is_no_longer_driven_by_the_recovery_flag(tmp_path, mo
     import local_operator.mobile.attach_client as attach_client
     import local_operator.session.runtime.launch as launch
 
-    monkeypatch.setattr(attach_client, "find_owner_record", lambda *a: (_live_record(), None))
+    monkeypatch.setattr(attach_client, "find_runtime_record", lambda *a: (_live_record(), None))
     monkeypatch.setattr(launch, "engage_runtime", lambda *a, **k: asyncio.sleep(0))
 
     remote._on_disconnected("send timeout")
@@ -614,9 +614,9 @@ async def test_the_refusal_is_no_longer_driven_by_the_recovery_flag(tmp_path, mo
 
 @pytest.mark.asyncio
 async def test_the_parked_prompt_is_released_by_the_bound(tmp_path, monkeypatch) -> None:
-    """The silent half of the defect: `prompt` waits on `_owner_ready` forever.
+    """The silent half of the defect: `prompt` waits on `_runtime_ready` forever.
 
-    `_on_disconnected` clears `_owner_ready` and the only setters are
+    `_on_disconnected` clears `_runtime_ready` and the only setters are
     `_go_cold`, the takeover branch and the deliberate-stop arms — none of
     which fired on this path. The user saw no message and no spinner
     resolution, which is worse than the refusal `/model` at least printed.
@@ -625,7 +625,7 @@ async def test_the_parked_prompt_is_released_by_the_bound(tmp_path, monkeypatch)
     released = asyncio.Event()
 
     async def parks_on_owner_ready() -> None:
-        await remote._owner_ready.wait()
+        await remote._runtime_ready.wait()
         released.set()
 
     waiter = asyncio.create_task(parks_on_owner_ready())
@@ -642,7 +642,7 @@ async def test_the_parked_prompt_is_released_by_the_bound(tmp_path, monkeypatch)
     waiter.cancel()
     await _cancel_recovery(remote)
 
-    assert was_released is True, "the prompt path is still parked on _owner_ready"
+    assert was_released is True, "the prompt path is still parked on _runtime_ready"
 
 
 @pytest.mark.asyncio
@@ -652,7 +652,7 @@ async def test_a_genuinely_dead_owner_still_takes_the_legacy_takeover_path(
     """Guard against over-reach: the chase contract survives for a DEAD owner.
 
     The give-up exit is scoped to a record having been SEEN (`record_seen` in
-    `_recover_owner`). With no record the loop must still reach
+    `_recover_runtime`). With no record the loop must still reach
     `_takeover_factory` and keep chasing, exactly as
     ``test_the_real_recovery_loop_bounds_the_turn_on_a_terminal_viewer`` pins.
 
@@ -667,7 +667,7 @@ async def test_a_genuinely_dead_owner_still_takes_the_legacy_takeover_path(
     """
     monkeypatch.setattr(remote_module, "COLD_FALLBACK_S", 0.05)
     monkeypatch.setattr(remote_module, "RECOVERY_GIVE_UP_S", 0.3)
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *a: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *a: (None, None))
     attempts: list[int] = []
 
     async def failing_takeover() -> Any:
@@ -725,7 +725,7 @@ async def test_an_unusable_record_is_not_a_sighting_for_the_give_up_exit(
 
     stale = _live_record()
     stale.protocol = 4  # a pre-frontend owner: discoverable, not attachable
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *a: (stale, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *a: (stale, None))
     attempts: list[int] = []
 
     async def failing_takeover() -> Any:
@@ -771,7 +771,7 @@ async def test_the_dial_failure_backoff_reaches_the_recovery_cap(tmp_path, monke
     """
     monkeypatch.setattr(remote_module, "COLD_FALLBACK_S", 60.0)
     monkeypatch.setattr(remote_module, "RECOVERY_GIVE_UP_S", 60.0)
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *a: (_live_record(), None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *a: (_live_record(), None))
 
     remote = RemoteSession(
         config_dir=tmp_path,

--- a/tests/unit/session/test_remote_move.py
+++ b/tests/unit/session/test_remote_move.py
@@ -329,7 +329,7 @@ async def test_a_move_while_the_owner_is_recovering_is_REFUSED(cold_session) -> 
     ``route_shared_slash`` in the same file declines during recovery because a
     request/response command that blocks until a replacement owner arrives
     answers a question the user has stopped asking. A move that reported
-    success here would be worse than slow: ``_recover_owner`` binds the
+    success here would be worse than slow: ``_recover_runtime`` binds the
     successor at whatever cwd the owner's RECORD names, so the "cold move"
     is silently undone and the viewer works somewhere it said it had left
     (review MINOR-1).

--- a/tests/unit/session/test_remote_refresh.py
+++ b/tests/unit/session/test_remote_refresh.py
@@ -34,7 +34,7 @@ async def test_retiring_goes_cold_now_and_fires_the_refresh_callback(tmp_path, m
     exist yet — the app spawns it. No ``_end_turn_locally``: that is what
     would paint ``interrupted`` for a turn that never existed.
     """
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(config_dir=tmp_path, session_id="s1", takeover_factory=_never_take_over)
     ended: list[str] = []
     monkeypatch.setattr(
@@ -54,13 +54,13 @@ async def test_retiring_goes_cold_now_and_fires_the_refresh_callback(tmp_path, m
     assert cold == [], "the went-cold callback is the death path; a refresh is not one"
     assert ended == [], "no turn end may be synthesised for an idle runtime that retired"
     assert remote._deliberate_stop is False, "a refresh is not a stop; the next prompt engages"
-    assert remote._owner_ready.is_set(), "a cold viewer is READY: the next prompt engages"
+    assert remote._runtime_ready.is_set(), "a cold viewer is READY: the next prompt engages"
 
 
 @pytest.mark.asyncio
 async def test_stopped_reason_still_parks_the_viewer(tmp_path, monkeypatch):
     """Regression guard: the new branch must not shadow the stop path."""
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(config_dir=tmp_path, session_id="s1", takeover_factory=_never_take_over)
     refreshed: list[str] = []
     remote.set_refresh_callback(lambda: refreshed.append("refresh"))
@@ -75,8 +75,8 @@ async def test_stopped_reason_still_parks_the_viewer(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_owner_death_still_recovers(tmp_path, monkeypatch):
-    """Regression guard: an unannounced exit still runs ``_recover_owner``."""
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    """Regression guard: an unannounced exit still runs ``_recover_runtime``."""
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(config_dir=tmp_path, session_id="s1", takeover_factory=_never_take_over)
     refreshed: list[str] = []
     remote.set_refresh_callback(lambda: refreshed.append("refresh"))
@@ -96,7 +96,7 @@ async def test_owner_death_still_recovers(tmp_path, monkeypatch):
 @pytest.mark.asyncio
 async def test_request_refresh_never_raises(tmp_path, monkeypatch):
     """Every failure is "kept": the reaper's own check is the fallback."""
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(config_dir=tmp_path, session_id="s1", takeover_factory=_never_take_over)
     assert (await remote.request_refresh()).startswith("kept:")
 
@@ -124,7 +124,7 @@ def test_owner_idle_reads_the_snapshot(tmp_path, monkeypatch):
     parked gate → busy; otherwise idle."""
     from types import SimpleNamespace
 
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(config_dir=tmp_path, session_id="s1", takeover_factory=_never_take_over)
     assert remote.owner_idle() is False, "a cold viewer has no owner to refresh"
 

--- a/tests/unit/session/test_remote_round2.py
+++ b/tests/unit/session/test_remote_round2.py
@@ -577,7 +577,7 @@ async def test_prompt_during_recovery_still_queues_and_delivers(
         assert remote._recovering is True
         prompt_task = asyncio.create_task(remote.prompt("queued during gap"))
         await asyncio.sleep(0.2)
-        assert not prompt_task.done()  # waiting on _owner_ready, not failing
+        assert not prompt_task.done()  # waiting on _runtime_ready, not failing
         replacement = RuntimeServer(handle, kind="tui")
         replacement.start()
         try:
@@ -848,7 +848,7 @@ async def test_follower_prompt_carries_a_caller_supplied_message_id() -> None:
     adopts as the Message id and announces back.
     """
     remote = _bare_remote(Path("/tmp/r1-f1-prompt"))
-    remote._owner_ready.set()
+    remote._runtime_ready.set()
     client = _RecordingClient()
     remote._client = client  # type: ignore[assignment]
 
@@ -868,7 +868,7 @@ async def test_follower_prompt_still_mints_an_id_when_none_is_supplied() -> None
     import uuid
 
     remote = _bare_remote(Path("/tmp/r1-f1-mint"))
-    remote._owner_ready.set()
+    remote._runtime_ready.set()
     client = _RecordingClient()
     remote._client = client  # type: ignore[assignment]
 
@@ -898,14 +898,14 @@ async def test_a_takeover_target_without_the_seam_is_not_handed_an_id() -> None:
             calls.append((text, {"message_id": message_id}))
 
     legacy = _bare_remote(Path("/tmp/r1-f1-legacy"))
-    legacy._owner_ready.set()
+    legacy._runtime_ready.set()
     legacy._takeover_target = _LegacyTarget()  # type: ignore[assignment]
     await legacy.prompt("hello", message_id="an-id")
     assert calls == [("hello", {})], "a legacy target must not receive the keyword"
 
     calls.clear()
     modern = _bare_remote(Path("/tmp/r1-f1-modern"))
-    modern._owner_ready.set()
+    modern._runtime_ready.set()
     modern._takeover_target = _ModernTarget()  # type: ignore[assignment]
     await modern.prompt("hello", message_id="an-id")
     assert calls == [("hello", {"message_id": "an-id"})], "the id must reach a capable target"

--- a/tests/unit/session/test_remote_startup.py
+++ b/tests/unit/session/test_remote_startup.py
@@ -70,7 +70,7 @@ async def test_initial_sync_blocks_mutations_and_replays_new_epoch_updates(
             await reached.wait()
             assert viewer._client is not None and viewer._client.connected
             assert viewer.is_cold, "a connected socket must not advertise canonical readiness"
-            assert not viewer._owner_ready.is_set()
+            assert not viewer._runtime_ready.is_set()
 
             entered = [asyncio.Event() for _ in range(3)]
 
@@ -98,7 +98,7 @@ async def test_initial_sync_blocks_mutations_and_replays_new_epoch_updates(
             await asyncio.gather(*tasks)
             assert engagements == 1
             assert not viewer.is_cold
-            assert viewer._owner_ready.is_set()
+            assert viewer._runtime_ready.is_set()
             assert viewer.frontend_state.epoch == handle.frontend_state_seed.epoch
             assert viewer.goal == "new owner state"
             assert [call[0] for call in handle.calls] == ["prompt", "run_slash_authoritative"]
@@ -171,7 +171,7 @@ async def test_interrupted_initial_sync_closes_socket_and_retries(
                 monkeypatch.setattr(viewer, "_load_history", original)
                 await viewer._ensure_bound()
                 assert not viewer.is_cold
-                assert viewer._owner_ready.is_set()
+                assert viewer._runtime_ready.is_set()
     finally:
         release.set()
         if not binding.done():
@@ -231,7 +231,7 @@ async def test_recovery_sync_is_the_only_binding_for_waiting_turns(
             await reached.wait()
             assert viewer._recovering
             assert viewer.is_cold
-            assert not viewer._owner_ready.is_set()
+            assert not viewer._runtime_ready.is_set()
             with pytest.raises(ConnectionError, match="reconnect"):
                 await viewer.route_shared_slash("goal", "do not queue during recovery")
 

--- a/tests/unit/session/test_remote_takeover.py
+++ b/tests/unit/session/test_remote_takeover.py
@@ -32,7 +32,7 @@ async def test_owner_death_takes_over_silently_and_retains_submitted_input(
     async def takeover():
         return winner
 
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(
         config_dir=tmp_path,
         session_id="s1",
@@ -47,7 +47,7 @@ async def test_owner_death_takes_over_silently_and_retains_submitted_input(
         await remote.dispose()
 
     remote.set_takeover_callback(adopt)
-    remote._owner_ready.set()
+    remote._runtime_ready.set()
     remote._on_disconnected("owner exited")
     submitted = asyncio.create_task(remote.prompt("continue after death"))
     await asyncio.wait_for(submitted, timeout=2)
@@ -91,7 +91,7 @@ async def test_takeover_swaps_subscription_and_updates_flow_from_the_winner(
     async def takeover():
         return winner
 
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(config_dir=tmp_path, session_id="s1", takeover_factory=takeover)
     remote._install_frontend(
         FrontendSessionState(session_id="s1", epoch="dead-owner", cumulative_parent_cost=12.34)
@@ -110,7 +110,7 @@ async def test_takeover_swaps_subscription_and_updates_flow_from_the_winner(
         await remote.dispose()
 
     remote.set_takeover_callback(adopt)
-    remote._owner_ready.set()
+    remote._runtime_ready.set()
     remote._on_disconnected("owner exited")
     for _ in range(200):
         if adopted:
@@ -130,7 +130,7 @@ async def test_deliberate_stop_never_takes_over(tmp_path, monkeypatch) -> None:
 
     The disconnect after the follower's own ``request_stop`` is the op
     landing, not owner death (U2-4): ``_deliberate_stop`` is set before the
-    op is sent, and ``_recover_owner`` must return immediately instead of
+    op is sent, and ``_recover_runtime`` must return immediately instead of
     calling the takeover factory (which would republish a live record for a
     session the user just ended).
     """
@@ -140,7 +140,7 @@ async def test_deliberate_stop_never_takes_over(tmp_path, monkeypatch) -> None:
         takeover_calls.append(True)
         raise AssertionError("takeover must not run after a deliberate stop")
 
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(
         config_dir=tmp_path,
         session_id="s1",
@@ -174,7 +174,7 @@ async def test_wire_stop_by_another_process_never_takes_over(tmp_path, monkeypat
         takeover_calls.append(True)
         raise AssertionError("takeover must not run after a deliberate stop")
 
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(
         config_dir=tmp_path,
         session_id="s1",
@@ -207,7 +207,7 @@ async def test_owner_death_without_stopped_marker_still_takes_over(tmp_path, mon
             pass
 
     winner = Winner()
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(
         config_dir=tmp_path,
         session_id="s1",
@@ -250,7 +250,7 @@ async def test_wire_stopping_frame_prevents_takeover_without_any_wake_entry(
     async def takeover():
         raise AssertionError("takeover must not run after an announced stop")
 
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(
         config_dir=tmp_path,
         session_id="s1",
@@ -263,7 +263,7 @@ async def test_wire_stopping_frame_prevents_takeover_without_any_wake_entry(
     assert remote._takeover_target is None
     # The viewer stays usable: a prompt resolves against the stopped notice
     # instead of blocking forever on an owner that will never return.
-    assert remote._owner_ready.is_set()
+    assert remote._runtime_ready.is_set()
 
 
 @pytest.mark.asyncio
@@ -292,7 +292,7 @@ async def test_a_failed_stop_does_not_disable_later_owner_death_recovery(
             pass
 
     winner = Winner()
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(
         config_dir=tmp_path,
         session_id="s1",
@@ -321,7 +321,7 @@ async def test_a_failed_stop_does_not_disable_later_owner_death_recovery(
 @pytest.mark.asyncio
 async def test_stop_with_no_client_attached_does_not_latch(tmp_path, monkeypatch) -> None:
     """The simpler failure shape: nothing attached, so nothing was stopped."""
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(
         config_dir=tmp_path,
         session_id="s1",
@@ -348,7 +348,7 @@ async def test_a_stopped_viewer_is_told_so_and_never_says_reconnecting(
     from local_operator.mobile.attach_client import STOPPED_REASON
 
     told: list[str] = []
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(
         config_dir=tmp_path,
         session_id="s1",
@@ -374,7 +374,7 @@ async def test_a_dropped_connection_still_says_reconnecting(tmp_path, monkeypatc
     The two states are opposites and must not collapse into one sentence —
     this is what stops the D3-1 fix from lying in the other direction.
     """
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(
         config_dir=tmp_path,
         session_id="s1",
@@ -400,7 +400,7 @@ async def test_a_deliberate_stop_ends_the_turn_in_both_states(
     """
     from local_operator.mobile.attach_client import STOPPED_REASON
 
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(
         config_dir=tmp_path,
         session_id="s1",
@@ -436,7 +436,7 @@ async def test_going_cold_ends_an_in_flight_turn_directly(tmp_path, monkeypatch)
     """
     from local_operator.harness.types import AgentEndEvent
 
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(
         config_dir=tmp_path,
         session_id="s1",
@@ -471,7 +471,7 @@ async def test_a_disconnect_followed_by_going_cold_ends_the_turn_once(
     """
     from local_operator.harness.types import AgentEndEvent
 
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(
         config_dir=tmp_path,
         session_id="s1",
@@ -529,7 +529,7 @@ async def test_going_cold_survives_a_controllers_higher_adopted_generation(
     previous_owner_generation = 6
     successor_first_turn_generation = 1  # Session.__init__ starts a fresh count
 
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(
         config_dir=tmp_path,
         session_id="s1",
@@ -576,7 +576,7 @@ async def test_going_cold_does_not_let_a_raising_handler_break_teardown(
     ``_go_cold`` already guards the client close and the went-cold callback
     because "a viewer notice must not break teardown". The end-the-turn call
     now sits between them and takes the same guard: without it a raising
-    handler skips ``_owner_ready.set()``, and the prompt path waits forever on
+    handler skips ``_runtime_ready.set()``, and the prompt path waits forever on
     an event nothing else will set.
 
     BOTH HALVES OF THE INVARIANT, deliberately (review round 2, MAJOR-2). The
@@ -589,7 +589,7 @@ async def test_going_cold_does_not_let_a_raising_handler_break_teardown(
     write, so a stuck True is a tab title asserting ``working`` for the life
     of the process.
     """
-    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(
         config_dir=tmp_path,
         session_id="s1",
@@ -606,6 +606,6 @@ async def test_going_cold_does_not_let_a_raising_handler_break_teardown(
 
     remote._go_cold()
 
-    assert remote._owner_ready.is_set(), "teardown was stranded by a raising handler"
+    assert remote._runtime_ready.is_set(), "teardown was stranded by a raising handler"
     assert remote.is_cold
     assert remote.is_streaming is False, "the facade reports a live turn forever on a cold session"

--- a/tests/unit/session/test_saved_preview.py
+++ b/tests/unit/session/test_saved_preview.py
@@ -42,7 +42,7 @@ async def test_unmaterialized_empty_view_requires_a_discoverable_owner(tmp_path,
 
     record = SimpleNamespace(cwd="/synthetic-owner")
     monkeypatch.setattr(
-        "local_operator.mobile.attach_client.find_owner_record", lambda *args: (record, 12345)
+        "local_operator.mobile.attach_client.find_runtime_record", lambda *args: (record, 12345)
     )
 
     async def no_takeover():
@@ -65,7 +65,7 @@ async def test_absent_owner_and_journal_refuse_before_building_facade(tmp_path, 
     from local_operator.session.remote import RemoteSession
 
     monkeypatch.setattr(
-        "local_operator.mobile.attach_client.find_owner_record", lambda *args: (None, None)
+        "local_operator.mobile.attach_client.find_runtime_record", lambda *args: (None, None)
     )
 
     async def no_takeover():

--- a/tests/unit/test_fork.py
+++ b/tests/unit/test_fork.py
@@ -47,7 +47,7 @@ from local_operator.resume import (
     TITLE_SIDECAR_NAME,
     TRANSCRIPT_NAME,
     is_user_session,
-    live_session_owner,
+    live_runtime_pid,
     mark_session_origin,
     recent_sessions,
     session_origin,
@@ -133,7 +133,7 @@ class TestTheCloneItself:
         process") or attaches the new window as a FOLLOWER of its parent
         instead of opening the branched conversation.
 
-        Asserted through ``live_session_owner`` rather than by checking that
+        Asserted through ``live_runtime_pid`` rather than by checking that
         the file is absent, deliberately: ownership is the property that
         actually matters, and a future claim written by some other path would
         slip past a filename assertion while breaking the boot exactly the same
@@ -142,7 +142,7 @@ class TestTheCloneItself:
         _seed_parent(tmp_path)
         fork_id = fork_session(tmp_path, PARENT_ID)
 
-        assert live_session_owner(tmp_path, fork_id) is None
+        assert live_runtime_pid(tmp_path, fork_id) is None
         assert not (tmp_path / "sessions" / fork_id / ".session.pid").exists()
 
     def test_the_parents_own_claim_is_untouched_by_a_fork(self, tmp_path: Path) -> None:
@@ -156,7 +156,7 @@ class TestTheCloneItself:
 
         fork_session(tmp_path, PARENT_ID)
 
-        assert live_session_owner(tmp_path, PARENT_ID) == os.getpid()
+        assert live_runtime_pid(tmp_path, PARENT_ID) == os.getpid()
 
     def test_a_missing_optional_sidecar_is_not_an_error(self, tmp_path: Path) -> None:
         """A young conversation has no title and no persona; forking still works."""

--- a/tests/unit/test_stored_session_title.py
+++ b/tests/unit/test_stored_session_title.py
@@ -18,7 +18,7 @@ from local_operator.resume import (
     TITLE_SIDECAR_NAME,
     _read_title_sidecar,
     backfill_session_titles,
-    live_session_owner,
+    live_runtime_pid,
     read_title_names,
     session_name,
     stored_session_title,
@@ -51,12 +51,12 @@ def test_a_live_pid_marker_is_the_owner_of_the_session(tmp_path: Path, monkeypat
     session.mkdir(parents=True)
     (session / "transcript.jsonl").write_text("{}\n", encoding="utf-8")
     (session / ".session.pid").write_text(str(os.getpid()), encoding="utf-8")
-    assert live_session_owner(tmp_path, "live00000001") == os.getpid()
+    assert live_runtime_pid(tmp_path, "live00000001") == os.getpid()
 
     (session / ".session.pid").write_text("2147483646", encoding="utf-8")
     monkeypatch.setattr(os, "kill", lambda pid, sig: (_ for _ in ()).throw(ProcessLookupError()))
-    assert live_session_owner(tmp_path, "live00000001") is None
-    assert live_session_owner(tmp_path, "missing000001") is None
+    assert live_runtime_pid(tmp_path, "live00000001") is None
+    assert live_runtime_pid(tmp_path, "missing000001") is None
 
 
 def test_a_windows_live_marker_is_trusted_without_os_kill(tmp_path: Path, monkeypatch) -> None:
@@ -76,7 +76,7 @@ def test_a_windows_live_marker_is_trusted_without_os_kill(tmp_path: Path, monkey
 
     monkeypatch.setattr("local_operator.resume.sys.platform", "win32")
     monkeypatch.setattr(os, "kill", _kill)
-    assert live_session_owner(tmp_path, "live00000002") == 4242
+    assert live_runtime_pid(tmp_path, "live00000002") == 4242
     assert killed == []
 
 

--- a/tests/unit/test_tui_responsiveness.py
+++ b/tests/unit/test_tui_responsiveness.py
@@ -468,7 +468,7 @@ async def test_reconnect_gap_replay_does_not_stall_the_loop(tmp_path: Path) -> N
     """The reconnect path parses the transcript in a thread, like connect.
 
     Round 3 found ``_replay_durable_suffix`` re-parsing the whole file
-    synchronously inside ``_recover_owner`` — a 60 MB transcript blocked the
+    synchronously inside ``_recover_runtime`` — a 60 MB transcript blocked the
     loop ~90 ms, past the 50 ms bar #300's connect fix established. The
     recovery now takes ONE threaded parse and feeds both the gap projection
     and the history bind from it, so this drives the actual production

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -9782,7 +9782,7 @@ async def test_switch_on_a_cold_viewer_says_nothing_switched() -> None:
 
 
 class _GaveUpRecoveryLabelSession(_ColdAsyncLabelSession):
-    """The facade shape ``_recover_owner``'s give-up exit actually produces.
+    """The facade shape ``_recover_runtime``'s give-up exit actually produces.
 
     CARRIES ``_ensure_bound``, and that attribute is the entire point of this
     stub. ``_needs_runtime_first`` routes a cold, non-recovering, non-stopped
@@ -9812,7 +9812,7 @@ class _GaveUpRecoveryLabelSession(_ColdAsyncLabelSession):
 async def test_switch_after_recovery_gave_up_retries_the_bind_and_says_so() -> None:
     """A give-up facade is REPAIRED by `/model`, not merely described by it.
 
-    The state ``RemoteSession._recover_owner`` reaches at
+    The state ``RemoteSession._recover_runtime`` reaches at
     ``RECOVERY_GIVE_UP_S`` is cold with a callable ``_ensure_bound``, which is
     exactly what ``_needs_runtime_first`` diverts into ``_bind_then_dispatch``.
     So the cold ladder in ``_activate_resolved_model`` is never consulted from

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -2479,7 +2479,7 @@ async def test_a_speculatively_leased_source_is_parked_and_stays_subscribed():
         with (
             patch("local_operator.session.remote.RemoteSession.connect", side_effect=connect),
             patch(
-                "local_operator.mobile.attach_client.find_owner_record",
+                "local_operator.mobile.attach_client.find_runtime_record",
                 return_value=(SimpleNamespace(pid=1), SimpleNamespace()),
             ),
         ):

--- a/tests/unit/tui/test_sidebar_live_tool_card.py
+++ b/tests/unit/tui/test_sidebar_live_tool_card.py
@@ -192,7 +192,7 @@ async def live_owners(
                 display_window=True,
             )
 
-        monkeypatch.setattr("local_operator.mobile.attach_client.find_owner_record", find)
+        monkeypatch.setattr("local_operator.mobile.attach_client.find_runtime_record", find)
         # Exposed on the callable so a test can reach the OWNER session (to run
         # its turn) without the fixture returning a second value every caller
         # would have to unpack.

--- a/tests/unit/tui/test_sidebar_longrun.py
+++ b/tests/unit/tui/test_sidebar_longrun.py
@@ -186,7 +186,7 @@ async def live_owners(
                 display_window=True,
             )
 
-        monkeypatch.setattr("local_operator.mobile.attach_client.find_owner_record", find)
+        monkeypatch.setattr("local_operator.mobile.attach_client.find_runtime_record", find)
         monkeypatch.setattr(OperatorApp, "_check_for_update", lambda self: None)
         yield ids, resume
     finally:

--- a/tests/unit/tui/test_stop_command.py
+++ b/tests/unit/tui/test_stop_command.py
@@ -703,7 +703,7 @@ async def test_owner_local_stop_announces_to_viewers_before_teardown(
     async with app.run_test(size=(100, 30)) as pilot:
         await _booted(app, pilot, session)
         # `.start()`, not `start_in_process()`: those are the two branches of
-        # `announce_stop`, split on `_on_owner_loop()`, and the TUI hosts its
+        # `announce_stop`, split on `_on_runtime_loop()`, and the TUI hosts its
         # registrant in a THREAD. The in-process branch is a path production
         # never takes (round-4 MINOR-4).
         server = RuntimeServer(FakeHandle(), kind="tui")
@@ -1215,7 +1215,7 @@ async def test_a_strand_mid_swap_leaves_the_kill_switch_armed(
         monkeypatch.setattr(app, "_reset_ledger_for_swap", explode)
 
         monkeypatch.setattr(
-            "local_operator.mobile.attach_client.find_owner_record",
+            "local_operator.mobile.attach_client.find_runtime_record",
             lambda root, concrete: (remote_record, 90909),
         )
         monkeypatch.setattr("local_operator.session.remote.RemoteSession.connect", fake_connect)


### PR DESCRIPTION
Release: patch — rename viewer-side owner identifiers to runtime (`_owner_ready`→`_runtime_ready`, `find_owner_record`→`find_runtime_record`, `live_session_owner`→`live_runtime_pid`); no protocol members, no wire keys.

## Summary

Stage 4 session-consolidation PR 2 of 7 (plan: `~/workspace/lop-session-consolidation/stage4-owner-retirement.md`, §5). Private/internal identifier rename only — no protocol members, no wire or persistence keys, no user-visible copy. Behaviour-preserving by construction; mid-attach-safe because nothing here crosses a socket or a disk schema.

## Rename table

| From | To | Where |
|---|---|---|
| `_owner_ready` | `_runtime_ready` | `session/remote.py` attach Event + test patches |
| `_recover_owner` | `_recover_runtime` | `remote.py` reconnect machinery + tests |
| `_owner_record` | `_runtime_record` | `remote.py` bound record field |
| `_lease_owner_alive` | `_lease_runtime_alive` | `session/cleanup.py` lease-liveness probe |
| `_on_owner_loop` | `_on_runtime_loop` | `session/runtime/server.py` loop predicate |
| `find_owner_record` | `find_runtime_record` | `mobile/attach_client.py` + callers (`launch.py`, `remote.py`, `cli.py`, `session_factory.py`, `mobile/daemon.py`, `wakes/supervisor.py`, `app.py`), tests, bench/diag scripts |
| `live_session_owner` | `live_runtime_pid` | `resume.py` + callers (`cli.py`, `app.py`, `attach_client.py`, `fork.py` comment) |
| `owner_rows` / `owner_usable` / `owner_parsed` / `owner_ref` | `runtime_rows` / `runtime_usable` / `runtime_parsed` / `runtime_ref` | locals in `app.py` catalogue/skew paths |

Tests that mentioned these identifiers were updated mechanically (import names, attribute names, patch targets, stale comment references). Test intent unchanged.

## Deliberately not renamed

- **`owns_runtime`** — Stage-3 predicate, guard-pinned and conformance-pinned; zero wire surface. Kept per plan §6.
- **Protocol members** `owner_idle`, `owner_version`, `owner_source_ref`, `owner_model_catalogue` — PR 3.
- **Wire/persistence** `DisplayHistoryWindow.owner_epoch`, HMAC page-token key, `STOPPED_REASON`/`RETIRING_REASON`, reaper ledger `owner_pid`/`owner_start`, roster/jobs `owner_id`, `OWNER_COMMANDS` emitted literal — PR 4.
- **`OwnedSessionHandle` / `runtime/owned.py`** — PR 7.
- **`_owner_is_dead`** (`tools/group_reaper.py`, `exec_mode.py`) — reaper identifier whose signature params (`owner_pid`, `owner_start`) are the PR-4 wire ledger keys; half-renaming now would split one function across two PRs.
- **`_owner_watch` / `_owner_fd`** (`evaluation/adapters/supervisor.py`) — the supervisor's *parent-process* liveness fd; a different axis from viewer-side session vocabulary.
- **`mobile/tui_handle.py` `owner_loop`** — an asyncio event loop, not the runtime-owner concept.
- **`owner_pid`** in `session_lease.py` — public function parameter / ledger-write key (PR 4 territory); could not be proven lease-internal-only, so left.
- **`owner_top`** in `tui/widgets/subagent_view.py` — comment-only references to a scroll geometry diagnostic, not the app.py catalogue path; left for the prose PRs (5/6).
- User-visible copy ("owner-backed" raises, "build skew (owner)") — PR 1 territory, not this rename.

## Over-scope proof

Changed lines grep (must be empty of protocol/wire names; the only hits are `owner_source_ref`/`owner_version` reads whose *strings* are untouched — the rename changed only the local variable they feed):

```
$ git diff origin/main...HEAD -U0 | grep -E '^[+-]' | grep -E 'owner_idle|owner_version|owner_source_ref|owner_model_catalogue|owner_epoch|STOPPED_REASON|RETIRING_REASON|OWNER_COMMANDS|owns_runtime'
-        owner_ref = str(getattr(session, "owner_source_ref", "") or "")
+        runtime_ref = str(getattr(session, "owner_source_ref", "") or "")
-        owner = BuildStamp(version=owner_version, source_ref=owner_ref) if owner_version else None
+        owner = BuildStamp(version=owner_version, source_ref=runtime_ref) if owner_version else None
```

Both lines keep the `owner_source_ref`/`owner_version` **protocol names** intact on the RHS; only the private local `owner_ref` became `runtime_ref`. No protocol member, wire key, or predicate identifier was renamed.

- `git diff origin/main...HEAD -- pyproject.toml` → **empty**. No version bump.
- `tests/unit/session/test_viewer_protocol.py` → **11 passed**, including the `len(viewer_only) == 50` pin (name-invariant; nothing renamed on the protocol).

Before/after identifier counts (old names → gone from intended files, new names → present):

| Identifier | before (files) | after (files) |
|---|---|---|
| `_owner_ready` → `_runtime_ready` | 7 | 0 → 7 |
| `_recover_owner` → `_recover_runtime` | 10 | 0 → 10 |
| `_owner_record` → `_runtime_record` | 1 | 0 → 1 |
| `_lease_owner_alive` → `_lease_runtime_alive` | 2 | 0 → 2 |
| `_on_owner_loop` → `_on_runtime_loop` | 2 (server.py + stale comment) | 0 → 2 |
| `find_owner_record` → `find_runtime_record` | 36 | 0 → 36 |
| `live_session_owner` → `live_runtime_pid` | 8 | 0 → 8 |
| `owner_rows/usable/parsed/ref` → `runtime_*` | 1 (app.py) | 0 → 1 each |

## Testing

- `pyright --pythonpath .venv/bin/python` whole-tree: **0 errors, 0 warnings**.
- `flake8` (7.3.0 pinned), `black --check` (26.1.0 pinned), `isort --check-only` (5.13.2 pinned): all clean. Four files needed reformatting after the rename pushed lines past 100 cols; reformatted with pinned black.
- `tests/unit/session/` (1939 tests, `-n 4`): **all passed**, including `test_viewer_protocol.py`.
- `tests/unit/tui/test_app_pilot.py`, `test_sidebar_connect_retry.py`, `test_session_sidebar.py`, `test_sidebar_live_tool_card.py`, `test_sidebar_longrun.py`, `test_stop_command.py`, `tests/unit/mobile/test_attach_client.py`, `test_phone_startup.py`, `tests/unit/test_fork.py`, `test_stored_session_title.py`, `test_tui_responsiveness.py`: 581 passed, **1 failed — the known ninth flake** `test_a_speculatively_leased_source_is_parked_and_stays_subscribed` (`RuntimeError: Sidebar navigation requires an owner-backed session`, load-dependent, fails on main; error string is PR-1 user-visible copy, untouched here).
- e2e (`-m e2e -n0`): `test_viewer_attach_e2e.py` (14), `test_viewer_cold_semantics_e2e.py`, `test_desktop_sessions.py`, `test_desktop_spawn.py`, `test_desktop_controls.py`, `test_fork_cold_e2e.py`, `test_fork_checkpoint_e2e.py`, `test_sidebar_display_e2e.py`, `test_sidebar_reconnect_e2e.py`, `test_sidebar_runtime_reap_e2e.py`: **33 passed**.

No visual frames — no user-visible change.
