### PR TITLE
fix: audit follow-ups — dual-alias tolerance, stale references, and runtime copy

### DIFF
--- a/docs/design-aside-deadline.md
+++ b/docs/design-aside-deadline.md
@@ -39,7 +39,7 @@ shared by all 19 ops that route through `_request`.
 carrying the whole conversation:
 
 * `tui/app.py:28660` — the aside worker awaits `session.complete_aside(...)`
-* `session/remote.py:4987-5000` — `RemoteSession.complete_aside` → `client.complete_aside`
+* `session/attached.py` — `AttachedSession.complete_aside` → `client.complete_aside`
 * `mobile/attach_client.py:765-766` — `return await self._request("complete_aside", turns=turns)`
 * `session/runtime/server.py:2141-2148` — dispatch awaits the handle
 * `mobile/tui_handle.py:528-536` — `asyncio.run_coroutine_threadsafe(session.complete_aside(messages), owner_loop)`, unbounded, no timeout, no cancellation
@@ -53,7 +53,7 @@ operation, not a fault — which is why the bug is "intermittent, reproducible
 under load" rather than rare.
 
 Blast radius is every terminal: since v0.45.0 every interactive `lop` TUI is a
-`RemoteSession` viewer, so every `/btw` everywhere takes this path.
+`AttachedSession` viewer, so every `/btw` everywhere takes this path.
 
 ### 1.1 Two corrections to the reported mechanism
 
@@ -101,12 +101,13 @@ parameter of the module-level `continue_command`, forwarded to
 ### 1.2 `/btw` is not the only op with this shape
 
 `/compact` from a viewer routes `client.slash("compact", "")`
-(`session/remote.py:5191`) through the same `_request` 15 s budget. The owner's
+(`session/attached.py`, in `compact_now`) through the same `_request` 15 s
+budget. The owner's
 summarization is a provider call the codebase itself measures at **"20-50 s on
 a large context"** (`session/session.py:447`).
 
 Its failure is quieter than `/btw`'s: `compact_now` catches `ConnectionError`
-(`remote.py:5192`) and returns
+(`attached.py`) and returns
 `CompactionOutcome(False, "unavailable", self._unavailable_reason())`, so a
 timeout is reported to the user as *the owner being unavailable* — no dangling
 colon, but a wrong diagnosis of a healthy owner.
@@ -126,14 +127,15 @@ the argument for adding the parameter rather than hard-coding a branch for
 `ConnectionError` from `_request` is load-bearing: callers read it to decide
 whether to redial. Auditing every catch that can see it:
 
-* `session/remote.py:2132` — `except (ConnectionError, OSError, TimeoutError)` (bind retry)
-* `session/remote.py:4418`, `4506` — `except (ConnectionError, OSError, TimeoutError)` (redial / takeover)
-* `session/remote.py:4571`, `4601`, `4647` — `except (ConnectionError, RuntimeError)` (capability absent → `return False`)
-* `session/remote.py:5183`, `5192` — `except ConnectionError` **alone** (routed slash, `compact_now`)
+* `session/attached.py` — `except (ConnectionError, OSError, TimeoutError)` (bind retry)
+* `session/attached.py` — `except (ConnectionError, OSError, TimeoutError)` (redial / takeover)
+* `session/attached.py` — `except (ConnectionError, RuntimeError)` (capability absent → `return False`)
+* `session/attached.py` — `except ConnectionError` **alone** (routed slash, `compact_now`)
 * `mobile/attach_client.py:424` — `except ConnectionError` alone (pump)
 * `server/routes/desktop_sessions.py:214` — `except ConnectionError` alone
 
-The two `ConnectionError`-only sites at `remote.py:5183/5192` are the
+The two `ConnectionError`-only sites in `session/attached.py`
+(`route_shared_slash`, `compact_now`) are the
 constraint. Re-raising an ack timeout as a plain `TimeoutError` would sail past
 both, and a timeout on `/compact` would escape as a raw exception instead of
 `CompactionOutcome(False, "unavailable", ...)`. **Changing the exception type to
@@ -169,7 +171,7 @@ from a slow one, and finding 9's test gap gets a test asserting on prose. It is
 smaller by about four lines and worse.
 
 Rejected: **plain `TimeoutError`**. Cleanest taxonomy, breaks
-`remote.py:5183/5192` as shown above.
+`route_shared_slash` / `compact_now` in `session/attached.py` as shown above.
 
 ## 3. Deadline policy
 
@@ -180,7 +182,7 @@ Four candidates, weighed against the corrected finding 5.
 no protocol change, no owner change. The other 18 ops are untouched because the
 default is unchanged.
 
-**(b) Real streaming.** `remote.py:4998-5003` already fakes it — it calls
+**(b) Real streaming.** `complete_aside` in `session/attached.py` already fakes it — it calls
 `on_delta` once with the settled answer — and the card is built to stream. Best
 end-state UX, and progress on the socket. But it needs an out-of-band
 owner→client frame, owner-side plumbing of `session.complete_aside(on_delta=)`,
@@ -247,7 +249,7 @@ rather than reinvented: an additive field on a known op is tolerated by
 `validate_control_frame` (`mobile/types.py:187-190` validates only `turns`); a
 new op gets `error: unknown op` from an old owner
 (`session/runtime/server.py:2257`, `2492`), which callers already handle
-(`remote.py:4571` treats it as capability-absent); and a capability string in
+(`session/attached.py` treats it as capability-absent); and a capability string in
 `record.capabilities` is the pre-dial probe, as `completion-ack-v1` does at
 `session/runtime/server.py:668-671` / `attach_client.py:218`.
 
@@ -296,7 +298,7 @@ aside worker renders a non-empty message and no trailing `:` — asserted on the
 rendered card text, not on the helper in isolation.
 
 Note the file boundary: slice 1 owns `mobile/attach_client.py`, slice 2 owns
-`tui/*`. Neither touches `session/remote.py`, which needs no change at all.
+`tui/*`. Neither touches `session/attached.py`, which needs no change at all.
 
 ### Slice 3 — the socket fix (follow-up, NOT this change)
 
@@ -305,7 +307,7 @@ Files: `local_operator/session/runtime/server.py`, `local_operator/mobile/tui_ha
 Scope: dispatch `complete_aside` off the reader loop (PR #678 shape) so it
 stops head-of-line blocking `server.py:1382`; deliver the answer out of band;
 add `cancel_aside`; then real streaming (§3b) reusing the delta channel
-`remote.py:4998-5003` currently fakes. Behind a capability string per §5.
+that `complete_aside` currently fakes. Behind a capability string per §5.
 
 Deferred honestly: this is the *correct* fix for the socket, and it is not what
 the user reported. It changes the protocol, so it carries skew risk that slices

--- a/docs/design-build-skew.md
+++ b/docs/design-build-skew.md
@@ -32,7 +32,7 @@ The Sep 5 incident is the concrete shape:
    the band and calls `_submit_command_prompt(request, attachments)`. The
    pre-#624 viewer prints `text` and has no consumer for `data.request`
    (verified: `git show v0.46.23:local_operator/tui/app.py` — the renderer
-   ends at `if text:`; and v0.46.23's `serving.py` still returned
+   ends at `if text:`; and v0.46.23's `owned.py` still returned
    `noop {"type": "team_mutate"}`, so the receipt type was brand new to it).
 5. Result: notice printed, request silently dropped. No user row, no turn.
 
@@ -281,7 +281,7 @@ incident.
 
 The discovery record **is** the version channel: an attach client reads it
 before dial (`find_runtime_record`) and holds it at bind
-(`AttachedSession._bind_to(record)`, remote.py:1002); the daemon reads records
+(`AttachedSession._bind_to(record)`, attached.py); the daemon reads records
 the same way. No frame change is needed — the "ready/hello" for a v5 attach
 client effectively arrives with the record. (The task suggested the frontend
 sync frame; the record is strictly earlier, needs no pydantic change, and

--- a/docs/design-idle-reap.md
+++ b/docs/design-idle-reap.md
@@ -125,7 +125,7 @@ in `_handle_client`'s request loop (`server.py:1345`, immediately before
 `_on_request`), so for a viewer that sends nothing it is the attach time and
 never moves. The task's 12-second spy on `_on_request` measuring zero ops is
 consistent with the code: I found no periodic op from an attach client —
-`remote.py` has no `set_interval`/keepalive, and the only recurring wire op
+`attached.py` has no `set_interval`/keepalive, and the only recurring wire op
 in the tree is the desktop host's `desktop_watch` lease
 (`desktop_sessions.py:354-376`), which is not a terminal TUI.
 
@@ -146,8 +146,8 @@ on the adopted session (`app.py:6039-6041`). `_on_runtime_refreshed`
 band would show the cold state until the user typed"). The `retiring` frame
 (`server.py:849-880`) lands as `RETIRING_REASON`
 (`attach_client.py:398-404`), which `_on_disconnected` routes to
-`_go_cold(refresh=True)` (`remote.py:3375-3384`), which fires that callback
-(`remote.py:3651`).
+`_go_cold(refresh=True)` (`attached.py`), which fires that callback
+(`attached.py`).
 
 Therefore a runtime that idle-reaps itself and announces `retiring` to the
 current TUI gets a **brand-new runtime spawned within ~1 s**: exit → spawn →
@@ -159,18 +159,18 @@ two, and both are wrong for an idle reap of a displayed session:
 
 | frame | viewer behaviour | verdict for idle-reap |
 |---|---|---|
-| `retiring` | `_go_cold(refresh=True)` → eager re-engage (`remote.py:3383`) | **churn loop** |
-| bare EOF | `_on_disconnected` → `_recovering = True` → `_recover_owner` (`remote.py:3400-3407`) | **worse** — see below |
+| `retiring` | `_go_cold(refresh=True)` → eager re-engage (`attached.py`) | **churn loop** |
+| bare EOF | `_on_disconnected` → `_recovering = True` → `_recover_owner` (`attached.py`) | **worse** — see below |
 | `stopping` | parks in the stopped state, tells the user `/resume` (`server.py:854-857`) | lies; the session did not end |
 
 Bare EOF is worse than it looks for exactly the sources we care about.
-`_can_go_cold` is set from `surface == "desktop"` (`remote.py:485`), and
+`_can_go_cold` is set from `surface == "desktop"` (`attached.py`), and
 `_lease_sidebar_source` calls `AttachedSession.connect` (`app.py:4056-4062`)
 without a `surface` argument, so it defaults to `"terminal"`
-(`remote.py:782`) and `_can_go_cold` is **False**. A parked source that sees
+(`attached.py`) and `_can_go_cold` is **False**. A parked source that sees
 EOF therefore enters runtime-death recovery and, per
-`remote.py:3768-3798`, chases a record for `COLD_FALLBACK_S = 8.0`
-(`remote.py:129`) and then — because it cannot go cold — keeps retrying
+`attached.py`, chases a record for `COLD_FALLBACK_S = 8.0`
+(`attached.py`) and then — because it cannot go cold — keeps retrying
 forever while the legacy contract tries to **take over** the session
 (`no_takeover` raises by construction, `app.py:4040-4043`, so it loops).
 A runtime-initiated EOF against a parked sidebar source is a redial storm.
@@ -182,7 +182,7 @@ I verified the parent's suspicion. `_lease_sidebar_source`
 frontend watch (4080) and **nothing else**. The three lifecycle callbacks —
 `set_takeover_callback`, `set_stopped_callback`, `set_refresh_callback` — are
 installed only in `_adopt_session` (`app.py:6025-6041`), for the CURRENT
-session. `set_went_cold_callback` is defined (`remote.py:3711`) but has no
+session. `set_went_cold_callback` is defined (`attached.py`) but has no
 caller anywhere in `local_operator/`.
 
 So a parked source has no refresh path (no churn loop) but also no cold path
@@ -204,7 +204,7 @@ what the two caches were always supposed to mean.
 Teardown is already correct for this. `_release_sidebar_source`
 (`app.py:4648-4679`) saves the draft, unsubscribes the frontend, disposes the
 controller and calls `session.dispose()` — which closes the client socket
-(`remote.py:4978-4983`, inside `dispose` at 4964) and nothing else. The runtime
+(`attached.py`, inside `dispose` at 4964) and nothing else. The runtime
 then sees a client disappear, `attach_clients()` drops to 0, and **the
 existing 3-second drain reaps it** (`process.py:341-359`). No new wire op, no
 new frame, no protocol change, and the runtime keeps full authority over its
@@ -391,7 +391,7 @@ post-broadcast re-check at 1930-1948).
 Question 5: **yes, it needs one thing beyond calling the existing op — but
 the op itself needs no change.**
 
-`retire_if_unused` (`remote.py:4927-4962`) is called from exactly three
+`retire_if_unused` (`attached.py`) is called from exactly three
 places, all of which ABANDON the *current* session: `/resume` onto a saved
 session (`app.py:8291`), `/resume` onto a live one (`app.py:9496`), and
 unmount/quit (`app.py:17642`). **No sidebar-leave path calls it.** So a user
@@ -408,7 +408,7 @@ Nothing else is required: the op already refuses when another viewer is
 attached (`server.py:1743-1745`) or anything durable exists
 (`is_pristine`, `serving.py:809-894`, every probe failing closed), and its
 failure mode is "the runtime stays up and the drain gets it"
-(`remote.py:4941-4944`).
+(`attached.py`).
 
 Strictly speaking §3.1 alone makes the empty case work — the socket drops and
 the drain reaps in 3 s. Adding the offer makes it *immediate* rather than

--- a/docs/design-idle-reap.md
+++ b/docs/design-idle-reap.md
@@ -204,7 +204,7 @@ what the two caches were always supposed to mean.
 Teardown is already correct for this. `_release_sidebar_source`
 (`app.py:4648-4679`) saves the draft, unsubscribes the frontend, disposes the
 controller and calls `session.dispose()` — which closes the client socket
-(`attached.py`, inside `dispose` at 4964) and nothing else. The runtime
+(`attached.py`, inside `dispose` at 5663) and nothing else. The runtime
 then sees a client disappear, `attach_clients()` drops to 0, and **the
 existing 3-second drain reaps it** (`process.py:341-359`). No new wire op, no
 new frame, no protocol change, and the runtime keeps full authority over its

--- a/docs/design-runtime-autorefresh.md
+++ b/docs/design-runtime-autorefresh.md
@@ -81,15 +81,15 @@ self._end_turn_locally()          # ← synthesises AgentEndEvent(aborted=True, 
 self._recovery_task = asyncio.create_task(self._recover_owner())
 ```
 
