### PR TITLE
refactor(session): rename the declared owner_* members to runtime_*

### DIFF
--- a/docs/design-build-skew.md
+++ b/docs/design-build-skew.md
@@ -311,8 +311,8 @@ one comparison at bind is complete.)
   (coder: confirm `RecordPublisher` rewrites from the live record object, and
   pin it in a test).
 - `local_operator/session/remote.py` — at bind, stash the owner's stamp on
-  the facade: `self.owner_version = record.version`,
-  `self.owner_source_ref = record.source_ref` in `_bind_to` (and the
+  the facade: `self.runtime_version = record.version`,
+  `self.runtime_source_ref = record.source_ref` in `_bind_to` (and the
   equivalent in `connect`).
 - `local_operator/tui/app.py` — compare and warn (§4.3).
 - `local_operator/cli.py` — `lop sessions --json` rows gain `"version"` and
@@ -335,14 +335,14 @@ loaded". Debounce state: `self._skew_notice_shown: set[tuple]`.
    - **A (disk drift):** `update.installed_build() != self._loaded_build` →
      warning notice (copy below).
    - **C (owner skew):** if the adopted session is already attached and
-     exposes `owner_version`, compare with `self._loaded_build`. An empty
-     `owner_version` means the runtime predates the field, i.e. it is older
+     exposes `runtime_version`, compare with `self._loaded_build`. An empty
+     `runtime_version` means the runtime predates the field, i.e. it is older
      than this window by construction — warn once per session with the
      absent-version copy.
 2. `_start_runtime_engage` (`app.py:8848`) and the success tail of
    `_bind_then_dispatch` (`app.py:9004`) — re-check A immediately before a
    spawn, and re-check C after a fresh bind (`ensure()` resolved
-   `owner_version`). Both are debounced, so the mount engage, the draft
+   `runtime_version`). Both are debounced, so the mount engage, the draft
    warm-up, and the slash-command engage cost one comparison each and paint at
    most one notice per distinct (kind, from, to, scope) key — scope being the
    session id for the owner notices and empty for disk drift, which is a fact
@@ -442,7 +442,7 @@ Unit — TUI (new `tests/unit/tui/test_build_skew.py`, plus one audit edit):
 10. Drift: monkeypatch `installed_build` to a new token after app init →
     `_adopt_session`/engage posts exactly one warning naming both builds and
     `/reload`; a second adopt with the same token posts nothing (debounce).
-11. Owner skew: facade with `owner_version` older/absent → the C notice with
+11. Owner skew: facade with `runtime_version` older/absent → the C notice with
     `/stop` copy; matching version → silence.
 12. Renderer: `noop {"type": "team_mutate"}` → warning notice, no exception,
     no submit; `team_attached` with request on a normal session still calls

--- a/docs/design-runtime-autorefresh.md
+++ b/docs/design-runtime-autorefresh.md
@@ -30,7 +30,7 @@ whose disk had been 0.49.9@f4a70b99 since ~05:00: `lop --resume a6a8186ea42d`
 at record construction (`server.py:411-443`), and never again.
 
 The only thing that notices is the *viewer*: `OperatorApp._check_build_skew`
-(`tui/app.py:14870-15011`) compares `owner_version/owner_source_ref` off the
+(`tui/app.py:14870-15011`) compares `runtime_version/runtime_source_ref` off the
 record with its own `_loaded_build` and paints notice C —
 `“<name>” is running 0.49.8@46a4e9b but this window is 0.49.9@f4a70b99 — some
 commands may not work. /stop, then send again to restart it.` — at
@@ -481,7 +481,7 @@ viewer never waits on a runtime that is "about to" leave.
 | `session/runtime/process.py` | `BUILD_CHECK_S/SETTLE_S/STAGGER_S`; `_build_changed`; reaper refresh branch |
 | `session/runtime/server.py` | `_boot_build`; `announce_retiring`; `refresh_if_idle` op; heartbeat republishes busy |
 | `mobile/attach_client.py` | `RETIRING_REASON`; `retiring` op in `_pump`; `request_refresh()` |
-| `session/remote.py` | `_on_disconnected` refresh branch; `_go_cold(refresh=)`; `set_refresh_callback`; `request_refresh()`; `owner_idle` helper |
+| `session/remote.py` | `_on_disconnected` refresh branch; `_go_cold(refresh=)`; `set_refresh_callback`; `request_refresh()`; `runtime_idle` helper |
 | `tui/app.py` | `_on_runtime_refreshed`; `_check_build_skew` C→C′ + belt; copy |
 | `update.py` | `build_marker_age_s()` (mtime of `.lop-source` or dist-info) |
 | `cli.py` | nothing (record fields unchanged) |

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -636,20 +636,20 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
     #: dial. ``""`` on a facade that has never bound AND on one bound to a
     #: runtime older than the field; hosts distinguish those by ``is_cold``,
     #: not by this value.
-    owner_version: str
-    #: The source ref of that build, same lifecycle as ``owner_version``.
-    owner_source_ref: str
+    runtime_version: str
+    #: The source ref of that build, same lifecycle as ``runtime_version``.
+    runtime_source_ref: str
     #: Why this viewer opened WITHOUT live state, when that was not the
     #: ordinary "no runtime was running" case. ``""`` when it was ordinary.
     degraded_reason: str
     #: Whether the saved preview this viewer opened against was partial.
     saved_preview_partial: bool
 
-    def owner_idle(self) -> bool:
+    def runtime_idle(self) -> bool:
         """Whether the runtime reports no turn in flight."""
         ...
 
-    def owner_model_catalogue(self) -> list[dict[str, Any]]:
+    def runtime_model_catalogue(self) -> list[dict[str, Any]]:
         """The model catalogue as the RUNTIME resolves it.
 
         A viewer must not answer from its own machine's catalogue: the runtime

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -594,8 +594,8 @@ class RemoteSession:
         #: those two the same way (it has no build to compare against) and
         #: distinguishes them by whether the facade is cold, not by this
         #: value. See ``app.py::_check_build_skew``.
-        self.owner_version: str = ""
-        self.owner_source_ref: str = ""
+        self.runtime_version: str = ""
+        self.runtime_source_ref: str = ""
         #: Why this viewer opened WITHOUT live state, when that was not the
         #: ordinary "no runtime was running" case. Set by the launcher when an
         #: attach to a live runtime failed and it fell back to cold; the TUI
@@ -1793,13 +1793,13 @@ class RemoteSession:
             self._cwd = cwd
             self._repoint_armed_wakes(cwd)
             return "cold"
-        # ``owner_idle`` is the SAME reading the build-refresh seam uses, and
+        # ``runtime_idle`` is the SAME reading the build-refresh seam uses, and
         # it already covers every term that matters here — streaming, a parked
         # approval/ask gate, and a running background job — so this asks one
         # question rather than reassembling the predicate and drifting from it.
         # The runtime re-checks on its own side anyway (``may_refresh``): a
         # retire that races work arriving is refused there and surfaces below.
-        if not self.owner_idle():
+        if not self.runtime_idle():
             raise RuntimeError(
                 "this session is working right now — /move again when the turn finishes"
             )
@@ -2318,8 +2318,8 @@ class RemoteSession:
         # compares these with its own build and names the skew (see
         # ``app.py::_check_build_skew``); nothing here decides anything, so a
         # missing stamp degrades to "unknown", never to a refused attach.
-        self.owner_version = getattr(record, "version", "") or ""
-        self.owner_source_ref = getattr(record, "source_ref", "") or ""
+        self.runtime_version = getattr(record, "version", "") or ""
+        self.runtime_source_ref = getattr(record, "source_ref", "") or ""
         # The runtime's working directory, kept so a viewer that was ATTACHED
         # (``connect``, the `lop --resume` path) can engage a successor after
         # its owner retires for a refresh. Only ``cold()`` used to set ``_cwd``;
@@ -4139,7 +4139,7 @@ class RemoteSession:
         """
         self._refresh_callback = callback
 
