### PR TITLE
docs(session): adopt the runtime glossary in session/harness comments

### DIFF
--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -1429,7 +1429,7 @@ class SubagentComms:
         # the envelope leaked beside the fact. ``steer_message`` is the
         # identity-preserving seam: it queues the caller-built Message
         # verbatim. On a follower-owned child the id rides the wire as the
-        # ContinuationCommand id, which the owner's handle hands back to
+        # ContinuationCommand id, which the runtime's handle hands back to
         # ``Session.steer`` as ``message_id``, so the correlation survives
         # that path too.
         record.child.steer_message(Message.user(str(message.details["text"]), id=message.id))

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -1,6 +1,6 @@
 """Async background job manager.
 
-Async job manager (jobs + the owner-scoped delivery sink; the adaptive poll
+Async job manager (jobs + the registrant-scoped delivery sink; the adaptive poll
 ladder and delivery-retry backoff live host-side in this rewrite).
 
 Semantics worth preserving exactly:
@@ -8,13 +8,13 @@ Semantics worth preserving exactly:
 - **Queued jobs hold no execution slot.** ``at_capacity`` and ``register``
   both count only ``status == running and not queued`` jobs, so a large
   parked batch cannot starve registration.
-- **Owned completions route exclusively through the owner's registered
-  sink.** If the owner has no live sink the delivery is DEAD-LETTERED
+- **Owned completions route exclusively through the registrant's registered
+  sink.** If the registrant has no live sink the delivery is DEAD-LETTERED
   (dropped with a warning; the row keeps ``result_text`` until retention
   eviction) — it is never routed to the generic fallback, because that would
   leak one agent's result into another agent's session. Only genuinely
   unowned jobs use the fallback.
-- ``cancel(job_id, owner_id)`` treats an owner mismatch as not-found, so a
+- ``cancel(job_id, owner_id)`` treats a registrant mismatch as not-found, so a
   subagent teardown cannot cancel its parent's jobs.
 """
 
