### PR TITLE
fix(tui): recover a stuck older-messages notice when the page fetch wedges

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1025,10 +1025,11 @@ RESUME_START_NOTICE = "start of conversation"
 #:
 #: Deliberately NOT "start of conversation" (which would be false) and not the
 #: "scroll up to load" instruction (which the reader cannot carry out here). It
-#: states what is true and offers the row itself as the way out: the notice is
-#: a control (:class:`OlderHistoryNotice`), so it does not have to recite a
-#: keyboard chord the product documents nowhere else.
-RESUME_UNREACHABLE_NOTICE = "older messages above — select to load"
+#: names the gesture the row actually honours: the notice is a control
+#: (:class:`OlderHistoryNotice`) with a full-width hover band, so "click"
+#: matches what the reader sees rather than a picker verb. Keyboard recovery
+#: is the documented ``ctrl+home`` chord, not this clause.
+RESUME_UNREACHABLE_NOTICE = "older messages above — click to load"
 
 #: The audit-phase twins of the two notices above, shown once the reader has
 #: drained everything the model can still see and the rows above are
@@ -1048,7 +1049,7 @@ RESUME_AUDIT_NOTICE = "earlier history above — scroll up to load"
 
 #: The unreachable twin: more pre-compaction history exists but this frame
 #: cannot be scrolled to it, so the row offers itself as the control instead.
-RESUME_AUDIT_UNREACHABLE_NOTICE = "earlier history above — select to load"
+RESUME_AUDIT_UNREACHABLE_NOTICE = "earlier history above — click to load"
 
 #: How many times one fetch transaction re-issues against a moved display
 #: window before declaring the head genuinely unstable. The window moves on a
@@ -1069,9 +1070,21 @@ _OLDER_PAGE_TRANSPORT_NOTICE = "session is reconnecting; earlier messages will l
 
 #: The genuine-fault message. Still an error — a contiguity violation or an
 #: unexpected failure must surface — but phrased for a human: what happened,
-#: and that scrolling up is the way to ask again. Never carries the internal
-#: `not attached` / `history changed while paging` wording.
+#: and how to ask again. The verb is geometry-aware because the same toast on
+#: an unscrollable frame used to instruct a gesture the head notice correctly
+#: said was impossible (UX U4). Never carries the internal `not attached` /
+#: `history changed while paging` wording.
 _OLDER_PAGE_FAULT_NOTICE = "Could not load earlier messages right now — scroll up to try again"
+_OLDER_PAGE_FAULT_NOTICE_CLICK = "Could not load earlier messages right now — click to try again"
+
+#: Restated onto the head notice while an unmounted paging lease is held.
+#: Wedged and in-flight are indistinguishable from this side of the gate, so
+#: the copy must not look idle ("scroll up" / "click to load") while a fetch
+#: is already the thing that will make the frame scrollable. A second click
+#: may still retire an unmounted lease — that is the wedge escape — but the
+#: row has to say a load is underway rather than asking the reader to start one.
+RESUME_LOADING_NOTICE = "loading older messages…"
+RESUME_AUDIT_LOADING_NOTICE = "loading earlier history…"
 
 
 @dataclass
@@ -1100,15 +1113,16 @@ class _PagingLease:
     retire a wedged holder have to live on the same object.
 
     ``mounted`` records whether THIS transaction ever painted a page. A lease
