### PR TITLE
fix(peer): never drive a turn into an unstarted session

### DIFF
--- a/local_operator/mobile/peer_send.py
+++ b/local_operator/mobile/peer_send.py
@@ -169,11 +169,13 @@ def resolve_peer_target(
         # the first prompt) is excluded from a BROADCAST/substring match: an
         # interrupt there would drive a turn into a session whose owner has not
         # started it. An EXACT ``--pid``/``--session`` send still resolves to it
-        # (the sender deliberately named that session) and is spooled by
-        # ``deliver_peer_message`` rather than dialled — see there. The default
-        # True keeps a record that simply lacks the attribute (a test double, a
-        # hand-built record) eligible; a pre-field binary's record round-trips
-        # through ``from_json`` with the conservative ``False`` instead.
+        # (the sender deliberately named that session); delivery then degrades
+        # to a quiet mailbox dial that drives no turn — see
+        # ``deliver_peer_message``. The default True keeps a record that simply
+        # lacks the attribute (a test double, a hand-built record) eligible; a
+        # pre-field binary's record round-trips through ``from_json``, which
+        # reads the ABSENT key as True (old peer behaviour preserved) — see the
+        # mixed-version note there.
         if not getattr(rec, "started", True):
             continue
         haystacks = [
@@ -365,6 +367,33 @@ def stored_candidate_lines(
     return lines
 
 
+async def _spool_quiet_note(
+    session_id: str, *, text: str, mode: str, sender: "dict[str, Any]"
+) -> str:
+    """Spool one message for a session with NO live runtime. Returns receipt.
+
+    The single spool writer for ``deliver_peer_message``'s cold branch (and
+    historically its unstarted branch): one ``O_APPEND`` row under the
+    session's directory, consumed by the runtime child's boot drain
+    (``process._drain_inbox_into``) the next time that session actually opens
+    a runtime. A spool is ONLY for a session nobody has open — the drain runs
+    once at child boot, so a session that is already live would never read
+    it, which is why a live-but-unstarted target is dialled quietly instead
+    (see ``deliver_peer_message``).
+    """
+    from local_operator.session.runtime.inbox import InboxLine, append_inbox
+
+    directory = config_dir() / "sessions" / session_id
+    written = await asyncio.to_thread(
+        append_inbox,
+        directory,
+        InboxLine(text=text, sender=dict(sender), mode=mode, written_at=time.time()),
+    )
+    if not written:
+        raise RuntimeError("could not spool the message for that session")
+    return "spooled (will be read when the session next opens)"
+
+
 async def deliver_peer_message(
     record: "Any | None",
     *,
@@ -377,9 +406,17 @@ async def deliver_peer_message(
 ) -> str:
     """Hand one message to a peer session, running or not. Returns the receipt.
 
-    Three cases, and the split between them is the whole point:
+    Four cases, and the split between them is the whole point:
 
-    - **A live record** — dial it, exactly as before.
+    - **A live, started record** — dial it, exactly as before.
+    - **A live, UNSTARTED record** (``/new``, owner still composing) — dial it
+      in the quiet mailbox shape (``mailbox`` + no wake) so the receive side
+      paints the peer card and persists the row WITHOUT driving a turn. A
+      spool would be wrong here: a live record means the session is already
+      open, and the only inbox consumer is the runtime child's boot drain, so
+      a spooled note would sit unread for that session's whole life while the
+      receipt claimed otherwise. Degrading wake/steer to the quiet dial is
+      the deliverable form of "never drive a turn into an unstarted session".
     - **No runtime, quiet note** (``wake=False`` and mailbox mode) — SPOOL it.
       Starting a runtime here would contradict what the sender asked for:
       ``wake=False`` means "read this on your next turn", not "start one now",
@@ -396,40 +433,24 @@ async def deliver_peer_message(
             # Belt-and-braces with the resolver's broadcast exclusion: an
             # exact-address send (or any caller that bypassed resolution) must
             # NEVER drive a turn into a session whose owner is still composing
-            # their first prompt. Degrade mailbox, mailbox+wake and steer alike
-            # to a quiet spool; the existing inbox-drain path hands the message
-            # to the session's first real turn. The default True is a defence
-            # against a NON-standard record that simply lacks the attribute (a
-            # test double, a hand-built record), keeping such a peer on the old
-            # socket path. A record a PRE-FIELD binary wrote round-trips through
-            # ``from_json``, which reads the absent key as the dataclass default
-            # ``False`` — the conservative mixed-version direction documented
-            # there — so an old working session is spooled, never driven.
-            from local_operator.session.runtime.inbox import InboxLine, append_inbox
-
-            directory = config_dir() / "sessions" / session_id
-            written = await asyncio.to_thread(
-                append_inbox,
-                directory,
-                InboxLine(text=text, sender=dict(sender), mode=mode, written_at=time.time()),
-            )
-            if not written:
-                raise RuntimeError("could not spool the message for that session")
-            return "spooled (session not started yet; will be read when it next opens)"
+            # their first prompt — so whatever mode/wake the sender asked for,
+            # the dial uses the record-only shape (``mailbox`` + no wake). The
+            # receive side's record-only branch persists the row and paints the
+            # peer card but spawns no turn, which makes the message visible to
+            # the already-open session NOW; a spool cannot (its only consumer
+            # is the runtime child's boot drain, and this session is past
+            # that). The default True is a defence against a NON-standard
+            # record that simply lacks the attribute (a test double, a
+            # hand-built record); a record a PRE-FIELD binary wrote round-trips
+            # through ``from_json``, which reads the absent key as ``True`` —
+            # old peer behaviour preserved — so an old working session is
+            # dialled normally, never degraded.
+            await send_peer_message(record, text=text, mode="mailbox", wake=False, sender=sender)
+            return "delivered to the mailbox (session not started yet; no turn driven)"
         return await send_peer_message(record, text=text, mode=mode, wake=wake, sender=sender)
 
     if not wake and mode == "mailbox":
-        from local_operator.session.runtime.inbox import InboxLine, append_inbox
-
-        directory = config_dir() / "sessions" / session_id
-        written = await asyncio.to_thread(
-            append_inbox,
-            directory,
-            InboxLine(text=text, sender=dict(sender), mode=mode, written_at=time.time()),
-        )
-        if not written:
-            raise RuntimeError("could not spool the message for that session")
-        return "spooled (will be read when the session next opens)"
+        return await _spool_quiet_note(session_id, text=text, mode=mode, sender=sender)
 
     from local_operator.session.runtime.launch import PeerMessageErrand, engage_runtime
 

--- a/local_operator/mobile/peer_send.py
+++ b/local_operator/mobile/peer_send.py
@@ -165,6 +165,17 @@ def resolve_peer_target(
     needle = needle_source.lower()
     matches: list[Any] = []
     for rec, _state in live:
+        # A session that has never run a turn (``/new``, owner still composing
+        # the first prompt) is excluded from a BROADCAST/substring match: an
+        # interrupt there would drive a turn into a session whose owner has not
+        # started it. An EXACT ``--pid``/``--session`` send still resolves to it
+        # (the sender deliberately named that session) and is spooled by
+        # ``deliver_peer_message`` rather than dialled — see there. The default
+        # True keeps a record that simply lacks the attribute (a test double, a
+        # hand-built record) eligible; a pre-field binary's record round-trips
+        # through ``from_json`` with the conservative ``False`` instead.
+        if not getattr(rec, "started", True):
+            continue
         haystacks = [
             rec.conversation_name or "",
             rec.session_id or "",
@@ -381,6 +392,30 @@ async def deliver_peer_message(
     from local_operator.mobile.peer_client import send_peer_message
 
     if record is not None:
+        if not getattr(record, "started", True):
+            # Belt-and-braces with the resolver's broadcast exclusion: an
+            # exact-address send (or any caller that bypassed resolution) must
+            # NEVER drive a turn into a session whose owner is still composing
+            # their first prompt. Degrade mailbox, mailbox+wake and steer alike
+            # to a quiet spool; the existing inbox-drain path hands the message
+            # to the session's first real turn. The default True is a defence
+            # against a NON-standard record that simply lacks the attribute (a
+            # test double, a hand-built record), keeping such a peer on the old
+            # socket path. A record a PRE-FIELD binary wrote round-trips through
+            # ``from_json``, which reads the absent key as the dataclass default
+            # ``False`` — the conservative mixed-version direction documented
+            # there — so an old working session is spooled, never driven.
+            from local_operator.session.runtime.inbox import InboxLine, append_inbox
+
+            directory = config_dir() / "sessions" / session_id
+            written = await asyncio.to_thread(
+                append_inbox,
+                directory,
+                InboxLine(text=text, sender=dict(sender), mode=mode, written_at=time.time()),
+            )
+            if not written:
+                raise RuntimeError("could not spool the message for that session")
+            return "spooled (session not started yet; will be read when it next opens)"
         return await send_peer_message(record, text=text, mode=mode, wake=wake, sender=sender)
 
     if not wake and mode == "mailbox":

--- a/local_operator/mobile/tui_handle.py
+++ b/local_operator/mobile/tui_handle.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-import json
 import logging
 import secrets
 from concurrent.futures import Future
@@ -51,6 +50,7 @@ from local_operator.mobile.types import (
 )
 from local_operator.session.runtime.server import (
     SessionHandle,
+    has_durable_history,
     image_blocks,
     image_blocks_in_thread,
 )
@@ -95,39 +95,6 @@ def _decode_attachments(images: list[dict[str, str]] | None) -> dict[int, Any]:
         index: Attachment(image=image, marker=f"[Image #{index}]")
         for index, image in enumerate(_image_blocks(images), start=1)
     }
-
-
-def _has_durable_history(session: Any) -> bool:
-    """Whether this session's transcript already holds a conversation.
-
-    The re-seed signal for ``TuiSessionHandle.rebind``: a ``/resume`` lands
-    here with history (the conversation ran turns under an earlier process)
-    while a ``/new`` lands with an empty or not-yet-materialised transcript.
-    A MESSAGE row is the discriminator, not just any row: bookkeeping rows
-    (a persisted ``system_prefix`` epoch, a title) can precede the first
-    turn, and counting those would mark a fresh composer as started — the
-    exact window the flag exists to gate. Read from the FILE rather than
-    the in-memory index — the index is built by replay and is not
-    guaranteed populated at rebind time — and defensively: a session shape
-    with no readable transcript (a reduced host) answers False, the
-    conservative "unstarted" direction a first real turn immediately
-    corrects.
-    """
-    path = getattr(getattr(session, "transcript", None), "path", None)
-    if path is None:
-        return False
-    try:
-        with open(path, "r", encoding="utf-8", errors="replace") as handle:
-            for row in handle:
-                try:
-                    entry = json.loads(row)
-                except ValueError:
-                    continue  # a torn line says nothing about history
-                if isinstance(entry, dict) and entry.get("type") == "message":
-                    return True
-    except OSError:
-        return False
-    return False
 
 
 class TuiSessionHandle(SessionHandle):
@@ -292,7 +259,7 @@ class TuiSessionHandle(SessionHandle):
         reseed = getattr(registrant, "reset_record_started", None)
         if callable(reseed):
             try:
-                reseed(_has_durable_history(session))
+                reseed(has_durable_history(session))
             except Exception:  # noqa: BLE001 — a stale bit must never break /new
                 logger.debug("could not re-seed the started bit on rebind", exc_info=True)
 

--- a/local_operator/mobile/tui_handle.py
+++ b/local_operator/mobile/tui_handle.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import logging
 import secrets
 from concurrent.futures import Future
@@ -96,12 +97,60 @@ def _decode_attachments(images: list[dict[str, str]] | None) -> dict[int, Any]:
     }
 
 
+def _has_durable_history(session: Any) -> bool:
+    """Whether this session's transcript already holds a conversation.
+
+    The re-seed signal for ``TuiSessionHandle.rebind``: a ``/resume`` lands
+    here with history (the conversation ran turns under an earlier process)
+    while a ``/new`` lands with an empty or not-yet-materialised transcript.
+    A MESSAGE row is the discriminator, not just any row: bookkeeping rows
+    (a persisted ``system_prefix`` epoch, a title) can precede the first
+    turn, and counting those would mark a fresh composer as started — the
+    exact window the flag exists to gate. Read from the FILE rather than
+    the in-memory index — the index is built by replay and is not
+    guaranteed populated at rebind time — and defensively: a session shape
+    with no readable transcript (a reduced host) answers False, the
+    conservative "unstarted" direction a first real turn immediately
+    corrects.
+    """
+    path = getattr(getattr(session, "transcript", None), "path", None)
+    if path is None:
+        return False
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as handle:
+            for row in handle:
+                try:
+                    entry = json.loads(row)
+                except ValueError:
+                    continue  # a torn line says nothing about history
+                if isinstance(entry, dict) and entry.get("type") == "message":
+                    return True
+    except OSError:
+        return False
+    return False
+
+
 class TuiSessionHandle(SessionHandle):
     def __init__(self, app: "OperatorApp") -> None:
         self._app = app
         session = app._session
         if session is None:
             raise RuntimeError("TUI session has not finished starting")
+        # Same wiring ``OwnedSessionHandle.__init__`` performs: the session
+        # flips the discovery record's ``started`` bit at the top of every
+        # real turn (``Session._run_turn_pipeline``), and the handle owns the
+        # publish. Without it a TUI-owned ``kind="tui"`` record would stay
+        # ``started=False`` for its whole life — permanently invisible to
+        # broadcasts and quietly mailbox-dialled on exact sends even after
+        # hundreds of turns. Guarded with ``hasattr`` so reduced hosts (test
+        # doubles standing in for a Session) keep constructing; the ignore
+        # matches the house pattern for duck-typed hooks
+        # (``RuntimeServer``'s ``handle._registrant`` assignment) — the
+        # protocol deliberately does not declare per-host hooks.
+        if hasattr(session, "_publish_session_started"):
+            session._publish_session_started = (  # type: ignore[attr-defined]
+                self._publish_session_started
+            )
         self._projection = SessionProjection(
             session_id=session.session_id,
             pid=0,
@@ -227,6 +276,44 @@ class TuiSessionHandle(SessionHandle):
             self.subscribe(self._on_projection)
         if self._on_event is not None:
             self.subscribe_events(self._on_event)
+        # The registrant outlives the session object, so two pieces of
+        # per-session state must follow the swap. First, the started hook:
+        # the NEW session object must get it or (on a TUI-owned record) it
+        # would never flip. Second, the registrant's ``started`` bit itself,
+        # which cannot simply carry over — it describes the OLD conversation:
+        # a ``/new`` after a working conversation must drop back to ``False``
+        # (the composer window the flag exists for), while a ``/resume`` must
+        # read ``True`` because that conversation already ran turns and a
+        # peer wake could always reach it. Re-seeded from the NEW session's
+        # own durable history so both directions come out right.
+        if hasattr(session, "_publish_session_started"):
+            session._publish_session_started = self._publish_session_started
+        registrant = getattr(self, "_registrant", None)
+        reseed = getattr(registrant, "reset_record_started", None)
+        if callable(reseed):
+            try:
+                reseed(_has_durable_history(session))
+            except Exception:  # noqa: BLE001 — a stale bit must never break /new
+                logger.debug("could not re-seed the started bit on rebind", exc_info=True)
+
+    def _publish_session_started(self) -> None:
+        """Flip the record's ``started`` bit once this session runs a real turn.
+
+        The ``kind="tui"`` twin of ``OwnedSessionHandle``'s hook, called from
+        ``Session._run_turn_pipeline`` at the top of every turn; the
+        registrant's ``set_record_started`` de-duplicates so only the first
+        turn publishes. Defensive in the same shape as the owned hook: a
+        reduced host with no registrant, or one predating the setter, is a
+        no-op rather than a failed turn.
+        """
+        registrant = getattr(self, "_registrant", None)
+        setter = getattr(registrant, "set_record_started", None)
+        if not callable(setter):
+            return
+        try:
+            setter(True)
+        except Exception:  # noqa: BLE001 — a stale flag is not worth a turn
+            logger.debug("could not publish the started state", exc_info=True)
 
     # -- SessionHandle -----------------------------------------------------------
 

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -392,6 +392,11 @@ class OwnedSessionHandle(SessionHandle):
         # sessions in tests that never grew the attribute keep working.
         if hasattr(session, "on_turn_settled"):
             session.on_turn_settled = self._publish_busy_soon
+        # Same shape as ``on_turn_settled``: the session flips the record's
+        # ``started`` bit the first time a real turn runs (see
+        # ``_run_turn_pipeline``), and the registrant owns the publish.
+        if hasattr(session, "_publish_session_started"):
+            session._publish_session_started = self._publish_session_started
         # Discovery/attachment does not authorize replacing a headless deny
         # gate with a parked interactive gate. Exec opts into that separately.
         #: Why the most recent admitted turn failed, for a headless caller that
@@ -3775,6 +3780,24 @@ class OwnedSessionHandle(SessionHandle):
         except Exception:  # noqa: BLE001 — a stale marker is not worth a turn
             logger.debug("could not publish the busy state", exc_info=True)
         self._publish_subagents()
+
+    def _publish_session_started(self) -> None:
+        """Flip the record's ``started`` bit once a real turn has run.
+
+        Called from ``Session._run_turn_pipeline`` at the top of every turn;
+        the registrant's ``set_record_started`` de-duplicates so only the
+        first call publishes. A peer message spooled into an unstarted
+        session's mailbox never reaches this — it only becomes ``started``
+        when its owner actually runs a turn.
+        """
+        server = self._registrant
+        setter = getattr(server, "set_record_started", None)
+        if not callable(setter):
+            return
+        try:
+            setter(True)
+        except Exception:  # noqa: BLE001 — a stale flag is not worth a turn
+            logger.debug("could not publish the started state", exc_info=True)
 
     def subagent_counts(self) -> tuple[int | None, int | None]:
         """``(running, queued)`` subagent trajectories, or ``(None, None)``.

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -578,6 +578,11 @@ class RuntimeServer:
         #: than read off the record so the publish is one assignment and the
         #: fields have a defined value before the record exists.
         self._pending: str | None = None
+        #: True once this session has run at least one real turn. Starts
+        #: False for every fresh boot (a ``/new`` session sitting in the
+        #: composer) and flips True the first time a turn actually runs — the
+        #: hook lives in ``Session._run_turn_pipeline``.
+        self._started = False
         self._busy = False
         #: Subagent trajectory counts, ``None`` until the handle answers the
         #: probe at least once. Starting at ``None`` rather than 0 is what
@@ -1639,6 +1644,24 @@ class RuntimeServer:
         self._busy = busy
         self._republish()
 
+    def set_record_started(self, started: bool) -> None:
+        """Record that this session has run at least one real turn.
+
+        One-way, like the ``busy`` bit's dual: once a turn has run the flag
+        stays True for the life of the record, so a ``False`` -> ``True``
+        transition is the only change worth republishing for (a no-op when
+        already True, and a second ``True`` writes nothing).
+        """
+        if self._started == started:
+            return
+        self._started = started
+        # Write through to the record NOW, not only on the next republish: the
+        # publisher serializes ``self._record``, and a caller reading the record
+        # between here and the republish (or a republish that never comes, e.g.
+        # no publisher yet) must already see the flipped bit.
+        self._record.started = started
+        self._republish()
+
     def set_subagents(self, running: int | None, queued: int | None) -> None:
         """Record this runtime's subagent trajectory counts.
 
@@ -1677,6 +1700,7 @@ class RuntimeServer:
             publisher.heartbeat(
                 pending=self._pending,
                 busy=self._busy,
+                started=self._started,
                 detached=not bool(self._visible_attach_surfaces()),
                 subagents_running=self._subagents_running,
                 subagents_queued=self._subagents_queued,

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -564,6 +564,40 @@ class ProjectionSink(Protocol):
     def set_pending(self, pending: Any) -> None: ...
 
 
+def has_durable_history(session: Any) -> bool:
+    """Whether this session's transcript already holds a conversation.
+
+    The seed signal for the record's ``started`` bit at two call sites that
+    face the same question — ``RuntimeServer.__init__`` (a resumed boot must
+    publish ``started=True`` before any turn runs in the NEW process) and
+    ``TuiSessionHandle.rebind`` (a ``/resume`` mid-flight re-seeds the bit for
+    the swapped identity). A MESSAGE row is the discriminator, not just any
+    row: bookkeeping rows (a persisted ``system_prefix`` epoch, a title) can
+    precede the first turn, and counting those would mark a fresh composer as
+    started — the exact window the flag exists to gate. Read from the FILE
+    rather than the in-memory index — the index is built by replay and is not
+    guaranteed populated at the moment either call site asks — and
+    defensively: a session shape with no readable transcript (a reduced
+    host) answers False, the conservative "unstarted" direction a first
+    real turn immediately corrects.
+    """
+    path = getattr(getattr(session, "transcript", None), "path", None)
+    if path is None:
+        return False
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as handle:
+            for row in handle:
+                try:
+                    entry = json.loads(row)
+                except ValueError:
+                    continue  # a torn line says nothing about history
+                if isinstance(entry, dict) and entry.get("type") == "message":
+                    return True
+    except OSError:
+        return False
+    return False
+
+
 class RuntimeServer:
     """One per interactive process. Construct, ``start()``, ``close()``."""
 
@@ -581,7 +615,10 @@ class RuntimeServer:
         #: True once this session has run at least one real turn. Starts
         #: False for every fresh boot (a ``/new`` session sitting in the
         #: composer) and flips True the first time a turn actually runs — the
-        #: hook lives in ``Session._run_turn_pipeline``.
+        #: hook lives in ``Session._run_turn_pipeline``. One exception at
+        #: birth, below: a boot that RESUMED a conversation with history
+        #: seeds True from the transcript, because those turns already ran
+        #: under an earlier process.
         self._started = False
         self._busy = False
         #: Subagent trajectory counts, ``None`` until the handle answers the
@@ -694,6 +731,26 @@ class RuntimeServer:
             version=build.version,
             source_ref=build.source_ref,
         )
+        # A resumed conversation has ALREADY run its turns under an earlier
+        # process, and the record must say so from its FIRST publish. Until
+        # the owner's first turn here, the bit would otherwise read False and
+        # peers would treat a working session as a composer window (QA Q3:
+        # after a terminal restart, `lop --resume <sid>` engaged a child whose
+        # record said ``started=false``, making the idle session invisible to
+        # broadcasts and degrading peer wakes to quiet notes until the owner
+        # typed once). Seeded from the session's own durable transcript — the
+        # same signal ``TuiSessionHandle.rebind`` uses — so a true ``/new``
+        # (no message rows) still boots as the composer window. Probed off
+        # ``handle._session`` because only the owned-handle shape carries its
+        # Session there; a handle without one (the TUI's, a reduced test
+        # host) keeps the conservative False a first real turn immediately
+        # corrects. Direct field writes, not ``set_record_started``: nothing
+        # is published yet, and this is a derivation at birth, not the
+        # per-turn signal.
+        owned_session = getattr(handle, "_session", None)
+        if owned_session is not None and has_durable_history(owned_session):
+            self._started = True
+            self._record.started = True
         self._publisher: RecordPublisher | None = None
         self._server: asyncio.AbstractServer | None = None
         self._unsubscribe_events: Callable[[], None] | None = None

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -67,6 +67,7 @@ from local_operator.session.runtime.types import (
     ClientLocality,
     SessionRecord,
 )
+from local_operator.session.transcript import durable_conversation_path
 
 logger = logging.getLogger(__name__)
 
@@ -565,37 +566,30 @@ class ProjectionSink(Protocol):
 
 
 def has_durable_history(session: Any) -> bool:
-    """Whether this session's transcript already holds a conversation.
+    """Whether this session's transcript already holds a REAL conversation turn.
 
     The seed signal for the record's ``started`` bit at two call sites that
     face the same question — ``RuntimeServer.__init__`` (a resumed boot must
     publish ``started=True`` before any turn runs in the NEW process) and
     ``TuiSessionHandle.rebind`` (a ``/resume`` mid-flight re-seeds the bit for
-    the swapped identity). A MESSAGE row is the discriminator, not just any
-    row: bookkeeping rows (a persisted ``system_prefix`` epoch, a title) can
-    precede the first turn, and counting those would mark a fresh composer as
-    started — the exact window the flag exists to gate. Read from the FILE
-    rather than the in-memory index — the index is built by replay and is not
-    guaranteed populated at the moment either call site asks — and
-    defensively: a session shape with no readable transcript (a reduced
-    host) answers False, the conservative "unstarted" direction a first
-    real turn immediately corrects.
+    the swapped identity). Thin wrapper over
+    :func:`~local_operator.session.transcript.durable_conversation_path`,
+    where the discriminator lives with the row shapes it reads: only a plain
+    ``Message`` row counts — a CustomMessage row (a quiet-dialled
+    ``peer_message`` note, a wake prompt) is persisted WITHOUT a turn running,
+    and counting one seeds ``started=True`` on a session whose owner never
+    typed, after which a peer ``--wake`` or broadcast drives an assistant
+    turn into it (QA Q4). Read off the session's declared
+    ``transcript_path`` rather than ``session.transcript.path`` — the same
+    read, through the session's own contract instead of two privates deep;
+    a session shape without one (a reduced host) answers False, the
+    conservative "unstarted" direction a first real turn immediately
+    corrects.
     """
-    path = getattr(getattr(session, "transcript", None), "path", None)
+    path = getattr(session, "transcript_path", None)
     if path is None:
         return False
-    try:
-        with open(path, "r", encoding="utf-8", errors="replace") as handle:
-            for row in handle:
-                try:
-                    entry = json.loads(row)
-                except ValueError:
-                    continue  # a torn line says nothing about history
-                if isinstance(entry, dict) and entry.get("type") == "message":
-                    return True
-    except OSError:
-        return False
-    return False
+    return durable_conversation_path(path)
 
 
 class RuntimeServer:

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -1167,6 +1167,14 @@ class RuntimeServer:
                         conversation_name=seed.conversation_name,
                         model_label=seed.model_label,
                         cwd=seed.cwd,
+                        # Carried explicitly rather than trusted to survive on
+                        # the record object: ``self._record is
+                        # publisher.record`` today, so omitting it happens to
+                        # work — but that identity is an implementation
+                        # detail, and one rebuild or copied publish away from
+                        # silently dropping the bit and making a working
+                        # session broadcast-invisible.
+                        started=self._started,
                     )
             except Exception:  # noqa: BLE001 — a missed heartbeat is self-healing
                 logger.debug("runtime heartbeat failed", exc_info=True)
@@ -1647,18 +1655,36 @@ class RuntimeServer:
     def set_record_started(self, started: bool) -> None:
         """Record that this session has run at least one real turn.
 
-        One-way, like the ``busy`` bit's dual: once a turn has run the flag
-        stays True for the life of the record, so a ``False`` -> ``True``
-        transition is the only change worth republishing for (a no-op when
-        already True, and a second ``True`` writes nothing).
+        One-way, and enforced: once a turn has run, ``False`` is IGNORED —
+        the caller is the per-turn hook in ``_run_turn_pipeline``, for which
+        ``False`` can only ever be a mistake (no code path un-runs a turn).
+        The only legitimate way the bit drops again is a session-identity
+        swap, which goes through :meth:`reset_record_started` instead.
         """
-        if self._started == started:
+        if not started or self._started:
             return
-        self._started = started
+        self._started = True
         # Write through to the record NOW, not only on the next republish: the
         # publisher serializes ``self._record``, and a caller reading the record
         # between here and the republish (or a republish that never comes, e.g.
         # no publisher yet) must already see the flipped bit.
+        self._record.started = True
+        self._republish()
+
+    def reset_record_started(self, started: bool) -> None:
+        """Re-seed the ``started`` bit for a NEW session identity.
+
+        NOT the turn-running signal :meth:`set_record_started` answers: a
+        TUI's registrant outlives ``/new`` and ``/resume``
+        (``TuiSessionHandle.rebind`` re-points it at the new session), so the
+        bit must be re-derived from the NEW session's own durable history
+        instead of inherited from the old one. A ``/new`` after a working
+        conversation must drop back to ``False`` — the composer window this
+        flag exists for — while a ``/resume`` must read ``True``, because that
+        conversation already ran turns and a peer wake could always reach it.
+        Both directions are legal HERE only because the identity changed.
+        """
+        self._started = started
         self._record.started = started
         self._republish()
 

--- a/local_operator/session/runtime/types.py
+++ b/local_operator/session/runtime/types.py
@@ -219,10 +219,14 @@ class SessionRecord:
     #: published but the owner is still composing their first prompt, so a
     #: peer broadcast or an exact-address wake/steer must not drive a turn
     #: into it. One-way per session identity: once a real turn has run it
-    #: stays True (a TUI ``/new`` rebind re-seeds it for the NEW identity —
-    #: see ``RuntimeServer.reset_record_started``), and every
-    #: heartbeat/republish carries it forward so it is never reset by a later
-    #: write. Deserialization overrides the default for pre-field records —
+    #: stays True. Two paths other than a turn set it — a TUI ``/new``
+    #: rebind re-seeds it for the NEW identity (see
+    #: ``RuntimeServer.reset_record_started``), and a boot that RESUMED a
+    #: history-bearing conversation seeds True at record construction (see
+    #: ``RuntimeServer.__init__``) so the idle session is peer-visible
+    #: before any turn runs in the new process. Every heartbeat/republish
+    #: carries it forward so it is never reset by a later write.
+    #: Deserialization overrides the default for pre-field records —
     #: see ``from_json``.
     started: bool = False
     #: No front end is attached. A working session with nobody watching is

--- a/local_operator/session/runtime/types.py
+++ b/local_operator/session/runtime/types.py
@@ -218,9 +218,12 @@ class SessionRecord:
     #: ``False`` marks the window after ``/new`` when the record is already
     #: published but the owner is still composing their first prompt, so a
     #: peer broadcast or an exact-address wake/steer must not drive a turn
-    #: into it. The flag is one-way: once a real turn has run it stays True
-    #: for the life of the record, and every heartbeat/republish carries it
-    #: forward so it is never reset by a later write.
+    #: into it. One-way per session identity: once a real turn has run it
+    #: stays True (a TUI ``/new`` rebind re-seeds it for the NEW identity —
+    #: see ``RuntimeServer.reset_record_started``), and every
+    #: heartbeat/republish carries it forward so it is never reset by a later
+    #: write. Deserialization overrides the default for pre-field records —
+    #: see ``from_json``.
     started: bool = False
     #: No front end is attached. A working session with nobody watching is
     #: exactly what this release makes possible, so it is worth naming.
@@ -293,18 +296,25 @@ class SessionRecord:
         # daemon mid-upgrade): forward-compat here is what lets a restart
         # rolling-upgrade the daemon without the phone losing sessions.
         #
-        # ``started`` therefore defaults to ``False`` for a record an OLDER
-        # binary wrote (no key): the conservative read treats it as not yet
-        # started, so a broadcast skips it and an exact-address send is spooled
-        # rather than driven. That is the safe direction — the only cost is the
-        # brief upgrade window where a genuinely-working OLD runtime reads as
-        # unstarted and is excluded from broadcasts / spooled on an exact send.
-        # The alternative (default True) would let a broadcast wake a fresh
-        # ``/new`` session sitting in the composer, which is the exact bug
-        # being fixed, so the transient misclassification of old sessions is
-        # accepted. The record carries ``started_at`` (process birth) and
-        # ``protocol`` either way, but neither can distinguish "old binary,
-        # actually working" from "new binary, not yet started" — no signal
-        # distinguishes them, so the default is deliberately conservative.
+        # ``started`` is the one field whose ABSENT key carries meaning: this
+        # binary always serializes it (``to_json`` is ``asdict``), so a record
+        # without the key was written by a PRE-field binary — and a pre-field
+        # session had no composer gate at all, so to it "started" can only
+        # mean True. Reading absent-as-True restores old-peer behaviour
+        # exactly: broadcasts still reach a working old runtime (it keeps
+        # heartbeating its key-less record until it restarts, which for
+        # daemon/cmux sessions is days, not an upgrade window), and an exact
+        # send dials it rather than spooling into an inbox only a boot-time
+        # drain ever reads. The honest cost is the mirror image: an OLD
+        # binary's fresh ``/new`` composer stays wakeable — but that is
+        # precisely the old binary's own behaviour, unfixable from here until
+        # it restarts, so True is the only default that does not penalise the
+        # working old sessions for a bug they do not have. The dataclass
+        # default stays ``False`` because a CONSTRUCTED record is a fresh
+        # this-binary session (the composer window the field exists for);
+        # only a deserialized key-less record is assumed pre-field.
         known = {f for f in SessionRecord.__dataclass_fields__}
-        return SessionRecord(**{k: v for k, v in data.items() if k in known})
+        fields = {k: v for k, v in data.items() if k in known}
+        if "started" not in data:
+            fields["started"] = True
+        return SessionRecord(**fields)

--- a/local_operator/session/runtime/types.py
+++ b/local_operator/session/runtime/types.py
@@ -213,6 +213,15 @@ class SessionRecord:
     #: A turn is running right now. The picker's liveness marker, and the
     #: difference between a session that is working and one merely resident.
     busy: bool = False
+    #: This session has run at least one REAL turn (a user prompt, a wake
+    #: delivery, a resume catch-up — anything through ``_run_turn_pipeline``).
+    #: ``False`` marks the window after ``/new`` when the record is already
+    #: published but the owner is still composing their first prompt, so a
+    #: peer broadcast or an exact-address wake/steer must not drive a turn
+    #: into it. The flag is one-way: once a real turn has run it stays True
+    #: for the life of the record, and every heartbeat/republish carries it
+    #: forward so it is never reset by a later write.
+    started: bool = False
     #: No front end is attached. A working session with nobody watching is
     #: exactly what this release makes possible, so it is worth naming.
     detached: bool = False
@@ -283,5 +292,19 @@ class SessionRecord:
         # Tolerate unknown keys (a NEWER binary's record read by an older
         # daemon mid-upgrade): forward-compat here is what lets a restart
         # rolling-upgrade the daemon without the phone losing sessions.
+        #
+        # ``started`` therefore defaults to ``False`` for a record an OLDER
+        # binary wrote (no key): the conservative read treats it as not yet
+        # started, so a broadcast skips it and an exact-address send is spooled
+        # rather than driven. That is the safe direction — the only cost is the
+        # brief upgrade window where a genuinely-working OLD runtime reads as
+        # unstarted and is excluded from broadcasts / spooled on an exact send.
+        # The alternative (default True) would let a broadcast wake a fresh
+        # ``/new`` session sitting in the composer, which is the exact bug
+        # being fixed, so the transient misclassification of old sessions is
+        # accepted. The record carries ``started_at`` (process birth) and
+        # ``protocol`` either way, but neither can distinguish "old binary,
+        # actually working" from "new binary, not yet started" — no signal
+        # distinguishes them, so the default is deliberately conservative.
         known = {f for f in SessionRecord.__dataclass_fields__}
         return SessionRecord(**{k: v for k, v in data.items() if k in known})

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -2163,6 +2163,9 @@ class Session:
         #: handle (``OwnedSessionHandle._publish_session_started``) and probed
         #: so a reduced host without it is a no-op.
         self._publish_session_started: Callable[[], None] | None = None
+        #: Guards the once-per-lifetime peer-inbox drain at the top of
+        #: ``_run_turn_pipeline`` — see ``_drain_spooled_peer_inbox``.
+        self._peer_inbox_drained = False
         self._abort_requested = False  # sticky across the continuation gap
         # Turns dropped back-to-back because they were born pre-aborted. Reset
         # by any turn that actually runs, so the honest "I am dropping these"
@@ -5202,6 +5205,50 @@ class Session:
             details={"text": wrapped, "body": text, "sender": sender},
         )
 
+    async def _drain_spooled_peer_inbox(self) -> None:
+        """Deliver any inbox rows spooled for this session. Once per lifetime.
+
+        Called at the top of ``_run_turn_pipeline`` (see the call site for
+        why the first real turn is the right moment). The session usually
+        never has spool: the runtime child's boot drain consumed it before
+        the socket even listened, and live deliveries dial instead of
+        spooling. This drain exists for the rows that bypass both — a sender
+        on an older binary, or a race that left the record unreadable — so
+        the flag is what keeps it off the steady-state turn path: after the
+        first attempt it is never tried again, and the cold-open drain
+        remains the owner of anything written later.
+
+        Best-effort per row, mirroring ``process._drain_inbox_into``: one
+        malformed or rejected row must not stop the rest, and none of it may
+        fail the turn it precedes.
+        """
+        if self._peer_inbox_drained:
+            return
+        self._peer_inbox_drained = True
+        # Imported in-function: the runtime inbox lives behind the mobile
+        # package's config-path machinery, and this module does not carry a
+        # module-level dependency on it for a once-per-session path.
+        from local_operator.session.runtime.inbox import drain_inbox
+
+        directory = getattr(self._transcript, "directory", None)
+        if directory is None:
+            return
+        try:
+            lines = await asyncio.to_thread(drain_inbox, directory)
+        except Exception:  # noqa: BLE001 — a bad spool must not fail the turn
+            logger.warning("peer inbox drain failed", exc_info=True)
+            return
+        for line in lines:
+            try:
+                # The quiet mailbox shape, never a wake: these were spooled
+                # as quiet notes, and a drain that opened a turn per row
+                # would turn "read this when you run" into "start work now".
+                await self.receive_peer_message(
+                    line.text, mode="mailbox", wake=False, sender=line.sender
+                )
+            except Exception:  # noqa: BLE001 — one bad row is not the others' problem
+                logger.warning("spooled peer message could not be delivered", exc_info=True)
+
     async def receive_peer_message(
         self,
         text: str,
@@ -6360,6 +6407,19 @@ class Session:
         opened the run, so the TUI's supersede guard still pairs them.
         """
         await self._refresh_context_metadata()
+        # Belt-and-braces for peer delivery: consume any inbox rows spooled
+        # for this session BEFORE the first real turn runs. The primary inbox
+        # consumer is the runtime child's boot drain (``process.amain``),
+        # which a session that opened some other way — or that was sent a
+        # spool by an older sender that had no live record for it — never
+        # passes through; without this drain those rows would sit unread
+        # until some future process cold-opens the session. Delivered in the
+        # quiet mailbox shape so the drain itself can never drive a turn.
+        # Runs BEFORE the started-flip below so the spooled notes are durable
+        # and visible even if this turn then fails; under the already-held
+        # ``_turn_lock`` their live-context append parks and rejoins at this
+        # very turn's first injection boundary (``_drain_steering``).
+        await self._drain_spooled_peer_inbox()
         # Flip the discovery record's ``started`` bit the first time a REAL
         # turn runs. This is the single choke point every spawn path funnels
         # through — the user's ``prompt()``, wake deliveries

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -2159,6 +2159,10 @@ class Session:
         #: result deliveries, resume catch-ups (design-runtime-autorefresh §1.2).
         #: Sync, non-raising by contract (the pipeline guards it anyway).
         self.on_turn_settled: Callable[[], None] | None = None
+        #: Flips the discovery record's ``started`` bit; wired by the runtime
+        #: handle (``OwnedSessionHandle._publish_session_started``) and probed
+        #: so a reduced host without it is a no-op.
+        self._publish_session_started: Callable[[], None] | None = None
         self._abort_requested = False  # sticky across the continuation gap
         # Turns dropped back-to-back because they were born pre-aborted. Reset
         # by any turn that actually runs, so the honest "I am dropping these"
@@ -6356,6 +6360,21 @@ class Session:
         opened the run, so the TUI's supersede guard still pairs them.
         """
         await self._refresh_context_metadata()
+        # Flip the discovery record's ``started`` bit the first time a REAL
+        # turn runs. This is the single choke point every spawn path funnels
+        # through — the user's ``prompt()``, wake deliveries
+        # (``_prompt_messages``), and the resume catch-up — so one hook covers
+        # them all and a fresh ``/new`` session that has only had a peer
+        # message spooled into its mailbox stays ``started=False`` until its
+        # owner actually sends a prompt. One-way and idempotent: the
+        # registrant's ``set_record_started`` de-duplicates, so the per-turn
+        # cost is one attribute probe on every turn after the first.
+        mark_started = getattr(self, "_publish_session_started", None)
+        if callable(mark_started):
+            try:
+                mark_started()
+            except Exception:  # noqa: BLE001 — a stale flag is not a turn failure
+                logger.debug("could not publish the started state", exc_info=True)
         # Re-arm the todo guardrail: a fresh user message may well be the answer
         # a stalled list was waiting for, so the latch must not carry over. It is
         # reset HERE and not in `_run_turn` on purpose — `_run_turn` also runs

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -3194,6 +3194,23 @@ class Session:
         return self._transcript
 
     @property
+    def transcript_path(self) -> Any:
+        """The transcript FILE path, or None on an in-memory store.
+
+        The ``started``-bit seeds answer one question — has this session run a
+        real turn — and only the durable file can answer it at construction
+        (the replayed index is not populated yet). Exposed so the seed reads
+        the session's declared contract instead of reaching two privates deep
+        (``session.transcript.path``) — and because a session whose transcript
+        attribute is None (a reduced host) must read as unstarted, not probe
+        an attribute that is not there.
+        """
+        transcript = self._transcript
+        if transcript is None:
+            return None
+        return getattr(transcript, "path", None)
+
+    @property
     def agent_id(self) -> str:
         return self._agent_id
 

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -75,6 +75,49 @@ CUSTOM_KIND_CUSTOM = "custom"
 #: context. Replay applies it; :meth:`Transcript.compact_file` folds it away.
 ENTRY_PRUNE = "prune"
 
+
+def durable_conversation_path(path: Any) -> bool:
+    """Whether the transcript file at ``path`` holds a REAL conversation turn.
+
+    The seed signal for the record's ``started`` bit: ``RuntimeServer.__init__``
+    (a resumed boot must publish ``started=True`` before any turn runs in the
+    NEW process) and ``TuiSessionHandle.rebind`` (a ``/resume`` mid-flight
+    re-seeds the bit for the swapped identity). A message row alone is NOT the
+    discriminator: a round-1 quiet-dial of a peer note persists a
+    ``peer_message`` CustomMessage as a message row (kind ``custom``) through
+    ``append_messages``, without a turn ever running, so a session whose only
+    durable rows are quiet-dial notes would seed ``started=True`` — and a
+    peer's ``--wake`` or a broadcast would then drive an assistant turn into a
+    session the owner never typed in (QA Q4). Only a plain ``Message`` row
+    (kind ``message`` — a real user/assistant/tool turn) counts. Read from the
+    FILE rather than the in-memory index — the index is built by replay and is
+    not guaranteed populated at the moment either call site asks — and
+    defensively: no readable file answers False, the conservative "unstarted"
+    direction a first real turn immediately corrects.
+    """
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as handle:
+            for row in handle:
+                try:
+                    entry = json.loads(row)
+                except ValueError:
+                    continue  # a torn line says nothing about history
+                if not isinstance(entry, dict) or entry.get("type") != ENTRY_MESSAGE:
+                    continue
+                payload = entry.get("payload")
+                if not isinstance(payload, dict):
+                    continue
+                # ``kind`` arrived with producer admission; a legacy row
+                # predating it IS a plain Message — the custom writer always
+                # tagged its rows.
+                if payload.get("kind", CUSTOM_KIND_MESSAGE) != CUSTOM_KIND_MESSAGE:
+                    continue
+                return True
+    except OSError:
+        return False
+    return False
+
+
 #: Rewrite the file only once this many bytes are provably reclaimable. A
 #: prune pass runs on most turns, and rewriting a multi-megabyte transcript
 #: every turn would cost far more I/O than the blanking saves. 256 KiB makes

--- a/tests/unit/mobile/test_peer_send.py
+++ b/tests/unit/mobile/test_peer_send.py
@@ -670,9 +670,12 @@ def test_a_non_dict_sender_cannot_escape_the_handler(monkeypatch) -> None:
 # --- ``started`` gating on the DELIVERY path ---------------------------------
 #
 # ``resolve_peer_target`` excludes an unstarted session from a broadcast, but
-# an exact-address send still resolves to it. The spool-below is the belt-and-
-# braces that makes "no turn is ever driven into an unstarted session" hold even
-# for a caller that bypassed resolution.
+# an exact-address send still resolves to it. The quiet-mailbox dial below is
+# the belt-and-braces that makes "no turn is ever driven into an unstarted
+# session" hold even for a caller that bypassed resolution — a DIAL, not a
+# spool, because a live record means an open session whose only inbox
+# consumer is the runtime child's boot drain (Q1: a spooled note was never
+# read while that session stayed open).
 
 
 def _unstarted_record(session_id: str = "fresh-id") -> registry.SessionRecord:
@@ -690,20 +693,26 @@ def _unstarted_record(session_id: str = "fresh-id") -> registry.SessionRecord:
 
 
 @pytest.mark.asyncio
-async def test_an_unstarted_session_is_spooled_not_dialled(monkeypatch, tmp_path) -> None:
-    """mailbox/wake/steer all degrade to a quiet spool for an unstarted session;
-    the socket is never dialled, so no turn can be driven."""
+async def test_an_unstarted_live_session_is_dialled_quietly_never_spooled(
+    monkeypatch, tmp_path
+) -> None:
+    """An exact send to a LIVE unstarted session DIALS in the record-only
+    shape (mailbox + no wake) whatever the sender asked for, so the peer card
+    is painted and the row persisted for the already-open session without
+    driving a turn — and nothing is spooled, because no live session would
+    ever drain it."""
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
     record = _unstarted_record()
-    dialed = False
+    dials: list[tuple[str, bool]] = []
 
-    async def _dial(*_a: Any, **_k: Any) -> str:
-        nonlocal dialed
-        dialed = True
-        return "delivered"
+    async def _dial(
+        rec: Any, *, text: str, mode: str, wake: bool, sender: Any
+    ) -> str:  # noqa: ANN401
+        assert rec is record
+        dials.append((mode, wake))
+        return "delivered to the mailbox (will be read on the next turn)"
 
     monkeypatch.setattr("local_operator.mobile.peer_client.send_peer_message", _dial, raising=True)
-    from local_operator.session.runtime.inbox import drain_inbox
 
     for mode, wake in (("mailbox", False), ("mailbox", True), ("steer", False), ("steer", True)):
         detail = await peer_send.deliver_peer_message(
@@ -714,17 +723,24 @@ async def test_an_unstarted_session_is_spooled_not_dialled(monkeypatch, tmp_path
             wake=wake,
             sender={"pid": 1},
         )
-        assert detail == "spooled (session not started yet; will be read when it next opens)"
-    assert not dialed, "an unstarted session must never be dialled"
-    # Every spooled line is drained by the existing inbox path on first open.
-    directory = tmp_path / "sessions" / record.session_id
-    assert len(drain_inbox(directory)) == 4
+        assert (
+            detail == "delivered to the mailbox (session not started yet; no turn driven)"
+        ), f"mode={mode} wake={wake}"
+
+    # Every requested mode/wake combination degraded to the quiet dial: a
+    # turn-driving shape (wake=True or a steer) must never reach the socket.
+    assert dials == [("mailbox", False)] * 4
+    # And nothing was spooled: a live unstarted session would only drain an
+    # inbox row at a future cold open, which is exactly the invisibility the
+    # dial exists to avoid. The delivery touched the socket, not the file.
+    assert not (tmp_path / "sessions" / record.session_id).exists()
 
 
 @pytest.mark.asyncio
 async def test_a_started_session_still_dials_the_socket(monkeypatch) -> None:
     """The new branch must not change the normal path: a started session is
-    dialled and its ack detail is returned verbatim."""
+    dialled with the sender's own mode/wake and its ack detail is returned
+    verbatim."""
     record = _unstarted_record()
     record.started = True
 
@@ -744,11 +760,12 @@ async def test_a_started_session_still_dials_the_socket(monkeypatch) -> None:
     assert detail == "delivered and woke the session"
 
 
-def test_a_record_without_the_started_key_reads_as_unstarted() -> None:
-    """Mixed-version: a record an OLDER binary wrote has no ``started`` key, so
-    the dataclass default ``False`` applies — the safe direction (excluded from
-    broadcasts, spooled on an exact send) rather than risk driving a turn into a
-    fresh ``/new`` session. See ``SessionRecord.from_json``."""
+def test_a_record_without_the_started_key_reads_as_started() -> None:
+    """Mixed-version: a record an OLDER (pre-field) binary wrote has no
+    ``started`` key, and such a session had no composer gate — so the absent
+    key reads True and old-peer behaviour is preserved (broadcasts reach a
+    working old runtime; exact sends dial it). A CONSTRUCTED record keeps the
+    dataclass default False. See ``SessionRecord.from_json``."""
     record = registry.SessionRecord.from_json(
         {
             "pid": 4242,
@@ -761,4 +778,34 @@ def test_a_record_without_the_started_key_reads_as_unstarted() -> None:
             "control_key": "k",
         }
     )
-    assert record.started is False
+    assert record.started is True
+    # The dataclass default is untouched: a fresh this-binary record (the
+    # composer window) is still constructed unstarted.
+    assert (
+        registry.SessionRecord(
+            pid=4242,
+            kind="tui",
+            session_id="new-id",
+            conversation_name="new",
+            cwd="/tmp",
+            model_label="test/model",
+            control_port=1,
+            control_key="k",
+        ).started
+        is False
+    )
+    # An explicit False on the wire still round-trips as False.
+    explicit = registry.SessionRecord.from_json(
+        {
+            "pid": 4242,
+            "kind": "tui",
+            "session_id": "fresh-wire",
+            "conversation_name": "fresh",
+            "cwd": "/tmp",
+            "model_label": "test/model",
+            "control_port": 1,
+            "control_key": "k",
+            "started": False,
+        }
+    )
+    assert explicit.started is False

--- a/tests/unit/mobile/test_peer_send.py
+++ b/tests/unit/mobile/test_peer_send.py
@@ -27,6 +27,7 @@ class _Record:
         conversation_name: str = "peer",
         model_label: str = "test/model",
         cwd: str = "/tmp",
+        started: bool = True,
     ) -> None:
         self.pid = pid
         self.session_id = session_id
@@ -35,6 +36,7 @@ class _Record:
         self.cwd = cwd
         self.control_port = 1
         self.control_key = "k"
+        self.started = started
 
 
 def _scan(records: "list[tuple[Any, str]]"):
@@ -198,6 +200,45 @@ def test_only_live_records_are_eligible(fake_scan) -> None:
     record, _c, error = peer_send.resolve_peer_target(target="slow")
     assert record is None
     assert "not responding" in error
+
+
+def test_a_broadcast_substring_skips_an_unstarted_session(fake_scan) -> None:
+    """A ``/new`` session sitting in the composer (``started=False``) is
+    invisible to a substring/broadcast match: an interrupt there would drive a
+    turn into a session whose owner has not started it."""
+    fresh = _Record(10, conversation_name="release", started=False)
+    working = _Record(20, conversation_name="release cutter", started=True)
+    fake_scan([(fresh, "live"), (working, "live")])
+    record, candidates, error = peer_send.resolve_peer_target(target="release")
+    assert record is working
+    assert candidates == []
+    assert error == ""
+
+
+def test_a_broadcast_matching_only_unstarted_sessions_finds_nothing(fake_scan) -> None:
+    fresh = _Record(10, conversation_name="release", started=False)
+    fake_scan([(fresh, "live")])
+    record, _c, error = peer_send.resolve_peer_target(target="release")
+    assert record is None
+    assert "no live session matches" in error
+
+
+def test_an_exact_pid_send_still_resolves_an_unstarted_session(fake_scan) -> None:
+    """The sender deliberately NAMED this session by pid, so it resolves — the
+    delivery layer spools rather than drives a turn (see deliver_peer_message)."""
+    fresh = _Record(10, conversation_name="release", started=False)
+    fake_scan([(fresh, "live")])
+    record, _c, error = peer_send.resolve_peer_target(pid=10)
+    assert record is fresh
+    assert error == ""
+
+
+def test_an_exact_session_send_still_resolves_an_unstarted_session(fake_scan) -> None:
+    fresh = _Record(10, session_id="fresh-id", started=False)
+    fake_scan([(fresh, "live")])
+    record, _c, error = peer_send.resolve_peer_target(session="fresh-id")
+    assert record is fresh
+    assert error == ""
 
 
 def test_no_target_is_a_clean_error(fake_scan) -> None:
@@ -624,3 +665,100 @@ def test_a_non_dict_sender_cannot_escape_the_handler(monkeypatch) -> None:
             raise RuntimeError("hostile keys")
 
     assert peer_send.resolve_sender_identity(_HostileMapping()) == {}
+
+
+# --- ``started`` gating on the DELIVERY path ---------------------------------
+#
+# ``resolve_peer_target`` excludes an unstarted session from a broadcast, but
+# an exact-address send still resolves to it. The spool-below is the belt-and-
+# braces that makes "no turn is ever driven into an unstarted session" hold even
+# for a caller that bypassed resolution.
+
+
+def _unstarted_record(session_id: str = "fresh-id") -> registry.SessionRecord:
+    return registry.SessionRecord(
+        pid=4242,
+        kind="tui",
+        session_id=session_id,
+        conversation_name="fresh",
+        cwd="/tmp",
+        model_label="test/model",
+        control_port=1,
+        control_key="k",
+        started=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_unstarted_session_is_spooled_not_dialled(monkeypatch, tmp_path) -> None:
+    """mailbox/wake/steer all degrade to a quiet spool for an unstarted session;
+    the socket is never dialled, so no turn can be driven."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    record = _unstarted_record()
+    dialed = False
+
+    async def _dial(*_a: Any, **_k: Any) -> str:
+        nonlocal dialed
+        dialed = True
+        return "delivered"
+
+    monkeypatch.setattr("local_operator.mobile.peer_client.send_peer_message", _dial, raising=True)
+    from local_operator.session.runtime.inbox import drain_inbox
+
+    for mode, wake in (("mailbox", False), ("mailbox", True), ("steer", False), ("steer", True)):
+        detail = await peer_send.deliver_peer_message(
+            record,
+            session_id=record.session_id,
+            text=f"note-{mode}-{wake}",
+            mode=mode,
+            wake=wake,
+            sender={"pid": 1},
+        )
+        assert detail == "spooled (session not started yet; will be read when it next opens)"
+    assert not dialed, "an unstarted session must never be dialled"
+    # Every spooled line is drained by the existing inbox path on first open.
+    directory = tmp_path / "sessions" / record.session_id
+    assert len(drain_inbox(directory)) == 4
+
+
+@pytest.mark.asyncio
+async def test_a_started_session_still_dials_the_socket(monkeypatch) -> None:
+    """The new branch must not change the normal path: a started session is
+    dialled and its ack detail is returned verbatim."""
+    record = _unstarted_record()
+    record.started = True
+
+    async def _dial(rec: Any, *, text: str, mode: str, wake: bool, sender: Any) -> str:
+        assert rec is record
+        return "delivered and woke the session" if wake else "delivered to the mailbox"
+
+    monkeypatch.setattr("local_operator.mobile.peer_client.send_peer_message", _dial, raising=True)
+    detail = await peer_send.deliver_peer_message(
+        record,
+        session_id=record.session_id,
+        text="hi",
+        mode="mailbox",
+        wake=True,
+        sender={"pid": 1},
+    )
+    assert detail == "delivered and woke the session"
+
+
+def test_a_record_without_the_started_key_reads_as_unstarted() -> None:
+    """Mixed-version: a record an OLDER binary wrote has no ``started`` key, so
+    the dataclass default ``False`` applies — the safe direction (excluded from
+    broadcasts, spooled on an exact send) rather than risk driving a turn into a
+    fresh ``/new`` session. See ``SessionRecord.from_json``."""
+    record = registry.SessionRecord.from_json(
+        {
+            "pid": 4242,
+            "kind": "tui",
+            "session_id": "old-id",
+            "conversation_name": "old",
+            "cwd": "/tmp",
+            "model_label": "test/model",
+            "control_port": 1,
+            "control_key": "k",
+        }
+    )
+    assert record.started is False

--- a/tests/unit/mobile/test_tui_bridge.py
+++ b/tests/unit/mobile/test_tui_bridge.py
@@ -224,7 +224,7 @@ def test_the_started_hook_is_wired_and_reseeded_on_rebind(tmp_path) -> None:
             path = tmp_path / session_id / "transcript.jsonl"
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text("".join(row + "\n" for row in transcript_rows))
-            self.transcript = SimpleNamespace(path=path)
+            self.transcript_path = path
 
         # FakeSession pins a constant "sess"; the rebind path copies this
         # onto the projection, so the test needs per-session values.
@@ -278,3 +278,17 @@ def test_the_started_hook_is_wired_and_reseeded_on_rebind(tmp_path) -> None:
     handle.rebind()
     assert newer._publish_session_started == handle._publish_session_started
     assert registrant.resets == [True, False]
+
+    # QA Q4: a transcript whose only message rows are quiet-dialled peer
+    # notes (``peer_message`` CustomMessages, persisted without a turn) is
+    # NOT durable history — the bit must stay False on rebind to it.
+    noted = _Session(
+        "noted-id",
+        [
+            '{"id":"p1","ts":4,"type":"message","payload":{"kind":"custom",'
+            '"custom_type":"peer_message","attribution":"user","details":{"text":"hi"}}}',
+        ],
+    )
+    handle._app = _App(noted)  # type: ignore[assignment]
+    handle.rebind()
+    assert registrant.resets == [True, False, False]

--- a/tests/unit/mobile/test_tui_bridge.py
+++ b/tests/unit/mobile/test_tui_bridge.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -203,3 +204,77 @@ async def test_tui_auto_registers_and_answers_control() -> None:
         writer.close()
 
     assert not registry.scan(), "record was not unpublished on exit"
+
+
+def test_the_started_hook_is_wired_and_reseeded_on_rebind(tmp_path) -> None:
+    """Q2: ``TuiSessionHandle`` must wire ``session._publish_session_started``
+    the way ``OwnedSessionHandle`` does, or a TUI-owned ``kind="tui"`` record
+    stays ``started=False`` forever. Rebind must RE-wire it on the new session
+    object and re-seed the registrant's bit from the new session's own durable
+    history: a ``/new`` (no message rows) drops back to False — the composer
+    window — while a ``/resume`` (message rows on disk) reads True."""
+
+    class _Session(FakeSession):
+        # The attribute OwnedSessionHandle/TuiSessionHandle wire onto a real
+        # Session; the fake does not carry it, so the test stands it up.
+        def __init__(self, session_id: str, transcript_rows: list[str]) -> None:  # noqa: ANN001
+            super().__init__()
+            self._publish_session_started: Any = None
+            self._sid = session_id
+            path = tmp_path / session_id / "transcript.jsonl"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("".join(row + "\n" for row in transcript_rows))
+            self.transcript = SimpleNamespace(path=path)
+
+        # FakeSession pins a constant "sess"; the rebind path copies this
+        # onto the projection, so the test needs per-session values.
+        @property
+        def session_id(self) -> str:
+            return self._sid
+
+    class _App:
+        def __init__(self, session) -> None:  # noqa: ANN001
+            self._session = session
+
+    class _Registrant:
+        def __init__(self) -> None:
+            self.resets: list[bool] = []
+            self.started_calls: list[bool] = []
+
+        def reset_record_started(self, started: bool) -> None:
+            self.resets.append(started)
+
+        def set_record_started(self, started: bool) -> None:
+            self.started_calls.append(started)
+
+    fresh = _Session("fresh-id", [])
+    resumed = _Session(
+        "resumed-id",
+        [
+            '{"id":"m1","ts":1,"type":"custom","payload":{"custom_type":"title"}}',
+            '{"id":"m2","ts":2,"type":"message","payload":{"role":"user"}}',
+        ],
+    )
+    registrant = _Registrant()
+    handle = TuiSessionHandle(_App(fresh))  # type: ignore[arg-type]
+    handle._registrant = registrant  # type: ignore[attr-defined]
+
+    # Wired at construction: the session's hook reaches the handle. Bound
+    # methods are compared with == (each attribute access mints a new object).
+    assert fresh._publish_session_started == handle._publish_session_started
+    fresh._publish_session_started()
+    assert registrant.started_calls == [True]
+
+    # /resume: message history on disk re-seeds the bit True even though THIS
+    # process has not run a turn for it.
+    handle._app = _App(resumed)  # type: ignore[assignment]
+    handle.rebind()
+    assert resumed._publish_session_started == handle._publish_session_started
+    assert registrant.resets == [True]
+
+    # /new after that working conversation: no message rows, bit drops False.
+    newer = _Session("newer-id", ['{"id":"t1","ts":3,"type":"custom","payload":{}}'])
+    handle._app = _App(newer)  # type: ignore[assignment]
+    handle.rebind()
+    assert newer._publish_session_started == handle._publish_session_started
+    assert registrant.resets == [True, False]

--- a/tests/unit/session/runtime/test_capability_surface.py
+++ b/tests/unit/session/runtime/test_capability_surface.py
@@ -54,6 +54,13 @@ OPTIONAL_CAPABILITIES = {
     # Set by the registrant on itself, not implemented by the handle.
     "_frontend",
     "_install_interactivity_probe",
+    # Owned-handle instance state (assigned in ``OwnedSessionHandle.__init__``),
+    # not a class-declared capability, so the class-level ``hasattr`` cannot
+    # see it. Read once at record construction to seed ``started`` from the
+    # resumed conversation's durable history; a handle without one (the TUI's,
+    # a reduced test host) takes the conservative ``started=False`` a first
+    # real turn immediately corrects — a designed degradation, not a defect.
+    "_session",
 }
 
 

--- a/tests/unit/session/runtime/test_inbox.py
+++ b/tests/unit/session/runtime/test_inbox.py
@@ -168,6 +168,45 @@ def test_the_drain_is_wired_before_the_socket_starts_listening() -> None:
     )
 
 
+def test_a_message_spooled_to_an_unstarted_session_drains_on_start(tmp_path: Path) -> None:
+    """The receive half of the unstarted-session spool: a message that
+    ``deliver_peer_message`` wrote to the inbox (because the target had not
+    started) is consumed by the ordinary drain the next time the session opens,
+    exactly like a message spooled to a COLD session. No new drain path is
+    introduced — this pins that the existing one is what serves the spool."""
+    import asyncio
+
+    from local_operator.session.runtime.process import _drain_inbox_into
+
+    session_dir = tmp_path / "sessions" / "freshsess"
+    session_dir.mkdir(parents=True)
+    assert append_inbox(session_dir, _line("held until you start"))
+
+    class _Transcript:
+        directory = session_dir
+
+    class _Session:
+        transcript = _Transcript()
+
+    class _Handle:
+        def __init__(self) -> None:
+            self._session = _Session()
+            self.received: list[tuple[str, str, bool]] = []
+
+        async def receive_peer_message(self, text, *, mode, wake, sender=None):
+            self.received.append((text, mode, wake))
+            return "ok"
+
+    handle = _Handle()
+    delivered = asyncio.run(_drain_inbox_into(handle))
+
+    assert delivered == 1
+    # Drained as a quiet mailbox note (never a wake), matching the cold path.
+    assert handle.received == [("held until you start", "mailbox", False)]
+    # And the spool is consumed, not peeked.
+    assert drain_inbox(session_dir) == []
+
+
 def test_the_drain_reads_a_property_the_session_exposes(tmp_path: Path) -> None:
     """Round 2 (U5): the drain read ``session.transcript`` while ``Session``
     only exposed ``_transcript``, so it bailed before calling ``drain_inbox``

--- a/tests/unit/session/runtime/test_inbox.py
+++ b/tests/unit/session/runtime/test_inbox.py
@@ -169,11 +169,13 @@ def test_the_drain_is_wired_before_the_socket_starts_listening() -> None:
 
 
 def test_a_message_spooled_to_an_unstarted_session_drains_on_start(tmp_path: Path) -> None:
-    """The receive half of the unstarted-session spool: a message that
-    ``deliver_peer_message`` wrote to the inbox (because the target had not
-    started) is consumed by the ordinary drain the next time the session opens,
-    exactly like a message spooled to a COLD session. No new drain path is
-    introduced — this pins that the existing one is what serves the spool."""
+    """The receive half of the cold-session spool: a message that
+    ``deliver_peer_message`` wrote to the inbox (a session with NO live
+    record) is consumed by the ordinary drain the next time the session
+    opens. A live-but-unstarted target is no longer spooled at all — it is
+    quietly dialled — but rows written by an older sender, or before a
+    record existed, still land here, and this pins that the boot drain is
+    what serves them."""
     import asyncio
 
     from local_operator.session.runtime.process import _drain_inbox_into

--- a/tests/unit/session/runtime/test_owned.py
+++ b/tests/unit/session/runtime/test_owned.py
@@ -228,6 +228,32 @@ def test_default_conversation_name_is_empty_not_a_placeholder() -> None:
     assert handle.session_projection_seed.conversation_name == ""
 
 
+def test_the_started_hook_reaches_the_registrant() -> None:
+    """``_publish_session_started`` (wired onto the session and called from
+    ``_run_turn_pipeline``) flips the registrant's record bit, and is a no-op
+    for a host that never grew one."""
+    handle, _ = make_handle()
+    started_calls: list[bool] = []
+
+    class _Registrant:
+        def set_record_started(self, started: bool) -> None:
+            started_calls.append(started)
+
+    handle._registrant = _Registrant()
+    handle._publish_session_started()
+    assert started_calls == [True]
+
+    # A reduced host with no registrant must not fail the turn.
+    handle._registrant = None  # type: ignore[attr-defined]
+    handle._publish_session_started()
+    assert started_calls == [True]
+
+    # A registrant that predates the setter (a reduced test double) is skipped.
+    handle._registrant = object()
+    handle._publish_session_started()
+    assert started_calls == [True]
+
+
 @pytest.mark.asyncio
 async def test_full_auto_approves_inline_without_a_card() -> None:
     """With the owner's saved default at full-auto, the gate answers True

--- a/tests/unit/session/runtime/test_server.py
+++ b/tests/unit/session/runtime/test_server.py
@@ -1174,6 +1174,43 @@ class TestLiveStateReachesTheRecord:
         server._republish_detached()  # unchanged: no publish
         assert len(publishes) == 1
 
+    @pytest.mark.asyncio
+    async def test_a_new_runtime_reports_itself_unstarted(self) -> None:
+        """A fresh boot (a ``/new`` session in the composer) has run no turn."""
+        server = RuntimeServer(FakeHandle(), kind="daemon")
+        assert server._record.started is False
+
+    @pytest.mark.asyncio
+    async def test_started_is_one_way_and_deduplicated(self) -> None:
+        """The flag flips once and a repeat ``True`` (every turn after the
+        first) publishes nothing."""
+        server = RuntimeServer(FakeHandle(), kind="daemon")
+        publishes: list[bool] = []
+        server._republish = lambda: publishes.append(server._started)  # type: ignore[method-assign]
+
+        server.set_record_started(True)
+        server.set_record_started(True)  # already started: must not republish
+
+        assert publishes == [True]
+
+    @pytest.mark.asyncio
+    async def test_started_survives_the_republish(self, tmp_path, monkeypatch) -> None:
+        """A heartbeat rewrite carries ``started`` forward rather than resetting
+        it — the field must stay True once set, or a working session would
+        become broadcast-invisible again on the next heartbeat."""
+        monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+        server = RuntimeServer(FakeHandle(), kind="tui")
+        server.start()
+        try:
+            await _wait_record()
+            server.set_record_started(True)
+            # A republish through the heartbeat path must keep the bit set.
+            server._republish()
+            found = registry.scan()
+            assert found and found[0][0].started is True
+        finally:
+            server.close()
+
 
 @pytest.mark.asyncio
 async def test_desktop_watch_lease_separates_visibility_and_notification_delivery() -> None:

--- a/tests/unit/session/runtime/test_server.py
+++ b/tests/unit/session/runtime/test_server.py
@@ -1185,7 +1185,8 @@ class TestLiveStateReachesTheRecord:
 
         The boot-seed path probes ``handle._session`` (the owned-handle shape
         — the daemon child and exec) and derives ``started`` from the
-        transcript FILE, so the fake only needs the path to be real.
+        transcript FILE via the session's declared ``transcript_path``, so the
+        fake only needs the path to be real.
         """
         from types import SimpleNamespace
 
@@ -1193,9 +1194,7 @@ class TestLiveStateReachesTheRecord:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("".join(row + "\n" for row in rows))
         handle = FakeHandle()
-        handle._session = SimpleNamespace(  # type: ignore[attr-defined]
-            transcript=SimpleNamespace(path=path)
-        )
+        handle._session = SimpleNamespace(transcript_path=path)  # type: ignore[attr-defined]
         return handle
 
     @pytest.mark.asyncio
@@ -1234,6 +1233,41 @@ class TestLiveStateReachesTheRecord:
             server = RuntimeServer(handle, kind="daemon")
             assert server._started is False
             assert server._record.started is False
+
+    @pytest.mark.asyncio
+    async def test_a_peer_note_only_transcript_boots_unstarted(self, tmp_path) -> None:
+        """QA Q4: a quiet-dialled peer note persists as a MESSAGE row (kind
+        ``custom``, a ``peer_message`` CustomMessage) WITHOUT a turn running,
+        so a message row alone cannot seed ``started`` — that marks the
+        session started, after which a peer ``--wake`` or a broadcast drives
+        an assistant turn into a session the owner never typed in. Only a
+        plain ``Message`` row (kind ``message``, or a legacy row that
+        predates the marker) counts."""
+        peer_note = (
+            '{"id":"p1","ts":1,"type":"message","payload":{"kind":"custom",'
+            '"custom_type":"peer_message","attribution":"user","details":{"text":"hi"}}}'
+        )
+        peer_notes_only = self._handle_over_transcript(tmp_path, "noted", [peer_note, peer_note])
+        mixed = self._handle_over_transcript(
+            tmp_path,
+            "mixed",
+            [
+                peer_note,
+                '{"id":"m1","ts":4,"type":"message","payload":{"kind":"message","role":"user"}}',
+            ],
+        )
+        legacy = self._handle_over_transcript(
+            tmp_path,
+            "legacy",
+            ['{"id":"m2","ts":5,"type":"message","payload":{"role":"assistant"}}'],
+        )
+        server = RuntimeServer(peer_notes_only, kind="daemon")
+        assert server._started is False
+        assert server._record.started is False
+        for handle in (mixed, legacy):
+            server = RuntimeServer(handle, kind="daemon")
+            assert server._started is True
+            assert server._record.started is True
 
     @pytest.mark.asyncio
     async def test_started_is_one_way_and_deduplicated(self) -> None:

--- a/tests/unit/session/runtime/test_server.py
+++ b/tests/unit/session/runtime/test_server.py
@@ -1183,15 +1183,89 @@ class TestLiveStateReachesTheRecord:
     @pytest.mark.asyncio
     async def test_started_is_one_way_and_deduplicated(self) -> None:
         """The flag flips once and a repeat ``True`` (every turn after the
-        first) publishes nothing."""
+        first) publishes nothing — and a ``False`` after ``True`` is IGNORED:
+        no code path un-runs a turn, so honouring it would let a mistake
+        un-publish a working session. Dropping the bit is reserved for a
+        session-identity swap (``reset_record_started``)."""
         server = RuntimeServer(FakeHandle(), kind="daemon")
         publishes: list[bool] = []
         server._republish = lambda: publishes.append(server._started)  # type: ignore[method-assign]
 
         server.set_record_started(True)
         server.set_record_started(True)  # already started: must not republish
+        server.set_record_started(False)  # one-way: a started record ignores False
 
         assert publishes == [True]
+        assert server._started is True
+        assert server._record.started is True
+
+    @pytest.mark.asyncio
+    async def test_reset_record_started_reseeds_for_a_new_identity(self) -> None:
+        """The rebind path: a ``/new`` drops the bit (the composer window
+        returns) and a ``/resume`` raises it without ever having run a turn
+        in THIS process — both legal only because the identity changed."""
+        server = RuntimeServer(FakeHandle(), kind="tui")
+        publishes: list[bool] = []
+        server._republish = lambda: publishes.append(server._started)  # type: ignore[method-assign]
+
+        server.set_record_started(True)  # the old conversation ran turns
+        server.reset_record_started(False)  # /new: fresh composer
+        assert server._started is False
+        assert server._record.started is False
+        server.reset_record_started(True)  # /resume of a session with history
+        assert server._started is True
+        assert server._record.started is True
+        # And the reset True is still one-way afterwards.
+        server.set_record_started(False)
+        assert server._started is True
+        assert publishes == [True, False, True]
+
+    @pytest.mark.asyncio
+    async def test_the_periodic_heartbeat_carries_started(self, tmp_path, monkeypatch) -> None:
+        """The timer heartbeat (the one that refreshes the record's IDENTITY
+        fields from the projection seed) must carry ``started`` explicitly.
+        Today the publish happens to survive on ``self._record is
+        publisher.record`` — an object-identity accident this pins away: a
+        rebuilt or copied record must not make a working session
+        broadcast-invisible one heartbeat later."""
+        import local_operator.session.runtime.server as server_module
+
+        monkeypatch.setattr(server_module, "HEARTBEAT_INTERVAL_S", 0.05)
+        # Isolated config dir: ``start_in_process`` constructs a real
+        # RecordPublisher before the recorder replaces it, and its writes
+        # must not touch the operator's live registry.
+        monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+        server = RuntimeServer(FakeHandle(), kind="tui")
+        timer_calls: list[dict[str, object]] = []
+
+        class _Recorder:
+            # Stands in for RecordPublisher on the timer path only; its call
+            # is told apart from ``_republish``'s by the identity fields,
+            # which only the timer passes. ``close`` because teardown joins
+            # the publisher it finds.
+            def heartbeat(self, **kwargs: object) -> None:
+                if "session_id" in kwargs:
+                    timer_calls.append(dict(kwargs))
+
+            def close(self) -> None:
+                pass
+
+        # In-process (the mobile child's own mode) so the heartbeat task
+        # shares THIS loop and the test can observe its ticks directly.
+        await server.start_in_process()
+        try:
+            # Point the loop at the recorder, flip the bit, and let a tick (or
+            # several — the loop is a 50 ms timer) pass.
+            server._publisher = _Recorder()  # type: ignore[assignment]
+            server.set_record_started(True)
+            deadline = asyncio.get_running_loop().time() + 5
+            while not timer_calls and asyncio.get_running_loop().time() < deadline:
+                await asyncio.sleep(0.02)
+            assert timer_calls, "the periodic heartbeat never fired"
+            assert all(call.get("started") is True for call in timer_calls)
+        finally:
+            server.close()
+            await asyncio.sleep(0)
 
     @pytest.mark.asyncio
     async def test_started_survives_the_republish(self, tmp_path, monkeypatch) -> None:

--- a/tests/unit/session/runtime/test_server.py
+++ b/tests/unit/session/runtime/test_server.py
@@ -1180,6 +1180,61 @@ class TestLiveStateReachesTheRecord:
         server = RuntimeServer(FakeHandle(), kind="daemon")
         assert server._record.started is False
 
+    def _handle_over_transcript(self, tmp_path, name: str, rows: list[str]) -> FakeHandle:
+        """A FakeHandle whose owned session reads a transcript file on disk.
+
+        The boot-seed path probes ``handle._session`` (the owned-handle shape
+        — the daemon child and exec) and derives ``started`` from the
+        transcript FILE, so the fake only needs the path to be real.
+        """
+        from types import SimpleNamespace
+
+        path = tmp_path / name / "transcript.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("".join(row + "\n" for row in rows))
+        handle = FakeHandle()
+        handle._session = SimpleNamespace(  # type: ignore[attr-defined]
+            transcript=SimpleNamespace(path=path)
+        )
+        return handle
+
+    @pytest.mark.asyncio
+    async def test_a_resumed_boot_seeds_started_from_durable_history(self, tmp_path) -> None:
+        """QA Q3: the daemon child behind ``lop --resume <sid>`` builds its
+        record at boot, and a conversation that already ran turns under an
+        earlier process must read ``started=True`` from the FIRST publish —
+        before the owner types anything in THIS process. Bookkeeping rows
+        (a persisted title) do not count; only a MESSAGE row does, exactly
+        as in ``TuiSessionHandle.rebind``'s re-seed."""
+        handle = self._handle_over_transcript(
+            tmp_path,
+            "resumed",
+            [
+                '{"id":"m1","ts":1,"type":"custom","payload":{"custom_type":"title"}}',
+                '{"id":"m2","ts":2,"type":"message","payload":{"role":"user"}}',
+            ],
+        )
+        server = RuntimeServer(handle, kind="daemon")
+        assert server._started is True
+        assert server._record.started is True
+
+    @pytest.mark.asyncio
+    async def test_an_empty_session_directory_boots_unstarted(self, tmp_path) -> None:
+        """The composer gate survives the seed: a true ``/new`` — no message
+        rows, whether the transcript is empty or holds only bookkeeping —
+        must still publish ``started=False`` so peer broadcasts do not drive
+        a turn into a session whose owner has not typed yet."""
+        empty = self._handle_over_transcript(tmp_path, "empty", [])
+        bookkeeping_only = self._handle_over_transcript(
+            tmp_path,
+            "titled",
+            ['{"id":"t1","ts":3,"type":"custom","payload":{"custom_type":"title"}}'],
+        )
+        for handle in (empty, bookkeeping_only):
+            server = RuntimeServer(handle, kind="daemon")
+            assert server._started is False
+            assert server._record.started is False
+
     @pytest.mark.asyncio
     async def test_started_is_one_way_and_deduplicated(self) -> None:
         """The flag flips once and a repeat ``True`` (every turn after the

--- a/tests/unit/session/test_session_peer.py
+++ b/tests/unit/session/test_session_peer.py
@@ -535,3 +535,59 @@ async def test_a_sender_with_no_record_still_delivers(tmp_path, monkeypatch):
     rows = _peer_rows(session)
     assert rows[0].payload["details"]["sender"] == {"pid": 999999}
     await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_spooled_peer_message_does_not_start_the_session(tmp_path):
+    """A mailbox message landing on an unstarted session must NOT flip the
+    record's ``started`` bit: the flag marks a REAL turn, not a spooled note."""
+    stream = ScriptedStream([[StreamTextDelta(delta="ack"), StreamEndEvent(stop_reason="stop")]])
+    session = make_session(tmp_path, stream)
+    marks: list[bool] = []
+    session._publish_session_started = lambda: marks.append(True)
+
+    await session.receive_peer_message("quiet note", mode="mailbox", wake=False, sender={"pid": 42})
+
+    assert marks == [], "a spooled mailbox message ran no turn, so it must not start the session"
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_first_real_turn_flips_started_once(tmp_path):
+    """A user prompt (and a wake-driven turn) each run a real turn; the hook
+    fires at the pipeline's choke point and the registrant de-duplicates, so the
+    first turn publishes exactly once and later turns republish nothing."""
+    stream = ScriptedStream(
+        [
+            [StreamTextDelta(delta="ack"), StreamEndEvent(stop_reason="stop")],
+            [StreamTextDelta(delta="ack"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    session = make_session(tmp_path, stream)
+    marks: list[bool] = []
+    session._publish_session_started = lambda: marks.append(True)
+
+    await session.prompt("first")
+    await session.prompt("second")
+
+    # The hook runs at the top of EVERY turn; the one-way dedupe lives in the
+    # registrant's set_record_started, so the session emits a mark per turn and
+    # the publish layer (not the session) is what collapses them to one write.
+    assert len(marks) == 2
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_wake_peer_message_that_opens_the_first_turn_starts_the_session(tmp_path):
+    """A wake/steer delivery that itself runs the session's first turn DOES set
+    the flag: the session is now genuinely working."""
+    stream = ScriptedStream([[StreamTextDelta(delta="ack"), StreamEndEvent(stop_reason="stop")]])
+    session = make_session(tmp_path, stream)
+    marks: list[bool] = []
+    session._publish_session_started = lambda: marks.append(True)
+
+    await session.receive_peer_message("wake up", mode="mailbox", wake=True, sender={"pid": 42})
+    await wait_for(lambda: len(marks) == 1)
+
+    assert len(marks) == 1
+    await session.dispose()

--- a/tests/unit/session/test_session_peer.py
+++ b/tests/unit/session/test_session_peer.py
@@ -591,3 +591,58 @@ async def test_a_wake_peer_message_that_opens_the_first_turn_starts_the_session(
 
     assert len(marks) == 1
     await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_first_real_turn_consumes_a_leftover_spool(tmp_path):
+    """Q1 belt-and-braces: rows already sitting in the session's inbox (written
+    by an older sender, or before a live record existed) are consumed by the
+    FIRST real turn itself — without anyone calling the boot drain. Before the
+    fix such rows stayed unread for as long as the session stayed open."""
+    from local_operator.session.runtime.inbox import (
+        InboxLine,
+        append_inbox,
+        drain_inbox,
+    )
+
+    stream = ScriptedStream(
+        [
+            [StreamTextDelta(delta="ack"), StreamEndEvent(stop_reason="stop")],
+            [StreamTextDelta(delta="ack"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    session = make_session(tmp_path, stream)
+
+    # Two rows spooled for THIS session, written straight to its inbox the way
+    # ``deliver_peer_message``'s cold branch does. Delivery below must come
+    # from the turn pipeline, not from any direct drain call in this test.
+    directory = session._transcript.directory
+    assert append_inbox(
+        directory, InboxLine(text="leftover one", sender={"pid": 7}, mode="mailbox", written_at=0.0)
+    )
+    assert append_inbox(
+        directory, InboxLine(text="leftover two", sender={"pid": 7}, mode="mailbox", written_at=0.1)
+    )
+
+    await session.prompt("first real prompt")
+    await wait_for(lambda: bool(stream.requests))
+
+    # The spool is consumed by the turn, and both notes are durable peer rows
+    # in the transcript — delivered as quiet mailbox notes, no extra turn.
+    assert drain_inbox(directory) == []
+    delivered = sorted(
+        row.payload["details"]["body"] for row in _peer_rows(session) if row.payload["details"]
+    )
+    assert "leftover one" in delivered and "leftover two" in delivered
+    assert len(stream.requests) == 1, "a spool drain must not drive extra turns"
+
+    # Once per lifetime: a second turn does not re-attempt the drain (the
+    # flag short-circuits), and rows spooled LATER are left for the cold-open
+    # drain, exactly as before.
+    assert append_inbox(
+        directory, InboxLine(text="later note", sender={"pid": 7}, mode="mailbox", written_at=0.2)
+    )
+    await session.prompt("second prompt")
+    await wait_for(lambda: len(stream.requests) == 2)
+    assert [line.text for line in drain_inbox(directory)] == ["later note"]
+    await session.dispose()

--- a/tests/unit/session/test_transcript.py
+++ b/tests/unit/session/test_transcript.py
@@ -882,3 +882,67 @@ async def test_audit_slice_never_begins_inside_a_tool_group(tmp_path):
     )
     assert messages[0].id == call.id
     assert [m.id for m in messages] == [call.id, result.id]
+
+
+class TestDurableConversationPath:
+    """The ``started``-bit seed discriminator: a REAL turn's row counts, a
+    CustomMessage row persisted without a turn (QA Q4) does not."""
+
+    #: The quiet-dial note exactly as ``append_messages`` persists it: a
+    #: message row whose payload kind is ``custom`` (QA Q4's repro row).
+    _PEER_NOTE = (
+        '{"id":"p1","ts":1,"type":"message","payload":{"kind":"custom",'
+        '"custom_type":"peer_message","attribution":"user","details":{"text":"hi"}}}'
+    )
+
+    def _write(self, tmp_path: Path, rows: list[str]) -> Path:
+        path = tmp_path / "transcript.jsonl"
+        path.write_text("".join(row + "\n" for row in rows))
+        return path
+
+    def test_a_real_user_turn_counts(self, tmp_path: Path) -> None:
+        from local_operator.session.transcript import durable_conversation_path
+
+        row = '{"id":"m1","ts":1,"type":"message","payload":{"kind":"message","role":"user"}}'
+        path = self._write(tmp_path, [row])
+        assert durable_conversation_path(path) is True
+
+    def test_a_peer_note_only_transcript_does_not_count(self, tmp_path: Path) -> None:
+        """QA Q4: a quiet-dialled peer note persists as a message row (kind
+        ``custom``) with NO turn running; treating it as history seeds
+        ``started=True`` and a peer wake then drives a turn into a session
+        the owner never typed in."""
+        from local_operator.session.transcript import durable_conversation_path
+
+        path = self._write(
+            tmp_path,
+            [
+                self._PEER_NOTE,
+                '{"id":"t1","ts":2,"type":"custom","payload":{"custom_type":"title"}}',
+            ],
+        )
+        assert durable_conversation_path(path) is False
+
+    def test_peer_notes_plus_a_real_turn_counts(self, tmp_path: Path) -> None:
+        from local_operator.session.transcript import durable_conversation_path
+
+        row = '{"id":"m1","ts":2,"type":"message","payload":{"kind":"message","role":"assistant"}}'
+        path = self._write(tmp_path, [self._PEER_NOTE, row])
+        assert durable_conversation_path(path) is True
+
+    def test_a_legacy_row_without_a_kind_marker_counts(self, tmp_path: Path) -> None:
+        """``kind`` arrived with producer admission; a row predating it IS a
+        plain Message — the custom writer always tagged its rows."""
+        from local_operator.session.transcript import durable_conversation_path
+
+        path = self._write(
+            tmp_path, ['{"id":"m1","ts":1,"type":"message","payload":{"role":"user"}}']
+        )
+        assert durable_conversation_path(path) is True
+
+    def test_missing_and_torn_files_read_as_unstarted(self, tmp_path: Path) -> None:
+        from local_operator.session.transcript import durable_conversation_path
+
+        assert durable_conversation_path(tmp_path / "absent.jsonl") is False
+        torn = self._write(tmp_path, ["{torn", "not json"])
+        assert durable_conversation_path(torn) is False

--- a/tests/unit/tools/test_send_tool.py
+++ b/tests/unit/tools/test_send_tool.py
@@ -59,6 +59,11 @@ async def _start_peer(conversation_name: str = "peer-target"):
     registrant = RuntimeServer(handle, kind="tui")
     registrant.start()
     try:
+        # The registrant's OWN record (pid = this process) is what the self-send
+        # guard and sender-identity tests resolve. A fresh RuntimeServer starts
+        # with ``started=False`` and would now be broadcast-invisible / spooled,
+        # so these working-session tests flip it the way a real first turn does.
+        registrant.set_record_started(True)
         own = await _wait_record()  # the registrant's record (pid = this process)
         alias = registry.SessionRecord(
             # The parent pid is alive and is not us: it passes both the
@@ -72,6 +77,10 @@ async def _start_peer(conversation_name: str = "peer-target"):
             model_label="test/model",
             control_port=own.control_port,
             control_key=own.control_key,
+            # These tests exercise a WORKING session's delivery; ``started``
+            # defaults False so the alias would be broadcast-invisible and
+            # spooled without this.
+            started=True,
         )
         registry.publish(alias)
         return registrant, alias, handle
@@ -247,6 +256,9 @@ async def test_ambiguous_target_returns_candidates_and_asks_for_a_pid() -> None:
                 model_label="test/model",
                 control_port=9,  # never dialed: disambiguation fires first
                 control_key="k",
+                # Working sessions: ``started`` defaults False and would make
+                # these broadcast-invisible without it.
+                started=True,
             )
         )
     result = await execute_send(
@@ -421,6 +433,7 @@ async def test_disambiguation_prints_the_parameter_syntax() -> None:
                 model_label="test/model",
                 control_port=9,
                 control_key="k",
+                started=True,
             )
         )
     result = await execute_send(


### PR DESCRIPTION
## Summary of Changes

A brand-new session (`/new`, owner still composing the first prompt) publishes its `SessionRecord` the moment it boots. `resolve_peer_target` and `deliver_peer_message` treated that record as a working session, so a peer broadcast (e.g. lop-dev release coordination) could paint a peer-message card into an untouched composer and — worse — a `mailbox + wake` or steer delivery would **drive a turn** on it.

Adds an additive `started: bool = False` field on `SessionRecord` (PROTOCOL_VERSION does **not** move; older readers drop the unknown key in `from_json`; newer readers see the dataclass default).

1. **Publish the flag.** `Session._run_turn_pipeline` (the choke point every spawn path funnels through — user prompt, wake delivery, resume catch-up) flips the bit via `OwnedSessionHandle._publish_session_started` → `RuntimeServer.set_record_started`. Heartbeat/`_republish` carries `started=self._started` so it stays true once set. A mailbox-only `receive_peer_message` does **not** set it; a wake/steer that itself opens the first turn **does**.
2. **Exclude unstarted sessions from peer SEND resolution and delivery.**
   - Substring/`target` match: skip `started=False` records. A broadcast has no business interrupting a session whose owner is mid-composition.
   - Exact `--pid`/`--session`: still resolve (the sender named that session), but `deliver_peer_message` takes the spool branch regardless of mode/wake and returns `spooled (session not started yet; will be read when it next opens)`. Belt-and-braces so a bypassed resolver still cannot dial the socket.
3. **Existing inbox drain** (`process._drain_inbox_into`) delivers the spool as quiet mailbox notes when the session later starts. No new drain path.

## Mixed-version default direction

`from_json` + the dataclass default `started=False` is the **conservative** read for a record an older binary wrote (no key):

- Broadcast skips it; exact send is spooled rather than driven.
- Cost: during the upgrade window a genuinely-working OLD runtime reads as unstarted.
- The alternative (`True`) would let a broadcast wake a fresh `/new` session sitting in the composer — the bug being fixed.
- `started_at` and `protocol` cannot distinguish "old binary, actually working" from "new binary, not yet started", so there is no better signal. The transient misclassification of old sessions is accepted.

`getattr(rec, "started", True)` on the send side is only a defence against a hand-built record that never went through `from_json`; a pre-field binary's file still round-trips as `False`.

## Related Issue(s)

- Internal: a `/new` session sitting in the composer received peer broadcasts and could be wake/steer-driven.

## Impact

- Additive, backwards-compatible. No PROTOCOL_VERSION bump, no dependency updates, no version bump (`pyproject.toml` stays at 0.54.5).
- Started sessions: byte-for-byte unchanged across mailbox, mailbox+wake, steer-busy, steer-idle (the new branch is skipped when `started` is True).
- Unstarted sessions: never have a turn driven by any peer message.

## Testing Details

Targeted suite (this change's surfaces):

```
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
  tests/unit/mobile/test_peer_send.py \
  tests/unit/session/runtime/test_inbox.py \
  tests/unit/session/runtime/test_owned.py \
  tests/unit/session/runtime/test_server.py \
  tests/unit/session/test_session_peer.py \
  tests/unit/tools/test_send_tool.py -q --tb=short
```

**200 passed, 4 warnings in 6.35s**

Coverage added:

- Broadcast/substring exclusion of unstarted sessions; exact pid/session still resolve.
- Exact-address spool for mailbox / wake / steer (socket never dialled).
- Started session still dials; ack detail returned verbatim.
- Mixed-version: a JSON record without `started` reads `False`.
- Flag is one-way, survives heartbeat rewrite, starts False on a fresh runtime.
- Spooled mailbox does not flip `started`; a wake that opens the first turn does; hook fires at `_run_turn_pipeline`.
- Existing inbox drain consumes a spool written for an unstarted session.

Quality gates on the worktree (pre-rebase, same diff): flake8, `uvx --from black==26.1.0 black --check .`, `uvx isort==5.13.2 --check .`, pyright — all clean. Full `tests/unit` is left to CI.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] Targeted unit tests pass (full suite on CI).
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required. (inline WHY comments; no user-facing docs)
- [x] Security considerations are addressed (especially for code execution features).
- [ ] I have linked all related issues.