### PR TITLE
fix(tui): project hidden peer receipts on first sidebar reveal

### DIFF
--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -38,6 +38,7 @@ from local_operator.harness.types import (
     AskUserFn,
     CompactionEndEvent,
     CompactionStartEvent,
+    CustomMessage,
     EventHandler,
     HistoryDeltaEvent,
     ImageContent,
@@ -93,6 +94,7 @@ from local_operator.session.frontend_state import (
 )
 from local_operator.session.history_window import DisplayHistoryWindow
 from local_operator.session.naming import ConversationName
+from local_operator.session.peer import PEER_MESSAGE_MESSAGE_TYPE
 from local_operator.session.protocol import (
     CompactionOutcome,
     RuntimeLocality,
@@ -3454,6 +3456,55 @@ class RemoteSession:
             result = Message.tool_result(event.result)
             result.id = f"live-tool:{event.tool_call_id}"
             self._live_history[result.id] = result
+        if isinstance(event, PeerMessageDeliveredEvent):
+            # A peer `lop send` persists its CustomMessage BEFORE it emits this
+            # receipt, so the row is SETTLED — a single durable row with no
+            # start/update/end lifecycle, which is why it is NOT in
+            # ``_MESSAGE_PHASE`` (that machinery orders the streaming beats of a
+            # turn; a phase rank is a category error for one settled append).
+            #
+            # The row is invisible to every viewer freshness signal without
+            # this branch: ``history_generation`` bumps only on compaction /
+            # prune, so a plain peer append never invalidates the display
+            # window, and the receipt carries no ``message`` payload for the
+            # generic path below to claim. The hidden session then keeps a
+            # stale ``history_message_count`` — so on reveal neither
+            # ``_sidebar_presentation_current``'s count guard rejects the stale
+            # cached presentation, nor ``_commit_sidebar_session``'s
+            # ``total > incoming.history_size`` delta fires, and the inbound
+            # row is never projected until a full reload. Recording the settled
+            # row here grows the count by exactly one, which is what makes both
+            # signals move.
+            #
+            # Painting stays with the existing replay/delta paths and their
+            # ``_live_peer_receipts`` / ``_resume_mounted_ids`` dedup guards:
+            # this branch stores the row for COUNT and durability, and adds the
+            # id to ``_durable_seed_ids`` so the next sync treats it as durable
+            # rather than re-painting it — it mounts nothing itself.
+            #
+            # Deliberately NOT gated on ``peer_id not in self._history_ids``.
+            # The owner persists the row BEFORE emitting this receipt, so a sync
+            # that raced the append may already carry the id in ``_history_ids``
+            # — yet the receipt is the authoritative "a new row landed" beat the
+            # count still has to advance for, or the reveal misses exactly the
+            # row the sync failed to surface. Each ``peer_id`` is delivered at
+            # most once, so recording it here cannot double-count; a re-delivery
+            # would collide on the dict key and keep the count at one. Skipped
+            # only when the receipt carries no id (an older/leaner sender),
+            # since an id-less row can neither be counted once nor deduped.
+            peer_id = str(getattr(event, "message_id", "") or "")
+            if peer_id:
+                peer_row = CustomMessage(
+                    custom_type=PEER_MESSAGE_MESSAGE_TYPE,
+                    attribution="user",
+                    details={"body": event.body, "sender": dict(event.sender)},
+                )
+                # The marker must carry the PERSISTED entry id so the next sync
+                # and the replay dedup both match on it.
+                peer_row.id = peer_id
+                self._live_history[peer_id] = peer_row
+                self._durable_seed_ids.add(peer_id)
+            return
         message = getattr(event, "message", None)
         message_id = str(getattr(message, "id", "") or "")
         if not message_id:

--- a/tests/unit/session/test_history_window.py
+++ b/tests/unit/session/test_history_window.py
@@ -24,6 +24,7 @@ from local_operator.session.history_window import (
     display_window,
     wire_payload,
 )
+from local_operator.session.peer import PEER_MESSAGE_MESSAGE_TYPE
 from local_operator.session.remote import RemoteSession
 from local_operator.session.runtime.owned import OwnedSessionHandle
 from local_operator.session.runtime.server import RuntimeServer
@@ -375,6 +376,78 @@ async def test_live_replay_mutations_refresh_without_replacing_the_connection(
         ]
         assert remote._display_history.history_generation == session._transcript._history_generation
         assert len(server._clients) == 1
+    finally:
+        if remote is not None:
+            await remote.dispose()
+        server.close()
+        await handle.dispose()
+
+
+@pytest.mark.asyncio
+async def test_peer_row_received_while_hidden_advances_the_viewer_count(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A `lop send` landing on a HIDDEN session must move the freshness count.
+
+    Regression for the missing-receipt resume: a peer CustomMessage is persisted
+    by the owner BEFORE it emits the ``PeerMessageDeliveredEvent``, and it bumps
+    neither ``history_generation`` (compaction/prune only) nor any
+    ``_MESSAGE_PHASE`` lifecycle (a settled row, not a streaming beat). Without
+    the ``_remember_live`` branch the hidden viewer's ``history_message_count``
+    stays frozen — so on reveal neither the stale-presentation guard rejects the
+    cache nor the ``total > history_size`` delta fires, and the inbound row is
+    never projected until a full reload. This drives a real owner + viewer over
+    the production socket and asserts the count advances exactly once and the
+    settled row is surfaced to the next display window.
+    """
+    config = tmp_path / "config"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config))
+    directory = config / "sessions" / "peer-count"
+    messages = [Message.user("initial"), Message.assistant("seeded answer")]
+    await seed_transcript(directory, messages)
+    session = build_session(directory, ScriptedStream([text_turn("unused")]), cwd=tmp_path)
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(tmp_path))
+    server = RuntimeServer(handle, kind="daemon")
+    await server.start_in_process()
+    remote = None
+    try:
+        remote = await RemoteSession.connect(
+            server._record,
+            "peer-count",
+            config_dir=config,
+            takeover_factory=_never_take_over,
+            display_window=True,
+        )
+        baseline = remote.history_message_count
+        await session.receive_peer_message(
+            "gates are green",
+            sender={"pid": 4242, "conversation_name": "peer-send"},
+        )
+        # The receipt crosses the socket asynchronously; wait for the settled
+        # row to land in the viewer's live history, then assert the count moved.
+        peer_row = None
+        for _ in range(100):
+            await asyncio.sleep(0.01)
+            peer_row = next(
+                (
+                    row
+                    for row in remote._live_history.values()
+                    if getattr(row, "custom_type", None) == PEER_MESSAGE_MESSAGE_TYPE
+                ),
+                None,
+            )
+            if peer_row is not None:
+                break
+        assert peer_row is not None, "the hidden viewer never filed the settled peer row"
+        assert remote.history_message_count == baseline + 1
+        # The marker carries the PERSISTED entry id, so the next display window
+        # (and the TUI's replay dedup) match on it — and the viewer hands the
+        # row to the next prepared replay.
+        assert peer_row.id in remote._durable_seed_ids
+        assert any(
+            getattr(row, "custom_type", None) == PEER_MESSAGE_MESSAGE_TYPE
+            for row in remote.display_history_window()
+        )
     finally:
         if remote is not None:
             await remote.dispose()

--- a/tests/unit/tui/test_sidebar_peer_receipt.py
+++ b/tests/unit/tui/test_sidebar_peer_receipt.py
@@ -129,7 +129,7 @@ async def live_owners(
                 display_window=True,
             )
 
-        monkeypatch.setattr("local_operator.mobile.attach_client.find_owner_record", find)
+        monkeypatch.setattr("local_operator.mobile.attach_client.find_runtime_record", find)
         resume.servers = servers  # type: ignore[attr-defined]
         yield resume
     finally:

--- a/tests/unit/tui/test_sidebar_peer_receipt.py
+++ b/tests/unit/tui/test_sidebar_peer_receipt.py
@@ -1,0 +1,213 @@
+"""A peer `lop send` landing on a HIDDEN session paints on the first reveal.
+
+The reported bug: an inbound ``peer_message`` CustomMessage appended while a
+session sat parked in the sidebar was invisible until a SECOND reload. The
+transcript showed the agent answering the note but the ``PeerMessageBlock``
+itself never mounted on the first reveal, on BOTH a cold resume and a warm
+session-to-session swap.
+
+The mechanism is that a settled peer append moves NONE of the viewer's
+freshness signals: ``history_generation`` bumps only on compaction/prune, and
+the ``PeerMessageDeliveredEvent`` carries no ``_MESSAGE_PHASE`` lifecycle (it is
+one settled row, not a streaming beat). So the hidden viewer's
+``history_message_count`` stayed frozen — which meant neither
+``_sidebar_presentation_current``'s count guard rejected the stale cached
+presentation, nor ``_commit_sidebar_session``'s ``total > history_size`` delta
+projection fired. The fix (``RemoteSession._remember_live``) files the settled
+row keyed by its persisted id so the count advances.
+
+This drives the full assembled path — a real owner behind a real socket, the
+production sidebar select, and the TUI's replay — asserting the block appears
+on the FIRST switch back, and is not painted twice.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import tempfile
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from local_operator.session.remote import RemoteSession
+from local_operator.session.runtime.owned import OwnedSessionHandle
+from local_operator.session.runtime.server import RuntimeServer
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.transcript import PeerMessageBlock
+from tests.e2e.harness import (
+    ScriptedStream,
+    assistant_message,
+    build_session,
+    seed_transcript,
+    text_turn,
+    user_message,
+    wait_for_adoption,
+)
+from tests.unit.harness.test_comms import DEADLOCK_GUARD_S
+
+
+@pytest.fixture(autouse=True)
+def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Headless apps must never rename the caller's real multiplexer workspace.
+    for key in tuple(os.environ):
+        if key.startswith("CMUX_"):
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_NOTIFICATIONS", "1")
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_TERMINAL_TITLE", "1")
+    monkeypatch.setattr(OperatorApp, "_check_for_update", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_terminal_title", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_multiplexer_broadcast", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_herdr_reporter", lambda _self: None)
+
+
+@asynccontextmanager
+async def live_owners(
+    config: Path, ids: list[str], monkeypatch: pytest.MonkeyPatch
+) -> AsyncIterator[Callable[[str | None], Awaitable[RemoteSession]]]:
+    """Real ``RuntimeServer`` owners behind one sidebar, one per id.
+
+    Mirrors ``test_sidebar_live_tool_card.live_owners`` minus the parking tool
+    and turn-driving stream: these sessions stay IDLE, because the receipt being
+    tested is the mailbox record-only path — no turn runs at all.
+    """
+    from local_operator.session.runtime import registry
+
+    def publish(record: Any, root: Path | None = None) -> Path:
+        directory = registry.run_dir(root)
+        record.heartbeat_at = time.time()
+        handle, path = tempfile.mkstemp(dir=directory, prefix=".x.", suffix=".tmp")
+        with os.fdopen(handle, "w") as stream:
+            json.dump(record.to_json(), stream)
+        target = directory / f"{record.pid}-{record.session_id}.json"
+        os.replace(path, target)
+        return target
+
+    monkeypatch.setattr(registry, "publish", publish)
+    monkeypatch.setattr(registry, "unpublish", lambda pid, root=None: None)
+
+    servers: dict[str, RuntimeServer] = {}
+    handles: list[OwnedSessionHandle] = []
+    try:
+        for session_id in ids:
+            directory = config / "sessions" / session_id
+            await seed_transcript(
+                directory,
+                [
+                    user_message(f"{session_id} question"),
+                    assistant_message(f"{session_id} saved answer"),
+                ],
+            )
+            owner = build_session(directory, ScriptedStream([text_turn("idle")]), cwd=config)
+            handle = OwnedSessionHandle(owner, asyncio.get_running_loop(), cwd=str(config))
+            handles.append(handle)
+            server = RuntimeServer(handle, kind="daemon")
+            await server.start_in_process()
+            servers[session_id] = server
+
+        def find(_directory: Path, session_id: str) -> tuple[Any, Any]:
+            server = servers.get(session_id)
+            return (server._record, server._record.pid) if server else (None, None)
+
+        async def never() -> Any:
+            raise AssertionError("view navigation must never take execution ownership")
+
+        async def resume(session_id: str | None) -> RemoteSession:
+            assert session_id is not None
+            return await RemoteSession.connect(
+                servers[session_id]._record,
+                session_id,
+                config_dir=config,
+                takeover_factory=never,
+                display_window=True,
+            )
+
+        monkeypatch.setattr("local_operator.mobile.attach_client.find_owner_record", find)
+        resume.servers = servers  # type: ignore[attr-defined]
+        yield resume
+    finally:
+        for server in servers.values():
+            await server.aclose()
+        for handle in handles:
+            await handle.dispose()
+
+
+async def _switch(app: OperatorApp, session_id: str, pilot: Any) -> None:
+    """The production sidebar path: select, then await the connection it opens."""
+    await asyncio.wait_for(app._sidebar_navigation.select(session_id), DEADLOCK_GUARD_S)
+    connection = app._interaction.connection_task
+    if connection is not None:
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(asyncio.shield(connection), DEADLOCK_GUARD_S)
+    for _ in range(40):
+        await pilot.pause()
+
+
+def _peer_blocks(app: OperatorApp) -> list[PeerMessageBlock]:
+    return [b for b in app._transcript_view().blocks() if isinstance(b, PeerMessageBlock)]
+
+
+@pytest.mark.asyncio
+async def test_peer_row_on_a_hidden_session_paints_on_the_first_reveal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Visit, leave, deliver a `lop send`, then click back: the block is there.
+
+    The exact operator repro: the hidden session receives the note while it is
+    parked, and the FIRST return must already show it. Asserted twice — that the
+    viewer's count advanced (the signal the reveal consults) and that exactly
+    one ``PeerMessageBlock`` mounted (no double-paint against the live receipt,
+    which a hidden session never paints).
+    """
+    config = tmp_path / "config"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config))
+    ids = ["home00", "peer01"]
+    async with live_owners(config, ids, monkeypatch) as resume:
+        app = OperatorApp(lambda: resume("home00"), resume_factory=resume)
+        async with app.run_test(size=(120, 36)) as pilot:
+            await wait_for_adoption(app, pilot)
+            app._set_sidebar_open(True)
+            if app._sidebar_timer is not None:
+                app._sidebar_timer.pause()  # no background prewarm races
+
+            # Visit the peer conversation, then leave it hidden — the state the
+            # bug needs: a connected, parked source with a cached presentation.
+            await _switch(app, "peer01", pilot)
+            await _switch(app, "home00", pilot)
+
+            owner = resume.servers["peer01"]._handle._session  # type: ignore[attr-defined]
+            await owner.receive_peer_message(
+                "gates are green",
+                sender={"pid": 4242, "conversation_name": "peer-send design"},
+            )
+
+            # The receipt crosses the socket asynchronously; wait until the
+            # hidden viewer has filed the settled row before the reveal, or the
+            # assertion measures a delivery race instead of the paint path.
+            # `cast`, because the protocol the app types its sources against
+            # does not declare the viewer-only `_live_history` this wait reads.
+            viewer = cast(Any, app._sidebar_sources["peer01"].session)
+            for _ in range(200):
+                await pilot.pause()
+                if any(
+                    getattr(row, "custom_type", None) == "peer_message"
+                    for row in viewer._live_history.values()
+                ):
+                    break
+            else:
+                raise AssertionError("the hidden viewer never filed the settled peer row")
+
+            await _switch(app, "peer01", pilot)
+
+            blocks = _peer_blocks(app)
+            assert (
+                len(blocks) == 1
+            ), f"expected exactly one peer receipt on the first reveal, got {len(blocks)}"
+            assert blocks[0].text() == "gates are green"


### PR DESCRIPTION
## What and why

**C2 — a peer `lop send` received while a session is hidden never paints on the first sidebar reveal / warm swap.** The inbound `PeerMessageBlock` is missing until a second reload. The operator sees an empty transcript on resume even though the receipt already landed; a later reload suddenly shows it.

### Root cause

`PeerMessageDeliveredEvent` is a settled durable row with no `_MESSAGE_PHASE` lifecycle (that machinery orders streaming beats of a turn; a phase rank is a category error for one settled append). `_remember_live` never recorded it in the viewer's `_live_history`.

Two freshness signals then stay still:

1. `history_generation` only bumps on compaction / prune, so a plain peer append never invalidates the display window.
2. `history_message_count` never grows, so `_sidebar_presentation_current`'s count guard reuses the stale cached presentation, and `_commit_sidebar_session`'s `total > incoming.history_size` delta never fires.

The inbound row is therefore never projected until a full reload rebuilds the window from disk.

### The fix

`_remember_live` now records the settled row keyed by the **persisted** `message_id` (and seeds `_durable_seed_ids` so the next sync treats it as durable rather than re-painting it). That grows the count by exactly one, which is what makes both freshness signals move. Painting stays with the existing replay / delta paths and their `_live_peer_receipts` / `_resume_mounted_ids` dedup guards — this branch mounts nothing itself.

Deliberately not gated on `peer_id not in self._history_ids`: the owner persists the row *before* emitting the receipt, so a racing sync may already carry the id, yet the receipt is still the authoritative "a new row landed" beat the count has to advance for.

## Testing evidence

Implementer's run on this branch (`cbd38972b`):

| gate | command | result |
| --- | --- | --- |
| flake8 | `.venv/bin/python -m flake8 .` | clean |
| black | `uvx --from black==26.1.0 black --check .` | clean |
| isort | `uvx isort==5.13.2 --check-only .` | clean |
| pyright (touched file) | `.venv/bin/python -m pyright --pythonpath .venv/bin/python local_operator/session/remote.py` | 0 errors |
| new tests | `tests/unit/session/test_history_window.py::test_peer_row_received_while_hidden_advances_the_viewer_count` and `tests/unit/tui/test_sidebar_peer_receipt.py::test_peer_row_on_a_hidden_session_paints_on_the_first_reveal` | 2 passed; both FAIL without the fix |
| session unit | `.venv/bin/python -m pytest tests/unit/session -q` | 1940 passed |
| related TUI | `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui/test_sidebar_peer_receipt.py tests/unit/tui/test_session_sidebar.py -q` | 61 passed |
| full `tests/unit/tui` | — | **timed out at 900s — not claimed as run** |

No version bump: `pyproject.toml` is untouched. Combined-release rule: PRs never carry a version bump; this one does not.

## Not addressed (deliberate)

- **Wake receipts (`WakeDeliveredEvent`)** remain a sibling gap — deferred. Same shape (settled event that never enters `_live_history`, so the first-reveal count never grows), different key (`(wake_id, occurrence)`). Not in this PR.