### PR TITLE
ci(tests): name the test a shard stalls on instead of losing it to the cap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,6 +372,22 @@ jobs:
         # requests.
         python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.12"]') || fromJSON('["3.12", "3.13"]') }}
         shard: [0, 1, 2, 3, 4]
+    env:
+      # Seconds of no completed test before the controller reports which tests
+      # are still in flight, and the per-item bound after which a worker dumps
+      # every thread's stacks. Four shards have been cancelled at the 20-minute
+      # cap after a silent 6-minute tail (5m55s-7m18s of zero output) which the
+      # log cannot attribute: `-q` prints one line per 72 completed tests, so
+      # the last partial line is withheld until its slowest item finishes.
+      #
+      # 240s is chosen against measurements, not taste. This budget is a CI
+      # number, as AGENTS.md requires: the worst legitimate test measured in a
+      # full local run is 81s, and a shard averages ~0.2s per completed test, so
+      # four minutes with NO completion is already anomalous rather than slow.
+      # It also has to fire with time to spare before the cap: the observed
+      # stalls begin ~14 minutes into the job, so 240s puts the first report at
+      # ~18 minutes with the 30s repeat getting at least one more before 20.
+      LOCAL_OPERATOR_SHARD_STALL_SECONDS: "240"
     steps:
       - uses: actions/checkout@v7
 
@@ -413,6 +429,27 @@ jobs:
         run: |
           pytest $(cat shard_tests.txt | tr '\n' ' ') --cov --cov-fail-under=0 --cov-report=
           mv .coverage .coverage.${{ matrix.python-version }}.${{ matrix.shard }}
