### PR TITLE
test(providers): release the port-squatter double's connections, which hung CI

### DIFF
--- a/tests/unit/providers/test_oauth_flows.py
+++ b/tests/unit/providers/test_oauth_flows.py
@@ -158,9 +158,95 @@ async def test_manual_input_only_pastes_code_without_server() -> None:
     assert flow.bound_port is None  # no server in manual mode
 
 
+class _PortSquatter:
+    """A server that occupies a port and answers nothing — without hanging.
+
+    Used as the ``client_connected_cb`` for the port-blocking doubles below.
+
+    WHY A HANDLER IS NOT OPTIONAL. ``Server.wait_closed()`` returns only when
+    the server is closed AND every connection it ACCEPTED has been released.
+    A handler that never closes its writer pins that count for the life of the
+    event loop, so ``await server.wait_closed()`` in a test's ``finally`` never
+    returns. That was this file's ``lambda r, w: None``: the flow's
+    best-effort ``GET /cancel`` probe is what connects here, the probe always
+    closes its own side, and on CPython 3.12 a closed peer is not enough —
+    ``StreamReaderProtocol.eof_received()`` returns True (a half-close is
+    legal HTTP), so the transport stays open and the server never detaches it.
+
+    Measured, because the two interpreters disagree and that is why this went
+    unnoticed: with ``lambda r, w: None``,
+    ``test_pinned_port_fails_before_browser_when_busy`` hangs and is killed by
+    ``timeout 45`` on **3.12.13, 3 of 3 runs** (its coroutine parked on an idle
+    event loop, its stack a bare ``await blocker.wait_closed()``), while on
+    3.14 the identical code passes, because asyncio replaced the
+    ``_active_count`` gate with a ``_clients`` set for 3.14. On CI that
+    difference is a 20-minute ``timeout-minutes`` cancel with no failing
+    assertion and a ~6-minute silent tail -- the stall the shard watchdog
+    (``tests/shard_stall_watchdog.py``) named in run 34558244102, job
+    103135419093 -- so the double, not the product, is the defect here.
+
+    Reading to EOF before closing keeps the double FAITHFUL as well as safe:
+    it still answers nothing, so the probe still has to wait out its own read
+    timeout, which is the behaviour under test. The read is bounded by the peer
+    closing, never by a clock.
+    """
+
+    def __init__(self) -> None:
+        self.accepted: list[asyncio.StreamWriter] = []
+        self.released = False
+
+    async def __call__(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        self.accepted.append(writer)
+        try:
+            await reader.read(-1)
+        except Exception:  # a reset counts as the peer going away
+            pass
+        finally:
+            writer.close()
+            self.released = True
+
+
+async def test_the_port_squatter_double_releases_what_it_accepts() -> None:
+    """Pin the double's contract, so the hang cannot come back unnoticed.
+
+    The regression this guards is real and costly: the previous
+    ``lambda r, w: None`` left the accepted connection attached forever, and
+    the only symptom was a shard cancelled at the workflow's 20-minute cap with
+    the suite at 99% and no failure anywhere.
+
+    What it catches, precisely -- mutation-tested, both interpreters: removing
+    the handler's ``writer.close()`` (so the connection is accepted, tracked and
+    never released) fails this guard in 5.32s on 3.12 AND on 3.14, because the
+    bounded ``wait_closed()`` below cannot return while a connection is still
+    attached. What it does NOT catch is a call site that stops using
+    ``_PortSquatter`` at all -- the literal ``lambda r, w: None`` binds at the
+    ``start_server`` call, not here. That case is covered by the test that owns
+    the behaviour instead: it hangs on 3.12, so the shard watchdog reports it in
+    four minutes rather than the workflow cap reporting it in twenty.
+    """
+    squatter = _PortSquatter()
+    blocker = await asyncio.start_server(squatter, "127.0.0.1", 0)
+    busy_port = int(blocker.sockets[0].getsockname()[1])
+    _reader, writer = await asyncio.open_connection("127.0.0.1", busy_port)
+    writer.write(b"GET /cancel HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n")
+    await writer.drain()
+    writer.close()
+    await writer.wait_closed()
+
+    assert squatter.accepted, "nothing connected, so this guard would prove nothing"
+    for _ in range(200):
+        if squatter.released:
+            break
+        await asyncio.sleep(0.01)
+    assert squatter.released, "the squatter kept an accepted connection attached"
+
+    blocker.close()
+    await asyncio.wait_for(blocker.wait_closed(), timeout=5.0)
+
+
 async def test_pinned_port_fails_before_browser_when_busy() -> None:
     """A provider-pinned port that is busy must fail fast — no browser."""
-    blocker = await asyncio.start_server(lambda r, w: None, "127.0.0.1", 0)
+    blocker = await asyncio.start_server(_PortSquatter(), "127.0.0.1", 0)
     busy_port = int(blocker.sockets[0].getsockname()[1])
     opened: list[str] = []
     try:
@@ -178,7 +264,7 @@ async def test_pinned_port_fails_before_browser_when_busy() -> None:
 
 
 async def test_port_fallback_when_allowed() -> None:
-    blocker = await asyncio.start_server(lambda r, w: None, "127.0.0.1", 0)
+    blocker = await asyncio.start_server(_PortSquatter(), "127.0.0.1", 0)
     busy_port = int(blocker.sockets[0].getsockname()[1])
     try:
         flow = _EchoFlow(

--- a/tests/unit/providers/test_oauth_flows.py
+++ b/tests/unit/providers/test_oauth_flows.py
@@ -158,6 +158,19 @@ async def test_manual_input_only_pastes_code_without_server() -> None:
     assert flow.bound_port is None  # no server in manual mode
 
 
+#: Backstop for the squatter's read, in seconds. NOT a timing assertion and
+#: not a bound on the behaviour under test: the read is normally ended by the
+#: peer closing (the flow's ``GET /cancel`` probe closes its writer in its own
+#: ``finally`` after a 2s read timeout, so the peer is gone within ~4s). This
+#: exists so that a FUTURE peer that connects and never closes cannot turn the
+#: double back into the unbounded wait it was written to remove -- the same
+#: shape ``tests/e2e/watchdog.py`` describes, where the deadline is there "so a
+#: genuine hang fails the run instead of blocking forever. It is a backstop,
+#: not the assertion." 60s is ~15x the worst measured peer-close (3.85s single
+#: test call on 3.12), so a healthy run can never reach it.
+_PEER_CLOSE_BACKSTOP_S = 60.0
+
+
 class _PortSquatter:
     """A server that occupies a port and answers nothing — without hanging.
 
@@ -173,33 +186,58 @@ class _PortSquatter:
     ``StreamReaderProtocol.eof_received()`` returns True (a half-close is
     legal HTTP), so the transport stays open and the server never detaches it.
 
-    Measured, because the two interpreters disagree and that is why this went
-    unnoticed: with ``lambda r, w: None``,
-    ``test_pinned_port_fails_before_browser_when_busy`` hangs and is killed by
-    ``timeout 45`` on **3.12.13, 3 of 3 runs** (its coroutine parked on an idle
-    event loop, its stack a bare ``await blocker.wait_closed()``), while on
-    3.14 the identical code passes, because asyncio replaced the
-    ``_active_count`` gate with a ``_clients`` set for 3.14. On CI that
-    difference is a 20-minute ``timeout-minutes`` cancel with no failing
-    assertion and a ~6-minute silent tail -- the stall the shard watchdog
-    (``tests/shard_stall_watchdog.py``) named in run 34558244102, job
+    WHAT THE INTERPRETERS ACTUALLY DIFFER ON, because the version number is not
+    the property and naming the property is what makes this readable on the
+    next machine. ``Server`` tracks accepted connections with
+    ``self._active_count = 0`` on 3.12 -- a plain counter, decremented only by
+    ``Server._detach()``, which runs from the transport's ``connection_lost``.
+    A handler that never closes its writer leaves the transport open, so
+    ``connection_lost`` never arrives, the counter stays at 1 and
+    ``wait_closed()`` waits for the life of the loop. From **3.13** the same
+    field is ``self._clients = weakref.WeakSet()``, and the server holds its
+    accepted transports only WEAKLY, so a connection nothing else keeps alive
+    stops counting against the waiter -- which is why ``wait_closed()`` returns
+    there even though the socket was never released.
+
+    Verified against the interpreters' own sources, not recalled:
+    ``3.12.13 asyncio/base_events.py:281`` has ``_active_count`` while
+    ``3.13.12`` and ``3.14.3`` both have ``_clients`` at ``:283``, and the same
+    probe returns on 3.13.12 and 3.14.3 and does not on 3.12.13. So the
+    divergence is 3.12 versus 3.13-and-later, and it is the WEAK reference --
+    not the version -- that decides it.
+
+    Measured consequence, because this is the reason it went unnoticed: with
+    ``lambda r, w: None``, ``test_pinned_port_fails_before_browser_when_busy``
+    hangs and is killed by ``timeout 45`` on **3.12.13, 3 of 3 runs** (its
+    coroutine parked on an idle event loop, its stack a bare
+    ``await blocker.wait_closed()``), while the identical code passes on 3.13
+    and 3.14. On CI that difference is a 20-minute ``timeout-minutes`` cancel
+    with no failing assertion and a ~6-minute silent tail -- the stall the shard
+    watchdog (``tests/shard_stall_watchdog.py``) named in run 34558244102, job
     103135419093 -- so the double, not the product, is the defect here.
 
     Reading to EOF before closing keeps the double FAITHFUL as well as safe:
     it still answers nothing, so the probe still has to wait out its own read
     timeout, which is the behaviour under test. The read is bounded by the peer
-    closing, never by a clock.
+    closing first, with :data:`_PEER_CLOSE_BACKSTOP_S` as a backstop so the
+    double cannot itself become the unbounded wait it exists to prevent.
     """
 
     def __init__(self) -> None:
         self.accepted: list[asyncio.StreamWriter] = []
+        # Deliberately STICKY: it means "at least one handler finished", which
+        # is all the guard's fast-path assertion needs, because a leak of any
+        # ADDITIONAL connection is caught by that guard's ``wait_for`` bound
+        # rather than by this flag. A count would only sharpen the failure
+        # message in a case that cannot arise at either call site (each accepts
+        # exactly one connection, the flow's cancel probe).
         self.released = False
 
     async def __call__(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         self.accepted.append(writer)
         try:
-            await reader.read(-1)
-        except Exception:  # a reset counts as the peer going away
+            await asyncio.wait_for(reader.read(-1), timeout=_PEER_CLOSE_BACKSTOP_S)
+        except Exception:  # a reset or the backstop: either way the peer is gone
             pass
         finally:
             writer.close()


### PR DESCRIPTION
# PR Description

## Summary of Changes

Fixes the shard-cap hang, at its root: the port-blocking **test double** in
`tests/unit/providers/test_oauth_flows.py` accepted a connection and never
released it, so the test's own `await blocker.wait_closed()` never returned and
a worker was parked for the rest of the CI job.

- Replaces `asyncio.start_server(lambda r, w: None, ...)` at both call sites with
  `_PortSquatter`, whose handler reads to EOF and then closes — it still answers
  nothing, so the behaviour under test is unchanged.
- Adds `test_the_port_squatter_double_releases_what_it_accepts`, mutation-tested.
- **No product change.** The fail-fast guarantee this test exists for holds.

## Related Issue(s)

Related: #940, #947 (admin-merged over `test (3.12, N)` cancels). Found by the
shard stall watchdog added in #951: run 34558244102, job 103135419093.

## Impact

- Test-only. One file, no production code, no dependency change, no version bump.
- Removes the cause of the `timeout-minutes: 20` cancels, which blocked PRs
  intermittently with no failing assertion anywhere in the log.

## Testing Details

### The await, named rather than inferred

`Task.get_stack()` on CPython 3.12 — the interpreter CI runs — parks the
coroutine on exactly one line of the test:

```
python 3.12.13  busy port 49903
flow.run() raised ConfigurationError  (the fail-fast guarantee held)
opened=[]  blocker active=1

=== task dump after 6s ===
--- Task-1 ---
    /tmp/repro312.py:68 in main          <-- await blocker.wait_closed()
blocker.wait_closed() HUNG  <-- the stall is in the TEST's finally
```

By that point `flow.run()` has already raised `ConfigurationError` and
`opened == []` holds, so **the product is not the defect** — the guarantee the
docstring promises ("A provider-pinned port that is busy must fail fast — no
browser") is intact. There is no reachable production path: the product's own
handler closes its writer on every path (`_handle_connection`'s tail and its
early return), so `_stop_server`'s `wait_closed()` has nothing to wait on.

### Why the double hangs it

`Server.wait_closed()` returns only once the server is closed **and every
connection it accepted has been released** — the stdlib docstring says it
outright: *"If it is closed, but there are still active connections, wait."*
`lambda r, w: None` accepts the flow's best-effort `GET /cancel` probe (which is
what connects here) and never releases it: the handler holds no writer and never
closes one, and a clean peer close is not enough, because
`StreamReaderProtocol.eof_received()` returns `True` — a half-close is legal
HTTP — so the transport stays open and the server never detaches the connection.

That leaves the counter pinned for the life of the loop: **unbounded**. On CI it
was measured in flight for 827s and still repeating at 1037s when the job died.

### Before / after, on the interpreter CI runs (3.12.13)

| command | before | after |
|---|---|---|
| `pytest tests/unit/providers/test_oauth_flows.py -n0` | **never finished** — killed at a 240s bound having burned **0.454s of CPU** (parked, not working) | **117 passed in 33.04s** |
| `pytest ...::test_pinned_port_fails_before_browser_when_busy -n0` | **never finished**, 3 of 3 runs at `timeout 45` | **1 passed in 4.02s** (call 3.84s) |
| `pytest tests/unit/providers -q` (3.14) | 1204 passed | 1204 passed in 17.29s |

The 3.84s after is the probe's own 2s read timeout plus the retry ladder, both
bounded — the test is *supposed* to sit there, and now nothing sits after it.

### Why it shipped and why it was intermittent

On **3.13 and 3.14 the identical code passes**, and the property that decides
it is the *weakness* of the reference, not the version: `Server` tracks accepted
connections with `self._active_count = 0` on 3.12 — a plain counter, decremented
only by `Server._detach()` from the transport's `connection_lost`, which never
arrives while a handler leaves its transport open. **From 3.13** the same field is
`self._clients = weakref.WeakSet()`, so the server holds accepted transports only
weakly and such a connection stops counting against `wait_closed()`.

Verified against the interpreters' own sources: `3.12.13 asyncio/base_events.py:281`
has `_active_count`, while `3.13.12` and `3.14.3` both have `_clients` at `:283` —
and the same probe returns on 3.13.12 and 3.14.3 and does not on 3.12.13. So the
divergence is **3.12 versus 3.13-and-later**, which is why the developer interpreter
tolerates the double and CI's does not; this is the whole reason the defect was
invisible locally. (The original commit message on this branch says "3.14" there;
it is superseded by this correction and by the code comment, which a rebase would
rewrite history to fix, so it is left as-is and named here instead.) Whether the accepted
connection is left half-attached also depends on the peer's close arriving as a
FIN rather than an RST, which is timing-dependent under a loaded runner; on
3.12 locally it is deterministic (3/3 hangs).

### The guard is mutation-tested

Removing the handler's `writer.close()` (accepted, tracked, never released):

```
FAILED ...::test_the_port_squatter_double_releases_what_it_accepts - TimeoutError
1 failed in 5.32s
```

— on **both** 3.12 and 3.14. What the guard cannot catch is a call site that
stops using the helper at all, since `lambda r, w: None` binds at the
`start_server` call; that case is covered by the named test itself, which hangs
on 3.12 and so is reported by the shard watchdog in four minutes rather than by
the workflow cap in twenty.

### Quality gates

- `flake8 .` → rc 0
- `uvx --from black==26.1.0 black --check .` → 1220 files unchanged
- `uvx isort==5.13.2 --check-only .` → clean
- `pyright` on the changed file → 0 errors, 0 warnings
- `tests/unit/providers` → 1204 passed (3.14), and the whole changed file on
  3.12 as above. Relying on CI for the full-tree run.

## Not addressed

- **`_stop_server`'s `await self._server.wait_closed()` is itself unbounded.**
  Not a live defect: the product's handler releases every connection, verified
  on all paths through `_handle_connection`, so it has nothing to wait on. Worth
  knowing that its safety rests on that, and that a future early `return` in
  `_handle_connection` before the closing tail would make it reachable.
- **`_respond` does not close the writer**; it relies on its callers reaching
  `_handle_connection`'s tail. Same reasoning, same note.
- Considered and **not** taken: wrapping the test's cleanup in
  `wait_for(..., timeout=…)`. It would convert this class of hang into a fast
  failure, but the structural fix is what makes the await return, and bounding
  it would hide the same trap rather than remove it. Flagging it as a reviewer's
  call rather than assuming.

