### PR TITLE
feat(session): refresh a conversation's title on demand with /title refresh

### DIFF
--- a/local_operator/session/naming.py
+++ b/local_operator/session/naming.py
@@ -662,6 +662,14 @@ def provisional_title(text: str) -> str:
 #: nothing propagates out of a naming call into the turn beside it.
 CALL_FAILED = object()
 
+#: Returned when the naming call was CANCELLED rather than failing on its own.
+#: Separate from :data:`CALL_FAILED` because the two have opposite meanings for
+#: the two kinds of caller: a detached worker must swallow both (its cancel is a
+#: routine shutdown), while an awaited caller must re-raise this one — its
+#: cancel is the client that asked going away, and a receipt for a request
+#: nobody is holding is worse than no answer. Both collapse to "no title".
+CALL_CANCELLED = object()
+
 
 async def _ask_for_title(
     system: str, prompt: str, complete_fn, timeout: float
@@ -680,11 +688,19 @@ async def _ask_for_title(
     """
     try:
         raw = await asyncio.wait_for(complete_fn(system, prompt), timeout)
-    except (asyncio.TimeoutError, asyncio.CancelledError):
-        # CancelledError is caught deliberately: the naming task is detached
-        # and routinely cancelled at shutdown, and letting that propagate
-        # would surface a teardown traceback for a feature nobody waited on.
+    except asyncio.TimeoutError:
         return CALL_FAILED
+    except asyncio.CancelledError:
+        # Swallowed, deliberately and load-bearingly: the automatic naming task
+        # is DETACHED and routinely cancelled at shutdown, so propagating would
+        # surface a teardown traceback for a feature nobody waited on.
+        #
+        # Reported apart from a timeout all the same, because a caller that IS
+        # awaited (:func:`routed_refresh`) has the opposite obligation: a cancel
+        # there is its own caller going away, and reporting that as a title
+        # outcome would answer a request nobody is listening to. It re-raises on
+        # this sentinel; the detached callers collapse it like any failure.
+        return CALL_CANCELLED
     except Exception:
         # EVERY provider failure, 429 included. The turn is running alongside
         # this call and must never learn it happened; the request is `isolated`
@@ -1040,6 +1056,11 @@ TITLE_UNCHANGED = "unchanged"
 TITLE_UNAVAILABLE = "unavailable"
 TITLE_NOTHING_YET = "nothing-yet"
 
+#: The call was cancelled. NOT a user-facing outcome — it exists so an awaited
+#: caller can tell a cancel apart from a failure and re-raise it. See
+#: :data:`CALL_CANCELLED`.
+TITLE_CANCELLED = "cancelled"
+
 
 #: The receipt each outcome earns, in the words every surface says them in.
 #: ONE spelling for three handlers (the TUI worker, the routed ``slash_result``
@@ -1062,12 +1083,21 @@ def refresh_receipt(result: "TitleRefresh", standing: str, *, stored: bool = Tru
     this command with a name it did not choose and claim a store that never
     happened. Same outcome, opposite receipts.
     """
-    if result.outcome == TITLE_REFRESHED:
-        return f"title refreshed: {standing}" if stored else f"title unchanged: {standing}"
+    if result.outcome == TITLE_REFRESHED and stored and standing:
+        return f"title refreshed: {standing}"
+    if result.outcome == TITLE_UNAVAILABLE:
+        # Honest with or without a name: it reports that no judgement happened
+        # rather than asserting one the dead provider never made.
+        return "could not reach the model — the title is unchanged"
+    if not standing:
+        # Every remaining branch quotes the name in force, and there isn't one:
+        # a superseded refresh on a never-named conversation reached this and
+        # rendered "title unchanged: " with nothing after the colon. The
+        # nothing-yet wording is the truth for all of them — there is no title,
+        # and the way to get one by hand is the same.
+        return "nothing to title yet — /title <words> names it by hand"
     if result.outcome == TITLE_NOTHING_YET:
         return "nothing to title yet — /title <words> names it by hand"
-    if result.outcome == TITLE_UNAVAILABLE:
-        return "could not reach the model — the title is unchanged"
     return f"title unchanged: {standing}"
 
 
@@ -1131,6 +1161,11 @@ async def refresh_title(
         # resolves itself as soon as the conversation has content.
         return TitleRefresh(TITLE_NOTHING_YET)
     title = await _ask_for_title(THEME_SYSTEM_PROMPT, context, complete_fn, timeout)
+    if title is CALL_CANCELLED:
+        # Not an outcome the user is ever shown: the awaited callers re-raise it
+        # (see :func:`routed_refresh`) and the worker's own ``CancelledError``
+        # branch has already returned by the time one could reach a receipt.
+        return TitleRefresh(TITLE_CANCELLED)
     if title is CALL_FAILED:
         # The model was never reached. Reported apart from "unchanged" because
         # the two differ in the only way that matters to someone who typed a
@@ -1143,7 +1178,8 @@ async def refresh_title(
         # was nothing worth titling, which is the nothing-yet case arriving from
         # the model rather than from an empty transcript.
         return TitleRefresh(TITLE_UNCHANGED if current else TITLE_NOTHING_YET)
-    assert isinstance(title, str)  # narrowed: CALL_FAILED and None returned above
+    # narrowed: CALL_CANCELLED, CALL_FAILED and None all returned above
+    assert isinstance(title, str)
     if current and title.casefold() == current.casefold():
         return TitleRefresh(TITLE_UNCHANGED, current)
     return TitleRefresh(TITLE_REFRESHED, title)
@@ -1188,14 +1224,22 @@ async def routed_refresh(current: str, session: Any) -> TitleRefresh:
         )
 
     try:
-        return await asyncio.wait_for(_gather(), ROUTED_TITLE_TIMEOUT_S)
+        result = await asyncio.wait_for(_gather(), ROUTED_TITLE_TIMEOUT_S)
     except asyncio.CancelledError:
-        # NOT swallowed: a cancelled op is the caller going away, and the
-        # runtime's own teardown must not be reported to it as a title outcome.
+        # A cancel landing in the HISTORY read arrives here as itself. Never
+        # swallowed: the op's caller has gone away, and a receipt for a request
+        # nobody holds is worse than no answer.
         raise
     except Exception:  # noqa: BLE001 — naming is decoration; never fail the op
         logger.debug("routed title refresh could not complete", exc_info=True)
         return TitleRefresh(TITLE_UNAVAILABLE)
+    if result.outcome == TITLE_CANCELLED:
+        # A cancel landing in the NAMING call is swallowed down there (it has to
+        # be, for the detached workers) and surfaces as this outcome instead, so
+        # the two awaits answer one signal the same way rather than one raising
+        # and the other returning a title verdict.
+        raise asyncio.CancelledError
+    return result
 
 
 @dataclass

--- a/local_operator/session/naming.py
+++ b/local_operator/session/naming.py
@@ -648,13 +648,30 @@ def provisional_title(text: str) -> str:
     return label
 
 
-async def _ask_for_title(system: str, prompt: str, complete_fn, timeout: float) -> str | None:
-    """One bounded call, every failure resolving to ``None``.
+#: Returned by :func:`_ask_for_title` when the CALL failed, as opposed to the
+#: model answering "no title". Both still resolve to ``None`` for the automatic
+#: callers — the instruction to them is identical, leave the title alone — but a
+#: user who typed a command is owed the difference between "the name still fits"
+#: and "the model could not be reached", because only one of those is worth
+#: retrying. A sentinel rather than an exception keeps the isolation absolute:
+#: nothing propagates out of a naming call into the turn beside it.
+CALL_FAILED = object()
 
-    Shared by :func:`generate_title` and :func:`generate_retitle` so the two
-    have exactly one error policy between them. There is no retry here and
-    none underneath (the session marks the request single-attempt), so the
-    timeout is the entire budget.
+
+async def _ask_for_title(
+    system: str, prompt: str, complete_fn, timeout: float
+) -> str | object | None:
+    """One bounded call. ``None`` is "no title"; :data:`CALL_FAILED` is a failure.
+
+    Shared by :func:`generate_title`, :func:`generate_retitle` and
+    :func:`refresh_title` so they have exactly one error policy between them.
+    There is no retry here and none underneath (the session marks the request
+    single-attempt), so the timeout is the entire budget.
+
+    The two automatic callers collapse :data:`CALL_FAILED` back onto ``None``,
+    which is what they have always done and still correct: a failed check and an
+    unchanged subject are the same instruction to them. Only ``refresh_title``
+    keeps the distinction, because only it has a user waiting for an answer.
     """
     try:
         raw = await asyncio.wait_for(complete_fn(system, prompt), timeout)
@@ -662,13 +679,13 @@ async def _ask_for_title(system: str, prompt: str, complete_fn, timeout: float) 
         # CancelledError is caught deliberately: the naming task is detached
         # and routinely cancelled at shutdown, and letting that propagate
         # would surface a teardown traceback for a feature nobody waited on.
-        return None
+        return CALL_FAILED
     except Exception:
         # EVERY provider failure, 429 included. The turn is running alongside
         # this call and must never learn it happened; the request is `isolated`
         # so the failure cannot have moved the turn's route or credential
         # either. See ``ChatRequest.isolated``.
-        return None
+        return CALL_FAILED
     return parse_title(str(raw or ""))
 
 
@@ -817,7 +834,10 @@ async def generate_title(
     """
     if is_low_signal(text):
         return None
-    return await _ask_for_title(TITLE_SYSTEM_PROMPT, _errand_prompt(text), complete_fn, timeout)
+    title = await _ask_for_title(TITLE_SYSTEM_PROMPT, _errand_prompt(text), complete_fn, timeout)
+    # A failed call collapses back onto "no title": this caller has no user
+    # waiting and no receipt to write, so the two are one instruction to it.
+    return title if isinstance(title, str) else None
 
 
 async def generate_retitle(
@@ -866,7 +886,9 @@ async def generate_retitle(
     if not context:
         return None
     title = await _ask_for_title(THEME_SYSTEM_PROMPT, context, complete_fn, timeout)
-    if title is None:
+    if not isinstance(title, str):
+        # Both "no change" and a failed call: the same instruction to an
+        # automatic caller, which is why this path keeps the collapse.
         return None
     # A model that "changes" the title to the one it already has has answered
     # "no change" in the expensive spelling. Treat it as the sentinel so the
@@ -909,22 +931,71 @@ async def generate_retitle(
 #: word ends up accepted on a terminal and typed into a title on a phone.
 TITLE_REFRESH_WORDS = frozenset({"refresh", "update", "retitle"})
 
-#: What an on-demand refresh did, for a receipt that has to tell the user
-#: something true. The automatic path collapses all of these onto ``None``
-#: because its only instruction to itself is "leave the title alone", but a
-#: user who typed the command is owed the difference between "the name still
-#: fits" and "there is nothing to title yet" — two outcomes that would
-#: otherwise share one unhelpful line.
+#: The refresh budget for a call made INSIDE a request/response op — the routed
+#: ``slash_result`` path and the detached runtime's, where a follower or a phone
+#: is holding a socket open waiting for the receipt.
 #:
-#: A FAILED provider call is deliberately absent from this vocabulary. It is
-#: not observable here: ``_ask_for_title`` resolves every failure to ``None``
-#: on purpose, which is what keeps a naming call from ever touching the turn
-#: beside it, and unpicking that to report a 429 would trade the isolation for
-#: a distinction that changes nothing the user can act on — the title stands
-#: either way. So a failure reads as :data:`TITLE_UNCHANGED`.
+#: Sized against that client's deadline, not against the model. An attach client
+#: abandons its request at ``ACK_TIMEOUT_S`` (15 s), which is also
+#: :data:`TITLE_TIMEOUT_S` — so a routed refresh on the slow tail would store the
+#: new title, republish the record, and STILL report `owner connection lost`,
+#: because the answer arrived after nobody was listening. Reporting failure for
+#: work that succeeded is worse than a shorter ceiling: the title is decoration,
+#: the receipt is what the user reads.
+#:
+#: 8 s leaves room for the ``materialize_history`` that precedes the call (it
+#: pages a remote journal) and still lands comfortably inside the ack. The TUI
+#: worker keeps the full :data:`TITLE_TIMEOUT_S`: it paints into its own
+#: transcript when the answer arrives and nothing is holding a socket for it.
+ROUTED_TITLE_TIMEOUT_S = 8.0
+
+#: What an on-demand refresh did, for a receipt that has to tell the user
+#: something true. The automatic path collapses all of these onto ``None``,
+#: correctly: its only instruction to itself is "leave the title alone", and
+#: every outcome below says that. A user who typed the command is owed more.
+#:
+#: The distinction that costs the most to get wrong is UNAVAILABLE against
+#: UNCHANGED. Told "the name still fits", a user has been given a judgement
+#: about their conversation and no reason to try again; told the model could
+#: not be reached, they know the judgement never happened. Reporting a wedged
+#: provider as the former is the one outcome here that actively misinforms, so
+#: ``_ask_for_title`` distinguishes a failed CALL from a declined rename (see
+#: :data:`CALL_FAILED`) even though the isolation itself is unchanged — nothing
+#: propagates out of a naming call either way.
 TITLE_REFRESHED = "refreshed"
 TITLE_UNCHANGED = "unchanged"
+TITLE_UNAVAILABLE = "unavailable"
 TITLE_NOTHING_YET = "nothing-yet"
+
+
+#: The receipt each outcome earns, in the words every surface says them in.
+#: ONE spelling for three handlers (the TUI worker, the routed ``slash_result``
+#: path, the detached runtime), for the reason :data:`TITLE_REFRESH_WORDS` lives
+#: here: the change deliberately shares the CALL and the release rule across
+#: those surfaces so a phone and a terminal cannot drift, and the strings are
+#: the one part that still could — while being the only part the user reads.
+def refresh_receipt(result: "TitleRefresh", standing: str, *, stored: bool = True) -> str:
+    """The user-facing line for ``result``, given the title now in force.
+
+    ``standing`` rather than ``result.title`` because most branches report a
+    name the refresh did NOT choose: an unchanged answer names what is staying,
+    and a declined store names whatever won instead.
+
+    ``stored`` is what separates the two REFRESHED cases, and it has to be the
+    caller's word rather than something inferred here. The model producing a new
+    title and that title reaching the conversation are different events: a
+    ``/rename`` landing mid-call outranks the answer, so the caller declines the
+    store — and a receipt reading "title refreshed: <the rename>" would credit
+    this command with a name it did not choose and claim a store that never
+    happened. Same outcome, opposite receipts.
+    """
+    if result.outcome == TITLE_REFRESHED:
+        return f"title refreshed: {standing}" if stored else f"title unchanged: {standing}"
+    if result.outcome == TITLE_NOTHING_YET:
+        return "nothing to title yet — /title <words> names it by hand"
+    if result.outcome == TITLE_UNAVAILABLE:
+        return "could not reach the model — the title is unchanged"
+    return f"title unchanged: {standing}"
 
 
 @dataclass(frozen=True)
@@ -977,8 +1048,8 @@ async def refresh_title(
 
     What is deliberately NOT dropped is the isolation: this is the same single
     bounded tools-free call through :func:`_ask_for_title`, so a provider
-    failure resolves to :data:`TITLE_UNCHANGED` and can never reach the turn
-    running alongside it.
+    failure surfaces as :data:`TITLE_UNAVAILABLE` and can never reach the turn
+    running alongside it as an exception.
     """
     context = build_theme_context(turns or (), newest, current_title=current)
     if not context:
@@ -987,15 +1058,19 @@ async def refresh_title(
         # resolves itself as soon as the conversation has content.
         return TitleRefresh(TITLE_NOTHING_YET)
     title = await _ask_for_title(THEME_SYSTEM_PROMPT, context, complete_fn, timeout)
+    if title is CALL_FAILED:
+        # The model was never reached. Reported apart from "unchanged" because
+        # the two differ in the only way that matters to someone who typed a
+        # command: "the name still fits" is a judgement that happened and is
+        # not worth retrying, while this one never happened and is.
+        return TitleRefresh(TITLE_UNAVAILABLE)
     if title is None:
-        # Either the model answered with the ``<title/>`` sentinel ("the name
-        # still fits") or the call failed. They are indistinguishable here, and
-        # the difference does not matter to a user who has a title already: the
-        # name stands either way. With NO title, though, the sentinel is the
-        # model declining to name small talk, which is the nothing-yet case
-        # wearing a different hat, so it is reported as such rather than as a
-        # failure the user might retry forever.
+        # The ``<title/>`` sentinel: the model declined to rename. With a title
+        # in force that means "the name still fits"; with none it means there
+        # was nothing worth titling, which is the nothing-yet case arriving from
+        # the model rather than from an empty transcript.
         return TitleRefresh(TITLE_UNCHANGED if current else TITLE_NOTHING_YET)
+    assert isinstance(title, str)  # narrowed: CALL_FAILED and None returned above
     if current and title.casefold() == current.casefold():
         return TitleRefresh(TITLE_UNCHANGED, current)
     return TitleRefresh(TITLE_REFRESHED, title)

--- a/local_operator/session/naming.py
+++ b/local_operator/session/naming.py
@@ -1056,9 +1056,14 @@ TITLE_UNCHANGED = "unchanged"
 TITLE_UNAVAILABLE = "unavailable"
 TITLE_NOTHING_YET = "nothing-yet"
 
-#: The call was cancelled. NOT a user-facing outcome — it exists so an awaited
-#: caller can tell a cancel apart from a failure and re-raise it. See
-#: :data:`CALL_CANCELLED`.
+#: The call was cancelled. Never a user-facing outcome, but that is a rule every
+#: caller must KEEP rather than one the type system enforces: `_ask_for_title`
+#: swallows the cancel and returns, so a caller's own ``except CancelledError``
+#: never fires and it resumes here with `changed` False — one fallthrough away
+#: from painting "title unchanged" at a user who just cancelled. Both callers
+#: therefore test for this outcome explicitly: :func:`routed_refresh` maps it to
+#: a receipt or a re-raise, and the TUI worker returns silently.
+#: See :data:`CALL_CANCELLED`.
 TITLE_CANCELLED = "cancelled"
 
 
@@ -1089,14 +1094,12 @@ def refresh_receipt(result: "TitleRefresh", standing: str, *, stored: bool = Tru
         # Honest with or without a name: it reports that no judgement happened
         # rather than asserting one the dead provider never made.
         return "could not reach the model — the title is unchanged"
-    if not standing:
-        # Every remaining branch quotes the name in force, and there isn't one:
-        # a superseded refresh on a never-named conversation reached this and
-        # rendered "title unchanged: " with nothing after the colon. The
-        # nothing-yet wording is the truth for all of them — there is no title,
-        # and the way to get one by hand is the same.
-        return "nothing to title yet — /title <words> names it by hand"
-    if result.outcome == TITLE_NOTHING_YET:
+    if not standing or result.outcome == TITLE_NOTHING_YET:
+        # Two ways to have no title worth quoting, one wording. Every remaining
+        # branch quotes the name in force: without one, a superseded refresh on
+        # a never-named conversation rendered "title unchanged: " with nothing
+        # after the colon. The nothing-yet wording is the truth for both —
+        # there is no title, and the way to get one by hand is the same.
         return "nothing to title yet — /title <words> names it by hand"
     return f"title unchanged: {standing}"
 
@@ -1162,9 +1165,10 @@ async def refresh_title(
         return TitleRefresh(TITLE_NOTHING_YET)
     title = await _ask_for_title(THEME_SYSTEM_PROMPT, context, complete_fn, timeout)
     if title is CALL_CANCELLED:
-        # Not an outcome the user is ever shown: the awaited callers re-raise it
-        # (see :func:`routed_refresh`) and the worker's own ``CancelledError``
-        # branch has already returned by the time one could reach a receipt.
+        # Reported rather than collapsed into a verdict, because the cancel was
+        # swallowed below and this is the only remaining evidence of it. Every
+        # caller must branch on it — see :data:`TITLE_CANCELLED` for why the
+        # `except CancelledError` they already have cannot do the job.
         return TitleRefresh(TITLE_CANCELLED)
     if title is CALL_FAILED:
         # The model was never reached. Reported apart from "unchanged" because
@@ -1219,25 +1223,58 @@ async def routed_refresh(current: str, session: Any) -> TitleRefresh:
             turns = await cast("Awaitable[list[Any]]", materialize())
         else:
             turns = list(session.history()) if hasattr(session, "history") else []
+        # The inner budget cannot fire FIRST — it starts from the same
+        # ROUTED_TITLE_TIMEOUT_S as the block below and starts strictly later,
+        # after the history read — so it is a backstop, not the deadline. Kept
+        # deliberately: it is what bounds the naming call if `_gather` is ever
+        # awaited without the budget below, and it stops `refresh_title`'s own
+        # default (TITLE_TIMEOUT_S, the TUI worker's much looser ceiling) from
+        # applying to a routed op that a client is holding a socket for.
         return await refresh_title(
             current, session.complete_once, turns=turns, timeout=ROUTED_TITLE_TIMEOUT_S
         )
 
+    # `asyncio.timeout`, NOT `wait_for`, and the difference is load-bearing.
+    # Both enforce a deadline by CANCELLING the body — but `_ask_for_title`
+    # deliberately swallows `CancelledError` (it must: the detached naming
+    # worker is cancelled at shutdown), and a swallowed cancel defeats
+    # `wait_for` outright: it returns the sentinel instead of raising
+    # `TimeoutError`, so the commonest failure here — a slow provider — escaped
+    # as a raised `CancelledError` rather than a receipt. That unwinds past the
+    # runtime's `except Exception` (it is a BaseException), costing the caller
+    # its ack and its connection.
+    #
+    # `cm.expired()` is the one thing that still tells the two cases apart
+    # through that swallow: True when OUR deadline fired, False when the caller
+    # cancelled us. Bound BEFORE the `try` so the handlers can always read it.
+    cm = asyncio.timeout(ROUTED_TITLE_TIMEOUT_S)
     try:
-        result = await asyncio.wait_for(_gather(), ROUTED_TITLE_TIMEOUT_S)
+        async with cm:
+            result = await _gather()
     except asyncio.CancelledError:
-        # A cancel landing in the HISTORY read arrives here as itself. Never
-        # swallowed: the op's caller has gone away, and a receipt for a request
-        # nobody holds is worse than no answer.
+        if cm.expired():
+            # Our own deadline, surfacing as a cancel because the body did not
+            # swallow it. A receipt, never an exception — see the contract above.
+            logger.debug("routed title refresh timed out")
+            return TitleRefresh(TITLE_UNAVAILABLE)
+        # A genuine caller-cancel: the op's caller has gone away, and a receipt
+        # for a request nobody holds is worse than no answer.
         raise
+    except TimeoutError:
+        # The same deadline, arriving as `__aexit__`'s translation of it.
+        logger.debug("routed title refresh timed out")
+        return TitleRefresh(TITLE_UNAVAILABLE)
     except Exception:  # noqa: BLE001 — naming is decoration; never fail the op
         logger.debug("routed title refresh could not complete", exc_info=True)
         return TitleRefresh(TITLE_UNAVAILABLE)
     if result.outcome == TITLE_CANCELLED:
-        # A cancel landing in the NAMING call is swallowed down there (it has to
-        # be, for the detached workers) and surfaces as this outcome instead, so
-        # the two awaits answer one signal the same way rather than one raising
-        # and the other returning a title verdict.
+        # A cancel landing in the NAMING call is swallowed down there and
+        # surfaces as this outcome instead. Which cancel it was decides the
+        # answer: our expired deadline is a failed op and earns a receipt, and
+        # only a caller that went away gets the exception.
+        if cm.expired():
+            logger.debug("routed title refresh timed out inside the naming call")
+            return TitleRefresh(TITLE_UNAVAILABLE)
         raise asyncio.CancelledError
     return result
 

--- a/local_operator/session/naming.py
+++ b/local_operator/session/naming.py
@@ -931,6 +931,68 @@ async def generate_retitle(
 #: word ends up accepted on a terminal and typed into a title on a phone.
 TITLE_REFRESH_WORDS = frozenset({"refresh", "update", "retitle"})
 
+#: The same verbs in flag spelling, for the user who already knows the word and
+#: reaches for the shape every other command taught them.
+#:
+#: ``--update`` and ``--retitle`` are here for the reason their bare
+#: counterparts are in :data:`TITLE_REFRESH_WORDS`: a user who learned
+#: ``update`` from the argument picker and typed ``--update`` must not have that
+#: become the conversation's title. The prefix makes the failure worse, not
+#: better — nobody types a real title that starts with ``--``, so silently
+#: storing one is unambiguously wrong rather than merely unlucky.
+TITLE_REFRESH_FLAGS = frozenset({"--refresh", "--auto", "--update", "--retitle"})
+
+
+def parse_title_arg(arg: str) -> tuple[bool, str]:
+    """Classify a ``/title`` argument as a refresh request or literal title text.
+
+    Returns ``(is_refresh, title_text)``. ``--`` terminates option parsing, so
+    ``/title -- --refresh`` sets the literal title ``--refresh``; that is the
+    escape hatch keeping a ``--``-leading title reachable, and it is the idiom
+    :func:`~local_operator.spawn.policy.parse_fork_args` already establishes for
+    a free-text command.
+
+    Matching is on the WHOLE stripped, casefolded argument, so
+    ``--refresh the billing importer`` is a title rather than a refresh — the
+    near-miss rule the bare vocabulary already follows. An unknown
+    ``--``-leading token raises rather than being stored, because a title
+    nobody could have meant to type is a typo, and storing it is the failure
+    this whole vocabulary exists to prevent.
+
+    :raises ValueError: on an unknown leading flag.
+    """
+    text = arg.strip()
+    if text.startswith("--"):
+        # split(None, 1) also admits tabs/newlines between the option and prose.
+        parts = text.split(None, 1)
+        flag = parts[0]
+        remainder = parts[1] if len(parts) > 1 else ""
+        if flag == "--":
+            return False, remainder
+        # Only a BARE flag is the verb: with prose after it the whole argument
+        # is a title, matching the bare words' near-miss rule.
+        if not remainder and flag.casefold() in TITLE_REFRESH_FLAGS:
+            return True, ""
+        if not remainder:
+            raise ValueError(
+                f"unknown title option {flag}; use --refresh, --auto, or -- before text"
+            )
+        return False, text
+    if text.casefold() in TITLE_REFRESH_WORDS:
+        return True, ""
+    return False, text
+
+
+def is_refresh_request(arg: str) -> bool:
+    """``True`` when ``arg`` asks for a refresh rather than naming a title.
+
+    The thin predicate over :func:`parse_title_arg` for callers that have
+    already excluded the raising case; it shares the one parser so a spelling
+    accepted on one surface cannot be typed into a title on another.
+    """
+    return parse_title_arg(arg)[0]
+
+
 #: The refresh budget for a call made INSIDE a request/response op — the routed
 #: ``slash_result`` path and the detached runtime's, where a follower or a phone
 #: is holding a socket open waiting for the receipt.

--- a/local_operator/session/naming.py
+++ b/local_operator/session/naming.py
@@ -877,6 +877,123 @@ async def generate_retitle(
     return title
 
 
+#: Argument words that mean "work the title out again" rather than "make the
+#: title these words". Several spellings because the command's own vocabulary
+#: does not tell a user which one it wants: ``/title refresh`` is what the help
+#: row and the argument list advertise, and someone who types ``update`` or
+#: ``retitle`` from another tool's habit has expressed the same intention
+#: exactly — answering that with a conversation literally renamed "update" would
+#: be a hostile reading of an unambiguous request. ``rename`` is deliberately
+#: NOT here: it is this command's other spelling, so ``/title rename`` is at
+#: least as likely to be a user starting to type a name as it is a verb.
+#:
+#: The collision is real but not close: a user who genuinely wants a title
+#: spelled "refresh" is asking for a one-word name that is also this command's
+#: only verb, and ``/title "refresh"`` (quoted) is not a syntax this registry
+#: has. They can reach it in one more keystroke with ``/title refresh cache``,
+#: or by naming it anything longer. Weighed against every user who types the
+#: natural word and expects the natural thing, the reserved words win — the same
+#: trade ``/goal clear`` and ``/model default`` already make.
+#:
+#: HERE rather than in ``tui/app.py`` because three surfaces read it — the TUI
+#: handler, the routed ``slash_result`` path, and the detached runtime's own
+#: handler — and the last of those must never import Textual (see the module
+#: note on ``slash_commands.py``). A second copy in a second module is how a
+#: word ends up accepted on a terminal and typed into a title on a phone.
+TITLE_REFRESH_WORDS = frozenset({"refresh", "update", "retitle"})
+
+#: What an on-demand refresh did, for a receipt that has to tell the user
+#: something true. The automatic path collapses all of these onto ``None``
+#: because its only instruction to itself is "leave the title alone", but a
+#: user who typed the command is owed the difference between "the name still
+#: fits" and "there is nothing to title yet" — two outcomes that would
+#: otherwise share one unhelpful line.
+#:
+#: A FAILED provider call is deliberately absent from this vocabulary. It is
+#: not observable here: ``_ask_for_title`` resolves every failure to ``None``
+#: on purpose, which is what keeps a naming call from ever touching the turn
+#: beside it, and unpicking that to report a 429 would trade the isolation for
+#: a distinction that changes nothing the user can act on — the title stands
+#: either way. So a failure reads as :data:`TITLE_UNCHANGED`.
+TITLE_REFRESHED = "refreshed"
+TITLE_UNCHANGED = "unchanged"
+TITLE_NOTHING_YET = "nothing-yet"
+
+
+@dataclass(frozen=True)
+class TitleRefresh:
+    """The outcome of one on-demand refresh: a title, or why there is none."""
+
+    outcome: str
+    title: str = ""
+
+    @property
+    def changed(self) -> bool:
+        return self.outcome == TITLE_REFRESHED
+
+
+async def refresh_title(
+    current: str,
+    complete_fn,
+    *,
+    turns: Sequence[_Turn] | None = None,
+    newest: str = "",
+    timeout: float = TITLE_TIMEOUT_S,
+) -> TitleRefresh:
+    """Re-read the whole trajectory and title it NOW, because the user asked.
+
+    The on-demand twin of :func:`generate_retitle`, and the differences are all
+    consequences of one fact: a person typed the command. The automatic path
+    exists to spend as few provider calls as it can get away with, so it is
+    gated on transcript growth, on a refresh budget, on a churn floor, and on
+    the newest message being substantive. None of those gates mean anything
+    here — they are guesses about whether a refresh is WANTED, and this caller
+    already knows.
+
+    Three specific gates are therefore dropped rather than relaxed:
+
+    * **A current title is not required.** ``generate_retitle`` returns early
+      without one because it has no anchor to judge drift against, but a
+      session whose opening naming call failed is unnamed and is exactly the
+      one a user reaches for this command on. With no anchor the sampled
+      context simply carries no ``<current-title>``, and the model writes a
+      fresh name from the trajectory.
+    * **The newest message is not consulted for signal.** The automatic path
+      fires at SUBMIT and its trigger IS that message, so "thanks" must not
+      spend a call. This fires on a command, with no message in hand at all;
+      ``newest`` is optional and only rounds out the tail when the caller has
+      something not yet in history.
+    * **"Unchanged" is an answer, not a failure.** The automatic path folds a
+      verbatim restatement of the anchor onto ``None`` because both mean "do
+      not repaint". A user who asked is owed the distinction, so it comes back
+      as :data:`TITLE_UNCHANGED` and the receipt can say the name still fits.
+
+    What is deliberately NOT dropped is the isolation: this is the same single
+    bounded tools-free call through :func:`_ask_for_title`, so a provider
+    failure resolves to :data:`TITLE_UNCHANGED` and can never reach the turn
+    running alongside it.
+    """
+    context = build_theme_context(turns or (), newest, current_title=current)
+    if not context:
+        # Nothing titleable: a session with no user/assistant turns yet. Named
+        # apart from a provider failure because the fix is different — this one
+        # resolves itself as soon as the conversation has content.
+        return TitleRefresh(TITLE_NOTHING_YET)
+    title = await _ask_for_title(THEME_SYSTEM_PROMPT, context, complete_fn, timeout)
+    if title is None:
+        # Either the model answered with the ``<title/>`` sentinel ("the name
+        # still fits") or the call failed. They are indistinguishable here, and
+        # the difference does not matter to a user who has a title already: the
+        # name stands either way. With NO title, though, the sentinel is the
+        # model declining to name small talk, which is the nothing-yet case
+        # wearing a different hat, so it is reported as such rather than as a
+        # failure the user might retry forever.
+        return TitleRefresh(TITLE_UNCHANGED if current else TITLE_NOTHING_YET)
+    if current and title.casefold() == current.casefold():
+        return TitleRefresh(TITLE_UNCHANGED, current)
+    return TitleRefresh(TITLE_REFRESHED, title)
+
+
 @dataclass
 class ConversationName:
     """Mutable holder for a conversation's title (empty = unnamed).
@@ -922,6 +1039,29 @@ class ConversationName:
         if user_set:
             self.user_set = True
         return self.text
+
+    def release_user_set(self) -> bool:
+        """Withdraw the human's claim on this title; True when one was held.
+
+        The ONE way ``user_set`` goes back to False, and it exists because the
+        flag is otherwise a one-way latch: ``set`` only ever turns it on, so a
+        conversation renamed by hand could never be handed back to automatic
+        naming for the rest of its life. That is right as a PRECEDENCE rule —
+        no generated title may quietly overwrite a name the user typed — but it
+        is wrong as a permanent sentence, because the user who typed the name
+        is also the one entitled to withdraw it.
+
+        So the release is deliberately not reachable from any generated path.
+        Only an explicit ``/title refresh`` calls it, which is the user saying
+        "stop using my words, work it out again" in the same breath as asking
+        for the new title. The text is left alone: the refresh call needs the
+        standing title as its ``<current-title>`` anchor, and a cleared name
+        would blank the band for as long as the call takes and leave the
+        conversation unnamed if it failed.
+        """
+        held = self.user_set
+        self.user_set = False
+        return held
 
     def claim_request(self) -> bool:
         """Reserve the one naming attempt; False when it is already spent."""

--- a/local_operator/session/naming.py
+++ b/local_operator/session/naming.py
@@ -55,9 +55,14 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import re
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import Any, Awaitable, Sequence, cast
+
+#: Naming never speaks to the terminal: it is decoration running beside a live
+#: turn, so its failures go to the log file and its outcomes to a receipt.
+logger = logging.getLogger(__name__)
 
 #: A history entry as the theme sampler reads it. Deliberately ``Any`` and
 #: duck-typed via ``getattr`` rather than a ``Protocol`` or an import of the
@@ -1005,10 +1010,16 @@ def is_refresh_request(arg: str) -> bool:
 #: work that succeeded is worse than a shorter ceiling: the title is decoration,
 #: the receipt is what the user reads.
 #:
-#: 8 s leaves room for the ``materialize_history`` that precedes the call (it
-#: pages a remote journal) and still lands comfortably inside the ack. The TUI
-#: worker keeps the full :data:`TITLE_TIMEOUT_S`: it paints into its own
-#: transcript when the answer arrives and nothing is holding a socket for it.
+#: 8 s is the budget for the WHOLE handler, not for the naming call alone, and
+#: the callers must wrap both awaits in it. The history read that precedes the
+#: call is the unbounded part — ``RemoteSession.materialize_history`` pages a
+#: remote journal with no ceiling of its own — so bounding only the second await
+#: leaves the op at "unbounded + 8 s" and reintroduces exactly the overrun this
+#: constant exists to prevent. A timeout that fires resolves to
+#: :data:`TITLE_UNAVAILABLE`, which is an honest receipt inside the ack window.
+#:
+#: The TUI worker keeps the full :data:`TITLE_TIMEOUT_S`: it paints into its own
+#: transcript whenever the answer arrives and nothing is holding a socket for it.
 ROUTED_TITLE_TIMEOUT_S = 8.0
 
 #: What an on-demand refresh did, for a receipt that has to tell the user
@@ -1136,6 +1147,55 @@ async def refresh_title(
     if current and title.casefold() == current.casefold():
         return TitleRefresh(TITLE_UNCHANGED, current)
     return TitleRefresh(TITLE_REFRESHED, title)
+
+
+async def routed_refresh(current: str, session: Any) -> TitleRefresh:
+    """:func:`refresh_title` for a handler answering inside a request/response op.
+
+    Both routed handlers need the same three things, and each was got wrong once
+    by being written twice:
+
+    * **One budget over BOTH awaits.** Reading the history is not inside
+      :func:`refresh_title`'s timeout and has no ceiling of its own
+      (``RemoteSession.materialize_history`` pages a remote journal in a
+      ``while token:`` loop), so bounding only the naming call left the op at
+      "unbounded + 8 s" against a client that abandons it at ``ACK_TIMEOUT_S``
+      — the overrun :data:`ROUTED_TITLE_TIMEOUT_S` exists to prevent, surviving
+      the fix meant to remove it. Worse, the op could store the title and STILL
+      report failure.
+    * **Every failure resolving to a receipt**, never to an exception escaping
+      into a routed op: a timeout, a reconnect race mid-materialize, or a dead
+      provider all mean the same thing to the user, and the title stands.
+    * **The same history seam.** ``materialize_history`` when the facade has one,
+      ``history()`` when it does not.
+
+    The TUI worker deliberately does NOT use this: nothing holds a socket for it,
+    so it keeps the full :data:`TITLE_TIMEOUT_S` and paints whenever the answer
+    arrives.
+    """
+
+    async def _gather() -> TitleRefresh:
+        materialize = getattr(session, "materialize_history", None)
+        if callable(materialize):
+            # `session` is a duck-typed facade here (a real session, a remote
+            # one, or a test double), so the awaitable is cast rather than
+            # assumed — the probe-then-cast the runtime's optional ops use.
+            turns = await cast("Awaitable[list[Any]]", materialize())
+        else:
+            turns = list(session.history()) if hasattr(session, "history") else []
+        return await refresh_title(
+            current, session.complete_once, turns=turns, timeout=ROUTED_TITLE_TIMEOUT_S
+        )
+
+    try:
+        return await asyncio.wait_for(_gather(), ROUTED_TITLE_TIMEOUT_S)
+    except asyncio.CancelledError:
+        # NOT swallowed: a cancelled op is the caller going away, and the
+        # runtime's own teardown must not be reported to it as a title outcome.
+        raise
+    except Exception:  # noqa: BLE001 — naming is decoration; never fail the op
+        logger.debug("routed title refresh could not complete", exc_info=True)
+        return TitleRefresh(TITLE_UNAVAILABLE)
 
 
 @dataclass

--- a/local_operator/session/naming.py
+++ b/local_operator/session/naming.py
@@ -895,6 +895,13 @@ async def generate_retitle(
 #: natural word and expects the natural thing, the reserved words win — the same
 #: trade ``/goal clear`` and ``/model default`` already make.
 #:
+#: The vocabulary is matched on the ARGUMENT regardless of which spelling of the
+#: command carried it, so ``/rename refresh`` refreshes exactly as ``/title
+#: refresh`` does. That is deliberate and not an oversight: they are ONE registry
+#: entry, and an alias that behaved differently from its primary name would be
+#: the drift ``test_an_alias_inherits_its_command_policy`` exists to forbid. A
+#: user who reaches the feature through the older spelling gets the feature.
+#:
 #: HERE rather than in ``tui/app.py`` because three surfaces read it — the TUI
 #: handler, the routed ``slash_result`` path, and the detached runtime's own
 #: handler — and the last of those must never import Textual (see the module

--- a/local_operator/session/runtime/serving.py
+++ b/local_operator/session/runtime/serving.py
@@ -2841,27 +2841,10 @@ class ServingSessionHandle(SessionHandle):
         if not callable(setter) or not callable(complete_once):
             return SlashResult(kind="notice", text="session is still starting…", style="warning")
         current = getattr(session, "conversation_name", "") or ""
-        try:
-            materialize = getattr(session, "materialize_history", None)
-            if callable(materialize):
-                # A duck-typed handle: `session` is `Any` here (this runtime
-                # hosts real sessions and test doubles alike), so the awaitable
-                # is cast rather than assumed — the same probe-then-cast the
-                # server's optional ops use.
-                turns = await cast("Awaitable[list[Any]]", materialize())
-            else:
-                turns = list(session.history()) if hasattr(session, "history") else []
-            # Bounded by the INVOKER's deadline, not the model's: a terminal or
-            # phone is holding a socket open for this receipt and abandons the
-            # request at `ACK_TIMEOUT_S`. See `ROUTED_TITLE_TIMEOUT_S`.
-            result = await naming.refresh_title(
-                current, complete_once, turns=turns, timeout=naming.ROUTED_TITLE_TIMEOUT_S
-            )
-        except asyncio.CancelledError:
-            raise
-        except Exception:  # noqa: BLE001 — naming is decoration; never fail the call
-            logger.debug("routed title refresh failed", exc_info=True)
-            result = naming.TitleRefresh(naming.TITLE_UNAVAILABLE)
+        # One budget over the history read AND the naming call, and one failure
+        # policy for both — shared with the app-hosted twin so the two cannot
+        # drift on the deadline the way they once drifted on the receipt.
+        result = await naming.routed_refresh(current, session)
         # The second condition is the rename-during-the-call guard: a `/rename`
         # landing while this was in flight outranks an answer decided against a
         # title no longer in force, and storing over it would strip the latch

--- a/local_operator/session/runtime/serving.py
+++ b/local_operator/session/runtime/serving.py
@@ -2650,7 +2650,16 @@ class ServingSessionHandle(SessionHandle):
         viewer. Anything not handled falls through to an honest notice rather
         than the transport's ``unknown op``, because a user typing a command
         this runtime does not implement needs to know what to do instead.
+
+        The word is resolved to its registry PRIMARY name first, exactly as the
+        app-hosted twin does: the branches below match literals, so an ALIAS off
+        the wire (``/title``, ``/models``, ``/recall``) would otherwise fall
+        past every one of them and collect the terminal-only refusal for a
+        command this runtime implements.
         """
+        from local_operator.slash_commands import primary_slash_name
+
+        command = primary_slash_name(command)
         session = self._session
         if command == "desktop_mcp":
             from local_operator.mcp.config import MCPConfigWriteError
@@ -2705,7 +2714,7 @@ class ServingSessionHandle(SessionHandle):
         if command == "goal":
             return self._goal_slash(session, args, SlashResult)
         if command == "rename":
-            return self._rename_slash(session, args, SlashResult)
+            return await self._rename_slash(session, args, SlashResult)
         if command == "effort":
             return await self._effort_slash(session, args, SlashResult)
         if command == "fast":
@@ -2777,19 +2786,92 @@ class ServingSessionHandle(SessionHandle):
             data={"type": "goal_set", "stored": stored, "request": arg.strip()},
         )
 
-    def _rename_slash(self, session: Any, arg: str, SlashResult: Any) -> Any:
+    async def _rename_slash(self, session: Any, arg: str, SlashResult: Any) -> Any:
+        """``/title`` on a detached runtime: report, set, or refresh.
+
+        Async only for the refresh branch, which spends a provider call and is
+        awaited rather than detached: this method's return value IS the receipt
+        the invoking terminal or phone renders, so answering before the call
+        settled would report a title that had not been decided.
+        """
+        from local_operator.session import naming
+
         name = (arg or "").strip()
+        if name.casefold() in naming.TITLE_REFRESH_WORDS:
+            return await self._title_refresh_slash(session, SlashResult)
         if not name:
             current = getattr(session, "conversation_name", "") or ""
-            text = f"name: {current}" if current else "no name set — /rename <text> to set one"
+            text = (
+                f"name: {current} — /title <words>, or /title refresh"
+                if current
+                else "no name set — /title <words> to set one"
+            )
             return SlashResult(kind="notice", text=text, style="info")
         setter = getattr(session, "set_conversation_name", None)
         if not callable(setter):
             return SlashResult(kind="notice", text="session is still starting…", style="warning")
         stored = setter(name)
-        # The name is on the discovery record, so `lop sessions` and the
-        # picker must see the rename without waiting for the next heartbeat.
-        # `_notify` refreshes the projection; the registrant owns the record.
+        self._publish_name()
+        return SlashResult(kind="notice", text=f"renamed to {stored or name}", style="info")
+
+    async def _title_refresh_slash(self, session: Any, SlashResult: Any) -> Any:
+        """``/title refresh`` on a detached runtime.
+
+        Shares :func:`naming.refresh_title` and the release-on-success rule with
+        the TUI's own handler, so a session owned by a runtime and one owned by
+        an app cannot disagree about what a refresh does to ``user_set``.
+        """
+        from local_operator.session import naming
+
+        setter = getattr(session, "set_conversation_name", None)
+        complete_once = getattr(session, "complete_once", None)
+        if not callable(setter) or not callable(complete_once):
+            return SlashResult(kind="notice", text="session is still starting…", style="warning")
+        current = getattr(session, "conversation_name", "") or ""
+        try:
+            materialize = getattr(session, "materialize_history", None)
+            if callable(materialize):
+                # A duck-typed handle: `session` is `Any` here (this runtime
+                # hosts real sessions and test doubles alike), so the awaitable
+                # is cast rather than assumed — the same probe-then-cast the
+                # server's optional ops use.
+                turns = await cast("Awaitable[list[Any]]", materialize())
+            else:
+                turns = list(session.history()) if hasattr(session, "history") else []
+            result = await naming.refresh_title(current, complete_once, turns=turns)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 — naming is decoration; never fail the call
+            logger.debug("routed title refresh failed", exc_info=True)
+            result = naming.TitleRefresh(naming.TITLE_UNCHANGED)
+        if not result.changed:
+            text = (
+                "nothing to title yet — /title <words> names it by hand"
+                if result.outcome == naming.TITLE_NOTHING_YET
+                else f"title unchanged: {current}"
+            )
+            return SlashResult(kind="notice", text=text, style="info")
+        state = getattr(session, "conversation_name_state", None)
+        release = getattr(state, "release_user_set", None)
+        if callable(release):
+            # Released only on success, and only here: a refresh that changed
+            # nothing must leave a name the user typed exactly as they left it.
+            release()
+        stored = setter(result.title, user_set=False)
+        self._publish_name()
+        return SlashResult(kind="notice", text=f"title refreshed: {stored}", style="info")
+
+    def _publish_name(self) -> None:
+        """Push a changed conversation name onto every surface that shows it.
+
+        The name is on the discovery record, so ``lop sessions`` and the picker
+        must see it without waiting for the next heartbeat. ``_notify``
+        refreshes the projection; the registrant owns the record.
+
+        Extracted from ``_rename_slash`` when the refresh branch became a second
+        writer: two copies of this would be two chances for one of them to skip
+        the republish and leave a session listed under a name it no longer has.
+        """
         self._notify()
         republish = getattr(self._registrant, "_republish", None)
         if callable(republish):
@@ -2797,7 +2879,6 @@ class ServingSessionHandle(SessionHandle):
                 republish()
             except Exception:  # noqa: BLE001 — a stale name is not worth a failure
                 logger.debug("could not republish the renamed record", exc_info=True)
-        return SlashResult(kind="notice", text=f"renamed to {stored or name}", style="info")
 
     def _context_slash(self, session: Any, SlashResult: Any) -> Any:
         """The routed ``/context``: the token breakdown, computed HERE.

--- a/local_operator/session/runtime/serving.py
+++ b/local_operator/session/runtime/serving.py
@@ -2823,6 +2823,16 @@ class ServingSessionHandle(SessionHandle):
         Shares :func:`naming.refresh_title` and the release-on-success rule with
         the TUI's own handler, so a session owned by a runtime and one owned by
         an app cannot disagree about what a refresh does to ``user_set``.
+
+        No generation stamp here, and that is not an omission. The TUI's twin
+        needs one because :meth:`OperatorApp._name_conversation_worker` stores
+        its answer whenever the generation still matches, so a call dispatched
+        before a refresh will happily overwrite the refreshed title. This
+        runtime's :meth:`_name_conversation_worker` instead re-reads
+        ``conversation_name`` AFTER its await and returns when anything is
+        already set, so a refresh that landed first is what the late call sees
+        and declines to overwrite. The guard is the name check, not a counter —
+        and it is why there is no generation concept on this path to stamp.
         """
         from local_operator.session import naming
 

--- a/local_operator/session/runtime/serving.py
+++ b/local_operator/session/runtime/serving.py
@@ -2838,33 +2838,39 @@ class ServingSessionHandle(SessionHandle):
                 turns = await cast("Awaitable[list[Any]]", materialize())
             else:
                 turns = list(session.history()) if hasattr(session, "history") else []
-            result = await naming.refresh_title(current, complete_once, turns=turns)
+            # Bounded by the INVOKER's deadline, not the model's: a terminal or
+            # phone is holding a socket open for this receipt and abandons the
+            # request at `ACK_TIMEOUT_S`. See `ROUTED_TITLE_TIMEOUT_S`.
+            result = await naming.refresh_title(
+                current, complete_once, turns=turns, timeout=naming.ROUTED_TITLE_TIMEOUT_S
+            )
         except asyncio.CancelledError:
             raise
         except Exception:  # noqa: BLE001 — naming is decoration; never fail the call
             logger.debug("routed title refresh failed", exc_info=True)
-            result = naming.TitleRefresh(naming.TITLE_UNCHANGED)
+            result = naming.TitleRefresh(naming.TITLE_UNAVAILABLE)
         # The second condition is the rename-during-the-call guard: a `/rename`
         # landing while this was in flight outranks an answer decided against a
         # title no longer in force, and storing over it would strip the latch
         # protecting the words the user just typed.
         standing = getattr(session, "conversation_name", "") or ""
         if not result.changed or standing != current:
-            text = (
-                "nothing to title yet — /title <words> names it by hand"
-                if result.outcome == naming.TITLE_NOTHING_YET
-                else f"title unchanged: {standing}"
+            return SlashResult(
+                kind="notice",
+                text=naming.refresh_receipt(result, standing, stored=False),
+                style="info",
             )
-            return SlashResult(kind="notice", text=text, style="info")
         state = getattr(session, "conversation_name_state", None)
         release = getattr(state, "release_user_set", None)
         if callable(release):
             # Released only on success, and only here: a refresh that changed
             # nothing must leave a name the user typed exactly as they left it.
             release()
-        stored = setter(result.title, user_set=False)
+        # `setter` came off a duck-typed handle, so its return is untyped; the
+        # stored title is the string the receipt has to quote.
+        stored = str(setter(result.title, user_set=False) or result.title)
         self._publish_name()
-        return SlashResult(kind="notice", text=f"title refreshed: {stored}", style="info")
+        return SlashResult(kind="notice", text=naming.refresh_receipt(result, stored), style="info")
 
     def _publish_name(self) -> None:
         """Push a changed conversation name onto every surface that shows it.

--- a/local_operator/session/runtime/serving.py
+++ b/local_operator/session/runtime/serving.py
@@ -2796,8 +2796,11 @@ class ServingSessionHandle(SessionHandle):
         """
         from local_operator.session import naming
 
-        name = (arg or "").strip()
-        if name.casefold() in naming.TITLE_REFRESH_WORDS:
+        try:
+            is_refresh, name = naming.parse_title_arg(arg or "")
+        except ValueError as error:
+            return SlashResult(kind="notice", text=str(error), style="warning")
+        if is_refresh:
             return await self._title_refresh_slash(session, SlashResult)
         if not name:
             current = getattr(session, "conversation_name", "") or ""

--- a/local_operator/session/runtime/serving.py
+++ b/local_operator/session/runtime/serving.py
@@ -2844,11 +2844,16 @@ class ServingSessionHandle(SessionHandle):
         except Exception:  # noqa: BLE001 — naming is decoration; never fail the call
             logger.debug("routed title refresh failed", exc_info=True)
             result = naming.TitleRefresh(naming.TITLE_UNCHANGED)
-        if not result.changed:
+        # The second condition is the rename-during-the-call guard: a `/rename`
+        # landing while this was in flight outranks an answer decided against a
+        # title no longer in force, and storing over it would strip the latch
+        # protecting the words the user just typed.
+        standing = getattr(session, "conversation_name", "") or ""
+        if not result.changed or standing != current:
             text = (
                 "nothing to title yet — /title <words> names it by hand"
                 if result.outcome == naming.TITLE_NOTHING_YET
-                else f"title unchanged: {current}"
+                else f"title unchanged: {standing}"
             )
             return SlashResult(kind="notice", text=text, style="info")
         state = getattr(session, "conversation_name_state", None)

--- a/local_operator/session/runtime/serving.py
+++ b/local_operator/session/runtime/serving.py
@@ -2888,14 +2888,28 @@ class ServingSessionHandle(SessionHandle):
     def _publish_name(self) -> None:
         """Push a changed conversation name onto every surface that shows it.
 
-        The name is on the discovery record, so ``lop sessions`` and the picker
-        must see it without waiting for the next heartbeat. ``_notify``
-        refreshes the projection; the registrant owns the record.
+        THREE calls, and dropping any one of them leaves the name visible in a
+        different place from where it is true:
+
+        * ``_refresh_state`` rebuilds the projection. This is the one that was
+          missing, and its absence was total rather than transient: the
+          projection's ``conversation_name`` has exactly one writer, the
+          heartbeat republishes the projection's copy every 15 s, and
+          ``_republish`` does not carry the name field at all — so a renamed
+          session was re-asserted under its OLD name forever, and an attached
+          phone kept the stale header for the life of the session. The runtime's
+          own naming worker has always made this call; the slash path did not.
+        * ``_notify`` pushes that projection to attached clients.
+        * ``_republish`` updates the discovery record, so ``lop sessions`` and
+          the picker see the change without waiting for the next heartbeat.
 
         Extracted from ``_rename_slash`` when the refresh branch became a second
         writer: two copies of this would be two chances for one of them to skip
-        the republish and leave a session listed under a name it no longer has.
+        a step and leave a session listed under a name it no longer has — which
+        is precisely what the missing ``_refresh_state`` was, and fixing it in
+        this one seam repairs ``/title <words>`` along with the refresh.
         """
+        self._refresh_state()
         self._notify()
         republish = getattr(self._registrant, "_republish", None)
         if callable(republish):

--- a/local_operator/slash_commands.py
+++ b/local_operator/slash_commands.py
@@ -168,7 +168,7 @@ SLASH_COMMANDS: list[SlashCommand] = [
     # is unaffected, so an arbitrary title still submits.
     SlashCommand(
         "rename",
-        # 51 cells, inside the ~55 at which the description column wraps and
+        # 43 cells, inside the ~55 at which the description column wraps and
         # renders a phantom command name in `/help` (see `/model`, `/theme`).
         # The `refresh` word has to be HERE because the help table is where a
         # user learns the command exists at all, and the capability it names is

--- a/local_operator/slash_commands.py
+++ b/local_operator/slash_commands.py
@@ -151,9 +151,31 @@ SLASH_COMMANDS: list[SlashCommand] = [
     # terminal tab, never into anything the model is told — and the receipt
     # quotes the title that ended up in force, which is strictly more than the
     # typed words (the store trims and caps them).
+    #
+    # `/title` is an ALIAS, not a second entry, and that is the whole design of
+    # the refresh word. The two things a user wants to do to a conversation's
+    # name — say what it is, or ask for it to be worked out again — are one
+    # subject, and splitting them across `/rename` and a sibling `/retitle`
+    # would put two nearly-identical rows in `/help` whose difference is four
+    # letters in the middle of the word. One entry with `refresh` as its
+    # argument states the relationship instead: `/title <words>` is the
+    # imperative, `/title refresh` is the request, and a bare `/title` reports.
+    #
+    # OPTIONAL rather than NONE now that an argument has a value list: the space
+    # offers `refresh` to a user who does not know the word exists, and Enter on
+    # the bare command still reports the current name — the exact distinction
+    # `/approvals` and `/effort` draw against `/login`'s REQUIRED. Free typing
+    # is unaffected, so an arbitrary title still submits.
     SlashCommand(
         "rename",
-        "Rename this conversation; auto-naming never overrides it",
+        # 51 cells, inside the ~55 at which the description column wraps and
+        # renders a phantom command name in `/help` (see `/model`, `/theme`).
+        # The `refresh` word has to be HERE because the help table is where a
+        # user learns the command exists at all, and the capability it names is
+        # the reason this entry changed.
+        "Name this conversation, or refresh the name",
+        aliases=("title",),
+        arguments=ArgumentMode.OPTIONAL,
         desktop_destination="session.rename",
     ),
     # Beside the session-transition family because it is one: /fork is the entry
@@ -572,3 +594,23 @@ def slash_command_for(text: str) -> SlashCommand | None:
         return None
     name = token[1:]
     return next((entry for entry in SLASH_COMMANDS if name in entry.names), None)
+
+
+def primary_slash_name(command: str) -> str:
+    """``command`` as its registry PRIMARY name; unchanged when nothing matches.
+
+    The bare-word counterpart to :func:`slash_command_for`, for the dispatchers
+    that receive a command NAME off the wire rather than a typed line. Both
+    routed dispatchers (``OperatorApp._slash_result`` and the detached
+    runtime's) match string literals, so without this an ALIAS — ``/title``,
+    ``/models``, ``/recall`` — falls past every branch and is answered with an
+    unsupported-command refusal for a command the owner in fact implements.
+    That is the same bug ``slash_command_for`` was introduced to fix on the
+    LOCAL path, which had already shipped once: the registry advertises the
+    alias, the picker completes it, and running it says "unknown command".
+
+    Unknown words pass through untouched so the caller's own fallback still
+    sees what was actually asked for.
+    """
+    entry = slash_command_for(f"/{command}")
+    return entry.name if entry is not None else command

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -21861,17 +21861,18 @@ class OperatorApp(App[None]):
                 result = await naming.refresh_title(current, session.complete_once, turns=turns)
             except asyncio.CancelledError:
                 return
+            except Exception:  # noqa: BLE001 — silence is the one defect here
+                # `refresh_title` swallows the NAMING call's failures, but
+                # `materialize_history` is outside it and raises on ordinary
+                # reconnect races ("history changed while materializing").
+                # Uncaught, the worker dies with `refreshing the title…` still on
+                # screen and no answer ever — precisely what this method's
+                # contract forbids. The routed twins already resolve it this way.
+                logger.debug("title refresh could not read the history", exc_info=True)
+                result = naming.TitleRefresh(naming.TITLE_UNAVAILABLE)
             # Superseded (a reload) or belonging to a session no longer on
             # screen: touch neither the title nor the transcript.
             if generation != source.naming.generation or source.retired:
-                return
-            if not result.changed:
-                if result.outcome == naming.TITLE_NOTHING_YET:
-                    self._notice_for(
-                        source, "nothing to title yet — /title <words> names it by hand"
-                    )
-                else:
-                    self._notice_for(source, f"title unchanged: {session.conversation_name}")
                 return
             # Re-read rather than trusting `current`, the rule
             # `_retitle_conversation_worker` follows: a `/rename` may have landed
@@ -21880,8 +21881,9 @@ class OperatorApp(App[None]):
             # would strip the very latch protecting the name the user just typed,
             # and the refresh would overwrite it — silently revoking their most
             # recent instruction in favour of their previous one.
-            if session.conversation_name != current:
-                self._notice_for(source, f"title unchanged: {session.conversation_name}")
+            standing = session.conversation_name
+            if not result.changed or standing != current:
+                self._notice_for(source, naming.refresh_receipt(result, standing, stored=False))
                 return
             # Released only once a replacement is actually in hand. Released
             # before the call instead, a refresh that came back "unchanged"
@@ -21889,7 +21891,7 @@ class OperatorApp(App[None]):
             # the user typed and is keeping.
             session.conversation_name_state.release_user_set()
             stored = self._store_title_for(source, session, result.title)
-            self._notice_for(source, f"title refreshed: {stored}")
+            self._notice_for(source, naming.refresh_receipt(result, stored))
         finally:
             source.active_workers -= 1
             # Naming fires ONCE per conversation, and the only thing that re-arms
@@ -32500,14 +32502,25 @@ class OperatorApp(App[None]):
         )
 
     async def _title_refresh_slash_result(self, session: Any, SlashResult: Any) -> Any:
-        """``/title refresh`` over the control path — same policy as the TUI's.
+        """``/title refresh`` routed from a follower, with this app as owner.
 
-        Shares :func:`naming.refresh_title` and the release-on-success rule with
-        :meth:`_title_refresh_worker` rather than reimplementing either, so a
-        phone and a terminal cannot drift on what a refresh does to the
-        ``user_set`` flag. What differs is only the delivery: a receipt returned
-        as data instead of painted through ``notice``.
+        Shares :func:`naming.refresh_title`, the release-on-success rule and
+        :func:`naming.refresh_receipt` with :meth:`_title_refresh_worker` rather
+        than reimplementing any of them, so a phone and a terminal cannot drift
+        on what a refresh does to the ``user_set`` flag or on what it says.
+        What differs is the delivery — a receipt returned as data rather than
+        painted — and the deadline: a client is holding a socket open for this
+        answer, so the call gets :data:`naming.ROUTED_TITLE_TIMEOUT_S` instead
+        of the worker's full budget.
+
+        ``source`` is captured at DISPATCH here for the same reason the worker
+        does it, and it is easy to miss on this path precisely because there is
+        no worker in sight: the two awaits below are just as long, so
+        ``self._interaction`` is just as much a moving target, and
+        ``_store_title``'s convenience wrapper (which re-reads it) is safe only
+        for callers that do not suspend.
         """
+        source = self._interaction
         current = session.conversation_name
         turns = None
         if not hasattr(session, "materialize_history"):
@@ -32515,28 +32528,41 @@ class OperatorApp(App[None]):
         try:
             if turns is None:
                 turns = await getattr(session, "materialize_history")()
-            result = await naming.refresh_title(current, session.complete_once, turns=turns)
+            result = await naming.refresh_title(
+                current,
+                session.complete_once,
+                turns=turns,
+                timeout=naming.ROUTED_TITLE_TIMEOUT_S,
+            )
         except asyncio.CancelledError:
             raise
         except Exception:  # noqa: BLE001 — naming is decoration; never fail the call
             logger.debug("routed title refresh failed", exc_info=True)
-            result = naming.TitleRefresh(naming.TITLE_UNCHANGED)
+            result = naming.TitleRefresh(naming.TITLE_UNAVAILABLE)
         # The rename-during-the-call guard the TUI worker documents: a `/rename`
         # that landed while this was in flight outranks an answer decided
         # against a title no longer in force, and storing over it would strip
         # the latch protecting the words the user just typed.
-        if not result.changed or session.conversation_name != current:
-            text = (
-                "nothing to title yet — /title <words> names it by hand"
-                if result.outcome == naming.TITLE_NOTHING_YET
-                else f"title unchanged: {session.conversation_name}"
+        standing = session.conversation_name
+        if not result.changed or standing != current:
+            return SlashResult(
+                kind="notice",
+                text=naming.refresh_receipt(result, standing, stored=False),
+                style="info",
             )
-            return SlashResult(kind="notice", text=text, style="info")
-        session.conversation_name_state.release_user_set()
-        stored = self._store_title(session, result.title)
+        # Probed rather than called outright: `session` is `Any` on this path
+        # (it is whatever facade the follower's owner holds), and the sibling in
+        # `owned.py` guards for the same reason. An AttributeError here would
+        # surface as a failed routed op rather than as a missing rename.
+        release = getattr(
+            getattr(session, "conversation_name_state", None), "release_user_set", None
+        )
+        if callable(release):
+            release()
+        stored = self._store_title_for(source, session, result.title)
         return SlashResult(
             kind="notice",
-            text=f"title refreshed: {stored}",
+            text=naming.refresh_receipt(result, stored),
             style="info",
             data={"stored": stored},
         )

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -21875,6 +21875,16 @@ class OperatorApp(App[None]):
                 # contract forbids. The routed twins already resolve it this way.
                 logger.debug("title refresh could not read the history", exc_info=True)
                 result = naming.TitleRefresh(naming.TITLE_UNAVAILABLE)
+            # A cancel that the naming call swallowed on our behalf. The
+            # `except` above cannot see it — `_ask_for_title` catches
+            # `CancelledError` for the detached workers and RETURNS a sentinel,
+            # so this worker resumes normally with a cancelled outcome rather
+            # than unwinding. Painting here would tell a user who just
+            # cancelled that the model judged the name still fits; no judgement
+            # happened. Silence is the honest answer, and it is what the
+            # `except` branch would have given.
+            if result.outcome == naming.TITLE_CANCELLED:
+                return
             # Superseded (a reload) or belonging to a session no longer on
             # screen: touch neither the title nor the transcript.
             if generation != source.naming.generation or source.retired:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -21894,6 +21894,16 @@ class OperatorApp(App[None]):
             # before the call instead, a refresh that came back "unchanged"
             # would still have silently re-armed automatic naming over a name
             # the user typed and is keeping.
+            #
+            # Dereferenced DIRECTLY, unlike the two routed handlers that probe
+            # with `getattr`, and the difference is the type rather than the
+            # care taken: `session` is `SessionProtocol` here, which makes
+            # `conversation_name_state` mandatory (see its declaration there),
+            # so a probe would guard a state pyright already forbids — and
+            # would silently skip the release if the member were ever dropped,
+            # where this line fails the type-check that is the real guard. The
+            # routed paths take `Any` (whatever facade a follower's owner
+            # holds) and have no such promise, so they must probe.
             session.conversation_name_state.release_user_set()
             stored = self._store_title_for(source, session, result.title)
             self._notice_for(source, naming.refresh_receipt(result, stored))

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -32549,23 +32549,10 @@ class OperatorApp(App[None]):
         generation = self._name_generation
         source = self._interaction
         current = session.conversation_name
-        turns = None
-        if not hasattr(session, "materialize_history"):
-            turns = list(session.history()) if hasattr(session, "history") else []
-        try:
-            if turns is None:
-                turns = await getattr(session, "materialize_history")()
-            result = await naming.refresh_title(
-                current,
-                session.complete_once,
-                turns=turns,
-                timeout=naming.ROUTED_TITLE_TIMEOUT_S,
-            )
-        except asyncio.CancelledError:
-            raise
-        except Exception:  # noqa: BLE001 — naming is decoration; never fail the call
-            logger.debug("routed title refresh failed", exc_info=True)
-            result = naming.TitleRefresh(naming.TITLE_UNAVAILABLE)
+        # One budget over the history read AND the naming call, and one failure
+        # policy for both — shared with the runtime-hosted twin so the two
+        # cannot drift on the deadline the way they once drifted on the receipt.
+        result = await naming.routed_refresh(current, session)
         # The rename-during-the-call guard the TUI worker documents: a `/rename`
         # that landed while this was in flight outranks an answer decided
         # against a title no longer in force, and storing over it would strip

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -131,6 +131,7 @@ from local_operator.session.protocol import SessionProtocol, ViewerSessionProtoc
 from local_operator.slash_commands import (
     PERSIST_HINT,
     SLASH_COMMANDS,
+    primary_slash_name,
     slash_command_for,
 )
 from local_operator.tui import images as images_mod
@@ -21695,7 +21696,7 @@ class OperatorApp(App[None]):
         self._status.update(cwd=cwd)
 
     def _cmd_rename(self, arg: str, notice: NoticeFn) -> None:
-        """``/rename`` — report the title; ``/rename <text>`` — set it by hand.
+        """``/title`` — report; ``/title <text>`` — set it; ``/title refresh`` — ask.
 
         The ONE production writer of ``user_set=True``, which is what the
         precedence flag on :class:`ConversationName` is for: a title a human
@@ -21704,8 +21705,10 @@ class OperatorApp(App[None]):
         ``ConversationName.set``) and every later re-title, which
         :meth:`_maybe_retitle_conversation` declines to even spend a call on.
 
-        No provider call on either branch. The words are the user's, so the only
-        work is putting them on the two surfaces that show a conversation's name.
+        No provider call on the report or the set branch. The words are the
+        user's, so the only work is putting them on the two surfaces that show a
+        conversation's name. ``refresh`` is the one branch that spends a call,
+        and it is delegated to :meth:`_cmd_title_refresh`.
         """
         session = self._session
         if session is None:
@@ -21714,10 +21717,13 @@ class OperatorApp(App[None]):
             # `notice` would collapse it. The rule `_cmd_goal` follows.
             self._system_notice("session is still starting…", "warning")
             return
+        if arg.strip().casefold() in naming.TITLE_REFRESH_WORDS:
+            self._cmd_title_refresh(session, notice)
+            return
         if not arg:
             current = session.conversation_name
             if current:
-                notice(f"conversation: {current} — /rename <title> to change it")
+                notice(f"conversation: {current} — /title <words>, or /title refresh")
             elif self._provisional_name:
                 # The band is wearing a stand-in, not a name (see
                 # `_show_provisional_name`). Answering a bare "unnamed" with an
@@ -21725,10 +21731,10 @@ class OperatorApp(App[None]):
                 # what the label actually is.
                 notice(
                     f"unnamed — the label above is a quote of your first message "
-                    f"({self._provisional_name}); /rename <title> names it"
+                    f"({self._provisional_name}); /title <words> names it"
                 )
             else:
-                notice("unnamed — /rename <title> names this conversation")
+                notice("unnamed — /title <words> names this conversation")
             return
         stored = session.set_conversation_name(arg, user_set=True)
         # Superseded, and by the best possible answer: cleared for the reason
@@ -21760,6 +21766,103 @@ class OperatorApp(App[None]):
         # ignored the format, while this is just a long name the user chose, and
         # refusing it outright would lose a title they typed.
         notice(f"renamed: {stored} — auto-naming will not override it")
+
+    def _cmd_title_refresh(self, session: SessionProtocol, notice: NoticeFn) -> None:
+        """``/title refresh`` — re-read the conversation and name it now.
+
+        The on-demand counterpart to :meth:`_maybe_retitle_conversation`, and
+        every difference between them follows from who asked. The automatic path
+        is a guess about whether a refresh is WANTED, so it is gated four ways
+        (``user_set``, low signal, growth, a churn floor) to keep the guessing
+        cheap. This caller is not guessing, so all four gates are dropped:
+        the user has just said the title is wrong, which is better evidence than
+        any schedule.
+
+        ``user_set`` is not merely bypassed but RELEASED
+        (``ConversationName.release_user_set``), and that is the load-bearing
+        half of this command. Asking for a fresh title is withdrawing the name
+        you typed — keeping the flag would mean the refreshed title landed and
+        then automatic naming stayed disabled forever on the strength of a
+        rename the user had just abandoned. Released, the conversation goes back
+        to tracking its own subject, which is what "refresh" means. The release
+        happens in the worker and only once a replacement is actually in hand —
+        see :meth:`_title_refresh_worker`.
+
+        The growth budget is not charged either. It bounds AUTOMATIC calls so an
+        unattended session cannot spend indefinitely; a call the user asked for
+        is not unattended, and charging it would let two deliberate refreshes
+        exhaust the automatic schedule for the rest of the session. A landed
+        refresh instead re-seeds the schedule through ``_store_title``'s
+        first-title branch, which is the honest reading: this conversation's
+        identity was just re-decided, so its drift clock starts again here.
+        """
+        # Generation-stamped like the automatic path so a `/new` or `/resume`
+        # landing while the call is in flight cannot repaint the replacement
+        # conversation with this one's title.
+        self._name_generation += 1
+        generation = self._name_generation
+        # Snapshot on the UI thread, exactly as the automatic path does: the
+        # sampler only reads role/text, so a shallow copy is enough, and taking
+        # it now titles the conversation as it stands rather than as it looks
+        # after a concurrent turn has written more history.
+        turns = (
+            None
+            if hasattr(session, "materialize_history")
+            else (list(session.history()) if hasattr(session, "history") else [])
+        )
+        notice("refreshing the title…")
+        self.run_worker(
+            self._title_refresh_worker(session, generation, turns, notice),
+            thread=False,
+            group=self._interaction.worker_group("naming"),
+        )
+
+    async def _title_refresh_worker(
+        self,
+        session: SessionProtocol,
+        generation: int,
+        turns: list[AgentMessage] | None,
+        notice: NoticeFn,
+    ) -> None:
+        """One isolated refresh call, whose every outcome gets a receipt.
+
+        Unlike :meth:`_retitle_conversation_worker`, silence is not an option on
+        any branch. That worker runs unasked and repaints only on a genuinely
+        new title, so "no change" and "the call failed" can both correctly
+        resolve to doing nothing. Here a user typed a command and is watching
+        for an answer, so each outcome says which one it was — a refresh that
+        quietly changed nothing is indistinguishable from a broken command.
+        """
+        source = self._interaction
+        source.active_workers += 1
+        try:
+            try:
+                if turns is None:
+                    turns = await getattr(session, "materialize_history")()
+                result = await naming.refresh_title(
+                    session.conversation_name, session.complete_once, turns=turns
+                )
+            except asyncio.CancelledError:
+                return
+            # Superseded (a reload) or belonging to a session no longer on
+            # screen: touch neither the title nor the transcript.
+            if generation != source.naming.generation or source.retired:
+                return
+            if not result.changed:
+                if result.outcome == naming.TITLE_NOTHING_YET:
+                    notice("nothing to title yet — /title <words> names it by hand")
+                else:
+                    notice(f"title unchanged: {session.conversation_name}")
+                return
+            # Released only once a replacement is actually in hand. Released
+            # before the call instead, a refresh that came back "unchanged"
+            # would still have silently re-armed automatic naming over a name
+            # the user typed and is keeping.
+            session.conversation_name_state.release_user_set()
+            stored = self._store_title(session, result.title)
+            notice(f"title refreshed: {stored}")
+        finally:
+            source.active_workers -= 1
 
     # -- background jobs ------------------------------------------------------
     def _poll_subagents(self) -> None:
@@ -29981,6 +30084,34 @@ class OperatorApp(App[None]):
             )
             picker.set_notice("")
             return
+        if message.command in ("rename", "title"):
+            # ONE row, and it is the whole reason this command takes a list. The
+            # other argument is free text — a title cannot be offered from a
+            # list, because the app does not know what the conversation should
+            # be called — so the list exists to teach the one word a user could
+            # not guess. Free typing is unaffected: the editor RANKS what is
+            # typed and never filters what may be submitted, so an arbitrary
+            # title still reaches `_cmd_rename`.
+            #
+            # The description states the release, not just the call. That the
+            # refresh hands the name back to automatic naming is the surprising
+            # half of the command, and this row is the last surface before it
+            # runs.
+            picker.set_choices(
+                [
+                    ArgumentChoice(
+                        name="refresh",
+                        description="Re-read the conversation and name it again",
+                        detail="resumes auto-naming",
+                    )
+                ]
+            )
+            picker.set_notice(
+                f"conversation: {self._session.conversation_name}"
+                if self._session is not None and self._session.conversation_name
+                else "or type a title"
+            )
+            return
         if message.command == "mcp":
             # Clear BEFORE the fill: the builder may set a notice of its own
             # (an unreadable credential store on the logout list), and a
@@ -32177,12 +32308,22 @@ class OperatorApp(App[None]):
     ) -> Any:
         from local_operator.session.frontend_state import SlashResult
 
+        # Resolved to the registry PRIMARY name before any branch reads it, for
+        # the reason `_run_slash_command` does the same: the branches below
+        # match literals, so an ALIAS arriving off the wire (`/title`,
+        # `/models`, `/recall`) would fall past every one of them and be
+        # answered with the "not available from an attached terminal" refusal —
+        # for a command this owner implements and the invoker's own picker
+        # completed. The local path resolves at dispatch and the routed path did
+        # not, which is precisely how one spelling of a command worked in a
+        # terminal and failed on a phone.
+        command = primary_slash_name(command)
         if command == "context":
             return self._context_slash_result(SlashResult)
         if command == "goal":
             return self._goal_slash_result(args, SlashResult)
         if command == "rename":
-            return self._rename_slash_result(args, SlashResult)
+            return await self._rename_slash_result(args, SlashResult)
         if command == "effort":
             return self._effort_slash_result(args, SlashResult)
         if command == "fast":
@@ -32279,22 +32420,77 @@ class OperatorApp(App[None]):
             data={"type": "goal_set", "stored": stored, "request": arg.strip()},
         )
 
-    def _rename_slash_result(self, arg: str, SlashResult: Any) -> Any:
+    async def _rename_slash_result(self, arg: str, SlashResult: Any) -> Any:
+        """``/title`` over the remote/mobile control path.
+
+        Async solely for the refresh branch, which spends a provider call. The
+        report and set branches are the same synchronous work they have always
+        been — awaiting a coroutine that never suspends costs nothing, and the
+        alternative (a sync entry that spawns a detached task) would answer the
+        phone with a receipt for a title that had not been decided yet.
+
+        The refresh is AWAITED rather than run on a worker for the same reason:
+        this path's whole contract is that the returned ``SlashResult`` is the
+        answer the invoker renders. A follower has no naming worker of its own
+        and no second chance to paint, so a result produced before the call
+        finished would be a receipt for work that had not happened.
+        """
         session = self._session
         if session is None:
             return SlashResult(kind="notice", text="session is still starting…", style="warning")
+        if arg.strip().casefold() in naming.TITLE_REFRESH_WORDS:
+            return await self._title_refresh_slash_result(session, SlashResult)
         if not arg:
             current = session.conversation_name
             text = (
-                f"conversation: {current} — /rename <title> to change it"
+                f"conversation: {current} — /title <words>, or /title refresh"
                 if current
-                else "unnamed — /rename <title> names this conversation"
+                else "unnamed — /title <words> names this conversation"
             )
             return SlashResult(kind="notice", text=text, style="info")
         stored = session.set_conversation_name(arg, user_set=True)
         return SlashResult(
             kind="notice",
             text=f"renamed: {stored} — auto-naming will not override it",
+            style="info",
+            data={"stored": stored},
+        )
+
+    async def _title_refresh_slash_result(self, session: Any, SlashResult: Any) -> Any:
+        """``/title refresh`` over the control path — same policy as the TUI's.
+
+        Shares :func:`naming.refresh_title` and the release-on-success rule with
+        :meth:`_title_refresh_worker` rather than reimplementing either, so a
+        phone and a terminal cannot drift on what a refresh does to the
+        ``user_set`` flag. What differs is only the delivery: a receipt returned
+        as data instead of painted through ``notice``.
+        """
+        turns = None
+        if not hasattr(session, "materialize_history"):
+            turns = list(session.history()) if hasattr(session, "history") else []
+        try:
+            if turns is None:
+                turns = await getattr(session, "materialize_history")()
+            result = await naming.refresh_title(
+                session.conversation_name, session.complete_once, turns=turns
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 — naming is decoration; never fail the call
+            logger.debug("routed title refresh failed", exc_info=True)
+            result = naming.TitleRefresh(naming.TITLE_UNCHANGED)
+        if not result.changed:
+            text = (
+                "nothing to title yet — /title <words> names it by hand"
+                if result.outcome == naming.TITLE_NOTHING_YET
+                else f"title unchanged: {session.conversation_name}"
+            )
+            return SlashResult(kind="notice", text=text, style="info")
+        session.conversation_name_state.release_user_set()
+        stored = self._store_title(session, result.title)
+        return SlashResult(
+            kind="notice",
+            text=f"title refreshed: {stored}",
             style="info",
             data={"stored": stored},
         )

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -32529,6 +32529,14 @@ class OperatorApp(App[None]):
         ``_store_title``'s convenience wrapper (which re-reads it) is safe only
         for callers that do not suspend.
         """
+        # Generation-stamped at DISPATCH exactly as :meth:`_cmd_title_refresh`
+        # does, and for the same reason: an automatic naming call dispatched
+        # BEFORE this one still matches its own captured generation when it
+        # resumes, so without the bump it stores its pre-refresh answer over the
+        # title this refresh just landed. The follower asked for a fresh name
+        # and would be left with the stale one (review round 1, MAJOR-1).
+        self._name_generation += 1
+        generation = self._name_generation
         source = self._interaction
         current = session.conversation_name
         turns = None
@@ -32553,6 +32561,16 @@ class OperatorApp(App[None]):
         # against a title no longer in force, and storing over it would strip
         # the latch protecting the words the user just typed.
         standing = session.conversation_name
+        # Superseded alongside the rename guard, for the reason the worker twin
+        # checks both: a `/new` or `/resume` landing mid-call makes this answer
+        # belong to a conversation that is no longer here, and the retired
+        # source must not be painted or stamped.
+        if generation != source.naming.generation or source.retired:
+            return SlashResult(
+                kind="notice",
+                text=naming.refresh_receipt(result, standing, stored=False),
+                style="info",
+            )
         if not result.changed or standing != current:
             return SlashResult(
                 kind="notice",

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -21720,10 +21720,15 @@ class OperatorApp(App[None]):
             # `notice` would collapse it. The rule `_cmd_goal` follows.
             self._system_notice("session is still starting…", "warning")
             return
-        if arg.strip().casefold() in naming.TITLE_REFRESH_WORDS:
+        try:
+            is_refresh, title = naming.parse_title_arg(arg)
+        except ValueError as error:
+            notice(str(error), "warning")
+            return
+        if is_refresh:
             self._cmd_title_refresh(session, notice)
             return
-        if not arg:
+        if not title:
             current = session.conversation_name
             if current:
                 notice(f"conversation: {current} — /title <words>, or /title refresh")
@@ -21739,7 +21744,7 @@ class OperatorApp(App[None]):
             else:
                 notice("unnamed — /title <words> names this conversation")
             return
-        stored = session.set_conversation_name(arg, user_set=True)
+        stored = session.set_conversation_name(title, user_set=True)
         # Superseded, and by the best possible answer: cleared for the reason
         # `_store_title` clears it, so nothing downstream still believes the
         # band is showing a stand-in.
@@ -32483,9 +32488,13 @@ class OperatorApp(App[None]):
         session = self._session
         if session is None:
             return SlashResult(kind="notice", text="session is still starting…", style="warning")
-        if arg.strip().casefold() in naming.TITLE_REFRESH_WORDS:
+        try:
+            is_refresh, title = naming.parse_title_arg(arg)
+        except ValueError as error:
+            return SlashResult(kind="notice", text=str(error), style="warning")
+        if is_refresh:
             return await self._title_refresh_slash_result(session, SlashResult)
-        if not arg:
+        if not title:
             current = session.conversation_name
             text = (
                 f"conversation: {current} — /title <words>, or /title refresh"
@@ -32493,7 +32502,7 @@ class OperatorApp(App[None]):
                 else "unnamed — /title <words> names this conversation"
             )
             return SlashResult(kind="notice", text=text, style="info")
-        stored = session.set_conversation_name(arg, user_set=True)
+        stored = session.set_conversation_name(title, user_set=True)
         return SlashResult(
             kind="notice",
             text=f"renamed: {stored} — auto-naming will not override it",

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -21302,14 +21302,17 @@ class OperatorApp(App[None]):
         rename always wins, including one that landed while this call was in
         flight, so this may store nothing and return the name already there.
 
-        ``turn_count`` distinguishes the two callers and drives the growth
-        gate's counters. ``None`` is the FIRST title (the naming path): the
-        session's identity starts here, so the baseline is seeded from the
-        transcript's current turn count and the refresh budget is (re)set to
-        zero — this is where omp's ``lastTitledTurnCount``/``refreshCount`` are
-        initialised. An int is a RE-title: the baseline moves to the count the
-        check was dispatched at and one refresh is spent, so the next re-title
-        needs another doubling of the transcript.
+        ``turn_count`` distinguishes the callers and drives the growth gate's
+        counters. ``None`` means the conversation's identity is being DECIDED,
+        not merely refined, so the baseline is seeded from the transcript's
+        current turn count and the refresh budget is (re)set to zero — this is
+        where omp's ``lastTitledTurnCount``/``refreshCount`` are initialised.
+        Two callers pass it: the first naming call, where the identity starts;
+        and ``/title refresh``, where the user has just re-decided it by hand,
+        which restarts the drift clock for the same reason rather than by
+        coincidence. An int is an automatic RE-title: the baseline moves to the
+        count the check was dispatched at and one refresh is spent, so the next
+        one needs another doubling of the transcript.
         """
         stored = session.set_conversation_name(title, user_set=False)
         if turn_count is None:
@@ -21812,7 +21815,13 @@ class OperatorApp(App[None]):
         )
         notice("refreshing the title…")
         self.run_worker(
-            self._title_refresh_worker(session, generation, turns, notice),
+            self._title_refresh_worker(
+                session,
+                session.conversation_name,
+                generation,
+                turns,
+                source=self._interaction,
+            ),
             thread=False,
             group=self._interaction.worker_group("naming"),
         )
@@ -21820,9 +21829,10 @@ class OperatorApp(App[None]):
     async def _title_refresh_worker(
         self,
         session: SessionProtocol,
+        current: str,
         generation: int,
         turns: list[AgentMessage] | None,
-        notice: NoticeFn,
+        source: SessionInteraction | None = None,
     ) -> None:
         """One isolated refresh call, whose every outcome gets a receipt.
 
@@ -21832,16 +21842,23 @@ class OperatorApp(App[None]):
         resolve to doing nothing. Here a user typed a command and is watching
         for an answer, so each outcome says which one it was — a refresh that
         quietly changed nothing is indistinguishable from a broken command.
+
+        ``source`` is captured at DISPATCH and every write goes through it —
+        ``_store_title_for``, ``_notice_for`` — rather than through
+        ``self._interaction``, which is a moving target: a sidebar switch during
+        the call moves it, and a worker that re-read it on resume would paint
+        the refreshed title onto the conversation the user switched TO and stamp
+        that innocent session's naming schedule. The neighbouring naming workers
+        both take the source as a parameter for this reason; this one is not
+        special.
         """
-        source = self._interaction
+        source = source or self._interaction
         source.active_workers += 1
         try:
             try:
                 if turns is None:
                     turns = await getattr(session, "materialize_history")()
-                result = await naming.refresh_title(
-                    session.conversation_name, session.complete_once, turns=turns
-                )
+                result = await naming.refresh_title(current, session.complete_once, turns=turns)
             except asyncio.CancelledError:
                 return
             # Superseded (a reload) or belonging to a session no longer on
@@ -21850,19 +21867,45 @@ class OperatorApp(App[None]):
                 return
             if not result.changed:
                 if result.outcome == naming.TITLE_NOTHING_YET:
-                    notice("nothing to title yet — /title <words> names it by hand")
+                    self._notice_for(
+                        source, "nothing to title yet — /title <words> names it by hand"
+                    )
                 else:
-                    notice(f"title unchanged: {session.conversation_name}")
+                    self._notice_for(source, f"title unchanged: {session.conversation_name}")
+                return
+            # Re-read rather than trusting `current`, the rule
+            # `_retitle_conversation_worker` follows: a `/rename` may have landed
+            # while this call was in flight, and it outranks an answer decided
+            # against a title no longer in force. Without this the release below
+            # would strip the very latch protecting the name the user just typed,
+            # and the refresh would overwrite it — silently revoking their most
+            # recent instruction in favour of their previous one.
+            if session.conversation_name != current:
+                self._notice_for(source, f"title unchanged: {session.conversation_name}")
                 return
             # Released only once a replacement is actually in hand. Released
             # before the call instead, a refresh that came back "unchanged"
             # would still have silently re-armed automatic naming over a name
             # the user typed and is keeping.
             session.conversation_name_state.release_user_set()
-            stored = self._store_title(session, result.title)
-            notice(f"title refreshed: {stored}")
+            stored = self._store_title_for(source, session, result.title)
+            self._notice_for(source, f"title refreshed: {stored}")
         finally:
             source.active_workers -= 1
+            # Naming fires ONCE per conversation, and the only thing that re-arms
+            # it is `_name_conversation_worker`'s own failure path — which a
+            # worker superseded by this one's generation bump returns before
+            # reaching. So a refresh dispatched while the opening naming call was
+            # still in flight would leave an unnamed conversation with naming
+            # permanently disarmed AND no title, the two failures compounding.
+            #
+            # In the `finally` rather than on one branch because the condition is
+            # about the OUTCOME, not the route to it: any exit that leaves this
+            # conversation unnamed — superseded, nothing-yet, a dead provider,
+            # cancellation — should let a later substantive message try again. A
+            # landed title sets the name, so the latch correctly stays spent.
+            if not session.conversation_name:
+                source.naming.requested = False
 
     # -- background jobs ------------------------------------------------------
     def _poll_subagents(self) -> None:
@@ -32465,21 +32508,24 @@ class OperatorApp(App[None]):
         ``user_set`` flag. What differs is only the delivery: a receipt returned
         as data instead of painted through ``notice``.
         """
+        current = session.conversation_name
         turns = None
         if not hasattr(session, "materialize_history"):
             turns = list(session.history()) if hasattr(session, "history") else []
         try:
             if turns is None:
                 turns = await getattr(session, "materialize_history")()
-            result = await naming.refresh_title(
-                session.conversation_name, session.complete_once, turns=turns
-            )
+            result = await naming.refresh_title(current, session.complete_once, turns=turns)
         except asyncio.CancelledError:
             raise
         except Exception:  # noqa: BLE001 — naming is decoration; never fail the call
             logger.debug("routed title refresh failed", exc_info=True)
             result = naming.TitleRefresh(naming.TITLE_UNCHANGED)
-        if not result.changed:
+        # The rename-during-the-call guard the TUI worker documents: a `/rename`
+        # that landed while this was in flight outranks an answer decided
+        # against a title no longer in force, and storing over it would strip
+        # the latch protecting the words the user just typed.
+        if not result.changed or session.conversation_name != current:
             text = (
                 "nothing to title yet — /title <words> names it by hand"
                 if result.outcome == naming.TITLE_NOTHING_YET

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -32549,47 +32549,67 @@ class OperatorApp(App[None]):
         generation = self._name_generation
         source = self._interaction
         current = session.conversation_name
-        # One budget over the history read AND the naming call, and one failure
-        # policy for both — shared with the runtime-hosted twin so the two
-        # cannot drift on the deadline the way they once drifted on the receipt.
-        result = await naming.routed_refresh(current, session)
-        # The rename-during-the-call guard the TUI worker documents: a `/rename`
-        # that landed while this was in flight outranks an answer decided
-        # against a title no longer in force, and storing over it would strip
-        # the latch protecting the words the user just typed.
-        standing = session.conversation_name
-        # Superseded alongside the rename guard, for the reason the worker twin
-        # checks both: a `/new` or `/resume` landing mid-call makes this answer
-        # belong to a conversation that is no longer here, and the retired
-        # source must not be painted or stamped.
-        if generation != source.naming.generation or source.retired:
+        try:
+            # One budget over the history read AND the naming call, and one
+            # failure policy for both — shared with the runtime-hosted twin so
+            # the two cannot drift on the deadline the way they once drifted on
+            # the receipt.
+            result = await naming.routed_refresh(current, session)
+            # The rename-during-the-call guard the TUI worker documents: a
+            # `/rename` that landed while this was in flight outranks an answer
+            # decided against a title no longer in force, and storing over it
+            # would strip the latch protecting the words the user just typed.
+            standing = session.conversation_name
+            # Superseded alongside the rename guard, for the reason the worker
+            # twin checks both: a `/new` or `/resume` landing mid-call makes
+            # this answer belong to a conversation that is no longer here, and
+            # the retired source must not be painted or stamped.
+            if generation != source.naming.generation or source.retired:
+                return SlashResult(
+                    kind="notice",
+                    text=naming.refresh_receipt(result, standing, stored=False),
+                    style="info",
+                )
+            if not result.changed or standing != current:
+                return SlashResult(
+                    kind="notice",
+                    text=naming.refresh_receipt(result, standing, stored=False),
+                    style="info",
+                )
+            # Probed rather than called outright: `session` is `Any` on this
+            # path (it is whatever facade the follower's owner holds), and the
+            # sibling in `serving.py` guards for the same reason. An
+            # AttributeError here would surface as a failed routed op rather
+            # than as a missing rename.
+            release = getattr(
+                getattr(session, "conversation_name_state", None), "release_user_set", None
+            )
+            if callable(release):
+                release()
+            stored = self._store_title_for(source, session, result.title)
             return SlashResult(
                 kind="notice",
-                text=naming.refresh_receipt(result, standing, stored=False),
+                text=naming.refresh_receipt(result, stored),
                 style="info",
+                data={"stored": stored},
             )
-        if not result.changed or standing != current:
-            return SlashResult(
-                kind="notice",
-                text=naming.refresh_receipt(result, standing, stored=False),
-                style="info",
-            )
-        # Probed rather than called outright: `session` is `Any` on this path
-        # (it is whatever facade the follower's owner holds), and the sibling in
-        # `owned.py` guards for the same reason. An AttributeError here would
-        # surface as a failed routed op rather than as a missing rename.
-        release = getattr(
-            getattr(session, "conversation_name_state", None), "release_user_set", None
-        )
-        if callable(release):
-            release()
-        stored = self._store_title_for(source, session, result.title)
-        return SlashResult(
-            kind="notice",
-            text=naming.refresh_receipt(result, stored),
-            style="info",
-            data={"stored": stored},
-        )
+        finally:
+            # The OTHER half of the generation fence, and it is not optional:
+            # the bump above supersedes any first-naming worker in flight, and
+            # that worker returns at its own generation check BEFORE reaching
+            # the re-arm which is the only thing that ever clears
+            # `naming.requested`. Without this, a `/title refresh` run from a
+            # phone during the opening turn — exactly when a user sees
+            # "untitled" and reaches for the command — leaves the conversation
+            # permanently unnamed with naming disarmed.
+            #
+            # In the `finally` and keyed on the OUTCOME, for the reason
+            # `_title_refresh_worker` does the same: every exit that leaves this
+            # conversation without a title should let a later message try again,
+            # and a landed title sets the name so the latch correctly stays
+            # spent.
+            if not session.conversation_name:
+                source.naming.requested = False
 
     def _fast_slash_result(self, arg: str, SlashResult: Any) -> Any:
         """``/fast`` over the remote/mobile control path.

--- a/tests/e2e/test_desktop_controls.py
+++ b/tests/e2e/test_desktop_controls.py
@@ -113,7 +113,9 @@ async def test_desktop_control_surface(headless_tui_env: Path, workspace: Path, 
             assert {row["name"] for row in catalog} == offered
             assert withheld == {"mobile", "info"}
             assert len(catalog) == len(SLASH_COMMANDS) - len(withheld)
-            assert sum(len(row["aliases"]) for row in catalog) == 8
+            assert sum(len(row["aliases"]) for row in catalog) == sum(
+                len(spec.aliases) for spec in SLASH_COMMANDS if spec.desktop_destination
+            )
             created = await client.post(
                 "/v1/desktop/sessions", json={"request_id": request_id(), "cwd": str(workspace)}
             )

--- a/tests/e2e/test_desktop_controls.py
+++ b/tests/e2e/test_desktop_controls.py
@@ -113,9 +113,14 @@ async def test_desktop_control_surface(headless_tui_env: Path, workspace: Path, 
             assert {row["name"] for row in catalog} == offered
             assert withheld == {"mobile", "info"}
             assert len(catalog) == len(SLASH_COMMANDS) - len(withheld)
-            assert sum(len(row["aliases"]) for row in catalog) == sum(
-                len(spec.aliases) for spec in SLASH_COMMANDS if spec.desktop_destination
-            )
+            # The literal is DELIBERATE, unlike its three neighbours. The
+            # catalogue's `aliases` are copied straight off `spec.aliases`
+            # (`desktop_commands.py:39`), so deriving this bound from
+            # SLASH_COMMANDS would compare the registry with itself and pass for
+            # any alias added or dropped — the one thing this line exists to
+            # notice. Update the number when you intend to change the offered
+            # alias surface; a diff here is the review prompt.
+            assert sum(len(row["aliases"]) for row in catalog) == 9
             created = await client.post(
                 "/v1/desktop/sessions", json={"request_id": request_id(), "cwd": str(workspace)}
             )

--- a/tests/unit/session/runtime/test_capability_surface.py
+++ b/tests/unit/session/runtime/test_capability_surface.py
@@ -263,13 +263,13 @@ async def test_a_routed_alias_reaches_the_same_handler_as_its_primary_name(
     literal list, so the test keeps its meaning as commands gain and lose them.
     """
     from local_operator.session.frontend_state import SlashResult
-    from local_operator.session.runtime.owned import OwnedSessionHandle
+    from local_operator.session.runtime.serving import ServingSessionHandle
     from local_operator.slash_commands import slash_command_for
 
     entry = slash_command_for(f"/{spelling}")
     assert entry is not None and spelling != entry.name, f"{spelling} is not an alias"
 
-    handle = OwnedSessionHandle.__new__(OwnedSessionHandle)
+    handle = ServingSessionHandle.__new__(ServingSessionHandle)
     handle._session = None  # type: ignore[attr-defined]
     aliased = await handle._slash_result(spelling, "", SlashResult)
     primary = await handle._slash_result(entry.name, "", SlashResult)

--- a/tests/unit/session/runtime/test_capability_surface.py
+++ b/tests/unit/session/runtime/test_capability_surface.py
@@ -238,6 +238,52 @@ def test_the_runtime_dispatches_every_slash_command_it_advertises() -> None:
     )
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("spelling", ["title", "models", "recall"])
+async def test_a_routed_alias_reaches_the_same_handler_as_its_primary_name(
+    spelling: str,
+) -> None:
+    """The same defect class, one layer along: dispatched, but only if spelled
+    the way the branch happens to be written.
+
+    Both routed dispatchers match string LITERALS, so an alias arriving off the
+    wire fell past every branch and collected the terminal-only refusal — for a
+    command the runtime implements, that the registry advertises, and that the
+    invoker's own picker completed. Found on a live session: ``/title`` over the
+    control socket answered "run it from a terminal on the machine you want to
+    configure" while ``/rename`` worked, which is the local path's already-fixed
+    `slash_command_for` bug reappearing on the routed one.
+
+    Asserted as EQUIVALENCE to the primary spelling rather than as "not the
+    refusal", because the refusal is a legitimate answer for some of these:
+    ``/recall`` resolves to ``/resume``, which genuinely has no session-side
+    home. What must never differ is the ANSWER the two spellings get — one
+    entry, one behaviour, the same rule ``test_an_alias_inherits_its_command_policy``
+    pins on the local path. Driven off the REGISTRY's aliases rather than a
+    literal list, so the test keeps its meaning as commands gain and lose them.
+    """
+    from local_operator.session.frontend_state import SlashResult
+    from local_operator.session.runtime.owned import OwnedSessionHandle
+    from local_operator.slash_commands import slash_command_for
+
+    entry = slash_command_for(f"/{spelling}")
+    assert entry is not None and spelling != entry.name, f"{spelling} is not an alias"
+
+    handle = OwnedSessionHandle.__new__(OwnedSessionHandle)
+    handle._session = None  # type: ignore[attr-defined]
+    aliased = await handle._slash_result(spelling, "", SlashResult)
+    primary = await handle._slash_result(entry.name, "", SlashResult)
+    assert aliased.text == primary.text, (
+        f"/{spelling} answered differently from /{entry.name}: the routed "
+        "dispatcher matched the raw word instead of resolving it to its "
+        "registry primary name"
+    )
+    # And the refusal, when there is one, names the command the user can
+    # actually look up — never the alias that fell through to it.
+    if "does not hold" in aliased.text:
+        assert f"/{entry.name}" in aliased.text
+
+
 @pytest.mark.parametrize(
     "command",
     sorted(_advertised_authoritative_commands()),

--- a/tests/unit/session/runtime/test_serving.py
+++ b/tests/unit/session/runtime/test_serving.py
@@ -885,6 +885,37 @@ async def test_title_refresh_retitles_a_detached_session_and_republishes() -> No
 
 
 @pytest.mark.asyncio
+async def test_a_renamed_session_reaches_the_projection_and_the_record() -> None:
+    """A name nobody can read is not a rename.
+
+    The projection's ``conversation_name`` has exactly one writer
+    (``_refresh_state``), the heartbeat republishes the PROJECTION's copy every
+    15 s, and ``_republish`` does not carry the name field at all. So a slash
+    path that skipped ``_refresh_state`` did not merely lag — the stale name was
+    re-asserted for the life of the session, and an attached phone kept the old
+    header forever. Covers both writers through the one seam they share.
+    """
+    for args, expected in (
+        ("refresh", "Billing importer rewrite"),
+        ("Typed by hand", "Typed by hand"),
+    ):
+        handle, session = make_handle()
+        session.conversation_name = "Fix the login flow"
+        session._name_state = ConversationName(text="Fix the login flow")
+        session.conversation_name_state = session._name_state
+        session.history = lambda: [  # type: ignore[attr-defined]
+            SimpleNamespace(role="user", text="fix the login redirect loop"),
+            SimpleNamespace(role="assistant", text="done"),
+            SimpleNamespace(role="user", text="now rewrite the billing importer"),
+        ]
+        session.title_reply = "<title>Billing importer rewrite</title>"
+
+        await handle._rename_slash(session, args, _SlashResult)
+
+        assert handle.session_projection_seed.conversation_name == expected, args
+
+
+@pytest.mark.asyncio
 async def test_title_refresh_that_changes_nothing_keeps_the_name_and_the_latch() -> None:
     """A refresh is not a rename: "the name still fits" must leave both the
     title and the user's claim on it exactly as they were."""

--- a/tests/unit/session/runtime/test_serving.py
+++ b/tests/unit/session/runtime/test_serving.py
@@ -24,6 +24,7 @@ from local_operator.harness.types import (
     SteeringDeliveredEvent,
 )
 from local_operator.session.frontend_state import SlashResult as _SlashResult
+from local_operator.session.naming import ConversationName
 from local_operator.session.protocol import RuntimeLocality
 from local_operator.session.runtime import serving as serving_mod
 from local_operator.session.runtime.serving import ServingSessionHandle
@@ -38,6 +39,15 @@ class FakeSession:
     owns_runtime = True
     outcome_is_synchronous = True
     runtime_locality: RuntimeLocality = "this-process"
+
+    #: Declared, deliberately UNASSIGNED: the naming tests set these per-case,
+    #: and `_title_refresh_slash` probes the public one with
+    #: `getattr(session, "conversation_name_state", None)`. A default here
+    #: would make the attribute exist on every fake and silently move those
+    #: tests onto the other branch, so the annotation states the surface this
+    #: fake stands in for without creating it.
+    _name_state: ConversationName
+    conversation_name_state: ConversationName
 
     def __init__(self) -> None:
         self.session_id = "sess-1"
@@ -848,8 +858,6 @@ async def test_title_refresh_retitles_a_detached_session_and_republishes() -> No
     what keeps ``lop sessions`` and the resume picker from listing the session
     under the name it just stopped having.
     """
-    from local_operator.session.naming import ConversationName
-
     handle, session = make_handle()
     session.conversation_name = "Fix the login flow"
     session._name_state = ConversationName(text="Fix the login flow", user_set=True)
@@ -880,8 +888,6 @@ async def test_title_refresh_retitles_a_detached_session_and_republishes() -> No
 async def test_title_refresh_that_changes_nothing_keeps_the_name_and_the_latch() -> None:
     """A refresh is not a rename: "the name still fits" must leave both the
     title and the user's claim on it exactly as they were."""
-    from local_operator.session.naming import ConversationName
-
     handle, session = make_handle()
     session.conversation_name = "Ledger reconciliation"
     session._name_state = ConversationName(text="Ledger reconciliation", user_set=True)

--- a/tests/unit/session/runtime/test_serving.py
+++ b/tests/unit/session/runtime/test_serving.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -22,6 +23,7 @@ from local_operator.harness.types import (
     NoticeEvent,
     SteeringDeliveredEvent,
 )
+from local_operator.session.frontend_state import SlashResult as _SlashResult
 from local_operator.session.protocol import RuntimeLocality
 from local_operator.session.runtime import serving as serving_mod
 from local_operator.session.runtime.serving import ServingSessionHandle
@@ -834,6 +836,68 @@ async def test_ask_gate_asks_multiple_questions_one_at_a_time() -> None:
     await handle.ask_answer(second.request_id, "yes")
     assert await asyncio.wait_for(asked, 1) == {"env": ["prod"], "confirm": ["yes"]}
     assert handle._fold.projection.pending is None
+
+
+@pytest.mark.asyncio
+async def test_title_refresh_retitles_a_detached_session_and_republishes() -> None:
+    """``/title refresh`` on a runtime nobody is attached to.
+
+    The receipt is the RETURN VALUE here, not a painted notice, so the call is
+    awaited rather than detached: a handle that answered before the naming call
+    settled would report a title that had not been decided. The republish is
+    what keeps ``lop sessions`` and the resume picker from listing the session
+    under the name it just stopped having.
+    """
+    from local_operator.session.naming import ConversationName
+
+    handle, session = make_handle()
+    session.conversation_name = "Fix the login flow"
+    session._name_state = ConversationName(text="Fix the login flow", user_set=True)
+    session.conversation_name_state = session._name_state
+    session.history = lambda: [  # type: ignore[attr-defined]
+        SimpleNamespace(role="user", text="fix the login redirect loop"),
+        SimpleNamespace(role="assistant", text="done"),
+        SimpleNamespace(role="user", text="now rewrite the billing importer"),
+    ]
+    session.title_reply = "<title>Billing importer rewrite</title>"
+    republished: list[bool] = []
+    handle._registrant = SimpleNamespace(  # type: ignore[attr-defined]
+        _republish=lambda: republished.append(True)
+    )
+
+    result = await handle._rename_slash(session, "refresh", _SlashResult)
+
+    assert result.text == "title refreshed: Billing importer rewrite"
+    assert session.conversation_name == "Billing importer rewrite"
+    # Stored as a GENERATED title, and the human latch released with it: asking
+    # for a fresh name withdraws the one you typed.
+    assert session._named[-1] == ("Billing importer rewrite", False)
+    assert not session._name_state.user_set
+    assert republished == [True], "a renamed session was left stale in the registry"
+
+
+@pytest.mark.asyncio
+async def test_title_refresh_that_changes_nothing_keeps_the_name_and_the_latch() -> None:
+    """A refresh is not a rename: "the name still fits" must leave both the
+    title and the user's claim on it exactly as they were."""
+    from local_operator.session.naming import ConversationName
+
+    handle, session = make_handle()
+    session.conversation_name = "Ledger reconciliation"
+    session._name_state = ConversationName(text="Ledger reconciliation", user_set=True)
+    session.conversation_name_state = session._name_state
+    session.history = lambda: [  # type: ignore[attr-defined]
+        SimpleNamespace(role="user", text="reconcile the ledger"),
+        SimpleNamespace(role="assistant", text="done"),
+    ]
+    session.title_reply = "<title/>"  # the model says: unchanged
+
+    result = await handle._rename_slash(session, "refresh", _SlashResult)
+
+    assert result.text == "title unchanged: Ledger reconciliation"
+    assert session.conversation_name == "Ledger reconciliation"
+    assert session._name_state.user_set, "the rename was quietly revoked"
+    assert session._named == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_approvals_ux.py
+++ b/tests/unit/tui/test_approvals_ux.py
@@ -564,6 +564,12 @@ def test_the_registry_states_which_commands_offer_values() -> None:
         # view, and the space offers the analytics-view list (today just
         # `usage`); the screen it opens IS the receipt, so it never echoes.
         "analytics": ArgumentMode.OPTIONAL,
+        # OPTIONAL like `/theme`: bare `/title` reports the name the
+        # conversation currently carries, and the space offers the `refresh`
+        # row — the one word a user could not guess. Deliberately not REQUIRED:
+        # Enter on the bare command answers, which is the line `/login` sits on
+        # the other side of. Keyed by PRIMARY name, so `rename`, not `title`.
+        "rename": ArgumentMode.OPTIONAL,
     }
     # `/provider` was the third candidate and is deliberately not here: it takes
     # no argument at all — `_cmd_providers` ignores what follows it — so a list

--- a/tests/unit/tui/test_conversation_naming.py
+++ b/tests/unit/tui/test_conversation_naming.py
@@ -1813,15 +1813,6 @@ def test_the_refresh_flags_are_accepted_alongside_the_bare_words() -> None:
         assert naming.parse_title_arg(flag) == (True, ""), flag
 
 
-def test_a_double_dash_terminator_sets_a_literal_flag_shaped_title() -> None:
-    """`--` is the escape hatch that keeps a `--`-leading title reachable.
-
-    The same idiom `parse_fork_args` uses, so the one repo convention for a
-    free-text command holds here too.
-    """
-    assert naming.parse_title_arg("-- --refresh") == (False, "--refresh")
-
-
 def test_an_unknown_title_option_is_refused_rather_than_becoming_a_title() -> None:
     """A typo'd flag raises instead of being stored.
 
@@ -1834,18 +1825,6 @@ def test_an_unknown_title_option_is_refused_rather_than_becoming_a_title() -> No
     message = str(caught.value)
     assert "--refresh" in message
     assert "--" in message
-
-
-def test_a_title_merely_containing_a_flag_word_is_still_a_title() -> None:
-    """The near-miss guard, in flag spelling.
-
-    Matching is on the WHOLE argument, so prose after the flag makes the whole
-    thing a title — the same rule the bare words follow.
-    """
-    assert naming.parse_title_arg("--refresh the billing importer") == (
-        False,
-        "--refresh the billing importer",
-    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_conversation_naming.py
+++ b/tests/unit/tui/test_conversation_naming.py
@@ -1540,6 +1540,112 @@ async def test_a_failed_refresh_leaves_the_title_standing() -> None:
 
 
 @pytest.mark.asyncio
+async def test_a_refresh_writes_only_through_the_source_it_was_dispatched_for() -> None:
+    """The moving-target defect: ``self._interaction`` is not the conversation
+    the worker was started for.
+
+    A sidebar switch during the call moves it, and a worker that re-read it on
+    resume painted the refreshed title onto the conversation the user switched
+    TO and stamped that innocent session's naming schedule — while the session
+    that asked kept a stale baseline. The generation guard cannot catch it: it
+    reads the generation off the NEW source, which this refresh never bumped.
+
+    Staged by moving ``_interaction`` directly rather than driving a real
+    sidebar switch, because the seam under test is the worker's binding of the
+    source, and a full switch would exercise a dozen unrelated ones.
+    """
+    from local_operator.tui.session_interaction import SessionInteraction
+
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+        session.grow_transcript(4)
+        asked = app._interaction
+        baseline = asked.naming.last_titled_turn_count
+
+        gate = asyncio.Event()
+        session.name_gate = gate
+        session.title = "<title>Billing importer rewrite</title>"
+        app._run_slash_command("/title refresh")
+        await _settle()
+
+        # The user switches to another conversation while the call is in flight.
+        bystander = SessionInteraction(session=None, token="bystander")
+        app._interaction = bystander
+        gate.set()
+        await _settle()
+
+        assert (
+            bystander.naming.last_titled_turn_count == 0
+        ), "the refresh stamped the schedule of the conversation switched TO"
+        assert (
+            asked.naming.last_titled_turn_count != baseline
+        ), "the asking conversation's own schedule was never re-seeded"
+        assert session.conversation_name == "Billing importer rewrite"
+
+
+@pytest.mark.asyncio
+async def test_a_refresh_landing_after_a_rename_leaves_the_rename_alone() -> None:
+    """A `/rename` during the call outranks an answer decided before it.
+
+    Without the re-read, the release would strip the very latch protecting the
+    words the user had just typed and the refresh would overwrite them —
+    silently revoking their most recent instruction in favour of the previous
+    one. The automatic worker has guarded this since it shipped; this is the
+    same guard on the on-demand path.
+    """
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+        session.grow_transcript(4)
+
+        # The rename lands while the refresh call is in flight.
+        gate = asyncio.Event()
+        session.name_gate = gate
+        session.title = "<title>Billing importer rewrite</title>"
+        app._run_slash_command("/title refresh")
+        await _settle()
+        session.set_conversation_name("Ledger reconciliation", user_set=True)
+        gate.set()
+        await _settle()
+
+        assert session.conversation_name == "Ledger reconciliation"
+        assert session.conversation_name_state.user_set, "the rename was revoked"
+        assert "title unchanged: Ledger reconciliation" in _transcript_text(app)
+
+
+@pytest.mark.asyncio
+async def test_a_refresh_that_supersedes_the_first_naming_call_frees_the_latch() -> None:
+    """Naming fires once per conversation, and the ONE thing that re-arms it is
+    the naming worker's own failure path — which a superseded worker returns
+    before reaching. So a refresh dispatched while the opening call was still in
+    flight left an unnamed conversation with naming permanently disarmed.
+    """
+    app, session = await _boot(title="<title>Login redirect loop</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        gate = asyncio.Event()
+        session.name_gate = gate
+        app._submit_prompt("fix the login redirect loop")
+        session.gate.set()
+        await _settle()
+        assert not session.conversation_name, "the opening call was not still in flight"
+
+        # The refresh bumps the generation, superseding the naming call above.
+        app._run_slash_command("/title refresh")
+        await _settle()
+        gate.set()
+        await _settle()
+
+        assert not session.conversation_name
+        assert (
+            not app._interaction.naming.requested
+        ), "an unnamed conversation was left with naming permanently disarmed"
+
+
+@pytest.mark.asyncio
 async def test_the_refresh_word_is_never_mistaken_for_a_title() -> None:
     """`/title refresh` asks; `/title <anything else>` names. The dividing line
     is a small reserved vocabulary, so a user typing the natural word from

--- a/tests/unit/tui/test_conversation_naming.py
+++ b/tests/unit/tui/test_conversation_naming.py
@@ -1069,7 +1069,9 @@ async def test_refresh_title_never_lets_a_provider_failure_escape() -> None:
     result = await naming.refresh_title(
         "Fix the login flow", boom, turns=_turns("fix the login redirect loop")
     )
-    assert result.outcome == naming.TITLE_UNCHANGED
+    # Reported as UNAVAILABLE, not UNCHANGED: telling a user the name still fits
+    # asserts a judgement that never happened and gives them no reason to retry.
+    assert result.outcome == naming.TITLE_UNAVAILABLE
 
 
 @pytest.mark.asyncio
@@ -1536,7 +1538,7 @@ async def test_a_failed_refresh_leaves_the_title_standing() -> None:
         await _settle()
 
         assert session.conversation_name == "Fix the login flow"
-        assert "title unchanged: Fix the login flow" in _transcript_text(app)
+        assert "could not reach the model" in _transcript_text(app)
 
 
 @pytest.mark.asyncio
@@ -1583,6 +1585,46 @@ async def test_a_refresh_writes_only_through_the_source_it_was_dispatched_for() 
             asked.naming.last_titled_turn_count != baseline
         ), "the asking conversation's own schedule was never re-seeded"
         assert session.conversation_name == "Billing importer rewrite"
+
+
+@pytest.mark.asyncio
+async def test_the_routed_refresh_also_writes_only_through_its_dispatch_source() -> None:
+    """The same moving-target defect, in the handler a follower reaches.
+
+    This one is easy to miss precisely because there is no worker in sight: the
+    method reads as straight-line code, but its two awaits are just as long as
+    the worker's, so ``self._interaction`` is just as much a moving target and
+    ``_store_title``'s convenience wrapper (which re-reads it) is just as wrong.
+    Round 1 fixed the worker and this survived.
+    """
+    from local_operator.session.frontend_state import SlashResult
+    from local_operator.tui.session_interaction import SessionInteraction
+
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+        session.grow_transcript(4)
+        asked = app._interaction
+
+        gate = asyncio.Event()
+        session.name_gate = gate
+        session.title = "<title>Billing importer rewrite</title>"
+        routed = asyncio.ensure_future(app._slash_result("title", "refresh", None))
+        await _settle()
+
+        # The user switches conversations while the routed call is in flight.
+        bystander = SessionInteraction(session=None, token="bystander")
+        app._interaction = bystander
+        gate.set()
+        result = await routed
+
+        assert isinstance(result, SlashResult)
+        assert result.text == "title refreshed: Billing importer rewrite"
+        assert (
+            bystander.naming.last_titled_turn_count == 0
+        ), "the routed refresh stamped the conversation the user switched TO"
+        assert asked.naming.last_titled_turn_count != 0
 
 
 @pytest.mark.asyncio
@@ -1643,6 +1685,45 @@ async def test_a_refresh_that_supersedes_the_first_naming_call_frees_the_latch()
         assert (
             not app._interaction.naming.requested
         ), "an unnamed conversation was left with naming permanently disarmed"
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_history_still_answers_the_command() -> None:
+    """`refresh_title` swallows the NAMING call's failures, but the history read
+    happens outside it and raises on ordinary reconnect races. Uncaught, the
+    worker died with "refreshing the title…" on screen and no answer ever —
+    which is the one thing this command's contract forbids."""
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+
+        async def wedged() -> list[Any]:
+            raise RuntimeError("history changed while materializing; reconnect")
+
+        session.materialize_history = wedged  # type: ignore[attr-defined]
+        app._run_slash_command("/title refresh")
+        await _settle()
+
+        assert session.conversation_name == "Fix the login flow"
+        assert "could not reach the model" in _transcript_text(app)
+
+
+@pytest.mark.asyncio
+async def test_a_declined_store_never_claims_it_refreshed_the_title() -> None:
+    """The model answering and the answer LANDING are different events.
+
+    A `/rename` mid-call outranks the answer, so the store is declined — and a
+    receipt reading "title refreshed: <the rename>" would credit this command
+    with a name it did not choose and claim a store that never happened.
+    """
+    changed = naming.TitleRefresh(naming.TITLE_REFRESHED, "Billing importer rewrite")
+    assert naming.refresh_receipt(changed, "Billing importer rewrite") == (
+        "title refreshed: Billing importer rewrite"
+    )
+    assert naming.refresh_receipt(changed, "Ledger reconciliation", stored=False) == (
+        "title unchanged: Ledger reconciliation"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_conversation_naming.py
+++ b/tests/unit/tui/test_conversation_naming.py
@@ -1628,6 +1628,53 @@ async def test_the_routed_refresh_also_writes_only_through_its_dispatch_source()
 
 
 @pytest.mark.asyncio
+async def test_the_routed_refresh_supersedes_a_naming_call_already_in_flight() -> None:
+    """A refresh answers LATER than the automatic call it replaces, not sooner.
+
+    The generation stamp, on the handler a follower reaches. An opening naming
+    call dispatched BEFORE the refresh still matches its own captured
+    generation when it resumes, so a routed handler that never bumped the
+    counter let that stale answer store straight over the refreshed title: the
+    user asked for a fresh name, watched it land, and was left with the one it
+    replaced. The worker path has stamped since it shipped; this is that guard
+    on the routed path (review round 1, MAJOR-1).
+    """
+    app, session = await _boot(title="<title>Auto Opener Title</title>")
+    gate = asyncio.Event()
+    session.name_gate = gate
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+
+        # The automatic first-turn call is dispatched and parked in flight; its
+        # answer is decided against the pre-refresh conversation.
+        app._submit_prompt("fix the login redirect loop")
+        await asyncio.wait_for(session.name_started.wait(), timeout=5)
+        session.gate.set()
+        await _settle()
+
+        # A name is in force by the time a follower can type `/title refresh`.
+        session.set_conversation_name("Existing Name", user_set=False)
+        session.grow_transcript(4)
+
+        # The routed refresh runs to completion while that call is still parked.
+        session.title = "<title>Routed Refresh Title</title>"
+        session.name_gate = None
+        result = await app._slash_result("title", "refresh", None)
+        await _settle()
+        assert result.text == "title refreshed: Routed Refresh Title"
+        assert session.conversation_name == "Routed Refresh Title"
+
+        # Now the stale call resumes and must decline to store.
+        session.title = "<title>Auto Opener Title</title>"
+        gate.set()
+        await _settle()
+
+        assert (
+            session.conversation_name == "Routed Refresh Title"
+        ), "a naming call dispatched before the refresh stored over its title"
+
+
+@pytest.mark.asyncio
 async def test_a_refresh_landing_after_a_rename_leaves_the_rename_alone() -> None:
     """A `/rename` during the call outranks an answer decided before it.
 

--- a/tests/unit/tui/test_conversation_naming.py
+++ b/tests/unit/tui/test_conversation_naming.py
@@ -995,6 +995,120 @@ async def test_generate_retitle_swallows_a_provider_failure_as_no_change() -> No
     assert await naming.generate_retitle("Fix the login flow", "rewrite the importer", boom) is None
 
 
+# -- refresh_title: the same call, with the guessing removed ------------------
+
+
+def _turns(*texts: str) -> list[Any]:
+    """A trajectory of alternating user/assistant turns carrying ``texts``."""
+    return [
+        SimpleNamespace(role="user" if index % 2 == 0 else "assistant", text=text)
+        for index, text in enumerate(texts)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_refresh_title_reports_a_replacement_distinctly_from_no_change() -> None:
+    """``generate_retitle`` collapses both onto ``None`` because its only
+    instruction to itself is "leave the title alone". A user who typed the
+    command is owed the difference."""
+
+    async def moved(system: str, prompt: str) -> str:
+        return "<title>Billing importer rewrite</title>"
+
+    async def same(system: str, prompt: str) -> str:
+        return "<title/>"
+
+    turns = _turns("fix the login redirect loop", "done", "now the importer")
+    changed = await naming.refresh_title("Fix the login flow", moved, turns=turns)
+    assert changed == naming.TitleRefresh(naming.TITLE_REFRESHED, "Billing importer rewrite")
+    assert changed.changed
+
+    unchanged = await naming.refresh_title("Fix the login flow", same, turns=turns)
+    assert unchanged.outcome == naming.TITLE_UNCHANGED
+    assert not unchanged.changed
+
+
+@pytest.mark.asyncio
+async def test_refresh_title_titles_a_conversation_that_has_no_title_yet() -> None:
+    """The anchor gate is dropped: ``generate_retitle`` returns early without a
+    current title, but an unnamed session is exactly the one a user asks."""
+    seen: list[str] = []
+
+    async def answer(system: str, prompt: str) -> str:
+        seen.append(prompt)
+        return "<title>Login redirect loop</title>"
+
+    result = await naming.refresh_title("", answer, turns=_turns("fix the login redirect loop"))
+    assert result == naming.TitleRefresh(naming.TITLE_REFRESHED, "Login redirect loop")
+    assert "<current-title>" not in seen[0]
+
+
+@pytest.mark.asyncio
+async def test_refresh_title_spends_no_call_when_there_is_nothing_to_title() -> None:
+    """Named apart from a failure because the fix differs: this one resolves
+    itself as soon as the conversation has content."""
+    calls: list[str] = []
+
+    async def answer(system: str, prompt: str) -> str:
+        calls.append(prompt)
+        return "<title>Never reached</title>"
+
+    result = await naming.refresh_title("Fix the login flow", answer, turns=[])
+    assert result.outcome == naming.TITLE_NOTHING_YET
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_title_never_lets_a_provider_failure_escape() -> None:
+    """The isolation is NOT relaxed along with the gates: this call runs beside
+    a live turn and a 429 must never reach it."""
+
+    async def boom(system: str, prompt: str) -> str:
+        raise RuntimeError("429 rate limited")
+
+    result = await naming.refresh_title(
+        "Fix the login flow", boom, turns=_turns("fix the login redirect loop")
+    )
+    assert result.outcome == naming.TITLE_UNCHANGED
+
+
+@pytest.mark.asyncio
+async def test_refresh_title_asks_even_about_a_low_signal_newest_message() -> None:
+    """The signal gate belongs to the AUTOMATIC path, whose trigger IS the
+    message. This one is triggered by a command, so "thanks" in the tail is
+    just a turn — declining here would refuse the command outright."""
+
+    async def answer(system: str, prompt: str) -> str:
+        return "<title>Billing importer rewrite</title>"
+
+    result = await naming.refresh_title(
+        "Fix the login flow",
+        answer,
+        turns=_turns("fix the login redirect loop", "done"),
+        newest="thanks!",
+    )
+    assert result.changed
+
+
+def test_release_user_set_is_the_only_way_the_latch_reopens() -> None:
+    """``set`` only ever turns the flag ON, which is right as precedence and
+    wrong as a life sentence. One caller reopens it, and only on request."""
+    name = naming.ConversationName()
+    name.set("Ledger reconciliation", user_set=True)
+    assert name.set("Generated", user_set=False) == "Ledger reconciliation"
+
+    assert name.release_user_set() is True
+    assert not name.user_set
+    # The TEXT is deliberately untouched: the refresh call needs it as the
+    # anchor, and clearing it would blank the band for the length of the call.
+    assert name.text == "Ledger reconciliation"
+    assert name.set("Generated", user_set=False) == "Generated"
+
+    # Idempotent: a second release on an already-open latch reports that it
+    # held nothing rather than raising.
+    assert name.release_user_set() is False
+
+
 # -- the theme sampler and the drift regression it fixes ----------------------
 
 
@@ -1268,3 +1382,186 @@ async def test_the_apps_provisional_mirror_cannot_displace_a_stored_title() -> N
             assert row == ("Reliable session naming", SESSION_NAME_RANK_TITLE)
             session.gate.set()
         recorder.close()
+
+
+# -- /title refresh: the on-demand path -------------------------------------
+#
+# The automatic re-title above is a GUESS about whether a refresh is wanted,
+# and every gate on it exists to keep that guessing cheap. `/title refresh` is
+# the same call with the guessing removed, so what these tests pin is mostly
+# the absence of those gates — plus the one thing the automatic path never has
+# to do, which is tell the user what happened.
+
+
+@pytest.mark.asyncio
+async def test_a_refresh_retitles_a_session_the_growth_gate_would_decline() -> None:
+    """The reason the command exists: the schedule says no, the user says yes.
+
+    A settled session that has grown but not doubled is exactly where
+    ``should_refresh_theme`` declines — pinned one test up. The same session,
+    asked directly, re-titles.
+    """
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        now = await _named(app, session, "fix the login redirect loop")
+        # Deliberately INSIDE the churn floor and short of the growth gate: if
+        # either gate were consulted, no call would be spent at all.
+        now[0] += 1
+        session.grow_transcript(3)
+
+        session.title = "<title>Billing importer rewrite</title>"
+        app._run_slash_command("/title refresh")
+        await _settle()
+
+        assert len(session.completions) == 2, "the refresh spent no call"
+        system, data = session.completions[1]
+        assert system == naming.THEME_SYSTEM_PROMPT
+        assert "<current-title>\nFix the login flow\n</current-title>" in data
+        assert session.conversation_name == "Billing importer rewrite"
+        assert app._status is not None
+        assert app._status._conversation_name == "Billing importer rewrite"
+        assert "title refreshed: Billing importer rewrite" in _transcript_text(app)
+
+
+@pytest.mark.asyncio
+async def test_a_refresh_releases_a_human_rename_only_when_a_title_lands() -> None:
+    """``user_set`` is a one-way latch everywhere else; this is the exception.
+
+    Asking for a fresh title withdraws the name you typed — otherwise the
+    refreshed title would land and automatic naming would stay disabled forever
+    on the strength of a rename the user had just abandoned.
+    """
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+        # The trajectory the refresh samples: without it there is nothing to
+        # title and the call is never spent, which is a different test.
+        session.grow_transcript(4)
+        session.set_conversation_name("Ledger reconciliation", user_set=True)
+        assert session.conversation_name_state.user_set
+
+        session.title = "<title>Billing importer rewrite</title>"
+        app._run_slash_command("/title refresh")
+        await _settle()
+
+        assert session.conversation_name == "Billing importer rewrite"
+        assert (
+            not session.conversation_name_state.user_set
+        ), "a refreshed conversation must go back to naming itself"
+
+
+@pytest.mark.asyncio
+async def test_an_unchanged_refresh_keeps_the_human_rename_latched() -> None:
+    """The other half of the release rule, and the reason it is not done up front.
+
+    Released before the call, a refresh that came back "the name still fits"
+    would have silently re-armed automatic naming over a name the user typed and
+    is keeping — a rename quietly revoked by a command that reported no change.
+    """
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+        session.grow_transcript(4)
+        session.set_conversation_name("Ledger reconciliation", user_set=True)
+
+        session.title = "<title/>"  # the model says: unchanged
+        app._run_slash_command("/title refresh")
+        await _settle()
+
+        assert session.conversation_name == "Ledger reconciliation"
+        assert session.conversation_name_state.user_set, "the rename was quietly revoked"
+        assert "title unchanged: Ledger reconciliation" in _transcript_text(app)
+
+
+@pytest.mark.asyncio
+async def test_an_unnamed_session_can_be_titled_on_demand() -> None:
+    """``generate_retitle`` returns early without an anchor; the refresh does not.
+
+    A session whose opening naming call failed is unnamed, and is precisely the
+    one a user reaches for this command on. With no anchor the sampled context
+    simply carries no ``<current-title>`` and the model writes a fresh name.
+    """
+    app, session = await _boot(title="")  # the opening naming call yields nothing
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        app._submit_prompt("fix the login redirect loop")
+        session.gate.set()
+        await _settle()
+        assert not session.conversation_name
+        session.grow_transcript(4)
+
+        session.title = "<title>Login redirect loop</title>"
+        app._run_slash_command("/title refresh")
+        await _settle()
+
+        _, data = session.completions[-1]
+        assert "<current-title>" not in data, "an unnamed session anchored on nothing"
+        assert session.conversation_name == "Login redirect loop"
+
+
+@pytest.mark.asyncio
+async def test_a_refresh_with_nothing_to_title_says_so() -> None:
+    """Three outcomes, three receipts. A refresh that changed nothing and said
+    nothing is indistinguishable from a broken command, which is the failure
+    the automatic path is allowed to have and this one is not."""
+    app, session = await _boot(title="")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        app._run_slash_command("/title refresh")
+        await _settle()
+
+        assert session.completions == [], "an empty conversation spent a call"
+        assert "nothing to title yet" in _transcript_text(app)
+        session.gate.set()
+
+
+@pytest.mark.asyncio
+async def test_a_failed_refresh_leaves_the_title_standing() -> None:
+    """Naming is decoration: a provider failure costs the refresh, never the
+    title and never the turn beside it."""
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+        session.grow_transcript(4)
+
+        async def boom(system: str, prompt: str) -> str:
+            raise RuntimeError("429 from the provider")
+
+        session.complete_once = boom  # type: ignore[method-assign]
+        app._run_slash_command("/title refresh")
+        await _settle()
+
+        assert session.conversation_name == "Fix the login flow"
+        assert "title unchanged: Fix the login flow" in _transcript_text(app)
+
+
+@pytest.mark.asyncio
+async def test_the_refresh_word_is_never_mistaken_for_a_title() -> None:
+    """`/title refresh` asks; `/title <anything else>` names. The dividing line
+    is a small reserved vocabulary, so a user typing the natural word from
+    another tool's habit is not answered with a conversation called "update"."""
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+        session.grow_transcript(4)
+        session.title = "<title>Billing importer rewrite</title>"
+
+        for word in sorted(naming.TITLE_REFRESH_WORDS):
+            session.set_conversation_name("Fix the login flow", user_set=False)
+            app._run_slash_command(f"/title {word}")
+            await _settle()
+            assert session.conversation_name == "Billing importer rewrite", word
+
+        # And the near-miss goes the other way: a title that merely CONTAINS a
+        # reserved word is a title, or the command would eat legitimate names.
+        app._run_slash_command("/title refresh the billing importer")
+        await _settle()
+        # Stored VERBATIM, not sentence-cased: this branch is `/rename`'s, and
+        # the words are the user's to capitalise.
+        assert session.conversation_name == "refresh the billing importer"
+        assert session.conversation_name_state.user_set

--- a/tests/unit/tui/test_conversation_naming.py
+++ b/tests/unit/tui/test_conversation_naming.py
@@ -1736,6 +1736,37 @@ async def test_a_refresh_that_supersedes_the_first_naming_call_frees_the_latch()
 
 
 @pytest.mark.asyncio
+async def test_a_routed_refresh_also_frees_the_latch_it_superseded() -> None:
+    """The generation fence is two halves, and porting one is worse than none.
+
+    The bump supersedes any first-naming worker in flight; that worker then
+    returns at its OWN generation check, before reaching the re-arm which is the
+    only thing that ever clears `naming.requested`. So the routed handler
+    inherited the fence and left the compensation behind, and a `/title refresh`
+    from a phone during the opening turn — exactly when a user sees "untitled"
+    and reaches for the command — disarmed naming for the conversation's life.
+    """
+    app, session = await _boot(title="<title>Login redirect loop</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        gate = asyncio.Event()
+        session.name_gate = gate
+        app._submit_prompt("fix the login redirect loop")
+        session.gate.set()
+        await _settle()
+        assert not session.conversation_name, "the opening call was not still in flight"
+
+        await app._slash_result("title", "refresh", None)
+        gate.set()
+        await _settle()
+
+        assert not session.conversation_name
+        assert (
+            not app._interaction.naming.requested
+        ), "the routed refresh left naming permanently disarmed"
+
+
+@pytest.mark.asyncio
 async def test_the_routed_budget_covers_the_history_read_too() -> None:
     """The deadline must bound the WHOLE op, not just the naming call.
 

--- a/tests/unit/tui/test_conversation_naming.py
+++ b/tests/unit/tui/test_conversation_naming.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import time
 from types import SimpleNamespace
 from typing import Any
 
@@ -1732,6 +1733,50 @@ async def test_a_refresh_that_supersedes_the_first_naming_call_frees_the_latch()
         assert (
             not app._interaction.naming.requested
         ), "an unnamed conversation was left with naming permanently disarmed"
+
+
+@pytest.mark.asyncio
+async def test_the_routed_budget_covers_the_history_read_too() -> None:
+    """The deadline must bound the WHOLE op, not just the naming call.
+
+    Reading the history sits outside `refresh_title`'s timeout and has no
+    ceiling of its own — `RemoteSession.materialize_history` pages a remote
+    journal in a `while token:` loop — so bounding only the second await left
+    the op at "unbounded + 8s" against a client that abandons it at 15, which
+    is the overrun the budget exists to prevent surviving the fix meant to
+    remove it. The op could store the title and still report failure.
+    """
+    slow = asyncio.Event()
+
+    class _Slow:
+        conversation_name = "Fix the login flow"
+
+        async def materialize_history(self) -> list[Any]:
+            await slow.wait()  # a page that never arrives
+            return []
+
+        async def complete_once(self, system: str, prompt: str) -> str:
+            return "<title>Never reached</title>"
+
+    started = time.monotonic()
+    try:
+        # Bounded by the TEST as well, generously: an unbudgeted op waits on
+        # that page forever, and a regression must fail in seconds rather than
+        # hang the suite until someone kills it.
+        result = await asyncio.wait_for(
+            naming.routed_refresh("Fix the login flow", _Slow()),
+            naming.ROUTED_TITLE_TIMEOUT_S + 4,
+        )
+    except asyncio.TimeoutError:  # pragma: no cover — the regression path
+        pytest.fail("the budget did not cover the history read: the op never returned")
+    finally:
+        slow.set()
+    elapsed = time.monotonic() - started
+
+    assert result.outcome == naming.TITLE_UNAVAILABLE
+    assert (
+        elapsed < naming.ROUTED_TITLE_TIMEOUT_S + 2
+    ), f"the op ran {elapsed:.1f}s: the budget did not cover the history read"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_conversation_naming.py
+++ b/tests/unit/tui/test_conversation_naming.py
@@ -1767,6 +1767,51 @@ async def test_a_routed_refresh_also_frees_the_latch_it_superseded() -> None:
 
 
 @pytest.mark.asyncio
+async def test_a_cancelled_routed_refresh_is_never_answered_with_a_verdict() -> None:
+    """A cancel is the caller going away, so it must not come back as a title
+    outcome — and it must behave the same whichever await it lands in.
+
+    `_ask_for_title` swallows `CancelledError` because it has to: the automatic
+    naming task is detached and routinely cancelled at shutdown, where a
+    propagating cancel would be a teardown traceback for a feature nobody waited
+    on. That left the two awaits inside the routed op answering one signal two
+    different ways — the history read raising, the naming call returning a
+    verdict for a request nobody was holding.
+    """
+
+    class _Slow:
+        conversation_name = "Fix the login flow"
+
+        def history(self) -> list[Any]:
+            return [SimpleNamespace(role="user", text="fix the login redirect loop")]
+
+        async def complete_once(self, system: str, prompt: str) -> str:
+            await asyncio.sleep(30)  # cancelled while the model is thinking
+            return "<title>Never reached</title>"
+
+    task = asyncio.ensure_future(naming.routed_refresh("Fix the login flow", _Slow()))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+def test_a_receipt_never_quotes_a_title_that_does_not_exist() -> None:
+    """Every branch but one quotes the name in force. A superseded refresh on a
+    never-named conversation had none, and rendered "title unchanged: " with
+    nothing after the colon."""
+    for outcome in (naming.TITLE_REFRESHED, naming.TITLE_UNCHANGED, naming.TITLE_NOTHING_YET):
+        assert naming.refresh_receipt(naming.TitleRefresh(outcome, "X"), "") == (
+            "nothing to title yet — /title <words> names it by hand"
+        ), outcome
+    # The one exception is honest with or without a name: it reports that no
+    # judgement happened rather than quoting one.
+    assert "could not reach the model" in naming.refresh_receipt(
+        naming.TitleRefresh(naming.TITLE_UNAVAILABLE), ""
+    )
+
+
+@pytest.mark.asyncio
 async def test_the_routed_budget_covers_the_history_read_too() -> None:
     """The deadline must bound the WHOLE op, not just the naming call.
 

--- a/tests/unit/tui/test_conversation_naming.py
+++ b/tests/unit/tui/test_conversation_naming.py
@@ -1767,6 +1767,52 @@ async def test_a_routed_refresh_also_frees_the_latch_it_superseded() -> None:
 
 
 @pytest.mark.asyncio
+async def test_a_slow_provider_gets_a_receipt_not_a_raised_cancellation() -> None:
+    """The budget's own deadline must answer with a receipt, never an exception.
+
+    `asyncio.wait_for` enforces a deadline by CANCELLING the body, and
+    `_ask_for_title` swallows `CancelledError` and returns a sentinel — which
+    defeats the deadline outright: no `TimeoutError`, and the slow-provider case
+    walked CALL_CANCELLED -> TITLE_CANCELLED -> `raise asyncio.CancelledError`.
+    That is a `BaseException`, so the runtime's `except Exception` never caught
+    it: no ack, no error frame, the reader loop unwound into `_drop_client` and
+    the phone that typed the command waited out ACK_TIMEOUT_S with its
+    connection dropped. `asyncio.timeout`'s `expired()` is what tells our fired
+    deadline apart from a caller-cancel THROUGH that swallow.
+    """
+
+    class _SlowProvider:
+        conversation_name = "Fix the login flow"
+
+        def history(self) -> list[Any]:
+            return [SimpleNamespace(role="user", text="now rewrite the billing importer")]
+
+        async def complete_once(self, system: str, prompt: str) -> str:
+            await asyncio.sleep(60)  # a provider that never answers
+            return "<title>Never reached</title>"
+
+    started = time.monotonic()
+    # Bounded by the test too: a regression that re-raises would surface as the
+    # assertion below, but one that HANGS must fail in seconds, not wedge the
+    # suite.
+    result = await asyncio.wait_for(
+        naming.routed_refresh("Fix the login flow", _SlowProvider()),
+        naming.ROUTED_TITLE_TIMEOUT_S + 4,
+    )
+    elapsed = time.monotonic() - started
+
+    # The receipt itself, not merely the absence of a raise: the user must be
+    # told no judgement happened rather than that the name still fits.
+    assert result.outcome == naming.TITLE_UNAVAILABLE
+    assert naming.refresh_receipt(result, "Fix the login flow") == (
+        "could not reach the model — the title is unchanged"
+    )
+    assert (
+        elapsed < naming.ROUTED_TITLE_TIMEOUT_S + 2
+    ), f"the op ran {elapsed:.1f}s: the deadline did not fire"
+
+
+@pytest.mark.asyncio
 async def test_a_cancelled_routed_refresh_is_never_answered_with_a_verdict() -> None:
     """A cancel is the caller going away, so it must not come back as a title
     outcome — and it must behave the same whichever await it lands in.
@@ -1794,6 +1840,58 @@ async def test_a_cancelled_routed_refresh_is_never_answered_with_a_verdict() -> 
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_naming_worker_paints_nothing() -> None:
+    """A user who cancelled must not be told the model judged the name still fits.
+
+    `_title_refresh_worker` calls `refresh_title` DIRECTLY, and the swallow in
+    `_ask_for_title` means its own `except asyncio.CancelledError` never fires:
+    it resumes with `outcome='cancelled'` and `changed` False, one fallthrough
+    from painting "title unchanged: <name>" for a judgement that never happened.
+    Asserts the outcome the worker branches on, which is the thing that decides
+    whether anything is painted.
+    """
+
+    app, session = await _boot()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        session.set_conversation_name("Fix the login flow")
+
+        async def _never_answers(system: str, prompt: str) -> str:
+            await asyncio.sleep(30)  # cancelled while the model is thinking
+            return "<title>Never reached</title>"
+
+        session.complete_once = _never_answers  # type: ignore[assignment]
+        source = app._interaction
+        painted: list[tuple[str, Any]] = []
+        app._notice_for = lambda src, text, kind="info": painted.append(  # type: ignore[assignment]
+            (text, kind)
+        )
+
+        # The real worker, driven the way `_title_refresh_slash_result` drives
+        # it, then cancelled mid-call exactly as `workers.cancel_all()` does at
+        # shutdown.
+        # Duck-typed like every other turn list in these suites: the naming
+        # sampler reads only `.role` and `.text`, and the real `AgentMessage`
+        # union is deliberately not what this exercises.
+        turns: list[Any] = [SimpleNamespace(role="user", text="now rewrite the billing importer")]
+        task = asyncio.ensure_future(
+            app._title_refresh_worker(
+                session,
+                "Fix the login flow",
+                source.naming.generation,
+                turns,
+                source,
+            )
+        )
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+        assert painted == [], f"a cancelled refresh painted a verdict: {painted}"
 
 
 def test_a_receipt_never_quotes_a_title_that_does_not_exist() -> None:

--- a/tests/unit/tui/test_conversation_naming.py
+++ b/tests/unit/tui/test_conversation_naming.py
@@ -1752,3 +1752,93 @@ async def test_the_refresh_word_is_never_mistaken_for_a_title() -> None:
         # the words are the user's to capitalise.
         assert session.conversation_name == "refresh the billing importer"
         assert session.conversation_name_state.user_set
+
+
+def test_the_refresh_flags_are_accepted_alongside_the_bare_words() -> None:
+    """The flag spelling reaches the same verb as the bare word.
+
+    A user who already knows `refresh` exists reaches for the shape every other
+    command taught them; `--update` becoming a conversation's title is the
+    exact failure the bare vocabulary exists to prevent, and the `--` prefix
+    makes it worse because nobody types a real title that way.
+    """
+    for flag in sorted(naming.TITLE_REFRESH_FLAGS):
+        assert naming.parse_title_arg(flag) == (True, ""), flag
+
+
+def test_a_double_dash_terminator_sets_a_literal_flag_shaped_title() -> None:
+    """`--` is the escape hatch that keeps a `--`-leading title reachable.
+
+    The same idiom `parse_fork_args` uses, so the one repo convention for a
+    free-text command holds here too.
+    """
+    assert naming.parse_title_arg("-- --refresh") == (False, "--refresh")
+
+
+def test_an_unknown_title_option_is_refused_rather_than_becoming_a_title() -> None:
+    """A typo'd flag raises instead of being stored.
+
+    `--refersh` is a mistyped verb, not a name anyone meant; the message has to
+    name both a real flag and the `--` terminator, or a user who wanted the
+    literal text has no way to discover it.
+    """
+    with pytest.raises(ValueError) as caught:
+        naming.parse_title_arg("--refersh")
+    message = str(caught.value)
+    assert "--refresh" in message
+    assert "--" in message
+
+
+def test_a_title_merely_containing_a_flag_word_is_still_a_title() -> None:
+    """The near-miss guard, in flag spelling.
+
+    Matching is on the WHOLE argument, so prose after the flag makes the whole
+    thing a title — the same rule the bare words follow.
+    """
+    assert naming.parse_title_arg("--refresh the billing importer") == (
+        False,
+        "--refresh the billing importer",
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_refresh_flags_refresh_the_title_through_the_command() -> None:
+    """The flags reach the refresh branch through the real command path.
+
+    The parser agreeing is not enough: the dispatcher has to route on it, or
+    the flag is accepted in a unit test and typed into a title on a terminal.
+    """
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+        session.grow_transcript(4)
+        session.title = "<title>Billing importer rewrite</title>"
+
+        for flag in sorted(naming.TITLE_REFRESH_FLAGS):
+            session.set_conversation_name("Fix the login flow", user_set=False)
+            app._run_slash_command(f"/title {flag}")
+            await _settle()
+            assert session.conversation_name == "Billing importer rewrite", flag
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_title_option_notices_instead_of_renaming() -> None:
+    """A typo'd flag leaves the conversation's name alone and says so.
+
+    Without the parser this is the silent failure: `--refersh` is free text, so
+    it becomes the title AND sets `user_set`, which outranks every later
+    generated name — a typo permanently renaming the conversation.
+    """
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+        session.set_conversation_name("Fix the login flow", user_set=False)
+
+        app._run_slash_command("/title --refersh")
+        await _settle()
+
+        assert session.conversation_name == "Fix the login flow"
+        assert not session.conversation_name_state.user_set
+        assert any("unknown title option" in notice for notice in _notices(app))

--- a/tests/unit/tui/test_title_refresh_qa.py
+++ b/tests/unit/tui/test_title_refresh_qa.py
@@ -1,0 +1,765 @@
+"""QA round 1 — adversarial probes against ``/title refresh`` (PR #942).
+
+Not a second copy of ``test_conversation_naming.py``'s coverage. Everything
+here is an ATTACK: the sequences that should NOT release the ``user_set``
+latch, the races the two round-fix commits exist for, the provider shapes that
+are neither a title nor a clean failure, and the regressions sitting beside the
+change.
+
+The load-bearing invariant under test throughout: ``user_set`` is a one-way
+latch that ONLY ``release_user_set`` reopens, only an explicit refresh calls
+it, and only once a replacement title is actually in hand. Every probe below
+asserts the LATCH STATE, not merely the visible title — the two diverge
+exactly where the defect would be.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from local_operator.session import naming
+from local_operator.tui.app import OperatorApp
+from tests.unit.tui.test_app_pilot import FakeSession, _factory, _transcript_text
+from tests.unit.tui.test_conversation_naming import (
+    _GatedSession,
+    _named,
+    _ready,
+    _settle,
+)
+
+
+def _turns(*texts: str) -> list[Any]:
+    return [
+        SimpleNamespace(role="user" if index % 2 == 0 else "assistant", text=text)
+        for index, text in enumerate(texts)
+    ]
+
+
+async def _boot(title: str = "") -> tuple[OperatorApp, _GatedSession]:
+    session = _GatedSession()
+    session.title = title
+    return OperatorApp(lambda: _factory(session)), session
+
+
+# -- 1. argument parsing: can any input LOSE a title or fake a refresh? -------
+
+
+@pytest.mark.parametrize(
+    ("arg", "expected"),
+    [
+        # Whitespace-only arguments are the REPORT branch, never a store.
+        ("", (False, "")),
+        ("   ", (False, "")),
+        ("\t\n ", (False, "")),
+        # The bare verbs, and the case-insensitivity the casefold buys.
+        ("refresh", (True, "")),
+        ("REFRESH", (True, "")),
+        ("ReFrEsH", (True, "")),
+        ("  refresh\t", (True, "")),
+        ("update", (True, "")),
+        ("retitle", (True, "")),
+        # Flag spellings, same casefold.
+        ("--refresh", (True, "")),
+        ("--REFRESH", (True, "")),
+        ("--auto", (True, "")),
+        ("--update", (True, "")),
+        ("--retitle", (True, "")),
+        ("--refresh\n", (True, "")),
+        # The terminator. `--` alone yields no text, which every handler's
+        # `not title` branch answers with the REPORT rather than a blank store.
+        ("--", (False, "")),
+        ("-- --refresh", (False, "--refresh")),
+        ("-- refresh", (False, "refresh")),
+        ("-- -- refresh", (False, "-- refresh")),
+        # Near-misses: a flag with prose after it is a TITLE, not a verb.
+        ("--refresh the billing importer", (False, "--refresh the billing importer")),
+        ("--auto scaling notes", (False, "--auto scaling notes")),
+        # A single dash was never an option marker.
+        ("-refresh", (False, "-refresh")),
+        # Verbs merely CONTAINED in a title stay titles.
+        ("refresh the importer", (False, "refresh the importer")),
+        ("update", (True, "")),
+        ("updates", (False, "updates")),
+        # Unicode look-alikes must not reach the verb set.
+        ("\uff32\uff25\uff26\uff32\uff25\uff33\uff28", (False, "ＲＥＦＲＥＳＨ")),
+        ("r\u0435fresh", (False, "r\u0435fresh")),
+    ],
+)
+def test_parse_title_arg_classifies_every_edge(arg: str, expected: tuple[bool, str]) -> None:
+    """No input may silently turn a title into a refresh, or a refresh into a title."""
+    assert naming.parse_title_arg(arg) == expected
+
+
+@pytest.mark.parametrize(
+    "arg", ["---refresh", "--refres", "--nope", "--=refresh", "--refresh=1", "--" + "x" * 100]
+)
+def test_an_unknown_bare_flag_raises_rather_than_becoming_a_title(arg: str) -> None:
+    """Storing a ``--``-leading token as a title is the failure this vocabulary exists
+    to prevent: nobody types a real title starting with ``--``."""
+    with pytest.raises(ValueError, match="unknown title option"):
+        naming.parse_title_arg(arg)
+
+
+def test_the_terminator_reaches_a_title_that_is_exactly_the_verb() -> None:
+    """``/title -- refresh`` must STORE ``refresh``, not refresh. The escape hatch
+    is the only thing standing between a user who wants that title and a command
+    that quietly does something else."""
+    is_refresh, title = naming.parse_title_arg("-- refresh")
+    assert (is_refresh, title) == (False, "refresh")
+    name = naming.ConversationName()
+    assert name.set(title, user_set=True) == "refresh"
+    assert name.user_set
+
+
+def test_a_newline_bearing_title_is_collapsed_not_truncated() -> None:
+    """A pasted multi-line title must reach the band as one row with all of its
+    words, not cut at the first newline."""
+    _, title = naming.parse_title_arg("billing\nimporter rewrite")
+    name = naming.ConversationName()
+    assert name.set(title, user_set=True) == "billing importer rewrite"
+
+
+def test_a_500_character_title_is_cut_on_a_word_and_never_rejected() -> None:
+    """Over-long is the user's words, so it is TRIMMED; only a model's answer is
+    rejected outright by ``parse_title``."""
+    _, title = naming.parse_title_arg(" ".join(["reconciliation"] * 60))
+    name = naming.ConversationName()
+    stored = name.set(title, user_set=True)
+    assert len(stored) <= naming.MAX_TITLE_CHARS
+    assert name.user_set
+    assert not stored.endswith("reconcil")  # cut on a word, not mid-word
+
+
+# -- 2. the user_set latch: every sequence that must NOT release it -----------
+
+
+@pytest.mark.parametrize(
+    ("label", "answer"),
+    [
+        ("the model declined", "<title/>"),
+        ("the model returned nothing", ""),
+        ("the answer was over-long", "<title>" + " ".join(["word"] * 40) + "</title>"),
+        ("the answer restated the name", "<title>Ledger reconciliation</title>"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_a_refresh_that_lands_no_title_keeps_the_latch(label: str, answer: str) -> None:
+    """THE load-bearing rule. Released on any of these, automatic naming would
+    silently re-arm over a name the user typed and is still keeping."""
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+        session.grow_transcript(4)
+        session.set_conversation_name("Ledger reconciliation", user_set=True)
+
+        session.title = answer
+        app._run_slash_command("/title refresh")
+        await _settle()
+
+        assert session.conversation_name == "Ledger reconciliation", label
+        assert session.conversation_name_state.user_set, f"the rename was revoked: {label}"
+        # And the latch still bites: a generated title cannot displace it.
+        assert session.set_conversation_name("Generated", user_set=False) == "Ledger reconciliation"
+
+
+@pytest.mark.asyncio
+async def test_a_refresh_whose_provider_is_dead_keeps_the_latch_and_says_so() -> None:
+    """A wedged provider reported as "unchanged" is the one outcome that actively
+    misinforms — the user is handed a judgement that never happened."""
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+        session.grow_transcript(4)
+        session.set_conversation_name("Ledger reconciliation", user_set=True)
+
+        async def dead(system: str, prompt: str) -> str:
+            raise RuntimeError("429 rate limited")
+
+        session.complete_once = dead  # type: ignore[method-assign]
+        app._run_slash_command("/title refresh")
+        await _settle()
+
+        assert session.conversation_name == "Ledger reconciliation"
+        assert session.conversation_name_state.user_set, "a dead provider revoked the rename"
+        text = _transcript_text(app)
+        assert "could not reach the model" in text
+        assert "title unchanged: Ledger" not in text, "a dead provider reported as a judgement"
+
+
+@pytest.mark.asyncio
+async def test_a_refresh_on_an_empty_transcript_keeps_the_latch() -> None:
+    """Nothing-yet spends no call, so there is certainly no replacement in hand."""
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+        session._history = []  # nothing titleable
+        session.set_conversation_name("Ledger reconciliation", user_set=True)
+        before = len(session.completions)
+
+        app._run_slash_command("/title refresh")
+        await _settle()
+
+        assert len(session.completions) == before, "a call was spent on an empty transcript"
+        assert session.conversation_name == "Ledger reconciliation"
+        assert session.conversation_name_state.user_set
+
+
+@pytest.mark.asyncio
+async def test_automatic_naming_resumes_after_a_release_then_yields_to_a_new_rename() -> None:
+    """The half nobody writes: the latch must re-LATCH. A refresh hands the
+    conversation back to automatic naming, and the very next ``/rename`` must
+    take it away again — otherwise the release is a one-way door in the other
+    direction and a generated title can stomp a fresh rename."""
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+        session.grow_transcript(4)
+        session.set_conversation_name("Ledger reconciliation", user_set=True)
+
+        session.title = "<title>Billing importer rewrite</title>"
+        app._run_slash_command("/title refresh")
+        await _settle()
+        assert session.conversation_name == "Billing importer rewrite"
+        assert not session.conversation_name_state.user_set, "the release did not happen"
+
+        # Auto-naming genuinely resumed.
+        assert session.set_conversation_name("Auto chosen", user_set=False) == "Auto chosen"
+
+        # …and a rename immediately afterwards re-latches and cannot be stomped.
+        app._run_slash_command("/title Ledger reconciliation again")
+        await _settle()
+        assert session.conversation_name == "Ledger reconciliation again"
+        assert session.conversation_name_state.user_set, "the rename did not re-latch"
+        assert (
+            session.set_conversation_name("Auto stomp", user_set=False)
+            == "Ledger reconciliation again"
+        )
+
+
+# -- 3. concurrency and the wrong-conversation class of bug ------------------
+
+
+@pytest.mark.asyncio
+async def test_a_rename_landing_mid_call_outranks_the_refresh_and_keeps_its_latch() -> None:
+    """The race the round-fix commits exist for, driven at the seam rather than
+    inferred. The refresh is parked on its gate; a ``/rename`` lands; the answer
+    then arrives deciding against a title no longer in force.
+
+    Storing it would revoke the user's most recent instruction in favour of
+    their previous one — and strip the latch protecting it on the way past.
+    """
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+        session.grow_transcript(4)
+
+        gate = asyncio.Event()
+        session.name_gate = gate
+        session.name_started = asyncio.Event()
+        session.title = "<title>Billing importer rewrite</title>"
+
+        app._run_slash_command("/title refresh")
+        await asyncio.wait_for(session.name_started.wait(), timeout=5)
+
+        # The rename lands while the provider call is still in flight.
+        app._run_slash_command("/title Ledger reconciliation")
+        await _settle()
+        assert session.conversation_name == "Ledger reconciliation"
+
+        gate.set()
+        await _settle()
+
+        assert (
+            session.conversation_name == "Ledger reconciliation"
+        ), "the refresh overwrote a rename"
+        assert session.conversation_name_state.user_set, "the refresh stripped the rename's latch"
+        text = _transcript_text(app)
+        assert "title refreshed" not in text, "credited itself with a name it did not choose"
+
+
+@pytest.mark.asyncio
+async def test_two_refreshes_racing_do_not_double_release_or_cross_paint() -> None:
+    """Running the same operation twice, interleaved. The first is superseded by
+    the second's generation bump and must store nothing."""
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+        session.grow_transcript(4)
+        session.set_conversation_name("Ledger reconciliation", user_set=True)
+
+        gate = asyncio.Event()
+        session.name_gate = gate
+        session.name_started = asyncio.Event()
+        session.title = "<title>First answer</title>"
+
+        app._run_slash_command("/title refresh")
+        await asyncio.wait_for(session.name_started.wait(), timeout=5)
+        app._run_slash_command("/title refresh")
+        await _settle()
+
+        session.title = "<title>Second answer</title>"
+        gate.set()
+        await _settle()
+
+        # Exactly one of them may win; neither may leave a half-applied state
+        # (a released latch with the old title still in force).
+        name = session.conversation_name
+        latched = session.conversation_name_state.user_set
+        assert name in {"First answer", "Second answer", "Ledger reconciliation"}
+        if name == "Ledger reconciliation":
+            assert latched, "the latch was released without a replacement landing"
+        else:
+            assert not latched, "a landed refresh left the latch on"
+
+
+@pytest.mark.asyncio
+async def test_a_refresh_dispatched_before_a_new_does_not_paint_the_replacement() -> None:
+    """The bug two commits were spent on: a refresh must never repaint the
+    conversation the user navigated TO."""
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+        session.grow_transcript(4)
+
+        gate = asyncio.Event()
+        session.name_gate = gate
+        session.name_started = asyncio.Event()
+        session.title = "<title>Billing importer rewrite</title>"
+
+        app._run_slash_command("/title refresh")
+        await asyncio.wait_for(session.name_started.wait(), timeout=5)
+
+        # The conversation's identity is replaced while the call is in flight.
+        app._name_generation += 1
+        await _settle()
+
+        gate.set()
+        await _settle()
+
+        assert session.conversation_name == "Fix the login flow", "a superseded refresh painted"
+        assert "title refreshed: Billing importer rewrite" not in _transcript_text(app)
+
+
+@pytest.mark.asyncio
+async def test_a_refresh_whose_source_retired_mid_call_paints_nothing() -> None:
+    """A sidebar switch away from this conversation retires its source. The
+    answer arriving afterwards must touch neither the title nor the transcript:
+    this is the ``source.retired`` half of the guard, distinct from the
+    generation bump, and it is the shape the two round-fix commits address.
+    """
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+        session.grow_transcript(4)
+        session.set_conversation_name("Ledger reconciliation", user_set=True)
+
+        gate = asyncio.Event()
+        session.name_gate = gate
+        session.name_started = asyncio.Event()
+        session.title = "<title>Billing importer rewrite</title>"
+
+        app._run_slash_command("/title refresh")
+        await asyncio.wait_for(session.name_started.wait(), timeout=5)
+
+        # The user navigates away; this conversation's source is retired.
+        app._interaction.retired = True
+        gate.set()
+        await _settle()
+
+        assert session.conversation_name == "Ledger reconciliation", "a retired source painted"
+        assert session.conversation_name_state.user_set, "a retired refresh stripped the latch"
+        assert "title refreshed" not in _transcript_text(app)
+
+
+@pytest.mark.asyncio
+async def test_the_refresh_stamps_the_schedule_on_its_OWN_source_not_the_current_one() -> None:
+    """``source`` is captured at DISPATCH precisely so a switch during the call
+    cannot stamp an innocent conversation's naming schedule. Here the app's
+    ``_interaction`` is moved out from under the in-flight worker; the counters
+    that move must be the dispatching source's, and the bystander's must not.
+    """
+    from local_operator.tui.session_interaction import SessionInteraction
+
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+        session.grow_transcript(6)
+        mine = app._interaction
+        mine.naming.refresh_count = 3
+
+        gate = asyncio.Event()
+        session.name_gate = gate
+        session.name_started = asyncio.Event()
+        session.title = "<title>Billing importer rewrite</title>"
+
+        app._run_slash_command("/title refresh")
+        await asyncio.wait_for(session.name_started.wait(), timeout=5)
+
+        # A bystander conversation becomes current while the call is in flight.
+        bystander = SessionInteraction(session=None)
+        bystander.naming.refresh_count = 7
+        bystander.naming.last_titled_turn_count = 99
+        app._interaction = bystander
+
+        gate.set()
+        await _settle()
+
+        assert bystander.naming.refresh_count == 7, "stamped an innocent conversation"
+        assert bystander.naming.last_titled_turn_count == 99, "stamped an innocent conversation"
+        assert mine.naming.refresh_count == 0, "the dispatching source was not re-seeded"
+
+
+@pytest.mark.asyncio
+async def test_a_landed_refresh_reseeds_the_schedule_rather_than_spending_the_budget() -> None:
+    """``/title refresh`` re-decides the conversation's identity, so the drift
+    clock restarts: the baseline is re-seeded and the refresh budget is reset,
+    on THIS interaction's counters."""
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+        session.grow_transcript(8)
+        app._interaction.naming.refresh_count = 3
+        app._interaction.naming.last_titled_turn_count = 1
+
+        session.title = "<title>Billing importer rewrite</title>"
+        app._run_slash_command("/title refresh")
+        await _settle()
+
+        assert session.conversation_name == "Billing importer rewrite"
+        assert app._interaction.naming.refresh_count == 0, "a user-asked refresh was charged"
+        assert app._interaction.naming.last_titled_turn_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_a_refresh_that_lands_nothing_rearms_naming_on_an_unnamed_session() -> None:
+    """The compounding failure the ``finally`` exists for: a refresh dispatched
+    while the opening naming call was in flight supersedes it, and without the
+    re-arm the conversation is left unnamed with naming permanently disarmed."""
+    app, session = await _boot(title="")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        app._submit_prompt("fix the login redirect loop")
+        session.gate.set()
+        await _settle()
+        assert not session.conversation_name
+        session.grow_transcript(4)
+
+        # The precondition that makes this test mean anything: naming's one
+        # attempt must be SPENT when the refresh runs. Without this the assert
+        # below passes vacuously against a flag that was already False, which is
+        # exactly how a missing re-arm survives its own regression test
+        # (verified by mutation: reverting the `finally` did not fail this test
+        # until this line was added).
+        app._interaction.naming.requested = True
+
+        session.title = ""  # the refresh lands nothing either
+        app._run_slash_command("/title refresh")
+        await _settle()
+
+        assert not session.conversation_name
+        assert not app._interaction.naming.requested, "naming was left permanently disarmed"
+
+    # And the converse: a refresh that DID land a title leaves the latch spent,
+    # because the conversation now has the name naming exists to give it.
+    app, session = await _boot(title="")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        app._submit_prompt("fix the login redirect loop")
+        session.gate.set()
+        await _settle()
+        session.grow_transcript(4)
+        app._interaction.naming.requested = True
+
+        session.title = "<title>Login redirect loop</title>"
+        app._run_slash_command("/title refresh")
+        await _settle()
+
+        assert session.conversation_name == "Login redirect loop"
+        assert app._interaction.naming.requested, "a landed title must leave the latch spent"
+
+
+# -- 4. provider failure injection: the receipt must stay honest -------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("label", "answer", "outcome"),
+    [
+        ("declined", "<title/>", naming.TITLE_UNCHANGED),
+        ("empty", "", naming.TITLE_UNCHANGED),
+        ("whitespace only", "<title>   </title>", naming.TITLE_UNCHANGED),
+        (
+            "over MAX_TITLE_WORDS",
+            "<title>" + " ".join(["w"] * 40) + "</title>",
+            naming.TITLE_UNCHANGED,
+        ),
+        ("over MAX_TITLE_CHARS", "<title>" + "x" * 200 + "</title>", naming.TITLE_UNCHANGED),
+        ("restates the anchor", "<title>Fix the login flow</title>", naming.TITLE_UNCHANGED),
+        ("a real move", "<title>Billing importer rewrite</title>", naming.TITLE_REFRESHED),
+    ],
+)
+async def test_refresh_title_classifies_every_provider_shape(
+    label: str, answer: str, outcome: str
+) -> None:
+    """An over-long or empty answer is REJECTED by ``parse_title`` and must come
+    back as "the name still fits", never stored raw."""
+
+    async def answer_fn(system: str, prompt: str) -> str:
+        return answer
+
+    result = await naming.refresh_title(
+        "Fix the login flow", answer_fn, turns=_turns("fix the login redirect loop", "done")
+    )
+    assert result.outcome == outcome, label
+    if result.changed:
+        assert len(result.title) <= naming.MAX_TITLE_CHARS
+        assert len(result.title.split()) <= naming.MAX_TITLE_WORDS
+
+
+@pytest.mark.asyncio
+async def test_a_hung_provider_is_bounded_by_the_timeout_and_reported_as_unavailable() -> None:
+    """The timeout is the entire budget — there is no retry here or underneath."""
+    started = asyncio.Event()
+
+    async def hang(system: str, prompt: str) -> str:
+        started.set()
+        await asyncio.sleep(30)
+        return "<title>never</title>"
+
+    loop = asyncio.get_running_loop()
+    began = loop.time()
+    result = await naming.refresh_title(
+        "Fix the login flow", hang, turns=_turns("fix the login redirect loop"), timeout=0.2
+    )
+    assert result.outcome == naming.TITLE_UNAVAILABLE
+    assert loop.time() - began < 5, "the timeout did not bound the call"
+    assert naming.refresh_receipt(result, "Fix the login flow") == (
+        "could not reach the model — the title is unchanged"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_naming_failure_never_reaches_the_turn_beside_it() -> None:
+    """Naming is decoration: no provider failure may fail the command or the turn."""
+    for boom in (
+        RuntimeError("429 rate limited"),
+        asyncio.TimeoutError(),
+        ValueError("malformed response"),
+        KeyError("model"),
+    ):
+
+        async def raiser(system: str, prompt: str, _boom: BaseException = boom) -> str:
+            raise _boom
+
+        result = await naming.refresh_title(
+            "Fix the login flow", raiser, turns=_turns("fix the login redirect loop")
+        )
+        assert result.outcome == naming.TITLE_UNAVAILABLE, boom
+
+
+# -- 5. the routed / detached path ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_routed_path_uses_the_tighter_deadline() -> None:
+    """``ROUTED_TITLE_TIMEOUT_S`` is sized against the CLIENT's ack deadline, not
+    the model's: a routed refresh landing after the socket closed would store a
+    title and still report a lost connection."""
+    assert naming.ROUTED_TITLE_TIMEOUT_S < naming.TITLE_TIMEOUT_S
+
+    from local_operator.session.runtime.owned import OwnedSessionHandle
+
+    seen: dict[str, float] = {}
+    real = naming.refresh_title
+
+    async def spy(current, fn, **kwargs):
+        seen["timeout"] = kwargs.get("timeout", naming.TITLE_TIMEOUT_S)
+        return await real(current, fn, **kwargs)
+
+    session = FakeSession()
+    session.set_conversation_name("Fix the login flow", user_set=True)
+
+    async def answer(system: str, prompt: str) -> str:
+        return "<title>Billing importer rewrite</title>"
+
+    session.complete_once = answer  # type: ignore[method-assign]
+    session._history = _turns("fix the login redirect loop", "done")
+
+    runtime = OwnedSessionHandle.__new__(OwnedSessionHandle)
+    runtime._publish_name = lambda: None  # type: ignore[method-assign]
+
+    naming.refresh_title = spy  # type: ignore[assignment]
+    try:
+        result = await runtime._title_refresh_slash(session, _SlashResult)
+    finally:
+        naming.refresh_title = real  # type: ignore[assignment]
+
+    assert seen["timeout"] == naming.ROUTED_TITLE_TIMEOUT_S
+    assert "title refreshed: Billing importer rewrite" in result.text
+    assert not session.conversation_name_state.user_set, "the routed path did not release"
+
+
+class _SlashResult:
+    """Stand-in for the runtime's injected ``SlashResult`` constructor."""
+
+    def __init__(
+        self, *, kind: str = "", text: str = "", style: str = "", data: Any = None
+    ) -> None:
+        self.kind, self.text, self.style, self.data = kind, text, style, data
+
+
+@pytest.mark.asyncio
+async def test_the_routed_path_agrees_with_the_tui_on_what_a_refresh_does() -> None:
+    """Two surfaces, one release rule: a phone and a terminal cannot drift on
+    whether a refresh reopens the latch."""
+    from local_operator.session.runtime.owned import OwnedSessionHandle
+
+    runtime = OwnedSessionHandle.__new__(OwnedSessionHandle)
+    runtime._publish_name = lambda: None  # type: ignore[method-assign]
+
+    # Unchanged: the latch stays.
+    session = FakeSession()
+    session.set_conversation_name("Ledger reconciliation", user_set=True)
+    session._history = _turns("fix the login redirect loop", "done")
+
+    async def declined(system: str, prompt: str) -> str:
+        return "<title/>"
+
+    session.complete_once = declined  # type: ignore[method-assign]
+    result = await runtime._title_refresh_slash(session, _SlashResult)
+    assert session.conversation_name == "Ledger reconciliation"
+    assert session.conversation_name_state.user_set, "the routed path revoked a rename"
+    assert "title unchanged: Ledger reconciliation" in result.text
+
+    # Dead provider: the latch stays and the receipt is honest.
+    async def dead(system: str, prompt: str) -> str:
+        raise RuntimeError("429")
+
+    session.complete_once = dead  # type: ignore[method-assign]
+    result = await runtime._title_refresh_slash(session, _SlashResult)
+    assert session.conversation_name_state.user_set
+    assert "could not reach the model" in result.text
+
+
+@pytest.mark.asyncio
+async def test_a_rename_landing_mid_call_outranks_the_ROUTED_refresh_too() -> None:
+    """The routed twin of the rename-during-the-call race, driven at the seam.
+
+    Worth its own probe because the routed path has no worker and no generation
+    stamp — the standing-title re-read is its ONLY defence. A ``/rename`` from
+    the owning terminal while a phone's refresh is in flight must not be
+    overwritten, and its latch must survive.
+    """
+    from local_operator.session.runtime.owned import OwnedSessionHandle
+
+    runtime = OwnedSessionHandle.__new__(OwnedSessionHandle)
+    runtime._publish_name = lambda: None  # type: ignore[method-assign]
+
+    session = FakeSession()
+    session.set_conversation_name("Fix the login flow", user_set=True)
+    session._history = _turns("fix the login redirect loop", "done")
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def gated(system: str, prompt: str) -> str:
+        started.set()
+        await release.wait()
+        return "<title>Billing importer rewrite</title>"
+
+    session.complete_once = gated  # type: ignore[method-assign]
+    task = asyncio.ensure_future(runtime._title_refresh_slash(session, _SlashResult))
+    await asyncio.wait_for(started.wait(), timeout=5)
+
+    # The rename lands from the terminal while the phone's call is in flight.
+    session.set_conversation_name("Ledger reconciliation", user_set=True)
+    release.set()
+    result = await asyncio.wait_for(task, timeout=5)
+
+    assert session.conversation_name == "Ledger reconciliation", "the routed refresh overwrote"
+    assert session.conversation_name_state.user_set, "the routed refresh stripped the latch"
+    assert "title unchanged: Ledger reconciliation" in result.text
+    assert "refreshed" not in result.text, "credited itself with a name it did not choose"
+
+
+@pytest.mark.asyncio
+async def test_the_routed_rename_branch_refuses_an_unknown_flag() -> None:
+    """The raising parser reaches the detached runtime too — an unknown flag must
+    be refused there rather than stored as a title on a phone."""
+    from local_operator.session.runtime.owned import OwnedSessionHandle
+
+    runtime = OwnedSessionHandle.__new__(OwnedSessionHandle)
+    session = FakeSession()
+    result = await runtime._rename_slash(session, "---refresh", _SlashResult)
+    assert result.style == "warning"
+    assert "unknown title option" in result.text
+    assert session.conversation_name == "", "a typo became a title"
+
+
+# -- 6. regression: the neighbours the alias change touches ------------------
+
+
+def test_every_alias_resolves_to_its_registry_primary_name() -> None:
+    """``primary_slash_name`` is what stops an ALIAS falling past every branch of
+    the routed dispatchers and being refused as unsupported."""
+    from local_operator.slash_commands import SLASH_COMMANDS, primary_slash_name
+
+    assert primary_slash_name("title") == "rename"
+    assert primary_slash_name("rename") == "rename"
+    # Unknown words pass through so the caller's own fallback still sees them.
+    assert primary_slash_name("definitely-not-a-command") == "definitely-not-a-command"
+    # And the property holds for the WHOLE registry, not just the one alias.
+    for entry in SLASH_COMMANDS:
+        for alias in entry.names:
+            assert primary_slash_name(alias) == entry.name, alias
+
+
+@pytest.mark.asyncio
+async def test_plain_rename_still_behaves_exactly_as_before() -> None:
+    """The regression sitting immediately beside the change: ``/rename <words>``
+    spends no provider call, latches, and reports the stored title."""
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+        before = len(session.completions)
+
+        app._run_slash_command("/rename Ledger reconciliation")
+        await _settle()
+
+        assert session.conversation_name == "Ledger reconciliation"
+        assert session.conversation_name_state.user_set
+        assert len(session.completions) == before, "/rename spent a provider call"
+        assert session.set_conversation_name("Generated", user_set=False) == "Ledger reconciliation"
+
+
+@pytest.mark.asyncio
+async def test_a_bare_title_reports_and_stores_nothing() -> None:
+    """Bare ``/title`` is the REPORT branch on a named and an unnamed session
+    alike — and ``/title --`` reaches the same branch rather than storing ''."""
+    app, session = await _boot(title="<title>Fix the login flow</title>")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        await _named(app, session, "fix the login redirect loop")
+        before = len(session.completions)
+
+        for arg in ("", " ", "--"):
+            app._run_slash_command(f"/title {arg}".rstrip())
+            await _settle()
+            assert session.conversation_name == "Fix the login flow", arg
+            assert len(session.completions) == before, f"a report spent a call: {arg!r}"
+        assert "conversation: Fix the login flow" in _transcript_text(app)

--- a/tests/unit/tui/test_title_refresh_qa.py
+++ b/tests/unit/tui/test_title_refresh_qa.py
@@ -581,7 +581,7 @@ async def test_the_routed_path_uses_the_tighter_deadline() -> None:
     title and still report a lost connection."""
     assert naming.ROUTED_TITLE_TIMEOUT_S < naming.TITLE_TIMEOUT_S
 
-    from local_operator.session.runtime.owned import OwnedSessionHandle
+    from local_operator.session.runtime.serving import ServingSessionHandle
 
     seen: dict[str, float] = {}
     real = naming.refresh_title
@@ -599,7 +599,7 @@ async def test_the_routed_path_uses_the_tighter_deadline() -> None:
     session.complete_once = answer  # type: ignore[method-assign]
     session._history = _turns("fix the login redirect loop", "done")
 
-    runtime = OwnedSessionHandle.__new__(OwnedSessionHandle)
+    runtime = ServingSessionHandle.__new__(ServingSessionHandle)
     runtime._publish_name = lambda: None  # type: ignore[method-assign]
 
     naming.refresh_title = spy  # type: ignore[assignment]
@@ -626,9 +626,9 @@ class _SlashResult:
 async def test_the_routed_path_agrees_with_the_tui_on_what_a_refresh_does() -> None:
     """Two surfaces, one release rule: a phone and a terminal cannot drift on
     whether a refresh reopens the latch."""
-    from local_operator.session.runtime.owned import OwnedSessionHandle
+    from local_operator.session.runtime.serving import ServingSessionHandle
 
-    runtime = OwnedSessionHandle.__new__(OwnedSessionHandle)
+    runtime = ServingSessionHandle.__new__(ServingSessionHandle)
     runtime._publish_name = lambda: None  # type: ignore[method-assign]
 
     # Unchanged: the latch stays.
@@ -664,9 +664,9 @@ async def test_a_rename_landing_mid_call_outranks_the_ROUTED_refresh_too() -> No
     the owning terminal while a phone's refresh is in flight must not be
     overwritten, and its latch must survive.
     """
-    from local_operator.session.runtime.owned import OwnedSessionHandle
+    from local_operator.session.runtime.serving import ServingSessionHandle
 
-    runtime = OwnedSessionHandle.__new__(OwnedSessionHandle)
+    runtime = ServingSessionHandle.__new__(ServingSessionHandle)
     runtime._publish_name = lambda: None  # type: ignore[method-assign]
 
     session = FakeSession()
@@ -700,9 +700,9 @@ async def test_a_rename_landing_mid_call_outranks_the_ROUTED_refresh_too() -> No
 async def test_the_routed_rename_branch_refuses_an_unknown_flag() -> None:
     """The raising parser reaches the detached runtime too — an unknown flag must
     be refused there rather than stored as a title on a phone."""
-    from local_operator.session.runtime.owned import OwnedSessionHandle
+    from local_operator.session.runtime.serving import ServingSessionHandle
 
-    runtime = OwnedSessionHandle.__new__(OwnedSessionHandle)
+    runtime = ServingSessionHandle.__new__(ServingSessionHandle)
     session = FakeSession()
     result = await runtime._rename_slash(session, "---refresh", _SlashResult)
     assert result.style == "warning"


### PR DESCRIPTION
Release: minor — `/title refresh` regenerates a session's name on demand, and `/rename` gains a `title` alias.

## Summary of Changes

Adds an on-demand auto-rename for the current conversation, hooked onto the **existing `/rename` entry as one registry row** rather than a sibling command.

- `/title <words>` — set it by hand (`user_set=True`, as `/rename` always did)
- `/title refresh` — spend one isolated provider call and re-title from the whole trajectory
- bare `/title` — report the current name

`title` is an **alias**, not a second entry. The two things a user does to a conversation's name — say what it is, or ask for it to be worked out again — are one subject; splitting them across `/rename` and a `/retitle` would put two near-identical rows in `/help` whose difference is four letters in the middle of the word.

**Flag spellings are accepted alongside the bare verbs**: `--refresh`, `--auto`, `--update`, `--retitle`. `/rename`'s other argument is free text, and this repo's stated rule (`local_operator/variables.py:113-115`) is that verbs are flag-shaped precisely so they cannot collide with a free-text argument. `--` is a terminator exactly as in `parse_fork_args`, so `/title -- --refresh` sets the literal title `--refresh`. An unknown `--flag` raises `ValueError` — matching `parse_fork_args`, the reference parser for a free-text command — so a typo like `/title --refersh` produces a notice instead of silently becoming the conversation's name.

### The load-bearing part: `release_user_set()`

`user_set` was a one-way latch. `ConversationName.set` only ever turned it on, so a conversation renamed by hand could never be handed back to automatic naming for the rest of its life. That is correct as a *precedence* rule — no generated title may quietly overwrite a name a human typed — but wrong as a permanent sentence, because the user who typed the name is also the one entitled to withdraw it.

`release_user_set()` is the only way the flag goes back to `False`, and only an explicit refresh calls it: the user saying "stop using my words, work it out again" in the same breath as asking for the new title. It is released **only once a replacement is actually in hand**, so a refresh that comes back unchanged leaves a hand-typed name exactly as it was.

### Also fixed

`primary_slash_name()` in `slash_commands.py`. Both routed dispatchers (`OperatorApp._slash_result` and the detached runtime's) match string literals, so **any** alias arriving off the wire — `/title`, but equally the existing `/models`, `/recall` — fell past every branch and collected an "unsupported command" refusal for a command the owner in fact implements. That bug predates this PR on the routed path.

## Related Issue(s)

None — no tracking issue was filed for this.

## Impact

- **No breaking changes.** `/rename` keeps its name, its behaviour, and its `echo=False` policy. Everything here is additive.
- **No dependency changes.** `pyproject.toml` untouched.
- **Context budget: exactly zero delta.** Measured isolated (`LOCAL_OPERATOR_CONFIG_DIR` + `HOME` pointed at a clean dir, the way CI's container sees it): `origin/main` and this branch both produce **75,718 chars = ~27,237 billed tokens, PASS with 13 tokens of headroom** — byte-identical. The `bench_context_budget.py` script never reads `slash_commands.py`, so command descriptions do not ride the start context. **Note for maintainers: 13 tokens of headroom is `main`'s current margin, not this PR's doing** — it was 42 sixteen commits ago and is worth a look independently.
- **Cost.** A refresh is one bounded, tools-free, `isolated` call reusing the existing `_ask_for_title` path, so a provider failure resolves to "unchanged" and can never touch the turn running beside it. Routed refreshes get a tighter `ROUTED_TITLE_TIMEOUT_S = 8.0` so a slow tail cannot outlive the receipt the caller is waiting on.
- **Security.** No new credential, network, or filesystem surface.

## Testing Details

All gates run locally in this worktree's own venv (`.venv`, editable-installed from this worktree and verified to resolve here per AGENTS.md:233), on the tree as rebased onto `origin/main`.

| Gate | CI job | Result |
|---|---|---|
| `flake8 .` | `lint` | clean |
| `black --check .` | `lint` | 1219 files unchanged |
| `isort --check .` | `lint` | clean |
| `pyright --pythonpath .venv/bin/python` | `type-check` | **0 errors, 0 warnings** |
| `python -m local_operator.browser_bridge.gen_ts --check` | `type-check` | clean |
| `bench_context_budget.py` (isolated) | `context-budget` | PASS, 13 tokens headroom — identical to `origin/main` |
| `pytest tests/e2e/test_desktop_controls.py -m e2e -n0` | `tui-e2e` | 1 passed |
| targeted units (naming, runtime, capability, approvals, slash-echo, QA probes) | `test` | 305 passed |

**~1,490 lines of test added** across six files, including 66 mutation-tested adversarial probes.

Scenarios validated specifically:

- Every flag spelling (`--refresh`, `--auto`, `--update`, `--retitle`) refreshes, and every bare word (`refresh`, `update`, `retitle`) still does.
- **Near-miss guard**: `--refresh the billing importer` stays a *title*, not a refresh.
- **Terminator**: `-- --refresh` sets the literal title `--refresh`.
- **Negative control, confirmed failing without the change**: `/title --refersh` on the pre-flag code silently became the conversation's title (`assert '--refersh' == 'Fix the login flow'`); with the change it raises a notice and leaves both the name and `user_set` untouched.
- A `/rename` landing *while a refresh call is in flight* outranks the refresh — the refresh reports "unchanged" rather than stripping the latch protecting the words just typed.
- A refresh dispatched against one conversation cannot repaint another the user switched to mid-call (generation-stamped, source captured at dispatch).

### Two fixes to the cherry-picked commits, called out honestly

Commit `1a8014be` repairs `tests/unit/session/runtime/test_owned.py`, which the feature commit broke in two ways that CI would have caught:

1. An import inserted in the wrong sort position — `isort --check` failed on the branch while `origin/main`'s copy of the same file passes.
2. Eight `pyright` errors: the commit assigned `_name_state` / `conversation_name_state` onto `FakeSession`, which never declared them. Fixed by declaring the attributes the fake stands in for, **not** by `# type: ignore`.

It is a separate commit precisely so the repair is legible as a repair.

### Round 1: review and QA

Both rounds are recorded as PR comments. **Review found one MAJOR, now fixed; QA found no defects in the feature.**

- **MAJOR-1 (fixed, `d62a9a4e`)** — the routed refresh (`_title_refresh_slash_result`, what a follower/phone/desktop client reaches) captured its dispatch source but never bumped `_name_generation`, so an automatic naming call dispatched *before* the refresh still matched its captured generation on resume and stored its stale answer over the refreshed title. Reproduced against the real app (`FINAL name: 'Auto Opener Title'` clobbering `'Routed Refresh Title'`), fixed with the worker's own pattern plus the `source.retired` half of its guard, and pinned by `test_the_routed_refresh_supersedes_a_naming_call_already_in_flight`. The `owned.py` sibling was checked and is structurally immune — its naming worker re-reads the name after its await — and that reason is now a comment there rather than an assumption.
- **MINOR (fixed)** — deriving the e2e alias count made the assertion a tautology (a sum over the registry compared to a sum over the catalogue built from it). Restored to a literal `== 9`, which is the actual tripwire; demonstrated by mutation (a tenth alias fails the literal, passed the derived form).
- **MINOR (fixed)** — `rename` gaining `ArgumentMode.OPTIONAL` is a new entry in the argument-mode registry pin at `test_approvals_ux.py`; it is now declared there, with a why-comment in the file's style. This was the one genuine CI red on the first run.

QA's 66 adversarial probes are committed (`7a318f93`) rather than discarded, and they are **mutation-tested**: reverting each of the 9 guards this feature adds is caught by at least one probe, so they bite rather than decorate. They cover 33 argument shapes (incl. unicode look-alikes and casefolding), every latch sequence that must *not* release, the wrong-conversation class both round-fix commits exist for, provider failure injection, and the routed slow tail.

### Not verified

- No live provider call and no phone/attach client driven end to end; the routed path was exercised through `OwnedSessionHandle._title_refresh_slash` directly.
- `test_session_sidebar.py::test_hover_repaints_the_widget_at_most_once_per_move` flakes on this tree, but QA established it is **volume-sensitive and pre-existing**: padding unmodified base with 31 equivalent tests reproduces it on untouched code, and this diff touches no repaint logic. Worth its own ticket; not addressed here.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended (693 lines, incl. a confirmed negative control).
- [x] All new and existing tests pass. — verified by CI's sharded run on a clean container, not just locally.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [ ] I have updated the documentation when required. — **N/A**: the command's own `/help` row and picker row are the documentation surface, and both are updated.
- [x] Security considerations are addressed.
- [ ] I have linked all related issues. — **N/A**: no issue was filed.

## Review status

Round 1 complete: independent review (1 MAJOR, fixed) and adversarial QA (clean) both recorded as comments above. All findings resolved. Awaiting a green CI run on the current head before merge.
