### PR TITLE
docs: adopt the runtime glossary in agent-facing docs

### DIFF
--- a/docs/ATTENTION.md
+++ b/docs/ATTENTION.md
@@ -10,7 +10,7 @@ lifecycle and are never answered or removed by a completion receipt.
 Canonical identities distinguish `session/<durable-id>` from legacy persistent
 `agent/<agent-id>` conversations. Selecting an agent profile does not alias an
 ordinary session to that profile's persistent conversation. Followers acknowledge
-through their authenticated owner connection, not through their own PID.
+through their authenticated runtime connection, not through their own PID.
 
 The logical run journals its token before execution. A settled eligible outcome
 is journaled after durable message persistence and imported idempotently into
@@ -21,7 +21,7 @@ Copied fork journals cannot reuse another conversation's token.
 
 A receipt advances through the supplied token's sequence using a monotonic
 watermark. Delayed or duplicate acknowledgement of A cannot acknowledge newer B.
-Owner epoch, transcript mtime, heartbeat time and stream sequence are not
+Runtime epoch, transcript mtime, heartbeat time and stream sequence are not
 completion clocks. The SQLite engine serializes writers across processes. All
 schema objects initialize in one transaction; readers of a positively identified
 empty, not-yet-initialized database see no published completion. Corrupt bytes or
@@ -63,7 +63,7 @@ key visible window's selected workspace and terminal surface.
 Mobile transcript rows carry `text_complete`. `final` means streaming settled;
 it does not prove transport retained the final row's ending. Both runtime and
 relay serialization preserve `text_complete=false` when clipping a row. Missing
-metadata from an older owner is unknown, not permission to acknowledge. Only a
+metadata from an older runtime is unknown, not permission to acknowledge. Only a
 rendered anchor with both flags true qualifies. Unrelated degraded rows do not
 prevent acknowledgement of a complete result. If a capped result cannot be
 hydrated in full on the phone, it remains unread until a full surface views it;

--- a/docs/DESKTOP_API.md
+++ b/docs/DESKTOP_API.md
@@ -108,7 +108,7 @@ it is not a cross-process compare-and-swap guarantee.
 
 The existing runtime attach protocol remains `client: "attach"`; desktop
 adapters additionally send `surface: "desktop"` only after discovering
-`desktop-watch-v1` in the runtime record's capabilities. An old owner is refused
+`desktop-watch-v1` in the runtime record's capabilities. An old runtime is refused
 before dialing, since it would otherwise mistake the HTTP proxy for a person at
 a terminal. Terminal and phone handshakes retain their existing defaults.
 
@@ -123,8 +123,8 @@ restores parked-gate OS fallback. A valid desktop notification lease suppresses
 that fallback, so one gate does not produce both an Electron and runtime toast.
 
 `RemoteSession(surface="desktop")` carries this metadata through its existing
-owner binding/recovery path. It goes cold rather than taking over an owner in
-the HTTP process; reconnect does not resurrect an expired desktop lease. Its
+runtime binding/recovery path. It goes cold rather than becoming the runtime
+in the HTTP process; reconnect does not resurrect an expired desktop lease. Its
 `bind_runtime`, `update_desktop_watch`, and identity-checked `answer_gate` helpers
 are host adapters, not another session daemon. Detach still closes only the
 viewer, never the canonical runtime.
@@ -161,38 +161,38 @@ falling back to the parent of the config root when no cwd was retained.
 | GET `.../{id}/history` | optional `before_id`, `limit` 1..500 | `{entries,has_more,cursor_missing}` |
 | POST `.../{id}/messages` | `{request_id,text,images?,mode?:prompt|steer}` | `{status:admitted,command_id,duplicate,detail,replayed?}` |
 | POST `.../{id}/commands` | `{request_id,command,args?,images?}` | `{command,result:SlashResult,replayed?}` |
-| POST `.../{id}/answers` | `{epoch,request_id,value,question_index}` OR `{epoch,request_id,approved}` | owner receipt; stale owner/request/question409 |
+| POST `.../{id}/answers` | `{epoch,request_id,value,question_index}` OR `{epoch,request_id,approved}` | runtime receipt; stale runtime/request/question409 |
 | GET `.../{id}/events` | optional `epoch`, `after_seq` | authenticated SSE, `data: <DesktopSessionFrame>` |
 | POST `.../{id}/watch` | `{subscription_id,visible,can_notify}` | `{lease_seconds:45}`; disconnected/wrong-session ID404 |
 
 Create/message/command `request_id` is a canonical lowercase UUID string, reused
 for a retry of the **same** operation. Answer `request_id` is instead the pending
-gate's opaque ID, and answer `epoch` is the **owner** epoch from frontend state,
+gate's opaque ID, and answer `epoch` is the **runtime** epoch from frontend state,
 not the HTTP stream epoch. Approval booleans and question indices are strict.
 Answer bodies are never retained in the HTTP receipt journal or echoed back.
 
 Images use the runtime's `{data_b64,mime_type}` shape (png/jpeg/gif/webp), at most8;
 the encoded message/command body must fit900,000bytes. Empty prompts without an
-image, invalid base64 and slash text on `/messages` return422 before owner binding.
+image, invalid base64 and slash text on `/messages` return422 before runtime binding.
 The existing Electron request transport currently has a smaller262,144byte body
 budget: this checkpoint does not claim larger native image uploads work.
 
 The command endpoint now accepts every shared canonical command and alias.
-Owner controls return actual SlashResult data; native/interactive controls return
+Runtime controls return actual SlashResult data; native/interactive controls return
 typed destination, arguments and form/source/submit metadata, never fake execution
 success. See [DESKTOP_CONTROLS.md](DESKTOP_CONTROLS.md) for all 35 rows and explicit
 frontend responsibilities. On a `team_attached` or `agent_attached` result, the
-owner's `data.request` plus images is admitted **once by the bridge**
+runtime's `data.request` plus images is admitted **once by the bridge**
 under the original request UUID; an added `result.admission` records that fact.
 The renderer must not independently re-submit that consumed request.
 
 ### Admission and retry semantics
 
 A200 message receipt means the canonical runtime acknowledged admission, not
-that the model succeeded or the turn completed. The owner's canonical events
+that the model succeeded or the turn completed. The runtime's canonical events
 and durable history are the authority for completion and side effects. Explicit
 mutations use `RemoteSession.bind_runtime` / existing `engage_runtime` lease
-arbitration. A cold read or stream attaches only to an already-live owner.
+arbitration. A cold read or stream attaches only to an already-live runtime.
 HTTP shutdown/last-reader cleanup only disposes the viewer; it never stops work.
 
 The private0600 `desktop-receipts.db` stores request fingerprints and completed
@@ -201,9 +201,9 @@ changed input returns409. A completed receipt survives HTTP restart. A control
 interrupted between durable reservation and result commit is **indeterminate**:
 a retry returns409 and requires state reconciliation, not another side effect.
 Only natural prompt/steer admissions can retry an indeterminate receipt, because
-the owner already reserves those UUIDs durably. This is at-most-once control
+the runtime already reserves those UUIDs durably. This is at-most-once control
 execution with honest crash ambiguity, not a claim of transactional exactly-once
-execution across the HTTP worker and canonical owner. Receipts currently follow
+execution across the HTTP worker and the canonical runtime. Receipts currently follow
 the retained session lifetime; no automatic deletion/expiry is claimed.
 
 ### Stream ordering and lifecycle
@@ -223,7 +223,7 @@ cursor**, independent of the inner canonical frontend `{epoch,sequence}`.
 4. New frames continue in receipt order: `frontend.update` is a canonical field
    delta, and `event` carries a typed canonical AgentEvent. Apply the snapshot
    after replay so an old cumulative record cannot repaint newer snapshot text.
-   Preserve owner sequence/epoch checks independently of semantic event dedupe.
+   Preserve runtime sequence/epoch checks independently of semantic event dedupe.
 
 A cold reconnect, HTTP restart, detached interval, expired replay cursor or future
 cursor requires a gap snapshot. One live shared bridge retains at most256frames
@@ -236,9 +236,9 @@ retrieval is not exposed by this HTTP checkpoint yet.
 Watch ownership belongs to an active SSE subscription, not an arbitrary window
 ID. Visibility and native-notification delivery are aggregated independently
 across its unexpired leases. Renew while the surface is genuinely alive; no
-heartbeat automatically grants presence. Expiry clears owner presence, and ASGI
+heartbeat automatically grants presence. Expiry clears runtime presence, and ASGI
 disconnect cleanup is shielded from the cancelled request scope so lease revoke
-and detach actually reach the owner. A stream alone means neither visible nor
+and detach actually reach the runtime. A stream alone means neither visible nor
 notification-capable. Electron must set can_notify=false until native delivery
 really exists; its gate/turn notification dedupe/click behavior is not implemented
 by these backend routes.
@@ -248,7 +248,7 @@ by these backend routes.
 `tests/e2e/test_desktop_sessions.py` drives real loopback HTTP and the production
 Session/OwnedSessionHandle/RuntimeServer/AttachClient with only the provider
 stream scripted: same-session terminal controls, consumed team prompt, durable
-single admission, actual owner ask/approval futures, invalid/stale answers,
+single admission, actual runtime ask/approval futures, invalid/stale answers,
 ordered replay, session isolation, disconnect/watch cleanup and reopen.
 `tests/e2e/test_desktop_spawn.py` additionally executes the real detached process
 launcher using the built-in test provider, then recreates the HTTP lifespan and

--- a/docs/DESKTOP_CONTROLS.md
+++ b/docs/DESKTOP_CONTROLS.md
@@ -20,7 +20,7 @@ its destination; the dispatcher only selects execution handlers.
 
 `POST /v1/desktop/sessions/{id}/commands` accepts the existing stable UUID
 request_id, command, args and optional images. Every canonical name and alias is
-accepted. Owner actions return the real SlashResult. Interactive/native actions
+accepted. Runtime actions return the real SlashResult. Interactive/native actions
 return `kind: native_action`, `destination`, `session_id`, `args`, typed `fields`
 and destination-specific `data` (sources, submit paths, scope and safety flags).
 This is a **presentation request**, not a receipt that the window closed, clipboard
@@ -52,61 +52,61 @@ and rendered verification.
 | Command / aliases | Backend behavior | Frontend responsibility |
 |---|---|---|
 | help | Registry-backed `commands` destination | Searchable palette, aliases/arguments |
