### PR TITLE
chore(release): bump version to 0.54.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.5"
+version = "0.54.6"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release: patch — stored-session discovery for send, plus the runtime glossary rename.

Owner session pid: 40924 (conversation: Send Tool Wake Previous).

Window since v0.54.5 (plain `git log`, never `--merges`):
- [x] #924 — docs(session): adopt the runtime glossary in session/harness comments (PATCH)
- [x] #925 — docs: adopt the runtime glossary in agent-facing docs (PATCH)
- [x] #916 — refactor(session): rename viewer-side owner identifiers to runtime (PATCH)
- [x] #928 — `lop sessions --all` lists stored sessions; `send`/`lop send` can address a closed session by conversation-name substring (PATCH)

Bump: PATCH → 0.54.6. One line in `pyproject.toml`. C0 scope-check round required.

Do not open a second chore(release) PR. Send PR# + merge SHA + Release: line if you merge before the tag.