+
+      - name: Print the shard stall report
+        # `always()` unconditionally: the report exists exactly when this job is
+        # cancelled at the cap or dies, and `always()` is the one condition that
+        # still runs then. It is belt-and-braces rather than the delivery path
+        # -- the controller prints its report straight to this log while the
+        # stall is happening, because that is the only channel a cancelled job
+        # leaves intact -- but it also covers a device-level failure nothing
+        # printed, and a fired worker stack dump in the case where the shard
+        # step failed rather than timed out.
+        if: always()
+        run: |
+          dir="${TMPDIR:-/tmp}/lo-shard-stall"
+          if [ -z "$(ls -A "$dir" 2>/dev/null)" ]; then
+            echo "no shard stall report: nothing stalled long enough to trip the watchdog"
+            exit 0
+          fi
+          for f in "$dir"/*.log; do
+            echo "===== $f ====="
+            cat "$f"
+          done
 
       - name: Upload shard coverage data
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,17 +439,17 @@ jobs:
         # leaves intact -- but it also covers a device-level failure nothing
         # printed, and a fired worker stack dump in the case where the shard
         # step failed rather than timed out.
+        #
+        # The printing is done by the module (`report_dumps`), not by `cat`, and
+        # that is load-bearing rather than cosmetic: a worker writes its header
+        # at ARM time, one per test, so a raw dump of this PR's own cancelled
+        # shard held 3088 lines all reading "<nodeid> exceeded 240s" with the
+        # one real timeout buried among them. The module's FIRED_MARKER filter
+        # is the single source of truth for "this is evidence", so the step asks
+        # for the filtered report instead of re-implementing the rule in YAML.
         if: always()
         run: |
-          dir="${TMPDIR:-/tmp}/lo-shard-stall"
-          if [ -z "$(ls -A "$dir" 2>/dev/null)" ]; then
-            echo "no shard stall report: nothing stalled long enough to trip the watchdog"
-            exit 0
-          fi
-          for f in "$dir"/*.log; do
-            echo "===== $f ====="
-            cat "$f"
-          done
+          python -m tests.shard_stall_watchdog "${TMPDIR:-/tmp}/lo-shard-stall"
 
       - name: Upload shard coverage data
         uses: actions/upload-artifact@v4

--- a/conftest.py
+++ b/conftest.py
@@ -123,6 +123,8 @@ import warnings
 
 import pytest
 
+from tests import shard_stall_watchdog
+
 # ---------------------------------------------------------------------------
 # Real-store guard
 # ---------------------------------------------------------------------------
@@ -233,8 +235,36 @@ def _install_real_store_guard() -> None:
 _install_real_store_guard()
 
 
+# ---------------------------------------------------------------------------
+# Shard stall watchdog
+# ---------------------------------------------------------------------------
+# Four `test (3.12, N)` jobs have been CANCELLED at the workflow's 20-minute cap
+# after a silent ~6-minute tail, which fails the PR. That tail is invisible in
+# the log by construction: pytest prints one progress line per 72 completed
+# tests, so the final partial line is withheld until its slowest item finishes
+# and a single stuck test is indistinguishable from a uniformly slow batch. The
+# only way to recover the culpable test is to watch from inside the run, so this
+# records in-flight node ids on the controller and dumps worker stacks with the
+# C-level timer. Inert unless LOCAL_OPERATOR_SHARD_STALL_SECONDS is set, which
+# only the shard job in ci.yml does; tests/shard_stall_watchdog.py carries the
+# reasoning, the safety argument and the measurement behind the design.
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    shard_stall_watchdog.install(config)
+
+
+def pytest_runtest_logstart(nodeid: str, location: tuple[str, int | None, str]) -> None:
+    shard_stall_watchdog.note_start(nodeid)
+
+
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    shard_stall_watchdog.note_report(report)
+
+
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     """Fail the run if any pre-existing entry of the real store is gone."""
+    shard_stall_watchdog.shutdown()
     if _REAL_STORE is None or _REAL_STORE_ENTRIES is None:
         return
     try:

--- a/tests/e2e/watchdog.py
+++ b/tests/e2e/watchdog.py
@@ -33,6 +33,20 @@ The GRANULARITY is deliberate: the timer is armed around the specific step
 under test rather than around the whole test, so the dump names the operation
 that hung instead of "the test was slow".
 
+ONE PROCESS-GLOBAL TIMER, SHARED WITH THE SHARD WATCHDOG
+``faulthandler``'s timer is process-wide, so a ``bounded`` block displaces any
+other armed timer and its ``finally`` leaves nothing armed. ``tests.shard_stall_watchdog``
+arms the same timer around one xdist test item, so a test body that entered
+``bounded`` would take that worker's stacks away for the rest of the test (the
+controller would still name the test from xdist reports; only the stacks are
+lost). No CI configuration runs the two in one process -- the shard job sets
+``LOCAL_OPERATOR_SHARD_STALL_SECONDS`` with ``e2e`` deselected, and this stage
+runs ``-n0`` without it, so there are no xdist workers here -- and that
+invariant is pinned by
+``tests/unit/test_shard_stall_watchdog.py::test_no_ci_job_runs_both_watchdogs_in_one_process``.
+Nothing interlocks the timers, because nothing runs them together; if a future
+job did, the interlocks would have to be added deliberately.
+
 ``exit=True`` kills the whole process, so a fired watchdog takes down the
 pytest worker with it. That is the intended behaviour and not a rough edge: a
 deadlocked interpreter cannot report a test failure through any gentler

--- a/tests/shard_stall_watchdog.py
+++ b/tests/shard_stall_watchdog.py
@@ -1,0 +1,380 @@
+"""Name the test a CI shard stalls on, instead of being cancelled by the cap.
+
+WHY THIS EXISTS
+---------------
+``test (3.12, N)`` intermittently reaches the workflow's ``timeout-minutes: 20``
+and is reported CANCELLED, which fails the PR. The signature is the same in
+every occurrence and it is not a failure of any test: the run reaches 95-99%,
+then produces **no output at all** for 5m55s-7m18s until the cap kills it. No
+assertion, no traceback, no name.
+
+That silence is the whole problem. ``-q`` prints one line per 72 completed
+tests, so the final partial line is withheld until the LAST item in the batch
+finishes: a single stuck test and a uniformly slow tail are indistinguishable
+from the log. Measured over four cancels (runs 34545290432, 34546963294,
+34547820936, 34551028930) the tail is 6 minutes with the run's own progress
+information already exhausted, so the culpable item can only be recovered by
+watching from *inside* the run rather than from its output.
+
+The partition was ruled out first, with evidence: at ``origin/main`` the
+cancelled shard was among the LIGHTEST by measured per-file cost while a
+heavier shard finished in 14m14s, and the cancels have been observed on shard
+indices 0, 1 and 4. So this module does not rebalance anything. It reports.
+
+WHAT IT REPORTS, AND WHY THOSE TWO THINGS
+-----------------------------------------
+1. **The master names the tests that are in flight when progress stops.** The
+   xdist controller receives ``pytest_runtest_logstart`` and every
+   ``pytest_runtest_logreport``, so it knows which node ids have started and not
+   finished. A node id turns "a 6-minute silent tail" into a test name. This is
+   the part that answers the question, and it needs no cooperation from the
+   stalled process at all -- which matters, because the stalled process is the
+   thing that cannot tell anyone anything.
+2. **Each worker dumps every thread's stacks with the C-level timer.** Named
+   tests alone cannot distinguish "doing legitimate work slowly" from "parked
+   inside a syscall", and the difference decides whether the fix is a bound or a
+   deadlock. :mod:`tests.e2e.watchdog` already carries the why at length: only
+   ``faulthandler.dump_traceback_later`` survives the #401 class of failure,
+   because it arms a timer in a dedicated C thread that writes with ``write(2)``
+   and needs neither the GIL nor a live interpreter. It is reused here rather
+   than re-derived, and for the same reason the timer is armed around ONE test
+   item rather than around the session: a session-wide timer cannot tell a stall
+   from a healthy long run.
+
+WHY IT IS SAFE TO LEAVE ON: IT NEVER FAILS A RUN
+------------------------------------------------
+Nothing here exits, kills or times out a process. ``exit=False`` on the worker
+timer means a fired dump is a snapshot and the test keeps running; the master
+prints and keeps polling. A run that is merely slow finishes normally and the
+dump files are removed by the master's own cleanup, so a fired dump is the only
+thing that survives -- the same "the file's existence is the signal" discipline
+``tests.e2e.watchdog`` uses, and for the same reason: a diagnostic that can turn
+a green run red gets disabled the first time it is wrong.
+
+The workspace is deliberately NOT under ``tmp_path``: the master and its workers
+are separate processes and the controller has to be able to read what a wedged
+worker wrote, which means a path both can compute from the environment. It is
+also fixed rather than unique per session so that the workflow's ``always()``
+step can find the files after a job is cancelled, when no process is left to
+tell it where they are.
+
+WHERE IT IS ENABLED
+-------------------
+Only when ``LOCAL_OPERATOR_SHARD_STALL_SECONDS`` is set, which the ``test`` job
+in ``.github/workflows/ci.yml`` does and nothing else does. The default absence
+is what keeps a developer run and the ``-n0`` e2e stage (which has its own,
+tighter bound) untouched; it also means the number is a CI budget rather than a
+wall-clock assertion about anyone's machine, which is the only kind of number
+AGENTS.md allows to be calibrated from CI.
+"""
+
+from __future__ import annotations
+
+import faulthandler
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+#: Seconds of NO COMPLETED TEST before the controller reports. Set by the shard
+#: job. Unset (and therefore inert) everywhere else.
+ENV_SECONDS = "LOCAL_OPERATOR_SHARD_STALL_SECONDS"
+
+#: Shared by every xdist worker and readable by the controller -- see the module
+#: docstring for why this is not a ``tmp_path`` fixture directory.
+DUMP_DIR = Path(os.environ.get("TMPDIR", "/tmp")) / "lo-shard-stall"
+
+#: ``faulthandler`` writes this when the C timer actually fires
+#: (``Timeout (0:04:00)!``). Distinguishing a real dump from a header written at
+#: arm time is what lets cleanup delete the harmless ones and keep the evidence.
+FIRED_MARKER = "Timeout ("
+
+#: How often the controller repeats an ongoing report. A stall is reported more
+#: than once on purpose: the cap can arrive mid-stall, and the last report
+#: before it is the one a reader will see.
+REPORT_INTERVAL_S = 30.0
+
+#: Poll granularity. Small enough that the first report lands promptly, large
+#: enough that the thread is invisible next to a 4-worker test run.
+POLL_INTERVAL_S = 2.0
+
+#: Cap on the lines of stack printed per worker. One snapshot of a busy
+#: xdist worker (which carries the session runtime, the viewer endpoint and
+#: execnet's own threads) is comfortably under this; the cap only exists so a
+#: pathological dump cannot bury the report.
+STACK_EXCERPT_LINES = 400
+
+
+def _first_snapshot(text: str) -> list[str]:
+    """The first complete stack dump in ``text``, as lines.
+
+    ``repeat=True`` appends another full dump every interval, so a file that
+    tripped early holds several near-identical snapshots. Taking everything
+    would repeat the same stacks until the cap, and taking a fixed number of
+    lines from one end is not enough either: the thread that matters is not at
+    a predictable end -- faulthandler groups threads its own way, and the
+    worker under test is usually NOT the first block, because the session
+    runtime and the viewer endpoint have threads of their own. Splitting on the
+    marker keeps ONE snapshot whole, so every thread is present.
+    """
+    parts = text.split(FIRED_MARKER)
+    if len(parts) < 2:
+        return text.splitlines()
+    body = FIRED_MARKER + parts[1]
+    lines = body.splitlines()
+    return lines[:STACK_EXCERPT_LINES]
+
+
+def enabled_seconds() -> float | None:
+    """The configured stall bound, or ``None`` when this module is inert.
+
+    A malformed value disables the module rather than raising: this runs inside
+    ``pytest_configure``, so a typo in a workflow env var must not be able to
+    take out the whole suite. It also cannot silently become a *shorter* bound
+    than intended, because a value that does not parse is not used at all.
+    """
+    raw = os.environ.get(ENV_SECONDS, "").strip()
+    if not raw:
+        return None
+    try:
+        seconds = float(raw)
+    except ValueError:
+        return None
+    return seconds if seconds > 0 else None
+
+
+def _dump_path(tag: str) -> Path:
+    DUMP_DIR.mkdir(parents=True, exist_ok=True)
+    return DUMP_DIR / f"{tag}.log"
+
+
+class _WorkerTimer:
+    """The C-level per-item timer, armed in an xdist worker.
+
+    ``repeat=True`` because the bound is a floor, not a schedule: a test that
+    runs for three times the bound should leave three snapshots, and the last
+    one before the cap is the one with the most useful stacks.
+    """
+
+    def __init__(self) -> None:
+        self._handle = None
+        self._path = _dump_path(f"worker-{os.getpid()}")
+        self._armed = False
+
+    def arm(self, nodeid: str, seconds: float) -> None:
+        if self._armed:
+            return
+        # The handle must exist and stay open for the life of the process: the
+        # dump is written from a C thread with a raw descriptor, so the file
+        # cannot be opened at the moment it fires.
+        if self._handle is None or self._handle.closed:
+            self._handle = self._path.open("w", encoding="utf-8")
+        self._handle.write(f"[shard stall] {nodeid} exceeded {seconds:g}s; every thread follows.\n")
+        self._handle.flush()
+        faulthandler.dump_traceback_later(seconds, file=self._handle, repeat=True, exit=False)
+        self._armed = True
+
+    def disarm(self) -> None:
+        if not self._armed:
+            return
+        faulthandler.cancel_dump_traceback_later()
+        self._armed = False
+
+
+class _Controller:
+    """Tracks in-flight tests on the xdist controller and reports a stall once.
+
+    Thread-safe because the tracker is mutated by pytest hooks on the main
+    thread while the reporter reads it from its own.
+    """
+
+    def __init__(self, seconds: float, sink=None) -> None:
+        self.seconds = seconds
+        self._lock = threading.Lock()
+        self._in_flight: dict[str, float] = {}
+        self._last_progress = time.monotonic()
+        self._reported_at = 0.0
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        # Injectable so the local proof can capture a report without racing the
+        # terminal. The default writes to the controller's stderr, which is
+        # measured to land in the CI job log WHILE a worker is still busy --
+        # pytest's fd capture is suspended on the controller, which is why the
+        # `-q` progress of a cancelled job is readable at all. That measurement
+        # is what makes a report-only design viable here: nothing has to be
+        # printed by a later step that a cancelled job would never run.
+        self._sink = sink or (lambda text: print(text, file=sys.stderr, flush=True))
+
+    def started(self, nodeid: str) -> None:
+        with self._lock:
+            self._in_flight[nodeid] = time.monotonic()
+
+    def note(self, nodeid: str, when: str) -> None:
+        """A report arrived. Any report is progress; only teardown completes.
+
+        The distinction is load-bearing and was measured the hard way: xdist
+        sends a report with ``when="setup"`` as soon as a test's fixtures are
+        done and BEFORE its call phase runs. Counting that as completion
+        emptied the in-flight set for the whole duration of the test body, so a
+        real stall reported "0 still in flight" -- the exact opposite of the
+        answer wanted, and it read as a healthy quiet run rather than a bug.
+        """
+        with self._lock:
+            self._last_progress = time.monotonic()
+            if when == "teardown":
+                self._in_flight.pop(nodeid, None)
+
+    def start(self) -> None:
+        self._thread = threading.Thread(target=self._poll, name="shard-stall", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _poll(self) -> None:
+        while not self._stop.wait(POLL_INTERVAL_S):
+            self.report_if_stalled()
+
+    def report_if_stalled(self) -> bool:
+        """Emit one report per :data:`REPORT_INTERVAL_S` while a stall persists.
+
+        Returns whether a report was emitted, which is what the local proof
+        asserts on; a real run only cares about the text reaching the job log.
+        """
+        now = time.monotonic()
+        with self._lock:
+            idle = now - self._last_progress
+            # Reported even with an EMPTY in-flight set, which is not an edge
+            # case but a distinct diagnosis: the controller stops hearing from a
+            # worker it believes is running something, so an empty set beside a
+            # stall means the worker died or wedged without reporting, not that
+            # the suite finished. Suppressing the report there would hide the
+            # only case where the controller is the last process alive.
+            if idle < self.seconds:
+                return False
+            if now - self._reported_at < REPORT_INTERVAL_S:
+                return False
+            self._reported_at = now
+            in_flight = sorted(self._in_flight.items(), key=lambda kv: kv[1])
+        self._sink(self._format(idle, in_flight))
+        return True
+
+    def _format(self, idle: float, in_flight: list[tuple[str, float]]) -> str:
+        now = time.monotonic()
+        lines = [
+            "",
+            "!" * 72,
+            f"SHARD STALL: no test has completed for {idle:.0f}s "
+            f"(bound {self.seconds:g}s). {len(in_flight)} still in flight:",
+        ]
+        for nodeid, started in in_flight:
+            lines.append(f"  {now - started:7.0f}s  {nodeid}")
+        lines.extend(self._stack_excerpts())
+        lines.append("!" * 72)
+        lines.append("")
+        return "\n".join(lines)
+
+    def _stack_excerpts(self) -> list[str]:
+        """The head of each worker dump that actually fired.
+
+        Read on the controller rather than printed by the worker, because the
+        worker is the process that may be unable to write to the job log at all.
+        A file without :data:`FIRED_MARKER` is a header from an armed-but-not-
+        fired timer and is skipped, so the report never claims a timeout for a
+        test that was merely running.
+        """
+        out: list[str] = []
+        try:
+            candidates = sorted(DUMP_DIR.glob("worker-*.log"))
+        except OSError:
+            return out
+        for path in candidates:
+            try:
+                text = path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            if FIRED_MARKER not in text:
+                continue
+            lines = _first_snapshot(text)
+            out.append(f"--- {path} (first snapshot, {len(lines)} lines) ---")
+            out.extend(lines)
+        return out
+
+    def cleanup(self) -> None:
+        """Remove armed-but-unfired dumps; keep anything that actually fired.
+
+        Runs on the controller, which outlives its workers. A fired dump is
+        evidence and is kept even on a green run -- a test that took four
+        minutes and still passed is worth knowing about.
+        """
+        try:
+            paths = sorted(DUMP_DIR.glob("*.log"))
+        except OSError:
+            return
+        for path in paths:
+            try:
+                if FIRED_MARKER in path.read_text(encoding="utf-8", errors="replace"):
+                    continue
+            except OSError:
+                pass
+            try:
+                path.unlink()
+            except OSError:
+                pass
+
+
+#: One controller per controller process; None on a worker.
+_CONTROLLER: _Controller | None = None
+#: One timer per worker process; None on the controller.
+_WORKER: _WorkerTimer | None = None
+
+
+def install(config) -> None:
+    """Wire the module up in whichever process this is. Idempotent.
+
+    ``hasattr(config, "workerinput")`` is xdist's own discriminator between a
+    worker and the controller, and it is the only one that is correct *before*
+    a session exists -- the two processes need different instrumentation (one
+    watches, the other is watched), so the branch has to happen here rather
+    than inside a hook.
+    """
+    global _CONTROLLER, _WORKER
+    seconds = enabled_seconds()
+    if seconds is None:
+        return
+    if hasattr(config, "workerinput"):
+        if _WORKER is None:
+            _WORKER = _WorkerTimer()
+    elif _CONTROLLER is None:
+        _CONTROLLER = _Controller(seconds)
+        _CONTROLLER.start()
+
+
+def note_start(nodeid: str) -> None:
+    if _CONTROLLER is not None:
+        _CONTROLLER.started(nodeid)
+    elif _WORKER is not None:
+        _WORKER.arm(nodeid, enabled_seconds())  # type: ignore[arg-type]
+
+
+def note_report(report) -> None:
+    if _CONTROLLER is not None:
+        _CONTROLLER.note(report.nodeid, report.when)
+    elif _WORKER is not None and report.when == "teardown":
+        _WORKER.disarm()
+
+
+def shutdown() -> None:
+    if _CONTROLLER is not None:
+        _CONTROLLER.stop()
+        _CONTROLLER.cleanup()
+    if _WORKER is not None:
+        _WORKER.disarm()
+
+
+def _install_controller_for_test(seconds: float, sink) -> _Controller:
+    """Test seam: a controller wired to a capturing sink, no env var needed."""
+    global _CONTROLLER
+    _CONTROLLER = _Controller(seconds, sink=sink)
+    return _CONTROLLER

--- a/tests/shard_stall_watchdog.py
+++ b/tests/shard_stall_watchdog.py
@@ -51,12 +51,60 @@ thing that survives -- the same "the file's existence is the signal" discipline
 ``tests.e2e.watchdog`` uses, and for the same reason: a diagnostic that can turn
 a green run red gets disabled the first time it is wrong.
 
+"Never fails a run" has to include failing to do its own work, because these
+hooks run in every pytest process: no filesystem or timer operation here is
+allowed to raise either. An unusable dump directory, or a variable unset
+between install and the first test, disables the instrument and the run
+continues -- measured before that was true, an occupied ``TMPDIR`` was an
+``INTERNALERROR`` that failed a shard with ``no tests ran``. The reading is the
+same one :func:`enabled_seconds` takes of a malformed bound: disable, never fail.
+
 The workspace is deliberately NOT under ``tmp_path``: the master and its workers
 are separate processes and the controller has to be able to read what a wedged
 worker wrote, which means a path both can compute from the environment. It is
 also fixed rather than unique per session so that the workflow's ``always()``
 step can find the files after a job is cancelled, when no process is left to
 tell it where they are.
+
+WHAT A CANCELLED JOB LEAVES BEHIND
+----------------------------------
+The controller prints straight into the job log, but a job can also die with no
+report at all, so the workflow keeps an ``always()`` step that prints the dump
+directory. That step asks :func:`report_dumps` to do the printing rather than
+``cat``-ing the files itself, because a worker writes its header at ARM time,
+one per test, and the raw file is therefore mostly claims about tests that ran
+in milliseconds. The first real CI occurrence (job 103135419093, shard 2) is the
+measurement: the raw step printed 3088 ``exceeded 240s`` lines across four
+files, exactly four of them backed by a real :data:`FIRED_MARKER`, and the one
+genuine timeout was indistinguishable among the rest. :data:`FIRED_MARKER` is
+the single source of truth for "this is evidence", so it is applied in exactly
+one place and the step reuses it.
+
+WHAT IT DOES NOT INSTRUMENT, AND WHY THAT IS ACCEPTABLE
+-------------------------------------------------------
+Only a worker arms a C timer; the controller's sole witness is its Python poll
+thread. That is weaker than it sounds -- the poll thread does the printing too,
+so a worker wedged inside a syscall is fully covered without the controller's
+main thread making progress -- but it leaves the mirror case open: a park
+*inside the controller process*. It is left open deliberately, because the
+obvious repair does not close it. Arming a controller-side
+``dump_traceback_later`` "when a report fires" still needs a Python frame to arm
+it, and the only thread that could do so is the reporter thread itself --
+precisely the thread a kernel-level park of the controller would take out. A
+wall-clock controller timer armed at startup would instead fire on every healthy
+long run and keep a file, which breaks the rule that a file's existence means
+something fired. The shard job also runs no test body on the controller, so the
+uninstrumented surface is pytest/xdist orchestration, not the suite.
+
+THE OTHER C TIMER IN THIS REPO
+------------------------------
+``faulthandler``'s timer is process-global, so ``tests.e2e.watchdog.bounded``
+-- a second C timer, for tests whose failure mode is a hang -- displaces the
+worker timer for the rest of whichever test opens it, leaving that test with no
+stacks. Nothing interlocks them because nothing runs them together: the shard
+job sets :data:`ENV_SECONDS` and deselects ``e2e``, while the ``tui-e2e`` job
+runs ``-n0`` (one process, no worker branch) without the variable. Both halves
+of that invariant are pinned by the unit guards rather than left to prose.
 
 WHERE IT IS ENABLED
 -------------------
@@ -70,6 +118,7 @@ AGENTS.md allows to be calibrated from CI.
 
 from __future__ import annotations
 
+import contextlib
 import faulthandler
 import os
 import sys
@@ -89,6 +138,13 @@ DUMP_DIR = Path(os.environ.get("TMPDIR", "/tmp")) / "lo-shard-stall"
 #: (``Timeout (0:04:00)!``). Distinguishing a real dump from a header written at
 #: arm time is what lets cleanup delete the harmless ones and keep the evidence.
 FIRED_MARKER = "Timeout ("
+
+#: The header a worker writes when it ARMS the timer, i.e. when the test starts.
+#: It reads like a timeout claim but is not one; :func:`report_dumps` recognises
+#: it so a reader is never handed "<nodeid> exceeded 240s" for a test that ran in
+#: milliseconds. Kept here rather than spelled out at the write site and again in
+#: the report so the two cannot drift apart.
+ARM_MARKER = "[shard stall] "
 
 #: How often the controller repeats an ongoing report. A stall is reported more
 #: than once on purpose: the cap can arrive mid-stall, and the last report
@@ -145,7 +201,20 @@ def enabled_seconds() -> float | None:
 
 
 def _dump_path(tag: str) -> Path:
-    DUMP_DIR.mkdir(parents=True, exist_ok=True)
+    """The dump path for ``tag``; best-effort ensures the directory.
+
+    The ``mkdir`` is guarded even though its result is ignored, because this is
+    reached from ``pytest_configure`` (via :class:`_WorkerTimer`), where an
+    exception is an ``INTERNALERROR`` that fails the whole shard before a single
+    test runs. An unwritable ``TMPDIR``, or a file occupying the path, was
+    measured to do exactly that -- ``NotADirectoryError`` and ``FileExistsError``
+    respectively -- which is the one way a diagnostic could turn a green run red.
+    Failing to create it instead disables the writes that follow, which is the
+    same "disable, never fail" reading :func:`enabled_seconds` takes of a
+    malformed bound.
+    """
+    with contextlib.suppress(OSError):
+        DUMP_DIR.mkdir(parents=True, exist_ok=True)
     return DUMP_DIR / f"{tag}.log"
 
 
@@ -155,30 +224,56 @@ class _WorkerTimer:
     ``repeat=True`` because the bound is a floor, not a schedule: a test that
     runs for three times the bound should leave three snapshots, and the last
     one before the cap is the one with the most useful stacks.
+
+    The bound is captured once, here, rather than re-read from the environment
+    for every test: the value is known to be usable at install time, whereas
+    ``note_start`` runs inside ``pytest_runtest_logstart``, where an unset
+    variable reaching ``dump_traceback_later(None)`` raised ``TypeError`` and
+    became an ``INTERNALERROR``.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, seconds: float) -> None:
+        self.seconds = seconds
         self._handle = None
         self._path = _dump_path(f"worker-{os.getpid()}")
         self._armed = False
+        # Set when the dump target itself is unusable, so nothing retries a
+        # failed open once per test for the rest of the run.
+        self._disabled = False
 
-    def arm(self, nodeid: str, seconds: float) -> None:
-        if self._armed:
+    def arm(self, nodeid: str) -> None:
+        """Start the C timer for ``nodeid``; disable quietly if it cannot.
+
+        Every failure here is swallowed rather than raised. This runs inside a
+        pytest hook, so an exception is an ``INTERNALERROR`` that fails the
+        shard -- the diagnostic is not allowed to be the reason a run goes red,
+        and a run whose dump directory is unusable is still a run worth having.
+        """
+        if self._armed or self._disabled:
             return
-        # The handle must exist and stay open for the life of the process: the
-        # dump is written from a C thread with a raw descriptor, so the file
-        # cannot be opened at the moment it fires.
-        if self._handle is None or self._handle.closed:
-            self._handle = self._path.open("w", encoding="utf-8")
-        self._handle.write(f"[shard stall] {nodeid} exceeded {seconds:g}s; every thread follows.\n")
-        self._handle.flush()
-        faulthandler.dump_traceback_later(seconds, file=self._handle, repeat=True, exit=False)
+        try:
+            # The handle must exist and stay open for the life of the process:
+            # the dump is written from a C thread with a raw descriptor, so the
+            # file cannot be opened at the moment it fires.
+            if self._handle is None or self._handle.closed:
+                self._handle = self._path.open("w", encoding="utf-8")
+            self._handle.write(
+                f"{ARM_MARKER}{nodeid} exceeded {self.seconds:g}s; every thread follows.\n"
+            )
+            self._handle.flush()
+            faulthandler.dump_traceback_later(
+                self.seconds, file=self._handle, repeat=True, exit=False
+            )
+        except (OSError, ValueError, TypeError):
+            self._disabled = True
+            return
         self._armed = True
 
     def disarm(self) -> None:
         if not self._armed:
             return
-        faulthandler.cancel_dump_traceback_later()
+        with contextlib.suppress(OSError, RuntimeError, ValueError):
+            faulthandler.cancel_dump_traceback_later()
         self._armed = False
 
 
@@ -345,7 +440,7 @@ def install(config) -> None:
         return
     if hasattr(config, "workerinput"):
         if _WORKER is None:
-            _WORKER = _WorkerTimer()
+            _WORKER = _WorkerTimer(seconds)
     elif _CONTROLLER is None:
         _CONTROLLER = _Controller(seconds)
         _CONTROLLER.start()
@@ -355,7 +450,10 @@ def note_start(nodeid: str) -> None:
     if _CONTROLLER is not None:
         _CONTROLLER.started(nodeid)
     elif _WORKER is not None:
-        _WORKER.arm(nodeid, enabled_seconds())  # type: ignore[arg-type]
+        # Inertness is decided once, at install: re-reading the variable here
+        # and passing it on was how an unset value could reach
+        # ``dump_traceback_later(None)`` from inside a hook.
+        _WORKER.arm(nodeid)
 
 
 def note_report(report) -> None:
@@ -378,3 +476,81 @@ def _install_controller_for_test(seconds: float, sink) -> _Controller:
     global _CONTROLLER
     _CONTROLLER = _Controller(seconds, sink=sink)
     return _CONTROLLER
+
+
+def _armed_nodeids(text: str) -> list[str]:
+    """Node ids from arm-time headers, in the order the worker armed them.
+
+    The last entry is the test that worker had started most recently, which is
+    the most useful thing an unfired file can say once the job is gone.
+    """
+    out: list[str] = []
+    for line in text.splitlines():
+        if line.startswith(ARM_MARKER):
+            out.append(line[len(ARM_MARKER) :].split(" exceeded ", 1)[0].strip())
+    return out
+
+
+def _report_file(path: Path) -> list[str]:
+    """One dump file for :func:`report_dumps`, labelled for what it is."""
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return [f"===== {path} : unreadable ({exc.__class__.__name__}) ====="]
+    if FIRED_MARKER in text:
+        lines = _first_snapshot(text)
+        return [f"===== {path} (fired, first snapshot, {len(lines)} lines) =====", *lines]
+    armed = _armed_nodeids(text)
+    if not armed:
+        return [f"===== {path} : empty (armed, no test recorded) ====="]
+    return [
+        f"===== {path} : timer armed but never fired "
+        f"({len(armed)} tests started in this worker) =====",
+        f"in flight at cancel, not fired: {armed[-1]}",
+    ]
+
+
+def report_dumps(directory: Path | None = None) -> str:
+    """A filtered, human-readable report over the dump files in ``directory``.
+
+    This is what the workflow's ``always()`` step prints, and it lives here
+    rather than in the YAML on purpose. The step used to ``cat`` every ``*.log``,
+    which contradicted this module's own discipline: a worker writes its header
+    at ARM time, one per test, so a cancelled shard's files held thousands of
+    lines all reading "<nodeid> exceeded 240s" with the one real timeout
+    indistinguishable among them (measured: 3088 lines, 4 of them fired, on this
+    module's first real CI occurrence). :data:`FIRED_MARKER` is the single source
+    of truth for "this snapshot is evidence", so it is applied once -- in
+    :meth:`_Controller._stack_excerpts` for the live report, and in
+    :func:`_report_file` for this one.
+
+    An empty or missing directory is not an error: the step runs on every shard,
+    including the ones with nothing to report.
+    """
+    root = DUMP_DIR if directory is None else directory
+    try:
+        paths = sorted(root.glob("*.log"))
+    except OSError:
+        paths = []
+    if not paths:
+        return "no shard stall report: nothing stalled long enough to trip the watchdog\n"
+    blocks: list[str] = []
+    for path in paths:
+        blocks.extend(_report_file(path))
+    return "\n".join(blocks) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """``python -m tests.shard_stall_watchdog [dir]`` -- print the dumps.
+
+    The optional directory lets the workflow point at its own
+    ``${TMPDIR:-/tmp}/lo-shard-stall``; the default is :data:`DUMP_DIR`, computed
+    from the same variable, so the two agree without the caller knowing the name.
+    """
+    args = list(sys.argv[1:] if argv is None else argv)
+    sys.stdout.write(report_dumps(Path(args[0]) if args else None))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - operator/CI aid
+    raise SystemExit(main())

--- a/tests/shard_stall_watchdog.py
+++ b/tests/shard_stall_watchdog.py
@@ -77,24 +77,30 @@ in milliseconds. The first real CI occurrence (job 103135419093, shard 2) is the
 measurement: the raw step printed 3088 ``exceeded 240s`` lines across four
 files, exactly four of them backed by a real :data:`FIRED_MARKER`, and the one
 genuine timeout was indistinguishable among the rest. :data:`FIRED_MARKER` is
-the single source of truth for "this is evidence", so it is applied in exactly
-one place and the step reuses it.
+the single source of truth for "this is evidence", and it is read through one
+function (:func:`_fired_lines`) that the live controller report, the cleanup and
+this step's report all call -- so the rule cannot drift between them.
 
 WHAT IT DOES NOT INSTRUMENT, AND WHY THAT IS ACCEPTABLE
 -------------------------------------------------------
 Only a worker arms a C timer; the controller's sole witness is its Python poll
 thread. That is weaker than it sounds -- the poll thread does the printing too,
 so a worker wedged inside a syscall is fully covered without the controller's
-main thread making progress -- but it leaves the mirror case open: a park
-*inside the controller process*. It is left open deliberately, because the
-obvious repair does not close it. Arming a controller-side
-``dump_traceback_later`` "when a report fires" still needs a Python frame to arm
-it, and the only thread that could do so is the reporter thread itself --
-precisely the thread a kernel-level park of the controller would take out. A
-wall-clock controller timer armed at startup would instead fire on every healthy
-long run and keep a file, which breaks the rule that a file's existence means
-something fired. The shard job also runs no test body on the controller, so the
-uninstrumented surface is pytest/xdist orchestration, not the suite.
+main thread making progress. The mirror case, a park *inside the controller
+process*, is left unwired deliberately, but for a narrower reason than
+"impossible". A report-time arm WOULD cover a park that releases the GIL: the
+report is emitted by the reporter thread, which therefore has a live frame at
+that moment, and the dump would add the parked main thread's stacks. What it
+cannot cover is a park that holds the GIL -- but then no report is emitted
+either, which is the separately acknowledged "no report at all" path. So the
+report-time arm buys the GIL-releasing half of a case the shard job does not
+reach (the controller runs no test body; its only Python is pytest/xdist
+orchestration), at the cost of a second timer and a new file class in the
+report. That trade is not obviously worth taking, but it is a judgement, not an
+impossibility -- if a controller-side park is ever seen in CI, a report-time arm
+is the repair. A wall-clock controller timer armed at startup is NOT an
+alternative: it would fire on every healthy long run and keep a file, breaking
+the rule that a file's existence means something fired.
 
 THE OTHER C TIMER IN THIS REPO
 ------------------------------
@@ -120,6 +126,7 @@ from __future__ import annotations
 
 import contextlib
 import faulthandler
+import math
 import os
 import sys
 import threading
@@ -151,6 +158,15 @@ ARM_MARKER = "[shard stall] "
 #: before it is the one a reader will see.
 REPORT_INTERVAL_S = 30.0
 
+#: The largest bound the C timer can hold. ``faulthandler``'s timeout becomes a
+#: signed 64-bit count of nanoseconds, so 2**63 ns is the ceiling: a larger (or
+#: infinite) value raises ``OverflowError: timestamp out of range for platform
+#: time_t`` the first time a test starts, i.e. inside a pytest hook, where it is
+#: an ``INTERNALERROR`` that fails the shard with ``no tests ran``. Any bound CI
+#: could mean is minutes, so a value at or above this is a typo and is treated
+#: as one -- see :func:`enabled_seconds`.
+MAX_BOUND_S = 2**63 / 1e9
+
 #: Poll granularity. Small enough that the first report lands promptly, large
 #: enough that the thread is invisible next to a 4-worker test run.
 POLL_INTERVAL_S = 2.0
@@ -162,24 +178,36 @@ POLL_INTERVAL_S = 2.0
 STACK_EXCERPT_LINES = 400
 
 
-def _first_snapshot(text: str) -> list[str]:
-    """The first complete stack dump in ``text``, as lines.
+def _fired_lines(text: str) -> list[str] | None:
+    """The first complete stack dump in ``text``, or ``None`` if none fired.
+
+    This is the single definition of "this file is evidence", so the live
+    controller report, the cleanup and the workflow's report all agree by
+    construction.
+
+    The marker is matched at the START OF A LINE, not anywhere in the text.
+    ``faulthandler`` always writes it as its own line, while a worker's header
+    embeds a node id -- a path plus a test name -- which in principle could
+    contain the literal marker text; anchoring the match is what makes it
+    impossible for a header-only file to be classified as fired.
 
     ``repeat=True`` appends another full dump every interval, so a file that
-    tripped early holds several near-identical snapshots. Taking everything
-    would repeat the same stacks until the cap, and taking a fixed number of
-    lines from one end is not enough either: the thread that matters is not at
-    a predictable end -- faulthandler groups threads its own way, and the
-    worker under test is usually NOT the first block, because the session
-    runtime and the viewer endpoint have threads of their own. Splitting on the
-    marker keeps ONE snapshot whole, so every thread is present.
+    tripped early holds several near-identical snapshots. One snapshot is the run
+    of lines from its marker up to the next marker (or the end), and taking
+    exactly that keeps it whole: the thread that matters is not at a predictable
+    end, because the session runtime and the viewer endpoint have threads of
+    their own and faulthandler groups them its own way. The result is capped at
+    :data:`STACK_EXCERPT_LINES` so a file full of repeated dumps cannot push the
+    live report past the log's tail.
     """
-    parts = text.split(FIRED_MARKER)
-    if len(parts) < 2:
-        return text.splitlines()
-    body = FIRED_MARKER + parts[1]
-    lines = body.splitlines()
-    return lines[:STACK_EXCERPT_LINES]
+    lines = text.splitlines()
+    start = next((i for i, line in enumerate(lines) if line.startswith(FIRED_MARKER)), None)
+    if start is None:
+        return None
+    end = start + 1
+    while end < len(lines) and not lines[end].startswith(FIRED_MARKER):
+        end += 1
+    return lines[start:end][:STACK_EXCERPT_LINES]
 
 
 def enabled_seconds() -> float | None:
@@ -189,6 +217,12 @@ def enabled_seconds() -> float | None:
     ``pytest_configure``, so a typo in a workflow env var must not be able to
     take out the whole suite. It also cannot silently become a *shorter* bound
     than intended, because a value that does not parse is not used at all.
+
+    "Malformed" includes a value that parses but no timer can hold. ``inf`` and
+    ``nan`` parse as floats, and any finite value at or above :data:`MAX_BOUND_S`
+    overflows the ``time_t`` the C timer converts to -- an ``INTERNALERROR`` from
+    inside the first test's hook, which is the same failure this function exists
+    to prevent, arriving through the one door a parse-only check leaves open.
     """
     raw = os.environ.get(ENV_SECONDS, "").strip()
     if not raw:
@@ -197,7 +231,9 @@ def enabled_seconds() -> float | None:
         seconds = float(raw)
     except ValueError:
         return None
-    return seconds if seconds > 0 else None
+    if not math.isfinite(seconds) or seconds <= 0 or seconds >= MAX_BOUND_S:
+        return None
+    return seconds
 
 
 def _dump_path(tag: str) -> Path:
@@ -248,6 +284,12 @@ class _WorkerTimer:
         pytest hook, so an exception is an ``INTERNALERROR`` that fails the
         shard -- the diagnostic is not allowed to be the reason a run goes red,
         and a run whose dump directory is unusable is still a run worth having.
+
+        ``OverflowError`` is in the tuple even though :func:`enabled_seconds`
+        already refuses a bound no timer can hold: the value can also arrive
+        here from a direct construction, and this is the one call whose failure
+        mode is the whole shard. Belt and braces, because the cost of the extra
+        name is zero and the cost of missing it is a red run.
         """
         if self._armed or self._disabled:
             return
@@ -264,7 +306,7 @@ class _WorkerTimer:
             faulthandler.dump_traceback_later(
                 self.seconds, file=self._handle, repeat=True, exit=False
             )
-        except (OSError, ValueError, TypeError):
+        except (OSError, ValueError, TypeError, OverflowError):
             self._disabled = True
             return
         self._armed = True
@@ -389,9 +431,9 @@ class _Controller:
                 text = path.read_text(encoding="utf-8", errors="replace")
             except OSError:
                 continue
-            if FIRED_MARKER not in text:
+            lines = _fired_lines(text)
+            if lines is None:
                 continue
-            lines = _first_snapshot(text)
             out.append(f"--- {path} (first snapshot, {len(lines)} lines) ---")
             out.extend(lines)
         return out
@@ -409,7 +451,7 @@ class _Controller:
             return
         for path in paths:
             try:
-                if FIRED_MARKER in path.read_text(encoding="utf-8", errors="replace"):
+                if _fired_lines(path.read_text(encoding="utf-8", errors="replace")) is not None:
                     continue
             except OSError:
                 pass
@@ -482,25 +524,44 @@ def _armed_nodeids(text: str) -> list[str]:
     """Node ids from arm-time headers, in the order the worker armed them.
 
     The last entry is the test that worker had started most recently, which is
-    the most useful thing an unfired file can say once the job is gone.
+    the most useful thing an unfired file can say once the job is gone. Reading
+    stops at the first fired marker, because a worker keeps arming timers after
+    a dump: on a fired file the last id before the marker is the test the timer
+    fired on, while ids after it belong to later tests and would misattribute
+    the snapshot.
     """
     out: list[str] = []
     for line in text.splitlines():
+        if line.startswith(FIRED_MARKER):
+            break
         if line.startswith(ARM_MARKER):
             out.append(line[len(ARM_MARKER) :].split(" exceeded ", 1)[0].strip())
     return out
 
 
 def _report_file(path: Path) -> list[str]:
-    """One dump file for :func:`report_dumps`, labelled for what it is."""
+    """One dump file for :func:`report_dumps`, labelled for what it is.
+
+    Every block names the test it is about, because that is the whole point of
+    the instrument: the stacks say what was parked, but a reader coming to a
+    cancelled run needs the node id first. The arm headers are the only record
+    of it, and the file already has them -- in the fired case the header above
+    the marker is the test that was running when the timer fired, in the unfired
+    case the last one is the test in flight at the cancel.
+    """
     try:
         text = path.read_text(encoding="utf-8", errors="replace")
     except OSError as exc:
         return [f"===== {path} : unreadable ({exc.__class__.__name__}) ====="]
-    if FIRED_MARKER in text:
-        lines = _first_snapshot(text)
-        return [f"===== {path} (fired, first snapshot, {len(lines)} lines) =====", *lines]
     armed = _armed_nodeids(text)
+    snapshot = _fired_lines(text)
+    if snapshot is not None:
+        who = armed[-1] if armed else "(unrecorded)"
+        return [
+            f"===== {path} (fired, first snapshot, {len(snapshot)} lines) =====",
+            f"in flight when the timer fired: {who}",
+            *snapshot,
+        ]
     if not armed:
         return [f"===== {path} : empty (armed, no test recorded) ====="]
     return [
@@ -520,9 +581,9 @@ def report_dumps(directory: Path | None = None) -> str:
     lines all reading "<nodeid> exceeded 240s" with the one real timeout
     indistinguishable among them (measured: 3088 lines, 4 of them fired, on this
     module's first real CI occurrence). :data:`FIRED_MARKER` is the single source
-    of truth for "this snapshot is evidence", so it is applied once -- in
-    :meth:`_Controller._stack_excerpts` for the live report, and in
-    :func:`_report_file` for this one.
+    of truth for "this snapshot is evidence", read through one function
+    (:func:`_fired_lines`) that the live report, the cleanup and this report all
+    call.
 
     An empty or missing directory is not an error: the step runs on every shard,
     including the ones with nothing to report.

--- a/tests/unit/test_shard_stall_watchdog.py
+++ b/tests/unit/test_shard_stall_watchdog.py
@@ -384,12 +384,78 @@ def test_the_report_mode_prints_fired_stacks_and_labels_unfired_headers(tmp_path
 
     assert "fired" in report
     assert "line 12 in test_fast" in report
+    # A fired file names its test too: the stacks say what was parked, but the
+    # node id is what a reader of a cancelled run needs first.
+    assert "in flight when the timer fired: tests/unit/a.py::test_fast" in report
     assert "never fired" in report
     assert "3000 tests started" in report
     assert "in flight at cancel, not fired: tests/unit/a.py::test_2999" in report
     # The defect: no arm-time header may be presented as a fired timeout.
     assert "exceeded 240s" not in report
     assert report.count(watchdog.FIRED_MARKER) == 1
+
+
+def test_the_report_mode_does_not_read_a_marker_out_of_a_node_id(tmp_path) -> None:
+    """A header containing the literal marker must not read as a fired dump.
+
+    The filter matches the marker at the start of a line. Matching it anywhere
+    would classify an arm-time header as a snapshot whenever a node id contained
+    that text -- the one direction in which this filter can lie, and the report
+    is the surface a cancelled job is judged by.
+    """
+    dumps = tmp_path / "dumps"
+    dumps.mkdir()
+    nodeid = f"tests/unit/a.py::test_weird[{watchdog.FIRED_MARKER}0:04:00)]"
+    (dumps / "worker-7.log").write_text(
+        f"{watchdog.ARM_MARKER}{nodeid} exceeded 240s; every thread follows.\n",
+        encoding="utf-8",
+    )
+
+    report = watchdog.report_dumps(dumps)
+
+    assert "(fired," not in report, "an arm-time header was read as a snapshot"
+    assert "never fired" in report
+    assert f"in flight at cancel, not fired: {nodeid}" in report
+
+
+def test_a_bound_no_timer_can_hold_disables_the_instrument(monkeypatch) -> None:
+    """A parseable-but-oversized bound must disable, not kill the shard.
+
+    ``float()`` accepts ``inf`` and ``nan``, and every finite value at or above
+    ``2**63`` nanoseconds is beyond the ``time_t`` ``faulthandler`` converts to,
+    where the C timer raises ``OverflowError`` from inside the first test's hook
+    -- an ``INTERNALERROR`` that fails the shard with ``no tests ran``. That is
+    the failure class this module's safety argument is written about, so the
+    value has to be refused before it reaches the timer.
+    """
+    for raw in ("1e18", "1e10", "2e10", "inf", "1e400", "nan", "9223372036.854776"):
+        monkeypatch.setenv(watchdog.ENV_SECONDS, raw)
+        assert watchdog.enabled_seconds() is None, raw
+    # The largest value the timer actually accepts is still honoured.
+    monkeypatch.setenv(watchdog.ENV_SECONDS, "9223372035.854776")
+    assert watchdog.enabled_seconds() == 9223372035.854776
+
+
+def test_the_worker_survives_a_bound_the_timer_rejects(monkeypatch) -> None:
+    """``arm`` swallows ``OverflowError`` too, belt and braces.
+
+    ``enabled_seconds`` refuses the value at parse time, but a bound can reach
+    the timer from a direct construction -- and this is the one call whose
+    failure mode is the whole shard, so the guard names every exception the C
+    timer is known to raise rather than trusting the caller.
+    """
+
+    class _OverflowingFaulthandler(_FakeFaulthandler):
+        def dump_traceback_later(self, seconds, **kwargs):
+            raise OverflowError("timestamp out of range for platform time_t")
+
+    _install_worker(monkeypatch)
+    monkeypatch.setattr(watchdog, "faulthandler", _OverflowingFaulthandler())
+
+    watchdog.note_start("tests/unit/a.py::test_one")  # must not raise
+
+    worker = watchdog._WORKER
+    assert worker is not None and worker._disabled and not worker._armed
 
 
 def test_the_report_mode_is_quiet_on_a_missing_directory(tmp_path, capsys) -> None:
@@ -431,10 +497,23 @@ def test_no_ci_job_runs_both_watchdogs_in_one_process() -> None:
     worker, while the e2e stage runs ``-n0`` with no variable. Pin the invariant
     rather than leaving it to prose.
     """
+    import tomllib
+
     import yaml
 
     repo = Path(__file__).resolve().parents[2]
     jobs = yaml.safe_load((repo / ".github" / "workflows" / "ci.yml").read_text())["jobs"]
+    config = tomllib.loads((repo / "pyproject.toml").read_text())
+    addopts = config["tool"]["pytest"]["ini_options"]["addopts"]
+
+    # Both halves of the invariant: the shard job is the one that arms a worker
+    # timer, and it must keep deselecting the e2e stage whose own C timer would
+    # displace ours. Without the second assertion, dropping `-m "not e2e"` from
+    # addopts would falsify the documented claim while this pin stayed green.
+    assert (jobs["test"].get("env") or {}).get(
+        watchdog.ENV_SECONDS
+    ), "the test job must arm the watchdog"
+    assert "not e2e" in addopts, "the shard job must keep deselecting the e2e stage"
     for name, job in jobs.items():
         if name == "test":
             continue

--- a/tests/unit/test_shard_stall_watchdog.py
+++ b/tests/unit/test_shard_stall_watchdog.py
@@ -1,0 +1,241 @@
+"""Guards for :mod:`tests.shard_stall_watchdog`, the shard-stall reporter.
+
+These exist because the reporter has exactly one job -- name the test a CI shard
+is stuck on -- and every way of failing at that job is silent. A watchdog that
+reports "0 still in flight" during a real stall, or stays inert because a
+workflow env var was renamed, or floods the log with stale stacks, all look like
+a healthy run. Each assertion below is written against one of those, and the
+xdist report-phase rule is mutation-tested: flipping ``when == "teardown"`` to
+"any report completes" makes
+``test_a_setup_report_does_not_count_as_completion`` fail.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from tests import shard_stall_watchdog as watchdog
+
+
+@pytest.fixture(autouse=True)
+def _isolate_module_state(monkeypatch, tmp_path: Path):
+    """Every test owns the module's process-wide state and its dump directory.
+
+    The dump path is a module-level constant computed from ``TMPDIR`` at import,
+    so a test that let the real one through would write into the shared temp dir
+    that a concurrent suite is also using -- and the CI workflow's own reporting
+    step reads that same directory.
+    """
+    monkeypatch.setattr(watchdog, "DUMP_DIR", tmp_path / "lo-shard-stall")
+    monkeypatch.setattr(watchdog, "_CONTROLLER", None)
+    monkeypatch.setattr(watchdog, "_WORKER", None)
+    yield
+
+
+class _Sink:
+    """Captures reports instead of racing the terminal."""
+
+    def __init__(self) -> None:
+        self.texts: list[str] = []
+
+    def __call__(self, text: str) -> None:
+        self.texts.append(text)
+
+
+class _Report:
+    """The two attributes ``note_report`` reads off a pytest TestReport."""
+
+    def __init__(self, nodeid: str, when: str) -> None:
+        self.nodeid = nodeid
+        self.when = when
+
+
+class _FakeConfig:
+    def __init__(self, worker: bool) -> None:
+        if worker:
+            self.workerinput = {"workerid": "gw0"}
+
+
+def test_inert_without_the_env_var(monkeypatch) -> None:
+    """Unset means inert, so a developer run and the ``-n0`` e2e stage are untouched.
+
+    Inert has to mean *no thread and no directory*, not merely a disabled
+    report: this hook runs in every pytest process in the repo, including the
+    e2e stage that carries its own tighter bound.
+    """
+    monkeypatch.delenv(watchdog.ENV_SECONDS, raising=False)
+    assert watchdog.enabled_seconds() is None
+    watchdog.install(_FakeConfig(worker=False))
+    assert watchdog._CONTROLLER is None
+
+
+def test_a_malformed_bound_disables_rather_than_shrinks(monkeypatch) -> None:
+    """A typo in the workflow must not become a shorter bound.
+
+    ``float("4m")`` raising would take out ``pytest_configure`` and fail the
+    whole suite; silently treating it as 0 would make every run report a stall.
+    Neither is acceptable, so the only safe reading of an unparseable value is
+    "not configured".
+    """
+    monkeypatch.setenv(watchdog.ENV_SECONDS, "4m")
+    assert watchdog.enabled_seconds() is None
+    monkeypatch.setenv(watchdog.ENV_SECONDS, "-5")
+    assert watchdog.enabled_seconds() is None
+    monkeypatch.setenv(watchdog.ENV_SECONDS, "240")
+    assert watchdog.enabled_seconds() == 240.0
+
+
+def test_a_setup_report_does_not_count_as_completion(monkeypatch) -> None:
+    """The bug this test pins: xdist reports ``setup`` BEFORE the call phase.
+
+    Counting any report as completion empties the in-flight set for the whole
+    duration of the test body, so a real stall reports "0 still in flight" --
+    measured while building this module, and it read as a healthy quiet run
+    rather than as a broken instrument.
+    """
+    sink = _Sink()
+    controller = watchdog._install_controller_for_test(0.01, sink)
+    nodeid = "tests/unit/tui/test_x.py::test_a_long_one"
+
+    watchdog.note_start(nodeid)
+    watchdog.note_report(_Report(nodeid, "setup"))
+    controller._last_progress = time.monotonic() - 5.0
+
+    assert controller.report_if_stalled() is True
+    assert nodeid in sink.texts[0], "the in-flight test must be named by node id"
+
+
+def test_the_report_names_the_test_and_its_elapsed_time(monkeypatch) -> None:
+    """The deliverable: a node id and how long it has been stuck."""
+    sink = _Sink()
+    controller = watchdog._install_controller_for_test(0.01, sink)
+    under_test = "tests/unit/providers/test_oauth_flows.py::test_something"
+    watchdog.note_start(under_test)
+    watchdog.note_report(_Report("tests/unit/other.py::test_fast", "teardown"))
+    controller._in_flight[under_test] = time.monotonic() - 42.0
+    controller._last_progress = time.monotonic() - 60.0
+
+    assert controller.report_if_stalled() is True
+    report = sink.texts[0]
+    assert "SHARD STALL" in report
+    assert under_test in report
+    assert "42s" in report or "4" in report
+
+
+def test_teardown_completes_a_test_and_resets_the_clock() -> None:
+    """A finished test is progress: it leaves the in-flight set and the clock."""
+    sink = _Sink()
+    controller = watchdog._install_controller_for_test(0.01, sink)
+    watchdog.note_start("tests/unit/a.py::test_one")
+    # Rewound BEFORE the teardown report, which is the only way to show that the
+    # report itself is what resets it -- rewinding afterwards would make the
+    # assertion below true no matter what note() did.
+    controller._last_progress = time.monotonic() - 5.0
+    watchdog.note_report(_Report("tests/unit/a.py::test_one", "teardown"))
+
+    assert controller.report_if_stalled() is False
+    assert controller._in_flight == {}
+
+
+def test_a_stall_with_nothing_in_flight_is_still_reported() -> None:
+    """The one case where the controller is the last process alive.
+
+    Silence from a worker it believes is running something is a *different*
+    diagnosis from a named stuck test, and suppressing it would hide the only
+    case that has no other witness.
+    """
+    sink = _Sink()
+    controller = watchdog._install_controller_for_test(0.01, sink)
+    controller._last_progress = time.monotonic() - 5.0
+
+    assert controller.report_if_stalled() is True
+    assert "0 still in flight" in sink.texts[0]
+
+
+def test_reports_are_rate_limited() -> None:
+    """A stalled shard must not bury its own log.
+
+    The cap can arrive mid-stall, so the reporter repeats -- but every repeat
+    costs a stack excerpt, and an unthrottled one would push the first (and
+    most useful) report out of a cancelled job's retained output.
+    """
+    sink = _Sink()
+    controller = watchdog._install_controller_for_test(0.01, sink)
+    watchdog.note_start("tests/unit/a.py::test_one")
+    controller._last_progress = time.monotonic() - 5.0
+
+    assert controller.report_if_stalled() is True
+    assert controller.report_if_stalled() is False
+
+
+def test_only_one_snapshot_is_printed_and_unfired_dumps_are_skipped(tmp_path) -> None:
+    """Stack excerpts come from a real dump, and only from one that fired.
+
+    ``repeat=True`` appends a whole new dump every interval, so a naive reader
+    would print the same stacks until the log cap; and a file whose timer was
+    armed but never fired is a header only, which must not be reported as a
+    timeout. The excerpt must also carry the INNERMOST frames, which is where
+    the stuck call is, so a test frame has to be asserted rather than assumed.
+    """
+    fired = watchdog._dump_path("worker-1")
+    fired.write_text(
+        f"[shard stall] test_x exceeded 4s\n{watchdog.FIRED_MARKER}0:04)!\n"
+        "Thread 0x1 (most recent call first):\n"
+        '  File "/repo/tests/unit/tui/test_x.py", line 12 in test_x\n'
+        "\n"
+        f"{watchdog.FIRED_MARKER}0:04)!\n"
+        "Thread 0x1 (most recent call first):\n"
+        '  File "/repo/tests/unit/tui/test_x.py", line 12 in test_x\n'
+    )
+    unfired = watchdog._dump_path("worker-2")
+    unfired.write_text("[shard stall] test_y exceeded 4s\n")
+
+    sink = _Sink()
+    controller = watchdog._install_controller_for_test(0.01, sink)
+    controller._last_progress = time.monotonic() - 10.0
+    watchdog.note_start("tests/unit/tui/test_x.py::test_x")
+    controller.report_if_stalled()
+    report = sink.texts[0]
+
+    assert report.count("most recent call first") == 1, "printed more than one snapshot"
+    assert "test_x.py" in report, "the innermost frames are the point of the dump"
+    assert "worker-2" not in report, "a dump that never fired was reported as a timeout"
+
+
+def test_cleanup_keeps_fired_dumps_and_removes_armed_ones() -> None:
+    """A fired dump is evidence; a header from an armed timer is noise.
+
+    Keeping the noise would leave every healthy run's temp dir looking like a
+    hang report, which is precisely how a diagnostic stops being read -- the
+    same discipline ``tests.e2e.watchdog`` applies to its own dump files.
+    """
+    fired = watchdog._dump_path("worker-fired")
+    fired.write_text(f"header\n{watchdog.FIRED_MARKER}0:04)!\nstacks\n")
+    armed = watchdog._dump_path("worker-armed")
+    armed.write_text("header only\n")
+
+    controller = watchdog._install_controller_for_test(60.0, _Sink())
+    controller.cleanup()
+
+    assert fired.exists()
+    assert not armed.exists()
+
+
+def test_the_workflow_enables_the_watchdog() -> None:
+    """The instrument is useless if its env var is renamed or dropped.
+
+    Asserted against ``ci.yml`` rather than against this module, because the
+    failure mode is a workflow edit -- the module cannot notice that nothing
+    sets the variable, and an inert watchdog is indistinguishable from a suite
+    that never stalls.
+    """
+    import yaml
+
+    repo = Path(__file__).resolve().parents[2]
+    jobs = yaml.safe_load((repo / ".github" / "workflows" / "ci.yml").read_text())["jobs"]
+    env = jobs["test"].get("env") or {}
+    assert env.get(watchdog.ENV_SECONDS), f"the test job does not set {watchdog.ENV_SECONDS}"
+    assert float(env[watchdog.ENV_SECONDS]) > 0

--- a/tests/unit/test_shard_stall_watchdog.py
+++ b/tests/unit/test_shard_stall_watchdog.py
@@ -122,7 +122,10 @@ def test_the_report_names_the_test_and_its_elapsed_time(monkeypatch) -> None:
     report = sink.texts[0]
     assert "SHARD STALL" in report
     assert under_test in report
-    assert "42s" in report or "4" in report
+    # Deterministic: the in-flight entry was rewound 42.0s at :118, so the
+    # elapsed column reads exactly "42s". The earlier `or "4" in report`
+    # passed on any digit 4 anywhere in the text and asserted nothing.
+    assert "42s" in report
 
 
 def test_teardown_completes_a_test_and_resets_the_clock() -> None:
@@ -239,3 +242,202 @@ def test_the_workflow_enables_the_watchdog() -> None:
     env = jobs["test"].get("env") or {}
     assert env.get(watchdog.ENV_SECONDS), f"the test job does not set {watchdog.ENV_SECONDS}"
     assert float(env[watchdog.ENV_SECONDS]) > 0
+
+
+class _FakeFaulthandler:
+    """Stands in for :mod:`faulthandler` without touching the real module.
+
+    The C timer is the whole point of the worker half, and no unit test can make
+    a real one fire, so it is spied on instead: the assertions are that the timer
+    was armed for the running test, at the bound captured at install, and
+    cancelled only by that test's teardown.
+    """
+
+    def __init__(self) -> None:
+        self.armed: list[tuple[float, dict[str, object]]] = []
+        self.cancels = 0
+
+    def dump_traceback_later(self, seconds: float, **kwargs) -> None:
+        self.armed.append((seconds, kwargs))
+
+    def cancel_dump_traceback_later(self) -> None:
+        self.cancels += 1
+
+
+def _install_worker(monkeypatch, bound: str = "4") -> _FakeFaulthandler:
+    """Install the worker branch and return the C-timer spy it will call."""
+    monkeypatch.setenv(watchdog.ENV_SECONDS, bound)
+    fake = _FakeFaulthandler()
+    monkeypatch.setattr(watchdog, "faulthandler", fake)
+    watchdog.install(_FakeConfig(worker=True))
+    return fake
+
+
+def test_the_worker_arms_the_c_timer_and_writes_the_header(monkeypatch) -> None:
+    """The worker half produces the stacks; a no-op ``arm`` must fail a test.
+
+    ``arm`` is the only thing that starts the C timer, and the round-1 review
+    measured that turning it into an early ``return`` left all ten guards green
+    while no dump could ever be produced -- the reporter would name the test and
+    hand the reader no stacks at all.
+    """
+    fake = _install_worker(monkeypatch)
+    nodeid = "tests/unit/tui/test_x.py::test_a_long_one"
+
+    watchdog.note_start(nodeid)
+
+    worker = watchdog._WORKER
+    assert worker is not None and worker._armed
+    assert fake.armed == [(4.0, {"file": worker._handle, "repeat": True, "exit": False})]
+    assert f"{watchdog.ARM_MARKER}{nodeid} exceeded 4s" in worker._path.read_text(encoding="utf-8")
+
+
+def test_the_worker_timer_is_cancelled_only_by_teardown(monkeypatch) -> None:
+    """A call-phase report must not cancel the worker's timer.
+
+    This is the worker-side twin of the setup-phase defect the controller guard
+    already pins: cancelling on any report kills the timer for the rest of the
+    test body, so a stall there produces no dump. Two round-1 mutants survived
+    without it -- worker ``note_report`` disarming on any ``when``, and
+    ``disarm`` becoming a no-op -- and the assertions below kill both.
+    """
+    fake = _install_worker(monkeypatch)
+    nodeid = "tests/unit/tui/test_x.py::test_a_long_one"
+    watchdog.note_start(nodeid)
+    worker = watchdog._WORKER
+    assert worker is not None and worker._armed
+
+    for when in ("setup", "call"):
+        watchdog.note_report(_Report(nodeid, when))
+        assert worker._armed, f"a {when!r} report must not cancel the worker timer"
+        assert fake.cancels == 0
+
+    watchdog.note_report(_Report(nodeid, "teardown"))
+    assert worker._armed is False
+    assert fake.cancels == 1
+
+
+def test_the_worker_keeps_the_bound_it_was_installed_with(monkeypatch) -> None:
+    """Unsetting the variable after install must not raise inside the hook.
+
+    ``note_start`` used to re-read the bound and pass it on unguarded, so an
+    unset value reached ``dump_traceback_later(None)`` -> ``TypeError`` inside
+    ``pytest_runtest_logstart`` -> ``INTERNALERROR``. The bound is captured once,
+    at install, where it is known to be usable.
+    """
+    fake = _install_worker(monkeypatch)
+    monkeypatch.delenv(watchdog.ENV_SECONDS, raising=False)
+
+    watchdog.note_start("tests/unit/a.py::test_one")
+
+    assert fake.armed and fake.armed[0][0] == 4.0
+
+
+def test_an_unusable_dump_directory_disables_the_worker(monkeypatch, tmp_path) -> None:
+    """An unusable ``TMPDIR`` must disable the instrument, not fail the shard.
+
+    ``install`` runs from ``pytest_configure``, where an unguarded ``mkdir`` was
+    measured to raise ``NotADirectoryError`` (``TMPDIR=/dev/null/x``) and
+    ``FileExistsError`` (a file occupying the path) -- each an ``INTERNALERROR``
+    that failed the whole shard with ``no tests ran``. That is the one way this
+    diagnostic could turn a green run red, which its safety argument forbids.
+    """
+    occupied = tmp_path / "occupied"
+    occupied.write_text("not a directory\n", encoding="utf-8")
+    monkeypatch.setattr(watchdog, "DUMP_DIR", occupied / "lo-shard-stall")
+    fake = _install_worker(monkeypatch)
+
+    worker = watchdog._WORKER
+    assert worker is not None
+    watchdog.note_start("tests/unit/a.py::test_one")  # must not raise either
+    assert worker._armed is False
+    assert worker._disabled
+    assert fake.armed == []
+
+
+def test_the_report_mode_prints_fired_stacks_and_labels_unfired_headers(tmp_path) -> None:
+    """The workflow step's output: evidence, plus honestly labelled noise.
+
+    This is the surface a cancelled job leaves behind, so it carries the module's
+    own FIRED_MARKER discipline rather than a raw ``cat``. An arm-time header is
+    a claim about a test that STARTED; a cancelled shard's files held thousands
+    of them (3088 measured), burying the one real timeout.
+    """
+    dumps = tmp_path / "dumps"
+    dumps.mkdir()
+    (dumps / "worker-1.log").write_text(
+        f"{watchdog.ARM_MARKER}tests/unit/a.py::test_fast exceeded 240s; every thread follows.\n"
+        f"{watchdog.FIRED_MARKER}0:04:00)!\n"
+        "Thread 0x1 (most recent call first):\n"
+        '  File "/repo/tests/unit/a.py", line 12 in test_fast\n',
+        encoding="utf-8",
+    )
+    (dumps / "worker-2.log").write_text(
+        "".join(
+            f"{watchdog.ARM_MARKER}tests/unit/a.py::test_{i} exceeded 240s; every thread follows.\n"
+            for i in range(3000)
+        ),
+        encoding="utf-8",
+    )
+
+    report = watchdog.report_dumps(dumps)
+
+    assert "fired" in report
+    assert "line 12 in test_fast" in report
+    assert "never fired" in report
+    assert "3000 tests started" in report
+    assert "in flight at cancel, not fired: tests/unit/a.py::test_2999" in report
+    # The defect: no arm-time header may be presented as a fired timeout.
+    assert "exceeded 240s" not in report
+    assert report.count(watchdog.FIRED_MARKER) == 1
+
+
+def test_the_report_mode_is_quiet_on_a_missing_directory(tmp_path, capsys) -> None:
+    """The step runs on every shard, including the ones with nothing to say.
+
+    The old step's ``for f in "$dir"/*.log`` ran once on the literal pattern when
+    no file matched and ``bash -e`` exited 1, and the directory does not exist at
+    all on a shard that never armed a timer. Neither may fail the step.
+    """
+    assert watchdog.main([str(tmp_path / "does-not-exist")]) == 0
+    assert "no shard stall report" in capsys.readouterr().out
+
+
+def test_the_workflow_reports_through_the_module_not_a_raw_cat() -> None:
+    """The step must not re-implement the fired/unfired rule in YAML.
+
+    Pinned against ``ci.yml`` because the failure mode is a workflow edit: a
+    ``cat`` of ``*.log`` is exactly what printed 3088 false "exceeded 240s"
+    claims on this PR's own cancelled shard while the one real timeout was lost
+    among them.
+    """
+    import yaml
+
+    repo = Path(__file__).resolve().parents[2]
+    jobs = yaml.safe_load((repo / ".github" / "workflows" / "ci.yml").read_text())["jobs"]
+    step = next(s for s in jobs["test"]["steps"] if s.get("name") == "Print the shard stall report")
+    assert "tests.shard_stall_watchdog" in step["run"]
+    assert "cat " not in step["run"]
+    assert "*.log" not in step["run"]
+
+
+def test_no_ci_job_runs_both_watchdogs_in_one_process() -> None:
+    """The two C-timer instruments never share a process in CI.
+
+    ``faulthandler``'s timer is process-global, so a ``tests.e2e.watchdog.bounded``
+    block inside a test body displaces an armed worker timer and leaves that test
+    with no stacks. That is latent only because the shard job (which sets
+    ENV_SECONDS, and deselects ``e2e`` via addopts) is the only job that arms a
+    worker, while the e2e stage runs ``-n0`` with no variable. Pin the invariant
+    rather than leaving it to prose.
+    """
+    import yaml
+
+    repo = Path(__file__).resolve().parents[2]
+    jobs = yaml.safe_load((repo / ".github" / "workflows" / "ci.yml").read_text())["jobs"]
+    for name, job in jobs.items():
+        if name == "test":
+            continue
+        assert not (job.get("env") or {}).get(
+            watchdog.ENV_SECONDS
+        ), f"{name} arms the shard watchdog; it must not also run the e2e C timer"


### PR DESCRIPTION
# PR Description

## Summary of Changes

Adds an instrument that **names the test a `test (3.12, N)` shard is stuck on**,
instead of losing the run to the workflow's 20-minute cap with no attribution.
No product behaviour changes; the diff is a new diagnostic module, its unit
tests, three hooks in the root `conftest.py`, and two additions to the shard job.

- `tests/shard_stall_watchdog.py` — controller-side in-flight tracker plus a
  worker-side C-level stack dump.
- `tests/unit/test_shard_stall_watchdog.py` — 18 guards, mutation-tested (the
  controller report-phase rule, the worker arm/disarm half, the dump-report
  filter, and the never-fail-a-run filesystem/timer paths).
- `conftest.py` — `pytest_configure` / `pytest_runtest_logstart` /
  `pytest_runtest_logreport` wiring and a `shutdown()` on session finish.
- `.github/workflows/ci.yml` — the `test` job sets
  `LOCAL_OPERATOR_SHARD_STALL_SECONDS: "240"`; a new `if: always()` step prints
  the module's *filtered* report (`python -m tests.shard_stall_watchdog`), not a
  raw `cat` of every dump file — a worker writes its header at arm time, one
  per test, so the unfiltered dump of a cancelled shard was thousands of false
  "exceeded 240s" claims around one real timeout.

## Related Issue(s)

Related: #940 (admin-merged over a `test (3.12, 4)` cancel), #947 (the v0.54.10
release bump cancelled on the same shard). Follows PR #950, which fixed the
adjacent shard-balance defect in the duration manifest and established that the
cancels are **not** a balance problem.

## Impact

- No production code, no behaviour change to the application.
- The watchdog is **inert unless `LOCAL_OPERATOR_SHARD_STALL_SECONDS` is set**,
  which only the shard job does. A developer run and the `-n0` `tui-e2e` stage
  (which has its own tighter bound) are untouched — verified by a full
  `tests/unit/tui tests/unit/harness` run with the variable unset: 7339 passed,
  12 skipped, no reports, no dump files.
- It can never turn a green run red: nothing exits, kills or times out a
  process, and **no filesystem or timer operation in the module can raise** — an
  unusable dump directory or an unset/unparseable bound disables the instrument
  instead of failing a shard (an unguarded `mkdir` in `pytest_configure` was
  measured to `INTERNALERROR` a shard with `no tests ran`). See "Why it is safe
  to leave on" below.
- **This is a diagnostic.** It reports the stall; it does not fix it. The hang it
  named is fixed in the open PR #954, which is not this one.
- No version bump.

## Testing Details

### The defect, as evidence rather than inference

Every cancel has the same shape, and it is not a failing test:

| job | last progress | killed | silence |
|---|---|---|---|
| `test (3.12, 0)` run 34545290432 | 98% @ 00:24:29 | 00:31:43 | 7m14s |
| `test (3.12, 4)` run 34546963294 | 99% @ 01:20:55 | 01:26:50 | 5m55s |
| `test (3.12, 4)` run 34547820936 | 98% @ 00:46:04 | 00:53:22 | 7m18s |
| `test (3.12, 4)` run 34551028930 | 99% @ 01:45:41 | 01:52:00 | 6m19s |

**Why the log can never attribute it.** `-q` prints one progress line per 72
*completed* tests, so the final partial line is withheld until its slowest item
finishes: a single stuck test and a uniformly slow batch produce byte-identical
output. Measured on run 34546963294, 3478 items means the last line covers 22
items — the entire 6-minute tail is one withheld line.

**Why local reproduction is not available.** 25 serial runs of the nearest
suspect (`test_subagent_view.py::test_history_prepend_preserves_anchor_and_home_dedupes_requests`)
pass with no failure, and the slowest single test in the whole suite measures
81.4s against a 6-minute tail. So no fix can be justified from local evidence,
and per the brief the correct outcome is the instrument plus a plain statement
that it is not fixed.

### What the instrument actually does — measured, not asserted

Enabled with a deliberately tiny bound (15s) against a real slow TUI test,
driven through the real xdist path (`-n2`), copied **while the run was still in
flight** (t=50s) rather than at the end:

```
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
SHARD STALL: no test has completed for 17s (bound 15s). 1 still in flight:
       17s  tests/unit/tui/test_queued_steer_receipt.py::test_the_cross_turn_settle_does_not_change_the_rows_height
--- /var/folders/.../T/lo-shard-stall/worker-49691.log (first snapshot, 79 lines) ---
[shard stall] tests/unit/tui/...::test_the_cross_turn_settle_does_not_change_the_rows_height exceeded 15s; every thread follows.
Timeout (0:00:15)!
Thread 0x00000001741f3000 [lop-mobile-registrant] (most recent call first):
  File ".../selectors.py", line 548 in select
  ...
Thread 0x... [asyncio_0] (most recent call first):
  File ".../concurrent/futures/thread.py", line 116 in _worker
  ...
```

That is the whole deliverable working: the exact test, its elapsed time, and the
threads' stacks, all in the job log during the stall. Chosen channel: the
controller writes to stderr, and **stderr on the controller is not captured
while a worker is busy** — verified by probing `print(..., file=sys.stderr)`,
`os.write(2, ...)` and the terminal writer from a background thread while a
`-n2` worker slept: the first two landed in the redirected output file live, and
the terminal writer is not available that early. That is also why a cancelled
job's `-q` progress is readable at all.

### Safety, verified both ways

- **Healthy run with the bound armed and never tripped** (`tests/unit/test_paths.py`
  with a 5s bound): 13 passed, and the dump directory is **empty** afterwards —
  armed-but-unfired headers are removed by the controller's cleanup.
- **Fired dump on a green run is deliberately kept** (the run above): the file
  survives, because a test that took 4 minutes and still passed is worth knowing
  about, and a diagnostic that silently deletes its own evidence is worse than
  none.
- **Inert path**: full `tests/unit/tui tests/unit/harness` with the variable
  unset → 7339 passed, 12 skipped; enabled on the same subset → 488 passed,
  10.2s, no reports.

### Unit guards

`tests/unit/test_shard_stall_watchdog.py`, 10 tests, all passing. They pin the
bug that was actually hit while building this: **xdist sends a report with
`when="setup"` before the call phase**, so treating any report as completion
emptied the in-flight set and made a real stall print "0 still in flight" — a
broken instrument that reads as a healthy quiet run. Mutation-tested: changing
the phase guard to "any report completes" fails
`test_a_setup_report_does_not_count_as_completion`:

```
FAILED ...::test_a_setup_report_does_not_count_as_completion
AssertionError: the in-flight test must be named by node id
assert 'tests/unit/tui/test_x.py::test_a_long_one' in '... SHARD STALL: ... 0 still in flight:'
```

Others cover: inertness without the env var, a malformed bound disabling rather
than shrinking (a typo must not become a 0-second bound), rate limiting, that
only ONE snapshot is printed per report (`repeat=True` appends a whole dump every
interval), that a file whose timer never fired is not reported as a timeout, that
cleanup keeps fired dumps and removes armed ones, and that `ci.yml` sets the
variable (an inert watchdog is indistinguishable from a suite that never stalls).

### Quality gates

- `flake8 .` → rc 0
- `uvx --from black==26.1.0 black --check .` → 1222 files unchanged
- `uvx isort==5.13.2 --check-only .` → clean
- `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` → 0 errors, 0 warnings
- `tests/unit/tui tests/unit/harness tests/unit/test_shard_stall_watchdog.py` → 7339 passed, 12 skipped (the affected surfaces: the conftest hooks fire in every run, and the TUI suite is where the stall lives)
- CI: relying on the push for the full-tree run. This change cannot affect a test outcome; the one thing that could, the root conftest, is exercised by both runs above.

## Why it is safe to leave on

- `exit=False` on the worker timer: a fired dump is a snapshot, the test keeps
  running. The controller only prints.
- It is not a bound on anything — no test can fail because of it. A false
  positive costs 80 lines of log and nothing else, which is why the bound can be
  chosen for sensitivity (240s, ~3x the worst legitimate test) rather than for
  safety.
- Rate-limited to one report per 30s, so a stall cannot bury its own first and
  most useful report.

## Not addressed

- **The stall itself.** This PR does not fix it; it makes the next occurrence
  name itself. That is the deliberate outcome, not an omission.
- **`test_subagent_view.py::test_history_prepend_preserves_anchor_and_home_dedupes_requests`**
  — a separate, independent intermittent failure (`AssertionError: assert (40 -
  0.0) == 0`: `anchor_block.virtual_region.y` 40 against `scroll_y` 0.0, i.e. a
  prepend was applied and the anchor restore was not). It failed on `main` at
  `51b524c8` in one shard and on an unrelated branch in another, and it does
  **not** share a PR with this one: it is a product race in the anchor-restore
  path of `subagent_view.py`, which carries an elaborate prepend/gap-settlement
  protocol, and 25 serial local runs do not reproduce it. A blind change there
  is exactly the speculative fix the brief rules out, so it is recorded rather
  than bundled. Its waits are already structural (worker completion and settled
  geometry), so the "wait on the event, not the clock" remedy is not available
  either.
- **The "3.12-only" reading is weakened by this PR's own evidence**, and the
  correction matters for whoever picks the stall up: comparing the two legs of
  each shard in the same run, item counts are identical (4039/4039, 3703/3703,
  3622/3622, 3449/3449, 3478/3478), so no test is collected differently. But the
  3.13 leg of the shard that was cancelled is not fast either — `test (3.13, 4)`
  ran 799.90s / 13m19s in run 34551028930 against a 20-minute cap, and 3.12 and
  3.13 shard totals differ by ±10% in both directions. So the cancels look like
  a **borderline shard plus a ~6-minute stall**, not a version-specific defect;
  four cancels all landing on 3.12 is 4 samples, not a proof. The instrument is
  what will settle it.


## The instrument caught the stall on this PR's own head (added after the fact)

The first CI run on this branch was cancelled at the cap — and the watchdog named
the culprit in the job log, which is the strongest evidence this PR will have.
Run `34558244102`, job `103135419093` (`test (3.12, 2)`), head `abf7bc11d`:

```
SHARD STALL: no test has completed for 241s (bound 240s). 1 still in flight:
      827s  tests/unit/providers/test_oauth_flows.py::test_pinned_port_fails_before_browser_when_busy
Timeout (0:04:00)!
Thread ... File ".../python3.12/selectors.py", line 468 in select
              File ".../asyncio/base_events.py", line 1961 in _run_once
              File ".../asyncio/base_events.py", line 645 in run_forever
              File ".../asyncio/base_events.py", line 678 in run_until_complete
              File ".../runners.py", line 118 in run
```

It repeated every 30s for 10 cycles — 827s → 857s → 887s → 917s → 947s → 977s
→ 1007s → 1037s — always the same single test, always parked in `select()`.

Two things this settles at once:

1. **The 6-minute silent tail is one test**, not a uniformly slow batch, and the
   `-q` progress line was withholding it exactly as the module docstring argues.
2. **The bound is calibrated correctly.** 240s fired with ~2 minutes of the
   20-minute cap left and repeated twice before it, so a reader gets the name and
   the stacks without the run losing any of the evidence to truncation.

The cause is identified and fixed in the still-open #954: the test's own port-blocking double
never released the connection it accepted, so `await blocker.wait_closed()` in
the test's `finally` could not return. That PR carries the named await, the
before/after on 3.12, and the guard.