-`_end_turn_locally` (`remote.py:1859-1918`) exists for three genuinely
+`_end_turn_locally` (`attached.py`) exists for three genuinely
 terminal outcomes (killed runtime, stopped runtime, going cold) but it is called
 *before* recovery has learned which of those — if any — applies. The
 synthesised end reaches `EventController._handle_agent_end` and the app's
 turn-end path, which calls `_retire_live_tool_cards` (`app.py:24152`, each
 live card → `⊘ interrupted`) and, when no card was live, appends
 `NoticeBlock("interrupted", "warning")` (`app.py:23732-23742`). Then
-`_recover_owner` (`remote.py:2037-2170`) finds the *same* record (same pid),
-re-dials within ~100 ms, and `_finish_sync` (`remote.py:1436-1468`) seeds a
+`_recover_owner` (`attached.py`) finds the *same* record (same pid),
+re-dials within ~100 ms, and `_finish_sync` (`attached.py`) seeds a
 fresh `AgentStartEvent` because `frontend_state.streaming` is still True.
 The band recovers; the ledger keeps the `⊘ interrupted` cards and the notice.
 That is exactly "interrupted painted mid-wait": the `wait` tool was still
@@ -104,7 +104,7 @@ Why the socket drops in the first place — every one of these is silent
    sends the **full capped projection to every client including TUI attach
    viewers**, ~20×/s while streaming (`_push_later` coalesces to 50 ms). The
    TUI's `AttachClient` was constructed with `lambda _projection: None`
-   (`remote.py:1257`) — it throws every one away. The projection is
+   (`attached.py`) — it throws every one away. The projection is
    100–900 KB on this host's resident runtimes. A TUI event-loop stall of
    >1 s (a large transcript reflow, a 60 MB parse on a sibling path, the
    compositor under load) leaves the kernel socket buffer full of projection
@@ -116,7 +116,7 @@ Why the socket drops in the first place — every one of these is silent
    updates pending before `frontend_ready` → drop.
 4. Reader EOF / reset (`:1010, :1017`) and shutdown (`:779-781`).
 
-Also `AttachedSession.abort` (`remote.py:2662-2664`) is
+Also `AttachedSession.abort` (`attached.py`) is
 `asyncio.create_task(self._client.abort())` with no done-callback; when the
 client is mid-recovery `_request_frame` raises `ConnectionError("not
 attached")` (`attach_client.py:461`) and the loop logs "Task exception was
@@ -163,8 +163,8 @@ the price of an idle exit (`process.py:57-66`).
 
 The operator says no, and the code agrees it need not: a viewer already
 survives runtime exit (`_recover_owner` → `_go_cold` after `COLD_FALLBACK_S`,
-`remote.py:2056-2066`) and a cold viewer already re-engages on the next
-prompt (`_ensure_bound`, `remote.py:1074-1144`). What is missing is only
+`attached.py`) and a cold viewer already re-engages on the next
+prompt (`_ensure_bound`, `attached.py`). What is missing is only
 (a) an announcement so the viewer does not spend 8 s chasing a record and
 then paint "runtime exited" for what was a planned refresh, and (b) that the
 announcement not be confused with `stopping` (which parks the viewer in the
@@ -200,7 +200,7 @@ So: **an attached viewer does not block retirement**; it receives a
 
 The deferral cannot hang the UI: every path out of `_recover_owner` already
 ends in `_go_cold` (which calls `_end_turn_locally(direct=True)`,
-`remote.py:1999`), `_notify_stopped` (§4 keeps the end there), or a
+`attached.py`), `_notify_stopped` (§4 keeps the end there), or a
 successful bind. The 8 s cold deadline bounds the wait.
 
 ## 3. PR A — self-refresh, busy-bit, notices
@@ -335,7 +335,7 @@ before `_clean_exit` on the same loop step, and `_clean_exit` →
 disconnect follows" signal and every viewer already reads it. Do **not**
 overload it: a viewer that reads `stopping` parks in the stopped state and
 tells the user `/resume` reopens it (`app.py:3162-3180`), and
-`_session_was_stopped` (`remote.py:1920-1947`) would then look for a
+`_session_was_stopped` (`attached.py`) would then look for a
 `stopped_at` marker that a refresh never writes. Add a new frame:
 
 ```python
@@ -355,7 +355,7 @@ by re-adopting on the next record).
 RETIRING_REASON` with `RETIRING_REASON = "owner retired for a newer build"`
 next to `STOPPED_REASON` (`:61`). `_ClientConn` needs nothing new.
 
-**Viewer.** `AttachedSession._on_disconnected` (`remote.py:1824`):
+**Viewer.** `AttachedSession._on_disconnected` (`attached.py`):
 
 ```python
 if _reason == RETIRING_REASON:
@@ -373,7 +373,7 @@ if _reason == RETIRING_REASON:
 (the runtime was idle by contract; `_streaming` is already False — assert
 that in the test) and calls a new `_refresh_callback` instead of
 `_went_cold_callback`. `set_refresh_callback` follows the
-`set_went_cold_callback` shape (`remote.py:2011-2017`).
+`set_went_cold_callback` shape (`attached.py`).
 
 `tui/app.py`: in `_adopt_session`'s viewer block (the `_is_viewer(session)`
 branch that installs the takeover/stopped callbacks) install
@@ -490,7 +490,7 @@ viewer never waits on a runtime that is "about to" leave.
 
 ### 4.1 Defer the synthesised abort
 
-`AttachedSession._on_disconnected` (`remote.py:1854-1857`) becomes:
+`AttachedSession._on_disconnected` (`attached.py`) becomes:
 
 ```python
 self._recovering = True
@@ -514,7 +514,7 @@ self._recovery_task = asyncio.create_task(self._recover_owner())
 | `retiring` (PR A) | n/a | never streaming by contract |
 
 `_streaming` stays True during recovery (it is what routes the next message
-to the steer branch, `remote.py:2608`); the app's band keeps `working` —
+to the steer branch, `attached.py`); the app's band keeps `working` —
 correct, since it is.
 
 `_apply_frontend_facades` (`:1631-1633`) already overwrites `_streaming` and
