### PR TITLE
fix(tui): never render an exception as an empty error

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -138,6 +138,7 @@ from local_operator.tui import theme as theme_mod
 from local_operator.tui.autocomplete import ArgumentChoice
 from local_operator.tui.copy_targets import CopyTarget, build_copy_targets
 from local_operator.tui.costs import job_cost, turn_cost
+from local_operator.tui.error_text import error_text
 from local_operator.tui.events import (
     AssistantDelta,
     AssistantMessageEnd,
@@ -28848,12 +28849,12 @@ class OperatorApp(App[None]):
                 if not accepts():
                     return
                 if self._is_current(source) and panel.accepts(generation):
-                    panel.fail_answer(generation, str(error))
+                    panel.fail_answer(generation, error_text(error))
                     if not self._editor().text.strip():
                         self._editor().load_text(question)
                     self._sync_aside_fork_hint()
                 else:
-                    target.fail(str(error))
+                    target.fail(error_text(error))
                     if not source.draft.text.strip():
                         source.draft.text = question
                 return

--- a/local_operator/tui/error_text.py
+++ b/local_operator/tui/error_text.py
@@ -1,0 +1,22 @@
+"""Turn an exception into text a human can act on, never into nothing.
+
+An exception whose ``str()`` is empty is not rare: ``TimeoutError()`` raised by
+``asyncio.wait_for`` is the case that reached users, rendering as the dangling
+``owner connection lost:``. Any bare ``raise SomeError`` does the same. Every
+place that paints ``str(error)`` into the UI goes through here, so the failure
+mode is fixed once rather than at each call site.
+
+See docs/design-aside-deadline.md §6, slice 2.
+"""
+
+from __future__ import annotations
+
+
+def error_text(error: BaseException) -> str:
+    """``str(error)``, or the exception's class name when that is blank.
+
+    The class name is chosen over a generic "something went wrong" because it
+    is the only fact available that still distinguishes one failure from
+    another — ``TimeoutError`` and ``PermissionError`` must not read alike.
+    """
+    return str(error).strip() or type(error).__name__

--- a/local_operator/tui/widgets/settings_view.py
+++ b/local_operator/tui/widgets/settings_view.py
@@ -58,6 +58,7 @@ from local_operator import settings_io
 from local_operator.settings_io import Kind, Section, Setting
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.autocomplete import score_command_text_match
+from local_operator.tui.error_text import error_text
 from local_operator.tui.widgets.command_picker import ghost_for
 from local_operator.tui.widgets.model_picker import ModelRow, rank_rows
 from local_operator.tui.widgets.subagent_view import HintButton
@@ -1963,7 +1964,7 @@ class SettingsView(Vertical):
             self._repaint()
             return False
         except ValueError as error:
-            self._error = str(error)
+            self._error = error_text(error)
             self._repaint()
             return False
         except TypeError as error:
@@ -2527,7 +2528,7 @@ class SettingsView(Vertical):
         try:
             value = settings_io.coerce(setting, text)
         except ValueError as error:
-            self._error = str(error)
+            self._error = error_text(error)
             self._repaint()
             return
         problem = settings_io.validate(setting, value, self._config_values())

--- a/tests/unit/tui/test_aside.py
+++ b/tests/unit/tui/test_aside.py
@@ -62,6 +62,10 @@ class AsideSession(FakeSession):
         self.forked: list[Message] = []
         self.streaming = False
         self.fail: str | None = None
+        #: An exception INSTANCE to raise from `complete_aside`, for failures
+        #: whose `str()` is empty. `fail` above carries a message; this carries
+        #: the exception itself.
+        self.fail_with: BaseException | None = None
         self._history = [Message.user("port the loop"), Message.assistant("done.")]
 
     @property
@@ -70,6 +74,8 @@ class AsideSession(FakeSession):
 
     async def complete_aside(self, turns, *, on_delta=None, on_usage=None) -> str:  # noqa: ANN001
         self.aside_calls.append(list(turns))
+        if self.fail_with is not None:
+            raise self.fail_with
         if self.fail is not None:
             raise RuntimeError(self.fail)
         if on_delta is not None:
@@ -687,6 +693,34 @@ def test_a_failed_aside_is_never_forkable() -> None:
 
     assert panel.fork_messages() == []
     assert "provider exploded" in "\n".join(panel.render_lines_for_test())
+
+
+@pytest.mark.asyncio
+async def test_an_error_with_no_message_still_names_itself_on_the_card() -> None:
+    """A failure the user cannot read is a failure the user cannot act on.
+
+    ``asyncio.wait_for`` raises a bare ``TimeoutError()``, whose ``str()`` is
+    ``''``. Painted straight into the card that rendered as a warning glyph
+    followed by nothing — and, upstream, as the dangling ``owner connection
+    lost:`` this fix is named for. Driven through the real worker and asserted
+    on the RENDERED rows rather than on the helper, because the helper being
+    correct proves nothing about whether the card calls it.
+    """
+    assert str(TimeoutError()) == "", "the premise: this exception has no message"
+
+    session = AsideSession()
+    session.fail_with = TimeoutError()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _settle_boot(pilot, app, session)
+        panel = await _open_with_question(pilot, app, "are the subagents stuck?")
+
+        lines = panel.render_lines_for_test()
+        rendered = "\n".join(lines)
+        assert "TimeoutError" in rendered
+        assert not any(line.rstrip().endswith(":") for line in lines)
+        assert panel._turns[-1].state == "error"
+        assert panel.fork_messages() == []
 
 
 def test_a_long_exchange_pins_the_owning_question_and_counts_questions() -> None:

--- a/tests/unit/tui/test_error_text.py
+++ b/tests/unit/tui/test_error_text.py
@@ -1,0 +1,22 @@
+"""The blank-message fallback, in isolation.
+
+The companion to ``test_aside.py::test_an_error_with_no_message_still_names_``
+``itself_on_the_card``, not a substitute for it: that test proves the card
+calls this, and this one proves the three inputs it has to survive.
+"""
+
+from __future__ import annotations
+
+from local_operator.tui.error_text import error_text
+
+
+def test_error_text_falls_back_to_the_class_name() -> None:
+    """A message when there is one; the class name when there is not.
+
+    The whitespace case is separate from the empty case because
+    ``str(exc).strip()`` is what makes ``ValueError("   ")`` — which renders as
+    a warning glyph followed by blank cells — take the fallback too.
+    """
+    assert error_text(ValueError("the port is already in use")) == "the port is already in use"
+    assert error_text(TimeoutError()) == "TimeoutError"
+    assert error_text(ValueError("   ")) == "ValueError"

--- a/tests/unit/tui/test_settings_view.py
+++ b/tests/unit/tui/test_settings_view.py
@@ -5099,3 +5099,38 @@ async def test_the_session_name_row_is_inert_while_notifications_are_off() -> No
         _select(view, "display.notification_session_name")
         await pilot.pause()
         assert "inert:" not in view.render_lines_for_test()[-1]
+
+
+@pytest.mark.asyncio
+async def test_a_coercion_error_with_no_message_still_shows_something(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The page's error slot must never be a warning glyph with nothing beside it.
+
+    ``settings_io.coerce`` composes its own messages today, so the reachable
+    blank is a future bare ``raise ValueError`` — the same class of bug as the
+    ``TimeoutError()`` that reached users through the aside card, and the
+    reason the fallback lives at the render site rather than in ``coerce``.
+    Driven through the real ``_commit_edit`` so this asserts about the arm the
+    page runs, and ``coerce`` is replaced only after the editor has been
+    seeded by the real one.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 32)) as pilot:
+        await pilot.pause()
+        view = await _open_page(pilot, app)
+        _select(view, "retry.maxRetries")
+        view.action_activate()
+        await pilot.pause()
+        assert view.editing_key == "retry.maxRetries", "premise: the text editor opened"
+        view._buffer = "6"
+
+        def _blank(setting: Any, text: str) -> Any:
+            raise ValueError()
+
+        monkeypatch.setattr(settings_io, "coerce", _blank)
+        view._commit_edit()
+        await pilot.pause()
+
+        assert view._error, "a coercion failure left the error slot empty"
+        assert view._error == "ValueError"


