### PR TITLE
fix(tui): apply the subagent page's Home offset at press time

### DIFF
--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -2189,22 +2189,58 @@ class SubagentView(Vertical):
         uses (``_reanchor_insert``, ``_scroll_to_tail``,
         ``_snap_landing_to_row_head``).
 
-        The follower is released explicitly because the programmatic guard
-        below suppresses the ``watch_scroll_y`` resync that used to carry that
+        The follower is released here too, because the programmatic guard below
+        suppresses the ``watch_scroll_y`` resync that used to carry that
         decision a frame later — and that frame is one an extent change could
-        use to drag the reader back to the bottom.
+        use to drag the reader back to the bottom. It is released only when the
+        press actually LEFT the tail (``scroll_y < max_scroll_y``): a press that
+        moved nothing cannot have left it, and a child page that is still short
+        is following its own output, so an eager release stops the rows it goes
+        on to produce from being carried into view (review round 1, M1).
         """
         body = self._body
-        body._tail_anchor.release()
         with body._tail_anchor.programmatic_scroll():
             body.scroll_home(animate=False, immediate=True)
-        # The intended offset is passed explicitly as well: it prevents the disk
-        # worker from sampling the old tail first and restoring it after the
-        # prepend, which made a real keyboard Home press appear to load nothing.
+        # Keyed on POSITION rather than on whether the move changed anything,
+        # the same shape `_snap_landing_to_row_head` uses for the same reason:
+        # `scroll_y < max_scroll_y` is what "this press left the tail" means.
+        # The move and the release are one synchronous step, so no extent change
+        # can land between them and `_scroll_to_tail()` the reader back down
+        # while the follower is still armed.
+        if body.scroll_y < body.max_scroll_y:
+            body._tail_anchor.release()
+        # The read is still requested HERE rather than left to the edge watcher
+        # the move triggers. That watcher (`_scroll_changed`) runs synchronously
+        # from the move and issues `_maybe_load_history()` of its own, with the
+        # same anchor — it samples the offset the move just wrote, which is this
+        # call's explicit 0.0 — but with `retry` off, so on the COMMON path it
+        # wins the race and this call returns early on `_history_loading`. The
+        # read count is unchanged either way; what only this call carries is
+        # `retry`, the one way through the `_history_error` /
+        # `_history_unavailable` latches a reader's Home uses to ask again, and
+        # `test_history_unavailable_and_error_retry_keep_trajectory_fallback`
+        # pins that second read. Stated because the two are otherwise identical,
+        # and only the immediate move above makes the anchors agree.
         self._maybe_load_history(anchor=0.0, retry=True)
 
     def action_end(self) -> None:
-        """Return to the live tail and re-acquire sticky following."""
+        """Return to the live tail and re-acquire sticky following.
+
+        The move stays DEFERRED here — ``scroll_end(animate=False)`` is the same
+        ``scroll_to(..., immediate=False)`` deferral ``action_home`` no longer
+        uses — and that difference is deliberate, not an oversight (review round
+        1, M3). End asks for the TAIL, so a late landing cannot put the reader
+        anywhere the press did not already ask for: either the insert's
+        transaction is still armed, and the travel folding rewrites the held gap
+        by exactly the travel it records (``target = block.y - gap`` with ``gap``
+        shifted by it, which lands on the new ``max_scroll_y``), or it has
+        already been consumed and the landing is simply the tail, re-acquiring
+        the follower through ``watch_scroll_y``'s ``resync(at_end=True)``.
+        Home's offset is NOT the tail, which is what makes the same lateness a
+        defect there — the reader is moved off the content the insert's anchor
+        hold exists to keep still. Reasoned from that arithmetic, not yet pinned
+        by a test: reaching the ordering needs fault injection.
+        """
         self._body.scroll_end(animate=False)
 
     def _maybe_load_history(

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -2169,12 +2169,38 @@ class SubagentView(Vertical):
         Repeated Home presses while the worker is active are intentionally a
         no-op: one edge crossing means one disk read, not a queue of duplicate
         requests that later prepend the same page several times.
+
+        The offset move is applied HERE and marked as this widget's own:
+        ``scroll_home(immediate=True)`` inside ``programmatic_scroll``, not
+        Textual's deferred default. ``scroll_home(animate=False)`` alone still
+        moves nothing now — ``scroll_to`` defaults to ``immediate=False`` and
+        defers the real call with ``call_after_refresh`` — and that deferral is
+        a window in which this page's own scroll stops being recognisable as its
+        own: the page the press requested can be read, mounted and
+        anchor-corrected on a LAYOUT pass before the deferred move lands, and
+        the landing then arrives as an unattributed offset change.
+        ``watch_scroll_y`` reads that as reader travel, rewrites the insert's
+        held gap by the travel it believes it saw, and the settle's restore
+        faithfully pins the reader back where the transaction began — anchor
+        block at y=40 against ``scroll_y`` 0, which is the intermittent
+        ``assert (40 - 0.0) == 0`` on CI (main ``51b524c8`` run 34549931882 job
+        ``test (3.13, 2)``; PR #950's run 34553433194 job ``test (3.12, 0)``).
+        This is the shape every other deliberate scroll on this widget already
+        uses (``_reanchor_insert``, ``_scroll_to_tail``,
+        ``_snap_landing_to_row_head``).
+
+        The follower is released explicitly because the programmatic guard
+        below suppresses the ``watch_scroll_y`` resync that used to carry that
+        decision a frame later — and that frame is one an extent change could
+        use to drag the reader back to the bottom.
         """
