### PR TITLE
refactor(session): dual-read reaper ledger runtime_pid/runtime_start keys

### DIFF
--- a/local_operator/tools/group_reaper.py
+++ b/local_operator/tools/group_reaper.py
@@ -338,8 +338,15 @@ def register_group(
     grp_leader_start = _owner_start_token(pgid)
     entry = {
         "pgid": pgid,
-        "owner_pid": pid,
-        "owner_start": owner_start,
+        # Stage-4 rename of the ledger identity keys to ``runtime_pid`` /
+        # ``runtime_start``: the sweep dual-reads them with the old
+        # ``owner_pid``/``owner_start`` keys (``_entry_owner_identity``), and
+        # ledgers are per-process and short-lived, so this write-new-only +
+        # dual-read-for-one-release shape is ample (stage4-owner-retirement
+        # §3). TODO: stop reading the old keys in the release that follows
+        # this change.
+        "runtime_pid": pid,
+        "runtime_start": owner_start,
         "grp_leader_start": grp_leader_start,
         "cmd": cmd[:_CMD_LOG_CHARS],
         # Diagnostics ONLY. BANNED as a decision input (§2 of the design): a
@@ -656,10 +663,12 @@ def sweep_orphan_groups(
     leader identity still matches, then unlinks the ledger. A LIVE owner's
     ledger is never touched — that is the live-trainer guarantee.
 
-    OWNER identity is two-factor (``owner_pid`` + ``owner_start``), because a
-    bare pid is forgeable: after the OS recycles a dead ``lop``'s pid onto an
-    unrelated live process, a bare-pid probe reads "alive" and the sweep would
-    refuse to reap a genuinely-orphaned group forever. The truth table:
+    OWNER identity is two-factor (``runtime_pid`` + ``runtime_start``; the
+    pre-rename ``owner_pid``/``owner_start`` keys are still accepted, see
+    ``_entry_owner_identity``), because a bare pid is forgeable: after the OS
+    recycles a dead ``lop``'s pid onto an unrelated live process, a bare-pid
+    probe reads "alive" and the sweep would refuse to reap a
+    genuinely-orphaned group forever. The truth table:
 
         _process_alive(owner_pid) | start token | verdict
         --------------------------|-------------|--------------------------------
@@ -710,11 +719,11 @@ def sweep_orphan_groups(
         # skip — but that only happens if a stale ledger from a PRIOR process
         # reused our pid, which the start-token check below still resolves
         # correctly.
-        owner_pid = entries[0].get("owner_pid")
-        owner_start = entries[0].get("owner_start")
-        if not isinstance(owner_pid, int) or not isinstance(owner_start, str):
+        identity = _entry_owner_identity(entries[0])
+        if identity is None:
             errors += 1
             continue
+        owner_pid, owner_start = identity
         if owner_pid == me:
             # Never reap groups attributed to the sweeping process itself; the
             # soft-death path owns those.
@@ -791,6 +800,33 @@ def _sweep_orphan_locks(groups_dir: Path) -> int:
             continue
         _safe_unlink(lock)
     return errors
+
+
+def _entry_owner_identity(entry: dict[str, object]) -> tuple[int, str] | None:
+    """Resolve an entry's two-factor owner identity, tolerating old ledgers.
+
+    The Stage-4 owner->runtime rename changed the ledger keys written by
+    ``register_group`` to ``runtime_pid``/``runtime_start``, but a ledger
+    written by an older binary still carries ``owner_pid``/``owner_start``. A
+    sweep that read only the new keys would fail the type check on those old
+    ledgers, count them as errors, and leave them in place forever — meaning a
+    hard-killed older build's groups are never reaped, the exact bug class
+    this module exists to close (stage4-owner-retirement §3). Dual-read is
+    safe because ledgers are per-process and short-lived, so one release of
+    it is ample. New key wins when both are present; ``None`` when neither
+    yields a well-typed pair.
+
+    TODO: drop the old-key fallback in the release that follows this change.
+    """
+    pid = entry.get("runtime_pid")
+    start = entry.get("runtime_start")
+    if isinstance(pid, int) and isinstance(start, str):
+        return pid, start
+    old_pid = entry.get("owner_pid")
+    old_start = entry.get("owner_start")
+    if isinstance(old_pid, int) and isinstance(old_start, str):
+        return old_pid, old_start
+    return None
 
 
 def _owner_is_dead(owner_pid: int, owner_start: str) -> bool | None:

--- a/tests/unit/tools/test_group_reaper.py
+++ b/tests/unit/tools/test_group_reaper.py
@@ -134,7 +134,13 @@ def test_register_writes_owner_keyed_ledger(tmp_path):
     assert files[0].name.startswith(f"{pid}-")
     entry = json.loads(files[0].read_text().splitlines()[0])
     assert entry["pgid"] == 4242
-    assert entry["owner_pid"] == pid
+    # Stage-4 rename: new ledgers carry the runtime_* identity keys only; the
+    # old owner_* keys must NOT be written any more (the sweep dual-reads them
+    # for one release — see _entry_owner_identity).
+    assert entry["runtime_pid"] == pid
+    assert isinstance(entry["runtime_start"], str)
+    assert "owner_pid" not in entry
+    assert "owner_start" not in entry
     assert entry["cmd"] == "pyright ."
     assert "ts" in entry  # written for diagnostics
 
@@ -167,6 +173,81 @@ def test_register_appends_multiple_groups_one_file(tmp_path):
     assert len(files) == 1
     lines = files[0].read_text().splitlines()
     assert {json.loads(x)["pgid"] for x in lines} == {11, 22}
+
+
+# --------------------------------------------------------------------------- #
+# dual-read of the pre-rename owner_* ledger keys (stage4-owner-retirement §3)
+# --------------------------------------------------------------------------- #
+def test_entry_owner_identity_prefers_new_keys():
+    """When both key spellings exist, the runtime_* pair wins."""
+    entry = {
+        "runtime_pid": 111,
+        "runtime_start": "new-token",
+        "owner_pid": 222,
+        "owner_start": "old-token",
+    }
+    assert group_reaper._entry_owner_identity(entry) == (111, "new-token")
+
+
+def test_entry_owner_identity_falls_back_to_old_keys():
+    """An entry from an older binary resolves via owner_pid/owner_start."""
+    entry = {"owner_pid": 222, "owner_start": "old-token"}
+    assert group_reaper._entry_owner_identity(entry) == (222, "old-token")
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {},  # neither spelling present
+        {"runtime_pid": "not-an-int", "runtime_start": "tok"},  # wrong type
+        {"runtime_pid": 111},  # missing start token
+        {"owner_pid": 222},  # old key present but token missing
+    ],
+)
+def test_entry_owner_identity_rejects_malformed(entry):
+    """A malformed identity stays None in either spelling -> sweep errors out."""
+    assert group_reaper._entry_owner_identity(entry) is None
+
+
+def test_sweep_reaps_ledger_written_with_old_owner_keys(tmp_path):
+    """A pre-rename ledger (owner_* keys only) is still reaped on owner death.
+
+    This is the compat the dual-read exists for: without it a ledger written
+    by an older binary would fail the identity check and be left in place
+    forever, so a hard-killed older build's groups would leak (stage4-owner-
+    retirement §3). Remove together with the fallback when the old keys are
+    dropped after the release that follows this change.
+    """
+    proc, pgid = _spawn_group()
+    try:
+        leader_start = group_reaper._owner_start_token(pgid)
+        dead = subprocess.Popen(["/bin/sh", "-c", "true"])
+        dead.wait()
+        _write_ledger(
+            tmp_path,
+            dead.pid,
+            "old-owner-token",
+            [
+                {
+                    "pgid": pgid,
+                    # Deliberately the PRE-RENAME keys only, as an older
+                    # binary's register_group wrote them.
+                    "owner_pid": dead.pid,
+                    "owner_start": "old-owner-token",
+                    "grp_leader_start": leader_start,
+                    "cmd": "sleep 600",
+                    "ts": 1.0,
+                }
+            ],
+        )
+        assert _alive(pgid)
+        result = sweep_orphan_groups(tmp_path)
+        assert result.reaped_groups == 1
+        assert _reaped(proc, pgid)
+        assert list(_groups_dir(tmp_path).glob("*.jsonl")) == []
+    finally:
+        _reap_group(pgid)
+        proc.wait(timeout=2)
 
 
 def test_unregister_drops_one_line_keeps_others(tmp_path):


### PR DESCRIPTION
Release: none — internal wire-key compat change (reaper ledger keys); `pyproject.toml` untouched.

## Summary

Stage 4 session-consolidation leftover from PR 4 (plan: `~/workspace/lop-session-consolidation/stage4-owner-retirement.md`, §3 item 3). The group-reaper ledger's owner-identity JSONL keys `owner_pid`/`owner_start` are a wire contract: a new sweep that read only renamed keys could never prove an old ledger's owner dead → groups never reaped → zombie processes, the exact bug class the reaper exists to close.

This lands the plan's compat shape exactly: **dual-read (new key, fall back to old), write new only**. `register_group` now writes `runtime_pid`/`runtime_start`; `sweep_orphan_groups` resolves each ledger's identity through the new `_entry_owner_identity()`, which prefers the new keys and falls back to `owner_pid`/`owner_start` for ledgers written by an older binary. Ledgers are per-process and short-lived, so one release of dual-read is ample; each compat site carries a comment with a TODO to drop the fallback in the release that follows this PR.

## Changed files (2, +127/−10)

- `local_operator/tools/group_reaper.py` — new-key write + comment in `register_group`; `_entry_owner_identity()` dual-read helper with the why (§3) and the drop-TODO; `sweep_orphan_groups` reads identity through it; module docstring's identity description updated to name the new keys and the fallback.
- `tests/unit/tools/test_group_reaper.py` — `test_register_writes_owner_keyed_ledger` now asserts the new keys are written **and the old ones are not**; new tests: `_entry_owner_identity` prefers new keys / falls back to old / rejects malformed entries in either spelling (parametrized), and an end-to-end sweep test proving a **pre-rename ledger** (`owner_*` keys only, fabricated as an older binary would have written it) is still reaped on owner death.

## Deliberately not changed

- `remote.py` / `session.py` / `resume.py` — owned by other Stage-4 PRs (class rename is PR 7).
- Lease `owner_pid` locals in `session_lease.py` — a different axis (lease holder identity, not the reaper ledger); the reaper's internal parameter/helper names (`owner_pid=` kwargs, `_owner_start_token`, `_owner_is_dead`) stay too: they belong to the later class-rename PR, not to this wire-key slice.
- `STOPPED`/`RETIRING` disconnect reasons and the HTTP `execution: "owner" | "native"` enum — separate boundaries, per plan §3.
- No version bump; `git diff origin/main...HEAD -- pyproject.toml` is empty.

## Verification

- `tests/unit/tools/test_group_reaper.py` → **38 passed** (`-n0`, `env -u NO_COLOR TERM=xterm-256color`).
- Neighbouring suites (`tests/unit/session -k "reap or cleanup or retention"`) → **95 passed**.
- `.venv/bin/pyright --pythonpath .venv/bin/python` (whole tree, pinned 1.1.411) → **0 errors, 0 warnings**.
- `flake8==7.3.0`, `black==26.1.0 --check`, `isort==5.13.2 --check-only` (CI pins) → clean on both changed files.
- Real-path exercise (script against this worktree): `register_group` writes keys `['cmd', 'grp_leader_start', 'pgid', 'runtime_pid', 'runtime_start', 'ts']` (no `owner_*` keys); sweep with the live owner skips (`skipped_live_owners=1`); a fabricated **old-format** ledger for a dead pid is read through the fallback and consumed by the sweep.
