### PR TITLE
fix(tui): never double-paint a live tool call on resume onto a running turn

### DIFF
--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -40,6 +40,36 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
     from local_operator.session.frontend_state import FrontendSessionState
 
 
+def unanswered_tail_call_ids(messages: Sequence[Any]) -> set[str]:
+    """Calls in the CURRENT turn's latest group that have no result yet.
+
+    The one scan behind both "this row is not finished" display questions
+    (``pending_display_tool_ids`` and ``executing_display_tool_ids``), which
+    differ only in what makes the call unfinished — a gate parked in front of
+    it, or the tool still executing. Held here rather than on either session
+    class because the rule is a property of the MESSAGE TAIL, not of the
+    transport: the local owner reads its in-memory context and a remote
+    viewer its display window, and the two must answer identically for the
+    same conversation or the same resumed row settles differently depending
+    on which surface replayed it.
+
+    The latest call group after the latest user boundary is the only eligible
+    group, so old interrupted turns keep their ``⊘`` and are never revived by
+    a later turn's liveness.
+    """
+    answered: set[str] = set()
+    for message in reversed(messages):
+        role = getattr(message, "role", "")
+        if role == "user":
+            break
+        if role == "tool":
+            answered.add(str(getattr(message, "tool_call_id", "")))
+        calls = getattr(message, "tool_calls", None)
+        if role == "assistant" and calls:
+            return {call.id for call in calls} - answered
+    return set()
+
+
 @dataclass(frozen=True, slots=True)
 class CompactionOutcome:
     """What one explicit compaction request did — see :meth:`SessionProtocol.compact_now`.

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -93,7 +93,11 @@ from local_operator.session.frontend_state import (
 )
 from local_operator.session.history_window import DisplayHistoryWindow
 from local_operator.session.naming import ConversationName
-from local_operator.session.protocol import CompactionOutcome, RuntimeLocality
+from local_operator.session.protocol import (
+    CompactionOutcome,
+    RuntimeLocality,
+    unanswered_tail_call_ids,
+)
 from local_operator.session.runtime.types import HEARTBEAT_TIMEOUT_S
 from local_operator.session.transcript import (
     Transcript,
@@ -2638,22 +2642,11 @@ class RemoteSession:
 
         Shared by the two "this row is not finished" questions below, which
         differ only in what makes the call unfinished — a gate parked in front
-        of it, or the tool still executing. The scan itself is one rule and
-        belongs in one place: the latest call group after the latest user
-        boundary is the only eligible group, so old interrupted turns keep
-        their ``⊘`` and are never revived by a later turn's liveness.
+        of it, or the tool still executing. The scan is the one rule in
+        :func:`session.protocol.unanswered_tail_call_ids`, shared with the
+        local owner so both surfaces answer identically for the same tail.
         """
-        answered: set[str] = set()
-        for message in reversed(self.display_history_window()):
-            role = getattr(message, "role", "")
-            if role == "user":
-                break
-            if role == "tool":
-                answered.add(str(getattr(message, "tool_call_id", "")))
-            calls = getattr(message, "tool_calls", None)
-            if role == "assistant" and calls:
-                return {call.id for call in calls} - answered
-        return set()
+        return unanswered_tail_call_ids(self.display_history_window())
 
     def pending_display_tool_ids(self) -> set[str]:
         """Unanswered calls in the pending gate's current serialized user turn.

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -152,7 +152,11 @@ from local_operator.session.naming import (
     ConversationName,
 )
 from local_operator.session.peer import PEER_MESSAGE_MESSAGE_TYPE
-from local_operator.session.protocol import CompactionOutcome, RuntimeLocality
+from local_operator.session.protocol import (
+    CompactionOutcome,
+    RuntimeLocality,
+    unanswered_tail_call_ids,
+)
 from local_operator.session.transcript import ENTRY_CUSTOM, Transcript
 from local_operator.tools.builtin import (
     TODO_REMINDER_MESSAGE_TYPE,
@@ -3492,6 +3496,43 @@ class Session:
         ``Message`` docstring).
         """
         return list(self._context.messages)