-| exit / quit | `window.close`, unsaved guard, detach-only | Native close without stopping owner |
+| exit / quit | `window.close`, unsaved guard, detach-only | Native close without stopping the runtime |
 | clear | `transcript.clear`, view-only/history untouched | Clear painted rows only |
 | copy | `transcript.copy`, history source and message/code/quote choices | Keyboard picker and clipboard |
 | new | `sessions.new`, canonical creation endpoint, cwd field | New conversation, preserve current work |
 | reload | `sessions.reload`, same canonical identity | Reopen/relaunch using installed runtime without resubmitting a turn |
 | update | `updates`, capabilities source and retained identity | Existing updater/compatibility UI |
 | resume / recall | `sessions.resume`, canonical list/source | Cold/live session picker and attach |
-| rename | Owner rename; bare name editor | Form and explicit-name receipt |
+| rename | Runtime rename; bare name editor | Form and explicit-name receipt |
 | fork | `session.fork`, canonical next-safe-boundary fork endpoint | Boundary explanation, child navigation, optional request once |
-| model / models | ProviderController catalogue and owner model change | Search/filter model picker, explicit default scope |
-| effort | Model-specific entities and owner effort change | Current choice/picker, unsupported model explanation |
-| fast | Owner control; native form marks premium pricing | Pricing warning and on/off control |
+| model / models | ProviderController catalogue and runtime model change | Search/filter model picker, explicit default scope |
+| effort | Model-specific entities and runtime effort change | Current choice/picker, unsupported model explanation |
+| fast | Runtime control; native form marks premium pricing | Pricing warning and on/off control |
 | theme / themes | `appearance`, desktop scope | Existing twelve-theme palette; terminal theme separate |
 | provider | `providers`, central provider/auth sources | Provider grid, real states and method choices |
 | settings / config | `settings`, full existing registry | Typed searchable editors, scope/reset |
 | search | `settings.search`, web-search filter | Settings filtering and masked key entry |
 | accounts | Central redacted accounts + account-specific removal | Account selection/confirmation and environment fallback |
-| failovers | Selected/effective owner models + configured default chains | Distinguish actual serving model from selected/default route |
+| failovers | Selected/effective runtime models + configured default chains | Distinguish actual serving model from selected/default route |
 | usage | ProviderController cached/live normalized reports and age/state | Freshness, quotas, partial/error/re-auth views |
-| context | Owner typed context result | Unknown vs estimate, breakdown display |
+| context | Runtime typed context result | Unknown vs estimate, breakdown display |
 | analytics | AnalyticsStore aggregate/daily queries | Query controls and cost-knowledge rendering |
-| goal | Owner show/set/clear | Echo only successful model-facing text |
-| loop | Owner-local cancelable count/goal orchestration, snapshot state | Form, progress/judge state, cancel; never auto-answer gates |
-| btw | Owner completion, off-record panels, explicit adoption | Aside panel and adoption confirmation |
-| compact | Existing owner compact control/events | Pending/completed/error from canonical events |
+| goal | Runtime show/set/clear | Echo only successful model-facing text |
+| loop | Runtime-local cancelable count/goal orchestration, snapshot state | Form, progress/judge state, cancel; never auto-answer gates |
+| btw | Runtime completion, off-record panels, explicit adoption | Aside panel and adoption confirmation |
+| compact | Existing runtime compact control/events | Pending/completed/error from canonical events |
 | stop | Explicit target list/confirmation, canonical stop protocol | Current/selected/all picker; submit exact IDs |
-| approvals | Owner mode; explicit default editor | Session/default scope and confirmation |
+| approvals | Runtime mode; explicit default editor | Session/default scope and confirmation |
 | skills | Effective discovered catalogue and closed skill:// detail resolver | Catalogue/details; distinguish discoverable from selected |
 | mcp | Effective source ownership, configuration, connections and grants | Server panel, forms, transport/downstream auth distinction |
 | login | Central provider/method action and existing auth operation | Browser/input/cancel flow without renderer secrets |
 | logout | Central provider/account selection and removal | Explicit confirmation; no implied environment removal |
-| credential / cred | Masked form, owner VariableStore operations | Secret input only, never composer echo/history |
-| team / teams | Team registry/chart and owner attachment | Team/request form; admission already consumes request once |
-| agent / agents | Shared persona resolver and owner attachment | Profile/request form; admission already consumes request once |
+| credential / cred | Masked form, runtime VariableStore operations | Secret input only, never composer echo/history |
+| team / teams | Team registry/chart and runtime attachment | Team/request form; admission already consumes request once |
+| agent / agents | Shared persona resolver and runtime attachment | Profile/request form; admission already consumes request once |
 
 ## Lifecycle endpoints
 
 All paths start `/v1/desktop/sessions/{id}` unless noted.
 
 - `POST /credentials`: action `list|store|forget`, optional key, secret value only
-  for store, confirmed=true for forget. It calls owner `credential_op`. Values
+  for store, confirmed=true for forget. It calls the runtime's `credential_op`. Values
   never enter the command receipt database or transcript; only key names are
-  journalled by the existing owner. `/credential <anything>` is rejected rather
+  journalled by the existing runtime. `/credential <anything>` is rejected rather
   than accidentally recording a secret. Names-only listing does not expose values.
 - `POST /fork`: stable request_id, optional message, boundary=`next_safe`.
-  The owner refuses compaction and uses `Session.request_fork` during a turn;
+  The runtime refuses compaction and uses `Session.request_fork` during a turn;
   otherwise it uses `fork_session`. This is the canonical complete-history fork
   at a safe boundary, not an arbitrary transcript rewrite. The parent is unchanged.
   The child gets a new canonical ID; optional message is admitted once using the
   same UUID, never both a boot-prompt sidecar and a renderer re-submit.
 - `POST /asides`: request_id, text, optional previous aside_id. Completion runs
-  on the owner but does not enter conversation history. GET `/asides/{aside_id}`
+  on the runtime but does not enter conversation history. GET `/asides/{aside_id}`
   recovers a response after HTTP loss; DELETE closes a settled panel. A continuation
   temporarily owns its prefix so two panels cannot adopt it twice.
-- `POST /asides/{aside_id}/adopt`: request_id and confirmed=true. Owner adoption
+- `POST /asides/{aside_id}/adopt`: request_id and confirmed=true. Runtime adoption
   enforces its idle guard and durable-first ordering. A latch before any await
   prevents distinct request IDs from duplicating adoption. An ambiguous failure
   is not retried under another ID. Already completed receipts replay safely.
@@ -114,18 +114,18 @@ All paths start `/v1/desktop/sessions/{id}` unless noted.
   HTTP shutdown clears them. They are not canonical/durable history until adopted.
 - `POST /v1/desktop/stop`: request_id, exact targets[] and confirmed=true. All
   targets are resolved before stopping any. Cold targets report already_stopped
-  without starting a process. Live targets call the canonical owner stop protocol;
+  without starting a process. Live targets call the canonical runtime stop protocol;
   stop_requested is acknowledgement, not an invented completed-exit receipt.
 
 `/loop <count>` uses the standing goal, max 25 iterations; `/loop <goal>` keeps an
 ephemeral goal and uses the shared terminal judge protocol. The shared prompts,
 verdict parser and count rules now live in `session/goal_loop.py`; terminal imports
-remain compatible. The owner waits for actual turn completion rather than HTTP
+remain compatible. The runtime waits for actual turn completion rather than HTTP
 admission. It never answers gates. `stop|cancel|abort` cancels the driver and only
 its own queued/active iteration; another frontend's manual turn is not cancelled
 as collateral. `/loop status` reads state. The canonical frontend snapshot carries
-loop status/count/reason. A viewer detach does not stop/restart it; owner teardown
-cancels it, and a replaced owner labels a retained active checkpoint interrupted
+loop status/count/reason. A viewer detach does not stop/restart it; runtime teardown
+cancels it, and a replaced runtime labels a retained active checkpoint interrupted
 rather than automatically spending more tokens.
 
 ## Provider and reporting endpoints
@@ -145,7 +145,7 @@ rather than automatically spending more tokens.
 - GET `/v1/desktop/analytics?since_ms=...&until_ms=...&session_id=...&days=...`:
   AnalyticsStore aggregate and daily series. The daily series explicitly reports
   all_sessions scope; it is not mislabelled as the optional aggregate session filter.
-- GET `.../sessions/{id}/failovers`: selected and effective owner models plus the
+- GET `.../sessions/{id}/failovers`: selected and effective runtime models plus the
   configured **default** chains. Defaults are labelled, not represented as a live
   provider's private cooldown/account routing state.
 - GET `/v1/desktop/skills?session_id=...&name=...`: session-cwd discovery and optional
@@ -154,7 +154,7 @@ rather than automatically spending more tokens.
 
 ## MCP controls
 
-GET `.../sessions/{id}/mcp` is a cold-safe effective-config read. A live owner supplies
+GET `.../sessions/{id}/mcp` is a cold-safe effective-config read. A live runtime supplies
 its own manager status. Rows report source, owned scope, transport/tool count and
 separate downstream_authorization=`unknown`. Tool discovery or a healthy MCP
 transport does **not** prove Google Workspace account authorization.
@@ -172,9 +172,9 @@ POST the same path accepts the closed `MCPControl` schema:
 - `probe` resolves actual transport OAuth capability through existing core code.
   A statically incompatible stdio/API-key server reports false; otherwise list
   metadata remains unknown until probed. Do not offer HTTP OAuth as stdio setup.
-- `login|logout|reauth` starts an owner operation; logout and reauth require explicit
+- `login|logout|reauth` starts a runtime operation; logout and reauth require explicit
   confirmation. `status|cancel` takes operation_id. Operations are bounded, one grant
-  at a time per owner, timeout after five minutes, and keep the owner resident.
+  at a time per runtime, timeout after five minutes, and keep the runtime resident.
   Credential deletion during reauth is reported even when the later login is
   cancelled. No grant tokens cross HTTP. Core OAuth owns callbacks, refresh locks
   and auth.db; desktop does not add a second store.

--- a/docs/EXEC.md
+++ b/docs/EXEC.md
@@ -30,7 +30,7 @@ lop --resume SESSION_ID
 | `--loop-goal TEXT` | Run continuation/judge iterations until achieved. No fixed iteration cap; repeated undecidable judge results fail safely. Mutually exclusive with `--loop`. |
 | `--name TEXT` | Set the persisted conversation title. |
 | `--effort LEVEL` | Set reasoning effort using the selected model's existing validation. Unsupported levels fail before a turn. |