-    that has held across one explicit click without mounting anything belongs
-    to a fetch that will never complete (a wedged owner socket that no
-    disconnect event reaches, or a settle callback that never fired), so a
-    second click retires it rather than standing down against a gate that
-    nothing will ever release — the stuck "older messages above" frame, where
-    no click and no scroll-up could trigger a fetch. A holder that HAS
-    mounted is merely settling, and keeps its gate (F1). A fetch that has not
-    yet returned is indistinguishable from a wedge, so the click is the
-    reader's way out of that wait.
+    that has held through an explicit request (click or the documented
+    ``ctrl+home`` chord) without mounting anything belongs to a fetch that
+    will never complete — a wedged owner socket that no disconnect event
+    reaches — so the next such request retires it rather than standing down
+    against a gate that nothing will ever release. A holder that HAS mounted
+    is merely settling, and keeps its gate (F1): a dropped ``insert_blocks``
+    settle is a TranscriptView defect outside this path, and breaking that
+    lease would re-consume a cursor whose rows are already painted. A fetch
+    that has not yet returned is indistinguishable from a wedge, so the
+    request is also the reader's way out of a hung wait.
     """
 
     source_token: str
@@ -3356,9 +3370,9 @@ class OperatorApp(App[None]):
         #: across the gaps between attempts where the gate is open.
         #:
         #: Read only by `_reconcile_head_notice`, to withhold the pessimistic
-        #: "select to load" copy while the fill is still working. Stating it
+        #: "click to load" copy while the fill is still working. Stating it
         #: from intermediate geometry made the row round-trip its own copy on
-        #: painted frames — `scroll up` -> `select` -> `scroll up` — which
+        #: painted frames — `scroll up` -> `click` -> `scroll up` — which
         #: reads as the notice changing its mind (review round 2, R6).
         self._resume_fill_active = False
         self._resume_fill_serial = 0
@@ -8819,8 +8833,8 @@ class OperatorApp(App[None]):
                 group=source.worker_group("history-page"),
             )
             # The fetch is now the thing that will make the frame scrollable.
-            # Until it lands, an unscrollable frame cannot honour "scroll up
-            # to load" — restate so the notice offers the click instead.
+            # Until it lands, an unmounted lease must not advertise a gesture
+            # the gate will swallow — restate as loading copy.
             self._reconcile_head_notice()
         else:
             self._resume_fill_active = False
@@ -8894,32 +8908,39 @@ class OperatorApp(App[None]):
             # rendered at `info`/`dim`, 3.77:1 on the light theme against the
             # 4.5:1 AA floor (design review round 1, D4).
             self._restate_head_notice(notice, RESUME_START_NOTICE, "note")
-        elif not scrollable and self._resume_fill_active:
+            return
+        lease = self._paging_leases.get(self._interaction.token)
+        if lease is not None and not lease.mounted:
+            # An unmounted lease is a fetch in flight or a wedge. Either way
+            # the wheel stands down against `_resume_paging`, so advertising
+            # "scroll up to load" is the stuck frame's lie on a scrollable
+            # geometry (UX U1) and "click to load" looks idle while a load is
+            # already underway (UX U3 / D2). Loading copy until a page mounts
+            # is the honest state; a second click or ctrl+home may still
+            # retire the lease. A holder that HAS mounted is merely settling
+            # and falls through so R6's skip still applies.
+            self._restate_head_notice(
+                notice,
+                RESUME_AUDIT_LOADING_NOTICE if audit else RESUME_LOADING_NOTICE,
+                "note",
+            )
+            return
+        if not scrollable and self._resume_fill_active:
             # A fill attempt is still in flight, and the frame it is about to
             # produce is the one worth describing. Stating "unreachable" from
             # intermediate geometry the fill is on its way to invalidating made
             # the row ROUND-TRIP its copy on painted frames — `scroll up` ->
-            # `select` -> `scroll up` at 120x300, which a reader sees as the
+            # `click` -> `scroll up` at 120x300, which a reader sees as the
             # notice changing its mind and changing it back (review round 2,
             # R6). The pessimistic state is worth stating once the fill has
             # actually given up, and the fill's own exits do exactly that:
             # every one of them clears this flag before reconciling.
             #
-            # Exception: a fill whose lease has mounted NOTHING and the frame
-            # still cannot scroll. That is the wedged holder, not an
-            # intermediate geometry — scrolling cannot work, and the click is
-            # the way out. Advertising "scroll up to load" here is the stuck
-            # frame's lie. A lease that HAS mounted is merely settling, and
-            # keeping the skip there is what prevents R6.
-            lease = self._paging_leases.get(self._interaction.token)
-            if lease is None or lease.mounted:
-                return
-            self._restate_head_notice(
-                notice,
-                RESUME_AUDIT_UNREACHABLE_NOTICE if audit else RESUME_UNREACHABLE_NOTICE,
-                "note",
-            )
-        elif not scrollable:
+            # Unmounted in-flight leases already returned above with loading
+            # copy. A fill that still has this flag with no such lease (or
+            # with a mounted one) is the R6 skip: keep the current row.
+            return
+        if not scrollable:
             # `note`, not `info`: this is the answer to "where did my history
             # go", which is the role `NoticeBlock` reserves `note` for, and it
             # carries an instruction the reader must be able to READ to act
@@ -9187,14 +9208,15 @@ class OperatorApp(App[None]):
         ASKING for the page the row advertises, so a gate that swallowed the
         previous ask without mounting anything is abandoned, not busy. Retire
         it and let this click fetch — otherwise a wedged holder (an owner
-        socket that never answers and is never torn down, a settle callback
-        that never fires) leaves the frame with a notice no input can answer:
-        the stuck "older messages above" state.
+        socket that never answers and is never torn down) leaves the frame
+        with a notice no input can answer: the stuck "older messages above"
+        state. ``ctrl+home`` carries the same retirement through
+        :meth:`_check_resume_page` so a keyboard reader is not stuck waiting
+        for a mouse.
         """
         message.stop()
         if message.notice is self._resume_head_notice:
             self._resume_fill_active = False
-            self._break_abandoned_paging_lease(self._interaction)
             self._resume_in_zone = True
             self._check_resume_page(force=True)
 
@@ -9354,7 +9376,7 @@ class OperatorApp(App[None]):
                     # can scroll. Fall through to the honest fault rather than
                     # live-lock; the next scroll-up asks again.
                     self._resume_fill_active = False
-                    self._notice(_OLDER_PAGE_FAULT_NOTICE, "error")
+                    self._notice(self._older_page_fault_notice(), "error")
                 elif failure == "transport":
                     # The connection is down; reattach is the transport
                     # layer's floor and is driven underneath this one. Do NOT
@@ -9373,7 +9395,7 @@ class OperatorApp(App[None]):
                     # as five identical red rows.
                     self._older_page_retries.pop(lease.source_token, None)
                     self._resume_fill_active = False
-                    self._notice(_OLDER_PAGE_FAULT_NOTICE, "error")
+                    self._notice(self._older_page_fault_notice(), "error")
         finally:
             # `transferred` means the mount now carries the lease to its settle.
             # Otherwise this transaction ends here, and only it may end itself.
@@ -9415,7 +9437,7 @@ class OperatorApp(App[None]):
         without going through either. So the copy was correct on every path a
         test drove and wrong on the one a reader takes most often: the notice
         told a reader to scroll up in a frame with no scrollbar after the
-        window grew, and went on offering `select to load` after it shrank back
+        window grew, and went on offering `click to load` after it shrank back
         into a scrollable frame (design review round 2, D1; QA Q5).
 
         Keyed on the EXTENT rather than on a resize event, which is the same
@@ -9434,6 +9456,21 @@ class OperatorApp(App[None]):
         if self._resume_head_notice is None:
             return
         self._reconcile_head_notice()