+
+    def pending_display_tool_ids(self) -> set[str]:
+        """Unanswered calls in the pending gate's current serialized user turn.
+
+        The local half of the display question ``RemoteSession`` already
+        answers for a viewer: a replay of the in-flight turn's tail must not
+        settle the row the gate is parked on. A gate can precede
+        tool_execution_start, so no invented start event is needed.
+        """
+        if self.pending_gate is None:
+            return set()
+        return unanswered_tail_call_ids(self._context.messages)
+
+    def executing_display_tool_ids(self) -> set[str]:
+        """Unanswered calls of a turn that is STILL RUNNING right now.
+
+        The gate's counterpart, and the reason it cannot answer for both. A
+        long tool — ``wait(wait_ms=1800000)``, a background ``bash``, a
+        ``task`` — parks the turn inside execution with NO gate open, so
+        ``pending_display_tool_ids`` returns nothing for it while the call is
+        very much alive.
+
+        Until this accessor existed the question was RemoteSession-only, so a
+        resume onto a LIVE LOCAL session replayed the in-flight call as a
+        settled row — a duplicate beside the card the running turn's own
+        events paint, one extra head in the "running N tools" count, and a
+        ``⊘ interrupted`` stamp on a call that had not stopped.
+
+        Gated on :attr:`is_streaming` and on the LATEST group only, so the answer
+        is "this turn, right now" and never "some turn once left a call
+        dangling". A turn that has ended reports nothing here and its
+        unanswered rows stay interrupted, which for a turn that really died
+        mid-flight is the truth.
+        """
+        if not self._is_streaming:
+            return set()
+        return unanswered_tail_call_ids(self._context.messages)
 
     def context_breakdown(self) -> dict[str, int]:
         """On-demand token breakdown for the context the next request sends.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -186,6 +186,7 @@ from local_operator.tui.session_presentation import (
     OlderHistoryNotice,
     PreparedReplay,
     SessionPresentation,
+    live_projection_call_ids,
 )
 from local_operator.tui.session_workspace import SessionWorkspace
 from local_operator.tui.settings import settings_get
@@ -4793,13 +4794,15 @@ class OperatorApp(App[None]):
             # An offscreen presentation has no `_session` the projection could
             # ask, so the caller hands the in-flight answer in: a call still
             # executing on the session being prepared must not grow a second
-            # settled row beside the live one.
-            executing = getattr(session, "executing_display_tool_ids", None)
+            # settled row beside the live one. The seed is the gate-free set
+            # (`live_projection_call_ids`) so the pending scan below keeps a
+            # gate-parked call `waiting` instead of the painter showing it
+            # `running`.
             replay.prepare(
                 history,
                 bound=max(12, self.size.height // 2),
                 anchor_id=source.draft.scroll_anchor_id if not source.draft.following_tail else "",
-                live_call_ids=cast(set[str], executing()) if callable(executing) else None,
+                live_call_ids=live_projection_call_ids(session),
             )
             preview_unavailable = (
                 not replay.blocks
@@ -8949,13 +8952,13 @@ class OperatorApp(App[None]):
         from local_operator.tui.session_presentation import project_settled_rows
 
         session = self._session
-        executing = getattr(session, "executing_display_tool_ids", None)
         # Snapshot the in-flight calls BEFORE the fold: the answer can change
-        # mid-projection, and replay reads only this set (its own session
-        # fallback finds nothing because the app is not the session).
-        self._projection_live_call_ids = (
-            cast(set[str], executing()) if callable(executing) else set()
-        )
+        # mid-projection, and replay reads only this set. The seed is the
+        # gate-free set (`live_projection_call_ids` documents the pending
+        # subtraction), so a gate-parked call keeps its `waiting` row from
+        # `_mark_pending_tool_rows` below; the fold's own fallback re-asks the
+        # same subtracted question for a target that never seeded.
+        self._projection_live_call_ids = live_projection_call_ids(session)
         try:
             projected = project_settled_rows(self, history, bound=bound)
             # The visible transcript, so the app's own registry is the right
@@ -8964,9 +8967,20 @@ class OperatorApp(App[None]):
             self._mark_pending_tool_rows(
                 self._transcript_view().blocks(), self._session, self._tool_cards
             )
-            self._paint_skipped_live_tool_rows(
+            painted = self._paint_skipped_live_tool_rows(
                 self._transcript_view(), self._tool_cards, self._projection_skipped_live
             )
+            if painted and self._controller is not None:
+                # The adopt path's settle seam. The skipped call's
+                # `ToolStarted` predates this process's subscription, so the
+                # controller never registered it: the eventual `ToolEnded`
+                # would be buffered as an orphan and dropped at turn end, and
+                # `_retire_live_tool_cards` would stamp a REAL success
+                # `interrupted`. Registering the painted ids — what the
+                # presentation-commit path does for its replayed rows — makes
+                # the controller pair the end with this card, and drains an
+                # end that already arrived while the card was being painted.
+                self._controller.register_restored_tools(set(painted))
             self._refresh_working_activity()
             return projected
         finally:
@@ -8981,8 +8995,14 @@ class OperatorApp(App[None]):
         calls: list[Any],
         *,
         collect: list[Any] | None = None,
-    ) -> None:
+    ) -> list[str]:
         """Paint the ONE row for a still-executing call the replay skipped.
+
+        Returns the ids it actually painted, so the caller can hand them to
+        the settle seam: the visible path registers them with the event
+        controller (`register_restored_tools`) because no `ToolStarted` will
+        ever pair their `ToolEnded`; the prepare path ignores the return and
+        registers at commit, where its presentation becomes the app's.
 
         The replay drops the settled row for an in-flight call so the live
         path owns it — but on a LOCAL resume the turn's ``ToolStarted`` fired