-    def owner_idle(self) -> bool:
+    def runtime_idle(self) -> bool:
         """Whether the bound runtime is doing nothing a refresh would lose.
 
         Read off the canonical snapshot rather than asked over the wire, so
@@ -5551,7 +5551,7 @@ class RemoteSession:
             if row.type == "task" and row.status == "running" and not row.queued
         )
 
-    def owner_model_catalogue(self) -> list[dict[str, Any]]:
+    def runtime_model_catalogue(self) -> list[dict[str, Any]]:
         """The owner's offerable model rows, as published canonical state.
 
         A follower's own provider controller describes the follower's

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -14215,14 +14215,14 @@ class OperatorApp(App[None]):
         """
         logger.debug("runtime retired for a newer build; re-engaging")
         session = self._session
-        version = str(getattr(session, "owner_version", "") or "")
+        version = str(getattr(session, "runtime_version", "") or "")
         if version:
             from local_operator.update import BuildStamp
 
             self._refreshed_from = (
                 BuildStamp(
                     version=version,
-                    source_ref=str(getattr(session, "owner_source_ref", "") or ""),
+                    source_ref=str(getattr(session, "runtime_source_ref", "") or ""),
                 ),
                 _session_subject(session),
                 # WHICH session retired. The subject alone cannot answer this:
@@ -14298,14 +14298,14 @@ class OperatorApp(App[None]):
                 getattr(session, "session_id", "") or "<none>",
             )
             return
-        version = str(getattr(session, "owner_version", "") or "")
+        version = str(getattr(session, "runtime_version", "") or "")
         if not version:
             return
         from local_operator.update import BuildStamp
 
         after = BuildStamp(
             version=version,
-            source_ref=str(getattr(session, "owner_source_ref", "") or ""),
+            source_ref=str(getattr(session, "runtime_source_ref", "") or ""),
         )
         if after == before:
             return
@@ -14623,7 +14623,7 @@ class OperatorApp(App[None]):
                     "warning",
                 )
                 return
-            # The bind resolved, so ``owner_version`` now holds the runtime's
+            # The bind resolved, so ``runtime_version`` now holds the runtime's
             # own stamp: this is the first moment the owner-skew comparison
             # has anything to compare. Before the command runs, because a
             # routed command is exactly what skew distorts.
@@ -23357,8 +23357,8 @@ class OperatorApp(App[None]):
         # report every cold session as a prehistoric runtime.
         if bool(getattr(session, "is_cold", False)):
             return
-        owner_version = str(getattr(session, "owner_version", "") or "")
-        runtime_ref = str(getattr(session, "owner_source_ref", "") or "")
+        runtime_version = str(getattr(session, "runtime_version", "") or "")
+        runtime_ref = str(getattr(session, "runtime_source_ref", "") or "")
         # The subject of an owner notice is the SESSION, so the debounce is
         # keyed by it: "once per session per process", which is what design
         # §6.7 and this method's own contract say. Keyed on the session id
@@ -23376,7 +23376,9 @@ class OperatorApp(App[None]):
         subject = _session_subject(session)
         from local_operator.update import BuildStamp
 
-        owner = BuildStamp(version=owner_version, source_ref=runtime_ref) if owner_version else None
+        owner = (
+            BuildStamp(version=runtime_version, source_ref=runtime_ref) if runtime_version else None
+        )
         if owner is not None and owner == loaded:
             return
         # WHICH SIDE IS STALE? A difference alone does not say, and this branch
@@ -23437,9 +23439,9 @@ class OperatorApp(App[None]):
         # is literally the condition the runtime waits for, and it is the one
         # that is also true of a session sitting at an empty prompt (design
         # review round 1, D3).
-        idle_probe = getattr(session, "owner_idle", None)
+        idle_probe = getattr(session, "runtime_idle", None)
         ask = getattr(session, "request_refresh", None)
-        owner_idle = bool(idle_probe()) if callable(idle_probe) else False
+        runtime_idle = bool(idle_probe()) if callable(idle_probe) else False
 
         def announce_stale() -> None:
             """C\u2032: this session is on an older build and will switch on its own.
@@ -23540,7 +23542,7 @@ class OperatorApp(App[None]):
                 notice_kind="note",
             )
 
