### PR TITLE
feat(providers): stamp prompt_cache_key on chat-completions for OpenRouter sticky routing

### DIFF
--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -2145,6 +2145,23 @@ class OpenAICompatClient:
             body["service_tier"] = fast.value
         if request.stop_sequences:
             body["stop"] = list(request.stop_sequences)
+        if request.model.supports_prompt_cache and request.prompt_cache_key:
+            # OpenRouter provider sticky routing expires after 10 minutes of
+            # inactivity (https://openrouter.ai/docs/guides/best-practices/prompt-caching).
+            # After expiry the next request can land on a different upstream
+            # endpoint where the provider's disk cache is cold. DeepSeek's cache
+            # requires a FULL prefix-unit match from token 0
+            # (https://api-docs.deepseek.com/guides/kv_cache/), which the
+            # harness's append-only history already satisfies. OpenRouter falls
+            # back to the OpenAI-style `prompt_cache_key` request field as the
+            # sticky key when no `session_id` is set, and this is the same wire
+            # field the Responses path already sends. We intentionally do NOT
+            # send `session_id`: unknown top-level fields on strict
+            # OpenAI-compatible endpoints could 400, and `prompt_cache_key`
+            # alone is the safe minimum that OpenRouter honours. Forks
+            # intentionally inherit the parent's key (`cache_lineage_id`) so a
+            # fork replays into the parent's warm prefix.
+            body["prompt_cache_key"] = request.prompt_cache_key
         return body
 
     @staticmethod

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -2362,29 +2362,48 @@ def test_openai_compat_chat_body_omits_prompt_cache_key_without_key():
     assert "prompt_cache_key" not in body
 
 
-def test_openai_compat_chat_body_preserves_fork_lineage():
-    """A fork inherits the parent's cache_lineage_id; the key must flow through
-    unchanged so the fork replays into the parent's warm prefix."""
+def test_openai_compat_chat_body_preserves_fork_lineage(tmp_path):
+    """A fork inherits the parent's cache_lineage_id via SessionStreamFn;
+    ``_build_body`` must emit that inherited id on the chat-completions wire.
+
+    Hardcoding the same key on both bodies would pass even if the stream-fn
+    path stopped plumbing ``cache_lineage_id``. Drive the real fork →
+    ``create_stream_fn(..., cache_lineage_id=...)`` path instead.
+    """
+    from local_operator.fork import fork_parent, fork_session
+    from local_operator.model.configure import create_stream_fn
     from local_operator.providers.clients import OpenAICompatClient
+    from local_operator.resume import TRANSCRIPT_NAME
+
+    parent_id = "parent-sess"
+    parent = tmp_path / "sessions" / parent_id
+    parent.mkdir(parents=True)
+    (parent / TRANSCRIPT_NAME).write_text("{}\n", encoding="utf-8")
+    fork_id = fork_session(tmp_path, parent_id)
+    fork_dir = tmp_path / "sessions" / fork_id
+
+    class _Auth:  # only the resolved ids are inspected; nothing is streamed
+        pass
+
+    stream = create_stream_fn(
+        _Auth(),  # type: ignore[arg-type]
+        settings={},
+        session_id=fork_id,
+        cache_lineage_id=fork_parent(fork_dir) or None,
+    )
+    lineage = stream._cache_lineage_id
+    assert lineage == parent_id
 
     spec = _spec()
     spec.supports_prompt_cache = True
