### PR TITLE
feat(tools): diagnose an unmatched edit hunk with the file's closest text

### DIFF
--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -3893,12 +3893,6 @@ def _match_windows(content: str, old_text: str) -> list[tuple[int, int, str]]:
 # unbounded one would cost more than the failure it reports. Each is applied
 # where it is named, and the whole message is capped last.
 
-#: Word overlap at or above which the closest region IS the hunk's own text.
-#: Only reachable when the two frames differ (on unchanged content the hunk
-#: would have matched, not been refused), so the report says which situation
-#: stands instead of printing "not found" beside "100% word overlap" with the
-#: caller's own text (review round 2, R10).
-_EDIT_SELF_MATCH_PERCENT = 100
 #: Failing hunks that get a full closest-region report. TWO, not three: a
 #: detailed report is up to ~15 rows in the tool card (six quoted lines, two
 #: candidates, the difference pair and the hint) and the expanded card paints
@@ -4181,8 +4175,25 @@ def _is_pure_insertion(pattern_lines: list[str], file_lines: list[str]) -> bool:
     return prefix + suffix >= limit
 
 
+def _own_text_on_disk(original: str, current: str, old_text: str) -> bool:
+    """Whether ``old_text`` is still in the FILE unchanged, while the batch state
+    no longer holds it.
+
+    The self-match clause needs an identity fact, and the similarity figure
+    cannot supply one: 100% bag-of-words overlap is also reached by a
+    punctuation-only rewrite, a reordered list, or any permutation of the same
+    words, so gating on it claimed an identity the metric never measured (review
+    round 3, R13 / design round 2, D8). A substring test answers the question
+    that is actually being asked, and it runs only for a hunk that already
+    failed. The frame comparison comes first because on unchanged content the
+    hunk would have matched rather than been refused, and the clause is about
+    what THIS call's earlier hunks did.
+    """
+    return current != original and old_text in original
+
+
 def _edit_not_found_compact(
-    scan: _FileScan, number: int, old_text: str, in_memory_moved: bool = False
+    scan: _FileScan, number: int, old_text: str, own_text_on_disk: bool = False
 ) -> list[str]:
     """One line for a failing hunk past the detailed-report cap.
 
@@ -4190,16 +4201,16 @@ def _edit_not_found_compact(
     roughly where the file says something similar — for about a tenth of a
     full report. ``scan`` is the ON-DISK frame, like the detailed report: a
     one-liner naming a line of the in-memory state would be the same wrong
-    answer, just shorter. ``in_memory_moved`` adds the self-match clause when
-    the closest region is the hunk's own text (review round 2, R10).
+    answer, just shorter. ``own_text_on_disk`` adds the clause for a hunk whose
+    own text is still in the file unchanged (review round 2, R10; gated on the
+    text itself rather than on the similarity figure in review round 3, D8).
     """
     regions = _closest_regions(scan, old_text.splitlines())
     if not regions:
         return [f"hunk {number}: old_text not found — no close match."]
     start, _end, overlap = regions[0]
-    self_match = in_memory_moved and _overlap_percent(overlap) >= _EDIT_SELF_MATCH_PERCENT
     if _overlap_percent(overlap) >= _EDIT_OVERLAP_LABEL_PERCENT:
