### PR TITLE
chore(release): bump version to 0.54.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.3"
+version = "0.54.4"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary of Changes

`chore(release): bump version to 0.54.4` — pyproject.toml only, one line (0.54.3 → 0.54.4). PATCH.

Window contents (`git log v0.54.3..main`, plain, never `--merges`):
- **#913** (02e2d1a0a) fix(info): skip capacity probes on a follower's SnapshotJobs facade — stops the false "Could not read / live.max_running / live.at_capacity" AttributeError rows on `/info` for follower sessions.

Bump class: PATCH — single bug fix on an existing surface, no API/wire/migration. Does not clear the step-function bar.

Window ownership: claimed after the post-v0.54.3 window was confirmed UNOWNED by peers (pid 88791, pid 24724 both yielded). This open `chore(release)` PR is the lock.

## Impact

- Version metadata only; no runtime code change in this PR.

## Testing Details

- C0 one-file scope-check round (see review comment). The carried fix #913 passed its own full gate (reviewer CLEAN, QA PASS, module suite 52/52) before merge.

## Checklist

- [x] One-line version bump only.
- [x] No version bump carried on any feature branch.
- [x] Plain `git log` window derivation.