@@ -526,7 +526,7 @@ two-line check right after `_install_frontend` in `_recover_owner`
 
 `_push` (`server.py:2053-2067`) and `_push_to` send the projection to
 every client. A client that declared `events=True` **and**
-`frontend_state=True` is a full-TUI viewer (`remote.py:1259-1261`); it
+`frontend_state=True` is a full-TUI viewer (`attached.py`); it
 consumes `frontend_sync`/`frontend_update`/`event` and discards
 projections. The welcome projection (`_on_connection:954`) is still needed —
 `AttachClient.connect` (`attach_client.py:259-263`) reads it as the identity
@@ -546,7 +546,7 @@ events; nothing on the TUI side reads it (`_dial:1257`). Justification for
 `_SEND_TIMEOUT_S` drop and it is a pure subtraction.
 
 Desktop surface (`surface == "desktop"`) declares the same two flags
-(`remote.py` constructs the client identically with `surface=self._surface`)
+(`attached.py` constructs the client identically with `surface=self._surface`)
 and also reads nothing from projections — confirm with the desktop tests
 (`tests/e2e/test_desktop_*.py`) that nothing keys on `op == "projection"`
 after the welcome; the coder must grep `desktop` for `_on_projection` before
@@ -589,7 +589,7 @@ sequence. Watch it in rollout (§7).
 
 ### 4.5 `AttachedSession.abort` unretrieved exception
 
-`remote.py:2662-2664`:
+`attached.py`:
 
 ```python
 def abort(self, reason: str = "interrupted") -> None:

--- a/docs/design/full-history-audit-window.md
+++ b/docs/design/full-history-audit-window.md
@@ -4,7 +4,7 @@ Status: proposal (architect). Not implemented. Scope: `local-operator` @ `f1ab7d
 
 All line citations are against `f1ab7d346`, read in a clean worktree
 (`/private/tmp/arch-hist/wt`) because the primary checkout has uncommitted edits
-to `remote.py` and `app.py` from a sibling session.
+to `attached.py` and `app.py` from a sibling session.
 
 ---
 
@@ -41,7 +41,7 @@ Twelve of the operator's sessions exceed 80% unreachable. This is the defect.
 
 `_reconcile_head_notice` (`app.py:7267-7269`) computes
 `more = bool(self._resume_pending_head) or bool(session.history_before_token)`,
-and `AttachedSession.history_before_token` (`remote.py:2603-2606`) returns the
+and `AttachedSession.history_before_token` (`attached.py`) returns the
 window's `before_token` — `None` once the truncated replay is drained. So
 `RESUME_START_NOTICE` (`app.py:1077`) is the honest rendering of a history layer
 that already discarded the older rows. **Do not fix the copy.** Fix the layer.
@@ -63,7 +63,7 @@ demonstrated by it. The `_resume_pending_head = []` resets (`app.py:4972`,
 fresh resume, `/clear`, a canonical reset) and each is followed by a
 re-projection of the *current* history, so none of them strands rows while
 claiming exhaustion. `load_older_display_page`'s `full_required` branch
-(`remote.py:2618-2620`) does not drop a page either — it escalates to
+(`attached.py`) does not drop a page either — it escalates to
 `materialize_history()` and returns the id-deduped difference.
 
 What that session *does* show is a different, real, and much smaller thing worth
@@ -166,7 +166,7 @@ file and integer offsets become lies. On resolve-failure, return `status="reset"
 
 `total_message_count` **stays the context total.** Do not inflate it. It is read
 by `_sidebar_presentation_current` (`app.py:3922-3924`) as a monotonic growth
-signal and by `history_message_count` (`remote.py:4280-4287`); redefining it
+signal and by `history_message_count` (`attached.py`); redefining it
 mid-chain would make cached presentations miss forever. Audit pages report their
 extent through `start`/`audit` only. Expose the audit depth, if it is ever
 needed, as a separate `audit_message_count` — but I would not add it until a
@@ -200,7 +200,7 @@ Three conclusions the coder must not relitigate:
    journal — a thousandfold regression for no benefit.
 2. **Never call full audit replay.** 0.29 s and 47 MB of peak allocation per
    call is exactly what budget B forbids. `audit_slice` is the only entry point.
-3. `read_replay_suffix` (`remote.py:99`, `transcript.py:360`) is for the
+3. `read_replay_suffix` (`attached.py`, `transcript.py:360`) is for the
    *attach* path and stays exactly as it is. Audit paging is a post-attach,
    reader-driven gesture on a runtime that already holds the journal. **The
    resume path's cost does not change at all.**
@@ -381,7 +381,7 @@ runtime also pages audit history". Two ways it breaks without a new string:
 - **Old viewer, new runtime.** `DisplayHistoryWindow` sets
   `model_config = ConfigDict(extra="forbid")` (`history_window.py:39`), so an
   old viewer validating a payload carrying `audit`/`audit_available` **raises**,
-  and `_fetch_history_page` (`remote.py:2490`) turns that into a failed attach.
+  and `_fetch_history_page` (`attached.py`) turns that into a failed attach.
   This is a hard cross-version break, and it is the single most likely way this
   change causes an incident during a staged rollout.
 
@@ -484,7 +484,7 @@ tests under `env -u NO_COLOR TERM=xterm-256color`.
    include audit rows breaks `_sidebar_presentation_current`'s monotonic growth
    check (`app.py:3922-3924`). Put the reason in a comment at the field, not
    only in this document.
-5. **Contiguity assertion** (`remote.py:2621`) — if the audit exemption is
+5. **Contiguity assertion** (`attached.py`) — if the audit exemption is
    missed, the first audit page raises `ConnectionError` and the reader sees a
    failed page rather than history. Cheap to get wrong, loud when it happens.
 
@@ -561,7 +561,7 @@ so the argument does not have to be rediscovered from this document.
 **Keeping `total_message_count` context-scoped.** The alternative — making it
 the true total — is arguably the more honest field name. Rejected on evidence:
 two consumers read it as a monotonic context-growth signal (`app.py:3922`,
-`remote.py:4287`), and redefining it silently breaks presentation caching. A
+`attached.py`), and redefining it silently breaks presentation caching. A
 separate `audit_message_count` is available if a surface ever needs it; I did
 not add it speculatively.
 

--- a/docs/design/peer-send.md
+++ b/docs/design/peer-send.md
@@ -204,7 +204,7 @@ it. Add it to the Protocol for documentation and typing on the real handles.
 
 ### 2.2 `ServingSessionHandle.receive_peer_message`
 
-`local_operator/mobile/serving.py` (add after `steer`, ~L623). This handle owns an
+`local_operator/session/runtime/serving.py` (add after `steer`). This handle owns an
 in-process `Session` on `self._loop`:
 
 ```python
@@ -220,7 +220,7 @@ async def receive_peer_message(
     detail = await self._session.receive_peer_message(
         text, mode=mode, wake=wake, sender=sender or {}
     )
-    # Mirror the phone fold the same way steer() does (serving.py:620-622): put a
+    # Mirror the phone fold the same way steer() does: put a
     # visible row on the projection now so any attached phone paints it without
     # waiting for the next MessageStartEvent.
     self._fold.note_peer_message(text, sender=sender or {})
@@ -962,7 +962,7 @@ Backend/protocol:
   `PROTOCOL_VERSION` bump (comment why).
 - `local_operator/mobile/registrant.py`: `_dispatch` peer branch;
   `SessionHandle` Protocol += `receive_peer_message`.
-- `local_operator/mobile/serving.py`: `ServingSessionHandle.receive_peer_message`.
+- `local_operator/session/runtime/serving.py`: `ServingSessionHandle.receive_peer_message`.
 - `local_operator/mobile/tui_handle.py`: `TuiSessionHandle.receive_peer_message`.
 - `local_operator/session/session.py`: `Session.receive_peer_message`;
   `_peer_custom_message`; add `PEER_MESSAGE_MESSAGE_TYPE` to the custom-type

--- a/docs/evidence/model-receipt/README.md
+++ b/docs/evidence/model-receipt/README.md
@@ -31,7 +31,7 @@ env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
   shapes answer differently and are pinned by tests rather than frames: a
   viewer `/stop` ended answers `this session was stopped; /resume <id> reopens
   it` ahead of the routing seam, and one redialing a dead runtime answers
-  `session owner is reconnecting; try /model again in a moment`.
+  `the runtime is reconnecting; try /model again in a moment`.
 
 The status band is unchanged between each pair on purpose: it repaints from
 the runtime's frontend-state sync, which the fake never delivers. The band's cwd

--- a/local_operator/guides/configuration/GUIDE.md
+++ b/local_operator/guides/configuration/GUIDE.md
@@ -131,7 +131,7 @@ For a **new conversation**, resolution precedence is agent profile, then CLI fla
 
 Resume and fork retain the conversation's saved selection, even after defaults or the previously bound agent profile change. A deliberate `--hosting`/`--model` on resume overrides that selection: `--model` alone retains the saved provider; `--hosting` alone uses that provider's default model. Subagents inherit their launching conversation's selection unless an explicit role/tier selection overrides it. Provider failover remains a separate effective route, not a replacement global default.
 
-Older transcripts recover the latest usable primary-model observation from their selection journal or frontend checkpoint. If none exists, the owner samples the current default once and announces that recovery; it cannot reconstruct an unrecorded historical model. Selections become durable when the owner admits real work, so merely opening and abandoning an empty draft does not create a conversation on disk.
+Older transcripts recover the latest usable primary-model observation from their selection journal or frontend checkpoint. If none exists, the runtime samples the current default once and announces that recovery; it cannot reconstruct an unrecorded historical model. Selections become durable when the runtime admits real work, so merely opening and abandoning an empty draft does not create a conversation on disk.
 
 Manage secrets separately; never place API keys in `config.yml`:
 

--- a/local_operator/guides/peer-messaging/GUIDE.md
+++ b/local_operator/guides/peer-messaging/GUIDE.md
@@ -135,7 +135,7 @@ The table prints `STATE PID KIND CONVERSATION MODEL RSS FOOTPRINT UPTIME
 HB_AGE`:
 
 - `STATE` — `live` (pid alive and heartbeating), `wedged` (pid alive but its
-  owner has not heartbeat within the timeout, so it will not service the socket
+  runtime has not heartbeat within the timeout, so it will not service the socket
   promptly), or `stale` (dead; the record is reaped on the next scan).
 - `PID` `KIND` `CONVERSATION` `MODEL` — session identity. `KIND` is `tui`
   (interactive), `daemon` (daemon-owned), or `exec` (headless one-shot).

--- a/local_operator/guides/peer-messaging/GUIDE.md
+++ b/local_operator/guides/peer-messaging/GUIDE.md
@@ -135,8 +135,9 @@ The table prints `STATE PID KIND CONVERSATION MODEL RSS FOOTPRINT UPTIME
 HB_AGE`:
 
 - `STATE` — `live` (pid alive and heartbeating), `wedged` (pid alive but its
-  runtime has not heartbeat within the timeout, so it will not service the socket
-  promptly), or `stale` (dead; the record is reaped on the next scan).
+  runtime has not sent a heartbeat within the timeout, so it will not service
+  the socket promptly), or `stale` (dead; the record is reaped on the next
+  scan).
 - `PID` `KIND` `CONVERSATION` `MODEL` — session identity. `KIND` is `tui`
   (interactive), `daemon` (daemon-owned), or `exec` (headless one-shot).
   `CONVERSATION` falls back to the session id when the session has no name yet.

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -552,7 +552,7 @@ class PeerArrivalProtocol(Protocol):
 
     Threading: the session's implementation sets the event on the loop that
     owns the session, because every registrant path hops there first
