### PR TITLE
chore(release): bump version to 0.54.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.8"
+version = "0.54.9"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
C0 one-file bump for the post-v0.54.8 release window.

Window PRs (plain `git log v0.54.8..main`):
- #930 (6bf06e6ee) — `/session` diagnostics header names the conversation the way the sidebar does
- #938 (c94723dc4) — stamp `prompt_cache_key` on chat-completions so OpenRouter sticky routing survives idle gaps
- #939 (e8d2a69f0) — inbound peer receipts paint on the first sidebar reveal instead of the second reload

Bump class: PATCH — two display-only TUI fixes and one provider-routing
metadata stamp; nothing here clears the step-function bar for a minor.

Branch note: cut from `main` at 6bf06e6ee (#930), so it does not itself
contain #938/#939. Merged as a MERGE COMMIT rather than rebased, so the
commit the `v0.54.9` tag points at (the merge of this PR) contains all three
window PRs; rebasing would invalidate the scope round already posted on this
head.

No code change. `pyproject.toml` version line only; `version-bump-guard`
is the real CI check for this diff.
