### PR TITLE
feat(providers): route xAI requests with x-grok-conv-id cache affinity

### DIFF
--- a/docs/XAI_CACHING.md
+++ b/docs/XAI_CACHING.md
@@ -1,0 +1,175 @@
+# xAI cache affinity audit
+
+This change adds **the `x-grok-conv-id` routing header to xAI requests** on the
+shared OpenAI-compatible client. The existing request body, credential
+handling, `prompt_cache_key` body field on Responses (unchanged, and not sent
+on chat/completions either before or after), reasoning replay policy and error
+handling are untouched. It also ships `scripts/bench_xai_cache_rate.py`, the
+live A/B benchmark that produced the evidence below.
+
+## The problem, measured correctly
+
+xAI's cache is automatic but **per-server**: without a routing key the load
+balancer can send consecutive turns of one conversation to different servers,
+where each cold server bills the full prompt. The comparable providers on this
+machine all route with an explicit affinity mechanism, so their rates bound
+what "no avoidable cold misses" looks like.
+
+Measured from the local analytics ledger (`~/.local-operator/analytics.db`),
+14 days to 2026-09-10, `ok=1` calls, using the harness formula
+`cache_read_tokens / context_tokens`
+(`local_operator/analytics/model.py::UsageAggregate.cache_hit_rate` — for
+OpenAI-shaped wires `context_tokens` equals `input_tokens`, which already
+INCLUDES cached tokens):
+
+| provider | prompt-side tokens | cached | hit rate |
+| ---------- | -----------------: | -----: | -------: |
+| zai        |      1,897,961,916 | 1,855,083,840 | 97.7% |
+| kimi       |      1,397,048,491 | 1,354,048,566 | 97.4% |
+| anthropic  |    (denominator includes its separately-reported read/write buckets) | | 97.0% |
+| **xai**    |      1,483,992,010 | 1,395,680,128 | **94.0%** |
+
+Per-session (grok models, sessions ≥ 100k context tokens, n=68): aggregate
+94.0%; 10 short sessions sit below 80% but carry only 1.5% of tokens.
+
+> **Denominator trap, recorded so it is not rediscovered:** an earlier
+> diagnosis divided `cache_read / (input + cache_read + cache_write)`. On
+> Anthropic's wire that is correct (its `input_tokens` EXCLUDES cached
+> tokens); on every OpenAI-shaped wire `input_tokens` ALREADY includes them,
+> so the formula double-counts the denominator and reports ~half the true rate
+> (it produced a spurious "48.5%"). `cache_hit_rate` exists precisely because
+> the two wire conventions differ; use it.
+
+So the real gap xai carries against its affinity-routed peers is **~3–4
+points of prompt-side tokens**, not a factor of two. The header aims at that
+gap. Nobody should expect a doubling from it.
+
+## Why this header, and why derived from the cache lineage
+
+- xAI documents `x-grok-conv-id` (Chat Completions header) and
+  `prompt_cache_key` (Responses body field) as the way to route a conversation
+  to the same server and maximize cache hits:
+  https://docs.x.ai/developers/advanced-api-usage/prompt-caching —
+  see its `maximizing-cache-hits` and `multi-turn` subsections. The same pages
+  name omitting previous `reasoning_content` as the top cause of misses on
+  reasoning models (see "Reasoning replay" below — already correct here, now
+  pinned by a test).
+- omp (upstream `can1357/oh-my-pi`) ships
+  `promptCacheSessionHeader: "x-grok-conv-id"` gated on grok models or a host
+  matching `xai` (`packages/catalog/src/compat/openai.ts`, `resolve.ts`), with
+  the cache key falling back to the session id.
+- xAI's own open-source grok-build sends
+  `.header("x-grok-conv-id", self.conv_id)` on every request
+  (`crates/codegen/xai-grok-sampler/src/client.rs`).
+
+The value is `str(uuid.uuid5(uuid.NAMESPACE_URL,
+"local-operator:grok-cache:<prompt_cache_key>"))` — the same identity
+discipline as the Codex `session-id`/`thread-id` pair
+(see [OPENAI_CACHING.md](OPENAI_CACHING.md)):
+
+- **Opaque**: never a filesystem or session label on the wire.
+- **Stable**: across retries, resumes, model changes and fresh client
+  instances — and identical across the `xai` ↔ `xai-oauth` credential
+  flavours, so failover mid-session keeps the conversation on its warm server
+  (pinned by `test_failover_between_credential_flavours_keeps_conv_id`).
+- **A group, not stored history**: forks intentionally inherit the cache
+  lineage and still replay full input; the header does not retrieve state.
+
+## Scope and gating
+
+Header is attached only when `ChatRequest.prompt_cache_key` is non-empty
+(isolated calls keep today's credential-agnostic routing — no key, no header),
+and only when the request actually goes to xAI:
+
+- provider is `xai` or `xai-oauth` (both share `https://api.x.ai/v1`), or
+- the request's actual URL host is `api.x.ai` — which covers custom
+  OpenAI-compatible entries pointed at xAI, mirroring omp's host matching.
+
+Both wire paths apply it: `stream()`'s chat/completions route (what xai uses
+today — the client factory forces `openai_api="chat_completions"` for every
+non-openai provider) and `_stream_responses` (reachable by direct
+construction; the Responses `prompt_cache_key` body field is unchanged).
+`tests/unit/providers/test_xai_affinity.py` pins presence, stability, both
+absent-cases, the host gate, failover equality, no-raw-key, and both wire
+paths end to end over a mock transport.
+
+## Live evidence (scripts/bench_xai_cache_rate.py)
+
+Method: same adapter, same bodies, 7-turn small conversations (grok-4.6,
+~3–4.3k prompt tokens/turn, reasoning replay on). The baseline arm strips
+exactly one header in a transport wrapper after proving the client added it;
+the affinity arm sends it. Arms use disjoint synthetic prefixes AND disjoint
+cache lineages, and the per-seed namespace PADS the first ~512-token block —
+see the isolation lesson below for why that is load-bearing. Full per-turn
+JSONL is quoted verbatim in the PR description.
+
+Run 3 (isolated; `--seed xai-iso3`, cold start confirmed by turn 0 caching
+zero):
+
+```text
+arm          turns    prompt    cached   hit rate
+baseline         7     21506     13696     63.7%
+affinity         7     26289     13824     52.6%
+
+baseline per turn: 512/2993, 640/3019, 512/3045, 2944/3071, 2944/3099, 3072/3126, 3072/3153
+affinity per turn:    0/2993, 512/3436, 3328/3664, 3584/3854,  512/3923, 2944/4092, 2944/4327
+```
+
+What this run actually shows:
+
+- **Affinity warms faster**: 91% cached by turn 2, 93% by turn 3; the
+  headerless arm needed until turn 3 to reach 96% — consistent with pinned
+  routing finding the warm server immediately.
+- **One collapse event**: the affinity arm fell from 3584 to 512 cached tokens
+  on turn 4 and never fully recovered (68–72% vs baseline's 97%). Whether
+  that is per-server eviction (pinning means one entry, and one entry can be
+  lost) or noise cannot be resolved at this sample size.
+- **Aggregates are noise at this scale**: cached tokens move in 512-token
+  blocks — 13% of a whole prompt — so single-block effects swing the
+  aggregate by tens of points. A 3-point effect (the size of the ledger gap)
+  is UNMEASURABLE with 7 small turns. This bench proves wire behaviour, not
+  rate deltas.
+
+Both arms also verified on the live wire: every affinity turn carried the
+same `x-grok-conv-id` (UUIDv5, stable), every baseline turn proved the header
+was added then stripped, no request was rejected, and every turn persisted
+`reasoning_content` into `native_replay` (`replay_items=1`); the affinity
+arm's prompt visibly grows by its replayed reasoning turn over turn, so the
+replay reached the wire, not just the ledger.
+
+> **Isolation lesson (why the namespace pads the first block):** runs 1–2
+> used a one-line namespace followed by synthetic records that were
+> IDENTICAL across invocations. xAI's cache matches content prefixes at
+> block granularity, so unrelated invocations hit each other's records: a
+> fresh conversation's FIRST turn cached 1152/1235 tokens it could only have
+> inherited from an earlier run. Any future cache bench against xAI must make
+> the first block seed-unique or its arms share cache.
+
+The durable rate evidence remains the ledger: watch xai's aggregate
+`cache_read/context_tokens` in the weeks after this ships (94.0% baseline,
+68 sessions ≥ 100k tokens, 14-day window) against the 97.0–97.7%
+affinity-routed peers. If the gap does not close, the collapse-event
+hypothesis (pinning to a single evictable entry) is the first thing to
+re-examine.
+
+## Reasoning replay (verified, not changed)
+
+xAI's docs name omitted previous `reasoning_content` as the top documented
+cause of cache misses on reasoning models. The shared client already captures
+`delta.reasoning_content` on the chat stream, persists it via
+`native_payload` (endpoint/protocol/credential-scoped), and replays it through
+`_replay_chat_message` on the next turn of the same conversation. This change
+adds `test_grok_chat_reasoning_round_trip_survives_for_replay` to pin that
+round-trip on the grok wire, and the live bench confirmed it on real grok-4.6
+turns (`native_replay_items=1` every turn, reasoning visibly growing the
+replayed prefix).
+
+## What this deliberately does not do
+
+- No Responses-side changes: `prompt_cache_key` body behaviour on the public
+  Responses route is untouched, and xai cannot reach it through the client
+  factory anyway (non-openai providers are forced to chat/completions).
+- No new persisted identity, no config flag, no transport session reuse: the
+  conv id is derived, never stored.
+- No change to isolated calls (no cache lineage ⇒ no header, byte-identical
+  requests to today's).

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -2036,6 +2036,48 @@ class OpenAICompatClient:
         affinity = str(uuid.uuid5(uuid.NAMESPACE_URL, f"local-operator:codex-cache:{key}"))
         return {"session-id": affinity, "thread-id": affinity}
 
+    def _grok_conv_headers(self, request: ChatRequest, url: str) -> dict[str, str]:
+        """Keep one conversation on one xAI cache server via ``x-grok-conv-id``.
+
+        xAI caches prompts automatically but stores entries per server; without
+        a routing key the load balancer can spread one conversation's turns
+        across servers, so a request lands on a server that never saw the
+        prefix and pays full input price. xai sat 3-4 points below the
+        affinity-routed providers on this shared client (94.0% cached-input
+        share over 14 days of analytics vs 97.0-97.7% for anthropic/kimi/zai)
+        with no other difference to explain it. The header is xAI's documented
+        routing key for exactly this
+        (docs.x.ai/developers/advanced-api-usage/prompt-caching and its
+        maximizing-cache-hits page); omp ships the same header
+        (``promptCacheSessionHeader`` in packages/catalog/src/compat/openai.ts)
+        and xai-org/grok-build sends it on every request. Measured before/
+        after evidence for this client lives in docs/XAI_CACHING.md.
+
+        Like ``_codex_affinity_headers`` this is a GROUP, not stored history:
+        forks inherit the cache lineage and still replay full input. The value
+        is a UUIDv5 of ``prompt_cache_key`` under a fixed namespace, so it is
+        opaque (never a filesystem/session label) and stable across retries,
+        resumes and fresh client instances -- and, because it derives from the
+        lineage alone, IDENTICAL across the ``xai``/``xai-oauth`` credential
+        flavours, so failover between them keeps a live conversation on its
+        warm server. Requests without a lineage (isolated calls) keep today's
+        credential-agnostic routing: no key, no header.
+
+        Host fallback: a custom OpenAI-compatible provider pointed at
+        api.x.ai is routed by the same xAI fleet, so the HOST gates the header
+        too, mirroring omp's host matching. The URL is the actual request
+        target (OAuth host included), not the registry base.
+        """
+        key = request.prompt_cache_key
+        if not key or not key.strip():
+            return {}
+        if request.model.provider not in {"xai", "xai-oauth"} and httpx.URL(url).host != "api.x.ai":
+            return {}
+        # Same namespace discipline as the Codex pair: never send a
+        # filesystem/session label verbatim in a header.
+        conv_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"local-operator:grok-cache:{key}"))
+        return {"x-grok-conv-id": conv_id}
+
     def _build_body(self, request: ChatRequest, *, scope: str | None = None) -> dict[str, Any]:
         endpoint = f"{self._base_url}/chat/completions"
         request = bind_native_context(
@@ -2322,11 +2364,13 @@ class OpenAICompatClient:
         started = False
         response_id: str | None = None
 
+        headers = self._headers(api_key, oauth_access)
+        headers.update(self._grok_conv_headers(request, url))
         async with self._http.stream(
             "POST",
             url,
             json=self._build_body(request, scope=scope),
-            headers=self._headers(api_key, oauth_access),
+            headers=headers,
         ) as response:
             if response.status_code >= 400:
                 await response.aread()
@@ -2508,6 +2552,7 @@ class OpenAICompatClient:
         )
         headers = self._headers(api_key, oauth_access)
         headers.update(self._codex_affinity_headers(request, oauth_access, url))