@@ -9003,6 +9023,7 @@ class OperatorApp(App[None]):
         caller's bulk mount rather than to the (unmountable) view. The visible
         path leaves it ``None`` and appends to the live view directly.
         """
+        painted: list[str] = []
         for call in calls:
             call_id = getattr(call, "id", "") or ""
             if not call_id or call_id in live_cards:
@@ -9030,6 +9051,8 @@ class OperatorApp(App[None]):
             # count it, and so `_retire_live_tool_cards` settles it if the
             # owner dies rather than returning a result.
             live_cards[call_id] = card
+            painted.append(call_id)
+        return painted
 
     def on_history_page_notice_requested(self, message: HistoryPageNotice.Requested) -> None:
         message.stop()

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3218,6 +3218,11 @@ class OperatorApp(App[None]):
         self._block_sink: list[Any] | None = None
         self._projection_message_id = ""
         self._projection_part = 0
+        # Seeded per projection by `_project_settled_rows`; see
+        # `session_presentation.project_settled_rows` for the contract. Default
+        # empty: a projection that never re-seeds is the cold-resume case.
+        self._projection_live_call_ids: set[str] = set()
+        self._projection_skipped_live: list[Any] = []
         #: One page per USER GESTURE, not per scroll callback. Held from the
         #: first trigger until the mount's settle pass has restored the scroll
         #: anchor: Textual ANIMATES pageup/home, so the scroll watcher fires
@@ -4785,10 +4790,16 @@ class OperatorApp(App[None]):
             history = session.display_history_window()
             replay_revision = session.display_history_revision
             source_stamp = self._sidebar_source_stamp(source)
+            # An offscreen presentation has no `_session` the projection could
+            # ask, so the caller hands the in-flight answer in: a call still
+            # executing on the session being prepared must not grow a second
+            # settled row beside the live one.
+            executing = getattr(session, "executing_display_tool_ids", None)
             replay.prepare(
                 history,
                 bound=max(12, self.size.height // 2),
                 anchor_id=source.draft.scroll_anchor_id if not source.draft.following_tail else "",
+                live_call_ids=cast(set[str], executing()) if callable(executing) else None,
             )
             preview_unavailable = (
                 not replay.blocks
@@ -4809,6 +4820,20 @@ class OperatorApp(App[None]):
             # which is the moment these cards become the app's to retire.
             prepared_live_cards: dict[str, ToolCard] = {}
             self._mark_pending_tool_rows(replay.blocks, session, prepared_live_cards)
+            # The replay SKIPPED the still-executing calls (see the `prepare`
+            # seed above) precisely so the live row would own them; where no
+            # live relay painted one (a local resume), paint the ONE row here
+            # from the calls the skip recorded. No-op when a card already
+            # exists for the call.
+            # The view is NOT mounted yet, so the painter cannot append to it
+            # directly; it collects into `replay.blocks` and the bulk append
+            # below mounts the row with the rest of the presentation.
+            self._paint_skipped_live_tool_rows(
+                replay.view,
+                prepared_live_cards,
+                replay._projection_skipped_live,
+                collect=replay.blocks,
+            )
             replay.view.styles.layer = "session-cache"
             # visibility:hidden removes the compositor map and makes size=0.
             # A screen overlay is excluded from flow/virtual bounds; parking it
@@ -8923,6 +8948,14 @@ class OperatorApp(App[None]):
     def _project_settled_rows(self, history: list[Any], *, bound: int | None = None) -> bool:
         from local_operator.tui.session_presentation import project_settled_rows
 
+        session = self._session
+        executing = getattr(session, "executing_display_tool_ids", None)
+        # Snapshot the in-flight calls BEFORE the fold: the answer can change
+        # mid-projection, and replay reads only this set (its own session
+        # fallback finds nothing because the app is not the session).
+        self._projection_live_call_ids = (
+            cast(set[str], executing()) if callable(executing) else set()
+        )
         try:
             projected = project_settled_rows(self, history, bound=bound)
             # The visible transcript, so the app's own registry is the right
@@ -8931,9 +8964,72 @@ class OperatorApp(App[None]):
             self._mark_pending_tool_rows(
                 self._transcript_view().blocks(), self._session, self._tool_cards
             )
+            self._paint_skipped_live_tool_rows(
+                self._transcript_view(), self._tool_cards, self._projection_skipped_live
+            )
+            self._refresh_working_activity()
             return projected
         finally:
             self._projection_message_id = ""
+            self._projection_live_call_ids = set()
+            self._projection_skipped_live = []
+
+    @staticmethod
+    def _paint_skipped_live_tool_rows(
+        view: Any,
+        live_cards: dict[str, ToolCard],
+        calls: list[Any],
+        *,
+        collect: list[Any] | None = None,
+    ) -> None:
+        """Paint the ONE row for a still-executing call the replay skipped.
+
+        The replay drops the settled row for an in-flight call so the live
+        path owns it — but on a LOCAL resume the turn's ``ToolStarted`` fired
+        before this process (re)subscribed, so no card ever arrives for it
+        and the transcript would show nothing for a call that is running.
+        Mounting here rather than inside the fold keeps the invariant "one
+        visible row per call": the check against the already-painted cards is
+        what makes this a no-op when a live row DOES exist (the reconnect gap,
+        where the relay painted it before the disconnect).
+
+        The registry is passed rather than read off ``self`` because the
+        prepare caller is painting a presentation that is not yet the app's:
+        registering into ``self._tool_cards`` there would attribute another
+        conversation's live call to the visible one.
+
+        ``collect`` is the prepare case: the presentation's view is not mounted
+        yet, so the row is appended to the presentation's block list for the
+        caller's bulk mount rather than to the (unmountable) view. The visible
+        path leaves it ``None`` and appends to the live view directly.
+        """
+        for call in calls:
+            call_id = getattr(call, "id", "") or ""
+            if not call_id or call_id in live_cards:
+                continue
+            haystack = collect if collect is not None else view.blocks()
+            if any(
+                isinstance(block, ToolCard) and block.tool_call_id == call_id for block in haystack
+            ):
+                continue
+            # `restore`, not the constructor's default running clock: the true
+            # start is when the tool began, not when this view painted the row,
+            # so the card must not invent an elapsed time it cannot know — the
+            # same reason `restore(state="running")` clears `_started`.
+            card = ToolCard(
+                call_id,
+                getattr(call, "name", "") or "",
+                getattr(call, "arguments", None) or {},
+            )
+            card.restore(state="running")
+            if collect is not None:
+                collect.append(card)
+            else:
+                view.append_block(card)
+            # Registered as live so the turn-death paths and the working line
+            # count it, and so `_retire_live_tool_cards` settles it if the
+            # owner dies rather than returning a result.
+            live_cards[call_id] = card
 
     def on_history_page_notice_requested(self, message: HistoryPageNotice.Requested) -> None:
         message.stop()

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import sys
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 from pydantic import BaseModel
 from textual import events
@@ -310,6 +310,19 @@ class ReplayState:
     _block_sink: list[Any] | None = None
     _projection_message_id: str = ""
     _projection_part: int = 0
+    #: Call ids of the turn still executing on the session being projected,
+    #: captured at projection time by the caller that knows the session (the
+    #: app for the visible transcript, the prepare caller for an offscreen
+    #: presentation). ``replay_tool_call`` skips the settled row for these —
+    #: the live path owns that call's one visible row — and the empty default
+    #: is the COLD-resume answer: no live turn, nothing to skip.
+    _projection_live_call_ids: set[str] = field(default_factory=set)
+    #: The CALL OBJECTS the projection skipped because their call id is live,
+    #: in transcript order. Read by the projection's owner after the fold to
+    #: paint the one visible row for a still-running call that no live path
+    #: will paint (a local resume onto a turn already in flight). Cleared with
+    #: the ids above.
+    _projection_skipped_live: list[Any] = field(default_factory=list)
 
 
 class ReplayTarget(Protocol):
@@ -325,6 +338,8 @@ class ReplayTarget(Protocol):
     _block_sink: list[Any] | None
     _projection_message_id: str
     _projection_part: int
+    _projection_live_call_ids: set[str]
+    _projection_skipped_live: list[Any]
 
     def _transcript_view(self) -> TranscriptView: ...
 
@@ -384,7 +399,19 @@ class PreparedReplay(ReplayState):
     ) -> None:
         replay_tool_call(self, call, results, user_run=user_run)
 
-    def prepare(self, history: list[Any], *, bound: int = 12, anchor_id: str = "") -> None:
+    def prepare(
+        self,
+        history: list[Any],
+        *,
+        bound: int = 12,
+        anchor_id: str = "",
+        live_call_ids: set[str] | None = None,
+    ) -> None:
+        # Snapshot the session's in-flight calls NOW, before the fold: the
+        # answer can change mid-projection, and a half-guarded tail is the
+        # duplicate this field exists to prevent.
+        self._projection_live_call_ids = set(live_call_ids or ())
+        self._projection_skipped_live = []
         self._block_sink = self.blocks
         anchor = (
             next(
@@ -413,6 +440,10 @@ class PreparedReplay(ReplayState):
             self._resume_tail_notice = HistoryPageNotice()
             self.blocks.append(self._resume_tail_notice)
         self._block_sink = None
+        # One projection's liveness answer must not leak into the next pass:
+        # the empty set is the cold-resume default, the only correct answer
+        # when nobody re-seeds it.
+        self._projection_live_call_ids = set()
 
 
 @dataclass
@@ -961,18 +992,63 @@ def replay_tool_call(
     duration: the harness persists the executor's measured interval as
     ``provider_payload.duration_s`` beside the result's ``details``, and it is
     restored here rather than recomputed from when this row was mounted.
+
+    One call has exactly ONE visible row. When the transcript carries an
+    outcome, a card the live path already painted is settled in place rather
+    than doubled by a second row. When the call is live IN THIS PROCESS right
+    now — the replay ran against a session whose turn is still in flight, as
+    ``/resume`` onto a running conversation does — mounting a settled row at
+    all is the reported duplicate: the running turn's own ``ToolStarted``
+    paints (or has painted) the live row, and this second card would sit
+    beside it, overcount "running N tools", and stamp ``⊘ interrupted`` on a
+    call that has not stopped. Skipping the settled row loses nothing: the
+    live row owns the call's intent (which the transcript does not persist)
+    and its real start time, and it settles through the ordinary
+    ``on_tool_ended`` path. A COLD resume has no live turn, so
+    ``executing_display_tool_ids()`` is empty there and killed-mid-turn calls
+    still render ``interrupted`` exactly as before.
     """
     from local_operator.tui.app import ImageContent, ToolCard, _first_line
     from local_operator.tui.widgets.tool_card import parse_duration
 
