### PR TITLE
feat(evaluation): score agent-stop for decision exhaustion and unanswered asks

### DIFF
--- a/local_operator/evaluation/evidence/models.py
+++ b/local_operator/evaluation/evidence/models.py
@@ -82,6 +82,7 @@ EventKind = Literal[
     "action_batch",
     "environment_step",
     "user_simulator_exchange",
+    "agent_stop",
     "finalization_start",
     "scoring_start",
     "scoring_result",
@@ -429,6 +430,31 @@ class UserSimulatorExchangePayload(ProtocolModel):
     receipt_id: Digest
 
 
+class AgentStopPayload(ProtocolModel):
+    """The episode stopped between steps with the environment still alive.
+
+    Truncation is scored ON a step and a deliberate finish is scored ON a
+    batch, but two stop causes happen BETWEEN steps -- after the previous
+    step's output observation was recorded and before any new batch exists:
+    the model spent its corrective re-prompts without a usable decision
+    (``model_failure``), or it asked a question no responder answered
+    (``ask_unanswered``). Both leave paid environment work that a
+    mid-episode failure path would seal unscored and thereby void, so the
+    runner records the stop here and finalizes scored on the state reached,
+    exactly like a truncation. The stop carries NO action batch: the
+    one-batch-per-observation rule means the stopped observation never gets
+    one, and the verifier binds the stop to that exact (latest, batchless)
+    observation. ``attempts`` counts the billed decision calls that produced
+    no usable batch, or the one ask that went unanswered.
+    """
+
+    stop_id: StrictIdentifier
+    reason: Literal["model_failure", "ask_unanswered"]
+    observation_id: StrictIdentifier
+    attempts: SafeCount
+    detail_artifact: EvidenceArtifactRef | None = None
+
+
 class FinalizationIntent(ProtocolModel):
     kind: Literal["score", "unscored"]
     scorer_id: StrictIdentifier | None = None
@@ -557,6 +583,7 @@ EventPayload: TypeAlias = (
     | ActionBatchPayload
     | EnvironmentStepPayload
     | UserSimulatorExchangePayload
+    | AgentStopPayload
     | FinalizationStartPayload
     | ScoringStartPayload
     | ScoringResultPayload
@@ -577,6 +604,7 @@ _EVENT_PAYLOAD_TYPES: dict[str, type[ProtocolModel]] = {
     "action_batch": ActionBatchPayload,
     "environment_step": EnvironmentStepPayload,
     "user_simulator_exchange": UserSimulatorExchangePayload,
+    "agent_stop": AgentStopPayload,
     "finalization_start": FinalizationStartPayload,
     "scoring_start": ScoringStartPayload,
     "scoring_result": ScoringResultPayload,

--- a/local_operator/evaluation/evidence/store.py
+++ b/local_operator/evaluation/evidence/store.py
@@ -30,6 +30,7 @@ from local_operator.evaluation.evidence.models import (
     AbandonmentReason,
     AbandonmentRecord,
     ActionBatchPayload,
+    AgentStopPayload,
     BudgetCommitmentPayload,
     CleanupPayload,
     ContextCompactionPayload,
@@ -758,6 +759,7 @@ class EvidenceWriter:
             ActionBatchPayload,
             EnvironmentStepPayload,
             UserSimulatorExchangePayload,
+            AgentStopPayload,
         )
         if event.kind == "preflight":
             if self._phase_preflight is not None or self._sequence != 0:
@@ -842,6 +844,7 @@ class EvidenceWriter:
                 ActionBatchPayload,
                 EnvironmentStepPayload,
                 UserSimulatorExchangePayload,
+                AgentStopPayload,
             ),
         ) or (isinstance(payload, LifecycleTransitionPayload) and payload.state == "running"):
             self._phase_execution = True

--- a/local_operator/evaluation/evidence/verify.py
+++ b/local_operator/evaluation/evidence/verify.py
@@ -22,6 +22,7 @@ from local_operator.evaluation.evidence.media import (
 from local_operator.evaluation.evidence.models import (
     AbandonmentRecord,
     ActionBatchPayload,
+    AgentStopPayload,
     ArtifactRef,
     BudgetCommitmentPayload,
     CleanupPayload,
@@ -415,6 +416,8 @@ def _verify_semantics(
     next_observation_sequence = 0
     exchanges: set[str] = set()
     last_exchange: str | None = None
+    agent_stops: dict[str, AgentStopPayload] = {}
+    latest_observation_id: str | None = None
     compactions: set[str] = set()
     lifecycle: dict[str, LifecycleTransitionPayload] = {}
     last_state_id: str | None = None
@@ -442,6 +445,7 @@ def _verify_semantics(
         ActionBatchPayload,
         EnvironmentStepPayload,
         UserSimulatorExchangePayload,
+        AgentStopPayload,
     )
     allowed_after_finalizing = {
         "scoring_start",
@@ -539,6 +543,13 @@ def _verify_semantics(
             cleaned = True
         elif terminal_lifecycle:
             terminal_lifecycle_seen = True
+        if agent_stops and execution_evidence and not isinstance(payload, AgentStopPayload):
+            # ``agent_stop`` IS the between-steps ending: the agent stopped
+            # acting on the named observation, so no request, batch, step,
+            # exchange or observation may follow it. Without this, a stop
+            # event followed by more execution would claim the episode both
+            # stopped and continued -- two endings for one bundle.
+            issues.error("event_order_invalid", location)
         if isinstance(payload, ModelRequestPayload):
             if payload.request_id in requests:
                 issues.error("receipt_binding_invalid", location)
@@ -588,6 +599,7 @@ def _verify_semantics(
             ):
                 issues.error("receipt_binding_invalid", location)
             observations[payload.observation_id] = payload
+            latest_observation_id = payload.observation_id
             if payload.observation_id == terminal_output_observation:
                 terminal_output_resolved = True
             expected_output_observation = None
@@ -636,6 +648,26 @@ def _verify_semantics(
                 issues.error("receipt_binding_invalid", location)
             exchanges.add(payload.exchange_id)
             last_exchange = payload.exchange_id
+        elif isinstance(payload, AgentStopPayload):
+            if terminal_output_observation is not None:
+                # A terminal step already recorded a deliberate ending ON the
+                # step; a stop event after it would be a second one.
+                issues.error("finalization_invalid", location)
+            if agent_stops:
+                issues.error("event_order_invalid", location)
+            elif (
+                payload.observation_id not in observations
+                or payload.observation_id != latest_observation_id
+                or payload.observation_id in observation_batches
+            ):
+                # The stop must name the observation the episode actually
+                # stopped on: the newest one, still batchless. A stop bound
+                # to an older observation would attribute the ending to a
+                # state the episode had already acted past, and one bound to
+                # a batched observation contradicts the runner's rule that a
+                # stopped observation never receives a batch.
+                issues.error("receipt_binding_invalid", location)
+            agent_stops[payload.stop_id] = payload
         elif isinstance(payload, LifecycleTransitionPayload):
             if payload.state_id in lifecycle or payload.previous_state_id != last_state_id:
                 issues.error("receipt_binding_invalid", location)
@@ -832,13 +864,45 @@ def _verify_semantics(
         interrupted = (
             len(terminal_states) == 1 and terminal_states[0].failure_kind is not None and unscored
         )
+        # Third deliberate ending: an ``agent_stop`` records that the agent
+        # itself stopped between steps (decision exhaustion, unanswered ask)
+        # while the environment stayed alive -- the two cases that cannot be
+        # recorded on a step or a batch because no new step or batch exists.
+        stop = next(iter(agent_stops.values())) if agent_stops else None
         if (
             environment_step_seen
             and not last_step_terminal
             and not finish_action_seen
+            and stop is None
             and not interrupted
         ):
             issues.error("finalization_invalid", terminal_location)
+        if terminal_states:
+            # A SCORED terminal may claim only the failure kinds that can
+            # honestly precede one: a clean run (None) or the agent under
+            # test stopping itself ("model", recorded by the agent_stop the
+            # next check requires). Crash/provider/cancel kinds mean the
+            # harness or the environment broke mid-rollout, and a score over
+            # that state -- however it got into the journal -- is a truncated
+            # run laundered into a reportable result, so it stays rejected.
+            kind = terminal_states[0].failure_kind
+            if not unscored and kind not in (None, "model"):
+                issues.error("finalization_invalid", terminal_location)
+            elif (
+                not unscored
+                and kind == "model"
+                and (stop is None or stop.reason != "model_failure")
+            ):
+                # A scored "model" kind must show the stop event that says so:
+                # it is the only writer path that seals a score with a failure
+                # kind, so its absence means the kind was asserted without the
+                # recorded exhaustion.
+                issues.error("finalization_invalid", terminal_location)
+            if stop is not None and (stop.reason == "model_failure") != (kind == "model"):
+                # Reason agreement, scored or not: the runner writes exactly
+                # the pairs (model_failure, "model") and (ask_unanswered,
+                # None), so any other pairing contradicts the terminal record.
+                issues.error("finalization_invalid", terminal_location)
         if terminal_output_observation is not None and not terminal_output_resolved:
             issues.error("receipt_binding_invalid", terminal_location)
     if outcome is not None:

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -67,6 +67,7 @@ from local_operator.evaluation.adapters.supervisor import (
 )
 from local_operator.evaluation.evidence.models import (
     ActionBatchPayload,
+    AgentStopPayload,
     BudgetCommitmentPayload,
     CancelPayload,
     CleanupPayload,
@@ -652,8 +653,42 @@ class EpisodeRunner:
         try:
             await self._reset_and_observe()
             await self._step_loop()
+        except _AskUnanswered as stop:
+            # An unanswered ask after environment work is an agent stop, not a
+            # cancellation: the steps already bought are gradable state, and
+            # voiding them because no human answered would throw away paid
+            # work exactly like the decision-exhaustion case below. Before any
+            # step there is nothing to grade, so the pre-existing cancellation
+            # path stands (nothing was paid for except model calls).
+            if self._steps_taken > 0:
+                return await self._finalize_agent_stop(
+                    handshake,
+                    reason="ask_unanswered",
+                    observation_id=stop.observation_id,
+                    attempts=1,
+                    detail=f"ask-user was not answered (ask {stop.ask_id})",
+                    failure_kind=None,
+                )
+            return await self._finalize_cancelled(str(stop) or "cancelled")
         except _Cancelled as cancel:
             return await self._finalize_cancelled(str(cancel) or "cancelled")
+        except _ModelFailure as failure:
+            # Between-steps model exhaustion after environment work: the
+            # session is still alive and the state reached is gradable, so the
+            # episode scores like a truncation instead of sealing unscored and
+            # voiding every step it already paid for. At zero steps there is
+            # no environment work to grade, so the unscored model-failure
+            # path is the honest outcome.
+            if self._steps_taken > 0:
+                return await self._finalize_agent_stop(
+                    handshake,
+                    reason="model_failure",
+                    observation_id=failure.observation_id,
+                    attempts=failure.attempts,
+                    detail=_diagnostic(failure, self._redactions),
+                    failure_kind="model",
+                )
+            return await self._finalize_failure(failure)
         except _EvidenceFailure:
             raise
         except EvidenceError as error:
@@ -786,7 +821,9 @@ class EpisodeRunner:
                 if rejections > self._config.max_decision_retries:
                     raise _ModelFailure(
                         f"model produced no usable decision after {rejections} attempt(s): "
-                        f"{rejection.diagnostic}"
+                        f"{rejection.diagnostic}",
+                        observation_id=observation.observation_id,
+                        attempts=rejections,
                     ) from rejection
 
     async def _decide_once(self, observation: Observation) -> Any:
@@ -1252,7 +1289,7 @@ class EpisodeRunner:
         else:
             answer = await self._responder.ask(prompt, self._config.ask_deadline_ms)
             if answer is None:
-                raise _Cancelled("ask-user was not answered")
+                raise _AskUnanswered(batch.observation_id, ask_id)
             finish = AskUserExchangeParams(
                 operation_id=f"ask-finish-{ask_id}",
                 episode_id=begin.episode_id,
@@ -1263,8 +1300,13 @@ class EpisodeRunner:
             result = await session.finish_ask(finish, timeout=self._config.step_timeout)
         # Refusal is a clean, unscored cancellation, never permission to publish
         # a host substitute or a synthetic empty answer into the model history.
-        if not result.accepted or answer is None:
-            raise _Cancelled("ask-user was not answered")
+        # Only a genuinely UNanswered ask (no answer at all, from either side of
+        # the adapter boundary) is an agent stop: a refusal is the harness
+        # declining on policy, which scores nothing.
+        if answer is None:
+            raise _AskUnanswered(batch.observation_id, ask_id)
+        if not result.accepted:
+            raise _Cancelled("ask-user answer was refused")
         request_artifact = self._publish(prompt.encode("utf-8"), media_type="text/plain")
         response_artifact = self._publish(answer.encode("utf-8"), media_type="text/plain")
         exchange_id = ask_id
@@ -1296,7 +1338,55 @@ class EpisodeRunner:
     # Terminal paths
     # ------------------------------------------------------------------
 
-    async def _finalize_scored(self, handshake: Handshake) -> EpisodeOutcome:
+    async def _finalize_agent_stop(
+        self,
+        handshake: Handshake,
+        *,
+        reason: Literal["model_failure", "ask_unanswered"],
+        observation_id: str,
+        attempts: int,
+        detail: str,
+        failure_kind: str | None,
+    ) -> EpisodeOutcome:
+        """Record the between-steps stop, then score the state reached.
+
+        The session is still alive on both call paths (the provider answered
+        every call; only the agent stopped acting), so unlike
+        ``_finalize_failure`` this scores rather than sealing unscored -- the
+        exact treatment a truncation gets. No ``action_batch`` is written for
+        the stopped observation: the verifier's one-batch-per-observation rule
+        means that observation never receives one, and the ``agent_stop`` event
+        is what records why the rollout ended. ``failure_kind`` is kept
+        ("model") on the decision-exhaustion path so the terminal snapshot
+        still tells an auditor the score grades a floundering run, not a
+        finished one; the verifier requires it to agree with the stop reason.
+        """
+
+        detail_artifact = None
+        try:
+            detail_artifact = self._publish(detail.encode("utf-8"), media_type="text/plain")
+        except (_EvidenceFailure, OSError):
+            # Best-effort like the fatal-error detail: this runs on a stop
+            # path whose whole point is preserving a score, and an
+            # unpublishable diagnostic must not cost the bundle its terminal.
+            # (A publish that poisoned the writer fails the append below and
+            # abandons honestly.)
+            detail_artifact = None
+        self._append(
+            "agent_stop",
+            AgentStopPayload(
+                stop_id=f"stop-{uuid.uuid4().hex[:12]}",
+                reason=reason,
+                observation_id=observation_id,
+                attempts=attempts,
+                detail_artifact=detail_artifact,
+            ),
+        )
+        return await self._finalize_scored(handshake, failure_kind=failure_kind)
+
+    async def _finalize_scored(
+        self, handshake: Handshake, *, failure_kind: str | None = None
+    ) -> EpisodeOutcome:
         session = self._require_session()
         intent = FinalizationIntent(
             kind="score",
@@ -1344,7 +1434,10 @@ class EpisodeRunner:
             # fail verification/publication. Rescue first, then abandon with the
             # existing finalization authority; ordinary failure intent is too late.
             return await self._abandon_after_scoring_failure(error)
-        return await self._close_out(score, failure_kind=None, cancelled=False)
+        # ``failure_kind`` is None on every deliberate ending and "model" on
+        # the agent-stop exhaustion path, where the verifier's laundering
+        # guard requires the terminal kind to agree with the stop reason.
+        return await self._close_out(score, failure_kind=failure_kind, cancelled=False)
 
     async def _finalize_failure(self, error: BaseException) -> EpisodeOutcome:
         """Finalize unscored after a mid-episode failure.
@@ -1954,7 +2047,33 @@ class _ModelFailure(Exception):
     billed: the provider worked, the agent under test did not. The bundle
     seals ``category="model"`` / ``reason="model_failure"`` so a run that
     ended this way is never counted as an infrastructure outage.
+
+    Carries the observation the model was deciding on and the billed attempt
+    count so the between-steps ``agent_stop`` event can name exactly where
+    and after how many attempts the episode stopped.
     """
+
+    def __init__(self, message: str, *, observation_id: str, attempts: int) -> None:
+        super().__init__(message)
+        self.observation_id = observation_id
+        self.attempts = attempts
+
+
+class _AskUnanswered(_Cancelled):
+    """An ask went unanswered: no answer exists and none may be invented.
+
+    Subclasses ``_Cancelled`` because the invariant is the same -- a host
+    substitute or synthetic empty answer must never reach the model history
+    -- but carries the observation the asking batch was decided on so the
+    runner can record a scored ``agent_stop`` when the episode already has
+    gradable state. A REFUSED answer stays a plain ``_Cancelled``: refusal is
+    the harness declining on policy, not a human who does not exist.
+    """
+
+    def __init__(self, observation_id: str, ask_id: str) -> None:
+        super().__init__("ask-user was not answered")
+        self.observation_id = observation_id
+        self.ask_id = ask_id
 
 
 def _reportability_label(

--- a/tests/unit/evaluation/evidence/test_store.py
+++ b/tests/unit/evaluation/evidence/test_store.py
@@ -17,6 +17,7 @@ from typing import Any
 import pytest
 
 from local_operator.evaluation.evidence.models import (
+    AgentStopPayload,
     BudgetCommitmentPayload,
     CancelPayload,
     FinalizationIntent,
@@ -400,6 +401,65 @@ def test_finalizing_marker_precedes_scoring_start_and_closes_execution(tmp_path:
                     finalization_id="final", scoring_operation_id="score-op", score=score
                 )
             )
+
+
+def test_agent_stop_is_between_steps_execution_evidence(tmp_path: Path) -> None:
+    """The stop event follows the execution phase rules exactly like a batch.
+
+    It is evidence about the rollout (it binds an observation), so it needs a
+    prior commitment, it closes with the journal when finalization begins,
+    and it roundtrips through the hash chain as its registered kind.
+    """
+
+    root = tmp_path / "bundle"
+    with EvidenceWriter.create(root, manifest(), redactions()) as writer:
+        stop = AgentStopPayload(
+            stop_id="stop-0",
+            reason="model_failure",
+            observation_id="obs-0",
+            attempts=3,
+        )
+        # Before the commitment: out of phase, exactly like a batch would be.
+        # (The attempt is never persisted, so the authority below is still
+        # event #0/#1.)
+        with pytest.raises(EvidenceBundleInvalid, match="prior commitment"):
+            writer.append("agent_stop", stop, monotonic_ns=1, wall_time_ms=1)
+        _append_authority(writer, timestamp=2)
+        writer.append(
+            "observation",
+            ObservationPayload(observation_id="obs-0", sequence=0),
+            monotonic_ns=3,
+            wall_time_ms=3,
+        )
+        record = writer.append("agent_stop", stop, monotonic_ns=4, wall_time_ms=4)
+        assert record.kind == "agent_stop"
+        assert record.payload == stop
+        writer.begin_finalization(
+            "final",
+            "score-op",
+            FinalizationIntent(kind="score", scorer_id="scorer", scorer_version="1"),
+            monotonic_ns=5,
+            wall_time_ms=5,
+        )
+        with pytest.raises(EvidenceTerminal):
+            writer.append(
+                "agent_stop",
+                stop.model_copy(update={"stop_id": "stop-1"}),
+                monotonic_ns=6,
+                wall_time_ms=6,
+            )
+    # The durable journal reparses as the registered kind, not generic JSON.
+    lines = (root / "events.jsonl").read_bytes().splitlines()
+    parsed = [json.loads(line) for line in lines]
+    assert [entry["kind"] for entry in parsed] == [
+        "preflight",
+        "budget_commitment",
+        "observation",
+        "agent_stop",
+        "finalization_start",
+        "scoring_start",
+    ]
+    assert parsed[3]["payload"] == stop.model_dump(mode="json")
 
 
 def test_redaction_rejects_all_encoded_canaries_without_echo(tmp_path: Path) -> None:

--- a/tests/unit/evaluation/evidence/test_verify.py
+++ b/tests/unit/evaluation/evidence/test_verify.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -1093,9 +1094,11 @@ def test_scoring_start_without_result_still_refuses_interruption(tmp_path: Path)
     root = _interrupted_bundle(tmp_path, failure_kind="crash", scored=True)
     _drop_events_rechain(root, {"scoring_result"})
     assert "finalization_invalid" in codes(root)
-    # Exactly one: the exemption. Under the M4 mutation (drop ``not starts``)
-    # this count falls to zero.
-    assert _finalization_invalid_count(root) == 1
+    # Exactly two: the deliberate-ending refusal plus the scored-terminal
+    # failure-kind guard (a score may carry only None/"model"). Under the M4
+    # mutation (drop ``not starts``) the exemption fires and this count falls
+    # to one -- only the kind guard remains.
+    assert _finalization_invalid_count(root) == 2
 
 
 def test_scoring_result_without_start_still_refuses_interruption(tmp_path: Path) -> None:
@@ -1111,6 +1114,211 @@ def test_scoring_result_without_start_still_refuses_interruption(tmp_path: Path)
     root = _interrupted_bundle(tmp_path, failure_kind="crash", scored=True)
     _drop_events_rechain(root, {"scoring_start"})
     assert "finalization_invalid" in codes(root)
-    # Two: the structural scoring violation plus the exemption. Under the M5
-    # mutation (drop ``not results``) this count falls to one.
+    # Three: the structural scoring violation, the deliberate-ending refusal,
+    # and the scored-terminal failure-kind guard. Dropping only ``not
+    # results`` (M5) exempts the bundle from the last two and the count falls
+    # to one.
+    assert _finalization_invalid_count(root) == 3
+
+
+def _rewrite_events(root: Path, transform: Any) -> None:
+    """Apply an arbitrary edit to the journal, then renumber and rechain.
+
+    Generalises ``_drop_events_rechain``: the transform may insert or edit
+    records (not only drop them), which is how the agent-stop matrix builds
+    shapes the writer's phase machine refuses to emit -- a stop bound to the
+    wrong observation, a second stop, execution after a stop. Timestamps are
+    renumbered to the sequence so an inserted record can never move time
+    backward.
+    """
+
+    events = [json.loads(line) for line in (root / "events.jsonl").read_bytes().splitlines()]
+    kept = transform(events)
+    previous = manifest().manifest_digest
+    records = []
+    for sequence, event in enumerate(kept):
+        event = dict(event)
+        event["sequence"] = sequence
+        event["previous_event_sha256"] = previous
+        event["monotonic_ns"] = sequence + 1
+        event["wall_time_ms"] = sequence + 1
+        event["event_id"] = "0" * 64
+        record = EventRecord.model_validate(event, strict=True)
+        records.append(record.to_canonical_json())
+        previous = record.event_id
+    (root / "events.jsonl").write_bytes(b"\n".join(records) + b"\n")
+
+
+def _stop_event(
+    reason: str, *, observation_id: str = "obs-1", stop_id: str = "stop-0"
+) -> dict[str, Any]:
+    return {
+        "kind": "agent_stop",
+        "payload": {
+            "stop_id": stop_id,
+            "reason": reason,
+            "observation_id": observation_id,
+            "attempts": 3,
+            "detail_artifact": None,
+        },
+    }
+
+
+def _insert_before(
+    events: list[dict[str, Any]], kind: str, new: dict[str, Any]
+) -> list[dict[str, Any]]:
+    index = next(i for i, event in enumerate(events) if event["kind"] == kind)
+    return [*events[:index], new, *events[index:]]
+
+
+def _stopped_bundle(
+    tmp_path: Path,
+    *,
+    reason: str,
+    failure_kind: str | None,
+    stop: dict[str, Any] | None,
+) -> Path:
+    """A scored bundle whose rollout ended on a between-steps agent stop.
+
+    ``_interrupted_bundle`` provides the stepped rollout (obs-0 -> step ->
+    obs-1, obs-1 batchless); the rewrite inserts the stop event (or leaves it
+    out when ``stop`` is None) immediately before finalization, which is where
+    the runner writes it.
+    """
+
+    root = _interrupted_bundle(tmp_path, failure_kind=failure_kind, scored=True)
+    if stop is not None:
+        _rewrite_events(root, lambda events: _insert_before(events, "finalization_start", stop))
+    return root
+
+
+_ERROR_CODES = {"finalization_invalid", "receipt_binding_invalid", "event_order_invalid"}
+
+
+@pytest.mark.parametrize(
+    ("reason", "failure_kind"),
+    [("model_failure", "model"), ("ask_unanswered", None)],
+)
+def test_agent_stop_is_a_deliberate_ending_that_may_score(
+    tmp_path: Path, reason: str, failure_kind: str | None
+) -> None:
+    """The two runner shapes verify clean.
+
+    Decision exhaustion keeps kind "model" for audit and an unanswered ask
+    keeps kind None; both score the state the episode reached, exactly like a
+    truncation. Each of the reject cases below pins one arm whose removal
+    would let exactly one of these laundered shapes through.
+    """
+
+    root = _stopped_bundle(
+        tmp_path, reason=reason, failure_kind=failure_kind, stop=_stop_event(reason)
+    )
+    assert not codes(root) & _ERROR_CODES
+
+
+def test_scored_model_failure_without_a_stop_is_rejected(tmp_path: Path) -> None:
+    """Pins the scored-kind guard's "stop required" direction.
+
+    A scored terminal may claim kind "model" ONLY beside the agent_stop that
+    records the exhaustion. Exactly two refusals fire: the deliberate-ending
+    check (no stop, no finish, no terminal step) and this guard -- so
+    removing EITHER arm is detectable as the count falling to one.
+    """
+
+    root = _stopped_bundle(tmp_path, reason="model_failure", failure_kind="model", stop=None)
     assert _finalization_invalid_count(root) == 2
+
+
+@pytest.mark.parametrize(
+    ("reason", "failure_kind"),
+    [("model_failure", None), ("ask_unanswered", "model")],
+)
+def test_stop_reason_must_agree_with_the_failure_kind(
+    tmp_path: Path, reason: str, failure_kind: str | None
+) -> None:
+    """Pins the reason-agreement guard's pairing direction.
+
+    The runner writes exactly the pairs (model_failure, "model") and
+    (ask_unanswered, None); either crossed pairing is a terminal record that
+    contradicts the stop event, so neither may verify. The (model_failure,
+    None) cross isolates the agreement arm -- the deliberate-ending check is
+    satisfied by the stop and the kind is None, so exactly one refusal fires.
+    """
+
+    root = _stopped_bundle(
+        tmp_path, reason=reason, failure_kind=failure_kind, stop=_stop_event(reason)
+    )
+    expected = 1 if failure_kind is None else 2
+    assert _finalization_invalid_count(root) == expected
+
+
+@pytest.mark.parametrize("failure_kind", ["crash", "infrastructure", "cancelled"])
+def test_an_agent_stop_cannot_launder_an_interrupted_score(
+    tmp_path: Path, failure_kind: str
+) -> None:
+    """Crash/provider/cancel kinds stay unscored-only even beside a stop.
+
+    The stop is a third deliberate ending, but the scored-terminal kind guard
+    is independent of it: a run whose terminal says the harness or the
+    environment broke can never report a score, however its journal ends.
+    Both the kind guard and the reason-agreement guard fire (the stop claims
+    model_failure against a crash-shaped kind), so removing either arm is
+    detectable as the count falling to one.
+    """
+
+    root = _stopped_bundle(
+        tmp_path,
+        reason="model_failure",
+        failure_kind=failure_kind,
+        stop=_stop_event("model_failure"),
+    )
+    assert _finalization_invalid_count(root) == 2
+
+
+def test_stop_must_bind_to_the_latest_batchless_observation(tmp_path: Path) -> None:
+    """Pins the binding arm: obs-0 is both stale and already batched.
+
+    A stop naming obs-0 would attribute the ending to a state the episode
+    had already acted past, and obs-0 carries batch-0 -- the runner's rule is
+    that a stopped observation never receives a batch.
+    """
+
+    root = _stopped_bundle(
+        tmp_path,
+        reason="model_failure",
+        failure_kind="model",
+        stop=_stop_event("model_failure", observation_id="obs-0"),
+    )
+    assert "receipt_binding_invalid" in codes(root)
+
+
+def test_nothing_may_execute_after_an_agent_stop(tmp_path: Path) -> None:
+    """Pins the post-stop ordering arm with an observation appended after it."""
+
+    root = _stopped_bundle(
+        tmp_path, reason="model_failure", failure_kind="model", stop=_stop_event("model_failure")
+    )
+    _rewrite_events(
+        root,
+        lambda events: _insert_before(
+            events,
+            "finalization_start",
+            {"kind": "observation", "payload": {"observation_id": "obs-2", "sequence": 2}},
+        ),
+    )
+    assert "event_order_invalid" in codes(root)
+
+
+def test_a_second_agent_stop_is_rejected(tmp_path: Path) -> None:
+    """Pins the single-stop arm: two endings cannot both be the ending."""
+
+    root = _stopped_bundle(
+        tmp_path, reason="model_failure", failure_kind="model", stop=_stop_event("model_failure")
+    )
+    _rewrite_events(
+        root,
+        lambda events: _insert_before(
+            events, "finalization_start", _stop_event("model_failure", stop_id="stop-1")
+        ),
+    )
+    assert "event_order_invalid" in codes(root)

--- a/tests/unit/evaluation/runner/test_episode.py
+++ b/tests/unit/evaluation/runner/test_episode.py
@@ -18,6 +18,8 @@ import pytest
 from local_operator.evaluation.adapters.api import Requirement, ScopedInfraValue
 from local_operator.evaluation.adapters.supervisor import SupervisionError
 from local_operator.evaluation.evidence.models import (
+    ActionBatchPayload,
+    AgentStopPayload,
     CleanupPayload,
     EnvironmentStepPayload,
     ErrorPayload,
@@ -239,6 +241,49 @@ async def test_unanswered_ask_cancels_rather_than_leaving_it_open(
     assert verify_bundle(root).valid
     assert "cancel" in _kinds(root)
     assert outcome.score is not None and outcome.score.reason == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_unanswered_ask_after_a_step_scores_the_reached_state(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """A human who does not exist must not void paid environment work.
+
+    The step-0 ask above stays a cancellation (nothing to grade); once a
+    step has landed, the same unanswered ask becomes a scored agent stop on
+    the state reached -- the ask is never written as a batch, so the stopped
+    observation stays batchless and the verifier accepts the stop binding.
+    """
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    runner = _runner(
+        tmp_path,
+        episode_id,
+        adapter=adapter,
+        model=ScriptedModel(["type", "ask", "finish"]),
+        responder=RecordingResponder(None),
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "completed"
+    assert outcome.reportability_label == "reportable"
+    assert outcome.score is not None and outcome.score.status == "scored"
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid, [issue.code for issue in report.issues]
+    kinds = _kinds(root)
+    assert "cancel" not in kinds
+    assert kinds.index("agent_stop") < kinds.index("finalization_start")
+    stops = payloads(root, AgentStopPayload)
+    assert len(stops) == 1
+    assert stops[0].reason == "ask_unanswered"
+    assert stops[0].attempts == 1
+    assert stops[0].observation_id == payloads(root, ObservationPayload)[-1].observation_id
+    assert stops[0].detail_artifact is not None
+    # The environment graded the state the one step reached.
+    assert "score" in adapter.calls
 
 
 @pytest.mark.asyncio
@@ -1001,6 +1046,66 @@ async def test_exhausted_decision_retries_seal_as_a_model_failure(
     assert errors[-1].diagnostic_code == "modelfailure"
     # Cleanup ran on the live session: the environment was never at fault.
     assert "cleanup" in adapter.calls
+
+
+@pytest.mark.asyncio
+async def test_decision_exhaustion_after_a_step_scores_the_reached_state(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """Exhaustion between steps grades the work already bought.
+
+    The step-0 exhaustion above stays unscored (no environment work to
+    grade); after a step has landed, the same exhaustion records an
+    ``agent_stop`` and scores the state reached. The terminal keeps
+    ``failure_kind="model"`` for audit -- so the episode reports failed --
+    and the verifier's laundering guard requires that kind to agree with the
+    stop reason. No action batch is written for the stopped observation.
+    """
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    model = ScriptedModel(["type", "reject", "reject", "reject"])
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        build_config(tmp_path, max_decision_retries=2),
+        selector=selector(tmp_path),
+        model=model,
+        launch=lambda _: adapter,
+        rescue=_rescue_ok,
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "failed"
+    assert outcome.reportability_label == "reportable"
+    assert outcome.score is not None and outcome.score.status == "scored"
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid, [issue.code for issue in report.issues]
+    kinds = _kinds(root)
+    assert kinds.index("agent_stop") < kinds.index("finalization_start")
+    stops = payloads(root, AgentStopPayload)
+    assert len(stops) == 1
+    assert stops[0].reason == "model_failure"
+    assert stops[0].attempts == 3
+    assert stops[0].observation_id == payloads(root, ObservationPayload)[-1].observation_id
+    assert stops[0].detail_artifact is not None
+    # The scored path writes no terminal model error: every rejection keeps
+    # its own retryable record and the stop carries the diagnostic.
+    errors = payloads(root, ErrorPayload)
+    assert [(error.category, error.retryable) for error in errors] == [
+        ("model", True),
+        ("model", True),
+        ("model", True),
+    ]
+    # The last observation never received a batch: one batch per observation,
+    # and the stopped one is the verifier's allowed batchless tail.
+    observations = payloads(root, ObservationPayload)
+    batches = payloads(root, ActionBatchPayload)
+    assert {batch.observation_id for batch in batches} == {
+        observation.observation_id for observation in observations[:-1]
+    }
+    assert "score" in adapter.calls
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Release: none — evaluation runner/evidence change; `pyproject.toml` untouched (combined-release rule: PRs never carry a bump).

## What and why

**A model that exhausts its decision retries between steps, or asks a human who does not exist, sealed the episode UNSCORED and thereby voided every paid environment step it had already bought.**

Truncation is scored and recorded ON a step (`EnvironmentStepPayload.truncated`). But decision exhaustion happens BETWEEN steps: the previous step's observation is already journalled, no new batch exists, and `_ModelFailure` fell into `_finalize_failure` → unscored `model_failure`. An unanswered `ask_user` raised `_Cancelled` before any batch was written → unscored `cancelled`. In both shapes the session is still alive and the environment state is gradable — the only thing missing was a way to record the stop.

This is deliberately general (not OSWorld-specific): any benchmark episode whose agent flounders or asks into a void now scores the state it reached, exactly like a truncation.

### The change

- **New between-steps evidence event `agent_stop`** (`AgentStopPayload`: `stop_id`, `reason: model_failure | ask_unanswered`, `observation_id`, `attempts`, `detail_artifact`), registered like `ErrorPayload`. It carries NO action batch — the one-batch-per-observation rule means the stopped observation never gets one, so it stays the verifier's allowed batchless tail.
- **Runner** (`episode.py`): `_ModelFailure` and the new `_AskUnanswered` (subclass of `_Cancelled`; a REFUSED answer stays a plain cancel — that is policy, not a missing human) are caught at the step-loop boundary. With at least one completed environment step → write `agent_stop` (diagnostic detail as a best-effort artifact, same rationale as the fatal-error detail) → `_finalize_scored`. The model-exhaustion path keeps `failure_kind="model"` on the terminal for audit (so `EpisodeOutcome.status` is honestly `"failed"` while the bundle is scored + reportable); the ask path keeps `failure_kind=None` → `completed`. At **zero steps nothing changes**: exhaustion stays unscored `model_failure` and an unanswered ask stays cancelled — there is no environment work to grade.
- **Verifier** (`verify.py`): `agent_stop` joins `execution_payload_types` (needs a prior commitment, refused after finalization) and becomes a **third deliberate ending**. Two new guards keep the laundering surface closed: a scored terminal may carry only `failure_kind` `None` or `"model"` (crash/provider/cancel + scored stays rejected, stop or no stop), and the stop reason must agree with the terminal `failure_kind` (exactly the pairs the runner writes: `model_failure`↔`"model"`, `ask_unanswered`↔`None`). Structural arms: the stop must bind to the latest, batchless observation; nothing may execute after a stop; at most one stop.
- **Store** (`store.py`): `agent_stop` follows the execution phase rules like a batch (prior commitment required; closed once finalization begins). Finalization intent flow untouched.

## Changed files (7, +598/−11)

- `local_operator/evaluation/evidence/models.py` — `agent_stop` kind, `AgentStopPayload`, payload union + registry.
- `local_operator/evaluation/evidence/store.py` — phase-machine membership (validate + advance).
- `local_operator/evaluation/evidence/verify.py` — execution type set; per-event stop arm (binding/single-stop/no-execute-after); third deliberate ending; scored-kind + reason-agreement guards.
- `local_operator/evaluation/runner/episode.py` — step-loop boundary catches, `_AskUnanswered`, `_ModelFailure` context, `_finalize_agent_stop`, `_finalize_scored(failure_kind=...)`.
- `tests/unit/evaluation/evidence/test_store.py` — phase roundtrip (out-of-phase → accepted → closed, journal reparses as the registered kind).
- `tests/unit/evaluation/evidence/test_verify.py` — accept/reject matrix (10 new tests + 2 updated counts); every new verifier arm mutation-checked.
- `tests/unit/evaluation/runner/test_episode.py` — scored exhaustion after a step; scored unanswered ask after a step.

## Testing evidence

Implementer's run on this branch (`01f778a46`), worktree venv (`uv pip install -e ".[all,dev]"`, resolves to the worktree):

| gate | command | result |
| --- | --- | --- |
| flake8 | `.venv/bin/python -m flake8 .` | clean |
| black | `uvx --from black==26.1.0 black --check .` | clean |
| isort | `uvx isort==5.13.2 --check .` | clean |
| pyright | `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | 0 errors, 0 warnings |
| evaluation suite | `env -u AWS_DEFAULT_PROFILE -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/evaluation -q` | **1341 passed, 1 skipped** |
| evidence/verify | `... -m pytest tests/unit/evaluation/evidence/test_verify.py -q` | 40 passed (12 new + 2 updated) |
| store | `... -m pytest tests/unit/evaluation/evidence/test_store.py -q` | 57 passed (1 new) |
| episode runner | `... -m pytest tests/unit/evaluation/runner/test_episode.py -q` | all passed (2 new scored-path tests) |
| mutation checks | each new verifier arm individually neutralised, matrix re-run | every targeted test FAILED as intended (third-arm removal → 2 accept cases fail; kind-guard removal → 3 laundering cases fail; agreement removal → 2 pairing cases fail; binding / post-stop / single-stop removals → their tests fail); verifier restored after |
| full `tests/unit` | running in background on a loaded machine | result posted as a PR comment when it lands — not claimed as run yet |

End-to-end proof (the two new episode tests drive the real `VerifiedAdapterSession`, real lifecycle authorities, real `EvidenceWriter`, and assert `verify_bundle(root).valid`):

- **Exhaustion after a step**: `ScriptedModel(["type", "reject", "reject", "reject"])`, `max_decision_retries=2` → one executed step then 3 billed rejections → outcome **scored** (`reportable`), status `failed` (kind `model` kept for audit), bundle verifies, `agent_stop(model_failure, attempts=3)` bound to the last (batchless) observation, only the three retryable `model` error events (no terminal error — the stop carries the diagnostic), last observation has no batch, `score` called on the adapter (state graded).
- **Unanswered ask after a step**: `ScriptedModel(["type", "ask", "finish"])` + `RecordingResponder(None)` → one executed step then an unanswered ask → outcome **scored**, status `completed`, no `cancel` event, `agent_stop(ask_unanswered, attempts=1)`, stop precedes `finalization_start`.
- **Regression, step-0 exhaustion stays unscored** — existing `test_exhausted_decision_retries_seal_as_a_model_failure` + `test_zero_decision_retries_restores_one_strike` (unchanged, still green).
- **Regression, step-0 ask stays cancelled** — existing `test_unanswered_ask_cancels_rather_than_leaving_it_open` (unchanged, still green).
- **Regression, mid-episode provider failure stays unscored** — existing `test_provider_failure_after_a_step_still_seals` (`reason == "infrastructure_failure"`, still green): provider failures are not converted to scores.

## Blast radius

Evaluation runner/evidence only. `grep` shows no consumers of the evidence event kinds outside `evaluation/` (guards.py references `EnvironmentStepPayload` in a docstring only). TUI/CLI/server untouched; `scripts/run_episode.py` behaviour is only that a scored-but-floundering episode still exits `EXIT_EPISODE` (status `failed`) while printing the scored outcome — same as today's failed exits.

## Not addressed (deliberate)

- `attempts` for `ask_unanswered` is fixed at 1 (one ask issued, one non-answer); no retry loop for asks exists to count.
- An `agent_stop` bundle whose scoring then fails still abandons (`_abandon_after_scoring_failure`), as every scored path does.