-| `--resume [ID]` | Reopen the same transcript; omit the ID to select the most recent session. A live headless owner is refused rather than raced; `lop --resume ID` attaches the TUI to that owner instead. |
+| `--resume [ID]` | Reopen the same transcript; omit the ID to select the most recent session. A live headless runtime is refused rather than raced; `lop --resume ID` attaches the TUI to that runtime instead. |
 | `--background` | Detach a worker. The launcher prints a bounded readiness receipt, not a claim that the work completed. |
 | `--status JOB_ID` | Print the durable job record as JSON, including terminal outcome and canonical session ID. Does not run a model; cannot combine with a prompt or run options. |
 | `--control` | Install supervisor approval/question gates. These may wait for an attached user. Runtime discovery and live TUI attachment work without this flag too. |
@@ -92,7 +92,7 @@ bounded wait); its exit code is **not** the eventual execution result. Follow
 `cancelled` or `interrupted`, and inspect its log. Worker termination disposes
 the session before writing the terminal result. Abrupt death cannot truthfully
 report success: status reconciliation compares the PID's process-start identity
-and marks a proven-dead owner interrupted. It never restarts a loop or cleans
+and marks a proven-dead runtime interrupted. It never restarts a loop or cleans
 up a successor's resources.
 
 The job ID identifies the execution receipt; the session ID identifies the

--- a/docs/REWRITE.md
+++ b/docs/REWRITE.md
@@ -105,7 +105,7 @@ Harness core contract:
   disposed explicitly and never keep the loop alive (track handles, cancel on
   dispose).
 - `jobs.py`: `AsyncJobManager` — register/running/completed/failed/cancelled,
-  max 15 running, 5 min retention, owner-scoped delivery sink, cancel scoping.
+  max 15 running, 5 min retention, runtime-scoped delivery sink, cancel scoping.
 - `session/session.py`: facade composing loop + tools + transcript + wake +
   jobs + skills + compaction hooks; `prompt(text)`, `steer()`,
   `subscribe(handler)`, `dispose()`. Session-scoped `asyncio.TaskGroup` for

--- a/docs/SESSION_DIAGNOSTICS.md
+++ b/docs/SESSION_DIAGNOSTICS.md
@@ -65,9 +65,9 @@ The UI runs that read off the event loop and updates only the loading screen
 that owns it; it never pushes a second screen on completion. Closing/unmounting
 invalidates that presentation even if the bounded read finishes in the background.
 Before displaying the result it checks the captured session object, ID and
-(when exposed) mirrored owner epoch, so
+(when exposed) mirrored runtime epoch, so
 `/new` or `/resume` cannot surface a stale report over another session, including
-an owner replacement behind the same remote facade.
+a runtime replacement behind the same remote facade.
 
 Remote terminal frontends use the same shared local analytics database and
 mirrored session identity/runtime scalars. The command is frontend-local, like

--- a/docs/SESSION_SIDEBAR.md
+++ b/docs/SESSION_SIDEBAR.md
@@ -1,7 +1,7 @@
 # In-app session sidebar
 
-The sidebar is an opt-in terminal view over existing session owners, not another
-owner or a new scheduler. `Ctrl+B` and `/sidebar` toggle visibility without moving
+The sidebar is an opt-in terminal view over existing session runtimes, not another
+runtime or a new scheduler. `Ctrl+B` and `/sidebar` toggle visibility without moving
 the editor caret. `F9` and `/sidebar focus` enter the list; F9 returns focus while
 leaving it open, and Escape dismisses it and returns to the last usable surface.
 `Ctrl+Shift+↑`/`Ctrl+Shift+↓` attach the previous/next conversation directly — the
@@ -37,10 +37,10 @@ and its pasted secret cannot be retained by sidebar bookkeeping.
 
 ## Opt-in durable display history
 
-An upgraded owner advertises `display-history-window-v1`. Sidebar connections ask
+An upgraded runtime advertises `display-history-window-v1`. Sidebar connections ask
 for `RemoteSession.connect(..., display_window=True)`; ordinary connections retain
 full-history initialization. The window rides the existing atomic frontend sync:
-owner snapshot, durable cursor, window selection and subscription share one
+runtime snapshot, durable cursor, window selection and subscription share one
 no-yield authoritative-loop boundary.
 
 `Transcript.build_llm_history(through_id=...)` selects the journal cut before
@@ -56,12 +56,12 @@ space reserved for metadata. The entire sync still respects the transport's
 truncated**: an explicit `full_required` result selects the existing off-thread
 local full replay at the captured cut. That fallback does not promise low latency.
 
-Signed tokens bind conversation, owner epoch, replay generation, durable cut and
+Signed tokens bind conversation, runtime epoch, replay generation, durable cut and
 message position; clients cannot provide filesystem paths or byte offsets.
 Appends preserve a captured cut. Compaction, pruning and file folding invalidate
 its generation. Paging returns a typed reset rather than mixing generations;
 the viewer obtains a fresh canonical sync without restarting or prompting the
-owner. A missing saved anchor resets to the new canonical tail, never a different
+runtime. A missing saved anchor resets to the new canonical tail, never a different
 row presented as the old anchor.
 
 `display_history_window()` is explicitly partial. `history_message_count`,
@@ -71,7 +71,7 @@ row presented as the old anchor.
 contiguous interval through it for the existing two-direction renderer.
 `materialize_history()` is the explicit full-trajectory API used by background
 naming. Calling `history()` on an unhydrated window raises, rather than silently
-returning a partial conversation. Owner/model/idempotency full-history callers
+returning a partial conversation. Runtime/model/idempotency full-history callers
 are unchanged.
 
 Loaded IDs, painted IDs and pre-cut live-seed IDs are distinct. Canonical live
@@ -83,10 +83,10 @@ a replay-changing generation produces an explicit presentation reset.
 ## Local workflows and compatibility
 
 The invoking TUI schedules `/loop`, while each iteration prompts its captured
-owner. Another conversation's stop cannot cancel it. Bang commands execute in the
-invoking terminal and forward their receipt to the captured owner. Stable IDs
+runtime. Another conversation's stop cannot cancel it. Bang commands execute in the
+invoking terminal and forward their receipt to the captured runtime. Stable IDs
 from the submitted tool-call ID make duplicate receipt delivery idempotent. A
-busy owner queues the receipt behind its turn; acceptance is not a claim that
+busy runtime queues the receipt behind its turn; acceptance is not a claim that
 queued persistence is already durable. Offscreen completion retains its result.
 
 Already-running older owners remain visible and selectable through authenticated

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -1457,7 +1457,7 @@ not a stub.
 
 ## The seam between the conversation and the composer (2026-08-11)
 
-Reported from the owner's own frame: the last two rows of a turn (`✕ name
+Reported from the runtime's own frame: the last two rows of a turn (`✕ name
 'CompactionOutcome' is not defined` / `✕ interrupted`) sitting directly on the
 composer's fill, so the ledger and the input read as one slab. "There needs to
 be one line of space between the thinking/tool calls/message text and the top

--- a/docs/design-idle-reap.md
+++ b/docs/design-idle-reap.md
@@ -168,7 +168,7 @@ Bare EOF is worse than it looks for exactly the sources we care about.
 `_lease_sidebar_source` calls `RemoteSession.connect` (`app.py:4056-4062`)
 without a `surface` argument, so it defaults to `"terminal"`
 (`remote.py:782`) and `_can_go_cold` is **False**. A parked source that sees
-EOF therefore enters owner-death recovery and, per
+EOF therefore enters runtime-death recovery and, per
 `remote.py:3768-3798`, chases a record for `COLD_FALLBACK_S = 8.0`
 (`remote.py:129`) and then — because it cannot go cold — keeps retrying
 forever while the legacy contract tries to **take over** the session
@@ -252,7 +252,7 @@ using the same method that produced the `app.py:1360-1362` numbers. If the
 p90 lands near the 246 ms cold figure on conversations the user actually
 alternates between, do (B) as a follow-up. My prior is that it will matter
 less than the raw number suggests, because a released source's rebuild no
-longer competes with 11 sibling sockets delivering owner deltas — but that
+longer competes with 11 sibling sockets delivering runtime deltas — but that
 is a prior, not a measurement, and I would not ship (B) on it.
 
 A cheaper middle path worth pricing during implementation: keep a **small**

--- a/docs/design-runtime-autorefresh.md
+++ b/docs/design-runtime-autorefresh.md
@@ -82,7 +82,7 @@ self._recovery_task = asyncio.create_task(self._recover_owner())
 ```
 
 `_end_turn_locally` (`remote.py:1859-1918`) exists for three genuinely