### PR DESCRIPTION
## Summary of Changes

An exception whose `str()` is blank rendered as **nothing** in the TUI: a dangling colon on the `/btw` aside card, and an empty error slot on the settings page. `TimeoutError()` raised by `asyncio.wait_for` is the case that reached a user (`! owner connection lost:`), but any bare `raise SomeError` does the same.

Adds `local_operator/tui/error_text.py`:

```python
def error_text(error: BaseException) -> str:
    return str(error).strip() or type(error).__name__
```

The class name rather than a generic "something went wrong", because it is the only fact still available that distinguishes one failure from another — `TimeoutError` and `PermissionError` must not read alike.

Used at the four sites that paint an exception into the UI: both aside failure paths in `tui/app.py` (`panel.fail_answer` and `target.fail`) and both `except ValueError` coercion arms in `tui/widgets/settings_view.py`. The neighbouring `ConfigUnreadableError` and `TypeError` arms are left alone — they build their own non-empty f-strings and were never at risk.

A new leaf module rather than a helper in either file: `app.py` already imports from `widgets/settings_view.py`, so placing it in either would make one import the other. `settings_view.py` imports nothing from `tui` beyond `theme`, `autocomplete` and sibling widgets, so a leaf keeps both directions clean.

## Related Issue(s)

- Same user report as the aside deadline fix (`dev-aside-ack-timeout`): `/btw` painted `! owner connection lost:` with no reason.

