### PR TITLE
chore(release): bump version to 0.54.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.6"
+version = "0.54.7"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release lock for the post-v0.54.6 window. `pyproject.toml` only, one line.

## Window

Re-derived from `origin/main` after latecomers landed while the first CI run was in flight. Plain `git log v0.54.6..origin/main` (never `--merges`):

| PR | Merge SHA | Impact |
|---|---|---|
| [#932](https://github.com/damianvtran/local-operator/pull/932) | `efeecc1e5` | rename declared `owner_*` protocol members to `runtime_*` |
| [#923](https://github.com/damianvtran/local-operator/pull/923) | `6c4b8fc60` | dual-read roster `owner_id` as `registrant_id` |
| [#922](https://github.com/damianvtran/local-operator/pull/922) | `4e484c2eb` | dual-read `DisplayHistoryWindow.runtime_epoch` (emit still `owner_epoch` this release) |
| [#931](https://github.com/damianvtran/local-operator/pull/931) | `f4f29a7cf` | xAI chat requests carry `x-grok-conv-id` so consecutive turns stick to one cache server |
| [#934](https://github.com/damianvtran/local-operator/pull/934) | `1f58e1b4c` | send tool + peer-messaging guide: `target` matches stored sessions; `lop sessions --all` lists them |
| [#927](https://github.com/damianvtran/local-operator/pull/927) | `b4c1f9ae6` | the composer is where the keyboard lives |
| [#870](https://github.com/damianvtran/local-operator/pull/870) | `85725a305` | pad comfortable action rows below the summary, not only above |
| [#926](https://github.com/damianvtran/local-operator/pull/926) | `2b7f795be` | never drive a turn into an unstarted session |
| [#919](https://github.com/damianvtran/local-operator/pull/919) | `e752b604a` | never render an exception as an empty error |

## Bump class

**PATCH → 0.54.7.** Fixes and mechanical identifier/compat dual-read on existing surfaces. No single PR clears the step-function bar. Materiality does not aggregate.

## Scope

This PR is one file, one line. C0.