### PR TITLE
chore(release): bump version to 0.54.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.9"
+version = "0.54.10"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release lock for the post-v0.54.9 window. `pyproject.toml` only, one line.

## Window

Re-derived from `origin/main` after #940 landed while the first CI run was in flight. Plain `git log v0.54.9..origin/main` (never `--merges`):

| PR | Merge SHA | Impact |
|---|---|---|
| [#937](https://github.com/damianvtran/local-operator/pull/937) | `51b524c85` | `RemoteSession` → `AttachedSession`; `OwnedSessionHandle` → `ServingSessionHandle`. Classes not merged. |
| [#940](https://github.com/damianvtran/local-operator/pull/940) | `05784120f` | `/settings` section "OpenRouter routing" builds the OpenRouter chat-completions `provider` object. Default = no `provider` key on the wire. |

## Bump class

**PATCH → 0.54.10.** Mechanical rename plus a settings surface over an existing request path. No API addition, no migration. Neither PR clears the step-function bar; materiality does not aggregate.

## Scope

This PR is one file, one line. C0.