-        self._body.scroll_home(animate=False)
-        # ``scroll_home`` is applied on Textual's next refresh. Passing the
-        # intended offset explicitly prevents the disk worker from sampling the
-        # old tail first and restoring it after the prepend, which made a real
-        # keyboard Home press appear to load nothing.
+        body = self._body
+        body._tail_anchor.release()
+        with body._tail_anchor.programmatic_scroll():
+            body.scroll_home(animate=False, immediate=True)
+        # The intended offset is passed explicitly as well: it prevents the disk
+        # worker from sampling the old tail first and restoring it after the
+        # prepend, which made a real keyboard Home press appear to load nothing.
         self._maybe_load_history(anchor=0.0, retry=True)
 
     def action_end(self) -> None:

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -1452,6 +1452,56 @@ async def test_history_prepend_preserves_anchor_and_home_dedupes_requests(
 
 
 @pytest.mark.asyncio
+async def test_action_home_moves_the_offset_at_press_time(tmp_path) -> None:
+    """A Home press must move the offset NOW, not on a later frame.
+
+    This is the pin for the intermittent `assert (40 - 0.0) == 0` failure of
+    the test above (main `51b524c8` run 34549931882 job `test (3.13, 2)`; PR
+    #950's run 34553433194 job `test (3.12, 0)`). The mechanism, reproduced
+    deterministically: Textual's ``scroll_home(animate=False)`` does not move
+    anything — ``scroll_to`` with ``immediate=False`` defers the real call with
+    ``call_after_refresh``. The page a press requests is read, mounted and
+    anchor-corrected on a LAYOUT pass, which can beat that deferred callback on
+    a loaded box; when it does, the widget's own move lands inside the insert's
+    anchor transaction and is indistinguishable from reader travel, so
+    ``watch_scroll_y`` rewrites the held gap by the travel it thinks it saw and
+    the settle's restore faithfully pins the reader back at the top spot the
+    transaction began from — anchor block at y=40, ``scroll_y`` 0.
+
+    So the assertion is the invariant that closes that window: at the instant
+    ``action_home`` returns, the body is at 0 and the tail follower is already
+    released (the programmatic move suppresses the ``watch_scroll_y`` resync
+    that used to carry that decision a frame later, which is also the frame in
+    which an extent change could have dragged the reader back to the bottom).
+    No ``pause`` between the press and the readings: a deferred move is exactly
+    what this asserts against.
+    """
+    transcript = Transcript(tmp_path / "child")
+    for index in range(140):
+        await transcript.append_message(Message.assistant(f"durable {index}"))
+    job = _job_with([], status="completed")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    session._subagent_comms = type(
+        "Comms", (), {"session_dir_of": lambda self, _job_id: transcript.directory}
+    )()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(90, 28)) as pilot:
+        view = await _open(pilot, app, job)
+        await _wait_history(pilot, view)
+        await _wait_geometry_settled(pilot, view._body)
+        # Opened on the tail and following it, so Home has something to do.
+        assert view._body.scroll_y > 1
+        assert view._body.is_following_tail is True
+
+        view.action_home()
+
+        assert view._body.scroll_y == 0
+        assert view._body.is_following_tail is False
+        await _wait_history(pilot, view)
+
+
+@pytest.mark.asyncio
 async def test_history_arriving_at_the_top_loads_one_page_then_stops(tmp_path) -> None:
     """Scrolling to the top loads history per ARRIVAL — never a cascade.
 

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -1502,6 +1502,52 @@ async def test_action_home_moves_the_offset_at_press_time(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_action_home_that_moves_nothing_keeps_following_the_tail(tmp_path) -> None:
+    """A Home press that cannot move the reader must not release the follower.
+
+    Review round 1, M1. A child page whose transcript still fits the viewport
+    (`max_scroll_y == 0`) is showing its own end, and it is LIVE: the rows it
+    goes on to produce have to be followed. `_size_updated` reaches
+    `_scroll_to_tail()` only `if changed and self._tail_anchor.following`, so
+    releasing here stops a still-short page dead — the next output lands below
+    the fold with no input to reveal it, the failure class
+    `TranscriptView.TailAnchor.note_user_scroll` documents.
+
+    The pre-fix code got this right only by accident: its release rode
+    `watch_scroll_y`, which needs an offset change to fire, so a press that
+    moved nothing released nothing. Releasing at press time must be keyed on
+    POSITION for the same reason ``_snap_landing_to_row_head`` keys its release
+    that way — `scroll_y < max_scroll_y` is what "this press left the tail"
+    means, and a press that moved nothing cannot have left it.
+    """
+    transcript = Transcript(tmp_path / "child")
+    for index in range(3):
+        await transcript.append_message(Message.assistant(f"short {index}"))
+    job = _job_with([], status="completed")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    session._subagent_comms = type(
+        "Comms", (), {"session_dir_of": lambda self, _job_id: transcript.directory}
+    )()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(90, 28)) as pilot:
+        view = await _open(pilot, app, job)
+        await _wait_history(pilot, view)
+        await _wait_geometry_settled(pilot, view._body)
+        # The whole page fits: Home has nowhere to go, and the reader is
+        # already at the end it is following.
+        assert view._body.max_scroll_y == 0
+        assert view._body.scroll_y == 0
+        assert view._body.is_following_tail is True
+
+        view.action_home()
+
+        assert view._body.scroll_y == 0
+        assert view._body.is_following_tail is True
+        await _wait_history(pilot, view)
+
+
+@pytest.mark.asyncio
 async def test_history_arriving_at_the_top_loads_one_page_then_stops(tmp_path) -> None:
     """Scrolling to the top loads history per ARRIVAL — never a cascade.
 


