### PR TITLE
feat(sessions): discover stored sessions for send and `lop sessions --all`

### DIFF
--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -564,10 +564,10 @@ def build_cli_parser() -> argparse.ArgumentParser:
     )
     sessions_parser.add_argument(
         "--limit",
-        type=int,
+        type=_positive_int,
         default=None,
         metavar="N",
-        help="with --all, cap the number of stored rows listed (default: 50)",
+        help="with --all, cap the stored rows listed; positive (default: 50)",
     )
     # `lop sessions cleanup`: the explicit, previewable way to run the session
     # cleanup policy. An optional sub-subcommand (dest defaults to None) so
@@ -2226,6 +2226,13 @@ def send_command(args: argparse.Namespace) -> int:
         _peer_red(bind_error)
         return 1
 
+    # Shared with the in-session send tool: the stored fallback below must run
+    # only on the live resolver's NO-MATCH form — see
+    # ``peer_send.live_scan_found_nothing`` for why a bare ``record is None``
+    # is not enough (it is also how a conflicting selector pair and a wedged
+    # unique match come back, and neither may be converted into a stored send).
+    from local_operator.mobile.peer_send import live_scan_found_nothing
+
     record, candidates, error = _resolve_peer_target(args, target)
     if candidates:
         # "REPLACE the target with", not "add --pid": appending the flag to the
@@ -2271,19 +2278,34 @@ def send_command(args: argparse.Namespace) -> int:
         from local_operator.mobile.peer_send import resolve_cold_session
 
         cold_session_id = resolve_cold_session(args.session or "") or ""
-    if not cold_session_id and not candidates and target and record is None:
+    if (
+        not cold_session_id
+        and not candidates
+        and target
+        and record is None
+        and live_scan_found_nothing(error)
+    ):
         # The substring found no LIVE record and named no exact id. Fall back
         # to the STORED store before refusing: a note addressed by the name a
         # session had before its terminal was closed must still deliver. The
         # resolver decides WHO; delivery still goes through the unchanged
         # cold path below, so live keeps winning over stored for the same
         # substring and the delivery mechanics are untouched.
+        #
+        # The ``live_scan_found_nothing(error)`` term is the whole point of
+        # this guard (review round 1, BLOCKER-1/MAJOR-1): ``record is None``
+        # is ALSO how a refused target+selector conflict and a wedged unique
+        # match come back, and delivering those to a similarly named stored
+        # session would be a send to a recipient the command never named.
         from local_operator.mobile.peer_send import (
             resolve_stored_target,
             stored_candidate_lines,
         )
 