+    call_id = getattr(call, "id", "") or ""
+    result = results.get(call_id)
+    if result is not None:
+        # The outcome is recorded, so the call cannot still be running: a card
+        # the live path already painted (a resumed live projection, a
+        # reconnect's pre-disconnect card) is settled in place through the same
+        # derivation instead of being doubled by a fresh row — review round 4,
+        # MINOR-1 built exactly this pairing for the gap replay.
+        painted = self._painted_tool_card(call_id)
+        if painted is not None:
+            self._settle_painted_tool_card(painted, result)
+            return
+    else:
+        # The snapshot the caller seeded for this projection first; a
+        # ReplayTarget carrying the session itself (the app) falls back to
+        # asking the session directly, which is how a live call is still
+        # honoured on a path that never seeds the set.
+        live_ids: set[str] = self._projection_live_call_ids
+        if not live_ids:
+            session = getattr(self, "_session", None)
+            executing = getattr(session, "executing_display_tool_ids", None)
+            live_ids = cast(set[str], executing()) if callable(executing) else set()
+        if call_id in live_ids:
+            # Record it, so the projection's owner can paint the ONE row for
+            # this call when no live path is going to (a local resume: the
+            # turn's ToolStarted fired before this process/subscription
+            # existed, so no card will arrive for it). The replay itself still
+            # mounts nothing — the owner paints it after the fold, where it
+            # knows whether a card is already on screen.
+            self._projection_skipped_live.append(call)
+            return
     card = ToolCard(
-        getattr(call, "id", "") or "",
+        call_id,
         getattr(call, "name", "") or "",
         getattr(call, "arguments", None) or {},
         user_run=user_run,
     )
     self._append_block(card)