+
+    def _older_page_fault_notice(self) -> str:
+        """Genuine-fault toast, with a verb this frame can actually honour.
+
+        The scrollable clause is the original instruction. On an unscrollable
+        frame it would contradict the head notice (UX U4): "scroll up to try
+        again" next to "click to load". Dropping the gesture entirely would
+        leave a toast with no next step; naming the click matches the control
+        the head row already is.
+        """
+        view = self._transcript_view()
+        viewport = view.container_size.height or view.size.height
+        if viewport and view.virtual_size.height > viewport:
+            return _OLDER_PAGE_FAULT_NOTICE
+        return _OLDER_PAGE_FAULT_NOTICE_CLICK
 
     @property
     def _resume_paging(self) -> bool:
@@ -9509,8 +9546,8 @@ class OperatorApp(App[None]):
             self._fetch_older_display_page(source, lease, on_settled=on_settled),
             group=source.worker_group("history-page"),
         )
-        # Until this fetch lands, an unscrollable frame cannot honour
-        # "scroll up to load". Restate so the notice offers the click.
+        # Until this fetch lands, an unmounted lease must not advertise a
+        # gesture the gate will swallow. Restate as loading copy.
         self._reconcile_head_notice()
 
     def _acquire_paging_lease(self, source: SessionInteraction) -> _PagingLease | None:
@@ -9545,19 +9582,25 @@ class OperatorApp(App[None]):
     def _break_abandoned_paging_lease(self, source: SessionInteraction) -> bool:
         """Retire a paging gate whose holder will never release it.
 
-        The reader's click is the only gesture that may do this, and only
-        against a lease that has produced NOTHING: it held the gate through
-        one explicit request and still mounted no rows. That combination means
-        the holder is wedged — a fetch parked on an owner socket that never
-        answers and whose teardown never arrives, or a mount whose settle
-        callback never fired — and every input gates on it, so the frame is
-        stuck until the lease is retired.
+        Only an explicit ASK may do this — the notice click, or the documented
+        ``ctrl+home`` chord — and only against a lease that has produced
+        NOTHING: it held the gate through one explicit request and still
+        mounted no rows. That combination means the holder is wedged — a fetch
+        parked on an owner socket that never answers and whose teardown never
+        arrives — and every input gates on it, so the frame is stuck until the
+        lease is retired. The wheel is not this gesture: every notch of a
+        healthy in-flight fetch would otherwise cancel and restart it.
 
         A fetch that has not yet returned is indistinguishable from a wedge
-        from this side of the gate, so the click is also the way out of a
-        hung wait. A holder that HAS mounted is merely settling, and keeping
-        that gate is F1: retiring it would let a second fetch re-consume the
-        same cursor.
+        from this side of the gate, so the ask is also the way out of a hung
+        wait. A holder that HAS mounted is merely settling, and keeping that
+        gate is F1: retiring it would let a second fetch re-consume the same
+        cursor. A dropped ``insert_blocks`` settle is a TranscriptView defect
+        outside this path and is deliberately not retired here.
+
+        The replacement inherits ``_older_page_retries`` for this source: the
+        budget is against a moving window, not a particular transaction, so a
+        wedged fetch that already spent retries should not get a fresh count.
 
         Retiring is safe because the wedged holder's own completion is fenced
         on identity: when it finally lands (or is cancelled) it no longer owns
@@ -9628,7 +9671,17 @@ class OperatorApp(App[None]):
             view.call_after_refresh(run_check)
 
     def _check_resume_page(self, *, force: bool = False) -> None:
-        """Spend one demand only after motion settles in the prefetch zone."""
+        """Spend one demand only after motion settles in the prefetch zone.
+
+        ``force=True`` is an explicit ASK (the notice click, or the documented
+        ``ctrl+home`` chord), not a wheel notch. A wedged unmounted lease
+        stands every other input down against `_resume_paging`; retiring it
+        here is what lets the documented keyboard route recover in place
+        (UX U2). The wheel still calls without force, so a healthy in-flight
+        fetch is not cancelled by every notch.
+        """
+        if force:
+            self._break_abandoned_paging_lease(self._interaction)
         if not self._resume_in_zone or self._resume_paging:
             return
         view = self._transcript_view()
@@ -27085,7 +27138,18 @@ class OperatorApp(App[None]):
         untouched — the whole point of the chord is that the composer keeps
         the caret, so a reader checking the start of a long session can type
         the moment they return with ``ctrl+end``.
+
+        On a wedged unscrollable frame the scroll itself is a no-op — there is
+        no offset to travel, and every later check stands down against the
+        held gate. The help screen documents this chord as the keyboard
+        recovery for that state, so it has to carry the same unmounted-lease
+        retirement the notice click got (UX U2). Retire first, then take the
+        existing scroll path: ``note_user_scroll`` still fires at y=0 (clamped
+        input rearms), and with the gate open the deferred check can fetch.
+        A wheel notch never comes through this action, so a healthy in-flight
+        fetch is not cancelled by scrolling.
         """
+        self._break_abandoned_paging_lease(self._interaction)
         self._transcript_view().action_scroll_home()
 
     def action_transcript_end(self) -> None:
@@ -31635,7 +31699,7 @@ class OperatorApp(App[None]):
         # is itself a chord (`fn+ctrl+←`) on most Mac keyboards.
         #
         # It says "loads" because that is the part a reader cannot guess. On a
-        # frame too tall to scroll, `select to load` is followable with a mouse
+        # frame too tall to scroll, `click to load` is followable with a mouse
         # in one click, while `pageup` and `home` are no-ops (there is no
         # offset to travel) and reaching the notice by arrow traversal costs
         # ~129 presses — so the only practical keyboard route was a key whose

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1074,7 +1074,7 @@ _OLDER_PAGE_TRANSPORT_NOTICE = "session is reconnecting; earlier messages will l
 _OLDER_PAGE_FAULT_NOTICE = "Could not load earlier messages right now — scroll up to try again"
 
 