-        if owner_idle and callable(ask):
+        if runtime_idle and callable(ask):
             logger.debug(
                 "build skew (owner) at %s: %s -> %s; owner idle, requesting refresh",
                 reason,
@@ -27014,11 +27016,11 @@ class OperatorApp(App[None]):
         # credential store — crossed out or dropped every row the session
         # could actually switch to (D3, review round 2).
         session = self._session
-        owner_catalogue = getattr(session, "owner_model_catalogue", None)
-        if callable(owner_catalogue):
+        runtime_catalogue = getattr(session, "runtime_model_catalogue", None)
+        if callable(runtime_catalogue):
             runtime_rows: list[dict[str, Any]] = []
             try:
-                fetched = owner_catalogue()
+                fetched = runtime_catalogue()
                 if isinstance(fetched, list):
                     runtime_rows = fetched
             except Exception:

--- a/scripts/build_skew_direction_repro.py
+++ b/scripts/build_skew_direction_repro.py
@@ -56,8 +56,8 @@ async def main() -> None:
         # NEWER than this window -- and it is idle. Its own refresh check
         # compares itself against disk, finds a match, and answers "kept".
         viewer = _BoundViewer(
-            owner_version="0.51.30",
-            owner_source_ref="d7f12d3a7",
+            runtime_version="0.51.30",
+            runtime_source_ref="d7f12d3a7",
             session_id="s1",
             conversation_name="Investigating suspicious pwned notification source",
             idle=True,

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -1437,7 +1437,7 @@ async def test_attach_succeeds_against_an_owner_offering_thousands_of_models(
         assert remote.frontend_state.model_catalogue_truncated is True
         # The rows that survived are usable, in the owner's own order.
         assert catalogue[0] == _catalogue_row(0)
-        assert remote.owner_model_catalogue()[0]["model_id"] == _catalogue_row(0)["model_id"]
+        assert remote.runtime_model_catalogue()[0]["model_id"] == _catalogue_row(0)["model_id"]
     finally:
         if remote is not None:
             await remote.dispose()

--- a/tests/unit/session/test_remote_move.py
+++ b/tests/unit/session/test_remote_move.py
@@ -129,7 +129,7 @@ async def test_a_move_while_a_live_runtime_is_resyncing_still_retires_it(
     client = FakeClient()
     _bind(session, client)
     session._ready_for_events = False  # mid-resync: cold by the old predicate
-    session.owner_idle = lambda: True  # type: ignore[method-assign]
+    session.runtime_idle = lambda: True  # type: ignore[method-assign]
 
     assert session.is_cold, "the predicate that used to decide the branch"
     outcome = await session.set_working_directory("/usr")
@@ -155,7 +155,7 @@ async def test_a_bound_idle_session_retires_its_runtime_and_rebinds(cold_session
     session = await cold_session("/tmp")
     client = FakeClient()
     _bind(session, client)
-    session.owner_idle = lambda: True  # type: ignore[method-assign]
+    session.runtime_idle = lambda: True  # type: ignore[method-assign]
     assert await session.set_working_directory("/usr") == "rebound"
     assert client.ops == ["retire_now"]
     assert session._cwd == "/usr"
@@ -169,7 +169,7 @@ async def test_a_move_does_NOT_park_the_viewer_in_the_stopped_state(cold_session
     anyway, because the disconnect that sets it arrives after this returns."""
     session = await cold_session("/tmp")
     _bind(session, FakeClient())
-    session.owner_idle = lambda: True  # type: ignore[method-assign]
+    session.runtime_idle = lambda: True  # type: ignore[method-assign]
     await session.set_working_directory("/usr")
     assert session._deliberate_stop is False
 
@@ -183,7 +183,7 @@ async def test_a_busy_session_is_REFUSED_and_does_not_move(cold_session) -> None
     session = await cold_session("/tmp")
     client = FakeClient()
     _bind(session, client)
-    session.owner_idle = lambda: False  # type: ignore[method-assign]
+    session.runtime_idle = lambda: False  # type: ignore[method-assign]
     with pytest.raises(RuntimeError, match="working right now"):
         await session.set_working_directory("/usr")
     assert session._cwd == "/tmp"
@@ -197,7 +197,7 @@ async def test_a_runtime_that_keeps_itself_rolls_the_directory_back(cold_session
     nothing moved so nothing is recorded as moved."""
     session = await cold_session("/tmp")
     _bind(session, FakeClient(answer="kept: busy"))
-    session.owner_idle = lambda: True  # type: ignore[method-assign]
+    session.runtime_idle = lambda: True  # type: ignore[method-assign]
     with pytest.raises(RuntimeError, match="busy"):
         await session.set_working_directory("/usr")
     assert session._cwd == "/tmp"
@@ -214,7 +214,7 @@ async def test_a_version_skewed_runtime_gets_the_vetted_sentence(cold_session) -
     """
     session = await cold_session("/tmp")
     _bind(session, FakeClient(error=RuntimeError("unknown op: 'retire_now'")))
-    session.owner_idle = lambda: True  # type: ignore[method-assign]
+    session.runtime_idle = lambda: True  # type: ignore[method-assign]
     with pytest.raises(RuntimeError, match="too old to be moved"):
         await session.set_working_directory("/usr")
     assert session._cwd == "/tmp"
@@ -225,7 +225,7 @@ async def test_any_other_transport_failure_rolls_the_directory_back(cold_session
     """A failure that is NOT version skew still refuses and restores the cwd."""
     session = await cold_session("/tmp")
     _bind(session, FakeClient(error=ConnectionError("socket closed")))
-    session.owner_idle = lambda: True  # type: ignore[method-assign]
+    session.runtime_idle = lambda: True  # type: ignore[method-assign]
     with pytest.raises(RuntimeError, match="could not move"):
         await session.set_working_directory("/usr")
     assert session._cwd == "/tmp"
@@ -236,7 +236,7 @@ async def test_a_runtime_too_old_to_know_the_op_refuses_cleanly(cold_session) ->
     """Rather than moving anyway and leaving the runtime in the old directory."""
     session = await cold_session("/tmp")
     _bind(session, SimpleNamespace(connected=True))
-    session.owner_idle = lambda: True  # type: ignore[method-assign]
+    session.runtime_idle = lambda: True  # type: ignore[method-assign]
     with pytest.raises(RuntimeError, match="too old"):
         await session.set_working_directory("/usr")
     assert session._cwd == "/tmp"
@@ -266,7 +266,7 @@ async def test_a_move_repoints_an_armed_wake_at_the_new_directory(
     )
     if bound:
         _bind(session, FakeClient())
-        session.owner_idle = lambda: True  # type: ignore[method-assign]
+        session.runtime_idle = lambda: True  # type: ignore[method-assign]
 
     await session.set_working_directory("/usr")
 
@@ -346,7 +346,7 @@ async def test_a_move_while_the_owner_is_recovering_is_REFUSED(cold_session) -> 
     # `rebound` and issuing a real retire while recovery was in progress.
     client = FakeClient()
     _bind(session, client)
-    session.owner_idle = lambda: True  # type: ignore[method-assign]
+    session.runtime_idle = lambda: True  # type: ignore[method-assign]
     with pytest.raises(ConnectionError, match="reconnecting"):
         await session.set_working_directory("/usr")
     assert session._cwd == "/tmp"
@@ -372,7 +372,7 @@ async def test_a_CANCELLED_move_rolls_the_directory_back(cold_session) -> None:
 
     # Cancelled inside the retire RPC: the widest window on the bound path.
     _bind(session, FakeClient(error=asyncio.CancelledError()))
-    session.owner_idle = lambda: True  # type: ignore[method-assign]
+    session.runtime_idle = lambda: True  # type: ignore[method-assign]
     with pytest.raises(asyncio.CancelledError):
         await session.set_working_directory("/usr")
     assert session._cwd == "/tmp", "a cancelled move left the directory moved"

--- a/tests/unit/session/test_remote_refresh.py
+++ b/tests/unit/session/test_remote_refresh.py
@@ -119,14 +119,14 @@ async def test_request_refresh_never_raises(tmp_path, monkeypatch):
     assert await remote.request_refresh() == "retiring"
 
 
-def test_owner_idle_reads_the_snapshot(tmp_path, monkeypatch):
+def test_runtime_idle_reads_the_snapshot(tmp_path, monkeypatch):
     """Cold → not idle (nothing to refresh); streaming, a running job or a
     parked gate → busy; otherwise idle."""
     from types import SimpleNamespace
 
     monkeypatch.setattr(remote_module, "find_runtime_record", lambda *args: (None, None))
     remote = RemoteSession(config_dir=tmp_path, session_id="s1", takeover_factory=_never_take_over)
-    assert remote.owner_idle() is False, "a cold viewer has no owner to refresh"
+    assert remote.runtime_idle() is False, "a cold viewer has no owner to refresh"
 
     class Client:
         connected = True
@@ -144,14 +144,14 @@ def test_owner_idle_reads_the_snapshot(tmp_path, monkeypatch):
         remote._frontend_store = store(**fields)  # type: ignore[assignment]
 
     with_state()
-    assert remote.owner_idle() is True
+    assert remote.runtime_idle() is True
     with_state(streaming=True)
-    assert remote.owner_idle() is False
+    assert remote.runtime_idle() is False
     with_state(pending_gate=object())
-    assert remote.owner_idle() is False
+    assert remote.runtime_idle() is False
     with_state(jobs=[SimpleNamespace(status="running")])
-    assert remote.owner_idle() is False
+    assert remote.runtime_idle() is False
     with_state(jobs=[SimpleNamespace(status="completed")])
-    assert remote.owner_idle() is True
+    assert remote.runtime_idle() is True
     remote._streaming = True
-    assert remote.owner_idle() is False
+    assert remote.runtime_idle() is False

--- a/tests/unit/session/test_viewer_protocol.py
+++ b/tests/unit/session/test_viewer_protocol.py
@@ -447,7 +447,7 @@ def _all_touched() -> dict[str, list[str]]:
 def _declared() -> set[str]:
     """Every name the two protocols declare.
 
-    ``dir()`` alone is not enough: a bare annotation (``owner_version: str``)
+    ``dir()`` alone is not enough: a bare annotation (``runtime_version: str``)
     declares a member for both pyright and ``isinstance``, but creates no class
     attribute, so it does not appear in ``dir()``. Reading
     ``__annotations__`` as well is what makes the four instance attributes on
@@ -470,7 +470,7 @@ def _members(klass: type, module: str, name: str) -> set[str]:
 
     ``dir(klass)`` sees only class-level members, so attributes assigned as
     ``self.x = ...`` in ``__init__`` are missing from it. That is not a corner
-    case here: ``RemoteSession`` sets ``owner_version``, ``degraded_reason``,
+    case here: ``RemoteSession`` sets ``runtime_version``, ``degraded_reason``,
     ``jobs`` and others that way, and ``Session`` sets ``agent_registry`` and
     ``team_registry`` that way while ``RemoteSession`` exposes them as
     properties. Comparing ``dir()`` to ``dir()`` therefore reported
@@ -546,7 +546,7 @@ def test_remote_session_satisfies_the_viewer_protocol_at_runtime() -> None:
     rounds, is an ``__init__``-assigned attribute disappearing. The four below
     are hand-assigned to satisfy ``__new__``, so the ``isinstance`` passes
     whether or not ``__init__`` still sets them — the reviewer deleted
-    ``owner_version`` from the class outright and got 7 tests passing against 2
+    ``runtime_version`` from the class outright and got 7 tests passing against 2
     pyright errors (review round 2, MINOR-2). For those four the division of
     labour runs the other way: **pyright is the guard and this test is
     structurally blind.** Stated here because a test believed to cover a case it
@@ -557,8 +557,8 @@ def test_remote_session_satisfies_the_viewer_protocol_at_runtime() -> None:
     # socket. Set them directly: presence is what the protocol requires, and
     # constructing a real facade would make this a network test. See the
     # docstring: this assignment is exactly why the four are pyright's to guard.
-    session.owner_version = ""
-    session.owner_source_ref = ""
+    session.runtime_version = ""
+    session.runtime_source_ref = ""
     session.degraded_reason = ""
     session.saved_preview_partial = False
 

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -2049,7 +2049,7 @@ async def test_follower_model_picker_lists_the_owners_models() -> None:
     class OwnerCatalogueSession(FakeSession):
         frontend_state: FrontendSessionState
 
-        def owner_model_catalogue(self) -> list[dict[str, Any]]:
+        def runtime_model_catalogue(self) -> list[dict[str, Any]]:
             return [
                 {
                     "provider": "anthropic",

--- a/tests/unit/tui/test_build_skew.py
+++ b/tests/unit/tui/test_build_skew.py
@@ -76,7 +76,7 @@ MOVES_OVER = "will switch to the new version when it is next idle"
 class _BoundViewer(FakeSession):
     """A follower facade that has already bound to a runtime.
 
-    Not owning the runtime, plus a resolved ``owner_version``, is what a real
+    Not owning the runtime, plus a resolved ``runtime_version``, is what a real
     ``RemoteSession`` looks like after ``_dial``; ``is_cold`` False is what
     makes the owner comparison meaningful, since a cold viewer has not dialled
     anything and its empty stamp would otherwise read as a prehistoric
@@ -92,17 +92,17 @@ class _BoundViewer(FakeSession):
 
     def __init__(
         self,
-        owner_version: str = "",
-        owner_source_ref: str = "",
+        runtime_version: str = "",
+        runtime_source_ref: str = "",
         session_id: str = "",
         conversation_name: str = "",
         idle: bool = False,
         refresh_answer: str = "retiring",
     ) -> None:
         super().__init__()
-        self.owner_version = owner_version
-        self.owner_source_ref = owner_source_ref
-        # ``idle`` is what a real ``RemoteSession.owner_idle`` reads off the
+        self.runtime_version = runtime_version
+        self.runtime_source_ref = runtime_source_ref
+        # ``idle`` is what a real ``RemoteSession.runtime_idle`` reads off the
         # canonical snapshot. The default is BUSY so every pre-existing cell
         # keeps exercising the notice path; the refresh cells opt in.
         self._skew_idle = idle
@@ -129,7 +129,7 @@ class _BoundViewer(FakeSession):
     def conversation_name(self) -> str:  # type: ignore[override]
         return self._skew_conversation_name
 
-    def owner_idle(self) -> bool:
+    def runtime_idle(self) -> bool:
         return self._skew_idle
 
     async def request_refresh(self):  # deliberately unannotated: see below
@@ -295,7 +295,7 @@ async def test_a_busy_older_runtime_is_told_it_will_move_over(monkeypatch, tmp_p
         import local_operator.update as update_mod
 
         monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
-        viewer = _BoundViewer(owner_version="0.46.23", idle=False)
+        viewer = _BoundViewer(runtime_version="0.46.23", idle=False)
         app._session = viewer
         app._check_build_skew(reason="bind")
         await pilot.pause()
@@ -331,7 +331,7 @@ async def test_an_idle_older_runtime_is_refreshed_silently(monkeypatch, tmp_path
         import local_operator.update as update_mod
 
         monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
-        viewer = _BoundViewer(owner_version="0.46.23", idle=True)
+        viewer = _BoundViewer(runtime_version="0.46.23", idle=True)
         app._session = viewer
         app._check_build_skew(reason="bind")
         await pilot.pause()
@@ -375,7 +375,7 @@ async def test_an_idle_owner_that_stays_still_gets_the_notice(
         import local_operator.update as update_mod
 
         monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
-        viewer = _BoundViewer(owner_version="0.46.23", idle=True, refresh_answer=answer)
+        viewer = _BoundViewer(runtime_version="0.46.23", idle=True, refresh_answer=answer)
         app._session = viewer
         app._check_build_skew(reason="bind")
         await pilot.pause()
@@ -411,7 +411,7 @@ async def test_an_unstamped_idle_owner_that_stays_gets_the_unknown_copy(
         import local_operator.update as update_mod
 
         monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
-        viewer = _BoundViewer(owner_version="", idle=True, refresh_answer="raise")
+        viewer = _BoundViewer(runtime_version="", idle=True, refresh_answer="raise")
         app._session = viewer
         app._check_build_skew(reason="bind")
         await pilot.pause()
@@ -453,7 +453,7 @@ async def test_a_non_string_answer_cannot_take_the_window_down(
         import local_operator.update as update_mod
 
         monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
-        app._session = _BoundViewer(owner_version="0.46.23", idle=True, refresh_answer=answer)
+        app._session = _BoundViewer(runtime_version="0.46.23", idle=True, refresh_answer=answer)
         app._check_build_skew(reason="bind")
         await pilot.pause()
         # Raises WorkerFailed on the unfixed tree, before any assertion below.
@@ -491,7 +491,7 @@ async def test_a_same_version_rebuild_names_only_the_refs(monkeypatch, tmp_path)
         import local_operator.update as update_mod
 
         monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
-        app._session = _BoundViewer(owner_version="0.49.0", owner_source_ref="aaaaaaa1111")
+        app._session = _BoundViewer(runtime_version="0.49.0", runtime_source_ref="aaaaaaa1111")
         app._check_build_skew(reason="bind")
         await pilot.pause()
         notices = _notices(app)
@@ -523,8 +523,8 @@ async def test_the_version_pair_survives_a_narrow_splash(monkeypatch, tmp_path) 
 
             monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
             app._session = _BoundViewer(
-                owner_version="0.49.8",
-                owner_source_ref="46a4e9b1234567",
+                runtime_version="0.49.8",
+                runtime_source_ref="46a4e9b1234567",
                 conversation_name="Runtime refresh notes",
             )
             app._check_build_skew(reason="bind")
@@ -581,7 +581,7 @@ async def test_a_runtime_without_a_stamp_is_reported_as_predating_it(monkeypatch
         import local_operator.update as update_mod
 
         monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
-        app._session = _BoundViewer(owner_version="")
+        app._session = _BoundViewer(runtime_version="")
         app._check_build_skew(reason="bind")
         app._check_build_skew(reason="bind-again")
         await pilot.pause()
@@ -615,12 +615,12 @@ async def test_a_second_stale_session_gets_its_own_notice(monkeypatch, tmp_path)
 
         monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
 
-        first = _BoundViewer(owner_version="", session_id="sessionaaaa1")
+        first = _BoundViewer(runtime_version="", session_id="sessionaaaa1")
         app._session = first
         app._check_build_skew(reason="bind")
         app._check_build_skew(reason="bind-again")  # same session: still once
 
-        second = _BoundViewer(owner_version="", session_id="sessionbbbb2")
+        second = _BoundViewer(runtime_version="", session_id="sessionbbbb2")
         app._session = second
         app._check_build_skew(reason="resume")
         await pilot.pause()
@@ -652,11 +652,11 @@ async def test_disk_drift_is_not_rescoped_by_a_session_swap(monkeypatch, tmp_pat
         monkeypatch.setattr(
             update_mod, "installed_build", lambda *_a, **_k: BuildStamp(version="0.49.0")
         )
-        first = _BoundViewer(owner_version="0.49.0", session_id="sessionaaaa1")
+        first = _BoundViewer(runtime_version="0.49.0", session_id="sessionaaaa1")
         app._session = first
         app._check_build_skew(reason="adopt")
 
-        second = _BoundViewer(owner_version="0.49.0", session_id="sessionbbbb2")
+        second = _BoundViewer(runtime_version="0.49.0", session_id="sessionbbbb2")
         app._session = second
         app._check_build_skew(reason="adopt-2")
         await pilot.pause()
@@ -679,7 +679,7 @@ async def test_a_matching_runtime_is_silent(monkeypatch, tmp_path) -> None:
         import local_operator.update as update_mod
 
         monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
-        app._session = _BoundViewer(owner_version="0.49.0", owner_source_ref="abc1234")
+        app._session = _BoundViewer(runtime_version="0.49.0", runtime_source_ref="abc1234")
         app._check_build_skew(reason="bind")
         await pilot.pause()
         notices = _notices(app)
@@ -694,7 +694,7 @@ async def test_a_cold_viewer_is_not_reported_as_a_prehistoric_runtime(
 ) -> None:
     """A cold viewer has not dialled anything, so it has no owner to compare.
 
-    Its ``owner_version`` is empty for the trivial reason that no runtime
+    Its ``runtime_version`` is empty for the trivial reason that no runtime
     exists yet. Reading that as "the runtime predates the field" would fire
     the notice on every fresh `lop`, which is the false-positive that would
     make the whole mechanism ignorable.
@@ -709,7 +709,7 @@ async def test_a_cold_viewer_is_not_reported_as_a_prehistoric_runtime(
         import local_operator.update as update_mod
 
         monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
-        cold = _BoundViewer(owner_version="")
+        cold = _BoundViewer(runtime_version="")
         cold.is_cold = True
         app._session = cold
         app._check_build_skew(reason="cold")
@@ -732,7 +732,7 @@ async def test_an_unreadable_own_build_disables_the_check(monkeypatch, tmp_path)
         await pilot.pause()
         app._loaded_build = None
         app._skew_notice_shown.clear()
-        app._session = _BoundViewer(owner_version="0.1.0")
+        app._session = _BoundViewer(runtime_version="0.1.0")
         app._check_build_skew(reason="unknown")
         await pilot.pause()
         notices = _notices(app)
@@ -994,13 +994,13 @@ async def test_two_stale_sessions_are_told_apart_by_name(monkeypatch, tmp_path) 
         monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
 
         first = _BoundViewer(
-            owner_version="", session_id="sessionaaaa1", conversation_name="ingest pipeline"
+            runtime_version="", session_id="sessionaaaa1", conversation_name="ingest pipeline"
         )
         app._session = first
         app._check_build_skew(reason="bind")
 
         second = _BoundViewer(
-            owner_version="", session_id="sessionbbbb2", conversation_name="release notes"
+            runtime_version="", session_id="sessionbbbb2", conversation_name="release notes"
         )
         app._session = second
         app._check_build_skew(reason="resume")
@@ -1034,7 +1034,7 @@ async def test_an_unnamed_session_falls_back_to_the_deictic(monkeypatch, tmp_pat
         import local_operator.update as update_mod
 
         monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
-        unnamed = _BoundViewer(owner_version="", session_id="sessionccccc")
+        unnamed = _BoundViewer(runtime_version="", session_id="sessionccccc")
         app._session = unnamed
         app._check_build_skew(reason="bind")
         await pilot.pause()
@@ -1141,8 +1141,8 @@ async def test_a_runtime_newer_than_this_window_is_completely_silent(monkeypatch
         on_disk = BuildStamp(version="0.51.30", source_ref="d7f12d3a7")
         monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: on_disk)
         viewer = _BoundViewer(
-            owner_version="0.51.30",
-            owner_source_ref="d7f12d3a7",
+            runtime_version="0.51.30",
+            runtime_source_ref="d7f12d3a7",
             idle=True,
             refresh_answer="kept: build on disk matches (or has not settled)",
         )
@@ -1182,7 +1182,7 @@ async def test_a_runtime_newer_than_this_window_is_silent_while_busy(monkeypatch
 
         on_disk = BuildStamp(version="0.51.30", source_ref="d7f12d3a7")
         monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: on_disk)
-        viewer = _BoundViewer(owner_version="0.51.30", owner_source_ref="d7f12d3a7", idle=False)
+        viewer = _BoundViewer(runtime_version="0.51.30", runtime_source_ref="d7f12d3a7", idle=False)
         app._session = viewer
         app._check_build_skew(reason="bind")
         await pilot.pause()
@@ -1212,7 +1212,9 @@ async def test_a_same_version_rebuild_is_directional_both_ways(monkeypatch, tmp_
         app._loaded_build = BuildStamp(version="0.51.30", source_ref="aaaaaaa1111")
         app._skew_notice_shown.clear()
         monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: on_disk)
-        viewer = _BoundViewer(owner_version="0.51.30", owner_source_ref="bbbbbbb2222", idle=False)
+        viewer = _BoundViewer(
+            runtime_version="0.51.30", runtime_source_ref="bbbbbbb2222", idle=False
+        )
         app._session = viewer
         app._check_build_skew(reason="bind")
         await pilot.pause()
@@ -1228,7 +1230,9 @@ async def test_a_same_version_rebuild_is_directional_both_ways(monkeypatch, tmp_
         app._loaded_build = on_disk
         app._skew_notice_shown.clear()
         monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: on_disk)
-        viewer = _BoundViewer(owner_version="0.51.30", owner_source_ref="aaaaaaa1111", idle=False)
+        viewer = _BoundViewer(
+            runtime_version="0.51.30", runtime_source_ref="aaaaaaa1111", idle=False
+        )
         app._session = viewer
         app._check_build_skew(reason="bind")
         await pilot.pause()
@@ -1259,7 +1263,7 @@ async def test_an_unreadable_disk_falls_back_to_version_order(monkeypatch, tmp_p
             raise OSError("no install metadata")
 
         monkeypatch.setattr(update_mod, "installed_build", _boom)
-        viewer = _BoundViewer(owner_version="0.51.30", idle=True)
+        viewer = _BoundViewer(runtime_version="0.51.30", idle=True)
         app._session = viewer
         app._check_build_skew(reason="bind")
         await pilot.pause()
@@ -1297,7 +1301,9 @@ async def test_an_inconclusive_order_keeps_todays_notice(monkeypatch, tmp_path) 
             raise OSError("no install metadata")
 
         monkeypatch.setattr(update_mod, "installed_build", _boom)
-        viewer = _BoundViewer(owner_version="0.51.30", owner_source_ref="bbbbbbb2222", idle=False)
+        viewer = _BoundViewer(
+            runtime_version="0.51.30", runtime_source_ref="bbbbbbb2222", idle=False
+        )
         app._session = viewer
         app._check_build_skew(reason="bind")
         await pilot.pause()
@@ -1331,7 +1337,7 @@ async def test_an_unparseable_version_is_not_guessed_at(monkeypatch, tmp_path) -
             raise OSError("no install metadata")
 
         monkeypatch.setattr(update_mod, "installed_build", _boom)
-        app._session = _BoundViewer(owner_version="0.51.30rc1", idle=False)
+        app._session = _BoundViewer(runtime_version="0.51.30rc1", idle=False)
         app._check_build_skew(reason="bind")
         await pilot.pause()
         notices = _notices(app)
@@ -1364,8 +1370,8 @@ async def test_a_completed_refresh_names_the_version_it_moved_to(monkeypatch, tm
         monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: None)
         # The runtime that is leaving.
         app._session = _BoundViewer(
-            owner_version="0.51.29",
-            owner_source_ref="2412b1daf",
+            runtime_version="0.51.29",
+            runtime_source_ref="2412b1daf",
             session_id="s1",
             conversation_name="Investigating suspicious pwned notification source",
         )
@@ -1374,7 +1380,7 @@ async def test_a_completed_refresh_names_the_version_it_moved_to(monkeypatch, tm
         # session rebound — the refresh keeps the id, which is exactly what the
         # belt keys on.
         app._session = _BoundViewer(
-            owner_version="0.51.30", owner_source_ref="d7f12d3a7", session_id="s1"
+            runtime_version="0.51.30", runtime_source_ref="d7f12d3a7", session_id="s1"
         )
         app._announce_refresh_completed()
         await pilot.pause()
@@ -1409,11 +1415,11 @@ async def test_an_unchanged_build_after_a_refresh_says_nothing(monkeypatch, tmp_
         app._skew_notice_shown.clear()
         monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: None)
         app._session = _BoundViewer(
-            owner_version="0.51.30", owner_source_ref="d7f12d3a7", session_id="s1"
+            runtime_version="0.51.30", runtime_source_ref="d7f12d3a7", session_id="s1"
         )
         app._on_runtime_refreshed()
         app._session = _BoundViewer(
-            owner_version="0.51.30", owner_source_ref="d7f12d3a7", session_id="s1"
+            runtime_version="0.51.30", runtime_source_ref="d7f12d3a7", session_id="s1"
         )
         app._announce_refresh_completed()
         await pilot.pause()
@@ -1430,7 +1436,7 @@ async def test_an_ordinary_engage_never_announces_a_refresh(monkeypatch, tmp_pat
     async with app.run_test(size=(100, 24)) as pilot:
         await pilot.pause()
         app._skew_notice_shown.clear()
-        app._session = _BoundViewer(owner_version="0.51.30", owner_source_ref="d7f12d3a7")
+        app._session = _BoundViewer(runtime_version="0.51.30", runtime_source_ref="d7f12d3a7")
         app._announce_refresh_completed()
         await pilot.pause()
         notices = _notices(app)
@@ -1453,11 +1459,11 @@ async def test_a_runtime_too_old_to_name_its_build_is_not_half_announced(
         await pilot.pause()
         app._skew_notice_shown.clear()
         monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: None)
-        app._session = _BoundViewer(owner_version="", session_id="s1")
+        app._session = _BoundViewer(runtime_version="", session_id="s1")
         app._on_runtime_refreshed()
         assert app._refreshed_from is None
         app._session = _BoundViewer(
-            owner_version="0.51.30", owner_source_ref="d7f12d3a7", session_id="s1"
+            runtime_version="0.51.30", runtime_source_ref="d7f12d3a7", session_id="s1"
         )
         app._announce_refresh_completed()
         await pilot.pause()
@@ -1501,8 +1507,8 @@ async def test_a_newer_runtime_is_silent_when_disk_has_moved_again(monkeypatch, 
             lambda *_a, **_k: BuildStamp(version="0.52.0", source_ref="5db5f6d65"),
         )
         viewer = _BoundViewer(
-            owner_version="0.51.30",
-            owner_source_ref="d7f12d3a7",
+            runtime_version="0.51.30",
+            runtime_source_ref="d7f12d3a7",
             idle=True,
             refresh_answer="kept: build on disk matches (or has not settled)",
         )
@@ -1537,7 +1543,7 @@ async def test_a_newer_runtime_stays_silent_while_busy_in_the_triple(monkeypatch
             "installed_build",
             lambda *_a, **_k: BuildStamp(version="0.52.0", source_ref="5db5f6d65"),
         )
-        viewer = _BoundViewer(owner_version="0.51.30", owner_source_ref="d7f12d3a7", idle=False)
+        viewer = _BoundViewer(runtime_version="0.51.30", runtime_source_ref="d7f12d3a7", idle=False)
         app._session = viewer
         app._check_build_skew(reason="bind")
         await pilot.pause()
@@ -1566,8 +1572,8 @@ async def test_a_long_lived_window_does_not_start_speaking_when_disk_moves_again
         import local_operator.update as update_mod
 
         viewer = _BoundViewer(
-            owner_version="0.51.30",
-            owner_source_ref="d7f12d3a7",
+            runtime_version="0.51.30",
+            runtime_source_ref="d7f12d3a7",
             idle=True,
             refresh_answer="kept: build on disk matches (or has not settled)",
         )
@@ -1621,7 +1627,7 @@ async def test_an_older_runtime_still_speaks_when_disk_has_moved_again(
             "installed_build",
             lambda *_a, **_k: BuildStamp(version="0.52.0", source_ref="5db5f6d65"),
         )
-        viewer = _BoundViewer(owner_version="0.51.28", owner_source_ref="8c2015f11", idle=False)
+        viewer = _BoundViewer(runtime_version="0.51.28", runtime_source_ref="8c2015f11", idle=False)
         app._session = viewer
         app._check_build_skew(reason="bind")
         await pilot.pause()
@@ -1657,7 +1663,7 @@ async def test_three_refs_at_one_version_claim_no_direction(monkeypatch, tmp_pat
             lambda *_a, **_k: BuildStamp(version="0.51.30", source_ref="ccccccc33"),
         )
         app._session = _BoundViewer(
-            owner_version="0.51.30", owner_source_ref="bbbbbbb22", idle=False
+            runtime_version="0.51.30", runtime_source_ref="bbbbbbb22", idle=False
         )
         app._check_build_skew(reason="bind")
         await pilot.pause()
@@ -1695,7 +1701,7 @@ async def test_a_ref_only_pair_still_uses_the_arrow_when_disk_ranks_it(
 
         monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: on_disk)
         app._session = _BoundViewer(
-            owner_version="0.51.30", owner_source_ref="aaaaaaa11", idle=False
+            runtime_version="0.51.30", runtime_source_ref="aaaaaaa11", idle=False
         )
         app._check_build_skew(reason="bind")
         await pilot.pause()
@@ -1728,8 +1734,8 @@ async def test_a_cancelled_engage_cannot_announce_the_previous_session(
         app._skew_notice_shown.clear()
         monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: None)
         app._session = _BoundViewer(
-            owner_version="0.51.29",
-            owner_source_ref="2412b1daf",
+            runtime_version="0.51.29",
+            runtime_source_ref="2412b1daf",
             session_id="sess-a",
             conversation_name="Session A",
         )
@@ -1742,8 +1748,8 @@ async def test_a_cancelled_engage_cannot_announce_the_previous_session(
 
         # Session B binds normally. Nothing about session A may be said.
         app._session = _BoundViewer(
-            owner_version="0.51.19",
-            owner_source_ref="dc6bec0aa",
+            runtime_version="0.51.19",
+            runtime_source_ref="dc6bec0aa",
             session_id="sess-b",
             conversation_name="Session B",
         )
@@ -1771,8 +1777,8 @@ async def test_a_sidebar_switch_cannot_announce_the_previous_session(monkeypatch
         app._skew_notice_shown.clear()
         monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: None)
         app._session = _BoundViewer(
-            owner_version="0.51.29",
-            owner_source_ref="2412b1daf",
+            runtime_version="0.51.29",
+            runtime_source_ref="2412b1daf",
             session_id="sess-a",
             conversation_name="Session A",
         )
@@ -1782,8 +1788,8 @@ async def test_a_sidebar_switch_cannot_announce_the_previous_session(monkeypatch
         # The sidebar swap: the pending slot SURVIVES this, which is the
         # route round 1 missed. Session B then binds and its engage tail runs.
         app._session = _BoundViewer(
-            owner_version="0.51.19",
-            owner_source_ref="dc6bec0aa",
+            runtime_version="0.51.19",
+            runtime_source_ref="dc6bec0aa",
             session_id="sess-b",
             conversation_name="Session B",
         )
@@ -1807,14 +1813,14 @@ async def test_a_refresh_rebind_to_the_same_session_still_announces(monkeypatch,
         app._skew_notice_shown.clear()
         monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: None)
         app._session = _BoundViewer(
-            owner_version="0.51.29",
-            owner_source_ref="2412b1daf",
+            runtime_version="0.51.29",
+            runtime_source_ref="2412b1daf",
             session_id="s1",
             conversation_name="Session A",
         )
         app._on_runtime_refreshed()
         app._session = _BoundViewer(
-            owner_version="0.51.30", owner_source_ref="d7f12d3a7", session_id="s1"
+            runtime_version="0.51.30", runtime_source_ref="d7f12d3a7", session_id="s1"
         )
         app._announce_refresh_completed()
         await pilot.pause()
@@ -1851,7 +1857,7 @@ async def test_one_build_pair_is_announced_once_across_a_disk_move(monkeypatch, 
             lambda *_a, **_k: BuildStamp(version="0.51.30", source_ref="aaaaaaa11"),
         )
         app._session = _BoundViewer(
-            owner_version="0.51.30", owner_source_ref="bbbbbbb22", session_id="s1", idle=False
+            runtime_version="0.51.30", runtime_source_ref="bbbbbbb22", session_id="s1", idle=False
         )
         app._check_build_skew(reason="adopt")
         await pilot.pause()
@@ -1900,7 +1906,7 @@ async def test_a_title_that_raises_does_not_cost_the_re_engage(monkeypatch, tmp_
         reasons: list[str] = []
         monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: reasons.append(reason))
         app._warm_engage_started = True
-        app._session = _Raising(owner_version="0.51.29", owner_source_ref="2412b1daf")
+        app._session = _Raising(runtime_version="0.51.29", runtime_source_ref="2412b1daf")
         app._on_runtime_refreshed()
         await pilot.pause()
 
@@ -1929,14 +1935,14 @@ async def test_the_refresh_note_keeps_its_version_pair_on_one_row(monkeypatch, t
                 app._skew_notice_shown.clear()
                 monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: None)
                 app._session = _BoundViewer(
-                    owner_version="0.51.29",
-                    owner_source_ref="2412b1daf",
+                    runtime_version="0.51.29",
+                    runtime_source_ref="2412b1daf",
                     session_id="s1",
                     conversation_name=name,
                 )
                 app._on_runtime_refreshed()
                 app._session = _BoundViewer(
-                    owner_version="0.51.30", owner_source_ref="d7f12d3a7", session_id="s1"
+                    runtime_version="0.51.30", runtime_source_ref="d7f12d3a7", session_id="s1"
                 )
                 app._announce_refresh_completed()
                 await pilot.pause()
@@ -1963,11 +1969,11 @@ async def test_the_refresh_note_does_not_restate_the_version_twice(monkeypatch, 
         app._skew_notice_shown.clear()
         monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: None)
         app._session = _BoundViewer(
-            owner_version="0.51.30", owner_source_ref="aaaaaaa11", session_id="s1"
+            runtime_version="0.51.30", runtime_source_ref="aaaaaaa11", session_id="s1"
         )
         app._on_runtime_refreshed()
         app._session = _BoundViewer(
-            owner_version="0.51.30", owner_source_ref="bbbbbbb22", session_id="s1"
+            runtime_version="0.51.30", runtime_source_ref="bbbbbbb22", session_id="s1"
         )
         app._announce_refresh_completed()
         await pilot.pause()

--- a/tests/unit/tui/test_startup_attachment.py
+++ b/tests/unit/tui/test_startup_attachment.py
@@ -192,7 +192,7 @@ async def test_sync_preserves_active_interaction(surface, tmp_path, monkeypatch)
             assert picker.highlighted_selector() == held
             await pilot.press("escape")
             handle._frontend.mutate(model_catalogue=[])
-            await _until(pilot, lambda: viewer.owner_model_catalogue() == [])
+            await _until(pilot, lambda: viewer.runtime_model_catalogue() == [])
             assert not picker.is_open(), "late data must not reopen an Esc-dismissed picker"
         await pilot.press("escape", "escape", "Z")
         assert "Z" in editor.text


### PR DESCRIPTION
## Summary

Stage 4 session-consolidation PR 3 of 7 (plan: `~/workspace/lop-session-consolidation/stage4-owner-retirement.md`, §5). The four **declared** `ViewerSessionProtocol` members lose the owner noun. Behaviour-preserving by construction: nothing here crosses a socket or a disk schema, so the mid-attach hazard does not apply. Builds on #916 (`43c1a35ac`), which already renamed the private identifiers.

## Rename table

| From | To | Where |
|---|---|---|
| `owner_idle` | `runtime_idle` | `protocol.py` decl + `RemoteSession` impl (`remote.py:4142`, `/move` idle check at `1802`), getattr probe string `app.py:23440`, local `app.py:23442/23543`, 11 sites in `test_remote_move.py`, 8 in `test_remote_refresh.py`, `_BoundViewer.owner_idle` + docstring note in `test_build_skew.py` |
| `owner_version` | `runtime_version` | `protocol.py` annotation, `remote.py` init (`597`) + `_bind_to` stash (`2321`), probe strings `app.py:14218/14301/23360`, locals `app.py:23360/23379`, `_BoundViewer` kwargs across `test_build_skew.py` (69-line file), `scripts/build_skew_direction_repro.py`, `test_viewer_protocol.py` docstring examples + pin assignments |
| `owner_source_ref` | `runtime_source_ref` | same sites as `owner_version` (annotation, init, `_bind_to`, probes `app.py:14225/14308/23361`, tests, repro script) |
| `owner_model_catalogue` | `runtime_model_catalogue` | `protocol.py` decl + `RemoteSession` impl (`remote.py:5554`), probe string `app.py:27017`, `test_app_pilot.py` fake (`OwnerCatalogueSession`), `test_attach_frame_size.py:1440`, `test_startup_attachment.py:195` |

Also renamed the `owner_catalogue` **local** at `app.py:27017-27021` to `runtime_catalogue` — it sits directly beside the renamed probe string, and a local named `owner_*` feeding `runtime_model_catalogue` would read as a missed site.

Two design docs reference the live member names and were updated mechanically (7 lines): `docs/design-build-skew.md` (`owner_version`/`owner_source_ref` as field names), `docs/design-runtime-autorefresh.md` (`owner_idle` helper row). Left alone they would name members that no longer exist after this PR; this is field-name accuracy, not the PR-5/6 glossary rewrite, which still owns the surrounding "owner" prose in those files.

The `len(viewer_only) >= 40` derivation pin in `test_viewer_protocol.py` is name-invariant (both sides renamed ⇒ count unchanged); the AST guard derives members from `app.py` source, so a missed probe string fails `test_every_session_member_a_host_touches_is_declared` loudly.

## Deliberately not renamed

- **`owns_runtime`** — Stage-3 predicate, conformance-pinned; plan §6 D-1.
- **`owner_epoch`** — #922's dual-read wire field; PR-4 territory.
- **Roster `owner_id`** — #923's dual-read rename; untouched here.
- **`STOPPED`/`RETIRING` disconnect strings, `OWNER_COMMANDS` emitted literal** — PR 4 wire compat.
- **`OwnedSessionHandle` / `runtime/owned.py`** — PR 7.
- **`_owner_catalogue_clipped_note`** (`app.py:26915`) — a private helper name, #916's private-identifier territory, not a declared member or probe string; adjacent, noted for PR-5/6 rather than swept into a protocol-member PR.
- Remaining "owner" prose in docstrings/comments ("The owner's offerable model rows", "after its owner retires") — PRs 5/6.
- User-visible copy — untouched; zero.

## Over-scope proof

Changed lines touching any must-not-rename identifier (**expect empty**):

```
$ git diff origin/main...HEAD -U0 | grep -E '^[+-]' \
    | grep -E 'owns_runtime|owner_epoch|OWNER_COMMANDS|OwnedSessionHandle|owner_id[^l]|\bowner_id\b|STOPPED|RETIRING' \
    | grep -v owner_idle
(no output)

$ git diff origin/main...HEAD -U0 | grep -E '^[+-]' | grep -cE 'owner_idle|owner_version|owner_source_ref|owner_model_catalogue'
131
```

The 131 lines are the rename's own −/+ pairs. Identifier counts over `local_operator/` (main → head, all identical):

| Identifier | main | head |
|---|---|---|
| `owns_runtime` | 20 | 20 |
| `owner_epoch` | 12 | 12 |
| `OWNER_COMMANDS` | 6 | 6 |
| `OwnedSessionHandle` | 35 | 35 |
| `STOPPED` | 15 | 15 |
| `RETIRING` | 6 | 6 |
| `owner_id` (word-boundary) | 28 | 28 |

(A naive substring count reports main=35/head=28 — the 7-line delta is exactly `owner_idle`, which *contains* `owner_id`+`le`; the word-boundary counts above are the real roster field, unchanged.)

- `git diff origin/main...HEAD -- local_operator/session/runtime/ pyproject.toml` → **empty**. No version bump, `runtime/` untouched.
- Old names gone tree-wide (`*.py` + `*.md`): **0 remaining**.

## Testing

All gates from `.github/workflows/ci.yml`, run over the whole tree in a fresh worktree venv (`uv pip install -e ".[all,dev]"`, verified `local_operator.__file__` resolves to the worktree):

- `pyright --pythonpath .venv/bin/python .` whole-tree: **0 errors, 0 warnings, 0 informations** — the load-bearing gate here (protocol members: a missed impl fails).
- `flake8 .` clean; `black --check` (26.1.0 pinned) clean — 2 files (`tui/app.py`, `tests/unit/tui/test_build_skew.py`) needed reformatting where `runtime_*` (+2 chars) pushed lines past 100 cols; `isort --check` (5.13.2 pinned) clean.
- Targeted suite (`-n 4`, `env -u NO_COLOR TERM=xterm-256color`): `test_viewer_protocol.py`, `test_remote_move.py`, `test_remote_refresh.py`, `test_attach_frame_size.py`, `test_build_skew.py`, `test_startup_attachment.py`, `test_app_pilot.py::test_follower_model_picker_lists_the_owners_models` → **231 passed** in 50.9s, including the AST guard, re-run individually: `1 passed`.

No visual frames — no user-visible change (probe strings, locals, comments, decls only).