@@ -144,7 +144,7 @@ def roster_expired(
       three places (pause sets it, cancel and resume clear it). Copying that
       onto the job row would create a second, independently-mutable source of
       truth for one fact — the drift this PR exists to remove — so the reader
-      consults the owner instead. The caller already holds the comms node, so
+      consults the owning record instead. The caller already holds the comms node, so
       this costs nothing to supply.
 
     The asymmetry with the ledger is deliberate and cheap: the manager may
@@ -447,11 +447,11 @@ class AsyncJob(BaseModel):
 
 
 class AsyncJobManager:
-    """Registers and tracks background jobs with owner-scoped delivery.
+    """Registers and tracks background jobs with registrant-scoped delivery.
 
-    A completion delivers exactly once: through the owner's sink when one is
+    A completion delivers exactly once: through the registrant's sink when one is
     registered, otherwise through the ``on_job_complete`` fallback for jobs
-    without an owner. Owned jobs with no live sink are dead-lettered.
+    without a registrant. Owned jobs with no live sink are dead-lettered.
     """
 
     def __init__(
@@ -473,7 +473,7 @@ class AsyncJobManager:
         # roster to disk without the manager knowing what a transcript is. Kept
         # as a bare callback rather than a persist coroutine because the manager
         # runs it on the hot path of every registration and settle: it signals
-        # "something changed", and the owner decides how (and how cheaply) to
+        # "something changed", and the session decides how (and how cheaply) to
         # persist. A raising callback must never break job bookkeeping, so the
         # single call site guards it.
         self._on_roster_change = on_roster_change
@@ -888,7 +888,7 @@ class AsyncJobManager:
         clobber a running child.
 
         Deliberately does NOT fire ``on_roster_change``: rehydrating the table
-        is not a roster *change* the owner needs to persist — the snapshot being
+        is not a roster *change* the session needs to persist — the snapshot being
         read is already on disk — and notifying here would re-append a
         byte-identical snapshot on every resume (and, if a host ever constructs
         a Session off-loop, raise a spurious warning from the persist spawn).
@@ -1002,7 +1002,7 @@ class AsyncJobManager:
             # Parked behind a caller-managed gate; holds no execution slot and
             # keeps its runner for start_queued().
             self._queued_runners[job_id] = run
-        # A new row is a roster change the owner may want to persist (task rows
+        # A new row is a roster change the session may want to persist (task rows
         # only carry a resumable transcript, but the listener filters that).
         if type == "task":
             self._invalidate_accounting()
@@ -1057,7 +1057,7 @@ class AsyncJobManager:
     # -- cancellation -------------------------------------------------------
 
     async def cancel(self, job_id: str, *, owner_id: str | None = None) -> bool:
-        """Cancel a job. An owner mismatch is treated as not-found so a
+        """Cancel a job. A registrant mismatch is treated as not-found so a
         subagent teardown cannot cancel its parent's jobs."""
         job = self.get(job_id)
         if job is None:
@@ -1125,8 +1125,8 @@ class AsyncJobManager:
                 logger.warning("job %s task raised on cancel", job_id, exc_info=True)
         # Teardown for a runner that was never entered. Awaiting the cancelled
         # task above does NOT run the coroutine body, so a resource the caller
-        # spawned before registering (a process group, a kernel) still has no
-        # owner at this point; without this it survives the job row that was
+        # spawned before registering (a process group, a kernel) is still
+        # unowned at this point; without this it survives the job row that was
         # meant to own it. Popped first so it can only ever fire once, and
         # AFTER the task await so a runner that did start has already claimed
         # ownership and removed it — the two paths cannot both kill.
@@ -1245,7 +1245,7 @@ class AsyncJobManager:
         # The runner is now entered, so its own teardown (its ``finally``, its
         # CancelledError handler) is authoritative for the resources it owns.
         # Dropping the pre-start cleanup here is what keeps a cancel from
-        # killing the same process twice through two different owners.
+        # killing the same process twice through two different claimants.
         self._pending_cleanups.pop(job.id, None)
         try:
             result = await coro

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -1257,7 +1257,7 @@ class AgentLoop:
 
         The model is resolved HERE, per call, not once per run — see
         :meth:`_current_model`. ``context_tokens_hint`` is stamped onto the
-        request by THIS loop, the owner of the conversation the call belongs
+        request by THIS loop, which owns the conversation the call belongs
         to — never remembered on the shared stream fn, where a subagent's
         registration would overwrite the parent's (review F8).
         """
@@ -1968,7 +1968,7 @@ class AgentLoop:
                 return self._synthetic_result(
                     call,
                     # FIRST LINE is the card's failure label (the TUI takes
-                    # `_first_line(result_text)`), which is the row the owner
+                    # `_first_line(result_text)`), which is the row read as
                     # read as `User denied approv…`. It therefore carries the
                     # whole diagnosis on its own and the detail follows below,
                     # where the expansion and the model both get it.

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -313,7 +313,7 @@ class Message(BaseModel):
         could recover it.
 
         That is not hypothetical. ``harness/loop.py::_append_results`` stamped
-        the payload onto the message AFTER calling this, so the owner's rows
+        the payload onto the message AFTER calling this, so the runtime's rows
         carried it and everyone else's did not — and
         ``RemoteSession._remember_live`` builds the live row for a relayed
         ``tool_execution_end`` through exactly this constructor. The interval
@@ -935,7 +935,7 @@ class ToolContext(BaseModel):
     # todo state it can persist alongside the transcript; otherwise the tool
     # falls back to a process-local table.
     todos: dict[str, list[dict[str, str]]] | None = None
-    # Optional owner hook for canonical full-TUI state. Tools call it only after
+    # Optional host hook for canonical full-TUI state. Tools call it only after
     # a successful mutation, never on read-only view or validation failures.
     on_todos_changed: Callable[[], None] | None = None
     # Injected by the HOST (see BrowserSurface), not created by the tool: this
@@ -1276,7 +1276,7 @@ class HistoryDeltaEvent(AgentEvent[Literal["history_delta"]]):
     """Settled transcript rows that became durable while no frontend painted them.
 
     Emitted by a reconnecting follower for the durable gap between what it
-    painted before losing the owner and the fresh sync's cursor. It is a
+    painted before losing the runtime and the fresh sync's cursor. It is a
     HISTORY contract, not a live one: every row is already settled, so the
     consumer must project each row through the same role-aware settled-history
     renderer a cold resume uses — user rows as user rows, assistant prose and
@@ -1449,7 +1449,7 @@ class PeerMessageDeliveredEvent(AgentEvent[Literal["peer_message_delivered"]]):
     """A message from ANOTHER local lop session (`lop send`) was delivered here.
 
     Fires the instant the message lands in this session's transcript/context,
-    even while the session is idle, so the owner TUI can paint the
+    even while the session is idle, so the attached TUI can paint the
     cross-session indicator immediately rather than waiting for the next turn
     render. Carries ``body`` (the raw text the human reads) and ``sender`` (the
     advisory pid/conversation/model identity for the indicator label).
@@ -1668,7 +1668,7 @@ class LoopConfig(BaseModel):
     # host (``Session._model``) and this config is a per-run value object: the
     # host would otherwise have to hold a reference to the config of whatever
     # run happens to be live and write through it. The loop asks instead, so
-    # the session stays the single owner of which model is current.
+    # the session stays the single authority on which model is current.
     #
     # The boundary is deliberately BETWEEN calls, never inside one. An
     # in-flight request keeps the spec it was issued with, so a switch cannot
@@ -1987,7 +1987,7 @@ class ChatRequest(BaseModel):
     #: the actual request until a counted boundary is available. ``0`` denotes
     #: an unrelated fresh one-shot prompt, whose own estimate should decide.
     context_tokens_hint: int | None = None
-    # Admission trusts a hint only after the conversation owner reconciles it
+    # Admission trusts a hint only after the loop that owns the conversation reconciles it
     # against this request and names the provider/model it measured. A fallback
     # to another model must use its own tokenizer estimate instead.
     context_tokens_hint_model: str | None = None

--- a/local_operator/session/attention.py
+++ b/local_operator/session/attention.py
@@ -428,13 +428,13 @@ class AttentionStore:
         *,
         baseline_seen: bool | None = None,
     ) -> dict[str, Any]:
-        """Import a durable outcome idempotently, including after owner restart.
+        """Import a durable outcome idempotently, including after runtime restart.
 
         A TOKEN MAY LEGITIMATELY ADVANCE OUT OF ITS PROVISIONAL RECORD, and
         refusing that used to brick a session permanently. One turn writes
         ``attention_started`` with token T and, on completion, writes the SAME T
         with the real anchor and kind. Anything that bootstraps while that turn
-        is in flight — a mobile daemon sweep, a resume attempt, a killed owner —
+        is in flight — a mobile daemon sweep, a resume attempt, a killed runtime —
         publishes the provisional ``(completion-T, interrupted)`` marker first.
         When the turn then finishes and the conversation is next opened, the
         journal's authoritative ``(<entry id>, complete)`` arrives for the same
@@ -545,7 +545,7 @@ class AttentionStore:
             if self._uninitialized(conn):
                 return (0, 0, 0)
             # This connection is READ-ONLY, so it cannot run the additive
-            # migration itself: a database written before this fix, whose owner
+            # migration itself: a database written before this fix, whose runtime
             # has not reconnected yet, legitimately has no `mutations` table and
             # must read as 0 rather than raising. A poller that raised here
             # would lose cross-process read sync for the life of the loop.
@@ -609,14 +609,14 @@ class AttentionStore:
         THE ACCEPTED RISK, stated plainly so the next reader does not have to
         rediscover it: a claimant killed between the claim and the spawn leaves
         that completion delivered-but-unannounced FOREVER. There is no lease,
-        no owner pid and no expiry \u2014 a re-claim returns False for good, and
+        no holder pid and no expiry \u2014 a re-claim returns False for good, and
         nothing sweeps it. That is bounded in CONSEQUENCE (one transient toast,
         for one completion, on a process that crashed) and unbounded in TIME,
         and it is accepted here because the alternative trade is worse: a lease
         needs a clock, and a clock in this predicate is what lets two observers
         with disagreeing time both deliver. The durable signal survives
         regardless, which is what makes the transient one safe to lose. A lease
-        carrying an owner pid is the natural fix if this ever stops being
+        carrying a holder pid is the natural fix if this ever stops being
         acceptable; the schema has no room for one today (review round 1 m1,
         QA round 1 Q3 \u2014 both judged the trade correct).
 

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -350,7 +350,7 @@ LIVE_EVENT_END_ROWS_MAX = 100
 #: has hundreds of kilobytes spare and is never touched. Only the pathological
 #: combination clips, which is the case the socket cannot carry anyway.
 #:
-#: Clipping keeps the FIRST rows in the owner's existing sort order (best/most
+#: Clipping keeps the FIRST rows in the runtime's existing sort order (best/most
 #: relevant first, the order the picker already renders) rather than dropping
 #: from the middle, and sets ``model_catalogue_truncated`` so the reader can
 #: say the list is partial instead of presenting it as the whole set.
@@ -664,7 +664,7 @@ def _inherited_identity_fixups(state: Any, session_id: str) -> dict[str, Any]:
 
 
 # Commands whose effect belongs to the process drawing the widgets. Every other
-# advertised slash is routed to the authoritative session owner; keeping this a
+# advertised slash is routed to the authoritative runtime; keeping this a
 # complement means adding a command without classification fails the test rather
 # than silently acquiring follower-local behavior.
 _FRONTEND_LOCAL_SLASHES = {
@@ -672,13 +672,13 @@ _FRONTEND_LOCAL_SLASHES = {
     "exit",
     "clear",
     # The terminal schedules source-bound iterations and owns sidebar focus;
-    # each iteration still submits through that conversation's real owner.
+    # each iteration still submits through that conversation's runtime.
     "loop",
     "sidebar",
     # The clipboard is the machine the USER IS SITTING AT, and every part of
     # this command is already here: the transcript it reads is painted by this
     # frontend, the picker it opens is painted by this frontend, and the OSC 52
-    # write goes out this terminal. Routed to the owner it would draw a chooser
+    # write goes out this terminal. Routed to the runtime it would draw a chooser
     # on a screen nobody is looking at and copy onto a host nobody is at, which
     # is the same argument `/theme` and `/settings` make about config.yml.
     "copy",
@@ -689,19 +689,19 @@ _FRONTEND_LOCAL_SLASHES = {
     # The picker draws on THIS terminal, its suggestions are read from THIS
     # machine's session records and wake index, and the directory a user means
     # is one on the machine they are sitting at — the same argument `/settings`
-    # and `/theme` make about config.yml. Routed to the owner it would offer a
+    # and `/theme` make about config.yml. Routed to the runtime it would offer a
     # remote host's directories to someone who cannot see them, and move a
     # session into a path that may not exist here at all.
     "move",
     # A fork opens a window on THIS machine and reads THIS machine's config.yml
     # for where to put it — the same argument `/settings` and `/theme` make. On a
-    # follower attached to a remote owner, forking must open a window here, not
-    # on the owner's host where nobody is sitting.
+    # follower attached to a remote runtime, forking must open a window here, not
+    # on the runtime's host where nobody is sitting.
     "fork",
     "theme",
     # The settings page reads and writes THIS machine's config.yml, exactly
-    # like `/theme` and `/search` above it. Routed to the owner it would open
-    # against the owner's config and persist a default governing a machine the
+    # like `/theme` and `/search` above it. Routed to the runtime it would open
+    # against the runtime's config and persist a default governing a machine the
     # user is not sitting at — the same rule `/model default` states explicitly
     # when it refuses to run on a follower.
     "settings",
@@ -710,17 +710,17 @@ _FRONTEND_LOCAL_SLASHES = {
     "accounts",
     # Reads config.yml and the local credential COUNTS, and compares the
     # frontend's own effective model — all of it available on a follower, so
-    # routing it to the owner would only add a hop.
+    # routing it to the runtime would only add a hop.
     "failovers",
     "usage",
     "analytics",
     # Like analytics, reads the shared local ledger for the mirrored current
-    # session ID. No owner RPC or new transport payload is needed.
+    # session ID. No runtime RPC or new transport payload is needed.
     "session",
     # Everything /info reports is a fact about the process DRAWING the screen:
     # its install prefix and resolved import path, its pid and control port, the
     # session registry on this host, this frontend's terminal and theme. Routed
-    # to the owner it would describe the owner's machine while the header names
+    # to the runtime it would describe the runtime's machine while the header names
     # this one — the wrong-machine answer on the one screen whose entire job is
     # "which code am I actually running". Same argument as `/theme`, `/settings`
     # and the `desktop_destination` this command deliberately omits.
@@ -729,37 +729,37 @@ _FRONTEND_LOCAL_SLASHES = {
     "login",
     "logout",
     # Remote access is enrolled using this frontend computer's OAuth store and
-    # service manager; routing to the session owner would expose another host.
+    # service manager; routing to the runtime would expose another host.
     "mobile",
     # FRONTEND-LOCAL because the command hosts a MASKED PASTE, and the user is
     # sitting at this terminal — routing the whole command would raise the
-    # paste prompt on the owner's screen, which nobody is looking at. This is
+    # paste prompt on the runtime host's screen, which nobody is looking at. This is
     # the same split bare ``/model`` makes: the interaction is hosted here, the
-    # effect lands on the owner.
+    # effect lands on the runtime.
     #
     # The STORE is emphatically NOT local. ``VariableStore._credentials`` is an
     # in-memory per-process dict, and the reader is ``credential_env()`` inside
-    # the `bash` tool, which runs in the OWNER's process. A viewer that stored
+    # the `bash` tool, which runs in the runtime's process. A viewer that stored
     # locally would hold a secret no tool could ever read while telling the
     # model the key exists — a silent failure whose workaround is pasting the
     # secret into the chat, which is the exact leak this feature prevents. So
     # ``_cmd_credential`` keeps the prompt here and routes every store/forget
-    # over the dedicated ``credential`` op to the owner's store.
+    # over the dedicated ``credential`` op to the runtime's store.
     "credential",
     # The overlay is local UI; its provider request crosses the authoritative
     # complete_aside operation on RemoteSession.
     "btw",
     # The kill switch is the one session command that must act from THIS
     # process even on a follower: bare /stop ends the session the viewer is
-    # looking at (the owner's runtime via the direct stop op, not a routed
+    # looking at (the attached runtime via the direct stop op, not a routed
     # slash), `/stop <target>` and `/stop all` enumerate THIS machine's
-    # registry — a different machine's registry than the owner's is exactly
-    # the point of stopping from here. Routing it to the owner would stop the
-    # OWNER's neighbours, not the viewer's.
+    # registry — a different machine's registry than the runtime's is exactly
+    # the point of stopping from here. Routing it to the runtime would stop the
+    # RUNTIME's neighbours, not the viewer's.
     "stop",
 }
 # Bare ``/mcp`` renders the canonical server list locally, but its grant
-# subcommands mutate OAuth state that lives on the authoritative owner — the
+# subcommands mutate OAuth state that lives on the authoritative runtime — the
 # follower's MCP facade is a read-only snapshot with no config accessor, so
 # routing the mutation (not faking it locally) is the only non-crashing,
 # non-divergent answer. The dispatch splits the two shapes by argument.
@@ -804,9 +804,9 @@ class SlashCapability(BaseModel):
 
 
 class SlashResult(BaseModel):
-    """The typed outcome of one slash command run on the authoritative owner.
+    """The typed outcome of one slash command run on the authoritative runtime.
 
-    The v5 replacement for the synthetic ``ran /…`` receipt: the owner runs a
+    The v5 replacement for the synthetic ``ran /…`` receipt: the runtime runs a
     shared slash command and returns WHAT happened as data, so the terminal
     that asked renders it locally instead of the answer painting in another
     process's transcript. Every product-facing string is produced by the
@@ -1083,7 +1083,7 @@ def _bound_launch_prompts_across_jobs(jobs: list[Any]) -> None:
         if not isinstance(prompts, dict) or not prompts:
             continue
         # Re-bounded HERE as well as in ``_with_lineage``. A ``JobState`` can be
-        # built directly — a restored reader row, a test, an owner that never
+        # built directly — a restored reader row, a test, a runtime that never
         # went through the comms path — so the wire boundary cannot assume the
         # construction-time bound ran. Cheap: the common row has no entries.
         prompts = _wire_launch_prompts(prompts)
@@ -1240,7 +1240,7 @@ def _drop_absent_launch_fields_in_place(job: dict[str, Any]) -> None:
     Omission is exactly equivalent to sending the empty values: ``JobState``
     defaults both, a delta rebuilds each row by revalidating the raw dict rather
     than merging it onto the prior row (``apply_update``), and a follower
-    reading neither key takes the same degrade path as one attached to an owner
+    reading neither key takes the same degrade path as one attached to a runtime
     that predates the fields. So this is a pure byte saving, not a semantic one.
 
     Applied at BOTH wire boundaries — the delta assembly in ``mutate`` and the
@@ -1280,7 +1280,7 @@ class JobState(BaseModel):
     """Read-only job shape used by the existing job widgets.
 
     ``extra='allow'`` is intentional: retained trajectory fields can grow without
-    forcing an older follower to reject a newer owner. Unknowns stay attached to
+    forcing an older follower to reject a newer runtime. Unknowns stay attached to
     the DTO and survive a round trip rather than being discarded.
     """
 
@@ -1299,7 +1299,7 @@ class JobState(BaseModel):
     model_label: str | None = None
     context_window: int | None = None
     usage: Usage | None = None
-    # None knowledge marks old owners, which still need the legacy pricing path.
+    # None knowledge marks old runtimes, which still need the legacy pricing path.
     # Explicit UNKNOWN forbids viewers from discovering/pricing independently.
     direct_cost: float | None = None
     direct_cost_knowledge: CostKnowledge | None = None
@@ -1307,18 +1307,18 @@ class JobState(BaseModel):
     started_at: float | None = None
     settled_at: float | None = None
     trajectory: list[dict[str, Any]] = Field(default_factory=list)
-    #: How many events the OWNER retains for this job, independent of how many
+    #: How many events the RUNTIME retains for this job, independent of how many
     #: ride this particular frame. The attach snapshot omits trajectories
     #: entirely (see :func:`_job_roster_row`) because a busy session's retained
     #: events exceed the socket's ``_MAX_LINE_BYTES`` and made the session
     #: unopenable; a viewer therefore needs the COUNT before it has the rows,
-    #: to say "loading 500 events" rather than "no activity". Owner-side this
-    #: is always ``len(trajectory)``; follower-side it stays the owner's number
+    #: to say "loading 500 events" rather than "no activity". Runtime-side this
+    #: is always ``len(trajectory)``; follower-side it stays the runtime's number
     #: even while the local list is empty or a partial page.
     trajectory_length: int = 0
     # Nested spend (#297): a finished grandchild's usage folds into its root's
     # row here. Without carrying it, follower-side child-cost pricing counted
-    # only the direct child while the owner priced the whole subtree.
+    # only the direct child while the runtime priced the whole subtree.
     descendant_usage: list[FrontendUsage] = Field(default_factory=list)
     prompt: str | None = None
     agent_role: str | None = None
@@ -1326,7 +1326,7 @@ class JobState(BaseModel):
     output_tail: str = ""
     output_seq: int = 0
     restored: bool = False
-    # Canonical lineage (U5): the owner's subagent-comms tree is not itself
+    # Canonical lineage (U5): the runtime's subagent-comms tree is not itself
     # serializable, but its one fact — who launched whom — is. Stamping the
     # parent's job id (and the child's session/role for the page header) lets
     # a follower rebuild the full parent/peer/child graph from ``state.jobs``
@@ -1336,12 +1336,12 @@ class JobState(BaseModel):
     session_id: str | None = None
     #: The child's durable session directory, as a string (``Path`` is not
     #: JSON-native). Projected here for the same reason ``session_id`` is:
-    #: the owner's ``SubagentComms`` registry never crosses the socket, and
+    #: the runtime's ``SubagentComms`` registry never crosses the socket, and
     #: the full-page view lazy-loads the child's ``transcript.jsonl`` through
     #: ``comms.session_dir_of(job_id)``. A follower with no directory treated
     #: every child as "no saved transcript" and could show only the 500-event
     #: in-memory trajectory window of a child that had hours of history on
-    #: disk. ``None`` from an owner that predates this field is tolerated —
+    #: disk. ``None`` from a runtime that predates this field is tolerated —
     #: ``SnapshotSubagentComms`` derives the path from ``session_id`` then.
     session_dir: str | None = None
     #: The deterministic ``subagent-launch:<job_id>`` id of the CURRENT launch
@@ -1363,9 +1363,9 @@ class JobState(BaseModel):
     #: wire boundary. It stays a MAPPING rather than collapsing to the current
     #: id: a resumed child's transcript holds one launch turn per collapsed
     #: attempt, and reconciling only the newest leaks every earlier attempt's
-    #: preamble (the exact defect owner-side review round 4 R4-1 fixed).
+    #: preamble (the exact defect runtime-side review round 4 R4-1 fixed).
     #:
-    #: Both are absent from an owner that predates them (``extra='allow'``), and
+    #: Both are absent from a runtime that predates them (``extra='allow'``), and
     #: a follower missing them degrades to rendering the synthetic head plus the
     #: unreconciled durable row — today's behaviour, not a crash.
     launch_message_id: str = ""
@@ -1382,9 +1382,9 @@ class JobState(BaseModel):
 
         Only when the caller supplied none. An explicit value is always kept,
         because on a FOLLOWER the two legitimately disagree: the wire snapshot
-        carries the owner's count with an empty list (the rows do not fit the
+        carries the runtime's count with an empty list (the rows do not fit the
         frame), and a watched job accumulates only the appends seen since its
-        page opened. Deriving unconditionally would replace the owner's real
+        page opened. Deriving unconditionally would replace the runtime's real
         number with the length of whatever partial window happens to be local.
         """
         if isinstance(data, dict) and "trajectory_length" not in data:
@@ -1476,7 +1476,7 @@ class JobState(BaseModel):
 
 
 class FrontendModelSpec(ModelSpec):
-    """Wire model spec that preserves fields introduced by newer owners."""
+    """Wire model spec that preserves fields introduced by newer runtimes."""
 
     model_config = ConfigDict(extra="allow")
 
@@ -1599,18 +1599,18 @@ class FrontendSessionState(BaseModel):
     loop: dict[str, Any] | None = None
     pending_gate: PendingGateState | None = None
     slash_capabilities: list[SlashCapability] = Field(default_factory=list)
-    # The owner's provider-catalogue rows, so an attached terminal's bare
+    # The runtime's provider-catalogue rows, so an attached terminal's bare
     # ``/model`` picker lists the models the SESSION can actually switch to
-    # (owner credentials/aggregators), never the follower's own possibly-
+    # (runtime credentials/aggregators), never the follower's own possibly-
     # credential-less registry (D3, review round 2). Bounded to the direct
     # (non-aggregator) rows; a follower's current model and its own live
     # refresh stay authoritative for their own rows.
     model_catalogue: list[dict[str, Any]] = Field(default_factory=list)
     #: True when the frame could not carry every catalogue row and
-    #: ``model_catalogue`` is a prefix of the owner's list rather than all of
+    #: ``model_catalogue`` is a prefix of the runtime's list rather than all of
     #: it (see :data:`MODEL_CATALOGUE_FLOOR_ROWS`).
     #:
-    #: Set at the WIRE boundary, not at accumulation: the owner's state holds
+    #: Set at the WIRE boundary, not at accumulation: the runtime's state holds
     #: the whole catalogue and only a frame that cannot fit clips, so this
     #: describes the copy the reader was actually sent. A reader that shows a
     #: clipped list as if it were complete is the failure this exists to
@@ -1620,7 +1620,7 @@ class FrontendSessionState(BaseModel):
     history_cursor: str | None = None
     history_generation: int = 0
     attachment_root: str | None = None
-    # Durable receipts are independent of owner epoch and pending action gates.
+    # Durable receipts are independent of the runtime epoch and pending action gates.
     attention: dict[str, Any] = Field(default_factory=dict)
 
     @model_serializer(mode="wrap")
@@ -1681,13 +1681,13 @@ class FrontendSessionState(BaseModel):
 def _freeze_state_jobs(
     state: FrontendSessionState, *, jobs_are_canonical: bool = False
 ) -> FrontendSessionState:
-    """Detach incoming owners, or preserve already-owned jobs on scalar updates."""
+    """Detach the incoming owning models, or preserve already-owned jobs on scalar updates."""
     jobs = state.jobs if jobs_are_canonical else (_freeze_job(job) for job in state.jobs)
     return state.model_copy(update={"jobs": _FrozenSequence(jobs)})
 
 
 def _public_job(job: JobState) -> JobState:
-    """Detach every Pydantic owner while sharing immutable retained payloads."""
+    """Detach every owning model while sharing immutable retained payloads."""
     values = {
         name: copy.deepcopy(value) if isinstance(value, BaseModel) else value
         for name, value in job.__dict__.items()
@@ -1752,7 +1752,7 @@ class FrontendUpdate(BaseModel):
     Refusing a malformed frame is NOT the same as tearing down the socket over
     a degraded one. The degrade path now labels its own frame, so the frame this
     validator rejects is one claiming to be a complete delta while carrying no
-    body — which no correct owner emits. The receiver refuses it and re-syncs
+    body — which no correct runtime emits. The receiver refuses it and re-syncs
     (``RemoteSession._on_frontend_update``), which is the recovery the transport
     already has for a gap. Staying loud is what keeps that recovery reachable.
     """
@@ -1762,13 +1762,13 @@ class FrontendUpdate(BaseModel):
     epoch: str
     sequence: int
     changes: dict[str, Any] = Field(default_factory=dict)
-    #: The owner shed this delta's body to keep the line under the socket limit.
+    #: The runtime shed this delta's body to keep the line under the socket limit.
     #: Sequencing is still authoritative; the FIELDS are not, so a receiver must
     #: re-snapshot rather than treat the empty body as "nothing changed".
     degraded: bool = False
     degraded_reason: str = ""
     job_trajectory_appends: dict[str, list[dict[str, Any]]] = Field(default_factory=dict)
-    # Jobs whose appended events are a REPLACEMENT, not a suffix. The owner's
+    # Jobs whose appended events are a REPLACEMENT, not a suffix. The runtime's
     # ``AsyncJob.trajectory`` evicts oldest past ``subagent.TRAJECTORY_CAP``, so
     # once a child crosses the cap the prefix check can never hold again;
     # without this marker a follower would extend forever (500 → 1000 → 1500…)
@@ -1786,7 +1786,7 @@ class FrontendUpdate(BaseModel):
         consumes a sequence and drifts the follower — the same shape as the
         defect this class is being fixed for. A normal delta always carries
         ``changes`` (``mutate`` returns ``None`` rather than emitting an empty
-        one), so requiring it here rejects only frames no correct owner sends.
+        one), so requiring it here rejects only frames no correct runtime sends.
         """
         if isinstance(data, dict) and "changes" not in data and not data.get("degraded"):
             raise ValueError(
@@ -1797,7 +1797,7 @@ class FrontendUpdate(BaseModel):
 
 
 # One watched plan must not take down the 1 MiB control stream. Larger plans
-# remain authoritative on the owner and are explicitly unavailable on a follower,
+# remain authoritative on the runtime and are explicitly unavailable on a follower,
 # never silently truncated into what looks like a complete task list.
 JOB_TODOS_WIRE_BYTES = 128 * 1024
 
@@ -1822,7 +1822,7 @@ def sync_wire_payload(sync: FrontendSync) -> dict[str, Any]:
     attached to — 12 of 17 sessions on the reference machine.
 
     Stripping happens HERE, at the wire boundary, rather than in
-    :class:`FrontendStateStore`: an in-process owner subscribes to the same
+    :class:`FrontendStateStore`: a front end in the runtime's process subscribes to the same
     store and still wants its rows, and the follower re-acquires them per job
     through the ``job_trajectory`` op once a reader actually opens that child's
     page. ``trajectory_length`` survives so the viewer can say how many events
@@ -1833,7 +1833,7 @@ def sync_wire_payload(sync: FrontendSync) -> dict[str, Any]:
     itself and the next unbounded field grew past the same cap on its own:
 
     * ``snapshot.usage_components`` — capped at accumulation
-      (:data:`USAGE_COMPONENT_CAP`), and capped AGAIN here because an owner
+      (:data:`USAGE_COMPONENT_CAP`), and capped AGAIN here because a runtime
       that restored a pre-cap checkpoint holds the uncapped list in memory for
       the life of that process.
     * each job's ``usage.cost_components`` and ``descendant_usage`` — the
@@ -1926,7 +1926,7 @@ def _bound_model_catalogue_in_place(payload: dict[str, Any], snapshot: dict[str,
     # thing being sent is the only quantity the socket cares about.
     if _frame_line_bytes(payload) <= _MODEL_CATALOGUE_LINE_LIMIT:
         return
-    # Binary search for the longest prefix that fits. The owner's order is the
+    # Binary search for the longest prefix that fits. The runtime's order is the
     # picker's order, so a prefix keeps the most relevant rows rather than an
     # arbitrary slice, and the flag below stops the short list from reading as
     # a complete one (MODEL_CATALOGUE_FLOOR_ROWS).
@@ -2209,7 +2209,7 @@ def oversized_frame_report(frame: dict[str, Any], cap_bytes: int) -> str | None:
     makes the reader's ``readline`` raise ``LimitOverrunError``, which killed
     the client's pump task, which left the viewer waiting out its full 15 s
     sync timeout and then degrading to a runtime-less cold session. A hard bug
-    therefore wore the costume of a slow/absent owner, and diagnosing it took a
+    therefore wore the costume of a slow/absent runtime, and diagnosing it took a
     profiling session rather than a log line.
 
     So the report names the size, the cap, and the biggest contributors by
@@ -2329,7 +2329,7 @@ class SnapshotWakeScheduler:
 class SnapshotSubagentComms:
     """A follower's read-only job-graph facade, rebuilt from canonical jobs.
 
-    The owner's ``SubagentComms`` is a live registry of running children and
+    The runtime's ``SubagentComms`` is a live registry of running children and
     cannot cross the socket, but every navigation the full-page view needs —
     parent/peer/child, ancestors, the node's session/role — is pure graph over
     ``(job_id, parent_job_id, label, session_id, prompt, agent_role, effort)``,
@@ -2378,26 +2378,26 @@ class SnapshotSubagentComms:
             # queued child's ``JobState.status`` is still ``"running"`` and the
             # distinction lives in the separate ``queued`` flag, so projecting
             # the raw status counts a child that has not started as one that is
-            # spending tokens. The owner reconstructs the same split in
+            # spending tokens. The runtime reconstructs the same split in
             # ``SubagentComms._describe``; this is that derivation, on the
-            # follower's side of the wire, so a follower and an owner looking
+            # follower's side of the wire, so a follower and the runtime looking
             # at the same child agree on its word.
             status=_snapshot_status(job),
             # Derived from the RESULTING status, not from the raw one, so a
             # queued child is never stamped live. Note this ``live`` means
-            # "counts as a running trajectory", which on the owner is
+            # "counts as a running trajectory", which on the runtime is
             # ``record.child is not None`` (child attached) — the two coincide
             # for every state either side can report, but they are not the same
             # question, and a future divergence belongs in one of these two
             # comments rather than being discovered from a wrong total.
             live=_snapshot_status(job) in RUNNING_SUBAGENT_STATUSES,
             # Launch-row reconciliation, read off the node by
-            # ``_refresh_subagent_view`` exactly as it is on an owner. Defaulted
-            # rather than conditional: an older owner sends neither field, and
+            # ``_refresh_subagent_view`` exactly as it is on the runtime. Defaulted
+            # rather than conditional: an older runtime sends neither field, and
             # the empty values are what the view already tolerates (it keeps the
             # synthetic head and leaves the durable row unreconciled).
             #
-            # RE-DERIVED only when the owner SAID it elided a derivable value
+            # RE-DERIVED only when the runtime SAID it elided a derivable value
             # (``launch_id_derived``). At 46.7 B on every task row the literal
             # string cost 43 rows of attach headroom, and an identity cannot be
             # truncated, so it is omitted where it is reconstructible instead.
@@ -2406,7 +2406,7 @@ class SnapshotSubagentComms:
             # ``task`` row can have a launch turn at all (``run_subagent`` is
             # the sole minting site; bash and eval jobs register as ``"bash"``),
             # so a bash row keeps the empty string it always had and no marker
-            # has to ride the wire to say so. A v0.49.2 owner's task rows are
+            # has to ride the wire to say so. A v0.49.2 runtime's task rows are
             # derived here too — the id is right whenever the child was launched
             # by this runtime, and a wrong-shaped guess simply matches no
             # durable row, which is the pre-#681 behaviour.
@@ -2438,7 +2438,7 @@ class SnapshotSubagentComms:
         and a follower window reported "no subagents" for a session that had
         several, with nothing named as degraded.
 
-        One flat list including nested descendants, like the owner's: the
+        One flat list including nested descendants, like the runtime's: the
         canonical jobs stream carries every depth tagged with its true
         ``parent_job_id``, so consumers count with ``len()`` over a filter and
         never a recursive walk.
@@ -2450,7 +2450,7 @@ class SnapshotSubagentComms:
 
     def job(self, job_id: str) -> Any | None:
         # The page reads live job fields from the jobs facade, not here; the
-        # comms lookup exists on the owner for a manager cross-reference the
+        # comms lookup exists on the runtime for a manager cross-reference the
         # follower resolves through its own SnapshotJobs instead.
         return None
 
@@ -2484,7 +2484,7 @@ class SnapshotSubagentComms:
     def session_dir_of(self, job_id: str) -> Path | None:
         """Where the child's durable transcript lives, for lazy history paging.
 
-        The owner answers this from its live registry; a follower answers it
+        The runtime answers this from its live registry; a follower answers it
         from the projected job (see :func:`_snapshot_session_dir`). Existence
         is deliberately NOT checked here: the view already re-probes a
         directory whose ``transcript.jsonl`` is missing on every refresh
@@ -2563,7 +2563,7 @@ def _derived_dir_belongs_to(directory: Path, label: str, agent_role: str) -> boo
     existing "no saved transcript" note — exactly what a follower saw before
     this derivation existed — whereas trusting them renders somebody else's
     conversation under this child's name. Nothing is lost that the wire path
-    does not already cover: an owner that stamps ``session_dir`` never reaches
+    does not already cover: a runtime that stamps ``session_dir`` never reaches
     this check at all.
 
     Neither is a missing, unreadable, or malformed marker ownership, and the
@@ -2633,7 +2633,7 @@ def _snapshot_status(job: JobState) -> str:
     both carry ``"running"``, with the difference held in the separate
     ``queued`` flag. Every "what is running" surface wants them apart — a queued
     child is delegated, not working — so the split is reconstructed here exactly
-    as the owner reconstructs it in ``SubagentComms._describe``.
+    as the runtime reconstructs it in ``SubagentComms._describe``.
 
     Kept as a named function rather than an inline expression because it is the
     follower's half of a derivation whose two halves must agree; a reader
@@ -2649,17 +2649,17 @@ def _snapshot_session_dir(job: JobState) -> Path | None:
 
     Two sources, in order of authority:
 
-    1. The wire ``session_dir`` the owner stamped (``_with_lineage``). This is
-       the owner's own ``Path`` and is right by construction, so it is trusted
-       as-is — the owner knows where it put the child.
-    2. ``config_dir() / "sessions" / session_id`` when the owner sent only a
+    1. The wire ``session_dir`` the runtime stamped (``_with_lineage``). This is
+       the runtime's own ``Path`` and is right by construction, so it is trusted
+       as-is — the runtime knows where it put the child.
+    2. ``config_dir() / "sessions" / session_id`` when the runtime sent only a
        ``session_id``. Children are always created there
        (``harness/subagent.py``: ``session_id`` IS ``session_dir.name``), and a
        TUI attached to a daemon on the same machine reads the same config
        root. The derivation exists so an already-running daemon from before
        ``session_dir`` rode the wire — the exact situation an operator is in
-       when they upgrade the viewer under a long-lived owner — gets history
-       without a restart, rather than only after the owner is relaunched. It
+       when they upgrade the viewer under a long-lived runtime — gets history
+       without a restart, rather than only after the runtime is relaunched. It
        is also what rescues a child rebuilt from the comms graph after a
        restart, which carries a ``session_id`` and never had a wire directory.
 
@@ -2854,17 +2854,17 @@ class FrontendStateStore:
             subscriber(update.model_copy(deep=True))
 
     def apply_update(self, update: FrontendUpdate) -> FrontendSessionState:
-        """Apply one already-validated ordered delta from an owner.
+        """Apply one already-validated ordered delta from the runtime.
 
         A DEGRADED delta advances the sequence and touches nothing else. The
-        owner shed the body to keep the line under the socket limit, so the
+        runtime shed the body to keep the line under the socket limit, so the
         fields it carried are unknown here — not unchanged. Rebuilding the
         payload from an empty ``changes`` would be indistinguishable from a
         no-op delta and would leave the store quietly wrong, so the only honest
         local action is to keep what we have and let the sequence advance in
-        step with the owner's.
+        step with the runtime's.
 
-        The sequence MUST still advance: the owner consumed that number, and
+        The sequence MUST still advance: the runtime consumed that number, and
         refusing it here would desynchronise this store from the transport's
         gap check and refuse every later delta. Recovering the shed fields is
         the SUBSCRIBER's job — ``RemoteSession`` forces a fresh ``frontend_sync``
@@ -2892,8 +2892,8 @@ class FrontendStateStore:
                 else:
                     trajectory = list(prior.trajectory if prior is not None else [])
                 trajectory.extend(update.job_trajectory_appends.get(job_id, []))
-                # Defensive mirror of the owner-side eviction: even a
-                # misbehaving owner cannot grow a follower without bound.
+                # Defensive mirror of the runtime-side eviction: even a
+                # misbehaving runtime cannot grow a follower without bound.
                 if len(trajectory) > _TRAJECTORY_CAP:
                     del trajectory[: len(trajectory) - _TRAJECTORY_CAP]
                 raw["trajectory"] = trajectory
@@ -2932,7 +2932,7 @@ class FrontendStateStore:
         fetched window two accumulators of the same list, and the page would
         show whichever won. Seeding is deliberately NOT a sequence-bearing
         mutation — no delta is published and the sequence does not move, since
-        this changes what this follower has locally, not what the owner said.
+        this changes what this follower has locally, not what the runtime said.
 
         Returns False when the job is no longer on the roster (it settled and
         was swept while the fetch was in flight), so the caller can leave the
@@ -3022,7 +3022,7 @@ class FrontendStateStore:
                 if trajectory[: len(old)] == old:
                     appended = trajectory[len(old) :]
                 else:
-                    # The owner list rotated past its cap (or was rebuilt):
+                    # The runtime's list rotated past its cap (or was rebuilt):
                     # a suffix no longer exists, so ship a replacement once
                     # rather than the whole list disguised as appends forever.
                     appended = trajectory
@@ -3126,12 +3126,12 @@ class FrontendStateStore:
         epoch = uuid.uuid4().hex
         session_id = str(session.session_id)
         state = restored or FrontendSessionState(session_id=session_id, epoch=epoch)
-        # A new owner epoch invalidates stale wire updates while preserving the
+        # A new runtime epoch invalidates stale wire updates while preserving the
         # durable checkpoint identity used to reconcile takeover without addition.
         #
         # The receipt cap is applied to the RESTORED value, not just to fresh
         # accumulation: every transcript written before the cap carries the full
-        # uncapped list (958 KB in the largest observed row), so an owner that
+        # uncapped list (958 KB in the largest observed row), so a runtime that
         # resumed one would emit an oversized attach frame and re-persist the fat
         # list forever despite the cap above. Capping on the way in is what makes
         # an existing session heal on its first resume rather than staying broken.
@@ -3140,7 +3140,7 @@ class FrontendStateStore:
                 "epoch": epoch,
                 "sequence": 0,
                 "usage_components": _capped_components(state.usage_components),
-                # The checkpoint describes a previous owner, not a scheduler
+                # The checkpoint describes a previous runtime, not a scheduler
                 # to restart. Keep its progress visible without claiming an
                 # iteration still runs (or replaying a possibly costly turn).
                 "loop": (
@@ -3373,11 +3373,11 @@ class FrontendStateStore:
         return self.mutate(jobs=jobs, child_costs=child_costs, **_ledger_cost(session))
 
     def refresh_model_catalogue(self, entries: Iterable[Any]) -> FrontendUpdate | None:
-        """Publish the owner's offerable model rows as canonical state.
+        """Publish the runtime's offerable model rows as canonical state.
 
         The catalogue answers one question — which models may this SESSION
-        switch to — and only the owner's provider controller knows it (the
-        owner's credentials, its aggregators, its registry). Kept out of
+        switch to — and only the runtime's provider controller knows it (the
+        runtime's credentials, its aggregators, its registry). Kept out of
         ``refresh_from_session`` because that runs on the session loop for
         every streaming edge; the catalogue changes on credential/registry
         timescales, so the TUI publishes it on adoption and after login-style
@@ -3787,7 +3787,7 @@ def _wire_launch_prompts(value: Any) -> dict[str, str]:
         # finding 3): a whitespace-only prompt otherwise rode the wire verbatim
         # and was then discarded by the view's own strip, spending bytes for an
         # entry that could never reconcile. The drop decision belongs here,
-        # owner-side, where it is made once.
+        # runtime-side, where it is made once.
         text = str(prompt or "").strip()
         if not identity or not text:
             continue
@@ -3816,7 +3816,7 @@ def _with_lineage(job: JobState, comms: Any) -> JobState:
     child_id = getattr(node, "session_id", None)
     has_plan = bool(child_id) and (bool(getattr(node, "live", False)) or child_id in TODO_STORE)
     # Stringified: the wire is JSON and ``Path`` is not. A follower's
-    # ``SnapshotSubagentComms`` turns it back into a ``Path``; the owner-side
+    # ``SnapshotSubagentComms`` turns it back into a ``Path``; the runtime-side
     # view never reads this field, it asks the live registry directly.
     session_dir = getattr(node, "session_dir", None)
     return job.model_copy(
@@ -3828,7 +3828,7 @@ def _with_lineage(job: JobState, comms: Any) -> JobState:
             # row: a live job knows only its own attempt, while the node
             # carries every attempt #314 collapsed into this record. The job's
             # own ``launch_message_id`` is the fallback for a node that has
-            # none, mirroring how the owner-side view reads the two.
+            # none, mirroring how the runtime-side view reads the two.
             "launch_message_id": str(
                 getattr(node, "launch_message_id", "")
                 or getattr(job, "launch_message_id", "")

--- a/local_operator/session/history_window.py
+++ b/local_operator/session/history_window.py
@@ -1,4 +1,4 @@
-"""Opt-in display pages of the owner's canonical durable replay.
+"""Opt-in display pages of the runtime's canonical durable replay.
 
 The journal may contain hundreds of MB of ignored host checkpoints while its
 conversation is only a few KB. Reuse the resident canonical replay, not a second
@@ -33,20 +33,20 @@ if TYPE_CHECKING:
 DISPLAY_HISTORY_CAPABILITY = "display-history-window-v1"
 
 #: Separate from the capability above, and it MUST stay separate. That one is a
-#: presence flag with no version handshake, so it cannot express "this owner
+#: presence flag with no version handshake, so it cannot express "this runtime
 #: also pages pre-compaction history". :class:`DisplayHistoryWindow` forbids
-#: extra fields, so an owner that emitted ``audit``/``audit_available`` to a
+#: extra fields, so a runtime that emitted ``audit``/``audit_available`` to a
 #: viewer built before those fields existed would fail that viewer's validation
 #: and turn into a FAILED ATTACH — not a degraded one. Mixed builds against one
 #: sessions directory are routine here (the global uv-tool runtime is updated
 #: independently of a repo checkout's venv), so this is a live rollout hazard
-#: rather than a theoretical one. The owner emits the new fields only to a
+#: rather than a theoretical one. The runtime emits the new fields only to a
 #: viewer that negotiated this string.
 DISPLAY_HISTORY_AUDIT_CAPABILITY = "display-history-audit-v1"
 DISPLAY_HISTORY_MESSAGES = 120
 DISPLAY_HISTORY_BYTES = 512 * 1024
 
-# Per OWNER, not per viewer: a fleet of sessions must not retain a full replay
+# Per RUNTIME, not per viewer: a fleet of sessions must not retain a full replay
 # per speculative attach. Admission examines only the already bounded page,
 # never walks the whole canonical history merely to decide whether to cache it.
 DISPLAY_PAGE_CACHE_ENTRIES = 4
@@ -106,7 +106,7 @@ def strip_audit_fields(payload: dict[str, Any], *, audit_capable: bool) -> dict[
 
     Stripping in only some of them yields a viewer that attaches cleanly and
     then fails later — on its first scroll up, or on the first refresh after
-    the owner appends a row — which is a worse failure than any single route
+    the runtime appends a row — which is a worse failure than any single route
     breaking on its own. Round 1 review found the third route unstripped after
     this docstring had asserted there were two: if a fourth is ever added,
     update this list in the same commit.
@@ -189,7 +189,7 @@ def _retained_size(value: object, limit: int) -> int | None:
     Deliberately an OVER-estimate: ``sys.getsizeof`` charges per-object CPython
     overhead (measured ~7.5x a pickled page — 91,960 accounted against 12,172
     serialized), so the effective retention ceiling is well under the nominal
-    2 MiB. That direction is the safe one for a per-owner budget multiplied
+    2 MiB. That direction is the safe one for a per-runtime budget multiplied
     across a fleet, but anyone re-tuning the constant should size it against
     ACCOUNTED bytes rather than expecting a wire-sized figure.
     The fixed allowance covers the four LRU nodes and bookkeeping. Framework
@@ -259,7 +259,7 @@ def display_window(
         # the signed ``before`` token, which is already keyed here, and the two
         # phases mint structurally different token payloads. So a context page
         # and an audit page can never collide on one key, and — because the
-        # phase is only ever read from a signature this owner minted — a viewer
+        # phase is only ever read from a signature this runtime minted — a viewer
         # cannot ask for audit rows without having been handed a cursor to them.
         before,
         anchor,

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -125,14 +125,14 @@ class SessionProtocol(Protocol):
     def owns_runtime(self) -> bool:
         """Whether THIS process runs the turn loop and writes the transcript.
 
-        True on an owner (`lop exec`, the server host, a subagent host), False
-        on a facade attached to a runtime that lives somewhere else. It is the
+        True on the runtime (`lop exec`, the server host, a subagent host),
+        False on a facade attached to a runtime that lives elsewhere. It is the
         lifecycle question: may this process end the session in-process, does
         an in-process abort reach the loop, is auto-naming this process's job.
 
         Not the same as :attr:`outcome_is_synchronous` even though both are
-        False for every `lop` TUI session today — an owner could in principle
-        admit a turn without running it to completion, and the two answers
+        False for every `lop` TUI session today — a runtime could in
+        principle admit a turn without running it to completion, and the two answers
         would then diverge. Keeping them separate is the point: the sites that
         ask them are asking different things.
         """
@@ -145,7 +145,7 @@ class SessionProtocol(Protocol):
         True where ``prompt()`` returns after the pipeline's ``finally`` has
         flushed ``agent_end``, so the caller HOLDS the outcome and may mark the
         turn failed or succeeded from its own stack. False where it returns on
-        the owner's durable-admission ACK — mid-turn, before the outcome exists
+        the runtime's durable-admission ACK — mid-turn, before the outcome exists
         — so the caller must wait for the event stream instead and must not
         infer success from the call returning.
 
@@ -489,9 +489,9 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
     """The surface a VIEWER offers on top of :class:`SessionProtocol`.
 
     A viewer is a facade attached to a runtime that executes turns somewhere
-    else. It cannot run the loop, but it can do things an owner has no need to
-    do: page a display window it did not build, ask the owner to stop, adopt a
-    takeover, report which build the owner is running.
+    else. It cannot run the loop, but it can do things a runtime has no need
+    to do: page a display window it did not build, ask the runtime to stop,
+    adopt a takeover, report which build the runtime is running.
 
     **Why this is declared.** These members exist only on ``RemoteSession``,
     and its hosts reached all of them through ``getattr(session, "name", None)``
@@ -506,8 +506,8 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
     exactly how ``/info`` reported zero subagents for a session that had
     several (see ``RemoteSession.subagent_comms``).
 
-    **Why it is a separate protocol and not more of SessionProtocol.** Owners
-    genuinely do not have these members and should not be forced to grow
+    **Why it is a separate protocol and not more of SessionProtocol.**
+    Runtimes genuinely do not have these members and should not be forced to grow
     no-op stubs for them; a stub that returns a plausible empty value is worse
     than an absent attribute, because the caller cannot tell "nothing to show"
     from "not this kind of session".
@@ -600,14 +600,14 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
 
         * never bound \u2014 a session id and a transcript but nothing executing:
           `lop` launched, the user opened the picker, nothing typed;
-        * bound and now unreachable \u2014 the socket dropped, the owner died, or
-          the facade is redialing a replacement.
+        * bound and now unreachable \u2014 the socket dropped, the runtime
+          died, or the facade is redialing a replacement.
 
         The implementation is "no client, or not connected, or not ready for
         events", so the second case is deliberate rather than incidental.
         ``app.py:23470`` states the dependency outright ("``is_cold`` is a
-        superset of the drop: it is also true while the facade is redialing an
-        owner that died"), and narrowing it to "never bound" would silently
+        superset of the drop: it is also true while the facade is redialing a
+        runtime that died"), and narrowing it to "never bound" would silently
         re-open the #625 shape at that site.
 
         So it does NOT distinguish never-bound from lost. A caller needing
@@ -631,7 +631,7 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
         """Whether leaving this session would leave a runtime running."""
         ...
 
-    # --- the owner on the other end ---------------------------------------
+    # --- the runtime on the other end -------------------------------------
     #: The BUILD the runtime is running, read off its discovery record at
     #: dial. ``""`` on a facade that has never bound AND on one bound to a
     #: runtime older than the field; hosts distinguish those by ``is_cold``,
@@ -646,11 +646,11 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
     saved_preview_partial: bool
 
     def owner_idle(self) -> bool:
-        """Whether the owner reports no turn in flight."""
+        """Whether the runtime reports no turn in flight."""
         ...
 
     def owner_model_catalogue(self) -> list[dict[str, Any]]:
-        """The model catalogue as the OWNER resolves it.
+        """The model catalogue as the RUNTIME resolves it.
 
         A viewer must not answer from its own machine's catalogue: the runtime
         may hold different credentials and therefore offer different models.
@@ -658,10 +658,10 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
         ...
 
     async def attach_existing(self) -> bool:
-        """Bind to an owner if one is already live, without starting one.
+        """Bind to a runtime if one is already live, without starting one.
 
         The desktop host calls this on a cold viewer so that serving a history
-        read never promotes a reader into an executor: losing the owner must
+        read never promotes a reader into an executor: losing the runtime must
         not move execution into the HTTP worker.
         """
         ...
@@ -702,10 +702,10 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
 
     @property
     def supports_completion_ack(self) -> bool:
-        """Whether the attached owner can acknowledge completion attention.
+        """Whether the attached runtime can acknowledge completion attention.
 
         Read by the DESKTOP host rather than the TUI: it decides whether the
-        phone portal is told completion-attention is supported. An owner too
+        phone portal is told completion-attention is supported. A runtime too
         old to carry the ack answers ``False``, which is why the host pairs
         this with ``is_cold`` instead of reading absence as a capability.
         """
@@ -713,7 +713,7 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
 
     # --- display history paging -------------------------------------------
     # A viewer renders a window over a transcript it does not own, so paging is
-    # a request to the owner rather than a slice of a local list. The revision
+    # a request to the runtime rather than a slice of a local list. The revision
     # counter is what lets the TUI tell "same window, redrawn" from "the window
     # moved" without diffing rows.
 
@@ -729,7 +729,7 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
 
     @property
     def history_message_count(self) -> int:
-        """How many messages the owner's transcript holds in total."""
+        """How many messages the runtime's transcript holds in total."""
         ...
 
     @property
@@ -744,7 +744,7 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
         The head notice branches its copy on this: rows behind the compaction
         cut are real history the model can no longer see, which is a different
         kind of row from "older messages" rather than merely an earlier one.
-        ``False`` on an owner too old to page them, so that viewer keeps the
+        ``False`` on a runtime too old to page them, so that viewer keeps the
         copy it always had.
         """
         ...
@@ -803,7 +803,7 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
         """
         ...
 
-    # --- driving the owner -------------------------------------------------
+    # --- driving the runtime -----------------------------------------------
     async def prompt_and_wait(
         self,
         text: str,
@@ -814,17 +814,17 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
         """Submit a turn and wait for its terminal outcome.
 
         The counterpart to :meth:`SessionProtocol.prompt`, which on a viewer
-        returns on the owner's admission ACK rather than on the outcome (see
+        returns on the runtime's admission ACK rather than on the outcome (see
         :attr:`SessionProtocol.outcome_is_synchronous`). A host that needs the
         result \u2014 exec mode, a scripted turn \u2014 must await THIS.
         """
         ...
 
     async def bind_runtime(self) -> None:
-        """Bind this viewer before an explicitly requested owner operation.
+        """Bind this viewer before an explicitly requested runtime operation.
 
         Declared because the desktop ROUTES call it as a HARD access on every
-        path that mutates owner state (``desktop_lifecycle.py`` /mcp,
+        path that mutates runtime state (``desktop_lifecycle.py`` /mcp,
         /credential, /fork, aside completion and adoption;
         ``desktop_sessions.py`` routed slash), reached through the
         ``bridge.remote`` binding. A rename on the facade is therefore an
@@ -850,13 +850,13 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
     async def admit_prompt(
         self, text: str, *, command_id: str, images: list[dict[str, str]], steer: bool = False
     ) -> tuple[str, bool]:
-        """Submit a prompt and return the owner's ADMISSION receipt.
+        """Submit a prompt and return the runtime's ADMISSION receipt.
 
-        ``(detail, duplicate)``: the owner's receipt text, and whether the
+        ``(detail, duplicate)``: the runtime's receipt text, and whether the
         stable ``command_id`` matched a reservation it already holds. It does
         not wait for the turn's outcome — that is the point. The desktop routes
         serve an HTTP request, and an HTTP disconnect must not cancel work the
-        owner already accepted, which is what awaiting completion would allow.
+        runtime already accepted, which is what awaiting completion would allow.
 
         Same declaration reasoning as :meth:`bind_runtime`: a HARD access from
         ``desktop_lifecycle.py`` and ``desktop_sessions.py``.
@@ -871,12 +871,12 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
         approved: bool | None = None,
         question_index: int | None = None,
     ) -> str:
-        """Answer the owner's open approval gate; returns its receipt.
+        """Answer the runtime's open approval gate; returns its receipt.
 
         ``request_id`` is checked against the gate the facade currently holds
         before anything crosses the wire, so a stale desktop popup cannot
         answer a NEWER gate that a reconnect or a multi-question ask advanced
-        in another window. The owner validates again on its side; this check is
+        in another window. The runtime validates again on its side; this check is
         what keeps the wrong answer from being sent at all.
 
         Same declaration reasoning as :meth:`bind_runtime`: a HARD access from
@@ -885,19 +885,19 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
         ...
 
     async def request_stop(self) -> str:
-        """Ask the owner to end the session; returns its receipt."""
+        """Ask the runtime to end the session; returns its receipt."""
         ...
 
     async def request_refresh(self) -> str:
-        """Ask the owner to re-send canonical state."""
+        """Ask the runtime to re-send canonical state."""
         ...
 
     async def retire_if_unused(self) -> str:
-        """Ask the owner to retire itself if nothing else is attached."""
+        """Ask the runtime to retire itself if nothing else is attached."""
         ...
 
     async def set_working_directory(self, cwd: str) -> str:
-        """Change the OWNER's working directory; returns its receipt."""
+        """Change the RUNTIME's working directory; returns its receipt."""
         ...
 
     async def route_shared_slash(
@@ -906,7 +906,7 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
         args: str,
         images: Sequence[ImageContent] | None = None,
     ) -> Any:
-        """Run a slash command on the owner and return its result."""
+        """Run a slash command on the runtime and return its result."""
         ...
 
     def move_will_wait(self) -> bool:
@@ -924,7 +924,7 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
 
     # --- approval gates across a detach ------------------------------------
     # A viewer that leaves must not strand a gate the user never answered, and
-    # one that returns must not replay a gate the owner already resolved.
+    # one that returns must not replay a gate the runtime already resolved.
 
     def suspend_viewer_gates(
         self, *, auto_approve: bool = False, keep_answer: bool = False
@@ -950,7 +950,7 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
 
     @property
     def has_pending_gate_reply(self) -> bool:
-        """Whether a latched answer is still in flight to the owner.
+        """Whether a latched answer is still in flight to the runtime.
 
         The sidebar reads this to avoid tearing down a source whose committed
         reply has not reached the runtime yet. Probed as a 3-arg ``getattr``
@@ -959,28 +959,28 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
         """
         ...
 
-    # --- owner-lifecycle callbacks -----------------------------------------
+    # --- runtime-lifecycle callbacks ---------------------------------------
     # Installed once at adoption. They are how a viewer learns about outcomes
-    # it cannot poll for: the owner died and this process won the lease, the
-    # owner ended the session, the owner retired itself for a newer build.
+    # it cannot poll for: the runtime died and this process won the lease, the
+    # runtime ended the session, the runtime retired itself for a newer build.
 
     def set_takeover_callback(self, callback: Callable[[Any], Any]) -> None:
-        """Called with a real owner session when this process wins the lease."""
+        """Called with a runtime-owning session when this process wins the lease."""
         ...
 
     def set_stopped_callback(self, callback: Callable[[], Any]) -> None:
-        """Called when the owner ENDED the session deliberately."""
+        """Called when the runtime ENDED the session deliberately."""
         ...
 
     def set_refresh_callback(self, callback: Callable[[], Any] | None) -> None:
-        """Called when the owner retired itself for a newer build."""
+        """Called when the runtime retired itself for a newer build."""
         ...
 
     def set_cancel_resolution(self, resolver: Callable[[int], None] | None) -> None:
         """Arm the seam that rewrites an optimistic cancel count.
 
         A follower's Esc reports the count it can see synchronously; the
-        authoritative number resolves on the owner and arrives later.
+        authoritative number resolves on the runtime and arrives later.
         """
         ...
 

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1761,8 +1761,8 @@ class Session:
         # above: the stream fn is SHARED with subagents, so a registered reader
         # is last-writer-wins — constructing a child overwrote the parent's
         # reader for good and downgraded every later parent request to 5m
-        # (review F8). The hint rides each request instead, stamped by its
-        # owner: the loop reads ``get_context_tokens_hint`` for turn calls and
+        # (review F8). The hint rides each request instead, stamped by whoever
+        # owns the call: the loop reads ``get_context_tokens_hint`` for turn calls and
         # the session's direct calls stamp ``_context_tokens_hint`` themselves.
         self._tools = list(tools)
         self._transcript = transcript
@@ -2053,7 +2053,7 @@ class Session:
         # Hosts reserve producer identities before a steer reaches its durable
         # boundary. A failed append must hand that identity back explicitly;
         # otherwise one disk error consumes both the retry ID and a bounded
-        # steering slot for the lifetime of the owner.
+        # steering slot for the lifetime of the runtime.
         self._steering_rejection_handlers: list[Callable[[str, str], None]] = []
         # Count of courtesy wake_prompt messages sitting in the steering
         # queue. The immediate-interrupt poll may cancel a RUNNING tool only
@@ -2116,8 +2116,8 @@ class Session:
         # not carry the conversation (their prompt is a different, write-once
         # prefix — see ``_one_shot_complete``). Moves in lockstep with
         # ``_last_usage`` (see ``_note_usage``) so a hint is never staler than
-        # the compaction trigger's figure, and is stamped per request by the
-        # call's owner: the loop seeds its run from it and then prefers its
+        # the compaction trigger's figure, and is stamped per request by whoever
+        # owns the call: the loop seeds its run from it and then prefers its
         # own in-run counts; asides and the advisor stamp it directly. Seeded
         # from the transcript's last usage so a RESUMED large session starts on
         # its real size instead of re-deriving it through the client's byte
@@ -2285,7 +2285,7 @@ class Session:
         #: Bang-mode receipts that completed while a turn or manual compaction
         #: owned the message list. They cannot be spliced into a live provider
         #: batch, but dropping them would make a visible command disappear on
-        #: resume. The owner flushes this FIFO before releasing `_turn_lock`.
+        #: resume. The runtime flushes this FIFO before releasing `_turn_lock`.
         self._pending_shell_records: list[tuple[str, ToolResult]] = []
         self._turn_lock = asyncio.Lock()  # serializes prompt() and wake deliveries
         # True only while an ON-DEMAND compaction holds ``_turn_lock``. The
@@ -2447,7 +2447,7 @@ class Session:
         from local_operator.browser_bridge.resources import BrowserResource
 
         self._browser = BrowserSurface(BrowserResource(transcript.directory, self._session_id))
-        # Connections and overlapping read requests have a conversation owner.
+        # Connections and overlapping read requests are owned by the conversation.
         # This avoids rebuilding pools for every tool call without allowing one
         # child's disposal to close a sibling's active transport.
         from local_operator.web_search.io import WebReadIO
@@ -4855,11 +4855,11 @@ class Session:
         await self._turn_lock.acquire()
         try:
             # Close the narrow completion-after-final-flush race: a shell
-            # receipt may have queued while the previous owner still held the
+            # receipt may have queued while the previous holder still held the
             # lock. It must be visible before this prompt builds its request.
             await self._flush_shell_records()
             # Same race, same window: a journal notice parked by the previous
-            # owner must reach the model before this prompt's request is built,
+            # holder must reach the model before this prompt's request is built,
             # or the switch it announces goes unmentioned for another turn.
             self._flush_context_journal()
             # A fresh user prompt supersedes any earlier interrupt request.
@@ -4925,7 +4925,7 @@ class Session:
         if self._seeded or self._context.messages or self._is_streaming:
             return
         self._seeded = True
-        # A history import may carry tool batches. One commit prevents owner
+        # A history import may carry tool batches. One commit prevents runtime
         # snapshots from observing half a seeded pair between per-row awaits.
         await self._transcript.append_messages(messages)
         self._context.messages.extend(messages)
@@ -4994,7 +4994,7 @@ class Session:
     async def fork_snapshot(self, message: str = "") -> dict[str, Any]:
         """Fork the committed prefix without interrupting the live agent loop.
 
-        Both in-process callers and socket owners use this same admission path.
+        Both in-process callers and socket-attached front ends use this same admission path.
         The transcript lock, not a viewer or a turn interruption, defines the
         copy boundary; active history rewrites are refused explicitly.
         """
@@ -5323,7 +5323,7 @@ class Session:
         return "delivered to the mailbox (will be read on the next turn)"
 
     async def _emit_peer_receipt(self, message: CustomMessage, sender: dict[str, Any]) -> None:
-        """Fire the live receipt so the owner TUI paints the indicator now.
+        """Fire the live receipt so the attached TUI paints the indicator now.
 
         Mirrors ``WakeDeliveredEvent`` firing before/around the turn spawn:
         even for the record-only idle case the front end must be told the
@@ -5870,7 +5870,7 @@ class Session:
         # Failure may precede the first assistant message. Its durable outcome
         # marker, not an unrelated previous answer, is the viewable anchor.
         anchor = messages[-1].id if kind == "complete" else provisional_anchor(token)
-        # The journal precedes publication: owner death between these writes is
+        # The journal precedes publication: runtime death between these writes is
         # repaired idempotently on resume, without fabricating a new token.
         await self._transcript.append_custom(
             ATTENTION_CUSTOM_TYPE,
@@ -5905,7 +5905,7 @@ class Session:
 
     @property
     def epoch(self):  # type: ignore[no-untyped-def]
-        """The owner epoch without the full-state clone.
+        """The runtime's epoch without the full-state clone.
 
         Paired with :attr:`pending_gate`: gate identity is epoch plus gate, so
         reading the epoch through ``frontend_state`` would restore the clone on
@@ -6704,7 +6704,7 @@ class Session:
             # resume. Placed on the normal path (a turn that raised past here
             # still has last turn's snapshot; the next clean turn re-writes it).
             await self._maybe_persist_todos()
-            # Spend must survive owner death at the same durability boundary as
+            # Spend must survive runtime death at the same durability boundary as
             # the messages it describes. The checkpoint is replacement state,
             # never an additive delta, so takeover cannot double it. A headless
             # store that observed nothing (no UI, no attach subscriber) skips
@@ -7505,7 +7505,7 @@ class Session:
         for handler in list(self._steering_rejection_handlers):
             try:
                 handler(command_id, reason)
-            except Exception:  # noqa: BLE001 - one owner cannot hide rejection from others
+            except Exception:  # noqa: BLE001 - one handler cannot hide rejection from others
                 logger.exception("steering rejection handler failed")
         await self._emit(
             NoticeEvent(
@@ -9345,7 +9345,7 @@ class Session:
             # may not have been delivered yet. Writing pending then would park
             # a summary the ceiling pass is about to make stale. Same shape as
             # the steer-receipt guard (PR #452): drop the delivery when the
-            # owner is no longer the current one.
+            # writer is no longer the current one.
             if self._disposed or self._compaction_pass_task is not asyncio.current_task():
                 return
             self._pending_compaction = _PendingCompaction(
@@ -10366,7 +10366,7 @@ class Session:
         A receipt that lands while a turn or manual compaction owns the message
         list is QUEUED, never discarded: splicing it into a live provider batch
         would produce an unsendable list, while dropping it would make a command
-        the user can see disappear on resume. The lock owner flushes the FIFO at
+        the user can see disappear on resume. The lock holder flushes the FIFO at
         its safe boundary before another prompt can start.
         """
         if self._transcript.has_entry(f"shell:{result.tool_call_id}:result") or any(
@@ -10826,7 +10826,8 @@ class Session:
     def _load_subagent_roster(self) -> None:
         """Rehydrate the subagent panel and the resume basis from disk.
 
-        Reads the newest snapshot and feeds each half to its owner: the comms
+        Reads the newest snapshot and feeds each half to the component that
+        owns it: the comms
         records to ``SubagentComms.restore`` (the resume basis) and the job rows
         to ``AsyncJobManager.restore`` (the panel). Restoring the records
         MINTS the comms instance if this session had not yet — a resumed session
@@ -11377,7 +11378,7 @@ class Session:
           per-call ``RetrySettings.from_settings`` reads. A subagent shares
           only the parent's transport pool; its routing state belongs to its
           own stream fn. Each child's watcher therefore applies the same live
-          settings to that independent owner. Legacy stream functions without
+          settings to that independent stream fn. Legacy stream functions without
           ``apply_settings`` retain their existing behavior.
         * ``subagents.max_running`` — pushed into the live job manager with
           the same validation the constructor applied; an unset or invalid
@@ -11771,7 +11772,7 @@ class Session:
             unsubscribe_state()
             self._unsubscribe_subagent_state = None
         # No later boundary can drain producer steers once disposal starts.
-        # Reject them while owner callbacks and viewers are still attached so
+        # Reject them while rejection subscribers and viewers are still attached so
         # capacity is released and the producer can safely reuse the same ID.
         while not self._steering_queue.empty():
             message = self._steering_queue.get_nowait()

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -351,7 +351,7 @@ class ReplaySuffix:
 
 
 #: Backward read granularity. One MiB is large enough that a compaction's kept
-#: window (355–456 messages on the reference owners) is usually inside the
+#: window (355–456 messages on the reference runtimes) is usually inside the
 #: first or second chunk, and small enough that a whole-file fallback on a
 #: journal with no compaction costs no more than the forward parse it replaces.
 _SUFFIX_CHUNK_BYTES = 1 << 20
@@ -417,7 +417,7 @@ def read_replay_suffix(
         handle.seek(0, os.SEEK_END)
         position = handle.tell()
         # EOF as the handle saw it. Re-stat'ing after the close would measure a
-        # file an appending owner may have grown in between, reporting bytes
+        # file an appending runtime may have grown in between, reporting bytes
         # this call never read (round 5, NIT).
         end_of_file = position
         # Invariant: ``pending`` is the bytes after ``position`` that have NOT
@@ -532,7 +532,7 @@ class Transcript:
         self._lock = asyncio.Lock()
         self._entries: list[TranscriptEntry] = []
         # Paging tokens survive appends, but not a replay-changing mutation or
-        # a new owner. The signing key never leaves this resident transcript.
+        # a new runtime. The signing key never leaves this resident transcript.
         self._history_generation = 0
         self._history_page_key = os.urandom(32)
         self._display_window_cache: _DisplayWindowCache | None = None
@@ -762,7 +762,7 @@ class Transcript:
     ) -> tuple[str, bool]:
         """Copy a committed transcript without racing append or file compaction.
 
-        The owner, not a viewer's cache, defines this boundary. Cancellation of
+        The runtime, not a viewer's cache, defines this boundary. Cancellation of
         a waiter cannot stop a filesystem copy, so retain the same ordering lock
         as `_commit` until the worker settles, even after repeated cancellation.
         The returned fork excludes live messages not yet durably committed.
@@ -829,7 +829,7 @@ class Transcript:
         """
         rebuild = not self.path.exists()
         if self._created_at is None and not rebuild:
-            # Another owner may have materialized a speculative transcript
+            # Another runtime may have materialized a speculative transcript
             # before our first append. Adopt its birth for later self-healing.
             self._created_at = session_created_at(self.directory)
         if not rebuild:
@@ -1504,10 +1504,10 @@ def audit_slice(
     Windowed rather than a full audit replay because the cost difference is the
     whole design: measured on the operator's 231 MB / 17,345-row journal, a
     naive full audit replay is 0.29 s and 47 MB of peak allocation per call,
-    while this walks back ``limit`` message rows over the owner's already
+    while this walks back ``limit`` message rows over the runtime's already
     resident ``_entries`` in under a millisecond. Reading the page off disk
     instead (``read_transcript_page``) measured ~1.03 s on the same journal.
-    Serve audit pages from RAM the owner already holds.
+    Serve audit pages from RAM the runtime already holds.
 
     ``prunes`` is passed in deliberately; see :func:`collect_prunes`.
     """


### PR DESCRIPTION
Release: patch — session/harness comments use the runtime glossary (`runtime` / `viewer` / `registrant`) instead of the retired owner vocabulary.

## Summary

Stage 4 session-consolidation PR 5 of 7 (plan: `~/workspace/lop-session-consolidation/stage4-owner-retirement.md`, §4.1 + §5). Comment/docstring glossary adoption in the files PR 2 (#916) does not own: the ~71% of the "owner" vocabulary that is prose an implementing agent reads — the mechanism behind the pid-1184 defect. **Zero code change** (proof below): no identifiers, protocol members, wire constants, or string literals move.

## Glossary applied (normative table, plan §4.1)

| Retired | Adopted | Where |
|---|---|---|
| "the owner" (session-sense noun) | the runtime / the runtime process | `protocol.py` (35 sites), `frontend_state.py` (79), `session.py`, `transcript.py`, `history_window.py`, `harness/{types,loop,comms}.py` |
| `owns_runtime` docstrings "True on an owner" | "True on the runtime" | `protocol.py:128`, `session.py` — identifier itself untouched |
| jobs/roster "owner" | registrant | `harness/jobs.py` (module + class docstrings, cancel mismatch prose) |
| lock/lease "owner" | holder | `session.py` FIFO/turn-lock races, `attention.py` lease prose |
| "owner-side"/"Owner-side" | runtime-side | `frontend_state.py` eviction, retention, subagent view |
| stale "the owner TUI" | the attached TUI | `session.py`, `harness/types.py` — every TUI has been a viewer since 0.46 |

Also rewritten: the `_FRONTEND_LOCAL_SLASHES` routing rationale (`frontend_state.py:667-762`, named in the plan) now routes "to the runtime"; the `# --- owner-lifecycle callbacks ---` section header is `runtime-lifecycle`; two pydantic "Detach incoming owners" docstrings became "owning models" (object-ownership idiom, no longer the bare axis noun); resource idioms that stay idioms use the verb ("owned by the conversation", "whoever owns the call", "still unowned", "single authority on").

## Over-scope proof — stronger than grep

Every changed file's **code token stream (comments and strings — docstrings included — dropped) is byte-identical to HEAD** via `tokenize`:

```
SAME local_operator/harness/comms.py      SAME local_operator/session/frontend_state.py
SAME local_operator/harness/jobs.py       SAME local_operator/session/history_window.py
SAME local_operator/harness/loop.py       SAME local_operator/session/protocol.py
SAME local_operator/harness/types.py      SAME local_operator/session/session.py
SAME local_operator/session/attention.py  SAME local_operator/session/transcript.py
```

Changed-lines grep for `def |class |owner_idle|find_owner_record|_owner_ready` matches only `+ - ``cancel(job_id, owner_id)`` treats a registrant mismatch…` — a module-docstring reference to the **unchanged** signature. `git diff -- pyproject.toml` → empty (no version bump). Deny list (remote.py, app.py, cleanup.py, runtime/*, resume.py, cli.py, attach_client.py, daemon.py, PR-916 tests) untouched.

Residual whole-word `owner` mentions in the touched files, all deliberate:

- `frontend_state.py:3150` — `"reason": "Owner restarted; iterations were not replayed"`: a wire value, zero string changes in this PR.
- `harness/jobs.py:1317` — dead-letter log format string naming `job.owner_id` (identifier, PR 4 territory).
- `harness/loop.py:2435` — "each slot has exactly one owner": concurrency slot idiom, not session sense.
- `protocol.py` quotes `app.py:23470` ("redialing an owner that died"); rewritten here to the target glossary — converges when PR 6 rewrites app.py's own copy.
- `tests/unit/harness/test_jobs.py:2` module docstring still says "owner-scoped delivery" — test files are outside this PR's allow list.
- `owner_idle`/`owner_version`/`owner_source_ref`/`owner_model_catalogue` identifiers and every `owner_id`/`owner_epoch` key: unchanged (PR 3/4).

## Testing

- `pyright --pythonpath .venv/bin/python .` whole-tree: **0 errors, 0 warnings**.
- `flake8`, `black --check` (26.1.0 pinned), `isort --check` (5.13.2 pinned): all clean.
- `tests/unit/session` + `tests/unit/harness` (`-n 4`, 2416 tests): **all passed** in 73s, including `test_viewer_protocol.py` conformance pins.
- Fresh worktree from `origin/main` @ `95bdc3c58` (#915, unrelated files) with its own venv.

No visual frames — no user-visible change (comment/docstring-only, token-proven).