### PR TITLE
chore(release): bump version to 0.54.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.4"
+version = "0.54.5"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

Release window post-v0.54.4. Owner session pid: 68817.

Bump: PATCH → **0.54.5**. One-file C0 change (`pyproject.toml` version line only).

Window (re-derived immediately before tagging):
- [x] #915 (`95bdc3c58`) — Release: patch — /usage no longer calls freshly-confirmed quota stale after `r`; latched accounts re-probe on a ~10 min jittered cadence so recovery is discoverable.
- [x] #896 (`15c2f7762`) — Release: patch — an inbound prompt carrying a pasted image over 1 MiB no longer kills the runtime's reader loop.
- [x] #921 (`0c96f699e`) — Release: patch — state `owns_runtime=False` on the speculative-lease test mock (CI shard-4 flake; test-only).

Rebased onto origin/main after #921 merged. Diff vs origin/main remains exactly `version = "0.54.4"` → `"0.54.5"` (`git range-diff` `=` vs reviewed `601864ef0` and `a8a5b891f`).

Release: patch — ship #915, #896, and #921.