-        tail = "; earlier hunks in this call would have replaced or moved it" if self_match else ""
+        tail = "; earlier hunks in this call would replace it" if own_text_on_disk else ""
         return [
             f"hunk {number}: old_text not found — closest text at line "
             f"{start + 1} ({_percent(overlap)} word overlap){tail}."
@@ -4232,7 +4243,7 @@ def _edit_not_found_report(
     old_text: str,
     display_path: str,
     anchor_line: int | None = None,
-    in_memory_moved: bool = False,
+    own_text_on_disk: bool = False,
 ) -> list[str]:
     """The closest-region report for one hunk whose ``old_text`` did not match.
 
@@ -4289,25 +4300,30 @@ def _edit_not_found_report(
     )
     if shown_last < last:
         heading += f" (showing first {_EDIT_MAX_WINDOW_LINES} of {last - first + 1})"
+    # The pair is decided here rather than after the clause because the clause
+    # may only appear when there is NO difference to show: "your text is still
+    # on disk, an earlier hunk would replace it" is false the moment the block
+    # goes on to diff the two texts.
+    pattern_index, file_index = _first_difference(pattern_lines, file_lines[start:end])
+    has_difference = pattern_index >= 0 or file_index >= 0
     lines = head + [heading + ":"]
     width = len(str(shown_last))
     for line_number in range(first, shown_last + 1):
         lines.append(f"    {line_number:>{width}}| {_clip_line(file_lines[line_number - 1])}")
-    if in_memory_moved and _overlap_percent(overlap) >= _EDIT_SELF_MATCH_PERCENT:
-        # "not found" beside "100% word overlap" with the caller's own text is
+    if own_text_on_disk and not has_difference:
+        # "not found" beside a quotation of the caller's own text is
         # self-contradictory on its face; name the situation instead (review
-        # round 2, R10). The region IS the hunk's text, unchanged on disk — what
-        # is missing is the text this call's earlier hunks would have left.
-        lines.append(
-            "  (this is this hunk's own text, still on disk unchanged — an earlier hunk in "
-            "this call would have replaced or moved it)"
-        )
+        # round 2, R10). The gate is the TEXT, not the similarity figure: a word
+        # bag reaches 100% for a punctuation-only rewrite or a reordered list,
+        # which is exactly when the clause was false (review round 3, R13 / D8).
+        # Short and cause-first, because the card clips every row from the right
+        # and the reason has to survive the 60-column budget (design round 2, D9).
+        lines.append("  (earlier hunks in this call would replace it; unchanged on disk)")
     for alt_start, alt_end, alt_overlap in regions[1:]:
         snippet = _clip_line(" ".join(file_lines[alt_start:alt_end]), _EDIT_MAX_SNIPPET_CHARS)
         lines.append(f'  also similar: line {alt_start + 1} ({_percent(alt_overlap)}) "{snippet}"')
 
-    pattern_index, file_index = _first_difference(pattern_lines, file_lines[start:end])
-    if pattern_index >= 0 or file_index >= 0:
+    if has_difference:
         your_number = pattern_index + 1 if pattern_index >= 0 else None
         file_number = start + file_index + 1 if file_index >= 0 else None
         lines.append(
@@ -4709,13 +4725,13 @@ def _edit_file_result_locked(
                     hunk.old_text,
                     display_path,
                     anchor_line,
-                    in_memory_moved=current != original,
+                    own_text_on_disk=_own_text_on_disk(original, current, hunk.old_text),
                 ),
                 lambda: _edit_not_found_compact(
                     _scan_for_disk(original),
                     number,
                     hunk.old_text,
-                    in_memory_moved=current != original,
+                    own_text_on_disk=_own_text_on_disk(original, current, hunk.old_text),
                 ),
             )
             continue

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -988,6 +988,11 @@ def _ambiguous_report(content: str, number: int, chosen: list[tuple[int, int, st
     trip this whole change exists to remove. The windows are already
     computed, so the line numbers are nearly free — but only the reported
     few are located, since counting newlines is linear in the file.
+
+    ``content`` is the state the matches were FOUND in (the in-memory batch
+    state), not the on-disk text: those occurrences may not exist on disk, and
+    naming disk lines for in-memory matches would be a fabrication. When the
+    two frames differ, the refusal's header note says so.
     """
     listed = [
         str(_line_of_offset(content, window[0])) for window in chosen[:_EDIT_MAX_AMBIGUOUS_LINES]
@@ -3731,21 +3736,27 @@ def _dice(pattern: Counter[str], window: Counter[str]) -> float:
 #: caller. A ContextVar set inside the ``to_thread`` worker is private to that
 #: thread's context copy, so concurrent edits of different files cannot see
 #: each other's snapshot.
-_EDIT_SCAN: ContextVar[_FileScan | None] = ContextVar("edit_scan", default=None)
+#:
+#: A small cache, not a single slot, because one call has TWO frames that are
+#: both live at once: the in-memory state hunks are matched against, and the
+#: on-disk content the diagnostics describe. ``_EDIT_MAX_SCANS`` bounds it, so
+#: a call builds at most that many snapshots however many hunks it has.
+_EDIT_SCANS: ContextVar[tuple[_FileScan, ...]] = ContextVar("edit_scans", default=())
 
 
 def _scan_for(content: str) -> _FileScan:
     """The current call's line views for ``content``, built once per snapshot.
 
-    Rebuilt only when the content is not the one the held scan describes —
-    i.e. an earlier hunk in the same call already rewrote the file — so a
-    multi-hunk batch builds the tolerant index and the word bags once, no
-    matter how many hunks fail against it.
+    A snapshot is reused only when it describes exactly this content, so a
+    multi-hunk batch builds each frame's tolerant index and word bags once, no
+    matter how many hunks are matched or fail against it.
     """
-    scan = _EDIT_SCAN.get()
-    if scan is None or not scan.matches(content):
-        scan = _FileScan(content)
-        _EDIT_SCAN.set(scan)
+    scans = _EDIT_SCANS.get()
+    for scan in scans:
+        if scan.matches(content):
+            return scan
+    scan = _FileScan(content)
+    _EDIT_SCANS.set((scan, *scans)[:_EDIT_MAX_SCANS])
     return scan
 
 
@@ -3819,13 +3830,23 @@ def _match_windows(content: str, old_text: str) -> list[tuple[int, int, str]]:
 # unbounded one would cost more than the failure it reports. Each is applied
 # where it is named, and the whole message is capped last.
 
-#: Failing hunks that get a full closest-region report.
-_EDIT_MAX_DETAILED_HUNKS = 3
+#: Failing hunks that get a full closest-region report. TWO, not three: a
+#: detailed report is up to ~15 rows in the tool card (six quoted lines, two
+#: candidates, the difference pair and the hint) and the expanded card paints
+#: at most EXPAND_MAX_LINES (40), so with three reports the last hunk's block
+#: was painted off the card entirely and no scroll could reach it (design
+#: round 1, D4). Blocks are dropped whole — see ``_edit_refusal`` — so a report
+#: is never sliced mid-sentence either.
+_EDIT_MAX_DETAILED_HUNKS = 2
 #: Further failing hunks that get one compact line each. Bounded because the
 #: failure count is caller-controlled: a 40-hunk batch that fails wholesale
-#: must not produce a 40-line report, and the count of the rest survives in
-#: the ``… (N more failing hunks not shown)`` tail.
+#: must not produce a 40-line report, and the count of the rest survives in the
+#: ``… and N more hunks failed (details suppressed)`` tail.
 _EDIT_MAX_COMPACT_HUNKS = 3
+#: Scans cached per edit call. Two, because a call has two frames that must not
+#: be confused: the in-memory state hunks are matched against, and the on-disk
+#: content the diagnostics describe (review round 1, R1).
+_EDIT_MAX_SCANS = 2
 #: Candidate regions reported per hunk (one with text, the rest as snippets).
 _EDIT_MAX_REGIONS = 3
 #: Candidate windows the full metric is run over (the prefilter's hard bound).
@@ -3837,19 +3858,36 @@ _EDIT_MAX_WINDOW_LINES = 6
 #: Displayed width of one quoted line, and of an ``also similar`` snippet.
 _EDIT_MAX_LINE_CHARS = 200
 _EDIT_MAX_SNIPPET_CHARS = 60
+#: Context shown BEFORE the first divergence in the difference pair, and the
+#: excerpt's total width. The card clips each row from the RIGHT, so an excerpt
+#: anchored at character 0 renders the `-` and `+` rows byte-identical whenever
+#: the divergence starts past the clip (reproduced at 80 and 100 columns, and
+#: from the tool side with a divergence at character 231). Leading with ~24
+#: characters of run-up puts the divergence inside the first ~30 columns of the
+#: excerpt, at any width (design round 1, D1).
+_EDIT_DIFF_LEAD_CHARS = 24
+_EDIT_DIFF_EXCERPT_CHARS = 160
 #: Hard bound on the whole refusal, tail included.
 _EDIT_MAX_MESSAGE_CHARS = 6000
 #: Above this word overlap the report says ``closest text``; below it, the
-#: honest ``no close match``. The label is derived from the metric, never
-#: asserted independently of it.
-_EDIT_OVERLAP_LABEL_THRESHOLD = 0.30
+#: honest ``no close match``. A whole percent, and the SAME rounded number the
+#: message prints, so ``30% word overlap`` can never appear under a
+#: ``no close match`` label (a raw 0.296 rounds to 30 but is below a 0.30
+#: cutoff — review round 1, R5).
+_EDIT_OVERLAP_LABEL_PERCENT = 30
 #: Match line numbers listed in the ambiguous-match refusal.
 _EDIT_MAX_AMBIGUOUS_LINES = 8
 
 
+def _overlap_percent(value: float) -> int:
+    """Word overlap as a whole percent — the ONE number the label and the
+    printed figure both read, so they cannot disagree with each other."""
+    return round(value * 100)
+
+
 def _percent(value: float) -> str:
     """Word overlap as a whole percent — the metric's name travels with it."""
-    return f"{round(value * 100)}%"
+    return f"{_overlap_percent(value)}%"
 
 
 def _clip_line(text: str, limit: int = _EDIT_MAX_LINE_CHARS) -> str:
@@ -3860,9 +3898,32 @@ def _clip_line(text: str, limit: int = _EDIT_MAX_LINE_CHARS) -> str:
     return text[: limit - 1] + "…"
 
 
-def _read_hint(path: Path, first: int, last: int) -> str:
-    """The exact ``read`` call that shows a line range, ready to paste."""
-    return f'read(path="{path}", range="{first}-{last}")'
+def _read_hint(path: Path, first: int, last: int, anchor_line: int | None) -> str:
+    """The next ``read`` call, FIRST on its line, then what to do with it.
+
+    The call leads because it is the one token the caller acts on and the tool
+    card clips every row from the right: a hint whose ``range`` argument was
+    cut mid-argument is unusable (design round 1, D2). ``anchor_line`` is
+    echoed when the caller supplied one — it is the only hint the caller gave
+    the tool about where it meant to edit, and it costs nothing to repeat
+    (review round 1, R4).
+    """
+    hint = f'  read(path="{path}", range="{first}-{last}") — confirm the current text, then retry'
+    if anchor_line is not None:
+        hint += f" (or read around line {anchor_line}, the anchor_line you gave)"
+    return hint + "; skip the hunk if the change is already there."
+
+
+def _line_range_label(first: int, last: int) -> str:
+    """``file line 7`` for a one-line region, ``file lines 7-9`` otherwise."""
+    if first == last:
+        return f"file line {first}"
+    return f"file lines {first}-{last}"
+
+
+def _count_label(count: int, noun: str) -> str:
+    """``1 line``, ``2 lines`` — a one-line file must not read ``1 lines``."""
+    return f"{count} {noun}" if count == 1 else f"{count} {noun}s"
 
 
 def _anchor_indices(pattern_lines: list[str]) -> list[int]:
@@ -3895,8 +3956,8 @@ def _closest_regions(
     and keeps the best ``_EDIT_MAX_CANDIDATE_STARTS`` window starts; stage two
     runs the real bag-of-words Dice over just those windows. Measured here
     (Darwin 25.6.0 arm64, CPython 3.12.13) on a synthetic 20,000-line file
-    with a 200-line drifted pattern: 21 ms against 6.6 s for scoring every
-    window (321x), with the same top window and score (0.97 at the true
+    with a 200-line drifted pattern: ~20 ms against ~6.5 s for scoring every
+    window (~330x), with the same top window and score (0.97 at the true
     start).
     """
     if not pattern_lines:
@@ -4011,13 +4072,15 @@ def _edit_not_found_compact(scan: _FileScan, number: int, old_text: str) -> list
 
     Keeps the two facts that tell the failures apart — this hunk failed, and
     roughly where the file says something similar — for about a tenth of a
-    full report.
+    full report. ``scan`` is the ON-DISK frame, like the detailed report: a
+    one-liner naming a line of the in-memory state would be the same wrong
+    answer, just shorter.
     """
     regions = _closest_regions(scan, old_text.splitlines())
     if not regions:
         return [f"hunk {number}: old_text not found — no close match."]
     start, _end, overlap = regions[0]
-    if overlap >= _EDIT_OVERLAP_LABEL_THRESHOLD:
+    if _overlap_percent(overlap) >= _EDIT_OVERLAP_LABEL_PERCENT:
         return [
             f"hunk {number}: old_text not found — closest text at line "
             f"{start + 1} ({_percent(overlap)} word overlap)."
@@ -4028,8 +4091,39 @@ def _edit_not_found_compact(scan: _FileScan, number: int, old_text: str) -> list
     ]
 
 
-def _edit_not_found_report(scan: _FileScan, number: int, old_text: str, path: Path) -> list[str]:
+def _difference_excerpt(line: str, common: int) -> str:
+    """A window of ``line`` with the divergence near its start, not its end.
+
+    ``common`` is the length of the raw common prefix of the two lines being
+    compared, so character ``common`` is where they part. Anchoring the
+    excerpt at ``common - _EDIT_DIFF_LEAD_CHARS`` (never below 0) puts the
+    divergence ~24 characters in, which keeps it visible under the tool card's
+    right-truncation at any width; the leading ``…`` marks that characters
+    were skipped. See ``_EDIT_DIFF_LEAD_CHARS`` for why character 0 is the
+    wrong anchor.
+    """
+    start = max(0, min(common, len(line)) - _EDIT_DIFF_LEAD_CHARS)
+    excerpt = line[start : start + _EDIT_DIFF_EXCERPT_CHARS]
+    return ("…" if start > 0 else "") + excerpt
+
+
+def _edit_not_found_report(
+    scan: _FileScan,
+    number: int,
+    old_text: str,
+    path: Path,
+    anchor_line: int | None = None,
+) -> list[str]:
     """The closest-region report for one hunk whose ``old_text`` did not match.
+
+    ``scan`` is the ON-DISK frame (``original``), never the state after earlier
+    hunks of the same call were applied in memory. The caller's next move is a
+    ``read`` of the file on disk, so the quoted text, the line numbers and the
+    suggested range have to be the disk's — a report computed against the
+    in-memory state names lines that do not contain what it quotes (review
+    round 1, R1 / QA round 1, Q1). Matching still runs against the in-memory
+    state, which is why the engine notes the frame in the header when the two
+    differ.
 
     DIAGNOSIS ONLY: nothing computed here is ever applied. Showing the current
     text is the whole point — in the corpus that motivated this, the file
@@ -4050,9 +4144,11 @@ def _edit_not_found_report(scan: _FileScan, number: int, old_text: str, path: Pa
         "matchers both failed)."
     ]
     if not regions:
+        # The file may be full of text; what the search established is that no
+        # line of it shares a word with this hunk, which is not the same claim.
         return head + [
-            "  no close match in the file; there is no text to compare against.",
-            "  Re-read the region you meant to change and anchor the hunk to the " "text you find.",
+            "  no close match in the file; no text in it shares any words with this hunk.",
+            _read_hint(path, 1, min(total_lines, _EDIT_MAX_WINDOW_LINES), anchor_line),
         ]
 
     start, end, overlap = regions[0]
@@ -4060,17 +4156,17 @@ def _edit_not_found_report(scan: _FileScan, number: int, old_text: str, path: Pa
     last = end
     read_first = max(1, first - 2)
     read_last = min(total_lines, last + 2)
-    if overlap < _EDIT_OVERLAP_LABEL_THRESHOLD:
+    if _overlap_percent(overlap) < _EDIT_OVERLAP_LABEL_PERCENT:
         return head + [
             f"  no close match in the file; the nearest text is line {first} "
             f"({_percent(overlap)} word overlap).",
-            f"  Re-read the region you meant to change — e.g. lines {read_first}-"
-            f"{read_last} (`{_read_hint(path, read_first, read_last)}`) — and anchor "
-            "the hunk to the text you find.",
+            _read_hint(path, read_first, read_last, anchor_line),
         ]
 
     shown_last = min(last, first + _EDIT_MAX_WINDOW_LINES - 1)
-    heading = f"  closest text — file lines {first}-{last} ({_percent(overlap)} word overlap)"
+    heading = (
+        f"  closest text — {_line_range_label(first, last)} " f"({_percent(overlap)} word overlap)"
+    )
     if shown_last < last:
         heading += f" (showing first {_EDIT_MAX_WINDOW_LINES} of {last - first + 1})"
     lines = head + [heading + ":"]
@@ -4089,28 +4185,16 @@ def _edit_not_found_report(scan: _FileScan, number: int, old_text: str, path: Pa
             f"  first difference — your line {your_number if your_number else '(none)'} "
             f"vs file line {file_number if file_number else '(none)'}:"
         )
-        lines.append(
-            "    - "
-            + (
-                _clip_line(pattern_lines[pattern_index])
-                if pattern_index >= 0
-                else "(no counterpart line in your hunk)"
-            )
-        )
-        lines.append(
-            "    + "
-            + (
-                _clip_line(file_lines[start + file_index])
-                if file_index >= 0
-                else "(no counterpart line in the file)"
-            )
-        )
         if pattern_index >= 0 and file_index >= 0:
             yours = pattern_lines[pattern_index]
             theirs = file_lines[start + file_index]
             common = 0
             while common < min(len(yours), len(theirs)) and yours[common] == theirs[common]:
                 common += 1
+            # Windowed around the divergence, so the two rows differ on screen
+            # and not only in the note underneath them.
+            lines.append("    - " + _difference_excerpt(yours, common))
+            lines.append("    + " + _difference_excerpt(theirs, common))
             if common == 0:
                 lines.append("    (they differ at the first character)")
             elif common == min(len(yours), len(theirs)):
@@ -4121,25 +4205,61 @@ def _edit_not_found_report(scan: _FileScan, number: int, old_text: str, path: Pa
                 lines.append(
                     f"    (identical for the first {common} characters, then they diverge)"
                 )
-        elif _is_pure_insertion(pattern_lines, file_lines[start:end]):
+        else:
             lines.append(
-                "    (the lines after it match again, so a line was added or removed "
-                "rather than reworded)"
+                "    - "
+                + (
+                    _clip_line(pattern_lines[pattern_index])
+                    if pattern_index >= 0
+                    else "(no counterpart line in your hunk)"
+                )
             )
+            lines.append(
+                "    + "
+                + (
+                    _clip_line(file_lines[start + file_index])
+                    if file_index >= 0
+                    else "(no counterpart line in the file)"
+                )
+            )
+            if _is_pure_insertion(pattern_lines, file_lines[start:end]):
+                lines.append(
+                    "    (the lines after it match again, so a line was added or removed "
+                    "rather than reworded)"
+                )
 
-    lines.append(
-        f"  Read lines {read_first}-{read_last} (`{_read_hint(path, read_first, read_last)}`) "
-        "to confirm the current text, then retry with old_text"
-    )
-    lines.append(
-        "  copied from it. If the current text already carries your change, skip "
-        "this hunk instead of re-applying it."
-    )
+    lines.append(_read_hint(path, read_first, read_last, anchor_line))
     return lines
 
 
-def _refusal_facts(path: Path, original: str, total_hunks: int, failed_hunks: int) -> str:
-    """The two lines every refusal opens with: what was refused, and where.
+def _refusal_headline(total_hunks: int, counts: list[tuple[str, int]]) -> str:
+    """The first line: how many hunks were refused, and WHY each one was.
+
+    A single reason names itself, because that is the common case and the
+    plainest sentence. A mixed batch lists its reasons, because "did not
+    match" is simply false for a hunk that matched twelve times (QA round 1,
+    Q2) — the header has to be true of every hunk it counts.
+    """
+    reasons = [(label, count) for label, count in counts if count]
+    refused = sum(count for _label, count in reasons)
+    if len(reasons) == 1:
+        what = reasons[0][0]
+    else:
+        what = "did not apply (" + ", ".join(f"{count} {label}" for label, count in reasons) + ")"
+    return (
+        f"edit aborted: {refused} of {total_hunks} hunks {what}; nothing was written "
+        "(a call applies all its hunks or none)."
+    )
+
+
+def _refusal_facts(
+    path: Path,
+    original: str,
+    total_hunks: int,
+    counts: list[tuple[str, int]],
+    in_memory_moved: bool,
+) -> str:
+    """The lines every refusal opens with: what was refused, where, and which frame.
 
     The atomicity sentence is not decoration. The old refusal reported a
     single failure and never said that a call applies all its hunks or none —
@@ -4147,46 +4267,66 @@ def _refusal_facts(path: Path, original: str, total_hunks: int, failed_hunks: in
     the whole batch, nine times out of eleven. The file facts are computed
     here, once, because `splitlines` and `encode` over a 100 KB document cost
     real time and the message is assembled a few times against the cap.
+
+    ``in_memory_moved`` says an earlier hunk of this call matched, so the
+    diagnostics describe the file on disk while the matching saw the would-be
+    result. That has to be stated: the line numbers are the disk's, and the
+    caller's next move is a `read` of the disk (review round 1, R1).
     """
-    return (
-        f"edit aborted: {failed_hunks} of {total_hunks} hunks did not match; "
-        "nothing was written (a call applies all its hunks or none).\n"
-        f"File: {path} — {len(original.splitlines())} lines, "
-        f"{len(original.encode('utf-8'))} bytes."
-    )
+    lines = [
+        _refusal_headline(total_hunks, counts),
+        f"File: {path} — {_count_label(len(original.splitlines()), 'line')}, "
+        f"{_count_label(len(original.encode('utf-8')), 'byte')}.",
+    ]
+    if in_memory_moved:
+        lines.append(
+            "  Note: earlier hunks in this call matched, so the file would have "
+            "changed; the text, line numbers and read range below describe the file "
+            "as it is on disk (nothing was written)."
+        )
+    return "\n".join(lines)
 
 
 def _edit_refusal(
-    path: Path, original: str, total_hunks: int, failed_hunks: int, reports: list[list[str]]
+    path: Path,
+    original: str,
+    total_hunks: int,
+    reports: list[list[str]],
+    refused_hunks: int,
+    counts: list[tuple[str, int]],
+    in_memory_moved: bool,
 ) -> str:
-    """Assemble the refusal under the whole-message cap, honestly.
+    """Assemble the refusal under the whole-message cap, by COMPLETE blocks.
 
-    Reports are added while the rendered message (including the tail that the
-    remaining failures would need) still fits; whatever does not fit joins the
-    count in the tail rather than being truncated mid-sentence. The count is
-    therefore always the truth about how many failing hunks were not shown.
+    A report is a block; the message is the header plus whole blocks plus, when
+    blocks had to go, one suppression line. Blocks are dropped from the tail
+    until the rendered message fits `_EDIT_MAX_MESSAGE_CHARS`, and the dropped
+    count is named — nothing is ever sliced mid-block, because the card paints
+    a prefix of the message and a half-block is unreadable by any means (design
+    round 1, D4). The count in the tail is therefore always the truth about how
+    many refusing hunks were left undescribed.
     """
-    facts = _refusal_facts(path, original, total_hunks, failed_hunks)
+    facts = _refusal_facts(path, original, total_hunks, counts, in_memory_moved)
 
     def _render(kept: list[list[str]], hidden: int) -> str:
         lines = [facts]
         for report in kept:
             lines.extend(report)
         if hidden > 0:
-            lines.append(f"… ({hidden} more failing hunks not shown)")
+            lines.append(f"… and {hidden} more hunks failed (details suppressed)")
         return "\n".join(lines)
 
     kept: list[list[str]] = []
-    message = _render(kept, failed_hunks)
+    message = _render(kept, refused_hunks)
     for report in reports:
         candidate = [*kept, report]
-        rendered = _render(candidate, failed_hunks - len(candidate))
+        rendered = _render(candidate, refused_hunks - len(candidate))
         if len(rendered) > _EDIT_MAX_MESSAGE_CHARS:
             break
         kept = candidate
         message = rendered
     if len(kept) != len(reports):
-        message = _render(kept, failed_hunks - len(kept))
+        message = _render(kept, refused_hunks - len(kept))
     if len(message) > _EDIT_MAX_MESSAGE_CHARS:
         # Only reachable when the header alone blows the cap (a pathological
         # path or byte count); the tail still has to survive.
@@ -4336,35 +4476,54 @@ def _edit_file_result_locked(
     (earlier successful hunks applied), because that is the state they would
     have seen had the batch been able to land.
 
-    Nothing here runs on the happy path: the line views a diagnostic needs are
-    fetched through ``_scan_for`` only inside a failure branch, so an all-exact
-    batch keeps its old cost. Measured with the pre-change module loaded from a
-    file into the same interpreter, 11 exact hunks over the 104 KB corpus file
-    come out at ~14 ms CPU either side of this change — both dominated by the
-    diff details the result already carried, with the rest inside run-to-run
-    noise.
+    Nothing here runs on the happy path: an all-exact batch builds no line
+    views at all. The views are fetched through ``_scan_for`` on any hunk that
+    needs the tolerant pass (a tolerant SUCCESS builds one), and again on the
+    failure path for the diagnostics. Measured with the pre-change module
+    loaded from a file into the same interpreter, 11 exact hunks over the
+    104 KB corpus file come out at ~14 ms CPU either side of this change —
+    both dominated by the diff details the result already carried, with the
+    rest inside run-to-run noise.
+
+    Two frames, deliberately. Hunks are MATCHED against ``current`` (the state
+    after earlier hunks of this batch were applied in memory), because that is
+    the state they would have seen had the batch been able to land. The
+    DIAGNOSTICS are computed against ``original`` (the file on disk), because
+    nothing was written and the caller's next move is a ``read`` of that file:
+    a report naming in-memory lines quotes lines that do not contain the text
+    it shows (review round 1, R1 / QA round 1, Q1). When the two frames differ
+    the header says so.
     """
     with path.open("r", encoding="utf-8", newline="") as stream:
         original = stream.read()
     current = original
     total_replacements = 0
-    failed = 0
+    refused = 0
+    counts: dict[str, int] = {
+        "did not match": 0,
+        "matched more than one place": 0,
+        "had an empty old_text": 0,
+    }
     reports: list[list[str]] = []
 
     def _record(
-        detailed_lines: Callable[[], list[str]], compact_lines: Callable[[], list[str]]
+        reason: str,
+        detailed_lines: Callable[[], list[str]],
+        compact_lines: Callable[[], list[str]],
     ) -> None:
-        """Collect one failure, within the diagnostic budget.
+        """Collect one refused hunk, within the diagnostic budget.
 
         The budget is what keeps a 40-hunk wholesale failure from returning a
-        40-hunk message: the header still counts every failure, the first few
-        get a report and the next few a one-line summary, and the tail states
-        how many were left out rather than dropping them silently. The report
-        is built by a factory that runs only when there is budget for it, so a
-        hunk past the cap never pays for a closest-region search.
+        40-hunk message: the header still counts every refusal and says why,
+        the first few get a report and the next few a one-line summary, and
+        the tail states how many were left out rather than dropping them
+        silently. A report is built by a factory that runs only when there is
+        budget for it, so a hunk past the cap never pays for a closest-region
+        search.
         """
-        nonlocal failed
-        failed += 1
+        nonlocal refused
+        refused += 1
+        counts[reason] += 1
         if len(reports) < _EDIT_MAX_DETAILED_HUNKS:
             reports.append(detailed_lines())
         elif len(reports) < _EDIT_MAX_DETAILED_HUNKS + _EDIT_MAX_COMPACT_HUNKS:
@@ -4374,6 +4533,7 @@ def _edit_file_result_locked(
         number = index + 1
         if hunk.old_text == "":
             _record(
+                "had an empty old_text",
                 lambda: [f"hunk {number}: old_text must be non-empty"],
                 lambda: [f"hunk {number}: old_text must be non-empty"],
             )
@@ -4381,8 +4541,11 @@ def _edit_file_result_locked(
         windows = _match_windows(current, hunk.old_text)
         if not windows:
             _record(
-                lambda: _edit_not_found_report(_scan_for(current), number, hunk.old_text, path),
-                lambda: _edit_not_found_compact(_scan_for(current), number, hunk.old_text),
+                "did not match",
+                lambda: _edit_not_found_report(
+                    _scan_for(original), number, hunk.old_text, path, anchor_line
+                ),
+                lambda: _edit_not_found_compact(_scan_for(original), number, hunk.old_text),
             )
             continue
         chosen = windows
@@ -4398,6 +4561,7 @@ def _edit_file_result_locked(
                     chosen = anchored
             if len(chosen) > 1:
                 _record(
+                    "matched more than one place",
                     lambda: [_ambiguous_report(current, number, chosen)],
                     lambda: [_ambiguous_report(current, number, chosen)],
                 )
@@ -4419,8 +4583,16 @@ def _edit_file_result_locked(
             current = current[:start] + replacement + current[end:]
             total_replacements += 1
 
-    if failed:
-        return _edit_refusal(path, original, len(hunks), failed, reports)
+    if refused:
+        return _edit_refusal(
+            path,
+            original,
+            len(hunks),
+            reports,
+            refused,
+            list(counts.items()),
+            current != original,
+        )
 
     if current != original:
         with path.open("w", encoding="utf-8", newline="") as stream:

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -980,7 +980,13 @@ def _display_url(raw: str) -> str | None:
     return f"{lead}{host}{tail}"
 
 
-def _ambiguous_report(content: str, number: int, chosen: list[tuple[int, int, str]]) -> str:
+def _ambiguous_report(
+    original: str,
+    current: str,
+    number: int,
+    chosen: list[tuple[int, int, str]],
+    old_text: str,
+) -> str:
     """The refusal for an ``old_text`` that matches more than one place.
 
     Names the lines, not just the count: ``matches 248 places`` leaves the
@@ -989,20 +995,46 @@ def _ambiguous_report(content: str, number: int, chosen: list[tuple[int, int, st
     computed, so the line numbers are nearly free — but only the reported
     few are located, since counting newlines is linear in the file.
 
-    ``content`` is the state the matches were FOUND in (the in-memory batch
-    state), not the on-disk text: those occurrences may not exist on disk, and
-    naming disk lines for in-memory matches would be a fabrication. When the
-    two frames differ, the refusal's header note says so.
+    The lines are located on ``original``, the file on disk, not on the state
+    the matches were FOUND in. An earlier hunk of the same call can move or
+    duplicate the text, so found-state line numbers can be shifted or can
+    describe lines the file does not have — and the caller's next act is a
+    ``read``, an ``anchor_line`` or a ``replace_all`` against the file, all of
+    which the header note promises are numbered the file's way (review round
+    2, R8). ``old_text`` is re-matched on the disk, which is a plain substring
+    scan in this case because the duplicate that got us here occurs on disk
+    too.
+
+    When the file does NOT hold a duplicate — the only duplicate is one an
+    earlier hunk of this call created — the row says that, and labels its
+    count as the batch's own state, rather than attaching file line numbers to
+    occurrences the file does not have.
     """
-    listed = [
-        str(_line_of_offset(content, window[0])) for window in chosen[:_EDIT_MAX_AMBIGUOUS_LINES]
-    ]
-    shown = ", ".join(listed)
-    if len(chosen) > _EDIT_MAX_AMBIGUOUS_LINES:
-        shown += ", …"
+    disk_windows = _match_windows(original, old_text)
+    if len(disk_windows) > 1:
+        listed = [
+            str(_line_of_offset(original, window[0]))
+            for window in disk_windows[:_EDIT_MAX_AMBIGUOUS_LINES]
+        ]
+        shown = ", ".join(listed)
+        if len(disk_windows) > _EDIT_MAX_AMBIGUOUS_LINES:
+            shown += ", …"
+        return (
+            f"hunk {number}: old_text matches {len(disk_windows)} places (lines {shown}); "
+            "include more surrounding context, give anchor_line, or set replace_all=true."
+        )
+    if disk_windows:
+        only_line = _line_of_offset(original, disk_windows[0][0])
+        return (
+            f"hunk {number}: old_text matches {len(chosen)} places in this call's in-memory "
+            f"state, but only 1 place in the file on disk (line {only_line}) — an earlier "
+            "hunk in this call created the duplicate. Re-send this hunk on its own against "
+            "the file, or set replace_all=true if every occurrence is meant."
+        )
     return (
-        f"hunk {number}: old_text matches {len(chosen)} places (lines {shown}); include "
-        "more surrounding context, give anchor_line, or set replace_all=true."
+        f"hunk {number}: old_text matches {len(chosen)} places in this call's in-memory "
+        "state, but does not occur in the file on disk at all — earlier hunks in this call "
+        "rewrote the text it matched. Re-read the file and re-send this hunk."
     )
 
 
@@ -3737,26 +3769,57 @@ def _dice(pattern: Counter[str], window: Counter[str]) -> float:
 #: thread's context copy, so concurrent edits of different files cannot see
 #: each other's snapshot.
 #:
-#: A small cache, not a single slot, because one call has TWO frames that are
-#: both live at once: the in-memory state hunks are matched against, and the
-#: on-disk content the diagnostics describe. ``_EDIT_MAX_SCANS`` bounds it, so
-#: a call builds at most that many snapshots however many hunks it has.
-_EDIT_SCANS: ContextVar[tuple[_FileScan, ...]] = ContextVar("edit_scans", default=())
+#: This holds the state hunks are MATCHED against, which changes as earlier
+#: hunks of the call are applied in memory; one slot is enough, because two
+#: hunks in a row share it until one of them writes.
+_EDIT_SCAN: ContextVar[_FileScan | None] = ContextVar("edit_scan", default=None)
+
+#: The line views of the call's ON-DISK content, pinned once at the call site.
+#:
+#: Diagnostics are built from this frame, never from ``_EDIT_SCAN``: the
+#: caller's next move is a ``read`` of the file, so the quoted text, line
+#: numbers and read ranges have to be the disk's (review round 1, R1 / QA
+#: round 1, Q1; the ambiguity list joined them in review round 2, R8).
+#:
+#: It needs its own slot rather than a slot in a shared cache: an
+#: apply-then-fail batch churns the matching frame once per applying hunk, and
+#: in a shared cache that churn evicted the disk frame, so every later failure
+#: rebuilt it too (review round 2, R11 — the review measured the rebuilds on a
+#: 10-hunk alternating batch). Pinned, the disk frame is built exactly once
+#: however the batch alternates; what remains is one matching frame per distinct
+#: content version, which is the matcher's own cost and not a cache defect.
+_EDIT_DISK_SCAN: ContextVar[_FileScan | None] = ContextVar("edit_disk_scan", default=None)
 
 
 def _scan_for(content: str) -> _FileScan:
-    """The current call's line views for ``content``, built once per snapshot.
+    """The current call's line views for the state hunks are matched against.
 
-    A snapshot is reused only when it describes exactly this content, so a
-    multi-hunk batch builds each frame's tolerant index and word bags once, no
-    matter how many hunks are matched or fail against it.
+    Reused only while it describes exactly this content, so a run of hunks
+    against an unchanged state pays for the tolerant index and the word bags
+    once. A hunk that writes retires it, and the next hunk builds its
+    successor — one frame per content version, not one per hunk.
     """
-    scans = _EDIT_SCANS.get()
-    for scan in scans:
-        if scan.matches(content):
-            return scan
+    scan = _EDIT_SCAN.get()
+    if scan is not None and scan.matches(content):
+        return scan
     scan = _FileScan(content)
-    _EDIT_SCANS.set((scan, *scans)[:_EDIT_MAX_SCANS])
+    _EDIT_SCAN.set(scan)
+    return scan
+
+
+def _scan_for_disk(content: str) -> _FileScan:
+    """The call's ON-DISK line views, built at most once per call.
+
+    ``content`` is always the call's ``original``; the identity check is there
+    so a stale pin can never be served (the ContextVar is per-thread, but a
+    future caller that reuses the context for another edit would otherwise
+    inherit a foreign frame).
+    """
+    scan = _EDIT_DISK_SCAN.get()
+    if scan is not None and scan.matches(content):
+        return scan
+    scan = _FileScan(content)
+    _EDIT_DISK_SCAN.set(scan)
     return scan
 
 
@@ -3830,6 +3893,12 @@ def _match_windows(content: str, old_text: str) -> list[tuple[int, int, str]]:
 # unbounded one would cost more than the failure it reports. Each is applied
 # where it is named, and the whole message is capped last.
 
+#: Word overlap at or above which the closest region IS the hunk's own text.
+#: Only reachable when the two frames differ (on unchanged content the hunk
+#: would have matched, not been refused), so the report says which situation
+#: stands instead of printing "not found" beside "100% word overlap" with the
+#: caller's own text (review round 2, R10).
+_EDIT_SELF_MATCH_PERCENT = 100
 #: Failing hunks that get a full closest-region report. TWO, not three: a
 #: detailed report is up to ~15 rows in the tool card (six quoted lines, two
 #: candidates, the difference pair and the hint) and the expanded card paints
@@ -3841,12 +3910,21 @@ _EDIT_MAX_DETAILED_HUNKS = 2
 #: Further failing hunks that get one compact line each. Bounded because the
 #: failure count is caller-controlled: a 40-hunk batch that fails wholesale
 #: must not produce a 40-line report, and the count of the rest survives in the
-#: ``… and N more hunks failed (details suppressed)`` tail.
+#: ``… and N more hunks were refused (details suppressed)`` tail.
 _EDIT_MAX_COMPACT_HUNKS = 3
-#: Scans cached per edit call. Two, because a call has two frames that must not
-#: be confused: the in-memory state hunks are matched against, and the on-disk
-#: content the diagnostics describe (review round 1, R1).
-_EDIT_MAX_SCANS = 2
+#: Line views built per edit call. Two DOCUMENTED bounds, because the two
+#: frames are accounted for differently.
+#:
+#: The on-disk frame is built exactly once per call, pinned in its own slot
+#: (``_EDIT_DISK_SCAN``), no matter how many hunks fail or alternate with ones
+#: that write (review round 2, R11). The matching frame is a separate slot and
+#: is rebuilt only when a hunk writes, so a call builds one per distinct content
+#: version — one for an all-failing batch however long it is, and one per
+#: applying hunk otherwise. Both counts are pinned by
+#: ``test_edit_builds_one_scan_per_frame_not_one_per_hunk`` and
+#: ``test_edit_pins_the_disk_frame_across_an_alternating_batch``.
+_EDIT_MAX_DISK_SCANS = 1
+_EDIT_MATCHING_SCANS_PER_VERSION = 1
 #: Candidate regions reported per hunk (one with text, the rest as snippets).
 _EDIT_MAX_REGIONS = 3
 #: Candidate windows the full metric is run over (the prefilter's hard bound).
@@ -3898,17 +3976,53 @@ def _clip_line(text: str, limit: int = _EDIT_MAX_LINE_CHARS) -> str:
     return text[: limit - 1] + "…"
 
 
-def _read_hint(path: Path, first: int, last: int, anchor_line: int | None) -> str:
+def _no_region_hint(display_path: str, total_lines: int, anchor_line: int | None) -> str:
+    """What to do when the file holds nothing resembling the hunk.
+
+    Never an invented range. There is no region the search can point at, and
+    the range this used to emit was the head of the file — or, on an empty
+    file, the inverted ``1-0`` — naming a place the failure gave no reason to
+    look at (review round 2, R9). A range is emitted only from the caller's own
+    ``anchor_line``, clamped into the file, because that is the one thing the
+    refusal knows about where they meant to edit; without it the caller is sent
+    back to the region they were already thinking of.
+    """
+    if anchor_line is not None and total_lines >= 1:
+        first = max(1, min(anchor_line, total_lines))
+        last = min(total_lines, first + _EDIT_MAX_WINDOW_LINES - 1)
+        return (
+            f'  read(range="{first}-{last}", path="{display_path}") — start at the line you '
+            "anchored to, then anchor the hunk to the text you find there; nothing in the file "
+            "resembles this hunk."
+        )
+    return (
+        "  re-read the region you meant to change (a ranged `read`) and anchor the hunk to the "
+        "text you find there; nothing in the file resembles this hunk."
+    )
+
+
+def _read_hint(display_path: str, first: int, last: int, anchor_line: int | None) -> str:
     """The next ``read`` call, FIRST on its line, then what to do with it.
 
-    The call leads because it is the one token the caller acts on and the tool
-    card clips every row from the right: a hint whose ``range`` argument was
-    cut mid-argument is unusable (design round 1, D2). ``anchor_line`` is
-    echoed when the caller supplied one — it is the only hint the caller gave
-    the tool about where it meant to edit, and it costs nothing to repeat
-    (review round 1, R4).
+    The call leads because it is the one token the caller acts on, and the tool
+    card clips every row from the right: a hint whose ``range`` argument was cut
+    mid-argument is unusable (design round 1, D2). ``range`` comes before
+    ``path`` for the same reason — the row budget at the narrowest supported
+    width is ~50 cells, which no realistic path plus ``range=`` fits in, so the
+    argument that carries the actionable numbers is the one that must survive
+    the clip (design round 2, D2 residual). The arguments are named, so their
+    order costs the caller nothing, and the path is printed in the caller's own
+    spelling: it is what they can re-use, and it is already on the ``File:``
+    line and the card's summary row if the row does clip it.
+
+    ``anchor_line`` is echoed when the caller supplied one — it is the only hint
+    the caller gave the tool about where it meant to edit, and it costs nothing
+    to repeat (review round 1, R4).
     """
-    hint = f'  read(path="{path}", range="{first}-{last}") — confirm the current text, then retry'
+    hint = (
+        f'  read(range="{first}-{last}", path="{display_path}") — confirm the current text, '
+        "then retry"
+    )
     if anchor_line is not None:
         hint += f" (or read around line {anchor_line}, the anchor_line you gave)"
     return hint + "; skip the hunk if the change is already there."
@@ -4067,23 +4181,28 @@ def _is_pure_insertion(pattern_lines: list[str], file_lines: list[str]) -> bool:
     return prefix + suffix >= limit
 
 
-def _edit_not_found_compact(scan: _FileScan, number: int, old_text: str) -> list[str]:
+def _edit_not_found_compact(
+    scan: _FileScan, number: int, old_text: str, in_memory_moved: bool = False
+) -> list[str]:
     """One line for a failing hunk past the detailed-report cap.
 
     Keeps the two facts that tell the failures apart — this hunk failed, and
     roughly where the file says something similar — for about a tenth of a
     full report. ``scan`` is the ON-DISK frame, like the detailed report: a
     one-liner naming a line of the in-memory state would be the same wrong
-    answer, just shorter.
+    answer, just shorter. ``in_memory_moved`` adds the self-match clause when
+    the closest region is the hunk's own text (review round 2, R10).
     """
     regions = _closest_regions(scan, old_text.splitlines())
     if not regions:
         return [f"hunk {number}: old_text not found — no close match."]
     start, _end, overlap = regions[0]
+    self_match = in_memory_moved and _overlap_percent(overlap) >= _EDIT_SELF_MATCH_PERCENT
     if _overlap_percent(overlap) >= _EDIT_OVERLAP_LABEL_PERCENT:
+        tail = "; earlier hunks in this call would have replaced or moved it" if self_match else ""
         return [
             f"hunk {number}: old_text not found — closest text at line "
-            f"{start + 1} ({_percent(overlap)} word overlap)."
+            f"{start + 1} ({_percent(overlap)} word overlap){tail}."
         ]
     return [
         f"hunk {number}: old_text not found — no close match (nearest line "
@@ -4111,8 +4230,9 @@ def _edit_not_found_report(
     scan: _FileScan,
     number: int,
     old_text: str,
-    path: Path,
+    display_path: str,
     anchor_line: int | None = None,
+    in_memory_moved: bool = False,
 ) -> list[str]:
     """The closest-region report for one hunk whose ``old_text`` did not match.
 
@@ -4148,7 +4268,7 @@ def _edit_not_found_report(
         # line of it shares a word with this hunk, which is not the same claim.
         return head + [
             "  no close match in the file; no text in it shares any words with this hunk.",
-            _read_hint(path, 1, min(total_lines, _EDIT_MAX_WINDOW_LINES), anchor_line),
+            _no_region_hint(display_path, total_lines, anchor_line),
         ]
 
     start, end, overlap = regions[0]
@@ -4160,7 +4280,7 @@ def _edit_not_found_report(
         return head + [
             f"  no close match in the file; the nearest text is line {first} "
             f"({_percent(overlap)} word overlap).",
-            _read_hint(path, read_first, read_last, anchor_line),
+            _read_hint(display_path, read_first, read_last, anchor_line),
         ]
 
     shown_last = min(last, first + _EDIT_MAX_WINDOW_LINES - 1)
@@ -4173,6 +4293,15 @@ def _edit_not_found_report(
     width = len(str(shown_last))
     for line_number in range(first, shown_last + 1):
         lines.append(f"    {line_number:>{width}}| {_clip_line(file_lines[line_number - 1])}")
+    if in_memory_moved and _overlap_percent(overlap) >= _EDIT_SELF_MATCH_PERCENT:
+        # "not found" beside "100% word overlap" with the caller's own text is
+        # self-contradictory on its face; name the situation instead (review
+        # round 2, R10). The region IS the hunk's text, unchanged on disk — what
+        # is missing is the text this call's earlier hunks would have left.
+        lines.append(
+            "  (this is this hunk's own text, still on disk unchanged — an earlier hunk in "
+            "this call would have replaced or moved it)"
+        )
     for alt_start, alt_end, alt_overlap in regions[1:]:
         snippet = _clip_line(" ".join(file_lines[alt_start:alt_end]), _EDIT_MAX_SNIPPET_CHARS)
         lines.append(f'  also similar: line {alt_start + 1} ({_percent(alt_overlap)}) "{snippet}"')
@@ -4228,7 +4357,7 @@ def _edit_not_found_report(
                     "rather than reworded)"
                 )
 
-    lines.append(_read_hint(path, read_first, read_last, anchor_line))
+    lines.append(_read_hint(display_path, read_first, read_last, anchor_line))
     return lines
 
 
@@ -4313,7 +4442,10 @@ def _edit_refusal(
         for report in kept:
             lines.extend(report)
         if hidden > 0:
-            lines.append(f"… and {hidden} more hunks failed (details suppressed)")
+            # "were refused", not "failed": the suppressed hunks may be ambiguity
+            # refusals, and the header above just took the trouble to name each
+            # reason (review round 2, R12).
+            lines.append(f"… and {hidden} more hunks were refused (details suppressed)")
         return "\n".join(lines)
 
     kept: list[list[str]] = []
@@ -4434,7 +4566,9 @@ async def execute_edit(
     # same load: file IO plus pure-Python matching and difflib over the whole
     # file. Keeping that work on the Textual loop merely moved the reported
     # freeze from the old one-hunk path into the new implementation.
-    outcome = await asyncio.to_thread(_edit_file_result, path, hunks, params.anchor_line)
+    outcome = await asyncio.to_thread(
+        _edit_file_result, path, hunks, params.anchor_line, params.path
+    )
     if isinstance(outcome, str):
         return _error(tool_call_id, "edit", outcome)
     total_replacements, details = outcome
@@ -4450,16 +4584,18 @@ def _edit_file_result(
     path: Path,
     hunks: list[EditHunk],
     anchor_line: int | None,
+    caller_path: str = "",
 ) -> tuple[int, dict[str, Any]] | str:
     """Serialize one file transaction across parent/child AgentLoops."""
     with _file_transaction(path):
-        return _edit_file_result_locked(path, hunks, anchor_line)
+        return _edit_file_result_locked(path, hunks, anchor_line, caller_path)
 
 
 def _edit_file_result_locked(
     path: Path,
     hunks: list[EditHunk],
     anchor_line: int | None,
+    caller_path: str = "",
 ) -> tuple[int, dict[str, Any]] | str:
     """The current multi-hunk edit engine, synchronous for ``to_thread``.
 
@@ -4478,8 +4614,10 @@ def _edit_file_result_locked(
 
     Nothing here runs on the happy path: an all-exact batch builds no line
     views at all. The views are fetched through ``_scan_for`` on any hunk that
-    needs the tolerant pass (a tolerant SUCCESS builds one), and again on the
-    failure path for the diagnostics. Measured with the pre-change module
+    needs the tolerant pass (a tolerant SUCCESS builds one), and through
+    ``_scan_for_disk`` on the failure path, where the frame is pinned for the
+    call so the diagnostics describe the file on disk without being rebuilt
+    (review round 2, R11). Measured with the pre-change module
     loaded from a file into the same interpreter, 11 exact hunks over the
     104 KB corpus file come out at ~14 ms CPU either side of this change —
     both dominated by the diff details the result already carried, with the
@@ -4491,9 +4629,32 @@ def _edit_file_result_locked(
     DIAGNOSTICS are computed against ``original`` (the file on disk), because
     nothing was written and the caller's next move is a ``read`` of that file:
     a report naming in-memory lines quotes lines that do not contain the text
-    it shows (review round 1, R1 / QA round 1, Q1). When the two frames differ
-    the header says so.
+    it shows (review round 1, R1 / QA round 1, Q1). That includes the
+    ambiguity refusal's match list, which is located on ``original`` again
+    rather than on the state the matches were found in, so no line number in
+    the message can disagree with the ``read`` the caller is about to make
+    (review round 2, R8). When the two frames differ the header says so.
+
+    The disk frame is PINNED for the call (``_EDIT_DISK_SCAN``), so it is
+    built at most once even in a batch that applies and fails alternately
+    (review round 2, R11). Both frames start unset: an all-exact batch builds
+    neither.
     """
+    # A fresh frame for this call. The pin is lazy — the first hunk that needs
+    # the disk views builds them, and every later hunk reuses them — which is
+    # what keeps the happy path free of line indexing.
+    _EDIT_SCAN.set(None)
+    _EDIT_DISK_SCAN.set(None)
+    # What the hints print as the path. The message is for the CALLER, and the
+    # resolved absolute path is both longer than their own spelling and less
+    # useful to them: they have to paste this into a follow-up `read`, and an
+    # 81-character repo path pushed the range argument off the card's row at
+    # every width (design round 2, D2 residual). Their spelling is resolved by
+    # the same `_resolve_workspace_path` call above, and the card's summary row
+    # already shows it, so it is a valid argument to the tool for them. Empty
+    # only if a future caller bypasses the tool's own validation; the absolute
+    # path is the honest fallback then.
+    display_path = caller_path.strip() or str(path)
     with path.open("r", encoding="utf-8", newline="") as stream:
         original = stream.read()
     current = original
@@ -4543,9 +4704,19 @@ def _edit_file_result_locked(
             _record(
                 "did not match",
                 lambda: _edit_not_found_report(
-                    _scan_for(original), number, hunk.old_text, path, anchor_line
+                    _scan_for_disk(original),
+                    number,
+                    hunk.old_text,
+                    display_path,
+                    anchor_line,
+                    in_memory_moved=current != original,
                 ),
-                lambda: _edit_not_found_compact(_scan_for(original), number, hunk.old_text),
+                lambda: _edit_not_found_compact(
+                    _scan_for_disk(original),
+                    number,
+                    hunk.old_text,
+                    in_memory_moved=current != original,
+                ),
             )
             continue
         chosen = windows
@@ -4562,8 +4733,8 @@ def _edit_file_result_locked(
             if len(chosen) > 1:
                 _record(
                     "matched more than one place",
-                    lambda: [_ambiguous_report(current, number, chosen)],
-                    lambda: [_ambiguous_report(current, number, chosen)],
+                    lambda: [_ambiguous_report(original, current, number, chosen, hunk.old_text)],
+                    lambda: [_ambiguous_report(original, current, number, chosen, hunk.old_text)],
                 )
                 continue
         # Apply back-to-front so earlier offsets stay valid within this hunk.

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -3608,15 +3608,19 @@ class _FileScan:
     lazy properties rather than built eagerly because the whole thing is a
     failure-path cost: an all-exact batch must not pay it once.
 
-    ``lines`` is cheap; ``token_set`` / ``bags`` are the expensive ones and are
-    built only by the diagnostics that need them.
+    ``lines`` / ``offsets`` / ``offline`` are cheap; ``token_set`` / ``bags`` /
+    ``doc_freq`` are the expensive ones and are built only by the two
+    consumers that need them.
     """
 
-    __slots__ = ("_content", "_lines", "_sets", "_bags")
+    __slots__ = ("_content", "_lines", "_raw_lines", "_offsets", "_stripped", "_sets", "_bags")
 
     def __init__(self, content: str) -> None:
         self._content = content
         self._lines: list[str] | None = None
+        self._raw_lines: list[str] | None = None
+        self._offsets: list[int] | None = None
+        self._stripped: dict[str, list[int]] | None = None
         self._sets: list[frozenset[str]] | None = None
         self._bags: list[Counter[str]] | None = None
 
@@ -3635,6 +3639,49 @@ class _FileScan:
         if self._lines is None:
             self._lines = self._content.splitlines()
         return self._lines
+
+    @property
+    def raw_lines(self) -> list[str]:
+        """Lines WITH their endings — what a matched window is rebuilt from.
+
+        Built from the raw content rather than by appending an ending to
+        ``lines``: ``str.splitlines`` also breaks on form feed and the C1
+        separators, so re-deriving the endings would silently disagree with
+        the line count for any file containing one.
+        """
+        if self._raw_lines is None:
+            self._raw_lines = self._content.splitlines(keepends=True)
+        return self._raw_lines
+
+    @property
+    def offsets(self) -> list[int]:
+        """Character offset each line starts at, aligned with ``lines``."""
+        if self._offsets is None:
+            offsets: list[int] = []
+            at = 0
+            for line in self.raw_lines:
+                offsets.append(at)
+                at += len(line)
+            self._offsets = offsets
+        return self._offsets
+
+    @property
+    def stripped_index(self) -> dict[str, list[int]]:
+        """``stripped line -> line indices``: the tolerant matcher's index.
+
+        Keyed on the bare ``strip()`` form, because that is exactly the
+        equality the tolerant pass tests — membership here is therefore not
+        an approximation of a tolerant match, it IS that match for one line.
+        CRLF spellings collapse onto the same key with their LF twins, which
+        is why the key is recomputed from the raw line instead of reused from
+        ``lines``.
+        """
+        if self._stripped is None:
+            index: dict[str, list[int]] = {}
+            for i, line in enumerate(self.raw_lines):
+                index.setdefault(line.strip(), []).append(i)
+            self._stripped = index
+        return self._stripped
 
     def token_set(self, index: int) -> frozenset[str]:
         """Distinct word tokens of one line — the candidate prefilter's unit."""
@@ -3712,6 +3759,17 @@ def _match_windows(content: str, old_text: str) -> list[tuple[int, int, str]]:
     Tolerance is one-directional by design: an exact match is never silently
     flexed, and a fuzzy match never silently wins over an exact one that
     exists elsewhere.
+
+    Pass 2 is index-driven rather than scan-driven. Every line of a tolerant
+    match must strip-equal its counterpart, so a window can only START where
+    the pattern's most selective stripped line occurs; the inverted index
+    hands those starts over directly and the remaining lines are verified by
+    dict membership. The naive loop this replaces (try every start, strip
+    every line of the window) was O(file_lines x pattern_lines) strip() calls
+    — 20,000 lines against a 200-line pattern is 4 million of them. The two
+    are equivalent by construction, and a unit test checks them against each
+    other on a generated corpus. The snapshot's index comes from ``_scan_for``
+    so it is shared with the not-found diagnostics of the same edit call.
     """
     windows: list[tuple[int, int, str]] = []
     start = content.find(old_text)
@@ -3721,30 +3779,34 @@ def _match_windows(content: str, old_text: str) -> list[tuple[int, int, str]]:
     if windows:
         return windows
 
-    file_lines = content.splitlines(keepends=True)
-    # Per-line start offsets so a window can be returned as a char span.
-    offsets: list[int] = []
-    at = 0
-    for line in file_lines:
-        offsets.append(at)
-        at += len(line)
+    scan = _scan_for(content)
     old_lines = old_text.splitlines()
+    stripped = [line.strip() for line in old_lines]
+    file_lines = scan.lines
     if not old_lines or len(old_lines) > len(file_lines):
         return []
 
-    def _tolerant(file_line: str, old_line: str) -> bool:
-        return file_line.strip() == old_line.strip()
-
-    for i in range(len(file_lines) - len(old_lines) + 1):
-        window = file_lines[i : i + len(old_lines)]
-        if all(_tolerant(f.rstrip("\r\n"), o) for f, o in zip(window, old_lines)):
+    # The seed is the pattern line whose stripped form occurs on the fewest
+    # file lines: one occurrence means one verification, and every other line
+    # of the window is then a single membership test. A seed that is absent
+    # from the index proves no window exists at all, however long the file.
+    index = scan.stripped_index
+    seed = min(range(len(stripped)), key=lambda i: len(index.get(stripped[i], ())))
+    candidates = index.get(stripped[seed], ())
+    offsets = scan.offsets
+    raw_lines = scan.raw_lines
+    width = len(old_lines)
+    for line_index in candidates:
+        first = line_index - seed
+        if first < 0 or first + width > len(file_lines):
+            continue
+        if all(file_lines[first + i].strip() == stripped[i] for i in range(width)):
             # The span runs to the end of the last matched line INCLUDING its
             # newline, so replacing it cannot splice the following line onto
             # the replacement's final line.
-            last_line = window[-1]
-            end = offsets[i + len(old_lines) - 1] + len(last_line)
-            matched = "".join(window)
-            windows.append((offsets[i], end, matched))
+            last_raw = raw_lines[first + width - 1]
+            matched = "".join(raw_lines[first : first + width])
+            windows.append((offsets[first], offsets[first + width - 1] + len(last_raw), matched))
     return windows
 
 
@@ -3831,10 +3893,11 @@ def _closest_regions(
     scores every file line against an anchor with a bare token-SET
     intersection (C-speed set ops, no Python loop over the anchor's tokens)
     and keeps the best ``_EDIT_MAX_CANDIDATE_STARTS`` window starts; stage two
-    runs the real bag-of-words Dice over just those windows. Measured on a
-    synthetic 20,000-line file with a 200-line drifted pattern: 19 ms against
-    6.07 s for scoring every window (326x), with the same top window and score
-    (0.97 at the true start).
+    runs the real bag-of-words Dice over just those windows. Measured here
+    (Darwin 25.6.0 arm64, CPython 3.12.13) on a synthetic 20,000-line file
+    with a 200-line drifted pattern: 21 ms against 6.6 s for scoring every
+    window (321x), with the same top window and score (0.97 at the true
+    start).
     """
     if not pattern_lines:
         return []

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -57,7 +57,7 @@ import threading
 import time
 import traceback
 import unicodedata
-from collections import deque
+from collections import Counter, deque
 from collections.abc import Awaitable, Callable, Iterable, Iterator, Sequence
 from contextvars import ContextVar
 from datetime import UTC, datetime
@@ -978,6 +978,27 @@ def _display_url(raw: str) -> str | None:
     # safe case, and the overwhelming majority) still costs nothing.
     lead = "" if parts.scheme == "https" else f"{parts.scheme}! "
     return f"{lead}{host}{tail}"
+
+
+def _ambiguous_report(content: str, number: int, chosen: list[tuple[int, int, str]]) -> str:
+    """The refusal for an ``old_text`` that matches more than one place.
+
+    Names the lines, not just the count: ``matches 248 places`` leaves the
+    caller to re-read the whole file to find out where, which is the round
+    trip this whole change exists to remove. The windows are already
+    computed, so the line numbers are nearly free — but only the reported
+    few are located, since counting newlines is linear in the file.
+    """
+    listed = [
+        str(_line_of_offset(content, window[0])) for window in chosen[:_EDIT_MAX_AMBIGUOUS_LINES]
+    ]
+    shown = ", ".join(listed)
+    if len(chosen) > _EDIT_MAX_AMBIGUOUS_LINES:
+        shown += ", …"
+    return (
+        f"hunk {number}: old_text matches {len(chosen)} places (lines {shown}); include "
+        "more surrounding context, give anchor_line, or set replace_all=true."
+    )
 
 
 def _error(tool_call_id: str, tool_name: str, message: str) -> ToolResult:
@@ -3552,6 +3573,135 @@ def _leading_ws(line: str) -> str:
     return line[: len(line) - len(line.lstrip())]
 
 
+# ---------------------------------------------------------------------------
+# edit: the shared line views and the word-overlap metric
+# ---------------------------------------------------------------------------
+#
+# Matching performance and the not-found diagnostics both need per-line views
+# of one file snapshot. ``_FileScan`` below owns them and builds each lazily,
+# because both consumers are FAILURE-PATH-ONLY concerns: a hunk whose
+# ``old_text`` matches exactly never touches any of it, and the happy path
+# (exact substrings, ``str.find``) is left exactly as it was.
+#
+# The metric is bag-of-words Dice over the whole candidate window. A
+# character-sequence metric was measured first and rejected: on the real
+# corpus behind this change SequenceMatcher.ratio scored the TRUE region of a
+# drifted hunk at 0.18-0.24 (it is dominated by order and punctuation), while
+# bag-Dice scored the same regions 0.59-0.99 -- useless for ranking against
+# 647 lines of prose. Order-insensitivity is the point, because the failure
+# being diagnosed is a paragraph that was reworded in place. It is a real
+# percentage of a different quantity, which is why every message that prints
+# it names the metric (``word overlap``) and never says ``similarity``.
+
+#: Word tokens. Digits and underscores count as word characters so identifiers
+#: such as ``_match_windows`` or ``S2-11`` stay whole; everything else splits.
+_WORD_RE = re.compile(r"[A-Za-z0-9_]+")
+
+
+class _FileScan:
+    """One file snapshot's line views, offset map and word bags.
+
+    Shared across the hunks of a single edit call so the tolerant matcher and
+    the diagnostics agree about the same snapshot, and rebuilt only when the
+    content actually changed since the scan was taken (a hunk that matched
+    exactly and rewrote the file). Modelled as a small call-scoped class with
+    lazy properties rather than built eagerly because the whole thing is a
+    failure-path cost: an all-exact batch must not pay it once.
+
+    ``lines`` is cheap; ``token_set`` / ``bags`` are the expensive ones and are
+    built only by the diagnostics that need them.
+    """
+
+    __slots__ = ("_content", "_lines", "_sets", "_bags")
+
+    def __init__(self, content: str) -> None:
+        self._content = content
+        self._lines: list[str] | None = None
+        self._sets: list[frozenset[str]] | None = None
+        self._bags: list[Counter[str]] | None = None
+
+    def matches(self, content: str) -> bool:
+        """True when this scan already describes ``content``.
+
+        An identity check first: the loop hands the same string back on every
+        hunk that did not write, so the equality comparison (a full copy of a
+        100 KB file) is normally never reached.
+        """
+        return content is self._content or content == self._content
+
+    @property
+    def lines(self) -> list[str]:
+        """Lines WITHOUT their endings, in file order."""
+        if self._lines is None:
+            self._lines = self._content.splitlines()
+        return self._lines
+
+    def token_set(self, index: int) -> frozenset[str]:
+        """Distinct word tokens of one line — the candidate prefilter's unit."""
+        if self._sets is None:
+            self._sets = [frozenset(_WORD_RE.findall(_norm_line(line))) for line in self.lines]
+        return self._sets[index]
+
+    @property
+    def bags(self) -> list[Counter[str]]:
+        """Per-line word-token Counters, built once per snapshot."""
+        if self._bags is None:
+            self._bags = [_token_bag(line) for line in self.lines]
+        return self._bags
+
+
+def _norm_line(line: str) -> str:
+    """Collapse space/tab runs and trim the ends — whitespace ONLY.
+
+    Deliberately not Unicode-normalised and not punctuation-folded: folding
+    punctuation variants would let two genuinely different passages score as
+    one, and the failure mode here is a REWORDED paragraph, not a re-encoded
+    one. Keeping the norm this narrow also keeps the number a caller reads
+    reproducible from the file text alone.
+    """
+    return re.sub(r"[ \t]+", " ", line.strip())
+
+
+def _token_bag(line: str) -> Counter[str]:
+    """The word-token bag of one line, for the window-level metric."""
+    return Counter(_WORD_RE.findall(_norm_line(line)))
+
+
+def _dice(pattern: Counter[str], window: Counter[str]) -> float:
+    """Bag-of-words Dice overlap: ``2*|P & W| / (|P| + |W|)``."""
+    if not pattern or not window:
+        return 0.0
+    shared = sum((pattern & window).values())
+    return 2.0 * shared / (sum(pattern.values()) + sum(window.values()))
+
+
+#: The line views of the edit call currently running on this thread.
+#:
+#: It travels on a ContextVar rather than as a parameter because
+#: ``_match_windows(content, old_text)`` is the engine's matching seam and the
+#: concurrency tests widen that seam by patching the module attribute with a
+#: two-argument stand-in; a third required parameter would break every such
+#: caller. A ContextVar set inside the ``to_thread`` worker is private to that
+#: thread's context copy, so concurrent edits of different files cannot see
+#: each other's snapshot.
+_EDIT_SCAN: ContextVar[_FileScan | None] = ContextVar("edit_scan", default=None)
+
+
+def _scan_for(content: str) -> _FileScan:
+    """The current call's line views for ``content``, built once per snapshot.
+
+    Rebuilt only when the content is not the one the held scan describes —
+    i.e. an earlier hunk in the same call already rewrote the file — so a
+    multi-hunk batch builds the tolerant index and the word bags once, no
+    matter how many hunks fail against it.
+    """
+    scan = _EDIT_SCAN.get()
+    if scan is None or not scan.matches(content):
+        scan = _FileScan(content)
+        _EDIT_SCAN.set(scan)
+    return scan
+
+
 def _match_windows(content: str, old_text: str) -> list[tuple[int, int, str]]:
     """``(start, end, matched_text)`` windows where ``old_text`` occurs.
 
@@ -3596,6 +3746,389 @@ def _match_windows(content: str, old_text: str) -> list[tuple[int, int, str]]:
             matched = "".join(window)
             windows.append((offsets[i], end, matched))
     return windows
+
+
+# ---------------------------------------------------------------------------
+# edit: closest-region diagnostics for a hunk that did not match
+# ---------------------------------------------------------------------------
+#
+# Every bound below exists so a failing edit on a large file cannot flood the
+# context it is trying to help: the refusal is the model's only signal, and an
+# unbounded one would cost more than the failure it reports. Each is applied
+# where it is named, and the whole message is capped last.
+
+#: Failing hunks that get a full closest-region report.
+_EDIT_MAX_DETAILED_HUNKS = 3
+#: Further failing hunks that get one compact line each. Bounded because the
+#: failure count is caller-controlled: a 40-hunk batch that fails wholesale
+#: must not produce a 40-line report, and the count of the rest survives in
+#: the ``… (N more failing hunks not shown)`` tail.
+_EDIT_MAX_COMPACT_HUNKS = 3
+#: Candidate regions reported per hunk (one with text, the rest as snippets).
+_EDIT_MAX_REGIONS = 3
+#: Candidate windows the full metric is run over (the prefilter's hard bound).
+_EDIT_MAX_CANDIDATE_STARTS = 12
+#: Pattern lines used as prefilter anchors (first line + the heaviest two).
+_EDIT_MAX_ANCHORS = 3
+#: Window lines quoted per hunk.
+_EDIT_MAX_WINDOW_LINES = 6
+#: Displayed width of one quoted line, and of an ``also similar`` snippet.
+_EDIT_MAX_LINE_CHARS = 200
+_EDIT_MAX_SNIPPET_CHARS = 60
+#: Hard bound on the whole refusal, tail included.
+_EDIT_MAX_MESSAGE_CHARS = 6000
+#: Above this word overlap the report says ``closest text``; below it, the
+#: honest ``no close match``. The label is derived from the metric, never
+#: asserted independently of it.
+_EDIT_OVERLAP_LABEL_THRESHOLD = 0.30
+#: Match line numbers listed in the ambiguous-match refusal.
+_EDIT_MAX_AMBIGUOUS_LINES = 8
+
+
+def _percent(value: float) -> str:
+    """Word overlap as a whole percent — the metric's name travels with it."""
+    return f"{round(value * 100)}%"
+
+
+def _clip_line(text: str, limit: int = _EDIT_MAX_LINE_CHARS) -> str:
+    """One displayed line, capped: a minified or single-line file is a real
+    input, and quoting it whole would put the file in the error message."""
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
+
+def _read_hint(path: Path, first: int, last: int) -> str:
+    """The exact ``read`` call that shows a line range, ready to paste."""
+    return f'read(path="{path}", range="{first}-{last}")'
+
+
+def _anchor_indices(pattern_lines: list[str]) -> list[int]:
+    """Up to three pattern lines to anchor the candidate search on.
+
+    The first line plus the two with the most tokens. A stale hunk keeps most
+    of its words, so its heaviest lines are its most selective anchors, and a
+    hunk whose opening line survived gives the least ambiguous window start.
+    """
+    sizes = [len(_WORD_RE.findall(_norm_line(line))) for line in pattern_lines]
+    heavy = sorted(range(len(pattern_lines)), key=lambda i: -sizes[i])
+    indices: list[int] = []
+    for i in [0, *heavy]:
+        if i not in indices:
+            indices.append(i)
+        if len(indices) >= _EDIT_MAX_ANCHORS:
+            break
+    return indices
+
+
+def _closest_regions(
+    scan: _FileScan, pattern_lines: list[str], limit: int = _EDIT_MAX_REGIONS
+) -> list[tuple[int, int, float]]:
+    """File windows that best match ``pattern_lines``, as ``(start, end, overlap)``.
+
+    ``start``/``end`` are a half-open line-index range. Ranking runs in two
+    stages so the expensive metric never runs O(file_lines) times: stage one
+    scores every file line against an anchor with a bare token-SET
+    intersection (C-speed set ops, no Python loop over the anchor's tokens)
+    and keeps the best ``_EDIT_MAX_CANDIDATE_STARTS`` window starts; stage two
+    runs the real bag-of-words Dice over just those windows. Measured on a
+    synthetic 20,000-line file with a 200-line drifted pattern: 19 ms against
+    6.07 s for scoring every window (326x), with the same top window and score
+    (0.97 at the true start).
+    """
+    if not pattern_lines:
+        return []
+    file_lines = scan.lines
+    n_lines = len(file_lines)
+    if n_lines == 0:
+        return []
+    width = len(pattern_lines)
+
+    best: dict[int, int] = {}
+    for anchor_index in _anchor_indices(pattern_lines):
+        anchor_set = frozenset(_WORD_RE.findall(_norm_line(pattern_lines[anchor_index])))
+        if not anchor_set:
+            continue
+        for file_index in range(n_lines):
+            overlap = len(anchor_set & scan.token_set(file_index))
+            if overlap == 0:
+                continue
+            start = file_index - anchor_index
+            if start < 0:
+                continue
+            if overlap > best.get(start, 0):
+                best[start] = overlap
+    if not best:
+        return []
+
+    pattern_bag = Counter()
+    for line in pattern_lines:
+        pattern_bag.update(_token_bag(line))
+    if not pattern_bag:
+        return []
+
+    ranked: list[tuple[int, int, float]] = []
+    bags = scan.bags
+    for start in sorted(best, key=lambda s: -best[s])[:_EDIT_MAX_CANDIDATE_STARTS]:
+        end = min(start + width, n_lines)
+        window_bag: Counter[str] = Counter()
+        for bag in bags[start:end]:
+            window_bag.update(bag)
+        if not window_bag:
+            continue
+        ranked.append((start, end, _dice(pattern_bag, window_bag)))
+    ranked.sort(key=lambda region: -region[2])
+
+    # Drop runner-ups that overlap a better region: three windows starting
+    # inside the same paragraph describe one place, not three candidates.
+    picked: list[tuple[int, int, float]] = []
+    for region in ranked:
+        if any(abs(region[0] - chosen[0]) < width for chosen in picked):
+            continue
+        picked.append(region)
+        if len(picked) >= limit:
+            break
+    return picked
+
+
+def _strip_eol(line: str) -> str:
+    return line.rstrip("\r\n")
+
+
+def _first_difference(pattern_lines: list[str], file_lines: list[str]) -> tuple[int, int]:
+    """The first pattern/file line pair that differs, as indices (``-1`` = none).
+
+    Line endings are ignored, because a CRLF file against an LF hunk is not a
+    difference a caller can act on. The trailing trim exists only to report
+    the *insertion* case honestly (see ``_edit_not_found_report``); the first
+    differing pair is decided by the leading trim alone.
+    """
+    pattern = [_strip_eol(line) for line in pattern_lines]
+    file_ = [_strip_eol(line) for line in file_lines]
+    limit = min(len(pattern), len(file_))
+    prefix = 0
+    while prefix < limit and pattern[prefix] == file_[prefix]:
+        prefix += 1
+    if prefix >= len(pattern) or prefix >= len(file_):
+        # One side ran out: either a pure insertion/deletion at ``prefix`` or
+        # no difference at all (equal lengths, everything matched).
+        if len(pattern) == len(file_):
+            return -1, -1
+        return (prefix if prefix < len(pattern) else -1, prefix if prefix < len(file_) else -1)
+    return prefix, prefix
+
+
+def _is_pure_insertion(pattern_lines: list[str], file_lines: list[str]) -> bool:
+    """True when the two differ by one side having extra whole lines.
+
+    The caller said something subtly different from what it means: a hunk
+    that is RIGHT except for an added or removed line fails the same way as a
+    reworded paragraph, and the two need different corrections.
+    """
+    pattern = [_strip_eol(line) for line in pattern_lines]
+    file_ = [_strip_eol(line) for line in file_lines]
+    if len(pattern) == len(file_):
+        return False
+    limit = min(len(pattern), len(file_))
+    prefix = 0
+    while prefix < limit and pattern[prefix] == file_[prefix]:
+        prefix += 1
+    suffix = 0
+    while (
+        suffix < len(pattern) - prefix
+        and suffix < len(file_) - prefix
+        and pattern[len(pattern) - 1 - suffix] == file_[len(file_) - 1 - suffix]
+    ):
+        suffix += 1
+    return prefix + suffix >= limit
+
+
+def _edit_not_found_compact(scan: _FileScan, number: int, old_text: str) -> list[str]:
+    """One line for a failing hunk past the detailed-report cap.
+
+    Keeps the two facts that tell the failures apart — this hunk failed, and
+    roughly where the file says something similar — for about a tenth of a
+    full report.
+    """
+    regions = _closest_regions(scan, old_text.splitlines())
+    if not regions:
+        return [f"hunk {number}: old_text not found — no close match."]
+    start, _end, overlap = regions[0]
+    if overlap >= _EDIT_OVERLAP_LABEL_THRESHOLD:
+        return [
+            f"hunk {number}: old_text not found — closest text at line "
+            f"{start + 1} ({_percent(overlap)} word overlap)."
+        ]
+    return [
+        f"hunk {number}: old_text not found — no close match (nearest line "
+        f"{start + 1}, {_percent(overlap)} word overlap)."
+    ]
+
+
+def _edit_not_found_report(scan: _FileScan, number: int, old_text: str, path: Path) -> list[str]:
+    """The closest-region report for one hunk whose ``old_text`` did not match.
+
+    DIAGNOSIS ONLY: nothing computed here is ever applied. Showing the current
+    text is the whole point — in the corpus that motivated this, the file
+    often held a LATER, better revision of the very paragraph the caller was
+    editing (a parallel review round had amended it in different words), so
+    the correct action is frequently to skip the hunk, and only the caller
+    can tell which. It is also why the tool never fuzzy-applies the closest
+    region: doing so would have overwritten a parallel review round's reviewed
+    wording with the caller's stale duplicate version, discarding another
+    agent's text and duplicating work that round had already done.
+    """
+    pattern_lines = old_text.splitlines()
+    regions = _closest_regions(scan, pattern_lines)
+    file_lines = scan.lines
+    total_lines = len(file_lines)
+    head = [
+        f"hunk {number}: old_text not found (exact and whitespace-tolerant "
+        "matchers both failed)."
+    ]
+    if not regions:
+        return head + [
+            "  no close match in the file; there is no text to compare against.",
+            "  Re-read the region you meant to change and anchor the hunk to the " "text you find.",
+        ]
+
+    start, end, overlap = regions[0]
+    first = start + 1
+    last = end
+    read_first = max(1, first - 2)
+    read_last = min(total_lines, last + 2)
+    if overlap < _EDIT_OVERLAP_LABEL_THRESHOLD:
+        return head + [
+            f"  no close match in the file; the nearest text is line {first} "
+            f"({_percent(overlap)} word overlap).",
+            f"  Re-read the region you meant to change — e.g. lines {read_first}-"
+            f"{read_last} (`{_read_hint(path, read_first, read_last)}`) — and anchor "
+            "the hunk to the text you find.",
+        ]
+
+    shown_last = min(last, first + _EDIT_MAX_WINDOW_LINES - 1)
+    heading = f"  closest text — file lines {first}-{last} ({_percent(overlap)} word overlap)"
+    if shown_last < last:
+        heading += f" (showing first {_EDIT_MAX_WINDOW_LINES} of {last - first + 1})"
+    lines = head + [heading + ":"]
+    width = len(str(shown_last))
+    for line_number in range(first, shown_last + 1):
+        lines.append(f"    {line_number:>{width}}| {_clip_line(file_lines[line_number - 1])}")
+    for alt_start, alt_end, alt_overlap in regions[1:]:
+        snippet = _clip_line(" ".join(file_lines[alt_start:alt_end]), _EDIT_MAX_SNIPPET_CHARS)
+        lines.append(f'  also similar: line {alt_start + 1} ({_percent(alt_overlap)}) "{snippet}"')
+
+    pattern_index, file_index = _first_difference(pattern_lines, file_lines[start:end])
+    if pattern_index >= 0 or file_index >= 0:
+        your_number = pattern_index + 1 if pattern_index >= 0 else None
+        file_number = start + file_index + 1 if file_index >= 0 else None
+        lines.append(
+            f"  first difference — your line {your_number if your_number else '(none)'} "
+            f"vs file line {file_number if file_number else '(none)'}:"
+        )
+        lines.append(
+            "    - "
+            + (
+                _clip_line(pattern_lines[pattern_index])
+                if pattern_index >= 0
+                else "(no counterpart line in your hunk)"
+            )
+        )
+        lines.append(
+            "    + "
+            + (
+                _clip_line(file_lines[start + file_index])
+                if file_index >= 0
+                else "(no counterpart line in the file)"
+            )
+        )
+        if pattern_index >= 0 and file_index >= 0:
+            yours = pattern_lines[pattern_index]
+            theirs = file_lines[start + file_index]
+            common = 0
+            while common < min(len(yours), len(theirs)) and yours[common] == theirs[common]:
+                common += 1
+            if common == 0:
+                lines.append("    (they differ at the first character)")
+            elif common == min(len(yours), len(theirs)):
+                lines.append(
+                    f"    (identical for the first {common} characters, then one line continues)"
+                )
+            else:
+                lines.append(
+                    f"    (identical for the first {common} characters, then they diverge)"
+                )
+        elif _is_pure_insertion(pattern_lines, file_lines[start:end]):
+            lines.append(
+                "    (the lines after it match again, so a line was added or removed "
+                "rather than reworded)"
+            )
+
+    lines.append(
+        f"  Read lines {read_first}-{read_last} (`{_read_hint(path, read_first, read_last)}`) "
+        "to confirm the current text, then retry with old_text"
+    )
+    lines.append(
+        "  copied from it. If the current text already carries your change, skip "
+        "this hunk instead of re-applying it."
+    )
+    return lines
+
+
+def _refusal_facts(path: Path, original: str, total_hunks: int, failed_hunks: int) -> str:
+    """The two lines every refusal opens with: what was refused, and where.
+
+    The atomicity sentence is not decoration. The old refusal reported a
+    single failure and never said that a call applies all its hunks or none —
+    a plausible reason the observed session answered a failure by re-sending
+    the whole batch, nine times out of eleven. The file facts are computed
+    here, once, because `splitlines` and `encode` over a 100 KB document cost
+    real time and the message is assembled a few times against the cap.
+    """
+    return (
+        f"edit aborted: {failed_hunks} of {total_hunks} hunks did not match; "
+        "nothing was written (a call applies all its hunks or none).\n"
+        f"File: {path} — {len(original.splitlines())} lines, "
+        f"{len(original.encode('utf-8'))} bytes."
+    )
+
+
+def _edit_refusal(
+    path: Path, original: str, total_hunks: int, failed_hunks: int, reports: list[list[str]]
+) -> str:
+    """Assemble the refusal under the whole-message cap, honestly.
+
+    Reports are added while the rendered message (including the tail that the
+    remaining failures would need) still fits; whatever does not fit joins the
+    count in the tail rather than being truncated mid-sentence. The count is
+    therefore always the truth about how many failing hunks were not shown.
+    """
+    facts = _refusal_facts(path, original, total_hunks, failed_hunks)
+
+    def _render(kept: list[list[str]], hidden: int) -> str:
+        lines = [facts]
+        for report in kept:
+            lines.extend(report)
+        if hidden > 0:
+            lines.append(f"… ({hidden} more failing hunks not shown)")
+        return "\n".join(lines)
+
+    kept: list[list[str]] = []
+    message = _render(kept, failed_hunks)
+    for report in reports:
+        candidate = [*kept, report]
+        rendered = _render(candidate, failed_hunks - len(candidate))
+        if len(rendered) > _EDIT_MAX_MESSAGE_CHARS:
+            break
+        kept = candidate
+        message = rendered
+    if len(kept) != len(reports):
+        message = _render(kept, failed_hunks - len(kept))
+    if len(message) > _EDIT_MAX_MESSAGE_CHARS:
+        # Only reachable when the header alone blows the cap (a pathological
+        # path or byte count); the tail still has to survive.
+        message = message[:_EDIT_MAX_MESSAGE_CHARS]
+    return message
 
 
 def _reindent_new_text(new_text: str, matched: str, old_text: str) -> str:
@@ -3730,26 +4263,65 @@ def _edit_file_result_locked(
     A string is the exact refusal the tool returns. Counting, ambiguity
     resolution and mutation all happen against one file snapshot, so moving
     the engine off-loop cannot split the read/decide/write transaction.
+
+    A refusal reports EVERY failing hunk, not just the first. One failing
+    hunk discards the whole call, and the session this behaviour comes from
+    spent 11 turns discovering that one hunk at a time — nine of the eleven
+    failures answered by re-sending the entire batch, so the second failure
+    was only ever discovered after the first round trip had been paid for
+    again. Hunks after a failure are still evaluated against ``current``
+    (earlier successful hunks applied), because that is the state they would
+    have seen had the batch been able to land.
+
+    Nothing here runs on the happy path: the line views a diagnostic needs are
+    fetched through ``_scan_for`` only inside a failure branch, so an all-exact
+    batch keeps its old cost. Measured with the pre-change module loaded from a
+    file into the same interpreter, 11 exact hunks over the 104 KB corpus file
+    come out at ~14 ms CPU either side of this change — both dominated by the
+    diff details the result already carried, with the rest inside run-to-run
+    noise.
     """
     with path.open("r", encoding="utf-8", newline="") as stream:
         original = stream.read()
     current = original
     total_replacements = 0
+    failed = 0
+    reports: list[list[str]] = []
+
+    def _record(
+        detailed_lines: Callable[[], list[str]], compact_lines: Callable[[], list[str]]
+    ) -> None:
+        """Collect one failure, within the diagnostic budget.
+
+        The budget is what keeps a 40-hunk wholesale failure from returning a
+        40-hunk message: the header still counts every failure, the first few
+        get a report and the next few a one-line summary, and the tail states
+        how many were left out rather than dropping them silently. The report
+        is built by a factory that runs only when there is budget for it, so a
+        hunk past the cap never pays for a closest-region search.
+        """
+        nonlocal failed
+        failed += 1
+        if len(reports) < _EDIT_MAX_DETAILED_HUNKS:
+            reports.append(detailed_lines())
+        elif len(reports) < _EDIT_MAX_DETAILED_HUNKS + _EDIT_MAX_COMPACT_HUNKS:
+            reports.append(compact_lines())
 
     for index, hunk in enumerate(hunks):
+        number = index + 1
         if hunk.old_text == "":
-            return f"hunk {index + 1}: old_text must be non-empty"
+            _record(
+                lambda: [f"hunk {number}: old_text must be non-empty"],
+                lambda: [f"hunk {number}: old_text must be non-empty"],
+            )
+            continue
         windows = _match_windows(current, hunk.old_text)
         if not windows:
-            advice = (
-                f" — or the range around line {anchor_line}"
-                if anchor_line
-                else " to get the current text"
+            _record(
+                lambda: _edit_not_found_report(_scan_for(current), number, hunk.old_text, path),
+                lambda: _edit_not_found_compact(_scan_for(current), number, hunk.old_text),
             )
-            return (
-                f"hunk {index + 1}: old_text not found (exact and whitespace-tolerant "
-                f"matchers both failed). Re-read the file{advice} and retry."
-            )
+            continue
         chosen = windows
         if len(windows) > 1 and not hunk.replace_all:
             if anchor_line is not None:
@@ -3762,10 +4334,11 @@ def _edit_file_result_locked(
                 if len(anchored) == 1:
                     chosen = anchored
             if len(chosen) > 1:
-                return (
-                    f"hunk {index + 1}: old_text matches {len(chosen)} places; include "
-                    "more surrounding context, give anchor_line, or set replace_all=true."
+                _record(
+                    lambda: [_ambiguous_report(current, number, chosen)],
+                    lambda: [_ambiguous_report(current, number, chosen)],
                 )
+                continue
         # Apply back-to-front so earlier offsets stay valid within this hunk.
         for start, end, matched in sorted(chosen, key=lambda window: window[0], reverse=True):
             exact = matched == hunk.old_text
@@ -3783,6 +4356,9 @@ def _edit_file_result_locked(
             current = current[:start] + replacement + current[end:]
             total_replacements += 1
 
+    if failed:
+        return _edit_refusal(path, original, len(hunks), failed, reports)
+
     if current != original:
         with path.open("w", encoding="utf-8", newline="") as stream:
             stream.write(current)
@@ -3797,7 +4373,9 @@ def build_edit_tool() -> AgentTool:
         description=(
             "Apply ordered SEARCH/REPLACE hunks to a file ('edits' list for "
             "several changes in one call; exact match first, then "
-            "whitespace-tolerant; anchor_line disambiguates repeats)."
+            "whitespace-tolerant; anchor_line disambiguates repeats). A hunk "
+            "that does not match writes nothing and the error names the "
+            "closest file lines — re-read those before retrying."
         ),
         parameters=EditParams.model_json_schema(),
         approval_tier="write",

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -816,6 +816,16 @@ class ExpandableActionBlock(TranscriptBlock):
         extent grows above it, and the reader lands mid-body with the heading
         and the first fields scrolled off and no key that reaches them (design
         round 1, D3). A row already in view is left exactly where it was.
+
+        The reveal is asked for twice on purpose. The immediate call covers a
+        row the reader had already scrolled past. It does NOT cover the live
+        case: a card that has just settled at the tail is still in view at this
+        instant (its top is at 0 while the viewport is at 0), and only the
+        refresh that follows the toggle moves the extent — the tail anchor then
+        holds the BOTTOM, so a card taller than the viewport ends up with its
+        top above the fold and the reader lands mid-diagnosis (design round 2,
+        D3, measured at 5 of 26 rows off-screen). The deferred call re-asks the
+        same question once the layout has settled, when the answer is truthful.
         """
         if not self._expanded and not self.can_expand():
             return self._expanded
@@ -828,6 +838,11 @@ class ExpandableActionBlock(TranscriptBlock):
             parent.refresh_gap_after(self)
             if self._expanded:
                 parent.reveal_block(self)
+                # Same decision, after the growth and the anchor's re-anchor
+                # have been laid out. `reveal_block` is a no-op unless the top
+                # really did end up above the viewport, so a card that still
+                # fits leaves the tail exactly where it was.
+                parent.call_after_refresh(lambda: parent.reveal_block(self))
         return self._expanded
 
     def activate(self) -> bool:

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -808,7 +808,15 @@ class ExpandableActionBlock(TranscriptBlock):
         return self._expanded
 
     def toggle_expanded(self) -> bool:
-        """Flip expansion when possible and refresh the adjacent block gap."""
+        """Flip expansion when possible and refresh the adjacent block gap.
+
+        Expanding a row reveals the body the collapsed line only summarised,
+        so when the row sits ABOVE the viewport the view is brought back to
+        its top: the tail anchor otherwise holds the bottom steady while the
+        extent grows above it, and the reader lands mid-body with the heading
+        and the first fields scrolled off and no key that reaches them (design
+        round 1, D3). A row already in view is left exactly where it was.
+        """
         if not self._expanded and not self.can_expand():
             return self._expanded
         self._expanded = not self._expanded
@@ -818,6 +826,8 @@ class ExpandableActionBlock(TranscriptBlock):
         parent = self.parent
         if isinstance(parent, TranscriptView):
             parent.refresh_gap_after(self)
+            if self._expanded:
+                parent.reveal_block(self)
         return self._expanded
 
     def activate(self) -> bool:
@@ -3776,6 +3786,30 @@ class TranscriptView(ScrollableContainer):
                 repaint = getattr(block, "refresh_row", None)
                 if callable(repaint):
                     repaint()
+
+    def reveal_block(self, block: TranscriptBlock) -> bool:
+        """Scroll ``block``'s top back into view after it grew in place.
+
+        Only the above-the-viewport case is corrected. A row already on screen
+        is left alone, and a row BELOW the viewport is the tail anchor's
+        business — the reader asked to follow the bottom, and yanking them
+        forward would fight that. Returns whether it moved the view.
+
+        The block's TOP does not move when it expands (the height grows
+        downward), so the virtual region read here is the same before and
+        after the growth that prompted the call.
+        """
+        if block.parent is not self:
+            return False
+        top = block.virtual_region.y
+        if top >= self.scroll_y - 0.5:
+            return False
+        # A reader-initiated reveal, not the transcript's own correction: it
+        # stops the tail following, exactly as a page-back anchor jump does.
+        self._tail_anchor.release()
+        with self._tail_anchor.programmatic_scroll():
+            self.scroll_to(y=max(0.0, top), animate=False, immediate=True)
+        return True
 
     def refresh_gap_after(self, block: TranscriptBlock) -> None:
         """Re-decide the gap for the first real block below ``block``.

--- a/scripts/bench_context_budget.py
+++ b/scripts/bench_context_budget.py
@@ -114,7 +114,19 @@ CHARS_PER_BILLED_TOKEN = 2.78
 #: arithmetic closes without re-measuring. Headroom at 27,250 is 49 tokens
 #: (~0.2% — tighter than the ~2% this comment's sibling describes, in the safe
 #: direction), and the next context reduction tightens it.
-BUDGET_BILLED_TOKENS = 27_250
+#:
+#: RAISED 27,250 -> 27,320 for the `edit` tool's not-found diagnostics, stated
+#: here because the guard exists to make this an explicit decision. Measured on
+#: this branch's base (``origin/main`` 0d6cde1f0) the figure was 27,237 — 13
+#: tokens of headroom, so no useful sentence fits under the old ceiling and the
+#: description had to be paid for rather than squeezed in. The added sentence
+#: (`edit` now says a non-matching hunk writes nothing and that the error names
+#: the closest file lines, so a caller re-reads instead of re-sending the
+#: batch) is 118 characters, i.e. 42 billed tokens at 2.78 chars/token — the
+#: whole of the increase, with 41 tokens of headroom left. The trade is not
+#: close: one avoided blind retry of an edit batch costs far more than 42
+#: tokens, and the observed session paid that retry nine times.
+BUDGET_BILLED_TOKENS = 27_320
 
 #: How much slack is allowed before the guard demands the ratchet be TIGHTENED.
 #:

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -2504,7 +2504,7 @@ async def test_edit_not_found_quotes_the_files_line_at_its_number(tools, context
     # The actionable call leads its own line with its range intact: the card
     # clips rows from the right, and a range cut mid-argument cannot be pasted
     # back (design round 1, D2).
-    assert re.search(r'^  read\(path="[^"]+", range="\d+-\d+"\) — ', result.text, re.M)
+    assert re.search(r'^  read\(range="\d+-\d+", path="[^"]+"\)', result.text, re.M)
 
 
 @pytest.mark.asyncio
@@ -2682,8 +2682,34 @@ async def test_edit_anchor_line_is_echoed_back(tools, context, tmp_path) -> None
         context,
     )
     assert result.is_error is True
-    assert "line 3" in result.text
-    assert "anchor_line" in result.text
+    # The suggestion is a real call whose range CONTAINS the anchor line, not a
+    # fixed range at the head of the file (review round 2, R9) — asserted as a
+    # fact about the range so a wording change does not break it (R7).
+    hint = re.search(r'read\(range="(\d+)-(\d+)", path="[^"]+"\)', result.text)
+    assert hint, result.text
+    first, last = (int(value) for value in hint.groups())
+    assert first <= 3 <= last
+    assert "anchor" in result.text
+
+
+@pytest.mark.asyncio
+async def test_edit_anchor_line_is_echoed_beside_a_close_region(tools, context, tmp_path) -> None:
+    """With a region to point at, the anchor is still repeated (R4/R7)."""
+    path = tmp_path / "anchor2.txt"
+    path.write_text("alpha\nbeta\nthe quick brown fox jumps over the lazy dog\ndelta\n")
+    result = await _call(
+        tools,
+        "edit",
+        {
+            "path": "anchor2.txt",
+            "old_text": "the quick brown cat jumps over the lazy dog",
+            "new_text": "x",
+            "anchor_line": 3,
+        },
+        context,
+    )
+    assert result.is_error is True
+    assert re.search(r"anchor[^\n]*\b3\b", result.text), result.text
 
 
 @pytest.mark.asyncio
@@ -2791,8 +2817,10 @@ async def test_edit_refusal_is_bounded_and_names_what_it_suppressed(
     compact = builtin._EDIT_MAX_COMPACT_HUNKS
     assert result.text.count("old_text not found") == detailed + compact
     # The suppression line names exactly the hunks that got no block at all, and
-    # every refusal is accounted for once.
-    assert re.search(rf"… and {10 - detailed - compact} more hunks failed", result.text)
+    # every refusal is accounted for once. Asserted as the number plus the
+    # suppression claim, so the tail's wording stays free (review round 2, R7).
+    tail = result.text.splitlines()[-1]
+    assert str(10 - detailed - compact) in tail and "suppress" in tail
 
 
 @pytest.mark.asyncio
@@ -2851,11 +2879,9 @@ async def test_edit_summarises_refusals_past_the_detailed_cap_compactly(
         rf"no close match \(nearest line \d+)",
         result.text,
     )
-    assert re.search(
-        rf"… and {8 - builtin._EDIT_MAX_DETAILED_HUNKS - builtin._EDIT_MAX_COMPACT_HUNKS} "
-        r"more hunks failed",
-        result.text,
-    )
+    tail = result.text.splitlines()[-1]
+    suppressed = 8 - builtin._EDIT_MAX_DETAILED_HUNKS - builtin._EDIT_MAX_COMPACT_HUNKS
+    assert str(suppressed) in tail and "suppress" in tail
 
 
 @pytest.mark.asyncio
@@ -2912,7 +2938,7 @@ def test_edit_label_follows_the_printed_percent(monkeypatch: pytest.MonkeyPatch)
     """
     monkeypatch.setattr(builtin, "_closest_regions", lambda scan, pattern, limit=3: [(0, 1, 0.296)])
     scan = builtin._FileScan("one line of text\nanother line of text\n")
-    detailed = "\n".join(builtin._edit_not_found_report(scan, 1, "some hunk text", Path("/tmp/x")))
+    detailed = "\n".join(builtin._edit_not_found_report(scan, 1, "some hunk text", "/tmp/x"))
     compact = "\n".join(builtin._edit_not_found_compact(scan, 1, "some hunk text"))
     for message in (detailed, compact):
         assert "30% word overlap" in message
@@ -3105,18 +3131,9 @@ def test_closest_region_search_scores_a_bounded_number_of_windows(
     assert counts[0] == counts[1]
 
 
-@pytest.mark.asyncio
-async def test_edit_builds_one_scan_per_frame_not_one_per_hunk(
-    tools, context, tmp_path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Two frames, two snapshots — not a rebuild for every hunk.
-
-    The diagnostics describe the file on disk while matching runs against the
-    in-memory state, so a failing batch legitimately needs two views. What it
-    must not do is rebuild them per hunk: the whole point of the call-scoped
-    cache is that a 10-hunk failure costs the same as a 2-hunk one.
-    """
-    built = []
+def _counting_file_scan(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Every ``_FileScan`` construction, in order (review round 2, R11)."""
+    built: list[str] = []
     real = builtin._FileScan
 
     class Counting(real):  # type: ignore[misc, valid-type]
@@ -3125,6 +3142,21 @@ async def test_edit_builds_one_scan_per_frame_not_one_per_hunk(
             super().__init__(content)
 
     monkeypatch.setattr(builtin, "_FileScan", Counting)
+    return built
+
+
+@pytest.mark.asyncio
+async def test_edit_builds_one_scan_per_frame_not_one_per_hunk(
+    tools, context, tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Frames are built per content version, not per hunk.
+
+    The diagnostics describe the file on disk while matching runs against the
+    in-memory state, so a failing batch legitimately needs two views. What it
+    must not do is rebuild them per hunk: a 10-hunk failure costs the same as a
+    2-hunk one.
+    """
+    built = _counting_file_scan(monkeypatch)
     path = tmp_path / "many.txt"
     path.write_text("".join(f"line {i} of the document\n" for i in range(1, 21)))
     edits = [
@@ -3132,4 +3164,238 @@ async def test_edit_builds_one_scan_per_frame_not_one_per_hunk(
     ] + [{"old_text": f"absent hunk {i} about quokkas", "new_text": "y"} for i in range(10)]
     result = await _call(tools, "edit", {"path": "many.txt", "edits": edits}, context)
     assert result.is_error is True
-    assert len(built) <= builtin._EDIT_MAX_SCANS, built
+    assert len(built) == 2, built
+
+
+@pytest.mark.asyncio
+async def test_edit_pins_the_disk_frame_across_an_alternating_batch(
+    tools, context, tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The on-disk frame survives a batch that applies and fails alternately.
+
+    Review round 2 (R11): with the two frames sharing one cache, an
+    apply-then-fail batch evicted the disk frame each time a hunk wrote, so
+    every later failure rebuilt it as well. Pinned in its own slot, the disk
+    frame is built EXACTLY once however the batch alternates, and the matching
+    frame is rebuilt only when a hunk actually writes — which is the honest
+    bound the comments state, and the bound asserted below.
+    """
+    original_text = "".join(f"line {i} of the document\n" for i in range(1, 31))
+    built = _counting_file_scan(monkeypatch)
+    path = tmp_path / "alternating.txt"
+    path.write_text(original_text)
+    applies = [
+        {"old_text": f"line {n} of the document\n", "new_text": f"line {n} revised\n"}
+        for n in (3, 7, 11)
+    ]
+    # An apply FIRST, so the matching frame can never be mistaken for the disk
+    # frame by content: from hunk 2 on, the two frames differ by construction.
+    edits = [
+        applies[0],
+        {"old_text": "absent hunk about quokkas", "new_text": "y"},
+        applies[1],
+        {"old_text": "another absent hunk about quokkas", "new_text": "y"},
+        applies[2],
+        {"old_text": "a third absent hunk about quokkas", "new_text": "y"},
+    ]
+    result = await _call(tools, "edit", {"path": "alternating.txt", "edits": edits}, context)
+    assert result.is_error is True
+    disk_builds = [content for content in built if content == original_text]
+    assert len(disk_builds) == builtin._EDIT_MAX_DISK_SCANS, built
+    # At most the pinned disk frame plus one matching frame per content version.
+    assert len(built) <= 1 + len(applies) + builtin._EDIT_MAX_DISK_SCANS, built
+
+
+_AMBIGUOUS_LINES_RE = re.compile(r"old_text matches \d+ places \(lines ([\d, …]+)\)")
+
+
+def _listed_match_lines(message: str) -> list[int]:
+    """The line numbers an ambiguity refusal lists, as integers."""
+    found = _AMBIGUOUS_LINES_RE.search(message)
+    assert found, message
+    return [int(value) for value in re.findall(r"\d+", found.group(1))]
+
+
+@pytest.mark.asyncio
+async def test_edit_ambiguous_list_names_the_files_lines_not_the_batchs(
+    tools, context, tmp_path
+) -> None:
+    """Review round 2, R8: the match list is the FILE's, like every other fact.
+
+    An earlier hunk of the same call had already inserted a line in memory, so
+    the batch's own numbering is shifted; the caller's next move is a `read` of
+    the file (or an `anchor_line` against it), so the listed numbers have to be
+    the file's.
+    """
+    path = tmp_path / "amb.txt"
+    path.write_text("x\nfoo\ny\nfoo\nz\n")
+    edits = [
+        {"old_text": "x\n", "new_text": "x\ninserted\n"},
+        {"old_text": "foo", "new_text": "bar"},
+    ]
+    result = await _call(tools, "edit", {"path": "amb.txt", "edits": edits}, context)
+    assert result.is_error is True
+    disk = path.read_text().splitlines()
+    listed = _listed_match_lines(result.text)
+    assert listed == [2, 4], result.text
+    # Each listed number is a line that really holds this text.
+    assert all(disk[number - 1] == "foo" for number in listed), listed
+    # And the frame note is present, because the frames really do differ here.
+    assert "Note: earlier hunks" in result.text
+
+
+@pytest.mark.asyncio
+async def test_edit_ambiguous_row_says_when_the_batch_created_the_duplicate(
+    tools, context, tmp_path
+) -> None:
+    """A duplicate this call created is named as such, never as a file line."""
+    path = tmp_path / "amb2.txt"
+    path.write_text("x\nfoo\ny\nz\n")
+    edits = [
+        {"old_text": "x\n", "new_text": "x\nfoo\n"},
+        {"old_text": "foo", "new_text": "bar"},
+    ]
+    result = await _call(tools, "edit", {"path": "amb2.txt", "edits": edits}, context)
+    assert result.is_error is True
+    disk = path.read_text().splitlines()
+    # The file holds one occurrence (line 2); the batch's second copy is what
+    # made the hunk ambiguous, and the message says so instead of listing a
+    # line the file does not have.
+    assert "in-memory" in result.text, result.text
+    assert "1 place in the file on disk (line 2)" in result.text, result.text
+    assert disk[1] == "foo"
+
+
+@pytest.mark.asyncio
+async def test_edit_hint_prints_the_callers_path_spelling(tools, context, tmp_path) -> None:
+    """Design round 2, D2 residual: the hint's path is the caller's own.
+
+    The message is for the caller and quotes a `read` they will re-use, so it
+    prints the spelling they passed. The resolved absolute path of this fixture
+    is much longer and pushed the range argument off the card's row at every
+    width, which is the defect this fixes.
+    """
+    nested = tmp_path / "local_operator" / "tools"
+    nested.mkdir(parents=True)
+    (nested / "builtin.py").write_text("".join(f"line {i} of the document\n" for i in range(1, 30)))
+    caller_path = "local_operator/tools/builtin.py"
+    result = await _call(
+        tools,
+        "edit",
+        # A drifted hunk, so the report carries a closest region AND a hint.
+        {"path": caller_path, "old_text": "line 7 of the documnt (typo)", "new_text": "y"},
+        context,
+    )
+    assert result.is_error is True
+    hint = next(line for line in result.text.splitlines() if line.strip().startswith("read("))
+    assert f'path="{caller_path}"' in hint, hint
+    assert str(tmp_path) not in hint, "the hint must not carry the resolved absolute path"
+    # range first: at the narrowest supported width it is the argument that
+    # survives the card's right-truncation. The header line keeps the resolved
+    # path, which is the one place an absolute path is the right answer.
+    assert re.match(r'^  read\(range="\d+-\d+", path="[^"]+"\)', hint), hint
+    assert str(tmp_path) in result.text.splitlines()[1]
+
+
+@pytest.mark.asyncio
+async def test_edit_no_region_hint_never_invents_a_range(tools, context, tmp_path) -> None:
+    """Review round 2, R9: with nothing to point at, no range is invented.
+
+    The old hint emitted the head of the file (and, on an empty file, the
+    inverted `1-0`) — a place the failure gave no reason to look at.
+    """
+    path = tmp_path / "big.txt"
+    path.write_text("".join(f"line {i} of the document\n" for i in range(1, 5001)))
+    result = await _call(
+        tools,
+        "edit",
+        {"path": "big.txt", "old_text": "quokka marsupial taxonomy", "new_text": "y"},
+        context,
+    )
+    assert result.is_error is True
+    assert "no close match" in result.text
+    assert not re.search(r'range="\d+-\d+"', result.text), result.text
+
+    empty = tmp_path / "empty.txt"
+    empty.write_text("")
+    result = await _call(
+        tools,
+        "edit",
+        {"path": "empty.txt", "old_text": "anything at all", "new_text": "y"},
+        context,
+    )
+    assert result.is_error is True
+    assert 'range="1-0"' not in result.text
+    assert not re.search(r'range="\d+-\d+"', result.text), result.text
+
+
+@pytest.mark.asyncio
+async def test_edit_no_region_hint_uses_the_anchor_line_when_given(
+    tools, context, tmp_path
+) -> None:
+    """With an anchor, the suggested range brackets it and stays in the file."""
+    path = tmp_path / "big2.txt"
+    path.write_text("".join(f"line {i} of the document\n" for i in range(1, 5001)))
+    result = await _call(
+        tools,
+        "edit",
+        {
+            "path": "big2.txt",
+            "old_text": "quokka marsupial taxonomy",
+            "new_text": "y",
+            "anchor_line": 4000,
+        },
+        context,
+    )
+    assert result.is_error is True
+    found = re.search(r'read\(range="(\d+)-(\d+)", path="[^"]+"\)', result.text)
+    assert found, result.text
+    first, last = (int(value) for value in found.groups())
+    assert first <= 4000 <= last <= 5000
+    # No quoted rows and no closest region: the file resembles nothing, so the
+    # only number in the message is the range around the caller's own anchor.
+    assert "closest text" not in result.text
+
+
+@pytest.mark.asyncio
+async def test_edit_consumed_hunk_says_its_text_is_still_on_disk(tools, context, tmp_path) -> None:
+    """Review round 2, R10: "not found" must not sit beside 100% of your own text.
+
+    Hunk 1 rewrites the paragraph in memory; hunk 2 sends the original wording.
+    The disk still holds hunk 2's text exactly, so the report has to name the
+    real situation — an earlier hunk of this call consumed it.
+    """
+    paragraph = "AAA BBB CCC the target paragraph\n"
+    path = tmp_path / "consumed.txt"
+    path.write_text(paragraph)
+    edits = [
+        {"old_text": paragraph, "new_text": "AAA BBB CCC the replacement paragraph\n"},
+        {"old_text": paragraph, "new_text": "AAA BBB CCC another paragraph\n"},
+    ]
+    result = await _call(tools, "edit", {"path": "consumed.txt", "edits": edits}, context)
+    assert result.is_error is True
+    assert "100% word overlap" in result.text
+    assert re.search(r"earlier hunk[^\n]*this call", result.text), result.text
+    assert path.read_text() == paragraph
+
+
+@pytest.mark.asyncio
+async def test_edit_suppression_tail_uses_the_headers_word_for_a_mixed_batch(
+    tools, context, tmp_path
+) -> None:
+    """Review round 2, R12: the tail does not name a reason the header avoided."""
+    path = tmp_path / "mixed.txt"
+    # "alpha" twice, so hunk 1 is ambiguous; then hunks that match nothing.
+    path.write_text(
+        "alpha\nalpha\nbeta\n" + "".join(f"line {i} of the document\n" for i in range(1, 20))
+    )
+    edits = [{"old_text": "alpha", "new_text": "ALPHA"}] + [
+        {"old_text": f"absent hunk {i} about quokkas", "new_text": "y"} for i in range(8)
+    ]
+    result = await _call(tools, "edit", {"path": "mixed.txt", "edits": edits}, context)
+    assert result.is_error is True
+    assert "did not apply" in result.text and "matched more than one place" in result.text
+    tail = result.text.splitlines()[-1]
+    suppressed = 9 - builtin._EDIT_MAX_DETAILED_HUNKS - builtin._EDIT_MAX_COMPACT_HUNKS
+    assert str(suppressed) in tail, tail
+    assert "refused" in tail, tail

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -13,6 +13,7 @@ import base64
 import io
 import os
 import random
+import re
 import struct
 import subprocess
 import threading
@@ -2421,3 +2422,399 @@ async def test_edit_tolerant_match_keeps_crlf_line_endings(tools, context, tmp_p
     )
     assert result.is_error is False
     assert path.read_bytes() == b"if ok:\r\n\tnew()\r\n\tadded()\r\nnext()\r\n"
+
+
+# ---------------------------------------------------------------------------
+# edit: the not-found refusal (closest-region diagnostics)
+# ---------------------------------------------------------------------------
+#
+# The failure these cover is a hunk written from a STALE copy of the file: the
+# paragraph still exists, reworded, and the file may even hold a later
+# revision of it. The refusal is therefore a diagnosis — it shows the file's
+# current text and never applies anything — and these tests pin both halves of
+# that contract: the facts it must carry, and the bounds that stop a failing
+# edit on a big file from flooding the context it is trying to help.
+
+_DRIFT_DOC = (
+    "Intro paragraph: how a stage holds and releases its key material.\n"
+    "Second line of background that the hunk does not touch at all.\n"
+    "- **Key release, custody and the possession handshake (S-5, S2-12).** A stage's key is\n"
+    "  released only after its quote verifies.\n"
+    "Trailing paragraph about something else entirely, for padding.\n"
+    "Last line of the document.\n"
+)
+
+#: The same sentence as the caller still has it: pre-review wording, and the
+#: marker rolled back.
+_DRIFT_STALE = (
+    "- **Key release and hygiene (S-5).** Session keys are released to a stage only\n"
+    "  after its quote verifies."
+)
+
+
+@pytest.mark.asyncio
+async def test_edit_not_found_names_the_closest_line_and_overlap(tools, context, tmp_path) -> None:
+    """The refusal quotes the FILE's text at a named line, and names its metric."""
+    path = tmp_path / "doc.md"
+    path.write_text(_DRIFT_DOC)
+    result = await _call(
+        tools,
+        "edit",
+        {"path": "doc.md", "old_text": _DRIFT_STALE, "new_text": "REPLACED"},
+        context,
+    )
+    assert result.is_error is True
+    assert "hunk 1: old_text not found" in result.text
+    assert "closest text — file lines 3-4" in result.text
+    # The file's own line, with its real line number — the whole point of the
+    # change: the caller can see what the text says NOW.
+    assert (
+        "    3| - **Key release, custody and the possession handshake (S-5, S2-12).**"
+        in result.text
+    )
+    # The metric is always named; a bare percentage would read as "similarity"
+    # of something the caller cannot reproduce.
+    assert re.search(r"\d+% word overlap", result.text)
+    # And the confirmation step, including the skip case that a fuzzy
+    # auto-apply would have taken away from the caller.
+    assert f'read(path="{path}", range="1-6")' in result.text
+    assert "skip this hunk instead of re-applying it" in result.text
+
+
+@pytest.mark.asyncio
+async def test_edit_not_found_shows_the_first_difference(tools, context, tmp_path) -> None:
+    """The differing line pair is the file's real line, not a reconstruction."""
+    path = tmp_path / "doc.md"
+    path.write_text(_DRIFT_DOC)
+    result = await _call(
+        tools,
+        "edit",
+        {"path": "doc.md", "old_text": _DRIFT_STALE, "new_text": "REPLACED"},
+        context,
+    )
+    assert "first difference — your line 1 vs file line 3:" in result.text
+    assert "- - **Key release and hygiene (S-5).**" in result.text
+    assert "+ - **Key release, custody and the possession handshake (S-5, S2-12).**" in result.text
+    assert re.search(r"identical for the first \d+ characters, then they diverge", result.text)
+
+
+@pytest.mark.asyncio
+async def test_edit_not_found_says_no_close_match_for_novel_text(tools, context, tmp_path) -> None:
+    """Nothing similar anywhere: say so, and do not fabricate a region."""
+    path = tmp_path / "doc.md"
+    path.write_text(_DRIFT_DOC)
+    result = await _call(
+        tools,
+        "edit",
+        {
+            "path": "doc.md",
+            "old_text": "quokka nimbus walrus zephyr marmot pelican saxophone",
+            "new_text": "x",
+        },
+        context,
+    )
+    assert result.is_error is True
+    assert "no close match" in result.text
+    # No quoted region and no labelled candidate: the honest answer here is
+    # that the caller is editing the wrong file or inventing the text.
+    assert "closest text" not in result.text
+    assert not re.search(r"^\s+\d+\| ", result.text, re.M)
+
+    # One shared word is enough to have a nearest line, and the label must
+    # stay honest: the overlap is still nowhere near a match.
+    shared = await _call(
+        tools,
+        "edit",
+        {
+            "path": "doc.md",
+            "old_text": "quokka nimbus walrus zephyr marmot pelican stage",
+            "new_text": "x",
+        },
+        context,
+    )
+    assert "no close match" in shared.text
+    assert re.search(r"nearest text is line \d+ \(\d+% word overlap\)", shared.text)
+    assert not re.search(r"^\s+\d+\| ", shared.text, re.M)
+
+
+@pytest.mark.asyncio
+async def test_edit_batch_reports_every_failure_and_writes_nothing(
+    tools, context, tmp_path
+) -> None:
+    """One round trip names all the bad hunks, and the good ones stay unwritten.
+
+    The old engine returned on the FIRST failing hunk, so a caller with two
+    broken hunks paid two round trips to learn what one message can say.
+    """
+    path = tmp_path / "batch.txt"
+    path.write_text("alpha line\nbeta line\ngamma line\n")
+    before = path.read_bytes()
+    result = await _call(
+        tools,
+        "edit",
+        {
+            "path": "batch.txt",
+            "edits": [
+                {"old_text": "alpha line", "new_text": "ALPHA"},
+                {"old_text": "missing one\n", "new_text": "x"},
+                {"old_text": "beta line", "new_text": "BETA"},
+                {"old_text": "missing two\n", "new_text": "y"},
+            ],
+        },
+        context,
+    )
+    assert result.is_error is True
+    assert "edit aborted: 2 of 4 hunks did not match" in result.text
+    assert "nothing was written (a call applies all its hunks or none)" in result.text
+    assert "hunk 2: old_text not found" in result.text
+    assert "hunk 4: old_text not found" in result.text
+    assert "hunk 1" not in result.text and "hunk 3" not in result.text
+    # Byte-identical: the atomicity claim is checked, not asserted in prose.
+    assert path.read_bytes() == before
+
+
+@pytest.mark.asyncio
+async def test_edit_ambiguous_refusal_lists_the_match_lines(tools, context, tmp_path) -> None:
+    """The count was always there; the line numbers were the missing half."""
+    path = tmp_path / "amb.txt"
+    path.write_text("  foo\nbar\n  foo\n")
+    result = await _call(
+        tools,
+        "edit",
+        {"path": "amb.txt", "old_text": "foo", "new_text": "X"},
+        context,
+    )
+    assert result.is_error is True
+    assert "old_text matches 2 places (lines 1, 3)" in result.text
+    assert "give anchor_line" in result.text
+
+
+def _failing_batch(count: int) -> list[dict[str, str]]:
+    return [
+        {"old_text": f"absent hunk number {i} about quokkas and walruses", "new_text": "x"}
+        for i in range(count)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_edit_refusal_is_bounded_and_counts_what_it_hides(tools, context, tmp_path) -> None:
+    """Ten failures stay under the cap, and the tail counts the rest exactly."""
+    path = tmp_path / "many.txt"
+    path.write_text("alpha beta gamma delta epsilon\n" * 5)
+    result = await _call(
+        tools,
+        "edit",
+        {"path": "many.txt", "edits": _failing_batch(10)},
+        context,
+    )
+    assert result.is_error is True
+    assert "edit aborted: 10 of 10 hunks did not match" in result.text
+    assert len(result.text) <= builtin._EDIT_MAX_MESSAGE_CHARS
+    detailed = builtin._EDIT_MAX_DETAILED_HUNKS
+    compact = builtin._EDIT_MAX_COMPACT_HUNKS
+    assert result.text.rstrip().endswith(
+        f"… ({10 - detailed - compact} more failing hunks not shown)"
+    )
+    # Every hunk that is not described is counted, and none is described twice.
+    assert result.text.count("old_text not found") == detailed + compact
+
+
+@pytest.mark.asyncio
+async def test_edit_refusal_stays_bounded_for_a_long_pattern_in_a_large_file(
+    tools, context, tmp_path
+) -> None:
+    """A 200-line pattern against a ~5k-line file still returns a bounded message.
+
+    This is the shape that would be unbounded by default: the window is 200
+    lines long, only 6 of them are ever quoted, and the note says so.
+    """
+    rng = random.Random(11)
+    words = [f"w{i}" for i in range(400)]
+    lines = [" ".join(rng.choice(words) for _ in range(12)) for _ in range(5000)]
+    path = tmp_path / "big.txt"
+    path.write_text("\n".join(lines) + "\n")
+    pattern = lines[2400:2600]
+    drifted = "\n".join(
+        " ".join(line.split()[1:]) if i % 4 == 0 else line for i, line in enumerate(pattern)
+    )
+    result = await _call(
+        tools,
+        "edit",
+        {"path": "big.txt", "old_text": drifted, "new_text": "x"},
+        context,
+    )
+    assert result.is_error is True
+    assert len(result.text) <= builtin._EDIT_MAX_MESSAGE_CHARS
+    assert "showing first 6 of 200" in result.text
+
+
+# The tolerant pass as it was before the index: the reference the prefilter
+# must agree with, kept here on purpose. It is the ONLY definition of the
+# semantics — the fast one is an optimisation of this, so a disagreement is a
+# bug in the fast one.
+def _naive_tolerant_windows(content: str, old_text: str) -> list[tuple[int, int, str]]:
+    windows: list[tuple[int, int, str]] = []
+    start = content.find(old_text)
+    while start != -1:
+        windows.append((start, start + len(old_text), old_text))
+        start = content.find(old_text, start + 1)
+    if windows:
+        return windows
+
+    file_lines = content.splitlines(keepends=True)
+    offsets: list[int] = []
+    at = 0
+    for line in file_lines:
+        offsets.append(at)
+        at += len(line)
+    old_lines = old_text.splitlines()
+    if not old_lines or len(old_lines) > len(file_lines):
+        return []
+
+    for i in range(len(file_lines) - len(old_lines) + 1):
+        window = file_lines[i : i + len(old_lines)]
+        if all(f.rstrip("\r\n").strip() == o.strip() for f, o in zip(window, old_lines)):
+            last_line = window[-1]
+            end = offsets[i + len(old_lines) - 1] + len(last_line)
+            windows.append((offsets[i], end, "".join(window)))
+    return windows
+
+
+def _tolerant_corpus() -> list[tuple[str, str]]:
+    """Patterns that exercise the seeded prefilter's edges, with a file each."""
+    lf = "alpha\n    beta\n\ngamma\nalpha\nbeta\n"
+    crlf = "alpha\r\n    beta\r\n\r\ngamma\r\nalpha\r\nbeta\r\n"
+    repeats = "x\nblock\nsame\nsame\nx\nblock\nsame\nsame\nend\n"
+    cases = [
+        # Indent drift in both directions, and a blank interior line.
+        (lf, "    alpha\nbeta"),
+        (lf, "alpha\n\tbeta\n\ngamma"),
+        # CRLF file against an LF hunk (and the reverse spelling).
+        (crlf, "    alpha\nbeta"),
+        (crlf, "alpha\n  beta\n\ngamma"),
+        # Repeated blocks: every candidate start must still be found.
+        (repeats, "block\nsame\nsame"),
+        # Pattern longer than the file.
+        (repeats, "block\nsame\nsame\nend\nmore"),
+        # Blank first line, and a pattern that is only a blank line.
+        (lf, "\ngamma"),
+        (lf, "\n"),
+        # Nothing that matches at all, plus a file with no newline at the end.
+        (lf, "nothing\nhere"),
+        ("tail-without-newline", "tail-without-newline"),
+        # Seed line present elsewhere with the WRONG neighbours: the indexed
+        # pass must reject the start the seed alone cannot rule out. Both
+        # pattern lines occur the same number of times, so the seed is the
+        # first of them, and only one of its occurrences has the right tail.
+        # The indent on the second line is what keeps pass 1 (exact) out of
+        # the way so pass 2 actually runs.
+        ("a\n  b\na\nc\n  b\nd\n", "a\nb"),
+        ("p\n  q\nx\np\ny\n  q\n", "p\nq"),
+    ]
+    return cases
+
+
+def test_tolerant_prefilter_matches_the_naive_reference() -> None:
+    """The seeded index is an optimisation, so it must be indistinguishable."""
+    for content, old_text in _tolerant_corpus():
+        expected = _naive_tolerant_windows(content, old_text)
+        actual = builtin._match_windows(content, old_text)
+        assert actual == expected, (content, old_text, expected, actual)
+
+
+def test_tolerant_prefilter_agrees_over_a_generated_corpus() -> None:
+    """Property-style version of the check above, over generated shapes."""
+    rng = random.Random(4242)
+    vocabulary = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta"]
+    for _ in range(120):
+        line_count = rng.randint(0, 30)
+        lines = []
+        for _ in range(line_count):
+            indent = " " * rng.choice([0, 0, 1, 2, 4, 8]) + ("\t" if rng.random() < 0.2 else "")
+            body = " ".join(rng.choice(vocabulary) for _ in range(rng.randint(0, 4)))
+            lines.append(indent + body)
+        ending = rng.choice(["\n", "\r\n"])
+        content = ending.join(lines) + (ending if lines and rng.random() < 0.8 else "")
+        start = rng.randrange(0, max(line_count, 1))
+        width = rng.randint(1, 4)
+        old_text = ending.join(lines[start : start + width])
+        if rng.random() < 0.35:
+            # Drift the pattern's indentation, the way a model writing from
+            # memory does.
+            old_text = "\n".join(
+                (" " * rng.choice([0, 2, 4, 8])) + line.strip() for line in old_text.splitlines()
+            )
+        assert builtin._match_windows(content, old_text) == _naive_tolerant_windows(
+            content, old_text
+        ), (content, old_text)
+
+
+class _ScoringCounter:
+    """Counts how many candidate windows the full metric is run over."""
+
+    def __init__(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self.count = 0
+        real = builtin._dice
+
+        def counting(pattern, window):  # type: ignore[no-untyped-def]
+            self.count += 1
+            return real(pattern, window)
+
+        monkeypatch.setattr(builtin, "_dice", counting)
+
+
+def test_closest_region_search_scores_a_bounded_number_of_windows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A structural bound, not a stopwatch: the work cannot grow with file size.
+
+    A timing assertion here would encode this laptop's core speed into the
+    test (see AGENTS.md, "Timing, flakes, and how to assert that something is
+    fast"). What actually matters is that the exhaustive O(file_lines x
+    pattern_lines) scan is gone, and that is a fact about how many windows are
+    scored.
+    """
+    pattern = [f"absent prose line {i} with several words" for i in range(40)]
+    counts = []
+    for line_count in (60, 6000):
+        content = "\n".join(f"filler line {i} of the document" for i in range(line_count))
+        counter = _ScoringCounter(monkeypatch)
+        builtin._closest_regions(builtin._FileScan(content), pattern)
+        counts.append(counter.count)
+    ceiling = builtin._EDIT_MAX_ANCHORS * builtin._EDIT_MAX_CANDIDATE_STARTS
+    assert all(count <= ceiling for count in counts), counts
+    # 100x the file, the same search: the prefilter is what makes that true.
+    assert counts[0] == counts[1]
+
+
+@pytest.mark.asyncio
+async def test_edit_not_found_reports_each_hunk_past_the_detailed_cap_compactly(
+    tools, context, tmp_path
+) -> None:
+    """Hunks past the detailed cap get one line each that still names a location.
+
+    Eight failures: three get the full report, the next three a one-line
+    summary, and the last two are counted in the tail. The caller can still
+    tell every failing hunk apart, which is what makes a single round trip
+    enough to fix the batch.
+    """
+    path = tmp_path / "mixed.txt"
+    path.write_text(_DRIFT_DOC)
+    edits = [{"old_text": _DRIFT_STALE, "new_text": "x"}] + [
+        {"old_text": f"absent hunk {i} about quokkas and walruses", "new_text": "y"}
+        for i in range(7)
+    ]
+    result = await _call(tools, "edit", {"path": "mixed.txt", "edits": edits}, context)
+    assert result.is_error is True
+    assert "edit aborted: 8 of 8 hunks did not match" in result.text
+    # Three full reports (the first one a closest-region report, the rest the
+    # honest no-close-match form), then one-line summaries, then the tail.
+    assert result.text.count("old_text not found (exact and whitespace-tolerant") == 3
+    assert result.text.count("closest text — file lines") == 1
+    assert result.text.count("hunk 4: old_text not found — ") == 1
+    assert re.search(
+        r"hunk 4: old_text not found — (closest text at line \d+|"
+        r"no close match \(nearest line \d+)",
+        result.text,
+    )
+    assert "… (2 more failing hunks not shown)" in result.text

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -2434,6 +2434,12 @@ async def test_edit_tolerant_match_keeps_crlf_line_endings(tools, context, tmp_p
 # current text and never applies anything — and these tests pin both halves of
 # that contract: the facts it must carry, and the bounds that stop a failing
 # edit on a big file from flooding the context it is trying to help.
+#
+# They assert FACTS (a line number, an overlap figure, the presence of the
+# difference pair, whether the two rows actually differ) rather than whole
+# sentences of copy, so a legitimate rewording cannot turn into four red tests
+# (review round 1, R7). Where the wording IS the subject — the label, the
+# frame note — the marker asserted is the shortest one that means it.
 
 _DRIFT_DOC = (
     "Intro paragraph: how a stage holds and releases its key material.\n"
@@ -2451,10 +2457,35 @@ _DRIFT_STALE = (
     "  after its quote verifies."
 )
 
+#: ``123| the text`` rows, ready to be checked against the file on disk.
+_QUOTED_LINE_RE = re.compile(r"^\s+(\d+)\| (.*)$", re.M)
+_READ_RANGE_RE = re.compile(r'range="(\d+)-(\d+)"')
+
+
+def _assert_quotes_match_the_disk(message: str, path: Path) -> None:
+    """Every quoted line must be that line of the FILE, at the number shown.
+
+    This is review round 1's R1 in test form: the diagnostics are built from
+    the on-disk content, so a quoted row can be checked against the bytes the
+    caller is about to `read`. A report computed from the in-memory batch state
+    fails here as soon as an earlier hunk of the same call matched.
+    """
+    quoted = _QUOTED_LINE_RE.findall(message)
+    assert quoted, f"nothing quoted to check:\n{message}"
+    disk = path.read_text().splitlines()
+    for number, text in quoted:
+        index = int(number)
+        assert 1 <= index <= len(disk), f"quoted line {index} of a {len(disk)}-line file"
+        assert disk[index - 1].startswith(
+            text.rstrip("…")[:60]
+        ), f"line {index} quoted as {text!r} but the file says {disk[index - 1]!r}"
+    for low, high in _READ_RANGE_RE.findall(message):
+        assert 1 <= int(low) <= int(high) <= len(disk), f"read range {low}-{high} outside the file"
+
 
 @pytest.mark.asyncio
-async def test_edit_not_found_names_the_closest_line_and_overlap(tools, context, tmp_path) -> None:
-    """The refusal quotes the FILE's text at a named line, and names its metric."""
+async def test_edit_not_found_quotes_the_files_line_at_its_number(tools, context, tmp_path) -> None:
+    """The refusal names a line, quotes the FILE's text there, and names its metric."""
     path = tmp_path / "doc.md"
     path.write_text(_DRIFT_DOC)
     result = await _call(
@@ -2465,25 +2496,71 @@ async def test_edit_not_found_names_the_closest_line_and_overlap(tools, context,
     )
     assert result.is_error is True
     assert "hunk 1: old_text not found" in result.text
-    assert "closest text — file lines 3-4" in result.text
-    # The file's own line, with its real line number — the whole point of the
-    # change: the caller can see what the text says NOW.
-    assert (
-        "    3| - **Key release, custody and the possession handshake (S-5, S2-12).**"
-        in result.text
+    assert re.search(r"closest text — file lines? \d+(-\d+)? \(\d+% word overlap\)", result.text)
+    # The window is the drifted paragraph (lines 3-4), and every row quoted is
+    # that line of the file — the whole point of the change.
+    assert "file lines 3-4" in result.text
+    _assert_quotes_match_the_disk(result.text, path)
+    # The actionable call leads its own line with its range intact: the card
+    # clips rows from the right, and a range cut mid-argument cannot be pasted
+    # back (design round 1, D2).
+    assert re.search(r'^  read\(path="[^"]+", range="\d+-\d+"\) — ', result.text, re.M)
+
+
+@pytest.mark.asyncio
+async def test_edit_diagnostics_agree_with_the_file_on_disk(tools, context, tmp_path) -> None:
+    """An earlier hunk matching must not move the lines the report names.
+
+    Eight lines on disk; hunk 1 inserts a line (so the in-memory text is nine
+    lines and everything after line 3 shifts), hunk 2 is a stale copy of disk
+    line 7. Computing the report against the in-memory state named line 8 of
+    the file and suggested reading past its end (review R1 / QA Q1); the
+    caller's next move is a `read` of the disk, so the report must describe the
+    disk.
+    """
+    path = tmp_path / "mixed.txt"
+    path.write_text("".join(f"line {i} of the document\n" for i in range(1, 9)))
+    result = await _call(
+        tools,
+        "edit",
+        {
+            "path": "mixed.txt",
+            "edits": [
+                {
+                    "old_text": "line 3 of the document\n",
+                    "new_text": "line 3 of the document\nan inserted line\n",
+                },
+                {"old_text": "line 7 of the documnt (typo, stale)", "new_text": "x"},
+            ],
+        },
+        context,
     )
-    # The metric is always named; a bare percentage would read as "similarity"
-    # of something the caller cannot reproduce.
-    assert re.search(r"\d+% word overlap", result.text)
-    # And the confirmation step, including the skip case that a fuzzy
-    # auto-apply would have taken away from the caller.
-    assert f'read(path="{path}", range="1-6")' in result.text
-    assert "skip this hunk instead of re-applying it" in result.text
+    assert result.is_error is True
+    assert "1 of 2 hunks did not match" in result.text
+    # Every quoted row and the read range are checked against the file itself.
+    _assert_quotes_match_the_disk(result.text, path)
+    assert "line 7 of the document" in result.text
+    # And the frame is stated, because the two views genuinely differ here.
+    assert "Note:" in result.text and "nothing was written" in result.text
+
+
+@pytest.mark.asyncio
+async def test_edit_frame_note_is_absent_when_nothing_matched_earlier(
+    tools, context, tmp_path
+) -> None:
+    """No earlier hunk matched, so there is nothing to disclaim."""
+    path = tmp_path / "plain.txt"
+    path.write_text("alpha\nbeta\ngamma\ndelta\n")
+    result = await _call(
+        tools, "edit", {"path": "plain.txt", "old_text": "zzz nope", "new_text": "x"}, context
+    )
+    assert result.is_error is True
+    assert "Note:" not in result.text
 
 
 @pytest.mark.asyncio
 async def test_edit_not_found_shows_the_first_difference(tools, context, tmp_path) -> None:
-    """The differing line pair is the file's real line, not a reconstruction."""
+    """The differing pair is the file's real line, and the two rows DO differ."""
     path = tmp_path / "doc.md"
     path.write_text(_DRIFT_DOC)
     result = await _call(
@@ -2493,13 +2570,53 @@ async def test_edit_not_found_shows_the_first_difference(tools, context, tmp_pat
         context,
     )
     assert "first difference — your line 1 vs file line 3:" in result.text
-    assert "- - **Key release and hygiene (S-5).**" in result.text
-    assert "+ - **Key release, custody and the possession handshake (S-5, S2-12).**" in result.text
+    rows = [
+        line
+        for line in result.text.splitlines()
+        if line.startswith("    - ") or line.startswith("    + ")
+    ]
+    assert len(rows) == 2
+    yours, theirs = (row[6:] for row in rows)
+    assert yours != theirs
+    assert theirs.startswith("- **Key release, custody")
     assert re.search(r"identical for the first \d+ characters, then they diverge", result.text)
 
 
+@pytest.mark.parametrize("cut", [77, 231])
 @pytest.mark.asyncio
-async def test_edit_not_found_says_no_close_match_for_novel_text(tools, context, tmp_path) -> None:
+async def test_edit_difference_rows_differ_inside_the_visible_excerpt(
+    cut: int, tools, context, tmp_path
+) -> None:
+    """The card clips rows from the RIGHT, so the pair must diverge near the start.
+
+    Both rows used to be windowed at character 0, which rendered them
+    byte-identical whenever the divergence sat past the clip (design round 1,
+    D1; QA round 1, Q3 — reproduced at character 231). The excerpt now leads
+    with ~24 characters of run-up, so the divergence is inside the first ~30
+    characters of what is actually painted.
+    """
+    path = tmp_path / "wide.txt"
+    filler = "a" * 400
+    path.write_text(filler[:cut] + "FILE-SIDE" + filler[cut:] + "\n")
+    hunk = filler[:cut] + "HUNK-SIDE" + filler[cut:]
+    result = await _call(
+        tools, "edit", {"path": "wide.txt", "old_text": hunk, "new_text": "x"}, context
+    )
+    rows = [
+        line
+        for line in result.text.splitlines()
+        if line.startswith("    - ") or line.startswith("    + ")
+    ]
+    assert len(rows) == 2, result.text
+    yours, theirs = (row[6:] for row in rows)
+    assert yours != theirs, "the two rows rendered identically"
+    assert yours[:40] != theirs[:40], "the divergence is past the visible part of the row"
+
+
+@pytest.mark.asyncio
+async def test_edit_not_found_says_no_close_match_without_inventing_a_region(
+    tools, context, tmp_path
+) -> None:
     """Nothing similar anywhere: say so, and do not fabricate a region."""
     path = tmp_path / "doc.md"
     path.write_text(_DRIFT_DOC)
@@ -2515,13 +2632,11 @@ async def test_edit_not_found_says_no_close_match_for_novel_text(tools, context,
     )
     assert result.is_error is True
     assert "no close match" in result.text
-    # No quoted region and no labelled candidate: the honest answer here is
-    # that the caller is editing the wrong file or inventing the text.
     assert "closest text" not in result.text
-    assert not re.search(r"^\s+\d+\| ", result.text, re.M)
+    assert not _QUOTED_LINE_RE.search(result.text)
 
-    # One shared word is enough to have a nearest line, and the label must
-    # stay honest: the overlap is still nowhere near a match.
+    # One shared word is enough to have a nearest line, and the label must stay
+    # honest: the overlap is still nowhere near a match.
     shared = await _call(
         tools,
         "edit",
@@ -2534,11 +2649,45 @@ async def test_edit_not_found_says_no_close_match_for_novel_text(tools, context,
     )
     assert "no close match" in shared.text
     assert re.search(r"nearest text is line \d+ \(\d+% word overlap\)", shared.text)
-    assert not re.search(r"^\s+\d+\| ", shared.text, re.M)
+    assert not _QUOTED_LINE_RE.search(shared.text)
 
 
 @pytest.mark.asyncio
-async def test_edit_batch_reports_every_failure_and_writes_nothing(
+async def test_edit_no_overlap_is_not_reported_as_an_empty_file(tools, context, tmp_path) -> None:
+    """A file full of text that shares no words is not an empty file."""
+    path = tmp_path / "text.txt"
+    path.write_text("alpha beta gamma delta\nepsilon zeta eta theta\n")
+    result = await _call(
+        tools, "edit", {"path": "text.txt", "old_text": "quokka", "new_text": "x"}, context
+    )
+    assert result.is_error is True
+    assert "no close match" in result.text
+    # The claim the search actually established, not one it did not.
+    assert "there is no text" not in result.text
+
+
+@pytest.mark.asyncio
+async def test_edit_anchor_line_is_echoed_back(tools, context, tmp_path) -> None:
+    """The one hint the caller gave the tool is repeated in the refusal.
+
+    It is free advice: the caller said which line it meant, and the old message
+    offered "the range around line N" back (review round 1, R4).
+    """
+    path = tmp_path / "anchor.txt"
+    path.write_text("alpha\nbeta\ngamma\ndelta\n")
+    result = await _call(
+        tools,
+        "edit",
+        {"path": "anchor.txt", "old_text": "zzz nope", "new_text": "x", "anchor_line": 3},
+        context,
+    )
+    assert result.is_error is True
+    assert "line 3" in result.text
+    assert "anchor_line" in result.text
+
+
+@pytest.mark.asyncio
+async def test_edit_batch_reports_every_refusal_and_writes_nothing(
     tools, context, tmp_path
 ) -> None:
     """One round trip names all the bad hunks, and the good ones stay unwritten.
@@ -2564,12 +2713,11 @@ async def test_edit_batch_reports_every_failure_and_writes_nothing(
         context,
     )
     assert result.is_error is True
-    assert "edit aborted: 2 of 4 hunks did not match" in result.text
-    assert "nothing was written (a call applies all its hunks or none)" in result.text
+    assert "2 of 4 hunks" in result.text
     assert "hunk 2: old_text not found" in result.text
     assert "hunk 4: old_text not found" in result.text
     assert "hunk 1" not in result.text and "hunk 3" not in result.text
-    # Byte-identical: the atomicity claim is checked, not asserted in prose.
+    # Byte-identical: the atomicity claim is checked, not restated in prose.
     assert path.read_bytes() == before
 
 
@@ -2587,6 +2735,33 @@ async def test_edit_ambiguous_refusal_lists_the_match_lines(tools, context, tmp_
     assert result.is_error is True
     assert "old_text matches 2 places (lines 1, 3)" in result.text
     assert "give anchor_line" in result.text
+    # And the header is about the reason that actually happened: the hunk
+    # matched, twice, which "did not match" would contradict (QA round 1, Q2).
+    assert "matched more than one place" in result.text
+    assert "did not match" not in result.text
+
+
+@pytest.mark.asyncio
+async def test_edit_mixed_refusal_reasons_are_named_in_the_header(tools, context, tmp_path) -> None:
+    """A batch that fails for two reasons says both, and counts each."""
+    path = tmp_path / "mixed.txt"
+    path.write_text("foo\nbar\nfoo\n")
+    result = await _call(
+        tools,
+        "edit",
+        {
+            "path": "mixed.txt",
+            "edits": [
+                {"old_text": "foo", "new_text": "X"},
+                {"old_text": "nothing like this at all", "new_text": "Y"},
+            ],
+        },
+        context,
+    )
+    assert result.is_error is True
+    assert "2 of 2 hunks did not apply" in result.text
+    assert "1 did not match" in result.text
+    assert "1 matched more than one place" in result.text
 
 
 def _failing_batch(count: int) -> list[dict[str, str]]:
@@ -2597,8 +2772,10 @@ def _failing_batch(count: int) -> list[dict[str, str]]:
 
 
 @pytest.mark.asyncio
-async def test_edit_refusal_is_bounded_and_counts_what_it_hides(tools, context, tmp_path) -> None:
-    """Ten failures stay under the cap, and the tail counts the rest exactly."""
+async def test_edit_refusal_is_bounded_and_names_what_it_suppressed(
+    tools, context, tmp_path
+) -> None:
+    """Ten refusals stay under the cap, are counted, and are never half-shown."""
     path = tmp_path / "many.txt"
     path.write_text("alpha beta gamma delta epsilon\n" * 5)
     result = await _call(
@@ -2608,15 +2785,14 @@ async def test_edit_refusal_is_bounded_and_counts_what_it_hides(tools, context, 
         context,
     )
     assert result.is_error is True
-    assert "edit aborted: 10 of 10 hunks did not match" in result.text
+    assert "10 of 10 hunks" in result.text
     assert len(result.text) <= builtin._EDIT_MAX_MESSAGE_CHARS
     detailed = builtin._EDIT_MAX_DETAILED_HUNKS
     compact = builtin._EDIT_MAX_COMPACT_HUNKS
-    assert result.text.rstrip().endswith(
-        f"… ({10 - detailed - compact} more failing hunks not shown)"
-    )
-    # Every hunk that is not described is counted, and none is described twice.
     assert result.text.count("old_text not found") == detailed + compact
+    # The suppression line names exactly the hunks that got no block at all, and
+    # every refusal is accounted for once.
+    assert re.search(rf"… and {10 - detailed - compact} more hunks failed", result.text)
 
 
 @pytest.mark.asyncio
@@ -2626,7 +2802,8 @@ async def test_edit_refusal_stays_bounded_for_a_long_pattern_in_a_large_file(
     """A 200-line pattern against a ~5k-line file still returns a bounded message.
 
     This is the shape that would be unbounded by default: the window is 200
-    lines long, only 6 of them are ever quoted, and the note says so.
+    lines long, only a handful of them are ever quoted, and the note says how
+    many there were.
     """
     rng = random.Random(11)
     words = [f"w{i}" for i in range(400)]
@@ -2645,7 +2822,148 @@ async def test_edit_refusal_stays_bounded_for_a_long_pattern_in_a_large_file(
     )
     assert result.is_error is True
     assert len(result.text) <= builtin._EDIT_MAX_MESSAGE_CHARS
-    assert "showing first 6 of 200" in result.text
+    quoted = _QUOTED_LINE_RE.findall(result.text)
+    assert 0 < len(quoted) <= builtin._EDIT_MAX_WINDOW_LINES
+    assert f"of {len(pattern)}" in result.text
+
+
+@pytest.mark.asyncio
+async def test_edit_summarises_refusals_past_the_detailed_cap_compactly(
+    tools, context, tmp_path
+) -> None:
+    """Past the detailed cap each refusal still gets one line naming a place."""
+    path = tmp_path / "mixed.txt"
+    path.write_text(_DRIFT_DOC)
+    edits = [{"old_text": _DRIFT_STALE, "new_text": "x"}] + [
+        {"old_text": f"absent hunk {i} about quokkas and walruses", "new_text": "y"}
+        for i in range(7)
+    ]
+    result = await _call(tools, "edit", {"path": "mixed.txt", "edits": edits}, context)
+    assert result.is_error is True
+    assert "8 of 8 hunks" in result.text
+    assert result.text.count("old_text not found (exact and whitespace-tolerant") == (
+        builtin._EDIT_MAX_DETAILED_HUNKS
+    )
+    # The first hunk the cap turned into a one-liner still names a line.
+    first_compact = builtin._EDIT_MAX_DETAILED_HUNKS + 1
+    assert re.search(
+        rf"hunk {first_compact}: old_text not found — (closest text at line \d+|"
+        rf"no close match \(nearest line \d+)",
+        result.text,
+    )
+    assert re.search(
+        rf"… and {8 - builtin._EDIT_MAX_DETAILED_HUNKS - builtin._EDIT_MAX_COMPACT_HUNKS} "
+        r"more hunks failed",
+        result.text,
+    )
+
+
+@pytest.mark.asyncio
+async def test_edit_worst_case_refusal_fits_the_expanded_card(tools, context, tmp_path) -> None:
+    """The most blocks this message can carry must still FIT the expanded card.
+
+    This is the constraint that sets ``_EDIT_MAX_DETAILED_HUNKS`` (design round
+    1, D4): the card paints at most ``EXPAND_MAX_LINES`` rows of a message and
+    silently drops the rest, so a message whose tail falls past that is a
+    diagnosis the reader cannot reach by any key. Two full reports plus the
+    compact lines plus the tail is the worst shape the caps allow; a third
+    report is ~15 more rows and does not fit.
+    """
+    from local_operator.tui.widgets.tool_card import EXPAND_MAX_LINES
+
+    vocabulary = [f"token{i}" for i in range(60)]
+    body: list[str] = []
+    starts: list[int] = []
+    for seed in range(6):
+        paragraph_rng = random.Random(seed)
+        starts.append(len(body))
+        body.extend(" ".join(paragraph_rng.choice(vocabulary) for _ in range(40)) for _ in range(8))
+        body.append("")
+
+    def drift(paragraph: list[str]) -> str:
+        return "\n".join(
+            " ".join(line.split()[: max(1, len(line.split()) - 3)]) if i % 2 == 0 else line
+            for i, line in enumerate(paragraph)
+        )
+
+    path = tmp_path / "worst.txt"
+    path.write_text("\n".join(body) + "\n")
+    # THREE full-size candidates, so a third detailed block would cost 15 more
+    # rows rather than a two-line no-close-match stub.
+    edits = [
+        {"old_text": drift(body[starts[index] : starts[index] + 6]), "new_text": "x"}
+        for index in (1, 3, 5)
+    ] + [{"old_text": f"absent hunk {i} with a few words", "new_text": "y"} for i in range(3)]
+    result = await _call(tools, "edit", {"path": "worst.txt", "edits": edits}, context)
+    assert result.is_error is True
+    assert result.text.count("old_text not found (exact and whitespace-tolerant") == (
+        builtin._EDIT_MAX_DETAILED_HUNKS
+    )
+    assert len(result.text.splitlines()) <= EXPAND_MAX_LINES
+
+
+def test_edit_label_follows_the_printed_percent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The label is decided by the number the message prints (review R5).
+
+    0.296 rounds to ``30%``, which is the label threshold — so the region gets
+    the ``closest text`` label, not ``no close match`` next to ``30% word
+    overlap``. This drives the real report builders with a forced score, so it
+    fails if either of them goes back to comparing the raw float.
+    """
+    monkeypatch.setattr(builtin, "_closest_regions", lambda scan, pattern, limit=3: [(0, 1, 0.296)])
+    scan = builtin._FileScan("one line of text\nanother line of text\n")
+    detailed = "\n".join(builtin._edit_not_found_report(scan, 1, "some hunk text", Path("/tmp/x")))
+    compact = "\n".join(builtin._edit_not_found_compact(scan, 1, "some hunk text"))
+    for message in (detailed, compact):
+        assert "30% word overlap" in message
+        assert "no close match" not in message
+
+
+@pytest.mark.asyncio
+async def test_edit_single_line_file_uses_singular_copy(tools, context, tmp_path) -> None:
+    """``1 line``, not ``1 lines`` — and a one-line region is ``file line 7``."""
+    path = tmp_path / "one.txt"
+    path.write_text("only line\n")
+    singular = await _call(
+        tools, "edit", {"path": "one.txt", "old_text": "zzz nope", "new_text": "x"}, context
+    )
+    assert "— 1 line," in singular.text
+    assert "1 lines" not in singular.text
+
+    path.write_text(_DRIFT_DOC)
+    one_line = await _call(
+        tools,
+        "edit",
+        {
+            "path": "one.txt",
+            "old_text": "Trailing paragraph about something else entirly",
+            "new_text": "x",
+        },
+        context,
+    )
+    assert "closest text — file line 5" in one_line.text
+    assert "file lines 5-5" not in one_line.text
+
+
+def test_edit_overlap_label_agrees_with_the_printed_percent() -> None:
+    """One rounded number decides the label AND what gets printed (review R5).
+
+    The raw float decided the label while the rounded integer got printed, so a
+    region at 0.296 printed ``30% word overlap`` under a ``no close match``
+    label. Both now read ``_overlap_percent``.
+    """
+    for value, expected in (
+        (0.296, "closest"),
+        (0.294, "no close"),
+        (0.30, "closest"),
+        (0.0, "no close"),
+    ):
+        printed = builtin._overlap_percent(value)
+        label = "closest" if printed >= builtin._EDIT_OVERLAP_LABEL_PERCENT else "no close"
+        assert label == expected, (value, printed)
+        assert builtin._percent(value) == f"{printed}%"
+    # A percent printed under the "no close match" label is always below it.
+    assert builtin._overlap_percent(0.294) < builtin._EDIT_OVERLAP_LABEL_PERCENT
 
 
 # The tolerant pass as it was before the index: the reference the prefilter
@@ -2788,33 +3106,30 @@ def test_closest_region_search_scores_a_bounded_number_of_windows(
 
 
 @pytest.mark.asyncio
-async def test_edit_not_found_reports_each_hunk_past_the_detailed_cap_compactly(
-    tools, context, tmp_path
+async def test_edit_builds_one_scan_per_frame_not_one_per_hunk(
+    tools, context, tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Hunks past the detailed cap get one line each that still names a location.
+    """Two frames, two snapshots — not a rebuild for every hunk.
 
-    Eight failures: three get the full report, the next three a one-line
-    summary, and the last two are counted in the tail. The caller can still
-    tell every failing hunk apart, which is what makes a single round trip
-    enough to fix the batch.
+    The diagnostics describe the file on disk while matching runs against the
+    in-memory state, so a failing batch legitimately needs two views. What it
+    must not do is rebuild them per hunk: the whole point of the call-scoped
+    cache is that a 10-hunk failure costs the same as a 2-hunk one.
     """
-    path = tmp_path / "mixed.txt"
-    path.write_text(_DRIFT_DOC)
-    edits = [{"old_text": _DRIFT_STALE, "new_text": "x"}] + [
-        {"old_text": f"absent hunk {i} about quokkas and walruses", "new_text": "y"}
-        for i in range(7)
-    ]
-    result = await _call(tools, "edit", {"path": "mixed.txt", "edits": edits}, context)
+    built = []
+    real = builtin._FileScan
+
+    class Counting(real):  # type: ignore[misc, valid-type]
+        def __init__(self, content: str) -> None:
+            built.append(content)
+            super().__init__(content)
+
+    monkeypatch.setattr(builtin, "_FileScan", Counting)
+    path = tmp_path / "many.txt"
+    path.write_text("".join(f"line {i} of the document\n" for i in range(1, 21)))
+    edits = [
+        {"old_text": "line 2 of the document\n", "new_text": "line 2 of the document\nmore\n"}
+    ] + [{"old_text": f"absent hunk {i} about quokkas", "new_text": "y"} for i in range(10)]
+    result = await _call(tools, "edit", {"path": "many.txt", "edits": edits}, context)
     assert result.is_error is True
-    assert "edit aborted: 8 of 8 hunks did not match" in result.text
-    # Three full reports (the first one a closest-region report, the rest the
-    # honest no-close-match form), then one-line summaries, then the tail.
-    assert result.text.count("old_text not found (exact and whitespace-tolerant") == 3
-    assert result.text.count("closest text — file lines") == 1
-    assert result.text.count("hunk 4: old_text not found — ") == 1
-    assert re.search(
-        r"hunk 4: old_text not found — (closest text at line \d+|"
-        r"no close match \(nearest line \d+)",
-        result.text,
-    )
-    assert "… (2 more failing hunks not shown)" in result.text
+    assert len(built) <= builtin._EDIT_MAX_SCANS, built

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -3357,6 +3357,132 @@ async def test_edit_no_region_hint_uses_the_anchor_line_when_given(
     assert "closest text" not in result.text
 
 
+def test_own_text_on_disk_is_an_identity_test_not_a_metric() -> None:
+    """The gate itself (review round 3, R13): text, never a similarity figure.
+
+    ``_overlap_percent`` is bag-of-words, so a punctuation-only rewrite of the
+    same words scores exactly 100% and the clause ("this is this hunk's own
+    text") would be false. This pins the gate directly, because the two
+    repro shapes are also covered by the no-difference-pair guard and would
+    therefore survive a metric-based gate on their own.
+    """
+    disk = "alpha, beta gamma\nmoved line\n"
+    current = "alpha, beta gamma\nmoved line\nrewritten\n"
+    # Same word bag, different text: NOT the hunk's own text.
+    assert builtin._own_text_on_disk(disk, current, "alpha beta gamma\n") is False
+    # A one-word drop from a 120-token line: raw overlap 0.9958, which ROUNDS to
+    # 100% and so fired the old percentage gate. The window is still not the
+    # hunk's text, which is what the gate has to answer.
+    long_line = " ".join(f"token{i}" for i in range(1, 121))
+    without_one = " ".join(word for word in long_line.split() if word != "token60")
+    assert (
+        builtin._own_text_on_disk(
+            long_line + "\nrewritten\n", long_line + "\nrewritten\n", without_one + "\n"
+        )
+        is False
+    )
+    # The genuine case: byte-identical on disk, moved on in the batch.
+    assert builtin._own_text_on_disk("target text\nother\n", "other\n", "target text\n") is True
+    # Frames identical: nothing was consumed, so there is no clause to make.
+    assert builtin._own_text_on_disk("target text\n", "target text\n", "target text\n") is False
+
+
+@pytest.mark.asyncio
+async def test_edit_self_match_clause_needs_text_identity_not_a_similarity(
+    tools, context, tmp_path
+) -> None:
+    """Review round 3, R13 / design round 2, D8: identity, not 100% overlap.
+
+    A bag-of-words figure reaches 100% for a punctuation-only rewrite or a
+    reordered list, which is exactly when the clause ("this is this hunk's own
+    text") was false — and false in the same block as the difference pair that
+    disproved it.
+    """
+    # (a) punctuation only: the same word bag, different text. Hunk 1 APPLIES,
+    # so the frames differ and only the identity test can withhold the clause —
+    # the shape both streams reproduced.
+    punctuation = tmp_path / "punctuation.txt"
+    punctuation.write_text("alpha, beta gamma\nother line\n")
+    result = await _call(
+        tools,
+        "edit",
+        {
+            "path": "punctuation.txt",
+            "edits": [
+                {"old_text": "other line\n", "new_text": "OTHER LINE\n"},
+                {"old_text": "alpha beta gamma\n", "new_text": "y\n"},
+            ],
+        },
+        context,
+    )
+    assert result.is_error is True
+    assert "100% word overlap" in result.text, result.text
+    assert "unchanged on disk" not in result.text, result.text
+    # ... and the block stays self-consistent: the pair that disproves the
+    # identity is right there, which is what made the clause self-contradictory.
+    assert "first difference" in result.text, result.text
+    assert punctuation.read_text() == "alpha, beta gamma\nother line\n"
+
+    # (b) one word dropped from a 120-token line: the designer's shape, where
+    # raw overlap is 0.9958 and therefore ROUNDS to 100% — the case that made a
+    # percentage gate fire on text that is not the hunk's.
+    long_line = " ".join(f"token{i}" for i in range(1, 121))
+    without_one = " ".join(word for word in long_line.split() if word != "token60")
+    body = f"{long_line}\na second line, so the batch has something to apply\n"
+    drifted = tmp_path / "drifted.txt"
+    drifted.write_text(body)
+    result = await _call(
+        tools,
+        "edit",
+        {
+            "path": "drifted.txt",
+            "edits": [
+                {
+                    "old_text": "a second line, so the batch has something to apply\n",
+                    "new_text": "a second line, rewritten\n",
+                },
+                {"old_text": without_one + "\n", "new_text": "y\n"},
+            ],
+        },
+        context,
+    )
+    assert result.is_error is True
+    assert "100% word overlap" in result.text, result.text
+    assert "unchanged on disk" not in result.text, result.text
+    assert drifted.read_text() == body
+
+
+@pytest.mark.asyncio
+async def test_edit_self_match_clause_is_short_and_leads_with_the_cause(
+    tools, context, tmp_path
+) -> None:
+    """Design round 2, D9: the clause must fit a narrow card, cause first.
+
+    At 60 columns the message body has ~50 visible cells and the card clips
+    every row from the right, so a 149-character clause lost the reason
+    entirely.
+    """
+    line = "the whole quote chain must verify before any plaintext leaves the stage\n"
+    path = tmp_path / "short.txt"
+    path.write_text(line)
+    result = await _call(
+        tools,
+        "edit",
+        {
+            "path": "short.txt",
+            "edits": [
+                {"old_text": line, "new_text": "the replacement chain must verify\n"},
+                {"old_text": line, "new_text": "another chain must verify\n"},
+            ],
+        },
+        context,
+    )
+    assert result.is_error is True
+    clause = next(row.strip() for row in result.text.splitlines() if "unchanged on disk" in row)
+    assert len(clause) <= 70, clause
+    assert clause.startswith("(") and "earlier hunks" in clause[:30], clause
+
+
 @pytest.mark.asyncio
 async def test_edit_consumed_hunk_says_its_text_is_still_on_disk(tools, context, tmp_path) -> None:
     """Review round 2, R10: "not found" must not sit beside 100% of your own text.

--- a/tests/unit/tui/test_transcript_focus.py
+++ b/tests/unit/tui/test_transcript_focus.py
@@ -571,6 +571,72 @@ async def test_expanding_a_row_above_the_viewport_reveals_its_top() -> None:
         assert view.scroll_y <= card.virtual_region.y + 0.5
 
 
+_LONG_REFUSAL = "\n".join(
+    [
+        "edit aborted: 2 of 2 hunks did not match; nothing was written "
+        "(a call applies all its hunks or none)."
+    ]
+    + ["File: /tmp/doc.md — 677 lines, 118203 bytes."]
+    + [
+        f"  hunk {n}: old_text not found (exact and whitespace-tolerant matchers both failed)."
+        for n in (1, 2)
+    ]
+    + [
+        f"    {line}| the file's own text, row {line} of the diagnosis body"
+        for line in range(1, 26)
+    ]
+)
+
+
+@pytest.mark.asyncio
+async def test_expanding_a_long_card_at_the_tail_reveals_its_top() -> None:
+    """A card TALLER than the viewport, expanded while following the tail.
+
+    The immediate reveal cannot fire here: at the instant of the toggle the card
+    is still in view (its top is at the viewport's top), and only the refresh
+    that follows the toggle moves the extent — the tail anchor then holds the
+    BOTTOM, so the headline and the `File:` line land above the fold and no key
+    reaches them (design round 2, D3). The reveal is re-asked once the layout
+    has settled.
+    """
+    app = _app()
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app.query_one(Editor).focus()
+        view = app.query_one(TranscriptView)
+        _seed_cards(app, 40)
+        for _ in range(4):
+            await pilot.pause()
+
+        card = ToolCard("t", "edit", {"path": "local_operator/tools/builtin.py"})
+        app._append_block(card)
+        card.mark_failed(_LONG_REFUSAL)
+        for _ in range(4):
+            await pilot.pause()
+        assert view.scroll_y >= view.max_scroll_y - 1, "premise: following the tail"
+
+        card.toggle_expanded()
+        for _ in range(6):
+            await pilot.pause()
+
+        assert card.expanded is True
+        top = card.virtual_region.y
+        assert (
+            card.virtual_region.height > view.size.height - 4
+        ), "premise: taller than the viewport"
+        assert view.scroll_y <= top + 0.5, "the reader must land on the card's top, not mid-body"
+
+        # ... and a new message must not move a view the reader is holding.
+        held = view.scroll_y
+        extra = ToolCard("x", "bash", {"command": "true"})
+        app._append_block(extra)
+        extra.mark_done("done")
+        for _ in range(4):
+            await pilot.pause()
+        assert view.scroll_y == held, "a new message moved a held view"
+        assert view.max_scroll_y > held
+
+
 @pytest.mark.asyncio
 async def test_expanding_a_row_at_the_tail_still_follows_the_tail() -> None:
     """The reveal is for rows ABOVE the fold only; the tail keeps the bottom.

--- a/tests/unit/tui/test_transcript_focus.py
+++ b/tests/unit/tui/test_transcript_focus.py
@@ -541,3 +541,55 @@ async def test_clicking_a_row_with_no_focus_of_its_own_reaches_the_composer() ->
 
         assert app.focused is editor
         assert app.query_one("#input-dock").has_class(COMPOSER_FOCUSED_CLASS)
+
+
+@pytest.mark.asyncio
+async def test_expanding_a_row_above_the_viewport_reveals_its_top() -> None:
+    """Expanding a row the reader has scrolled past brings its top back.
+
+    The row's body grows BELOW its top, and with the tail anchor holding the
+    bottom steady the growth lands above the viewport: the reader presses
+    expand and gets the middle of the body, with the heading and the first
+    fields off-screen and no key that reaches them (design round 1, D3).
+    Reveal-then-act is this ledger's existing convention for a key that acts on
+    a row it may have left off-screen.
+    """
+    app = _app()
+    async with app.run_test(size=(120, 24)) as pilot:
+        await pilot.pause()
+        app.query_one(Editor).focus()
+        view = app.query_one(TranscriptView)
+        cards = _seed_cards(app, 40)
+        for _ in range(4):
+            await pilot.pause()
+
+        card = cards[0]
+        assert card.virtual_region.y < view.scroll_y, "premise: the row is above the fold"
+        card.toggle_expanded()
+        await pilot.pause()
+        assert card.expanded is True
+        assert view.scroll_y <= card.virtual_region.y + 0.5
+
+
+@pytest.mark.asyncio
+async def test_expanding_a_row_at_the_tail_still_follows_the_tail() -> None:
+    """The reveal is for rows ABOVE the fold only; the tail keeps the bottom.
+
+    Expanding the newest row must not yank the view back to its top: the
+    reader is following the bottom, the growth is below their eyes, and the
+    tail anchor is what holds the offset there.
+    """
+    app = _app()
+    async with app.run_test(size=(120, 24)) as pilot:
+        await pilot.pause()
+        app.query_one(Editor).focus()
+        view = app.query_one(TranscriptView)
+        cards = _seed_cards(app, 40)
+        for _ in range(4):
+            await pilot.pause()
+        assert view.scroll_y >= view.max_scroll_y - 1, "premise: following the tail"
+
+        cards[-1].toggle_expanded()
+        await pilot.pause()
+        assert cards[-1].expanded is True
+        assert view.scroll_y >= view.max_scroll_y - 1


### PR DESCRIPTION
Release: patch — the `edit` tool's not-found refusal names every failing hunk's closest file text (line numbers, word overlap, a read range), and the whitespace-tolerant matcher is reseeded from an inverted line index

## What and why

Forensic analysis of a real lop session (`dbfa6a0fc303`) recorded **31 `edit` calls against one document**, of which **11 failed** with the entire diagnosis being:

```
hunk 1: old_text not found (exact and whitespace-tolerant matchers both failed). Re-read the file to get the current text and retry.
```

No location, no current text, no sense of how far off the hunk was. Recovery was worse than the failure: **9 of the 11 failures were followed by blind whole-batch retries** and only 2 used a targeted ranged read.

All eleven share one root cause: the hunk was written from a **stale copy** of the file, so `old_text` is a superseded version of a paragraph that still exists, reworded. In that corpus the file often held a **later revision of the very paragraph under edit** — a parallel review round had amended it in different words — so the right action is frequently to *skip* the hunk, and only the caller can tell which. That is why this change is a **diagnosis only, never an application**: a fuzzy auto-apply would have silently overwritten that review round's reviewed wording with the caller's stale duplicate, discarding another agent's text and redoing work that round had already finished.

### The change

**1. The refusal reports every refusing hunk, with the closest file text** (`local_operator/tools/builtin.py`):

```
edit aborted: 3 of 3 hunks did not match; nothing was written (a call applies all its hunks or none).
File: /private/tmp/rfc-after.md — 677 lines, 118203 bytes.
hunk 1: old_text not found (exact and whitespace-tolerant matchers both failed).
  closest text — file line 397 (65% word overlap):
    397| - **Key release, custody and the possession handshake (S-5, S2-12).** A stage's key is released only after its quote verifies, and release MUST be a handshake in which the stage proves possession of …
  also similar: line 54 (36%) "| R-5 | In the **confidential tier**, a node operator MUST …"
  also similar: line 620 (32%) "Invariants: every payload on the compute path is bound to a…"
  first difference — your line 1 vs file line 397:
    - - **Key release and hygiene (S-5).** Session keys are released to a stage only after its quote verifies, and release MUST be a handshake in which the stage prov
    + - **Key release, custody and the possession handshake (S-5, S2-12).** A stage's key is released only after its quote verifies, and release MUST be a handshake i
    (identical for the first 15 characters, then they diverge)
  read(path="/private/tmp/rfc-after.md", range="395-399") — confirm the current text, then retry; skip the hunk if the change is already there.
hunk 2: <same shape; the marker case, 99% word overlap at line 397>
hunk 3: old_text not found — closest text at line 288 (33% word overlap).
```

- **Every** refusing hunk, not just the first, judged in order against the state a later hunk would have seen.
- The **atomicity sentence** in the header is new information: the old message never said that one bad hunk discards the good ones, which is a plausible reason the session kept re-sending whole batches.
- The metric is bag-of-words Dice and the message **always names it** — `word overlap`, never `similarity`. A character-sequence metric was measured first and rejected: `SequenceMatcher.ratio` put the true region of a drifted hunk at 0.18–0.24 on this corpus while bag-Dice put the same regions at 0.59–0.99.
- The label follows the **printed** number: `closest text` at ≥ 30% word overlap (the same rounded percent the message shows), otherwise an honest `no close match` naming the nearest line and its overlap.
- The ambiguity refusal gains the line numbers it always had the data for: `old_text matches 3 places (lines 12, 88, 402); …`, with its own accurate header (see remediation below).

**2. The tolerant matcher is seeded from an inverted line index** (`_match_windows` pass 2). It previously tried every start and re-`strip()`ed every line of the window — O(file_lines × pattern_lines) `strip()` calls. A tolerant match requires *every* line to strip-match, so a window can only start where the pattern's most selective stripped line occurs: `stripped_line -> [line indices]` is built once per snapshot, seeded from the rarest pattern line, and the remaining lines are verified by dict membership. **Semantics are provably identical**, and the test file keeps the original naive algorithm as the reference implementation and checks the two against each other on a corpus built for it.

Pass 1 (`str.find`, exact) is untouched, no observable tolerance changes, and `_reindent_new_text` still owns indentation and line endings on the tolerant path.

**3. The line views are built lazily and shared per call** — two frames at most, in a call-scoped `ContextVar` cache (matching uses the in-memory state, the diagnostics use the on-disk content), rebuilt only when the content changes. An all-exact batch builds none.

**4. `edit`'s description gains one sentence** (rung 1 of the tool-surface footprint ladder — no new tool, no schema change, no new parameter). Measured cost: **+118 characters**, i.e. **42 billed tokens** at the surface's measured 2.78 chars/token. That needed the start-of-session context ceiling to move, and `scripts/bench_context_budget.py` carries the arithmetic rather than a bare new number: **`origin/main` measures 27,237 billed tokens against a 27,250 ceiling — 13 tokens of headroom — so no useful sentence fits without paying for it.** The ceiling moves **27,250 → 27,320** (41 tokens of headroom). One avoided blind retry of an edit batch costs far more than 42 tokens, and the observed session paid that retry nine times.

## Remediation round 1 (head `de7cab2d7`)

| finding | fix |
| --- | --- |
| **R1 / Q1** (major) | Diagnostics are computed against `original` (the file on disk) while matching keeps `current`; the header adds one sentence when the two frames differ; every quoted line and the read range are now asserted against the file's actual bytes in a test. The scan cache holds both frames, so a failing batch builds at most two snapshots (counted by a test). |
| **D1 / Q3** (major) | Each `first difference` row is an excerpt starting ~24 characters before the divergence, capped at 160 with a leading `…`; tested at 77 and 231 characters for rows that actually differ, with the divergence inside the first 40 visible characters. |
| **D2** (major) | The `read(...)` hint leads its own line, call first and prose after, range intact, redundant `Read lines N-M (` prefix dropped. |
| **D4** (major) | Detailed reports capped at **2**, compact one-liners kept, and an explicit suppression line that names the dropped count. Blocks are dropped whole. A test renders the worst shape the caps allow and asserts it fits `EXPAND_MAX_LINES` (40). |
| **Q2 / E** | Accurate headers: one reason names itself (`… hunks matched more than one place`); a mixed batch counts each (`2 of 3 hunks did not apply (1 did not match, 1 matched more than one place)`); atomicity clause on every form. |
| **R2 / F** | `1 line`, `file line 7` (and `1 byte`). |
| **R3 / G** | The no-overlap branch says what the search established — no text in the file shares any words with this hunk — rather than claiming the file has no text. |
| **R4 / H** | The caller's `anchor_line` is echoed back in the hint. |
| **R5** | The label and the printed figure read one rounded percent. |
| **R6** | Docstring corrected: the views are built on the tolerant path too; an all-exact batch builds none. |
| **R7** | Tests assert facts (a line number, an overlap figure, whether the two rows differ, the byte-identical file) instead of whole sentences; the bounds are referenced through `_EDIT_MAX_*`. |
| **D3 / J** | `TranscriptView.reveal_block` brings an expanded row back into view when its top is above the viewport; rows already on screen and the tail-follow behaviour are untouched, both pinned by tests. |

Every one of these was mutation-checked by restoring the defect (1–2 tests fail each; the D4 cap is caught by the card-fit test). Two deliberate deviations, stated for the record: the frame note reads "below" rather than "above" because it sits directly under the header, and the ambiguity line list locates its matches in the state they were found in — those occurrences may not exist on disk at all, so naming disk lines for them would be a fabrication, and the frame note covers the difference.

## Changed files (5)

- `local_operator/tools/builtin.py` — `_FileScan`, the word-overlap metric, `_closest_regions`, the report builders, the accurate headline, the two-frame scan cache, the seeded tolerant pass, the `edit` description.
- `local_operator/tui/widgets/transcript.py` — `reveal_block`, called from `toggle_expanded` (D3).
- `scripts/bench_context_budget.py` — the ceiling raise above, with its arithmetic at the constant.
- `tests/unit/tools/test_builtin_tools.py` — the diagnostics, bounds, frame, label and prefilter-equivalence tests.
- `tests/unit/tui/test_transcript_focus.py` — reveal-on-expand, and the tail behaviour it must not disturb.

## Testing evidence

### 1. Real before/after transcript (the actual tool, not a mock)

`execute_edit` driven through the real tool registry (`create_tools` → `tool.execute`) against a **copy** of `/Users/damian/radient-ml/radient-net/docs/RFC-001-radient-net.md` in `/tmp`; the original is never touched. Three hunks modelled on the three real drift cases.

**Before** (installed runtime, `~/.local/share/uv/tools/local-operator/bin/python`):

```
hunk 1: old_text not found (exact and whitespace-tolerant matchers both failed). Re-read the file to get the current text and retry.
[is_error=True  file unchanged: True]
```

**After** — the three-hunk refusal quoted in "The change" above (hunk 1 and hunk 3 shown there; hunk 2 is the marker case): three refusals discovered in **one** round trip, file unchanged, the last one as a compact one-liner because the detailed cap is two.

### 2. The loop closes in one extra round trip

The suggestion is parsed **out of the refusal itself** (no guessing), then followed:

```
suggested read: path=rfc-after.md, range=395-399
closest-text line quoted by the refusal: 397
395| - The client MUST verify the **whole chain before the first plaintext activation leaves it** …
retry with old_text copied from that read -> is_error=False
Edited /private/tmp/rfc-after.md: 1 hunk(s), 1 replacement(s) applied.
REVISED in file: True
```

### 3. The marker case, reproduced (99% word overlap)

A stale copy of the file's line 397 with its marker rolled back to the pre-review form:

```
hunk 1: old_text not found (exact and whitespace-tolerant matchers both failed).
  closest text — file line 397 (99% word overlap):
    397| - **Key release, custody and the possession handshake (S-5, S2-12).** A stage's key is released only after its quote verifies, …
  first difference — your line 1 vs file line 397:
    - …ossession handshake (S-5).** A stage's key is released only after its quote verifies, …
    + …ossession handshake (S-5, S2-12).** A stage's key is released only after its quote verifies, …
    (identical for the first 58 characters, then they diverge)
  read(path="/private/tmp/rfc-verbatim.md", range="395-399") — confirm the current text, then retry; skip the hunk if the change is already there.
```

Both difference rows now show the marker, and the divergence is inside the visible part of each row. The document has moved on since the round-1 capture (677 lines, and the paragraph that carried the `(S-20, S2-11)` marker in the original session has since been rewritten out), so the case is rebuilt from a line that carries the same shape today.

### 4. Numbers (Darwin 25.6.0 arm64, CPython 3.12.13, CPU time via `time.thread_time()`)

| measurement | result |
| --- | --- |
| drifted-hunk ranking, the real 677-line doc (53 drop-a-word hunks) | true region ranked **first 53/53** |
| closest-region search per hunk, 677-line file | **11.6 ms** CPU |
| per-line token bags, 20,000-line synthetic file | **67 ms** (failure path only) |
| exhaustive scan-and-score, 20,000-line file / 200-line drifted pattern | **6,299 ms** → start 12000, score 0.97 |
| prefiltered search, same input | **19 ms** → start 12000, score 0.97 (**337×**) |
| happy path: 11 exact hunks, pre-change module vs this branch, same interpreter | **11.20 ms → 11.17 ms** (unchanged) |
| worst-case refusal (2 full reports + 3 one-liners + tail) | **36 lines**, inside the card's 40-row cap (was 57 before D4) |

### 5. TUI: the card renders the whole refusal, tail included

Rendered through the real `OperatorApp` (`scripts.visual_capture.save_capture`, 120×40, then rasterised with `rsvg-convert` and inspected as an image): the card shows the header, the frame note, **both** detailed blocks with their quoted lines, difference pairs and `read(...)` hints, *and* the third hunk's compact line — nothing cut off, every hint's `range` fully visible. The expanded card flattens whitespace into one paragraph (`tool_card.py:1121`) by design, so multi-line text cannot break its layout; each physical row is truncated at the widget width, which is why the actionable call leads its own line (D2).

### 6. Gates (worktree venv, head `de7cab2d7`)

| gate | command | result |
| --- | --- | --- |
| flake8 | `.venv/bin/python -m flake8 .` | clean |
| black | `uvx --from black==26.1.0 black --check .` | 1220 files unchanged |
| isort | `uvx isort==5.13.2 --check .` | clean (2 skipped) |
| pyright | `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | 0 errors, 0 warnings |
| context budget | `.venv/bin/python scripts/bench_context_budget.py` | PASS, 41 billed tokens of headroom (27,279 vs 27,320) |
| tools + TUI suites | `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tools tests/unit/tui -q` | **7701 passed, 12 skipped** |
| targeted | `... -q -k "edit or tolerant_prefilter or closest_region"` | 38 passed |
| mutation checks | each remediated defect restored in turn | R1 → 1 fail · D1 → 2 · D4 → 1 · Q2/E → 2 · R2/F → 1 · R5 → 1 · scan-per-frame → 1. All restored. |

The round-1 description listed a "closest-region search removed → 3 fail" row that the reviewer's blunt emulation answered with 5. The difference was the mutation's shape, not the behaviour: stubbing `_closest_regions` to `[]` also collapses the no-close-match branch, which two further tests read. The row is replaced above by the checks actually run in this round.

### 7. CI

Run `34559228733`, and the run at this head — result posted as a comment when it lands. Two infrastructure notes, neither this diff:

- **`test (3.12, 1)` has twice been CANCELLED at the job's 20-minute cap**, once after reaching **98%** and stalling for 6m46s in the long tail. It is base-wide pressure, not this PR: the partitioner assigns whole FILES from `tests/durations.json`, this branch adds no file, and `scripts/shard_tests.py` projects **~21.5 test-min for every one of the five shards** against that same 20-minute cap. Shard 1 passed in 10m15s on this PR's first run, and 0/2/3/4 plus `tui-e2e` (macOS + Ubuntu) passed on the attempt that cancelled it.
- **`test (3.12, 0)` failed once** on `tests/unit/tui/test_subagent_view.py::test_history_prepend_preserves_anchor_and_home_dedupes_requests` (`assert (40 - 0.0) == 0` — a scroll-anchor position under a loaded runner). Untouched by this diff, passes locally on this head (`1 passed`), passed on rerun.

## Not addressed (deliberate)

- **No fuzzy auto-apply** — the file often holds a later, reviewed revision of the paragraph being edited, so applying the caller's stale hunk would overwrite another agent's wording.
- **No session-scoped read snapshot / "this file changed since you read it" warning** — that needs per-session read/edit bookkeeping on `ToolContext` and belongs in its own PR.
- **D6 deferred** (ink/emphasis for the actionable token): it would require the renderer to parse the message's prose; the right shape is a structured affordance, which is its own change.
- **D7 deferred** (the collapsed settled row still truncates to `edit aborted: 2 of 5 h…`): pre-existing, equally truncated on `main`, and a wording-order call rather than a layout one.
- **D5 dropped** — not a real gap. QA round 1 (Q4) drove the real `ProjectionFold` and showed the phone **does** receive the whole refusal: only the collapsed row's `error` field is compacted to 200 characters, while `details["output"]` carries all 3,120 and the web client renders it on expand (`web/src/components/tool-row.tsx:214`). Thank you to the QA round for the correction; the earlier note in this description was wrong about it.
- **No CI change** for the shard-1 cap above; re-balancing the duration manifest or raising the cap is a CI change of its own.