-    (``mobile/tui_handle.py``, ``mobile/serving.py`` both use
+    (``mobile/tui_handle.py``, ``session/runtime/serving.py`` both use
     ``run_coroutine_threadsafe``). A future caller that invokes
     ``receive_peer_message`` from its own thread WITHOUT that hop would need
     ``loop.call_soon_threadsafe`` — ``asyncio.Event.set`` is not thread-safe.

--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -151,9 +151,10 @@ class OwnerAckTimeout(ConnectionError, TimeoutError):
     """The owner is alive; it did not answer THIS request in time.
 
     Both bases are load-bearing. ``ConnectionError`` preserves every existing
-    caller: ``session/remote.py:5183`` and ``:5192`` catch ``ConnectionError``
-    ALONE, so a plain ``TimeoutError`` would escape ``compact_now`` as a raw
-    exception instead of a ``CompactionOutcome``. ``TimeoutError`` lets code
+    caller: ``session/attached.py``'s ``route_shared_slash`` and ``compact_now``
+    catch ``ConnectionError`` ALONE, so a plain ``TimeoutError`` would escape
+    ``compact_now`` as a raw exception instead of a ``CompactionOutcome``.
+    ``TimeoutError`` lets code
     that wants to tell a slow owner from a dead one ask, rather than parse the
     message. See docs/design-aside-deadline.md §2.
     """

--- a/local_operator/mobile/types.py
+++ b/local_operator/mobile/types.py
@@ -525,7 +525,8 @@ def ask_pending_request(
     """Build the phone's ask card from an ``AskQuestion`` (harness type).
 
     The single seam both projection sites use — the TUI bridge
-    (:mod:`.tui_handle`) and the daemon-owned gate (:mod:`.owned`) — so the two
+    (:mod:`.tui_handle`) and the daemon-owned gate
+    (:mod:`local_operator.session.runtime.serving`) — so the two
     surfaces cannot drift in what they carry to the phone (was UX nit-1: one
     site used a ``str(option)`` fallback, the other ``""``). Reading through
     ``getattr`` keeps this decoupled from the pydantic model and lets tests pass

--- a/local_operator/session/attached.py
+++ b/local_operator/session/attached.py
@@ -1728,7 +1728,7 @@ class AttachedSession:
         self._cwd = cwd
         # JOINED by awaiting ``_ensure_bound`` rather than by blocking on the
         # lock directly — the same construction ``run_slash_authoritative``
-        # uses for the same reason (remote.py, "Join its lock before mutating").
+        # uses for the same reason (attached.py, "Join its lock before mutating").
         # Waiting on the raw lock would park this coroutine for as long as the
         # engage takes with no bound on failure, so a spawn that never
         # completes would hang the command instead of refusing it; awaiting the

--- a/local_operator/session/attached.py
+++ b/local_operator/session/attached.py
@@ -4086,7 +4086,7 @@ class AttachedSession:
         """
         if self._deliberate_stop:
             return "this session was stopped"
-        return "session owner is reconnecting"
+        return "the runtime is reconnecting"
 
     def _go_cold(self, *, refresh: bool = False) -> None:
         """Unbind from a runtime that is gone, keeping the conversation.

--- a/local_operator/session/history_window.py
+++ b/local_operator/session/history_window.py
@@ -16,7 +16,7 @@ import sys
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
 
 from local_operator.harness.types import AgentMessage, Message
 from local_operator.session.transcript import (
@@ -95,6 +95,28 @@ class DisplayHistoryWindow(BaseModel):
     #: Lets the viewer say "earlier history above" at the moment the context
     #: phase drains, rather than claiming the conversation starts there.
     audit_available: bool = False
+
+    @model_validator(mode="before")
+    @classmethod
+    def _collapse_epoch_alias(cls, data: Any) -> Any:
+        """Accept the epoch under either key, including both at once.
+
+        ``AliasChoices`` consumes only the FIRST match and the model forbids
+        extras, so a payload carrying ``owner_epoch`` AND ``runtime_epoch``
+        raised ``extra_forbidden`` on the second key instead of validating.
+        That is the one shape a producer mid-rename can emit — the old key for
+        viewers that have not flipped, the new one for those that have — and a
+        hard failure there breaks the attach outright. Collapse the pair to
+        the single key the field reads.
+
+        ``runtime_epoch`` wins when both are present: a payload that carries it
+        comes from the newer producer, so its value is the authoritative one,
+        and the alternative is honouring a key the rename is retiring. Delete
+        with ``AliasChoices`` on the flip release.
+        """
+        if isinstance(data, dict) and "runtime_epoch" in data:
+            data["owner_epoch"] = data.pop("runtime_epoch")
+        return data
 
     @property
     def runtime_epoch(self) -> str:

--- a/local_operator/session/history_window.py
+++ b/local_operator/session/history_window.py
@@ -113,8 +113,18 @@ class DisplayHistoryWindow(BaseModel):
         comes from the newer producer, so its value is the authoritative one,
         and the alternative is honouring a key the rename is retiring. Delete
         with ``AliasChoices`` on the flip release.
+
+        A ``mode="before"`` validator is handed the CALLER's object, not a
+        pydantic-owned copy, so popping and assigning here would mutate the
+        dict the caller passed to ``model_validate`` in place — the caller
+        would lose ``runtime_epoch`` and see ``owner_epoch`` silently
+        overwritten. Today's sole caller passes a fresh dict, but a caller
+        that reuses a payload (validating one dict against two models, or
+        logging it after validation) would be corrupted. Copy before
+        rewriting.
         """
         if isinstance(data, dict) and "runtime_epoch" in data:
+            data = dict(data)
             data["owner_epoch"] = data.pop("runtime_epoch")
         return data
 

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -134,7 +134,7 @@ class SessionProtocol(Protocol):
     # Three predicates that name what hosts actually need to know about the
     # relationship between this process and the session's runtime. They exist
     # because an undeclared ``is_remote`` attribute conflated them: it was
-    # written in exactly one place (``remote.py``), was never declared on this
+    # written in exactly one place (``attached.py``), was never declared on this
     # protocol, and was read through ``getattr(session, "is_remote", False)`` at
     # every call site, where the default silently meant "in-process" and a typo
     # in the string was invisible to pyright.

--- a/local_operator/session/runtime/__init__.py
+++ b/local_operator/session/runtime/__init__.py
@@ -46,7 +46,7 @@ forever" — later PRs in this series give this package public entry points
 **importing this package must never pull the heavy graph**:
 :mod:`.types` and :mod:`.registry` are stdlib-only because the runtime
 publishes its record on the CLI startup path, where dragging in
-:mod:`.server` (asyncio) or :mod:`.owned` (the composition root) is paid by
+:mod:`.server` (asyncio) or :mod:`.serving` (the composition root) is paid by
 every ``lop`` invocation including ``--version``.
 
 So an entry point added here must resolve its heavy dependencies lazily

--- a/local_operator/session/runtime/exec_control.py
+++ b/local_operator/session/runtime/exec_control.py
@@ -160,9 +160,9 @@ async def start_exec_control(
     outranks a later ``tool_approval_mode`` edit, while an un-flagged run
     follows the file like every other runtime gate.
 
-    Imports are function-local by contract, not by habit: ``owned`` pulls the
+    Imports are function-local by contract, not by habit: ``serving`` pulls the
     composition root and ``server`` pulls asyncio, and this package sits on the
-    CLI startup path (see the module header and :mod:`.owned`).
+    CLI startup path (see the module header and :mod:`.serving`).
     """
     import asyncio
 

--- a/local_operator/session/runtime/types.py
+++ b/local_operator/session/runtime/types.py
@@ -263,7 +263,7 @@ class SessionRecord:
     # and for the same reason: PROTOCOL_VERSION deliberately does NOT move.
     # It gates SOCKET FRAME compatibility and is read as a pre-dial CAPABILITY
     # ASSERTION by peers already running — ``attach_client`` refuses below 2,
-    # ``session_factory`` and the TUI's takeover path below 4, ``remote``'s
+    # ``session_factory`` and the TUI's takeover path below 4, ``attached``'s
     # canonical attach below 5. Those readers take a HIGHER number as a promise
     # that every frame through v5 is understood. Two JSON integers that touch
     # no frame do not make that promise different, so bumping would spend the

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -3527,7 +3527,7 @@ class Session:
     def pending_display_tool_ids(self) -> set[str]:
         """Unanswered calls in the pending gate's current serialized user turn.
 
-        The local half of the display question ``RemoteSession`` already
+        The local half of the display question ``AttachedSession`` already
         answers for a viewer: a replay of the in-flight turn's tail must not
         settle the row the gate is parked on. A gate can precede
         tool_execution_start, so no invented start event is needed.
@@ -3545,7 +3545,7 @@ class Session:
         ``pending_display_tool_ids`` returns nothing for it while the call is
         very much alive.
 
-        Until this accessor existed the question was RemoteSession-only, so a
+        Until this accessor existed the question was AttachedSession-only, so a
         resume onto a LIVE LOCAL session replayed the in-flight call as a
         settled row — a duplicate beside the card the running turn's own
         events paint, one extra head in the "running N tools" count, and a

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -1795,6 +1795,17 @@ def _entry_to_message(
     entry: TranscriptEntry, attachments: AttachmentStore | None = None
 ) -> AgentMessage | None:
     """Rehydrate one message entry; malformed rows are dropped individually."""
+    # Bookkeeping rows are not messages and must not be reported as a failed
+    # parse. Custom host snapshots (``attention_started``, ``selected_model``,
+    # ``system_prefix``, ``todo_snapshot``) and ``prune`` markers are read by
+    # their own consumers (``latest_custom``, ``_apply_prune``) and simply are
+    # not message payloads, so validating them here only ever produced the
+    # same "dropping unparseable transcript message entry" warning a genuinely
+    # corrupt MESSAGE row produces — several per resume, which buries the real
+    # one during triage. Only a message row that fails to parse is a drop.
+    if entry.type != ENTRY_MESSAGE:
+        logger.debug("skipping non-message transcript entry %s (%s)", entry.id, entry.type)
+        return None
     payload = dict(entry.payload)
     kind = payload.pop("kind", CUSTOM_KIND_MESSAGE)
     # Producer identity belongs to the transcript envelope, never the Message

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -4755,7 +4755,7 @@ class OperatorApp(App[None]):
         else:
             record, owner = await asyncio.to_thread(find_runtime_record, directory, session_id)
             if record is None or owner is None:
-                raise RuntimeError("The prepared owner is no longer active")
+                raise RuntimeError("The prepared runtime is no longer active")
             remote = await AttachedSession.connect(
                 record,
                 session_id,
@@ -4764,7 +4764,7 @@ class OperatorApp(App[None]):
                 display_window=True,
             )
         if not _is_viewer(remote):
-            raise RuntimeError("Sidebar navigation requires an owner-backed session")
+            raise RuntimeError("Sidebar navigation requires a runtime-backed session")
         try:
             if remote.session_id != session_id:
                 raise RuntimeError("The launcher returned a different conversation")
@@ -4840,7 +4840,7 @@ class OperatorApp(App[None]):
         try:
             session = source.session
             if not _is_viewer(session):
-                raise RuntimeError("Sidebar navigation requires an owner-backed session")
+                raise RuntimeError("Sidebar navigation requires a runtime-backed session")
             # Canonical synchronization belongs to the source connection task,
             # never to a click waiting for its first useful viewport.
             #
@@ -4858,7 +4858,7 @@ class OperatorApp(App[None]):
             # logs at debug and whose `finally` releases the preparation, so no
             # user-visible surface observes it.
             if speculative and session.is_cold:
-                raise RuntimeError("The prepared owner is no longer ready")
+                raise RuntimeError("The prepared runtime is no longer ready")
             if speculative or refresh:
                 await session.ensure_display_current()
             if not refresh:
@@ -5725,8 +5725,9 @@ class OperatorApp(App[None]):
         preparation loop expensive.
 
         Both terms move only on durable content. `display_history_revision` is
-        bumped by compaction, prune and recovery (`remote.py:1385,1506`) — the
-        rewrites that can make an over-budget window SMALLER.
+        bumped by compaction, prune and recovery (`attached.py`'s
+        `_invalidate_display_history`) — the rewrites that can make an
+        over-budget window SMALLER.
         `history_message_count` is the durable row count.
         """
         session = source.session
@@ -5945,7 +5946,7 @@ class OperatorApp(App[None]):
         if source is self._interaction and incoming.replay.view is self._transcript_view():
             return
         if not _is_viewer(session):
-            raise RuntimeError("The conversation is not owner-backed")
+            raise RuntimeError("The conversation is not runtime-backed")
         if not source.display_only and (
             not session.display_history_current
             or incoming.replay_revision != session.display_history_revision
@@ -5958,7 +5959,7 @@ class OperatorApp(App[None]):
         focused_before_refresh = self.focused if refreshing else None
         previous = outgoing.session
         if previous is not None and not _is_viewer(previous):
-            raise RuntimeError("Sidebar navigation requires an owner-backed current session")
+            raise RuntimeError("Sidebar navigation requires a runtime-backed current session")
         if not refreshing:
             self._close_subagent_view()
             self._close_org_chart_view()
@@ -6443,7 +6444,7 @@ class OperatorApp(App[None]):
                 # A BIND THAT DID NOT BIND IS A FAILURE. The bind has two
                 # silent returns that look identical here — "already bound,
                 # nothing to do" and "cannot bind right now" (the facade is
-                # `_recovering`, remote.py) — and only the second leaves the
+                # `_recovering`, attached.py) — and only the second leaves the
                 # session cold. Committing on that second one publishes a COLD
                 # session as connected: `display_only` goes False, the saved
                 # transcript is swapped in live, and then
@@ -16450,7 +16451,7 @@ class OperatorApp(App[None]):
                         # recoverable (press again), so it renders as a
                         # warning that says exactly what is unknown.
                         self._replace_stop_notice(
-                            f"could not confirm the stop with the session owner — "
+                            f"could not confirm the stop with the runtime — "
                             f"{offered} subagent{'s' if offered != 1 else ''} may still "
                             "be running; press Esc twice again to retry",
                             "warning",
@@ -20148,7 +20149,7 @@ class OperatorApp(App[None]):
             record = getattr(session, "record_shell", None) if session is not None else None
             if not callable(record):
                 self._notice_for(
-                    source, "Shell finished, but this owner cannot save its receipt", "error"
+                    source, "Shell finished, but this runtime cannot save its receipt", "error"
                 )
                 return
             try:
@@ -23922,7 +23923,7 @@ class OperatorApp(App[None]):
             # second line about the same fact pointing the other way is the
             # defect, not the diagnosis.
             logger.debug(
-                "build skew (owner) at %s: %s is current, this window (%s) is behind",
+                "build skew (runtime) at %s: %s is current, this window (%s) is behind",
                 reason,
                 owner.label(),
                 loaded.label(),
@@ -23992,7 +23993,7 @@ class OperatorApp(App[None]):
                 # in this build, so anything without it is older than this
                 # window.
                 announce(
-                    "owner-unknown",
+                    "runtime-unknown",
                     "",
                     loaded.label(),
                     f"{subject} is running an older version than this window \u2014 it "
@@ -24027,7 +24028,7 @@ class OperatorApp(App[None]):
                 # reaper compares itself against disk and acts on the answer
                 # (QA round 1, Q-1 all-refs sub-case).
                 announce(
-                    "owner",
+                    "runtime",
                     owner.label(),
                     loaded.label(),
                     # Collapsed by hand when the versions are EQUAL (the
@@ -24057,7 +24058,7 @@ class OperatorApp(App[None]):
                 )
                 return
             announce(
-                "owner",
+                "runtime",
                 owner.label(),
                 loaded.label(),
                 f"{subject} is running {_build_change(owner, loaded)} \u2014 it will "
@@ -24068,7 +24069,7 @@ class OperatorApp(App[None]):
 
         if runtime_idle and callable(ask):
             logger.debug(
-                "build skew (owner) at %s: %s -> %s; owner idle, requesting refresh",
+                "build skew (runtime) at %s: %s -> %s; runtime idle, requesting refresh",
                 reason,
                 owner.label() if owner is not None else "<unstamped>",
                 loaded.label(),
@@ -24625,8 +24626,8 @@ class OperatorApp(App[None]):
             # list (a reduced test double) still falls through, matching the
             # pre-guard behaviour the round-4 walk established.
             self._system_notice(
-                f"/{entry.name} is not available from this session's owner; "
-                "run it in the owner's terminal",
+                f"/{entry.name} is not available from this session's runtime; "
+                "run it in the runtime's terminal",
                 "warning",
             )
             return
@@ -25073,7 +25074,7 @@ class OperatorApp(App[None]):
             # `AttachedSession.request_stop` does.
             self._issued_own_stop = False
             self._system_notice(
-                "cannot stop this session's owner — the owner is an older process; "
+                "cannot stop this session's runtime — the runtime is an older process; "
                 "close it there or upgrade",
                 "warning",
             )
@@ -35297,7 +35298,7 @@ class OperatorApp(App[None]):
         if session is not self._session:
             logger.debug("dropped a recall refusal for a session that is no longer current")
             return
-        logger.debug("session owner refused the recall of steer %s", command_id)
+        logger.debug("session runtime refused the recall of steer %s", command_id)
         self._append_block(NoticeBlock(RECALL_UNCONFIRMED_NOTICE, "warning"))
 
     def _settle_queued_steer_notices_unsent(self) -> None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -7770,7 +7770,7 @@ class OperatorApp(App[None]):
         Says the same thing the owner's own ``/stop`` says, because it is the
         same fact: the session is cold and ``/resume`` is the way back. The
         id is recorded FIRST — ``_no_session_notice`` is gated on it, so it
-        is what turns every later "owner is reconnecting" into the truth.
+        is what turns every later "runtime is reconnecting" into the truth.
         """
         source = source or self._interaction
         session = source.session
@@ -25764,14 +25764,16 @@ class OperatorApp(App[None]):
                 self._system_notice(text_line, kind)
             elif bool(getattr(session, "_recovering", False)):
                 # `is_cold` is a superset of the drop: it is also true while
-                # the facade is redialing an owner that died. There "send a
+                # the facade is redialing a runtime that died. There "send a
                 # message" is not the lever — the facade's own answer for the
-                # gap is `_unavailable_reason()` ("session owner is
+                # gap is `_unavailable_reason()` ("the runtime is
                 # reconnecting"), the sentence the prompt path already uses
-                # (review round 2, R2-M1).
+                # (review round 2, R2-M1). That literal is matched nowhere;
+                # `_is_runtime_gone` excludes it on the `reconnecting`
+                # substring alone, which the wording keeps.
                 reason = getattr(session, "_unavailable_reason", None)
                 self._system_notice(
-                    f"{reason() if callable(reason) else 'session owner is reconnecting'}; "
+                    f"{reason() if callable(reason) else 'the runtime is reconnecting'}; "
                     "try /model again in a moment",
                     "warning",
                 )

--- a/local_operator/tui/events.py
+++ b/local_operator/tui/events.py
@@ -548,7 +548,7 @@ class EventController:
         WHY IT IS A MODE HERE, AND NOT A DEFERRED ``subscribe()``. The obvious
         fix -- do not subscribe a speculative source at all -- does not work,
         and it fails silently. ``AttachedSession._emit_or_buffer`` does not DROP
-        an event when nobody is subscribed, it BUFFERS it (``remote.py``: ``if
+        an event when nobody is subscribed, it BUFFERS it (``attached.py``: ``if
         not self._ready_for_events or not self._handlers: ...append``). A
         parked source is ready-for-events with zero handlers, which is exactly
         that branch, so deferring the subscribe trades CPU for an unbounded

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -2612,7 +2612,16 @@ class ToolCard(ExpandableActionBlock):
             # this one says `1m57s`, and `117s` two seconds later on the same
             # row is the app disagreeing with itself about how it writes a
             # duration.
-            if elapsed < 10:
+            if elapsed < 0.05:
+                # `<0.1s`, never `0.0s`. Rounding a genuinely fast tool to
+                # `0.0s` reprints the exact string the fabricated-duration bug
+                # produced, which is why the missing-duration report came back
+                # against a tool that had simply returned at once — the reader
+                # cannot tell a real sub-50 ms call from a row whose duration
+                # was lost. Reads as "too fast to measure", and is exactly
+                # DURATION_COL wide so the column still holds.
+                duration = "<0.1s"
+            elif elapsed < 10:
                 duration = f"{elapsed:.1f}s"
             elif elapsed < 60:
                 duration = f"{elapsed:.0f}s"

--- a/tests/unit/session/test_history_window.py
+++ b/tests/unit/session/test_history_window.py
@@ -183,6 +183,45 @@ async def test_the_wire_keeps_the_old_epoch_key_and_reads_both(
 
 
 @pytest.mark.asyncio
+async def test_a_page_carrying_both_epoch_aliases_still_validates(tmp_path: Path) -> None:
+    """Tolerate the transitional payload that carries BOTH epoch keys.
+
+    ``AliasChoices`` consumes only the FIRST match and this DTO forbids extras,
+    so a payload with ``owner_epoch`` AND ``runtime_epoch`` used to raise
+    ``extra_forbidden`` on the second key. That is the one shape a producer
+    mid-rename can emit — the old key for viewers that have not flipped, the
+    new key for those that have — so it has to validate rather than kill the
+    attach. ``runtime_epoch`` wins when both are present: the payload carrying
+    it came from the newer producer. The emit stays ``owner_epoch`` alone, or
+    a pre-rename viewer's ``extra="forbid"`` DTO rejects our pages.
+    """
+    transcript = Transcript(tmp_path)
+    await transcript.append_message(Message.user("row"))
+    base = {
+        "conversation_id": "c",
+        "history_generation": 1,
+        "through_id": None,
+    }
+
+    old_only = DisplayHistoryWindow.model_validate({**base, "owner_epoch": "e"})
+    assert old_only.owner_epoch == "e"
+
+    new_only = DisplayHistoryWindow.model_validate({**base, "runtime_epoch": "e"})
+    assert new_only.owner_epoch == "e"
+    assert new_only.runtime_epoch == "e"
+
+    both = DisplayHistoryWindow.model_validate(
+        {**base, "owner_epoch": "stale", "runtime_epoch": "e"}
+    )
+    assert both.owner_epoch == "e"
+    assert both.runtime_epoch == "e"
+
+    emitted = window(transcript).model_dump(mode="json")
+    assert "runtime_epoch" not in emitted
+    assert emitted["owner_epoch"] == "synthetic-epoch"
+
+
+@pytest.mark.asyncio
 async def test_a_pre_rename_viewer_still_accepts_the_wire_page(tmp_path: Path) -> None:
     """The exact attach break round 1 flagged, held shut by a fixture viewer.
 

--- a/tests/unit/session/test_history_window.py
+++ b/tests/unit/session/test_history_window.py
@@ -221,6 +221,34 @@ async def test_a_page_carrying_both_epoch_aliases_still_validates(tmp_path: Path
     assert emitted["owner_epoch"] == "synthetic-epoch"
 
 
+def test_the_alias_collapse_does_not_mutate_the_callers_dict() -> None:
+    """The ``mode="before"`` validator must not write through its input.
+
+    A before-validator is handed the caller's OWN object — not a pydantic-owned
+    copy — so the pop/assign that collapses the aliases used to rewrite the
+    dict passed to ``model_validate`` in place: the caller lost
+    ``runtime_epoch`` and had ``owner_epoch`` overwritten with the new value.
+    Today's sole caller passes a fresh dict, so nothing observable broke, but
+    the next caller that reuses a payload (validating one dict against two
+    models, or logging it after validation) would be silently corrupted. Hold
+    the caller's dict to its snapshot across the call.
+    """
+    payload = {
+        "conversation_id": "c",
+        "history_generation": 1,
+        "through_id": None,
+        "owner_epoch": "stale",
+        "runtime_epoch": "fresh",
+    }
+    snapshot = dict(payload)
+
+    validated = DisplayHistoryWindow.model_validate(payload)
+
+    assert validated.owner_epoch == "fresh"
+    assert validated.runtime_epoch == "fresh"
+    assert payload == snapshot
+
+
 @pytest.mark.asyncio
 async def test_a_pre_rename_viewer_still_accepts_the_wire_page(tmp_path: Path) -> None:
     """The exact attach break round 1 flagged, held shut by a fixture viewer.

--- a/tests/unit/session/test_remote_takeover.py
+++ b/tests/unit/session/test_remote_takeover.py
@@ -380,7 +380,7 @@ async def test_a_dropped_connection_still_says_reconnecting(tmp_path, monkeypatc
         session_id="s1",
         takeover_factory=lambda: asyncio.sleep(0, result=None),
     )
-    assert remote._unavailable_reason() == "session owner is reconnecting"
+    assert remote._unavailable_reason() == "the runtime is reconnecting"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -1557,7 +1557,7 @@ async def test_follower_mcp_grant_routes_instead_of_crashing_on_snapshot_manager
         assert "MCP servers" in listing
         assert "linear" in listing
         assert not any(
-            "not available from this session's owner" in (b.text() or "")
+            "not available from this session's runtime" in (b.text() or "")
             for b in app.query(NoticeBlock)
         )
         assert routed == []
@@ -1616,7 +1616,7 @@ async def test_unadvertised_shared_slash_refuses_instead_of_running_locally() ->
         for _ in range(60):
             await pilot.pause()
             if any(
-                "not available from this session's owner" in (b.text() or "")
+                "not available from this session's runtime" in (b.text() or "")
                 for b in app.query(NoticeBlock)
             ):
                 break
@@ -1624,7 +1624,7 @@ async def test_unadvertised_shared_slash_refuses_instead_of_running_locally() ->
         # owner never advertised it) and it did not run locally (the
         # follower's goal is untouched).
         assert any(
-            "not available from this session's owner" in (b.text() or "")
+            "not available from this session's runtime" in (b.text() or "")
             for b in app.query(NoticeBlock)
         )
         assert routed == []

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -10035,7 +10035,7 @@ class _RecoveringAsyncLabelSession(_ColdAsyncLabelSession):
     _recovering = True
 
     def _unavailable_reason(self) -> str:
-        return "session owner is reconnecting"
+        return "the runtime is reconnecting"
 
 
 @pytest.mark.asyncio
@@ -10051,7 +10051,7 @@ async def test_switch_while_the_owner_is_being_recovered_says_reconnecting() -> 
         await pilot.pause()
         text = _unwrapped(_transcript_text(app))
     assert session.requested == [], session.requested
-    assert _unwrapped("session owner is reconnecting; try /model again in a moment") in text, text
+    assert _unwrapped("the runtime is reconnecting; try /model again in a moment") in text, text
     assert _unwrapped("send a message to start one") not in text, text
     assert _unwrapped("(this session)") not in text, text
 

--- a/tests/unit/tui/test_sidebar_connect_retry.py
+++ b/tests/unit/tui/test_sidebar_connect_retry.py
@@ -81,7 +81,7 @@ class RecoveringRemote(AttachedSession):
     """A viewer that reproduces the ``_recovering`` silent return.
 
     ``_ensure_bound`` returns without raising and without clearing ``is_cold``,
-    which is what the real method does at ``remote.py`` when the facade is
+    which is what the real method does at ``attached.py`` when the facade is
     mid-recovery. ``heals_after`` binds on the Nth call so the retry budget has
     something to succeed against, mirroring the real timeline where the facade
     stops being ``_recovering`` once ``COLD_FALLBACK_S`` elapses.

--- a/tests/unit/tui/test_sidebar_duration_replay.py
+++ b/tests/unit/tui/test_sidebar_duration_replay.py
@@ -51,7 +51,6 @@ from local_operator.session.runtime.serving import ServingSessionHandle
 from local_operator.tools.builtin import build_write_tool
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.widgets.tool_card import ToolCard
-from local_operator.tui.widgets.transcript import TranscriptView
 from tests.e2e.harness import (
     ScriptedStream,
     build_session,
@@ -81,7 +80,13 @@ def isolated(tmp_path, monkeypatch):
 
 
 def _cells(app: OperatorApp) -> list[float | None]:
-    view = app.query_one(TranscriptView)
+    # ``_transcript_view()``, NOT ``query_one(TranscriptView)``. The sidebar
+    # gesture this file exercises leaves the OUTGOING conversation's view in
+    # the DOM beside the adopted one, and ``query_one`` returns the first in
+    # DOM order — the transcript being left behind. The assertion would then
+    # silently grade the wrong conversation, which is exactly the class of
+    # false green this file exists to prevent.
+    view = app._transcript_view()
     return [b._duration for b in view.blocks() if isinstance(b, ToolCard)]
 
 

--- a/tests/unit/tui/test_sidebar_duration_replay.py
+++ b/tests/unit/tui/test_sidebar_duration_replay.py
@@ -80,12 +80,16 @@ def isolated(tmp_path, monkeypatch):
 
 
 def _cells(app: OperatorApp) -> list[float | None]:
-    # ``_transcript_view()``, NOT ``query_one(TranscriptView)``. The sidebar
-    # gesture this file exercises leaves the OUTGOING conversation's view in
-    # the DOM beside the adopted one, and ``query_one`` returns the first in
-    # DOM order — the transcript being left behind. The assertion would then
-    # silently grade the wrong conversation, which is exactly the class of
-    # false green this file exists to prevent.
+    # ``_transcript_view()``, NOT ``query_one(TranscriptView)``. The divergence
+    # is real only on a genuine sidebar SWITCH to a different conversation:
+    # ``_select_sidebar_session(<other conversation>)`` leaves BOTH transcripts
+    # mounted, and ``query_one`` returns the first in DOM order — the OUTGOING
+    # conversation being left behind (measured: 22 blocks in the outgoing view
+    # against the adopted view's 11). This file's own gesture,
+    # ``_adopt_session(remote)`` on the same session, never diverges (one
+    # ``TranscriptView`` throughout, both accessors equal), so only a switch
+    # would expose it — and an assertion grading the wrong conversation is
+    # exactly the class of false green this file exists to prevent.
     view = app._transcript_view()
     return [b._duration for b in view.blocks() if isinstance(b, ToolCard)]
 

--- a/tests/unit/tui/test_sidebar_idle_reap.py
+++ b/tests/unit/tui/test_sidebar_idle_reap.py
@@ -100,7 +100,7 @@ def _make_remote(app, session_id, clock, parked_for, *, history=4, poison=False)
     every assertion here vacuously true.
 
     ``poison`` makes ``frontend_state`` raise the way the real property does
-    before its store syncs (``remote.py``), which is the reachable way a probe
+    before its store syncs (``attached.py``), which is the reachable way a probe
     can throw — the predicate reads it through ``retained_for_auto_work``.
     Declared on the class rather than assigned afterwards so the raise is part
     of the type, as it is in production.

--- a/tests/unit/tui/test_tool_card.py
+++ b/tests/unit/tui/test_tool_card.py
@@ -49,6 +49,7 @@ from local_operator.tui.widgets import tool_card as card_mod
 from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.tool_card import (
     COLLAPSE_HINT,
+    DURATION_COL,
     EXPAND_HINT,
     EXPAND_MAX_LINES,
     ICON_ERROR,
@@ -1289,6 +1290,43 @@ def test_the_outcome_glyph_holds_one_column_whatever_the_duration() -> None:
         plain = card._build_row(80).plain.rstrip()
         offsets.append(len(plain) - plain.rindex("✓"))
     assert len(set(offsets)) == 1, offsets
+
+
+def test_a_sub_50ms_tool_never_renders_the_fabricated_0_0s() -> None:
+    """A real sub-50 ms call must not reprint the bug's own string.
+
+    ``f"{0.04:.1f}s"`` is ``0.0s`` — byte-identical to what the fabricated-
+    duration defect printed on a row whose duration was simply missing, which
+    is why that report was re-filed against a tool that had returned at once.
+    ``<0.1s`` says "too fast to measure", and it is exactly DURATION_COL wide,
+    so the pass/fail column does not move.
+    """
+    fast = ToolCard("a", "bash", {"command": "pytest"})
+    fast.mark_done("passed")
+    fast._duration = 0.04
+    row = fast._build_row(80).plain
+    assert "<0.1s" in row
+    assert "0.0s" not in row
+
+    assert len("<0.1s") == DURATION_COL
+    offsets = []
+    for elapsed in (0.04, 0.4):
+        card = ToolCard("t", "bash", {"command": "pytest"})
+        card.mark_done("passed")
+        card._duration = elapsed
+        plain = card._build_row(80).plain.rstrip()
+        offsets.append(len(plain) - plain.rindex("✓"))
+    assert len(set(offsets)) == 1, offsets
+
+
+def test_an_unknown_duration_stays_blank_rather_than_claiming_fast() -> None:
+    """``<0.1s`` is a CLAIM; a lost duration must keep saying nothing."""
+    card = ToolCard("t", "bash", {"command": "pytest"})
+    card.mark_done("passed")
+    card._duration = None
+    row = card._build_row(80).plain
+    assert "<0.1s" not in row
+    assert "0.0s" not in row
 
 
 def test_all_three_settled_outcomes_share_the_glyph_column() -> None:

--- a/tests/unit/tui/test_turn_abandoned.py
+++ b/tests/unit/tui/test_turn_abandoned.py
@@ -1504,7 +1504,7 @@ async def test_a_follower_whose_prompt_is_refused_before_start_still_clears_the_
         runtime_locality: RuntimeLocality = "this-machine"
 
         async def prompt(self, text: str, images: Any = None, **kwargs: Any) -> None:
-            raise RuntimeError("session owner is reconnecting")
+            raise RuntimeError("the runtime is reconnecting")
 
     app = OperatorApp(lambda: _factory(RefusingFollowerSession()))
     async with app.run_test(size=(100, 30)) as pilot:

--- a/tests/unit/tui/test_turn_abandoned.py
+++ b/tests/unit/tui/test_turn_abandoned.py
@@ -114,7 +114,7 @@ class HangingFollowerSession(JobsSession):
     rather than merely the one that happens to run first.
     """
 
-    #: What `AttachedSession` declares (`remote.py:203`), and the app reads it to
+    #: What `AttachedSession` declares (`attached.py`), and the app reads it to
     #: know this worker's `error=None` means "the owner did not tell me" rather
     #: than "the turn succeeded". A follower fake without it models the wire
     #: ORDER while claiming the authority of an in-process session.
@@ -133,7 +133,7 @@ class OwnerEndRacingFollowerSession(JobsSession):
     """The follower interleaving that breaks a latch placed at the CALL SITE.
 
     `AttachedSession._on_wire_event` clears `_streaming` and only THEN emits the
-    relayed `agent_end` (remote.py: the `AgentEndEvent` arm), and it runs on the
+    relayed `agent_end` (attached.py: the `AgentEndEvent` arm), and it runs on the
     socket read pump — a different task from Textual's message pump. So the
     owner's end can land inside the fallback's own post-to-dispatch window:
     guard 2 reads a just-cleared False, the fallback proceeds, and the real


### PR DESCRIPTION
Release: patch — accepts history pages that carry both epoch aliases, retires stale module references, and finishes the owner→runtime copy migration; `pyproject.toml` untouched (combined-release rule: PRs never carry a bump).

## What and why

A retroactive regression audit of `origin/main` (v0.54.11, `b133eba9`) found **no regressions** — the resume/sidebar duration defects are verified fixed there — but left nine loose ends behind. This is the one batched remediation: one commit, one review round, no version bump.

Every item below was reproduced or grepped against `origin/main` `47655cf60` before it was touched. `F4` is the one whose described *trigger* I could not reproduce; that is written up honestly rather than papered over.

## F1 — a page carrying BOTH epoch aliases hard-failed

`DisplayHistoryWindow` is `extra="forbid"` with `owner_epoch: Field(validation_alias=AliasChoices("owner_epoch", "runtime_epoch"))`. `AliasChoices` consumes only the FIRST match, so a payload carrying **both** keys fails as an extra input — the one shape a producer mid-rename can emit (old key for viewers that have not flipped, new key for those that have).

Reproduction (`model_validate` of a minimal payload, one key each / both), before and after:

```
########## BEFORE (pristine origin/main) ##########
OK    owner_epoch only     -> epoch='OLD'
OK    runtime_epoch only   -> epoch='NEW'
FAIL  BOTH aliases         -> ValidationError: runtime_epoch
emit keys carrying 'epoch': ['owner_epoch']
########## AFTER (fix/audit-followups) ##########
OK    owner_epoch only     -> epoch='OLD'
OK    runtime_epoch only   -> epoch='NEW'
OK    BOTH aliases         -> epoch='NEW'
emit keys carrying 'epoch': ['owner_epoch']
```

The fix is a `mode="before"` validator that collapses the alias pair to the single key the field reads, mirroring `harness/jobs.py`'s `_coerce_legacy_owner_id` precedent. `runtime_epoch` wins when both are present: a payload carrying it came from the newer producer, and the alternative honours a key the rename is retiring. The **emit direction is unchanged** — `owner_epoch` alone — because that is what keeps a pre-rename viewer's `extra="forbid"` DTO accepting our pages; a regression test pins all three read shapes *and* the emit.

New test: `tests/unit/session/test_history_window.py::test_a_page_carrying_both_epoch_aliases_still_validates` (`2 passed` alongside the existing wire-compat test).

## F2 — stale file/symbol references left by the Stage-4 rename

`session/remote.py` does not exist (it is `session/attached.py`), `RemoteSession` is `AttachedSession`, and the serving handle's module is `session/runtime/serving.py` (the audit's "`mobile/owned.py` never existed" is close but not exact: `mobile/owned.py` **is** a tracked one-release re-export shim, so the stale citation is `local_operator/mobile/serving.py`, which does not exist).

Fixed across source comments, tests and six design docs:

* `session/remote.py` → `session/attached.py`, `RemoteSession` → `AttachedSession` — `session/session.py`, `session/protocol.py`, `session/attached.py`, `tui/events.py`, `tui/app.py`, `mobile/attach_client.py`, four design docs and three tests.
* `mobile/serving.py` → `session/runtime/serving.py` — `docs/design/peer-send.md` (3 sites) and `harness/types.py`.
* `:mod:`.owned`` → `:mod:`.serving`` — `session/runtime/__init__.py`, `session/runtime/exec_control.py`, `mobile/types.py`.
* `docs/design-build-skew.md`: `v0.46.23's serving.py` restored to `owned.py` — a #937 sweep artefact, since that file did not exist at v0.46.23.
* The genuinely version-pinned `v0.46.23's remote.py` (same file, correct as written) is left alone.

**Line numbers.** Every `remote.py:<n>` citation was checked against today's `attached.py`: none of them resolves to the construct it names (the file grew from the 5,686 lines the docs pin at their declared base commits to 5,747, and the named symbols moved 40–200 lines). They were **dropped rather than re-derived** — re-deriving would silently re-pin a point-in-time design record to today's file, which is a bigger change than this cleanup. Symbols are kept, and where a citation's own sentence used the number to identify a site the symbol is now named instead (`route_shared_slash`, `compact_now`, `complete_aside`, `_invalidate_display_history`).

Verification — the only surviving `remote.py` string in the tree is the historical one:

```
$ grep -rn "remote\.py" --include=*.py --include=*.md . | grep -v "^./.venv"
./docs/design-build-skew.md:224:     subscribes with `events=True` (verified in v0.46.23's remote.py) — paints
$ grep -rn "RemoteSession" . | grep -v "^./.venv"          # → no matches
$ grep -rn "mobile/serving\.py\|mobile/owned\.py" --include=*.py --include=*.md . | grep -v "^./.venv"
./tests/unit/session/runtime/test_backcompat_shims.py:48:    shim = importlib.import_module("local_operator.mobile.owned")   # the shim itself
```

## F3 — user-visible copy still said "owner"

`owner` → `runtime` in the session sense, in the two shipped `skill://` guides and in the TUI's runtime errors, stop notices and build-skew diagnostics:

* `guides/configuration/GUIDE.md` — "the owner samples the current default" / "durable when the owner admits real work" → runtime.
* `guides/peer-messaging/GUIDE.md` — "its owner has not heartbeat within the timeout" → its runtime.
* `tui/app.py` — `owner-backed` → `runtime-backed` (5 sidebar/commit seams), "The prepared owner is no longer…" → runtime, "could not confirm the stop with the session owner" → the runtime, "this owner cannot save its receipt" → runtime, "not available from this session's owner" → runtime, "cannot stop this session's owner — the owner is an older process" → runtime, and the build-skew diagnostics (`build skew (owner)` → `(runtime)`, `owner-unknown` → `runtime-unknown`, the two `announce("owner", …)` keys, `session owner refused the recall` → runtime).

`tests/unit/tui/test_app_pilot.py` pinned the `/goal` refusal copy and is updated with it.

**Deliberately not touched** (the standing exclusions, plus one I found and left): POSIX/file owners, browser-tab ownership, `OwnerAckTimeout`, the human release owner, the HTTP `execution: "owner"|"native"` literal, and the runtime-side disconnect/reconnect strings from `AttachedSession._unavailable_reason()` (`"session owner is reconnecting"`). That last one is user-visible, and `tests/unit/session/test_remote_takeover.py::…` pins it directly — it belongs to the later dual-read slice #937 named, and the app-side fallback at `app.py` mirrors that same sentence. Changing one without the other would print two different sentences for one state.

## F4 — a misleading log that hides real drops

`_entry_to_message` popped `kind` with a `CUSTOM_KIND_MESSAGE` default, so a bookkeeping row — a custom host snapshot (`attention_started`, `selected_model`, `system_prefix`, `todo_snapshot`) or a `prune` marker — fell through to `Message.model_validate` and logged `dropping unparseable transcript message entry <id>`, byte-identical to the warning a genuinely corrupt MESSAGE row produces. Non-message entries now return silently (debug-logged); a message row that fails to parse still warns, unchanged.

**One thing I could not reproduce, stated plainly:** the audit's claim that this "fires several times per resume" does not hold on `origin/main`. Every call site (`transcript._replay_row`/`build_llm_history`/`_admitted_command_id`, `mobile/durable.py` ×2, `scripts/bench_session_footprint.py`) already guards on `entry.type == ENTRY_MESSAGE`. Instrumenting `_entry_to_message` and running the whole TUI e2e stage — boot, a real turn through a real tool, `/resume` — shows only `type=message` arguments:

```
$ … -m pytest tests/e2e/test_tui_e2e.py -m e2e -n0 -q --log-cli-level=WARNING   # with a probe in _entry_to_message
   2 F4PROBE type=message id=e336c062499241c9aa35dbdcda80da44 kind=message
   2 F4PROBE type=message id=0bc612c610f14843938edc47832d9391 kind=message
   1 ======================== 3 passed, 2 warnings in 12.54s ========================
```

So this is a latent hazard, not a live one: the change makes the two cases distinguishable for any future or defensive caller and is behaviour-preserving for messages. I did not claim a drop was happening.

## F5 — `0.0s` on a genuinely fast tool

`f"{elapsed:.1f}s"` renders any tool under 50 ms as `0.0s`, the exact string the fabricated-duration defect printed — which is why the missing-duration report was re-filed against a tool that had simply returned at once. Sub-0.05 s now renders `<0.1s`, which is exactly `DURATION_COL` (5) wide, so the pass/fail column does not move. A card with **no** duration still renders blank: `<0.1s` is a claim, blank is the truth.

Rendered frames (`scripts/visual_capture.save_capture` over the real `OperatorApp`, 108×20, three settled rows differing only in `_duration`: 0.04 s / 0.42 s / none), `before` taken from a pristine `origin/main` worktree:

```
_BEFORE  _duration=0.04   ✓  0.0s
         _duration=0.42   ✓  0.4s
         _duration=None   ✓      (blank)
_AFTER   _duration=0.04   ✓ <0.1s
         _duration=0.42   ✓  0.4s
         _duration=None   ✓      (blank)
```

Both SVGs were rasterised and viewed (`rsvg-convert` → PNG, cropped to the three rows): the fast row reads `0.0s` before and `<0.1s` after, the 0.4 s row and the blank row are pixel-identical between the two frames, and the duration column's right edge does not move. The `.geometry.json` beside each capture is **identical in every field** (0 differing values): `ToolCard` 104×1 at the same region in both, `TranscriptView` 105×11 content region, no scrollbar either side — the change is text only, no reflow. Artifacts: `/tmp/f5-before.svg`, `/tmp/f5-after.svg`, `/tmp/f5-*-crop.png` on this host.

## F6 — test hygiene

`tests/unit/tui/test_sidebar_duration_replay.py::_cells` used `app.query_one(TranscriptView)`. That file *performs* the sidebar gesture (`app._adopt_session(remote)`), which leaves the outgoing conversation's view in the DOM beside the adopted one, and `query_one` returns the first in DOM order — the outgoing transcript. It now uses `app._transcript_view()`, the correct accessor, so the assertion cannot silently grade the conversation the test just left.

## Changed files (31, +289/−115)

**Findings:** `session/history_window.py` (F1), `session/transcript.py` (F4), `tui/widgets/tool_card.py` (F5), `tui/app.py` + two shipped guides (F3), and the F2 reference fixes across `session/*`, `session/runtime/*`, `tui/events.py`, `mobile/{attach_client,types}.py`, `harness/types.py`, `*/GUIDE.md` and six `docs/design*` files.
**Tests:** new `test_history_window.py::test_a_page_carrying_both_epoch_aliases_still_validates`; two new `test_tool_card.py` duration-column tests; updated copy/accessor assertions in `test_app_pilot.py`, `test_sidebar_duration_replay.py`, `test_turn_abandoned.py`, `test_sidebar_connect_retry.py`, `test_sidebar_idle_reap.py`.
**Round 1 remediation (`d9a7abb4`, 11 files, +65/−20):** the agent-review, design and QA round-1 findings, one batched commit — `session/history_window.py` (MINOR 1) plus its regression test, `docs/design-idle-reap.md` (MINOR 2), `session/attached.py` + `tui/app.py` + three tests + `docs/evidence/model-receipt/README.md` (D1), `guides/peer-messaging/GUIDE.md` (D2, NIT 1), `tests/unit/tui/test_sidebar_duration_replay.py` (Q-1). `pyproject.toml` untouched.

## Testing evidence

Implementer's original run on this branch (head `5b814143e`, before the round-1 remediation; worktree `/private/tmp/lo-audit-ft.l5J78C`, venv installed editable **from** that worktree — `python -c "import local_operator"` resolves there):

| gate | command | result |
| --- | --- | --- |
| flake8 | `.venv/bin/python -m flake8 .` | clean |
| black | `uvx black==26.1.0 --check .` | `1220 files would be left unchanged` |
| isort | `uvx isort==5.13.2 --check .` | clean |
| pyright | `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | **0 errors, 0 warnings, 0 informations** |
| session suite | `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/session -q` | **2002 passed** |
| tui suite | `… -m pytest tests/unit/tui -q` | **6852 passed, 12 skipped, 1 failed** — see the flake note below |
| mobile suite | `… -m pytest tests/unit/mobile -q` | **307 passed** |
| e2e stage | `… -m pytest tests/e2e -m e2e -n0 -q` (CMUX_* unset; none were set) | **107 passed, 7 skipped** |
| visual | `scripts/visual_capture.save_capture`, before/after, viewed as rasterised PNG | as in F5 |
| F1 repro | `/tmp/f1_repro.py` against a pristine `origin/main` and against this branch | as in F1 |

**Flake note (not a regression).** The one `tests/unit/tui` failure was `test_subagent_view.py::test_a_follower_page_that_gains_a_directory_re_arms_history` (`assert 0 == 30`). It passes in isolation (`1 passed in 5.62s`) and with its whole file (`140 passed in 18.94s`), and the suite run took 14m47s on a host carrying load average ~18 from sibling worktrees. Nothing in this diff touches subagent paging. Treating it as timing-under-load; CI carries the authoritative matrix.

**Full `tests/unit` was deliberately not run to completion** (per the task: the host is saturated with sibling suites and it wedges at 92-99%); CI carries that matrix.

### Round 1 remediation gates (`d9a7abb4`)

Implementer's run on the remediation head, same worktree and venv (`python -c "import local_operator"` resolves there): flake8 `.` → exit 0; `uvx --from black==26.1.0 black --check .` → `1220 files would be left unchanged`; `uvx isort==5.13.2 --check .` → clean; `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` → **0 errors, 0 warnings, 0 informations**; targeted `tests/unit/session` (history-window, remote takeover/round2/move) → **74 passed**; targeted `tests/unit/tui` (app pilot, turn abandoned, sidebar duration replay) → **374 passed**; `tests/unit/session tests/unit/mobile` → **2310 passed**; `tests/unit/tui` → **6853 passed, 12 skipped** (whole tree, 13m41s). The MINOR 1 regression test was proven able to fail (with the `dict(data)` copy removed it reports exactly the in-place mutation). Every changed file is named by a round-1 finding.

## Not addressed

* F4's "fires several times per resume" — not reproducible on `origin/main`; the hazard is latent (detailed above).
* Line numbers were dropped, not re-derived, in the six design docs (rationale in F2).
* The runtime-side reconnect reason string: originally left as `"session owner is reconnecting"` pending the dual-read slice (F3); **retired in the round-1 remediation (D1)** — `_unavailable_reason()` and its `/model` fallback now answer `"the runtime is reconnecting"`, keeping the `reconnecting` substring `_is_runtime_gone` keys off.