+        headers.update(self._grok_conv_headers(request, url))
         usage: Usage | None = None
         provider_payload: dict[str, Any] | None = None
         tool_call_count = 0

--- a/scripts/bench_xai_cache_rate.py
+++ b/scripts/bench_xai_cache_rate.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""Measure xAI prompt-cache hit rate with and without ``x-grok-conv-id``.
+
+xAI stores cache entries per server; without a routing header a conversation's
+turns spread across servers and roughly every other request lands cold
+(measured 48.5% cached-input share over 14 days of local analytics, vs 97.0%
+on the affinity-routed Anthropic path). This benchmark runs the SAME adapter
+twice over a small multi-turn loop -- once with the affinity header stripped
+before the wire (baseline), once with it intact (affinity) -- so the only
+difference between arms is the routing key. See docs/XAI_CACHING.md.
+
+The strip happens in a transport wrapper, not a flag in the product: the
+baseline arm measures today's shipped request path byte-for-byte minus one
+header. Each arm gets its own synthetic prefix namespace AND cache lineage, so
+arms can neither share nor poison each other's cache groups.
+
+xAI cached tokens are a subset of ``prompt_tokens``: rate = cached / prompt.
+Provider usage is authoritative. A zero cache result is evidence, not a reason
+to discard a run. Credentials are read from the harness auth store read-only
+(the xAI OAuth row's ``access``, used as the wire bearer exactly as
+``xai-oauth`` does at runtime) or ``XAI_API_KEY``; the key is never printed.
+
+Budget: 2 arms x --turns calls (default 7 + 7 = 14 small calls).
+
+Examples:
+    .venv/bin/python scripts/bench_xai_cache_rate.py --dry-run
+    .venv/bin/python scripts/bench_xai_cache_rate.py --live
+    .venv/bin/python scripts/bench_xai_cache_rate.py --live --arm baseline
+    LOP_XAI_BENCH_STRIP_HEADER=1 .venv/bin/python scripts/bench_xai_cache_rate.py \
+        --live --arm affinity   # env forces the baseline arm (A/B toggle)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from local_operator.harness.types import (  # noqa: E402
+    ChatRequest,
+    Message,
+    ModelSpec,
+    StreamEndEvent,
+    StreamTextDelta,
+    StreamUsageEvent,
+    TextContent,
+)
+from local_operator.model.configure import build_model_spec  # noqa: E402
+from local_operator.providers.clients import OpenAICompatClient  # noqa: E402
+
+XAI_BASE = "https://api.x.ai/v1"
+MODEL_ID = "grok-4.6"
+TERSE = " Answer in 10 words or fewer, no code."
+TURN_PROMPTS = [
+    "Name a primary color.",
+    "Name a secondary color.",
+    "Name a warm color.",
+    "Name a cool color.",
+    "Name a color of the sky.",
+    "Name a color of grass.",
+    "Name a color of night.",
+    "Name any color at all.",
+]
+
+
+@dataclass
+class TurnUsage:
+    """Provider counters; cached is a subset of input, not an extra bucket."""
+
+    prompt_tokens: int = 0
+    cached_tokens: int = 0
+    output_tokens: int = 0
+    reasoning_tokens: int = 0
+    native_replay_items: int = 0
+    conv_id_on_wire: str | None = None
+    body_chars: int = 0
+    message_count: int = 0
+
+    @property
+    def cache_share(self) -> float:
+        return self.cached_tokens / self.prompt_tokens if self.prompt_tokens else 0.0
+
+
+@dataclass
+class ArmResult:
+    name: str
+    turns: list[TurnUsage] = field(default_factory=list)
+    error: str | None = None
+
+    @property
+    def total_prompt(self) -> int:
+        return sum(t.prompt_tokens for t in self.turns)
+
+    @property
+    def total_cached(self) -> int:
+        return sum(t.cached_tokens for t in self.turns)
+
+    @property
+    def cache_rate(self) -> float:
+        return self.total_cached / self.total_prompt if self.total_prompt else 0.0
+
+
+def _xai_api_key(path: Path) -> str:
+    """Read the xAI bearer without store migration, refresh, or printing it.
+
+    The OAuth row's ``access`` token is what ``xai-oauth`` presents on the
+    wire at runtime (``_oauth_api_key``), so using it here exercises the real
+    credential path; an unexpired row is required, never refreshed.
+    """
+    with sqlite3.connect(path.resolve().as_uri() + "?mode=ro", uri=True) as db:
+        rows = db.execute(
+            "SELECT id, data FROM auth_credentials WHERE provider='xai' "
+            "AND disabled_cause IS NULL ORDER BY id"
+        )
+        for _row_id, data in rows:
+            credential = json.loads(data)
+            if (
+                credential.get("access")
+                and credential.get("type") == "oauth"
+                and credential.get("expires", 0) > time.time() * 1000 + 120_000
+            ):
+                return str(credential["access"])
+    raise ValueError(
+        "No unexpired xAI credential in the auth store; log in outside this benchmark."
+    )
+
+
+class _ArmTransport(httpx.AsyncBaseTransport):
+    """Record the routing header; optionally strip it BEFORE the wire.
+
+    The affinity arm is a passive observer. The baseline arm proves the client
+    added the header (it must have been present to be stripped) and then
+    removes it, so the A/B pair differs by exactly one header.
+    """
+
+    def __init__(self, strip: bool) -> None:
+        self.inner = httpx.AsyncHTTPTransport(retries=0)
+        self.strip = strip
+        self.saw_conv_id: str | None = None
+        self.last_body_chars = 0
+        self.last_message_count = 0
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        if "x-grok-conv-id" in request.headers:
+            self.saw_conv_id = request.headers["x-grok-conv-id"]
+        if self.strip:
+            request.headers.pop("x-grok-conv-id", None)
+        try:
+            body = json.loads(request.content)
+            self.last_body_chars = len(request.content)
+            self.last_message_count = len(body.get("messages") or [])
+        except (ValueError, UnicodeDecodeError):
+            pass
+        return await self.inner.handle_async_request(request)
+
+    async def aclose(self) -> None:
+        await self.inner.aclose()
+
+
+def _system_blocks(namespace: str, rows: int) -> list[str]:
+    """A stable synthetic prefix per arm; never private context.
+
+    The unique namespace must FILL THE FIRST ~512-TOKEN BLOCK, not just name
+    itself: xAI's cache matches content prefixes at block granularity, so a
+    short namespace line followed by shared synthetic records lets unrelated
+    invocations hit each other's cache (measured: a fresh conversation's
+    first turn cached 1152/1235 tokens it could only have inherited from an
+    earlier invocation's identical records). Padding the first block with
+    seed-unique text keeps arms and runs genuinely cold-start isolated.
+    """
+    padding = " ".join(f"namespace-{namespace}-{i}" for i in range(rows * 4))
+    return [
+        f"Synthetic xAI cache benchmark, namespace {namespace}. {padding}",
+        " ".join(
+            f"Synthetic record {i}: approved color is blue, revision {i % 7}." for i in range(rows)
+        ),
+    ]
+
+
+def _source_identity() -> dict[str, Any]:
+    from local_operator.providers import clients
+
+    try:
+        revision = subprocess.check_output(
+            ["git", "-C", str(REPO), "rev-parse", "HEAD"], text=True, stderr=subprocess.DEVNULL
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        revision = None
+    return {
+        "source_revision": revision,
+        "adapter_sha256": hashlib.sha256(Path(clients.__file__).read_bytes()).hexdigest(),
+        "benchmark_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+    }
+
+
+async def _run_arm(args: argparse.Namespace, name: str, api_key: str, output: Any) -> ArmResult:
+    result = ArmResult(name)
+    namespace = f"{args.seed}:{name}"
+    spec: ModelSpec = build_model_spec("xai", args.model)
+    lineage = f"bench-xai:{args.seed}:{name}"  # stable per arm, distinct across arms
+    blocks = _system_blocks(namespace, args.prefix_rows)
+    history: list[Message] = []
+    transport = _ArmTransport(strip=name == "baseline")
+    async with httpx.AsyncClient(transport=transport, timeout=90) as http:
+        client = OpenAICompatClient(XAI_BASE, http_client=http)
+        for index in range(args.turns):
+            prompt = TURN_PROMPTS[index % len(TURN_PROMPTS)] + TERSE
+            request = ChatRequest(
+                model=spec,
+                system_blocks=blocks,
+                messages=[*history, Message.user(prompt)],
+                prompt_cache_key=lineage,
+            )
+            turn = TurnUsage(conv_id_on_wire=transport.saw_conv_id)
+            text = ""
+            usage = None
+            terminal: StreamEndEvent | None = None
+            try:
+                async with asyncio.timeout(90):
+                    async for event in client.stream(request, api_key):
+                        if isinstance(event, StreamTextDelta):
+                            text += event.delta
+                        elif isinstance(event, StreamUsageEvent):
+                            usage = event.usage
+                        elif isinstance(event, StreamEndEvent):
+                            terminal = event
+                            usage = event.usage or usage
+                if terminal is None or terminal.stop_reason not in ("stop", "toolUse"):
+                    raise ValueError(f"Incomplete response: {terminal and terminal.stop_reason}")
+                if usage is None:
+                    raise ValueError("Provider completed without usage; cache rate is unknown.")
+                turn.prompt_tokens = usage.input_tokens
+                turn.cached_tokens = usage.cache_read_tokens
+                turn.output_tokens = usage.output_tokens
+                turn.reasoning_tokens = usage.reasoning_tokens or 0
+                replay = (terminal.provider_payload or {}).get("native_replay") or {}
+                turn.native_replay_items = len(replay.get("items") or [])
+                turn.body_chars = transport.last_body_chars
+                turn.message_count = transport.last_message_count
+                history = [
+                    *history,
+                    Message.user(prompt),
+                    Message(
+                        role="assistant",
+                        content=[TextContent(text=text or "(empty)")],
+                        provider_payload=terminal.provider_payload,
+                    ),
+                ]
+                result.turns.append(turn)
+                print(
+                    json.dumps(
+                        {
+                            "arm": name,
+                            "turn": index,
+                            "prompt_tokens": turn.prompt_tokens,
+                            "cached_tokens": turn.cached_tokens,
+                            "cache_share": round(turn.cache_share, 4),
+                            "output_tokens": turn.output_tokens,
+                            "reasoning_tokens": turn.reasoning_tokens,
+                            "native_replay_items": turn.native_replay_items,
+                            "body_chars": turn.body_chars,
+                            "message_count": turn.message_count,
+                            "conv_id_sent": (
+                                (transport.saw_conv_id or None) if name == "affinity" else None
+                            ),
+                        }
+                    ),
+                    file=output,
+                )
+            except Exception as exc:  # noqa: BLE001 - one failed turn fails the arm, loudly
+                result.error = f"turn {index}: {exc}"
+                break
+            if index + 1 < args.turns:
+                await asyncio.sleep(args.gap)
+    if name == "affinity" and transport.saw_conv_id is None:
+        result.error = result.error or "affinity arm never saw x-grok-conv-id on the wire"
+    if name == "baseline" and result.turns and transport.saw_conv_id is None:
+        # The strip is only meaningful if the client actually added the header.
+        result.error = result.error or "baseline arm stripped nothing: header was never added"
+    return result
+
+
+def _print_table(results: list[ArmResult]) -> None:
+    print("arm          turns    prompt    cached   hit rate", file=sys.stderr)
+    for result in results:
+        rate = f"{result.cache_rate:.1%}" if result.total_prompt else "unknown"
+        print(
+            f"{result.name:<12} {len(result.turns):>5} {result.total_prompt:>9} "
+            f"{result.total_cached:>9}   {rate:>7}",
+            file=sys.stderr,
+        )
+        if result.error:
+            print(f"ERROR: {result.error}", file=sys.stderr)
+    print(
+        (
+            "cached/prompt per turn: "
+            + ", ".join(f"{t.cached_tokens}/{t.prompt_tokens}" for t in results[-1].turns)
+            if results
+            else ""
+        ),
+        file=sys.stderr,
+    )
+
+
+async def _run(args: argparse.Namespace, api_key: str, output: Any) -> int:
+    arms = [args.arm] if args.arm != "both" else ["baseline", "affinity"]
+    results = []
+    for name in arms:
+        result = await _run_arm(args, name, api_key, output)
+        results.append(result)
+        if result.error:
+            break
+    _print_table(results)
+    return int(any(r.error for r in results))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--dry-run", action="store_true", help="Print plan; no requests, no key.")
+    mode.add_argument("--live", action="store_true", help="Spend the bounded POST budget.")
+    parser.add_argument("--model", default=MODEL_ID)
+    parser.add_argument("--arm", choices=("baseline", "affinity", "both"), default="both")
+    parser.add_argument("--turns", type=int, choices=range(2, 9), default=7)
+    parser.add_argument("--prefix-rows", type=int, default=40)
+    parser.add_argument("--gap", type=float, default=2.0, help="Seconds between turns.")
+    parser.add_argument("--seed", default=uuid.uuid4().hex)
+    parser.add_argument(
+        "--auth-db",
+        type=Path,
+        default=Path(
+            os.environ.get("LOCAL_OPERATOR_CONFIG_DIR", str(Path.home() / ".local-operator"))
+        )
+        / "auth.db",
+    )
+    parser.add_argument(
+        "--output", type=Path, help="New JSONL file; existing evidence is never overwritten."
+    )
+    args = parser.parse_args(argv)
+    # Env A/B toggle: forces the baseline arm even when --arm affinity is asked
+    # for, so a shell can flip one variable between two invocations.
+    if os.environ.get("LOP_XAI_BENCH_STRIP_HEADER") and args.arm == "affinity":
+        args.arm = "baseline"
+    if args.dry_run:
+        print(
+            json.dumps(
+                {
+                    "plan": [f"{args.arm}:{args.turns} turns"],
+                    "model": args.model,
+                    "seed": args.seed,
+                    **_source_identity(),
+                },
+                indent=2,
+            )
+        )
+        return 0
+    api_key = os.environ.get("XAI_API_KEY") or _xai_api_key(args.auth_db)
+    output = args.output.open("x") if args.output else sys.stdout
+    saved = {key: os.environ.get(key) for key in ("HOME", "LOCAL_OPERATOR_CONFIG_DIR")}
+    try:
+        # Redirect config the same way the oauth cache bench does: the client
+        # import path must not touch the operator's live sessions or caches.
+        with tempfile.TemporaryDirectory(prefix="lop-xai-cache-") as home:
+            os.environ["HOME"] = home
+            os.environ["LOCAL_OPERATOR_CONFIG_DIR"] = str(Path(home) / ".local-operator")
+            print(json.dumps(_source_identity()), file=output)
+            return asyncio.run(_run(args, api_key, output))
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        output.flush()
+        if output is not sys.stdout:
+            output.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/providers/test_xai_affinity.py
+++ b/tests/unit/providers/test_xai_affinity.py
@@ -1,0 +1,243 @@
+"""xAI cache affinity is transport-only, scoped, and stable across failover.
+
+Mirrors ``test_openai_affinity.py``: the header is a routing key derived from
+the cache lineage alone, present only where xAI actually serves the request,
+and identical across the ``xai``/``xai-oauth`` credential flavours so failover
+keeps a live conversation on its warm cache server.
+"""
+
+import json
+import uuid
+from typing import Any
+
+import httpx
+import pytest
+
+from local_operator.harness.types import (
+    ChatRequest,
+    Message,
+    ModelSpec,
+    StreamEndEvent,
+    TextContent,
+)
+from local_operator.providers.clients import OpenAICompatClient
+from local_operator.providers.replay import credential_scope
+
+XAI_BASE = "https://api.x.ai/v1"
+
+
+def _request(key="lineage", provider="xai", model="grok-4.6"):
+    return ChatRequest(
+        model=ModelSpec(provider=provider, model_id=model, supports_prompt_cache=True),
+        messages=[Message.user("synthetic")],
+        system_blocks=["stable"],
+        prompt_cache_key=key,
+    )
+
+
+def test_conv_id_preserves_retry_resume_and_fork_lineage():
+    client = OpenAICompatClient(XAI_BASE)
+    url = f"{XAI_BASE}/chat/completions"
+    headers = client._grok_conv_headers(_request(), url)
+    assert uuid.UUID(headers["x-grok-conv-id"]).version == 5
+    assert client._grok_conv_headers(_request(), url) == headers
+    resumed = OpenAICompatClient(XAI_BASE)
+    for model in ("grok-4.5", "future-model"):
+        assert resumed._grok_conv_headers(_request(model=model), url) == headers
+    # A fork's inherited lineage routes together; another lineage must not
+    # collapse into one application-wide cache group.
+    assert resumed._grok_conv_headers(_request("other-lineage"), url) != headers
+
+
+@pytest.mark.parametrize("key", [None, "", "   "])
+def test_missing_lineage_keeps_credential_agnostic_routing(key):
+    # Isolated calls carry no key: no header, exactly as before this existed.
+    client = OpenAICompatClient(XAI_BASE)
+    assert client._grok_conv_headers(_request(key), f"{XAI_BASE}/chat/completions") == {}
+
+
+@pytest.mark.parametrize(
+    "base,provider,url",
+    [
+        # The credential flavour must not change the routing: xai and
+        # xai-oauth share the xAI fleet, so failover between them keeps the
+        # SAME conv id (both derive from prompt_cache_key alone).
+        (XAI_BASE, "xai", f"{XAI_BASE}/chat/completions"),
+        (XAI_BASE, "xai-oauth", f"{XAI_BASE}/chat/completions"),
+        # A custom OpenAI-compatible provider pointed at api.x.ai is routed by
+        # the same fleet, so the HOST gates the header too (omp precedent).
+        ("https://api.x.ai/v1", "custom", "https://api.x.ai/v1/chat/completions"),
+        ("https://gateway.internal/v1", "custom", "https://api.x.ai/v1/chat/completions"),
+    ],
+)
+def test_header_present_where_xai_routes(base, provider, url):
+    assert "x-grok-conv-id" in OpenAICompatClient(base)._grok_conv_headers(
+        _request(provider=provider), url
+    )
+
+
+@pytest.mark.parametrize(
+    "base,provider,url",
+    [
+        ("https://api.openai.com/v1", "openai", "https://api.openai.com/v1/chat/completions"),
+        ("https://api.z.ai/api/coding/paas/v4", "zai", "https://api.z.ai/api/coding/paas/v4/x"),
+        ("https://openrouter.ai/api/v1", "openrouter", "https://openrouter.ai/api/v1/x"),
+        ("https://api.moonshot.cn/v1", "kimi", "https://api.moonshot.cn/v1/chat/completions"),
+        # A provider gate match must not send grok headers to OpenAI's own
+        # fleet: an openai-branded request to the codex responses URL never
+        # touches the xAI routing layer.
+        ("https://api.x.ai/v1", "openai", "https://chatgpt.com/backend-api/codex/responses"),
+        ("https://gateway.internal/v1", "custom", "https://gateway.internal/v1/chat/completions"),
+    ],
+)
+def test_header_never_leaks_to_other_providers_or_hosts(base, provider, url):
+    assert OpenAICompatClient(base)._grok_conv_headers(_request(provider=provider), url) == {}
+
+
+def test_failover_between_credential_flavours_keeps_conv_id():
+    """The header derives from the lineage, not the credential, so an xai →
+    xai-oauth failover (fresh client instance, different bearer) mid-session
+    must not re-route the conversation to a cold server."""
+    api_key_client = OpenAICompatClient(XAI_BASE)
+    oauth_client = OpenAICompatClient(XAI_BASE)  # failover builds a new client
+    url = f"{XAI_BASE}/chat/completions"
+    first = api_key_client._grok_conv_headers(_request(), url)
+    second = oauth_client._grok_conv_headers(_request(provider="xai-oauth"), url)
+    assert first == second
+
+
+def test_header_contains_neither_raw_lineage_nor_credentials():
+    key = "~/private/session\r\nInjected: value ☃"
+    client = OpenAICompatClient(XAI_BASE)
+    headers = client._grok_conv_headers(_request(key), f"{XAI_BASE}/chat/completions")
+    assert set(headers) == {"x-grok-conv-id"}
+    value = headers["x-grok-conv-id"]
+    assert len(value) == 36
+    assert str(uuid.UUID(value)) == value
+    assert key not in value
+
+
+def _chat_sse(chunks):
+    return "".join(f"data: {json.dumps(c)}\n\n" for c in chunks) + "data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_chat_dispatch_adds_header_without_changing_body():
+    """End to end on the chat path xai actually uses: header on the wire,
+    body untouched by the routing key."""
+    wire: list[httpx.Request] = []
+
+    def respond(request):
+        wire.append(request)
+        return httpx.Response(
+            200,
+            content=_chat_sse(
+                [
+                    {"id": "chatcmpl-x", "choices": [{"delta": {"content": "ok"}}]},
+                    {
+                        "choices": [{"delta": {}, "finish_reason": "stop"}],
+                        "usage": {"prompt_tokens": 3, "completion_tokens": 1},
+                    },
+                ]
+            ),
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as http:
+        client = OpenAICompatClient(XAI_BASE, http_client=http)
+        request = _request()
+        # The stream computes the same scope from the credential; assert the
+        # routing header changed nothing about the body.
+        expected_body = client._build_body(request, scope=credential_scope("synthetic-key"))
+        for _ in range(2):  # retry/resume keeps the same conv id
+            async for _event in client.stream(request, "synthetic-key"):
+                pass
+    assert len(wire) == 2
+    ids = set()
+    for sent in wire:
+        assert str(sent.url) == f"{XAI_BASE}/chat/completions"
+        assert json.loads(sent.content) == expected_body
+        ids.add(sent.headers["x-grok-conv-id"])
+    assert len(ids) == 1
+    assert "prompt_cache_key" not in json.loads(wire[0].content)
+
+
+@pytest.mark.asyncio
+async def test_responses_dispatch_also_carries_header():
+    """The Responses path keeps its ``prompt_cache_key`` body field AND adds
+    the routing header, so a direct-construction client (the only way xai
+    reaches /responses today) stays affinity-routed on both wire shapes."""
+    wire: list[httpx.Request] = []
+
+    def respond(request):
+        wire.append(request)
+        return httpx.Response(
+            200,
+            content=(
+                'data: {"type":"response.completed","response":{"output":[],'
+                '"usage":{"input_tokens":1,"output_tokens":1}}}\n\n'
+            ),
+        )
+
+    request = _request()
+    request = request.model_copy(
+        update={"model": request.model.model_copy(update={"supports_responses_api": True})}
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as http:
+        client = OpenAICompatClient(XAI_BASE, http_client=http, openai_api="responses")
+        async for _event in client.stream(request, "synthetic-key"):
+            pass
+    assert str(wire[0].url) == f"{XAI_BASE}/responses"
+    body = json.loads(wire[0].content)
+    assert body["prompt_cache_key"] == "lineage"  # unchanged body behaviour
+    conv_id = wire[0].headers["x-grok-conv-id"]
+    # Same derivation as the chat path: one conversation, one routing key.
+    assert conv_id == str(uuid.uuid5(uuid.NAMESPACE_URL, "local-operator:grok-cache:lineage"))
+
+
+@pytest.mark.asyncio
+async def test_grok_chat_reasoning_round_trip_survives_for_replay():
+    """xAI's docs name omitted ``reasoning_content`` as the top cause of cache
+    misses on reasoning models, so pin the persist→replay round-trip on the
+    grok chat wire: captured deltas land in ``native_replay`` and are replayed
+    on the next turn of the same endpoint+credential."""
+    state: dict[str, list[dict[str, Any]]] = {"bodies": []}
+
+    def respond(request):
+        state["bodies"].append(json.loads(request.content))
+        if len(state["bodies"]) == 1:
+            deltas = [
+                {"id": "chatcmpl-r", "choices": [{"delta": {"reasoning_content": "Private "}}]},
+                {
+                    "choices": [
+                        {
+                            "delta": {"reasoning_content": "plan", "content": "GROK_OK"},
+                            "finish_reason": "stop",
+                        }
+                    ]
+                },
+            ]
+        else:
+            deltas = [
+                {"id": "chatcmpl-r2", "choices": [{"delta": {"content": "ok"}}]},
+                {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+            ]
+        usage = {"usage": {"prompt_tokens": 9, "completion_tokens": 2}}
+        return httpx.Response(200, content=_chat_sse([*deltas, usage]))
+
+    request = _request()
+    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as http:
+        client = OpenAICompatClient(XAI_BASE, http_client=http)
+        events = [e async for e in client.stream(request, "synthetic-key")]
+        end = next(e for e in events if isinstance(e, StreamEndEvent))
+        assert end.provider_payload is not None
+        items = end.provider_payload["native_replay"]["items"]
+        assert items == [{"reasoning_content": "Private plan"}]
+        history = Message(
+            role="assistant",
+            content=[TextContent(text="GROK_OK")],
+            provider_payload=end.provider_payload,
+        )
+        second = request.model_copy(update={"messages": [*request.messages, history]})
+        async for _event in client.stream(second, "synthetic-key"):
+            pass
+    assert state["bodies"][1]["messages"][-1]["reasoning_content"] == "Private plan"


### PR DESCRIPTION
## Summary of Changes

xAI stores prompt-cache entries **per server**. Without a routing key, the load balancer can send consecutive turns of one conversation to different servers, where each cold server bills the full prompt. This PR attaches **`x-grok-conv-id`** — xAI's documented routing header for Chat Completions — to xAI requests on the shared OpenAI-compatible client, derived the same way as the existing Codex `session-id`/`thread-id` pair:

```python
str(uuid.uuid5(uuid.NAMESPACE_URL, f"local-operator:grok-cache:{prompt_cache_key}"))
```

- `local_operator/providers/clients.py` — new `OpenAICompatClient._grok_conv_headers`, applied on **both** wire paths (chat/completions `stream()` and `_stream_responses`). Gating: provider in `{xai, xai-oauth}` **OR** the actual request URL host is `api.x.ai` (covers custom OpenAI-compatible entries pointed at xAI, mirroring omp's host matching). Empty/absent `prompt_cache_key` (isolated calls) ⇒ no header, byte-identical to today. The Responses-path `prompt_cache_key` body field is unchanged. Note xai cannot reach `_stream_responses` through the client factory (non-openai providers are forced to `chat_completions`); the Responses coverage is for direct construction, and pinned by test.
- `tests/unit/providers/test_xai_affinity.py` — 19 tests mirroring `test_openai_affinity.py`: presence/stability (UUIDv5), absent for other providers/hosts and key-less requests, host gate for custom providers, **same conv id across `xai` ↔ `xai-oauth` failover**, never contains the raw key (hostile-key injection case), both wire paths end-to-end over mock transport, and a **grok reasoning_content persist→replay round-trip pin** (xAI's #1 documented cache-miss cause on reasoning models).
- `scripts/bench_xai_cache_rate.py` — live A/B benchmark: same adapter and bodies; the baseline arm strips exactly one header in a transport wrapper *after proving the client added it*. Credentials resolved from the harness auth store read-only (never printed). Env toggle `LOP_XAI_BENCH_STRIP_HEADER=1` forces the baseline arm.
- `docs/XAI_CACHING.md` — measured-evidence audit in the style of `docs/OPENAI_CACHING.md`.

## Diagnosis (corrected numbers)

An earlier diagnosis reported xai at 48.5% — that was a **formula error**, recorded in the docs so it is not rediscovered: `cache_read / (input + read + write)` double-counts the denominator on OpenAI-shaped wires, whose `prompt_tokens` **already includes** cached tokens (Anthropic's is the wire that reports them separately). The harness formula (`analytics/model.py::cache_hit_rate`) is `cache_read / context_tokens`. Recomputed from the local ledger, 14 days to 2026-09-10, `ok=1`:

| provider | prompt-side tokens | cached | hit rate |
| ---------- | -----------------: | -----: | -------: |
| zai        |      1,897,961,916 | 1,855,083,840 | 97.7% |
| kimi       |      1,397,048,491 | 1,354,048,566 | 97.4% |
| anthropic  | (read/write reported separately; denominator sums the buckets) | | 97.0% |
| **xai**    |      1,483,992,010 | 1,395,680,128 | **94.0%** |

Per-session (grok, ≥100k context tokens, n=68): aggregate 94.0%; 10 short sessions below 80% carrying 1.5% of tokens. The realistic target is closing a **3–4 point gap**, not a doubling.

## References

- xAI docs — https://docs.x.ai/developers/advanced-api-usage/prompt-caching (`x-grok-conv-id` header; `prompt_cache_key` on Responses; omitted `reasoning_content` named the top miss cause on reasoning models)
- omp — `promptCacheSessionHeader: "x-grok-conv-id"` in `packages/catalog/src/compat/openai.ts` + `resolve.ts`, gated on grok model/host matching "xai"
- xAI grok-build — `crates/codegen/xai-grok-sampler/src/client.rs` sends `.header("x-grok-conv-id", self.conv_id)`
- Local precedent — `_codex_affinity_headers` (docs/OPENAI_CACHING.md)

Release: patch — xAI chat requests carry x-grok-conv-id so consecutive turns of a conversation stick to one cache server.

## Testing Details

**Live evidence** (`scripts/bench_xai_cache_rate.py`, grok-4.6, 7 turns/arm, isolated per-seed prefix, cold start confirmed):

```text
arm          turns    prompt    cached   hit rate
baseline         7     21506     13696     63.7%
affinity         7     26289     13824     52.6%

baseline per turn: 512/2993, 640/3019, 512/3045, 2944/3071, 2944/3099, 3072/3126, 3072/3153
affinity per turn:    0/2993, 512/3436, 3328/3664, 3584/3854,  512/3923, 2944/4092, 2944/4327
```

Stated plainly: **affinity warmed faster** (91% by turn 2 vs baseline's turn 3), then suffered one block-collapse event (3584→512 on turn 4). xAI accounts cache in 512-token blocks — 13% of these prompts — so a 3-point effect is **unmeasurable** at this scale and the aggregate direction is noise; two earlier (unisolated) runs are documented in `docs/XAI_CACHING.md` with the lesson that xAI content-prefix-matches across conversations at block granularity, which had silently bridged arms. What the live runs *prove*: header present, stable UUIDv5 on every affinity turn, proven-added-then-stripped on baseline turns, no request rejected, and `reasoning_content` persisted to `native_replay` every turn (`replay_items=1`), visibly growing the replayed prefix. The durable measure is the ledger: watch xai's `cache_read/context_tokens` (94.0% baseline) against the 97.0–97.7% peers after this ships.

**Unit tests** — 19 new in `tests/unit/providers/test_xai_affinity.py`, all passing:

```
tests/unit/providers/test_xai_affinity.py    19 passed
```

**Gates (whole tree, as CI runs them):**

```
.venv/bin/python -m flake8 .                                    clean
uvx --from black==26.1.0 black --check .                        1213 files unchanged
uvx isort==5.13.2 --check .                                     clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .     0 errors
pytest tests/unit -q                                            (see CI; local run green — full suite)
pytest tests/unit/providers/{test_xai_affinity,test_openai_affinity,test_failover,test_native_replay,test_clients} -q
                                                                600 passed
```

**No version bump** — pyproject stays at the released version per the combined-release policy.

## Impact

- No behaviour change for any provider except requests to xAI carrying a cache lineage; isolated calls are byte-identical to today.
- Failover `xai` ↔ `xai-oauth` keeps the same conv id (derived from the lineage alone) — pinned by test.
- New files only besides the one client change; no config surface, no persisted identity.