### PR DESCRIPTION
# PR Description

## Summary of Changes

Fixes the intermittent `AssertionError: assert (40 - 0.0) == 0` in
`tests/unit/tui/test_subagent_view.py::test_history_prepend_preserves_anchor_and_home_dedupes_requests`.
The defect is in the product, not the test: a **Home press on the subagent page
performs its offset move on a later frame, and when that move lands after the
page the press requested has been inserted, the widget's own scroll is
misattributed as reader travel** and the insert's anchor hold is undone.

- `local_operator/tui/widgets/subagent_view.py` — `action_home` now applies the
  move itself (`scroll_home(animate=False, immediate=True)` inside
  `_tail_anchor.programmatic_scroll()`) and releases the tail follower
  explicitly, instead of leaving both to Textual's deferred `scroll_home` and
  the `watch_scroll_y` resync a frame later.
- `tests/unit/tui/test_subagent_view.py` — one new guard,
  `test_action_home_moves_the_offset_at_press_time`, that reads the offset with
  **no pause between the press and the assertions**, so a deferred move is what
  it fails on. It is red on the unfixed tree (`assert 87 == 0`) and green here.

No version bump — `pyproject.toml` is untouched. No other file is touched, and
`conftest.py` / `.github/workflows/ci.yml` (PR #951's files) are untouched.

## Related Issue(s)

Related: the failure has no issue; these are the runs it was reported on.

- main `51b524c8`, run [34549931882](https://github.com/damianvtran/local-operator/actions/runs/34549931882), job `test (3.13, 2)` — 1 failed, 3681 passed.
- PR #950's branch, run [34553433194](https://github.com/damianvtran/local-operator/actions/runs/34553433194), job `test (3.12, 0)` — 1 failed, 3681 passed.

## Impact

**User-visible, narrowly.** `insert_blocks`' documented invariant is that a
prepend "mount[s] older blocks above the viewport without moving its content",
and `test_history_home_key_lands_on_newly_loaded_page` pins the same contract
from the reader's side (`growth <= scroll_y <= growth + 4`, i.e. Home lands
*with* the prepended page). When the deferred move lands late, the reader is
dropped at absolute `0` instead — the page moves under them with no input. It is
a wrong offset, not a crash or data loss; the transcript content is unaffected.

- No breaking change, no dependency change, no security implication. One method,
  one test.
- The changed behaviour is timing-affine, so it is not observable in a
  screenshot and there is nothing visual to attach.

## Testing Details

### 1. The mechanism, reproduced against the CI signature

Textual's `Widget.scroll_home(animate=False)` does not scroll: `scroll_to`
defaults to `immediate=False` and defers the real call through
`call_after_refresh` (`textual/widget.py:2912-2924`). Meanwhile the page the
press requested is read off-loop, mounted, and **anchor-corrected on a layout
pass** (`TranscriptView.arrange` / `_reanchor_insert`). When that layout pass
beats the deferred callback, this happens (`DIAG` lines from a temporary
instrumented copy of the failing test, all of it inside the test's own
`run_test` pilot — the instrumentation was deleted before this commit):

```
DIAG ('action_home', 'scroll_y', 0)                     # the press (no-op: already at the top)
DIAG ('reanchor', 'held', (0, 0.0), 'scroll', 0)        # insert: anchor armed, its y still stale
DIAG ('reanchor', 'held', (40, 0.0), 'scroll', 40.0)    # layout pass -> the anchor hold is applied
DIAG ('LATE-HOME-APPLIED', 40.0)                        # the deferred move lands now
DIAG ('_scroll_to', 0, 0, 'animate', False, 'depth', 0) # ... outside the programmatic guard
DIAG ('watch', 40.0, 0, 'depth', 0, 'armed', True, 'following', False)   # read as READER TRAVEL
DIAG ('FINAL', 'calls', 1, 'anc_y', 40, 'scroll_y', 0.0, ...)
E   AssertionError: assert (40 - 0.0) == 0
E    +  where 40 = Region(x=0, y=40, width=85, height=1).y
E    +    where Region(x=0, y=40, width=85, height=1) = AssistantBlock(classes='assistant-block').virtual_region
E    +  and   0.0 = SubagentTranscriptView(classes='subagent-view-body').scroll_y
```

Byte-for-byte the CI failure, including the block width, and it is
`watch_scroll_y`'s own documented rule doing the damage: an unattributed offset
change is folded into the in-flight insert as "new user travel", so the settle's
restore faithfully restores the *travel* — `40 - 40 = 0` — instead of the
anchor.

**Proven:** that interleaving produces the reported signature, and the timing it
depends on is one Textual's deferral permits (the deferred callback only runs
when the screen next goes idle, and it must lose a race against a mount plus a
layout pass). **Inferred, not proven:** that the two CI occurrences were exactly
this interleaving — neither log carries the internal state, only the assertion.
No other mechanism I could construct produces `anchor y=40, scroll_y=0.0` with
`before_gap=0`: the restore's target is `anchor.y - gap`, and for that to be 0
while `anchor.y` is 40 the gap must have been rewritten by 40 rows of
"travel" — which is what the trace above shows happening.