-    parent = OpenAICompatClient("https://openrouter.ai/api/v1")._build_body(
-        ChatRequest(
-            model=spec,
-            messages=[Message.user("a")],
-            prompt_cache_key="parent-lineage",
-        )
-    )
-    fork = OpenAICompatClient("https://openrouter.ai/api/v1")._build_body(
+    body = OpenAICompatClient("https://openrouter.ai/api/v1")._build_body(
         ChatRequest(
             model=spec,
             messages=[Message.user("a"), Message.user("forked")],
-            prompt_cache_key="parent-lineage",
+            prompt_cache_key=lineage,
         )
     )
-    assert parent["prompt_cache_key"] == "parent-lineage"
-    assert fork["prompt_cache_key"] == "parent-lineage"
+    assert body["prompt_cache_key"] == parent_id
 
 
 def test_reasoning_effort_reaches_openai_and_anthropic_wires() -> None:

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -2318,6 +2318,75 @@ def test_openai_compat_markers_gate_on_cache_support():
     assert "cache_control" not in str(plain["messages"])
 
 
+def test_openai_compat_chat_body_carries_prompt_cache_key():
+    """Chat-completions body carries prompt_cache_key when the model supports
+    caching and the request carries a lineage key. OpenRouter uses this as the
+    sticky-routing key; the field is absent when the model reports no cache
+    support so non-caching providers are not sent a field they may not know."""
+    from local_operator.providers.clients import OpenAICompatClient
+
+    spec = _spec()
+    spec.supports_prompt_cache = True
+    body = OpenAICompatClient("https://openrouter.ai/api/v1")._build_body(
+        ChatRequest(
+            model=spec,
+            messages=[Message.user("a")],
+            prompt_cache_key="lineage-123",
+        )
+    )
+    assert body["prompt_cache_key"] == "lineage-123"
+
+    spec_nocache = _spec()
+    spec_nocache.supports_prompt_cache = False
+    body = OpenAICompatClient("https://openrouter.ai/api/v1")._build_body(
+        ChatRequest(
+            model=spec_nocache,
+            messages=[Message.user("a")],
+            prompt_cache_key="lineage-123",
+        )
+    )
+    assert "prompt_cache_key" not in body
+
+
+def test_openai_compat_chat_body_omits_prompt_cache_key_without_key():
+    """No prompt_cache_key is sent when the request does not carry one, even if
+    the model supports caching. This keeps the wire minimal for callers that
+    have not opted into lineage-based cache affinity."""
+    from local_operator.providers.clients import OpenAICompatClient
+
+    spec = _spec()
+    spec.supports_prompt_cache = True
+    body = OpenAICompatClient("https://openrouter.ai/api/v1")._build_body(
+        ChatRequest(model=spec, messages=[Message.user("a")])
+    )
+    assert "prompt_cache_key" not in body
+
+
+def test_openai_compat_chat_body_preserves_fork_lineage():
+    """A fork inherits the parent's cache_lineage_id; the key must flow through
+    unchanged so the fork replays into the parent's warm prefix."""
+    from local_operator.providers.clients import OpenAICompatClient
+
+    spec = _spec()
+    spec.supports_prompt_cache = True
+    parent = OpenAICompatClient("https://openrouter.ai/api/v1")._build_body(
+        ChatRequest(
+            model=spec,
+            messages=[Message.user("a")],
+            prompt_cache_key="parent-lineage",
+        )
+    )
+    fork = OpenAICompatClient("https://openrouter.ai/api/v1")._build_body(
+        ChatRequest(
+            model=spec,
+            messages=[Message.user("a"), Message.user("forked")],
+            prompt_cache_key="parent-lineage",
+        )
+    )
+    assert parent["prompt_cache_key"] == "parent-lineage"
+    assert fork["prompt_cache_key"] == "parent-lineage"
+
+
 def test_reasoning_effort_reaches_openai_and_anthropic_wires() -> None:
     # The ladder is declared on both specs: `_reasoning_effort` refuses a level
     # the model does not accept, so a spec that names one but never lists it is

--- a/tests/unit/providers/test_xai_affinity.py
+++ b/tests/unit/providers/test_xai_affinity.py
@@ -124,7 +124,13 @@ def _chat_sse(chunks):
 @pytest.mark.asyncio
 async def test_chat_dispatch_adds_header_without_changing_body():
     """End to end on the chat path xai actually uses: header on the wire,
-    body untouched by the routing key."""
+    and the chat body carries ``prompt_cache_key``.
+
+    xAI lists ``prompt_cache_key`` as a first-class chat-completions field
+    plumbed to ``x-grok-conv-id``, so the stamp that every cache-capable
+    openai-compat client now sends is expected here too — the routing header
+    is additive, not a substitute for the body field.
+    """
     wire: list[httpx.Request] = []
 
     def respond(request):
@@ -145,8 +151,8 @@ async def test_chat_dispatch_adds_header_without_changing_body():
     async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as http:
         client = OpenAICompatClient(XAI_BASE, http_client=http)
         request = _request()
-        # The stream computes the same scope from the credential; assert the
-        # routing header changed nothing about the body.
+        # The stream computes the same scope from the credential; the routing
+        # header is additive — the body still carries prompt_cache_key.
         expected_body = client._build_body(request, scope=credential_scope("synthetic-key"))
         for _ in range(2):  # retry/resume keeps the same conv id
             async for _event in client.stream(request, "synthetic-key"):
@@ -158,7 +164,7 @@ async def test_chat_dispatch_adds_header_without_changing_body():
         assert json.loads(sent.content) == expected_body
         ids.add(sent.headers["x-grok-conv-id"])
     assert len(ids) == 1
-    assert "prompt_cache_key" not in json.loads(wire[0].content)
+    assert json.loads(wire[0].content)["prompt_cache_key"] == "lineage"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_fork.py
+++ b/tests/unit/test_fork.py
@@ -1074,10 +1074,11 @@ class TestTheForkInheritsItsParentsCacheKey:
     def test_the_key_reaches_the_openai_wire_body(self, tmp_path: Path) -> None:
         """The inherited id is only worth anything if it is actually SENT.
 
-        ``_build_responses_body`` is the sole place the key reaches the wire,
-        gated on ``supports_prompt_cache``; the chat-completions body never
-        carries it. This drives the real builder rather than asserting on
-        source, so a change to the gate or the field name fails here.
+        Both ``_build_body`` (chat-completions; OpenRouter sticky routing) and
+        ``_build_responses_body`` stamp ``prompt_cache_key``, gated on
+        ``supports_prompt_cache``. This drives the real builders rather than
+        asserting on source, so a change to the gate or the field name fails
+        here.
         """
         from local_operator.harness.types import ChatRequest, Message
         from local_operator.model.configure import build_model_spec
@@ -1092,15 +1093,16 @@ class TestTheForkInheritsItsParentsCacheKey:
         assert spec.supports_prompt_cache, "the gate this key rides on is off for gpt-5.4"
 
         client = OpenAICompatClient(base_url="https://api.openai.com/v1", openai_api="responses")
-        body = client._build_responses_body(
-            ChatRequest(
-                model=spec,
-                system_blocks=["stable prefix"],
-                messages=[Message.user("go")],
-                prompt_cache_key=lineage,
-            )
+        request = ChatRequest(
+            model=spec,
+            system_blocks=["stable prefix"],
+            messages=[Message.user("go")],
+            prompt_cache_key=lineage,
         )
+        chat_body = client._build_body(request)
+        assert chat_body["prompt_cache_key"] == PARENT_ID
 
+        body = client._build_responses_body(request)
         assert body["prompt_cache_key"] == PARENT_ID
         assert body["prompt_cache_retention"] == "24h"
 


### PR DESCRIPTION
## Summary of Changes

OpenRouter provider sticky routing expires after 10 minutes of inactivity. After expiry the next request can land on a different upstream endpoint where DeepSeek's disk cache is cold (measured: 95–100% cache hit within a continuous conversation, 0–28% after idle gaps >10 min while subagents ran). DeepSeek's cache requires a FULL prefix-unit match from token 0, which the harness's append-only history already satisfies.

The OpenAI Responses path already stamped `prompt_cache_key` on the body. The chat-completions path used for OpenRouter did not. This PR adds it when `supports_prompt_cache` and a lineage key are both set.

- `local_operator/providers/clients.py` — `_build_body` (chat-completions) now sets `body["prompt_cache_key"] = request.prompt_cache_key` under the same gate as the Responses path. Does **not** set `prompt_cache_retention` (OpenAI-Responses-specific; unknown on OpenRouter chat completions). Does **not** send `session_id`: unknown top-level fields on strict OpenAI-compatible endpoints could 400, and OpenRouter already uses `prompt_cache_key` as the sticky-key fallback. Forks continue to inherit the parent's `cache_lineage_id`.
- `tests/unit/providers/test_clients.py` — asserts the key is present when cache support + key are set, omitted when the model reports no cache support, omitted when no key is supplied, and that a fork replaying the parent lineage still sends the same key.

No `provider.order` / provider-sort config is added anywhere — manual ordering disables sticky routing.

## Design decision

`prompt_cache_key` only, not `session_id`. OpenRouter documents `session_id` (body or `x-session-id` header) as the primary sticky key and `prompt_cache_key` as the fallback. Sending `session_id` would require gating on `provider == "openrouter"` / `openrouter.ai` host, which is fragile for custom OpenAI-compatible entries pointed at OpenRouter. `prompt_cache_key` is already the Responses-path field, OpenAI honours it, and other OpenAI-compatible providers ignore unknown fields. Measured vs assumed: sticky-routing expiry and DeepSeek prefix-unit matching are from the linked docs plus session 32cc6288b38f; that `session_id` would 400 on a strict endpoint is assumed, which is why it is not sent.

## References

- OpenRouter prompt caching — https://openrouter.ai/docs/guides/best-practices/prompt-caching (sticky routing, 10 min expiry, `session_id` / `prompt_cache_key`)
- DeepSeek KV cache — https://api-docs.deepseek.com/guides/kv_cache/ (full prefix-unit match from token 0)

## Testing Details

**Unit tests** (targeted, 3 passed after rebase onto current main including #931 grok-cache-affinity):

```
tests/unit/providers/test_clients.py -k openai_compat_chat_body
  test_openai_compat_chat_body_carries_prompt_cache_key          PASSED
  test_openai_compat_chat_body_omits_prompt_cache_key_without_key PASSED
  test_openai_compat_chat_body_preserves_fork_lineage            PASSED
```

**Gates (whole tree, as CI runs them):**

```
.venv/bin/python -m flake8 .                                    clean
uvx --from black==26.1.0 black --check .                        1211 files unchanged
uvx isort==5.13.2 --check .                                     clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .     0 errors
```

Full `pytest tests/unit -q` was started locally but hung at ~99% under host contention from sibling worktree suites (leftover `brokerd` processes); not a regression of this change. CI is the full-suite evidence.

**No version bump** — pyproject stays at the released version per the combined-release policy.

## Impact

- Chat-completions requests for cache-capable models now carry the same per-session lineage key the Responses path already sent, so OpenRouter can pin sticky routing across idle gaps.
- No behaviour change when the model reports no cache support, or when no `prompt_cache_key` is set (isolated calls remain byte-identical).
- Forks still inherit the parent's key so a fork replays into the parent's warm prefix.