-@dataclass(frozen=True)
+@dataclass
 class _PagingLease:
     """Ownership of ONE backward-paging transaction, request through settle.
 
@@ -1091,9 +1091,28 @@ class _PagingLease:
     and are checked separately. Ownership answers a different question — may
     this completion open the gate — and the honest answer is "only if the gate
     is still the one it took", which is object identity and nothing else.
+
+    ``mounted`` is mutated in place on THIS object rather than by swapping a
+    replacement into the dict: ``owns()`` and ``_release_paging_lease``
+    compare identity, so replacing the stored lease would make the in-flight
+    fetch's object no longer the holder and its settle would refuse to
+    release. Frozen was the original F1 shape; the flags that let a click
+    retire a wedged holder have to live on the same object.
+
+    ``mounted`` records whether THIS transaction ever painted a page. A lease
+    that has held across one explicit click without mounting anything belongs
+    to a fetch that will never complete (a wedged owner socket that no
+    disconnect event reaches, or a settle callback that never fired), so a
+    second click retires it rather than standing down against a gate that
+    nothing will ever release — the stuck "older messages above" frame, where
+    no click and no scroll-up could trigger a fetch. A holder that HAS
+    mounted is merely settling, and keeps its gate (F1). A fetch that has not
+    yet returned is indistinguishable from a wedge, so the click is the
+    reader's way out of that wait.
     """
 
     source_token: str
+    mounted: bool = False
 
 
 def _resume_tail_start(history: list[Any], bound: int) -> int:
@@ -8799,6 +8818,10 @@ class OperatorApp(App[None]):
                 self._fetch_older_display_page(source, lease, on_settled=settled),
                 group=source.worker_group("history-page"),
             )
+            # The fetch is now the thing that will make the frame scrollable.
+            # Until it lands, an unscrollable frame cannot honour "scroll up
+            # to load" — restate so the notice offers the click instead.
+            self._reconcile_head_notice()
         else:
             self._resume_fill_active = False
             self._reconcile_head_notice()
@@ -8881,7 +8904,21 @@ class OperatorApp(App[None]):
             # R6). The pessimistic state is worth stating once the fill has
             # actually given up, and the fill's own exits do exactly that:
             # every one of them clears this flag before reconciling.
-            return
+            #
+            # Exception: a fill whose lease has mounted NOTHING and the frame
+            # still cannot scroll. That is the wedged holder, not an
+            # intermediate geometry — scrolling cannot work, and the click is
+            # the way out. Advertising "scroll up to load" here is the stuck
+            # frame's lie. A lease that HAS mounted is merely settling, and
+            # keeping the skip there is what prevents R6.
+            lease = self._paging_leases.get(self._interaction.token)
+            if lease is None or lease.mounted:
+                return
+            self._restate_head_notice(
+                notice,
+                RESUME_AUDIT_UNREACHABLE_NOTICE if audit else RESUME_UNREACHABLE_NOTICE,
+                "note",
+            )
         elif not scrollable:
             # `note`, not `info`: this is the answer to "where did my history
             # go", which is the role `NoticeBlock` reserves `note` for, and it
@@ -9144,10 +9181,20 @@ class OperatorApp(App[None]):
             self._mount_newer_resume_page()
 
     def on_older_history_notice_requested(self, message: OlderHistoryNotice.Requested) -> None:
-        """The explicit affordance uses the same demand lease as upward input."""
+        """The explicit affordance uses the same demand lease as upward input.
+
+        One extra duty the wheel does not carry: the click is the reader
+        ASKING for the page the row advertises, so a gate that swallowed the
+        previous ask without mounting anything is abandoned, not busy. Retire
+        it and let this click fetch — otherwise a wedged holder (an owner
+        socket that never answers and is never torn down, a settle callback
+        that never fires) leaves the frame with a notice no input can answer:
+        the stuck "older messages above" state.
+        """
         message.stop()
         if message.notice is self._resume_head_notice:
             self._resume_fill_active = False
+            self._break_abandoned_paging_lease(self._interaction)
             self._resume_in_zone = True
             self._check_resume_page(force=True)
 
@@ -9462,6 +9509,9 @@ class OperatorApp(App[None]):
             self._fetch_older_display_page(source, lease, on_settled=on_settled),
             group=source.worker_group("history-page"),
         )
