### PR TITLE
fix(tui): state owns_runtime=False on the speculative-lease test's mock

### DIFF
--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -2458,6 +2458,11 @@ async def test_a_speculatively_leased_source_is_parked_and_stays_subscribed():
     from local_operator.session.remote import RemoteSession
 
     remote = MagicMock(spec=RemoteSession)
+    # ``owns_runtime`` is a property: ``spec=`` constrains which names exist but
+    # does not run them, so a spec'd mock auto-fabricates a TRUTHY ``Mock`` —
+    # the exact opposite of the viewer this stands in for. Same pattern as
+    # the two sibling tests above (line 596/700).
+    remote.owns_runtime = False
     remote.session_id = "spec"
     remote.is_cold = False
     remote.frontend_state = SimpleNamespace(pending_gate=None)


### PR DESCRIPTION
## Problem

`test_a_speculatively_leased_source_is_parked_and_stays_subscribed` fails on main with:

```
RuntimeError: Sidebar navigation requires an owner-backed session
```

This has been failing on every PR's test (3.12/3.13, shard 4) job since #898 merged.

## Root cause

#898 retired `isinstance(session, RemoteSession)` for the declared `_is_viewer()` predicate, which reads `session.owns_runtime`. The test's `MagicMock(spec=RemoteSession)` auto-fabricates a **truthy** `owns_runtime` (properties are not run by `spec=`, only constrained by name), so `_is_viewer()` correctly rejects it as not-a-viewer.

The two sibling tests at lines 596 and 700 already state `remote.owns_runtime = False` explicitly with a comment explaining why — this test was missed.

## Fix

One line: `remote.owns_runtime = False` with the same explanatory comment as the siblings.

## Evidence

- Reproduced on clean main: `FAILED` with the exact CI error
- After fix: test passes (1 passed)
- Full sidebar file: 62 passed
- Full conversation-naming file (the other failure in one shard-4 job): 43 passed