### PR TITLE
fix(mcp): never discard an OAuth rotation the authorization server performed

### DIFF
--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -153,11 +153,12 @@ GRANT_DEAD_AT_KEY = "grant_dead_at"
 #: (:data:`UNCONFIRMED_SEND_TTL_S`) and why a connect-phase failure clears it.
 GRANT_UNCONFIRMED_SEND_KEY = "grant_refresh_unconfirmed"
 
-#: Outcome of one refresh attempt. Six-valued rather than ``bool`` because each
+#: Outcome of one refresh attempt. Seven-valued rather than ``bool`` because each
 #: refusal has its OWN truthful user-visible message (lock contention, a budget
-#: overrun, a server refusal, a possibly-spent token needing a fresh sign-in)
-#: and because the coordinator must tell a DEAD grant (never present this token
-#: again) from a merely FAILED one (transient; today's behaviour is correct).
+#: overrun, a server that answered without a token, a token endpoint that could
+#: not be reached, a possibly-spent token needing a fresh sign-in) and because
+#: the coordinator must tell a DEAD grant (never present this token again) from a
+#: merely FAILED one (transient; today's behaviour is correct).
 #: CAUTION: every member is a truthy string — every call site must compare
 #: against a member explicitly, never test truthiness.
 RefreshOutcome = Literal[
@@ -167,6 +168,7 @@ RefreshOutcome = Literal[
     "contended",
     "overran",
     "unacknowledged",
+    "unreachable",
 ]
 
 #: Refresh this far BEFORE the stored access token's deadline. A connect that
@@ -212,22 +214,45 @@ REFRESH_LATE_RESPONSE_GRACE_S = 30.0
 #: expiry can only degrade to the status quo ante, never to something worse.
 UNCONFIRMED_SEND_TTL_S = 3600.0
 
-#: Why a refresh was refused — one value per truthful user-visible message (see
-#: :class:`McpRefreshContendedError` and :class:`McpRefreshUnconfirmedError`).
-#: The manager re-voices a transport-mangled cancellation from these and the
-#: tests assert the rendered copy verbatim, so the set is closed and short.
+#: Why a refresh was refused — ONE STABLE CODE per truthfully different
+#: situation. This block is the SEAM the user-visible wording hangs off: the auth
+#: layer carries the code on the exception (:attr:`McpRefreshContendedError`'s
+#: ``reason_code`` / :attr:`McpAuthRequiredError.reason_code`) and the manager —
+#: the only layer that knows the server's NAME — composes the short rendered
+#: text from it (:meth:`McpManager._auth_failure_text`). Nothing here is copy.
 #:
-#: * ``REFRESH_REFUSAL_LOCK`` — no exclusivity, so nothing was presented.
+#: The split exists because one sentence covered all of these and was therefore
+#: untrue on most of them. A first attempt at splitting reworded the verbose
+#: sentence instead, which does not work at any terminal width: that sentence
+#: opens with ``MCP OAuth token refresh for <full server URL>``, which is ~55 of
+#: a 58-cell toast card, so the distinguishing clause was always the part
+#: tail-truncated away and all three refusals rendered byte-identically at 100
+#: columns and below (design review D1/D2). A CODE travels independently of the
+#: sentence, so the rendered text can be short while the sentence stays verbose
+#: where verbose is right — ``str(exc)`` and the logs.
+#:
+#: The set is closed and short: the manager re-voices a transport-mangled
+#: cancellation from these and the tests assert the mapped copy verbatim.
+#:
+#: * ``REFRESH_REFUSAL_LOCK`` — no exclusivity, so nothing was presented; another
+#:   session is refreshing this grant right now.
 #: * ``REFRESH_REFUSAL_INFLIGHT`` — the exchange outran the connect's budget and
 #:   is still running; a late rotation will still be persisted.
 #: * ``REFRESH_REFUSAL_ENDPOINT`` — the exchange ran and the authorization
-#:   server's answer was not a usable token.
+#:   server's answer carried no usable token.
+#: * ``REFRESH_REFUSAL_UNREACHABLE`` — the request never reached the wire (httpx's
+#:   own pre-send taxonomy, see :func:`_refresh_request_never_sent`), so nothing
+#:   was presented and there is no rotation to keep. Split out of
+#:   ``REFRESH_REFUSAL_ENDPOINT`` deliberately: an unreachable endpoint is not a
+#:   server that rejected us, and saying it was (review round 2, minor 1) tells
+#:   the user the grant was refused when the request never left the machine.
 #: * ``REFRESH_REFUSAL_UNCONFIRMED`` — a token may already be spent (it was
 #:   presented, or an earlier presentation was never acknowledged), so nothing
 #:   may be presented until an interactive grant replaces it.
 REFRESH_REFUSAL_LOCK = "lock"
 REFRESH_REFUSAL_INFLIGHT = "inflight"
 REFRESH_REFUSAL_ENDPOINT = "endpoint"
+REFRESH_REFUSAL_UNREACHABLE = "unreachable"
 REFRESH_REFUSAL_UNCONFIRMED = "unconfirmed"
 
 #: Bound on ACQUIRING the cross-process refresh lock. The critical section it
@@ -291,15 +316,34 @@ class McpAuthRequiredError(RuntimeError):
     line, so the command still comes first. ``None`` (the default) keeps the
     generic "authorization expired" wording, which is the truthful summary for
     every other route into this error: the stored grant could not be refreshed.
+
+    ``reason_code`` is the STABLE CODE for why (:data:`REFRESH_REFUSAL_LOCK` and
+    friends), and it is the seam user-visible copy is composed from: the manager
+    maps the code to short rendered text, while ``str(self)`` keeps the verbose
+    technical sentence for the logs. ``None`` means "no more specific reason than
+    an unusable grant". See the ``REFRESH_REFUSAL_*`` block for why the copy is
+    not carried here as prose.
     """
 
-    def __init__(self, server_url: str, *, detail: str | None = None) -> None:
+    #: See :attr:`reason_code` in the class docstring; class-level so the
+    #: subclasses that know their reason set it without touching ``__init__``.
+    reason_code: str | None = None
+
+    def __init__(
+        self,
+        server_url: str,
+        *,
+        detail: str | None = None,
+        reason_code: str | None = None,
+    ) -> None:
         message = f"MCP OAuth authorization required for {server_url}"
         if detail is not None:
             message = f"{message}: {detail}"
         super().__init__(message)
         self.server_url = server_url
         self.detail = detail
+        if reason_code is not None:
+            self.reason_code = reason_code
 
 
 class McpRefreshContendedError(RuntimeError):
@@ -316,13 +360,15 @@ class McpRefreshContendedError(RuntimeError):
     ``_RefreshCoordinatingOAuthProvider._refuse_unlocked_refresh``) so the
     suppressed SDK refresh cannot run either way.
 
-    One message per ``refusal``, because the three paths that reach it say
-    different things and a single string was untrue on two of them: the lock
-    being held elsewhere is not a server refusal, and a server that ANSWERED
-    500 did not fail "under the refresh lock". It also deliberately does NOT
-    promise a retry: the mid-session reconnect path does retry with backoff,
-    but the startup gate renders this same string as the reason a server is
-    unavailable and schedules no retry there.
+    One verbose SENTENCE per reason, and one stable CODE: the code is what the
+    manager turns into user-visible text (this string opens with the server's
+    full URL and is ~55 cells before it says anything distinguishing, so it can
+    never be the rendered copy — see the ``REFRESH_REFUSAL_*`` block), while the
+    sentence below stays for ``str(exc)`` and the logs, where the URL and the
+    wording are exactly what a maintainer wants. The sentences also deliberately
+    do NOT promise a retry: the mid-session reconnect path does retry with
+    backoff, but the startup gate schedules none, so the log sentence may not
+    claim one either.
 
     This type reaches the manager INDIRECTLY. The MCP streamable-HTTP transport
     runs the request inside anyio cancel scopes, so an exception raised out of
@@ -334,16 +380,20 @@ class McpRefreshContendedError(RuntimeError):
     caller) see the raise itself.
     """
 
-    def __init__(self, server_url: str, *, refusal: str = REFRESH_REFUSAL_LOCK) -> None:
-        if refusal == REFRESH_REFUSAL_INFLIGHT:
+    def __init__(self, server_url: str, *, reason_code: str = REFRESH_REFUSAL_LOCK) -> None:
+        if reason_code == REFRESH_REFUSAL_INFLIGHT:
             message = (
                 f"MCP OAuth token refresh for {server_url} did not finish in time; "
                 "a rotation is kept if the response lands"
             )
-        elif refusal == REFRESH_REFUSAL_ENDPOINT:
+        elif reason_code == REFRESH_REFUSAL_ENDPOINT:
             message = (
-                f"MCP OAuth token refresh for {server_url} was rejected by the "
-                "authorization server"
+                f"MCP OAuth token refresh for {server_url} was answered without a " "usable token"
+            )
+        elif reason_code == REFRESH_REFUSAL_UNREACHABLE:
+            message = (
+                f"MCP OAuth token refresh for {server_url} could not be sent: the "
+                "token endpoint was unreachable, so no token was presented"
             )
         else:
             message = (
@@ -352,7 +402,7 @@ class McpRefreshContendedError(RuntimeError):
             )
         super().__init__(message)
         self.server_url = server_url
-        self.refusal = refusal
+        self.reason_code = reason_code
 
 
 class McpRefreshUnconfirmedError(McpAuthRequiredError):
@@ -371,13 +421,16 @@ class McpRefreshUnconfirmedError(McpAuthRequiredError):
     grant", so it takes the auth block, the actionable toast and the abandoned
     auto-reconnect that every other auth requirement takes. ``detail`` is what
     keeps the toast truthful — a refresh that was SENT but never confirmed is not
-    an expired authorization.
+    an expired authorization — and it is kept SHORT because it is the tail of a
+    line the startup toast then clamps (`refresh unconfirmed`, where the previous
+    sentence-length wording was itself truncated off the card).
     """
 
     def __init__(self, server_url: str) -> None:
         super().__init__(
             server_url,
-            detail="a token refresh was sent but never confirmed",
+            detail="refresh unconfirmed",
+            reason_code=REFRESH_REFUSAL_UNCONFIRMED,
         )
         # We necessarily HOLD a grant for this server (the refusal exists because
         # its stored refresh token may have been spent), so the user-visible
@@ -853,9 +906,30 @@ class McpTokenStorage:
 
         So the write re-reads the row immediately before writing and persists
         only while the payload still holds the refresh token THIS exchange
-        presented. A row that is gone entirely is re-created: absence is not
-        evidence that somebody replaced the grant, and the rotation is still
-        ours to keep.
+        presented.
+
+        A row that is gone ENTIRELY is treated as the same fact, not as licence
+        to re-create: an explicitly removed row stays removed, so a `/mcp logout`
+        or a `/mcp reauth` that lands while our exchange is in flight is never
+        silently undone by a refresh that was already on the wire (QA round 2,
+        Q6). This used to re-create the row on the stated reasoning that
+        "absence is not evidence that somebody replaced the grant" — and that
+        half is still true, which is why the three-valued
+        :meth:`has_stored_row` decides it: a DEFINITE absence is an act by
+        another writer and this write is dropped with an INFO line naming the
+        writer and the reason, while an UNREADABLE store
+        (:meth:`has_stored_row` returns ``None``) is not evidence of removal
+        either and keeps the old behaviour, the rotation is still written. That
+        direction is deliberate and is the one the family's safety rests on: a
+        rotation we drop while the spent token stays in the row is re-presented
+        by the next refresh, which is the reuse-detecting POST that revokes
+        every session. Dropping a rotation costs at most one interactive
+        sign-in; keeping a spent token costs the whole family.
+
+        This is now symmetric with :meth:`mark_grant_dead`, which declines to
+        write on a payload that no longer holds the token it rejected. Two
+        writers racing a removal must give the same answer, and before this fix
+        they gave opposite ones.
 
         Two disciplines separate this from :meth:`set_tokens`:
 
@@ -865,18 +939,32 @@ class McpTokenStorage:
           resurrect a family it has already killed. The write still happens —
           the rotation is real and worth keeping for support — and the marker
           keeps it from ever being presented.
-        * a dropped write is logged at INFO, naming this writer. A lost rotation
-          is what support has to be able to read out of the log after an
-          incident; it is never a debug detail.
+        * a dropped write is logged at INFO, naming this writer and the reason.
+          A lost rotation is what support has to be able to read out of the log
+          after an incident; it is never a debug detail.
+
+        The first-grant path is unaffected: ``set_tokens`` still creates the row
+        for a completed interactive grant. A refresh can only ever run against a
+        row that already held the token it presented, so absence here always
+        means a REMOVAL that raced us, never a first grant.
 
         Caller: :func:`_perform_refresh_exchange`, which holds the refresh lock
         across this call, so the only writers it races are the ones that
         deliberately do not take the lock (a completed interactive login, the
-        SDK's client-info writes).
+        SDK's client-info writes, a `/mcp logout`).
 
         Returns ``True`` when the response was written.
         """
         creds = self._read()
+        if creds is None and self.has_stored_row() is False:
+            logger.info(
+                "MCP token refresh for %s was NOT persisted: the credential row was "
+                "removed while this exchange was in flight (a logout or reauth), so "
+                "the removal is honoured rather than re-created "
+                "[writer: McpTokenStorage.store_refresh_result]",
+                self.server_url,
+            )
+            return False
         if creds is not None and not _payload_holds_refresh_token(creds, presented_refresh_token):
             logger.info(
                 "MCP token refresh for %s was NOT persisted: the stored grant moved on "
@@ -922,13 +1010,24 @@ class McpTokenStorage:
         self._write(creds)
 
     def clear_send_unconfirmed(self) -> None:
-        """Resolve the send marker: the exchange reached an ANSWER for its token.
+        """Resolve the send marker: the exchange reached a DEFINITIVE answer.
 
-        Called for any HTTP response (the server answered, so it either
-        rotated-and-told-us or refused without rotating) and for a connect-phase
-        failure (the token never reached the wire). Deliberately NOT called when
-        the request was written and no answer arrived, which is exactly the state
-        the marker describes.
+        Called only for an answer that proves our presented token was not left
+        spent (see :func:`_answer_resolves_send_marker`), and for a connect-phase
+        failure (the token never reached the wire, so nothing was spent).
+        Deliberately NOT called for the two other shapes, which is the whole
+        point of the marker:
+
+        * the request was written and no answer arrived — the state the marker
+          describes;
+        * an answer that does not prove anything about our token, such as a
+          ``5xx`` or a ``429``. A provider that commits a rotation and THEN
+          fails the response leaves the row holding a spent token, so clearing
+          the marker there would let the next connect re-present it: the
+          reuse-detection POST that revokes the whole family (review round 2,
+          minor 2). Keeping it costs at most one interactive sign-in — and since
+          a marked token is never presented again, it can also never be
+          double-spent, which is the property that matters more.
         """
         creds = self._read()
         if creds is None or GRANT_UNCONFIRMED_SEND_KEY not in creds:
@@ -1366,6 +1465,16 @@ def _refresh_request_never_sent(exc: BaseException) -> bool:
     ``RemoteProtocolError`` — can have been written, so it is treated as suspect.
     That asymmetry is deliberate: a wrongly-suspect failure costs one interactive
     sign-in, a wrongly-trusted one costs the whole token family.
+
+    The annotation is ``BaseException`` because the predicate is TOTAL over
+    exceptions by construction: it answers "was this demonstrably pre-send?"
+    and anything it does not recognise — including ``asyncio.CancelledError`` —
+    answers ``False``, i.e. suspect. That is the conservative answer, and it is
+    why the caller needs no special case for cancellation: the caller's ``except
+    (httpx.HTTPError, TimeoutError)`` cannot catch a ``CancelledError``, so a
+    cancelled send keeps the marker by PROPAGATION, while this predicate — were
+    it ever asked — would keep it too. This docstring must not claim a
+    classification the caller never requests (review round 2, nit).
     """
     import httpx
 
@@ -1379,6 +1488,38 @@ def _refresh_request_never_sent(exc: BaseException) -> bool:
             httpx.LocalProtocolError,
         ),
     )
+
+
+def _answer_resolves_send_marker(status_code: int, *, invalid_grant: bool) -> bool:
+    """Whether a token-endpoint ANSWER proves our presented token is not spent.
+
+    The ONE place the marker's clearing rule lives, so no future status-code
+    tweak can quietly re-open the family-revoking POST (review round 2, minor
+    2). Clearing the marker says "the next connect may present this token
+    again", so it is allowed only for an answer that settles the question:
+
+    * ``200`` with a body already parsed into a usable token — the exchange ran,
+      so the presented token is consumed and the row holds its replacement.
+      :func:`_perform_refresh_exchange` asks only after the body parsed; the
+      unreadable-200 shape is ``unacknowledged`` by definition and never reaches
+      here;
+    * ``400`` whose body names ``invalid_grant`` — the authorization server
+      answered that this token is not acceptable (spent, revoked, or already
+      rotated away), and the caller records the tombstone that is the outcome.
+      There is nothing left for the marker to protect.
+
+    Everything else is an UNKNOWN answer and keeps the marker: ``5xx`` and
+    ``429`` (a provider that commits the rotation and THEN fails the response
+    would otherwise leave a spent token re-presentable), and any other 4xx that
+    is not an ``invalid_grant`` (a refusal that is not readable as a statement
+    about our token). The cost is bounded and stated: the marker expires
+    (:data:`UNCONFIRMED_SEND_TTL_S`), so an authorization-server outage can cost
+    the affected grant ONE interactive sign-in rather than risking a fleet-wide
+    revocation. That is the trade this module takes on purpose.
+    """
+    if status_code == 200:
+        return True
+    return status_code == 400 and invalid_grant
 
 
 def _stored_token_is_fresh(storage: "McpTokenStorage", tokens: Any) -> bool:
@@ -2953,10 +3094,13 @@ async def _refresh_oauth_token_locked(
     is written and the token must never be presented again), ``"contended"``
     (no exclusivity, so NOTHING was presented), ``"overran"`` (the budget was
     spent with the exchange still running; a rotation that still lands is
-    persisted), ``"unacknowledged"`` (a token may already be spent, so nothing
-    was or may be presented until an interactive grant), and ``"failed"`` for
-    every other outcome, including "nothing to refresh". Callers MUST compare
-    against a member: every member is a truthy string.
+    persisted), ``"unreachable"`` (the request never reached the wire, so
+    nothing was presented and there is nothing to keep — a pre-send transport
+    failure, which is NOT a server rejection), ``"unacknowledged"`` (a token may
+    already be spent, so nothing was or may be presented until an interactive
+    grant), and ``"failed"`` for every other outcome, including "nothing to
+    refresh". Callers MUST compare against a member: every member is a truthy
+    string.
 
     The caller holds the cross-process refresh lock and passes its HANDLE, which
     this function hands to the exchange task before its first cancellable await.
@@ -3229,7 +3373,12 @@ async def _perform_refresh_exchange(
                     server_url,
                     type(exc).__name__,
                 )
-                return "failed"
+                # Its OWN outcome, not "failed": nothing was presented, so
+                # nothing was refused. The user-visible text says "could not
+                # be reached" instead of claiming an authorization server
+                # rejected a request it never received (review round 2, minor
+                # 1), and the manager composes that text from the code.
+                return "unreachable"
             # SENT and never answered: the token may already be spent, so a
             # retry is exactly the reuse-detection POST. The request already
             # armed the marker, and this outcome is what makes the caller take
@@ -3247,10 +3396,27 @@ async def _perform_refresh_exchange(
             return "unacknowledged"
 
         if response.status_code != 200:
-            # The authorization server ANSWERED, so the request is resolved
-            # either way: it rotated-and-told-us (a 200) or it refused without
-            # rotating. An answer also means the marker's question is answered.
-            storage.clear_send_unconfirmed()
+            # Whether this answer resolves the send marker is a decision, not a
+            # reflex: it is cleared only when the response is DEFINITIVE about
+            # our token (a 200 we could parse, or a parsed ``invalid_grant``),
+            # and kept for every answer that leaves the outcome unknown —
+            # ``5xx``/``429`` among them. Clearing it on a 5xx would let the
+            # next connect re-present a token a provider may have spent before
+            # failing the response: the reuse-detection POST that revokes the
+            # family this whole mechanism exists to protect. See
+            # :func:`_answer_resolves_send_marker` for the rule and its cost.
+            invalid_grant = response.status_code == 400 and _is_invalid_grant(response.content)
+            if _answer_resolves_send_marker(response.status_code, invalid_grant=invalid_grant):
+                storage.clear_send_unconfirmed()
+            else:
+                logger.info(
+                    "MCP token refresh for %s got HTTP %s, which does not prove the "
+                    "presented refresh token was not consumed; the token will not be "
+                    "presented again, so this server may need one fresh sign-in "
+                    "[writer: locked refresh exchange]",
+                    server_url,
+                    response.status_code,
+                )
             # A revoked-grant rejection is qualitatively different from a
             # transient one and must be logged as such: for a rotating provider
             # that runs refresh-token REUSE DETECTION (Notion), presenting an
@@ -3263,7 +3429,7 @@ async def _perform_refresh_exchange(
             # McpAuthRequiredError, which the manager turns into a suspended
             # reconnect (see manager._reconnect's McpAuthRequiredError arm)
             # rather than hammering a dead grant.
-            if response.status_code == 400 and _is_invalid_grant(response.content):
+            if invalid_grant:
                 logger.info(
                     "MCP OAuth grant revoked for %s (invalid_grant); run /mcp login to "
                     "restore it",
@@ -3419,7 +3585,7 @@ async def ensure_mcp_oauth_fresh(
         outcome = await _refresh_oauth_token_locked(
             server_url, storage, endpoints, lock=lock, peer_refresh_is_success=True
         )
-        if outcome in ("contended", "overran", "failed", "unacknowledged"):
+        if outcome in ("contended", "overran", "failed", "unreachable", "unacknowledged"):
             # Best-effort by contract: the connect proceeds and re-reads under
             # the lock on its next attempt. Each refusal already logged its own
             # reason at INFO, naming that writer — no second line here, because
@@ -3748,7 +3914,7 @@ def _make_refresh_coordinating_provider(
                 # reuse-detection POST. The honest disposition is an interactive
                 # sign-in, not a retry — see McpRefreshUnconfirmedError.
                 self._refuse_unconfirmed_exchange(ctx)
-            elif outcome in ("contended", "overran", "failed"):
+            elif outcome in ("contended", "overran", "failed", "unreachable"):
                 self._refuse_unlocked_refresh(ctx, outcome)
             # POST-CONDITION, in ONE place so no exit path can miss it: we are
             # about to return into ``async_auth_flow``, whose very next act is to
@@ -3792,19 +3958,26 @@ def _make_refresh_coordinating_provider(
               strand a healthy server on a login prompt the user has no reason
               to run.
 
-            ``outcome`` becomes the refusal REASON, which is what makes the
-            user-visible string truthful per path: unable to take the lock, a
-            budget overrun, and a rejected refresh are three different things
-            and were one sentence before (design review input). The reason is
-            carried onto the ledger so the manager's re-voiced error says the
-            same thing.
+            ``outcome`` becomes the refusal REASON CODE, which is what lets the
+            manager render a truthful short message per path: unable to take the
+            lock, a budget overrun, an unreachable token endpoint and an answer
+            without a usable token are four different things and were one
+            sentence before (design review input; review round 2 minor 1 split
+            the last of those off). The code is carried onto the ledger so the
+            manager's re-voiced error says the same thing.
             """
             if not ctx.can_refresh_token() or ctx.is_token_valid():
                 return
             self._strip_in_memory_refresh_token(ctx)
-            refusal = {
+            # ``.get``'s default is the ANSWERED-but-unusable case, which is what
+            # every remaining outcome ("failed", and the post-condition's
+            # fall-through) actually is. ``unreachable`` must be listed: without
+            # its own arm a request that never left the machine would be reported
+            # to the user as a server refusal.
+            reason_code = {
                 "contended": REFRESH_REFUSAL_LOCK,
                 "overran": REFRESH_REFUSAL_INFLIGHT,
+                "unreachable": REFRESH_REFUSAL_UNREACHABLE,
             }.get(outcome, REFRESH_REFUSAL_ENDPOINT)
             # ARM THE SIDE CHANNEL BEFORE RAISING, and do it here rather than in
             # the raise's caller: the MCP transport will NOT deliver this error.
@@ -3814,8 +3987,8 @@ def _make_refresh_coordinating_provider(
             # re-voices that cancellation using this record — reason and all —
             # and only when the cancellation was NOT a genuine external one, so
             # a dispose still wins. See :class:`RefreshContentionLedger`.
-            REFRESH_CONTENTION.record(self._refresh_coord_server_url, refusal)
-            raise McpRefreshContendedError(self._refresh_coord_server_url, refusal=refusal)
+            REFRESH_CONTENTION.record(self._refresh_coord_server_url, reason_code)
+            raise McpRefreshContendedError(self._refresh_coord_server_url, reason_code=reason_code)
 
         def _refuse_unconfirmed_exchange(self, ctx: Any) -> None:
             """Refuse to re-present a refresh token that may already be spent.

--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -141,15 +141,45 @@ REFRESH_SKEW_S = 60.0
 #: the startup gate defers us, and the breaker bounds retries.
 REFRESH_HTTP_TIMEOUT_S = 10.0
 
+#: How long PAST the refresh budget a token response is still accepted and
+#: persisted. The budget above caps how long a CONNECT — and the cross-process
+#: lock it holds — waits for a refresh. It must not also cap how long the
+#: response stays welcome, because for a rotating provider the response is the
+#: ONLY copy of the new refresh token: discarding a rotation the server has
+#: already performed leaves a spent token stored, and the next presentation of
+#: that token is a reuse-detection double-spend that revokes the whole family.
+#:
+#: WHAT IT BOUNDS, precisely: the response READ of one exchange task that has
+#: outlived the connect that started it. It is not a lock budget and not a
+#: connect budget. The lock is still held for at most ``REFRESH_HTTP_TIMEOUT_S``
+#: (``_refresh_oauth_token_locked`` shields the exchange behind
+#: ``asyncio.timeout(REFRESH_HTTP_TIMEOUT_S)`` and returns at that bound), so
+#: ``LOCK_ACQUIRE_TIMEOUT_S``'s derivation — that the critical section cannot
+#: outlast the POST cap — still holds and is unaffected by this constant. A
+#: CANCELLED connect waits only for the REMAINDER of the budget while a rotation
+#: is actually in flight, never for this grace, so teardown is never held longer
+#: than it already could be; by the time this grace is running, no connect and
+#: no lock is waiting on the result.
+#:
+#: Finite on purpose: a server that never answers must not leave a task reading
+#: a socket for the life of the process.
+REFRESH_LATE_RESPONSE_GRACE_S = 30.0
+
 #: Bound on ACQUIRING the cross-process refresh lock, derived from the budget of
 #: the critical section it guards: one token POST plus a couple of SQLite reads.
 #: That derivation is only sound because the POST is capped in TOTAL wall time
 #: (see the ``asyncio.timeout`` in :func:`_refresh_oauth_token_locked`) —
 #: ``httpx.Timeout(REFRESH_HTTP_TIMEOUT_S)`` alone does NOT bound a request:
 #: it is per operation, and its read timeout is per socket read, so a dribbling
-#: server measured 140.7s inside a nominal 10s timeout. Keep the two in step: if
-#: the POST's cap is ever raised or removed, this bound stops being honest and a
-#: slow-but-working peer starts getting timed out by its own siblings.
+#: server measured 140.7s inside a nominal 10s timeout. The lock's critical
+#: section is therefore bounded by the ``asyncio.timeout`` in
+#: ``_refresh_oauth_token_locked`` instead — the exchange runs as a shielded
+#: task and the coroutine that HOLDS THE LOCK returns at that bound. Keep the
+#: two in step: if the POST's overall cap is ever raised or removed, this bound
+#: stops being honest and a slow-but-working peer starts getting timed out by
+#: its own siblings. (The exchange task may keep READING its response past that
+#: bound — ``REFRESH_LATE_RESPONSE_GRACE_S`` — but by then it holds no lock and
+#: nobody is waiting on it, which is why the derivation still holds.)
 #: Overrunning this bound therefore means the holder really is not working — a
 #: leaked lock from a killed process, or a peer wedged on something that is not
 #: our problem. Waiting longer than the work can possibly take buys nothing and
@@ -186,6 +216,38 @@ class McpAuthRequiredError(RuntimeError):
 
     def __init__(self, server_url: str) -> None:
         super().__init__(f"MCP OAuth authorization required for {server_url}")
+        self.server_url = server_url
+
+
+class McpRefreshContendedError(RuntimeError):
+    """A refresh could not be performed under the refresh lock this time.
+
+    Raised instead of falling through to the SDK's own UNLOCKED refresh, which
+    reads the in-memory token directly and would present a possibly-already-
+    rotated refresh token — the family-revoking request this subsystem exists to
+    prevent. Deliberately NOT a subclass of :class:`McpAuthRequiredError` and
+    deliberately not raised anywhere near a grant that is known dead: this is a
+    CONTENTION/transient outcome, so the manager's generic reconnect arm retries
+    it with backoff and never takes an auth block on it. The in-memory refresh
+    token is stripped before the raise (see
+    ``_RefreshCoordinatingOAuthProvider._refuse_unlocked_refresh``) so the
+    suppressed SDK refresh cannot run either way.
+
+    This type reaches the manager INDIRECTLY. The MCP streamable-HTTP transport
+    runs the request inside anyio cancel scopes, so an exception raised out of
+    the auth flow is not delivered — it arrives at ``_connect_server`` as a bare
+    ``CancelledError('Cancelled via cancel scope …')``. The provider therefore
+    arms :data:`REFRESH_CONTENTION` immediately before raising, and the manager
+    re-voices exactly that cancellation as this error. Callers that drive
+    ``async_auth_flow`` without the transport (tests, and any future in-process
+    caller) see the raise itself.
+    """
+
+    def __init__(self, server_url: str) -> None:
+        super().__init__(
+            f"MCP OAuth token refresh for {server_url} could not be performed "
+            "under the refresh lock; retrying"
+        )
         self.server_url = server_url
 
 
@@ -597,6 +659,14 @@ class McpTokenStorage:
     async def set_tokens(self, tokens: OAuthToken) -> None:
         """Persist fresh/refreshed tokens (access + refresh together).
 
+        This is the SDK's ``TokenStorage`` write and stays UNCONDITIONAL: the
+        SDK's own refresh, a completed browser grant and a pinned-client seed
+        all land here, and none of them has a rotation to compare against. That
+        leaves a residual race recorded in the PR rather than fixed here: a
+        sibling that persists its own rotation between this read and this write
+        loses it. It cannot tombstone a live grant (the marker write is the one
+        that does that, and it compares — see :meth:`mark_grant_dead`).
+
         The issuing WALL-CLOCK time is written alongside them. ``OAuthToken``
         carries only the relative ``expires_in`` the server quoted, which is
         meaningless once the process that received it has exited — and the SDK
@@ -685,33 +755,49 @@ class McpTokenStorage:
         marker = creds.get(GRANT_DEAD_AT_KEY)
         return isinstance(marker, (int, float)) and not isinstance(marker, bool) and marker > 0
 
-    def mark_grant_dead(self) -> None:
+    def mark_grant_dead(self, *, rejected_refresh_token: str | None = None) -> bool:
         """Record that this row's refresh token was rejected as ``invalid_grant``.
 
-        Best-effort read-modify-write: a store failure here must not break the
-        connect that is already failing over a dead grant, so it degrades to
-        today's behaviour (the storm) rather than raising. See
-        :data:`GRANT_DEAD_AT_KEY` for why this carries no expiry.
+        Best-effort: a store failure here must not break the connect that is
+        already failing over a dead grant, so it degrades to writing nothing
+        rather than raising. See :data:`GRANT_DEAD_AT_KEY` for why this carries
+        no expiry.
 
-        Known window, recorded because a FALSE tombstone is the worst failure
-        this marker can introduce: the read-modify-write is not inside
-        :func:`_oauth_refresh_lock`, so a sibling process that persists a
-        rotated token between our read and our write has that write overwritten
-        by our stale snapshot plus the marker, and a live grant then reads as
-        dead until an interactive login. The ordering makes it unlikely — we
-        only reach here after the server rejected the grant, under the lock on
-        the coordinator path — and it is a pre-existing property of the same
-        read-modify-write in :meth:`set_tokens`, so it is left as-is rather than
-        fixed here alone; closing it means giving both writers the lock.
+        ``rejected_refresh_token`` makes the FRESHNESS RE-READ a
+        compare-and-skip, and it exists because the marker is a whole-payload
+        read-modify-write: a sibling that persisted a fresh rotation between
+        our read and our write otherwise had a live token rewritten as dead (or
+        its token erased by our pre-rotation snapshot) and stayed suppressed
+        until an interactive login. Re-reading here and writing only when the
+        row still holds the token the server rejected keeps the write inside
+        the window it was computed in. It mirrors the check-then-write
+        convention ``providers.auth_store.AuthStore`` already uses, rather than
+        introducing a second write primitive.
+
+        Returns ``True`` when the marker was written, ``False`` when it was
+        skipped or the write failed.
+
+        Its caller :func:`_refresh_oauth_token_locked` holds
+        :func:`_oauth_refresh_lock`; the remaining gap is against writers that
+        deliberately do NOT take the lock — the interactive-login completion and
+        the client-info writes that go through the SDK — so this narrows the
+        window to the microseconds between the compare and the write instead of
+        the whole exchange.
         """
         try:
             creds = self._read() or {}
+            if rejected_refresh_token is not None and not _payload_holds_refresh_token(
+                creds, rejected_refresh_token
+            ):
+                return False
             creds[GRANT_DEAD_AT_KEY] = time.time()
             self._write(creds)
+            return True
         except Exception:  # noqa: BLE001 — marking is an optimisation, never a gate
             logger.debug(
                 "MCP dead-grant marker write failed for %s", self.credential_id, exc_info=True
             )
+            return False
 
     def stored_token_expiry(self) -> float | None:
         """Epoch seconds at which the stored access token expires, if knowable.
@@ -929,6 +1015,27 @@ def payload_carries_grant(payload: dict[str, Any] | None) -> bool:
     if not isinstance(tokens, dict):
         return False
     return bool(tokens.get("access_token") or tokens.get("refresh_token"))
+
+
+def _payload_holds_refresh_token(payload: dict[str, Any] | None, refresh_token: str) -> bool:
+    """Whether a payload's stored grant still carries ``refresh_token``.
+
+    The predicate behind :meth:`McpTokenStorage.mark_grant_dead`'s
+    compare-and-skip, kept next to :func:`payload_carries_grant` because it is
+    the same question asked about a specific token rather than any token: has
+    the grant this write was computed from been replaced since?
+
+    False for a payload whose grant was removed entirely (a logout or a
+    ``/mcp reauth`` that deleted the row). That is deliberate: the writers that
+    remove a grant do NOT take :func:`_oauth_refresh_lock`, so a tombstone
+    written after one would re-create a row the user just asked us to forget.
+    """
+    if not isinstance(payload, dict):
+        return False
+    tokens = payload.get("tokens")
+    if not isinstance(tokens, dict):
+        return False
+    return tokens.get("refresh_token") == refresh_token
 
 
 def server_rejects_oauth(cfg: MCPServerConfig) -> bool:
@@ -1396,6 +1503,75 @@ class AbandonedGrantLedger:
 
 
 ABANDONED_GRANTS = AbandonedGrantLedger()
+
+#: How long a refusal-to-refresh record may sit unread. The manager consumes it
+#: within microseconds of the raise (it is popped in the very same
+#: ``_connect_server`` that armed it), so the horizon only bounds a LEAK for a
+#: refusal whose CancelledError was swallowed somewhere before classification —
+#: and a leaked record would otherwise be attributed to the next, unrelated
+#: cancellation of that server and turn a teardown into a retry.
+_REFRESH_CONTENTION_TTL_S = 5.0
+
+
+class RefreshContentionLedger:
+    """Servers whose coordinator refused to spend a refresh token UNLOCKED.
+
+    The side channel that survives the transport, and it exists for exactly the
+    reason :class:`AbandonedGrantLedger` does: an ordinary exception raised out
+    of ``async_auth_flow`` is NOT delivered to ``_connect_server``. The MCP
+    streamable-HTTP transport runs the request inside anyio cancel scopes, so
+    anything raised out of the auth flow cancels that scope and reaches the
+    caller as a bare ``CancelledError('Cancelled via cancel scope …')`` with no
+    trace of the original error — verified for this exact raise, and for a plain
+    ``RuntimeError`` raised from the same place, so it is a transport property
+    rather than anything about :class:`McpRefreshContendedError`.
+
+    The manager consults this ledger to tell "we refused to refresh without
+    exclusivity" apart from "this connect was disposed", because the two need
+    opposite treatment: the first is contention and must be retried with
+    backoff, the second must never be converted into a retry.
+
+    Keyed by server URL and SINGLE-USE (``pop`` semantics): one refusal re-voices
+    at most one cancellation, never two. Records also age out, so a record whose
+    cancellation never reached the manager cannot be attributed to an unrelated
+    cancellation later.
+    """
+
+    def __init__(self) -> None:
+        self._records: dict[str, float] = {}
+
+    def record(self, server_url: str) -> None:
+        """Arm one server's record, pruning anything past the horizon."""
+        now = time.monotonic()
+        for old_url, at in list(self._records.items()):
+            if now - at > _REFRESH_CONTENTION_TTL_S:
+                self._records.pop(old_url, None)
+        self._records[server_url] = now
+
+    def pop(self, server_url: str) -> bool:
+        """Consume one server's record; ``True`` when a FRESH one was there.
+
+        Always removes the entry, fresh or stale: the caller uses a single
+        answer for the whole classification, so leaving a stale record behind
+        would only let it be misattributed later.
+        """
+        at = self._records.pop(server_url, None)
+        if at is None:
+            return False
+        return time.monotonic() - at <= _REFRESH_CONTENTION_TTL_S
+
+    def clear(self) -> None:
+        """Drop every record. Used by test isolation; no production caller.
+
+        Nothing in the running system wants to forget a live refusal — the
+        manager consumes records as it classifies, and stale ones age out — but
+        a record is process-global state, and a test that armed one must not be
+        able to change what the NEXT test observes.
+        """
+        self._records.clear()
+
+
+REFRESH_CONTENTION = RefreshContentionLedger()
 
 
 class LoopbackAuthFlow:
@@ -2111,10 +2287,18 @@ async def _oauth_refresh_lock(server_url: str):
     padding byte, which ``msvcrt.locking`` requires to have a range to lock).
 
     Yields True when the lock was taken and False when the bounded acquire gave
-    up. A False body must still be SAFE to run: the guarantee degrades from
-    "exactly one process refreshes" to "we tried", which is the best-effort
-    contract :func:`ensure_mcp_oauth_fresh` already documents. Blocking the
-    connect instead would trade a rare double-spend for a guaranteed hang.
+    up. A False body must still be SAFE to run, and that is now a narrower
+    promise than "best-effort": it may NOT perform the refresh exchange, because
+    an unexclusive exchange is the family-revoking double-spend this lock
+    exists to prevent. :func:`ensure_mcp_oauth_fresh` can afford to skip the
+    refresh on a False lock (its caller still connects and will re-read under
+    the lock on the next attempt), and
+    ``_RefreshCoordinatingOAuthProvider._coordinate_inflight_refresh`` must not
+    fall through to the SDK's unlocked refresh either — it refuses with
+    :class:`McpRefreshContendedError` instead. Blocking the connect while
+    waiting for exclusivity is still not an option: it would trade a rare
+    double-spend for a guaranteed hang, which is the freeze this function was
+    rewritten to remove.
 
     Two rules this function exists to enforce, both learned from a freeze that
     took the whole TUI down:
@@ -2303,8 +2487,6 @@ async def _refresh_oauth_token_locked(
     import base64
     from urllib.parse import quote
 
-    import httpx
-    from mcp.shared.auth import OAuthToken
     from mcp.shared.auth_utils import resource_url_from_server_url
 
     tokens = await storage.get_tokens()
@@ -2345,27 +2527,101 @@ async def _refresh_oauth_token_locked(
         encoded = base64.b64encode(f"{cid}:{csecret}".encode()).decode()
         headers["Authorization"] = f"Basic {encoded}"
 
+    # The exchange runs in its OWN task, and the await below is a SHIELD around
+    # it: neither a cancellation of this connect nor the total timeout can
+    # abort the POST. For a rotating provider the response is the only copy of
+    # the new refresh token, so an aborted request does not just fail a refresh
+    # — the server has already spent the token we presented, and the store is
+    # left holding a spent one whose next presentation is a reuse-detection
+    # double-spend that logs out the whole fleet. The task persists its result
+    # itself, so the rotation survives whichever of the three ways this ends:
+    # completed in time, cancelled mid-flight, or landed after the bound.
+    #
+    # The cap stays what it was: the LOCK is never held for longer than
+    # ``REFRESH_HTTP_TIMEOUT_S``. Only the response read gets the late grace.
+    exchange: asyncio.Task[RefreshOutcome] = asyncio.ensure_future(
+        _perform_refresh_exchange(server_url, storage, tokens, token_endpoint, data, headers)
+    )
+    started = time.monotonic()
     try:
-        # TOTAL wall-clock cap, not just httpx's per-operation timeouts.
-        # ``httpx.Timeout(N)`` sets connect/read/write/pool to N EACH, and the
-        # read timeout applies per socket read rather than to the whole
-        # response — so a server that dribbles the body stays inside every
-        # individual read and takes arbitrarily long. Measured against a server
-        # sending one byte every 2s, this exact request returned HTTP 200 after
-        # 140.7s with the 10s timeout set and never tripping it.
-        #
-        # That matters because this call runs UNDER the cross-process refresh
-        # lock, and ``LOCK_ACQUIRE_TIMEOUT_S`` is derived from the claim that
-        # the section is bounded by ``REFRESH_HTTP_TIMEOUT_S``. Without an
-        # overall cap that claim is false, and a slow-but-honest provider would
-        # systematically push every peer past its acquire bound onto the
-        # unlocked degrade path — which for the in-flight coordinator means the
-        # SDK's own unlocked refresh, i.e. the rotating-token double-spend this
-        # subsystem exists to prevent, reached by timeout instead of by race.
-        # Bounding the POST is what makes the documented budget true.
         async with asyncio.timeout(REFRESH_HTTP_TIMEOUT_S):
-            async with httpx.AsyncClient(timeout=httpx.Timeout(REFRESH_HTTP_TIMEOUT_S)) as client:
-                response = await client.post(token_endpoint, data=data, headers=headers)
+            return await asyncio.shield(exchange)
+    except TimeoutError:
+        # The budget is spent, so this connect is done with it; the exchange is
+        # not, and its persistence is the whole point of detaching it.
+        logger.debug(
+            "MCP token refresh overran its %.0fs budget for %s; a response that still "
+            "lands will be persisted",
+            REFRESH_HTTP_TIMEOUT_S,
+            server_url,
+        )
+        _detach_refresh_exchange(exchange, server_url)
+        return "failed"
+    except asyncio.CancelledError:
+        # Routine teardown: every sidebar switch disposes a manager and cancels
+        # its in-flight connects. Wait out the REMAINDER of the budget for the
+        # response so the rotation reaches the store BEFORE the caller's lock
+        # is released — leaving it to a detached task would let a sibling
+        # acquire the lock first and spend the token this exchange already
+        # spent. Never longer than the bound, so teardown is never held longer
+        # than it already could be.
+        remaining = max(0.0, REFRESH_HTTP_TIMEOUT_S - (time.monotonic() - started))
+        with contextlib.suppress(BaseException):
+            await asyncio.wait_for(asyncio.shield(exchange), remaining)
+        _detach_refresh_exchange(exchange, server_url)
+        raise
+
+
+def _detach_refresh_exchange(exchange: "asyncio.Task[RefreshOutcome]", server_url: str) -> None:
+    """Make a refresh exchange that outlived its connect safe to leave running.
+
+    The task persists its own result (see :func:`_perform_refresh_exchange`),
+    so nothing here consumes a value: this exists so a task nobody awaits is
+    not reported as "exception was never retrieved" when the loop closes, and
+    so a failure inside it is logged against the server it belongs to.
+    """
+
+    def _settle(finished: "asyncio.Task[RefreshOutcome]") -> None:
+        if finished.cancelled():
+            return
+        with contextlib.suppress(BaseException):
+            exc = finished.exception()
+            if exc is not None:
+                logger.debug("detached MCP token refresh for %s failed", server_url, exc_info=exc)
+
+    exchange.add_done_callback(_settle)
+
+
+async def _perform_refresh_exchange(
+    server_url: str,
+    storage: McpTokenStorage,
+    tokens: OAuthToken,
+    token_endpoint: str,
+    data: dict[str, str],
+    headers: dict[str, str],
+) -> RefreshOutcome:
+    """POST one refresh grant and persist whatever the authorization server decided.
+
+    Owns the whole exchange — request, classification, persistence — so it can
+    be detached from the connect that started it without any part of the result
+    depending on a listener. Split out of :func:`_refresh_oauth_token_locked`
+    for exactly that reason: the response is the only copy of a rotated refresh
+    token, and every path that used to drop it (cancellation, the total
+    timeout) did so by cancelling the request rather than by deciding against
+    it.
+    """
+    import httpx
+    from mcp.shared.auth import OAuthToken
+
+    try:
+        # ``read`` is the LATE GRACE, not the budget: a response that lands
+        # after the awaiting connect has given up is still a rotation we must
+        # not throw away. Connect/write/pool keep the budget, so a server that
+        # never accepts the request still fails fast.
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(REFRESH_HTTP_TIMEOUT_S, read=REFRESH_LATE_RESPONSE_GRACE_S)
+        ) as client:
+            response = await client.post(token_endpoint, data=data, headers=headers)
     except (httpx.HTTPError, TimeoutError):
         # ``asyncio.timeout`` raises TimeoutError (which ``httpx.HTTPError``
         # does not cover); a refresh that overran its budget is simply a failed
@@ -2380,7 +2636,7 @@ async def _refresh_oauth_token_locked(
         # the ENTIRE token family, logging out every session at once. When that
         # happens the only recovery is an interactive login, so the log names
         # that action instead of implying a retry will heal it. We never
-        # auto-retry here regardless: returning False lets the connect surface
+        # auto-retry here regardless: returning "dead" lets the connect surface
         # McpAuthRequiredError, which the manager turns into a suspended
         # reconnect (see manager._reconnect's McpAuthRequiredError arm) rather
         # than hammering a dead grant.
@@ -2394,7 +2650,10 @@ async def _refresh_oauth_token_locked(
             # that the grant itself is gone rather than the server having a bad
             # minute. Misclassifying a transient 400 would permanently suppress
             # refresh on a live grant until the user ran an interactive login.
-            storage.mark_grant_dead()
+            # The rejected token travels with the marker so the write can check
+            # the grant has not moved on without us — see
+            # :meth:`McpTokenStorage.mark_grant_dead`.
+            storage.mark_grant_dead(rejected_refresh_token=tokens.refresh_token)
             return "dead"
         # Informational, not debug: a rejected refresh is the thing that turns
         # into a login prompt, so its cause belongs in the readable log.
@@ -2442,11 +2701,14 @@ async def ensure_mcp_oauth_fresh(
 
     The refresh is wrapped in a cross-process lock with a re-read after
     acquiring it, so only one of several concurrently STARTING sessions spends
-    a rotating refresh token. Scope honestly stated: the SDK's own in-flow 401
-    refresh (a token that dies mid-session) takes no such lock, so two
-    already-running sessions can still race a rotation there; that path fails
-    into the non-interactive handler (an actionable error, not a popup) and
-    the next startup heals it here.
+    a rotating refresh token. Scope honestly stated: this function is one of
+    three ways a refresh can start, and the other two — the in-flight
+    coordinator an ``async_auth_flow`` runs before every request, and the
+    401-recovery refresh — also take this lock and re-read under it. What is
+    NOT covered is another PROCESS that never takes it: a completed interactive
+    login persists its tokens through the SDK's own ``set_tokens``, which does
+    not lock, so a writer racing one of these refreshes can still lose its
+    rotation on the narrow window between our read and our write.
 
     A grant previously rejected with ``invalid_grant`` short-circuits before the
     lock is taken: see :data:`GRANT_DEAD_AT_KEY`.
@@ -2501,10 +2763,13 @@ async def ensure_mcp_oauth_fresh(
         if not locked:
             # The bounded acquire gave up, so we cannot claim exclusivity and
             # must not spend the rotating refresh token on a guess. Skip the
-            # PROACTIVE refresh and connect anyway: the SDK's own in-flow
-            # refresh still runs on the first 401, and the coordinator wrapper
-            # re-reads the store before it does. A skipped optimisation costs a
-            # round trip; blocking the connect costs the whole session.
+            # PROACTIVE refresh and connect anyway: this function does not leak
+            # an unlocked POST on its own, because the provider's
+            # ``async_auth_flow`` always runs the in-flight coordinator before
+            # it delegates to the SDK — and that coordinator refuses to fall
+            # through to the SDK's unlocked ``_refresh_token``
+            # (:class:`McpRefreshContendedError`). A skipped optimisation costs
+            # a round trip; blocking the connect costs the whole session.
             return endpoints
         # Re-read under the lock: another session may have refreshed while we
         # waited. Spending a rotated refresh token a second time is exactly the
@@ -2734,9 +2999,7 @@ def _make_refresh_coordinating_provider(
                 # read False, so the SDK skips its refresh branch and goes to
                 # the authorization branch, which our non-interactive redirect
                 # handler turns into an actionable McpAuthRequiredError.
-                with contextlib.suppress(Exception):
-                    if ctx.current_tokens is not None:
-                        ctx.current_tokens.refresh_token = None
+                self._strip_in_memory_refresh_token(ctx)
                 return
             try:
                 async with _oauth_refresh_lock(self._refresh_coord_server_url) as locked:
@@ -2748,60 +3011,74 @@ def _make_refresh_coordinating_provider(
                         # No exclusivity, so we must not perform the exchange
                         # ourselves. The re-read above still upholds the
                         # invariant that matters most (the SDK never spends an
-                        # in-memory refresh token older than storage's), and the
-                        # SDK's own refresh then proceeds — the pre-coordination
-                        # behaviour, which is the correct degrade.
-                        return
-                    if ctx.is_token_valid():
+                        # in-memory refresh token older than storage's).
+                        #
+                        # It no longer DEGRADES to the SDK's unlocked refresh:
+                        # that was the main route by which a stale rotating
+                        # refresh token reached the wire outside
+                        # ``_oauth_refresh_lock`` (the SDK POSTs the in-memory
+                        # token directly, with no re-read), which for a
+                        # reuse-detecting provider is the family-revoking
+                        # request. The post-condition at the end of this method
+                        # turns "still invalid and still refreshable" into a
+                        # transient error the manager retries with backoff,
+                        # instead of an unlocked spend.
+                        pass
+                    elif ctx.is_token_valid():
                         return  # a peer already refreshed; do not spend again
-                    # The invariant this whole block exists to guarantee: the
-                    # SDK's own ``_refresh_token`` must NEVER run with an
-                    # in-memory refresh token older than the one in storage. The
-                    # SDK loads the token once at ``_initialize`` and spends it
-                    # unlocked; a sibling that rotated it in between leaves us
-                    # holding a stale refresh token, and presenting that to a
-                    # reuse-detecting provider (Notion) returns
-                    # ``invalid_grant`` and revokes the ENTIRE token family —
-                    # logging out every session at once. So we always perform
-                    # the refresh ourselves, UNDER THE LOCK, with a fresh
-                    # re-read; the SDK's unlocked path is never reached with a
-                    # stale token.
-                    endpoints = self._refresh_coord_endpoints
-                    if endpoints is None:
-                        # Discovery failed at startup, but we must still refresh
-                        # under the lock rather than fall through to the SDK's
-                        # UNLOCKED refresh (which would spend the possibly-stale
-                        # boot-time token and risk the family revocation above).
-                        # Synthesize the exact endpoint the SDK itself would
-                        # fall back to (``<scheme>://<netloc>/token``) so the
-                        # locked, re-reading refresh targets the same URL the
-                        # unlocked path would have.
-                        endpoints = _fallback_endpoints_for(self._refresh_coord_server_url)
-                    outcome = await _refresh_oauth_token_locked(
-                        self._refresh_coord_server_url,
-                        self._refresh_coord_storage,
-                        endpoints,
-                    )
-                    # Compare explicitly: ``"failed"`` is a truthy string, so a
-                    # ``if outcome:`` here would invert this branch silently and
-                    # pyright would not catch it.
-                    if outcome == "refreshed":
-                        await self._resync_from_store(ctx)
-                    elif outcome == "dead":
-                        # The third POST of the per-boot triple, and the one that
-                        # actually revokes the token family. Returning here still
-                        # falls through to the SDK's own UNLOCKED _refresh_token,
-                        # which would spend the token the authorization server
-                        # just rejected. Dropping the in-memory refresh token
-                        # makes the SDK's can_refresh_token() read False, so it
-                        # skips its refresh branch entirely and goes to the
-                        # authorization branch — which our non-interactive
-                        # redirect handler already turns into an actionable
-                        # McpAuthRequiredError. Same user-visible outcome, one
-                        # fewer family-revoking POST.
-                        with contextlib.suppress(Exception):
-                            if ctx.current_tokens is not None:
-                                ctx.current_tokens.refresh_token = None
+                    else:
+                        # The invariant this whole block exists to guarantee: the
+                        # SDK's own ``_refresh_token`` must NEVER run with an
+                        # in-memory refresh token older than the one in storage. The
+                        # SDK loads the token once at ``_initialize`` and spends it
+                        # unlocked; a sibling that rotated it in between leaves us
+                        # holding a stale refresh token, and presenting that to a
+                        # reuse-detecting provider (Notion) returns
+                        # ``invalid_grant`` and revokes the ENTIRE token family —
+                        # logging out every session at once. So we always perform
+                        # the refresh ourselves, UNDER THE LOCK, with a fresh
+                        # re-read; the SDK's unlocked path is never reached with a
+                        # stale token.
+                        endpoints = self._refresh_coord_endpoints
+                        if endpoints is None:
+                            # Discovery failed at startup, but we must still refresh
+                            # under the lock rather than fall through to the SDK's
+                            # UNLOCKED refresh (which would spend the possibly-stale
+                            # boot-time token and risk the family revocation above).
+                            # Synthesize the exact endpoint the SDK itself would
+                            # fall back to (``<scheme>://<netloc>/token``) so the
+                            # locked, re-reading refresh targets the same URL the
+                            # unlocked path would have.
+                            endpoints = _fallback_endpoints_for(self._refresh_coord_server_url)
+                        outcome = await _refresh_oauth_token_locked(
+                            self._refresh_coord_server_url,
+                            self._refresh_coord_storage,
+                            endpoints,
+                        )
+                        # Compare explicitly: ``"failed"`` is a truthy string, so a
+                        # ``if outcome:`` here would invert this branch silently and
+                        # pyright would not catch it.
+                        if outcome == "refreshed":
+                            await self._resync_from_store(ctx)
+                        elif outcome == "dead":
+                            # The third POST of the per-boot triple, and the one that
+                            # actually revokes the token family. Returning here still
+                            # falls through to the SDK's own UNLOCKED _refresh_token,
+                            # which would spend the token the authorization server
+                            # just rejected. Dropping the in-memory refresh token
+                            # makes the SDK's can_refresh_token() read False, so it
+                            # skips its refresh branch entirely and goes to the
+                            # authorization branch — which our non-interactive
+                            # redirect handler already turns into an actionable
+                            # McpAuthRequiredError. Same user-visible outcome, one
+                            # fewer family-revoking POST.
+                            self._strip_in_memory_refresh_token(ctx)
+                        # ``outcome == "failed"`` deliberately has NO arm here any
+                        # more. Silently falling out of this block used to hand the
+                        # SDK's unlocked _refresh_token a still-refreshable stale
+                        # token — the live route the incident logs show (14+
+                        # ``httpx2 ... /token 400``). The post-condition below
+                        # decides it instead: stripped and retried as transient.
             except Exception:  # noqa: BLE001 — coordination is best-effort
                 # A failed re-read/refresh must never break the request. But we
                 # must NOT let the SDK's unlocked refresh then spend a stale
@@ -2818,6 +3095,54 @@ def _make_refresh_coordinating_provider(
                     exc_info=True,
                 )
                 await self._adopt_freshest_stored_token(ctx)
+            # POST-CONDITION, in ONE place so no exit path can miss it: we are
+            # about to return into ``async_auth_flow``, whose very next act is to
+            # hand the context to the SDK's ``async_auth_flow``. If the token is
+            # still invalid AND still refreshable at that point, the SDK will
+            # POST its in-memory refresh token with no lock and no re-read — the
+            # unlocked spend this whole method exists to prevent. Refuse instead.
+            self._refuse_unlocked_refresh(ctx)
+
+        def _refuse_unlocked_refresh(self, ctx: Any) -> None:
+            """Never hand the SDK an in-memory refresh token we failed to refresh.
+
+            The post-condition of :meth:`_coordinate_inflight_refresh`, called
+            once at the end so no exit path can skip it. Reaching here with an
+            invalid-but-refreshable context means coordination did not produce
+            a working token this time (the lock was unavailable, the locked
+            refresh returned ``"failed"``, or the fall-through could not find a
+            fresher stored one). ``async_auth_flow`` returns straight into the
+            SDK's own flow at that point, and the SDK's ``_refresh_token``
+            POSTs ``ctx.current_tokens.refresh_token`` DIRECTLY — no lock, no
+            re-read — so the next thing on the wire would be a possibly
+            already-rotated token, which a reuse-detecting provider answers with
+            ``invalid_grant`` AND a family revocation.
+
+            So strip it and raise a TRANSIENT error instead. Two properties are
+            load-bearing:
+
+            * the strip makes ``can_refresh_token()`` read False, so even if a
+              caller swallows this error the SDK's refresh branch cannot run;
+              and
+            * the error is not an auth error, so it reaches the manager's
+              generic reconnect arm — backoff and retry — rather than
+              ``_block_on_auth``. Being unable to take a lock is contention,
+              not a dead grant: blocking on auth here would strand a healthy
+              server on a login prompt the user has no reason to run.
+            """
+            if not ctx.can_refresh_token() or ctx.is_token_valid():
+                return
+            self._strip_in_memory_refresh_token(ctx)
+            # ARM THE SIDE CHANNEL BEFORE RAISING, and do it here rather than in
+            # the raise's caller: the MCP transport will NOT deliver this error.
+            # It runs the request inside anyio cancel scopes, so the raise
+            # cancels the scope and reaches ``_connect_server`` as a bare
+            # ``CancelledError('Cancelled via cancel scope …')``. The manager
+            # re-voices that cancellation using this record — and only when the
+            # cancellation was NOT a genuine external one, so a dispose still
+            # wins. See :class:`RefreshContentionLedger`.
+            REFRESH_CONTENTION.record(self._refresh_coord_server_url)
+            raise McpRefreshContendedError(self._refresh_coord_server_url)
 
         async def _resync_from_store(self, ctx: Any) -> None:
             """Overwrite the in-memory token with the persisted one.
@@ -2942,26 +3267,21 @@ def _make_refresh_coordinating_provider(
                         # comes back. The SDK's answer to a 401 is the FULL
                         # browser authorization (non-interactive connects turn
                         # that into McpAuthRequiredError and suspend
-                        # auto-reconnect), even though the shared store already
-                        # holds the sibling's fresh token. So before the 401
-                        # reaches the SDK, re-read the store under the refresh
-                        # lock and adopt a DIFFERENT token if a peer wrote one.
+                        # auto-reconnect), even though the shared store may
+                        # already hold the sibling's fresh token. So before the
+                        # 401 reaches the SDK, recover under the refresh lock —
+                        # by adopting a peer's DIFFERENT stored token when there
+                        # is one, and otherwise by performing the refresh HERE,
+                        # under that lock, rather than letting the SDK do it
+                        # unlocked (see :meth:`_recover_from_401_once`).
                         #
-                        # Adoption is race-free without spending anything: it
-                        # copies a token a sibling already paid a refresh for,
-                        # so it cannot invalidate anything and cannot double-
-                        # spend the rotating refresh token. The lock only
-                        # serializes the re-read against a concurrent rotation
-                        # so the adopted value is not mid-write. It is bounded
-                        # to ONE attempt per flow: if the adopted token ALSO
-                        # 401s (a genuinely dead grant, e.g. the user revoked
-                        # access server-side), the second 401 passes through to
-                        # the SDK's own full-flow branch exactly as before —
-                        # adoption never loops. A grant that is truly dead
-                        # (stored token identical to ours, or none) also passes
-                        # through unchanged on this first 401.
+                        # Both arms are bounded to ONE attempt per flow: if the
+                        # adopted or refreshed token ALSO 401s (a genuinely dead
+                        # grant, e.g. the user revoked access server-side), the
+                        # second 401 passes through to the SDK's own full-flow
+                        # branch exactly as before — recovery never loops.
                         adoption_attempted = True
-                        retry_request = await self._adopt_peer_token_once(original_request)
+                        retry_request = await self._recover_from_401_once(original_request)
                         if retry_request is not None:
                             # Re-yield the retry request: the SAME httpx client
                             # that sent the original sends this one (same
@@ -2993,8 +3313,11 @@ def _make_refresh_coordinating_provider(
                             except StopAsyncIteration:
                                 return
                             continue
-                        # No peer token to adopt: fall through and hand the 401
-                        # to the SDK unchanged (existing dead-grant behaviour).
+                        # No recovery was possible: fall through and hand the 401
+                        # to the SDK unchanged (the dead-grant behaviour).
+                        # ``can_refresh_token()`` is False by then, so the SDK's
+                        # own refresh branch cannot run and no unlocked token
+                        # POST follows.
                     # ``response`` is whatever the caller sent into the flow;
                     # httpx always sends a real Response, so the None case is a
                     # type-narrowing artifact, not a reachable state.
@@ -3009,56 +3332,140 @@ def _make_refresh_coordinating_provider(
                 # never left suspended. Idempotent if already exhausted/closed.
                 await inner.aclose()
 
-        async def _adopt_peer_token_once(self, original_request: Any) -> Any:
-            """Adopt a peer-rotated token and return the request to retry, if any.
+        async def _recover_from_401_once(self, original_request: Any) -> Any:
+            """Recover from a 401 and return the request to retry, or ``None``.
 
-            Returns the ORIGINAL request with its Authorization header rewritten
-            to the adopted token when the store held an access token DIFFERENT
-            from the one in memory — the caller re-yields it so the SAME httpx
-            client that sent the original sends the retry (same proxies, TLS,
-            and event hooks). Returns ``None`` when there is nothing to adopt
-            (stored token identical to ours, or no row), in which case the
-            caller passes the original 401 through to the SDK.
+            Returns the ORIGINAL request with its ``Authorization`` header
+            rewritten when there is a working token to send, and ``None`` when
+            the 401 must pass through to the SDK. Both arms run under ONE
+            acquisition of the refresh lock, because both are decisions about a
+            rotating grant and both must see a settled store:
 
-            Mutating the request object in place (rather than building a new
-            one) matches the SDK's own end-of-flow 401 retry contract:
-            ``_add_auth_header`` rewrites the same object's Authorization header
-            and re-yields it. Header mutation never touches the request
-            body/stream, so the re-send is body-safe.
+            * **Adoption** (unchanged from the previous behaviour): the store
+              holds an access token DIFFERENT from the one in memory, so a
+              sibling rotated the grant; copy it and retry. Adoption spends
+              nothing, so it can never double-spend, and the lock only
+              serializes the re-read against a concurrent rotation.
+            * **Refresh** (new): the store holds the SAME token (or none) and
+              the grant is still refreshable. A 401 is then NOT evidence of a
+              dead grant — it is evidence that nobody has rotated yet — so the
+              refresh is performed HERE, under the lock, with the same re-read
+              and endpoint discipline as the pre-request coordinator. Before
+              this existed, this case fell straight through to the SDK, whose
+              ``async_auth_flow`` POSTs ``current_tokens.refresh_token``
+              directly: no lock, no re-read, and with the sibling's rotation
+              already spent the request is a reuse-detection double-spend. It is
+              also the one place a genuinely dead grant can be TOMBSTONED from a
+              401 — :func:`_refresh_oauth_token_locked` writes the marker on a
+              parsed ``invalid_grant``, which this path previously never
+              reached, so every later boot re-POSTed the same rejected token.
+
+            On ``"dead"`` and on ``"failed"`` the in-memory refresh token is
+            stripped and ``None`` is returned, so the SDK's own unlockable
+            refresh cannot run either way. ``"dead"`` went through the refresh
+            (the marker is written); ``"failed"`` is transient and deliberately
+            writes NO tombstone.
             """
+            from local_operator.mcp import auth as auth_mod
+
             try:
-                async with _oauth_refresh_lock(self._refresh_coord_server_url):
-                    # Adoption only READS the store and rewrites our own header;
-                    # it never spends the refresh token, so an unlocked pass is
-                    # safe and still beats handing a 401 straight to the SDK.
+                async with _oauth_refresh_lock(self._refresh_coord_server_url) as locked:
                     stored = await self.context.storage.get_tokens()
-                    if stored is None or not stored.access_token:
-                        return None
                     current = self.context.current_tokens
-                    if current is not None and stored.access_token == current.access_token:
-                        # The store still holds exactly the token that just 401'd:
-                        # this grant is dead everywhere, not merely revoked for
-                        # us. The SDK's full flow is the right answer.
+                    if (
+                        stored is not None
+                        and stored.access_token
+                        and (current is None or stored.access_token != current.access_token)
+                    ):
+                        # Adopt the peer's rotation: spend nothing, invalidate
+                        # nothing, just send the token the server already issued.
+                        self.context.current_tokens = stored
+                        self.context.token_expiry_time = (
+                            self._refresh_coord_storage.stored_token_expiry()
+                        )
+                        original_request.headers["Authorization"] = f"Bearer {stored.access_token}"
+                        logger.debug(
+                            "MCP 401 for %s: retrying with a peer-rotated stored token",
+                            self._refresh_coord_server_url,
+                        )
+                        return original_request
+                    if not self.context.can_refresh_token():
+                        # Nothing stored to adopt and nothing left to spend: the
+                        # SDK's full authorization branch is the right answer,
+                        # and with no refresh token it cannot POST one.
                         return None
-                    self.context.current_tokens = stored
-                    self.context.token_expiry_time = (
-                        self._refresh_coord_storage.stored_token_expiry()
+                    if not locked:
+                        # We do not hold exclusivity, so we must not perform the
+                        # exchange. Strip the in-memory refresh token anyway so
+                        # the SDK cannot make the unlocked POST we just declined
+                        # to make ourselves, and let the 401 reach its
+                        # authorization branch.
+                        self._strip_in_memory_refresh_token(self.context)
+                        return None
+                    endpoints = self._refresh_coord_endpoints
+                    if endpoints is None:
+                        endpoints = auth_mod._fallback_endpoints_for(self._refresh_coord_server_url)
+                    outcome = await _refresh_oauth_token_locked(
+                        self._refresh_coord_server_url,
+                        self._refresh_coord_storage,
+                        endpoints,
                     )
-                    original_request.headers["Authorization"] = f"Bearer {stored.access_token}"
-            except Exception:  # noqa: BLE001 — adoption is best-effort
-                # A failed re-read must not break the request: defer to the
-                # SDK's own 401 handling rather than inventing a new failure.
+                    if outcome == "refreshed":
+                        await self._resync_from_store(self.context)
+                        fresh = self.context.current_tokens
+                        if fresh is None or not fresh.access_token:
+                            # The refresh reported success but nothing
+                            # persistable came back; let the SDK handle the 401.
+                            self._strip_in_memory_refresh_token(self.context)
+                            return None
+                        original_request.headers["Authorization"] = f"Bearer {fresh.access_token}"
+                        logger.debug(
+                            "MCP 401 for %s: retrying after a locked refresh",
+                            self._refresh_coord_server_url,
+                        )
+                        return original_request
+                    # ``"dead"`` (marker written by the refresh) and ``"failed"``
+                    # (transient, no marker) both end here: strip so the SDK's
+                    # unlocked refresh cannot spend the token, then let the 401
+                    # through. Deliberately NOT converted into a retryable error
+                    # on this path: after a 401 the manager's
+                    # ``_AuthChallengeWatcher`` has already latched, so a raise
+                    # here is reclassified as McpAuthChallengeError and blocks on
+                    # auth regardless. Changing that needs manager surgery, not a
+                    # different exception from here.
+                    self._strip_in_memory_refresh_token(self.context)
+                    return None
+            except Exception:  # noqa: BLE001 — best-effort; never break the request
+                # A failed re-read/refresh must not break the flow, and it must
+                # not leave a refreshable token for the SDK to POST unlocked
+                # either.
                 logger.debug(
-                    "MCP 401 token adoption failed for %s",
+                    "MCP 401 recovery failed for %s",
                     self._refresh_coord_server_url,
                     exc_info=True,
                 )
+                self._strip_in_memory_refresh_token(self.context)
                 return None
-            logger.debug(
-                "MCP 401 adoption retrying %s with a peer-rotated token",
-                self._refresh_coord_server_url,
-            )
-            return original_request
+
+        @staticmethod
+        def _strip_in_memory_refresh_token(ctx: Any) -> None:
+            """Drop the in-memory refresh token so the SDK cannot POST it unlocked.
+
+            Every refusal in this provider ends here, and the strip is what
+            makes the refusal COMPLETE rather than cosmetic: returning from
+            ``async_auth_flow`` hands the context to the SDK's own flow, whose
+            ``_refresh_token`` POSTs ``ctx.current_tokens.refresh_token``
+            directly — no lock, no re-read. ``can_refresh_token()`` reads False
+            once this is done, so the SDK skips its refresh branch and goes to
+            the authorization branch, which the non-interactive redirect handler
+            turns into an actionable McpAuthRequiredError. Suppressing OUR
+            refresh while leaving the token in place would keep the one harmful
+            POST and drop the harmless ones — strictly worse than not
+            suppressing at all, because it also looks fixed.
+            """
+            with contextlib.suppress(Exception):
+                if ctx.current_tokens is not None:
+                    ctx.current_tokens.refresh_token = None
 
     return _RefreshCoordinatingOAuthProvider(**kwargs)
 

--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -424,6 +424,23 @@ class McpRefreshContendedError(RuntimeError):
                 f"MCP OAuth token refresh for {server_url} could not be sent: the "
                 "token endpoint was unreachable, so no token was presented"
             )
+        # The two LOCAL codes get their own sentence rather than falling through
+        # to the lock's (review round 4, N4.1's sibling; QA round 3, Q2). The
+        # fall-through was untrue in the log for both: neither ran into another
+        # session's lock — ``unsent`` never had anything to present, and
+        # ``unattributed`` is our own coordination failing without any answer to
+        # blame. This is the LOG sentence only; the rendered copy is composed
+        # from the code by ``McpManager._auth_failure_text`` and is unchanged.
+        elif reason_code == REFRESH_REFUSAL_UNSENT:
+            message = (
+                f"MCP OAuth token refresh for {server_url} was not sent: the stored grant "
+                "held nothing to present (no refresh token, or no client registration)"
+            )
+        elif reason_code == REFRESH_REFUSAL_UNATTRIBUTED:
+            message = (
+                f"MCP OAuth token refresh for {server_url} did not complete, and the "
+                "outcome cannot be attributed to an answer from the authorization server"
+            )
         else:
             message = (
                 f"MCP OAuth token refresh for {server_url} was skipped: another "
@@ -3688,7 +3705,14 @@ async def ensure_mcp_oauth_fresh(
         outcome = await _refresh_oauth_token_locked(
             server_url, storage, endpoints, lock=lock, peer_refresh_is_success=True
         )
-        if outcome in ("contended", "overran", "failed", "unreachable", "unacknowledged"):
+        if outcome in (
+            "contended",
+            "overran",
+            "failed",
+            "unreachable",
+            "unacknowledged",
+            "unsent",
+        ):
             # Best-effort by contract: the connect proceeds and re-reads under
             # the lock on its next attempt. Each refusal already logged its own
             # reason at INFO, naming that writer — no second line here, because

--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -153,11 +153,12 @@ GRANT_DEAD_AT_KEY = "grant_dead_at"
 #: (:data:`UNCONFIRMED_SEND_TTL_S`) and why a connect-phase failure clears it.
 GRANT_UNCONFIRMED_SEND_KEY = "grant_refresh_unconfirmed"
 
-#: Outcome of one refresh attempt. Seven-valued rather than ``bool`` because each
+#: Outcome of one refresh attempt. Multi-valued rather than ``bool`` because each
 #: refusal has its OWN truthful user-visible message (lock contention, a budget
 #: overrun, a server that answered without a token, a token endpoint that could
-#: not be reached, a possibly-spent token needing a fresh sign-in) and because
-#: the coordinator must tell a DEAD grant (never present this token again) from a
+#: not be reached, a token that was never sent because the row held nothing to
+#: present, a possibly-spent token needing a fresh sign-in) and because the
+#: coordinator must tell a DEAD grant (never present this token again) from a
 #: merely FAILED one (transient; today's behaviour is correct).
 #: CAUTION: every member is a truthy string — every call site must compare
 #: against a member explicitly, never test truthiness.
@@ -169,6 +170,8 @@ RefreshOutcome = Literal[
     "overran",
     "unacknowledged",
     "unreachable",
+    "unsent",
+    "unattributed",
 ]
 
 #: Refresh this far BEFORE the stored access token's deadline. A connect that
@@ -249,11 +252,24 @@ UNCONFIRMED_SEND_TTL_S = 3600.0
 #: * ``REFRESH_REFUSAL_UNCONFIRMED`` — a token may already be spent (it was
 #:   presented, or an earlier presentation was never acknowledged), so nothing
 #:   may be presented until an interactive grant replaces it.
+#: * ``REFRESH_REFUSAL_UNSENT`` — the exchange ran and found nothing it could
+#:   present (no stored refresh token, or no client registration to authenticate
+#:   with), so NO request was made. It has its own code because the
+#:   ``REFRESH_REFUSAL_ENDPOINT`` text ("the server returned no token") is false
+#:   about both the wire and the server for a request that never left the
+#:   machine (review round 3, M2).
+#: * ``REFRESH_REFUSAL_UNATTRIBUTED`` — a failure of our OWN coordination (a
+#:   re-read that raised, a lock that could never be taken, the post-condition
+#:   finding nothing usable) which cannot be attributed to a server answer at
+#:   all. Same reason as ``UNSENT`` for existing: the honest statement names no
+#:   server, so no server may be blamed for it.
 REFRESH_REFUSAL_LOCK = "lock"
 REFRESH_REFUSAL_INFLIGHT = "inflight"
 REFRESH_REFUSAL_ENDPOINT = "endpoint"
 REFRESH_REFUSAL_UNREACHABLE = "unreachable"
 REFRESH_REFUSAL_UNCONFIRMED = "unconfirmed"
+REFRESH_REFUSAL_UNSENT = "unsent"
+REFRESH_REFUSAL_UNATTRIBUTED = "unattributed"
 
 #: Bound on ACQUIRING the cross-process refresh lock. The critical section it
 #: guards is one token POST, the response read that may outlive it, and a couple
@@ -314,8 +330,17 @@ class McpAuthRequiredError(RuntimeError):
     SENT but never confirmed (:class:`McpRefreshUnconfirmedError`). The
     manager's ``_auth_required_text`` renders it as the tail of the actionable
     line, so the command still comes first. ``None`` (the default) keeps the
-    generic "authorization expired" wording, which is the truthful summary for
-    every other route into this error: the stored grant could not be refreshed.
+    app's house wording for a dead credential (``sign-in expired``), which is
+    the truthful summary for every other route into this error: the stored grant
+    could not be refreshed.
+
+    ``log_detail`` is the SEPARATE sentence for ``str(self)`` when the rendered
+    tail has to be shorter than the technical fact (review round 3, N3).
+    ``detail`` is what a user reads on a card that clamps it twice; ``str()``
+    feeds the logs, where the mechanism is the thing support needs. The two
+    audiences were separated deliberately by the reason-code seam, and collapsing
+    them back into one string is what made a shortened tail also shorten the log
+    line.
 
     ``reason_code`` is the STABLE CODE for why (:data:`REFRESH_REFUSAL_LOCK` and
     friends), and it is the seam user-visible copy is composed from: the manager
@@ -334,11 +359,15 @@ class McpAuthRequiredError(RuntimeError):
         server_url: str,
         *,
         detail: str | None = None,
+        log_detail: str | None = None,
         reason_code: str | None = None,
     ) -> None:
         message = f"MCP OAuth authorization required for {server_url}"
-        if detail is not None:
-            message = f"{message}: {detail}"
+        # ``log_detail`` when given, so a tail trimmed for the card does not trim
+        # the sentence the log keeps — see the class docstring.
+        sentence = log_detail if log_detail is not None else detail
+        if sentence is not None:
+            message = f"{message}: {sentence}"
         super().__init__(message)
         self.server_url = server_url
         self.detail = detail
@@ -423,13 +452,24 @@ class McpRefreshUnconfirmedError(McpAuthRequiredError):
     keeps the toast truthful — a refresh that was SENT but never confirmed is not
     an expired authorization — and it is kept SHORT because it is the tail of a
     line the startup toast then clamps (`refresh unconfirmed`, where the previous
-    sentence-length wording was itself truncated off the card).
+    sentence-length wording was itself truncated off the card). ``log_detail``
+    carries the mechanism that tail used to carry, for ``str(self)`` and the logs
+    only: a truncated copy string is not a reason to lose the fact from an
+    incident log (review round 3, N3).
     """
 
     def __init__(self, server_url: str) -> None:
         super().__init__(
             server_url,
             detail="refresh unconfirmed",
+            # The technical fact the card cannot fit: the marker was armed before
+            # the POST, so a token WAS presented by an exchange whose answer
+            # never arrived. Restored here rather than in ``detail`` (N3) because
+            # the log is where support reads the mechanism.
+            log_detail=(
+                "a token refresh was sent but never confirmed, so the presented "
+                "refresh token may already be spent and will not be presented again"
+            ),
             reason_code=REFRESH_REFUSAL_UNCONFIRMED,
         )
         # We necessarily HOLD a grant for this server (the refusal exists because
@@ -775,6 +815,31 @@ class McpTokenStorage:
         data = row.data
         return dict(data) if isinstance(data, dict) else None
 
+    def _row_was_removed(self) -> bool:
+        """Whether this server's credential row is DEFINITIVELY gone (a logout).
+
+        The one question every writer that MUTATES an existing row has to answer
+        the same way, which is why it lives here rather than being open-coded at
+        each call site (review round 3, M1: a third writer was answering it with
+        ``self._read() or {}``, so a ``/mcp logout`` racing the refresh path was
+        silently undone by a marker write that re-created the row it had just
+        deleted).
+
+        The two-valued answer is deliberate, and ``has_stored_row`` is three-
+        valued for the same reason: ``None`` means the store could not be read,
+        which is NOT evidence of removal, so an unreadable store keeps writing.
+        Dropping a rotation costs at most one interactive sign-in while keeping a
+        spent token risks the whole family — this predicate only ever fires on a
+        removal we actually observed.
+
+        Only the MUTATORS ask: ``set_tokens``, ``set_client_info`` and
+        ``seed_client_info`` are the CREATION funnel (a completed interactive
+        grant, a dynamic registration, a pinned-client seed), where absence is
+        the normal state of a server being logged into for the first time and
+        refusing to write would break every first login.
+        """
+        return self._read() is None and self.has_stored_row() is False
+
     def _write(self, creds: dict[str, Any]) -> None:
         store = self._store
         if store is None:
@@ -956,7 +1021,7 @@ class McpTokenStorage:
         Returns ``True`` when the response was written.
         """
         creds = self._read()
-        if creds is None and self.has_stored_row() is False:
+        if self._row_was_removed():
             logger.info(
                 "MCP token refresh for %s was NOT persisted: the credential row was "
                 "removed while this exchange was in flight (a logout or reauth), so "
@@ -1001,7 +1066,24 @@ class McpTokenStorage:
 
         Best-effort like every other write here: a store failure must not stop
         the POST, and losing the marker just restores the pre-marker behaviour.
+
+        A row removed underneath us (a ``/mcp logout`` racing this exchange) is
+        NOT re-created, which is the symmetry ``store_refresh_result`` and
+        ``mark_grant_dead`` already keep: an explicitly removed credential stays
+        removed, and a marker arming a presentation for a row that no longer
+        exists protects nothing. The refusal is logged at INFO rather than
+        silently swallowed, because a refresh running against a deleted row is
+        something support has to be able to read out of the log.
         """
+        if self._row_was_removed():
+            logger.info(
+                "MCP send marker for %s was NOT armed: the credential row was removed "
+                "while this exchange was being set up (a logout or reauth), so the "
+                "removal is honoured rather than re-created "
+                "[writer: McpTokenStorage.mark_send_unconfirmed]",
+                self.server_url,
+            )
+            return
         creds = self._read() or {}
         creds[GRANT_UNCONFIRMED_SEND_KEY] = {
             "digest": _refresh_token_digest(presented_refresh_token),
@@ -1166,7 +1248,10 @@ class McpTokenStorage:
         introducing a second write primitive.
 
         Returns ``True`` when the marker was written, ``False`` when it was
-        skipped or the write failed.
+        skipped or the write failed. A row removed underneath us (a racing
+        ``/mcp logout``) is the ``False`` case, whatever the token argument: the
+        removal is honoured, which is the answer its two sibling mutators give
+        too (review round 3, M1).
 
         Its caller :func:`_perform_refresh_exchange` holds
         :func:`_oauth_refresh_lock` for the whole call, and writes through the
@@ -1181,6 +1266,19 @@ class McpTokenStorage:
         detached exchange wrote with no lock at all; it does not any more.
         """
         try:
+            if self._row_was_removed():
+                # Same answer as its two siblings, for the same reason (review
+                # round 3, M1): a tombstone on a row the user just deleted is
+                # re-creating the credential the removal asked us to forget. The
+                # freshness compare below only covers the case where a token IS
+                # given; without this guard the no-token call re-created the row.
+                logger.info(
+                    "MCP dead-grant marker for %s was NOT written: the credential row "
+                    "was removed (a logout or reauth), so the removal is honoured "
+                    "rather than re-created [writer: McpTokenStorage.mark_grant_dead]",
+                    self.server_url,
+                )
+                return False
             creds = self._read() or {}
             if rejected_refresh_token is not None and not _payload_holds_refresh_token(
                 creds, rejected_refresh_token
@@ -3096,11 +3194,13 @@ async def _refresh_oauth_token_locked(
     spent with the exchange still running; a rotation that still lands is
     persisted), ``"unreachable"`` (the request never reached the wire, so
     nothing was presented and there is nothing to keep — a pre-send transport
-    failure, which is NOT a server rejection), ``"unacknowledged"`` (a token may
-    already be spent, so nothing was or may be presented until an interactive
-    grant), and ``"failed"`` for every other outcome, including "nothing to
-    refresh". Callers MUST compare against a member: every member is a truthy
-    string.
+    failure, which is NOT a server rejection), ``"unsent"`` (the row held
+    nothing this exchange could present, so no request was made — its own member
+    because a server may not be blamed for an answer it was never asked for),
+    ``"unacknowledged"`` (a token may already be spent, so nothing was or may be
+    presented until an interactive grant), and ``"failed"`` for an exchange the
+    server ANSWERED without a usable token. Callers MUST compare against a
+    member: every member is a truthy string.
 
     The caller holds the cross-process refresh lock and passes its HANDLE, which
     this function hands to the exchange task before its first cancellable await.
@@ -3278,8 +3378,11 @@ async def _perform_refresh_exchange(
         client_info = await storage.get_client_info()
         if tokens is None or not tokens.refresh_token or client_info is None:
             # Nothing to spend — a missing token is not evidence that the grant
-            # is dead, so this must never tombstone.
-            return "failed"
+            # is dead, so this must never tombstone. Its OWN outcome rather than
+            # "failed": no request is made on this path at all, and "failed" is
+            # composed for the user as the endpoint code, whose text blames the
+            # server for an answer it never gave (review round 3, M2).
+            return "unsent"
 
         if storage.grant_is_dead():
             # A grant the authorization server already rejected must cost no
@@ -3885,7 +3988,12 @@ def _make_refresh_coordinating_provider(
                     exc_info=True,
                 )
                 await self._adopt_freshest_stored_token(ctx)
-                outcome = "failed"
+                # NOT "failed". This arm is a LOCAL failure — a re-read that
+                # raised, a lock that could never be taken, an unexpected raise —
+                # so nothing here knows what a server did or did not answer, and
+                # the endpoint copy would blame one for a request that may never
+                # have gone out (review round 3, M2).
+                outcome = "unattributed"
             # The OUTCOMES are decided out here, deliberately: a refusal is a
             # DECISION, not a failure, and raising it inside the ``try`` above
             # would let the ``except Exception`` arm swallow it — which would put
@@ -3914,7 +4022,7 @@ def _make_refresh_coordinating_provider(
                 # reuse-detection POST. The honest disposition is an interactive
                 # sign-in, not a retry — see McpRefreshUnconfirmedError.
                 self._refuse_unconfirmed_exchange(ctx)
-            elif outcome in ("contended", "overran", "failed", "unreachable"):
+            elif outcome in ("contended", "overran", "failed", "unreachable", "unsent"):
                 self._refuse_unlocked_refresh(ctx, outcome)
             # POST-CONDITION, in ONE place so no exit path can miss it: we are
             # about to return into ``async_auth_flow``, whose very next act is to
@@ -3923,21 +4031,28 @@ def _make_refresh_coordinating_provider(
             # POST its in-memory refresh token with no lock and no re-read — the
             # unlocked spend this whole method exists to prevent. Refuse instead.
             #
-            # ``"failed"`` is the default reason rather than the lock: this arm
-            # is reached when the exchange ran (or could not be attributed to a
-            # single cause) and left nothing usable, and the message says the
-            # authorization server's answer was not a usable token.
-            self._refuse_unlocked_refresh(ctx, "failed")
+            # ``"unattributed"`` is the default reason rather than the endpoint
+            # code: this arm is reached when the exchange ran (or could not be
+            # attributed to a single cause) and left nothing usable, and NOTHING
+            # here establishes that a server answered us — the endpoint code's
+            # "the server returned no token" is a claim about a request that may
+            # never have gone out (review round 3, M2). The endpoint code is
+            # carried EXPLICITLY by the one outcome that did get an answer.
+            self._refuse_unlocked_refresh(ctx, "unattributed")
 
-        def _refuse_unlocked_refresh(self, ctx: Any, outcome: str = "failed") -> None:
+        def _refuse_unlocked_refresh(self, ctx: Any, outcome: str = "unattributed") -> None:
             """Never hand the SDK an in-memory refresh token we failed to refresh.
 
             The post-condition of :meth:`_coordinate_inflight_refresh`, called
             once at the end so no exit path can skip it. Reaching here with an
             invalid-but-refreshable context means coordination did not produce
             a working token this time (the lock was unavailable, the exchange
-            overran the connect's budget, the refresh returned ``"failed"``, or
-            the fall-through could not find a fresher stored one).
+            overran the connect's budget, the row held nothing it could present,
+            the server answered without a usable token, or our own re-read/lock
+            handling raised). The parameter DEFAULTS to the unattributed reason
+            for the last of those: a caller that forgets to pass one gets the
+            honest generic rather than the endpoint wording, which asserts
+            something about a server it has not established.
             ``async_auth_flow`` returns straight into the SDK's own flow at that
             point, and the SDK's ``_refresh_token`` POSTs
             ``ctx.current_tokens.refresh_token`` DIRECTLY — no lock, no re-read —
@@ -3969,16 +4084,19 @@ def _make_refresh_coordinating_provider(
             if not ctx.can_refresh_token() or ctx.is_token_valid():
                 return
             self._strip_in_memory_refresh_token(ctx)
-            # ``.get``'s default is the ANSWERED-but-unusable case, which is what
-            # every remaining outcome ("failed", and the post-condition's
-            # fall-through) actually is. ``unreachable`` must be listed: without
-            # its own arm a request that never left the machine would be reported
-            # to the user as a server refusal.
+            # Every code is listed EXPLICITLY, including the two local shapes,
+            # and the default is the UNATTRIBUTED code rather than the
+            # endpoint's. "failed" is the one outcome that DID get an answer (a
+            # non-200 carrying no usable token), so blaming the server is its
+            # alone to make: a request that never left the machine must never be
+            # rendered as a server refusal (review round 3, M2).
             reason_code = {
                 "contended": REFRESH_REFUSAL_LOCK,
                 "overran": REFRESH_REFUSAL_INFLIGHT,
                 "unreachable": REFRESH_REFUSAL_UNREACHABLE,
-            }.get(outcome, REFRESH_REFUSAL_ENDPOINT)
+                "unsent": REFRESH_REFUSAL_UNSENT,
+                "failed": REFRESH_REFUSAL_ENDPOINT,
+            }.get(outcome, REFRESH_REFUSAL_UNATTRIBUTED)
             # ARM THE SIDE CHANNEL BEFORE RAISING, and do it here rather than in
             # the raise's caller: the MCP transport will NOT deliver this error.
             # It runs the request inside anyio cancel scopes, so the raise

--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -10,9 +10,12 @@ Flow (official SDK PKCE + RFC 7591 DCR under the hood):
   server's OAuth metadata (PRM + ASM discovery). This is what stops a day-old
   token from forcing a browser grant on startup for providers whose token
   endpoint is not ``<server_base>/token`` (the SDK's fallback guess 404s for
-  e.g. Datadog). The refresh is serialized across processes with a file lock
-  and the token is re-read under it, so concurrently starting sessions cannot
-  spend a rotating refresh token twice.
+  e.g. Datadog). The refresh is serialized across processes with a file lock,
+  and the exchange task OWNS that lock from its acquire to its store write —
+  the connect only passes the handle over — so a cancelled or over-budget
+  connect cannot free it while the POST is still on the wire, and the token is
+  re-read under it, so concurrently starting sessions cannot spend a rotating
+  refresh token twice.
 - ``wire_oauth_auth(server_url, cfg)`` returns the ``OAuthClientProvider``
   kwargs: client metadata with a loopback redirect URI, a token storage bound
   to the shared credential store, and a :class:`LoopbackAuthFlow` that
@@ -60,6 +63,8 @@ from local_operator.callback_page import callback_response
 from local_operator.interpreter import python_argv
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     # The SDK is an optional extra: these names are needed for annotations
     # only, so importing them here keeps this module importable without it.
     from mcp.shared.auth import (
@@ -118,17 +123,51 @@ TOKENS_OBTAINED_AT_KEY = "tokens_obtained_at"
 #:
 #: Living in the row payload makes it atomic with the grant it describes:
 #: :meth:`McpTokenStorage.clear` deletes it with the row, and
-#: :meth:`McpTokenStorage.set_tokens` clears it on any successful token write, so
+#: :meth:`McpTokenStorage.set_tokens` clears it on an INTERACTIVE token write, so
 #: there is no way to leave a tombstone pointing at a token that no longer
 #: exists. It needs no migration — the payload already round-trips unknown keys.
+#:
+#: :meth:`McpTokenStorage.store_refresh_result` deliberately does NOT clear it.
+#: Only an interactive grant (login/reauth) may un-dead a grant: a token minted
+#: by a refresh belongs to the family the marker says the authorization server
+#: revoked, so a late refresh response landing after a tombstone must leave the
+#: grant reading DEAD rather than resurrect it.
 GRANT_DEAD_AT_KEY = "grant_dead_at"
 
-#: Outcome of one locked refresh attempt. Three-valued rather than ``bool``
-#: because the coordinator must tell a DEAD grant (never present this token
+#: Payload key recording that THIS row's refresh token was PRESENTED by an
+#: exchange whose outcome never arrived — the request may have been written and
+#: the token spent, and re-presenting a spent token is the reuse-detection POST
+#: that revokes the whole family. Value is
+#: ``{"digest": <short digest of the presented token>, "at": <epoch seconds>}``.
+#:
+#: Why a DIGEST rather than the token: the marker only ever answers "is the
+#: token in this row the one an exchange is unsure about?", and a digest keeps
+#: the payload from carrying the same live credential twice. It is not a
+#: confidentiality measure — the token itself lives in the same row.
+#:
+#: Why it is ARMED BEFORE THE POST: a process that dies mid-request takes its
+#: in-memory knowledge with it, and the next boot would present a token that may
+#: already be spent. The write-ahead marker is the only channel that survives
+#: that death. The price is a false positive in the narrow window between the
+#: arm and the wire, which is why the marker EXPIRES
+#: (:data:`UNCONFIRMED_SEND_TTL_S`) and why a connect-phase failure clears it.
+GRANT_UNCONFIRMED_SEND_KEY = "grant_refresh_unconfirmed"
+
+#: Outcome of one refresh attempt. Six-valued rather than ``bool`` because each
+#: refusal has its OWN truthful user-visible message (lock contention, a budget
+#: overrun, a server refusal, a possibly-spent token needing a fresh sign-in)
+#: and because the coordinator must tell a DEAD grant (never present this token
 #: again) from a merely FAILED one (transient; today's behaviour is correct).
-#: CAUTION: ``"failed"`` is a truthy string — every call site must compare
+#: CAUTION: every member is a truthy string — every call site must compare
 #: against a member explicitly, never test truthiness.
-RefreshOutcome = Literal["refreshed", "failed", "dead"]
+RefreshOutcome = Literal[
+    "refreshed",
+    "failed",
+    "dead",
+    "contended",
+    "overran",
+    "unacknowledged",
+]
 
 #: Refresh this far BEFORE the stored access token's deadline. A connect that
 #: starts with a token dying in ten seconds would otherwise open with a 401 and
@@ -142,49 +181,81 @@ REFRESH_SKEW_S = 60.0
 REFRESH_HTTP_TIMEOUT_S = 10.0
 
 #: How long PAST the refresh budget a token response is still accepted and
-#: persisted. The budget above caps how long a CONNECT — and the cross-process
-#: lock it holds — waits for a refresh. It must not also cap how long the
-#: response stays welcome, because for a rotating provider the response is the
-#: ONLY copy of the new refresh token: discarding a rotation the server has
-#: already performed leaves a spent token stored, and the next presentation of
-#: that token is a reuse-detection double-spend that revokes the whole family.
-#:
-#: WHAT IT BOUNDS, precisely: the response READ of one exchange task that has
-#: outlived the connect that started it. It is not a lock budget and not a
-#: connect budget. The lock is still held for at most ``REFRESH_HTTP_TIMEOUT_S``
-#: (``_refresh_oauth_token_locked`` shields the exchange behind
-#: ``asyncio.timeout(REFRESH_HTTP_TIMEOUT_S)`` and returns at that bound), so
-#: ``LOCK_ACQUIRE_TIMEOUT_S``'s derivation — that the critical section cannot
-#: outlast the POST cap — still holds and is unaffected by this constant. A
-#: CANCELLED connect waits only for the REMAINDER of the budget while a rotation
-#: is actually in flight, never for this grace, so teardown is never held longer
-#: than it already could be; by the time this grace is running, no connect and
-#: no lock is waiting on the result.
+#: persisted. What it bounds, precisely: the response READ of the exchange task
+#: once the connect that started it has given up waiting. It is not a connect
+#: budget. The exchange still OWNS the refresh lock while this grace runs (the
+#: lock is acquired and released INSIDE the exchange task — see
+#: :func:`_perform_refresh_exchange` — precisely so a waiter's cancellation or
+#: timeout cannot free it mid-POST), so a holder's critical section is bounded by
+#: ``REFRESH_HTTP_TIMEOUT_S + REFRESH_LATE_RESPONSE_GRACE_S``; that is longer
+#: than ``LOCK_ACQUIRE_TIMEOUT_S``, deliberately, and the derivation comment
+#: there states why giving up instead of waiting is safe. A CANCELLED connect
+#: detaches immediately and never waits for this grace, so teardown latency is
+#: not paid out of the budget any more.
 #:
 #: Finite on purpose: a server that never answers must not leave a task reading
 #: a socket for the life of the process.
 REFRESH_LATE_RESPONSE_GRACE_S = 30.0
 
-#: Bound on ACQUIRING the cross-process refresh lock, derived from the budget of
-#: the critical section it guards: one token POST plus a couple of SQLite reads.
-#: That derivation is only sound because the POST is capped in TOTAL wall time
-#: (see the ``asyncio.timeout`` in :func:`_refresh_oauth_token_locked`) —
-#: ``httpx.Timeout(REFRESH_HTTP_TIMEOUT_S)`` alone does NOT bound a request:
+#: How long a "presented but unacknowledged" send marker stays live (see
+#: :data:`GRANT_UNCONFIRMED_SEND_KEY`).
+#:
+#: The marker exists to stop us re-presenting a token an exchange may already
+#: have spent, and the price of believing it is one interactive sign-in, so it
+#: must be BOUNDED. A marker armed in the window between the marker write and
+#: the request reaching the wire (a crash, a refused connection) describes a
+#: token nothing ever presented, and a marker that never expired would suppress
+#: that server's refresh until the user happened to re-auth — the "bricked
+#: server" failure mode. An hour covers a restart, a slow session or a user who
+#: stepped away, and after it lapses we present the stored token again, which is
+#: exactly the behaviour every boot had BEFORE this marker existed. So the
+#: expiry can only degrade to the status quo ante, never to something worse.
+UNCONFIRMED_SEND_TTL_S = 3600.0
+
+#: Why a refresh was refused — one value per truthful user-visible message (see
+#: :class:`McpRefreshContendedError` and :class:`McpRefreshUnconfirmedError`).
+#: The manager re-voices a transport-mangled cancellation from these and the
+#: tests assert the rendered copy verbatim, so the set is closed and short.
+#:
+#: * ``REFRESH_REFUSAL_LOCK`` — no exclusivity, so nothing was presented.
+#: * ``REFRESH_REFUSAL_INFLIGHT`` — the exchange outran the connect's budget and
+#:   is still running; a late rotation will still be persisted.
+#: * ``REFRESH_REFUSAL_ENDPOINT`` — the exchange ran and the authorization
+#:   server's answer was not a usable token.
+#: * ``REFRESH_REFUSAL_UNCONFIRMED`` — a token may already be spent (it was
+#:   presented, or an earlier presentation was never acknowledged), so nothing
+#:   may be presented until an interactive grant replaces it.
+REFRESH_REFUSAL_LOCK = "lock"
+REFRESH_REFUSAL_INFLIGHT = "inflight"
+REFRESH_REFUSAL_ENDPOINT = "endpoint"
+REFRESH_REFUSAL_UNCONFIRMED = "unconfirmed"
+
+#: Bound on ACQUIRING the cross-process refresh lock. The critical section it
+#: guards is one token POST, the response read that may outlive it, and a couple
+#: of SQLite reads — and since the exchange task owns the lock for all of that,
+#: its worst case is ``REFRESH_HTTP_TIMEOUT_S + REFRESH_LATE_RESPONSE_GRACE_S``
+#: (40s), which EXCEEDS this bound. That inversion is deliberate and safe, and
+#: it is why this constant can no longer be derived as "longer than the work".
+#: A waiter that gives up here does not proceed unlocked: it takes the contended
+#: path (strip the in-memory refresh token, raise
+#: :class:`McpRefreshContendedError`), which the manager retries on its backoff
+#: ladder, and the holder's rotation still reaches the store. Presenting a
+#: rotating token without exclusivity is the family-revoking POST, so waiting is
+#: never the safe option; bounding the wait is.
+#:
+#: The POST is still capped in TOTAL wall time (``asyncio.timeout`` in
+#: :func:`_refresh_oauth_token_locked`, which bounds how long the caller waits)
+#: — ``httpx.Timeout(REFRESH_HTTP_TIMEOUT_S)`` alone does NOT bound a request:
 #: it is per operation, and its read timeout is per socket read, so a dribbling
-#: server measured 140.7s inside a nominal 10s timeout. The lock's critical
-#: section is therefore bounded by the ``asyncio.timeout`` in
-#: ``_refresh_oauth_token_locked`` instead — the exchange runs as a shielded
-#: task and the coroutine that HOLDS THE LOCK returns at that bound. Keep the
-#: two in step: if the POST's overall cap is ever raised or removed, this bound
-#: stops being honest and a slow-but-working peer starts getting timed out by
-#: its own siblings. (The exchange task may keep READING its response past that
-#: bound — ``REFRESH_LATE_RESPONSE_GRACE_S`` — but by then it holds no lock and
-#: nobody is waiting on it, which is why the derivation still holds.)
-#: Overrunning this bound therefore means the holder really is not working — a
-#: leaked lock from a killed process, or a peer wedged on something that is not
-#: our problem. Waiting longer than the work can possibly take buys nothing and
-#: costs a hung connect, so we give up and degrade (see
-#: :func:`_oauth_refresh_lock`, which yields False rather than raising).
+#: server measured 140.7s inside a nominal 10s timeout.
+#:
+#: Overrunning this bound therefore means the holder is either doing the one
+#: thing it may legitimately do for longer than we will wait (a late response
+#: read) or is not working at all — a leaked lock from a killed process, or a
+#: peer wedged on something that is not our problem. Both are answered the same
+#: way: give up and degrade (see :func:`_oauth_refresh_lock`, which yields a
+#: FALSY handle rather than raising), because a hung connect is worse than a
+#: retried one.
 LOCK_ACQUIRE_TIMEOUT_S = 15.0
 
 #: FIRST gap between non-blocking lock attempts, and the cancellation
@@ -212,26 +283,46 @@ class McpAuthRequiredError(RuntimeError):
     sessions starting at once would each pop one. The connect fails with an
     actionable message instead; ``/mcp login <name>`` (or
     ``local-operator mcp login <name>``) runs the same grant deliberately.
+
+    ``detail`` names WHY the grant is unusable when the reason is specific
+    enough to be worth telling the user — today only a token refresh that was
+    SENT but never confirmed (:class:`McpRefreshUnconfirmedError`). The
+    manager's ``_auth_required_text`` renders it as the tail of the actionable
+    line, so the command still comes first. ``None`` (the default) keeps the
+    generic "authorization expired" wording, which is the truthful summary for
+    every other route into this error: the stored grant could not be refreshed.
     """
 
-    def __init__(self, server_url: str) -> None:
-        super().__init__(f"MCP OAuth authorization required for {server_url}")
+    def __init__(self, server_url: str, *, detail: str | None = None) -> None:
+        message = f"MCP OAuth authorization required for {server_url}"
+        if detail is not None:
+            message = f"{message}: {detail}"
+        super().__init__(message)
         self.server_url = server_url
+        self.detail = detail
 
 
 class McpRefreshContendedError(RuntimeError):
-    """A refresh could not be performed under the refresh lock this time.
+    """A refresh was NOT performed this time, and why.
 
     Raised instead of falling through to the SDK's own UNLOCKED refresh, which
     reads the in-memory token directly and would present a possibly-already-
     rotated refresh token — the family-revoking request this subsystem exists to
     prevent. Deliberately NOT a subclass of :class:`McpAuthRequiredError` and
-    deliberately not raised anywhere near a grant that is known dead: this is a
-    CONTENTION/transient outcome, so the manager's generic reconnect arm retries
-    it with backoff and never takes an auth block on it. The in-memory refresh
-    token is stripped before the raise (see
+    deliberately never raised for a grant that is known dead: this is a
+    transient outcome, so the manager's generic reconnect arm retries it with
+    backoff and never takes an auth block on it. The in-memory refresh token is
+    stripped before the raise (see
     ``_RefreshCoordinatingOAuthProvider._refuse_unlocked_refresh``) so the
     suppressed SDK refresh cannot run either way.
+
+    One message per ``refusal``, because the three paths that reach it say
+    different things and a single string was untrue on two of them: the lock
+    being held elsewhere is not a server refusal, and a server that ANSWERED
+    500 did not fail "under the refresh lock". It also deliberately does NOT
+    promise a retry: the mid-session reconnect path does retry with backoff,
+    but the startup gate renders this same string as the reason a server is
+    unavailable and schedules no retry there.
 
     This type reaches the manager INDIRECTLY. The MCP streamable-HTTP transport
     runs the request inside anyio cancel scopes, so an exception raised out of
@@ -243,12 +334,60 @@ class McpRefreshContendedError(RuntimeError):
     caller) see the raise itself.
     """
 
+    def __init__(self, server_url: str, *, refusal: str = REFRESH_REFUSAL_LOCK) -> None:
+        if refusal == REFRESH_REFUSAL_INFLIGHT:
+            message = (
+                f"MCP OAuth token refresh for {server_url} did not finish in time; "
+                "a rotation is kept if the response lands"
+            )
+        elif refusal == REFRESH_REFUSAL_ENDPOINT:
+            message = (
+                f"MCP OAuth token refresh for {server_url} was rejected by the "
+                "authorization server"
+            )
+        else:
+            message = (
+                f"MCP OAuth token refresh for {server_url} was skipped: another "
+                "session holds the refresh lock"
+            )
+        super().__init__(message)
+        self.server_url = server_url
+        self.refusal = refusal
+
+
+class McpRefreshUnconfirmedError(McpAuthRequiredError):
+    """A refresh token was PRESENTED by an exchange whose outcome never arrived.
+
+    The one thing a rotating provider must never see again is a token that may
+    already have been spent: re-presenting it is the reuse-detection POST that
+    revokes the entire family, every session included. So the refresh path
+    refuses to POST while its row still holds a token an unacknowledged exchange
+    presented (see :data:`GRANT_UNCONFIRMED_SEND_KEY`), and this error is the
+    honest alternative to a retry: a transient retry would spend the token
+    again, so the recovery is one interactive sign-in.
+
+    Subclassing :class:`McpAuthRequiredError` rather than standing alone is the
+    point, not a shortcut: the disposition IS "this server needs an interactive
+    grant", so it takes the auth block, the actionable toast and the abandoned
+    auto-reconnect that every other auth requirement takes. ``detail`` is what
+    keeps the toast truthful — a refresh that was SENT but never confirmed is not
+    an expired authorization.
+    """
+
     def __init__(self, server_url: str) -> None:
         super().__init__(
-            f"MCP OAuth token refresh for {server_url} could not be performed "
-            "under the refresh lock; retrying"
+            server_url,
+            detail="a token refresh was sent but never confirmed",
         )
-        self.server_url = server_url
+        # We necessarily HOLD a grant for this server (the refusal exists because
+        # its stored refresh token may have been spent), so the user-visible
+        # command is ``reauth`` — replace the credential — not ``login``, which
+        # would leave the stale one in place. Carried on the error rather than
+        # left to ``_auth_required_text``'s store lookup for the reason that
+        # helper documents: the lookup answers about the DEFAULT store, while
+        # this fact was established against the store this connect is actually
+        # using (F4).
+        self.has_stored_grant = True
 
 
 class McpAuthChallengeError(RuntimeError):
@@ -659,13 +798,19 @@ class McpTokenStorage:
     async def set_tokens(self, tokens: OAuthToken) -> None:
         """Persist fresh/refreshed tokens (access + refresh together).
 
-        This is the SDK's ``TokenStorage`` write and stays UNCONDITIONAL: the
-        SDK's own refresh, a completed browser grant and a pinned-client seed
-        all land here, and none of them has a rotation to compare against. That
-        leaves a residual race recorded in the PR rather than fixed here: a
-        sibling that persists its own rotation between this read and this write
-        loses it. It cannot tombstone a live grant (the marker write is the one
-        that does that, and it compares — see :meth:`mark_grant_dead`).
+        This is the SDK's ``TokenStorage`` write, and after this PR it is the
+        INTERACTIVE funnel: a completed browser grant, a pinned-client seed, and
+        the SDK's own in-flow refresh (which the coordinating provider suppresses
+        — see :class:`McpRefreshContendedError`). It stays UNCONDITIONAL because
+        none of those has a rotation to compare against, and clearing the
+        dead-grant tombstone is correct for all of them: they all mean "a working
+        grant was obtained", which is the one thing that may un-dead a server.
+
+        The refresh path does NOT come through here: it calls
+        :meth:`store_refresh_result`, which conditions its write on the grant it
+        was computed from and never clears the tombstone. Routing a refresh
+        response through this method is what let a detached exchange's late HTTP
+        200 resurrect a family the authorization server had already revoked.
 
         The issuing WALL-CLOCK time is written alongside them. ``OAuthToken``
         carries only the relative ``expires_in`` the server quoted, which is
@@ -684,7 +829,154 @@ class McpTokenStorage:
         # browser grant, and a refresh that unexpectedly succeeds), so a login
         # path added later cannot forget to un-stick a suppressed server.
         creds.pop(GRANT_DEAD_AT_KEY, None)
+        # A new interactive grant also answers any outstanding "was that token
+        # spent?" question, so the send marker goes with it. Keeping it would
+        # suppress the FIRST refresh of the brand-new grant — a false positive
+        # the user pays for with another browser visit.
+        creds.pop(GRANT_UNCONFIRMED_SEND_KEY, None)
         self._write(creds)
+
+    def store_refresh_result(self, tokens: OAuthToken, *, presented_refresh_token: str) -> bool:
+        """Persist a refresh response, but only into the grant it was computed from.
+
+        The refresh path used to write through :meth:`set_tokens`, which is
+        unconditional, so a response that landed after a later, better-informed
+        verdict overwrote it. Two measured consequences, both the reuse-storm
+        this module exists to prevent: a detached exchange's late HTTP 200
+        cleared a tombstone another exchange had just written (a revoked family
+        reading ALIVE, so every later boot re-POSTed it), and the same late write
+        erased a rotation a peer had persisted in between. An error BEFORE this
+        path could not fix it either: with two slow exchanges the tombstone's own
+        compare-and-skip saw the row moved and never wrote the marker at all,
+        because the row it inspected had itself been moved by an exchange the
+        revocation invalidated.
+
+        So the write re-reads the row immediately before writing and persists
+        only while the payload still holds the refresh token THIS exchange
+        presented. A row that is gone entirely is re-created: absence is not
+        evidence that somebody replaced the grant, and the rotation is still
+        ours to keep.
+
+        Two disciplines separate this from :meth:`set_tokens`:
+
+        * the dead-grant marker is NEVER cleared here. Only an interactive grant
+          may un-dead a grant; a refresh-derived token is exactly the thing the
+          marker says the authorization server revoked, so clearing it would
+          resurrect a family it has already killed. The write still happens —
+          the rotation is real and worth keeping for support — and the marker
+          keeps it from ever being presented.
+        * a dropped write is logged at INFO, naming this writer. A lost rotation
+          is what support has to be able to read out of the log after an
+          incident; it is never a debug detail.
+
+        Caller: :func:`_perform_refresh_exchange`, which holds the refresh lock
+        across this call, so the only writers it races are the ones that
+        deliberately do not take the lock (a completed interactive login, the
+        SDK's client-info writes).
+
+        Returns ``True`` when the response was written.
+        """
+        creds = self._read()
+        if creds is not None and not _payload_holds_refresh_token(creds, presented_refresh_token):
+            logger.info(
+                "MCP token refresh for %s was NOT persisted: the stored grant moved on "
+                "(another writer rotated it first), so the newer state is left "
+                "untouched [writer: McpTokenStorage.store_refresh_result]",
+                self.server_url,
+            )
+            return False
+        creds = creds or {}
+        creds["tokens"] = tokens.model_dump(mode="json")
+        creds[TOKENS_OBTAINED_AT_KEY] = time.time()
+        # The exchange DID get an answer, so any write-ahead send marker is
+        # resolved by construction: the response is the acknowledgement.
+        creds.pop(GRANT_UNCONFIRMED_SEND_KEY, None)
+        if GRANT_DEAD_AT_KEY in creds:
+            logger.info(
+                "MCP token refresh for %s persisted a rotation while its grant is marked "
+                "dead; the dead-grant marker is KEPT so the token is never presented "
+                "[writer: McpTokenStorage.store_refresh_result]",
+                self.server_url,
+            )
+        self._write(creds)
+        return True
+
+    def mark_send_unconfirmed(self, presented_refresh_token: str) -> None:
+        """Arm the write-ahead marker for a token an exchange is about to present.
+
+        Called BEFORE the POST is written, while the refresh lock is held: that
+        ordering is the whole point. A process that dies between the write and
+        the response takes all in-memory knowledge with it, and the next boot
+        would present a token the server may already have spent — the
+        reuse-detection POST that revokes the family. The marker is the only
+        channel that survives that death.
+
+        Best-effort like every other write here: a store failure must not stop
+        the POST, and losing the marker just restores the pre-marker behaviour.
+        """
+        creds = self._read() or {}
+        creds[GRANT_UNCONFIRMED_SEND_KEY] = {
+            "digest": _refresh_token_digest(presented_refresh_token),
+            "at": time.time(),
+        }
+        self._write(creds)
+
+    def clear_send_unconfirmed(self) -> None:
+        """Resolve the send marker: the exchange reached an ANSWER for its token.
+
+        Called for any HTTP response (the server answered, so it either
+        rotated-and-told-us or refused without rotating) and for a connect-phase
+        failure (the token never reached the wire). Deliberately NOT called when
+        the request was written and no answer arrived, which is exactly the state
+        the marker describes.
+        """
+        creds = self._read()
+        if creds is None or GRANT_UNCONFIRMED_SEND_KEY not in creds:
+            return
+        creds.pop(GRANT_UNCONFIRMED_SEND_KEY, None)
+        self._write(creds)
+
+    def send_unconfirmed(self, refresh_token: str | None = None) -> bool:
+        """Whether a LIVE marker says ``refresh_token`` may already be spent.
+
+        ``refresh_token`` defaults to the stored one, which is the question the
+        refresh path asks before it POSTs. A marker whose digest does not match
+        is STALE — a peer has rotated the row since — and is cleared on the way
+        past rather than believed: suppressing a healthy, newly rotated token
+        because of an unrelated send is a false positive the user pays for with a
+        browser visit. Expiry is applied the same way, so a marker that never
+        resolved cannot suppress a server's refresh indefinitely (see
+        :data:`UNCONFIRMED_SEND_TTL_S`).
+
+        Read-modify-write, like :meth:`mark_grant_dead` and for the same reason:
+        clearing a stale marker is part of answering the question, and a stale
+        marker left in place would be re-evaluated (and re-cleared) forever.
+        """
+        creds = self._read()
+        if creds is None:
+            return False
+        marker = creds.get(GRANT_UNCONFIRMED_SEND_KEY)
+        if not isinstance(marker, dict):
+            if marker is not None:
+                # A malformed marker cannot be compared against anything, so it
+                # can never be believed; drop it rather than keep consulting it.
+                self.clear_send_unconfirmed()
+            return False
+        target = refresh_token
+        if target is None:
+            stored = creds.get("tokens")
+            target = stored.get("refresh_token") if isinstance(stored, dict) else None
+        at = marker.get("at")
+        digest = marker.get("digest")
+        live = (
+            isinstance(at, (int, float))
+            and not isinstance(at, bool)
+            and 0 <= time.time() - at <= UNCONFIRMED_SEND_TTL_S
+        )
+        if live and isinstance(target, str) and target and digest == _refresh_token_digest(target):
+            return True
+        self.clear_send_unconfirmed()
+        return False
 
     def grant_marker(self) -> tuple[float, bool] | None:
         """``(tokens_obtained_at, grant_is_dead)``, or ``None`` if unreadable.
@@ -777,12 +1069,17 @@ class McpTokenStorage:
         Returns ``True`` when the marker was written, ``False`` when it was
         skipped or the write failed.
 
-        Its caller :func:`_refresh_oauth_token_locked` holds
-        :func:`_oauth_refresh_lock`; the remaining gap is against writers that
+        Its caller :func:`_perform_refresh_exchange` holds
+        :func:`_oauth_refresh_lock` for the whole call, and writes through the
+        same lock the FRESHNESS-conditioned sibling write uses
+        (:meth:`store_refresh_result`), so the two can never disagree about
+        which writer owns the grant; the remaining gap is against writers that
         deliberately do NOT take the lock — the interactive-login completion and
         the client-info writes that go through the SDK — so this narrows the
         window to the microseconds between the compare and the write instead of
-        the whole exchange.
+        the whole exchange. The gap used to be bounded by
+        :data:`REFRESH_LATE_RESPONSE_GRACE_S`, not by microseconds, because the
+        detached exchange wrote with no lock at all; it does not any more.
         """
         try:
             creds = self._read() or {}
@@ -1036,6 +1333,70 @@ def _payload_holds_refresh_token(payload: dict[str, Any] | None, refresh_token: 
     if not isinstance(tokens, dict):
         return False
     return tokens.get("refresh_token") == refresh_token
+
+
+def _refresh_token_digest(refresh_token: str) -> str:
+    """Short stable digest of one refresh token, for the send marker.
+
+    Never a credential in its own right: it only ever answers "is the token in
+    this row the one an exchange presented?", so keeping the digest rather than a
+    second copy of the token keeps the payload from carrying the same live secret
+    twice. Truncated, because the question compares a handful of our own tokens
+    rather than searching an adversarial keyspace.
+    """
+    import hashlib
+
+    return hashlib.sha256(refresh_token.encode("utf-8")).hexdigest()[:16]
+
+
+def _refresh_request_never_sent(exc: BaseException) -> bool:
+    """Whether an httpx failure happened BEFORE the request reached the wire.
+
+    The distinction is load-bearing and httpx's own, not a guess: a refresh
+    token presented to a rotating provider is spent by the REQUEST, so a failure
+    that happened before the request was written leaves the token untouched and
+    is an ordinary transient retry, while one that happened after may have spent
+    it and must not be retried without an interactive sign-in.
+
+    Pre-send, per httpx's taxonomy: ``ConnectError`` (refused, DNS, TLS
+    handshake), ``ConnectTimeout`` / ``PoolTimeout`` (waiting for a connection
+    or a pool slot), ``UnsupportedProtocol`` and ``LocalProtocolError`` (the
+    request was never even formatted for a socket). Everything else —
+    ``ReadTimeout``, ``ReadError``, ``WriteError``, ``WriteTimeout``,
+    ``RemoteProtocolError`` — can have been written, so it is treated as suspect.
+    That asymmetry is deliberate: a wrongly-suspect failure costs one interactive
+    sign-in, a wrongly-trusted one costs the whole token family.
+    """
+    import httpx
+
+    return isinstance(
+        exc,
+        (
+            httpx.ConnectError,
+            httpx.ConnectTimeout,
+            httpx.PoolTimeout,
+            httpx.UnsupportedProtocol,
+            httpx.LocalProtocolError,
+        ),
+    )
+
+
+def _stored_token_is_fresh(storage: "McpTokenStorage", tokens: Any) -> bool:
+    """Whether the STORED access token is still comfortably usable.
+
+    The shared answer to "is a refresh needed?" for the proactive site and for
+    the exchange inside its lock, so the two cannot drift: the exchange asks it
+    to notice that a peer rotated the grant while it waited for the lock, and the
+    proactive site asks it to skip the lock entirely in the common case.
+
+    An expiry of ``None`` means "no opinion" (see
+    :meth:`McpTokenStorage.stored_token_expiry`) and reads as fresh, because a
+    provider that quotes no lifetime must not be re-authorized on a guess.
+    """
+    if tokens is None or not getattr(tokens, "access_token", None):
+        return False
+    expiry = storage.stored_token_expiry()
+    return expiry is None or time.time() < expiry - REFRESH_SKEW_S
 
 
 def server_rejects_oauth(cfg: MCPServerConfig) -> bool:
@@ -1514,7 +1875,7 @@ _REFRESH_CONTENTION_TTL_S = 5.0
 
 
 class RefreshContentionLedger:
-    """Servers whose coordinator refused to spend a refresh token UNLOCKED.
+    """Servers whose coordinator refused to spend a refresh token, and WHY.
 
     The side channel that survives the transport, and it exists for exactly the
     reason :class:`AbandonedGrantLedger` does: an ordinary exception raised out
@@ -1529,36 +1890,60 @@ class RefreshContentionLedger:
     The manager consults this ledger to tell "we refused to refresh without
     exclusivity" apart from "this connect was disposed", because the two need
     opposite treatment: the first is contention and must be retried with
-    backoff, the second must never be converted into a retry.
+    backoff, the second must never be converted into a retry. It also carries the
+    REASON, because the alternative is one string that is untrue on two of the
+    three paths (see :class:`McpRefreshContendedError`) and one that promises a
+    fresh sign-in without saying why.
 
-    Keyed by server URL and SINGLE-USE (``pop`` semantics): one refusal re-voices
-    at most one cancellation, never two. Records also age out, so a record whose
-    cancellation never reached the manager cannot be attributed to an unrelated
-    cancellation later.
+    Keyed by server URL. Each record is SINGLE-USE (``pop`` semantics: one
+    refusal re-voices at most one cancellation, never two), but a server may hold
+    SEVERAL live records at once — two concurrent connects for the same URL can
+    both refuse, and a single slot let the second one's refusal vanish, which
+    reaches ``_reconnect`` as a bare ``CancelledError``, is not an ``Exception``,
+    and therefore kills the reconnect task silently instead of retrying it.
+    Records also age out, so a record whose cancellation never reached the
+    manager cannot be attributed to an unrelated cancellation later.
     """
 
     def __init__(self) -> None:
-        self._records: dict[str, float] = {}
+        #: url -> oldest-first ``(monotonic armed-at, refusal reason)``.
+        self._records: dict[str, list[tuple[float, str]]] = {}
 
-    def record(self, server_url: str) -> None:
-        """Arm one server's record, pruning anything past the horizon."""
+    def record(self, server_url: str, reason: str = REFRESH_REFUSAL_LOCK) -> None:
+        """Append one server's record, pruning anything past the horizon."""
         now = time.monotonic()
-        for old_url, at in list(self._records.items()):
-            if now - at > _REFRESH_CONTENTION_TTL_S:
+        for old_url, entries in list(self._records.items()):
+            kept = [entry for entry in entries if now - entry[0] <= _REFRESH_CONTENTION_TTL_S]
+            if kept:
+                self._records[old_url] = kept
+            else:
                 self._records.pop(old_url, None)
-        self._records[server_url] = now
+        self._records.setdefault(server_url, []).append((now, reason))
 
-    def pop(self, server_url: str) -> bool:
-        """Consume one server's record; ``True`` when a FRESH one was there.
+    def pop(self, server_url: str) -> str | None:
+        """Consume one server's OLDEST record; its reason when FRESH, else ``None``.
 
-        Always removes the entry, fresh or stale: the caller uses a single
-        answer for the whole classification, so leaving a stale record behind
-        would only let it be misattributed later.
+        Stale records are dropped rather than returned: a record older than the
+        horizon belongs to a cancellation that was swallowed somewhere else, and
+        believing it would turn an unrelated teardown into a retry. Consuming
+        one record leaves any later ones in place, which is what lets a second
+        concurrent refusal for the same server still be re-voiced.
         """
-        at = self._records.pop(server_url, None)
-        if at is None:
-            return False
-        return time.monotonic() - at <= _REFRESH_CONTENTION_TTL_S
+        now = time.monotonic()
+        entries = [
+            entry
+            for entry in self._records.get(server_url, [])
+            if now - entry[0] <= _REFRESH_CONTENTION_TTL_S
+        ]
+        if not entries:
+            self._records.pop(server_url, None)
+            return None
+        _, reason = entries.pop(0)
+        if entries:
+            self._records[server_url] = entries
+        else:
+            self._records.pop(server_url, None)
+        return reason
 
     def clear(self) -> None:
         """Drop every record. Used by test isolation; no production caller.
@@ -2273,7 +2658,7 @@ def _oauth_refresh_lock_path(server_url: str) -> Path:
 
 
 @contextlib.asynccontextmanager
-async def _oauth_refresh_lock(server_url: str):
+async def _oauth_refresh_lock(server_url: str) -> AsyncIterator["_OAuthRefreshLock"]:
     """Serialize the refresh exchange across processes for one server.
 
     Rotating refresh tokens make concurrent refreshes destructive: whichever
@@ -2286,19 +2671,27 @@ async def _oauth_refresh_lock(server_url: str):
     flocked, never read or written for content (on Windows it holds a single
     padding byte, which ``msvcrt.locking`` requires to have a range to lock).
 
-    Yields True when the lock was taken and False when the bounded acquire gave
-    up. A False body must still be SAFE to run, and that is now a narrower
-    promise than "best-effort": it may NOT perform the refresh exchange, because
-    an unexclusive exchange is the family-revoking double-spend this lock
-    exists to prevent. :func:`ensure_mcp_oauth_fresh` can afford to skip the
-    refresh on a False lock (its caller still connects and will re-read under
-    the lock on the next attempt), and
+    Yields a HANDLE that is truthy when the lock was taken and falsy when the
+    bounded acquire gave up (see :class:`_OAuthRefreshLock`). A falsy body must
+    still be SAFE to run, and that is now a narrower promise than "best-effort":
+    it may NOT perform the refresh exchange, because an unexclusive exchange is
+    the family-revoking double-spend this lock exists to prevent.
+    :func:`ensure_mcp_oauth_fresh` can afford to skip the refresh on a falsy
+    handle (its caller still connects and will re-read under the lock on the
+    next attempt), and
     ``_RefreshCoordinatingOAuthProvider._coordinate_inflight_refresh`` must not
     fall through to the SDK's unlocked refresh either — it refuses with
     :class:`McpRefreshContendedError` instead. Blocking the connect while
     waiting for exclusivity is still not an option: it would trade a rare
     double-spend for a guaranteed hang, which is the freeze this function was
     rewritten to remove.
+
+    The handle exists (rather than a plain ``bool``) because the ownership of
+    the RELEASE has to be transferable: an exchange that outlives its connect
+    keeps this lock until it has persisted its rotation
+    (``_OAuthRefreshLock.transfer``), so neither a waiter's cancellation nor a
+    budget overrun can free it while the POST is still on the wire — the window
+    that let a sibling re-present the spent token and revoke the family.
 
     Two rules this function exists to enforce, both learned from a freeze that
     took the whole TUI down:
@@ -2336,21 +2729,100 @@ async def _oauth_refresh_lock(server_url: str):
         acquire.add_done_callback(_close_abandoned_lock_fd)
         raise
     if fd is None:
-        logger.debug(
-            "MCP OAuth refresh lock not acquired within %.0fs for %s; proceeding unlocked",
+        # INFO, not debug: this is a refusal that costs a connect its proactive
+        # refresh, and the caller's next step (contention refusal or a skipped
+        # optimisation) is easier to read next to its cause.
+        logger.info(
+            "MCP OAuth refresh lock not acquired within %.0fs for %s; no token " "was presented",
             LOCK_ACQUIRE_TIMEOUT_S,
             server_url,
         )
-        yield False
+        handle = _OAuthRefreshLock(None)
+        try:
+            yield handle
+        finally:
+            handle.release_in_scope()
         return
+    handle = _OAuthRefreshLock(fd)
     try:
-        yield True
+        yield handle
     finally:
-        # Safe to close on this thread: the worker returned the fd only after
-        # its lock call completed, so no thread is parked on it.
+        handle.release_in_scope()
+
+
+class _OAuthRefreshLock:
+    """One held refresh lock whose RELEASE can be handed to another task.
+
+    A plain ``async with`` would release the lock when the COROUTINE holding it
+    returns, and the exchange task outlives that coroutine by design: it is
+    detached at the budget and keeps reading a response for up to
+    :data:`REFRESH_LATE_RESPONSE_GRACE_S`. Releasing there meant a sibling could
+    acquire the lock, re-read the store (still holding the token this exchange
+    had already presented) and POST it again — the reuse-detection request that
+    revokes the whole family, measured against the real fixture.
+
+    So the lock has an owner rather than a scope. The connect acquires it,
+    decides, hands the POST to a task, and TRANSFERS the release to that task
+    before its first cancellable await: from then on the exchange owns it and
+    frees it only in its own ``finally``, after the store write. Nothing about
+    the acquire changes — a waiter still either takes the lock within
+    ``LOCK_ACQUIRE_TIMEOUT_S`` or gives up and takes the contended path.
+
+    ``release`` is idempotent and safe to call from the event loop: the fd was
+    handed over by the worker thread only after its last lock syscall completed
+    (see :func:`_oauth_refresh_lock`).
+    """
+
+    __slots__ = ("_fd", "_deferred")
+
+    def __init__(self, fd: int | None) -> None:
+        self._fd = fd
+        #: Set by :meth:`transfer`: the ``async with`` that produced this handle
+        #: must NOT release it, because the exchange task owns the release now.
+        self._deferred = False
+
+    def __bool__(self) -> bool:
+        """Whether the lock is HELD — by anyone, including a transferred owner.
+
+        Truthiness is the caller's only signal (``if not lock: take the
+        contended path``), and after :meth:`transfer` the honest answer is still
+        "held": the exchange is holding it, and a second POST would be the
+        double-spend the lock exists to prevent.
+        """
+        return self._fd is not None
+
+    def transfer(self) -> None:
+        """Hand the release to whoever owns this handle next.
+
+        Called by the connect once the exchange task has been created and
+        before it awaits: after this, the ``async with`` block it was created in
+        releases nothing, and the task's own ``finally`` does.
+        """
+        self._deferred = True
+
+    def release_in_scope(self) -> None:
+        """Release on behalf of the ``async with`` that created this handle.
+
+        A no-op when the release was transferred to an exchange task — which is
+        the difference between this and a plain ``__exit__``: releasing here
+        after a transfer would free the lock while the POST it guards is still
+        on the wire.
+        """
+        if self._deferred:
+            return
+        self.release()
+
+    def release(self) -> None:
+        """Drop the lock. No-op once released, and safe to call twice."""
+        fd, self._fd = self._fd, None
+        if fd is None:
+            return
         with contextlib.suppress(Exception):
             _unlock(fd)
-        os.close(fd)
+        # Safe to close on this thread: the worker returned the fd only after
+        # its lock call completed, so no thread is parked on it.
+        with contextlib.suppress(OSError):
+            os.close(fd)
 
 
 def _close_abandoned_lock_fd(task: asyncio.Task[int | None]) -> None:
@@ -2469,105 +2941,92 @@ async def _refresh_oauth_token_locked(
     server_url: str,
     storage: McpTokenStorage,
     endpoints: DiscoveredOAuthEndpoints,
+    *,
+    lock: _OAuthRefreshLock | None = None,
+    peer_refresh_is_success: bool = False,
 ) -> RefreshOutcome:
     """Spend the stored refresh token against the DISCOVERED token endpoint.
 
-    Returns ``"refreshed"`` when a fresh access token was persisted, ``"dead"``
-    when the authorization server rejected the grant with ``invalid_grant`` (a
-    tombstone is written and the token must never be presented again), and
-    ``"failed"`` for every other outcome, including "nothing to refresh".
-    Callers MUST compare against a member: ``"failed"`` is truthy.
+    Outcome is the whole result, and each member has its own caller treatment:
+    ``"refreshed"`` (a fresh access token is in the store), ``"dead"`` (the
+    authorization server rejected the grant with ``invalid_grant``; a tombstone
+    is written and the token must never be presented again), ``"contended"``
+    (no exclusivity, so NOTHING was presented), ``"overran"`` (the budget was
+    spent with the exchange still running; a rotation that still lands is
+    persisted), ``"unacknowledged"`` (a token may already be spent, so nothing
+    was or may be presented until an interactive grant), and ``"failed"`` for
+    every other outcome, including "nothing to refresh". Callers MUST compare
+    against a member: every member is a truthy string.
 
-    The caller holds
-    the cross-process refresh lock, so exactly one process performs this
-    exchange even when several sessions start together. Mirrors the SDK's
-    refresh request exactly (grant type, client auth methods, RFC 6749 §6
-    carry-forward) so a provider cannot tell the two apart.
+    The caller holds the cross-process refresh lock and passes its HANDLE, which
+    this function hands to the exchange task before its first cancellable await.
+    That transfer is the point of the whole shape: the task owns the lock until
+    it has persisted, so neither a cancellation of this connect nor the budget
+    expiring can free it while the POST is still on the wire. Releasing it there
+    let a sibling acquire the lock, re-read the store (still holding the token
+    this exchange had already presented) and POST it a second time — the
+    reuse-detection request that revokes the whole family.
+
+    ``peer_refresh_is_success`` is for the PROACTIVE site, whose re-read under
+    the lock exists to notice that a peer already refreshed while it waited: with
+    it set, an already-fresh store is reported as ``"refreshed"`` without a
+    POST. It is deliberately off for the other two callers, where a locally fresh
+    token is exactly the state that needs spending (a session holding a
+    locally-valid access token the server has since revoked).
     """
-    import base64
-    from urllib.parse import quote
-
-    from mcp.shared.auth_utils import resource_url_from_server_url
-
-    tokens = await storage.get_tokens()
-    client_info = await storage.get_client_info()
-    if tokens is None or not tokens.refresh_token or client_info is None:
-        # Nothing to spend — a missing token is not evidence that the grant is
-        # dead, so this must never tombstone.
-        return "failed"
-
-    token_endpoint = str(endpoints.oauth_metadata.token_endpoint)
-    data: dict[str, str] = {
-        "grant_type": "refresh_token",
-        "refresh_token": tokens.refresh_token,
-        "client_id": client_info.client_id,
-    }
-    # RFC 8707 resource indicator: included when the server publishes protected
-    # resource metadata, matching the SDK's ``should_include_resource_param``.
-    if endpoints.protected_resource_metadata is not None:
-        data["resource"] = resource_url_from_server_url(server_url)
-
-    headers = {
-        "Content-Type": "application/x-www-form-urlencoded",
-        # Explicit UA, not httpx's default. mcp.notion.com sits behind
-        # Cloudflare, whose bot heuristics return HTTP 403 "error code 1010"
-        # to a refresh POST carrying NO User-Agent (observed live this cycle:
-        # httpx's built-in UA slips through, a missing one is blocked). Pinning
-        # our own identifier means a future httpx default change or a stricter
-        # Cloudflare rule cannot silently turn every refresh into a 403 and
-        # force a browser grant on the whole fleet.
-        "User-Agent": _refresh_user_agent(),
-    }
-    auth_method = client_info.token_endpoint_auth_method
-    if auth_method == "client_secret_post" and client_info.client_secret:
-        data["client_secret"] = client_info.client_secret
-    elif auth_method == "client_secret_basic" and client_info.client_secret:
-        cid = quote(client_info.client_id, safe="")
-        csecret = quote(client_info.client_secret, safe="")
-        encoded = base64.b64encode(f"{cid}:{csecret}".encode()).decode()
-        headers["Authorization"] = f"Basic {encoded}"
-
     # The exchange runs in its OWN task, and the await below is a SHIELD around
-    # it: neither a cancellation of this connect nor the total timeout can
-    # abort the POST. For a rotating provider the response is the only copy of
-    # the new refresh token, so an aborted request does not just fail a refresh
-    # — the server has already spent the token we presented, and the store is
-    # left holding a spent one whose next presentation is a reuse-detection
-    # double-spend that logs out the whole fleet. The task persists its result
-    # itself, so the rotation survives whichever of the three ways this ends:
-    # completed in time, cancelled mid-flight, or landed after the bound.
-    #
-    # The cap stays what it was: the LOCK is never held for longer than
-    # ``REFRESH_HTTP_TIMEOUT_S``. Only the response read gets the late grace.
+    # it: neither a cancellation of this connect nor the total timeout can abort
+    # the POST. For a rotating provider the response is the only copy of the new
+    # refresh token, so an aborted request does not just fail a refresh — the
+    # server has already spent the token we presented, and the store is left
+    # holding a spent one whose next presentation is a reuse-detection
+    # double-spend that logs out the whole fleet. The task persists its own
+    # result and releases the lock itself, so the rotation survives whichever of
+    # the three ways this ends: completed in time, cancelled mid-flight, or
+    # landed after the bound.
     exchange: asyncio.Task[RefreshOutcome] = asyncio.ensure_future(
-        _perform_refresh_exchange(server_url, storage, tokens, token_endpoint, data, headers)
+        _perform_refresh_exchange(
+            server_url,
+            storage,
+            endpoints,
+            lock=lock,
+            peer_refresh_is_success=peer_refresh_is_success,
+        )
     )
-    started = time.monotonic()
+    if lock is not None:
+        # BEFORE the first await: from here the exchange owns the release, so
+        # whichever way this coroutine leaves — return, timeout, cancellation —
+        # the lock stays held until the rotation is in the store. ``getattr``
+        # because the test doubles for ``_oauth_refresh_lock`` are plain bools.
+        transfer = getattr(lock, "transfer", None)
+        if transfer is not None:
+            transfer()
     try:
         async with asyncio.timeout(REFRESH_HTTP_TIMEOUT_S):
             return await asyncio.shield(exchange)
     except TimeoutError:
         # The budget is spent, so this connect is done with it; the exchange is
         # not, and its persistence is the whole point of detaching it.
-        logger.debug(
-            "MCP token refresh overran its %.0fs budget for %s; a response that still "
-            "lands will be persisted",
-            REFRESH_HTTP_TIMEOUT_S,
+        logger.info(
+            "MCP token refresh for %s overran its %.0fs budget; the exchange still "
+            "holds the refresh lock and a rotation that lands will be persisted "
+            "[writer: detached refresh exchange]",
             server_url,
+            REFRESH_HTTP_TIMEOUT_S,
         )
         _detach_refresh_exchange(exchange, server_url)
-        return "failed"
+        return "overran"
     except asyncio.CancelledError:
         # Routine teardown: every sidebar switch disposes a manager and cancels
-        # its in-flight connects. Wait out the REMAINDER of the budget for the
-        # response so the rotation reaches the store BEFORE the caller's lock
-        # is released — leaving it to a detached task would let a sibling
-        # acquire the lock first and spend the token this exchange already
-        # spent. Never longer than the bound, so teardown is never held longer
-        # than it already could be.
-        remaining = max(0.0, REFRESH_HTTP_TIMEOUT_S - (time.monotonic() - started))
-        with contextlib.suppress(BaseException):
-            await asyncio.wait_for(asyncio.shield(exchange), remaining)
+        # its in-flight connects. Nothing is waited for here, deliberately — the
+        # exchange owns the lock and persists its own result, so this coroutine
+        # has nothing left to do but leave. Waiting out the remainder of the
+        # budget used to be the only thing keeping a sibling from acquiring the
+        # lock mid-POST, and it did not do that anyway (measured: the flock was
+        # already free at the instant of the cancel, because the response read
+        # outlived the remainder); the ownership transfer replaces it, and
+        # teardown is now immediate instead of blocked for up to
+        # ``REFRESH_HTTP_TIMEOUT_S``.
         _detach_refresh_exchange(exchange, server_url)
         raise
 
@@ -2579,6 +3038,10 @@ def _detach_refresh_exchange(exchange: "asyncio.Task[RefreshOutcome]", server_ur
     so nothing here consumes a value: this exists so a task nobody awaits is
     not reported as "exception was never retrieved" when the loop closes, and
     so a failure inside it is logged against the server it belongs to.
+
+    INFO, not debug, for the same reason the write paths say so: an exchange
+    nobody awaited is exactly the state whose rotation support has to be able to
+    read out of a log after the fact.
     """
 
     def _settle(finished: "asyncio.Task[RefreshOutcome]") -> None:
@@ -2587,7 +3050,21 @@ def _detach_refresh_exchange(exchange: "asyncio.Task[RefreshOutcome]", server_ur
         with contextlib.suppress(BaseException):
             exc = finished.exception()
             if exc is not None:
-                logger.debug("detached MCP token refresh for %s failed", server_url, exc_info=exc)
+                logger.info(
+                    "detached MCP token refresh for %s failed"
+                    " [writer: detached refresh exchange]",
+                    server_url,
+                    exc_info=exc,
+                )
+                return
+            outcome = finished.result()
+            if outcome != "refreshed":
+                logger.info(
+                    "detached MCP token refresh for %s ended %r without persisting"
+                    " [writer: detached refresh exchange]",
+                    server_url,
+                    outcome,
+                )
 
     exchange.add_done_callback(_settle)
 
@@ -2595,87 +3072,258 @@ def _detach_refresh_exchange(exchange: "asyncio.Task[RefreshOutcome]", server_ur
 async def _perform_refresh_exchange(
     server_url: str,
     storage: McpTokenStorage,
-    tokens: OAuthToken,
-    token_endpoint: str,
-    data: dict[str, str],
-    headers: dict[str, str],
+    endpoints: DiscoveredOAuthEndpoints,
+    *,
+    lock: _OAuthRefreshLock | None = None,
+    peer_refresh_is_success: bool = False,
 ) -> RefreshOutcome:
-    """POST one refresh grant and persist whatever the authorization server decided.
+    """POST one refresh grant and persist whatever the server decided.
 
-    Owns the whole exchange — request, classification, persistence — so it can
-    be detached from the connect that started it without any part of the result
+    Owns the whole exchange — the locked re-read, the request, the
+    classification, the persistence AND the release of ``lock`` — so it can be
+    detached from the connect that started it with no part of the result
     depending on a listener. Split out of :func:`_refresh_oauth_token_locked`
     for exactly that reason: the response is the only copy of a rotated refresh
-    token, and every path that used to drop it (cancellation, the total
-    timeout) did so by cancelling the request rather than by deciding against
-    it.
+    token, and every path that used to drop it (cancellation, the total timeout)
+    did so by cancelling the request rather than by deciding against it.
+
+    Holding the lock to the very END is what the reviewer's M2 was about. The
+    caller-releases-it variant let a sibling in during the response read, where
+    the store still holds the token this exchange has already spent — the
+    reuse-detection POST that revokes the family.
+
+    The request is also WRITE-AHEAD MARKED
+    (:meth:`McpTokenStorage.mark_send_unconfirmed`) immediately before the POST,
+    because the token is spent by the REQUEST and a process that dies mid-flight
+    takes all in-memory knowledge with it. A failure BEFORE the request was
+    written clears the marker again (the token was never presented, so that is
+    an ordinary transient retry); anything later leaves it armed, and the
+    refresh path then refuses to present that token until an interactive grant
+    replaces it (see :data:`GRANT_UNCONFIRMED_SEND_KEY`).
+
+    ``lock=None`` means the CALLER owns exclusivity (the direct-call path used
+    by the unit tests and by nothing else); a caller that hands over a handle it
+    could not acquire gets a refusal instead of a POST.
     """
+    import base64
+    from urllib.parse import quote
+
+    if lock is not None and not lock:
+        # Defence in depth for the one mistake that costs a token family: an
+        # exchange must never run against a handle that says "no exclusivity".
+        # The callers refuse earlier so this is not the path a user sees, but a
+        # future call site that forgets the check fails closed here. Note the
+        # test doubles for ``_oauth_refresh_lock`` are plain bools, so this reads
+        # truthiness rather than an attribute.
+        logger.info(
+            "MCP token refresh for %s refused: no refresh lock was held, so nothing "
+            "was presented [writer: locked refresh exchange]",
+            server_url,
+        )
+        return "contended"
+
     import httpx
     from mcp.shared.auth import OAuthToken
+    from mcp.shared.auth_utils import resource_url_from_server_url
 
     try:
-        # ``read`` is the LATE GRACE, not the budget: a response that lands
-        # after the awaiting connect has given up is still a rotation we must
-        # not throw away. Connect/write/pool keep the budget, so a server that
-        # never accepts the request still fails fast.
-        async with httpx.AsyncClient(
-            timeout=httpx.Timeout(REFRESH_HTTP_TIMEOUT_S, read=REFRESH_LATE_RESPONSE_GRACE_S)
-        ) as client:
-            response = await client.post(token_endpoint, data=data, headers=headers)
-    except (httpx.HTTPError, TimeoutError):
-        # ``asyncio.timeout`` raises TimeoutError (which ``httpx.HTTPError``
-        # does not cover); a refresh that overran its budget is simply a failed
-        # refresh, handled exactly like a transport error.
-        logger.debug("MCP token refresh request failed for %s", server_url, exc_info=True)
-        return "failed"
-    if response.status_code != 200:
-        # A revoked-grant rejection is qualitatively different from a transient
-        # one and must be logged as such: for a rotating provider that runs
-        # refresh-token REUSE DETECTION (Notion), presenting an already-rotated
-        # refresh token returns HTTP 400 {"error":"invalid_grant"} and revokes
-        # the ENTIRE token family, logging out every session at once. When that
-        # happens the only recovery is an interactive login, so the log names
-        # that action instead of implying a retry will heal it. We never
-        # auto-retry here regardless: returning "dead" lets the connect surface
-        # McpAuthRequiredError, which the manager turns into a suspended
-        # reconnect (see manager._reconnect's McpAuthRequiredError arm) rather
-        # than hammering a dead grant.
-        if response.status_code == 400 and _is_invalid_grant(response.content):
+        # Re-read UNDER the lock, inside the task that owns it: whatever we
+        # spend must be what the store holds NOW, not what it held when the
+        # connect decided to refresh.
+        tokens = await storage.get_tokens()
+        client_info = await storage.get_client_info()
+        if tokens is None or not tokens.refresh_token or client_info is None:
+            # Nothing to spend — a missing token is not evidence that the grant
+            # is dead, so this must never tombstone.
+            return "failed"
+
+        if storage.grant_is_dead():
+            # A grant the authorization server already rejected must cost no
+            # POST at all. The callers check this before taking the lock; this
+            # is the same question asked again under it, for the case where a
+            # sibling tombstoned the grant while we waited for exclusivity.
+            return "dead"
+
+        if peer_refresh_is_success and _stored_token_is_fresh(storage, tokens):
+            # Somebody rotated the grant while we waited for the lock. Spending
+            # the token we read before the lock would present a spent one; the
+            # caller re-reads the store and uses what the peer persisted.
+            return "refreshed"
+
+        if storage.send_unconfirmed(tokens.refresh_token):
+            # The token in this row was presented by an exchange whose answer
+            # never arrived, so it MAY already be spent, and re-presenting a
+            # spent token is the reuse-detection POST that revokes the whole
+            # family. Refuse, and say so at INFO: this state costs the user an
+            # interactive sign-in, and that has to be readable in a log rather
+            # than inferred from an unexplained failure.
             logger.info(
-                "MCP OAuth grant revoked for %s (invalid_grant); run /mcp login to restore it",
+                "MCP token refresh for %s refused: this refresh token was already "
+                "presented by an exchange that was never acknowledged, and presenting "
+                "it again may revoke the whole token family — run /mcp reauth to sign "
+                "in again [writer: locked refresh exchange]",
                 server_url,
             )
-            # Tombstone from HERE and nowhere else: this is the only site that
-            # has proof (a PARSED ``invalid_grant`` body, never a bare HTTP 400)
-            # that the grant itself is gone rather than the server having a bad
-            # minute. Misclassifying a transient 400 would permanently suppress
-            # refresh on a live grant until the user ran an interactive login.
-            # The rejected token travels with the marker so the write can check
-            # the grant has not moved on without us — see
-            # :meth:`McpTokenStorage.mark_grant_dead`.
-            storage.mark_grant_dead(rejected_refresh_token=tokens.refresh_token)
-            return "dead"
-        # Informational, not debug: a rejected refresh is the thing that turns
-        # into a login prompt, so its cause belongs in the readable log.
-        logger.info("MCP token refresh rejected for %s: HTTP %s", server_url, response.status_code)
-        return "failed"
-    try:
-        new_tokens = OAuthToken.model_validate_json(response.content)
-    except Exception:  # noqa: BLE001 — an unparseable token is a failed refresh
-        logger.debug(
-            "MCP token refresh returned an invalid token for %s", server_url, exc_info=True
-        )
-        return "failed"
+            return "unacknowledged"
 
-    # RFC 6749 §6: a refresh response may omit ``scope`` (unchanged) and
-    # ``refresh_token`` (not rotated). Carry both forward so the persisted row
-    # stays self-describing and can refresh again next time.
-    if new_tokens.scope is None and tokens.scope is not None:
-        new_tokens.scope = tokens.scope
-    if new_tokens.refresh_token is None:
-        new_tokens.refresh_token = tokens.refresh_token
-    await storage.set_tokens(new_tokens)
-    return "refreshed"
+        token_endpoint = str(endpoints.oauth_metadata.token_endpoint)
+        data: dict[str, str] = {
+            "grant_type": "refresh_token",
+            "refresh_token": tokens.refresh_token,
+            "client_id": client_info.client_id,
+        }
+        # RFC 8707 resource indicator: included when the server publishes
+        # protected resource metadata, matching the SDK's
+        # ``should_include_resource_param``.
+        if endpoints.protected_resource_metadata is not None:
+            data["resource"] = resource_url_from_server_url(server_url)
+
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            # Explicit UA, not httpx's default. mcp.notion.com sits behind
+            # Cloudflare, whose bot heuristics return HTTP 403 "error code 1010"
+            # to a refresh POST carrying NO User-Agent (observed live this cycle:
+            # httpx's built-in UA slips through, a missing one is blocked).
+            # Pinning our own identifier means a future httpx default change or a
+            # stricter Cloudflare rule cannot silently turn every refresh into a
+            # 403 and force a browser grant on the whole fleet.
+            "User-Agent": _refresh_user_agent(),
+        }
+        auth_method = client_info.token_endpoint_auth_method
+        if auth_method == "client_secret_post" and client_info.client_secret:
+            data["client_secret"] = client_info.client_secret
+        elif auth_method == "client_secret_basic" and client_info.client_secret:
+            cid = quote(client_info.client_id, safe="")
+            csecret = quote(client_info.client_secret, safe="")
+            encoded = base64.b64encode(f"{cid}:{csecret}".encode()).decode()
+            headers["Authorization"] = f"Basic {encoded}"
+
+        # WRITE-AHEAD, before the request can be on the wire: from this instant
+        # the row records that this token may have been spent, so a crash or a
+        # kill between here and the response cannot leave a spent token looking
+        # untouched to the next boot.
+        storage.mark_send_unconfirmed(tokens.refresh_token)
+        try:
+            # ``read`` is the LATE GRACE, not the budget: a response that lands
+            # after the awaiting connect has given up is still a rotation we
+            # must not throw away. Connect/write/pool keep the budget, so a
+            # server that never accepts the request still fails fast.
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(REFRESH_HTTP_TIMEOUT_S, read=REFRESH_LATE_RESPONSE_GRACE_S)
+            ) as client:
+                response = await client.post(token_endpoint, data=data, headers=headers)
+        except (httpx.HTTPError, TimeoutError) as exc:
+            # ``asyncio.timeout`` raises TimeoutError, which ``httpx.HTTPError``
+            # does not cover; an exchange that overran its budget inside the
+            # httpx call is handled exactly like a transport error. httpx's own
+            # taxonomy decides whether the request ever reached the wire, which
+            # is the difference between "no harm done" and "this token may be
+            # gone" (see :func:`_refresh_request_never_sent`): guessing either
+            # way is guessing about the family.
+            if _refresh_request_never_sent(exc):
+                storage.clear_send_unconfirmed()
+                logger.info(
+                    "MCP token refresh for %s could not reach the authorization server "
+                    "(%s); the refresh token was never presented "
+                    "[writer: locked refresh exchange]",
+                    server_url,
+                    type(exc).__name__,
+                )
+                return "failed"
+            # SENT and never answered: the token may already be spent, so a
+            # retry is exactly the reuse-detection POST. The request already
+            # armed the marker, and this outcome is what makes the caller take
+            # the honest non-POST path — strip the in-memory token and raise the
+            # auth error that names the fresh sign-in, rather than pretending
+            # this was a transient failure the manager can retry.
+            logger.info(
+                "MCP token refresh for %s got no answer after the request was sent "
+                "(%s); this refresh token may already be spent, so it will not be "
+                "presented again and the server needs a fresh sign-in "
+                "[writer: locked refresh exchange]",
+                server_url,
+                type(exc).__name__,
+            )
+            return "unacknowledged"
+
+        if response.status_code != 200:
+            # The authorization server ANSWERED, so the request is resolved
+            # either way: it rotated-and-told-us (a 200) or it refused without
+            # rotating. An answer also means the marker's question is answered.
+            storage.clear_send_unconfirmed()
+            # A revoked-grant rejection is qualitatively different from a
+            # transient one and must be logged as such: for a rotating provider
+            # that runs refresh-token REUSE DETECTION (Notion), presenting an
+            # already-rotated refresh token returns HTTP 400
+            # {"error":"invalid_grant"} and revokes the ENTIRE token family,
+            # logging out every session at once. When that happens the only
+            # recovery is an interactive login, so the log names that action
+            # instead of implying a retry will heal it. We never auto-retry here
+            # regardless: returning "dead" lets the connect surface
+            # McpAuthRequiredError, which the manager turns into a suspended
+            # reconnect (see manager._reconnect's McpAuthRequiredError arm)
+            # rather than hammering a dead grant.
+            if response.status_code == 400 and _is_invalid_grant(response.content):
+                logger.info(
+                    "MCP OAuth grant revoked for %s (invalid_grant); run /mcp login to "
+                    "restore it",
+                    server_url,
+                )
+                # Tombstone from HERE and nowhere else: this is the only site
+                # that has proof (a PARSED ``invalid_grant`` body, never a bare
+                # HTTP 400) that the grant itself is gone rather than the server
+                # having a bad minute. Misclassifying a transient 400 would
+                # permanently suppress refresh on a live grant until the user ran
+                # an interactive login. The rejected token travels with the
+                # marker so the write can check the grant has not moved on
+                # without us — see :meth:`McpTokenStorage.mark_grant_dead`. The
+                # lock is held here for all of it, which is what keeps that
+                # compare-then-write window at the microseconds between the two
+                # calls.
+                storage.mark_grant_dead(rejected_refresh_token=tokens.refresh_token)
+                return "dead"
+            # Informational, not debug: a rejected refresh is the thing that
+            # turns into a login prompt, so its cause belongs in the readable
+            # log.
+            logger.info(
+                "MCP token refresh rejected for %s: HTTP %s", server_url, response.status_code
+            )
+            return "failed"
+        try:
+            new_tokens = OAuthToken.model_validate_json(response.content)
+        except Exception:  # noqa: BLE001 — an unparseable token is a failed refresh
+            # HTTP 200 with a body we cannot read is NOT a clean failure: the
+            # server processed the exchange and rotated, and the new token is
+            # unreadable, so the token in the store IS spent. The marker stays
+            # armed rather than being cleared, because presenting that token
+            # again is a definite double-spend — this is the one case the
+            # "presented but never acknowledged" state describes exactly.
+            logger.info(
+                "MCP token refresh for %s returned HTTP 200 with an unusable body; the "
+                "presented token is spent and will not be presented again — run "
+                "/mcp reauth [writer: locked refresh exchange]",
+                server_url,
+            )
+            return "unacknowledged"
+        storage.clear_send_unconfirmed()
+
+        # RFC 6749 §6: a refresh response may omit ``scope`` (unchanged) and
+        # ``refresh_token`` (not rotated). Carry both forward so the persisted
+        # row stays self-describing and can refresh again next time.
+        if new_tokens.scope is None and tokens.scope is not None:
+            new_tokens.scope = tokens.scope
+        if new_tokens.refresh_token is None:
+            new_tokens.refresh_token = tokens.refresh_token
+        # The refresh path's OWN write, never ``set_tokens``: it is conditioned
+        # on the grant this exchange was computed from and it never clears the
+        # dead-grant marker (see :meth:`McpTokenStorage.store_refresh_result`).
+        storage.store_refresh_result(new_tokens, presented_refresh_token=tokens.refresh_token)
+        return "refreshed"
+    finally:
+        # The lock is released HERE, after the persist, whatever the outcome.
+        # This is the ownership the connect transferred before its first await.
+        if lock is not None:
+            lock.release()
 
 
 async def ensure_mcp_oauth_fresh(
@@ -2717,14 +3365,7 @@ async def ensure_mcp_oauth_fresh(
     storage = McpTokenStorage(server_url, store)
     endpoints = await discover_oauth_endpoints(server_url)
 
-    def _still_good(expiry: float | None, tokens: Any) -> bool:
-        # ``expiry is None`` means "no lifetime recorded" — the SDK treats such
-        # a token as valid, so we must not force a refresh on it.
-        return bool(tokens is not None and tokens.access_token) and (
-            expiry is None or time.time() < expiry - REFRESH_SKEW_S
-        )
-
-    if _still_good(storage.stored_token_expiry(), await storage.get_tokens()):
+    if _stored_token_is_fresh(storage, await storage.get_tokens()):
         return endpoints
 
     if storage.grant_is_dead():
@@ -2759,8 +3400,8 @@ async def ensure_mcp_oauth_fresh(
     ):
         return endpoints
 
-    async with _oauth_refresh_lock(server_url) as locked:
-        if not locked:
+    async with _oauth_refresh_lock(server_url) as lock:
+        if not lock:
             # The bounded acquire gave up, so we cannot claim exclusivity and
             # must not spend the rotating refresh token on a guess. Skip the
             # PROACTIVE refresh and connect anyway: this function does not leak
@@ -2771,11 +3412,19 @@ async def ensure_mcp_oauth_fresh(
             # (:class:`McpRefreshContendedError`). A skipped optimisation costs
             # a round trip; blocking the connect costs the whole session.
             return endpoints
-        # Re-read under the lock: another session may have refreshed while we
-        # waited. Spending a rotated refresh token a second time is exactly the
-        # race this lock exists to prevent.
-        if not _still_good(storage.stored_token_expiry(), await storage.get_tokens()):
-            await _refresh_oauth_token_locked(server_url, storage, endpoints)
+        # The exchange re-reads the store UNDER this lock (and takes the release
+        # over: see :func:`_refresh_oauth_token_locked`). Handing it the lock we
+        # already hold is what keeps a cancelled or over-budget connect from
+        # freeing it while the POST is still on the wire.
+        outcome = await _refresh_oauth_token_locked(
+            server_url, storage, endpoints, lock=lock, peer_refresh_is_success=True
+        )
+        if outcome in ("contended", "overran", "failed", "unacknowledged"):
+            # Best-effort by contract: the connect proceeds and re-reads under
+            # the lock on its next attempt. Each refusal already logged its own
+            # reason at INFO, naming that writer — no second line here, because
+            # a duplicate would read as a second failure.
+            logger.debug("MCP proactive refresh for %s ended %r", server_url, outcome)
     return endpoints
 
 
@@ -3001,121 +3650,133 @@ def _make_refresh_coordinating_provider(
                 # handler turns into an actionable McpAuthRequiredError.
                 self._strip_in_memory_refresh_token(ctx)
                 return
+            outcome: RefreshOutcome | None = None
             try:
-                async with _oauth_refresh_lock(self._refresh_coord_server_url) as locked:
+                async with _oauth_refresh_lock(self._refresh_coord_server_url) as lock:
                     # Re-read under the lock: a sibling process may have rotated
                     # the token while we waited. Adopting its result is what
                     # turns a double-spend into a no-op.
                     await self._resync_from_store(ctx)
-                    if not locked:
-                        # No exclusivity, so we must not perform the exchange
-                        # ourselves. The re-read above still upholds the
-                        # invariant that matters most (the SDK never spends an
-                        # in-memory refresh token older than storage's).
-                        #
-                        # It no longer DEGRADES to the SDK's unlocked refresh:
-                        # that was the main route by which a stale rotating
-                        # refresh token reached the wire outside
-                        # ``_oauth_refresh_lock`` (the SDK POSTs the in-memory
-                        # token directly, with no re-read), which for a
-                        # reuse-detecting provider is the family-revoking
-                        # request. The post-condition at the end of this method
-                        # turns "still invalid and still refreshable" into a
-                        # transient error the manager retries with backoff,
-                        # instead of an unlocked spend.
-                        pass
-                    elif ctx.is_token_valid():
+                    if ctx.is_token_valid():
                         return  # a peer already refreshed; do not spend again
+                    if not lock:
+                        # No exclusivity, so nothing may be presented — not even
+                        # by the exchange, whose whole contract is that the
+                        # caller hands it a HELD lock. The refusal below decides
+                        # what the user sees; the exchange is never entered, so a
+                        # refusal costs zero POSTs.
+                        outcome = "contended"
                     else:
                         # The invariant this whole block exists to guarantee: the
                         # SDK's own ``_refresh_token`` must NEVER run with an
-                        # in-memory refresh token older than the one in storage. The
-                        # SDK loads the token once at ``_initialize`` and spends it
-                        # unlocked; a sibling that rotated it in between leaves us
-                        # holding a stale refresh token, and presenting that to a
-                        # reuse-detecting provider (Notion) returns
-                        # ``invalid_grant`` and revokes the ENTIRE token family —
-                        # logging out every session at once. So we always perform
-                        # the refresh ourselves, UNDER THE LOCK, with a fresh
-                        # re-read; the SDK's unlocked path is never reached with a
-                        # stale token.
+                        # in-memory refresh token older than the one in storage.
+                        # The SDK loads the token once at ``_initialize`` and
+                        # spends it unlocked; a sibling that rotated it in
+                        # between leaves us holding a stale refresh token, and
+                        # presenting that to a reuse-detecting provider (Notion)
+                        # returns ``invalid_grant`` and revokes the ENTIRE token
+                        # family — logging out every session at once. So we
+                        # always perform the refresh ourselves, UNDER THE LOCK,
+                        # with a fresh re-read; the SDK's unlocked path is never
+                        # reached with a stale token.
                         endpoints = self._refresh_coord_endpoints
                         if endpoints is None:
-                            # Discovery failed at startup, but we must still refresh
-                            # under the lock rather than fall through to the SDK's
-                            # UNLOCKED refresh (which would spend the possibly-stale
-                            # boot-time token and risk the family revocation above).
-                            # Synthesize the exact endpoint the SDK itself would
-                            # fall back to (``<scheme>://<netloc>/token``) so the
-                            # locked, re-reading refresh targets the same URL the
-                            # unlocked path would have.
+                            # Discovery failed at startup, but we must still
+                            # refresh under the lock rather than fall through to
+                            # the SDK's UNLOCKED refresh (which would spend the
+                            # possibly-stale boot-time token and risk the family
+                            # revocation above). Synthesize the exact endpoint the
+                            # SDK itself would fall back to
+                            # (``<scheme>://<netloc>/token``) so the locked,
+                            # re-reading refresh targets the same URL the unlocked
+                            # path would have.
                             endpoints = _fallback_endpoints_for(self._refresh_coord_server_url)
+                        # The exchange re-reads the store UNDER this lock and
+                        # takes the release over before its first await, so the
+                        # token it spends is the one on disk at the moment of the
+                        # POST — not the one this read saw — and no waiter's
+                        # cancellation or timeout can free the lock while that
+                        # POST is on the wire.
                         outcome = await _refresh_oauth_token_locked(
                             self._refresh_coord_server_url,
                             self._refresh_coord_storage,
                             endpoints,
+                            lock=lock,
                         )
-                        # Compare explicitly: ``"failed"`` is a truthy string, so a
-                        # ``if outcome:`` here would invert this branch silently and
-                        # pyright would not catch it.
-                        if outcome == "refreshed":
-                            await self._resync_from_store(ctx)
-                        elif outcome == "dead":
-                            # The third POST of the per-boot triple, and the one that
-                            # actually revokes the token family. Returning here still
-                            # falls through to the SDK's own UNLOCKED _refresh_token,
-                            # which would spend the token the authorization server
-                            # just rejected. Dropping the in-memory refresh token
-                            # makes the SDK's can_refresh_token() read False, so it
-                            # skips its refresh branch entirely and goes to the
-                            # authorization branch — which our non-interactive
-                            # redirect handler already turns into an actionable
-                            # McpAuthRequiredError. Same user-visible outcome, one
-                            # fewer family-revoking POST.
-                            self._strip_in_memory_refresh_token(ctx)
-                        # ``outcome == "failed"`` deliberately has NO arm here any
-                        # more. Silently falling out of this block used to hand the
-                        # SDK's unlocked _refresh_token a still-refreshable stale
-                        # token — the live route the incident logs show (14+
-                        # ``httpx2 ... /token 400``). The post-condition below
-                        # decides it instead: stripped and retried as transient.
             except Exception:  # noqa: BLE001 — coordination is best-effort
                 # A failed re-read/refresh must never break the request. But we
                 # must NOT let the SDK's unlocked refresh then spend a stale
-                # boot-time token: re-read storage one final time under the lock
-                # and overwrite the in-memory token with whatever is persisted,
-                # so whatever the SDK spends next is at least the freshest
-                # stored refresh token, never an older one a sibling already
-                # rotated away. This upholds the same invariant on the exception
-                # fall-through path (a raised locked-refresh, a transient store
-                # error) as the success path does.
+                # boot-time token: re-read storage one final time and overwrite
+                # the in-memory token with whatever is persisted, so whatever the
+                # SDK spends next is at least the freshest stored refresh token,
+                # never an older one a sibling already rotated away. This upholds
+                # the same invariant on the exception fall-through path (a
+                # transient store error, an unexpected raise) as the success path
+                # does.
                 logger.debug(
                     "MCP in-flight refresh coordination failed for %s",
                     self._refresh_coord_server_url,
                     exc_info=True,
                 )
                 await self._adopt_freshest_stored_token(ctx)
+                outcome = "failed"
+            # The OUTCOMES are decided out here, deliberately: a refusal is a
+            # DECISION, not a failure, and raising it inside the ``try`` above
+            # would let the ``except Exception`` arm swallow it — which would put
+            # the SDK's unlocked refresh back on the wire, the one thing this
+            # method exists to prevent.
+            #
+            # Compare explicitly: every member is a truthy string, so a
+            # ``if outcome:`` here would invert these branches silently and
+            # pyright would not catch it.
+            if outcome == "refreshed":
+                await self._resync_from_store(ctx)
+            elif outcome == "dead":
+                # The one POST that actually revokes the token family is the
+                # replay; returning here still falls through to the SDK's own
+                # UNLOCKED _refresh_token, which would spend the token the
+                # authorization server just rejected. Dropping the in-memory
+                # refresh token makes the SDK's can_refresh_token() read False,
+                # so it skips its refresh branch entirely and goes to the
+                # authorization branch — which our non-interactive redirect
+                # handler already turns into an actionable McpAuthRequiredError.
+                # Same user-visible outcome, one fewer family-revoking POST.
+                self._strip_in_memory_refresh_token(ctx)
+            elif outcome == "unacknowledged":
+                # A token that was presented (or may have been) and never
+                # acknowledged must not be presented again: that is the
+                # reuse-detection POST. The honest disposition is an interactive
+                # sign-in, not a retry — see McpRefreshUnconfirmedError.
+                self._refuse_unconfirmed_exchange(ctx)
+            elif outcome in ("contended", "overran", "failed"):
+                self._refuse_unlocked_refresh(ctx, outcome)
             # POST-CONDITION, in ONE place so no exit path can miss it: we are
             # about to return into ``async_auth_flow``, whose very next act is to
             # hand the context to the SDK's ``async_auth_flow``. If the token is
             # still invalid AND still refreshable at that point, the SDK will
             # POST its in-memory refresh token with no lock and no re-read — the
             # unlocked spend this whole method exists to prevent. Refuse instead.
-            self._refuse_unlocked_refresh(ctx)
+            #
+            # ``"failed"`` is the default reason rather than the lock: this arm
+            # is reached when the exchange ran (or could not be attributed to a
+            # single cause) and left nothing usable, and the message says the
+            # authorization server's answer was not a usable token.
+            self._refuse_unlocked_refresh(ctx, "failed")
 
-        def _refuse_unlocked_refresh(self, ctx: Any) -> None:
+        def _refuse_unlocked_refresh(self, ctx: Any, outcome: str = "failed") -> None:
             """Never hand the SDK an in-memory refresh token we failed to refresh.
 
             The post-condition of :meth:`_coordinate_inflight_refresh`, called
             once at the end so no exit path can skip it. Reaching here with an
             invalid-but-refreshable context means coordination did not produce
-            a working token this time (the lock was unavailable, the locked
-            refresh returned ``"failed"``, or the fall-through could not find a
-            fresher stored one). ``async_auth_flow`` returns straight into the
-            SDK's own flow at that point, and the SDK's ``_refresh_token``
-            POSTs ``ctx.current_tokens.refresh_token`` DIRECTLY — no lock, no
-            re-read — so the next thing on the wire would be a possibly
-            already-rotated token, which a reuse-detecting provider answers with
+            a working token this time (the lock was unavailable, the exchange
+            overran the connect's budget, the refresh returned ``"failed"``, or
+            the fall-through could not find a fresher stored one).
+            ``async_auth_flow`` returns straight into the SDK's own flow at that
+            point, and the SDK's ``_refresh_token`` POSTs
+            ``ctx.current_tokens.refresh_token`` DIRECTLY — no lock, no re-read —
+            so the next thing on the wire would be a possibly already-rotated
+            token, which a reuse-detecting provider answers with
             ``invalid_grant`` AND a family revocation.
 
             So strip it and raise a TRANSIENT error instead. Two properties are
@@ -3126,23 +3787,53 @@ def _make_refresh_coordinating_provider(
               and
             * the error is not an auth error, so it reaches the manager's
               generic reconnect arm — backoff and retry — rather than
-              ``_block_on_auth``. Being unable to take a lock is contention,
-              not a dead grant: blocking on auth here would strand a healthy
-              server on a login prompt the user has no reason to run.
+              ``_block_on_auth``. Being unable to refresh is contention or a
+              server fault, not a dead grant: blocking on auth here would
+              strand a healthy server on a login prompt the user has no reason
+              to run.
+
+            ``outcome`` becomes the refusal REASON, which is what makes the
+            user-visible string truthful per path: unable to take the lock, a
+            budget overrun, and a rejected refresh are three different things
+            and were one sentence before (design review input). The reason is
+            carried onto the ledger so the manager's re-voiced error says the
+            same thing.
             """
             if not ctx.can_refresh_token() or ctx.is_token_valid():
                 return
             self._strip_in_memory_refresh_token(ctx)
+            refusal = {
+                "contended": REFRESH_REFUSAL_LOCK,
+                "overran": REFRESH_REFUSAL_INFLIGHT,
+            }.get(outcome, REFRESH_REFUSAL_ENDPOINT)
             # ARM THE SIDE CHANNEL BEFORE RAISING, and do it here rather than in
             # the raise's caller: the MCP transport will NOT deliver this error.
             # It runs the request inside anyio cancel scopes, so the raise
             # cancels the scope and reaches ``_connect_server`` as a bare
             # ``CancelledError('Cancelled via cancel scope …')``. The manager
-            # re-voices that cancellation using this record — and only when the
-            # cancellation was NOT a genuine external one, so a dispose still
-            # wins. See :class:`RefreshContentionLedger`.
-            REFRESH_CONTENTION.record(self._refresh_coord_server_url)
-            raise McpRefreshContendedError(self._refresh_coord_server_url)
+            # re-voices that cancellation using this record — reason and all —
+            # and only when the cancellation was NOT a genuine external one, so
+            # a dispose still wins. See :class:`RefreshContentionLedger`.
+            REFRESH_CONTENTION.record(self._refresh_coord_server_url, refusal)
+            raise McpRefreshContendedError(self._refresh_coord_server_url, refusal=refusal)
+
+        def _refuse_unconfirmed_exchange(self, ctx: Any) -> None:
+            """Refuse to re-present a refresh token that may already be spent.
+
+            The disposition for ``outcome == "unacknowledged"``: the store holds
+            a token an exchange presented and never got an answer for, so
+            another POST of it is the reuse-detection request that revokes the
+            whole family. A retry would spend it again, which is why this raises
+            an AUTH error (the honest recovery is ``/mcp reauth``) rather than a
+            transient one the manager would retry on its backoff ladder.
+
+            Stripping the in-memory token first is the same load-bearing step as
+            in :meth:`_refuse_unlocked_refresh`: without it the SDK's unlocked
+            ``_refresh_token`` would present exactly the token we refused.
+            """
+            self._strip_in_memory_refresh_token(ctx)
+            REFRESH_CONTENTION.record(self._refresh_coord_server_url, REFRESH_REFUSAL_UNCONFIRMED)
+            raise McpRefreshUnconfirmedError(self._refresh_coord_server_url)
 
         async def _resync_from_store(self, ctx: Any) -> None:
             """Overwrite the in-memory token with the persisted one.
@@ -3346,12 +4037,12 @@ def _make_refresh_coordinating_provider(
               sibling rotated the grant; copy it and retry. Adoption spends
               nothing, so it can never double-spend, and the lock only
               serializes the re-read against a concurrent rotation.
-            * **Refresh** (new): the store holds the SAME token (or none) and
-              the grant is still refreshable. A 401 is then NOT evidence of a
-              dead grant — it is evidence that nobody has rotated yet — so the
-              refresh is performed HERE, under the lock, with the same re-read
-              and endpoint discipline as the pre-request coordinator. Before
-              this existed, this case fell straight through to the SDK, whose
+            * **Refresh**: the store holds the SAME token (or none) and the grant
+              is still refreshable. A 401 is then NOT evidence of a dead grant —
+              it is evidence that nobody has rotated yet — so the refresh is
+              performed HERE, under the lock, with the same re-read and endpoint
+              discipline as the pre-request coordinator. Before this existed,
+              this case fell straight through to the SDK, whose
               ``async_auth_flow`` POSTs ``current_tokens.refresh_token``
               directly: no lock, no re-read, and with the sibling's rotation
               already spent the request is a reuse-detection double-spend. It is
@@ -3360,16 +4051,26 @@ def _make_refresh_coordinating_provider(
               parsed ``invalid_grant``, which this path previously never
               reached, so every later boot re-POSTed the same rejected token.
 
-            On ``"dead"`` and on ``"failed"`` the in-memory refresh token is
-            stripped and ``None`` is returned, so the SDK's own unlockable
-            refresh cannot run either way. ``"dead"`` went through the refresh
-            (the marker is written); ``"failed"`` is transient and deliberately
-            writes NO tombstone.
+            ``"dead"``, ``"failed"``, ``"contended"`` and ``"overran"`` all
+            strip the in-memory refresh token and return ``None``: the SDK's own
+            unlockable refresh cannot run either way, and the 401 reaches the
+            SDK's authorization branch. They are deliberately NOT converted into
+            a retryable error on this path — after a 401 the manager's
+            ``_AuthChallengeWatcher`` has already latched, so a raise here is
+            reclassified as McpAuthChallengeError and blocks on auth regardless.
+
+            ``"unacknowledged"`` is the exception, and it is raised: the
+            disposition is the same (auth is required), but the challenge text
+            ("authorization expired") would be untrue for a refresh that was
+            SENT and never confirmed, and that string is what the user reads.
+            The raise carries the same ledger-backed re-voicing as the
+            coordinator's refusal, so the manager renders the honest reason.
             """
             from local_operator.mcp import auth as auth_mod
 
+            outcome: RefreshOutcome | None = None
             try:
-                async with _oauth_refresh_lock(self._refresh_coord_server_url) as locked:
+                async with _oauth_refresh_lock(self._refresh_coord_server_url) as lock:
                     stored = await self.context.storage.get_tokens()
                     current = self.context.current_tokens
                     if (
@@ -3394,47 +4095,33 @@ def _make_refresh_coordinating_provider(
                         # SDK's full authorization branch is the right answer,
                         # and with no refresh token it cannot POST one.
                         return None
-                    if not locked:
-                        # We do not hold exclusivity, so we must not perform the
-                        # exchange. Strip the in-memory refresh token anyway so
-                        # the SDK cannot make the unlocked POST we just declined
-                        # to make ourselves, and let the 401 reach its
-                        # authorization branch.
-                        self._strip_in_memory_refresh_token(self.context)
-                        return None
                     endpoints = self._refresh_coord_endpoints
                     if endpoints is None:
                         endpoints = auth_mod._fallback_endpoints_for(self._refresh_coord_server_url)
+                    # The exchange re-reads under this lock and takes the release
+                    # over, exactly as at the other two sites: nothing a waiter's
+                    # cancellation or timeout does can free it mid-POST.
                     outcome = await _refresh_oauth_token_locked(
                         self._refresh_coord_server_url,
                         self._refresh_coord_storage,
                         endpoints,
+                        lock=lock,
                     )
                     if outcome == "refreshed":
                         await self._resync_from_store(self.context)
                         fresh = self.context.current_tokens
-                        if fresh is None or not fresh.access_token:
-                            # The refresh reported success but nothing
-                            # persistable came back; let the SDK handle the 401.
-                            self._strip_in_memory_refresh_token(self.context)
-                            return None
-                        original_request.headers["Authorization"] = f"Bearer {fresh.access_token}"
-                        logger.debug(
-                            "MCP 401 for %s: retrying after a locked refresh",
-                            self._refresh_coord_server_url,
-                        )
-                        return original_request
-                    # ``"dead"`` (marker written by the refresh) and ``"failed"``
-                    # (transient, no marker) both end here: strip so the SDK's
-                    # unlocked refresh cannot spend the token, then let the 401
-                    # through. Deliberately NOT converted into a retryable error
-                    # on this path: after a 401 the manager's
-                    # ``_AuthChallengeWatcher`` has already latched, so a raise
-                    # here is reclassified as McpAuthChallengeError and blocks on
-                    # auth regardless. Changing that needs manager surgery, not a
-                    # different exception from here.
-                    self._strip_in_memory_refresh_token(self.context)
-                    return None
+                        if fresh is not None and fresh.access_token:
+                            original_request.headers["Authorization"] = (
+                                f"Bearer {fresh.access_token}"
+                            )
+                            logger.debug(
+                                "MCP 401 for %s: retrying after a locked refresh",
+                                self._refresh_coord_server_url,
+                            )
+                            return original_request
+                        # The refresh reported success but nothing persistable came
+                        # back; fall through to the refusal below and let the
+                        # authorization branch handle the 401.
             except Exception:  # noqa: BLE001 — best-effort; never break the request
                 # A failed re-read/refresh must not break the flow, and it must
                 # not leave a refreshable token for the SDK to POST unlocked
@@ -3446,6 +4133,14 @@ def _make_refresh_coordinating_provider(
                 )
                 self._strip_in_memory_refresh_token(self.context)
                 return None
+            # Refusals are decided OUT HERE so the ``except Exception``
+            # best-effort arm above cannot swallow them (it would put the SDK's
+            # unlocked refresh back on the wire, which is the one outcome this
+            # whole provider exists to prevent).
+            self._strip_in_memory_refresh_token(self.context)
+            if outcome == "unacknowledged":
+                self._refuse_unconfirmed_exchange(self.context)
+            return None
 
         @staticmethod
         def _strip_in_memory_refresh_token(ctx: Any) -> None:

--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -55,7 +55,11 @@ from local_operator.harness.types import (
 )
 from local_operator.mcp.auth import (
     REFRESH_CONTENTION,
+    REFRESH_REFUSAL_ENDPOINT,
+    REFRESH_REFUSAL_INFLIGHT,
+    REFRESH_REFUSAL_LOCK,
     REFRESH_REFUSAL_UNCONFIRMED,
+    REFRESH_REFUSAL_UNREACHABLE,
     McpAuthChallengeError,
     McpAuthRequiredError,
     McpRefreshContendedError,
@@ -115,6 +119,48 @@ def _sdk_available() -> bool:
 #: rather than sniffing the text — the alternative is a substring match that goes
 #: quietly wrong the day the wording changes.
 MCP_SDK_MISSING_ERROR = missing_extra_error("mcp", "Connecting to MCP servers")
+
+#: Short, user-visible text per TRANSIENT refresh refusal, keyed by the stable
+#: reason code the auth layer carries on the exception
+#: (:data:`~local_operator.mcp.auth.REFRESH_REFUSAL_LOCK` and friends). Composed
+#: HERE rather than in ``auth.py`` because the code, not the sentence, is what
+#: travels: the auth layer's own ``str(exc)`` opens with
+#: ``MCP OAuth token refresh for https://<host>/<path>`` and is ~55 cells before
+#: it says anything distinguishing, so it cannot be the rendered copy.
+#:
+#: Every entry is measured against the two surfaces that clamp it — the startup
+#: toast, whose detail line is ``failed: <name> — <this>`` truncated to 58 cells
+#: at 100 columns and 36 at 44 (so <this> gets 41 and 19 respectively) — and the
+#: durable notice, which is the full terminal width. The rules the wording obeys:
+#:
+#: * NO full URL and no subsystem internals (no "refresh lock", no "rotation"):
+#:   the host line already names the server, and a user cannot act on our nouns;
+#: * the DISTINGUISHING word comes first, because the toast tail-truncates: all
+#:   four must differ within their first ~19 cells or the 44-column card renders
+#:   the same fragment for every one of them (design review D1);
+#: * the condition, not a promise: the two in-flight refusals read as states that
+#:   may clear on their own (another session is on it; the exchange is still
+#:   running), the other two name the server side as the problem, which is the
+#:   only "does this heal by itself?" signal a user can get;
+#: * NO command and NO "retrying": for a transient refusal the remedy
+#:   mid-session is the manager's own backoff reconnect, while the startup gate
+#:   schedules nothing at all — so offering a command would send the user at a
+#:   destructive ``reauth`` for a self-healing condition, and promising a retry
+#:   would be untrue at boot. Only the auth requirement
+#:   (``McpRefreshUnconfirmedError``) leads with a command, and it is rendered by
+#:   ``_auth_required_text``, not from this table.
+_REFRESH_REFUSAL_TEXT: dict[str, str] = {
+    REFRESH_REFUSAL_LOCK: "another session is refreshing",
+    REFRESH_REFUSAL_INFLIGHT: "refresh still in progress",
+    REFRESH_REFUSAL_ENDPOINT: "the server returned no token",
+    REFRESH_REFUSAL_UNREACHABLE: "cannot reach the server",
+}
+
+#: Fallback for a refusal code this build does not know (a newer peer writes a
+#: code we cannot name). Deliberately says only what is true of every refusal in
+#: the set — never ``str(exc)``, whose URL prefix would render as the fragment
+#: this whole mapping exists to remove.
+REFRESH_REFUSAL_UNKNOWN_TEXT = "the refresh did not complete"
 
 # Fast-startup gate: how long discovery blocks before deferring slow servers.
 STARTUP_GATE_MS = 250
@@ -1499,8 +1545,16 @@ class McpManager:
                 _settle_future_error(waiter, exc)
                 continue
             except Exception as exc:
-                result.errors[name] = str(exc)
-                self._startup_failures[name] = str(exc)
+                # Through the dispatcher, not ``str(exc)``: a transient refresh
+                # refusal (a peer holding the refresh lock, an exchange that
+                # overran the budget) lands HERE, and its own ``str`` is the
+                # URL-prefixed log sentence that renders as an identical
+                # truncated fragment for every refusal. The dispatcher maps the
+                # exception's reason code to the short rendered text; for any
+                # exception it does not know it returns ``str(exc)`` unchanged.
+                message = self._auth_failure_text(name, exc)
+                result.errors[name] = message
+                self._startup_failures[name] = message
                 logger.warning("MCP server %r failed to connect: %s", name, exc)
                 # A parked waiter (reload) must fail, not hang (MCP-08).
                 waiter = self._connect_futures.pop(name, None)
@@ -1769,7 +1823,7 @@ class McpManager:
             # be misattributed to a later, unrelated cancellation of the same
             # server. The ledger holds one record per refusal, so a second
             # concurrent connect's refusal is still there for its own arm.
-            refusal = (
+            reason_code = (
                 REFRESH_CONTENTION.pop(url)
                 if isinstance(exc, asyncio.CancelledError) and isinstance(url, str) and url
                 else None
@@ -1813,11 +1867,11 @@ class McpManager:
                 # actionable reauth command instead of "authorization expired".
                 # The externally_cancelled guard above has already run, so a
                 # genuine teardown never reaches here.
-                if refusal is not None:
+                if reason_code is not None:
                     assert isinstance(url, str)
-                    if refusal == REFRESH_REFUSAL_UNCONFIRMED:
+                    if reason_code == REFRESH_REFUSAL_UNCONFIRMED:
                         raise McpRefreshUnconfirmedError(url) from exc
-                    raise McpRefreshContendedError(url, refusal=refusal) from exc
+                    raise McpRefreshContendedError(url, reason_code=reason_code) from exc
                 from local_operator.mcp.auth import (
                     ABANDONED_GRANTS,
                     McpLoginCancelledError,
@@ -2159,7 +2213,13 @@ class McpManager:
         # leads. Only a refresh that was SENT but never confirmed carries one
         # today (see McpRefreshUnconfirmedError): calling that an expired
         # authorization would send the user looking for a grant that is
-        # perfectly valid on disk.
+        # perfectly valid on disk. It is kept SHORT (``refresh unconfirmed``)
+        # because this whole line is the tail of the toast's
+        # ``failed: <name> — <line>`` and is therefore clamped twice: at ~58
+        # cells the previous sentence-length detail was itself truncated off the
+        # card (design review D4), which left the added reason invisible on the
+        # first surface the user reads. The command still leads and there is
+        # still exactly one dash, which is the rule D4's fix had to preserve.
         detail = getattr(exc, "detail", None)
         if has_stored_grant:
             return f"run /mcp reauth {name} — {detail or 'authorization expired'}"
@@ -2209,11 +2269,22 @@ class McpManager:
         incident sink and ``/mcp`` never drift apart on what a user is told to
         run — the two shapes reach the same surfaces by different routes
         (a configured grant that needs a browser vs a server that refused us).
+
+        The TRANSIENT refresh refusals are rendered here too, and they are the
+        reason this is the composition point: they used to fall through to
+        ``str(exc)``, whose ``MCP OAuth token refresh for <url> …`` prefix filled
+        the toast card on its own, so all four rendered as one identical
+        truncated fragment at 100 columns and below (design review D1/D2). The
+        short text is keyed by the exception's stable reason code, so the auth
+        layer keeps only the code and the log sentence.
         """
         if isinstance(exc, McpAuthChallengeError):
             return cls._auth_challenge_text(name, exc)
         if isinstance(exc, McpAuthRequiredError):
             return cls._auth_required_text(name, exc)
+        reason_code = getattr(exc, "reason_code", None)
+        if reason_code is not None:
+            return _REFRESH_REFUSAL_TEXT.get(reason_code, REFRESH_REFUSAL_UNKNOWN_TEXT)
         return str(exc)
 
     def auth_recovery_hint(self, rendered_error: str) -> str | None:
@@ -2431,14 +2502,20 @@ class McpManager:
             # owns it.
             current_round = not self._disposed and epoch == self._epoch
             if current_round:
-                # Record the failure into the round accumulator (an auth
-                # requirement as its actionable text, else the raw reason) and
-                # settle this deferred server BEFORE firing tools-changed, so the
-                # front end that re-reports on settle sees the complete map.
-                if isinstance(auth_exc, (McpAuthRequiredError, McpAuthChallengeError)):
-                    self._startup_failures[name] = self._auth_failure_text(name, auth_exc)
-                else:
-                    self._startup_failures[name] = str(exc)
+                # Record the failure into the round accumulator and settle this
+                # deferred server BEFORE firing tools-changed, so the front end
+                # that re-reports on settle sees the complete map. ONE dispatcher
+                # for both shapes: the auth requirement renders as its actionable
+                # command, and a transient refresh refusal renders as the short
+                # reason its code maps to. Reaching for ``str(exc)`` on the
+                # non-auth side is what made every refusal identical on the card
+                # (design review D1), and the dispatcher returns ``str(exc)``
+                # unchanged for anything it does not recognise.
+                # ``auth_exc`` is the auth requirement found anywhere in a
+                # transport ``ExceptionGroup``, else the original exception — and
+                # a re-voiced refusal is raised directly by ``_connect_server``,
+                # so the same value carries both shapes unchanged.
+                self._startup_failures[name] = self._auth_failure_text(name, auth_exc)
             # Re-fetch the waiter: a reload during the await may have swapped
             # it, and settling the stale one would strand the current waiters.
             _settle_future_error(self._connect_futures.get(name), exc)

--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -53,7 +53,11 @@ from local_operator.harness.types import (
     ToolContext,
     ToolResult,
 )
-from local_operator.mcp.auth import McpAuthChallengeError, McpAuthRequiredError
+from local_operator.mcp.auth import (
+    REFRESH_CONTENTION,
+    McpAuthChallengeError,
+    McpAuthRequiredError,
+)
 from local_operator.mcp.config import (
     MCPHttpServerConfig,
     MCPServerConfig,
@@ -1729,6 +1733,13 @@ class McpManager:
                 await stack.aclose()
             except BaseException as ce:  # noqa: BLE001 — examined below, never lost
                 close_exc = ce
+            # ONE pop for the whole classification, whatever the exception turns
+            # out to be, so a record cannot leak into a later connect of the
+            # same server. It is consumed below only by the cancellation arm,
+            # and only when this cancellation did NOT come from outside — a
+            # record armed by a refused unlocked refresh must never turn a
+            # genuine dispose/epoch teardown into a reconnect.
+            contended = REFRESH_CONTENTION.pop(url) if isinstance(url, str) and url else False
             # A GENUINE external cancellation (dispose/reload/esc) keeps its
             # priority even when the teardown surfaced a grouped auth error:
             # the task itself was asked to cancel (``cancelling() > 0``), and
@@ -1765,12 +1776,22 @@ class McpManager:
             # cancellation's priority, so a recorded abandonment here can be
             # re-voiced as the receipt the user reads.
             if isinstance(exc, asyncio.CancelledError):
+                # The refusal arm comes FIRST: a coordinator that declined to
+                # spend the refresh token without exclusivity recorded that on
+                # its way out, and the transport rewrote the reason into this
+                # bare cancellation. Re-voicing it is what lands it in
+                # ``_reconnect``'s generic arm (backoff retry, no auth block)
+                # instead of looking like a dispose.
+                if contended:
+                    from local_operator.mcp.auth import McpRefreshContendedError
+
+                    assert isinstance(url, str)
+                    raise McpRefreshContendedError(url) from exc
                 from local_operator.mcp.auth import (
                     ABANDONED_GRANTS,
                     McpLoginCancelledError,
                 )
 
-                url = getattr(cfg, "url", None)
                 flow = self._oauth_flows.pop(url, None) if isinstance(url, str) else None
                 if flow is not None and ABANDONED_GRANTS.pop(flow):
                     raise McpLoginCancelledError(

--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -58,8 +58,10 @@ from local_operator.mcp.auth import (
     REFRESH_REFUSAL_ENDPOINT,
     REFRESH_REFUSAL_INFLIGHT,
     REFRESH_REFUSAL_LOCK,
+    REFRESH_REFUSAL_UNATTRIBUTED,
     REFRESH_REFUSAL_UNCONFIRMED,
     REFRESH_REFUSAL_UNREACHABLE,
+    REFRESH_REFUSAL_UNSENT,
     McpAuthChallengeError,
     McpAuthRequiredError,
     McpRefreshContendedError,
@@ -120,6 +122,15 @@ def _sdk_available() -> bool:
 #: quietly wrong the day the wording changes.
 MCP_SDK_MISSING_ERROR = missing_extra_error("mcp", "Connecting to MCP servers")
 
+#: Fallback for a refusal code this build does not know (a newer peer writes a
+#: code we cannot name), and the honest wording for our OWN failures that cannot
+#: be attributed to a server answer at all (``REFRESH_REFUSAL_UNATTRIBUTED``).
+#: Deliberately says only what is true of every refusal in the set — never
+#: ``str(exc)``, whose URL prefix would render as the fragment this whole mapping
+#: exists to remove. Defined ABOVE the table so the table can reference it rather
+#: than repeat the sentence.
+REFRESH_REFUSAL_UNKNOWN_TEXT = "the refresh did not complete"
+
 #: Short, user-visible text per TRANSIENT refresh refusal, keyed by the stable
 #: reason code the auth layer carries on the exception
 #: (:data:`~local_operator.mcp.auth.REFRESH_REFUSAL_LOCK` and friends). Composed
@@ -135,13 +146,18 @@ MCP_SDK_MISSING_ERROR = missing_extra_error("mcp", "Connecting to MCP servers")
 #:
 #: * NO full URL and no subsystem internals (no "refresh lock", no "rotation"):
 #:   the host line already names the server, and a user cannot act on our nouns;
-#: * the DISTINGUISHING word comes first, because the toast tail-truncates: all
-#:   four must differ within their first ~19 cells or the 44-column card renders
-#:   the same fragment for every one of them (design review D1);
+#: * the DISTINGUISHING word comes first, because the toast tail-truncates: every
+#:   entry must differ within its first ~19 cells or the 44-column card renders
+#:   the same fragment for all of them (design review D1);
 #: * the condition, not a promise: the two in-flight refusals read as states that
 #:   may clear on their own (another session is on it; the exchange is still
 #:   running), the other two name the server side as the problem, which is the
 #:   only "does this heal by itself?" signal a user can get;
+#: * NEVER blame a server for a request that did not go out. The two LOCAL
+#:   shapes — nothing in the row the exchange could present, and a failure of
+#:   our own coordination — get their own wording, because the endpoint code's
+#:   "the server returned no token" is false about the wire AND about the
+#:   server for both (review round 3, M2);
 #: * NO command and NO "retrying": for a transient refusal the remedy
 #:   mid-session is the manager's own backoff reconnect, while the startup gate
 #:   schedules nothing at all — so offering a command would send the user at a
@@ -149,18 +165,18 @@ MCP_SDK_MISSING_ERROR = missing_extra_error("mcp", "Connecting to MCP servers")
 #:   would be untrue at boot. Only the auth requirement
 #:   (``McpRefreshUnconfirmedError``) leads with a command, and it is rendered by
 #:   ``_auth_required_text``, not from this table.
+#:
+#: ``REFRESH_REFUSAL_UNATTRIBUTED`` shares :data:`REFRESH_REFUSAL_UNKNOWN_TEXT`
+#: rather than minting a near-synonym: both mean "we cannot name a cause", and
+#: two sentences for one honest statement would only invite them to drift.
 _REFRESH_REFUSAL_TEXT: dict[str, str] = {
     REFRESH_REFUSAL_LOCK: "another session is refreshing",
     REFRESH_REFUSAL_INFLIGHT: "refresh still in progress",
     REFRESH_REFUSAL_ENDPOINT: "the server returned no token",
     REFRESH_REFUSAL_UNREACHABLE: "cannot reach the server",
+    REFRESH_REFUSAL_UNSENT: "no stored token to send",
+    REFRESH_REFUSAL_UNATTRIBUTED: REFRESH_REFUSAL_UNKNOWN_TEXT,
 }
-
-#: Fallback for a refusal code this build does not know (a newer peer writes a
-#: code we cannot name). Deliberately says only what is true of every refusal in
-#: the set — never ``str(exc)``, whose URL prefix would render as the fragment
-#: this whole mapping exists to remove.
-REFRESH_REFUSAL_UNKNOWN_TEXT = "the refresh did not complete"
 
 # Fast-startup gate: how long discovery blocks before deferring slow servers.
 STARTUP_GATE_MS = 250
@@ -2179,13 +2195,23 @@ class McpManager:
 
         Leads with the COMMAND that fixes it rather than the diagnosis. The
         toast renders this after a ``failed: <name> — `` prefix and then clamps
-        to the card width, so the tail is what gets truncated: putting
-        ``run /mcp login <name>`` first keeps the one actionable thing on screen
-        even on a narrow terminal, where ``needs authorization — run /mcp login
-        <name>`` used to sever the command mid-word (design review D1). One
-        ``—`` only, so the composed line is not a chain of dashes (D4). The same
-        string lands in the durable transcript notice and in ``/mcp``, so one
-        helper keeps all three surfaces agreeing.
+        to the card width, so the tail is what gets truncated: putting the
+        command first keeps the one actionable thing on screen even on a narrow
+        terminal, where ``needs authorization — /mcp login <name>`` used to
+        sever the command mid-word (design review D1). One ``—`` only, so the
+        composed line is not a chain of dashes (D4). The same string lands in
+        the durable transcript notice and in ``/mcp``, so one helper keeps all
+        three surfaces agreeing.
+
+        The command is BARE (``/mcp reauth <name>``, not ``run /mcp reauth
+        <name>``), and that is a measurement rather than a style choice (design
+        review D9): the ``run `` wrapper spends four cells, which is exactly the
+        shortfall that pushed the reason past the toast card's clamp at 100
+        columns and cut the server name mid-word at 44. The bare form is also
+        the app's own habit for a runnable command (``/       command picker``
+        on the splash, ``sign-in expired — /login kimi`` in the usage panel),
+        and the name argument has to stay: ``/mcp reauth`` with no name is
+        ``usage: /mcp reauth <name>``, an instruction that errors when followed.
 
         ``login`` vs ``reauth`` is decided by whether a stored grant exists,
         not guessed. Reaching this error at all means the stored grant could
@@ -2208,10 +2234,10 @@ class McpManager:
             from local_operator.mcp.auth import server_has_stored_grant
 
             has_stored_grant = server_has_stored_grant(exc.server_url)
-        # ``detail`` is the ONE place a reason more specific than "expired" can
-        # reach this line, and it is rendered as the tail so the command still
-        # leads. Only a refresh that was SENT but never confirmed carries one
-        # today (see McpRefreshUnconfirmedError): calling that an expired
+        # ``detail`` is the ONE place a reason more specific than the default
+        # can reach this line, and it is rendered as the tail so the command
+        # still leads. Only a refresh that was SENT but never confirmed carries
+        # one today (see McpRefreshUnconfirmedError): calling that an expired
         # authorization would send the user looking for a grant that is
         # perfectly valid on disk. It is kept SHORT (``refresh unconfirmed``)
         # because this whole line is the tail of the toast's
@@ -2220,10 +2246,15 @@ class McpManager:
         # card (design review D4), which left the added reason invisible on the
         # first surface the user reads. The command still leads and there is
         # still exactly one dash, which is the rule D4's fix had to preserve.
+        # The default tail is the app's EXISTING house phrase for a dead
+        # credential (``sign-in expired`` — usage_panel.py), not a new coinage:
+        # the user has signed in, and what they need to know is that it stopped
+        # working. "authorization expired" spent five more cells to say the same
+        # thing less plainly.
         detail = getattr(exc, "detail", None)
         if has_stored_grant:
-            return f"run /mcp reauth {name} — {detail or 'authorization expired'}"
-        return f"run /mcp login {name} to authorize"
+            return f"/mcp reauth {name} — {detail or 'sign-in expired'}"
+        return f"/mcp login {name} to authorize"
 
     @staticmethod
     def _auth_challenge_text(name: str, exc: McpAuthChallengeError) -> str:

--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -55,8 +55,11 @@ from local_operator.harness.types import (
 )
 from local_operator.mcp.auth import (
     REFRESH_CONTENTION,
+    REFRESH_REFUSAL_UNCONFIRMED,
     McpAuthChallengeError,
     McpAuthRequiredError,
+    McpRefreshContendedError,
+    McpRefreshUnconfirmedError,
 )
 from local_operator.mcp.config import (
     MCPHttpServerConfig,
@@ -1739,7 +1742,15 @@ class McpManager:
             # and only when this cancellation did NOT come from outside — a
             # record armed by a refused unlocked refresh must never turn a
             # genuine dispose/epoch teardown into a reconnect.
-            contended = REFRESH_CONTENTION.pop(url) if isinstance(url, str) and url else False
+            #
+            # NOTE the pop happens only in the cancellation arm, not on every
+            # failure path: a record can only be CONSUMED here, and popping
+            # earlier threw one away on ordinary failures — with a single slot
+            # per server that silently killed a concurrent connect's retry. The
+            # ledger holds one record per refusal (several per server), so a
+            # second concurrent connect's refusal is still there for it, and a
+            # record this arm does not believe is still discarded (see below),
+            # never left to be misattributed to a later cancellation.
             # A GENUINE external cancellation (dispose/reload/esc) keeps its
             # priority even when the teardown surfaced a grouped auth error:
             # the task itself was asked to cancel (``cancelling() > 0``), and
@@ -1748,6 +1759,21 @@ class McpManager:
             # internal delivery — the auth flow failing inside the transport's
             # task group — raises CancelledError WITHOUT marking this task as
             # cancelling, which is exactly what lets the two be told apart.
+            # Consume ONE record for this server the moment the cancellation is
+            # recognised, and decide what it is WORTH below. Gating the pop on
+            # the exception type is deliberate: only this arm can use a record,
+            # and popping it on every failure path threw it away for nothing —
+            # with a single slot per server that silently killed a concurrent
+            # connect's retry. Consuming it here also means it is discarded even
+            # when the guard below (a genuine dispose) outranks it, so it cannot
+            # be misattributed to a later, unrelated cancellation of the same
+            # server. The ledger holds one record per refusal, so a second
+            # concurrent connect's refusal is still there for its own arm.
+            refusal = (
+                REFRESH_CONTENTION.pop(url)
+                if isinstance(exc, asyncio.CancelledError) and isinstance(url, str) and url
+                else None
+            )
             current = asyncio.current_task()
             externally_cancelled = (
                 current is not None
@@ -1776,17 +1802,22 @@ class McpManager:
             # cancellation's priority, so a recorded abandonment here can be
             # re-voiced as the receipt the user reads.
             if isinstance(exc, asyncio.CancelledError):
-                # The refusal arm comes FIRST: a coordinator that declined to
-                # spend the refresh token without exclusivity recorded that on
-                # its way out, and the transport rewrote the reason into this
-                # bare cancellation. Re-voicing it is what lands it in
+                # A refusal re-voice comes FIRST among the things a bare
+                # cancellation can mean: the coordinator declined to spend the
+                # refresh token and recorded WHY on its way out, and the
+                # transport rewrote that reason into this bare
+                # ``CancelledError``. Re-voicing it is what lands it in
                 # ``_reconnect``'s generic arm (backoff retry, no auth block)
-                # instead of looking like a dispose.
-                if contended:
-                    from local_operator.mcp.auth import McpRefreshContendedError
-
+                # instead of looking like a dispose — or, for a token that may
+                # already be spent, what makes the user-visible reason the
+                # actionable reauth command instead of "authorization expired".
+                # The externally_cancelled guard above has already run, so a
+                # genuine teardown never reaches here.
+                if refusal is not None:
                     assert isinstance(url, str)
-                    raise McpRefreshContendedError(url) from exc
+                    if refusal == REFRESH_REFUSAL_UNCONFIRMED:
+                        raise McpRefreshUnconfirmedError(url) from exc
+                    raise McpRefreshContendedError(url, refusal=refusal) from exc
                 from local_operator.mcp.auth import (
                     ABANDONED_GRANTS,
                     McpLoginCancelledError,
@@ -2123,8 +2154,15 @@ class McpManager:
             from local_operator.mcp.auth import server_has_stored_grant
 
             has_stored_grant = server_has_stored_grant(exc.server_url)
+        # ``detail`` is the ONE place a reason more specific than "expired" can
+        # reach this line, and it is rendered as the tail so the command still
+        # leads. Only a refresh that was SENT but never confirmed carries one
+        # today (see McpRefreshUnconfirmedError): calling that an expired
+        # authorization would send the user looking for a grant that is
+        # perfectly valid on disk.
+        detail = getattr(exc, "detail", None)
         if has_stored_grant:
-            return f"run /mcp reauth {name} — authorization expired"
+            return f"run /mcp reauth {name} — {detail or 'authorization expired'}"
         return f"run /mcp login {name} to authorize"
 
     @staticmethod

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -12819,11 +12819,18 @@ class OperatorApp(App[None]):
             # case for HTTP servers) or mid-session never reached the boot
             # toast, so raise a fresh one here. Hop onto the Textual thread:
             # this fires from the manager's connect/reconnect task.
+            #
+            # ``server_name`` is deliberately unused: every message this sink is
+            # handed (``_auth_required_text`` and ``_auth_challenge_text``) already
+            # names its server — the auth line does so inside its command — so
+            # prefixing the name here rendered it BEFORE the command and left
+            # ``notion run /mcp reauth`` with no separator between the two (design
+            # review D8). The command leads because the message leads.
             def _show() -> None:
                 from local_operator.tui.widgets.toast import TOAST_FAILURE_MS, Toast
 
                 toast = self.query_one(Toast)
-                toast.show(f"{ICON_MCP} MCP {server_name} {message}", duration_ms=TOAST_FAILURE_MS)
+                toast.show(f"{ICON_MCP} MCP {message}", duration_ms=TOAST_FAILURE_MS)
 
             self.call_later(_show)
 
@@ -12992,7 +12999,12 @@ class OperatorApp(App[None]):
         :attr:`_mcp_failure_notices`. It also names ``/mcp``, because the toast
         is now one-shot and the standing answer needs signposting at the moment
         the failure is read (U4); the pointer goes on the durable line, where
-        there is room, and not on the width-budgeted toast.
+        there is room, and not on the width-budgeted toast. It is omitted when
+        the failure text ALREADY names ``/mcp`` (an auth requirement leads with
+        its own ``/mcp reauth`` command): appending it there produced two
+        em-dashes in one sentence against the house one-dash rule and pushed the
+        line past 100 cells, which is where the tail wrapped and orphaned
+        "— /mcp for details" onto a row of its own (design review D5).
         """
         outcome = getattr(session, "mcp_startup", None)
         if outcome is None:
@@ -13082,14 +13094,27 @@ class OperatorApp(App[None]):
             return
         # No "server" in the wording: one failure key is ``discovery`` (the
         # config layer itself), and "MCP server discovery failed" would name a
-        # server that does not exist. `/mcp` is named because it is the standing
-        # answer and this is the durable surface with room to point at it.
+        # server that does not exist. ``/mcp`` is named on the durable line
+        # because it is the standing answer and this is the surface with room to
+        # point at it — except when the failure text is already a ``/mcp``
+        # command, where the pointer is skipped instead of doubling the dash
+        # (design review D5).
         for name, error in sorted(outcome.failures.items()):
             notice_key = (session_key, name, str(error))
             if notice_key in self._mcp_failure_notices:
                 continue
             self._mcp_failure_notices.add(notice_key)
-            self._system_notice(f"MCP {name} failed: {error} — /mcp for details", "error")
+            # The pointer is appended ONLY when the line does not already name
+            # ``/mcp`` itself. The auth requirement leads with its own
+            # ``/mcp reauth`` command, so appending "— /mcp for details" gave the
+            # composed sentence TWO dashes (against the house one-dash rule) and
+            # pushed the tail past a 100-cell line, where a wrapped continuation
+            # is what orphaned "— /mcp for details" onto a row of its own (design
+            # review D5). The pointer is for failures whose text is a diagnostic
+            # rather than an instruction; when the text is already the command,
+            # the reader has the answer.
+            pointer = "" if "/mcp" in str(error) else " — /mcp for details"
+            self._system_notice(f"MCP {name} failed: {error}{pointer}", "error")
 
     def on_toast_evicted(self, message: Toast.Evicted) -> None:
         """Un-record the MCP announce when its card was thrown away unread.

--- a/local_operator/tui/widgets/toast.py
+++ b/local_operator/tui/widgets/toast.py
@@ -112,6 +112,76 @@ def toast_max_width(terminal_width: int) -> int:
     )
 
 
+#: The separator between a failure line's COMMAND and the reason that trails
+#: it. ``McpManager._auth_required_text`` is the one composer that builds this
+#: shape (``/mcp reauth notion — refresh unconfirmed``): the command first, so a
+#: clamp can only ever eat the tail (design review D1/D4/D9), then `` — `` and
+#: the reason.
+_FAILURE_REASON_SEP = " — "
+
+#: What a failure line must LEAD with for its tail to be a droppable REASON.
+#: Deliberately the command prefix rather than "the text contains a dash": the
+#: no-OAuth-endpoint challenge line (``notion rejected our credentials (401) —
+#: set its API key or headers``) is a diagnostic whose second clause is half of
+#: the statement, and it is explicitly out of this change's scope (design review
+#: D10), so it must keep rendering exactly as it does today.
+_COMMAND_LEAD = "/mcp "
+
+
+def _fit_failure_line(name: str, text: str, max_cells: int) -> str:
+    """``failed: <name> — <text>``, composed against the card's real budget.
+
+    WHY a composer rather than the bare clamp that used to sit here: this row is
+    ``failed: `` + name + `` — `` + the failure text, and the auth text names the
+    server a SECOND time inside its command. The unconfirmed form is therefore
+    ``45 + 2n`` cells for an ``n``-cell name against the card's 58 content cells
+    (``60 - TOAST_PADDING_CELLS``, at any terminal 66 cells or wider), so it fits
+    while ``n <= 6`` and the clamp then eats whatever sits at the END of the line
+    — which for ``minerva-qa`` (10 cells) was 7 cells of the REASON at 100
+    columns, and for ``launchdarkly`` (12) the command's own name argument at 44
+    (design review round 3, D11: measured rows ``failed: minerva-qa — /mcp reauth
+    minerva-qa — refresh unc…`` and ``failed: launchdarkly — /mcp reauth…``, the
+    latter a command that errors if the user follows it).
+
+    So the budget decides what gets SHED, not merely where the string is cut:
+
+    * **Rung 1** — the whole row, whenever it fits. Byte-identical to the clamp
+      for the corpus design review D9 verified at 100 columns (57/53/47 cells at
+      a 6-cell name), so the pinned rows are untouched.
+    * **Rung 2** — the command, marked as having shed the reason. The reason is
+      the right part to lose: it is the only piece that is not a command the
+      user has to be able to type, and ``/mcp`` plus the durable transcript
+      notice both carry it whole. The ``…`` is the same cue the 44-column card
+      has always shown (D9 accepted it as marking the shed reason);
+    * **Rung 3** — the command alone, for the widths where even the mark does
+      not fit (a 51-cell terminal has a 43-cell card, exactly the width of
+      ``failed: minerva-qa — /mcp reauth minerva-qa``). Without this rung the
+      clamp cut the name's last character — the same D11 defect, one cell over.
+    * **Backstop** — the clamp, for a text that is not a command-with-reason
+      (every plain diagnostic, the D10 challenge line, a 200-cell error) and for
+      a name so long that not even the command fits on the row. Never worse than
+      the behaviour it replaces.
+
+    The 44-column card is deliberately UNCHANGED for 8+ cell names, and that is
+    a recorded limit rather than an oversight: the command ALONE is ``23 + 2n``
+    cells against a 36-cell card, so no composition of this line puts a whole
+    ``/mcp reauth <name>`` on that card at ``n >= 7`` without a second row or a
+    different card shape. Both are layout decisions this change does not make
+    (D11's resolution 2), so the fall-through keeps the base's pixels there and
+    the named constraint is recorded on the deferral instead.
+    """
+    label = f"failed: {name} — "
+    full = label + text
+    if cell_len(full) <= max_cells:
+        return full
+    if text.startswith(_COMMAND_LEAD) and _FAILURE_REASON_SEP in text:
+        command = text.split(_FAILURE_REASON_SEP, 1)[0]
+        for shed in (f"{label}{command}…", f"{label}{command}"):
+            if cell_len(shed) <= max_cells:
+                return shed
+    return truncate_cells(full, max_cells)
+
+
 def format_mcp_startup(
     outcome: McpStartupOutcome,
     max_cells: int = TOAST_MAX_WIDTH - TOAST_PADDING_CELLS,
@@ -167,12 +237,12 @@ def format_mcp_startup(
             # server the head line meant and read the name twice to do it. Both
             # variants now open on the same word, which is what makes the second
             # line scannable as a failure list rather than as prose.
-            detail = f"failed: {names[0]} — {outcome.failures[names[0]]}"
+            detail = _fit_failure_line(names[0], outcome.failures[names[0]], max(1, max_cells))
         else:
-            detail = "failed: " + ", ".join(names)
+            detail = truncate_cells("failed: " + ", ".join(names), max(1, max_cells))
         text.append("\n")
         text.append(
-            truncate_cells(detail, max(1, max_cells)),
+            detail,
             style=Style(color=theme_mod.semantic_color("danger")),
         )
 

--- a/tests/e2e/test_mcp_oauth_rotation_e2e.py
+++ b/tests/e2e/test_mcp_oauth_rotation_e2e.py
@@ -23,8 +23,11 @@ two claims here are stated in the terms the incident was described in:
 
 Before the corresponding fixes, (1) leaves the spent token stored and the next
 session's refresh POST revokes the family — ``"MCP authorization failed; run
-/mcp reauth"`` for every later session — and (2) ends the request in a
-non-interactive ``McpAuthRequiredError``. Both are asserted as outcomes here
+/mcp reauth"`` for every later session — and (2) ends in a transport-mangled
+``CancelledError`` ("Cancelled via cancel scope") with no token POST and no
+recovery: the 401 is handed to the SDK's authorization branch, whose browser
+refusal the anyio cancel scope swallows, so the session neither heals nor
+reports an actionable auth requirement. Both are asserted as outcomes here
 rather than as call counts, so the stage fails if the recovery merely looks
 plausible.
 """
@@ -282,6 +285,15 @@ async def test_a_cancelled_refresh_keeps_its_rotation_and_the_next_session_conne
                 await task
 
             tokens = _stored_tokens(store, url)
+            # The cancellation is delivered IMMEDIATELY now — teardown no longer
+            # waits out the refresh budget — and the rotation lands a moment
+            # later, persisted by the detached exchange, which still owns the
+            # refresh lock until it has. Polling is part of the contract rather
+            # than a concession: nothing else can recover that token.
+            deadline = time.monotonic() + 5
+            while tokens.get("refresh_token") != "refresh-1" and time.monotonic() < deadline:
+                await asyncio.sleep(0.05)
+                tokens = _stored_tokens(store, url)
             assert tokens.get("refresh_token") == "refresh-1", (
                 "the cancelled exchange lost the server's rotation; the store is "
                 f"holding a spent token: {tokens!r}"

--- a/tests/e2e/test_mcp_oauth_rotation_e2e.py
+++ b/tests/e2e/test_mcp_oauth_rotation_e2e.py
@@ -1,0 +1,366 @@
+"""Real-transport end-to-end proof of refresh durability across sessions.
+
+``tests/unit/mcp/test_oauth_refresh_durability.py`` reproduces each defect
+against the real machinery in isolation. This stage is the other half: the REAL
+MCP streamable-HTTP transport, the REAL ``OAuthClientProvider`` wiring and the
+REAL credential store, against a LOCAL authorization server that behaves like
+Notion — it rotates the refresh token on every exchange, invalidates the access
+token that went with it, and runs REFRESH-TOKEN REUSE DETECTION (presenting
+anything other than the current refresh token returns ``invalid_grant`` AND
+revokes the whole family).
+
+That last property is what makes the defect fleet-wide rather than local, so the
+two claims here are stated in the terms the incident was described in:
+
+1. a session whose refresh is CANCELLED mid-flight (every sidebar switch
+   disposes a manager and cancels its in-flight connects) must not lose the
+   rotation that exchange performed — the store must hold the NEW refresh
+   token, and the next session must be able to connect WITHOUT posting a spent
+   one and killing the family;
+2. a session whose access token the server has revoked underneath it (a
+   sibling's rotation) must recover from its 401 by refreshing UNDER THE LOCK,
+   not by handing the 401 to the SDK's authorization branch.
+
+Before the corresponding fixes, (1) leaves the spent token stored and the next
+session's refresh POST revokes the family — ``"MCP authorization failed; run
+/mcp reauth"`` for every later session — and (2) ends the request in a
+non-interactive ``McpAuthRequiredError``. Both are asserted as outcomes here
+rather than as call counts, so the stage fails if the recovery merely looks
+plausible.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+from urllib.parse import parse_qsl
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, Response
+
+from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+from local_operator.mcp.manager import McpManager
+from local_operator.providers.auth_store import AuthStore
+from tests.e2e.test_desktop_radient import serve
+
+pytestmark = pytest.mark.e2e
+
+
+class RotatingIssuer:
+    """A local authorization server AND MCP endpoint that rotates and revokes.
+
+    Two behaviours, both taken from Notion's observed behaviour rather than from
+    RFC 6749 (which permits, but does not require, either): every successful
+    refresh issues a NEW refresh token and invalidates the access token that
+    went with the old one, and a refresh presenting anything but the current
+    refresh token is treated as a REPLAY — ``invalid_grant`` plus revocation of
+    the entire family, so every later exchange fails too.
+
+    ``post_delay_s`` holds the RESPONSE back after the rotation has been applied,
+    which is the window these tests cancel inside.
+    """
+
+    def __init__(self) -> None:
+        self.origin = ""
+        self.access_token = "access-0"
+        self.refresh_token = "refresh-0"
+        self.revoked = False
+        self.rotations = 0
+        self.token_posts = 0
+        self.reuse_attempts = 0
+        self.post_delay_s = 0.0
+        self.rotated = asyncio.Event()
+        self.app = FastAPI()
+        self._wire()
+
+    def rotate_now(self) -> None:
+        """Rotate without a client request: what a sibling process does."""
+        self._rotate()
+
+    def revoke_access_tokens(self) -> None:
+        """Invalidate the access tokens issued so far, WITHOUT spending the
+        refresh token.
+
+        The state a 401-recovery exists for: our stored refresh token is still
+        the current one, so nothing looks wrong in memory, but the bearer token
+        every session is carrying has stopped being accepted. A sibling's
+        rotation does this as a side effect; a server can also do it on its own.
+        """
+        self.access_token = f"revoked-{self.rotations}"
+
+    def _rotate(self) -> None:
+        self.rotations += 1
+        self.access_token = f"access-{self.rotations}"
+        self.refresh_token = f"refresh-{self.rotations}"
+        self.rotated.set()
+
+    def _wire(self) -> None:
+        app = self.app
+
+        @app.get("/.well-known/oauth-protected-resource")
+        @app.get("/.well-known/oauth-protected-resource/mcp")
+        async def protected_resource() -> dict[str, Any]:
+            return {"resource": self.origin + "/mcp", "authorization_servers": [self.origin]}
+
+        @app.get("/.well-known/oauth-authorization-server")
+        async def authorization_server() -> dict[str, Any]:
+            return {
+                "issuer": self.origin,
+                "authorization_endpoint": self.origin + "/authorize",
+                "token_endpoint": self.origin + "/token",
+                "registration_endpoint": self.origin + "/register",
+                "response_types_supported": ["code"],
+                "grant_types_supported": ["authorization_code", "refresh_token"],
+                "code_challenge_methods_supported": ["S256"],
+                "token_endpoint_auth_methods_supported": ["none"],
+            }
+
+        @app.post("/register")
+        async def register(request: Request) -> JSONResponse:
+            body = await request.json()
+            return JSONResponse(
+                {**body, "client_id": "e2e-rotation", "token_endpoint_auth_method": "none"},
+                status_code=201,
+            )
+
+        @app.post("/token")
+        async def token(request: Request) -> JSONResponse:
+            self.token_posts += 1
+            form = dict(parse_qsl((await request.body()).decode("utf-8")))
+            if form.get("grant_type") != "refresh_token":
+                return JSONResponse({"error": "unsupported_grant_type"}, status_code=400)
+            if form.get("refresh_token") != self.refresh_token:
+                self.reuse_attempts += 1
+                self.revoked = True
+                return JSONResponse({"error": "invalid_grant"}, status_code=400)
+            self._rotate()
+            if self.post_delay_s:
+                # AFTER the rotation: a client that walks away now has spent the
+                # token it presented and has no way to learn the new one.
+                await asyncio.sleep(self.post_delay_s)
+            return JSONResponse(
+                {
+                    "access_token": self.access_token,
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                    "refresh_token": self.refresh_token,
+                    "scope": "fixture",
+                }
+            )
+
+        @app.api_route("/mcp", methods=["GET", "POST", "DELETE"])
+        async def mcp(request: Request) -> Response:
+            if request.headers.get("authorization") != "Bearer " + self.access_token:
+                return JSONResponse(
+                    {"error": "unauthorized"},
+                    status_code=401,
+                    headers={
+                        "WWW-Authenticate": (
+                            f'Bearer resource_metadata="'
+                            f'{self.origin}/.well-known/oauth-protected-resource"'
+                        )
+                    },
+                )
+            if request.method != "POST":
+                return Response(status_code=405)
+            body = await request.json()
+            if "id" not in body:
+                return Response(status_code=202)
+            method = body.get("method")
+            if method == "initialize":
+                result: dict[str, Any] = {
+                    "protocolVersion": body.get("params", {}).get("protocolVersion", "2025-03-26"),
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "rotation-fixture", "version": "1"},
+                }
+            elif method == "tools/list":
+                result = {
+                    "tools": [
+                        {
+                            "name": "fixture",
+                            "description": "Fixture tool",
+                            "inputSchema": {"type": "object", "properties": {}},
+                        }
+                    ]
+                }
+            elif method == "tools/call":
+                result = {"content": [{"type": "text", "text": "ok"}], "isError": False}
+            else:
+                result = {}
+            return JSONResponse({"jsonrpc": "2.0", "id": body["id"], "result": result})
+
+
+async def _seed_grant(
+    store: AuthStore,
+    url: str,
+    *,
+    access: str,
+    refresh: str,
+    age_s: float = 0.0,
+    lifetime_s: int = 3600,
+) -> None:
+    """Install a stored grant, optionally aged past its lifetime.
+
+    Goes through ``McpTokenStorage`` for the write — the same funnel production
+    uses — and re-upserts the row to backdate ``tokens_obtained_at``, because
+    expiry is computed from that stamp and a fresh stamp would let the
+    proactive refresh skip the exchange these tests are about.
+    """
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+    from local_operator.mcp.auth import MCP_OAUTH_PROVIDER, McpTokenStorage
+
+    storage = McpTokenStorage(url, store)
+    await storage.set_client_info(OAuthClientInformationFull(client_id="e2e-rotation"))
+    await storage.set_tokens(
+        OAuthToken(access_token=access, refresh_token=refresh, expires_in=lifetime_s)
+    )
+    if not age_s:
+        return
+    rows = store.list_credentials(MCP_OAUTH_PROVIDER)
+    assert rows, "the grant was not stored"
+    payload = {k: v for k, v in rows[0].data.items() if k != "type"}
+    payload["project_id"] = url
+    payload["tokens_obtained_at"] = time.time() - age_s
+    store.upsert_credential(MCP_OAUTH_PROVIDER, payload)
+
+
+def _stored_tokens(store: AuthStore, url: str) -> dict[str, Any]:
+    from local_operator.mcp.auth import MCP_OAUTH_PROVIDER
+
+    for row in store.list_credentials(MCP_OAUTH_PROVIDER):
+        if row.data.get("project_id") == url or row.data.get("identity_key") == url:
+            return dict(row.data.get("tokens") or {})
+    return {}
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_refresh_keeps_its_rotation_and_the_next_session_connects(
+    headless_tui_env, tmp_path, monkeypatch
+) -> None:
+    """One cancelled refresh must not cost the fleet its grant.
+
+    Phase 1 is the routine teardown: a connect is cancelled while its refresh
+    POST is in flight, and the server has ALREADY rotated. Phase 2 is the next
+    session, which is where the damage shows — if the store kept the spent
+    token, its proactive refresh posts that token, the server treats it as a
+    replay, and the family dies (``auth-required`` for every later session).
+
+    So the assertions are the two outcomes a user would feel: the store holds
+    the NEW refresh token, and the later session connects with ZERO token POSTs
+    and zero reuse attempts.
+    """
+    store = AuthStore(headless_tui_env / "auth.db")
+    issuer = RotatingIssuer()
+    try:
+        async with serve(issuer.app) as origin:
+            issuer.origin = origin
+            url = origin + "/mcp"
+            cfg = MCPHttpServerConfig(url=url, auth=MCPAuthConfig(type="oauth"))
+            workspace = tmp_path / "ws"
+            workspace.mkdir()
+            await _seed_grant(
+                store,
+                url,
+                access="access-0",
+                refresh="refresh-0",
+                age_s=600,
+                lifetime_s=60,
+            )
+
+            # --- Phase 1: cancel the connect while its refresh POST is in
+            # flight, after the server has applied the rotation.
+            issuer.post_delay_s = 0.6
+            manager = McpManager(str(workspace), auth_store=store)
+            task = asyncio.ensure_future(manager._connect_server("dd", cfg))
+            await asyncio.wait_for(issuer.rotated.wait(), 10)
+            assert issuer.rotations == 1, "the exchange never reached the server"
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            tokens = _stored_tokens(store, url)
+            assert tokens.get("refresh_token") == "refresh-1", (
+                "the cancelled exchange lost the server's rotation; the store is "
+                f"holding a spent token: {tokens!r}"
+            )
+            assert issuer.reuse_attempts == 0
+
+            # --- Phase 2: a later session. It must connect from the rotated
+            # grant without posting anything, and without a reuse detection.
+            issuer.post_delay_s = 0.0
+            posts_before = issuer.token_posts
+            later = McpManager(str(workspace), auth_store=store)
+            conn = await later._connect_server("dd", cfg)
+            assert conn is not None
+            assert conn.tools, "the session connected without tools"
+            assert issuer.token_posts == posts_before, (
+                "a later session re-posted a refresh token for an already-rotated " "grant"
+            )
+            assert issuer.reuse_attempts == 0, (
+                "the stale refresh token reached the server: the family is revoked "
+                "and every later session needs a human re-grant"
+            )
+            assert isinstance(conn.config, MCPHttpServerConfig)
+            assert conn.config.url == url
+    finally:
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_a_401_on_a_revoked_token_recovers_by_refreshing_under_the_lock(
+    headless_tui_env, tmp_path
+) -> None:
+    """A 401 must be recovered by a locked refresh, not by a browser grant.
+
+    The state: our access token is still VALID locally (unexpired), and it is
+    the same one the shared store holds — so there is no peer rotation to adopt.
+    The server has simply stopped accepting it, so the request comes back 401.
+    The refresh token we hold is still the current one, so the correct recovery
+    is to spend it under the refresh lock and retry.
+
+    Handing that 401 to the SDK instead ends in the SDK's authorization branch,
+    which a non-interactive connect turns into ``McpAuthRequiredError`` — an
+    actionable-looking error telling the user to run ``/mcp reauth`` for a grant
+    that only needed a refresh. So the assertion is the user-visible outcome:
+    the tool call succeeds, the grant is reported connected, and the store holds
+    the ROTATED token.
+    """
+    store = AuthStore(headless_tui_env / "auth.db")
+    issuer = RotatingIssuer()
+    try:
+        async with serve(issuer.app) as origin:
+            issuer.origin = origin
+            url = origin + "/mcp"
+            cfg = MCPHttpServerConfig(url=url, auth=MCPAuthConfig(type="oauth"))
+            workspace = tmp_path / "ws"
+            workspace.mkdir()
+            # Unexpired on purpose: this token is valid in memory and revoked
+            # server-side, which is exactly the state a 401-recovery exists for.
+            await _seed_grant(store, url, access="access-0", refresh="refresh-0")
+
+            manager = McpManager(str(workspace), auth_store=store)
+            conn = await manager._connect_server("dd", cfg)
+            assert (
+                issuer.token_posts == 0
+            ), "a fresh, unexpired grant must connect without any token POST"
+
+            # The access tokens this session is carrying stop being accepted,
+            # while the stored refresh token stays the current one.
+            issuer.revoke_access_tokens()
+            posts_before = issuer.token_posts
+
+            result = await conn.live_session.call_tool("fixture", {}, read_timeout_seconds=30)
+            assert result.is_error is False
+            assert (
+                issuer.token_posts == posts_before + 1
+            ), "the 401 did not trigger the locked refresh"
+            assert issuer.reuse_attempts == 0
+            tokens = _stored_tokens(store, url)
+            assert (
+                tokens.get("refresh_token") == "refresh-1"
+            ), f"the rotated grant was not persisted: {tokens!r}"
+    finally:
+        store.close()

--- a/tests/unit/mcp/conftest.py
+++ b/tests/unit/mcp/conftest.py
@@ -7,6 +7,14 @@ failures into bare cancellations. A record left armed by a test would be
 attributed to the next test's unrelated cancellation and turn it into a retry,
 so it is cleared on both sides of every test rather than inside the tests that
 happen to care.
+
+Imported INSIDE the fixture, deliberately. The module-level form of this import
+made the branch's first commit uncollectable on its own: that commit adds these
+tests but not ``REFRESH_CONTENTION``, which the fix commit introduces, so
+``pytest`` aborted during conftest collection and the failing-case evidence its
+message quotes could not be reproduced from that commit at all. Deferring the
+import means the pre-fix tree collects, runs, and reports the three failures the
+commit documents — a repro commit has to be runnable on the tree it reproduces.
 """
 
 from __future__ import annotations
@@ -15,12 +23,17 @@ from collections.abc import Iterator
 
 import pytest
 
-from local_operator.mcp.auth import REFRESH_CONTENTION
-
 
 @pytest.fixture(autouse=True)
 def _no_leaked_refresh_contention_records() -> Iterator[None]:
     """Clear the contention ledger around every MCP unit test."""
+    try:
+        from local_operator.mcp.auth import REFRESH_CONTENTION
+    except ImportError:  # pragma: no cover - the pre-fix tree has no ledger yet
+        # No ledger to clear: this fixture exists to isolate process-global
+        # state that does not exist on that tree.
+        yield
+        return
     REFRESH_CONTENTION.clear()
     yield
     REFRESH_CONTENTION.clear()

--- a/tests/unit/mcp/conftest.py
+++ b/tests/unit/mcp/conftest.py
@@ -1,0 +1,26 @@
+"""Shared isolation for the MCP unit tests.
+
+One piece of state here outlives a single test and is process-global by design:
+``auth.REFRESH_CONTENTION`` is the side channel that carries "we refused to
+spend a refresh token without the lock" past a transport that rewrites auth-flow
+failures into bare cancellations. A record left armed by a test would be
+attributed to the next test's unrelated cancellation and turn it into a retry,
+so it is cleared on both sides of every test rather than inside the tests that
+happen to care.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from local_operator.mcp.auth import REFRESH_CONTENTION
+
+
+@pytest.fixture(autouse=True)
+def _no_leaked_refresh_contention_records() -> Iterator[None]:
+    """Clear the contention ledger around every MCP unit test."""
+    REFRESH_CONTENTION.clear()
+    yield
+    REFRESH_CONTENTION.clear()

--- a/tests/unit/mcp/rotating_oauth_server.py
+++ b/tests/unit/mcp/rotating_oauth_server.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import http
 import json
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -53,6 +54,7 @@ class FakeTokenEndpoint:
         refresh_token: str = "refresh-0",
         response_delay_s: float = 0.0,
         on_reject: Callable[[], Awaitable[None]] | None = None,
+        commit_then_fail_status: int | None = None,
     ) -> None:
         self.access_token = access_token
         self.refresh_token = refresh_token
@@ -61,6 +63,14 @@ class FakeTokenEndpoint:
         #: test model the SIBLING process that persists its own rotation while
         #: our request is in flight — the window D3 is about.
         self.on_reject = on_reject
+        #: When set, a refresh that the server ACCEPTS is still answered with
+        #: this status (an error body) AFTER the rotation is committed — the
+        #: provider shape review round 2 (minor 2) was about: a 5xx that leaves
+        #: the presented token spent while telling the client nothing. Real
+        #: enough to be the failure mode of a proxy in front of a rotating
+        #: issuer, and the only way to test the marker's clearing rule without
+        #: guessing at one.
+        self.commit_then_fail_status = commit_then_fail_status
         self.requests: list[dict[str, str]] = []
         self.reuse_attempts = 0
         self.rotation_count = 0
@@ -133,6 +143,12 @@ class FakeTokenEndpoint:
         self.refresh_token = f"refresh-{self.rotation_count}"
         self.access_token = f"access-{self.rotation_count}"
         self.rotation_applied.set()
+        if self.commit_then_fail_status is not None:
+            # The rotation above HAPPENED and the client is told nothing usable:
+            # the committed state is the one a next exchange would have to
+            # present, which is exactly what makes clearing the send marker on a
+            # non-200 a family-revoking mistake.
+            return self.commit_then_fail_status, {"error": "server_error"}
         return 200, {
             "access_token": self.access_token,
             "token_type": "Bearer",
@@ -144,7 +160,10 @@ class FakeTokenEndpoint:
     @staticmethod
     def _write(writer: asyncio.StreamWriter, status: int, payload: dict[str, Any]) -> None:
         body = json.dumps(payload).encode("utf-8")
-        reason = "OK" if status == 200 else "Bad Request"
+        # The real phrase, not a hardcoded "Bad Request": a 500 written as
+        # "500 Bad Request" is a fixture artifact that makes a status-code test
+        # look like it is reading a 400.
+        reason = http.HTTPStatus(status).phrase
         writer.write(
             (
                 f"HTTP/1.1 {status} {reason}\r\n"

--- a/tests/unit/mcp/rotating_oauth_server.py
+++ b/tests/unit/mcp/rotating_oauth_server.py
@@ -1,0 +1,156 @@
+"""A local token endpoint that ROTATES and runs REFRESH-TOKEN REUSE DETECTION.
+
+Stands in for ``mcp.notion.com`` in the refresh-durability tests. The two
+behaviours it models are the ones that make a discarded rotation destructive
+rather than merely wasteful:
+
+* every successful ``refresh_token`` exchange ISSUES A NEW REFRESH TOKEN and
+  invalidates the previous access token, so an old refresh token is spent the
+  moment the exchange lands; and
+* presenting anything other than the CURRENT refresh token returns
+  ``invalid_grant`` AND revokes the whole family, so every later exchange fails
+  too. That is Notion's reuse detection, and it is why one stale POST logs out
+  every session at once.
+
+A real socket is deliberate. The defects these tests reproduce are about what
+happens to an HTTP request that is still on the wire when its awaiter is
+cancelled or times out — a ``MockTransport`` handler is awaited inside the
+request coroutine itself, so it is cancelled with it and cannot show whether
+the server's rotation survived. The client is a real ``httpx.AsyncClient``
+talking to 127.0.0.1, exactly as ``_refresh_oauth_token_locked`` does it.
+
+Rotation happens BEFORE ``response_delay_s`` elapses, so a request cancelled or
+timed out inside that window has already had its rotation performed server-side
+even though its response never reaches the caller. That is the window the
+tests care about.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any
+from urllib.parse import parse_qsl
+
+
+class FakeTokenEndpoint:
+    """One rotating, reuse-detecting token endpoint on 127.0.0.1.
+
+    Use as an async context manager: ``async with FakeTokenEndpoint() as ep``
+    binds a port and exposes ``ep.token_endpoint``. Recorded traffic is on
+    ``requests`` (every form body the server parsed), and ``reuse_attempts``
+    counts the requests that presented a spent token — the counter the
+    durability assertions rest on, because it is the family-revoking request
+    itself.
+    """
+
+    def __init__(
+        self,
+        *,
+        access_token: str = "access-0",
+        refresh_token: str = "refresh-0",
+        response_delay_s: float = 0.0,
+        on_reject: Callable[[], Awaitable[None]] | None = None,
+    ) -> None:
+        self.access_token = access_token
+        self.refresh_token = refresh_token
+        self.response_delay_s = response_delay_s
+        #: Awaited just before an ``invalid_grant`` response is written. Lets a
+        #: test model the SIBLING process that persists its own rotation while
+        #: our request is in flight — the window D3 is about.
+        self.on_reject = on_reject
+        self.requests: list[dict[str, str]] = []
+        self.reuse_attempts = 0
+        self.rotation_count = 0
+        self.revoked = False
+        #: Set once a rotation has been applied server-side, so a test can
+        #: cancel exactly inside the window where the response is still
+        #: unwritten.
+        self.rotation_applied = asyncio.Event()
+        self._server: asyncio.Server | None = None
+        self._port = 0
+
+    @property
+    def token_endpoint(self) -> str:
+        return f"http://127.0.0.1:{self._port}/token"
+
+    async def __aenter__(self) -> FakeTokenEndpoint:
+        self._server = await asyncio.start_server(self._handle, "127.0.0.1", 0)
+        self._port = self._server.sockets[0].getsockname()[1]
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        server = self._server
+        if server is not None:
+            server.close()
+            await server.wait_closed()
+            self._server = None
+
+    async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            head = await reader.readuntil(b"\r\n\r\n")
+            headers = {}
+            for line in head.decode("latin-1").split("\r\n")[1:]:
+                name, _, value = line.partition(":")
+                headers[name.strip().lower()] = value.strip()
+            length = int(headers.get("content-length", "0") or 0)
+            body = await reader.readexactly(length) if length else b""
+            status, payload = self._decide(dict(parse_qsl(body.decode("utf-8"))))
+            if status != 200 and self.on_reject is not None:
+                # Awaited BEFORE the rejection is written, so the sibling's
+                # write lands after our pre-POST read and before the tombstone
+                # write — exactly the window the marker documents.
+                await self.on_reject()
+            if self.response_delay_s:
+                # AFTER the rotation above: a client that walks away now has had
+                # its token spent and its rotation performed.
+                await asyncio.sleep(self.response_delay_s)
+            self._write(writer, status, payload)
+        except Exception:  # noqa: BLE001 — a fixture must never fail a test by raising
+            pass
+        finally:
+            # ``Exception``, not ``BaseException``: ``CancelledError`` is not a
+            # subclass of it, so a shutdown of the server still propagates.
+            with contextlib.suppress(Exception):
+                writer.close()
+
+    def _decide(self, form: dict[str, str]) -> tuple[int, dict[str, Any]]:
+        self.requests.append(form)
+        if form.get("grant_type") != "refresh_token":
+            return 400, {"error": "unsupported_grant_type"}
+        if self.revoked or form.get("refresh_token") != self.refresh_token:
+            # Reuse detection. A revoked family never recovers, and a spent
+            # token presents exactly like a token from a revoked family.
+            self.reuse_attempts += 1
+            self.revoked = True
+            return 400, {"error": "invalid_grant"}
+        self.rotation_count += 1
+        # Rotate, and invalidate the access token the old grant carried: a
+        # rotating provider revokes every previously issued access token when
+        # it issues a new one.
+        self.refresh_token = f"refresh-{self.rotation_count}"
+        self.access_token = f"access-{self.rotation_count}"
+        self.rotation_applied.set()
+        return 200, {
+            "access_token": self.access_token,
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "refresh_token": self.refresh_token,
+            "scope": "fixture",
+        }
+
+    @staticmethod
+    def _write(writer: asyncio.StreamWriter, status: int, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        reason = "OK" if status == 200 else "Bad Request"
+        writer.write(
+            (
+                f"HTTP/1.1 {status} {reason}\r\n"
+                "Content-Type: application/json\r\n"
+                f"Content-Length: {len(body)}\r\n"
+                "Connection: close\r\n\r\n"
+            ).encode("utf-8")
+            + body
+        )

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -2773,6 +2773,11 @@ class TestInflightRefreshCoordination:
         Both halves are asserted because they are the same exit path: the
         adoption really ran on the freshest stored token (observed by wrapping
         the real method), and the refusal really followed it.
+
+        The refusal's REASON is asserted too (review round 3, M2): a local raise
+        cannot say what a server answered, so this arm carries the unattributed
+        code — the endpoint code's "the server returned no token" would blame a
+        server for a request that may never have gone out.
         """
         import time
 
@@ -2816,8 +2821,10 @@ class TestInflightRefreshCoordination:
 
         monkeypatch.setattr(provider, "_adopt_freshest_stored_token", spy_adopt)
 
-        with pytest.raises(auth_mod.McpRefreshContendedError):
+        with pytest.raises(auth_mod.McpRefreshContendedError) as refused:
             await provider._coordinate_inflight_refresh()
+
+        assert refused.value.reason_code == auth_mod.REFRESH_REFUSAL_UNATTRIBUTED
 
         # The adoption ran, and it took the freshest persisted token — the
         # freshness invariant the fall-through exists for still holds.
@@ -3849,9 +3856,15 @@ class TestDeadGrantTombstone:
         assert storage.grant_is_dead() is False
 
     @pytest.mark.asyncio
-    async def test_nothing_to_refresh_is_failed_not_dead(self) -> None:
+    async def test_nothing_to_refresh_is_unsent_not_dead(self) -> None:
         """F2c: a row with no refresh token is "nothing to spend", not proof
-        that the grant was rejected."""
+        that the grant was rejected.
+
+        The OUTCOME is its own member rather than ``"failed"`` (review round 3,
+        M2): ``"failed"`` is composed for the user as the endpoint text — "the
+        server returned no token" — and no request is made on this path at all,
+        so that sentence would be false about the wire and about the server.
+        """
         from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 
         from local_operator.mcp import auth as auth_mod
@@ -3863,7 +3876,7 @@ class TestDeadGrantTombstone:
 
         outcome = await auth_mod._refresh_oauth_token_locked(self.URL, storage, self._endpoints())
 
-        assert outcome == "failed"
+        assert outcome == "unsent"
         assert storage.grant_is_dead() is False
 
     # --- F3: the proactive site spends nothing ----------------------------

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -2023,9 +2023,13 @@ class TestInflightRefreshCoordination:
 
         refresh_calls = {"n": 0}
 
-        async def fake_refresh(server_url, storage_arg, endpoints) -> auth_mod.RefreshOutcome:
+        async def fake_refresh(
+            server_url, storage_arg, endpoints, *, lock=None, **kwargs: Any
+        ) -> auth_mod.RefreshOutcome:
             refresh_calls["n"] += 1
-            # Mirror the real refresh: persist a fresh token under the lock.
+            # Mirror the real refresh: persist a fresh token under the lock
+            # (which the real one takes over from the caller and releases in
+            # its own finally, hence the ``lock`` keyword this fake accepts).
             await storage_arg.set_tokens(
                 OAuthToken(access_token="refreshed", refresh_token="r2", expires_in=3600)
             )
@@ -2175,7 +2179,7 @@ class TestInflightRefreshCoordination:
         refresh_calls: dict[str, Any] = {"n": 0, "endpoint": None}
 
         async def fake_refresh(
-            server_url: str, storage_arg: Any, endpoints: Any
+            server_url: str, storage_arg: Any, endpoints: Any, *, lock: Any = None, **kw: Any
         ) -> auth_mod.RefreshOutcome:
             refresh_calls["n"] += 1
             refresh_calls["endpoint"] = str(endpoints.oauth_metadata.token_endpoint)
@@ -2309,7 +2313,7 @@ class TestInflightRefreshCoordination:
         # The contention record is armed for the manager to re-voice: the MCP
         # transport turns the raise into a bare CancelledError, so the record is
         # the only channel that survives it.
-        assert auth_mod.REFRESH_CONTENTION.pop(self.URL) is True
+        assert auth_mod.REFRESH_CONTENTION.pop(self.URL) == auth_mod.REFRESH_REFUSAL_LOCK
 
     async def _drive_401_flow(self, provider, responder) -> list[Any]:
         """Pump ``async_auth_flow`` the way httpx does, recording every request
@@ -2448,7 +2452,7 @@ class TestInflightRefreshCoordination:
         spent: list[str] = []
 
         async def fake_refresh(
-            server_url: str, storage_arg: Any, endpoints: Any
+            server_url: str, storage_arg: Any, endpoints: Any, *, lock: Any = None, **kw: Any
         ) -> auth_mod.RefreshOutcome:
             tokens = await storage_arg.get_tokens()
             spent.append(tokens.refresh_token if tokens else "")
@@ -2518,7 +2522,7 @@ class TestInflightRefreshCoordination:
             await provider._initialize()
 
         async def dead_refresh(
-            server_url: str, storage_arg: Any, endpoints: Any
+            server_url: str, storage_arg: Any, endpoints: Any, *, lock: Any = None, **kw: Any
         ) -> auth_mod.RefreshOutcome:
             # Exactly what the real exchange does on a parsed invalid_grant: the
             # marker is written from THERE, keyed to the token it presented.
@@ -2589,7 +2593,7 @@ class TestInflightRefreshCoordination:
         posts: list[str] = []
 
         async def failed_refresh(
-            server_url: str, storage_arg: Any, endpoints: Any
+            server_url: str, storage_arg: Any, endpoints: Any, *, lock: Any = None, **kw: Any
         ) -> auth_mod.RefreshOutcome:
             posts.append("locked")
             return "failed"
@@ -2731,7 +2735,7 @@ class TestInflightRefreshCoordination:
         spent: dict[str, Any] = {}
 
         async def spy_refresh(
-            server_url: str, storage_arg: Any, endpoints: Any
+            server_url: str, storage_arg: Any, endpoints: Any, *, lock: Any = None, **kw: Any
         ) -> auth_mod.RefreshOutcome:
             tokens = await storage_arg.get_tokens()
             spent["refresh_token"] = tokens.refresh_token if tokens else None
@@ -3108,8 +3112,10 @@ asyncio.run(main())
         self, _cfg_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A leaked lock (killed process) must not park a connect eternally: the
-        acquire gives up at the bound and yields False so the caller degrades to
-        the SDK's own refresh instead of hanging."""
+        acquire gives up at the bound and yields a FALSY handle, so the caller
+        takes the contended path (no POST) instead of hanging. Falsy, not
+        "proceed unlocked": an unexclusive exchange is the family-revoking
+        double-spend the lock exists to prevent."""
         import asyncio
         import time as _time
 
@@ -3125,7 +3131,7 @@ asyncio.run(main())
                 async with auth_mod._oauth_refresh_lock(self.URL_A) as locked:
                     elapsed = _time.monotonic() - started
                     # Degraded, but the body RAN: the connect proceeds.
-                    assert locked is False
+                    assert not locked
             assert elapsed < 10.0
 
     @pytest.mark.skipif(os.name == "nt", reason="POSIX flock semantics")
@@ -3146,7 +3152,7 @@ asyncio.run(main())
             started = _time.monotonic()
             async with asyncio.timeout(20):
                 async with auth_mod._oauth_refresh_lock(self.URL_A) as locked:
-                    assert locked is True  # uncontended
+                    assert locked  # uncontended
             assert _time.monotonic() - started < 5.0
 
     @pytest.mark.skipif(os.name == "nt", reason="POSIX flock semantics")
@@ -3157,9 +3163,9 @@ asyncio.run(main())
         from local_operator.mcp import auth as auth_mod
 
         async with auth_mod._oauth_refresh_lock(self.URL_A) as first:
-            assert first is True
+            assert first
         async with auth_mod._oauth_refresh_lock(self.URL_A) as second:
-            assert second is True
+            assert second
 
 
 class TestRefreshLockDegradePaths:
@@ -3724,7 +3730,7 @@ class TestDeadGrantTombstone:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "factory_name",
-        ["server_error", "transport_error", "unparseable_body"],
+        ["server_error", "transport_error"],
     )
     async def test_transient_failures_never_tombstone(
         self, monkeypatch: pytest.MonkeyPatch, factory_name: str
@@ -3746,9 +3752,6 @@ class TestDeadGrantTombstone:
         def server_error(request):
             return httpx.Response(500, text="upstream exploded", request=request)
 
-        def unparseable_body(request):
-            return httpx.Response(200, text="not a token at all", request=request)
-
         def transport_error(request):
             raise httpx.ConnectError("network down", request=request)
 
@@ -3759,6 +3762,53 @@ class TestDeadGrantTombstone:
         assert outcome == "failed"
         assert storage.grant_is_dead() is False
         assert auth_mod.GRANT_DEAD_AT_KEY not in store.rows[0].data
+        # Neither failure leaves a "presented but unacknowledged" marker: a 5xx
+        # is an ANSWER (the server refused without rotating) and a ConnectError
+        # happens BEFORE the request is written, so in both cases the stored
+        # token is untouched and the next attempt is an ordinary retry.
+        assert auth_mod.GRANT_UNCONFIRMED_SEND_KEY not in store.rows[0].data
+
+    @pytest.mark.asyncio
+    async def test_a_200_with_an_unreadable_body_marks_the_token_as_spent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An HTTP 200 whose body cannot be parsed is NOT a transient failure.
+
+        Unlike the two cases above, the server processed the exchange and
+        rotated: the token we presented IS spent, and its only replacement is in
+        a body we could not read. Retrying therefore means presenting a spent
+        token, which a reuse-detecting provider answers with ``invalid_grant``
+        AND a family revocation — the opposite of what the old ``"failed"``
+        classification implied. So the outcome is ``"unacknowledged"``: the
+        write-ahead send marker stays armed and the next refresh refuses to POST
+        (see ``test_a_sent_but_unacknowledged_exchange_blocks_the_next_post``).
+        No tombstone: nothing told us the GRANT is dead, only that this response
+        was unreadable.
+        """
+        import httpx
+
+        from local_operator.mcp import auth as auth_mod
+
+        store = FakeAuthStore()
+        storage = await self._seed_expired(store)
+
+        self._mock_token_endpoint(
+            monkeypatch, lambda request: httpx.Response(200, text="not a token", request=request)
+        )
+
+        outcome = await auth_mod._refresh_oauth_token_locked(self.URL, storage, self._endpoints())
+
+        assert outcome == "unacknowledged"
+        assert storage.grant_is_dead() is False
+        assert auth_mod.GRANT_DEAD_AT_KEY not in store.rows[0].data
+        marker = store.rows[0].data[auth_mod.GRANT_UNCONFIRMED_SEND_KEY]
+        presented = await storage.get_tokens()
+        assert presented is not None
+        assert presented.refresh_token is not None
+        # Keyed to the token this exchange actually presented, so a later
+        # rotation of the row makes it stale instead of suppressing the new one.
+        assert marker["digest"] == auth_mod._refresh_token_digest(presented.refresh_token)
+        assert storage.send_unconfirmed() is True
 
     @pytest.mark.asyncio
     async def test_a_400_that_is_not_invalid_grant_never_tombstones(

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -3735,12 +3735,19 @@ class TestDeadGrantTombstone:
     async def test_transient_failures_never_tombstone(
         self, monkeypatch: pytest.MonkeyPatch, factory_name: str
     ) -> None:
-        """F2: a 500, a transport error and an unparseable 200 are all "failed"
-        with NO marker.
+        """F2: a 500 and a transport error are both non-tombstoning.
 
         This is the regression guard for the design's stated risk 1: gating on a
         bare HTTP 400 (or on any failure) would let one flaky provider minute
         permanently suppress refresh on a live grant until the user noticed.
+
+        The two are NOT the same shape, which is the point of the two outcomes
+        asserted here: a 500 is an ANSWER that proves nothing about our token,
+        so it keeps the write-ahead marker (review round 2, minor 2 — the
+        marker's rule, not the tombstone's), while a ConnectError never reached
+        the wire, so it is "unreachable" rather than "failed" and leaves no
+        marker at all (review round 2, minor 1). Neither writes a tombstone:
+        nothing told us the GRANT is dead.
         """
         import httpx
 
@@ -3759,14 +3766,21 @@ class TestDeadGrantTombstone:
 
         outcome = await auth_mod._refresh_oauth_token_locked(self.URL, storage, self._endpoints())
 
-        assert outcome == "failed"
+        if factory_name == "server_error":
+            assert outcome == "failed"
+            # An answer that does not prove the presented token was not consumed
+            # keeps the marker: a provider that commits a rotation and then fails
+            # the response would otherwise leave a spent token re-presentable.
+            assert auth_mod.GRANT_UNCONFIRMED_SEND_KEY in store.rows[0].data
+            assert storage.send_unconfirmed() is True
+        else:
+            assert outcome == "unreachable"
+            # Nothing was written, so nothing may be suspect: an ordinary
+            # transient retry, and the user is not sent at a reauth.
+            assert auth_mod.GRANT_UNCONFIRMED_SEND_KEY not in store.rows[0].data
+            assert storage.send_unconfirmed() is False
         assert storage.grant_is_dead() is False
         assert auth_mod.GRANT_DEAD_AT_KEY not in store.rows[0].data
-        # Neither failure leaves a "presented but unacknowledged" marker: a 5xx
-        # is an ANSWER (the server refused without rotating) and a ConnectError
-        # happens BEFORE the request is written, so in both cases the stored
-        # token is untouched and the next attempt is an ordinary retry.
-        assert auth_mod.GRANT_UNCONFIRMED_SEND_KEY not in store.rows[0].data
 
     @pytest.mark.asyncio
     async def test_a_200_with_an_unreadable_body_marks_the_token_as_spent(

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -1877,6 +1877,24 @@ class TestProviderEndpointPriming:
         assert provider.context.oauth_metadata is None
 
 
+async def _seed_expired_grant(url: str, store: FakeAuthStore) -> McpTokenStorage:
+    """A row whose access token is already past its deadline, so every refresh
+    site engages.
+
+    Module-level because several classes need the same fixture and a second copy
+    would be a second definition of "expired enough to refresh".
+    """
+    import time
+
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+    storage = McpTokenStorage(url, store)
+    await storage.set_tokens(OAuthToken(access_token="a-old", refresh_token="r-old", expires_in=60))
+    await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
+    store.rows[0].data["tokens_obtained_at"] = time.time() - 600
+    return storage
+
+
 class TestInflightRefreshCoordination:
     """The in-flow (mid-session) refresh is race-free across processes.
 
@@ -2161,6 +2179,12 @@ class TestInflightRefreshCoordination:
         ) -> auth_mod.RefreshOutcome:
             refresh_calls["n"] += 1
             refresh_calls["endpoint"] = str(endpoints.oauth_metadata.token_endpoint)
+            # A refresh that reports "refreshed" leaves a usable token behind —
+            # the coordinator's post-condition holds this fake to the real
+            # contract instead of letting it claim a success it did not achieve.
+            await storage_arg.set_tokens(
+                OAuthToken(access_token="fresh", refresh_token="r-new", expires_in=3600)
+            )
             return "refreshed"
 
         monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", fake_refresh)
@@ -2170,6 +2194,122 @@ class TestInflightRefreshCoordination:
         # token endpoint (server base with the path stripped, plus ``/token``).
         assert refresh_calls["n"] == 1
         assert refresh_calls["endpoint"] == "https://mcp.example.com/token"
+
+    @pytest.mark.asyncio
+    async def test_coordinator_transient_failure_never_falls_through_to_unlocked_sdk_post(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The headline regression: ``"failed"`` must not become an unlocked POST.
+
+        The old contract had NO arm for ``"failed"``: the locked refresh
+        returned that outcome, the coordinator returned normally, and
+        ``async_auth_flow`` fell through to the SDK's own ``_refresh_token`` —
+        which POSTs ``ctx.current_tokens.refresh_token`` with no lock and no
+        re-read. Measured on this machine's live log before the fix: 100
+        ``httpx2 ... POST https://mcp.notion.com/token 400`` requests, i.e. the
+        stale rotating token on the wire outside the lock, which a
+        reuse-detecting provider answers by revoking the whole family.
+
+        Asserted at the WIRE rather than on the state that follows: a flow that
+        yields a token request is the request the authorization server sees, and
+        a stripped in-memory token is what makes the SDK skip its refresh
+        branch. Both are checked, and ``yields == []`` is the strong form of the
+        claim — the refusal happens before anything at all is sent.
+        """
+        import httpx
+
+        from local_operator.mcp import auth as auth_mod
+        from local_operator.mcp.auth import (
+            McpRefreshContendedError,
+            build_oauth_provider,
+        )
+
+        store = FakeAuthStore()
+        await _seed_expired_grant(self.URL, store)
+
+        provider = build_oauth_provider(self.URL, self._cfg(), store=store, endpoints=None)
+        async with provider.context.lock:
+            await provider._initialize()
+
+        refreshes: list[str] = []
+
+        async def failed_refresh(*args: Any, **kwargs: Any) -> auth_mod.RefreshOutcome:
+            refreshes.append("locked")
+            return "failed"
+
+        monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", failed_refresh)
+
+        yields: list[Any] = []
+        gen = provider.async_auth_flow(httpx.Request("POST", self.URL))
+        with pytest.raises(McpRefreshContendedError):
+            first = await gen.__anext__()
+            yields.append(first)
+        await gen.aclose()
+
+        assert refreshes == ["locked"], "the locked refresh did not run"
+        assert yields == [], (
+            "the SDK yielded a request (its unlocked refresh or the resource "
+            f"call) after the locked refresh failed: {yields!r}"
+        )
+        # And the reason it cannot: there is nothing left to refresh with.
+        assert provider.context.current_tokens is not None
+        assert provider.context.current_tokens.refresh_token is None
+        assert provider.context.can_refresh_token() is False
+
+    @pytest.mark.asyncio
+    async def test_coordinator_raises_transient_when_lock_unavailable_and_store_still_expired(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No exclusivity + still expired is CONTENTION, not a licence to POST.
+
+        The main route of the unchecked unlocked POST before the fix: the
+        bounded acquire gave up, the coordinator re-read the store (still an
+        expired token), returned, and the SDK's unlocked ``_refresh_token``
+        spent that token with no lock. The re-read still runs — a peer's
+        rotation must be adopted — but an un-refreshed, still-refreshable
+        context now refuses instead of degrading.
+        """
+        import contextlib as _contextlib
+
+        from local_operator.mcp import auth as auth_mod
+        from local_operator.mcp.auth import (
+            McpRefreshContendedError,
+            build_oauth_provider,
+        )
+
+        store = FakeAuthStore()
+        await _seed_expired_grant(self.URL, store)
+
+        provider = build_oauth_provider(self.URL, self._cfg(), store=store, endpoints=None)
+        async with provider.context.lock:
+            await provider._initialize()
+
+        attempts: list[str] = []
+
+        async def spy_refresh(*args: Any, **kwargs: Any) -> auth_mod.RefreshOutcome:
+            attempts.append("spent")
+            return "refreshed"
+
+        monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", spy_refresh)
+
+        @_contextlib.asynccontextmanager
+        async def _unavailable(server_url: str):
+            yield False
+
+        monkeypatch.setattr(auth_mod, "_oauth_refresh_lock", _unavailable)
+
+        with pytest.raises(McpRefreshContendedError):
+            await provider._coordinate_inflight_refresh()
+
+        # The exchange was never attempted without exclusivity, and the token is
+        # gone from memory so the SDK cannot attempt it either.
+        assert attempts == []
+        assert provider.context.current_tokens is not None
+        assert provider.context.current_tokens.refresh_token is None
+        # The contention record is armed for the manager to re-voice: the MCP
+        # transport turns the raise into a bare CancelledError, so the record is
+        # the only channel that survives it.
+        assert auth_mod.REFRESH_CONTENTION.pop(self.URL) is True
 
     async def _drive_401_flow(self, provider, responder) -> list[Any]:
         """Pump ``async_auth_flow`` the way httpx does, recording every request
@@ -2269,13 +2409,27 @@ class TestInflightRefreshCoordination:
         assert provider.context.current_tokens.access_token == "fresh-by-peer"
 
     @pytest.mark.asyncio
-    async def test_401_with_identical_stored_token_passes_through_to_sdk(self) -> None:
-        """The store holds exactly the token that just 401'd: the grant is dead
-        everywhere, not merely revoked for us. The 401 must pass through to the
-        SDK unchanged (its full-flow branch becomes reachable, as before the
-        fix) and NO adoption retry may be re-yielded."""
+    async def test_401_with_identical_refreshable_grant_refreshes_under_lock_and_retries(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A 401 on the stored token, with a refreshable grant, refreshes under
+        the LOCK and retries the same request.
+
+        REPLACES ``test_401_with_identical_stored_token_passes_through_to_sdk``,
+        which encoded the old behaviour: hand the 401 straight to the SDK, whose
+        ``async_auth_flow`` then POSTs ``current_tokens.refresh_token`` with no
+        lock and no re-read. Nothing about a 401 distinguishes "this grant is
+        dead" from "nobody has rotated it yet" — the refresh itself is what
+        answers that, and doing it here keeps it inside the cross-process lock,
+        with the store re-read under it.
+
+        The positive counterpart of the dead case below: identical stored token
+        + a refresh that SUCCEEDS must retry with the fresh token and must not
+        reach the SDK's full authorization flow.
+        """
         from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 
+        from local_operator.mcp import auth as auth_mod
         from local_operator.mcp.auth import build_oauth_provider
 
         store = FakeAuthStore()
@@ -2285,47 +2439,184 @@ class TestInflightRefreshCoordination:
         )
         await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
 
-        # interactive=False: if the 401 wrongly reaches the SDK's full-flow
-        # branch and gets as far as authorization, the flow must RAISE
-        # (McpAuthRequiredError) rather than open a browser in the test run.
         provider = build_oauth_provider(
             self.URL, self._cfg(), store=store, endpoints=self._endpoints(), interactive=False
         )
+        async with provider.context.lock:
+            await provider._initialize()
+
+        spent: list[str] = []
+
+        async def fake_refresh(
+            server_url: str, storage_arg: Any, endpoints: Any
+        ) -> auth_mod.RefreshOutcome:
+            tokens = await storage_arg.get_tokens()
+            spent.append(tokens.refresh_token if tokens else "")
+            # A real "refreshed" leaves a usable token behind; the post-condition
+            # in the coordinator holds this fake to the same contract.
+            await storage_arg.set_tokens(
+                OAuthToken(access_token="fresh-after-refresh", refresh_token="r2", expires_in=3600)
+            )
+            return "refreshed"
+
+        monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", fake_refresh)
+
+        import httpx
+
+        calls: list[tuple[httpx.Request, str]] = []
+
+        def responder(request: httpx.Request) -> httpx.Response:
+            calls.append((request, request.headers.get("Authorization", "")))
+            if request.headers.get("Authorization") == "Bearer fresh-after-refresh":
+                return httpx.Response(200, request=request)
+            return httpx.Response(401, request=request)
+
+        yielded = await self._drive_401_flow(provider, responder)
+
+        # Exactly two requests: the original 401 and the retry carrying the
+        # refreshed token. The SDK's full-flow machinery never produced one.
+        assert len(yielded) == 2
+        assert yielded[1] is yielded[0], "the retry must re-yield the SAME request object"
+        assert calls[0][1] == "Bearer dead-token"
+        assert calls[1][1] == "Bearer fresh-after-refresh"
+        # The exchange spent the STORED token under the lock, once.
+        assert spent == ["r1"]
+        assert provider.context.current_tokens is not None
+        assert provider.context.current_tokens.access_token == "fresh-after-refresh"
+
+    @pytest.mark.asyncio
+    async def test_401_with_identical_grant_and_dead_refresh_strips_and_reaches_auth_required(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A 401 on the stored token whose refresh comes back DEAD ends the
+        attempt, with the in-memory refresh token stripped.
+
+        This is the site that used to leave the marker unwritten for the whole
+        life of a 401: the refresh path that can prove a dead grant is now
+        reachable from here, so a genuinely dead grant is tombstoned here too
+        (asserted on the store) instead of being re-POSTed by every later boot.
+        The strip is what keeps the SDK's own refresh branch from spending the
+        rejected token — its full-flow machinery may still run, which is the
+        user-visible outcome we keep.
+        """
+        from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+        from local_operator.mcp import auth as auth_mod
+        from local_operator.mcp.auth import build_oauth_provider
+
+        store = FakeAuthStore()
+        storage = McpTokenStorage(self.URL, store)
+        await storage.set_tokens(
+            OAuthToken(access_token="dead-token", refresh_token="r1", expires_in=3600)
+        )
+        await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
+
+        provider = build_oauth_provider(
+            self.URL, self._cfg(), store=store, endpoints=self._endpoints(), interactive=False
+        )
+        async with provider.context.lock:
+            await provider._initialize()
+
+        async def dead_refresh(
+            server_url: str, storage_arg: Any, endpoints: Any
+        ) -> auth_mod.RefreshOutcome:
+            # Exactly what the real exchange does on a parsed invalid_grant: the
+            # marker is written from THERE, keyed to the token it presented.
+            storage_arg.mark_grant_dead(rejected_refresh_token="r1")
+            return "dead"
+
+        monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", dead_refresh)
 
         import httpx
 
         yields: list[tuple[httpx.Request, str]] = []
-        seen_401 = {"done": False}
 
         def responder(request: httpx.Request) -> httpx.Response:
             yields.append((request, request.headers.get("Authorization", "")))
-            if not seen_401["done"]:
-                # The original request: answer with the 401 challenge.
-                seen_401["done"] = True
+            if str(request.url) == self.URL:
                 return httpx.Response(401, request=request)
-            # Anything yielded AFTER the 401 is the SDK's full-flow machinery
-            # (protected-resource discovery first) — proof the challenge
-            # reached the SDK rather than being answered by an adoption retry.
-            # Fail it so the flow terminates without a browser grant.
+            # Anything after the 401 is the SDK's full-flow machinery; fail its
+            # discovery so the flow terminates without a browser grant.
             return httpx.Response(404, request=request)
 
+        import contextlib
+
         with contextlib.suppress(Exception):
-            # The failed discovery may or may not raise out of the flow (SDK
-            # version dependent); the yields below are the assertion.
             await self._drive_401_flow(provider, responder)
 
-        # The FIRST yield is the original request, still bearing the dead token
-        # (adoption did NOT rewrite it — the stored token was identical).
-        assert yields[0][1] == "Bearer dead-token"
-        # The 401 reached the SDK: its full-flow branch yielded at least one
-        # discovery/registration request after the original.
-        assert len(yields) >= 2, "the 401 never reached the SDK's full-flow branch"
-        # No adoption retry: exactly ONE request went to the resource URL (the
-        # original). Everything after it is the SDK's own machinery on other
-        # URLs (discovery/registration), which the SDK may yield several of.
+        # Exactly ONE request to the resource URL: the original. No retry was
+        # re-yielded, because there was nothing to retry with.
         to_resource = [y for y in yields if str(y[0].url) == self.URL]
         assert len(to_resource) == 1
-        assert yields[1][0].url != yields[0][0].url
+        # The grant is recorded dead, and cannot be refreshed from memory any
+        # more — so the SDK cannot POST the rejected token either.
+        assert storage.grant_is_dead() is True
+        assert provider.context.current_tokens is not None
+        assert provider.context.current_tokens.refresh_token is None
+        assert provider.context.can_refresh_token() is False
+
+    @pytest.mark.asyncio
+    async def test_401_transient_refresh_failure_writes_no_tombstone_and_posts_once(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A TRANSIENT failure on the 401 path tombstones nothing and retries
+        nothing.
+
+        The distinction the marker depends on: a transient failure (network,
+        5xx, timeout) says nothing about the grant, so it must leave no marker —
+        a false tombstone suppresses refresh on a live grant until an interactive
+        login. And it must not re-yield the blocked request either: the token it
+        would carry is the one that just 401'd.
+        """
+        from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+        from local_operator.mcp import auth as auth_mod
+        from local_operator.mcp.auth import build_oauth_provider
+
+        store = FakeAuthStore()
+        storage = McpTokenStorage(self.URL, store)
+        await storage.set_tokens(
+            OAuthToken(access_token="dead-token", refresh_token="r1", expires_in=3600)
+        )
+        await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
+
+        provider = build_oauth_provider(
+            self.URL, self._cfg(), store=store, endpoints=self._endpoints(), interactive=False
+        )
+        async with provider.context.lock:
+            await provider._initialize()
+
+        posts: list[str] = []
+
+        async def failed_refresh(
+            server_url: str, storage_arg: Any, endpoints: Any
+        ) -> auth_mod.RefreshOutcome:
+            posts.append("locked")
+            return "failed"
+
+        monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", failed_refresh)
+
+        import httpx
+
+        yields: list[Any] = []
+
+        def responder(request: httpx.Request) -> httpx.Response:
+            yields.append(request)
+            if str(request.url) == self.URL:
+                return httpx.Response(401, request=request)
+            return httpx.Response(404, request=request)
+
+        import contextlib
+
+        with contextlib.suppress(Exception):
+            await self._drive_401_flow(provider, responder)
+
+        to_resource = [y for y in yields if str(y.url) == self.URL]
+        assert len(to_resource) == 1, "the 401 must not be retried with a spent token"
+        assert posts == ["locked"]
+        assert storage.grant_is_dead() is False, "a transient failure must not tombstone"
+        assert provider.context.current_tokens is not None
+        assert provider.context.current_tokens.refresh_token is None
 
     @pytest.mark.asyncio
     async def test_second_401_after_adoption_retry_passes_through(self) -> None:
@@ -2445,6 +2736,11 @@ class TestInflightRefreshCoordination:
             tokens = await storage_arg.get_tokens()
             spent["refresh_token"] = tokens.refresh_token if tokens else None
             spent["endpoint"] = str(endpoints.oauth_metadata.token_endpoint)
+            # Persist, so the coordinator's post-condition sees what a real
+            # successful exchange leaves behind (see the note above).
+            await storage_arg.set_tokens(
+                OAuthToken(access_token="fresh", refresh_token="r-next", expires_in=3600)
+            )
             return "refreshed"
 
         monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", spy_refresh)
@@ -2457,13 +2753,23 @@ class TestInflightRefreshCoordination:
         assert spent["endpoint"] == "https://mcp.example.com/token"
 
     @pytest.mark.asyncio
-    async def test_locked_refresh_raise_still_adopts_freshest_before_sdk(
+    async def test_a_raising_refresh_still_adopts_the_freshest_stored_token(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The exception fall-through upholds the invariant too: if the locked
-        refresh RAISES, a final under-lock re-read adopts the freshest persisted
-        token, so the SDK's subsequent unlocked refresh cannot spend an
-        in-memory refresh token older than storage."""
+        """A RAISED locked refresh adopts the freshest stored token, then refuses.
+
+        The exception fall-through is unchanged: it re-reads storage and adopts
+        whatever a sibling persisted, so the SDK never holds a token older than
+        storage's. What changed is what happens NEXT. Adoption does not make an
+        EXPIRED token valid, so this used to end with a still-refreshable
+        context handed to the SDK's unlocked refresh — the family-revoking POST.
+        Now the post-condition refuses instead, and the in-memory refresh token
+        is stripped on the way out.
+
+        Both halves are asserted because they are the same exit path: the
+        adoption really ran on the freshest stored token (observed by wrapping
+        the real method), and the refusal really followed it.
+        """
         import time
 
         from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
@@ -2496,12 +2802,26 @@ class TestInflightRefreshCoordination:
 
         monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", boom)
 
-        await provider._coordinate_inflight_refresh()
+        adopted: list[str | None] = []
+        real_adopt = provider._adopt_freshest_stored_token
 
-        # Even though the refresh raised, the in-memory token is now the freshest
-        # persisted one — the SDK will not spend the stale "r-old".
+        async def spy_adopt(ctx: Any) -> None:
+            await real_adopt(ctx)
+            tokens = ctx.current_tokens
+            adopted.append(tokens.refresh_token if tokens is not None else None)
+
+        monkeypatch.setattr(provider, "_adopt_freshest_stored_token", spy_adopt)
+
+        with pytest.raises(auth_mod.McpRefreshContendedError):
+            await provider._coordinate_inflight_refresh()
+
+        # The adoption ran, and it took the freshest persisted token — the
+        # freshness invariant the fall-through exists for still holds.
+        assert adopted == ["r-new"]
+        # And the refusal followed it rather than degrading to an unlocked POST.
         assert provider.context.current_tokens is not None
-        assert provider.context.current_tokens.refresh_token == "r-new"
+        assert provider.context.current_tokens.refresh_token is None
+        assert provider.context.can_refresh_token() is False
 
 
 class TestRefreshOAuthTokenLocked:
@@ -3346,17 +3666,7 @@ class TestDeadGrantTombstone:
     async def _seed_expired(self, store: FakeAuthStore) -> McpTokenStorage:
         """A row whose access token is already past its deadline, so every
         refresh site engages."""
-        import time
-
-        from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
-
-        storage = McpTokenStorage(self.URL, store)
-        await storage.set_tokens(
-            OAuthToken(access_token="a-old", refresh_token="r-old", expires_in=60)
-        )
-        await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
-        store.rows[0].data["tokens_obtained_at"] = time.time() - 600
-        return storage
+        return await _seed_expired_grant(self.URL, store)
 
     def _mock_token_endpoint(self, monkeypatch: pytest.MonkeyPatch, response_factory):
         """Route every httpx POST this module makes to an in-process handler and
@@ -3686,40 +3996,6 @@ class TestDeadGrantTombstone:
         # The predicate the SDK gates its refresh branch on now reads False, so
         # it goes to the authorization branch -> McpAuthRequiredError.
         assert provider.context.can_refresh_token() is False
-
-    @pytest.mark.asyncio
-    async def test_failed_outcome_leaves_the_refresh_token_alone(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """The inversion guard for the truthy-"failed" hazard.
-
-        ``"failed"`` is a truthy string, so a ``if outcome:`` at this call site
-        would treat a transient failure as a success and a dead grant as one
-        too. A transient failure must change nothing: today's behaviour (the SDK
-        retries unlocked) is correct for it.
-        """
-        from local_operator.mcp import auth as auth_mod
-        from local_operator.mcp.auth import build_oauth_provider
-
-        store = FakeAuthStore()
-        await self._seed_expired(store)
-
-        provider = build_oauth_provider(self.URL, self._cfg(), store=store, endpoints=None)
-        async with provider.context.lock:
-            await provider._initialize()
-
-        async def failed_refresh(*args: Any, **kwargs: Any) -> auth_mod.RefreshOutcome:
-            return "failed"
-
-        monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", failed_refresh)
-
-        # Scoped to the coordinator deliberately: driving the whole flow would
-        # then run the SDK's own unlocked refresh, which nulls current_tokens
-        # itself when it fails: that would assert the SDK's behaviour, not ours.
-        await provider._coordinate_inflight_refresh()
-
-        assert provider.context.current_tokens is not None
-        assert provider.context.current_tokens.refresh_token == "r-old"
 
     @pytest.mark.asyncio
     async def test_already_tombstoned_boot_yields_no_token_post(

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -21,7 +21,9 @@ from local_operator.mcp.auth import (
     REFRESH_REFUSAL_ENDPOINT,
     REFRESH_REFUSAL_INFLIGHT,
     REFRESH_REFUSAL_LOCK,
+    REFRESH_REFUSAL_UNATTRIBUTED,
     REFRESH_REFUSAL_UNREACHABLE,
+    REFRESH_REFUSAL_UNSENT,
 )
 from local_operator.mcp.config import MCPStdioServerConfig
 from local_operator.mcp.manager import (
@@ -1531,7 +1533,7 @@ class TestAuthRequiredHandling:
 
     Startup and auto-reconnect are non-interactive: when the stored grant
     cannot be refreshed, the connect raises ``McpAuthRequiredError``. The
-    manager turns that into a ``run /mcp login <name>`` message for the toast,
+    manager turns that into a ``/mcp login <name>`` message for the toast,
     and the reconnect loop abandons (an expired grant will not heal by
     retrying) instead of burning the breaker window.
     """
@@ -1586,7 +1588,7 @@ class TestAuthRequiredHandling:
         seen: list[tuple[str, str]] = []
         manager.on_auth_required = lambda name, msg: seen.append((name, msg))
         manager._fire_auth_required("notion", McpAuthRequiredError("https://mcp.notion.com/mcp"))
-        assert seen == [("notion", "run /mcp login notion to authorize")]
+        assert seen == [("notion", "/mcp login notion to authorize")]
 
     def test_fire_auth_required_survives_a_raising_sink(self) -> None:
         """A broken UI hook must not take down the connect machinery."""
@@ -2160,7 +2162,7 @@ class TestAuthChallengeMessaging:
         """Design constraint D1: the toast clamps to the card width and the
         TAIL is what truncates, so the command has to lead."""
         text = McpManager._auth_failure_text("launchdarkly", self._exc())
-        assert text.startswith("run /mcp login launchdarkly")
+        assert text.startswith("/mcp login launchdarkly")
         assert text.count("—") <= 1  # D4: not a chain of dashes
 
     @pytest.mark.asyncio
@@ -2199,7 +2201,7 @@ class TestAuthChallengeMessaging:
     async def test_a_non_auth_failure_is_never_relabelled_as_an_auth_problem(
         self, tmp_path: Path
     ) -> None:
-        """Routing a network outage into "run /mcp login" would be a worse
+        """Routing a network outage into "/mcp login" would be a worse
         error than the opaque one this change replaces. No observed challenge
         means no conversion."""
         from local_operator.mcp.config import MCPHttpServerConfig
@@ -2484,7 +2486,7 @@ class TestMcpAuthRecoveryHint:
         from local_operator.mcp.manager import mcp_auth_recovery_hint
 
         hint = mcp_auth_recovery_hint(
-            "MCP authorization failed", "run /mcp login minerva-qa to authorize"
+            "MCP authorization failed", "/mcp login minerva-qa to authorize"
         )
         assert hint is not None
         assert "/mcp login minerva-qa" in hint
@@ -2557,7 +2559,7 @@ class TestMcpAuthRecoveryHint:
         hostname puts on both sides of the name. That made the loose pass, whose
         documented job is "the fallback for the URL-shaped messages", match
         NOTHING: ``linear``, ``notion``, ``sentry`` and ``minerva-qa`` all went
-        from resolved to ``None``, and every actionable ``run /mcp reauth
+        from resolved to ``None``, and every actionable ``/mcp reauth
         linear`` silently became the generic referral.
 
         Both existing layers missed it because the quoted form asserted above is
@@ -3965,7 +3967,7 @@ class TestAnUnreadableGrantMarkerIsNotAChangedGrant:
 
 
 class TestRefreshRefusalCopy:
-    """The exact RENDERED strings for the four refusals and the auth line.
+    """The exact RENDERED strings for the refusal reasons and the auth line.
 
     Round 1 split one message into three truthful sentences and design review
     round 1 (D1/D2) showed why that was not enough: every one of those sentences
@@ -3977,6 +3979,11 @@ class TestRefreshRefusalCopy:
     assertions are made against the RENDERED line at both real card widths —
     not against the code's idea of the sentence, which is exactly the mistake
     that let four different refusals look the same.
+
+    Two rounds later the same seam carries the LOCAL shapes (unsent, unattributed)
+    that must never borrow the endpoint's "the server returned no token", and the
+    auth requirement's three pinned lines (D9), which are asserted here as the
+    painted rows rather than as source strings.
 
     The 44-column case is the tight one and the reason the wording is this
     short: ``failed: notion — `` spends 17 of the 36 available cells, leaving 19
@@ -4074,45 +4081,114 @@ class TestRefreshRefusalCopy:
         line = self._toast_failure_line(text, 36)
         assert line == "failed: notion — the refresh did no…"
 
-    def test_an_unacknowledged_send_renders_the_actionable_reauth_command(
+    #: The three auth lines design review round 2 (D9) pinned CHARACTER FOR
+    #: CHARACTER, with the composed toast row each produces at the two widths
+    #: the designer measured (58 content cells for a 100-column terminal, 36 for
+    #: 44). The `run ` wrapper is gone because it cost four cells — exactly the
+    #: shortfall that pushed the reason past the card's clamp at 100 columns and
+    #: cut the server name mid-word at 44 — and the bare slash command is the
+    #: app's own habit for a runnable command (the splash, the usage panel).
+    AUTH_LINE_EXPECTED = {
+        "unconfirmed": (
+            "/mcp reauth notion — refresh unconfirmed",
+            "failed: notion — /mcp reauth notion — refresh unconfirmed",
+            "failed: notion — /mcp reauth notion…",
+        ),
+        "default": (
+            "/mcp reauth notion — sign-in expired",
+            "failed: notion — /mcp reauth notion — sign-in expired",
+            "failed: notion — /mcp reauth notion…",
+        ),
+        "no-grant": (
+            "/mcp login notion to authorize",
+            "failed: notion — /mcp login notion to authorize",
+            "failed: notion — /mcp login notion…",
+        ),
+    }
+
+    #: The two LOCAL refusal reasons (review round 3, M2). Neither may describe a
+    #: request that never went out, so neither may borrow the endpoint wording.
+    LOCAL_REFUSAL_EXPECTED = {
+        REFRESH_REFUSAL_UNSENT: (
+            "failed: notion — no stored token to send",
+            "failed: notion — no stored token to…",
+        ),
+        REFRESH_REFUSAL_UNATTRIBUTED: (
+            "failed: notion — the refresh did not complete",
+            "failed: notion — the refresh did no…",
+        ),
+    }
+
+    def test_the_three_auth_lines_render_exactly_as_pinned_at_both_widths(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The auth line, at the surface a user reads, on ONE card row.
+        """D9, asserted on the PAINTED row at 58 and 36 content cells.
 
-        ``_auth_required_text`` composes the startup-toast line (and the
-        transcript notice, and ``/mcp``), leading with the command and carrying
-        exactly one em-dash. A refresh that was SENT and never confirmed is not
-        an expired authorization, so the error carries the reason as a SHORT
-        tail — the previous sentence-length tail was itself clipped off the card
-        (design review D4).
+        The old assertion pinned the CLIPPED row (``… — run /mcp reauth notion —
+        refresh unconfi…``), which was the finding: the word that says WHY was
+        off the card on the first surface a user reads, and at 44 columns the
+        server name the command hands over was itself cut mid-word.
         """
         from local_operator.mcp.auth import (
             McpAuthRequiredError,
             McpRefreshUnconfirmedError,
         )
 
-        # We hold a grant for this URL (the unconfirmed state presupposes one), so
-        # the command is ``reauth``; the lookup itself is not what is under test.
-        monkeypatch.setattr(
-            "local_operator.mcp.auth.server_has_stored_grant",
-            lambda url, store=None: True,
+        cases = {
+            # Unconfirmed carries the reason on the error, so it never looks the
+            # grant up; the other two go through the store lookup, which is
+            # stubbed here rather than read from the developer's machine.
+            "unconfirmed": (McpRefreshUnconfirmedError(self.URL), True),
+            "default": (McpAuthRequiredError(self.URL), True),
+            "no-grant": (McpAuthRequiredError(self.URL), False),
+        }
+        for key, (exc, has_grant) in cases.items():
+            monkeypatch.setattr(
+                "local_operator.mcp.auth.server_has_stored_grant",
+                lambda url, store=None, _g=has_grant: _g,
+            )
+            text, wide, narrow = self.AUTH_LINE_EXPECTED[key]
+            assert McpManager._auth_required_text("notion", exc) == text, key
+            assert text.count("—") <= 1, (key, text)  # D4: not a chain of dashes
+            assert text.startswith("/mcp "), (key, text)
+            assert "run /mcp" not in text, (key, text)
+            assert (
+                self._toast_failure_line(text, 58) == wide
+            ), f"{key}: D9 measured {wide!r} at 100 columns"
+            assert len(wide) <= 58, (key, wide)
+            assert self._toast_failure_line(text, 36) == narrow, (key, narrow)
+            if key != "no-grant":
+                # The D9 constraint at 44 columns: what is shed is the REASON,
+                # never the server name the command has to hand over.
+                assert "/mcp reauth notion" in narrow, (key, narrow)
+
+    def test_the_local_refusals_never_blame_a_server(self) -> None:
+        """The endpoint copy is false about a request that was never made.
+
+        Review round 3, M2: the exchange returns ``"failed"`` for shapes that
+        produced no request at all (an empty row), and the manager's default
+        mapped that to the endpoint code — "the server returned no token" —
+        which is untrue about the WIRE (nothing was sent) and about the SERVER
+        (it was never asked). Each local shape now carries its own code, and
+        both still fit the 44-column card's 19-cell reason budget.
+        """
+        from local_operator.mcp.auth import McpRefreshContendedError
+
+        endpoint = McpManager._auth_failure_text(
+            "notion", McpRefreshContendedError(self.URL, reason_code=REFRESH_REFUSAL_ENDPOINT)
         )
-
-        rendered = McpManager._auth_required_text("notion", McpRefreshUnconfirmedError(self.URL))
-        assert rendered == "run /mcp reauth notion — refresh unconfirmed"
-        assert rendered.count("—") == 1
-        assert rendered.startswith("run /mcp reauth notion"), "the command must lead"
-
-        # And the unchanged generic wording, so the new detail cannot silently
-        # become the text every other auth requirement renders.
-        assert (
-            McpManager._auth_required_text("notion", McpAuthRequiredError(self.URL))
-            == "run /mcp reauth notion — authorization expired"
-        )
-
-        # Rendered by the real card composer, the reason survives at 100 columns.
-        line = self._toast_failure_line(rendered, 58)
-        assert line == "failed: notion — run /mcp reauth notion — refresh unconfi…"
+        rendered: dict[str, str] = {}
+        for reason, (wide, narrow) in self.LOCAL_REFUSAL_EXPECTED.items():
+            text = McpManager._auth_failure_text(
+                "notion", McpRefreshContendedError(self.URL, reason_code=reason)
+            )
+            rendered[reason] = text
+            assert "server" not in text, (reason, text)
+            assert "http" not in text, (reason, text)
+            assert text != endpoint, (reason, text)
+            assert self._toast_failure_line(text, 58) == wide, (reason, wide)
+            assert self._toast_failure_line(text, 36) == narrow, (reason, narrow)
+        assert len(set(rendered.values())) == 2, rendered
 
     def test_the_log_sentence_still_carries_the_url_and_the_technical_reason(self) -> None:
         """``str(exc)`` stays verbose for the logs, which is the other half of D1.
@@ -4205,7 +4281,7 @@ class TestRefreshRefusalCopy:
         assert manager.auth_blocked("dd") is True
         assert manager.get_connection_status("dd") == "auth-required"
         assert incidents[-1][1] == (
-            "MCP authorization failed; run /mcp reauth dd — refresh unconfirmed"
+            "MCP authorization failed; /mcp reauth dd — refresh unconfirmed"
         ), incidents
 
     def test_each_refusal_reason_is_carried_on_the_ledger(

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -17,6 +17,12 @@ import pytest
 from mcp.types import CallToolResult, ListToolsResult, TextContent, Tool
 
 from local_operator.harness.types import AbortSignal, ToolContext, ToolResult
+from local_operator.mcp.auth import (
+    REFRESH_REFUSAL_ENDPOINT,
+    REFRESH_REFUSAL_INFLIGHT,
+    REFRESH_REFUSAL_LOCK,
+    REFRESH_REFUSAL_UNREACHABLE,
+)
 from local_operator.mcp.config import MCPStdioServerConfig
 from local_operator.mcp.manager import (
     McpManager,
@@ -3959,55 +3965,126 @@ class TestAnUnreadableGrantMarkerIsNotAChangedGrant:
 
 
 class TestRefreshRefusalCopy:
-    """The exact user-visible strings for the three split refusals.
+    """The exact RENDERED strings for the four refusals and the auth line.
 
-    The reviewer's minor and QA's Q5 both landed here: one message covered three
-    different situations, so it was untrue on two of them — a token endpoint
-    that ANSWERED 500 had not failed "under the refresh lock", and a lock held by
-    another session is not a server refusal. It also promised a retry that the
-    startup gate never performs. These assertions pin the rendered text because
-    a design review round follows, and copy that is not pinned drifts.
+    Round 1 split one message into three truthful sentences and design review
+    round 1 (D1/D2) showed why that was not enough: every one of those sentences
+    opens with ``MCP OAuth token refresh for <full server URL>``, which is ~55
+    of the toast card's 58 content cells, so the distinguishing clause was
+    always the part tail-truncated away and all of them rendered byte-identically
+    at 100 columns and below. The split now lives on the exception as a stable
+    reason CODE and the manager composes the short text from it, so these
+    assertions are made against the RENDERED line at both real card widths —
+    not against the code's idea of the sentence, which is exactly the mistake
+    that let four different refusals look the same.
+
+    The 44-column case is the tight one and the reason the wording is this
+    short: ``failed: notion — `` spends 17 of the 36 available cells, leaving 19
+    for the reason, so each reason must be DISTINGUISHABLE inside its first 19
+    cells.
     """
 
     URL = "https://mcp.example.com/v1/mcp"
 
-    def test_the_three_refusals_say_different_true_things(self) -> None:
-        from local_operator.mcp.auth import (
-            REFRESH_REFUSAL_ENDPOINT,
-            REFRESH_REFUSAL_INFLIGHT,
-            REFRESH_REFUSAL_LOCK,
-            McpRefreshContendedError,
-        )
+    #: Rendered at 100 columns (58 content cells) and at 44 (36).
+    EXPECTED = {
+        REFRESH_REFUSAL_LOCK: (
+            "failed: notion — another session is refreshing",
+            "failed: notion — another session is…",
+        ),
+        REFRESH_REFUSAL_INFLIGHT: (
+            "failed: notion — refresh still in progress",
+            "failed: notion — refresh still in p…",
+        ),
+        REFRESH_REFUSAL_ENDPOINT: (
+            "failed: notion — the server returned no token",
+            "failed: notion — the server returne…",
+        ),
+        REFRESH_REFUSAL_UNREACHABLE: (
+            "failed: notion — cannot reach the server",
+            "failed: notion — cannot reach the s…",
+        ),
+    }
 
-        lock = str(McpRefreshContendedError(self.URL, refusal=REFRESH_REFUSAL_LOCK))
-        inflight = str(McpRefreshContendedError(self.URL, refusal=REFRESH_REFUSAL_INFLIGHT))
-        endpoint = str(McpRefreshContendedError(self.URL, refusal=REFRESH_REFUSAL_ENDPOINT))
+    @staticmethod
+    def _toast_failure_line(reason: str, cells: int) -> str:
+        """The failure row the REAL toast composer paints, for ``reason``."""
+        from local_operator.session.mcp_status import McpStartupOutcome
+        from local_operator.tui.widgets.toast import format_mcp_startup
 
-        # No "retrying": the same string is the startup gate's reason a server
-        # is unavailable, and nothing schedules a retry there.
-        assert lock == (
-            f"MCP OAuth token refresh for {self.URL} was skipped: another session "
-            "holds the refresh lock"
-        )
-        assert inflight == (
-            f"MCP OAuth token refresh for {self.URL} did not finish in time; a rotation "
-            "is kept if the response lands"
-        )
-        assert endpoint == (
-            f"MCP OAuth token refresh for {self.URL} was rejected by the authorization server"
-        )
-        assert len({lock, inflight, endpoint}) == 3
-        assert str(McpRefreshContendedError(self.URL)) == lock
+        outcome = McpStartupOutcome(configured=("notion",), failures={"notion": reason})
+        payload = format_mcp_startup(outcome, max_cells=cells)
+        assert payload is not None
+        return payload[0].plain.split("\n")[1]
+
+    def test_the_reason_codes_compose_short_copy_with_no_url_or_internals(self) -> None:
+        """Each code maps to its own sentence, and the sentence is safe to render."""
+        from local_operator.mcp.auth import McpRefreshContendedError
+
+        rendered = McpManager._auth_failure_text  # readability
+        texts: dict[str, str] = {}
+        for reason in self.EXPECTED:
+            exc = McpRefreshContendedError(self.URL, reason_code=reason)
+            texts[reason] = rendered("notion", exc)
+
+        assert len(set(texts.values())) == 4, texts
+        for reason, text in texts.items():
+            assert "http" not in text, (reason, text)
+            # The internals the design review named: a user cannot act on either.
+            for jargon in ("lock", "rotation", "token refresh for"):
+                assert jargon not in text, (reason, text)
+            # No promise of a retry: the startup gate schedules none, so a card
+            # that said "retrying" would be untrue at the surface most users see.
+            assert "retry" not in text.lower() and "retrying" not in text.lower(), text
+
+    def test_the_toast_card_renders_every_reason_distinguishably_at_both_widths(self) -> None:
+        """The whole point of the fix, asserted on the painted line.
+
+        A green unit test on ``str(exc)`` is what let this defect through round
+        1: the strings differed, and the CARD did not. So this pins the exact
+        rendered row at 58 cells (a 100-column terminal) and 36 (44 columns).
+        """
+        from local_operator.mcp.auth import McpRefreshContendedError
+
+        for cells_index, cells in enumerate((58, 36)):
+            lines = []
+            for reason, expected in self.EXPECTED.items():
+                reason_text = McpManager._auth_failure_text(
+                    "notion", McpRefreshContendedError(self.URL, reason_code=reason)
+                )
+                line = self._toast_failure_line(reason_text, cells)
+                assert line == expected[cells_index], (reason, cells, line)
+                lines.append(line)
+            assert len(set(lines)) == 4, (cells, lines)
+
+    def test_an_unknown_reason_code_never_falls_back_to_the_verbose_sentence(self) -> None:
+        """A code this build does not know must still render short and URL-free.
+
+        A newer peer process can write a reason we cannot name. Falling back to
+        ``str(exc)`` there would put the ~55-cell URL preamble back on the card
+        — the defect this mapping exists to remove — so the fallback states only
+        what is true of every refusal in the set.
+        """
+        from local_operator.mcp.auth import McpRefreshContendedError
+
+        exc = McpRefreshContendedError(self.URL, reason_code="a-code-from-the-future")
+        text = McpManager._auth_failure_text("notion", exc)
+        assert text == "the refresh did not complete"
+        assert "http" not in text
+        line = self._toast_failure_line(text, 36)
+        assert line == "failed: notion — the refresh did no…"
 
     def test_an_unacknowledged_send_renders_the_actionable_reauth_command(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The third message, at the surface a user actually reads.
+        """The auth line, at the surface a user reads, on ONE card row.
 
         ``_auth_required_text`` composes the startup-toast line (and the
-        transcript notice, and ``/mcp``), leading with the command. A refresh
-        that was SENT and never confirmed is not an expired authorization, so the
-        error carries the reason and the tail says it instead.
+        transcript notice, and ``/mcp``), leading with the command and carrying
+        exactly one em-dash. A refresh that was SENT and never confirmed is not
+        an expired authorization, so the error carries the reason as a SHORT
+        tail — the previous sentence-length tail was itself clipped off the card
+        (design review D4).
         """
         from local_operator.mcp.auth import (
             McpAuthRequiredError,
@@ -4022,13 +4099,57 @@ class TestRefreshRefusalCopy:
         )
 
         rendered = McpManager._auth_required_text("notion", McpRefreshUnconfirmedError(self.URL))
-        assert rendered == "run /mcp reauth notion — a token refresh was sent but never confirmed"
+        assert rendered == "run /mcp reauth notion — refresh unconfirmed"
+        assert rendered.count("—") == 1
+        assert rendered.startswith("run /mcp reauth notion"), "the command must lead"
 
         # And the unchanged generic wording, so the new detail cannot silently
         # become the text every other auth requirement renders.
         assert (
             McpManager._auth_required_text("notion", McpAuthRequiredError(self.URL))
             == "run /mcp reauth notion — authorization expired"
+        )
+
+        # Rendered by the real card composer, the reason survives at 100 columns.
+        line = self._toast_failure_line(rendered, 58)
+        assert line == "failed: notion — run /mcp reauth notion — refresh unconfi…"
+
+    def test_the_log_sentence_still_carries_the_url_and_the_technical_reason(self) -> None:
+        """``str(exc)`` stays verbose for the logs, which is the other half of D1.
+
+        The reason code exists so the COPY can be short; the sentence is not
+        deleted, just moved off the user's surfaces — support needs the URL and
+        the mechanism when reading a log after an incident.
+        """
+        from local_operator.mcp.auth import (
+            REFRESH_REFUSAL_ENDPOINT,
+            REFRESH_REFUSAL_INFLIGHT,
+            REFRESH_REFUSAL_LOCK,
+            REFRESH_REFUSAL_UNREACHABLE,
+            McpRefreshContendedError,
+        )
+
+        assert str(McpRefreshContendedError(self.URL)) == (
+            f"MCP OAuth token refresh for {self.URL} was skipped: another session "
+            "holds the refresh lock"
+        )
+        assert str(McpRefreshContendedError(self.URL, reason_code=REFRESH_REFUSAL_INFLIGHT)) == (
+            f"MCP OAuth token refresh for {self.URL} did not finish in time; a rotation "
+            "is kept if the response lands"
+        )
+        # A pre-send transport failure is NOT a rejection by the authorization
+        # server: it never reached one (review round 2, minor 1).
+        unreachable = str(
+            McpRefreshContendedError(self.URL, reason_code=REFRESH_REFUSAL_UNREACHABLE)
+        )
+        assert "unreachable" in unreachable
+        assert "no token was presented" in unreachable
+        assert "rejected" not in unreachable
+        endpoint = str(McpRefreshContendedError(self.URL, reason_code=REFRESH_REFUSAL_ENDPOINT))
+        assert "rejected" not in endpoint
+        # The lock sentence still says the lock: it is the accurate log line.
+        assert "holds the refresh lock" in str(
+            McpRefreshContendedError(self.URL, reason_code=REFRESH_REFUSAL_LOCK)
         )
 
     @pytest.mark.asyncio
@@ -4065,7 +4186,7 @@ class TestRefreshRefusalCopy:
         REFRESH_CONTENTION.record(url, REFRESH_REFUSAL_UNCONFIRMED)
         with pytest.raises(McpRefreshUnconfirmedError) as excinfo:
             await manager._connect_server("dd", cfg)
-        assert excinfo.value.detail == "a token refresh was sent but never confirmed"
+        assert excinfo.value.detail == "refresh unconfirmed"
 
         # The manager arm for an auth requirement: blocked, not retried.
         scheduled = {"called": False}
@@ -4084,8 +4205,7 @@ class TestRefreshRefusalCopy:
         assert manager.auth_blocked("dd") is True
         assert manager.get_connection_status("dd") == "auth-required"
         assert incidents[-1][1] == (
-            "MCP authorization failed; run /mcp reauth dd — a token refresh was sent "
-            "but never confirmed"
+            "MCP authorization failed; run /mcp reauth dd — refresh unconfirmed"
         ), incidents
 
     def test_each_refusal_reason_is_carried_on_the_ledger(

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -1811,6 +1811,254 @@ class TestAuthRequiredHandling:
             server.server_close()
 
     @pytest.mark.asyncio
+    async def test_transient_refresh_failure_does_not_block_on_auth(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Contention is NOT an auth failure, and the manager must retry it.
+
+        The decisive property of the coordination contract, measured through the
+        REAL ``streamable_http_client``: when the in-flight coordinator cannot
+        refresh under the lock, it refuses to let the SDK POST the in-memory
+        refresh token unlocked. That refusal does not survive the transport as
+        an exception — the transport runs the request inside anyio cancel
+        scopes, so it arrives as a bare
+        ``CancelledError('Cancelled via cancel scope …')`` — so the provider arms
+        ``REFRESH_CONTENTION`` and ``_connect_server`` re-voices the
+        cancellation from that record.
+
+        Two outcomes are asserted, and they are the difference between "a
+        healthy server on a login prompt" and "a healthy server that retries":
+        the reconnect is re-scheduled with backoff and the server does NOT take
+        an auth block. ``token_posts`` is the same claim measured at the wire —
+        ZERO POSTs to the token endpoint, locked or unlocked.
+        """
+        import json
+        import threading
+        import time
+        from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+        from local_operator.mcp import auth as auth_mod
+        from local_operator.mcp.auth import (
+            McpAuthRequiredError,
+            McpRefreshContendedError,
+            McpTokenStorage,
+        )
+        from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+        from tests.unit.mcp.test_auth import FakeAuthStore
+
+        token_posts: list[dict[str, Any]] = []
+
+        class StubServer(BaseHTTPRequestHandler):
+            """Just enough OAuth metadata and MCP endpoint to reach the flow."""
+
+            def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+                return
+
+            def _json(self, payload: dict[str, Any], status: int = 200) -> None:
+                body = json.dumps(payload).encode()
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            @property
+            def _base(self) -> str:
+                assert isinstance(self.server, ThreadingHTTPServer)
+                return f"http://127.0.0.1:{self.server.server_port}"
+
+            def do_GET(self) -> None:
+                if self.path.startswith("/.well-known/oauth-protected-resource"):
+                    self._json(
+                        {"resource": self._base + "/mcp", "authorization_servers": [self._base]}
+                    )
+                elif self.path.startswith("/.well-known/oauth-authorization-server"):
+                    self._json(
+                        {
+                            "issuer": self._base,
+                            "authorization_endpoint": self._base + "/authorize",
+                            "token_endpoint": self._base + "/token",
+                            "registration_endpoint": self._base + "/register",
+                        }
+                    )
+                else:
+                    self._json({"error": "not found"}, status=404)
+
+            def do_POST(self) -> None:
+                length = int(self.headers.get("Content-Length") or 0)
+                body = self.rfile.read(length)
+                if self.path == "/token":
+                    # Every POST here — locked or unlocked — is a failure of the
+                    # claim under test, so record it and answer dead.
+                    token_posts.append(
+                        dict(
+                            __import__("urllib.parse", fromlist=["parse_qsl"]).parse_qsl(
+                                body.decode()
+                            )
+                        )
+                    )
+                    self._json({"error": "invalid_grant"}, status=400)
+                else:
+                    self._json({"error": "unauthorized"}, status=401)
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), StubServer)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            url = f"http://127.0.0.1:{server.server_port}/mcp"
+            cfg = MCPHttpServerConfig(url=url, auth=MCPAuthConfig(type="oauth"))
+            store = FakeAuthStore()
+            manager = McpManager(str(tmp_path))
+            manager.auth_store = cast(Any, store)
+            manager._configs["dd"] = cfg
+
+            # An EXPIRED, refreshable stored grant: exactly the state the
+            # coordinator exists to act on. Without an expiry the coordinator
+            # would return early and nothing would be proven.
+            from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+            storage = McpTokenStorage(url, store)
+            await storage.set_client_info(OAuthClientInformationFull(client_id="stub-client"))
+            await storage.set_tokens(
+                OAuthToken(access_token="stale", refresh_token="r-old", expires_in=60)
+            )
+            store.rows[0].data["tokens_obtained_at"] = time.time() - 600
+
+            # A peer process holds the refresh lock: the bounded acquire gives
+            # up, which is the contention this contract is about. Patched on the
+            # module the provider looks the name up on, so the REAL provider
+            # runs — only the lock's outcome is forced.
+            import contextlib as _contextlib
+
+            @_contextlib.asynccontextmanager
+            async def _foreign_held_lock(server_url: str):
+                yield False
+
+            monkeypatch.setattr(auth_mod, "_oauth_refresh_lock", _foreign_held_lock)
+
+            def _leaves(exc: BaseException) -> list[BaseException]:
+                if isinstance(exc, BaseExceptionGroup):
+                    out: list[BaseException] = []
+                    for child in exc.exceptions:
+                        out.extend(_leaves(child))
+                    return out
+                return [exc]
+
+            with pytest.raises(BaseException) as excinfo:
+                await manager._connect_server("dd", cfg)
+            leaves = _leaves(excinfo.value)
+            assert any(isinstance(leaf, McpRefreshContendedError) for leaf in leaves), (
+                "the refused unlocked refresh was not re-voiced from the ledger: "
+                f"{excinfo.value!r}"
+            )
+            assert not any(
+                isinstance(leaf, McpAuthRequiredError) for leaf in leaves
+            ), "contention was flattened into an auth requirement"
+            # And it cost ZERO token POSTs: the SDK's unlocked refresh never ran.
+            assert token_posts == [], f"a refresh POST reached the wire: {token_posts}"
+
+            # The manager arm: a generic failure re-schedules with backoff and
+            # does NOT block on auth (the whole point of a non-auth raise).
+            scheduled = {"called": False}
+            monkeypatch.setattr(
+                manager, "_schedule_reconnect", lambda name: scheduled.__setitem__("called", True)
+            )
+            await manager._reconnect("dd", 0.0, manager._epoch)
+            assert scheduled["called"] is True
+            assert manager.auth_blocked("dd") is False
+            assert manager.reconnect_suspended("dd") is False
+            assert manager.get_connection_status("dd") != "auth-required"
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    @pytest.mark.asyncio
+    async def test_a_genuine_dispose_cancellation_is_not_re_voiced(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A real teardown must stay a teardown, even with a record armed.
+
+        The guard that keeps the re-voice safe: a cancellation the TASK ITSELF
+        was asked for (``cancelling() > 0`` — a dispose, a reload, an epoch
+        change, the user leaving) keeps its priority, and the contention record
+        is discarded rather than believed. Without this, a refusal armed a moment
+        before a disposal would convert the disposal into a reconnect attempt —
+        the retry storm the abandoned-grant arm already guards against.
+
+        Also asserts the record is CONSUMED on that path, so it cannot be
+        attributed to an unrelated cancellation of the same server later.
+        """
+        from local_operator.mcp.auth import REFRESH_CONTENTION
+        from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+
+        url = "https://srv.example/mcp"
+        manager = McpManager(str(tmp_path))
+        cfg = MCPHttpServerConfig(url=url, auth=MCPAuthConfig(type="oauth"))
+        manager._configs["dd"] = cfg
+
+        parked = asyncio.Event()
+
+        async def park(*_a: Any, **_kw: Any) -> Any:
+            await parked.wait()
+            raise AssertionError("released without being cancelled")
+
+        monkeypatch.setattr(manager, "_open_transport_and_session", park)
+        monkeypatch.setattr(manager, "_ensure_oauth_fresh", lambda *a, **k: asyncio.sleep(0))
+
+        scheduled = {"called": False}
+        monkeypatch.setattr(
+            manager, "_schedule_reconnect", lambda name: scheduled.__setitem__("called", True)
+        )
+
+        # Fresh ledger entries are cleared around every test by the fixture
+        # below; arm one here to prove the guard beats the record.
+        REFRESH_CONTENTION.record(url)
+        task = asyncio.ensure_future(manager._connect_server("dd", cfg))
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert scheduled["called"] is False
+        assert manager.auth_blocked("dd") is False
+        assert REFRESH_CONTENTION.pop(url) is False, "the record leaked past the disposal"
+
+    @pytest.mark.asyncio
+    async def test_the_contention_record_is_single_use(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One refusal re-voices ONE cancellation, never two.
+
+        The transport's rewrite of an auth-flow failure is a bare CancelledError
+        with no cancelling count, which is exactly what the abandoned-grant arm
+        sees too — so the record is what distinguishes them, and a record that
+        outlived its own cancellation would turn the NEXT unrelated one into a
+        retry.
+        """
+        from local_operator.mcp.auth import REFRESH_CONTENTION, McpRefreshContendedError
+        from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+
+        url = "https://srv.example/mcp"
+        manager = McpManager(str(tmp_path))
+        cfg = MCPHttpServerConfig(url=url, auth=MCPAuthConfig(type="oauth"))
+        manager._configs["dd"] = cfg
+
+        async def bare_cancel(*_a: Any, **_kw: Any) -> Any:
+            # What the transport delivers: a CancelledError with NO cancelling
+            # count on the task, i.e. not an external cancellation.
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(manager, "_open_transport_and_session", bare_cancel)
+        monkeypatch.setattr(manager, "_ensure_oauth_fresh", lambda *a, **k: asyncio.sleep(0))
+
+        REFRESH_CONTENTION.record(url)
+        with pytest.raises(McpRefreshContendedError):
+            await manager._connect_server("dd", cfg)
+        # Second attempt, same server, nothing armed: the cancellation stays a
+        # cancellation (the abandoned-grant arm finds no flow either).
+        with pytest.raises(asyncio.CancelledError):
+            await manager._connect_server("dd", cfg)
+
+    @pytest.mark.asyncio
     async def test_login_resets_the_breaker_and_scopes_the_timeout(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -4014,12 +4014,17 @@ class TestRefreshRefusalCopy:
     }
 
     @staticmethod
-    def _toast_failure_line(reason: str, cells: int) -> str:
-        """The failure row the REAL toast composer paints, for ``reason``."""
+    def _toast_failure_line(reason: str, cells: int, name: str = "notion") -> str:
+        """The failure row the REAL toast composer paints, for ``reason``.
+
+        ``name`` defaults to the 6-cell pseudonym every D9 pin was measured on;
+        the long-name cases pass the server name they are about, because the
+        row's budget depends on its width (D11).
+        """
         from local_operator.session.mcp_status import McpStartupOutcome
         from local_operator.tui.widgets.toast import format_mcp_startup
 
-        outcome = McpStartupOutcome(configured=("notion",), failures={"notion": reason})
+        outcome = McpStartupOutcome(configured=(name,), failures={name: reason})
         payload = format_mcp_startup(outcome, max_cells=cells)
         assert payload is not None
         return payload[0].plain.split("\n")[1]
@@ -4162,6 +4167,80 @@ class TestRefreshRefusalCopy:
                 # never the server name the command has to hand over.
                 assert "/mcp reauth notion" in narrow, (key, narrow)
 
+    #: The D11 rows, measured on the head that fixes them. Both names are this
+    #: project's own server names: ``minerva-qa`` (10 cells) is the one
+    #: ``test_turn_abandoned.py`` uses, and ``launchdarkly`` (12) the one this
+    #: file already copies. The wide row keeps the whole command and sheds the
+    #: reason; the narrow one is asserted VERBATIM as the base renders it, which
+    #: is the recorded deferral (see the test's docstring).
+    LONG_NAME_EXPECTED = {
+        "minerva-qa": (
+            "failed: minerva-qa — /mcp reauth minerva-qa…",
+            "failed: minerva-qa — /mcp reauth mi…",
+        ),
+        "launchdarkly": (
+            "failed: launchdarkly — /mcp reauth launchdarkly…",
+            "failed: launchdarkly — /mcp reauth…",
+        ),
+    }
+
+    def test_a_long_name_sheds_the_reason_rather_than_clipping_the_command(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Design review round 3, D11: the D9 pin held only for 6-cell names.
+
+        The row is ``failed: <name> — <command> — <reason>`` and the command
+        repeats the name, so it needs ``45 + 2n`` cells against the card's 58
+        and fits only while the name is 6 cells. ``minerva-qa`` and
+        ``launchdarkly`` are 10 and 12, and the clamp ate the END of the line:
+        the REASON at 100 columns (``— refresh unc…``) and the command's own name
+        argument at 44 (``/mcp reauth mi…`` — a command that errors if followed).
+        The budget now decides what is SHED: the command survives whole and the
+        reason is dropped, marked with the ``…`` the 44-column card has always
+        shown (D9 accepted it as marking the shed reason). The reason is the
+        right part to lose — ``/mcp`` and the durable transcript notice carry it
+        whole.
+        """
+        from local_operator.mcp.auth import McpRefreshUnconfirmedError
+
+        monkeypatch.setattr(
+            "local_operator.mcp.auth.server_has_stored_grant", lambda url, store=None: True
+        )
+        for name, (wide, narrow) in self.LONG_NAME_EXPECTED.items():
+            text = McpManager._auth_required_text(name, McpRefreshUnconfirmedError(self.URL))
+            assert text == f"/mcp reauth {name} — refresh unconfirmed", name
+            rendered = self._toast_failure_line(text, 58, name)
+            assert rendered == wide, (name, rendered)
+            # The whole command with its name, and NOTHING of the reason: what
+            # this removes is a half-rendered reason, which the user cannot act
+            # on and which the other two surfaces state in full.
+            assert f"/mcp reauth {name}" in rendered, (name, rendered)
+            assert "refresh" not in rendered and "unconfirmed" not in rendered, rendered
+            assert rendered.count("—") == 1, rendered  # D4: not a chain of dashes
+            assert len(rendered) <= 58, (name, rendered)
+            # At 44 columns the command ALONE is ``23 + 2n`` cells against 36, so
+            # no composition of this line fits for names >= 7 without a second
+            # row or a different card shape — both layout decisions this change
+            # does not make (D11 resolution 2). The base row is pinned verbatim
+            # instead, so a future regression is visible rather than silent.
+            assert self._toast_failure_line(text, 36, name) == narrow, (name, narrow)
+
+    def test_the_shed_boundary_is_the_seventh_cell_of_the_name(self) -> None:
+        """The boundary the shed starts at, pinned from BOTH sides.
+
+        ``45 + 2n`` against 58 makes ``n <= 6`` the range where
+        ``name + command-with-name + reason`` fits: ``github``'s unconfirmed row
+        is 57 cells and keeps its reason, while ``datadog`` (7) is 59 and sheds
+        it. Both names are real servers in this repo's own config vocabulary, so
+        the boundary is asserted on the two names a user would actually read.
+        """
+        kept = self._toast_failure_line("/mcp reauth github — refresh unconfirmed", 58, "github")
+        assert kept == "failed: github — /mcp reauth github — refresh unconfirmed"
+        assert len(kept) == 57, kept
+        shed = self._toast_failure_line("/mcp reauth datadog — refresh unconfirmed", 58, "datadog")
+        assert shed == "failed: datadog — /mcp reauth datadog…"
+        assert len(shed) == 38, shed
+
     def test_the_local_refusals_never_blame_a_server(self) -> None:
         """The endpoint copy is false about a request that was never made.
 
@@ -4201,7 +4280,9 @@ class TestRefreshRefusalCopy:
             REFRESH_REFUSAL_ENDPOINT,
             REFRESH_REFUSAL_INFLIGHT,
             REFRESH_REFUSAL_LOCK,
+            REFRESH_REFUSAL_UNATTRIBUTED,
             REFRESH_REFUSAL_UNREACHABLE,
+            REFRESH_REFUSAL_UNSENT,
             McpRefreshContendedError,
         )
 
@@ -4226,6 +4307,34 @@ class TestRefreshRefusalCopy:
         # The lock sentence still says the lock: it is the accurate log line.
         assert "holds the refresh lock" in str(
             McpRefreshContendedError(self.URL, reason_code=REFRESH_REFUSAL_LOCK)
+        )
+        # The two LOCAL codes say what happened to THEM instead of borrowing
+        # that sentence, which was untrue for both — neither ran into another
+        # session's lock (QA round 3, Q2; review round 4, N4.1 is its sibling in
+        # the proactive site's outcome tuple).
+        unsent = str(McpRefreshContendedError(self.URL, reason_code=REFRESH_REFUSAL_UNSENT))
+        assert "was not sent" in unsent
+        assert "nothing to present" in unsent
+        assert "holds the refresh lock" not in unsent
+        unattributed = str(
+            McpRefreshContendedError(self.URL, reason_code=REFRESH_REFUSAL_UNATTRIBUTED)
+        )
+        assert "cannot be attributed" in unattributed
+        assert "holds the refresh lock" not in unattributed
+        # …and the split is log-only by construction: the rendered copy is
+        # composed from the CODE, so neither sentence can reach a user surface.
+        assert (
+            McpManager._auth_failure_text(
+                "notion", McpRefreshContendedError(self.URL, reason_code=REFRESH_REFUSAL_UNSENT)
+            )
+            == "no stored token to send"
+        )
+        assert (
+            McpManager._auth_failure_text(
+                "notion",
+                McpRefreshContendedError(self.URL, reason_code=REFRESH_REFUSAL_UNATTRIBUTED),
+            )
+            == "the refresh did not complete"
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -2020,7 +2020,7 @@ class TestAuthRequiredHandling:
 
         assert scheduled["called"] is False
         assert manager.auth_blocked("dd") is False
-        assert REFRESH_CONTENTION.pop(url) is False, "the record leaked past the disposal"
+        assert REFRESH_CONTENTION.pop(url) is None, "the record leaked past the disposal"
 
     @pytest.mark.asyncio
     async def test_the_contention_record_is_single_use(
@@ -3956,3 +3956,164 @@ class TestAnUnreadableGrantMarkerIsNotAChangedGrant:
         finally:
             await manager.disconnect_all()
             store.close()
+
+
+class TestRefreshRefusalCopy:
+    """The exact user-visible strings for the three split refusals.
+
+    The reviewer's minor and QA's Q5 both landed here: one message covered three
+    different situations, so it was untrue on two of them — a token endpoint
+    that ANSWERED 500 had not failed "under the refresh lock", and a lock held by
+    another session is not a server refusal. It also promised a retry that the
+    startup gate never performs. These assertions pin the rendered text because
+    a design review round follows, and copy that is not pinned drifts.
+    """
+
+    URL = "https://mcp.example.com/v1/mcp"
+
+    def test_the_three_refusals_say_different_true_things(self) -> None:
+        from local_operator.mcp.auth import (
+            REFRESH_REFUSAL_ENDPOINT,
+            REFRESH_REFUSAL_INFLIGHT,
+            REFRESH_REFUSAL_LOCK,
+            McpRefreshContendedError,
+        )
+
+        lock = str(McpRefreshContendedError(self.URL, refusal=REFRESH_REFUSAL_LOCK))
+        inflight = str(McpRefreshContendedError(self.URL, refusal=REFRESH_REFUSAL_INFLIGHT))
+        endpoint = str(McpRefreshContendedError(self.URL, refusal=REFRESH_REFUSAL_ENDPOINT))
+
+        # No "retrying": the same string is the startup gate's reason a server
+        # is unavailable, and nothing schedules a retry there.
+        assert lock == (
+            f"MCP OAuth token refresh for {self.URL} was skipped: another session "
+            "holds the refresh lock"
+        )
+        assert inflight == (
+            f"MCP OAuth token refresh for {self.URL} did not finish in time; a rotation "
+            "is kept if the response lands"
+        )
+        assert endpoint == (
+            f"MCP OAuth token refresh for {self.URL} was rejected by the authorization server"
+        )
+        assert len({lock, inflight, endpoint}) == 3
+        assert str(McpRefreshContendedError(self.URL)) == lock
+
+    def test_an_unacknowledged_send_renders_the_actionable_reauth_command(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The third message, at the surface a user actually reads.
+
+        ``_auth_required_text`` composes the startup-toast line (and the
+        transcript notice, and ``/mcp``), leading with the command. A refresh
+        that was SENT and never confirmed is not an expired authorization, so the
+        error carries the reason and the tail says it instead.
+        """
+        from local_operator.mcp.auth import (
+            McpAuthRequiredError,
+            McpRefreshUnconfirmedError,
+        )
+
+        # We hold a grant for this URL (the unconfirmed state presupposes one), so
+        # the command is ``reauth``; the lookup itself is not what is under test.
+        monkeypatch.setattr(
+            "local_operator.mcp.auth.server_has_stored_grant",
+            lambda url, store=None: True,
+        )
+
+        rendered = McpManager._auth_required_text("notion", McpRefreshUnconfirmedError(self.URL))
+        assert rendered == "run /mcp reauth notion — a token refresh was sent but never confirmed"
+
+        # And the unchanged generic wording, so the new detail cannot silently
+        # become the text every other auth requirement renders.
+        assert (
+            McpManager._auth_required_text("notion", McpAuthRequiredError(self.URL))
+            == "run /mcp reauth notion — authorization expired"
+        )
+
+    @pytest.mark.asyncio
+    async def test_an_unacknowledged_refusal_is_re_voiced_as_an_auth_requirement(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The re-voice: a spent-possibly token must NOT be retried on backoff.
+
+        Contention is transient and retries. A token that may already be spent is
+        the opposite: retrying IS the reuse-detection POST, so this refusal has to
+        arrive as an auth requirement — auth block, actionable toast, abandoned
+        auto-reconnect — while carrying the truthful reason.
+        """
+        from local_operator.mcp.auth import (
+            REFRESH_CONTENTION,
+            REFRESH_REFUSAL_UNCONFIRMED,
+            McpRefreshUnconfirmedError,
+        )
+        from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+
+        url = "https://srv.example/mcp"
+        manager = McpManager(str(tmp_path))
+        cfg = MCPHttpServerConfig(url=url, auth=MCPAuthConfig(type="oauth"))
+        manager._configs["dd"] = cfg
+
+        async def bare_cancel(*_a: Any, **_kw: Any) -> Any:
+            # Exactly what the transport delivers: a CancelledError with no
+            # cancelling count, i.e. not an external cancellation.
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(manager, "_open_transport_and_session", bare_cancel)
+        monkeypatch.setattr(manager, "_ensure_oauth_fresh", lambda *a, **k: asyncio.sleep(0))
+
+        REFRESH_CONTENTION.record(url, REFRESH_REFUSAL_UNCONFIRMED)
+        with pytest.raises(McpRefreshUnconfirmedError) as excinfo:
+            await manager._connect_server("dd", cfg)
+        assert excinfo.value.detail == "a token refresh was sent but never confirmed"
+
+        # The manager arm for an auth requirement: blocked, not retried.
+        scheduled = {"called": False}
+        monkeypatch.setattr(
+            manager, "_schedule_reconnect", lambda name: scheduled.__setitem__("called", True)
+        )
+        # Arm a FRESH record: the connect above consumed the first one (single
+        # use), and a reconnect is its own refused attempt in reality.
+        incidents: list[tuple[str, str]] = []
+        manager.on_incident = lambda name, text: incidents.append((name, text))
+        REFRESH_CONTENTION.record(url, REFRESH_REFUSAL_UNCONFIRMED)
+        # ``_reconnect`` does not re-raise an auth requirement: it blocks on the
+        # grant, abandons the ladder and tells the model why.
+        await manager._reconnect("dd", 0.0, manager._epoch)
+        assert scheduled["called"] is False, "a spent-possibly token must not be retried"
+        assert manager.auth_blocked("dd") is True
+        assert manager.get_connection_status("dd") == "auth-required"
+        assert incidents[-1][1] == (
+            "MCP authorization failed; run /mcp reauth dd — a token refresh was sent "
+            "but never confirmed"
+        ), incidents
+
+    def test_each_refusal_reason_is_carried_on_the_ledger(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The reason survives the transport with the record, one per refusal.
+
+        Two concurrent connects for the same server can both refuse; the ledger
+        holds one record each, so the second is not silently dropped (that reached
+        ``_reconnect`` as a bare cancellation and killed the reconnect task
+        instead of retrying it).
+        """
+        from local_operator.mcp.auth import (
+            REFRESH_CONTENTION,
+            REFRESH_REFUSAL_ENDPOINT,
+            REFRESH_REFUSAL_INFLIGHT,
+            REFRESH_REFUSAL_LOCK,
+        )
+
+        url = "https://srv.example/mcp/two"
+        REFRESH_CONTENTION.record(url, REFRESH_REFUSAL_LOCK)
+        REFRESH_CONTENTION.record(url, REFRESH_REFUSAL_INFLIGHT)
+
+        assert REFRESH_CONTENTION.pop(url) == REFRESH_REFUSAL_LOCK
+        assert REFRESH_CONTENTION.pop(url) == REFRESH_REFUSAL_INFLIGHT
+        assert REFRESH_CONTENTION.pop(url) is None
+
+        # A reason is not a boolean: an unarmed server must pop as None, and a
+        # reason must never be confused with the un-armed answer.
+        REFRESH_CONTENTION.record(url, REFRESH_REFUSAL_ENDPOINT)
+        assert REFRESH_CONTENTION.pop(url) == REFRESH_REFUSAL_ENDPOINT

--- a/tests/unit/mcp/test_oauth_refresh_durability.py
+++ b/tests/unit/mcp/test_oauth_refresh_durability.py
@@ -26,7 +26,9 @@ stays on record rather than only in a review comment.
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -107,6 +109,23 @@ async def _until(predicate: Any, timeout_s: float = 5.0) -> Any:
     return value
 
 
+@pytest.fixture(autouse=True)
+def _isolated_lock_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep this module's refresh lock out of the operator's real config dir.
+
+    ``_oauth_refresh_lock_path`` resolves under ``config_dir()``, so without this
+    every test here creates — and briefly flocks — a file in
+    ``~/.local-operator``, and two xdist workers running this module at once
+    contend on the SAME path. The lock-hold assertions below would then read a
+    sibling worker's exchange as this test's, which is exactly the cross-test
+    coupling that makes a concurrency test lie. A per-test directory also means
+    a leaked lock can never outlive the test that took it.
+    """
+    from local_operator.paths import CONFIG_DIR_ENV
+
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(tmp_path / "cfg"))
+
+
 @pytest.mark.asyncio
 async def test_cancelling_the_connect_mid_post_keeps_the_rotated_token(
     monkeypatch: pytest.MonkeyPatch,
@@ -119,6 +138,13 @@ async def test_cancelling_the_connect_mid_post_keeps_the_rotated_token(
     state whose next POST is a reuse-detection double-spend. The server has
     already rotated to ``refresh-1`` and revoked ``access-0``, so nothing but
     that response could ever have carried the new token.
+
+    The cancellation is delivered IMMEDIATELY now — teardown is no longer
+    blocked on the exchange — so the rotation lands a moment after the connect
+    raises, persisted by the detached exchange, which holds the refresh lock
+    until it does. Polling for it is therefore part of the contract, not a
+    concession: nothing else can recover the token, and the lock is what stops
+    a sibling from presenting the spent one while that happens.
     """
     store = FakeAuthStore()
     storage = await _seed_expired_grant(store)
@@ -136,8 +162,18 @@ async def test_cancelling_the_connect_mid_post_keeps_the_rotated_token(
         with pytest.raises(asyncio.CancelledError):
             await task
 
+        async def _rotated() -> bool:
+            tokens = await storage.get_tokens()
+            return tokens is not None and tokens.refresh_token == "refresh-1"
+
+        persisted = await _until(_rotated)
         tokens = await storage.get_tokens()
 
+    assert persisted, (
+        "the rotation the server performed must survive the cancellation; a "
+        "spent token left as the only stored one is the reuse-detection "
+        "double-spend this subsystem exists to prevent"
+    )
     assert tokens is not None
     assert tokens.refresh_token == "refresh-1", (
         "the rotation the server performed must survive the cancellation; a "
@@ -216,9 +252,12 @@ async def test_tombstone_skipped_when_a_peer_rotated_the_grant_mid_refresh(
         access_token="peer-access", refresh_token="peer-1", on_reject=_peer_persists_its_rotation
     ) as endpoint:
         _stub_discovery(monkeypatch, endpoint.token_endpoint)
-        async with auth_mod._oauth_refresh_lock(SERVER_URL):
+        # The caller acquires and HANDS OVER the lock, exactly as the real call
+        # sites do: the exchange owns the release, so it stays held until the
+        # store write is done.
+        async with auth_mod._oauth_refresh_lock(SERVER_URL) as lock:
             outcome = await auth_mod._refresh_oauth_token_locked(
-                SERVER_URL, storage, _endpoints_for(endpoint.token_endpoint)
+                SERVER_URL, storage, _endpoints_for(endpoint.token_endpoint), lock=lock
             )
 
     assert outcome == "dead"
@@ -253,10 +292,451 @@ async def test_tombstone_written_when_grant_unchanged(
     # is exactly the state the marker is for.
     async with FakeTokenEndpoint(refresh_token="elsewhere-0") as endpoint:
         _stub_discovery(monkeypatch, endpoint.token_endpoint)
-        async with auth_mod._oauth_refresh_lock(SERVER_URL):
+        # The caller acquires and HANDS OVER the lock, exactly as the real call
+        # sites do: the exchange owns the release, so it stays held until the
+        # store write is done.
+        async with auth_mod._oauth_refresh_lock(SERVER_URL) as lock:
             outcome = await auth_mod._refresh_oauth_token_locked(
-                SERVER_URL, storage, _endpoints_for(endpoint.token_endpoint)
+                SERVER_URL, storage, _endpoints_for(endpoint.token_endpoint), lock=lock
             )
 
     assert outcome == "dead"
     assert storage.grant_is_dead() is True
+
+
+# --------------------------------------------------------------------------
+# The write FRESHNESS discipline (review B1): a detached exchange's late
+# success must not resurrect or erase grant state a better-informed writer
+# established while it was in flight.
+# --------------------------------------------------------------------------
+
+
+def _lock_is_held(lock_path: Path) -> bool:
+    """Whether a FOREIGN open file description can take the refresh lock.
+
+    A same-process re-flock is useless as evidence — ``flock`` is per open file
+    description — so this opens its OWN descriptor and makes one non-blocking
+    exclusive attempt. ``True`` means somebody else holds it.
+    """
+    import os
+
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        return not auth_mod._try_lock_exclusive(fd)
+    finally:
+        os.close(fd)
+
+
+@pytest.mark.asyncio
+async def test_a_late_success_cannot_clear_a_newer_tombstone(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A response that lands after a tombstone must keep the grant DEAD.
+
+    The reviewer's B1(a): the exchange persisted unconditionally and
+    ``set_tokens`` cleared the dead-grant marker unconditionally, so a late HTTP
+    200 rewrote a revoked family's token as ALIVE — every later boot re-POSTed
+    it (the storm the marker exists to stop) and ``grant_marker()`` moved, so a
+    fresh grant appeared to exist.
+
+    The rotation is still kept — it really happened, and support should be able
+    to see it — but the marker is not cleared, so nothing can ever present it.
+    """
+    caplog.set_level(logging.INFO, logger="local_operator.mcp.auth")
+    store = FakeAuthStore()
+    storage = await _seed_expired_grant(store)
+
+    async with FakeTokenEndpoint(response_delay_s=0.3) as endpoint:
+        _stub_discovery(monkeypatch, endpoint.token_endpoint)
+        exchange = asyncio.ensure_future(
+            auth_mod._perform_refresh_exchange(
+                SERVER_URL, storage, _endpoints_for(endpoint.token_endpoint)
+            )
+        )
+        await asyncio.wait_for(endpoint.rotation_applied.wait(), 5)
+        # A better-informed writer lands first: this is the tombstone a PEER
+        # writes when it presents the token we are spending right now.
+        assert storage.mark_grant_dead(rejected_refresh_token="refresh-0") is True
+        assert await _until(lambda: _resolved(exchange)) is True
+        outcome = await exchange
+
+    assert outcome == "refreshed"
+    tokens = await storage.get_tokens()
+    assert tokens is not None
+    assert tokens.refresh_token == "refresh-1", "the rotation the server performed is kept"
+    assert storage.grant_is_dead() is True, (
+        "the late success cleared a newer tombstone: the revoked family reads "
+        "ALIVE again and every later boot re-POSTs it"
+    )
+    assert any(
+        "store_refresh_result" in record.getMessage() for record in caplog.records
+    ), "the kept-marker write must name its writer"
+
+
+@pytest.mark.asyncio
+async def test_a_late_success_cannot_overwrite_a_newer_rotation(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A late response must not erase a rotation a peer persisted first.
+
+    The other half of B1: the write is conditioned on the row still holding the
+    refresh token THIS exchange presented, so a response computed from a grant
+    somebody has since replaced is dropped rather than written over the newer
+    state. Before the fix the late write clobbered the peer's token.
+    """
+    from mcp.shared.auth import OAuthToken
+
+    caplog.set_level(logging.INFO, logger="local_operator.mcp.auth")
+    store = FakeAuthStore()
+    storage = await _seed_expired_grant(store)
+
+    async with FakeTokenEndpoint(response_delay_s=0.3) as endpoint:
+        _stub_discovery(monkeypatch, endpoint.token_endpoint)
+        exchange = asyncio.ensure_future(
+            auth_mod._perform_refresh_exchange(
+                SERVER_URL, storage, _endpoints_for(endpoint.token_endpoint)
+            )
+        )
+        await asyncio.wait_for(endpoint.rotation_applied.wait(), 5)
+        peer = McpTokenStorage(SERVER_URL, store)
+        await peer.set_tokens(
+            OAuthToken(access_token="peer-access", refresh_token="refresh-9", expires_in=3600)
+        )
+        assert await _until(lambda: _resolved(exchange)) is True
+        outcome = await exchange
+
+    assert outcome == "refreshed"  # the store holds something usable; the caller re-reads
+    tokens = await storage.get_tokens()
+    assert tokens is not None
+    assert tokens.refresh_token == "refresh-9", "the peer's rotation was overwritten"
+    assert tokens.access_token == "peer-access"
+    assert any(
+        "store_refresh_result" in record.getMessage() and "NOT persisted" in record.getMessage()
+        for record in caplog.records
+    ), "a dropped rotation must be logged at INFO, naming its writer"
+
+
+async def _resolved(task: "asyncio.Task[Any]") -> bool:
+    """Poll helper: has this exchange task finished?"""
+    return task.done()
+
+
+@pytest.mark.asyncio
+async def test_two_concurrent_slow_exchanges_never_revoke_the_family(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two sessions refreshing the same grant must not double-spend it.
+
+    The reviewer's B1(b) and M2 measured together: with two slow exchanges, the
+    replayed token triggered reuse detection (``reuse_attempts == 1``, family
+    revoked) and the row was left holding a token of that revoked family reading
+    ALIVE. Here the second attempt cannot even POST: the exchange owns the lock
+    for the whole request and the write, so the sibling's bounded acquire gives
+    up and takes the contended path.
+    """
+    store = FakeAuthStore()
+    storage = await _seed_expired_grant(store)
+    # Small enough that a refusal is quick, large enough that the holder (whose
+    # response takes 0.4s) is still working when the sibling gives up.
+    monkeypatch.setattr(auth_mod, "LOCK_ACQUIRE_TIMEOUT_S", 0.1)
+    endpoints = None
+
+    async with FakeTokenEndpoint(response_delay_s=0.4) as endpoint:
+        _stub_discovery(monkeypatch, endpoint.token_endpoint)
+        endpoints = _endpoints_for(endpoint.token_endpoint)
+
+        async def attempt() -> Any:
+            # The real call shape at both refresh sites: acquire, then hand the
+            # lock to the exchange so IT owns the release.
+            async with auth_mod._oauth_refresh_lock(SERVER_URL) as lock:
+                if not lock:
+                    return "contended"
+                return await auth_mod._refresh_oauth_token_locked(
+                    SERVER_URL, storage, endpoints, lock=lock
+                )
+
+        outcomes = await asyncio.gather(attempt(), attempt())
+
+    assert endpoint.reuse_attempts == 0, (
+        "the spent token was presented a second time: reuse detection revokes " "the whole family"
+    )
+    assert endpoint.revoked is False
+    assert endpoint.rotation_count == 1, "exactly one exchange consumed the grant"
+    assert sorted(outcomes, key=str) == ["contended", "refreshed"]
+    tokens = await storage.get_tokens()
+    assert tokens is not None
+    assert tokens.refresh_token == "refresh-1"
+    assert storage.grant_is_dead() is False
+
+
+@pytest.mark.asyncio
+async def test_the_lock_is_held_when_the_awaiter_is_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancelling the connect must NOT free the lock while the POST is in flight.
+
+    The reviewer's M2, measured: the lock used to be released the instant the
+    cancellation was delivered (they measured the flock FREE at the cancel
+    instant), so a sibling acquired it, re-read the still-old row and re-presented
+    the spent token — the family-revoking request. Now the exchange owns the lock
+    until it has persisted, and a sibling cannot get in.
+    """
+    store = FakeAuthStore()
+    await _seed_expired_grant(store)
+    lock_path = auth_mod._oauth_refresh_lock_path(SERVER_URL)
+
+    async with FakeTokenEndpoint(response_delay_s=0.4) as endpoint:
+        _stub_discovery(monkeypatch, endpoint.token_endpoint)
+        task = asyncio.ensure_future(
+            auth_mod.ensure_mcp_oauth_fresh(SERVER_URL, _cfg(), store=store)
+        )
+        await asyncio.wait_for(endpoint.rotation_applied.wait(), 5)
+        assert _lock_is_held(lock_path) is True, "the exchange should hold the lock"
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # The instant the awaiter is gone.
+        held = _lock_is_held(lock_path)
+        assert held is True, (
+            "the lock was freed while the POST was still in flight: a sibling can "
+            "acquire it and re-present the spent token"
+        )
+        assert endpoint.reuse_attempts == 0
+
+        async def _free() -> bool:
+            return not _lock_is_held(lock_path)
+
+        assert await _until(_free) is True, "the exchange never released the lock"
+
+
+@pytest.mark.asyncio
+async def test_the_lock_is_held_when_the_awaiter_overruns_its_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The budget bounds the WAIT, not the lock — and teardown is not delayed.
+
+    The two halves of the reviewer's M2/minor pair. The timeout arm used to
+    return with no wait at all while the lock was released by the awaiter's
+    context manager; the cancel arm waited out the remainder of the budget
+    (measured: 1.97s of a patched 2s budget blocked teardown) for a guarantee it
+    did not deliver. Now the exchange owns the lock for both, and neither path
+    waits.
+    """
+    store = FakeAuthStore()
+    storage = await _seed_expired_grant(store)
+    lock_path = auth_mod._oauth_refresh_lock_path(SERVER_URL)
+    monkeypatch.setattr(auth_mod, "REFRESH_HTTP_TIMEOUT_S", 0.1)
+
+    async with FakeTokenEndpoint(response_delay_s=0.6) as endpoint:
+        _stub_discovery(monkeypatch, endpoint.token_endpoint)
+        started = time.monotonic()
+        await auth_mod.ensure_mcp_oauth_fresh(SERVER_URL, _cfg(), store=store)
+        elapsed = time.monotonic() - started
+        assert (
+            elapsed < 0.5
+        ), "the awaiter waited for the exchange instead of returning at its budget"
+        assert (
+            _lock_is_held(lock_path) is True
+        ), "the over-budget exchange must keep the lock it is still POSTing under"
+        assert endpoint.reuse_attempts == 0
+
+        async def _rotated() -> bool:
+            tokens = await storage.get_tokens()
+            return tokens is not None and tokens.refresh_token == "refresh-1"
+
+        assert await _until(_rotated) is True, "a rotation that lands must still be persisted"
+
+        async def _free() -> bool:
+            return not _lock_is_held(lock_path)
+
+        assert await _until(_free) is True
+
+
+@pytest.mark.asyncio
+async def test_a_sent_but_unacknowledged_exchange_blocks_the_next_post(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A request that was SENT and never answered must not be re-presented.
+
+    The state the whole marker exists for: after a read timeout the server may
+    well have rotated and revoked, so the next refresh must take an honest
+    non-POST path — a fresh sign-in — rather than spending the token again. The
+    claim is measured at the wire: exactly ONE request ever reaches the
+    endpoint.
+    """
+    store = FakeAuthStore()
+    storage = await _seed_expired_grant(store)
+    # ONLY the read grace is shrunk: the request connects and is written (the
+    # budget is untouched at 10s), so this is httpx's post-send ReadTimeout —
+    # the suspect shape — rather than the connect's own budget overrunning.
+    monkeypatch.setattr(auth_mod, "REFRESH_LATE_RESPONSE_GRACE_S", 0.15)
+
+    async with FakeTokenEndpoint(response_delay_s=1.0) as endpoint:
+        _stub_discovery(monkeypatch, endpoint.token_endpoint)
+        endpoints = _endpoints_for(endpoint.token_endpoint)
+
+        first = await auth_mod._refresh_oauth_token_locked(SERVER_URL, storage, endpoints)
+
+        assert first == "unacknowledged"
+        assert len(endpoint.requests) == 1
+        assert (
+            storage.send_unconfirmed() is True
+        ), "the presented token must be recorded as possibly spent"
+
+        # The next refresh — the one that would replay the token — refuses, and
+        # costs no request at all.
+        async with auth_mod._oauth_refresh_lock(SERVER_URL) as lock:
+            second = await auth_mod._refresh_oauth_token_locked(
+                SERVER_URL, storage, endpoints, lock=lock
+            )
+
+        assert second == "unacknowledged"
+        assert len(endpoint.requests) == 1, "the spent token was presented again"
+        assert endpoint.reuse_attempts == 0
+
+
+@pytest.mark.asyncio
+async def test_a_peer_rotation_clears_a_stale_send_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A marker keyed to a token nobody holds any more must not suppress anything.
+
+    Self-healing, both halves: the marker records a DIGEST of the presented
+    token, so a peer's rotation makes it stale ("ignore and clear it"), and the
+    TTL bounds a marker nothing ever resolved. Without the staleness test a
+    healthy new grant would be refused a refresh until the user re-authed —
+    a false positive paid for with a browser visit.
+    """
+    store = FakeAuthStore()
+    storage = await _seed_expired_grant(store)
+    storage.mark_send_unconfirmed("refresh-0")
+    assert storage.send_unconfirmed() is True
+
+    # A peer rotates the grant in the shared row: the marker no longer describes
+    # anything that can be presented.
+    from mcp.shared.auth import OAuthToken
+
+    peer = McpTokenStorage(SERVER_URL, store)
+    await peer.set_tokens(
+        OAuthToken(access_token="peer-access", refresh_token="refresh-2", expires_in=60)
+    )
+    store.rows[0].data["tokens_obtained_at"] = time.time() - 600
+
+    assert storage.send_unconfirmed() is False
+    assert (
+        auth_mod.GRANT_UNCONFIRMED_SEND_KEY not in store.rows[0].data
+    ), "the stale marker was believed and left in place"
+
+    # And the peer's token refreshes normally: nothing was suppressed.
+    async with FakeTokenEndpoint(refresh_token="refresh-2") as endpoint:
+        _stub_discovery(monkeypatch, endpoint.token_endpoint)
+        async with auth_mod._oauth_refresh_lock(SERVER_URL) as lock:
+            outcome = await auth_mod._refresh_oauth_token_locked(
+                SERVER_URL, storage, _endpoints_for(endpoint.token_endpoint), lock=lock
+            )
+
+    assert outcome == "refreshed"
+    assert len(endpoint.requests) == 1
+    assert endpoint.reuse_attempts == 0
+    tokens = await storage.get_tokens()
+    assert tokens is not None and tokens.refresh_token == "refresh-1"
+
+
+@pytest.mark.asyncio
+async def test_a_connect_phase_failure_leaves_no_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nothing was written, so nothing may be suspect.
+
+    httpx distinguishes the connect phase (refused, DNS, TLS handshake, no pool
+    slot) from a failure after the request was written, and the marker follows
+    that distinction exactly: a refused connection never presented the token, so
+    the next attempt is an ordinary transient retry. Arming the marker here would
+    cost the user an interactive sign-in for a network blip.
+    """
+    import httpx
+
+    store = FakeAuthStore()
+    storage = await _seed_expired_grant(store)
+    calls = {"n": 0}
+
+    def _refused(request: "httpx.Request") -> "httpx.Response":
+        calls["n"] += 1
+        raise httpx.ConnectError("connection refused", request=request)
+
+    transport = httpx.MockTransport(_refused)
+    real_client = httpx.AsyncClient
+
+    def patched_client(*args: Any, **kwargs: Any) -> Any:
+        kwargs["transport"] = transport
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", patched_client)
+
+    outcome = await auth_mod._refresh_oauth_token_locked(
+        SERVER_URL, storage, _endpoints_for("http://127.0.0.1:1/token")
+    )
+
+    assert calls["n"] == 1
+    assert outcome == "failed"
+    assert auth_mod.GRANT_UNCONFIRMED_SEND_KEY not in store.rows[0].data
+    assert storage.send_unconfirmed() is False
+
+
+@pytest.mark.asyncio
+async def test_a_post_send_failure_keeps_the_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The mirror image: a read timeout CAN have been written, so it is suspect.
+
+    Same taxonomy, opposite conclusion. ``ReadTimeout`` happens after the
+    request is on the wire, so the token may have been spent and the next
+    refresh must refuse rather than replay it.
+    """
+    import httpx
+
+    store = FakeAuthStore()
+    storage = await _seed_expired_grant(store)
+
+    def _timed_out(request: "httpx.Request") -> "httpx.Response":
+        raise httpx.ReadTimeout("no response", request=request)
+
+    transport = httpx.MockTransport(_timed_out)
+    real_client = httpx.AsyncClient
+
+    def patched_client(*args: Any, **kwargs: Any) -> Any:
+        kwargs["transport"] = transport
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", patched_client)
+
+    outcome = await auth_mod._refresh_oauth_token_locked(
+        SERVER_URL, storage, _endpoints_for("http://127.0.0.1:1/token")
+    )
+
+    assert outcome == "unacknowledged"
+    assert auth_mod.GRANT_UNCONFIRMED_SEND_KEY in store.rows[0].data
+    assert storage.send_unconfirmed() is True
+
+
+@pytest.mark.asyncio
+async def test_an_unresolved_marker_expires(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The marker is BOUNDED: it cannot suppress a server's refresh forever.
+
+    The stated trade-off made testable. A marker armed in the crash-between-arm-
+    and-wire window describes a token nothing ever presented, so after the TTL
+    the refresh path presents it again — exactly the pre-marker behaviour, which
+    is the floor this can degrade to.
+    """
+    store = FakeAuthStore()
+    storage = await _seed_expired_grant(store)
+    monkeypatch.setattr(auth_mod, "UNCONFIRMED_SEND_TTL_S", 0.0)
+
+    storage.mark_send_unconfirmed("refresh-0")
+
+    assert (
+        storage.send_unconfirmed() is False
+    ), "an expired marker must not keep suppressing the refresh path"
+    assert auth_mod.GRANT_UNCONFIRMED_SEND_KEY not in store.rows[0].data

--- a/tests/unit/mcp/test_oauth_refresh_durability.py
+++ b/tests/unit/mcp/test_oauth_refresh_durability.py
@@ -680,7 +680,11 @@ async def test_a_connect_phase_failure_leaves_no_marker(
     )
 
     assert calls["n"] == 1
-    assert outcome == "failed"
+    # Its OWN outcome, not "failed": nothing was presented, so nothing could
+    # have been refused. The split is what lets the user-visible text say "could
+    # not be reached" instead of reporting a rejection by a server that was
+    # never contacted (review round 2, minor 1).
+    assert outcome == "unreachable"
     assert auth_mod.GRANT_UNCONFIRMED_SEND_KEY not in store.rows[0].data
     assert storage.send_unconfirmed() is False
 
@@ -740,3 +744,147 @@ async def test_an_unresolved_marker_expires(tmp_path: Any, monkeypatch: pytest.M
         storage.send_unconfirmed() is False
     ), "an expired marker must not keep suppressing the refresh path"
     assert auth_mod.GRANT_UNCONFIRMED_SEND_KEY not in store.rows[0].data
+
+
+@pytest.mark.asyncio
+async def test_a_5xx_after_the_rotation_keeps_the_marker_and_blocks_the_next_post(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An answer that proves NOTHING about our token must not clear the marker.
+
+    Review round 2, minor 2. Every non-200 used to resolve the send marker, on
+    the premise that "the server answered, so it either rotated-and-told-us or
+    refused without rotating". The first half of that is false for a provider
+    that COMMITS the rotation and then fails the response (a proxy in front of a
+    rotating issuer is enough): the row is left holding a spent token, the
+    marker is gone, and the next connect re-presents it — the reuse-detecting
+    POST this whole mechanism exists to prevent, with the family as the cost.
+
+    The fix is a rule, not a status-code tweak: clear only for an answer that
+    settles the question (a parsed 200, or a parsed ``invalid_grant``). The
+    fixture here rotates and THEN answers 500, so both halves are measured —
+    the rotation really happened, and the marker survives it.
+    """
+    store = FakeAuthStore()
+    storage = await _seed_expired_grant(store)
+
+    async with FakeTokenEndpoint(commit_then_fail_status=500) as endpoint:
+        _stub_discovery(monkeypatch, endpoint.token_endpoint)
+        endpoints = _endpoints_for(endpoint.token_endpoint)
+
+        first = await auth_mod._refresh_oauth_token_locked(SERVER_URL, storage, endpoints)
+
+        assert first == "failed"
+        assert endpoint.rotation_count == 1, "the fixture must have committed the rotation"
+        assert endpoint.reuse_attempts == 0
+        assert (
+            storage.send_unconfirmed() is True
+        ), "a 5xx is an unknown outcome: the presented token may already be spent"
+
+        # The next refresh is the one that would replay the possibly-spent token.
+        async with auth_mod._oauth_refresh_lock(SERVER_URL) as lock:
+            second = await auth_mod._refresh_oauth_token_locked(
+                SERVER_URL, storage, endpoints, lock=lock
+            )
+
+        assert second == "unacknowledged"
+    assert len(endpoint.requests) == 1, "the possibly-spent token was presented again"
+    assert endpoint.reuse_attempts == 0
+
+
+@pytest.mark.asyncio
+async def test_a_4xx_that_is_not_invalid_grant_also_keeps_the_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The rule is "proves it was not consumed", not "is a 5xx".
+
+    A 403 from a bot filter is a refusal we cannot read as a statement about
+    our token — it says nothing about whether the exchange was performed — so it
+    takes the same conservative path. The counter-case (a definitive 400
+    ``invalid_grant`` clears the marker, because the tombstone that follows IS
+    the recorded outcome) is covered by the tombstone tests above.
+    """
+    store = FakeAuthStore()
+    storage = await _seed_expired_grant(store)
+
+    async with FakeTokenEndpoint(commit_then_fail_status=403) as endpoint:
+        _stub_discovery(monkeypatch, endpoint.token_endpoint)
+        outcome = await auth_mod._refresh_oauth_token_locked(
+            SERVER_URL, storage, _endpoints_for(endpoint.token_endpoint)
+        )
+
+    assert outcome == "failed"
+    assert storage.send_unconfirmed() is True
+    assert endpoint.reuse_attempts == 0
+
+
+@pytest.mark.asyncio
+async def test_a_logout_during_an_in_flight_exchange_is_not_undone(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A removed row stays removed: the two writers now agree (QA round 2, Q6).
+
+    ``store_refresh_result`` used to re-create a row it found absent, reasoning
+    that "absence is not evidence that somebody replaced the grant", while its
+    sibling ``mark_grant_dead`` declined to write on the same absent row for the
+    opposite reason. So a ``/mcp logout`` landing inside the detached-exchange
+    grace was silently undone by a refresh that was already on the wire, and the
+    re-created row holds a live rotation — the next boot re-authorizes a server
+    the user asked us to forget.
+
+    An absent row is now treated as the deliberate removal it is (the
+    three-valued ``has_stored_row`` keeps "the store could not be read"
+    distinct), and the drop is logged at INFO naming the writer, so support can
+    read the loss out of the log.
+    """
+    caplog.set_level(logging.INFO, logger="local_operator.mcp.auth")
+    store = FakeAuthStore()
+    storage = await _seed_expired_grant(store)
+
+    async with FakeTokenEndpoint(response_delay_s=0.3) as endpoint:
+        _stub_discovery(monkeypatch, endpoint.token_endpoint)
+        exchange = asyncio.ensure_future(
+            auth_mod._perform_refresh_exchange(
+                SERVER_URL, storage, _endpoints_for(endpoint.token_endpoint)
+            )
+        )
+        await asyncio.wait_for(endpoint.rotation_applied.wait(), 5)
+        # The user asks us to forget this server while the response is in flight.
+        assert storage.clear() is True
+        assert store.rows == []
+        assert await _until(lambda: _resolved(exchange)) is True
+        outcome = await exchange
+
+    assert outcome == "refreshed"  # the exchange itself completed and rotated
+    assert store.rows == [], "a logout was silently undone by an in-flight refresh"
+    assert await storage.get_tokens() is None
+    assert any(
+        "store_refresh_result" in record.getMessage()
+        and "removed while this exchange was in flight" in record.getMessage()
+        for record in caplog.records
+    ), "a dropped rotation must be logged at INFO, naming its writer and the reason"
+
+
+@pytest.mark.asyncio
+async def test_a_first_grant_still_creates_its_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The removal rule must not stop the ordinary creation path.
+
+    ``store_refresh_result`` never creates a grant — a refresh can only run
+    against a row that already held the token it presented — so the only writer
+    that may create one is ``set_tokens``, which is what a completed interactive
+    login calls. Pinned here because the Q6 fix is a change to a WRITE path, and
+    the cheap way to get it wrong is to make absence fatal everywhere.
+    """
+    from mcp.shared.auth import OAuthToken
+
+    store = FakeAuthStore()
+    storage = McpTokenStorage(SERVER_URL, store)
+    assert await storage.get_tokens() is None
+
+    await storage.set_tokens(OAuthToken(access_token="acc", refresh_token="ref", expires_in=60))
+
+    tokens = await storage.get_tokens()
+    assert tokens is not None and tokens.refresh_token == "ref"

--- a/tests/unit/mcp/test_oauth_refresh_durability.py
+++ b/tests/unit/mcp/test_oauth_refresh_durability.py
@@ -867,6 +867,93 @@ async def test_a_logout_during_an_in_flight_exchange_is_not_undone(
 
 
 @pytest.mark.asyncio
+async def test_a_marker_write_never_re_creates_a_removed_row(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A removal that beat the marker write stays a removal (review round 3, M1).
+
+    ``mark_send_unconfirmed`` used ``self._read() or {}``, so a ``/mcp logout``
+    landing between the exchange's locked re-read and the write-ahead arming was
+    silently undone: the upsert re-created the row keyed on ``project_id``
+    (probed before the fix: ``rows == []`` -> one row of
+    ``grant_refresh_unconfirmed`` + ``project_id``, and the next
+    ``send_unconfirmed()`` then cleared the marker and left the empty row
+    behind). The impact is bounded — no grant comes back, so the wording and
+    ``server_has_stored_grant`` are unaffected — but it contradicts the symmetry
+    this delta states ("two writers racing a removal must give the same answer"):
+    ``store_refresh_result`` and ``mark_grant_dead`` both declined on a
+    definitively removed row and this third writer did not.
+
+    The rule is narrow, and the second half pins that: an UNREADABLE store is
+    not evidence of removal, so the marker is still written. Suppressing a
+    healthy refresh over a transient store error would cost the user a browser
+    visit for nothing.
+    """
+    caplog.set_level(logging.INFO, logger="local_operator.mcp.auth")
+    store = FakeAuthStore()
+    storage = await _seed_expired_grant(store)
+    assert storage.clear() is True
+    assert store.rows == []
+
+    storage.mark_send_unconfirmed("refresh-0")
+
+    assert store.rows == [], "the marker write re-created the row a logout removed"
+    assert storage.send_unconfirmed() is False
+    assert any(
+        "mark_send_unconfirmed" in record.getMessage() for record in caplog.records
+    ), "a refusal to arm the marker must be logged, naming its writer"
+
+    # The sibling mutator answers the same question the same way — including on
+    # the call that carries no rejected token, which was the other shape that
+    # re-created the row.
+    assert storage.mark_grant_dead() is False
+    assert store.rows == []
+    assert storage.grant_is_dead() is False
+
+    class _UnreadableStore(FakeAuthStore):
+        def list_credentials(self, provider: Any = None, include_disabled: bool = False) -> Any:
+            raise RuntimeError("store unavailable")
+
+    unreadable = _UnreadableStore()
+    blind = McpTokenStorage(SERVER_URL, unreadable)
+    blind.mark_send_unconfirmed("refresh-0")
+    assert unreadable.rows != [], "an unreadable store must not read as a removal"
+
+
+@pytest.mark.asyncio
+async def test_an_empty_row_is_unsent_so_no_server_is_blamed() -> None:
+    """Nothing to present means no request at all (review round 3, M2).
+
+    This shape returned ``"failed"``, which the manager composes as the ENDPOINT
+    text — "the server returned no token" — a claim that is untrue about the
+    WIRE (no request was made) and about the SERVER (it was never asked). Probed
+    before the fix: ``client_info`` present, no stored tokens -> outcome
+    ``"failed"`` -> the endpoint wording on the card.
+    """
+    from mcp.shared.auth import OAuthClientInformationFull
+
+    from local_operator.mcp.auth import REFRESH_REFUSAL_UNSENT, McpRefreshContendedError
+    from local_operator.mcp.manager import McpManager
+
+    store = FakeAuthStore()
+    storage = McpTokenStorage(SERVER_URL, store)
+    await storage.set_client_info(OAuthClientInformationFull(client_id=CLIENT_ID))
+
+    # The endpoint points at a closed port: had this shape made a request, the
+    # exchange would have failed rather than reported an outcome.
+    outcome = await auth_mod._refresh_oauth_token_locked(
+        SERVER_URL, storage, _endpoints_for("http://127.0.0.1:1/token")
+    )
+
+    assert outcome == "unsent"
+    text = McpManager._auth_failure_text(
+        "notion", McpRefreshContendedError(SERVER_URL, reason_code=REFRESH_REFUSAL_UNSENT)
+    )
+    assert text == "no stored token to send"
+    assert "server" not in text
+
+
+@pytest.mark.asyncio
 async def test_a_first_grant_still_creates_its_row(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/mcp/test_oauth_refresh_durability.py
+++ b/tests/unit/mcp/test_oauth_refresh_durability.py
@@ -1,0 +1,262 @@
+"""Durability of one MCP OAuth refresh exchange across cancellation and peers.
+
+``_refresh_oauth_token_locked`` spends a rotating refresh token, and for a
+provider running reuse detection (Notion) the WS response is the ONLY copy of
+the rotation: presenting the spent token again returns ``invalid_grant`` AND
+revokes the whole family. So an exchange whose result is discarded does not
+merely lose an optimisation — it leaves a spent token on disk whose next use
+logs out every session.
+
+Three ways that happened, each reproduced here against the real machinery: the
+real ``_refresh_oauth_token_locked`` / ``ensure_mcp_oauth_fresh``, a real
+``McpTokenStorage`` over the credential row, the real cross-process flock, and
+a real HTTP token endpoint (see ``rotating_oauth_server``) that rotates on
+every exchange and revokes the family on a replay:
+
+(a) cancelling the awaiting task while the POST was in flight — routine, since
+    every sidebar switch disposes a manager and cancels its in-flight connects;
+(b) a response that arrived after the total timeout;
+(c) a peer persisting its own fresh rotation while our POST was in flight, then
+    having it overwritten by our tombstone write (a live grant reading dead).
+
+Each test states the before-fix failure in its docstring so the failing case
+stays on record rather than only in a review comment.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import pytest
+
+from local_operator.mcp import auth as auth_mod
+from local_operator.mcp.auth import McpTokenStorage
+from tests.unit.mcp.rotating_oauth_server import FakeTokenEndpoint
+from tests.unit.mcp.test_auth import FakeAuthStore
+
+#: A reserved-by-RFC ``.test`` name: nothing here may reach a real host, and an
+#: accidental attempt should fail loudly rather than succeed against one.
+SERVER_URL = "https://mcp.rotation.test/mcp"
+CLIENT_ID = "rotation-client"
+
+
+def _cfg() -> Any:
+    from local_operator.mcp.config import MCPAuthConfig, MCPHttpServerConfig
+
+    return MCPHttpServerConfig(url=SERVER_URL, auth=MCPAuthConfig(type="oauth"))
+
+
+def _endpoints_for(token_endpoint: str) -> Any:
+    """Discovered endpoints whose token endpoint is the local fixture."""
+    from mcp.shared.auth import OAuthMetadata
+
+    from local_operator.mcp.auth import DiscoveredOAuthEndpoints
+
+    return DiscoveredOAuthEndpoints(
+        oauth_metadata=OAuthMetadata.model_validate(
+            {
+                "issuer": "https://issuer.rotation.test",
+                "authorization_endpoint": "https://issuer.rotation.test/authorize",
+                "token_endpoint": token_endpoint,
+            }
+        )
+    )
+
+
+def _stub_discovery(monkeypatch: pytest.MonkeyPatch, token_endpoint: str) -> None:
+    """Answer metadata discovery with the fixture's endpoint instead of HTTP.
+
+    Discovery is not what these tests are about, and letting it hit the network
+    would make them depend on DNS for ``.test``.
+    """
+    auth_mod._DISCOVERED_ENDPOINTS_CACHE.clear()
+
+    async def _discovery(server_url: str) -> Any:
+        return _endpoints_for(token_endpoint)
+
+    monkeypatch.setattr(auth_mod, "discover_oauth_endpoints", _discovery)
+
+
+async def _seed_expired_grant(
+    store: FakeAuthStore, *, access: str = "access-0", refresh: str = "refresh-0"
+) -> McpTokenStorage:
+    """Store a grant old enough that the proactive refresh actually runs.
+
+    Without an EXPIRED access token ``ensure_mcp_oauth_fresh`` returns before
+    reaching the lock and the test would silently exercise nothing.
+    """
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+    storage = McpTokenStorage(SERVER_URL, store)
+    await storage.set_client_info(OAuthClientInformationFull(client_id=CLIENT_ID))
+    await storage.set_tokens(OAuthToken(access_token=access, refresh_token=refresh, expires_in=60))
+    # Age it past its lifetime; expiry is computed from this stamp.
+    store.rows[0].data["tokens_obtained_at"] = time.time() - 600
+    return storage
+
+
+async def _until(predicate: Any, timeout_s: float = 5.0) -> Any:
+    """Poll an async predicate; return its last value when it turns truthy."""
+    deadline = time.monotonic() + timeout_s
+    value = await predicate()
+    while not value and time.monotonic() < deadline:
+        await asyncio.sleep(0.05)
+        value = await predicate()
+    return value
+
+
+@pytest.mark.asyncio
+async def test_cancelling_the_connect_mid_post_keeps_the_rotated_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """(a) A cancelled POST must not discard the rotation it already caused.
+
+    Before the fix this fails: the cancellation is delivered straight into the
+    in-flight ``client.post`` inside ``asyncio.timeout``, the response is
+    discarded, and the store is left holding the SPENT ``refresh-0`` — the
+    state whose next POST is a reuse-detection double-spend. The server has
+    already rotated to ``refresh-1`` and revoked ``access-0``, so nothing but
+    that response could ever have carried the new token.
+    """
+    store = FakeAuthStore()
+    storage = await _seed_expired_grant(store)
+
+    async with FakeTokenEndpoint(response_delay_s=0.25) as endpoint:
+        _stub_discovery(monkeypatch, endpoint.token_endpoint)
+        task = asyncio.ensure_future(
+            auth_mod.ensure_mcp_oauth_fresh(SERVER_URL, _cfg(), store=store)
+        )
+        # Cancel only once the exchange has LANDED server-side: the window this
+        # test is about is "rotated but response still unwritten".
+        await asyncio.wait_for(endpoint.rotation_applied.wait(), 5)
+        assert endpoint.rotation_count == 1
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        tokens = await storage.get_tokens()
+
+    assert tokens is not None
+    assert tokens.refresh_token == "refresh-1", (
+        "the rotation the server performed must survive the cancellation; a "
+        "spent token left as the only stored one is the reuse-detection "
+        "double-spend this subsystem exists to prevent"
+    )
+    assert tokens.access_token == "access-1"
+    assert endpoint.reuse_attempts == 0
+
+
+@pytest.mark.asyncio
+async def test_a_response_past_the_timeout_is_still_persisted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """(b) A response that arrives after the total timeout must still persist.
+
+    Before the fix this fails: the ``asyncio.timeout`` overrun cancels the
+    request, classifies the refresh ``"failed"``, and throws away a rotation the
+    server has already performed. The bound is patched down so the test does
+    not spend the real ten seconds; the behaviour under test is unchanged by
+    that, because the module reads the constant at call time.
+    """
+    monkeypatch.setattr(auth_mod, "REFRESH_HTTP_TIMEOUT_S", 0.2)
+    store = FakeAuthStore()
+    storage = await _seed_expired_grant(store)
+
+    async with FakeTokenEndpoint(response_delay_s=0.6) as endpoint:
+        _stub_discovery(monkeypatch, endpoint.token_endpoint)
+        # Returns "failed" at the bound; the exchange is still in flight.
+        await auth_mod.ensure_mcp_oauth_fresh(SERVER_URL, _cfg(), store=store)
+
+        async def _rotated() -> bool:
+            tokens = await storage.get_tokens()
+            return tokens is not None and tokens.refresh_token == "refresh-1"
+
+        persisted = await _until(_rotated)
+
+    assert persisted, (
+        "a rotation that lands after the timeout must be persisted rather than "
+        "discarded: the server has spent refresh-0 and nothing else holds "
+        "refresh-1"
+    )
+    assert endpoint.reuse_attempts == 0
+
+
+@pytest.mark.asyncio
+async def test_tombstone_skipped_when_a_peer_rotated_the_grant_mid_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """(c) A tombstone must not overwrite a rotation a peer just persisted.
+
+    The documented window at ``GRANT_DEAD_AT_KEY``: ``mark_grant_dead`` reads
+    the payload, adds the marker, and writes the WHOLE snapshot back. A sibling
+    that persisted a fresh rotation inside that window had its live grant
+    rewritten as dead (or, if it wrote a moment later, its token erased by our
+    pre-rotation snapshot) — the user's cure was an interactive login.
+
+    Before the fix this fails: the marker lands on the peer's fresh grant, so
+    ``grant_is_dead()`` reads True for a token that works.
+
+    The real flock is held here, because the write it guards is the whole point:
+    a mocked lock would make the test a statement about the mock.
+    """
+    store = FakeAuthStore()
+    storage = await _seed_expired_grant(store, refresh="spent-0")
+
+    async def _peer_persists_its_rotation() -> None:
+        """What a sibling process does while our POST is in flight."""
+        from mcp.shared.auth import OAuthToken
+
+        await storage.set_tokens(
+            OAuthToken(access_token="peer-access", refresh_token="peer-1", expires_in=3600)
+        )
+
+    async with FakeTokenEndpoint(
+        access_token="peer-access", refresh_token="peer-1", on_reject=_peer_persists_its_rotation
+    ) as endpoint:
+        _stub_discovery(monkeypatch, endpoint.token_endpoint)
+        async with auth_mod._oauth_refresh_lock(SERVER_URL):
+            outcome = await auth_mod._refresh_oauth_token_locked(
+                SERVER_URL, storage, _endpoints_for(endpoint.token_endpoint)
+            )
+
+    assert outcome == "dead"
+    tokens = await storage.get_tokens()
+    assert tokens is not None
+    assert tokens.refresh_token == "peer-1", "the peer's rotation must not be erased"
+    assert tokens.access_token == "peer-access"
+    assert storage.grant_is_dead() is False, (
+        "a live grant must not read dead: the tombstone would suppress refresh "
+        "on a working token until an interactive login"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tombstone_written_when_grant_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The positive half of the compare-and-skip: an UNCHANGED grant is still
+    tombstoned.
+
+    The check must not cost the marker its purpose. When the stored payload
+    still holds the refresh token the server rejected, the rejection is about
+    THIS grant, so it is recorded — that is what stops every later boot from
+    re-presenting the token and (on a reuse-detecting provider) revoking the
+    family again.
+    """
+    store = FakeAuthStore()
+    storage = await _seed_expired_grant(store, refresh="spent-0")
+
+    # The endpoint's current token is something else, so our presentation is
+    # rejected as a replay and nothing is rotated: the store is untouched, which
+    # is exactly the state the marker is for.
+    async with FakeTokenEndpoint(refresh_token="elsewhere-0") as endpoint:
+        _stub_discovery(monkeypatch, endpoint.token_endpoint)
+        async with auth_mod._oauth_refresh_lock(SERVER_URL):
+            outcome = await auth_mod._refresh_oauth_token_locked(
+                SERVER_URL, storage, _endpoints_for(endpoint.token_endpoint)
+            )
+
+    assert outcome == "dead"
+    assert storage.grant_is_dead() is True

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -1043,7 +1043,7 @@ async def test_settling_boot_snapshot_is_provisional_and_re_reported_on_settle(
         configured=["notion", "linear"],
         connected=["linear"],
         settling=True,
-        startup_failures={"notion": "run /mcp login notion to authorize"},
+        startup_failures={"notion": "/mcp login notion to authorize"},
     )
 
     async def fake_discover(cwd, auth_store=None):

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -6089,6 +6089,11 @@ class FakeMcpManager:
         #: Servers still connecting past the startup gate — the state a slow
         #: HTTP MCP server is in on every launch.
         self._connecting: set[str] = set()
+        #: Installed by the app's MCP wiring (``_wire_mcp_status``), exactly as
+        #: the real manager receives it. Declared so a test can drive an
+        #: after-boot grant expiry through the sink the app installed, rather
+        #: than waiting for a real grant to lapse.
+        self.on_auth_required: Any = None
 
     def get_all_server_names(self) -> list[str]:
         return sorted(self._configured)
@@ -12438,3 +12443,70 @@ async def test_the_follower_band_agrees_with_the_owner_band_on_auth_required() -
         # The projection's own placeholder still counts when no manager exists.
         assert band_for(("github", "failed")).failed is True
         assert band_for(("github", "connected")).failed is False
+
+
+@pytest.mark.asyncio
+async def test_the_durable_notice_carries_one_dash_and_no_orphaned_pointer() -> None:
+    """D5: the notice must not append its pointer to a line that IS a command.
+
+    The auth requirement leads with ``run /mcp reauth notion — …``, so the
+    template's unconditional ``— /mcp for details`` gave the composed sentence
+    TWO em-dashes (against the house one-dash rule) and pushed it to 107 cells,
+    where the wrap orphaned the pointer onto a row of its own. The pointer is
+    for diagnostic text ("command not found: …"); when the text is already the
+    command, the reader has the answer.
+    """
+    failure = "run /mcp reauth notion — refresh unconfirmed"
+    diagnostic = "command not found: slack-mcp"
+    manager = FakeMcpManager(["notion", "slack"], [])
+    startup = McpStartupOutcome(
+        configured=("notion", "slack"),
+        failures={"notion": failure, "slack": diagnostic},
+    )
+    session = McpSession(manager=manager, startup=startup)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        app.query_one(Toast).dismiss_toast()
+        await pilot.pause()
+        rows = _transcript_text(app).split("\n")
+        notice = [row for row in rows if "MCP notion failed" in row]
+        assert notice, "the failure must survive the toast"
+        # The notice carries the transcript's spine indent and outcome glyph, so
+        # the assertion is on the sentence itself.
+        line = notice[0].strip().lstrip("✗ ").strip()
+        assert line == f"MCP notion failed: {failure}", notice[0]
+        assert line.count("—") == 1, line
+        assert "/mcp for details" not in line
+
+        # A DIAGNOSTIC failure still gets the pointer: the rule is about a line
+        # that already names /mcp, not about suppressing the signpost.
+        assert any(diagnostic in row and "/mcp for details" in row for row in rows), rows
+
+
+@pytest.mark.asyncio
+async def test_the_mid_session_auth_toast_leads_with_the_command() -> None:
+    """D8: the card must not put the server name in front of the command.
+
+    ``on_auth_required`` fires when a grant expires after boot. Its message
+    already names the server (the auth line does so inside its command), so the
+    old ``{ICON} MCP {name} {message}`` prefix rendered ``notion`` first — ahead
+    of the command the user has to run — and left ``notion run /mcp reauth`` with
+    no separator between them. The message now leads the card unchanged.
+    """
+    from local_operator.tui.widgets.status_line import ICON_MCP
+
+    manager = FakeMcpManager(["notion"], ["notion"])
+    session = McpSession(manager=manager)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        manager.on_auth_required("notion", "run /mcp reauth notion — refresh unconfirmed")
+        for _ in range(4):
+            await pilot.pause()
+        toast = app.query_one(Toast)
+        assert toast.display is True
+        assert toast.message == f"{ICON_MCP} MCP run /mcp reauth notion — refresh unconfirmed"
+        assert "notion run /mcp" not in toast.message, "the name must not precede the command"

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -12449,40 +12449,61 @@ async def test_the_follower_band_agrees_with_the_owner_band_on_auth_required() -
 async def test_the_durable_notice_carries_one_dash_and_no_orphaned_pointer() -> None:
     """D5: the notice must not append its pointer to a line that IS a command.
 
-    The auth requirement leads with ``run /mcp reauth notion — …``, so the
+    The auth requirement leads with ``/mcp reauth notion — …``, so the
     template's unconditional ``— /mcp for details`` gave the composed sentence
     TWO em-dashes (against the house one-dash rule) and pushed it to 107 cells,
     where the wrap orphaned the pointer onto a row of its own. The pointer is
     for diagnostic text ("command not found: …"); when the text is already the
     command, the reader has the answer.
-    """
-    failure = "run /mcp reauth notion — refresh unconfirmed"
-    diagnostic = "command not found: slack-mcp"
-    manager = FakeMcpManager(["notion", "slack"], [])
-    startup = McpStartupOutcome(
-        configured=("notion", "slack"),
-        failures={"notion": failure, "slack": diagnostic},
-    )
-    session = McpSession(manager=manager, startup=startup)
-    app = OperatorApp(lambda: _factory(session))
-    async with app.run_test(size=(100, 24)) as pilot:
-        for _ in range(6):
-            await pilot.pause()
-        app.query_one(Toast).dismiss_toast()
-        await pilot.pause()
-        rows = _transcript_text(app).split("\n")
-        notice = [row for row in rows if "MCP notion failed" in row]
-        assert notice, "the failure must survive the toast"
-        # The notice carries the transcript's spine indent and outcome glyph, so
-        # the assertion is on the sentence itself.
-        line = notice[0].strip().lstrip("✗ ").strip()
-        assert line == f"MCP notion failed: {failure}", notice[0]
-        assert line.count("—") == 1, line
-        assert "/mcp for details" not in line
 
-        # A DIAGNOSTIC failure still gets the pointer: the rule is about a line
-        # that already names /mcp, not about suppressing the signpost.
-        assert any(diagnostic in row and "/mcp for details" in row for row in rows), rows
+    Asserted at BOTH widths because that is what D9 pinned: at 100 columns the
+    notice is one row, and at 44 it wraps carrying the whole command — the bare
+    form is four cells shorter, which is the difference between the name being
+    handed over whole and being cut mid-word.
+    """
+    failure = "/mcp reauth notion — refresh unconfirmed"
+    diagnostic = "command not found: slack-mcp"
+    for width in (100, 44):
+        manager = FakeMcpManager(["notion", "slack"], [])
+        startup = McpStartupOutcome(
+            configured=("notion", "slack"),
+            failures={"notion": failure, "slack": diagnostic},
+        )
+        session = McpSession(manager=manager, startup=startup)
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(width, 24)) as pilot:
+            for _ in range(6):
+                await pilot.pause()
+            app.query_one(Toast).dismiss_toast()
+            await pilot.pause()
+            rows = _transcript_text(app).split("\n")
+            at = next((index for index, row in enumerate(rows) if "MCP notion failed" in row), None)
+            assert at is not None, "the failure must survive the toast"
+            # The notice carries the transcript's spine indent and outcome glyph,
+            # so the assertion is on the sentence itself; at 44 columns the row
+            # wraps, so the block is re-joined with normalised whitespace rather
+            # than asserted row by row (the wrap's missing hanging indent is
+            # D6's separate, deferred property).
+            block = [rows[at]]
+            for row in rows[at + 1 :]:
+                if not row.strip() or ("MCP " in row and "failed:" in row):
+                    break
+                block.append(row)
+            joined = " ".join(part.strip() for part in block if part.strip())
+            assert joined == f"✗ MCP notion failed: {failure}", joined
+            assert joined.count("—") == 1, joined
+            assert "/mcp for details" not in joined
+
+            # A DIAGNOSTIC failure still gets the pointer: the rule is about a
+            # line that already names /mcp, not about suppressing the signpost.
+            # Read across the wrap, since the diagnostic row wraps too at 44.
+            diagnostic_block = " ".join(
+                row.strip()
+                for row in rows[rows.index(next(r for r in rows if "MCP slack failed" in r)) :]
+                if row.strip()
+            )
+            assert diagnostic in diagnostic_block, diagnostic_block
+            assert "/mcp for details" in diagnostic_block, diagnostic_block
 
 
 @pytest.mark.asyncio
@@ -12492,21 +12513,23 @@ async def test_the_mid_session_auth_toast_leads_with_the_command() -> None:
     ``on_auth_required`` fires when a grant expires after boot. Its message
     already names the server (the auth line does so inside its command), so the
     old ``{ICON} MCP {name} {message}`` prefix rendered ``notion`` first — ahead
-    of the command the user has to run — and left ``notion run /mcp reauth`` with
-    no separator between them. The message now leads the card unchanged.
+    of the command the user has to run — and left ``notion /mcp reauth`` with no
+    separator between them. The message now leads the card unchanged, and D9's
+    bare command keeps it on one row at 100 columns.
     """
     from local_operator.tui.widgets.status_line import ICON_MCP
 
-    manager = FakeMcpManager(["notion"], ["notion"])
-    session = McpSession(manager=manager)
-    app = OperatorApp(lambda: _factory(session))
-    async with app.run_test(size=(100, 24)) as pilot:
-        for _ in range(6):
-            await pilot.pause()
-        manager.on_auth_required("notion", "run /mcp reauth notion — refresh unconfirmed")
-        for _ in range(4):
-            await pilot.pause()
-        toast = app.query_one(Toast)
-        assert toast.display is True
-        assert toast.message == f"{ICON_MCP} MCP run /mcp reauth notion — refresh unconfirmed"
-        assert "notion run /mcp" not in toast.message, "the name must not precede the command"
+    for width in (100, 44):
+        manager = FakeMcpManager(["notion"], ["notion"])
+        session = McpSession(manager=manager)
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(width, 24)) as pilot:
+            for _ in range(6):
+                await pilot.pause()
+            manager.on_auth_required("notion", "/mcp reauth notion — refresh unconfirmed")
+            for _ in range(4):
+                await pilot.pause()
+            toast = app.query_one(Toast)
+            assert toast.display is True
+            assert toast.message == f"{ICON_MCP} MCP /mcp reauth notion — refresh unconfirmed"
+            assert "notion /mcp" not in toast.message, "the name must not precede the command"

--- a/tests/unit/tui/test_toast.py
+++ b/tests/unit/tui/test_toast.py
@@ -224,6 +224,51 @@ def test_the_message_is_clamped_to_the_cells_it_was_given() -> None:
         assert cell_len(line) <= 30, line
 
 
+def _failure_row(name: str, error: str, cells: int) -> str:
+    """The failure row the real composer paints, without a live app."""
+    payload = format_mcp_startup(
+        McpStartupOutcome(configured=(name,), failures={name: error}), max_cells=cells
+    )
+    assert payload is not None
+    return payload[0].plain.split("\n")[1]
+
+
+def test_a_command_with_a_reason_sheds_the_reason_before_the_command() -> None:
+    """Design review round 3, D11, at the composer's own seam.
+
+    The clamp is character-based, so an auth line — which names the server in the
+    label AND inside its command — had its END cut when the budget ran out:
+    measured on the round-3 head, ``minerva-qa`` rendered ``… — refresh unc…`` at
+    100 columns and ``/mcp reauth mi…`` at 44, a command that errors if followed.
+    The budget now picks a RUNG: the whole row, then the command with the shed
+    reason marked, then the command alone, and only then the old clamp.
+    """
+    line = "/mcp reauth minerva-qa — refresh unconfirmed"
+    # 58 content cells: the command survives whole, the reason is GONE rather
+    # than clipped — the mark is the same cue the 44-column card already uses.
+    assert _failure_row("minerva-qa", line, 58) == "failed: minerva-qa — /mcp reauth minerva-qa…"
+    # 44 is where the mark itself stops fitting but the command still does; the
+    # bare command is what keeps the clamp from eating the name's last cell.
+    assert _failure_row("minerva-qa", line, 44).endswith("minerva-qa…")
+    assert _failure_row("minerva-qa", line, 43) == "failed: minerva-qa — /mcp reauth minerva-qa"
+
+
+def test_a_diagnostic_with_a_dash_is_still_clamped_exactly_as_before() -> None:
+    """The shed is keyed on a LEADING command, never on the dash.
+
+    The no-OAuth-endpoint challenge line is a diagnostic whose second clause is
+    half the statement rather than a droppable reason, so it is not a
+    command-with-reason and keeps the base's pixels byte for byte (design review
+    D10 is explicitly out of this change's scope).
+    """
+    from local_operator.tui.widgets.tool_card import truncate_cells
+
+    text = "notion rejected our credentials (401) — set its API key or headers"
+    row = _failure_row("notion", text, 58)
+    assert row == truncate_cells(f"failed: notion — {text}", 58)
+    assert row == "failed: notion — notion rejected our credentials (401) —…"
+
+
 # -- width -------------------------------------------------------------------
 
 

--- a/tests/unit/tui/test_turn_abandoned.py
+++ b/tests/unit/tui/test_turn_abandoned.py
@@ -800,7 +800,7 @@ class _NamedServers:
     def auth_recovery_hint(self, rendered_error: str) -> str | None:
         if "linear" not in rendered_error:
             return None
-        return "run /mcp reauth linear — authorization expired"
+        return "/mcp reauth linear — sign-in expired"
 
 
 class McpAuthRaisingSession(JobsSession):


### PR DESCRIPTION
## What this fixes

A rotating OAuth provider issues the exchange **response**, and only the response, as
the new refresh token; presenting the spent one again returns `invalid_grant` **and
revokes the entire token family** (Notion's reuse detection). So an exchange whose
result is dropped does not merely fail a refresh — it logs out every session until a
human re-grants. Three paths dropped it, and two more handed a still-refreshable grant
to the SDK's *unlocked* refresh.

**Live evidence from this machine's runtime log** (`~/Library/Logs/local-operator/mobile.log`):

| logger | what it is | notion `/token` POSTs |
| --- | --- | --- |
| `httpx2` | the MCP SDK's client — **no refresh lock, no re-read** | 125 total, **106 of them HTTP 400** (a SNAPSHOT, counted to line 6694154, where the running totals read 121/102 — the four later POSTs are all 400s) |
| `httpx` | our locked `_refresh_oauth_token_locked` | 32 |

plus 143 `Token refresh failed: 400` and 387 `OAuth flow error` — the fleet-wide
logout the incident tickets describe (`MCP authorization failed; run /mcp reauth notion
— authorization expired`).

## The four changes

**D2 — the exchange now survives its awaiter.** `_refresh_oauth_token_locked` runs the
POST, the classification and the persistence as their **own task** behind
`asyncio.shield`, so neither a cancellation nor the total timeout can abort the request.
Cancellation — routine, since every sidebar switch disposes a manager and cancels its
in-flight connects — waits out the **remainder of `REFRESH_HTTP_TIMEOUT_S`** (never
longer) so the rotation reaches the store *before the caller's lock is released*; a
response that lands after the bound is still persisted by the detached task. The lock
wait is unchanged, so `LOCK_ACQUIRE_TIMEOUT_S`'s derivation still holds; only the
response **read** gets `REFRESH_LATE_RESPONSE_GRACE_S`, a finite bound on a task nobody
waits for (without it the httpx per-read timeout fired at the same instant as the outer
cap and dropped the late rotation anyway).

**D3 — a tombstone can no longer destroy a newer rotation.**
`mark_grant_dead(rejected_refresh_token=...)` re-reads the row and writes only while it
still holds the token the server rejected. The marker is a whole-payload read-modify-write,
so a peer that persisted a fresh rotation in between had a live grant rewritten as dead —
or, writing a moment later, its token erased by our pre-rotation snapshot. This mirrors
the check-then-write convention `AuthStore` already uses rather than adding a primitive.

**D1 — the 401 arm recovers instead of passing through.** Under **one**
`_oauth_refresh_lock` acquisition: a *different* stored access token is adopted and the
original request re-yielded (unchanged); an *identical* one with a refreshable grant is
refreshed **here, under the lock**, and retried; `"dead"` and `"failed"` strip the
in-memory refresh token and hand the 401 to the SDK — so its unlocked `_refresh_token`
can never POST the token. This is also the one place a genuinely dead grant can be
**tombstoned from a 401**; previously every later boot re-POSTed the same rejected token.

**Decision 2 — the coordinator refuses rather than degrading.** `"failed"` had no arm and
fell straight through to the SDK's unlocked POST (the live route above);
the lock-unavailable arm returned and did the same. A single end-of-method post-condition
now strips the in-memory refresh token and raises `McpRefreshContendedError` — contention,
not an auth failure, so `_reconnect`'s generic arm retries with backoff and never takes an
auth block.

### The escape channel (why a ledger, not just an exception)

**The raise does not survive the transport.** The MCP streamable-HTTP client runs the
request inside anyio cancel scopes, so an exception out of the auth flow reaches
`_connect_server` as a bare `CancelledError('Cancelled via cancel scope …')` — verified
for this error *and* for a plain `RuntimeError` raised from the same place, so it is a
transport property, and it is the same property `ABANDONED_GRANTS` exists for. A
`CancelledError` is also not an `Exception`, so the generic reconnect arm never saw it:
pre-fix, the coordinator's refusal left the server stuck on `connecting` with no retry.

So there is now a dedicated, per-server, **single-use** `REFRESH_CONTENTION` ledger —
armed immediately before the raise, popped once per classification, aged out — mirroring
`AbandonedGrantLedger`. `_connect_server` re-voices exactly that cancellation and keeps
its existing `externally_cancelled` guard, so a genuine dispose/epoch teardown still wins
and is never converted into a retry.

## Evidence

### 1. Unit repros — real machinery, real flock, real local rotating server

`tests/unit/mcp/rotating_oauth_server.py` is a real HTTP token endpoint that rotates on
every exchange and revokes the family on a replay. (`MockTransport` cannot serve here: its
handler is awaited *inside* the request coroutine, so it is cancelled with it and cannot
show whether the server's rotation survived.) The rotation is applied **before** the
response delay, so a cancelled exchange has already spent the token it presented.

```sh
.venv/bin/python -m pytest tests/unit/mcp/test_oauth_refresh_durability.py -n0 -q
```

**Before** (3 failed, kept on record — this is the first commit of the branch):

```
FAILED test_cancelling_the_connect_mid_post_keeps_the_rotated_token
       AssertionError: the rotation the server performed must survive the cancellation;
       a spent token left as the only stored one is the reuse-detection double-spend
       assert 'refresh-0' == 'refresh-1'
FAILED test_a_response_past_the_timeout_is_still_persisted
       AssertionError: a rotation that lands after the timeout must be persisted rather
       than discarded: the server has spent refresh-0 and nothing else holds refresh-1
FAILED test_tombstone_skipped_when_a_peer_rotated_the_grant_mid_refresh
       AssertionError: a live grant must not read dead: the tombstone would suppress
       refresh on a working token until an interactive login
```

**After** (this head):

```
$ .venv/bin/python -m pytest tests/unit/mcp/test_oauth_refresh_durability.py -n0 -q
4 passed
```

### 2. End-to-end — real transport, real provider wiring, real credential store

`tests/e2e/test_mcp_oauth_rotation_e2e.py` stands up a local authorization server *and*
MCP endpoint that rotates on every exchange and runs reuse detection, and drives the real
`streamable_http_client` through `_connect_server`.

```sh
.venv/bin/python -m pytest tests/e2e/test_mcp_oauth_rotation_e2e.py -m e2e -n0 -q
```

**Before** (2 failed):

```
FAILED test_a_cancelled_refresh_keeps_its_rotation_and_the_next_session_connects
  AssertionError: the cancelled exchange lost the server's rotation; the store is
  holding a spent token: {'access_token': 'access-0', ..., 'refresh_token': 'refresh-0'}
  assert 'refresh-0' == 'refresh-1'

FAILED test_a_401_on_a_revoked_token_recovers_by_refreshing_under_the_lock
  local_operator.mcp.auth.McpAuthRequiredError:
  MCP OAuth authorization required for http://127.0.0.1:56362/mcp
```

**The family death, measured directly** (pre-fix probe at that same commit — the state a
cancelled refresh leaves behind: the server has rotated, the store still holds the spent
token):

```
$ .venv/bin/python /tmp/probe_family.py          # pre-fix
RESULT: connect raised McpAuthRequiredError MCP OAuth authorization required for http://127.0.0.1:56596/mcp
reuse_attempts: 1 family_revoked: True
store after: refresh-0
```

i.e. the later session's refresh POST is a **replay**, the family is revoked, and every
later session needs a human re-grant — the incident reproduced end-to-end.

**After** (this head):

```
$ .venv/bin/python -m pytest tests/e2e/test_mcp_oauth_rotation_e2e.py -m e2e -n0 -q
2 passed
```

## Existing tests that encoded the old behaviour (rewritten, not relaxed)

* `test_401_with_identical_stored_token_passes_through_to_sdk` → **replaced** by
  `test_401_with_identical_refreshable_grant_refreshes_under_lock_and_retries`. It
  asserted the pass-through whose unlocked POST is the defect.
* `test_failed_outcome_leaves_the_refresh_token_alone` → **removed**. Its docstring
  stated the old contract outright — *"today's behaviour (the SDK retries unlocked) is
  correct for it"*. Its successor is the headline test
  `test_coordinator_transient_failure_never_falls_through_to_unlocked_sdk_post`, which
  asserts **zero yielded requests** (not merely zero calls to our helper) plus the
  stripped in-memory token. The marker half is covered by
  `test_transient_failures_never_tombstone`.
* `test_no_endpoints_still_refreshes_under_the_lock`,
  `test_no_endpoints_spends_the_fresh_stored_refresh_token`,
  `test_locked_refresh_raise_still_adopts_freshest_before_sdk` (renamed to
  `test_a_raising_refresh_still_adopts_the_freshest_stored_token`): assertions kept, but
  their fakes no longer report `"refreshed"` while persisting nothing — a successful
  refresh now has to leave a usable token, which is the post-condition.

## Residuals (not addressed here, stated rather than implied)

* The microsecond window between a write's re-read and its write — now the same shape for
  the tombstone and for the freshness-conditioned refresh write, both taken under the lock.
* `set_tokens` is deliberately **unguarded**: a peer rotation can still be lost by a
  writer that does not take the lock. It cannot, however, tombstone a live grant.
* The 401-path refresh runs while the SDK holds its `context.lock`, so concurrent requests
  to that server serialise for up to `REFRESH_HTTP_TIMEOUT_S`. Bounded, in-process, 401-only.
* Sidebar-switch contention itself is unchanged — this removes the unlocked POST and the
  false tombstone; it does not zero the failure class.
* Converting the 401 transient arm into a *retryable* error needs manager surgery (the
  `_AuthChallengeWatcher` is already latched by then); follow-up, not this PR.
* **`deferred` — the auth line cannot carry `name + command-with-name + reason` on a
  44-column card (design review round 3, D11's resolution 2).** The command alone is
  `23 + 2n` cells against that card's 36, so no composition of this line puts a whole
  `/mcp reauth <name>` there for names of 7+ cells without a second row or a different
  card shape; both are layout decisions with their own before/after frames, not this
  change. The base clipping (`/mcp reauth mi…`) is asserted verbatim in tests so a
  future regression is visible, and the 100-column case IS fixed here (the command with
  its name stays whole; the reason is what gets shed).

## Scope notes

* **Copy scope, corrected in remediation round 1.** This PR *does* change user-visible
  copy after all: the refusal string reaches the user verbatim (`result.errors[name] =
  str(exc)` at the startup gate), so "could not be performed under the refresh lock;
  retrying" was untrue on two paths and promised a retry the startup gate never performs.
  It is now split by what actually happened on each path, and the new unconfirmed-refresh
  error carries a `detail` that `_auth_required_text` renders as its tail. A design round
  follows this remediation, and tests pin the exact strings.
* `_auth_challenge_text` is untouched.
* **No version bump** (`pyproject.toml` untouched).
* Docstrings updated to the new contract: `_oauth_refresh_lock`'s *"a False body is still
  SAFE to run"* (it may no longer spend the token) and `ensure_mcp_oauth_fresh`'s scope note.

## Testing evidence

Gates, run over the whole tree exactly as CI does:

| gate | command | result |
| --- | --- | --- |
| flake8 | `.venv/bin/python -m flake8 .` | clean (rc=0) |
| black | `uvx --from black==26.1.0 black --check .` | 1223 files unchanged |
| isort | `uvx isort==5.13.2 --check .` | clean |
| pyright | `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | 0 errors, 0 warnings |
| new unit repros | `.venv/bin/python -m pytest tests/unit/mcp/test_oauth_refresh_durability.py -n0 -q` | 4 passed (3 FAILED before the fix) |
| new e2e stage | `.venv/bin/python -m pytest tests/e2e/test_mcp_oauth_rotation_e2e.py -m e2e -n0 -q` | 2 passed (2 FAILED before the fix) |
| existing oauth e2e (neighbour) | `.venv/bin/python -m pytest tests/e2e/test_desktop_mcp_oauth.py -m e2e -n0 -q` | 1 passed |
| MCP unit suite | `.venv/bin/python -m pytest tests/unit/mcp -q` | 435 passed |
| full `tests/unit` | every path in `tests/unit`, chunked `-n 2` | green — ~10k passed, 6 skipped |
| `tests/unit/tui` | `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui -n 2 -q` | **6823 passed, 12 skipped** |
| `tests/unit/session` | `.venv/bin/python -m pytest tests/unit/session -n 2 -q` | **1987 passed** |
| `tests/unit/providers` | `.venv/bin/python -m pytest tests/unit/providers -n 2 -q --deselect ...::test_pinned_port_fails_before_browser_when_busy` | **1195 passed** |

Two caveats, stated rather than smoothed over:

* **`tests/unit/providers` needs one test deselected.** `test_pinned_port_fails_before_browser_when_busy` HANGS (>900 s) on this host. It is **not** caused by this PR: the same test times out (rc=124) with this branch's *source* changes stashed, and neither that module nor anything under `local_operator/providers/` imports the MCP auth path. Everything else in the chunk passes.
* **The first chunked `tests/unit/session` pass is invalid.** It ran while a cross-worktree `git stash` collision (below) had left `SyntaxError`-producing conflict markers in `local_operator/server/models/desktop_sessions.py`. Re-run on the clean tree: 1987 passed, rc=0.

The suite was chunked because this host was carrying six concurrent agent suites: single `-n auto` runs were OOM-killed, and load average peaked at 51 with 4 GB of the 5 GB swap in use. CI remains the authoritative single run.

### Incident while testing (unrelated to this PR)

`git stash` is **repository-global across worktrees**. Another agent's tooling popped a stash in a sibling worktree while this one was testing; a later `git stash pop` here applied *their* work onto this tree's base and left conflict markers in eight files this branch never touches. Resolved by restoring those paths from `HEAD`; their stash entries are intact in `git stash list` and a copy of the conflicted files is in `/tmp/stash-collision-backup`. This branch's three commits and every file it owns were unaffected — `git diff HEAD -- local_operator/mcp tests/unit/mcp tests/e2e` was empty throughout, and the three commits are exactly the branch head.

---

# Remediation round 1 — head `498844561`

Round 1 found the fix incomplete in exactly the window the incident lives in: a
detached exchange outliving its connect. Three changes close it, and the tests
that were missing are now in the round-1 suites (real flock, real rotating
endpoint, no mocking of the lock).

### B1 (blocker) — a refresh write is bound to the grant it was computed from

`store_refresh_result(...)` re-reads the row under the lock and persists only
while it still holds the refresh token THAT exchange presented, and it never
clears the dead-grant marker: only an interactive grant may un-dead a server.
A dropped write leaves the newer state untouched and logs at INFO naming the
writer. Measured before it: a late HTTP 200 after a peer's `invalid_grant`
tombstone rewrote a revoked family's token as ALIVE, and with two slow exchanges
the tombstone never landed at all (its compare-and-skip saw a row the revocation
had itself invalidated).

### M2 (major) — the exchange task owns the lock

The lock is acquired INSIDE the exchange task, transferred by the connect before
its first await, and released in the task's own `finally` after the persist.
Nothing a waiter's cancellation or timeout does can free it while the POST is on
the wire; a sibling's bounded acquire instead gives up and takes the contended
path (strip the in-memory token, `McpRefreshContendedError`), never a stale
POST. The cancellation arm no longer waits out the budget at all, so teardown is
immediate (the reviewer measured 1.97s of a patched 2s budget before).
`LOCK_ACQUIRE_TIMEOUT_S`'s derivation now states the real arithmetic — the
holder may legitimately hold for `REFRESH_HTTP_TIMEOUT_S +
REFRESH_LATE_RESPONSE_GRACE_S` (40s), which EXCEEDS the 15s acquire bound, and
that is safe precisely because giving up degrades to contention rather than to
an unlocked spend.

### The "presented but unacknowledged" marker (new, manager-owned)

A refresh token is spent by the REQUEST, so an exchange that was sent and never
answered leaves a token that MAY be gone; re-presenting it is the
reuse-detection POST. A per-server marker — digest of the presented token plus a
timestamp — is armed WRITE-AHEAD, before the request can reach the wire, so a
process that dies mid-flight leaves the fact on disk rather than in a dead
process's memory. The refresh path then refuses to POST while the stored token
still matches a LIVE marker and takes an honest non-POST path (an interactive
sign-in) instead.

The two failure shapes are told apart by httpx's own taxonomy, not by guessing:
`ConnectError` / `ConnectTimeout` / `PoolTimeout` / `UnsupportedProtocol` /
`LocalProtocolError` happen BEFORE the request is written, so the token is
untouched, the marker is cleared and this stays an ordinary transient retry; a
read timeout, a dropped connection or a cancellation after the send keeps it. An
ANSWER resolves the marker only when it is DEFINITIVE about the token we
presented: a 200 whose body parses into a usable token (the exchange ran, so the
row holds its replacement), or a 400 whose body names `invalid_grant` (the server
has stated our token is not acceptable, and the tombstone path records it). Every
OTHER answer KEEPS it — `5xx`, `429`, and any other 4xx that is not a readable
`invalid_grant`, plus the unparseable 200 (the server rotated and we cannot read
the new token, so the stored one IS spent). A provider that commits the rotation
and THEN fails the response would otherwise leave a spent token re-presentable,
which is the reuse-detection POST this mechanism exists to prevent. One function
owns the rule (`_answer_resolves_send_marker`) so no status-code tweak can
quietly reopen it. A peer rotation makes the marker stale and it is cleared on
the way past, and it expires after `UNCONFIRMED_SEND_TTL_S` (1h) so it can never
brick a server.

**Stated trade-off:** in the rare "sent but never processed" case (a crash
between the arm and the wire, or a timeout that never reached the server) this
forces ONE interactive re-auth rather than risking a fleet-wide revocation. The
alternative — retrying — is the incident.

**Stated trade-off, measured (QA round 3, Q3): a post-send 5xx also costs one
interactive sign-in.** The same fixture — a token endpoint answering a plain
HTTP 500 with no rotation — on three trees:

| tree | raised | token POSTs | marker |
| --- | --- | --- | --- |
| merge base `e752b604a` (pre-PR) | *none* | `ours refresh-0` x3 **and `sdk-authflow refresh-0` x3** (the incident) | — |
| `498844561` (pre-delta) | `McpRefreshContendedError` (retryable) | `ours refresh-0` x2 | not kept |
| this head | `McpRefreshUnconfirmedError` (**auth-required**) | `ours refresh-0` x1 | kept |

So a transient provider fault AFTER the request was sent now ends in one
interactive sign-in (`/mcp reauth <name> — refresh unconfirmed`) instead of a
backoff retry. That is the accepted price of never re-presenting a token the
server may have spent; recorded as the measured consequence of the marker rule,
not as an accident. It is also why `probe_wire.py`'s "transient stays transient"
assertion (S8) fails at this head while it passed at `498844561`. Contention
(`lock`) and pre-send (`unreachable`) DO stay transient and DO retry.

### Also in this round

* The refusal copy is split by path and no longer promises a retry. What a
  USER reads is composed from the reason code, never from `str(exc)`:
  `another session is refreshing` / `refresh still in progress` /
  `the server returned no token` / `cannot reach the server` /
  `no stored token to send` / `the refresh did not complete`. The matching LOG
  sentences stay verbose for support, one per code, and the two LOCAL codes
  (`unsent`, `unattributed`) now carry their own instead of borrowing the lock's
  (review round 4, N4.1's sibling; QA round 3, Q2).
* The auth requirement's three pinned lines (design review D9) are
  `/mcp reauth <name> — refresh unconfirmed` / `/mcp reauth <name> — sign-in
  expired` / `/mcp login <name> to authorize`, and the startup toast composes
  them against the card's budget (design review round 3, D11): the command with
  its name stays whole and the REASON is what gets shed, marked with `…`.
* `REFRESH_CONTENTION` holds one record per refusal per server (a single slot
  let a second concurrent refusal vanish into a bare `CancelledError`, which is
  not an `Exception`, killing the reconnect task silently), is consumed only by
  the cancellation arm, and its `externally_cancelled` guard still wins first.
* A lost rotation logs at INFO naming its writer, on every path that can lose
  one (`store_refresh_result`, the detached settle callback, the exchange's own
  refusals).
* `tests/unit/mcp/conftest.py` imports the ledger inside its fixture, so the
  branch's first commit is collectable on the tree it reproduces. Commit
  `3de5edcef` itself is NOT rewritten — round 1 pinned that SHA, and rewriting
  published history would invalidate the reviewer's and QA's re-check — so the
  PR claim is restated instead: the before-fix failures were produced by pairing
  the new tests with the base implementation, which the reviewer did
  independently.
* The e2e docstring's stated pre-fix failure mode is corrected to what QA
  measured: a transport-mangled `CancelledError` with no token POST and no
  recovery, not an `McpAuthRequiredError`.
* QA's Q4 (an in-session tool call on a rejected grant reaching the caller as a
  bare cancellation) is verified identical pre-fix, so it is **deferred —
  pre-existing, unchanged by this PR, out of scope**.

### Round-1 remediation evidence

```sh
.venv/bin/python -m pytest tests/unit/mcp -q
# 449 passed
.venv/bin/python -m pytest tests/unit/mcp/test_oauth_refresh_durability.py -n0 -q
# 14 passed
.venv/bin/python -m pytest tests/e2e/test_mcp_oauth_rotation_e2e.py -m e2e -n0 -q
# 2 passed
```

New coverage, all on the real machinery: a late success against a newer tombstone
(the marker survives), a late success against a peer's rotation (the write is
dropped and logged), two concurrent slow exchanges (one witness, zero reuse
attempts, family alive), the lock still held at the instant the awaiter is
cancelled AND at the instant it overruns its budget, the marker's arm / clear /
stale-clear / expire paths, a connect-phase failure leaving no marker, and the
exact rendered text of the four refusal strings.

Release: patch — a rotating OAuth provider's refresh token can no longer be spent outside the cross-process lock or lost to a cancelled exchange, which is what revoked Notion's whole token family and forced a manual re-auth across every running session.