-    result = results.get(getattr(call, "id", "") or "")
     if result is None:
         # No result recorded: the session ended between the call and its
         # answer. Showing it as complete would invent an outcome, and there is

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -1079,6 +1079,15 @@ def replay_tool_call(
             # knows whether a card is already on screen.
             self._projection_skipped_live.append(call)
             return
+        # The gate-free seed answered "not live", but the seed is a snapshot:
+        # a call parked at an approval gate is subtracted out of it (so the
+        # row paints `waiting`, not `running`) while the live ToolStarted
+        # already mounted a card during adoption. Mounting a second row here
+        # is the same duplicate the live-skip above prevents, one arm over —
+        # consult the already-painted registry exactly as the outcome branch
+        # does (QA round 2, Q-R2-1).
+        if self._painted_tool_card(call_id) is not None:
+            return
     card = ToolCard(
         call_id,
         getattr(call, "name", "") or "",

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -80,6 +80,37 @@ RETAIN_TEXT_BYTES = 1024 * 1024
 COMPACTION_MARKER_NOTICE = "context compacted — earlier history above the agent no longer sees"
 
 
+def live_projection_call_ids(session: Any) -> set[str]:
+    """Call ids a settled replay must SKIP because they are executing NOW.
+
+    ``executing() - pending()``, and the subtraction is the load-bearing
+    half. A turn parked at an approval gate is ALSO a streaming one, so both
+    accessors answer with exactly the call the gate is holding; seeding a
+    projection with the un-subtracted set would skip that call out of the
+    replay, and the skip path (``_paint_skipped_live_tool_rows``) paints
+    ``running`` without consulting the gate — bypassing the "waiting wins"
+    rule ``_mark_pending_tool_rows`` exists to enforce. With the held call
+    left out of the seed, the replay mounts its row and the pending scan
+    marks it ``waiting``: the honest state for a call parked on the USER,
+    not on a tool.
+
+    One helper because three sites ask this question — the visible seed in
+    ``_project_settled_rows``, the offscreen seed in the sidebar prepare
+    path, and the fold's own fallback for a target that never seeded — and
+    a divergence between any two reopens the gate bug on exactly one path.
+    Lives here rather than on the app so the fold can ask it without a
+    circular import.
+    """
+    executing = getattr(session, "executing_display_tool_ids", None)
+    if not callable(executing):
+        return set()
+    live = cast(set[str], executing())
+    pending = getattr(session, "pending_display_tool_ids", None)
+    if callable(pending):
+        live -= cast(set[str], pending())
+    return live
+
+
 class CompactionMarkerBlock(NoticeBlock):
     """The compaction seam, spaced apart from whatever it lands beside.
 
@@ -1003,10 +1034,14 @@ def replay_tool_call(
     beside it, overcount "running N tools", and stamp ``⊘ interrupted`` on a
     call that has not stopped. Skipping the settled row loses nothing: the
     live row owns the call's intent (which the transcript does not persist)
-    and its real start time, and it settles through the ordinary
-    ``on_tool_ended`` path. A COLD resume has no live turn, so
-    ``executing_display_tool_ids()`` is empty there and killed-mid-turn calls
-    still render ``interrupted`` exactly as before.
+    and its real start time. Where no live row exists yet — the local adopt,
+    whose ``ToolStarted`` predates this process's subscription — the
+    projection's owner paints the one row afterwards
+    (``_paint_skipped_live_tool_rows``) and registers it with the event
+    controller, so it settles through the ordinary ``on_tool_ended`` path.
+    A COLD resume has no live turn, so ``executing_display_tool_ids()`` is
+    empty there and killed-mid-turn calls still render ``interrupted``
+    exactly as before.
     """
     from local_operator.tui.app import ImageContent, ToolCard, _first_line
     from local_operator.tui.widgets.tool_card import parse_duration
@@ -1026,13 +1061,15 @@ def replay_tool_call(
     else:
         # The snapshot the caller seeded for this projection first; a
         # ReplayTarget carrying the session itself (the app) falls back to
-        # asking the session directly, which is how a live call is still
-        # honoured on a path that never seeds the set.
+        # asking the session directly through the SAME subtracted question
+        # the seed uses, so a caller that never seeded cannot reopen the
+        # gate-parked-skip bug (a target with no session — a prepared
+        # presentation — answers nothing and mounts, which for a prepared
+        # tail the commit path repaints is the pre-existing behaviour).
         live_ids: set[str] = self._projection_live_call_ids
         if not live_ids:
             session = getattr(self, "_session", None)
-            executing = getattr(session, "executing_display_tool_ids", None)
-            live_ids = cast(set[str], executing()) if callable(executing) else set()
+            live_ids = live_projection_call_ids(session)
         if call_id in live_ids:
             # Record it, so the projection's owner can paint the ONE row for
             # this call when no live path is going to (a local resume: the

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -1477,6 +1477,16 @@ class ToolCard(ExpandableActionBlock):
         call finally starts.
         """
         self._stop_clock()
+        # A card restored onto the screen mid-execution (`restore(state="running")`)
+        # holds ``_started=None`` DELIBERATELY: no surface ever learned when
+        # the call began, so it refuses to invent an elapsed time. A re-delivered
+        # ``ToolStarted`` reaches exactly that card — `/resume` onto the running
+        # turn, or a switch away and back replaying the owner's live seed — and
+        # restarting the clock here would fabricate `0s` at arrival, tick from
+        # the RESUME instant, and settle the receipt to "time since the
+        # command" instead of the call's life. The withheld clock survives
+        # re-entry; only a card that can date itself restarts.
+        clockless = self._state == "running" and self._started is None
         # The name comes from the EXECUTION, not from the announcement. The first
         # compose event fires on the first name fragment — deliberately, so the
         # row appears immediately — and a provider that splits `write` into `wr`
@@ -1488,8 +1498,9 @@ class ToolCard(ExpandableActionBlock):
         # so a `write` that executed in 0.1s settled as `✓ 2.4s`, and on the
         # reported 1m41s case would have read `✓ 101s`. Two receipts on one
         # ledger would then be measuring different things with no way to tell
-        # which from the row.
-        self._started = time.monotonic()
+        # which from the row. Unless the clock was withheld (above): a
+        # clockless card has no zero to restart from.
+        self._started = None if clockless else time.monotonic()
         self._state = "running"
         # The same construction the constructor uses, so an adopted row is
         # byte-identical to one that had never been a composing row — including
@@ -1532,8 +1543,11 @@ class ToolCard(ExpandableActionBlock):
         # Without it the duration on a running row is painted once, at zero,
         # and then holds still for the whole call — which is the frame this
         # change exists to stop producing, since a timer that never moves is
-        # indistinguishable from a hung command.
-        self._start_clock()
+        # indistinguishable from a hung command. A clockless card starts no
+        # timer at all: its tick cannot paint a duration (see `_elapsed`) and
+        # would only burn a repaint per second.
+        if not clockless:
+            self._start_clock()
         self._refresh_row()
 
     def set_partial_detail(self, detail: str) -> None:

--- a/tests/unit/session/test_viewer_protocol.py
+++ b/tests/unit/session/test_viewer_protocol.py
@@ -203,7 +203,7 @@ _INFO_SESSION_EXPRS = frozenset({"session"})
 #: MEMBERS (and 363 of 414 ``file:line`` SITES, deduped per member and line), so
 #: any single global floor loose enough to survive ordinary churn there cannot
 #: notice a smaller host going dark at all. Measured, not guessed: dropping the
-#: desktop utils host costs 3 VIEWER-ONLY MEMBERS out of 49 and dropping
+#: desktop utils host costs 3 VIEWER-ONLY MEMBERS out of 47 and dropping
 #: ``info/collect.py`` costs 0, so both slid under a global ``>= 40`` — the exact
 #: slack review round 2 (MINOR-1) raised, reproduced one floor higher. A count
 #: stated beside each path fires on the host that actually decayed and names it.
@@ -629,7 +629,7 @@ def test_the_viewer_protocol_covers_what_only_the_facade_has() -> None:
     # 113 distinct public MEMBERS, so a number that survives ordinary churn
     # there is necessarily far above every other host's entire contribution.
     # Measured on this head — dropping the desktop utils host costs 3
-    # viewer-only members of 49, dropping ``info/collect.py`` costs 0 — so both
+    # viewer-only members of 47, dropping ``info/collect.py`` costs 0 — so both
     # single-point decays slid under a global ``>= 40`` exactly as they slid
     # under the ``>= 20`` that review round 2 (MINOR-1) rejected. Raising one
     # number would only move the blind spot. Each host is now asserted against
@@ -760,9 +760,15 @@ def test_app_py_dominates_the_derivation_so_a_global_floor_cannot_work() -> None
     # left the viewer-only population by becoming declared for both shapes.
     # That move is the fix for the inline ``/credential`` half-feature; a
     # LATER drop back to this figure would mean the word crept home again.
-    assert len(viewer_only) == 49, (
+    #
+    # 49 → 47 is the same shape of move, twice over: the live-tool-row resume
+    # work needs the pending/executing display ids on a LOCAL session too, so
+    # ``pending_display_tool_ids`` and ``executing_display_tool_ids`` moved
+    # onto ``SessionProtocol`` and both left the viewer-only population by
+    # becoming declared for both shapes.
+    assert len(viewer_only) == 47, (
         f"there are {len(viewer_only)} viewer-only members; _SCANNED's comment "
-        "says 49, and the aggregate floor is set at 40 against that number. A "
+        "says 47, and the aggregate floor is set at 40 against that number. A "
         "drop here is the decay that floor exists to catch, so check it is "
         "genuinely a removal before editing this figure."
     )
@@ -1047,7 +1053,7 @@ def test_every_registered_session_binding_still_matches_the_source() -> None:
 
     The count is pinned as well as the contribution, because the two decays are
     different and only one of them is a rename. DELETING ``source.session``
-    outright costs 2 of 49 viewer-only members — under any floor, per-host or
+    outright costs 2 of 47 viewer-only members — under any floor, per-host or
     aggregate, and invisible to the zero-sites check because a removed entry is
     not an entry that derives nothing. It was the last planted violation this
     guard did not catch. A registered binding is a coverage claim, so removing

--- a/tests/unit/tui/test_sidebar_live_tool_card.py
+++ b/tests/unit/tui/test_sidebar_live_tool_card.py
@@ -49,7 +49,13 @@ from typing import Any, cast
 
 import pytest
 
-from local_operator.harness.types import AgentTool, TextContent, ToolResult
+from local_operator.harness.types import (
+    AgentTool,
+    Message,
+    TextContent,
+    ToolCall,
+    ToolResult,
+)
 from local_operator.session.remote import RemoteSession
 from local_operator.session.runtime.owned import OwnedSessionHandle
 from local_operator.session.runtime.server import RuntimeServer
@@ -655,3 +661,188 @@ async def test_a_replayed_running_row_never_starts_its_clock() -> None:
         OperatorApp._paint_skipped_live_tool_rows(view, app._tool_cards, [_call("call-clock")])
         assert len(app._tool_cards) == 1
         assert len([b for b in view.blocks() if isinstance(b, ToolCard)]) == 1
+
+
+def _history_with_one_call(call_id: str, tool_name: str = PARKING_TOOL) -> list[Message]:
+    """A tail whose last assistant message asks for exactly one call.
+
+    The shape every live-projection test needs: the call has no result yet,
+    so whether the replay settles it, skips it, or the pending scan re-marks
+    it is exactly what each test asserts on.
+    """
+    return [
+        user_message("run the thing"),
+        Message(
+            role="assistant",
+            content=[TextContent(text="")],
+            tool_calls=[ToolCall(id=call_id, name=tool_name, arguments={"job_id": "j1"})],
+            stop_reason="toolUse",
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_gate_parked_call_keeps_its_waiting_row_on_a_live_projection() -> None:
+    """Round 1 MAJOR-1: the projection seed subtracts the pending set.
+
+    A turn parked at an approval gate is ALSO a streaming one, so both
+    live-id accessors answer with exactly the call the gate holds. Seeding
+    the skip set with the un-subtracted answer skipped that call out of the
+    replay, and the painter then showed it `running` while it waited on the
+    user — the documented "waiting wins" rule of `_mark_pending_tool_rows`
+    could not fire, because no replayed row existed to re-mark. The seed is
+    the gate-free set, so the held call takes the mount → `mark_waiting`
+    route that predates this PR.
+    """
+    from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+    class Gated(FakeSession):
+        """Both accessors answer with the held call: a gated turn is streaming."""
+
+        def pending_display_tool_ids(self) -> set[str]:
+            return {"call-gated"}
+
+        def executing_display_tool_ids(self) -> set[str]:
+            return {"call-gated"}
+
+    session = Gated()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await wait_for_adoption(app, pilot)
+        await pilot.pause()
+        app._session = session
+        app._project_settled_rows(_history_with_one_call("call-gated"))
+        cards = [b for b in app._transcript_view().blocks() if isinstance(b, ToolCard)]
+        assert len(cards) == 1, "one row for the held call, mounted by the replay"
+        assert cards[0]._state == "waiting"
+        assert "tool-running" not in cards[0].classes
+        # A waiting row owns no clock either: nothing started executing.
+        assert cards[0]._started is None
+
+
+@pytest.mark.asyncio
+async def test_a_painted_skipped_row_settles_success_through_the_controller() -> None:
+    """Round 1 Q-1: the adopt path registers the row it paints.
+
+    The skipped call's ToolStarted predates this process's subscription, so
+    the controller never knew the call: the real ToolEnded buffered as an
+    orphan and turn-end retirement stamped a genuinely successful call
+    `interrupted`. The projection now registers the painted ids with the
+    controller — the same seam the presentation-commit path uses — so the
+    end pairs with the painted card and the receipt reads success.
+    """
+    from local_operator.harness.types import ToolExecutionEndEvent, ToolResult
+    from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+    class Live(FakeSession):
+        def pending_display_tool_ids(self) -> set[str]:
+            return set()
+
+        def executing_display_tool_ids(self) -> set[str]:
+            return {"call-live"}
+
+    session = Live()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await wait_for_adoption(app, pilot)
+        await pilot.pause()
+        app._session = session
+        app._project_settled_rows(_history_with_one_call("call-live"))
+        card = app._tool_cards["call-live"]
+        assert card._state == "running"
+
+        # The end takes the route a real session's end takes: through the
+        # controller, not straight to the card. Registered at paint time, it
+        # pairs here instead of buffering behind a start nobody saw.
+        end = ToolExecutionEndEvent(
+            tool_call_id="call-live",
+            tool_name=PARKING_TOOL,
+            result=ToolResult(
+                tool_call_id="call-live",
+                tool_name=PARKING_TOOL,
+                content=[TextContent(text="The job finished.")],
+                duration_s=2.4,
+            ),
+            duration_s=2.4,
+        )
+        controller = app._controller
+        assert controller is not None
+        controller._on_event(end)
+        await pilot.pause()
+        await pilot.pause()
+
+        assert card._state == "success", "a real success must not read interrupted"
+        assert card._duration == 2.4, "the executor's measured interval is the receipt"
+        # Settled through the ordinary path: the registry released the card,
+        # so turn death has nothing left to retire as interrupted.
+        assert "call-live" not in app._tool_cards
+        assert app._retire_live_tool_cards() == 0
+
+
+@pytest.mark.asyncio
+async def test_a_re_delivered_start_never_rearms_the_withheld_clock() -> None:
+    """Round 1 U1/U2: re-entry preserves the withheld clock, settle stays honest.
+
+    `/resume` onto a parked turn, and a switch away and back, both re-deliver
+    the still-in-flight ToolStarted to the card the projection painted.
+    `begin_running` used to restart `_started` at that instant: `0s` on
+    arrival, a clock ticking from the RESUME, and a receipt settled to the
+    time since the command. A restored card cannot date itself, so the
+    re-entry must not arm a clock; the settle falls back to the executor's
+    measured interval — the only number that is about the call.
+    """
+    from local_operator.harness.types import (
+        ToolExecutionEndEvent,
+        ToolExecutionStartEvent,
+        ToolResult,
+    )
+    from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+    class Live(FakeSession):
+        def pending_display_tool_ids(self) -> set[str]:
+            return set()
+
+        def executing_display_tool_ids(self) -> set[str]:
+            return {"call-live"}
+
+    session = Live()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await wait_for_adoption(app, pilot)
+        await pilot.pause()
+        app._session = session
+        app._project_settled_rows(_history_with_one_call("call-live"))
+        card = app._tool_cards["call-live"]
+        assert card._state == "running"
+        assert card._started is None
+
+        # The re-delivered start — the exact re-entry `/resume` and a return
+        # visit produce when the owner's live seed replays through the
+        # controller.
+        controller = app._controller
+        assert controller is not None
+        controller._on_event(
+            ToolExecutionStartEvent(
+                tool_call_id="call-live",
+                tool_name=PARKING_TOOL,
+                args={"job_id": "j1"},
+            )
+        )
+        await pilot.pause()
+        await pilot.pause()
+
+        assert card._started is None, "re-entry must not date a card that cannot know"
+        assert card._elapsed() is None, "no elapsed time exists to paint or settle from"
+
+        end = ToolExecutionEndEvent(
+            tool_call_id="call-live",
+            tool_name=PARKING_TOOL,
+            result=ToolResult(tool_call_id="call-live", tool_name=PARKING_TOOL, duration_s=6.0),
+            duration_s=6.0,
+        )
+        controller._on_event(end)
+        await pilot.pause()
+        await pilot.pause()
+
+        assert card._state == "success"
+        assert card._duration == 6.0, "the measured interval, not time since re-delivery"

--- a/tests/unit/tui/test_sidebar_live_tool_card.py
+++ b/tests/unit/tui/test_sidebar_live_tool_card.py
@@ -44,6 +44,7 @@ import time
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -538,3 +539,119 @@ def test_a_clockless_running_row_reserves_the_settled_spine() -> None:
     # same ladder `waiting` uses one arm up.
     assert [text for text, _style in card._status_runs(cap=len(RUNNING_LABEL))] == [RUNNING_LABEL]
     assert [text for text, _style in card._status_runs(cap=len(RUNNING_LABEL) - 1)] == [""]
+
+
+# --- the resume-onto-a-running-turn duplicate --------------------------------
+#
+# The tests above cover the SIDEBAR: a conversation parked in a tool, switched
+# to, repainted live. The resume variant is one step further on and was a
+# separate defect: `/resume` (and `--resume`, and the owner-reconnect gap) run
+# the SAME projection against a session whose turn is in flight IN THIS
+# PROCESS. The replay then painted a second row for a call the running turn's
+# own events were already painting — two rows for one call, a "running N
+# tools" count that included the replayed ghost, and an `interrupted` stamp on
+# a call that had not stopped. The seam is `replay_tool_call`, so these pin it
+# there directly; the assembled path is covered by the frames on the MR.
+
+
+def _call(call_id: str, name: str = PARKING_TOOL) -> Any:
+    """One transcript tool-call record, the shape ``replay_tool_call`` reads."""
+
+    return SimpleNamespace(id=call_id, name=name, arguments={"job_id": "7a73c97ffc54"})
+
+
+@pytest.mark.asyncio
+async def test_a_replayed_live_call_is_not_doubled() -> None:
+    """A call live in this process mounts ONE row, and the band counts ONE.
+
+    The replay skips its settled row for an in-flight call so the live path
+    owns it; where no live path will paint (a local resume: the turn's
+    ToolStarted fired before this process subscribed), the projection's owner
+    paints the single row afterwards. Either way the call has exactly one
+    visible row and the working line's count reflects the one real call.
+    """
+    from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+    session = FakeSession()
+    session.streaming = True
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await wait_for_adoption(app, pilot)
+        await pilot.pause()
+        app._session = session
+
+        call = _call("call-live")
+        app._projection_live_call_ids = {"call-live"}
+        app._projection_skipped_live = []
+        app._replay_tool_call(call, {})
+        # The replay mounted nothing for the live call, and recorded it for
+        # the owner to paint.
+        assert app._projection_skipped_live == [call]
+        assert not [
+            b for b in app._transcript_view().blocks() if isinstance(b, ToolCard)
+        ], "the replay mounted a settled row beside the live one"
+
+        # The owner paints the one row, clock withheld, counted once.
+        app._paint_skipped_live_tool_rows(
+            app._transcript_view(), app._tool_cards, app._projection_skipped_live
+        )
+        cards = [b for b in app._transcript_view().blocks() if isinstance(b, ToolCard)]
+        assert len(cards) == 1, "a live call must have exactly one visible row"
+        assert cards[0]._state == "running"
+        assert cards[0]._started is None, "the painted row must not invent a start time"
+        assert len(app._tool_cards) == 1, "the working line must count one live tool"
+
+
+@pytest.mark.asyncio
+async def test_a_cold_resume_of_the_same_history_still_marks_interrupted() -> None:
+    """Nothing is live: the same unanswered call still renders interrupted.
+
+    The guard must not become "never paint interrupted" — a turn that really
+    died mid-flight is exactly the case the settled projection exists to
+    report, and an empty executing set is the cold-resume answer.
+    """
+    from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await wait_for_adoption(app, pilot)
+        await pilot.pause()
+
+        app._projection_live_call_ids = set()  # cold: no live turn
+        app._projection_skipped_live = []
+        app._replay_tool_call(_call("call-dead"), {})
+        cards = [b for b in app._transcript_view().blocks() if isinstance(b, ToolCard)]
+        assert len(cards) == 1
+        assert cards[0]._state == "interrupted", (
+            "a call from a turn that genuinely stopped was repainted live; "
+            "interrupted must remain its outcome"
+        )
+        assert app._projection_skipped_live == []
+
+
+@pytest.mark.asyncio
+async def test_a_replayed_running_row_never_starts_its_clock() -> None:
+    """A painted live row withholds its clock exactly as restore does.
+
+    The transcript carries no true start time for an in-flight call, so the
+    one row the owner paints must refuse to count from when it was painted —
+    the same guarantee `restore(state="running")` makes, pinned here on the
+    painter the projection path uses. Driven through the app's own view so
+    the mount is real.
+    """
+    from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await wait_for_adoption(app, pilot)
+        await pilot.pause()
+
+        view = app._transcript_view()
+        OperatorApp._paint_skipped_live_tool_rows(view, app._tool_cards, [_call("call-clock")])
+        card = app._tool_cards["call-clock"]
+        assert card._state == "running"
+        assert card._started is None
+        # One row per call: painting the same skipped call again is a no-op.
+        OperatorApp._paint_skipped_live_tool_rows(view, app._tool_cards, [_call("call-clock")])
+        assert len(app._tool_cards) == 1
+        assert len([b for b in view.blocks() if isinstance(b, ToolCard)]) == 1

--- a/tests/unit/tui/test_sidebar_live_tool_card.py
+++ b/tests/unit/tui/test_sidebar_live_tool_card.py
@@ -721,6 +721,61 @@ async def test_a_gate_parked_call_keeps_its_waiting_row_on_a_live_projection() -
 
 
 @pytest.mark.asyncio
+async def test_a_live_waiting_card_is_not_doubled_by_the_gated_projection() -> None:
+    """Round 2 Q-R2-1: the fold's mount consults the already-painted registry.
+
+    The MAJOR-1 test above drives a FakeSession whose gate answers WITHOUT any
+    live card ever mounted, so the fold's append is the only row and a double
+    mount cannot show. On the REAL path — ``/resume`` onto a gated turn, or a
+    sidebar switch back to one — the turn's own ``ToolStarted`` mounted a
+    clocked card during adoption, and the gate-free seed subtraction correctly
+    declines to skip the held call: the fold then appended a SECOND ``waiting``
+    row beside the live one, and ``_paint_skipped_live_tool_rows`` had nothing
+    to reconcile because the skip list was empty. The one-row rule the live-skip
+    arm enforces now covers this arm too: a call id with a card already on
+    screen mounts nothing, and the pending scan re-marks the EXISTING row.
+    """
+    from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+    class Gated(FakeSession):
+        """Both accessors answer with the held call: a gated turn is streaming."""
+
+        def pending_display_tool_ids(self) -> set[str]:
+            return {"call-gated"}
+
+        def executing_display_tool_ids(self) -> set[str]:
+            return {"call-gated"}
+
+    session = Gated()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await wait_for_adoption(app, pilot)
+        await pilot.pause()
+        app._session = session
+
+        # The live turn mounted its card when ToolStarted fired: clocked and
+        # registered, exactly as adoption leaves it when the projection runs.
+        live_card = ToolCard("call-gated", PARKING_TOOL, {"job_id": "j1"})
+        app._append_block(live_card)
+        app._tool_cards["call-gated"] = live_card
+
+        app._project_settled_rows(_history_with_one_call("call-gated"))
+        cards = [
+            b
+            for b in app._transcript_view().blocks()
+            if isinstance(b, ToolCard) and b.tool_call_id == "call-gated"
+        ]
+        assert len(cards) == 1, (
+            "the projection mounted a second row beside the live card — "
+            "one call has exactly one visible row on the gated path too"
+        )
+        assert cards[0] is live_card, "the surviving row must be the live one"
+        assert (
+            cards[0]._state == "waiting"
+        ), "the pending scan still owns the state correction: waiting, not running"
+
+
+@pytest.mark.asyncio
 async def test_a_painted_skipped_row_settles_success_through_the_controller() -> None:
     """Round 1 Q-1: the adopt path registers the row it paints.
 


### PR DESCRIPTION
## What and why

**C2 — `/resume` (and `--resume`, owner reconnect/durable-gap replay) onto a still-running turn painted two rows for one live tool call.** The operator's screenshot: two identical `wait 4200516337e3 2400000` rows, both `running`, and the working line saying `running 2 tools` for one real call. A replayed in-flight row also invented a ticking duration measured from paint time.

### Root cause

`project_settled_rows` / `replay_tool_call` treat every transcript `tool_calls` entry as settled history. That is correct for a **cold** resume (process died, nothing is live). The same projection also runs on paths where the session is **live** and the tail belongs to a turn still in flight. Those in-flight calls are simultaneously painted by the loop's own `ToolStarted` events (`OperatorApp.on_tool_started`). Result: two rows, one call.

There was a partial mitigation: `_mark_pending_tool_rows` re-marks replayed rows whose ids are in `pending_display_tool_ids()` / `executing_display_tool_ids()`. That accessor pair lived on `RemoteSession` only. Local `Session` had no such surface, so a local resume painted the duplicate.

Tool-call ids are stable. The transcript does **not** persist durations or the model's `i:` intent on the assistant message, so a replayed in-flight row cannot recover the live card's intent or true start time. The live row must own both.

### The invariant

**A tool call has exactly one visible row.** If that call is currently live in this process, the live row is the only row: replay either skips it or hands the row to the live path rather than mounting a second.

## The fix

1. Give local `Session` the same `pending_display_tool_ids` / `executing_display_tool_ids` surface the viewer already answers with. The one tail-scan (`unanswered_tail_call_ids` in `session/protocol.py`) is shared so both sides read the same conversation identically.
2. Seed each projection with the session's in-flight call ids. `replay_tool_call` skips the settled row for a live call, settles a result-backed call onto an already-painted card (`_settle_painted_tool_card`) instead of doubling it, and records the skip so the projection's owner paints the **one** row (clock withheld via `restore(state="running")`, registered as live) when no live path will paint it — the local-resume case, where the turn's `ToolStarted` fired before this process subscribed.
3. Cold resume is unchanged: an empty executing set leaves killed-mid-turn calls `interrupted`. The subagent panel was already correct (`AsyncJobManager.restore` downgrades persisted `running` rows to `interrupted`); not touched.

## Visual evidence

Real `OperatorApp` under Textual `run_test()`, stylesheet loaded, `scripts.visual_capture.save_capture`. Scripted provider issues a parking `await_job` that stays running; `/resume` onto that session while the call is live.

**Before** (origin/main): the in-flight call is replayed as `interrupted` with no live counterpart. The session is still streaming.

![Before: in-flight call replayed as interrupted](https://github.com/user-attachments/assets/336fa6c4-90d2-4d59-89c9-b2b209294a6c)

**After** (this branch): one `await_job … running` row, no fabricated duration, working line counts one.

![After: one running row, no fabricated duration](https://github.com/user-attachments/assets/19e146ea-59df-4d91-a254-feca292b01d1)

## Testing evidence

Targeted (the seam this PR owns):

```
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
  tests/unit/tui/test_sidebar_live_tool_card.py tests/unit/tui/test_session_sidebar.py -q
70 passed, 12 warnings in 33.85s
```

New tests in `test_sidebar_live_tool_card.py`:
- a replayed live call mounts **one** row and the working-line registry counts one
- a cold resume of the same unanswered call still paints `interrupted`
- a replayed running row never starts its clock (`_started is None`); painting the same skipped call twice is a no-op
- existing sidebar-switch live-row test still passes (prepare path collects the skipped live row into `replay.blocks` because the view is not mounted yet)

Gates (whole tree, as CI):

```
.venv/bin/python -m flake8 .                                          # clean
uvx --from black==26.1.0 black --check .                              # 1211 files unchanged
uvx isort==5.13.2 --check .                                           # skipped 2, clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .           # 0 errors
```

e2e (touches resume):

```
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
107 passed, 7 skipped, 6 warnings in 205.10s
```

Full `tests/unit` was run once in the background (~20 min budget). pytest lastfailed is empty after that run. Targeted + e2e + lint/type are the gates this PR is claiming.

## Notes

- No version bump. `pyproject.toml` is byte-identical to origin/main (`0.54.5`).
- Do not merge — reviewer and QA rounds run next.
- Not done: reconnect-gap visual frame (the skip + `_settle_painted_tool_card` reuse covers it in code; the captured frame is the local `/resume` path the user reported). Subagent panel left alone on purpose.