-        stored_id, stored_candidates, stored_error = resolve_stored_target(target)
+        stored_id, stored_candidates, _stored_error = resolve_stored_target(target)
+        # ``_stored_error`` is deliberately unread: a no-match returns "" by
+        # contract and the refusal the user sees is composed in the final
+        # block below, where the live miss is known to have happened too.
         if stored_candidates:
             print(
                 f"{len(stored_candidates)} stored sessions match; replace the "
@@ -2295,11 +2317,8 @@ def send_command(args: argparse.Namespace) -> int:
             return 1
         if stored_id:
             cold_session_id = stored_id
-        elif stored_error:
-            _peer_red(stored_error)
-            return 1
     if not cold_session_id and (error or record is None):
-        if error and "no live session matches" in error:
+        if error and live_scan_found_nothing(error):
             # The stored fallback just failed too, so the message names BOTH
             # searches rather than leaving the user to discover the store on
             # their own.
@@ -2565,6 +2584,26 @@ def sessions_cleanup_command(args: argparse.Namespace) -> int:
     return 3 if result.errors else 0
 
 
+def _positive_int(value: str) -> int:
+    """Argparse type for counts where 0 or negative is a typo, not a request.
+
+    `lop sessions --all --limit 0` parsed fine and listed NOTHING (`rows[:0]`),
+    which reads on screen as "no sessions exist" — a lie about the store
+    (review round 1, Q2). There is no zero-or-uncapped spelling to protect
+    either: 0 stored rows is what plain `lop sessions` already means, and the
+    no-cap case is served by the advertised DEFAULT, not by a magic number.
+    """
+    try:
+        parsed = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{value!r} is not an integer") from None
+    if parsed < 1:
+        raise argparse.ArgumentTypeError(
+            f"must be a positive integer, got {value!r} — omit --limit for the default cap"
+        )
+    return parsed
+
+
 def sessions_command(args: argparse.Namespace) -> int:
     """``lop sessions`` — list active sessions and their resource usage.
 
@@ -2600,7 +2639,10 @@ def sessions_command(args: argparse.Namespace) -> int:
         return 0
 
     if not rows:
-        print("no active lop sessions")
+        # `--all` asked about the STORE as well as the fleet; the live-only
+        # empty line would answer a question the user did not ask (review
+        # round 1, MINOR-5). The default listing keeps its established copy.
+        print("no lop sessions (live or stored)" if args.all else "no active lop sessions")
         return 0
 
     # NEEDS is the column this release adds, and it earns its width: a parked
@@ -2608,8 +2650,10 @@ def sessions_command(args: argparse.Namespace) -> int:
     # waiting on me" has to be answerable from the same place the memory is
     # visible. Blank for every session that is simply working.
     #
-    # LAST_ACTIVE appears only under ``--all``: a stored session has no process,
-    # so PID/RSS/FOOTPRINT/UPTIME/HB_AGE read "—" for it, and the one fact a
+    # LAST_ACTIVE appears only when stored rows are present — normally under
+    # ``--all``, but NOT when the flag found none to add (every stored id
+    # already live, or an empty store): a stored session has no process, so
+    # PID/RSS/FOOTPRINT/UPTIME/HB_AGE read "—" for it, and the one fact a
     # stored row CAN offer is when its transcript last moved. Adding the column
     # unconditionally would re-flow the live-only listing every existing
     # consumer parses, so it is appended only when the flag brought stored rows.

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -554,6 +554,21 @@ def build_cli_parser() -> argparse.ArgumentParser:
         parents=[parent_parser],
     )
     sessions_parser.add_argument("--json", action="store_true", help="machine-readable output")
+    sessions_parser.add_argument(
+        "--all",
+        action="store_true",
+        help=(
+            "also list stored sessions that are not running (RSS/UPTIME/etc. are "
+            "shown as — for these; sorted newest-first by last activity)"
+        ),
+    )
+    sessions_parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        metavar="N",
+        help="with --all, cap the number of stored rows listed (default: 50)",
+    )
     # `lop sessions cleanup`: the explicit, previewable way to run the session
     # cleanup policy. An optional sub-subcommand (dest defaults to None) so
     # bare `lop sessions` keeps listing.
@@ -2256,7 +2271,39 @@ def send_command(args: argparse.Namespace) -> int:
         from local_operator.mobile.peer_send import resolve_cold_session
 
         cold_session_id = resolve_cold_session(args.session or "") or ""
+    if not cold_session_id and not candidates and target and record is None:
+        # The substring found no LIVE record and named no exact id. Fall back
+        # to the STORED store before refusing: a note addressed by the name a
+        # session had before its terminal was closed must still deliver. The
+        # resolver decides WHO; delivery still goes through the unchanged
+        # cold path below, so live keeps winning over stored for the same
+        # substring and the delivery mechanics are untouched.
+        from local_operator.mobile.peer_send import (
+            resolve_stored_target,
+            stored_candidate_lines,
+        )
+
+        stored_id, stored_candidates, stored_error = resolve_stored_target(target)
+        if stored_candidates:
+            print(
+                f"{len(stored_candidates)} stored sessions match; replace the "
+                "target with one of these:",
+                file=sys.stderr,
+            )
+            for line in stored_candidate_lines(stored_candidates, indent="  ", prefix="--session"):
+                print(line, file=sys.stderr)
+            return 1
+        if stored_id:
+            cold_session_id = stored_id
+        elif stored_error:
+            _peer_red(stored_error)
+            return 1
     if not cold_session_id and (error or record is None):
+        if error and "no live session matches" in error:
+            # The stored fallback just failed too, so the message names BOTH
+            # searches rather than leaving the user to discover the store on
+            # their own.
+            error = f"no session matches {target!r} (searched live and stored sessions)"
         _peer_red(error or "no target resolved")
         return 1
 
@@ -2543,7 +2590,10 @@ def sessions_command(args: argparse.Namespace) -> int:
     # ``is_self``, a field this command never had.
     from local_operator.info.collect import session_rows
 
-    rows = session_rows(config_dir())
+    # ``--limit`` bounds the STORED rows only — the live fleet is always listed
+    # in full, and a stored cap means nothing without ``--all`` asking for them.
+    # ``None`` lets ``collect`` apply its own stored cap.
+    rows = session_rows(config_dir(), include_stored=args.all, stored_limit=args.limit)
 
     if args.json:
         print(_json.dumps(rows, indent=2))
@@ -2557,22 +2607,40 @@ def sessions_command(args: argparse.Namespace) -> int:
     # question holds a runtime resident for up to a day, so "which of these is
     # waiting on me" has to be answerable from the same place the memory is
     # visible. Blank for every session that is simply working.
+    #
+    # LAST_ACTIVE appears only under ``--all``: a stored session has no process,
+    # so PID/RSS/FOOTPRINT/UPTIME/HB_AGE read "—" for it, and the one fact a
+    # stored row CAN offer is when its transcript last moved. Adding the column
+    # unconditionally would re-flow the live-only listing every existing
+    # consumer parses, so it is appended only when the flag brought stored rows.
+    show_stored = any(row["state"] == "stored" for row in rows)
     header = (
         f"{'STATE':<7} {'PID':>7} {'KIND':<7} {'NEEDS':<8} {'CONVERSATION':<24} "
         f"{'MODEL':<24} {'RSS':>8} {'FOOTPRINT':>9} {'UPTIME':>8} {'HB_AGE':>7}"
     )
+    if show_stored:
+        header += f" {'LAST_ACTIVE':>11}"
     print(header)
+    now = time.time()
     for row in rows:
         name = (row["conversation_name"] or row["session_id"] or "")[:24]
         model = (row["model_label"] or "")[:24]
         needs = (row.get("pending") or "")[:8]
-        print(
-            f"{row['state']:<7} {row['pid']:>7} {row['kind']:<7} {needs:<8} {name:<24} "
+        stored = row["state"] == "stored"
+        line = (
+            f"{row['state']:<7} "
+            f"{('—' if stored else str(row['pid'])):>7} "
+            f"{(row['kind'] or '—'):<7} {needs:<8} {name:<24} "
             f"{model:<24} {_format_bytes(row['rss_bytes']):>8} "
             f"{_format_bytes(row['footprint_bytes']):>9} "
-            f"{_format_duration(row['uptime_s']):>8} "
-            f"{_format_duration(row['heartbeat_age_s']):>7}"
+            f"{('—' if stored else _format_duration(row['uptime_s'])):>8} "
+            f"{('—' if stored else _format_duration(row['heartbeat_age_s'])):>7}"
         )
+        if show_stored:
+            stamp = row["last_activity_s"]
+            age = "—" if stamp is None else _format_duration(max(0.0, now - stamp))
+            line += f" {age:>11}"
+        print(line)
     return 0
 
 

--- a/local_operator/guides/peer-messaging/GUIDE.md
+++ b/local_operator/guides/peer-messaging/GUIDE.md
@@ -115,7 +115,9 @@ Refusals are answers too, and each names its own fix:
 
 - An ambiguous `target` returns the candidate list — `2 sessions match; retry
   with pid=<n>:` followed by one `pid=<n>` line per session.
-- No match returns `no live session matches '<target>'`.
+- No match returns `no session matches '<target>' (searched live and stored
+  sessions)` — a name only a closed session had still resolves, so a miss
+  means neither the running fleet nor the store answered to it.
 - A session cannot send to itself; the tool refuses before it dials.
 - A body over the 256 KB cap is rejected with the measured size, not truncated.
 - If the ack is lost after the peer committed the message, the tool says the

--- a/local_operator/info/collect.py
+++ b/local_operator/info/collect.py
@@ -312,6 +312,8 @@ def collect_sessions(
     usage: Callable[..., dict[int, Any]] | None = None,
     self_pid: int | None = None,
     now: float | None = None,
+    include_stored: bool = False,
+    stored_limit: int | None = None,
 ) -> SessionsInfo:
     """Every session on this machine, as ``lop sessions`` already describes them.
 
@@ -331,6 +333,18 @@ def collect_sessions(
 
     ``scan`` / ``usage`` / ``now`` are injectable seams so the tests can pin the
     degradation matrix without a real machine's sessions under them.
+
+    ``include_stored`` folds in sessions that are NOT running — directories
+    under ``config_dir()/sessions/`` with no live record — as ``stored`` rows
+    carrying only ``session_id`` / ``conversation_name`` / ``last_activity_s``
+    (the process-level fields are meaningless for a dead session and stay at
+    their defaults). It is the ``lop sessions --all`` opt-in: the default path
+    stays exactly the live-only listing every consumer already reads, and the
+    /info panel — which is about the running fleet's cost — never asks for it.
+    Stored rows come from the same ``resume.recent_session_rows`` scan the
+    ``/resume`` picker uses, so a session is named here by the title the picker
+    would show, and a directory the picker hides (subagent scratch) is not a
+    session for messaging either.
     """
     from local_operator.mobile.resources import session_resource_usage
     from local_operator.session.runtime import registry
@@ -380,7 +394,17 @@ def collect_sessions(
             )
         )
 
-    builds = {(line.version, line.source_ref) for line in lines if line.state == "live"}
+    if include_stored and root is not None:
+        lines.extend(_stored_lines(root, {line.session_id for line in lines}, stored_limit))
+
+    # The roll-up counters describe the RUNNING fleet, so they count only the
+    # rows the registry published. A ``stored`` row (``include_stored``) names a
+    # session that is not running; counting it under ``total``/``live`` would
+    # make the /info header report sessions that have no runtime, the exact
+    # misreading those counters exist to prevent. ``lines`` keeps them (the
+    # listing is the point of the flag); the counters ignore them.
+    live_only = [line for line in lines if line.state != "stored"]
+    builds = {(line.version, line.source_ref) for line in live_only if line.state == "live"}
     builds.discard(("", ""))
 
     # The population is every RUNNING PROCESS: ``live`` and ``wedged`` both
@@ -390,7 +414,7 @@ def collect_sessions(
     # last published counts and the renderer's caveat says they are as of its
     # last heartbeat. A ``stale`` record is excluded outright: the scan above
     # just DELETED its file because the pid is gone, so it is not a runtime.
-    live_lines = [line for line in lines if line.state in ("live", "wedged")]
+    live_lines = [line for line in live_only if line.state in ("live", "wedged")]
     reporting = [line for line in live_lines if line.subagents_running is not None]
     fleet_running = sum(line.subagents_running or 0 for line in reporting)
     # Session trajectories and subagent trajectories are DISJOINT by
@@ -401,13 +425,13 @@ def collect_sessions(
     session_trajectories = sum(1 for line in live_lines if line.busy)
     return SessionsInfo(
         lines=tuple(lines),
-        total=len(lines),
-        live=sum(1 for line in lines if line.state == "live"),
-        wedged=sum(1 for line in lines if line.state == "wedged"),
-        stale=sum(1 for line in lines if line.state == "stale"),
-        busy=sum(1 for line in lines if line.busy),
-        pending=sum(1 for line in lines if line.pending),
-        detached=sum(1 for line in lines if line.detached),
+        total=len(live_only),
+        live=sum(1 for line in live_only if line.state == "live"),
+        wedged=sum(1 for line in live_only if line.state == "wedged"),
+        stale=sum(1 for line in live_only if line.state == "stale"),
+        busy=sum(1 for line in live_only if line.busy),
+        pending=sum(1 for line in live_only if line.pending),
+        detached=sum(1 for line in live_only if line.detached),
         build_skew=len(builds) > 1,
         # "Nothing measured at all" is a different fact from "this pid could
         # not be measured", and only the first should suppress the column.
@@ -422,7 +446,64 @@ def collect_sessions(
     )
 
 
-def session_rows(root: Path | None = None) -> list[dict[str, Any]]:
+#: How many stored sessions ``lop sessions --all`` lists when no ``--limit`` is
+#: given. The store grows without bound on a well-used machine, so the listing
+#: caps the rows it shows to the most recent rather than printing a wall; the
+#: flag is an opt-in and the cap is named so a consumer can see where it is
+#: chosen. ``None`` (no cap) is expressible via ``--limit 0``'s absence being a
+#: distinct argument — see ``sessions_command``.
+STORED_SESSIONS_DEFAULT_LIMIT = 50
+
+
+def _stored_lines(root: Path, live_ids: set[str], limit: int | None) -> list[SessionLine]:
+    """One ``SessionLine`` per STORED session: a directory with no live record.
+
+    Read from the same ``resume.recent_session_rows`` scan the ``/resume``
+    picker uses, so a session is named here by the title the picker would show
+    and a directory the picker hides (subagent scratch) is not offered for
+    messaging either. The scan is newest-first on the transcript activity clock
+    (``session.retention.session_activity``) — the recency a human recognises
+    — so the cap truncates the tail of an ordering that is already useful.
+
+    Only the durable identity fields are filled: ``pid``, RSS, uptime and
+    heartbeat age are properties of a RUNNING process and are meaningless for a
+    dead session, so they keep the empty defaults the renderer turns into ``—``.
+    ``last_activity_s`` carries the transcript mtime in their place.
+
+    Best-effort, never a gate: a store that cannot be read yields no stored rows
+    rather than failing a listing whose first job is the LIVE fleet.
+    """
+    from local_operator.resume import recent_session_rows
+
+    try:
+        rows = recent_session_rows(root, limit)
+    except Exception:  # noqa: BLE001 — a listing must not fail on the store
+        return []
+    lines: list[SessionLine] = []
+    for row in rows:
+        # Live wins: a session the registry just published for is not "stored",
+        # and listing it twice would double-count one conversation in the
+        # output the operator reads to decide what to send where.
+        if row.id in live_ids:
+            continue
+        lines.append(
+            SessionLine(
+                pid=0,
+                state="stored",
+                session_id=row.id,
+                conversation_name=row.name,
+                last_activity_s=row.mtime,
+            )
+        )
+    return lines
+
+
+def session_rows(
+    root: Path | None = None,
+    *,
+    include_stored: bool = False,
+    stored_limit: int | None = None,
+) -> list[dict[str, Any]]:
     """``lop sessions --json``'s rows, in its established key order.
 
     The CLI's ``--json`` contract is a published surface, so the key order and
@@ -430,8 +511,17 @@ def session_rows(root: Path | None = None) -> list[dict[str, Any]]:
     compares against the pre-extraction literal) rather than derived from
     ``dataclasses.asdict``, which would leak ``is_self`` — a field the CLI never
     had — into it.
+
+    ``include_stored`` appends ``stored`` rows for sessions with a directory but
+    no live record (the ``--all`` opt-in). The published shape is EXTENDED, not
+    broken: the established keys stay first and in order, and the stored-only
+    ``last_activity_s`` rides at the END so every existing key position is
+    preserved. It is present on every row (``None`` on a live one) because a
+    consumer that must branch on key EXISTENCE per row is a worse contract than
+    a stable shape with one nullable field. The extraction test asserts exactly
+    this order, so the expectation is updated in the same change.
     """
-    info = collect_sessions(root)
+    info = collect_sessions(root, include_stored=include_stored, stored_limit=stored_limit)
     return [
         {
             "state": line.state,
@@ -459,6 +549,11 @@ def session_rows(root: Path | None = None) -> list[dict[str, Any]]:
             # unreported-vs-zero distinction the screen makes.
             "subagents_running": line.subagents_running,
             "subagents_queued": line.subagents_queued,
+            # The stored row's only clock (transcript activity mtime); ``None``
+            # on every live/wedged/stale row, which carries ``uptime_s`` and
+            # ``heartbeat_age_s`` instead. Last in the dict so the pinned order
+            # above is untouched.
+            "last_activity_s": line.last_activity_s,
         }
         for line in info.lines
     ]

--- a/local_operator/info/collect.py
+++ b/local_operator/info/collect.py
@@ -344,7 +344,9 @@ def collect_sessions(
     Stored rows come from the same ``resume.recent_session_rows`` scan the
     ``/resume`` picker uses, so a session is named here by the title the picker
     would show, and a directory the picker hides (subagent scratch) is not a
-    session for messaging either.
+    session for messaging either. ``stored_limit`` is the CLI's ``--limit``
+    verbatim; ``None`` (no flag passed) becomes
+    :data:`STORED_SESSIONS_DEFAULT_LIMIT` inside ``_stored_lines``.
     """
     from local_operator.mobile.resources import session_resource_usage
     from local_operator.session.runtime import registry
@@ -450,8 +452,11 @@ def collect_sessions(
 #: given. The store grows without bound on a well-used machine, so the listing
 #: caps the rows it shows to the most recent rather than printing a wall; the
 #: flag is an opt-in and the cap is named so a consumer can see where it is
-#: chosen. ``None`` (no cap) is expressible via ``--limit 0``'s absence being a
-#: distinct argument — see ``sessions_command``.
+#: chosen. Applied inside ``_stored_lines`` — the CLI passes ``None`` for
+#: "no --limit given" and relies on this default; a caller that wants a
+#: different number passes its own at its own call site, and there is no
+#: uncapped spelling (review round 1, MAJOR-2: the constant shipped unwired
+#: and ``--all`` listed the entire store).
 STORED_SESSIONS_DEFAULT_LIMIT = 50
 
 
@@ -472,11 +477,19 @@ def _stored_lines(root: Path, live_ids: set[str], limit: int | None) -> list[Ses
 
     Best-effort, never a gate: a store that cannot be read yields no stored rows
     rather than failing a listing whose first job is the LIVE fleet.
+
+    ``limit`` is the CLI's ``--limit`` verbatim when given; ``None`` means no
+    flag was passed and becomes :data:`STORED_SESSIONS_DEFAULT_LIMIT` HERE
+    rather than in argparse, so the number a consumer reads out of the listing
+    is the number this module chose and advertises in ``--limit``'s help. The
+    caller validates positivity; a given value is forwarded as-is because
+    ``recent_session_rows`` owns slicing semantics.
     """
     from local_operator.resume import recent_session_rows
 
+    resolved = STORED_SESSIONS_DEFAULT_LIMIT if limit is None else limit
     try:
-        rows = recent_session_rows(root, limit)
+        rows = recent_session_rows(root, resolved)
     except Exception:  # noqa: BLE001 — a listing must not fail on the store
         return []
     lines: list[SessionLine] = []

--- a/local_operator/info/model.py
+++ b/local_operator/info/model.py
@@ -135,8 +135,11 @@ class SessionLine:
 
     pid: int = 0
     kind: str = ""
-    #: ``live`` | ``wedged`` | ``stale``. ``stale`` means the scan just DELETED
-    #: the record file (``registry.scan``), not that the session is idle.
+    #: ``live`` | ``wedged`` | ``stale`` | ``stored``. ``stale`` means the scan
+    #: just DELETED the record file (``registry.scan``), not that the session is
+    #: idle. ``stored`` is a session directory with NO live record — the
+    #: ``--all`` listing's addition — where the process-level fields (pid, RSS,
+    #: uptime, heartbeat) are meaningless and left at their empty defaults.
     state: str = ""
     session_id: str = ""
     conversation_name: str = ""
@@ -146,6 +149,11 @@ class SessionLine:
     heartbeat_age_s: float = 0.0
     rss_bytes: int | None = None
     footprint_bytes: int | None = None
+    #: Last-activity stamp for a ``stored`` row (transcript mtime), so the
+    #: ``--all`` listing can sort and show recency for a session that has no
+    #: uptime to report. ``None`` for a live/wedged/stale row, which carries
+    #: ``uptime_s``/``heartbeat_age_s`` instead.
+    last_activity_s: float | None = None
     pending: str | None = None
     busy: bool = False
     detached: bool = False

--- a/local_operator/mobile/peer_send.py
+++ b/local_operator/mobile/peer_send.py
@@ -251,6 +251,25 @@ class StoredCandidate(NamedTuple):
 #: on name and id only.
 
 
+def live_scan_found_nothing(error: str) -> bool:
+    """True only for the live resolver's "no match anywhere" refusal.
+
+    The stored fallback (:func:`resolve_stored_target`'s callers) runs on this
+    predicate and NOTHING looser. Every OTHER no-record outcome of
+    :func:`resolve_peer_target` is a refusal ABOUT a live session the caller
+    did reach — a conflicting ``target``+selector pair, a unique match that is
+    wedged, a selector naming a dead session — and each of those must stand as
+    the answer: delivering anyway, to a stored session that merely shares the
+    name, would send the message to a recipient the call never named
+    (review round 1, BLOCKER-1) or spool it behind a wedged process that
+    still owns the session (MAJOR-1). ``record is None`` cannot tell those
+    apart; only this error form means the live scan genuinely came up empty
+    and a stored search is a NEW question rather than a second try at a
+    refused one.
+    """
+    return "no live session matches" in error
+
+
 def resolve_stored_target(
     needle: str,
     *,
@@ -270,18 +289,25 @@ def resolve_stored_target(
     path does, over name and session id (a stored session has no recoverable
     cwd — see :class:`StoredCandidate`).
 
-    ``live_ids`` excludes sessions that already have a runtime: live wins over
-    stored for the same substring, and without the exclusion a name both a
-    running session and its own stored directory answer to would be reported
-    ambiguous between itself. ``resolve_peer_target`` passes every id its scan
-    saw; the CLI's exact-id path does not consult this function at all.
+    ``live_ids`` is an optional exclusion for callers that know which session
+    ids already have a runtime; it exists for the id-collision case, where a
+    stored row's id belongs to a live session and a cold delivery would queue
+    behind a process that could have been dialled. The CLI and the tool pass
+    none: they enter this fallback only on :func:`live_scan_found_nothing`, so
+    no live NAME match can have survived to here, and a stored row and its
+    live session read their name from the same transcript — a collision that
+    differs by name is a rename-timing edge, not a case worth a second
+    registry scan on every stored send to catch.
 
-    Returns ``(session_id, candidates, error)`` with the same contract as
-    :func:`resolve_peer_target`: exactly one of the first or last is
-    meaningful, and ``candidates`` lists the ambiguous matches for the caller
-    to disambiguate. The resolved id feeds the EXISTING
-    :func:`resolve_cold_session` / :func:`deliver_peer_message` path — this
-    function decides WHO, never HOW a message is delivered.
+    Returns ``(session_id, candidates, error)`` shaped like
+    :func:`resolve_peer_target`'s triple for symmetry, with one deliberate
+    difference: ``error`` is ALWAYS empty. A plain no-match is not this
+    function's fact to report — the caller just watched the live scan miss,
+    so the refusal it owes the user names BOTH searches ("searched live and
+    stored sessions"), a sentence only the caller can say. The first or the
+    second element is meaningful, never both; the resolved id feeds the
+    EXISTING :func:`resolve_cold_session` / :func:`deliver_peer_message`
+    path — this function decides WHO, never HOW a message is delivered.
     """
     from local_operator.resume import recent_session_rows
 

--- a/local_operator/mobile/peer_send.py
+++ b/local_operator/mobile/peer_send.py
@@ -23,10 +23,22 @@ import asyncio
 import os
 import subprocess
 import time
-from typing import Any
+from pathlib import Path
+from typing import Any, NamedTuple
 
 from local_operator.paths import config_dir
 from local_operator.session.runtime import registry
+
+#: How much of a stored session store the send-side fallback scans while
+#: hunting for a substring match. Discovery over the WHOLE store would pay one
+#: bounded name read per directory (hundreds exist on a well-used machine) on
+#: a path whose whole job is to answer quickly; the mtime-ordered scan
+#: underneath (:func:`resume._scan_sessions`) visits every directory anyway,
+#: so this caps the ROW-BUILDING half, not the scan. A target that matches
+#: nothing in the newest window is answered with the no-match error naming
+#: ``--session`` — an exact id always resolves, so no message is made
+#: undeliverable by the cap, only un-findable by NAME.
+STORED_DISCOVERY_LIMIT = 200
 
 #: Peer messaging body cap. Well under the registrant's 1 MB line limit so a huge
 #: paste is rejected with a clear message here rather than becoming a silently
@@ -196,9 +208,10 @@ def resolve_cold_session(session: str) -> "str | None":
     publish, so before this a note to a session whose terminal was closed had
     no target at all — the very case the quiet mailbox mode is for. An exact
     session id is the only accepted form here on purpose: a substring match
-    against on-disk directories has no conversation name to match on and could
-    silently pick the wrong transcript, and picking the wrong recipient is the
-    one failure this whole path must not have.
+    against on-disk directories needs the conversation names that only the
+    picker path reads, which is what :func:`resolve_stored_target` adds.
+    Picking the wrong recipient is the one failure this whole path must not
+    have.
 
     Returns the id when its session directory exists, else None.
     """
@@ -209,6 +222,110 @@ def resolve_cold_session(session: str) -> "str | None":
         return session if directory.is_dir() else None
     except OSError:
         return None
+
+
+class StoredCandidate(NamedTuple):
+    """One stored session a substring target could mean.
+
+    The fields mirror the live :class:`SessionRecord`'s identity fields
+    (``session_id``/``conversation_name``/``cwd``) so the caller's
+    disambiguation code can treat live and stored matches alike. There is no
+    ``pid`` — nothing is running — which is exactly why
+    :func:`stored_candidate_lines` exists rather than the shared
+    :func:`candidate_lines`: a ``pid=`` hint against a stored session is an
+    address that can never resolve.
+    """
+
+    session_id: str
+    conversation_name: str
+    cwd: str = ""
+
+
+#: A stored session's ``cwd`` is deliberately an EMPTY string. There is no
+#: cheap on-disk record of where a session was last opened — the only writer
+#: is the transcript's ``session`` entry, whose head a bounded scan can miss
+#: and whose parse would drag the engine onto an import-guarded path. The
+#: exact-id stored resolution (:func:`resolve_cold_session`) already resolves
+#: with no cwd and delivers correctly; matching by cwd-basename would be a
+#: marginal convenience bought with a fragile scan, so stored candidates match
+#: on name and id only.
+
+
+def resolve_stored_target(
+    needle: str,
+    *,
+    live_ids: "set[str] | None" = None,
+    limit: int = STORED_DISCOVERY_LIMIT,
+    root: "Path | None" = None,
+) -> "tuple[str | None, list[StoredCandidate], str]":
+    """Match a substring against STORED sessions the live scan did not claim.
+
+    The fallback half of send-side discovery: :func:`resolve_peer_target`
+    searches discovery records, which only RUNNING sessions publish, so a note
+    addressed to a session by the name it had before its terminal was closed
+    found nothing at all. This searches the session store the same way the
+    ``/resume`` picker lists it — :func:`resume.recent_session_rows` for the
+    id/name ordering, one bounded read per row, subagent scratch sessions
+    excluded — and applies the same case-insensitive substring rule the live
+    path does, over name and session id (a stored session has no recoverable
+    cwd — see :class:`StoredCandidate`).
+
+    ``live_ids`` excludes sessions that already have a runtime: live wins over
+    stored for the same substring, and without the exclusion a name both a
+    running session and its own stored directory answer to would be reported
+    ambiguous between itself. ``resolve_peer_target`` passes every id its scan
+    saw; the CLI's exact-id path does not consult this function at all.
+
+    Returns ``(session_id, candidates, error)`` with the same contract as
+    :func:`resolve_peer_target`: exactly one of the first or last is
+    meaningful, and ``candidates`` lists the ambiguous matches for the caller
+    to disambiguate. The resolved id feeds the EXISTING
+    :func:`resolve_cold_session` / :func:`deliver_peer_message` path — this
+    function decides WHO, never HOW a message is delivered.
+    """
+    from local_operator.resume import recent_session_rows
+
+    directory = config_dir() if root is None else root
+    try:
+        rows = recent_session_rows(directory, limit)
+    except Exception:  # noqa: BLE001 — discovery must never refuse a send
+        return None, [], ""
+    needle_folded = needle.strip().lower()
+    if not needle_folded:
+        return None, [], ""
+    excluded = live_ids or set()
+    matches: list[StoredCandidate] = []
+    for row in rows:
+        if row.id in excluded:
+            continue
+        candidate = StoredCandidate(session_id=row.id, conversation_name=row.name)
+        haystacks = [candidate.conversation_name, candidate.session_id]
+        if any(needle_folded in field.lower() for field in haystacks):
+            matches.append(candidate)
+    if not matches:
+        return None, [], ""
+    if len(matches) > 1:
+        return None, matches, ""
+    return matches[0].session_id, [], ""
+
+
+def stored_candidate_lines(
+    candidates: "list[StoredCandidate]", *, indent: str = "", prefix: str = "session"
+) -> "list[str]":
+    """One disambiguation line per ambiguous STORED candidate.
+
+    The stored sibling of :func:`candidate_lines`, which prints ``pid=`` hints
+    a stored session can never satisfy — there is no pid. Same layout, same
+    caller-controlled separator convention, but the address shown is the
+    session id: the one form of a stored session's name that always resolves.
+    """
+    lines: list[str] = []
+    gap = "" if prefix.endswith("=") else " "
+    id_w = max(len(c.session_id) for c in candidates)
+    for c in candidates:
+        name = c.conversation_name or "(unnamed)"
+        lines.append(f"{indent}{prefix}{gap}{c.session_id:>{id_w}}  {name}  (not running)")
+    return lines
 
 
 async def deliver_peer_message(

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -5854,7 +5854,34 @@ async def execute_send(
 
         cold_session_id = await asyncio.to_thread(resolve_cold_session, params.session or "")
         cold_session_id = cold_session_id or ""
+    if not cold_session_id and not candidates and params.target and record is None:
+        # The substring found no LIVE record. Fall back to the STORED store
+        # before refusing, so a note addressed by the name a session had before
+        # its terminal was closed still delivers. The resolver decides WHO;
+        # delivery below is the unchanged cold path (spool / engage), so live
+        # still wins over stored for the same substring.
+        from local_operator.mobile.peer_send import (
+            resolve_stored_target,
+            stored_candidate_lines,
+        )
+
+        stored_id, stored_candidates, stored_error = await asyncio.to_thread(
+            resolve_stored_target, params.target
+        )
+        if stored_candidates:
+            lines = [
+                f"{len(stored_candidates)} stored sessions match; drop `target` and "
+                "retry with session=<id> instead (passing both is refused):"
+            ]
+            lines.extend(stored_candidate_lines(stored_candidates, indent="  ", prefix="session="))
+            return _error(tool_call_id, "send", "\n".join(lines))
+        if stored_id:
+            cold_session_id = stored_id
+        elif stored_error:
+            return _error(tool_call_id, "send", stored_error)
     if not cold_session_id and (error or record is None):
+        if error and "no live session matches" in error:
+            error = f"no session matches {params.target!r} (searched live and stored sessions)"
         return _error(tool_call_id, "send", error or "no target resolved")
 
     # Self-send guard: the tool runs INSIDE the sender's session process, so

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -5624,13 +5624,11 @@ class SendParams(BaseModel):
         default=None,
         description=(
             "Peer to message: case-insensitive substring of the conversation "
-            "name or session id. RUNNING sessions are searched first (`lop "
-            "sessions` lists them), then stored ones a closed session left "
-            "behind (`lop sessions --all`), so a name from a finished session "
-            "still resolves. The cwd basename matches only while the session "
-            "runs. ALTERNATIVE to pid/session, not a companion — pass exactly "
-            "one way of addressing the peer; target together with pid or "
-            "session is refused as an ambiguous recipient."
+            "name, session id, or cwd basename (live only). Live sessions "
+            "match first, then stored ones (`lop sessions --all`); "
+            "disambiguate with pid=/session=. ALTERNATIVE to pid/session, "
+            "not a companion — passing target with either is refused as an "
+            "ambiguous recipient."
         ),
     )
     pid: int | None = Field(

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -5623,11 +5623,14 @@ class SendParams(BaseModel):
     target: str | None = Field(
         default=None,
         description=(
-            "Peer to message: case-insensitive substring of the conversation name, "
-            "session id, or cwd basename (`lop sessions` lists what is running). "
-            "ALTERNATIVE to pid/session, not a companion — pass exactly one way of "
-            "addressing the peer; target together with pid or session is refused as "
-            "an ambiguous recipient."
+            "Peer to message: case-insensitive substring of the conversation "
+            "name or session id. RUNNING sessions are searched first (`lop "
+            "sessions` lists them), then stored ones a closed session left "
+            "behind (`lop sessions --all`), so a name from a finished session "
+            "still resolves. The cwd basename matches only while the session "
+            "runs. ALTERNATIVE to pid/session, not a companion — pass exactly "
+            "one way of addressing the peer; target together with pid or "
+            "session is refused as an ambiguous recipient."
         ),
     )
     pid: int | None = Field(
@@ -5815,6 +5818,7 @@ async def execute_send(
 
     from local_operator.mobile.peer_send import (
         candidate_lines,
+        live_scan_found_nothing,
         peer_sender_identity_async,
         resolve_peer_target,
         validate_peer_body,
@@ -5854,20 +5858,38 @@ async def execute_send(
 
         cold_session_id = await asyncio.to_thread(resolve_cold_session, params.session or "")
         cold_session_id = cold_session_id or ""
-    if not cold_session_id and not candidates and params.target and record is None:
+    if (
+        not cold_session_id
+        and not candidates
+        and params.target
+        and record is None
+        and live_scan_found_nothing(error)
+    ):
         # The substring found no LIVE record. Fall back to the STORED store
         # before refusing, so a note addressed by the name a session had before
         # its terminal was closed still delivers. The resolver decides WHO;
         # delivery below is the unchanged cold path (spool / engage), so live
         # still wins over stored for the same substring.
+        #
+        # Entry requires the live error's NO-MATCH form, not a bare
+        # ``record is None``: the resolver also returns no record for a
+        # conflicting target+selector pair (BLOCKER-1) and for a unique match
+        # that is wedged (MAJOR-1). Both are refusals about a live session the
+        # call DID reach — falling through here would deliver to a stored
+        # session that merely shares the name, or spool behind a wedged
+        # process that still owns the target. See
+        # ``peer_send.live_scan_found_nothing``.
         from local_operator.mobile.peer_send import (
             resolve_stored_target,
             stored_candidate_lines,
         )
 
-        stored_id, stored_candidates, stored_error = await asyncio.to_thread(
+        stored_id, stored_candidates, _stored_error = await asyncio.to_thread(
             resolve_stored_target, params.target
         )
+        # ``_stored_error`` is deliberately unread: the resolver returns ""
+        # for a no-match by contract (see its docstring) and the refusal that
+        # reaches the user is composed below, where the live miss is known.
         if stored_candidates:
             lines = [
                 f"{len(stored_candidates)} stored sessions match; drop `target` and "
@@ -5877,10 +5899,8 @@ async def execute_send(
             return _error(tool_call_id, "send", "\n".join(lines))
         if stored_id:
             cold_session_id = stored_id
-        elif stored_error:
-            return _error(tool_call_id, "send", stored_error)
     if not cold_session_id and (error or record is None):
-        if error and "no live session matches" in error:
+        if error and live_scan_found_nothing(error):
             error = f"no session matches {params.target!r} (searched live and stored sessions)"
         return _error(tool_call_id, "send", error or "no target resolved")
 

--- a/tests/unit/info/test_collect.py
+++ b/tests/unit/info/test_collect.py
@@ -264,6 +264,99 @@ def test_no_live_sessions_is_not_an_unmeasurable_host() -> None:
     assert info.usage_available is True
 
 
+# -- stored sessions (lop sessions --all) --------------------------------------
+#
+# ``include_stored`` folds in sessions that have a directory but no live
+# record. These pin that the default path is unchanged (live-only), the stored
+# rows carry only the durable identity fields, and the fleet roll-up counters
+# never count a session that has no runtime.
+
+
+class _StoredRow:
+    """The ``SessionRow`` fields ``_stored_lines`` reads."""
+
+    def __init__(self, session_id: str, name: str, mtime: float) -> None:
+        self.id = session_id
+        self.name = name
+        self.mtime = mtime
+
+
+def _stored(monkeypatch: Any, rows: list[_StoredRow]) -> None:
+    monkeypatch.setattr(
+        "local_operator.resume.recent_session_rows", lambda directory, limit=None: rows
+    )
+
+
+def test_default_listing_never_includes_stored(monkeypatch: Any, tmp_path: Path) -> None:
+    _stored(monkeypatch, [_StoredRow("dead00000001", "old work", 5.0)])
+    info = collect_sessions(
+        tmp_path, scan=_scan([(_Record(pid=1), "live")]), usage=_usage({}), now=100.0
+    )
+    assert [line.state for line in info.lines] == ["live"]
+
+
+def test_include_stored_appends_stored_rows(monkeypatch: Any, tmp_path: Path) -> None:
+    _stored(monkeypatch, [_StoredRow("dead00000001", "old work", 5.0)])
+    info = collect_sessions(
+        tmp_path,
+        scan=_scan([(_Record(pid=1), "live")]),
+        usage=_usage({}),
+        now=100.0,
+        include_stored=True,
+    )
+    states = [line.state for line in info.lines]
+    assert "stored" in states
+    stored = next(line for line in info.lines if line.state == "stored")
+    assert stored.session_id == "dead00000001"
+    assert stored.conversation_name == "old work"
+    assert stored.last_activity_s == 5.0
+    # Process-level fields are meaningless for a dead session and stay empty.
+    assert stored.pid == 0 and stored.rss_bytes is None and stored.uptime_s == 0.0
+
+
+def test_stored_rows_never_inflate_the_fleet_counters(monkeypatch: Any, tmp_path: Path) -> None:
+    """A stored session has no runtime; ``total``/``live`` must not count it."""
+    _stored(monkeypatch, [_StoredRow("dead00000001", "old work", 5.0)])
+    info = collect_sessions(
+        tmp_path,
+        scan=_scan([(_Record(pid=1), "live")]),
+        usage=_usage({}),
+        now=100.0,
+        include_stored=True,
+    )
+    assert info.total == 1 and info.live == 1 and info.stale == 0
+
+
+def test_live_wins_over_a_stored_row_with_the_same_id(monkeypatch: Any, tmp_path: Path) -> None:
+    """A session the registry just published for is not listed twice."""
+    _stored(monkeypatch, [_StoredRow("live-session", "shared", 5.0)])
+    info = collect_sessions(
+        tmp_path,
+        scan=_scan([(_Record(pid=1, session_id="live-session"), "live")]),
+        usage=_usage({}),
+        now=100.0,
+        include_stored=True,
+    )
+    assert [line.state for line in info.lines] == ["live"]
+
+
+def test_an_unreadable_store_yields_no_stored_rows_not_a_failure(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    def _boom(directory: Any, limit: Any = None) -> Any:
+        raise OSError("disk gone")
+
+    monkeypatch.setattr("local_operator.resume.recent_session_rows", _boom)
+    info = collect_sessions(
+        tmp_path,
+        scan=_scan([(_Record(pid=1), "live")]),
+        usage=_usage({}),
+        now=0.0,
+        include_stored=True,
+    )
+    assert [line.state for line in info.lines] == ["live"]
+
+
 # -- the subagent tree --------------------------------------------------------
 
 

--- a/tests/unit/info/test_collect.py
+++ b/tests/unit/info/test_collect.py
@@ -1173,3 +1173,58 @@ def test_an_absurd_count_is_refused_rather_than_breaking_the_layout() -> None:
         assert info.available is True
         assert (info.lines[1].subagents_running is not None) is reported, value
         assert info.subagents_unreported == (0 if reported else 1), value
+
+
+def test_stored_rows_default_to_the_advertised_cap_on_a_real_store(
+    tmp_path: Path,
+) -> None:
+    """MAJOR-2/QA Q1: `--all` with no --limit lists 50, not the whole store.
+
+    Deliberately does NOT patch ``recent_session_rows``: round 1 shipped
+    ``STORED_SESSIONS_DEFAULT_LIMIT`` unwired because every test mocked the
+    scan, and ``limit=None`` — "no truncation" to the scan — reached it
+    straight from the CLI's argparse default. The store below is built on
+    disk (60 transcript-carrying directories, distinct activity stamps) so
+    the default path is exercised end to end through the real scan.
+    """
+    import json
+    import os
+
+    sessions = tmp_path / "sessions"
+    # The writer's envelope (``type: message`` wrapping a ``payload`` whose text
+    # sits in a ``content`` list) — the shape the real name scan parses, so the
+    # rows carry a name exactly as a picker-listed session would.
+    entry = json.dumps(
+        {
+            "type": "message",
+            "payload": {"role": "user", "content": [{"type": "text", "text": "old work"}]},
+        }
+    )
+    for index in range(60):
+        session_dir = sessions / f"dead{index:04d}"
+        session_dir.mkdir(parents=True)
+        transcript = session_dir / "transcript.jsonl"
+        transcript.write_text(entry + "\n")
+        stamp = 1000.0 + index
+        os.utime(transcript, (stamp, stamp))
+    info = collect_sessions(
+        tmp_path, scan=_scan([]), usage=_usage({}), now=0.0, include_stored=True
+    )
+    stored = [line for line in info.lines if line.state == "stored"]
+    assert len(stored) == collect_mod.STORED_SESSIONS_DEFAULT_LIMIT
+    # The rows are real scan output, so the name resolves too — this also keeps
+    # the fixture honest: a transcript shape the name scan cannot parse would
+    # still cap correctly but would no longer be a store the picker recognises.
+    assert stored[0].conversation_name == "old work"
+    # The cap keeps the NEWEST rows (the top of the picker's ordering), not
+    # whichever 50 scandir happened to yield first.
+    assert stored[0].session_id == "dead0059"
+    assert stored[-1].session_id == "dead0010"
+
+    # An explicit limit still wins over the default, through the same real scan.
+    capped = collect_sessions(
+        tmp_path, scan=_scan([]), usage=_usage({}), now=0.0, include_stored=True, stored_limit=7
+    )
+    assert [line.session_id for line in capped.lines if line.state == "stored"] == [
+        f"dead{index:04d}" for index in range(59, 52, -1)
+    ]

--- a/tests/unit/info/test_sessions_extraction.py
+++ b/tests/unit/info/test_sessions_extraction.py
@@ -272,3 +272,89 @@ def test_cli_table_still_renders_every_row(monkeypatch: Any, capsys: Any) -> Non
     assert out.count("\n") == 4  # header + one row per fixture record
     # And the key never reaches a terminal either.
     assert "control_key" not in out
+
+
+def test_sessions_all_without_limit_passes_the_advertised_default(
+    monkeypatch: Any, tmp_path: Any, capsys: Any
+) -> None:
+    """QA Q1/MAJOR-2 at the CLI wiring: ``None`` must reach collect as 50.
+
+    The default cap is applied inside ``_stored_lines``; this pins that the
+    CLI's argparse default (``None``) is what reaches it and becomes
+    ``STORED_SESSIONS_DEFAULT_LIMIT`` there — the exact wiring whose absence
+    made round 1 list the entire store. The scan is recorded rather than
+    faked wholesale so the argument itself is the assertion.
+    """
+    import argparse
+
+    from local_operator import cli
+    from local_operator.info import collect as collect_mod
+
+    _install_fixture(monkeypatch)
+    seen: list[Any] = []
+
+    class _Row:
+        id = "dead00000001"
+        name = "old work"
+        mtime = 5.0
+
+    def _record(directory: Any, limit: Any = None) -> list[Any]:
+        seen.append(limit)
+        return [_Row()]
+
+    monkeypatch.setattr("local_operator.resume.recent_session_rows", _record)
+    monkeypatch.setattr(cli, "config_dir", lambda: tmp_path)
+    code = cli.sessions_command(
+        argparse.Namespace(json=True, sessions_command=None, all=True, limit=None)
+    )
+    assert code == 0
+    capsys.readouterr()
+    assert seen == [collect_mod.STORED_SESSIONS_DEFAULT_LIMIT]
+
+
+def test_sessions_limit_rejects_zero_and_negative(capsys: Any) -> None:
+    """QA Q2: ``--limit 0`` parsed, listed nothing, and read as "no sessions".
+
+    Zero and negative caps are typos, not requests — "no stored rows" is what
+    plain `lop sessions` already means — so argparse refuses them up front
+    rather than printing an empty listing that lies about the store.
+    """
+    import pytest as _pytest
+
+    from local_operator import cli
+
+    for bad in ("0", "-1"):
+        with _pytest.raises(SystemExit) as raised:
+            cli.build_cli_parser().parse_args(["sessions", "--all", "--limit", bad])
+        assert raised.value.code == 2
+        assert "positive integer" in capsys.readouterr().err
+
+
+def test_sessions_empty_copy_names_the_search_that_was_asked_for(
+    monkeypatch: Any, tmp_path: Any, capsys: Any
+) -> None:
+    """MINOR-5: `--all` on an empty store must not answer "no ACTIVE sessions".
+
+    The live-only line re-teaches the old vocabulary on the very flag that
+    opts into the store; the default listing keeps its established copy.
+    """
+    import argparse
+
+    from local_operator import cli
+
+    monkeypatch.setattr(cli, "config_dir", lambda: tmp_path)
+    from local_operator.session.runtime import registry
+
+    monkeypatch.setattr(registry, "scan", lambda root=None: [])
+
+    code = cli.sessions_command(
+        argparse.Namespace(json=False, sessions_command=None, all=True, limit=None)
+    )
+    assert code == 0
+    assert "live or stored" in capsys.readouterr().out
+
+    code = cli.sessions_command(
+        argparse.Namespace(json=False, sessions_command=None, all=False, limit=None)
+    )
+    assert code == 0
+    assert capsys.readouterr().out.strip() == "no active lop sessions"

--- a/tests/unit/info/test_sessions_extraction.py
+++ b/tests/unit/info/test_sessions_extraction.py
@@ -140,6 +140,11 @@ EXPECTED = [
         "source_ref": "4311eb653aa9",
         "subagents_running": 2,
         "subagents_queued": 1,
+        # The stored row's clock (transcript activity); None on a live row,
+        # which reports uptime_s/heartbeat_age_s instead. Present on every row
+        # so the published shape is stable — a consumer never branches on key
+        # existence.
+        "last_activity_s": None,
     },
     {
         "state": "live",
@@ -160,6 +165,7 @@ EXPECTED = [
         "source_ref": "",
         "subagents_running": None,
         "subagents_queued": None,
+        "last_activity_s": None,
     },
     {
         "state": "stale",
@@ -183,6 +189,7 @@ EXPECTED = [
         # whole point of the pair — see ``SessionsInfo.subagents_unreported``.
         "subagents_running": None,
         "subagents_queued": None,
+        "last_activity_s": None,
     },
 ]
 
@@ -233,7 +240,9 @@ def test_cli_sessions_command_uses_the_shared_builder(monkeypatch: Any, capsys: 
     from local_operator import cli
 
     _install_fixture(monkeypatch)
-    code = cli.sessions_command(argparse.Namespace(json=True, sessions_command=None))
+    code = cli.sessions_command(
+        argparse.Namespace(json=True, sessions_command=None, all=False, limit=None)
+    )
     assert code == 0
 
     import json
@@ -248,7 +257,9 @@ def test_cli_table_still_renders_every_row(monkeypatch: Any, capsys: Any) -> Non
     from local_operator import cli
 
     _install_fixture(monkeypatch)
-    code = cli.sessions_command(argparse.Namespace(json=False, sessions_command=None))
+    code = cli.sessions_command(
+        argparse.Namespace(json=False, sessions_command=None, all=False, limit=None)
+    )
     assert code == 0
 
     out = capsys.readouterr().out

--- a/tests/unit/mobile/test_peer_send.py
+++ b/tests/unit/mobile/test_peer_send.py
@@ -248,18 +248,29 @@ def test_stored_match_is_case_insensitive(monkeypatch, fake_scan) -> None:
     assert session_id == "abc123def456"
 
 
-def test_live_session_wins_over_a_stored_row_with_the_same_name(monkeypatch, fake_scan) -> None:
-    live = _Record(10, session_id="live1", conversation_name="shared name")
+def test_live_ids_exclude_a_running_session_s_own_stored_row(monkeypatch, fake_scan) -> None:
+    """The exclusion is by ID, not by name, and exists for the id collision.
+
+    The fallback is entered only after the live scan matched nothing (see
+    ``live_scan_found_nothing``), so a live session sharing the stored row's
+    NAME cannot be what this guards: both read their name from the same
+    transcript. What the exclusion exists for is a stored row whose ID belongs
+    to a session that currently has a runtime — delivering cold to it would
+    queue behind a process that could have been dialled. Review round 1,
+    MINOR-3: an earlier draft of this test passed a live NAME and asserted the
+    stored row still returned, which pinned nothing the production callers
+    exercise.
+    """
+    live = _Record(10, session_id="shared-id", conversation_name="live name")
     fake_scan([(live, "live")])
-    _stored(monkeypatch, [_StoredRow("stored1", "shared name")])
-    # The stored resolver is told which ids are already live so it cannot
-    # report one conversation as ambiguous with itself.
+    _stored(monkeypatch, [_StoredRow("shared-id", "old name"), _StoredRow("other-id", "old name")])
     session_id, candidates, error = peer_send.resolve_stored_target(
-        "shared name", live_ids={"live1"}
+        "old name", live_ids={"shared-id"}
     )
     assert error == ""
     assert candidates == []
-    assert session_id == "stored1"
+    # The live-owned row is skipped; the distinct stored row still resolves.
+    assert session_id == "other-id"
 
 
 def test_ambiguous_stored_matches_are_refused_with_candidates(monkeypatch, fake_scan) -> None:

--- a/tests/unit/mobile/test_peer_send.py
+++ b/tests/unit/mobile/test_peer_send.py
@@ -206,6 +206,126 @@ def test_no_target_is_a_clean_error(fake_scan) -> None:
     assert "no target given" in error
 
 
+# --- Stored-session discovery (resolve_stored_target) ----------------------
+#
+# A note addressed by the name a session had before its terminal was closed
+# must still deliver. These pin the fallback's contract: live wins, ambiguity
+# refuses with candidates, and a single stored match resolves to the id that
+# feeds the unchanged cold-delivery path. The store is faked by patching
+# ``resume.recent_session_rows`` — the same scan the picker uses — so the test
+# pins the matching rule, not the filesystem walk.
+
+
+class _StoredRow:
+    """The ``SessionRow`` fields ``resolve_stored_target`` reads."""
+
+    def __init__(self, session_id: str, name: str, mtime: float = 0.0) -> None:
+        self.id = session_id
+        self.name = name
+        self.mtime = mtime
+
+
+def _stored(monkeypatch, rows):
+    monkeypatch.setattr(
+        "local_operator.resume.recent_session_rows",
+        lambda directory, limit=None: rows,
+    )
+
+
+def test_stored_match_by_name_resolves_when_no_live_record(monkeypatch, fake_scan) -> None:
+    fake_scan([])
+    _stored(monkeypatch, [_StoredRow("abc123def456", "Improve /credential skill")])
+    session_id, candidates, error = peer_send.resolve_stored_target("credential")
+    assert error == ""
+    assert candidates == []
+    assert session_id == "abc123def456"
+
+
+def test_stored_match_is_case_insensitive(monkeypatch, fake_scan) -> None:
+    fake_scan([])
+    _stored(monkeypatch, [_StoredRow("abc123def456", "Release Cutter")])
+    session_id, _c, _e = peer_send.resolve_stored_target("release cutter")
+    assert session_id == "abc123def456"
+
+
+def test_live_session_wins_over_a_stored_row_with_the_same_name(monkeypatch, fake_scan) -> None:
+    live = _Record(10, session_id="live1", conversation_name="shared name")
+    fake_scan([(live, "live")])
+    _stored(monkeypatch, [_StoredRow("stored1", "shared name")])
+    # The stored resolver is told which ids are already live so it cannot
+    # report one conversation as ambiguous with itself.
+    session_id, candidates, error = peer_send.resolve_stored_target(
+        "shared name", live_ids={"live1"}
+    )
+    assert error == ""
+    assert candidates == []
+    assert session_id == "stored1"
+
+
+def test_ambiguous_stored_matches_are_refused_with_candidates(monkeypatch, fake_scan) -> None:
+    fake_scan([])
+    _stored(
+        monkeypatch,
+        [_StoredRow("id1", "multi one"), _StoredRow("id2", "multi two")],
+    )
+    session_id, candidates, error = peer_send.resolve_stored_target("multi")
+    assert session_id is None
+    assert error == ""
+    assert [c.session_id for c in candidates] == ["id1", "id2"]
+    lines = peer_send.stored_candidate_lines(candidates, indent="  ", prefix="session")
+    assert lines == [
+        "  session id1  multi one  (not running)",
+        "  session id2  multi two  (not running)",
+    ]
+
+
+def test_no_stored_match_is_a_clean_no_match(monkeypatch, fake_scan) -> None:
+    fake_scan([])
+    _stored(monkeypatch, [_StoredRow("id1", "something else")])
+    session_id, candidates, error = peer_send.resolve_stored_target("nothing-here")
+    assert (session_id, candidates, error) == (None, [], "")
+
+
+def test_an_unreadable_store_never_refuses_a_send(monkeypatch, fake_scan) -> None:
+    fake_scan([])
+
+    def _boom(directory, limit=None):
+        raise OSError("disk gone")
+
+    monkeypatch.setattr("local_operator.resume.recent_session_rows", _boom)
+    session_id, candidates, error = peer_send.resolve_stored_target("anything")
+    assert (session_id, candidates, error) == (None, [], "")
+
+
+def test_stored_resolution_flows_into_spool_delivery(monkeypatch, tmp_path) -> None:
+    """A stored substring match delivers through the EXISTING cold path.
+
+    ``resolve_stored_target`` decides WHO; ``deliver_peer_message`` still owns
+    HOW. This pins that a resolved stored id spools to the inbox on a quiet
+    mailbox (wake=False) exactly as an exact-id cold send does — the fallback
+    does not rebuild delivery.
+    """
+    import asyncio
+
+    sid = "deadbeef0123"
+    directory = tmp_path / "sessions" / sid
+    directory.mkdir(parents=True)
+    monkeypatch.setattr(peer_send, "config_dir", lambda: tmp_path)
+
+    receipt = asyncio.run(
+        peer_send.deliver_peer_message(
+            None,
+            session_id=sid,
+            text="hello from the past",
+            mode="mailbox",
+            wake=False,
+            sender={},
+        )
+    )
+    assert receipt == "spooled (will be read when the session next opens)"
+    assert (directory / "inbox.jsonl").is_file()
+
+
 def test_validate_body_rejects_empty_and_oversized() -> None:
     assert peer_send.validate_peer_body("   ") == "message is empty"
     big = "x" * (peer_send.PEER_MESSAGE_MAX_BYTES + 1)

--- a/tests/unit/test_cli_send.py
+++ b/tests/unit/test_cli_send.py
@@ -548,6 +548,85 @@ def test_the_guide_quotes_the_ambiguity_error_verbatim() -> None:
     assert documented == actual
 
 
+def test_send_to_a_stored_session_by_name_spools(monkeypatch, tmp_path, capsys) -> None:
+    """THE FEATURE: a name that matches no live record but one stored session.
+
+    ``resolve_peer_target`` sees no live record, so the CLI falls back to the
+    stored store, resolves the name to the stored id, and delivers through the
+    unchanged cold path — a quiet mailbox spool, not a refusal.
+    """
+    monkeypatch.setattr("sys.stdin", _FakeTtyStdin())
+    sid = "cafe0123beef"
+    (tmp_path / "sessions" / sid).mkdir(parents=True)
+
+    class _Row:
+        id = sid
+        name = "Improve /credential skill"
+        mtime = 0.0
+
+    monkeypatch.setattr("local_operator.cli.config_dir", lambda: tmp_path)
+    monkeypatch.setattr("local_operator.mobile.peer_send.config_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        "local_operator.resume.recent_session_rows", lambda directory, limit=None: [_Row()]
+    )
+    with (
+        patch(
+            "local_operator.cli._resolve_peer_target",
+            return_value=(None, [], "no live session matches"),
+        ),
+        # The guard walks the CLI's parent chain for a self-send; there is no
+        # record for this test pid, so the walk must not find one.
+        patch("local_operator.mobile.peer_send._record_for_pid", lambda pid: None),
+        patch("local_operator.mobile.peer_send._parent_pid", lambda pid: None),
+    ):
+        rc = send_command(_parse_send(["credential", "rebased and green"]))
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "spooled" in out
+    assert (tmp_path / "sessions" / sid / "inbox.jsonl").is_file()
+
+
+def test_no_match_now_names_both_live_and_stored(capsys, tmp_path, monkeypatch) -> None:
+    """When the stored fallback also finds nothing the error says so."""
+    monkeypatch.setattr("sys.stdin", _FakeTtyStdin())
+    monkeypatch.setattr("local_operator.cli.config_dir", lambda: tmp_path)
+    monkeypatch.setattr("local_operator.mobile.peer_send.config_dir", lambda: tmp_path)
+    monkeypatch.setattr("local_operator.resume.recent_session_rows", lambda d, limit=None: [])
+    with patch(
+        "local_operator.cli._resolve_peer_target",
+        return_value=(None, [], "no live session matches 'ghost'"),
+    ):
+        rc = send_command(_parse_send(["ghost", "hello"]))
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "searched live and stored sessions" in err
+
+
+def test_ambiguous_stored_matches_list_sessions_not_pids(capsys, tmp_path, monkeypatch) -> None:
+    """A stored ambiguity names session ids (a pid is an address that can never
+    resolve for a session that is not running)."""
+    monkeypatch.setattr("sys.stdin", _FakeTtyStdin())
+    monkeypatch.setattr("local_operator.cli.config_dir", lambda: tmp_path)
+    monkeypatch.setattr("local_operator.mobile.peer_send.config_dir", lambda: tmp_path)
+
+    class _Row:
+        def __init__(self, sid, name):
+            self.id, self.name, self.mtime = sid, name, 0.0
+
+    rows = [_Row("aaaa1111bbbb", "review multi A"), _Row("cccc2222dddd", "review multi B")]
+    monkeypatch.setattr("local_operator.resume.recent_session_rows", lambda d, limit=None: rows)
+    with patch(
+        "local_operator.cli._resolve_peer_target",
+        return_value=(None, [], "no live session matches"),
+    ):
+        rc = send_command(_parse_send(["review multi", "ping"]))
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "aaaa1111bbbb" in err and "cccc2222dddd" in err
+    assert "(not running)" in err
+
+
 def test_self_send_is_refused_before_any_network_call(capsys) -> None:
     """A target whose pid is os.getppid() (the launching session) is rejected
     with a clear message and never reaches ``send_peer_message``."""

--- a/tests/unit/test_cli_send.py
+++ b/tests/unit/test_cli_send.py
@@ -722,3 +722,45 @@ def test_a_grandparent_session_does_not_block_a_send_to_a_third_party(capsys) ->
     assert "that target is this session" not in err
     # It got past the guard and failed on the dial instead (no live peer here).
     assert code == 1
+
+
+def test_a_live_refusal_is_not_converted_into_a_stored_send(capsys, tmp_path, monkeypatch) -> None:
+    """BLOCKER-1/MAJOR-1 at the CLI: a refusal about a live session stands.
+
+    The binder rejects `target` + `--pid` before resolution, so this drives the
+    guard the way the in-session tool actually reaches it: resolution returns
+    one of the no-record refusals (a conflicting pair, or a wedged unique
+    match) while a stored session sharing the substring exists on disk. Either
+    falling through to the store would deliver the message to a session the
+    command never named, so both forms must be refused with their own error
+    and nothing spooled.
+    """
+    monkeypatch.setattr("sys.stdin", _FakeTtyStdin())
+    monkeypatch.setattr("local_operator.cli.config_dir", lambda: tmp_path)
+    monkeypatch.setattr("local_operator.mobile.peer_send.config_dir", lambda: tmp_path)
+    sid = "dead00000abc"
+    (tmp_path / "sessions" / sid).mkdir(parents=True)
+
+    class _Row:
+        id = sid
+        name = "Improve /credential skill"
+        mtime = 0.0
+
+    monkeypatch.setattr(
+        "local_operator.resume.recent_session_rows", lambda directory, limit=None: [_Row()]
+    )
+    refusals = {
+        "conflict": (
+            "pass either a target substring or an exact pid/session, not both — "
+            "they name different sessions"
+        ),
+        "wedged": "the only match for 'credential' is not responding (pid 4242); try again shortly",
+    }
+    for label, live_error in refusals.items():
+        with patch("local_operator.cli._resolve_peer_target", return_value=(None, [], live_error)):
+            rc = send_command(_parse_send(["credential", "hello"]))
+        assert rc == 1, label
+        err = capsys.readouterr().err
+        assert ("not both" in err) or ("not responding" in err), label
+        # The stored lookalike received nothing: the refusal was the answer.
+        assert not (tmp_path / "sessions" / sid / "inbox.jsonl").exists(), label

--- a/tests/unit/tools/test_send_tool.py
+++ b/tests/unit/tools/test_send_tool.py
@@ -16,7 +16,9 @@ guard. The self-send test targets the registrant's OWN record to trip the guard.
 
 from __future__ import annotations
 
+import json
 import os
+from pathlib import Path
 from typing import Any, cast
 
 import pytest
@@ -456,3 +458,104 @@ async def test_addressing_by_pid_and_session_id() -> None:
         assert len([c for c in handle.calls if c[0] == "receive_peer_message"]) == 2
     finally:
         registrant.close()
+
+
+# -- the stored fallback's entry guard (review round 1) ----------------------
+#
+# BLOCKER-1 and MAJOR-1 both live in ONE decision: the stored fallback runs
+# only when the live resolver said "no match anywhere". Every other
+# no-record outcome — a conflicting target+selector pair, a unique match that
+# is wedged — is a refusal about a live session the call DID reach, and
+# round 1 delivered those to a stored session that merely shared the
+# substring. Both tests fake ONLY the live resolver and put a REAL stored
+# session on disk, so a regressed guard spools a real file and is caught.
+
+
+def _plant_stored_session(monkeypatch, tmp_path, session_id: str, name: str) -> Path:
+    """A real store row the fallback would find if its guard regresses.
+
+    The transcript is what both the name scan and the activity clock read, so
+    this is the store the picker would list — not a mock of it. The line is the
+    writer's envelope (``type: message`` wrapping a ``payload``; the text nested
+    in a ``content`` list): a bare ``{"role": ..., "text": ...}`` row yields an
+    EMPTY name from the scan, which once made an earlier version of this
+    fixture vacuous — the fallback found no name match, so a regressed guard
+    passed the test anyway.
+    """
+    from local_operator.mobile import peer_send
+
+    session_dir = tmp_path / "sessions" / session_id
+    session_dir.mkdir(parents=True)
+    entry = json.dumps(
+        {
+            "type": "message",
+            "payload": {
+                "role": "user",
+                "content": [{"type": "text", "text": name}],
+            },
+        }
+    )
+    (session_dir / "transcript.jsonl").write_text(entry + "\n")
+    monkeypatch.setattr(peer_send, "config_dir", lambda: tmp_path)
+    return session_dir
+
+
+@pytest.mark.asyncio
+async def test_a_live_target_conflict_is_refused_not_stored_delivered(
+    monkeypatch, tmp_path
+) -> None:
+    """BLOCKER-1: `target` + `pid` is a refusal, never a stored-session send."""
+    from local_operator.mobile import peer_send
+
+    _plant_stored_session(monkeypatch, tmp_path, "dead00000abc", "credential work")
+
+    def _conflict(**_kwargs: Any) -> tuple[None, list[Any], str]:
+        return (
+            None,
+            [],
+            "pass either a target substring or an exact pid/session, not both — "
+            "they name different sessions",
+        )
+
+    monkeypatch.setattr(peer_send, "resolve_peer_target", _conflict)
+    result = await execute_send(
+        "t12",
+        {"target": "credential", "pid": 12345, "message": "hello", "wake": False},
+        None,
+        None,
+        _context(),
+    )
+    assert result.is_error is True
+    assert "not both" in result.text
+    assert "searched live and stored" not in result.text
+    # The refusal is the answer: nothing was spooled to the lookalike store row.
+    assert not (tmp_path / "sessions" / "dead00000abc" / "inbox.jsonl").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_wedged_unique_live_match_is_refused_not_stored_delivered(
+    monkeypatch, tmp_path
+) -> None:
+    """MAJOR-1: a wedged live session is still THE session — no cold send."""
+    from local_operator.mobile import peer_send
+
+    _plant_stored_session(monkeypatch, tmp_path, "wedge0000abc", "credential work")
+
+    def _wedged(**_kwargs: Any) -> tuple[None, list[Any], str]:
+        return (
+            None,
+            [],
+            "the only match for 'credential' is not responding (pid 4242); " "try again shortly",
+        )
+
+    monkeypatch.setattr(peer_send, "resolve_peer_target", _wedged)
+    result = await execute_send(
+        "t13",
+        {"target": "credential", "message": "hello", "wake": False},
+        None,
+        None,
+        _context(),
+    )
+    assert result.is_error is True
+    assert "not responding" in result.text
+    assert not (tmp_path / "sessions" / "wedge0000abc" / "inbox.jsonl").exists()

--- a/tests/unit/tools/test_send_tool.py
+++ b/tests/unit/tools/test_send_tool.py
@@ -276,7 +276,10 @@ async def test_no_matching_target_is_a_clean_error() -> None:
         _context(),
     )
     assert result.is_error is True
-    assert "no live session matches" in result.text
+    # The send now searches BOTH the live registry and the stored session store
+    # before refusing, and the error says so rather than implying only the live
+    # fleet was checked.
+    assert "searched live and stored sessions" in result.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Release: patch — `lop sessions --all` lists stored sessions; `send`/`lop send` can address a closed session by conversation-name substring (wake engages a runtime, quiet mailbox spools).

## Problem

Delivery to a closed session already works by exact session id (`resolve_cold_session` → spool/engage). Discovery does not: `resolve_peer_target` matches live registry records only, so `send(target="Improve /credential skill")` fails with "no live session matches" once the peer is closed. `lop sessions` likewise lists only live/wedged records. A human/agent rarely knows the 12-char id.

## Solution

- **`lop sessions --all`**: include stored sessions (a directory under `config_dir()/sessions/` with no live record), named via `resume.recent_session_rows` (the `/resume` picker scan — title sidecar, not a full transcript parse). PID/RSS/UPTIME/HB_AGE read `—`; a `LAST_ACTIVE` column (transcript activity mtime) appears only when `--all` actually brought stored rows, so the live-only table is unchanged. `--limit` caps stored rows (default 50). `--json` extends the pinned key order with `last_activity_s` last (`None` on live rows). Fleet roll-ups (`total`/`live`) still count running processes only.
- **Send-side fallback**: when no live record matches a substring, `resolve_stored_target` searches stored sessions by name then id (case-insensitive). Live wins over stored for the same substring; ambiguity refuses with session ids, never pids. A single match feeds the existing cold path (spool on `wake=False` mailbox, engage on wake/steer). Exact-id behaviour is unchanged. No-match error now reads `no session matches '<target>' (searched live and stored sessions)`.
- Stored cwd is not recovered (no cheap sidecar); stored matches are name + id only.

No version bump.

## Testing Details

- Isolated fake store: `lop sessions` (live-only) → `no active lop sessions`; `lop sessions --all` lists `Improve /credential skill` as `stored`; `--json` includes `last_activity_s`.
- `lop send credential "rebased and green"` against that store → `→ dead00000abc (not running): spooled`; inbox.jsonl written. Ghost target → `no session matches 'nonexistent-xyz' (searched live and stored sessions)`.
- Affected unit tests: **148 passed** (`test_peer_send.py`, `test_sessions_extraction.py`, `test_collect.py`, `test_cli_send.py`, `test_send_tool.py`).
- Gates: flake8, `black --check` (pinned), `isort --check-only`, pyright — all green.
- Full `tests/unit` was not completed locally: host was contended (sibling worktrees' pytest), a 900s run was killed at ~83%. CI will run the full suite.

## Checklist

- [x] Conventional commit, no pyproject bump
- [x] Existing default (`lop sessions` live-only) unchanged
- [x] Live substring still wins over stored
- [x] Assigned @damianvtran