What the new guard pins is the **deferral**, not the race: it is a deterministic
proxy for the mechanism (`assert 87 == 0` on base, i.e. "the press moved
nothing yet"), not a reproducer of the `(40 - 0.0)` frame. That removing the
deferral removes the intermittent failure is **reasoned, not demonstrated** —
the designer's round-1 fault-injection run is the closest thing to a
demonstration: with the late move injected, base settles on that frame and head
has no deferral to hold.

### 2. The guard fails on the unfixed tree and passes here

```
# unfixed tree (main + the new test only)
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
    tests/unit/tui/test_subagent_view.py::test_action_home_moves_the_offset_at_press_time -n0 -q
FAILED ... - AssertionError: assert 87 == 0
 +  where 87 = SubagentTranscriptView(classes='subagent-view-body').scroll_y

# this head
$ ... same command
1 passed
```

Five consecutive runs of the three Home/prepend tests, `-n0`:
`3 passed ... in 3.03s` / `2.91s` / `2.88s` / `2.88s` / `2.91s`.

### 3. Adjacent surfaces (all `-n0`, `env -u NO_COLOR TERM=xterm-256color`)

- `test_subagent_view.py test_page_back_latch.py test_rendered_history_paging.py test_transcript_focus.py test_transcript_scrollbar_grab.py` → **203 passed** in 209s.
- `test_band_panels.py test_subagent_scope.py test_subagent_stats.py test_transcript_selection.py` → **332 passed** in 325s.

The box is shared and was under load average ~30-50 throughout, so these are
targeted rather than whole-suite runs; the full suite is CI's job.

### 4. Quality gates (CI's own pins)

- `flake8` 7.3.0 `flake8 .` → clean.
- `black` 26.1.0 `black --check .` → 1220 files unchanged.
- `isort` 5.13.2 `isort --check .` → clean.
- `pyright` 1.1.411 → **0 errors, 0 warnings** (`--pythonpath .venv/bin/python`;
  without it pyright cannot see the venv and reports 1635 phantom import
  errors).

### 5. Review round 1 remediation — one commit, `cfc0f8590`

M1 (MAJOR, the release added by this PR was unconditional) is fixed at
`cfc0f8590`; m2 and m3 are disposed at the site. The offset-at-press-time fix
itself is unchanged. Dispositions are in the
`### Agent review remediation — round 1` comment.

The M1 guard's red→green runs, all `env -u NO_COLOR TERM=xterm-256color`:

```
# previous head 9ce0f2f01 (unconditional release)
$ .venv/bin/python -m pytest ...::test_action_home_that_moves_nothing_keeps_following_the_tail -q
FAILED ... AssertionError: assert False is True          # max_scroll_y == 0, nothing moved
# pre-PR base 35078ab9f (same test file, base product)
1 passed, 1 failed                                       # this test passes; the press-time guard fails
# head cfc0f8590
6 passed                                                 # all six Home/prepend/retry tests
```

Post-remediation surfaces, run as CI does (no explicit `-n`):
`test_subagent_view.py test_page_back_latch.py test_rendered_history_paging.py`
→ **178 passed**; `test_band_panels.py test_subagent_scope.py
test_subagent_stats.py test_transcript_focus.py
test_transcript_scrollbar_grab.py test_transcript_selection.py
tests/unit/session/test_subagent_view_state.py` → **383 passed**. Gates re-run at
the remediation head: `flake8` clean, `black --check` 1220 files unchanged,
`isort --check` clean, `pyright` 0 errors.

## Not addressed (found on the way, deliberately out of this slice)

- **`action_end` uses the same deferred shape** (`scroll_end(animate=False)`,
  `subagent_view.py`). Its late landing is *not* a defect by the same
  arithmetic: the travel folding rewrites the gap to exactly the offset the End
  press asked for, so the restore lands the reader on the tail either way.
  Noted, not changed, to keep this to the failing path.
- **`AttributeError: 'Comms' object has no attribute 'roster'` — #953 does not
  cover it.** It is a pre-existing **test-double** gap, not the flake's other
  half and not a product defect: production defines `SubagentComms.roster`
  (`harness/comms.py:943`), and the exception comes from the ad-hoc
  `type("Comms", (), {"session_dir_of": ...})` doubles the TUI tests build, via
  `session/runtime/server.py:919` (the session's runtime server subscribes) →
  `MobileTuiHandle.subscribe` → `_refresh_state` →
  `MobileProjectionFold.set_subagent_details`.
  - It is **not a small fix**: `set_subagent_details` needs `comms.roster()`,
    `comms.nodes()` and `comms.job(...)` (`mobile/projection.py:1434-1469`), and
    the doubles are per-test ad-hoc stand-ins, not a shared factory — 38
    constructions in `test_subagent_view.py`, 2 in `test_page_back_latch.py`,
    2 more under `tests/unit/session`. The honest fix is either a shared test
    double or a capability-tolerant projection, and the second is a product
    decision, not this slice's. Deferred to its own slice.
  - Observed on a **passing** run, which is the part worth its own slice: with
    `--log-cli-level=WARNING` the traceback is printed for this test at
    `1 passed`, **6 of 6** runs, and for all three of
    `-o log_cli=true --log-cli-level=WARNING` / `--log-cli-level=WARNING` /
    `-o log_cli=true --log-cli-level=DEBUG` (1 match each). Without a log flag it
    is captured and discarded, so the runtime-server thread dies unnoticed in
    every run of these tests. (Round 1 could not reproduce it with
    `-o log_cli=true --log-cli-level=WARNING`; that null did not reproduce here.
    I cannot explain the divergence, so the claim here is only what is measured
    above, with the command.)

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required. (The mechanism, its
      constraint and the CI runs are documented in the `action_home` docstring
      and the guard's docstring; no user-facing doc describes this timing.)
- [x] Security considerations are addressed (especially for code execution features). (No new input surface, no subprocess, no path handling.)
- [x] I have linked all related issues.