-terminal outcomes (killed owner, stopped owner, going cold) but it is called
+terminal outcomes (killed runtime, stopped runtime, going cold) but it is called
 *before* recovery has learned which of those — if any — applies. The
 synthesised end reaches `EventController._handle_agent_end` and the app's
 turn-end path, which calls `_retire_live_tool_cards` (`app.py:24152`, each
@@ -136,7 +136,7 @@ never retrieved" — 12 such rows in the operator's log today (10:28).
 
 ### 2.1 Where the refresh decision lives
 
-**A. Viewer-side only.** `_check_build_skew` sends `stop` when the owner is
+**A. Viewer-side only.** `_check_build_skew` sends `stop` when the runtime is
 stale and idle, then re-engages. Rejected as the *primary* mechanism: a
 runtime with no viewer attached (the phone's SSE daemon attach is `daemon`
 kind; a `send`-woken session) is never looked at by a TUI, so it would stay
@@ -162,7 +162,7 @@ the price of an idle exit (`process.py:57-66`).
 ### 2.2 Should an attached viewer block the refresh?
 
 The operator says no, and the code agrees it need not: a viewer already
-survives owner exit (`_recover_owner` → `_go_cold` after `COLD_FALLBACK_S`,
+survives runtime exit (`_recover_owner` → `_go_cold` after `COLD_FALLBACK_S`,
 `remote.py:2056-2066`) and a cold viewer already re-engages on the next
 prompt (`_ensure_bound`, `remote.py:1074-1144`). What is missing is only
 (a) an announcement so the viewer does not spend 8 s chasing a record and
@@ -188,7 +188,7 @@ So: **an attached viewer does not block retirement**; it receives a
 
 ### 2.4 Disconnect handling: synthesise the abort now, or defer?
 
-- *Now* (status quo): honest for owner death, false for transient drops.
+- *Now* (status quo): honest for runtime death, false for transient drops.
 - *Defer until recovery's verdict* (recommended): `_on_disconnected` marks
   the turn *suspect* and starts recovery; the synthesised end fires only when
   recovery goes cold, learns the stop, or re-binds to a snapshot whose
@@ -348,7 +348,7 @@ Emitted by `RuntimeServer.announce_retiring(reason)`, a sibling of
 do. Additive: an old viewer ignores the unknown op, sees EOF, runs the
 existing `_recover_owner`, and goes cold after 8 s — the pre-PR behaviour, so
 no `PROTOCOL_VERSION` bump. Not sent to `daemon` clients (the phone's
-projection path stays byte-identical; the daemon already handles owner exit
+projection path stays byte-identical; the daemon already handles runtime exit
 by re-adopting on the next record).
 
 `attach_client.py::_pump` (`:373-381`): add `elif op == "retiring": reason =
@@ -359,7 +359,7 @@ next to `STOPPED_REASON` (`:61`). `_ClientConn` needs nothing new.
 
 ```python
 if _reason == RETIRING_REASON:
-    # A planned refresh, not owner death and not a stop: the runtime
+    # A planned refresh, not runtime death and not a stop: the runtime
     # left so the next engage runs the build now on disk. Nothing to
     # recover — the successor does not exist yet — and nothing was
     # interrupted (the runtime retires only when idle). Go cold NOW
@@ -389,7 +389,7 @@ def _on_runtime_refreshed(self) -> None:
 ```
 
 `_start_runtime_engage` (`app.py:8501-8555`) already re-runs
-`_check_build_skew` after the bind; with a fresh runtime the owner stamp
+`_check_build_skew` after the bind; with a fresh runtime the runtime stamp
 equals the disk stamp and notice C is silent. If the *window* itself is stale
 (notice A), the fresh runtime is newer than the window — that is the
 incident class `design-build-skew.md` §4.1 (B) already repairs, and A's
@@ -404,15 +404,15 @@ line of prose for a background housekeeping event is the pattern
 overrule; if it does, the copy is one dim line:
 `updated to 0.49.9@f4a70b9` — never a warning.
 
-### 3.3 Viewer-side belt: resume/bind against a stale idle owner
+### 3.3 Viewer-side belt: resume/bind against a stale idle runtime
 
 `_check_build_skew`'s C branch (`app.py:14957-15011`) becomes:
 
 ```
-owner stale?
-  ├─ owner idle (frontend_state.streaming False AND no running jobs AND
+runtime stale?
+  ├─ runtime idle (frontend_state.streaming False AND no running jobs AND
   │  no pending gate)  → request refresh; NO notice
-  └─ owner busy       → notice C′ (copy below), once per session
+  └─ runtime busy     → notice C′ (copy below), once per session
 ```
 
 "Request refresh" = `session.request_refresh()` → new `AttachClient.
@@ -643,8 +643,8 @@ Unit — `tests/unit/session/test_remote_refresh.py`:
 9. `_on_disconnected(STOPPED_REASON)` unchanged (regression guard).
 
 Unit — `tests/unit/tui/test_build_skew.py` (extend):
-10. Stale + idle owner → `request_refresh` called, no notice.
-11. Stale + busy owner → C′ info notice, no `/stop` substring anywhere in
+10. Stale + idle runtime → `request_refresh` called, no notice.
+11. Stale + busy runtime → C′ info notice, no `/stop` substring anywhere in
     the ledger (`assert "/stop" not in transcript_text(app)`).
 12. Refresh callback → `_start_runtime_engage(reason="refresh")` and
     `_warm_engage_started` reset.

--- a/docs/design/full-history-audit-window.md
+++ b/docs/design/full-history-audit-window.md
@@ -184,7 +184,7 @@ Measured, not assumed, on the operator's real journals:
 
 | operation | `bda7b76d34e0` (231 MB) | `9f8e5b652ac7` (75 MB) |
 |---|---|---|
-| owner `Transcript` ctor (already paid) | 1.37 s | 0.34 s |
+| runtime `Transcript` ctor (already paid) | 1.37 s | 0.34 s |
 | naive full audit replay | 0.29 s, **47 MB peak** | 0.18 s, 33 MB |
 | windowed audit slice (120 rows, tail) | **<1 ms** | 1 ms |
 | windowed audit slice (120 rows, mid-file) | **<1 ms** | <1 ms |
@@ -192,7 +192,7 @@ Measured, not assumed, on the operator's real journals:
 
 Three conclusions the coder must not relitigate:
 
-1. **Serve audit pages from the owner's resident `_entries`, never from a disk
+1. **Serve audit pages from the runtime's resident `_entries`, never from a disk
    re-read.** `Transcript.__init__` already parses the whole file into
    `self._entries` (`transcript.py:557-566`). The rows are in RAM before any
    page is requested; a windowed replay over them is ~1 ms. Using
@@ -202,13 +202,13 @@ Three conclusions the coder must not relitigate:
    call is exactly what budget B forbids. `audit_slice` is the only entry point.
 3. `read_replay_suffix` (`remote.py:99`, `transcript.py:360`) is for the
    *attach* path and stays exactly as it is. Audit paging is a post-attach,
-   reader-driven gesture on an owner that already holds the journal. **The
+   reader-driven gesture on a runtime that already holds the journal. **The
    resume path's cost does not change at all.**
 
 Page residency is bounded by the existing machinery, unchanged:
 `DISPLAY_HISTORY_MESSAGES`/`DISPLAY_HISTORY_BYTES` (`history_window.py:27-28`)
 bound each page; `_DisplayWindowCache` and `_retained_size` (`:82-162`) bound
-per-owner retention; `RESUME_RENDER_MESSAGES` (`app.py:1049`) bounds first
+per-runtime retention; `RESUME_RENDER_MESSAGES` (`app.py:1049`) bounds first
 paint; `SessionPresentation.retainable` (`session_presentation.py:317`) bounds a
 parked view. Audit pages flow through all four untouched — they are ordinary
 `DisplayHistoryWindow` pages carrying an extra boolean.
@@ -372,20 +372,20 @@ should see the vocabulary change with it.
 (`history_window.py:26`) is advertised at `runtime/server.py:659` on the mere
 presence of `history_page`, and negotiated at `mobile/attach_client.py:245`.
 It is a *presence* flag with no version handshake, so it cannot express "this
-owner also pages audit history". Two ways it breaks without a new string:
+runtime also pages audit history". Two ways it breaks without a new string:
 
-- **New viewer, old owner.** The viewer receives `audit_available` absent →
+- **New viewer, old runtime.** The viewer receives `audit_available` absent →
   Pydantic default `False` → it never asks for an audit page. Safe by
   construction. But `extra="forbid"` on the model means the reverse direction
   is not safe:
-- **Old viewer, new owner.** `DisplayHistoryWindow` sets
+- **Old viewer, new runtime.** `DisplayHistoryWindow` sets
   `model_config = ConfigDict(extra="forbid")` (`history_window.py:39`), so an
   old viewer validating a payload carrying `audit`/`audit_available` **raises**,
   and `_fetch_history_page` (`remote.py:2490`) turns that into a failed attach.
   This is a hard cross-version break, and it is the single most likely way this
   change causes an incident during a staged rollout.
 
-So: the owner advertises `display-history-audit-v1` and **only emits the two new
+So: the runtime advertises `display-history-audit-v1` and **only emits the two new
 fields when the attaching viewer negotiated it**, exactly as `display_window` is
 negotiated today (`runtime/server.py:1253`, `attach_client.py:245`). Mixed
 versions on one machine are the norm here — the global `lop` runtime is a
@@ -472,7 +472,7 @@ tests under `env -u NO_COLOR TERM=xterm-256color`.
 
 1. **Cross-version payload rejection (§6)** — the `extra="forbid"` break. Highest
    severity, and entirely preventable by gating the fields on the negotiated
-   capability. Verify with a real old-binary viewer against a new owner, not
+   capability. Verify with a real old-binary viewer against a new runtime, not
    only with a unit test.
 2. **`materialize_history` walking into audit** — would feed 17,000 rows to the
    retitle sampler and to `history()`. Guard it explicitly (§5) and assert it.

--- a/docs/design/peer-send.md
+++ b/docs/design/peer-send.md
@@ -163,7 +163,7 @@ Add before the final `raise`:
 if op == "peer_message":
     receive = getattr(h, "receive_peer_message", None)
     if not callable(receive):
-        # An owner host that predates peer messaging. Same optional-capability
+        # A host runtime that predates peer messaging. Same optional-capability
         # pattern as recall_steer (registrant.py:657).
         raise ValueError("this session cannot receive peer messages")
     typed = cast(
@@ -231,9 +231,9 @@ async def receive_peer_message(
 ### 2.3 `TuiSessionHandle.receive_peer_message`
 
 `local_operator/mobile/tui_handle.py` (add after `steer`, ~L306). This handle
-bridges to the app's live `Session` via `self._on_app(...)` / the owner loop.
+bridges to the app's live `Session` via `self._on_app(...)` / the host loop.
 Follow the `steer` shape (`tui_handle.py:272-306`): run the session mutation on
-the owner loop, then fold + notify:
+the host loop, then fold + notify:
 
 ```python
 async def receive_peer_message(
@@ -251,7 +251,7 @@ async def receive_peer_message(
         )
     )
     # session.receive_peer_message is async; _on_app runs sync callables on the
-    # Textual thread. Prefer scheduling the coroutine on the owner loop the same
+    # Textual thread. Prefer scheduling the coroutine on the host loop the same
     # way TuiSessionHandle.prompt does (tui_handle.py:256) via
     # run_coroutine_threadsafe, then awaiting the future. See implementation
     # note below.
@@ -262,9 +262,9 @@ async def receive_peer_message(
 ```
 
 **Implementation note for the coder:** `Session.receive_peer_message` is a
-coroutine that must run on the owner event loop (it touches `_context.messages`,
+coroutine that must run on the host event loop (it touches `_context.messages`,
 the transcript, and may spawn a turn). `TuiSessionHandle` already has the exact
-machinery for "run a coroutine on the owner loop and await it from the
+machinery for "run a coroutine on the host loop and await it from the
 registrant's bridge coroutine" — see `prompt` (`tui_handle.py:231-270`) using
 `asyncio.run_coroutine_threadsafe(run_turn(), owner_loop)` and `_await_future`.
 Reuse that pattern rather than `_on_app` (which is for *sync* callables on the
@@ -406,13 +406,13 @@ that are *not* LLM-visible (wake schedules, checkpoints) — wrong tool here.
 
 Add `PeerMessageDeliveredEvent` to `harness/types.py` beside `WakeDeliveredEvent`
 (`harness/types.py:997`), carrying `body: str` and `sender: dict`. Emit it in the
-record-only branch (§2.4) so the owner TUI paints the indicator the instant the
+record-only branch (§2.4) so the host TUI paints the indicator the instant the
 message lands, even while idle. For the wake/steer branches the row appears
 through the normal turn render, but still emit the receipt so the *indicator* is
 consistent. (Model this on `WakeDeliveredEvent`, which fires *before* the turn
 spawn — `session.py:5599-5610`.)
 
-### 3.3 TUI rendering (owner terminal)
+### 3.3 TUI rendering (host terminal)
 
 Two paths, both in `local_operator/tui/`:
 
@@ -556,7 +556,7 @@ target selector accepts, in priority order:
    candidates (the `sessions` table, §4.4) and exit non-zero asking the user to
    disambiguate with `--pid`. If zero, error.
 
-Only `state == "live"` records are eligible targets (a `wedged` record's owner
+Only `state == "live"` records are eligible targets (a `wedged` record's runtime
 is stuck and will not service the socket promptly; `stale` is dead). If the best
 match is `wedged`, say so explicitly rather than hanging on a dial.
 
@@ -908,7 +908,7 @@ by the unit test if a live old binary is unavailable).
   not try to forbid it.
 - **Target mid-restart (wedged).** `scan` returns `wedged` for a live pid whose
   heartbeat is stale (`registry.py:116`). The socket may still answer, but the
-  owner is stuck. Policy: refuse to dial a `wedged` target with a clear message
+  runtime is stuck. Policy: refuse to dial a `wedged` target with a clear message
   ("target pid N is not responding (heartbeat 90s old); try again"), rather than
   hang. `live` only.
 - **Stale pid reuse.** A `stale` record's pid is gone (`registry.py:110`); `scan`

--- a/docs/design/secret-store.md
+++ b/docs/design/secret-store.md
@@ -947,7 +947,7 @@ can never be displayed again to catch it. Measured before the fix: `ABCDEFGH`,
 masked capture, so a hand-typed key name is minted as a short secret rather than
 reaching the `<KEY>` prompt. The command is still *parsed* — a pasted whole line
 reaches it, and it stays the route a viewer session uses to hand a secret to its
-owner — but nothing advertises it as typable any more: `CREDENTIAL_USAGE` and
+runtime — but nothing advertises it as typable any more: `CREDENTIAL_USAGE` and
 the `--persist` advice both name the inline gesture and the generated
 `LOP_SECRET_` name instead. Usage text and behaviour have to agree (QA round 1,
 Q1).
@@ -1094,7 +1094,7 @@ lifeline — it is consulted per retrieval. So:
 > registered one** (only tests did). After `harden` the correct passphrase was
 > refused and even `status` failed, with the plaintext key already deleted. The
 > tier had therefore never worked end to end in either direction: unreachable
-> for its owner, and bypassable by anyone else (§2.1's amendment).
+> for its runtime, and bypassable by anyone else (§2.1's amendment).
 >
 > Three changes, which have to land together:
 >

--- a/docs/evidence/model-receipt/README.md
+++ b/docs/evidence/model-receipt/README.md
@@ -7,8 +7,8 @@ the cold-viewer refusal that keeps that receipt honest when nothing is bound.
 Captured with `shot.py.txt`, which imports the SAME `_AsyncLabelSession` the
 regression tests in `tests/unit/tui/test_app_pilot.py` assert against — a
 fake whose `set_model` records the request and never moves the label, which is
-how `RemoteSession` reads for a terminal attached to another owner's session
-until the owner's frontend-state sync arrives. Run from anywhere; the script
+how `RemoteSession` reads for a terminal attached to another runtime's session
+until the runtime's frontend-state sync arrives. Run from anywhere; the script
 locates the repo root from its own path:
 
 ```sh
@@ -30,11 +30,11 @@ env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
   for every command that changed nothing (`_system_notice`). Two other cold
   shapes answer differently and are pinned by tests rather than frames: a
   viewer `/stop` ended answers `this session was stopped; /resume <id> reopens
-  it` ahead of the routing seam, and one redialing a dead owner answers
+  it` ahead of the routing seam, and one redialing a dead runtime answers
   `session owner is reconnecting; try /model again in a moment`.
 
 The status band is unchanged between each pair on purpose: it repaints from
-the owner's frontend-state sync, which the fake never delivers. The band's cwd
+the runtime's frontend-state sync, which the fake never delivers. The band's cwd
 is `/private/tmp` because the script `chdir`s there before painting, so no
 worktree path lands in a committed frame. The script stubs the update check
 and waits for the splash's model row to settle, so two runs paint the same

--- a/docs/evidence/subagent-accounting/README.md
+++ b/docs/evidence/subagent-accounting/README.md
@@ -2,7 +2,7 @@
 
 ## Acceptance contract
 
-C2 standard/pre-authorized reliability fix. A background owner's known child
+C2 standard/pre-authorized reliability fix. A background runtime's known child
 spend must reach a cold viewer without viewer-side provider discovery. Direct
 rows remain self/current-attempt only. The session total includes descendants,
 prior attempts and retention-swept work exactly once, including after restart.
@@ -17,18 +17,18 @@ historically unknown prices into invented dollar amounts.
 All execution used an isolated HOME and LOCAL_OPERATOR_CONFIG_DIR. The worktree
 has its own Python 3.12 editable venv. Production Session, child runner, bash,
 transcripts, OwnedSessionHandle, RuntimeServer TCP socket, RemoteSession and
-OperatorApp were exercised. Only provider events and owner model-listing prices
+OperatorApp were exercised. Only provider events and runtime model-listing prices
 were scripted; this proves application accounting, not vendor invoice accuracy.
 
 The original model shape was a dynamically listed Anthropic model, 57 token
-receipts and no provider USD receipts. The owner knew its price. The cold viewer
+receipts and no provider USD receipts. The runtime knew its price. The cold viewer
 ran `job_stats` in a worker thread; paint-cache refresh refuses an off-loop
 caller. Retrying therefore could never populate the cache. Explicit USD receipts
 worked throughout, ruling out blanket usage loss in transport.
 
-Independent QA ran separate owner and viewer processes. Before: owner and wire
-cost `.006`, viewer row `$—`, context `1200`. After: owner and viewer `.006`.
-The coder's real socket reproduction independently returned `.375` owner vs
+Independent QA ran separate runtime and viewer processes. Before: runtime and wire
+cost `.006`, viewer row `$—`, context `1200`. After: runtime and viewer `.006`.
+The coder's real socket reproduction independently returned `.375` runtime vs
 `None` cold viewer before, and `.375` on both after. Its screen and virtual size
 were both 118×38; no screen scrollbar appeared.
 
@@ -39,18 +39,18 @@ were both 118×38; no screen scrollbar appeared.
 | Mixed `.125` receipt plus unpriced call | row `$0.125+`; unknown amount not erased |
 | Estimated `.006` + mixed child | canonical and rendered footer `≥$0.131` |
 | Free vs unknown | `$0.0000` vs `$—` |
-| Offline reconstructed owner/viewer | estimate `.006`, mixed `.125+`, total `≥.131` retained |
-| Live nested work | manager, owner and socket viewer include running grandchild |
+| Offline reconstructed runtime/viewer | estimate `.006`, mixed `.125+`, total `≥.131` retained |
+| Live nested work | manager, runtime and socket viewer include running grandchild |
 | Sweep, restart, new billed work | lifetime survives instead of resetting to retained rows |
 | Failed and cancelled billed tool loops | prior `.125` retained; real bash wrote side-effect files |
 | Queued child | no provider request before promotion; promoted on capacity release |
-| Invalid resume, wrong owner, missing/invalid socket auth | rejected, no unauthorized control |
+| Invalid resume, wrong runtime, missing/invalid socket auth | rejected, no unauthorized control |
 
 The committed automated real-path guard is
 `tests/e2e/test_subagent_accounting_e2e.py`: a child requests real bash writing
 `billed`, reports `.125`, fails its next provider call, resumes to `.25`, is
 retention-swept, is reconstructed from disk, and spends another `.125` for `.375`
-lifetime. It asserts owner and socket-viewer totals and the actual sidecar.
+lifetime. It asserts runtime and socket-viewer totals and the actual sidecar.
 
 ```sh
 env -u NO_COLOR HOME=/tmp/accounting-validation \
@@ -72,7 +72,7 @@ SVG stills rendered to PNG and viewed. Independent QA captured consecutive
 settled frames. No layout, control or navigation change is intended.
 
 - [Before cold viewer](before-cold-viewer.png): row unknown despite priced footer.
-- [After cold viewer](after-cold-viewer.png): both show the owner's `.006`.
+- [After cold viewer](after-cold-viewer.png): both show the runtime's `.006`.
 - [Before mixed money](before-money.png): known mixed receipt omitted.
 - [After offline restart](after-offline.png): estimate, genuine zero, unknown and
   partial rows; footer uses the same authoritative `.131` lower bound.

--- a/docs/evidence/subagent-accounting/round-2/README.md
+++ b/docs/evidence/subagent-accounting/round-2/README.md
@@ -9,7 +9,7 @@ legacy accounting leaves the checkpoint fallback; a valid empty ledger replaces
 it. Retained rows are not summed, so swept-only money survives.
 
 Independent QA ran real billed background children and ownerless RemoteSession,
-then reattached the same facade to a real owner. Actual before/after:
+then reattached the same facade to a real runtime. Actual before/after:
 
 | State | Before cold total | After cold / rendered / bound total |
 | --- | --- | --- |

--- a/docs/fork.md
+++ b/docs/fork.md
@@ -33,8 +33,8 @@ a dead end that keeps being re-billed, `/new` and rebuilding from scratch, or
 3. **The original's work keeps running in its runtime.** Tools, subagents, wakes,
    and unanswered approvals stay with the original, even when
    `runtime.background_on_resume` is false. The receipt gives `/resume <parent-id>`
-   to return in this same terminal, attaching to the same active owner rather
-   than restarting it. An idle owner can naturally reap; its saved conversation
+   to return in this same terminal, attaching to the same active runtime rather
+   than restarting it. An idle runtime can naturally reap; its saved conversation
    remains resumable. This is not a promise to keep an idle process alive forever.
 4. If you passed a message, the fork starts working on it as its first turn.
    Normal reattachment does not replay that opening instruction. This does not

--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -72,7 +72,7 @@ the daemon itself publishes a record at startup and removes it at exit:
 
 The daemon scans this directory every 2 s and validates each record by pid
 liveness — a SIGKILLed session leaves its record behind, and the heartbeat
-catches a live pid whose owner wedged. Publication is staged-write + rename.
+catches a live pid whose runtime wedged. Publication is staged-write + rename.
 
 ### The control socket
 
@@ -190,8 +190,8 @@ UUID and the daemon de-duplicates an already-admitted instruction instead of
 running it twice. The rule (source of truth: `web/src/continuation-command.ts`):
 
 - **Keep** across anything that leaves the outcome ambiguous — transport failure,
-  HTTP **502/504/408** (acknowledgement loss *after* the daemon drained the owner
-  frame, not rejection), page reload, SSE reconnect, and navigating between the
+  HTTP **502/504/408** (acknowledgement loss *after* the daemon drained the frame
+  to the runtime, not rejection), page reload, SSE reconnect, and navigating between the
   owner's own conversations. Envelopes are scoped **per session** and bounded by
   **count** (oldest evicted, never the active route), so an ordinary conversation
   switch never silently drops the recovery affordance.

--- a/local_operator/mobile/command_reservation.py
+++ b/local_operator/mobile/command_reservation.py
@@ -1,4 +1,4 @@
-"""Owner-loop command identity reservations for mobile continuation input."""
+"""Runtime-loop command identity reservations for mobile continuation input."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ _CommandKind = Literal["prompt", "steer"]
 
 
 class CommandReservations:
-    """Bounded undurable identities, mutated only on the session owner's loop.
+    """Bounded undurable identities, mutated only on the session runtime's loop.
 
     The transcript's append-only index is the lifetime authority.  This map
     closes only the pre-append gap, so durable callbacks remove entries without

--- a/local_operator/mobile/peer_send.py
+++ b/local_operator/mobile/peer_send.py
@@ -56,12 +56,12 @@ def resolve_peer_target(
     record has that pid does the digit string fall through to the substring
     match, so a session id or name that happens to be numeric still works.
 
-    Only ``live`` records are eligible (a ``wedged`` owner will not service
+    Only ``live`` records are eligible (a ``wedged`` runtime will not service
     the socket promptly; ``stale`` is dead) — unless ``include_wedged``,
     which the kill switch passes: a wedged session is exactly the one a user
     needs to be able to STOP, and the stop ladder's signal rungs are built
-    for an owner that will not answer. A send never wants that; a message to
-    a wedged owner is a message nobody reads.
+    for a runtime that will not answer. A send never wants that; a message to
+    a wedged runtime is a message nobody reads.
 
     A selector (``pid``/``session``) alongside a ``target`` substring is REFUSED
     rather than resolved. The two name different sessions, and the precedence

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -1065,7 +1065,7 @@ class ProjectionFold:
             # equivalent keeps ``getattr`` because its dispatch routes on
             # ``event.type`` without re-validating, so a legacy relayed frame
             # reaches it as a bare ``AgentEvent`` (see the comment there).
-            # An older owner that omits the field arrives as ``None`` and takes
+            # An older runtime that omits the field arrives as ``None`` and takes
             # the falsy no-op path below.
             superseded = event.supersedes_tool_call_id
             if superseded:
@@ -1593,7 +1593,7 @@ class ProjectionFold:
         ]
 
     def set_todos(self, phases: list[dict[str, Any]]) -> None:
-        """Refresh the todo list from the tool store. Called by the owner
+        """Refresh the todo list from the tool store. Called by the runtime
         after every event batch: the store is the only writer, so re-reading
         it is the fold — there is no todo event to listen for.
 

--- a/local_operator/mobile/tui_handle.py
+++ b/local_operator/mobile/tui_handle.py
@@ -24,10 +24,10 @@ its own ``settle`` path on the Textual loop, so the terminal screen comes down
 too and exactly one answer wins whichever front end got there first. When the
 picker settles by any route, :meth:`note_ask_settled` clears the phone card.
 
-Protocol-v4 full-TUI followers can answer approvals mounted by the owner TUI.
+Protocol-v4 full-TUI followers can answer approvals mounted by the host TUI.
 The approval is carried as follower-only pending state (never added to daemon
 projection frames, preserving the phone path byte-for-byte) and
-:meth:`approval_answer` resolves the owner's real ``ApprovalPrompt`` on the
+:meth:`approval_answer` resolves the host's real ``ApprovalPrompt`` on the
 Textual loop, so exactly one front end wins.
 """
 
@@ -137,7 +137,7 @@ class TuiSessionHandle(SessionHandle):
         # so this normally holds at most one entry, but a dict keeps pop-by-id
         # honest. Mutated ONLY on the Textual loop (mount/settle) and read there
         # too (``ask_answer`` hops onto it before touching this), so the
-        # single-winner race is decided by one owner, not by dict atomicity.
+        # single-winner race is decided by one loop, not by dict atomicity.
         self._ask_pending: dict[str, Any] = {}
         # Child transcripts can contain thousands of attachment-backed entries.
         # Keep their I/O off Textual's loop and bound work to one coalescing
@@ -426,11 +426,11 @@ class TuiSessionHandle(SessionHandle):
         wake: bool = False,
         sender: dict[str, Any] | None = None,
     ) -> str:
-        # Session.receive_peer_message is a COROUTINE that must run on the owner
+        # Session.receive_peer_message is a COROUTINE that must run on the host's
         # event loop (it touches _context.messages, the transcript, and may
         # spawn a turn). `_on_app` only runs SYNC callables on the Textual
         # thread, so we reuse the prompt() machinery: a sync shim scheduled on
-        # the app captures the owner loop and schedules the coroutine there with
+        # the app captures the host loop and schedules the coroutine there with
         # run_coroutine_threadsafe, and we await its result from this bridge
         # coroutine. Do NOT call the coroutine directly off-loop.
         sender = sender or {}
@@ -500,7 +500,7 @@ class TuiSessionHandle(SessionHandle):
             name = str(getattr(session, "conversation_name", "") or sid)
             self._app.run_worker(self._app._stop_local_session(), thread=False, group="session")
             # The follower's receipt: what ended and the way back, the same
-            # line the owner's own transcript paints.
+            # line the host's own transcript paints.
             reopen = f"/resume {sid}" if sid else "/resume"
             return f'stopping "{name}" — {reopen} reopens it'
 
@@ -561,8 +561,8 @@ class TuiSessionHandle(SessionHandle):
     ) -> dict[str, Any]:
         """Run one shared slash command and return its typed outcome.
 
-        The owner-side backend for a follower's ``route_shared_slash``. Unlike
-        ``slash_images`` — which runs the command's UI in the OWNER's terminal
+        The host-side backend for a follower's ``route_shared_slash``. Unlike
+        ``slash_images`` — which runs the command's UI in the HOST's terminal
         and returns a ``ran /…`` receipt — this asks the app for a
         :class:`SlashResult` payload the INVOKING terminal renders locally, so
         ``/goal``/``/rename``/``/mcp``/``/context`` answer where they were
@@ -585,8 +585,8 @@ class TuiSessionHandle(SessionHandle):
         on ``OwnedSessionHandle``: a session can be hosted either by a detached
         runtime or by this app, and a follower must get the same answer from
         both. A viewer that does not consume action-carrying receipts has its
-        request completed HERE when this TUI is the owner, exactly as the
-        runtime would.
+        request completed HERE when this TUI is the host, exactly as the
+        runtime itself would.
         """
         owner_loop = await self._on_app(asyncio.get_running_loop)
         done: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
@@ -635,7 +635,7 @@ class TuiSessionHandle(SessionHandle):
         return f"forked {len(parsed) // 2} aside exchange(s) into the chat"
 
     def cancel_subagents_count(self) -> int:
-        """Cancel every running subagent on the owner; return the REAL count."""
+        """Cancel every running subagent on the runtime; return the REAL count."""
         session = self._session()
         cancel = getattr(session, "cancel_subagents", None)
         if not callable(cancel):
@@ -663,7 +663,7 @@ class TuiSessionHandle(SessionHandle):
         return f"resumed {session_id}"
 
     async def approval_answer(self, request_id: str, approved: bool, remember: bool) -> str:
-        """Settle the owner's real ApprovalPrompt from another front end.
+        """Settle the host's real ApprovalPrompt from another front end.
 
         The prompt's ``resolve`` is idempotent and runs on Textual's loop, so
         terminal, phone and follower answers share one arbitration point. A
@@ -691,7 +691,7 @@ class TuiSessionHandle(SessionHandle):
         Called on the registrant/daemon loop, so the whole resolve hops ONTO
         the Textual loop via :meth:`_on_app`: the pending-map read, the
         single-winner guard, and the picker advance/settle all run there,
-        against the one owner that also mounts and settles the card. That is
+        against the one loop that also mounts and settles the card. That is
         what makes the race safe without locking — by the time this callback
         runs, either the picker is still live (answer it) or the terminal
         already answered (``settled`` is set / the entry is gone).
@@ -778,7 +778,7 @@ class TuiSessionHandle(SessionHandle):
     # -- approval / ask mirroring ---------------------------------------------
 
     def note_approval_pending(self, card: Any) -> None:
-        """Project the owner's real approval prompt to v4 followers.
+        """Project the host's real approval prompt to v4 followers.
 
         The request id is stored on the prompt itself because approvals are
         serialized and the prompt is the one arbitration object every answer
@@ -929,7 +929,7 @@ class TuiSessionHandle(SessionHandle):
             self._on_projection()
 
     def _publish_pending_gate(self, pending: PendingRequest | None) -> None:
-        """Publish the owner gate into the canonical full-TUI contract."""
+        """Publish the host gate into the canonical full-TUI contract."""
         session = self._session()
         store = getattr(session, "_frontend_state_store", None)
         if store is None:

--- a/local_operator/mobile/types.py
+++ b/local_operator/mobile/types.py
@@ -45,7 +45,7 @@ from typing import Any, Literal
 # Discovery + control-plane primitives now live in the session runtime package:
 # a record, a heartbeat, a client kind and an attach cap describe one session
 # reachable over a control socket, and the phone is one client of that, not
-# its owner. They are re-exported here (and NOT redefined) so the whole mobile
+# its runtime. They are re-exported here (and NOT redefined) so the whole mobile
 # stack — daemon, web layer, attach client, peer send — keeps importing them
 # from the path it always has. See local_operator/session/runtime/types.py for
 # why that package is neutral and why RUN_DIRNAME keeps its mobile-era name.
@@ -96,7 +96,7 @@ class ContinuationCommand:
         This constructor sits on both HTTP and control-socket boundaries. Silent
         ``str(...)`` coercion turns missing, object, and list fields into model
         input and lets malformed UUIDs escape as route-level 500s, so invalid
-        producer data is rejected before any owner is spawned or transcript is
+        producer data is rejected before any runtime is spawned or transcript is
         opened.
         """
         if not isinstance(data, dict):
@@ -223,7 +223,7 @@ def validate_control_frame(frame: dict[str, Any]) -> None:
     elif op == "recall_steer":
         # v4: a follower unsending a queued steer names the message identity it
         # queued (the ContinuationCommand id that became the Message id). The
-        # owner matches by id in its steering queue; a drained or unknown id is
+        # runtime matches by id in its steering queue; a drained or unknown id is
         # an ordinary "no longer queued" error, never a crash.
         if not isinstance(frame.get("command_id"), str) or not frame["command_id"]:
             raise ValueError("command_id must be a non-empty string")
@@ -291,7 +291,7 @@ ControlOp = Literal[
     "unwatch",  # {} — the last phone SSE subscriber left
     # v4 (full-TUI attach): unsend one queued steering message by identity.
     # Follower Esc-recall parity — the TUI matches queue contents by the
-    # Message id it queued, and the owner recalls exactly that entry.
+    # Message id it queued, and the runtime recalls exactly that entry.
     "recall_steer",  # {command_id}
     # Peer-to-peer session messaging (`lop send`): a short-lived sender process
     # from ANOTHER local lop session hands a message to this one. Additive; no
@@ -318,10 +318,10 @@ EventOp = Literal[
     "projection",  # full projection repaint (the only push form — no deltas)
     "ack",  # {req, detail} — a request landed
     "error",  # {req, message} — a request was rejected/failed
-    # v4, event-subscribed attach clients ONLY (never the daemon): the owner
-    # session's raw AgentEvent stream, serialized with model_dump(mode="json").
+    # v4, event-subscribed attach clients ONLY (never the daemon): the session
+    # runtime's raw AgentEvent stream, serialized with model_dump(mode="json").
     # Fidelity by construction — the follower renders the same events the
-    # owner's own EventController consumes, so nothing is inverse-folded.
+    # runtime's own EventController consumes, so nothing is inverse-folded.
     "event",  # {data: <AgentEvent dump>}
     "frontend_sync",  # v5 attach-only atomic FrontendSessionState snapshot
     "frontend_update",  # v5 attach-only ordered state replacement
@@ -639,7 +639,7 @@ def _projection_from_json(data: dict[str, Any], record: SessionRecord) -> Sessio
         for item in items:
             values = {k: v for k, v in item.items() if k in known}
             if cls is TranscriptEntry:
-                # Older owners did not say whether the real row ending survived.
+                # Older runtimes did not say whether the real row ending survived.
                 # Unknown completeness cannot authorize a completion receipt.
                 values["text_complete"] = item.get("text_complete") is True
             result.append(cls(**values))

--- a/local_operator/server/models/desktop_sessions.py
+++ b/local_operator/server/models/desktop_sessions.py
@@ -1,7 +1,7 @@
 """Additive HTTP response models over the canonical runtime's own state schema.
 
 Keep FrontendSync and SlashResult shared with attach clients. A parallel HTTP
-projection would drop new owner fields and turn unknown accounting into zeros.
+projection would drop new runtime fields and turn unknown accounting into zeros.
 """
 
 from typing import Any, Literal
@@ -126,7 +126,7 @@ class AttentionState(BaseModel):
     kind: Literal["complete", "error", "interrupted"] | None
     unseen: bool
     #: ``[published, acknowledged]`` -- monotonic per conversation, and
-    #: independent of the owner epoch, so it orders a conversation's own states
+    #: independent of the runtime epoch, so it orders a conversation's own states
     #: rather than depending on arrival order.
     #:
     #: NOT a merge key: a heal deliberately REPUBLISHES a corrected state under
@@ -136,5 +136,5 @@ class AttentionState(BaseModel):
     #: reads this field; it is a diagnostic ordering hint, and any future
     #: consumer must treat an equal pair as "possibly changed", never as stale.
     revision: list[int]
-    #: Absent on the cold list path; only a live owner can answer it.
+    #: Absent on the cold list path; only a live runtime can answer it.
     supported: bool | None = None

--- a/local_operator/server/routes/desktop_catalogues.py
+++ b/local_operator/server/routes/desktop_catalogues.py
@@ -268,7 +268,7 @@ async def entities(
             finally:
                 controller.close()
         elif spec.name == "effort":
-            # Owner-resolved capabilities can differ from the static model-id
+            # Runtime-resolved capabilities can differ from the static model-id
             # registry (aggregator listings and explicit model overrides).
             rows = [{"value": value} for value in remote.model.reasoning_efforts]
             current = remote.model.reasoning_effort

--- a/local_operator/server/routes/desktop_lifecycle.py
+++ b/local_operator/server/routes/desktop_lifecycle.py
@@ -1,4 +1,4 @@
-"""Explicit desktop lifecycle operations through the canonical session owner."""
+"""Explicit desktop lifecycle operations through the canonical session runtime."""
 
 from __future__ import annotations
 
@@ -217,7 +217,7 @@ async def stop(body: Stop, request: Request):
         for target in dict.fromkeys(body.targets):
             async with errors(), host(request).session(target) as bridge:
                 assert bridge.remote is not None
-                # A stop never engages a cold owner merely to shut it down.
+                # A stop never engages a cold runtime merely to shut it down.
                 if bridge.remote.is_cold:
                     rows.append({"session_id": target, "status": "already_stopped"})
                 else:

--- a/local_operator/server/routes/desktop_sessions.py
+++ b/local_operator/server/routes/desktop_sessions.py
@@ -83,7 +83,7 @@ class Input(BaseModel):
 
 class Seen(Input):
     # A durable completion UUID is the only admission: timestamps or a caller's
-    # owner epoch could accidentally acknowledge a later, unseen outcome.
+    # runtime epoch could accidentally acknowledge a later, unseen outcome.
     completion_token: RequestID
 
 
@@ -212,7 +212,7 @@ async def errors() -> AsyncIterator[None]:
             503, "Read state is busy right now. It will catch up on its own."
         ) from None
     except ConnectionError as error:
-        # A cold session that cannot start an owner reports WHY -- but only when
+        # A cold session that cannot start a runtime reports WHY -- but only when
         # the reason arrives as an `ActionableConnectionError`, whose TYPE is
         # what certifies the message as one of the vetted configuration
         # sentences (`launch._ACTIONABLE_STARTUP_REASONS`).
@@ -461,7 +461,7 @@ async def command(session_id: str, body: Command, request: Request):
             consumed = outcome.data.get("request", "")
             attached = outcome.data.get("type") in {"team_attached", "agent_attached"}
             if attached and (consumed or body.images):
-                # The owner returns attachment metadata, not a started turn.
+                # The runtime returns attachment metadata, not a started turn.
                 # Match its typed discriminator rather than blindly submitting
                 # any string a listing/picker happens to call a request.
                 detail, duplicate = await bridge.remote.admit_prompt(

--- a/local_operator/server/utils/desktop_receipts.py
+++ b/local_operator/server/utils/desktop_receipts.py
@@ -1,9 +1,9 @@
 """Durable at-most-once receipts for desktop control requests.
 
-The owner already reserves natural prompt IDs across process replacement. Slash
+The runtime already reserves natural prompt IDs across process replacement. Slash
 controls do not have that property, so an HTTP retry must not re-run a side
 effect merely because its response was lost. A pending receipt after a crash is
-explicitly indeterminate; only replay-safe owner admissions may resume it. No
+explicitly indeterminate; only replay-safe runtime admissions may resume it. No
 secret input or raw request body is journalled here.
 """
 
@@ -73,7 +73,7 @@ class DesktopReceipts:
         fingerprint = hashlib.sha256(
             json.dumps(body, sort_keys=True, separators=(",", ":")).encode()
         ).hexdigest()
-        # Coalesce retries of THIS request, not unrelated sessions: an owner
+        # Coalesce retries of THIS request, not unrelated sessions: a runtime
         # compaction can wait on a provider, and must not block another session's
         # prompt admission. Cross-process races still use the SQLite transaction.
         lock, users = self.locks.get(key, (asyncio.Lock(), 0))

--- a/local_operator/server/utils/desktop_sessions.py
+++ b/local_operator/server/utils/desktop_sessions.py
@@ -1,7 +1,7 @@
 """HTTP viewers of canonical runtimes, never a second execution host.
 
 One bridge is shared by concurrent HTTP operations and event subscribers. Its
-receipt sequence is deliberately independent of the owner's frontend revision:
+receipt sequence is deliberately independent of the runtime's frontend revision:
 a snapshot covers paint state, not semantic receipts such as steering delivery.
 The last reader detaches; neither socket disposal nor HTTP shutdown stops work.
 """
@@ -104,7 +104,7 @@ class DesktopSessionBridge:
                     )
                     self.remote = remote
                     # A detached interval has no receipt feed. A new epoch makes
-                    # that gap explicit even when the owner itself never died.
+                    # that gap explicit even when the runtime itself never died.
                     self.epoch = uuid.uuid4().hex
                     self.sequence = 0
                     self.replay.clear()
@@ -145,10 +145,10 @@ class DesktopSessionBridge:
         # LAST, and suppressing the task's OWN failure rather than only
         # CancelledError: awaiting a task that already died re-raises its
         # exception, and with this block ahead of `dispose()` a store error
-        # aborted teardown midway -- leaking the owner session and its
+        # aborted teardown midway -- leaking the runtime's session and its
         # subscriptions while `users` had already reached 0, so a later
         # `acquire()` reused a half-torn bridge. A read receipt must never
-        # strand a session owner.
+        # strand a session runtime.
         if self.attention_task is not None:
             self.attention_task.cancel()
             with contextlib.suppress(BaseException):
@@ -199,12 +199,12 @@ class DesktopSessionBridge:
         self.publish("event", event.model_dump(mode="json"))
 
     def _frontend(self, update: FrontendUpdate) -> None:
-        # Keep the owner's field deltas, not a full snapshot per streamed token.
+        # Keep the runtime's field deltas, not a full snapshot per streamed token.
         # Trajectories are intentionally opt-in on the runtime and absent here;
         # large roster/usage fields still pass through the shared wire budget.
         payload = update.model_dump(mode="json")
-        # Receipt revisions outlive an owner epoch. Only the independent durable
-        # projection below may update them; a delayed owner delta must not undo
+        # Receipt revisions outlive a runtime epoch. Only the independent durable
+        # projection below may update them; a delayed runtime delta must not undo
         # a read made through another process while this stream stays mounted.
         payload["changes"].pop("attention", None)
         payload["job_trajectory_appends"] = {}
@@ -229,14 +229,14 @@ class DesktopSessionBridge:
             previous = self.attention
             self.attention = state
             # The initial snapshot owns the baseline; later changes have their
-            # own receipt clock rather than borrowing a runtime owner sequence.
+            # own receipt clock rather than borrowing a runtime sequence.
             if previous:
                 self.publish("attention", state)
         return state
 
     async def _poll_attention(self) -> None:
         # Read-only polling is shared by every subscriber of this bridge and
-        # independent of watch leases. It also works while no owner is running.
+        # independent of watch leases. It also works while no runtime is running.
         #
         # The body is guarded because this store has other writers: a `database
         # is locked` that outlives its 2 s timeout is routine contention, and
@@ -253,8 +253,8 @@ class DesktopSessionBridge:
                 # than the full per-conversation read; the steady state is a
                 # store nothing has written since the last tick.
                 #
-                # The owner's own state is part of the key because `supported`
-                # is derived from it, not from the store: an owner starting or
+                # The runtime's own state is part of the key because `supported`
+                # is derived from it, not from the store: a runtime starting or
                 # going cold changes that answer while the store is untouched,
                 # so gating on the revision alone would pin `supported` to
                 # whatever happened to be true when the bridge attached.
@@ -387,11 +387,11 @@ class DesktopSessionBridge:
             ]
             if not remaining:
                 # LAST lease has expired. Returning here without a final refresh
-                # left the owner holding whatever presence the previous pass
+                # left the runtime holding whatever presence the previous pass
                 # asserted -- visible, notifiable -- for the rest of the
                 # session, because nothing else recomputes it once the loop is
                 # gone. The expiry that ends the loop is exactly the one the
-                # owner still needs to be told about.
+                # runtime still needs to be told about.
                 with contextlib.suppress(ConnectionError, RuntimeError):
                     await self.refresh_watch()
                 return
@@ -450,7 +450,7 @@ class DesktopSessionBridge:
         finally:
             self.subscribers.pop(sub.id, None)
             # ASGI disconnect runs inside a cancelled anyio scope. Cleanup must
-            # still reach the owner; otherwise a dead renderer leaves presence
+            # still reach the runtime; otherwise a dead renderer leaves presence
             # asserted until TTL expiry and the bridge never releases its socket.
             with CancelScope(shield=True), contextlib.suppress(ConnectionError, RuntimeError):
                 await self.refresh_watch()
@@ -465,11 +465,11 @@ class DesktopSessions:
         self.lock = asyncio.Lock()
 
     async def acknowledge_attention(self, session_id: str, token: str) -> dict[str, Any]:
-        """A read receipt never admits work, binds a viewer, or starts an owner.
+        """A read receipt never admits work, binds a viewer, or starts a runtime.
 
         Validate the same durable user-session namespace as the bridge, but do
         not enter its acquire path: a completed cold conversation is readable
-        even when its owner and the mobile daemon are both stopped.
+        even when its runtime and the mobile daemon are both stopped.
         """
 
         def acknowledge() -> dict[str, Any]:
@@ -496,7 +496,7 @@ class DesktopSessions:
 
         Deliberately outside :meth:`session`, exactly like
         :meth:`acknowledge_attention` and for the same reason: reading a
-        screenshot out of a finished conversation must not start an owner
+        screenshot out of a finished conversation must not start a runtime
         process. The session id is still validated against the same durable
         user-session namespace, so the route cannot be used to probe arbitrary
         directories, and the store is shared rather than per-session because


### PR DESCRIPTION
Release: patch — agent-facing docs (AGENTS.md, guides) use the runtime glossary instead of the retired owner vocabulary.

## Summary

Stage 4 session-consolidation PR 6 of 7 (plan: `~/workspace/lop-session-consolidation/stage4-owner-retirement.md`, §4.1 + §5). Prose-only adoption of the runtime glossary in agent-facing documentation and in comments/docstrings of the mobile and server surfaces. No behaviour change: every hunk is an exact-match prose replacement; no identifiers, no string literals, no wire constants, no `pyproject.toml`.

## Glossary applied

| Retire | Adopt | Sense |
|---|---|---|
| "the owner" (noun) | "the runtime" / "the runtime process" | the process hosting the session |
| "the owner TUI" / "owner-side" | "the host TUI" / "host-side" | the front end hosting the runtime |
| "owner-backed" shapes ("on the owner", "start an owner") | "on the runtime", "start a runtime" | execution locus |
| "owner epoch" (prose concept) | "runtime epoch" | frontend-state epoch of the hosting process |

## Files (29, +180/−180)

- **docs/** — all markdown except `design-build-skew.md` (PR-2 exclusive): ATTENTION, DESKTOP_API, DESKTOP_CONTROLS, EXEC, REWRITE, SESSION_DIAGNOSTICS, SESSION_SIDEBAR, VERIFICATION, design-idle-reap, design-runtime-autorefresh, fork, mobile, plus `docs/design/{peer-send,secret-store,full-history-audit-window}.md` and evidence READMEs (`model-receipt`, `subagent-accounting` + round-2). AGENTS.md was audited case-insensitively: all 52 occurrences are release-window/code-owner (human) senses — nothing to change.
- **`local_operator/mobile/*.py`** (except PR-2's `attach_client.py`, `daemon.py`) — comments/docstrings only: `command_reservation`, `peer_send`, `projection`, `tui_handle`, `types`.
- **`local_operator/server/**`** — comments/docstrings only where session-sense: `models/desktop_sessions`, `routes/desktop_{catalogues,lifecycle,sessions}`, `utils/desktop_{receipts,sessions}`.

## Deliberately kept (not session-sense)

- **Human senses**: release owner / code owner / `repos/<owner>/<repo>` (AGENTS.md, security-advisory-runbook, design-runtime-autorefresh L4), mobile auth's single owner (auth.py, seen.py, mobile.md L222), "the owner's own conversations" (mobile.md L195).
- **Other real ownership relations**: POSIX file owner (secret-store, osworld_2), X11 CLIPBOARD owner (computer-input), tunnel/credential owner (tunnels.md), modal single-holder idiom (mobile.md L178), CSS-layout "one owner per seam/row" (VERIFICATION L1493/L1551, openai-context-max L96).
- **Event-loop idiom**: "Textual's owner loop" / "owner-loop future" / the `owner_loop` identifier in `tui_handle.py` (kept per plan §2.4's verify-and-keep list; the loop is not the session host).
- **Wire/compat surfaces, by construction untouched**: `execution: "owner"|"native"` enum and `live_model_source: "owner"` (desktop_catalogues/desktop_commands), `OWNER_COMMANDS`, HTTP error string literals ("Session owner is unavailable…", "earlier session owner"), `peer_send`'s refusal string, quoted error text in comments (desktop_sessions.py L221-222), the `RETIRING_REASON` wire string quoted in design-runtime-autorefresh, the authd log quote in secret-store, and `session owner is reconnecting…` quoted in model-receipt/README.
- **Verbatim captures**: `docs/evidence/**/*.txt` are captured program output — never edited.
- **`owns_runtime`** — not renamed anywhere.

## Left because of the PR-2 deny list (report, not fixed)

- `docs/design-idle-reap.md` L97 and L217 quote code comments that live in `tui/app.py` (denied) and `session/session_interaction.py` (PR-5's slice) — quotes stay verbatim.
- `docs/design-phased-todos.md` (4 occurrences) mirrors `tools/builtin.py`'s own "owner key" todo-store vocabulary (`builtin.py:4820/4936/4944`), which no stage-4 PR owns — rewriting the doc alone would make it contradict the code it cites.
- `local_operator/mobile/attach_client.py` and `daemon.py` still carry ~30 session-sense comment sentences (PR-2 exclusive files), and `mobile/web/src/*.ts` ("daemon writes and drains the owner frame") is not `.py` and outside this slice.
- `docs/design-runtime-autorefresh.md` keeps the `_recover_owner` backtick reference verbatim (current main's identifier); #916 renames it to `_recover_runtime`, so the doc reference goes stale the moment that merges — left for that PR's doc sync or PR-5.

## Zero-identifier / zero-string proof

```
$ git diff origin/main...HEAD -U0 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
    | grep -E '_owner_ready|owner_idle|find_owner_record|owns_runtime|_recover_owner|owner_version|owner_source_ref|owner_model_catalogue|OWNER_COMMANDS|STOPPED_REASON|RETIRING_REASON'
-survives owner exit (`_recover_owner` → `_go_cold` after `COLD_FALLBACK_S`,
+survives runtime exit (`_recover_owner` → `_go_cold` after `COLD_FALLBACK_S`,
```

The only hit is the **kept** identifier on both sides (the prose around it changed); no identifier token was altered. String-literal grep over `+` lines: empty. Remaining case-insensitive `owner` in scope: 107 lines, each accounted for above.

## Verification

- `.venv/bin/python -m flake8 .` → clean (worktree-local venv; `import local_operator` resolves into this worktree).
- `uvx --from black==26.1.0 black --check .` → 1210 files unchanged.
- `uvx isort==5.13.2 --check .` → clean.
- `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` → 0 errors, 0 warnings.
- Targeted tests (`env -u NO_COLOR TERM=xterm-256color`, `-n 4`): `tests/unit/mobile tests/unit/server` → **625 passed, 2 skipped**; `tests/unit/tui/test_ask_picker.py tests/unit/tui/test_stop_command.py tests/unit/session/runtime/test_subagent_counts_published.py` → **166 passed**.
- `git diff origin/main...HEAD -- pyproject.toml` → **empty**. No version bump.

Docs-only + comments-only by construction; no runtime surface exercised beyond the import/test smoke above (nothing executable changed).