### PR TITLE
chore(release): bump version to 0.54.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.7"
+version = "0.54.8"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
C0 one-file bump for the post-v0.54.7 release window.

Window PRs:
- #929 — resume live-tool double-paint
- #936 — reaper ledger dual-read

Bump class: PATCH — both window PRs are bug fixes; neither clears the
step-function bar for a minor.

No code change. `pyproject.toml` version line only; `version-bump-guard`
is the real CI check for this diff.