### PR TITLE
chore(release): bump version to 0.54.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.10"
+version = "0.54.11"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release lock for the post-v0.54.10 window. `pyproject.toml` only, one line.

## Window

Re-derived from `origin/main` at `51405f468`. Plain `git log v0.54.10..origin/main` (never `--merges`):

| PR | Merge SHA | Impact |
|---|---|---|
| [#943](https://github.com/damianvtran/local-operator/pull/943) | `51405f468` (`6acd0d66c`) | `fix(tui)`: recover the stuck older-messages notice. |

## Bump class

**PATCH → 0.54.11.** Single bug-fix PR; no API addition, no migration. Does not clear the step-function bar for minor.

## Scope

This PR is one file, one line. C0.