+        # Until this fetch lands, an unscrollable frame cannot honour
+        # "scroll up to load". Restate so the notice offers the click.
+        self._reconcile_head_notice()
 
     def _acquire_paging_lease(self, source: SessionInteraction) -> _PagingLease | None:
         """Take the backward-paging gate for ``source``, or refuse.
@@ -9490,6 +9540,43 @@ class OperatorApp(App[None]):
         if self._paging_leases.get(lease.source_token) is not lease:
             return False
         del self._paging_leases[lease.source_token]
+        return True
+
+    def _break_abandoned_paging_lease(self, source: SessionInteraction) -> bool:
+        """Retire a paging gate whose holder will never release it.
+
+        The reader's click is the only gesture that may do this, and only
+        against a lease that has produced NOTHING: it held the gate through
+        one explicit request and still mounted no rows. That combination means
+        the holder is wedged — a fetch parked on an owner socket that never
+        answers and whose teardown never arrives, or a mount whose settle
+        callback never fired — and every input gates on it, so the frame is
+        stuck until the lease is retired.
+
+        A fetch that has not yet returned is indistinguishable from a wedge
+        from this side of the gate, so the click is also the way out of a
+        hung wait. A holder that HAS mounted is merely settling, and keeping
+        that gate is F1: retiring it would let a second fetch re-consume the
+        same cursor.
+
+        Retiring is safe because the wedged holder's own completion is fenced
+        on identity: when it finally lands (or is cancelled) it no longer owns
+        the gate, so it releases nothing it does not hold and publishes nothing
+        to a screen it no longer owns. The replacement fetch re-reads the same
+        ``history_before_token`` cursor the wedged one never consumed, so no
+        page is skipped or duplicated.
+
+        Returns whether a lease was retired, so the caller can decide whether
+        the gesture should now proceed to a fresh fetch.
+        """
+        lease = self._paging_leases.get(source.token)
+        if lease is None or lease.mounted:
+            return False
+        # Cancel the wedged fetch's worker so its coroutine unwinds through
+        # its own `finally` (which now releases nothing, having lost the gate)
+        # rather than lingering against the retired lease.
+        self.workers.cancel_group(self, source.worker_group("history-page"))
+        del self._paging_leases[source.token]
         return True
 
     def _transcript_scrolled(self, *args: Any, continuous: bool = False) -> None:
@@ -9688,6 +9775,10 @@ class OperatorApp(App[None]):
             # stays the top row and the conversation keeps its order.
             mounted = transcript.blocks()
             index = 1 if mounted and notice is not None and mounted[0] is notice else 0
+            # Flag BEFORE the insert's settle: a click arriving while gaps
+            # are still answering must see a working transaction, not a
+            # wedge. Mutated on this object so identity (F1) is unchanged.
+            lease.mounted = True
             transcript.insert_blocks(index, blocks, on_settled=release_gate)
         else:
             # Hidden-only pages still yield; otherwise initial fill projects

--- a/tests/unit/tui/test_rendered_history_paging.py
+++ b/tests/unit/tui/test_rendered_history_paging.py
@@ -1315,19 +1315,26 @@ async def test_a_wedged_page_fetch_is_retired_by_the_next_click(tmp_path) -> Non
             remote.load_older_display_page = wedged_load
             notice = app._resume_head_notice
             assert isinstance(notice, OlderHistoryNotice)
-            notice.action_older()
+            view = app._transcript_view()
+            view.scroll_to(y=0, animate=False, immediate=True)
+            await _pump(pilot, 4)
+            await pilot.click(notice)
             await asyncio.wait_for(fetched.wait(), 5)
             await _pump(pilot, 10)
 
-            # The wedge holds the gate; the notice keeps promising a load.
+            # The wedge holds the gate; the notice names the in-flight load
+            # rather than advertising a gesture the gate will swallow.
             assert app._resume_paging
-            assert "load" in notice.text()
+            assert "loading older messages" in notice.text()
+            assert "scroll up to load" not in notice.text()
 
             # The transport is healthy again underneath, and the reader clicks
             # the same row a second time — the gesture that used to be
             # swallowed by the gate the wedged holder never released.
             remote.load_older_display_page = real_load
-            notice.action_older()
+            view.scroll_to(y=0, animate=False, immediate=True)
+            await _pump(pilot, 4)
+            await pilot.click(notice)
             await settled(app, pilot)
             for _ in range(8):
                 await pilot.pause()
@@ -1376,7 +1383,7 @@ async def test_a_failed_fetch_leaves_a_retryable_notice(tmp_path) -> None:
 
             failing["flag"] = False
             assert isinstance(notice, OlderHistoryNotice)
-            app.on_older_history_notice_requested(OlderHistoryNotice.Requested(notice))
+            await pilot.click(notice)
             await settled(app, pilot)
             for _ in range(12):
                 await pilot.pause()
@@ -1421,12 +1428,14 @@ async def test_an_unscrollable_stuck_frame_loads_on_click(tmp_path) -> None:
             assert view.virtual_size.height <= viewport
             assert app._resume_paging
             assert remote.history_before_token
-            # Scrolling cannot work on this frame; the copy must not claim it can.
-            assert "select to load" in notice.text()
+            # An unmounted lease is in flight (or wedged): the copy must not
+            # look idle, and must not advertise a gesture the gate swallows.
+            assert "loading older messages" in notice.text()
+            assert "scroll up to load" not in notice.text()
 
             wedged["flag"] = False
             assert isinstance(notice, OlderHistoryNotice)
-            app.on_older_history_notice_requested(OlderHistoryNotice.Requested(notice))
+            await pilot.click(notice)
             await settled(app, pilot)
             for _ in range(16):
                 await pilot.pause()
@@ -1460,3 +1469,201 @@ async def test_a_mounted_lease_survives_a_second_click(tmp_path) -> None:
             assert app._paging_leases.get(source.token) is lease
             app._release_paging_lease(lease)
             assert source.token not in app._paging_leases
+
+
+def _wheel_up(view) -> None:
+    view.post_message(MouseScrollUp(view, 1, 1, 0, -1, 0, False, False, False))
+
+
+@pytest.mark.asyncio
+async def test_a_scrollable_wedged_lease_does_not_advertise_scroll_up(tmp_path) -> None:
+    """U1: an unmounted lease on a scrollable frame must not promise the wheel.
+
+    Reconcile used to flip back to "scroll up to load" as soon as the frame
+    could scroll, while the gate still swallowed every notch. The honest
+    restatement is loading copy until a page mounts; recovery is click or
+    ctrl+home, not the wheel. After recovery a healthy gate still pages on
+    scroll-up.
+    """
+    async with remote_session(tmp_path, history(count=600)) as remote:
+        wedged = {"flag": True}
+        stall = asyncio.Event()
+        real_load = remote.load_older_display_page
+        calls = {"n": 0}
+
+        async def load():
+            calls["n"] += 1
+            if wedged["flag"]:
+                try:
+                    await asyncio.wait_for(stall.wait(), 20)
+                except asyncio.TimeoutError as exc:
+                    raise ConnectionError("history owner is unavailable") from exc
+            return await real_load()
+
+        remote.load_older_display_page = load
+
+        async def factory():
+            return remote
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 200)) as pilot:
+            await _pump(pilot, 80)
+            view = app._transcript_view()
+            viewport = view.container_size.height or view.size.height
+            assert app._resume_paging
+            assert view.virtual_size.height <= viewport
+            notice = app._resume_head_notice
+            assert isinstance(notice, OlderHistoryNotice)
+            assert "loading older messages" in notice.text()
+
+            await pilot.resize_terminal(100, 40)
+            await _pump(pilot, 12)
+            viewport = view.container_size.height or view.size.height
+            assert view.virtual_size.height > viewport, "resize made the frame scrollable"
+            assert app._resume_paging
+            assert "scroll up to load" not in notice.text()
+            assert "loading older messages" in notice.text()
+
+            view.scroll_to(y=0, animate=False, immediate=True)
+            await _pump(pilot, 4)
+            before_calls = calls["n"]
+            _wheel_up(view)
+            await _pump(pilot, 8)
+            assert calls["n"] == before_calls, "wheel must not be the recovery"
+
+            wedged["flag"] = False
+            await pilot.click(notice)
+            stall.set()
+            await _pump(pilot, 80)
+            assert not app._resume_paging
+            assert "scroll up to load" in notice.text() or "start of conversation" in notice.text()
+            remaining = len(app._resume_pending_head)
+            view.scroll_to(y=0, animate=False, immediate=True)
+            await _pump(pilot, 8)
+            after_calls = calls["n"]
+            for _ in range(6):
+                _wheel_up(view)
+                await _pump(pilot, 8)
+            if remaining:
+                assert len(app._resume_pending_head) < remaining, (
+                    "healthy gate still pages on scroll-up "
+                    f"(pending {remaining}->{len(app._resume_pending_head)}, "
+                    f"calls {after_calls}->{calls['n']})"
+                )
+            else:
+                assert "start of conversation" in notice.text()
+
+
+@pytest.mark.asyncio
+async def test_ctrl_home_recovers_a_wedged_unscrollable_frame(tmp_path) -> None:
+    """U2: the documented keyboard chord must retire an unmounted lease.
+
+    ``ctrl+home`` is the help-screen recovery for this state. Walking the
+    real key path — not ``action_older`` — has to load in place.
+    """
+    async with remote_session(tmp_path, history(count=250)) as remote:
+        wedged = {"flag": True}
+        stall = asyncio.Event()
+        real_load = remote.load_older_display_page
+        calls = {"n": 0}
+
+        async def load():
+            calls["n"] += 1
+            if wedged["flag"]:
+                try:
+                    await asyncio.wait_for(stall.wait(), 20)
+                except asyncio.TimeoutError as exc:
+                    raise ConnectionError("history owner is unavailable") from exc
+            return await real_load()
+
+        remote.load_older_display_page = load
+
+        async def factory():
+            return remote
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 200)) as pilot:
+            await _pump(pilot, 80)
+            view = app._transcript_view()
+            viewport = view.container_size.height or view.size.height
+            assert view.virtual_size.height <= viewport
+            assert app._resume_paging
+            first = calls["n"]
+            assert first >= 1
+
+            wedged["flag"] = False
+            await pilot.press("ctrl+home")
+            stall.set()
+            await _pump(pilot, 80)
+            assert calls["n"] > first
+            assert not app._resume_paging
+            notice = app._resume_head_notice
+            assert notice is not None
+            assert "start of conversation" in notice.text()
+
+
+@pytest.mark.asyncio
+async def test_an_unmounted_in_flight_notice_is_not_idle_copy(tmp_path) -> None:
+    """U3: while an unmounted lease is held the notice must not look idle."""
+    async with remote_session(tmp_path, history(count=250)) as remote:
+        stall = asyncio.Event()
+        real_load = remote.load_older_display_page
+
+        async def slow_load():
+            await stall.wait()
+            return await real_load()
+
+        remote.load_older_display_page = slow_load
+
+        async def factory():
+            return remote
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 200)) as pilot:
+            await _pump(pilot, 80)
+            notice = app._resume_head_notice
+            assert isinstance(notice, OlderHistoryNotice)
+            assert app._resume_paging
+            text = notice.text()
+            assert "loading older messages" in text
+            assert "scroll up to load" not in text
+            assert "click to load" not in text
+            stall.set()
+            await _pump(pilot, 80)
+
+
+@pytest.mark.asyncio
+async def test_a_failed_fetch_on_an_unscrollable_frame_does_not_tell_the_reader_to_scroll(
+    tmp_path,
+) -> None:
+    """U4: the fault toast inherits the geometry-aware verb."""
+    async with remote_session(tmp_path, history(count=250)) as remote:
+        real_load = remote.load_older_display_page
+
+        async def failing_load():
+            raise RuntimeError("unexpected paging failure")
+
+        remote.load_older_display_page = failing_load
+
+        async def factory():
+            return remote
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 200)) as pilot:
+            await _pump(pilot, 80)
+            view = app._transcript_view()
+            viewport = view.container_size.height or view.size.height
+            assert view.virtual_size.height <= viewport
+            assert not app._resume_paging
+            notice = app._resume_head_notice
+            assert notice is not None
+            assert "click to load" in notice.text()
+            faults = [
+                block.text()
+                for block in view.blocks()
+                if isinstance(block, NoticeBlock) and "Could not load earlier" in block.text()
+            ]
+            assert faults, "the genuine-fault toast never appeared"
+            assert all("scroll up" not in text for text in faults)
+            assert any("click" in text for text in faults)
+            remote.load_older_display_page = real_load

--- a/tests/unit/tui/test_rendered_history_paging.py
+++ b/tests/unit/tui/test_rendered_history_paging.py
@@ -1270,3 +1270,193 @@ def test_the_compaction_marker_is_spaced_apart_from_the_head_notice() -> None:
         "share a glyph, an ink and their opening words, and one is clickable "
         "while the other is not"
     )
+
+
+async def _pump(pilot, count: int) -> None:
+    for _ in range(count):
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_a_wedged_page_fetch_is_retired_by_the_next_click(tmp_path) -> None:
+    """The stuck frame from the operator's report, and its fix.
+
+    A fetch whose owner socket never answers — and whose teardown never
+    arrives to cancel it — holds the paging lease forever. Every gesture gates
+    on that lease: the click's `_check_resume_page` and the wheel's
+    `_transcript_scrolled` both stand down against `_resume_paging`, so the
+    frame is left unscrollable with the head notice still advertising an action
+    no input can take. The reader's repeated click must retire the abandoned
+    gate and load the page itself.
+    """
+    async with remote_session(tmp_path, history(count=130)) as remote:
+
+        async def factory():
+            return remote
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 60)) as pilot:
+            await settled(app, pilot)
+            assert remote.history_before_token or app._resume_pending_head
+
+            fetched = asyncio.Event()
+            stall = asyncio.Event()
+            real_load = remote.load_older_display_page
+
+            async def wedged_load():
+                fetched.set()
+                try:
+                    # Bound so a missed cancel cannot hang an xdist worker.
+                    await asyncio.wait_for(stall.wait(), 20)
+                except asyncio.TimeoutError as exc:
+                    raise ConnectionError("history owner is unavailable") from exc
+                return await real_load()
+
+            remote.load_older_display_page = wedged_load
+            notice = app._resume_head_notice
+            assert isinstance(notice, OlderHistoryNotice)
+            notice.action_older()
+            await asyncio.wait_for(fetched.wait(), 5)
+            await _pump(pilot, 10)
+
+            # The wedge holds the gate; the notice keeps promising a load.
+            assert app._resume_paging
+            assert "load" in notice.text()
+
+            # The transport is healthy again underneath, and the reader clicks
+            # the same row a second time — the gesture that used to be
+            # swallowed by the gate the wedged holder never released.
+            remote.load_older_display_page = real_load
+            notice.action_older()
+            await settled(app, pilot)
+            for _ in range(8):
+                await pilot.pause()
+
+            # The retired holder freed the gate and the retry mounted rows.
+            assert not app._resume_paging
+            assert not remote.history_before_token
+            assert not app._resume_pending_head
+            assert notice.text() == "start of conversation"
+            stall.set()
+
+
+@pytest.mark.asyncio
+async def test_a_failed_fetch_leaves_a_retryable_notice(tmp_path) -> None:
+    """A transport drop at attach must not strand the head notice.
+
+    The first fill's remote fetch raises ConnectionError; the fill stands
+    down, the frame is unscrollable, and the notice still says there is more
+    to load. Clicking it after the transport recovers must fetch and mount.
+    """
+    async with remote_session(tmp_path, history(count=130)) as remote:
+        real_load = remote.load_older_display_page
+        failing = {"flag": True}
+
+        async def flaky_load():
+            if failing["flag"]:
+                raise ConnectionError("history owner is unavailable")
+            return await real_load()
+
+        remote.load_older_display_page = flaky_load
+
+        async def factory():
+            return remote
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 200)) as pilot:
+            await _pump(pilot, 80)
+            notice = app._resume_head_notice
+            assert notice is not None
+            assert "load" in notice.text()
+            view = app._transcript_view()
+            viewport = view.container_size.height or view.size.height
+            assert view.virtual_size.height <= viewport
+            assert remote.history_before_token
+            assert not app._resume_paging
+
+            failing["flag"] = False
+            assert isinstance(notice, OlderHistoryNotice)
+            app.on_older_history_notice_requested(OlderHistoryNotice.Requested(notice))
+            await settled(app, pilot)
+            for _ in range(12):
+                await pilot.pause()
+            assert not remote.history_before_token
+            assert notice.text() == "start of conversation"
+
+
+@pytest.mark.asyncio
+async def test_an_unscrollable_stuck_frame_loads_on_click(tmp_path) -> None:
+    """The operator's stuck state: no scrollbar, notice present, click loads.
+
+    A wedged first fetch holds the lease with the local head already drained
+    into an unscrollable frame. Neither a wheel notch nor a first click that
+    stood down against the lease used to recover; the second click (after
+    the breaker) must.
+    """
+    async with remote_session(tmp_path, history(count=250)) as remote:
+        wedged = {"flag": True}
+        stall = asyncio.Event()
+        real_load = remote.load_older_display_page
+
+        async def load():
+            if wedged["flag"]:
+                try:
+                    await asyncio.wait_for(stall.wait(), 20)
+                except asyncio.TimeoutError as exc:
+                    raise ConnectionError("history owner is unavailable") from exc
+            return await real_load()
+
+        remote.load_older_display_page = load
+
+        async def factory():
+            return remote
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 200)) as pilot:
+            await _pump(pilot, 80)
+            notice = app._resume_head_notice
+            assert notice is not None
+            view = app._transcript_view()
+            viewport = view.container_size.height or view.size.height
+            assert view.virtual_size.height <= viewport
+            assert app._resume_paging
+            assert remote.history_before_token
+            # Scrolling cannot work on this frame; the copy must not claim it can.
+            assert "select to load" in notice.text()
+
+            wedged["flag"] = False
+            assert isinstance(notice, OlderHistoryNotice)
+            app.on_older_history_notice_requested(OlderHistoryNotice.Requested(notice))
+            await settled(app, pilot)
+            for _ in range(16):
+                await pilot.pause()
+            assert not remote.history_before_token
+            assert not app._resume_paging
+            stall.set()
+
+
+@pytest.mark.asyncio
+async def test_a_mounted_lease_survives_a_second_click(tmp_path) -> None:
+    """F1: a click must not retire a lease that has already painted rows.
+
+    The breaker exists for wedges, not for a healthy insert whose settle is
+    still answering. A second click against a mounted lease must leave the
+    holder in place so the in-flight settle is the one that releases it.
+    """
+    async with remote_session(tmp_path, history(count=250)) as remote:
+
+        async def factory():
+            return remote
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settled(app, pilot)
+            source = app._interaction
+            lease = app._acquire_paging_lease(source)
+            assert lease is not None
+            lease.mounted = True
+            broke = app._break_abandoned_paging_lease(source)
+            assert broke is False
+            assert app._paging_leases.get(source.token) is lease
+            app._release_paging_lease(lease)
+            assert source.token not in app._paging_leases


### PR DESCRIPTION
Release: patch — clicking the "older messages above" notice loads history even when the frame cannot scroll

## What and why

**C1 — user-visible defect.** Switching into a long session sometimes painted only the recent tail, with a head notice ("older messages above — scroll up to load" / "select to load") and **no scrollbar**. Neither scrolling up nor clicking the notice loaded anything. Reloading did not help; switching away and back a couple of times eventually did.

The stuck state is a **held paging lease that nothing can ever release**. `_check_resume_page` (click) and `_transcript_scrolled` (wheel) both gate on `_resume_paging`. The lease is released only by the fetch's `finally` or the mount's settle callback. A fetch whose owner socket never answers — and whose teardown never arrives to cancel the worker — holds that gate forever. From that frame every click and every scroll-up is swallowed, while the notice stays interactive and promises an action no input can take.

Reproduced headless against a real `RemoteSession` / `RuntimeServer` (same harness as `tests/unit/tui/test_rendered_history_paging.py`):

```
# 250-row remote history, 100x200 viewport so the initial window does not fill
# the frame; the fill's first remote fetch is wedged (never returns).
notice: older messages above — scroll up to load
scrollable: False  virtual: 191  viewport: 191
paging: True  leases: [<token>]
# click 1, click 2, wheel notch: no fetch, still unscrollable, still paging
VERDICT: STUCK
```

Switching away and back "fixed" it only when the cached presentation was rebuilt without the wedged worker — matching the operator's recovery.

## The fix

The reader's **click** is the gesture that asked for the page the row advertises, so a gate that swallowed the previous ask without mounting anything is abandoned, not busy:

- `_PagingLease.mounted` is mutated **in place** on the same object (identity is F1; swapping a replacement would make the in-flight fetch no longer the holder).
- Set `mounted=True` when rows are actually inserted, **before** the settle callback.
- `on_older_history_notice_requested` calls `_break_abandoned_paging_lease`: if the current source's lease has mounted nothing, cancel its `history-page` worker, drop the lease, and let this click fetch.
- A lease that HAS mounted is merely settling and is left alone (F1: a second fetch against the same cursor is the duplicate the original lease exists to prevent).
- A fetch that has not yet returned is indistinguishable from a wedge from this side of the gate, so the click is also the way out of a hung wait. The replacement fetch re-reads the same `history_before_token` the wedged one never consumed.
- Copy: "scroll up to load" only while the frame can actually scroll. A wedged, unscrollable fill restates to **"select to load"** — clicking is THE way out.

Failed fetches (`ConnectionError("history owner is unavailable")`) already released the lease and left a retryable notice; that path is now covered by a regression test so it cannot regress into the same stuck promise.

## Testing evidence

Real `OperatorApp` + real owner socket. Each new test **failed on the unfixed tree** (app.py stashed) and **passed after**:

| test | unfixed | fixed |
|---|---|---|
| `test_a_wedged_page_fetch_is_retired_by_the_next_click` | FAIL (`history presentation never settled` — click swallowed) | PASS |
| `test_an_unscrollable_stuck_frame_loads_on_click` | FAIL (same) | PASS |
| `test_a_failed_fetch_leaves_a_retryable_notice` | PASS (lease already released on exception) | PASS |
| `test_a_mounted_lease_survives_a_second_click` | n/a (new F1 guard) | PASS |

`tests/unit/tui/test_rendered_history_paging.py`: **36 passed** (`-n0`, `env -u NO_COLOR TERM=xterm-256color`).

### Visual frames (viewed, not just saved)

Captured with `save_capture` on the real `OperatorApp` + stylesheet, 100×200 — the operator's unscrollable geometry.

**Before (stuck):** notice `older messages above — select to load`; `TranscriptView` size `[97, 191]` virtual `[96, 191]`; **no scrollbar**; content ends mid-frame with empty cells below.

**After (click):** notice restated to `start of conversation`; virtual `[96, 253]`; **scrollbar True**; tail through row 0250.

Frame files (not committed): `/tmp/lo-older-page-stuck-frames/before-tall.svg`, `after-tall.svg`, plus PNG crops `before-tall-top.png` / `after-tall-bottom.png`.

### Quality gates

- `flake8` — clean
- `black --check` (26.1.0) — clean
- `isort --check` (5.13.2) — clean
- `pyright` — **0 errors, 0 warnings**
- `tests/unit/tui/test_rendered_history_paging.py` — **36 passed**
- `tests/unit` full tree: started on a loaded host (20 min reached ~99% with no failure line before the wait cap); CI is the authoritative full run. The paging file is the regression surface for this TUI-only diff.

## Not in this PR

- No version bump.
- Did not auto-retry from `_transcript_extent_changed` (a fill re-arm on every geometry change livelocks a no-progress page). Click is the recovery path.
- Did not change the one-page-per-gesture gate or the per-source lease contract beyond allowing the reader to retire a holder that produced nothing.