## Impact

- No breaking changes, no dependency updates, no behaviour change on any path where the exception already had a message — `str(error).strip()` is `str(error)` for every non-blank message today.
- **Independent of the transport fix.** That PR removes the one exception known to arrive blank; this makes the rendering safe for every exception that ever will. Either can merge without the other.

## Scope, stated plainly

There are ~27 further `str(error)`/`str(exc)` sites in `local_operator/tui/`, three of which already carry ad-hoc `or "..."` guards — evidence this hazard was hit before and patched per-site. **This PR deliberately stops at the four the design names.** A blind sweep would be a regression, not a cleanup: some of those sites have domain-specific fallback text (`str(error) or "Connection unavailable"`) that a generic class name would be worse than, and some (`text = str(error).lower()`) are not render sites at all. Converting the rest is a separate, deliberate pass against each site's actual UX. Filed as a follow-up.

## Testing Details

Three tests added, one touched:

- `test_aside.py::test_an_error_with_no_message_still_names_itself_on_the_card` — drives the real `OperatorApp`: types `/btw <question>` via `pilot.press`, fails `complete_aside` with an exception whose `str()` is `''`, and asserts on `panel.render_lines_for_test()`. **Rendered output, not the helper in isolation.**
- `test_error_text.py::test_error_text_falls_back_to_the_class_name`
- `test_settings_view.py::test_a_coercion_error_with_no_message_still_shows_something`
- `test_aside.py::test_a_failed_aside_is_never_forkable` — updated for the new `FakeSession.fail_with` seam (a sibling attribute, so the existing `.fail`-based tests are untouched and still pass; `.fail` carries a string and cannot express `str() == ''`).

**Hand-verified failing without the fix.** With the production files reverted to `origin/main` and the tests kept:

- `AssertionError: assert 'TimeoutError' in '...! the aside failed...'` — the card fell back to the generic text.
- `AssertionError: a coercion failure left the error slot empty` / `assert ''`

**Real path exercised**, beyond the suite — driving the actual `OperatorApp`: the card renders `'  ! TimeoutError'`, turn state `error`, `fork_messages() == []`. Settings page: `view._error == 'ValueError'`, painted on the page.

**Gates:**

```
pytest tests/unit/tui -q    1 failed, 6729 passed, 12 skipped in 1243s
flake8 .                     exit 0
black --check .              1211 files would be left unchanged
isort --check .              exit 0
pyright                      0 errors, 0 warnings, 0 informations
```

The one failure is **pre-existing on `origin/main` and unrelated**: `test_session_sidebar.py::test_a_speculatively_leased_source_is_parked_and_stays_subscribed`, `RuntimeError: Sidebar navigation requires an owner-backed session`. Verified twice — once by stashing this branch's changes, and independently by a reviewer in a disposable worktree at the base commit — with a byte-identical error and traceback location. Nothing in this diff touches sidebar or session-lease code.

Reviewed independently: no BLOCKER, no MAJOR. Three MINORs recorded as follow-ups rather than fixed here — a multi-line exception message would render with embedded newlines into a single-line slot (no such exception exists in this codebase today), a custom `__str__` that itself raises would propagate through the helper, and a local variable named `error_text` inside `run_prompt` shadows the import within that one function (no bug today, since it is only ever assigned `str(error)` and never calls the helper in that scope).

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass. (one pre-existing unrelated failure, verified on the base commit)
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required. (module docstring; the design doc ships with the sibling PR)
- [x] Security considerations are addressed.
- [x] I have linked all related issues.
