### PR TITLE
perf(tui): render the /analytics body per line and patch only the hovered rows

### DIFF
--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -2032,8 +2032,12 @@ MovePickerScreen .move-picker {
  * with Esc — and giving diagnostics their own visual language would make one
  * more screen look like a different app. It differs in one structural way:
  * the body can be long (a per-session table grows without bound), so the card
- * pins a title and a hint and puts the report itself in a VerticalScroll
- * between them, rather than sizing to content the way the picker does. */
+ * pins a title and a hint and gives the report a scrolling body between them,
+ * rather than sizing to content the way the picker does. `/usage`'s body and
+ * `/info`'s are a `Static` in a `VerticalScroll`; `/analytics`'s is a
+ * `ReportView`, which paints its own lines and is its own scroller — the rule
+ * (`#analytics-scroll`) and the reason (it repaints per mouse event, not per
+ * key) are below. */
 AnalyticsScreen, SessionScreen, InfoScreen {
     align: center middle;
     background: $lo-sunken;

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -2033,11 +2033,13 @@ MovePickerScreen .move-picker {
  * more screen look like a different app. It differs in one structural way:
  * the body can be long (a per-session table grows without bound), so the card
  * pins a title and a hint and gives the report a scrolling body between them,
- * rather than sizing to content the way the picker does. `/usage`'s body and
- * `/info`'s are a `Static` in a `VerticalScroll`; `/analytics`'s is a
- * `ReportView`, which paints its own lines and is its own scroller — the rule
- * (`#analytics-scroll`) and the reason (it repaints per mouse event, not per
- * key) are below. */
+ * rather than sizing to content the way the picker does. The three bodies
+ * differ, and the difference is the point: `/info`'s is a `Static` inside a
+ * `VerticalScroll`, `/usage`'s is the `UsagePanel` `Static` scrolling itself
+ * inside a plain container (it paints its own bar), and `/analytics`'s is a
+ * `ReportView` — a line-API widget that converts only the lines the compositor
+ * asks for. Why that one needed its own shape (it repaints per mouse event, not
+ * per key) and its rule (`#analytics-scroll`) are below. */
 AnalyticsScreen, SessionScreen, InfoScreen {
     align: center middle;
     background: $lo-sunken;

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -2086,9 +2086,26 @@ InfoScreen .analytics-panel {
     scrollbar-color-active: $lo-accent;
 }
 
-#analytics-body, #session-report-body, #info-body {
+/* `#analytics-body` is gone: the analytics body is a `ReportView` that paints
+ * its own lines and is its own scroller, so it carries `#analytics-scroll`
+ * above and has no `Static` to size. `#session-report-body`/`#info-body` keep
+ * the shape — those panels repaint once per key, not per mouse event, so they
+ * do not pay the price this rule used to cost. */
+#session-report-body, #info-body {
     width: auto;
     height: auto;
+    color: $lo-fg;
+}
+
+#analytics-scroll {
+    /* The report body's own foreground. The body used to get this from the
+     * `#analytics-body` rule; with the body and the viewport now one widget it
+     * belongs on the widget that paints. Kept as its own rule rather than added
+     * to the shared `#analytics-scroll, #session-report-scroll, #info-scroll`
+     * block above, so the two sibling panels' styles are not touched by an
+     * analytics change. Drop it and the report's unstyled cells (blank spacer
+     * lines, the pads between columns) would paint in the app default instead
+     * of `fg`, which the frame comparison would catch. */
     color: $lo-fg;
 }
 

--- a/local_operator/tui/widgets/analytics_panel.py
+++ b/local_operator/tui/widgets/analytics_panel.py
@@ -24,6 +24,23 @@ the content can be asserted as plain strings in a test
 (``render_lines_for_test``), exactly like ``usage_panel`` and
 ``session_picker`` do — a passing test is not evidence a TUI looks right, but
 it is the right way to pin what the screen SAYS.
+
+The body is a :class:`~local_operator.tui.widgets.report_view.ReportView`, not
+a ``Static``, and that is a fix rather than a preference. A ``Static`` renders
+its whole content on every dirty repaint — ``Widget._render_content`` converts
+the widget's OWN height to strips — and this body's height is the whole report
+(846 lines / 85,446 cells on the operator's ledger against a 2,929-cell
+viewport), so every pointer row crossing re-stripped the entire report to
+change two of its lines. Measured on a copy of that ledger at 120x45 through
+the real app, loop-thread CPU: **243 ms mean / 320 ms max per row crossed**,
+174 ms per wheel line with the pointer resting on the table, against a 6.6 ms
+mean / 13.6 ms max floor for the same pointer moves with no analytics screen
+open. ``ReportView`` renders only the lines the compositor asks for, and a
+hover change recomposes just the two rows whose tint changed — 8 ms mean per
+row-to-row crossing, of which the body's own share is two strip conversions
+(4 ms across twelve crossings in total). The widths a single-row recompose
+needs come from :class:`ReportLayout`, never from the row list it is handed —
+see :func:`_session_row_line` for why that is load-bearing rather than tidy.
 """
 
 from __future__ import annotations
@@ -36,7 +53,7 @@ from rich.style import Style
 from rich.text import Text
 from textual.app import ComposeResult
 from textual.binding import Binding
-from textual.containers import Container, VerticalScroll
+from textual.containers import Container
 from textual.screen import ModalScreen
 from textual.widgets import Static
 
@@ -50,6 +67,7 @@ from local_operator.analytics.model import (
     session_table_labels,
 )
 from local_operator.tui import theme as theme_mod
+from local_operator.tui.widgets.report_view import ReportView
 from local_operator.tui.widgets.tool_card import truncate_cells
 
 
@@ -924,6 +942,7 @@ def build_report(
                 cursor=cursor_index,
                 hover=hover_index,
                 suffixes=[suffixes[row.session_id] for row in structure],
+                layout=layout,
             )
         )
 
@@ -936,6 +955,30 @@ def build_report(
         lines.append(legend)
 
     return lines
+
+
+def _flatten_blocks(blocks: list[Text]) -> list[Text]:
+    """One ``Text`` per BODY LINE, from the multi-line blocks the report builds.
+
+    ``build_report`` composes section by section — a table is one ``Text``
+    holding hundreds of lines — because that is the readable way to write it,
+    and it keeps returning blocks on purpose: the plain-text tests index a
+    section's own block, so flattening AT THE RENDERER would move a test's
+    premise for no reader-visible gain. The body widget is where the shape has
+    to change, because it addresses lines by index; the split therefore happens
+    at that boundary, which is also where the blocks stop being readable.
+
+    The line numbering ``ReportLayout.session_first_line`` publishes (and so
+    every hit-test and every patch) is a count of THESE lines, which is why the
+    two must agree about blank spacers: ``allow_blank=True`` is load-bearing,
+    since a plain ``str.split`` drops the empty pieces and every index below a
+    section break would shift by one. Splitting a ``Text`` is style-preserving,
+    so a row keeps its spans.
+    """
+    flat: list[Text] = []
+    for block in blocks:
+        flat.extend(block.split("\n", allow_blank=True))
+    return flat
 
 
 #: Below this content width the per-group tables drop the cache column to keep
@@ -952,11 +995,14 @@ _WIDE_TABLE_MIN = 72
 _MIN_NAME_COL = 30
 _MAX_NAME_COL = 48
 
-#: Cells the scroll container reserves for its vertical scrollbar. The
+#: Cells the body widget reserves for its own vertical scrollbar. The
 #: ``#analytics-scroll`` rule sets ``scrollbar-gutter: stable``, so the column is
 #: held whether or not the bar is drawn — a report composed against the full
 #: card width therefore paints one cell wider than the box that receives it, and
-#: the rightmost column is cut. Kept beside the width maths that spends it.
+#: the rightmost column is cut. The gutter belongs to the ``ReportView`` that
+#: paints the report (body and viewport are one widget), which is why it is still
+#: subtracted here and not measured off a child. Kept beside the width maths
+#: that spends it.
 _SCROLLBAR_GUTTER = 1
 
 
@@ -1133,6 +1179,26 @@ class ReportLayout:
     #: above it, and row ``i`` is at ``session_first_line + i`` because every row
     #: is composed ``no_wrap`` and truncated to the content box.
     session_first_line: int = 0
+    #: The ``(label, depth, aggregate)`` triples the table painted, in the same
+    #: order as ``session_rows``. Kept because a single-row REPAINT needs the
+    #: inputs the full paint used, and re-deriving them means walking the forest
+    #: again (31 ms on the operator's ledger) as a second definition of what is
+    #: visible that could disagree with the paint.
+    session_triples: list[tuple[str, int, "UsageAggregate"]] = field(default_factory=list)
+    #: The table's column widths AS PAINTED, alongside the switches that decide
+    #: which columns exist. A repaint of one row must take every width from
+    #: here: these are maxima over the whole table, and a caller that recomposes
+    #: a single row from that row's OWN figures gets a narrower column and moves
+    #: the row sideways (see :func:`_session_row_line`).
+    name_col: int = 0
+    tokens_col: int = 0
+    cost_col: int = 0
+    calls_col: int = 0
+    #: Whether the ``% cache`` column is present — the width switch, not a width.
+    show_cache: bool = False
+    #: The ``+N subagents`` tail each row advertises, parallel to
+    #: ``session_triples``. Part of the row's content, so a repaint needs it too.
+    suffixes: list[str] = field(default_factory=list)
 
 
 def _descendant_count(node: "SessionNode") -> int:
@@ -1333,6 +1399,7 @@ def _session_section(
     cursor: int | None = None,
     hover: int | None = None,
     suffixes: Sequence[str] | None = None,
+    layout: "ReportLayout | None" = None,
 ) -> Text:
     """The per-session table, pre-ordered and pre-indented by the forest walk.
 
@@ -1385,79 +1452,127 @@ def _session_section(
     and the section meta beside it are all dim. Passing the string rather than a
     length keeps the split honest under truncation: a suffix the budget cut is
     simply not found at the tail and the row paints in one style, as before.
+
+    ``layout`` publishes everything a LATER single-row repaint needs — the row
+    triples, the label budget, the four column widths and their switch. The
+    screen owns a long-lived layout and asks for one row to be recomposed on
+    every pointer crossing; without these figures the patch path would have to
+    walk the forest and re-measure the columns a second time, which is both the
+    31 ms it exists to avoid and a second definition of the table's geometry
+    that could disagree with the paint. ``None`` (the default, and what the
+    plain-text callers and the scripts pass) just skips publishing.
     """
-    fg = semantic_style("fg")
     dim = semantic_style("dim")
-    accent = semantic_style("accent")
     block = section_header("By session", meta)
     if not rows:
         block.append("\n  (none)", style=dim)
         return block
 
-    show_cache = width >= _WIDE_TABLE_MIN
+    # Every column is a maximum over the WHOLE table, which is exactly why it is
+    # published rather than left in the loop: a single-row repaint recomposes
+    # one row against the table's columns, and a row measured against ITSELF
+    # gets a narrower column and shifts sideways (the width trap).
+    target = layout if layout is not None else ReportLayout()
     pairs = [(label, agg) for label, _, agg in rows]
-    cost_col = max(len(format_cost(agg)) for _, agg in pairs)
-    tokens_col = _tokens_col(pairs)
-    calls_col = _calls_col(pairs)
-    for index, (label, depth, agg) in enumerate(rows):
+    target.session_triples = rows
+    target.name_col = name_col
+    target.tokens_col = _tokens_col(pairs)
+    target.cost_col = max(len(format_cost(agg)) for _, agg in pairs)
+    target.calls_col = _calls_col(pairs)
+    target.show_cache = width >= _WIDE_TABLE_MIN
+    target.suffixes = list(suffixes) if suffixes is not None else [""] * len(rows)
+    for index, row in enumerate(rows):
         block.append("\n")
-        # Where this row's cells begin, so the hover tint can be laid over the
-        # WHOLE row once it is composed. Taken after the newline, which belongs
-        # to the row above: tinting it would paint a notch into the previous
-        # row's right edge.
-        row_start = len(block.plain)
-        # A nested row is dimmed as well as indented: its dollars are already
-        # inside the root above it, so it must not compete visually with the
-        # rows that actually partition the total.
-        style = fg if depth == 0 else dim
-        on_cursor = cursor is not None and index == cursor
-        on_hover = hover is not None and index == hover
-        if on_cursor:
-            block.append(f"{_ROW_CURSOR} ", style=accent)
-        else:
-            block.append("  ")
-        # TRUNCATE as well as pad, in CELLS, exactly as ``_group_section`` does:
-        # a bare ``{label:<{name_col}}`` pushes every numeric column right by
-        # whatever the label overran, and the cost column is the one thing this
-        # screen exists to let you scan straight down. Labels arrive budgeted
-        # (prefix included), so this is a backstop rather than the mechanism.
-        clipped = truncate_cells(label, name_col)
-        pad = " " * max(0, name_col - cell_len(clipped))
-        suffix = suffixes[index] if suffixes is not None and index < len(suffixes) else ""
-        # The cursor row keeps ONE style across the whole label: the caret's
-        # highlight is what says "you are here", and breaking it in the middle
-        # would read as two spans rather than one selected row.
-        if suffix and not on_cursor and clipped.endswith(suffix):
-            block.append(clipped[: len(clipped) - len(suffix)], style=style)
-            block.append(suffix, style=dim)
-            block.append(pad)
-        else:
-            block.append(clipped + pad, style=accent if on_cursor else style)
-        block.append(f"{format_tokens(agg.total_tokens):>{tokens_col}} tokens", style=style)
-        block.append("   ")
-        append_cost(block, agg, cost_col, style, dim)
-        block.append(f"   {agg.calls:>{calls_col}} calls", style=dim)
-        if show_cache:
-            block.append(f"   {format_percent(agg.cache_hit_rate):>4} cache", style=dim)
-        if on_hover:
-            # A BACKGROUND laid over the finished row, never a re-styling of it:
-            # `Text.stylize` adds a span, so every foreground the row already
-            # chose (dim suffix, dim calls, accent caret) survives underneath and
-            # only the ground changes. Re-composing the row in a "hover style"
-            # would flatten those distinctions exactly on the row the user is
-            # looking at hardest.
-            #
-            # Spanned to the row's own composed cells rather than padded out to
-            # ``width``: the table is narrower than the card whenever the name
-            # column hits its cap (100 cells inside a 134-cell box), and a tint
-            # run to the box edge would highlight a band of empty margin that is
-            # not part of the table. Every row composes to the same cell count,
-            # so the tint is a clean rectangle down the table.
-            ground = "tint-select-hi" if on_cursor else "tint-select"
-            block.stylize(
-                Style(bgcolor=theme_mod.semantic_color(ground)), row_start, len(block.plain)
-            )
+        block.append_text(_session_row_line(target, index, row, cursor=cursor, hover=hover))
     return block
+
+
+def _session_row_line(
+    layout: ReportLayout,
+    index: int,
+    row: tuple[str, int, "UsageAggregate"],
+    *,
+    cursor: int | None,
+    hover: int | None,
+) -> Text:
+    """ONE row of the per-session table, composed from the LAYOUT's columns.
+
+    One composer with two call sites: the full paint loops over the rows, and a
+    hover/cursor change recomposes the one or two rows whose appearance changed
+    instead of the whole table. A second composer for the patch path would be a
+    second definition of what a row looks like, and the two would drift.
+
+    **The argument it takes is the layout, not a row list, and that is the
+    point.** ``tokens_col``/``cost_col``/``calls_col`` are maxima over every row
+    in the table, so composing a row against its OWN figures silently changes
+    the numeric columns: measured on the operator's ledger, a patch that
+    re-entered the table composer with a one-row list produced rows shifted
+    sideways in 24 of the 26 crossings, and 26 of 26 were byte-identical to a
+    full recompose only once the widths were hoisted out of the loop and read
+    from the layout. Passing ``ReportLayout`` rather than the widths keeps that
+    trap out of reach of a future caller, which a bag of four integers would not.
+
+    The two indices are the paint's current selection state, both resolved
+    against the layout's row order: ``cursor`` is the row the keyboard is on,
+    ``hover`` the row the pointer is on. A row is a pure function of the layout,
+    its index and those two indices, which is what lets the patch path recompose
+    a row and get exactly the cells the full paint would have produced.
+    """
+    fg = semantic_style("fg")
+    dim = semantic_style("dim")
+    accent = semantic_style("accent")
+    label, depth, agg = row
+    on_cursor = cursor is not None and index == cursor
+    on_hover = hover is not None and index == hover
+    line = Text()
+    # A nested row is dimmed as well as indented: its dollars are already inside
+    # the root above it, so it must not compete visually with the rows that
+    # actually partition the total.
+    style = fg if depth == 0 else dim
+    if on_cursor:
+        line.append(f"{_ROW_CURSOR} ", style=accent)
+    else:
+        line.append("  ")
+    # TRUNCATE as well as pad, in CELLS, exactly as ``_group_section`` does: a
+    # bare ``{label:<{name_col}}`` pushes every numeric column right by whatever
+    # the label overran, and the cost column is the one thing this screen exists
+    # to let you scan straight down. Labels arrive budgeted (prefix included), so
+    # this is a backstop rather than the mechanism.
+    clipped = truncate_cells(label, layout.name_col)
+    pad = " " * max(0, layout.name_col - cell_len(clipped))
+    suffix = layout.suffixes[index] if index < len(layout.suffixes) else ""
+    # The cursor row keeps ONE style across the whole label: the caret's
+    # highlight is what says "you are here", and breaking it in the middle would
+    # read as two spans rather than one selected row.
+    if suffix and not on_cursor and clipped.endswith(suffix):
+        line.append(clipped[: len(clipped) - len(suffix)], style=style)
+        line.append(suffix, style=dim)
+        line.append(pad)
+    else:
+        line.append(clipped + pad, style=accent if on_cursor else style)
+    line.append(f"{format_tokens(agg.total_tokens):>{layout.tokens_col}} tokens", style=style)
+    line.append("   ")
+    append_cost(line, agg, layout.cost_col, style, dim)
+    line.append(f"   {agg.calls:>{layout.calls_col}} calls", style=dim)
+    if layout.show_cache:
+        line.append(f"   {format_percent(agg.cache_hit_rate):>4} cache", style=dim)
+    if on_hover:
+        # A BACKGROUND laid over the finished row, never a re-styling of it:
+        # `Text.stylize` adds a span, so every foreground the row already chose
+        # (dim suffix, dim calls, accent caret) survives underneath and only the
+        # ground changes. Re-composing the row in a "hover style" would flatten
+        # those distinctions exactly on the row the user is looking at hardest.
+        #
+        # Spanned to the row's own composed cells rather than padded out to the
+        # box: the table is narrower than the card whenever the name column hits
+        # its cap (100 cells inside a 134-cell box), and a tint run to the box
+        # edge would highlight a band of empty margin that is not part of the
+        # table. Every row composes to the same cell count, so the tint is a
+        # clean rectangle down the table. The run starts at 0 because this is one
+        # row's `Text`, not a slice of the multi-row block the full paint builds.
+        ground = "tint-select-hi" if on_cursor else "tint-select"
+        line.stylize(Style(bgcolor=theme_mod.semantic_color(ground)), 0, len(line.plain))
+    return line
 
 
 def _group_section(
@@ -1545,8 +1660,17 @@ class AnalyticsScreen(ModalScreen[None]):
     restores the previous view exactly — the screen reads the ledger and shows
     it, it never mutates anything, so leaving it is a plain pop with no state to
     reconcile. Modelled on :class:`SessionPickerScreen`: a centred card over a
-    dimmed transcript, one ``Static`` body inside a ``VerticalScroll`` so a long
-    per-session table scrolls rather than clipping.
+    dimmed transcript, and a scrolling body so a long per-session table scrolls
+    rather than clipping.
+
+    The body is a :class:`ReportView` — one widget that is BOTH the scroller and
+    the renderer — rather than a ``Static`` inside a ``VerticalScroll``. That is
+    not a preference: the two-widget shape re-renders the whole report on every
+    dirty repaint, and this screen repaints on every pointer row crossing (see
+    the module docstring for the measured cost). Keeping the body and the
+    viewport in one widget is also what makes the hit-test honest: the row under
+    a screen coordinate is the viewport's own geometry, not a second widget's
+    region that lagged a scroll by a frame.
     """
 
     BINDINGS = [
@@ -1554,9 +1678,10 @@ class AnalyticsScreen(ModalScreen[None]):
         Binding("q", "dismiss_screen", "Back", show=False),
         Binding("t", "toggle_metric", "Cost/tokens", show=False),
         # ``priority=True`` on the row keys, and it is load-bearing rather than
-        # defensive. Focus sits on the inner ``VerticalScroll``, which handles
-        # the arrows itself whenever it can still scroll — so a plain screen
-        # binding is reached only at the ends of the travel. That is why the
+        # defensive. Focus sits on the scroller (the ``ReportView`` body, whose
+        # ``ScrollableContainer`` base handles the arrows itself whenever it can
+        # still scroll) — so a plain screen binding is reached only at the ends
+        # of the travel. That is why the
         # ``action_scroll_up``/``down`` this replaces were effectively dead on
         # any report tall enough to scroll, and why the cursor would otherwise
         # move only on a short one (measured: it worked at 110x40, where the
@@ -1651,8 +1776,12 @@ class AnalyticsScreen(ModalScreen[None]):
         #: Lazily built by ``_forest()``; see there for why it is cached.
         self._forest_cache: list["SessionNode"] | None = None
         self._title: Static
-        self._body: Static
-        self._scroll: VerticalScroll
+        #: The body IS the viewport — one ``ReportView``, aliased twice because
+        #: the screen has always spoken of them separately (``_body`` where it
+        #: paints, ``_scroll`` where it scrolls) and the geometry is now the
+        #: same object's either way.
+        self._body: ReportView
+        self._scroll: ReportView
 
     def compose(self) -> ComposeResult:
         with Container(classes="analytics-panel"):
@@ -1660,10 +1789,17 @@ class AnalyticsScreen(ModalScreen[None]):
             # (the ``bars: cost``/``bars: tokens`` suffix — reviews U1/U4).
             self._title = Static(self._title_text(), id="analytics-title")
             yield self._title
-            with VerticalScroll(id="analytics-scroll") as scroll:
-                self._scroll = scroll
-                self._body = Static(id="analytics-body")
-                yield self._body
+            # One widget for the body AND the viewport, deliberately: ``_body``
+            # and ``_scroll`` are the same object, so the row under a screen
+            # coordinate is the scroller's own geometry (see ``_row_at``) and
+            # none of this screen's state can disagree with itself about where a
+            # row is. The id stays ``analytics-scroll`` because that rule is
+            # what gives the body its height and scrollbar chrome; it must NOT
+            # become ``analytics-body``, whose ``height: auto`` would collapse
+            # the viewport to the report's height and take the scrolling away.
+            view = ReportView(id="analytics-scroll")
+            self._body = self._scroll = view
+            yield view
             self._hint = Static(self._hint_text(scrollable=False), id="analytics-hint")
             yield self._hint
 
@@ -1743,11 +1879,15 @@ class AnalyticsScreen(ModalScreen[None]):
         #
         # ``_SCROLLBAR_GUTTER`` comes off the top because ``#analytics-scroll``
         # sets ``scrollbar-gutter: stable`` (see the stylesheet): the column is
-        # reserved whether or not the bar is currently drawn, so the body is
+        # reserved whether or not the bar is currently drawn, so the report is
         # ALWAYS painted one cell narrower than the card. Counting it here
         # rather than at the call sites keeps one number describing "cells the
         # report may paint into" — measured, not assumed: at a 114-column
-        # terminal the card is 96 and ``scrollable_content_region`` is 95.
+        # terminal the card is 96 and ``scrollable_content_region`` is 95. It
+        # was measured with a ``Static`` body inside a ``VerticalScroll`` and is
+        # deliberately unchanged now the body and the viewport are one widget:
+        # the reserved column is the same column either way, and the frame
+        # comparison pins that the paint did not move.
         try:
             terminal = self.app.size.width
             card = min(140, int(terminal * 0.9))
@@ -1936,14 +2076,17 @@ class AnalyticsScreen(ModalScreen[None]):
         return any(row.expandable for row in self._layout.session_rows)
 
     def _repaint(self, *, force: bool = True) -> None:
-        """Recompose the body, unless a width-driven repaint would change nothing.
+        """Recompose the WHOLE body, unless a width-driven repaint changes nothing.
 
         ``force=False`` is the resize path (see ``on_resize``): a rebuild is
         0.5-0.6 s on a real ledger and a terminal drag emits a burst of resize
         events, so the ones that leave the content box unchanged must not each
-        pay for one. Every other caller changed the CONTENT (metric flipped, a
-        row expanded, the cursor moved) and forces, because the width is the same
-        by definition and only the content differs.
+        pay for one.
+
+        This is the coarse path, and it is the right one whenever the REPORT's
+        SHAPE changes: a metric flip re-draws the charts, an expand inserts rows
+        and so renumbers every line below it, a resize recomposes at a new width.
+        The narrow path for a change of two rows' COLOUR is ``_patch_rows``.
         """
         body = getattr(self, "_body", None)
         if body is None or not body.is_mounted:
@@ -1951,16 +2094,55 @@ class AnalyticsScreen(ModalScreen[None]):
         width = self._card_width()
         if not force and width == self._painted_width:
             return
-        combined = Text()
-        for i, line in enumerate(self._report_lines()):
-            if i:
-                combined.append("\n")
-            combined.append_text(line)
-        body.update(combined)
+        body.set_lines(_flatten_blocks(self._report_lines()), width)
         self._painted_width = width
 
+    def _patch_rows(self, indices: Sequence[int | None]) -> None:
+        """Recompose and repaint ONLY the listed session rows.
+
+        The point of the whole virtualized body. A hover change alters the
+        composed text of exactly two rows — the one the pointer left and the one
+        it entered — and re-entering ``build_report`` for that costs a full
+        recompose of all 846 lines (measured: 40 ms per crossing with the
+        virtualized body alone, against 4.0 ms for two patched rows).
+
+        The rows are composed by :func:`_session_row_line`, the SAME function
+        the full paint uses, fed the layout the full paint published. Taking the
+        widths from anywhere else is the trap that misaligns a patched row.
+
+        Out-of-range indices are dropped rather than clamping: an index that no
+        longer names a row means the paint it came from is stale, and painting a
+        different row's content on that line would be worse than leaving it.
+        """
+        body = getattr(self, "_body", None)
+        if body is None or not body.is_mounted:
+            return
+        layout = self._layout
+        triples = layout.session_triples
+        if not triples:
+            # Nothing painted yet (or no table in this report): fall back so a
+            # caller never has to know which shape it is in.
+            self._repaint()
+            return
+        cursor = self._cursor_index()
+        hover = self._hover_index()
+        for index in sorted({i for i in indices if i is not None}):
+            if not 0 <= index < len(triples):
+                continue
+            body.set_line(
+                layout.session_first_line + index,
+                _session_row_line(layout, index, triples[index], cursor=cursor, hover=hover),
+            )
+
     def render_lines_for_test(self) -> list[str]:
-        """The report as plain strings — what a user reads."""
+        """The report as plain strings — what a user reads.
+
+        Reads the renderer, not the widget: this is what the report SAYS, which
+        is what the plain-text tests are about. ``_body.lines_for_test()`` is the
+        report as PAINTED (the lines the strips are built from) and is what a
+        test that asks about the shape of the body — one line per row, patched
+        rows included — should read.
+        """
         out: list[str] = []
         for line in self._report_lines():
             out.extend(line.plain.split("\n"))
@@ -2029,6 +2211,22 @@ class AnalyticsScreen(ModalScreen[None]):
                 for i, row in enumerate(self._layout.session_rows)
                 if row.session_id == self._cursor
             ),
+            None,
+        )
+
+    def _hover_index(self) -> int | None:
+        """Where the POINTER sits in the CURRENT paint, or ``None`` if nowhere.
+
+        The mirror of ``_cursor_index``, and it exists for the same reason: the
+        hover is stored as a session id (so it survives a rebuild), while a
+        repaint needs the row it lands on. Resolved against the same layout the
+        paint published, so the index a patch is composed for is the index the
+        row is painted at.
+        """
+        if self._hover is None:
+            return None
+        return next(
+            (i for i, row in enumerate(self._layout.session_rows) if row.session_id == self._hover),
             None,
         )
 
@@ -2120,28 +2318,33 @@ class AnalyticsScreen(ModalScreen[None]):
     def _row_at(self, event) -> int | None:  # type: ignore[no-untyped-def]
         """Index of the session row under a mouse event, or ``None``.
 
-        Resolved against the VIEWPORT plus the scroll offset, and deliberately
-        NOT against ``_body.region``. The two are arithmetically identical — the
-        body is ``height: auto`` inside the container, so ``body.y ==
-        viewport.y - scroll_offset.y`` held exactly at every offset measured —
-        but they are not equally CURRENT. ``body.region`` is recomputed by
-        layout and lags a scroll by a frame, while ``scroll_y`` is the reactive
-        whose change notifies ``_viewport_moved`` in the first place. Basing the
-        hit-test on the body read a stale ``body.y`` of -9 against an already
-        settled offset of 0 (measured), resolving the pointer 16 rows away from
-        the truth and leaving the highlight stuck on a row it had scrolled past.
-        This basis is correct at the instant the watcher runs.
+        Resolved against the VIEWPORT plus the scroll offset. Note that after
+        the body was virtualized the viewport and the body are the SAME widget,
+        so this is no longer a choice between two regions — but the reason the
+        arithmetic reads ``scrollable_content_region`` and ``scroll_offset``
+        rather than ``region`` is worth keeping, because it was measured: a hit
+        test based on the body widget's ``region`` was recomputed by layout and
+        lagged a scroll by a frame, while ``scroll_y`` is the reactive whose
+        change notifies ``_viewport_moved`` in the first place. That basis read
+        a stale ``body.y`` of -9 against an already settled offset of 0
+        (measured), resolving the pointer 16 rows away from the truth and
+        leaving the highlight stuck on a row it had scrolled past. This basis is
+        correct at the instant the watcher runs.
 
         Two guards, and the FIRST is mandatory rather than defensive:
 
         - the point must be inside the SCROLL VIEWPORT, not merely inside the
-          body's region. The body overhangs the viewport by however much of the
-          report is scrolled out of sight — measured at 27 rows on a 40-row
-          frame — so ``body.region.contains`` alone resolves coordinates that
-          are clipped, including the hint line below the card (measured: the
-          hint at y=33 is inside ``body.region`` and outside the viewport). This
-          is a modal over the transcript, so the backdrop also bubbles events
-          from well outside the panel, which the same guard rejects;
+          widget's own box. It always was, and it still is now that the body IS
+          the scroller: the content region is the box minus the reserved
+          scrollbar gutter, so the gutter column resolves to no row, and a
+          coordinate BELOW the card (the hint line, or the modal's backdrop,
+          which bubbles events from well outside the panel) is outside the box
+          entirely and is rejected by the same test. The regression this pins is
+          older and worse — while the body was a separate ``Static`` it
+          overhung the viewport by everything scrolled out of sight (measured:
+          27 rows on a 40-row frame) and its region CONTAINED the hint line, so
+          a guard written against the body region alone resolved clipped
+          coordinates to real rows;
         - and the resulting index must be a row that EXISTS. The table is one
           section of a long report: everything above it (totals, both charts,
           the input attribution, the provider table) and the legend below it
@@ -2168,7 +2371,7 @@ class AnalyticsScreen(ModalScreen[None]):
     def on_leave(self, event) -> None:  # type: ignore[no-untyped-def]
         """Drop the highlight when the pointer leaves the rows.
 
-        ``Leave`` bubbles from the body ``Static``, and its ORDERING relative to
+        ``Leave`` bubbles from the body widget, and its ORDERING relative to
         the ``MouseMove`` that lands somewhere else was measured before relying
         on it: moving row -> hint delivers ``move`` and then ``leave``, and hint
         -> row delivers ``leave`` (of the hint) and then ``move``. In neither
@@ -2198,8 +2401,25 @@ class AnalyticsScreen(ModalScreen[None]):
         self.styles.pointer = "pointer" if row is not None and row.expandable else "default"
         if session_id == self._hover:
             return
+        # The row the pointer left and the row it entered — no more. Both are
+        # recomposed from the layout's own columns, so the cells are the ones a
+        # full paint would have produced; the rest of the report is untouched.
+        #
+        # This covers entering and leaving the table as well as crossing inside
+        # it, and that is worth stating because the obvious reading — "if either
+        # index is missing, fall back to the whole body" — costs a full 846-line
+        # recompose on two ordinary gestures (measured on the real ledger: 71 ms
+        # entering the table, 40 ms leaving it, against 2-4 ms for a patched
+        # pair). Neither index being absent changes anything for the OTHER row:
+        # a row's cells are a function of the layout, its index and the current
+        # cursor/hover indices, so with no hover painted anywhere the row to
+        # un-tint is exactly the one ``previous`` names.
+        #
+        # ``_patch_rows`` still falls back to ``_repaint`` when there is no
+        # layout to patch (nothing painted yet), so this needs no guard here.
+        previous = self._hover_index()
         self._hover = session_id
-        self._repaint()
+        self._patch_rows([previous, index])
 
     def _refresh_hover(self) -> None:
         """Re-resolve the highlight against the LAST KNOWN pointer position.
@@ -2315,8 +2535,13 @@ class AnalyticsScreen(ModalScreen[None]):
             target = self._visible_row_index() or 0
         else:
             target = max(0, min(len(rows) - 1, index + delta))
+        # Both caret positions, taken BEFORE the id moves: a cursor that drifted
+        # off screen still has a painted line inside the body's model, and a
+        # wheel or a scroll back would show a stale caret on it if the patch
+        # only covered the rows the viewport can see.
+        previous = self._cursor_index()
         self._cursor = rows[target].session_id
-        self._repaint()
+        self._patch_rows([previous, target])
         self._scroll_cursor_into_view()
 
     def _scroll_cursor_into_view(self) -> None:

--- a/local_operator/tui/widgets/report_view.py
+++ b/local_operator/tui/widgets/report_view.py
@@ -49,8 +49,12 @@ for a line-API widget: ``Widget.get_selection`` extracts text only from a
 ``Text``/``Content`` returned by ``_render()``, and this widget returns neither,
 so without the overrides below a drag over the report selected nothing, painted
 nothing and handed ``ctrl+c`` an empty string — a silent loss of an affordance
-that exists on the ``Static`` body it replaces. ``RichLog`` carries the same two
-overrides for the same reason: the text, and the per-line highlight.
+that exists on the ``Static`` body it replaces. ``Log`` carries the same two
+overrides for the same reason (``textual/widgets/_log.py``: ``get_selection`` and
+``selection_updated``): the text, and the per-line highlight. It is ``Log``, not
+``RichLog``, that is the model for all three of the selection hooks here —
+``Log`` is also the only widget in the library that stamps its strips with
+``apply_offsets``, which is what makes the drag resolvable at all.
 """
 
 from __future__ import annotations
@@ -65,25 +69,6 @@ from textual.scroll_view import ScrollView
 from textual.selection import Selection
 from textual.strip import Strip
 from textual.visual import Visual, visualize
-
-
-def _cell_to_char(plain: str, cells: int) -> int:
-    """Character index at cell column ``cells`` of ``plain``.
-
-    Selection offsets arrive in CELLS (a terminal address by column) while
-    ``Text.stylize`` spans are CHARACTER indices, and the two only agree while
-    every glyph is one cell wide. This report's labels are free text — a session
-    name can carry CJK or an emoji — so the conversion is done rather than
-    assumed; without it the highlight drifts a cell per wide glyph before the
-    selection start. Iterative on purpose: it runs once per selected line, per
-    repaint, and only while a drag is live.
-    """
-    column = 0
-    for index, char in enumerate(plain):
-        if column >= cells:
-            return index
-        column += cell_len(char)
-    return len(plain)
 
 
 class ReportView(ScrollView):
@@ -124,8 +109,9 @@ class ReportView(ScrollView):
     def get_selection(self, selection: Selection) -> tuple[str, str] | None:
         """The text under a drag selection — the affordance a line API loses.
 
-        This is `RichLog.get_selection`'s shape, joined over the same model the
-        strips are built from, so what is copied is exactly what is painted.
+        This is `Log.get_selection`'s shape (`textual/widgets/_log.py`, which is
+        also where the offset stamp below comes from), joined over the same model
+        the strips are built from, so what is copied is exactly what is painted.
         """
         return selection.extract("\n".join(line.plain for line in self._lines)), "\n"
 
@@ -141,7 +127,9 @@ class ReportView(ScrollView):
 
         A strip bakes in the component style it was rendered with, so a theme or
         stylesheet change leaves every cached line pinning the previous ramp
-        (`RichLog` and `OptionList` clear their caches here for the same reason).
+        (`RichLog.notify_style_update` clears its line cache on this hook for the
+        same reason; `OptionList` refreshes here and clears its caches on
+        `_on_resize` instead, which is the other half of the same idea).
         """
         super().notify_style_update()
         self._strips.clear()
@@ -267,9 +255,16 @@ class ReportView(ScrollView):
         meta on the segments it renders (``_compositor.get_widget_and_offset_at``),
         so a strip returned without it resolves the pointer's line to nothing —
         the drag then has a start and no end, which textually means "select to
-        the end of everything". ``RichLog`` stamps its strips for exactly this
-        reason; the base ``Static`` body got the same meta from Textual's own
-        render path.
+        the end of everything". ``Log`` stamps its strips for exactly this reason
+        (it is the library's only ``apply_offsets`` caller); the base ``Static``
+        body got the same meta from Textual's own render path.
+
+        The stamp's x is ``scroll_offset.x``, and that is only honest because the
+        strip is served UNCROPPED and the axis is pinned: ``Log`` crops by
+        ``scroll_x`` before stamping, while this widget strips at the line's own
+        width and lets the compositor crop, so enabling horizontal scrolling
+        here would offset every meta by ``scroll_x`` without any test noticing.
+        If that axis is ever turned on, crop-then-stamp first.
         """
         width = self.size.width
         if width != self._strip_width:
@@ -312,15 +307,33 @@ class ReportView(ScrollView):
             max(width, cell_len(line.plain)),
             1,
             self.visual_style,
+            # The generic path resolves a selection against the visual it is
+            # handed, and this one is a SINGLE LINE, so every strip would read
+            # the span of body line 0: a selection starting on line 0 (which is
+            # where `/analytics` opens — the `Totals` line) then banded EVERY
+            # line of the report, 1394 cells over 28 rows where 4 rows are
+            # selected (measured, 120x45). The span above is applied by the only
+            # code that knows this line's index, so the visual must not apply one.
+            apply_selection=False,
         )[0]
 
     def _selection_span(self, index: int) -> tuple[int, int] | None:
         """Character span of the live selection on body line ``index``.
 
-        ``Selection.get_span`` answers in the widget's own content coordinates,
-        which for this widget are body line indices — the same numbering
-        ``set_line`` and the report's layout use. ``-1`` means "to the end of the
-        line", which is resolved here because only the line knows its length.
+        ``Selection`` offsets are CHARACTER offsets, not cell columns, and they
+        are read raw here on purpose: ``Strip.apply_offsets`` advances ``x`` by
+        ``len(segment.text)`` per segment, ``Compositor.get_widget_and_offset_at``
+        counts characters into the segment the pointer landed on, and
+        ``Selection.extract`` (``get_selection`` above) slices the plain string
+        with the same numbers. Converting them a second time from cells — which
+        an earlier revision did — is the identity only while every glyph is one
+        cell wide, and drifts the highlight by a character per wide glyph while
+        the copy stays right, i.e. the frame ends up describing different
+        characters than ctrl+c hands over. This is `Log._render_line_strip`'s
+        arithmetic.
+
+        ``-1`` means "to the end of the line", which is resolved here because
+        only the line knows its length.
         """
         selection = self.text_selection
         if selection is None:
@@ -328,7 +341,5 @@ class ReportView(ScrollView):
         span = selection.get_span(index)
         if span is None:
             return None
-        start_cells, end_cells = span
-        plain = self._lines[index].plain
-        end_cells = cell_len(plain) if end_cells == -1 else end_cells
-        return _cell_to_char(plain, start_cells), _cell_to_char(plain, end_cells)
+        start, end = span
+        return start, len(self._lines[index].plain) if end == -1 else end

--- a/local_operator/tui/widgets/report_view.py
+++ b/local_operator/tui/widgets/report_view.py
@@ -92,11 +92,12 @@ class ReportView(ScrollView):
     def set_lines(self, lines: list[Text], width: int) -> None:
         """Replace the whole body — one ``Text`` per line — and repaint.
 
-        ``lines`` are already split (``build_report`` returns one ``Text`` per
-        body line), so this is a straight hand-off, not a re-render: the body's
-        line numbering and the caller's must be the same numbering, or the
-        caller's "patch line N" would address a different row than the one it
-        composed.
+        ``lines`` are already split — the screen flattens ``build_report``'s
+        multi-line blocks into one ``Text`` per line before handing them over
+        (see ``analytics_panel._flatten_blocks``) — so this is a straight
+        hand-off, not a re-render. The body's line numbering and the caller's
+        must be the same numbering, or the caller's "patch line N" would
+        address a different row than the one it composed.
 
         ``width`` is the width the lines were COMPOSED for. The content size is
         the wider of that and the longest line, which reproduces what the

--- a/local_operator/tui/widgets/report_view.py
+++ b/local_operator/tui/widgets/report_view.py
@@ -1,0 +1,214 @@
+"""The shared report body: a line-API widget that strips ONE line at a time.
+
+Extracted from ``/analytics`` (``analytics_panel``) because the shape it
+replaces — a ``Static`` whose height is the whole report, inside a
+``VerticalScroll`` — has a cost that is invisible until the report is long and
+the widget is repainted often.
+
+Why the ``Static`` shape cannot be afforded on a screen that repaints per
+POINTER event: ``Widget._render_content`` converts the widget's OWN height to
+strips on every dirty repaint (``textual/widget.py``: ``width, height =
+self.size`` then ``Visual.to_strips(..., width, height, ...)``). The height of
+the body is the height of the report, not of the viewport, so one hover change
+— a pointer crossing a row — re-stripped all 846 body lines / 85,446 cells to
+change 2 of them. Measured on a copy of the operator's 156 MB ledger at 120x45
+through the real app: **243 ms mean / 320 ms max of loop-thread CPU per row
+crossed**, against a 6.6 ms mean / 13.6 ms max floor for the same pointer moves
+with no analytics screen open. Scrolling with the pointer resting on the table
+is the same defect from the other side — the rows slide, the hovered id
+changes, the report is re-stripped — at 174 ms per wheel line.
+``Visual.to_strips`` is the entire cost, and the viewport it is converted for is
+3.4% of it.
+
+So this widget throws away the "one big renderable" model and renders the way
+``RichLog`` and ``OptionList`` do: it owns its ``virtual_size`` and answers
+``render_line(y)`` for the lines the compositor actually asks for, caching one
+``Strip`` per line. Render becomes O(viewport) instead of O(report), and a
+caller that knows which lines changed can invalidate exactly those with
+``set_line`` (``refresh_line``) instead of rebuilding the body. Measured on the
+same ledger, that takes a row-to-row pointer crossing from 243 ms to 8 ms, of
+which the body's own part is the two strip conversions for the two rows whose
+tint changed.
+
+The strip is built through ``Visual.to_strips`` and the widget's own
+``visual_style``, exactly as ``Widget._render_content`` would: styles,
+selection and the CSS-derived foreground stay Textual's, not this widget's, so
+the painted frame is byte-identical to the one the ``Static`` body produced
+(asserted by the frame comparison the PR carries).
+
+Two rules matter for a caller:
+
+* **``set_lines`` is a full repaint, ``set_line`` is a single row.** Lines are
+  addressed by BODY LINE index — the same index the report's own layout uses.
+* **A line index is only meaningful at the width it was composed for.** The
+  strip cache is dropped when the widget's own width changes, because a
+  ``Strip`` is cut to the width it was built at.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rich.cells import cell_len
+from rich.text import Text
+from textual.geometry import Size
+from textual.scroll_view import ScrollView
+from textual.strip import Strip
+from textual.visual import Visual, visualize
+
+
+class ReportView(ScrollView):
+    """A report body rendered line by line, with per-line strip caching."""
+
+    #: ``overflow-x`` is pinned to ``hidden`` deliberately. ``ScrollView``'s own
+    #: default is ``auto``, and this body takes the place of a ``Static`` inside
+    #: a ``VerticalScroll`` — which is ``overflow-y: auto; overflow-x: hidden``.
+    #: A report can be a few cells wider than its box on a narrow frame (the
+    #: tables' numeric columns are sized to the data), so the inherited default
+    #: put a horizontal scrollbar on the screen and cost the body a row of
+    #: height that the replaced widget never cost it (measured at 90x40: content
+    #: height 25 -> 24). The bar is not an affordance anyone asked for — the
+    #: report reads down, and a line that overruns is cropped exactly as it was
+    #: before.
+    DEFAULT_CSS = """
+    ReportView {
+        overflow-x: hidden;
+        overflow-y: auto;
+    }
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._lines: list[Text] = []
+        self._strips: dict[int, Strip] = {}
+        #: Width the cached strips were built at. A ``Strip`` is cut to the
+        #: width it was built at, so a width change invalidates the whole cache
+        #: — see ``render_line``. Zero until the first render, which is why the
+        #: first comparison is against the live ``self.size.width``.
+        self._strip_width: int = 0
+
+    # -- model ---------------------------------------------------------------
+
+    def set_lines(self, lines: list[Text], width: int) -> None:
+        """Replace the whole body — one ``Text`` per line — and repaint.
+
+        ``lines`` are already split (``build_report`` returns one ``Text`` per
+        body line), so this is a straight hand-off, not a re-render: the body's
+        line numbering and the caller's must be the same numbering, or the
+        caller's "patch line N" would address a different row than the one it
+        composed.
+
+        ``width`` is the width the lines were COMPOSED for. The content size is
+        the wider of that and the longest line, which reproduces what the
+        widget this replaces did as ``width: auto``: a report that overruns the
+        box it was composed into (the tables' numeric columns are sized to the
+        data, so a narrow frame can overrun by a few cells) kept its own wider
+        content size, so it was croppable rather than wrapped. Sizing the
+        content to the box instead would silently drop the tail of any such
+        line — see ``_make_strip``.
+        """
+        # Keep the strips of lines that came back byte-identical (a metric
+        # toggle or an expand rewrites one section and leaves the rest alone),
+        # but only at an unchanged width: the lines of a report recomposed at a
+        # new width are cut differently even when their PLAIN text happens to
+        # match, and a stale strip would paint the old width's row.
+        if self.size.width != self._strip_width:
+            self._strips.clear()
+        else:
+            self._strips = {
+                index: strip
+                for index, strip in self._strips.items()
+                if index < len(lines)
+                and index < len(self._lines)
+                and lines[index] == self._lines[index]
+            }
+        self._lines = lines
+        widest = max((cell_len(line.plain) for line in lines), default=0)
+        # At least the box, at least the width the lines were composed for, at
+        # least the widest line: the ``width: auto`` body this replaces sized
+        # itself to the content it was given and stretched to its container,
+        # and the geometry a reader can see (the scroll extent) should not move
+        # because the widget changed shape underneath it.
+        self._resize_virtual(max(width, widest, self.scrollable_content_region.width), len(lines))
+        self.refresh()
+
+    def set_line(self, index: int, line: Text) -> None:
+        """Replace ONE line and repaint only it.
+
+        The index is a body line, not a viewport row: ``ScrollView.refresh_line``
+        subtracts the scroll offset itself, so a caller never has to know where
+        the viewport happens to be sitting.
+        """
+        if not 0 <= index < len(self._lines):
+            return
+        self._lines[index] = line
+        self._strips.pop(index, None)
+        self.refresh_line(index)
+
+    def lines_for_test(self) -> list[Text]:
+        """The composed lines, in body order — what ``render_line`` will paint.
+
+        The same idea as ``AnalyticsScreen.render_lines_for_test``: a test can
+        assert on the body without going through the compositor, and it reads
+        the model the strips are built from rather than a second copy of it.
+        """
+        return self._lines
+
+    def _resize_virtual(self, width: int, height: int) -> None:
+        """Publish the content size, so the scrollbar maths follows the report.
+
+        ``height`` is the line count, and it is what makes the view scroll at
+        all: without it ``max_scroll_y`` stays 0 and the body would be cropped
+        rather than scrolled. The ``OptionList`` idiom (``virtual_size`` then
+        ``_scroll_update``), because setting ``virtual_size`` alone leaves the
+        scrollbars describing the old content.
+        """
+        size = Size(max(1, width), height)
+        if size != self.virtual_size:
+            self.virtual_size = size
+            self._scroll_update(size)
+
+    # -- render --------------------------------------------------------------
+
+    def render_line(self, y: int) -> Strip:
+        """The strip for viewport row ``y``, built once and cached per line.
+
+        ``y`` is viewport-relative — Textual asks for the rows it is about to
+        paint — so the body line is the scroll offset plus ``y``. This is the
+        whole point of the widget: the report's other 800-odd lines are never
+        converted at all.
+        """
+        width = self.size.width
+        if width != self._strip_width:
+            self._strips.clear()
+            self._strip_width = width
+        index = int(self.scroll_offset.y) + y
+        strip = self._strips.get(index)
+        if strip is None:
+            strip = self._make_strip(index, width)
+            self._strips[index] = strip
+        return strip
+
+    def _make_strip(self, index: int, width: int) -> Strip:
+        if not 0 <= index < len(self._lines):
+            # Past the end of the report: a blank of the same width and style,
+            # not a short strip, or the region below the last line would be
+            # painted with segments missing their background.
+            return Strip.blank(width, self.visual_style.rich_style)
+        line = self._lines[index]
+        # A line wider than the widget is stripped at its OWN width and left for
+        # the compositor to crop. Stripping it at the widget width instead would
+        # wrap it and return line 1 — the tail of the row silently missing from
+        # the frame (measured on the operator's ledger at 90 columns: the
+        # ``Context read`` row is 77 cells inside a 74-cell box and lost its last
+        # five, which the ``width: auto`` body it replaces cropped rather than
+        # wrapped). Cropping loses the cells the viewport hides; wrapping loses
+        # cells that would have been painted there, which is a different and
+        # visible answer.
+        return Visual.to_strips(
+            self,
+            visualize(self, line),
+            max(width, cell_len(line.plain)),
+            1,
+            self.visual_style,
+        )[0]

--- a/local_operator/tui/widgets/report_view.py
+++ b/local_operator/tui/widgets/report_view.py
@@ -43,6 +43,14 @@ Two rules matter for a caller:
 * **A line index is only meaningful at the width it was composed for.** The
   strip cache is dropped when the widget's own width changes, because a
   ``Strip`` is cut to the width it was built at.
+
+Selection is NOT free here, and that is easy to miss when swapping a ``Static``
+for a line-API widget: ``Widget.get_selection`` extracts text only from a
+``Text``/``Content`` returned by ``_render()``, and this widget returns neither,
+so without the overrides below a drag over the report selected nothing, painted
+nothing and handed ``ctrl+c`` an empty string — a silent loss of an affordance
+that exists on the ``Static`` body it replaces. ``RichLog`` carries the same two
+overrides for the same reason: the text, and the per-line highlight.
 """
 
 from __future__ import annotations
@@ -51,10 +59,31 @@ from typing import Any
 
 from rich.cells import cell_len
 from rich.text import Text
+from textual import events
 from textual.geometry import Size
 from textual.scroll_view import ScrollView
+from textual.selection import Selection
 from textual.strip import Strip
 from textual.visual import Visual, visualize
+
+
+def _cell_to_char(plain: str, cells: int) -> int:
+    """Character index at cell column ``cells`` of ``plain``.
+
+    Selection offsets arrive in CELLS (a terminal address by column) while
+    ``Text.stylize`` spans are CHARACTER indices, and the two only agree while
+    every glyph is one cell wide. This report's labels are free text — a session
+    name can carry CJK or an emoji — so the conversion is done rather than
+    assumed; without it the highlight drifts a cell per wide glyph before the
+    selection start. Iterative on purpose: it runs once per selected line, per
+    repaint, and only while a drag is live.
+    """
+    column = 0
+    for index, char in enumerate(plain):
+        if column >= cells:
+            return index
+        column += cell_len(char)
+    return len(plain)
 
 
 class ReportView(ScrollView):
@@ -81,11 +110,42 @@ class ReportView(ScrollView):
         super().__init__(**kwargs)
         self._lines: list[Text] = []
         self._strips: dict[int, Strip] = {}
+        #: Width the caller COMPOSED the lines for — the one input the resize
+        #: handler cannot recover from the widget, since it survives a resize.
+        self._composed_width: int = 0
         #: Width the cached strips were built at. A ``Strip`` is cut to the
         #: width it was built at, so a width change invalidates the whole cache
         #: — see ``render_line``. Zero until the first render, which is why the
         #: first comparison is against the live ``self.size.width``.
         self._strip_width: int = 0
+
+    # -- selection -----------------------------------------------------------
+
+    def get_selection(self, selection: Selection) -> tuple[str, str] | None:
+        """The text under a drag selection — the affordance a line API loses.
+
+        This is `RichLog.get_selection`'s shape, joined over the same model the
+        strips are built from, so what is copied is exactly what is painted.
+        """
+        return selection.extract("\n".join(line.plain for line in self._lines)), "\n"
+
+    def selection_updated(self, selection: Selection | None) -> None:
+        """Repaint: the cached strips were built without the new selection."""
+        self._strips.clear()
+        self.refresh()
+
+    # -- lifecycle -----------------------------------------------------------
+
+    def notify_style_update(self) -> None:
+        """Drop cached strips, which hold the OLD resolved styles.
+
+        A strip bakes in the component style it was rendered with, so a theme or
+        stylesheet change leaves every cached line pinning the previous ramp
+        (`RichLog` and `OptionList` clear their caches here for the same reason).
+        """
+        super().notify_style_update()
+        self._strips.clear()
+        self.refresh()
 
     # -- model ---------------------------------------------------------------
 
@@ -124,14 +184,36 @@ class ReportView(ScrollView):
                 and lines[index] == self._lines[index]
             }
         self._lines = lines
-        widest = max((cell_len(line.plain) for line in lines), default=0)
-        # At least the box, at least the width the lines were composed for, at
-        # least the widest line: the ``width: auto`` body this replaces sized
-        # itself to the content it was given and stretched to its container,
-        # and the geometry a reader can see (the scroll extent) should not move
-        # because the widget changed shape underneath it.
-        self._resize_virtual(max(width, widest, self.scrollable_content_region.width), len(lines))
+        self._composed_width = width
+        self._publish_virtual_size()
         self.refresh()
+
+    def _publish_virtual_size(self) -> None:
+        """Publish the content size from the lines, the caller's width and the box.
+
+        At least the box, at least the width the lines were composed for, at
+        least the widest line: the ``width: auto`` body this replaces sized
+        itself to the content it was given and stretched to its container, and
+        the geometry a reader can see (the scroll extent) should not move
+        because the widget changed shape underneath it.
+
+        Called again from ``on_resize`` because the box term is only correct
+        once layout has settled: a resize-triggered ``set_lines`` reads the
+        region BEFORE layout, so it republishes the pre-resize width and the
+        content stays that wide until something else repaints it (measured: 101
+        kept after a live 120x45 -> 90x40, where a fresh open at 90x40 reports
+        86). No visible effect was found for it — the box clips and horizontal
+        scrolling is off — but a stale published width is a wrong claim about
+        the widget, and it is fixed at the one place that knows better.
+        """
+        widest = max((cell_len(line.plain) for line in self._lines), default=0)
+        self._resize_virtual(
+            max(self._composed_width, widest, self.scrollable_content_region.width),
+            len(self._lines),
+        )
+
+    def on_resize(self, event: events.Resize) -> None:
+        self._publish_virtual_size()
 
     def set_line(self, index: int, line: Text) -> None:
         """Replace ONE line and repaint only it.
@@ -178,6 +260,16 @@ class ReportView(ScrollView):
         paint — so the body line is the scroll offset plus ``y``. This is the
         whole point of the widget: the report's other 800-odd lines are never
         converted at all.
+
+        ``apply_offsets`` is not decoration, and it is the one thing a line-API
+        widget must remember for a drag selection to work: the compositor
+        recovers the CONTENT offset under the pointer from a ``"offset"`` style
+        meta on the segments it renders (``_compositor.get_widget_and_offset_at``),
+        so a strip returned without it resolves the pointer's line to nothing —
+        the drag then has a start and no end, which textually means "select to
+        the end of everything". ``RichLog`` stamps its strips for exactly this
+        reason; the base ``Static`` body got the same meta from Textual's own
+        render path.
         """
         width = self.size.width
         if width != self._strip_width:
@@ -188,7 +280,7 @@ class ReportView(ScrollView):
         if strip is None:
             strip = self._make_strip(index, width)
             self._strips[index] = strip
-        return strip
+        return strip.apply_offsets(int(self.scroll_offset.x), index)
 
     def _make_strip(self, index: int, width: int) -> Strip:
         if not 0 <= index < len(self._lines):
@@ -197,6 +289,14 @@ class ReportView(ScrollView):
             # painted with segments missing their background.
             return Strip.blank(width, self.visual_style.rich_style)
         line = self._lines[index]
+        span = self._selection_span(index)
+        if span is not None:
+            # COPY before styling: ``self._lines`` are the screen's own Text
+            # objects, reused by the next ``set_lines`` equality check and by
+            # ``build_report`` recomposes, so a paint concern must not mutate
+            # them.
+            line = line.copy()
+            line.stylize(self.screen.get_component_rich_style("screen--selection"), *span)
         # A line wider than the widget is stripped at its OWN width and left for
         # the compositor to crop. Stripping it at the widget width instead would
         # wrap it and return line 1 — the tail of the row silently missing from
@@ -213,3 +313,22 @@ class ReportView(ScrollView):
             1,
             self.visual_style,
         )[0]
+
+    def _selection_span(self, index: int) -> tuple[int, int] | None:
+        """Character span of the live selection on body line ``index``.
+
+        ``Selection.get_span`` answers in the widget's own content coordinates,
+        which for this widget are body line indices — the same numbering
+        ``set_line`` and the report's layout use. ``-1`` means "to the end of the
+        line", which is resolved here because only the line knows its length.
+        """
+        selection = self.text_selection
+        if selection is None:
+            return None
+        span = selection.get_span(index)
+        if span is None:
+            return None
+        start_cells, end_cells = span
+        plain = self._lines[index].plain
+        end_cells = cell_len(plain) if end_cells == -1 else end_cells
+        return _cell_to_char(plain, start_cells), _cell_to_char(plain, end_cells)

--- a/tests/unit/tui/test_analytics_mouse.py
+++ b/tests/unit/tui/test_analytics_mouse.py
@@ -96,6 +96,61 @@ def _click(screen: AnalyticsScreen, x: int, y: int, button: int = 1) -> events.C
     )
 
 
+def _press(screen: AnalyticsScreen, x: int, y: int) -> events.MouseDown:
+    """Mouse button DOWN at a screen coordinate, as the screen sees it."""
+    return events.MouseDown(
+        widget=screen._body,
+        x=x,
+        y=y,
+        delta_x=0,
+        delta_y=0,
+        button=1,
+        shift=False,
+        meta=False,
+        ctrl=False,
+        screen_x=x,
+        screen_y=y,
+    )
+
+
+def _drag_to(screen: AnalyticsScreen, x: int, y: int) -> events.MouseMove:
+    """A move with the button HELD — the event a drag is made of.
+
+    ``button=1`` rather than ``_move``'s 0, because the screen's selection
+    machinery only grows a selection while a button is down; a hover move is a
+    different event as far as this path is concerned.
+    """
+    return events.MouseMove(
+        widget=screen._body,
+        x=0,
+        y=0,
+        delta_x=0,
+        delta_y=0,
+        button=1,
+        shift=False,
+        meta=False,
+        ctrl=False,
+        screen_x=x,
+        screen_y=y,
+    )
+
+
+def _release(screen: AnalyticsScreen, x: int, y: int) -> events.MouseUp:
+    return events.MouseUp(
+        widget=screen._body,
+        x=x,
+        y=y,
+        delta_x=0,
+        delta_y=0,
+        button=1,
+        shift=False,
+        meta=False,
+        ctrl=False,
+        screen_x=x,
+        screen_y=y,
+    )
+
+
 def _hover_index(screen: AnalyticsScreen) -> int | None:
     """The hovered row as an INDEX, resolved against the painted layout.
 
@@ -877,5 +932,101 @@ def test_the_empty_scrollbar_gutter_takes_no_hover_and_no_click():
             await pilot.click(screen, offset=(gutter_x, row_y))
             await pilot.pause()
             assert screen._expanded == before, "the empty gutter took a click"
+
+    asyncio.run(run())
+
+
+# -- text selection -----------------------------------------------------------
+
+
+def test_a_drag_across_the_rows_selects_them_and_copies_them():
+    """The drag/ctrl+c affordance the widget swap could silently have taken.
+
+    A line-API widget returns no ``Text``/``Content`` from ``_render()``, so
+    ``Widget.get_selection`` extracts nothing; and because the compositor
+    recovers the pointer's CONTENT offset from an ``"offset"`` style meta on the
+    rendered segments, a strip returned without one makes the drag resolve a
+    start and no end — textually "select everything from here to the end". Both
+    halves are asserted here because both were broken at once: the selection
+    must PAINT (a drag that highlights nothing reads as "the drag did nothing")
+    and ``ctrl+c`` must hand over those rows' text, which is the only way a
+    session name or a figure leaves this read-only screen.
+
+    The report is the ``Static`` body's replacement, so this is a regression
+    pin rather than a new feature: on the tree before the swap a drag over these
+    same three rows paints them and copies their text.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(120, 45)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            _show_table(screen)
+            await pilot.pause()
+            first = 1
+            x = _row_x(screen)
+            top = _row_y(screen, first)
+            bottom = _row_y(screen, first + 2)
+            expected = screen.render_lines_for_test()
+            rows = [expected[screen._layout.session_first_line + i].strip() for i in (1, 2, 3)]
+
+            def painted() -> dict[int, tuple[tuple[str, str | None], ...]]:
+                """Row -> (text, background) per segment: what the eye actually sees.
+
+                Iterated rather than indexed: ``Strip.__getitem__`` is a CROP, not
+                a sequence access, so ``strip[0]`` is not the first segment.
+                """
+                out: dict[int, tuple[tuple[str, str | None], ...]] = {}
+                for index, strip in enumerate(app.screen._compositor.render_strips()):
+                    out[index] = tuple(
+                        (segment.text, str(segment.style.bgcolor) if segment.style else None)
+                        for segment in strip
+                        if segment.text
+                    )
+                return out
+
+            before = painted()
+            expanded_before = set(screen._expanded)
+
+            screen._forward_event(_press(screen, x, top))
+            await pilot.pause()
+            for step in range(1, 4):
+                screen._forward_event(
+                    _drag_to(screen, x + 20 * step, top + (bottom - top) * step // 3)
+                )
+                await pilot.pause()
+            screen._forward_event(_release(screen, x + 60, bottom))
+            await pilot.pause()
+
+            selected = app.screen.get_selected_text()
+            assert selected, "the drag selected nothing — the body paints no selection"
+            # The drag starts mid-row, so the FIRST row is only partially covered;
+            # the row in the middle is fully inside it, so its whole composed text
+            # must be in the copy. Asserted on the text the user reads, taken from
+            # the same renderer the tests always read the report through.
+            rows = [expected[screen._layout.session_first_line + i] for i in (1, 2, 3)]
+            assert (
+                rows[1].strip() in selected
+            ), f"the dragged row is not in the copied text: {selected[:120]!r}"
+            assert rows[0].strip()[-24:] in selected, "the first dragged row's tail is missing"
+            assert selected.count("\n") >= 2, f"fewer than three rows copied: {selected!r}"
+
+            dragged = {screen._scroll.scrollable_content_region.y + first - 1 + i for i in range(4)}
+            changed = {index for index, bg in painted().items() if before[index] != bg}
+            assert (
+                changed & dragged
+            ), f"the drag painted no selection on the rows it covered: changed={sorted(changed)}"
+
+            # The gesture must not be read as a row action: no expansion.
+            assert screen._expanded == expanded_before, "a drag toggled a row"
+
+            # And the paint goes away with the selection, so the highlight is the
+            # selection and not a side effect of moving the pointer.
+            app.screen.clear_selection()
+            await pilot.pause()
+            after_clear = painted()
+            assert all(
+                after_clear[index] == before[index] for index in dragged
+            ), "clearing the selection did not repaint the rows it had highlighted"
 
     asyncio.run(run())

--- a/tests/unit/tui/test_analytics_mouse.py
+++ b/tests/unit/tui/test_analytics_mouse.py
@@ -119,11 +119,19 @@ def _drag_to(screen: AnalyticsScreen, x: int, y: int) -> events.MouseMove:
     ``button=1`` rather than ``_move``'s 0, because the screen's selection
     machinery only grows a selection while a button is down; a hover move is a
     different event as far as this path is concerned.
+
+    ``x``/``y`` carry the SCREEN coordinate, like ``_press``/``_release`` and
+    unlike ``_move``'s 0,0: the screen resolves the selection's content offset by
+    hit-testing the pointer position it is given (``get_widget_and_offset_at``),
+    so a zeroed position resolves no offset at all — the drag then has a start
+    and no end, which Textual reads as "select to the end of the report". A
+    silently unbounded copy is exactly the kind of thing a test asserting
+    "the row is in the copied text" cannot see.
     """
     return events.MouseMove(
         widget=screen._body,
-        x=0,
-        y=0,
+        x=x,
+        y=y,
         delta_x=0,
         delta_y=0,
         button=1,
@@ -968,7 +976,6 @@ def test_a_drag_across_the_rows_selects_them_and_copies_them():
             top = _row_y(screen, first)
             bottom = _row_y(screen, first + 2)
             expected = screen.render_lines_for_test()
-            rows = [expected[screen._layout.session_first_line + i].strip() for i in (1, 2, 3)]
 
             def painted() -> dict[int, tuple[tuple[str, str | None], ...]]:
                 """Row -> (text, background) per segment: what the eye actually sees.
@@ -1010,6 +1017,12 @@ def test_a_drag_across_the_rows_selects_them_and_copies_them():
             ), f"the dragged row is not in the copied text: {selected[:120]!r}"
             assert rows[0].strip()[-24:] in selected, "the first dragged row's tail is missing"
             assert selected.count("\n") >= 2, f"fewer than three rows copied: {selected!r}"
+            # ...and no more than the rows the drag covered: an unresolved end
+            # offset reads as "select to the end of the report" (~40 lines here),
+            # which every other assertion in this test would happily accept.
+            assert (
+                selected.count("\n") <= 4
+            ), f"the drag selected past the rows it covered: {selected.count(chr(10))} lines"
 
             dragged = {screen._scroll.scrollable_content_region.y + first - 1 + i for i in range(4)}
             changed = {index for index, bg in painted().items() if before[index] != bg}
@@ -1028,5 +1041,132 @@ def test_a_drag_across_the_rows_selects_them_and_copies_them():
             assert all(
                 after_clear[index] == before[index] for index in dragged
             ), "clearing the selection did not repaint the rows it had highlighted"
+
+    asyncio.run(run())
+
+
+# -- paint == copy ------------------------------------------------------------
+
+
+def _selection_ground(app: OperatorApp) -> str:
+    """The background the selection band paints with, as the strips report it."""
+    return str(app.screen.get_component_rich_style("screen--selection").bgcolor)
+
+
+def _painted_by_selection(app: OperatorApp) -> dict[int, str]:
+    """Screen row -> the text the SELECTION ground is painted on, per row.
+
+    Read off the compositor's own strips, so it is the frame the reader sees
+    rather than what the widget intended: the concatenated text of the segments
+    whose background is the selection ground.
+    """
+    ground = _selection_ground(app)
+    rows: dict[int, str] = {}
+    for index, strip in enumerate(app.screen._compositor.render_strips()):
+        text = "".join(
+            segment.text
+            for segment in strip
+            if segment.text and segment.style and str(segment.style.bgcolor) == ground
+        )
+        if text:
+            rows[index] = text
+    return rows
+
+
+def test_the_selection_band_paints_the_characters_ctrl_c_copies():
+    """Paint and copy must describe the SAME characters — wide glyphs included.
+
+    The offsets a drag produces are CHARACTER offsets: ``Strip.apply_offsets``
+    advances ``x`` by ``len(segment.text)``, the compositor counts characters
+    into the segment the pointer landed on, and ``Selection.extract`` (what
+    ctrl+c ends up with) slices the plain string with the same numbers. Reading
+    them as cell columns and converting again is the identity only while every
+    glyph is one cell wide — true of the operator's real ledger and of every
+    other fixture here, which is exactly why the drift hid: on a line whose
+    prefix carries a 2-cell glyph the band highlights a different range than the
+    copy. A session title is free text, so a wide-glyph label is reachable even
+    though the ledger the PR was measured on has none.
+    """
+
+    async def run():
+        app = _app()
+        agg = _tall_report_agg()
+        # The first table row (the priciest root). Renamed rather than added so
+        # the row keeps its place, its widths and its sort order.
+        # setattr, not attribute access: the fixture hangs the labels on the
+        # aggregate the same way (`analytics_panel` reads them with `getattr`), so
+        # this is the shape the report actually consumes.
+        names = dict(getattr(agg, "session_names", {}))
+        names["root00000000"] = "日本語セッション"
+        setattr(agg, "session_names", names)
+        async with app.run_test(size=(120, 45)) as pilot:
+            screen = await _push(pilot, app, agg)
+            _show_table(screen)
+            await pilot.pause()
+            y = _row_y(screen, 0)
+            row = screen.render_lines_for_test()[screen._layout.session_first_line]
+            assert "語" in row, f"fixture row has no wide glyph: {row!r}"
+            start = _row_x(screen) + 2
+            screen._forward_event(_press(screen, start, y))
+            await pilot.pause()
+            for step in (1, 2, 3):
+                screen._forward_event(_drag_to(screen, start + 10 * step, y))
+                await pilot.pause()
+            screen._forward_event(_release(screen, start + 30, y))
+            await pilot.pause()
+
+            copied = app.screen.get_selected_text()
+            assert copied, "the drag selected nothing"
+            painted = _painted_by_selection(app).get(y, "")
+            assert painted, "the drag painted no selection band"
+            assert (
+                "語" in copied or "語" in painted
+            ), f"the drag missed the wide glyph, so this proves nothing: {copied!r}"
+            assert painted == copied, (
+                f"the band highlights {painted!r} while ctrl+c copies {copied!r} — "
+                f"the frame describes different characters than the clipboard"
+            )
+
+    asyncio.run(run())
+
+
+def test_a_selection_from_the_report_top_bands_only_the_selected_rows():
+    """A drag that starts on the report's FIRST line must band only its own rows.
+
+    ``/analytics`` opens at the report top, so body line 0 is the line under the
+    reader's pointer — and a drag upward is normalised to start there, so this is
+    the first gesture the screen offers. The selection style is applied per line
+    here (this widget knows the line index; a single-line visual does not), but
+    the generic visual path re-resolves the selection against the one line it is
+    handed, which reads body line 0's span for EVERY strip: with a selection
+    starting at line 0 the ground then covered all 28 visible rows / 1394 cells
+    where 4 rows were selected (measured, 120x45). The frame is what lies —
+    the copy was always right — so the copy cannot be the guard here.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(120, 45)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            screen._scroll.scroll_to(y=0, animate=False)
+            await pilot.pause()
+            content = screen._scroll.scrollable_content_region
+            x = _row_x(screen)
+            screen._forward_event(_press(screen, x, content.y))
+            await pilot.pause()
+            for step in (1, 2, 3):
+                screen._forward_event(_drag_to(screen, x + 40, content.y + step))
+                await pilot.pause()
+            screen._forward_event(_release(screen, x + 40, content.y + 3))
+            await pilot.pause()
+
+            assert app.screen.get_selected_text(), "the drag selected nothing"
+            selected_rows = set(range(content.y, content.y + 4))
+            banded = set(_painted_by_selection(app))
+            assert banded, "no row carries the selection ground, so this proves nothing"
+            assert banded <= selected_rows, (
+                f"a selection from body line 0 banded rows outside it: "
+                f"{sorted(banded - selected_rows)} (banded {sorted(banded)})"
+            )
 
     asyncio.run(run())

--- a/tests/unit/tui/test_analytics_mouse.py
+++ b/tests/unit/tui/test_analytics_mouse.py
@@ -9,16 +9,20 @@ declare no ``CSS_PATH``, so a card sized by percentage rules is not sized at
 all under one, and a mouse coordinate against an unsized card means nothing.
 
 The hit-test geometry these tests pin was MEASURED before it was written, and
-two of the measurements are why the guards exist:
+one of the measurements is why the guards exist:
 
-* ``_body`` is ``height: auto`` inside the scroll container, so its region
-  tracks the scroll offset (measured: ``region.y`` 8 -> 4 for an offset of 3).
-  The body line under a screen row is therefore a plain subtraction.
-* the body OVERHANGS the viewport by everything scrolled out of sight
-  (measured: 27 rows on a 40-row frame), and ``body.region`` contains the hint
-  line below the card. A hit-test guarded by the body alone resolves clipped
-  coordinates to real rows, which is what ``test_a_click_below_the_viewport_
-  is_not_a_row`` pins.
+* the body and the viewport are now the SAME widget (``ReportView``), so a row's
+  screen position is the viewport plus the scroll offset with nothing in
+  between: ``region.y`` cannot lag a scroll because there are no longer two
+  regions to disagree. Before that they were a ``Static`` inside a
+  ``VerticalScroll``, its region tracked the scroll offset a frame late
+  (measured: ``region.y`` 8 -> 4 for an offset of 3) and it OVERHANGED the
+  viewport by everything scrolled out of sight (measured: 27 rows on a 40-row
+  frame). A hit-test guarded by the body region alone therefore resolved clipped
+  coordinates to real rows, and ``test_a_click_below_the_viewport_is_not_a_row``
+  still asserts the guard that rejects them — one widget does not make the guard
+  unnecessary, it just makes it the only thing standing between the pointer and
+  the row arithmetic, which that test's precondition pins.
 """
 
 from __future__ import annotations
@@ -322,11 +326,21 @@ def test_a_right_click_does_not_toggle_a_row():
 
 
 def test_a_click_below_the_viewport_is_not_a_row():
-    """The body overhangs the viewport, so ``body.region`` alone is not a guard.
+    """A coordinate BELOW the viewport is not a row, whatever the row maths says.
 
-    Measured on this fixture: the body extends well past the scroll viewport
-    and its region CONTAINS the hint line under the card. Clicking there must
-    not resolve to whatever table row happens to sit at that body line.
+    The defect this pins came with the body-inside-a-scroll-container shape: the
+    body overhung the viewport by everything scrolled out of sight and its region
+    contained the hint line under the card, so a hit-test that trusted the body
+    resolved a clipped coordinate to a real table row.
+
+    The body and the viewport are one widget now, which is what makes the
+    precondition below the interesting half of this test: the row arithmetic on
+    its own — screen y, minus the viewport's top, plus the scroll offset, minus
+    the table's first line — DOES name a real row at this coordinate. So the
+    viewport guard is the only thing rejecting the click, and this test would
+    pass on a hit-test that had lost it only if the fixture stopped aiming below
+    the frame. Asserting that is the difference between exercising the guard and
+    asserting something that was already true.
     """
 
     async def run():
@@ -335,17 +349,21 @@ def test_a_click_below_the_viewport_is_not_a_row():
             screen = await _push(pilot, app, _tall_report_agg())
             _show_table(screen)
             await pilot.pause()
-            body = screen._body.region
-            hint_y = screen._hint.region.y
-            # The precondition this test exists for: the coordinate really is
-            # inside the body and outside the viewport, so the guard is being
-            # exercised rather than trivially satisfied.
-            assert body.contains(_row_x(screen), hint_y), "fixture no longer reproduces overhang"
-            assert not screen._scroll.scrollable_content_region.contains(_row_x(screen), hint_y)
+            viewport = screen._scroll.scrollable_content_region
+            x, hint_y = _row_x(screen), screen._hint.region.y
+            # The coordinate is outside the viewport...
+            assert not viewport.contains(x, hint_y), "fixture no longer aims below the frame"
+            # ...and the arithmetic the guard protects would land on a real row.
+            line = hint_y - viewport.y + int(screen._scroll.scroll_offset.y)
+            index = line - screen._layout.session_first_line
+            assert 0 <= index < len(screen._layout.session_rows), (
+                "the unguarded arithmetic no longer resolves a row, so this test "
+                "would pass without the viewport guard"
+            )
 
             before = set(screen._expanded)
-            assert screen._row_at(_click(screen, _row_x(screen), hint_y)) is None
-            screen.on_click(_click(screen, _row_x(screen), hint_y))
+            assert screen._row_at(_click(screen, x, hint_y)) is None
+            screen.on_click(_click(screen, x, hint_y))
             await pilot.pause()
             assert screen._expanded == before
 

--- a/tests/unit/tui/test_analytics_panel.py
+++ b/tests/unit/tui/test_analytics_panel.py
@@ -1864,9 +1864,9 @@ def test_the_cursor_is_scrolled_into_view_when_it_moves():
 
 
 def test_the_row_keys_work_on_a_report_too_tall_to_fit():
-    """Focus sits on the inner ``VerticalScroll``, which eats the arrows while it
-    can still scroll — so a non-priority binding reaches the screen only at the
-    ends of the travel.
+    """Focus sits on the scrolling body (``ReportView``, a ``ScrollView``), which
+    eats the arrows while it can still scroll — so a non-priority binding reaches
+    the screen only at the ends of the travel.
 
     Pinned at two heights because the symptom is invisible at one: the cursor
     moved fine at 110x40, where the body fits, and never at 110x20, where it does

--- a/tests/unit/tui/test_analytics_repaint.py
+++ b/tests/unit/tui/test_analytics_repaint.py
@@ -89,13 +89,15 @@ def _ragged_columns_agg() -> UsageAggregate:
 
 
 def _styled(line: Text) -> tuple[str, tuple[tuple[int, int, str], ...]]:
-    """A row's text AND its styling.
+    """A row's text AND its styling, as a comparable pair.
 
-    ``rich.Text.__eq__`` compares the plain text and the base style but NOT the
-    spans, so comparing ``Text`` objects would pass for a row that lost its
-    hover ground, or one whose column styles moved — the two things a patch can
-    plausibly get wrong. Comparing the spans is what makes this a byte-level
-    comparison of the painted row.
+    ``rich.Text.__eq__`` compares the plain text and the span list, so a plain
+    ``Text == Text`` would in fact catch a lost hover ground — what this adds is
+    the SPANS IN READABLE FORM, so a failure prints ``(plain, spans)`` instead of
+    a bare ``False``, and the assertion below can compare one row at a time
+    without building a second composition to diff against. (It also makes the
+    comparison explicit about what "the same row" means, which the width-trap
+    test leans on.)
     """
     return (line.plain, tuple((span.start, span.end, str(span.style)) for span in line.spans))
 
@@ -164,7 +166,7 @@ def test_a_hover_crossing_does_not_recompose_the_report(monkeypatch):
 
 
 def test_a_hover_crossing_converts_only_the_lines_that_changed(monkeypatch):
-    """One crossing converts a handful of lines, not the whole report.
+    """One crossing converts a handful of lines, and goes through the PATCH path.
 
     Counted at ``Visual.to_strips`` — the call that IS the cost (measured at
     1,850 ms of the 3,006 ms a 12-step crossing run spent on the stock tree).
@@ -172,6 +174,17 @@ def test_a_hover_crossing_converts_only_the_lines_that_changed(monkeypatch):
     expected and four allows for a line being built twice (a cache miss after a
     scroll, say). The stock tree spends 846 per crossing, so this cannot pass
     without the fix.
+
+    **The strip budget alone does not prove the patch path ran**, and saying so
+    here matters more than the assertion: ``set_lines`` reuses the strips of
+    lines that came back byte-identical, so a full ``_repaint()`` also converts
+    about two lines and this budget passes under an always-``_repaint`` mutant.
+    What the budget catches is a body that renders every line again (the
+    virtualize-only shape: 31 conversions per crossing). The patch path itself
+    is asserted below by the call that distinguishes them — a crossing must call
+    ``set_line`` and must NOT call ``set_lines`` — and by
+    ``test_a_hover_crossing_does_not_recompose_the_report``, which counts the
+    renderer.
     """
 
     async def run():
@@ -183,6 +196,10 @@ def test_a_hover_crossing_converts_only_the_lines_that_changed(monkeypatch):
 
             seen: list[tuple[Any, int]] = []
             real = Visual.to_strips
+            body = screen._body
+            sets: list[tuple[str, int]] = []
+            real_set_lines = type(body).set_lines
+            real_set_line = type(body).set_line
 
             def counting(  # type: ignore[no-untyped-def]
                 cls, widget, visual, width, height, style, **kwargs
@@ -190,13 +207,31 @@ def test_a_hover_crossing_converts_only_the_lines_that_changed(monkeypatch):
                 seen.append((widget, height or 0))
                 return real(widget, visual, width, height, style, **kwargs)
 
+            def counting_set_lines(self, *args: Any, **kwargs: Any) -> None:
+                sets.append(("set_lines", len(args[0]) if args else -1))
+                return real_set_lines(self, *args, **kwargs)
+
+            def counting_set_line(self, *args: Any, **kwargs: Any) -> None:
+                sets.append(("set_line", args[0] if args else -1))
+                return real_set_line(self, *args, **kwargs)
+
             monkeypatch.setattr(Visual, "to_strips", classmethod(counting))
+            monkeypatch.setattr(type(body), "set_lines", counting_set_lines)
+            monkeypatch.setattr(type(body), "set_line", counting_set_line)
             await pilot.hover(screen, offset=(_row_x(screen), _row_y(screen, 0)))
             await pilot.pause()
             seen.clear()
+            sets.clear()
 
             await pilot.hover(screen, offset=(_row_x(screen), _row_y(screen, 1)))
             await pilot.pause()
+
+            assert [kind for kind, _ in sets].count(
+                "set_lines"
+            ) == 0, f"the crossing rebuilt the whole body instead of patching rows: {sets}"
+            assert [kind for kind, _ in sets].count(
+                "set_line"
+            ) == 2, f"the crossing did not repaint exactly the two rows involved: {sets}"
 
             body_lines = sum(height for widget, height in seen if widget is screen._body)
             assert body_lines <= 4, (
@@ -338,5 +373,72 @@ def test_entering_and_leaving_the_table_touch_one_row_each(monkeypatch):
             cleared = _styled(_body_lines(screen)[first + 1])
             assert calls == [], "leaving the table recomposed the whole report"
             assert tinted[1] != cleared[1], "the highlight was not cleared from the row"
+
+    asyncio.run(run())
+
+
+def test_a_style_update_drops_the_cached_strips():
+    """A cached strip pins the style it was rendered with, so styles must clear it.
+
+    Two halves, both of which the widget owns: the cache is DROPPED (or the next
+    frame pins the old ramp — a mixed-ramp body the moment anything restyles the
+    app while this screen is up) and the body actually repaints from the new
+    styles (a cache nobody reads from would be no bug at all). ``RichLog`` and
+    ``OptionList`` clear their line caches on the same hook for the same reason.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            _show_table(screen)
+            await pilot.pause()
+            body = screen._body
+            # Render a frame first, so there is a cache to drop.
+            strips = [body.render_line(y) for y in range(4)]
+            assert body._strips, "nothing was cached, so this test would prove nothing"
+            stale = [id(strip) for strip in strips]
+
+            body.notify_style_update()
+            assert not body._strips, "a style update left the stale strips in the cache"
+            await pilot.pause()
+            assert [
+                id(strip) for strip in (body.render_line(y) for y in range(4))
+            ] != stale, "the body repainted the same strip objects after a style update"
+
+    asyncio.run(run())
+
+
+def test_a_live_resize_republishes_the_width_it_composed_for():
+    """What the body claims to be as wide as must survive a live resize.
+
+    ``set_lines`` sizes the content from the lines, the width they were composed
+    for and the content box — and the box is read BEFORE layout settles on a
+    resize, so the pre-resize width would stay published (measured: 101 kept
+    after 120x45 -> 90x40, where a fresh open at 90x40 reports 86). No frame
+    difference was found for it, and it is asserted anyway: a stale published
+    width is a wrong claim about the widget that anything reading
+    ``virtual_size`` — a scroll extent, a later feature — would act on.
+    """
+
+    async def run():
+        async def width_after(size: tuple[int, int], resize: tuple[int, int] | None) -> int:
+            app = _app()
+            async with app.run_test(size=size) as pilot:
+                screen = await _push(pilot, app, _tall_report_agg())
+                _show_table(screen)
+                await pilot.pause()
+                if resize is not None:
+                    await pilot.resize_terminal(*resize)
+                    await pilot.pause()
+                    await pilot.pause()
+                return int(screen._body.virtual_size.width)
+
+        fresh = await width_after((90, 40), None)
+        resized = await width_after((120, 45), (90, 40))
+        assert resized == fresh, (
+            f"a live resize to 90x40 published content width {resized}, "
+            f"where a fresh open at the same size publishes {fresh}"
+        )
 
     asyncio.run(run())

--- a/tests/unit/tui/test_analytics_repaint.py
+++ b/tests/unit/tui/test_analytics_repaint.py
@@ -1,0 +1,342 @@
+"""The ``/analytics`` body repaints a hover change, and how MUCH it repaints.
+
+Separate from ``test_analytics_mouse.py`` (which asks whether the surface
+behaves when driven) because these are not questions about the pointer: they are
+about the WORK a pointer event causes, and they are the guard for the defect the
+whole ``ReportView`` exists to remove.
+
+The defect, measured on the operator's real 156 MB ledger at 120x45: the body was
+one ``Static`` whose height was the whole report, and ``Widget._render_content``
+converts the widget's OWN height to strips on every dirty repaint, so a pointer
+crossing one row re-stripped all 846 body lines / 85,446 cells to change two of
+them — 205 ms mean / 261 ms max of loop-thread CPU per row crossed (and 134-147
+ms per wheel line with the pointer resting). 3.4% of the report was visible.
+
+**So these tests assert the work, not the clock.** A CPU ceiling calibrated on
+this laptop would be a bet on machine load rather than a statement about the
+screen (AGENTS.md "Calibrate ceilings from CI"; the ``test_launch_subagent.py``
+account is the cautionary tale). The invariants below are the ones that hold at
+any speed, and each one is false on the unfixed tree:
+
+* a hover change does not re-enter the renderer (stock: ``build_report`` runs
+  once per crossing);
+* a hover change converts at most a handful of lines to strips (stock: 846 per
+  crossing);
+* the row that IS recomposed is byte-equal to the same row composed by a full
+  rebuild, styling included — the invariant that catches a patch taking its
+  column widths from the row it was handed instead of from the table (see
+  ``_session_row_line``: 24 of 26 patched rows were misaligned that way);
+* the hover adds no CELL to the row it lands on — a highlight that moves text
+  would reflow the table under a moving pointer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from rich.text import Text
+from textual.visual import Visual
+
+from local_operator.analytics.model import UsageAggregate
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets import analytics_panel as ap
+from local_operator.tui.widgets.analytics_panel import AnalyticsScreen, _flatten_blocks
+from tests.unit.tui.test_analytics_mouse import _row_x, _row_y, _show_table
+from tests.unit.tui.test_analytics_panel import _push, _tall_report_agg
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+def _app() -> OperatorApp:
+    return OperatorApp(lambda: _factory(FakeSession()))
+
+
+def _ragged_columns_agg() -> UsageAggregate:
+    """A session table whose rows DISAGREE about their column widths.
+
+    The trap ``test_a_recomposed_row_equals_the_full_rebuild`` exists for cannot
+    be seen in a table whose rows are all the same width: on the operator-shaped
+    fixture the first twelve rows all carry a six-cell cost and a calls count at
+    the four-cell floor, so a patch that measured the single row it was handed
+    would still agree with the full paint and the test would pass while the bug
+    it is named after went unnoticed (verified by mutation: the naive patch
+    survived on that fixture and dies on this one).
+
+    Here the rows differ in every column that is a maximum over the table — a
+    five-cell ``$1.00`` beside a seven-cell ``$123.46``, a one-digit call count
+    beside a six-digit one — so a patch reading its own row's figures produces a
+    row that is not the painted one, and the comparison catches it.
+    """
+
+    def scope(cost_micro: int, calls: int, tokens: int) -> UsageAggregate:
+        return UsageAggregate(
+            calls=calls,
+            ok_calls=calls,
+            input_tokens=tokens,
+            context_tokens=tokens,
+            cost_micro=cost_micro,
+            cost_known_calls=calls,
+        )
+
+    agg = scope(123_456_789 + 1_000_000 + 9_000 + 4, 317_977 + 96 + 7 + 1, 4_200_000_000)
+    agg.by_session = {
+        "aaaa11112222": scope(123_456_789, 317_977, 4_200_000_000),
+        "bbbb22223333": scope(1_000_000, 96, 1_500),
+        "cccc33334444": scope(9_000, 7, 1_500_000),
+        "dddd44445555": scope(4, 1, 900),
+    }
+    return agg
+
+
+def _styled(line: Text) -> tuple[str, tuple[tuple[int, int, str], ...]]:
+    """A row's text AND its styling.
+
+    ``rich.Text.__eq__`` compares the plain text and the base style but NOT the
+    spans, so comparing ``Text`` objects would pass for a row that lost its
+    hover ground, or one whose column styles moved — the two things a patch can
+    plausibly get wrong. Comparing the spans is what makes this a byte-level
+    comparison of the painted row.
+    """
+    return (line.plain, tuple((span.start, span.end, str(span.style)) for span in line.spans))
+
+
+def _full_rows(screen: AnalyticsScreen) -> list[Text]:
+    """What a FULL repaint would paint right now, as one ``Text`` per body line.
+
+    The screen's own renderer, fed the screen's own state — so this is the
+    reference a patch has to agree with, not a second implementation of it.
+    """
+    return _flatten_blocks(screen._report_lines())
+
+
+def _body_lines(screen: AnalyticsScreen) -> list[Text]:
+    """The body widget's own lines: what it will hand the compositor as strips."""
+    return screen._body.lines_for_test()
+
+
+def test_a_hover_crossing_does_not_recompose_the_report(monkeypatch):
+    """A pointer crossing a row must not re-run the report renderer.
+
+    The stock tree re-enters ``build_report`` for every crossing, which is the
+    whole defect: 846 lines recomposed to move a tint two rows. This asserts the
+    renderer is NOT reached, and that the frame still shows the new highlight —
+    a body that skipped the work by not highlighting anything would satisfy the
+    first half alone.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            _show_table(screen)
+            await pilot.pause()
+            assert isinstance(screen._body, ap.ReportView), "the body is not virtualized"
+
+            calls: list[int] = []
+            real = ap.build_report
+
+            def counted(*args: Any, **kwargs: Any) -> list[Text]:
+                calls.append(1)
+                return real(*args, **kwargs)
+
+            monkeypatch.setattr(ap, "build_report", counted)
+            # Land the pointer on row 0 first: the crossing being measured is
+            # the row-to-row one, which is the operator's gesture.
+            await pilot.hover(screen, offset=(_row_x(screen), _row_y(screen, 0)))
+            await pilot.pause()
+            calls.clear()
+
+            await pilot.hover(screen, offset=(_row_x(screen), _row_y(screen, 1)))
+            await pilot.pause()
+
+            assert calls == [], "a hover crossing recomposed the whole report"
+            assert screen._hover_index() == 1, "the fixture did not cross a row"
+            # The new row IS tinted, out of the model the strips are built from.
+            from local_operator.tui import theme as theme_mod
+
+            tint = str(theme_mod.semantic_color("tint-select"))
+            line = _body_lines(screen)[screen._layout.session_first_line + 1]
+            assert tint in [str(span.style) for span in line.spans] or any(
+                tint in str(span.style) for span in line.spans
+            ), f"the crossed-into row painted no hover ground: {line.spans}"
+
+    asyncio.run(run())
+
+
+def test_a_hover_crossing_converts_only_the_lines_that_changed(monkeypatch):
+    """One crossing converts a handful of lines, not the whole report.
+
+    Counted at ``Visual.to_strips`` — the call that IS the cost (measured at
+    1,850 ms of the 3,006 ms a 12-step crossing run spent on the stock tree).
+    The budget is deliberately loose: two rows change, so two conversions are
+    expected and four allows for a line being built twice (a cache miss after a
+    scroll, say). The stock tree spends 846 per crossing, so this cannot pass
+    without the fix.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            _show_table(screen)
+            await pilot.pause()
+
+            seen: list[tuple[Any, int]] = []
+            real = Visual.to_strips
+
+            def counting(  # type: ignore[no-untyped-def]
+                cls, widget, visual, width, height, style, **kwargs
+            ):
+                seen.append((widget, height or 0))
+                return real(widget, visual, width, height, style, **kwargs)
+
+            monkeypatch.setattr(Visual, "to_strips", classmethod(counting))
+            await pilot.hover(screen, offset=(_row_x(screen), _row_y(screen, 0)))
+            await pilot.pause()
+            seen.clear()
+
+            await pilot.hover(screen, offset=(_row_x(screen), _row_y(screen, 1)))
+            await pilot.pause()
+
+            body_lines = sum(height for widget, height in seen if widget is screen._body)
+            assert body_lines <= 4, (
+                f"a hover crossing converted {body_lines} body lines to strips; the "
+                f"report has {len(_body_lines(screen))} lines and only two rows changed"
+            )
+            assert body_lines > 0, "the frame was not repainted at all, so this proves nothing"
+
+    asyncio.run(run())
+
+
+def test_a_recomposed_row_equals_the_full_rebuild(monkeypatch):
+    """A patched row must be byte-equal to the same row from a full recompose.
+
+    THE test for the width trap. The table's ``tokens``/``cost``/``calls``
+    columns are maxima over every row in it, so a patch that measures the row it
+    is composing — rather than reading the columns the table was painted with —
+    gets a narrower column and shifts the row sideways. Measured on the real
+    ledger: 24 of 26 patched rows differed from a full recompose that way, and
+    all 26 matched once the widths came from the layout.
+
+    Every row, compared after each crossing, styling included, because a row
+    that matches in text but not in style is still a wrong row. The fixture is
+    deliberately ragged (see ``_ragged_columns_agg``): on an evenly sized
+    table this test cannot fail even when the trap is planted.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            agg = _ragged_columns_agg()
+            screen = await _push(pilot, app, agg)
+            _show_table(screen)
+            await pilot.pause()
+            first = screen._layout.session_first_line
+            rows = len(screen._layout.session_rows)
+            assert rows >= 4, f"the ragged fixture collapsed to {rows} rows"
+            visited: list[int] = []
+
+            for index in range(rows):
+                await pilot.hover(screen, offset=(_row_x(screen), _row_y(screen, index)))
+                await pilot.pause()
+                assert screen._hover_index() == index, f"the pointer did not land on row {index}"
+                visited.append(index)
+                patched = _body_lines(screen)
+                full = _full_rows(screen)
+                for seen in visited:
+                    assert _styled(patched[first + seen]) == _styled(full[first + seen]), (
+                        f"row {seen} as painted differs from a full recompose — a patch "
+                        f"composed it against the wrong columns"
+                    )
+
+    asyncio.run(run())
+
+
+def test_the_hover_adds_no_cell_to_the_row_it_lands_on():
+    """No reflow on hover, asserted on the PATCHED row rather than a rebuild.
+
+    The highlight is a background span: the row's text and its cell count must be
+    identical hovered and not, or the table shifts under a pointer that is moving
+    across it — the one place a layout shift is least forgivable (three review
+    rounds of #873 pinned this for the full paint; this pins it for the patch,
+    which is now the path that paints every hovered row).
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            _show_table(screen)
+            await pilot.pause()
+            first = screen._layout.session_first_line
+
+            await pilot.hover(screen, offset=(_row_x(screen), _row_y(screen, 2)))
+            await pilot.pause()
+            assert screen._hover_index() == 2, "the fixture did not hover a row"
+
+            hovered = _styled(_body_lines(screen)[first + 2])
+
+            # The same row, composed with no hover at all. Cleared on the screen
+            # and in the widget: the renderer reads the screen's state, and the
+            # widget's own line is the thing being compared, so it has to be
+            # recomposed rather than read back.
+            saved = screen._hover
+            screen._hover = None
+            try:
+                plain = _styled(_full_rows(screen)[first + 2])
+            finally:
+                screen._hover = saved
+
+            assert hovered[0] == plain[0], "the hover changed the row's TEXT"
+            assert len(hovered[0]) == len(plain[0]), "the hover changed the row's cell count"
+            assert hovered[1] != plain[1], (
+                "the hover changed nothing about the row's styling, so it painted no "
+                "highlight at all"
+            )
+
+    asyncio.run(run())
+
+
+def test_entering_and_leaving_the_table_touch_one_row_each(monkeypatch):
+    """The pointer arriving on, or leaving, the table is a one-row change too.
+
+    Both are ordinary gestures (moving up off the table onto the totals, or back
+    down onto it) and both were worth a full 846-line recompose under the
+    obvious "if either row index is missing, rebuild everything" rule: measured
+    at 71 ms to enter the table and 40 ms to leave it, against 2-4 ms to patch
+    the single row whose tint actually changed. This pins that they patch.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(110, 40)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            _show_table(screen)
+            await pilot.pause()
+
+            calls: list[int] = []
+            real = ap.build_report
+
+            def counted(*args: Any, **kwargs: Any) -> list[Text]:
+                calls.append(1)
+                return real(*args, **kwargs)
+
+            monkeypatch.setattr(ap, "build_report", counted)
+            first = screen._layout.session_first_line
+
+            # ENTER: no row was hovered, now row 1 is.
+            await pilot.hover(screen, offset=(_row_x(screen), _row_y(screen, 1)))
+            await pilot.pause()
+            assert screen._hover_index() == 1
+            tinted = _styled(_body_lines(screen)[first + 1])
+            assert calls == [], "entering the table recomposed the whole report"
+
+            # LEAVE: onto the hint line below the card, which is no row at all.
+            await pilot.hover(screen, offset=(_row_x(screen), screen._hint.region.y))
+            await pilot.pause()
+            assert screen._hover is None, "the pointer left the rows and the highlight stayed"
+            cleared = _styled(_body_lines(screen)[first + 1])
+            assert calls == [], "leaving the table recomposed the whole report"
+            assert tinted[1] != cleared[1], "the highlight was not cleared from the row"
+
+    asyncio.run(run())


### PR DESCRIPTION
Release: patch — an interaction-cost fix on an existing surface (no new API, no new UI); it removes ~235 ms of loop-thread CPU per pointer row crossing on a real ledger.

## What and why

**C1 — user-visible defect, reported by the operator:** the TUI crawls while the pointer scans the `/analytics` session table.

Mechanism, read from the source rather than inferred: `Widget._render_content` (`textual/widget.py`) converts the widget's **own height** to strips on every dirty repaint. The body was one `Static` inside a `VerticalScroll`, and its height is the whole report — **846 lines / 85,446 cells** — against a **29-line viewport (3.4%)**. So every pointer row crossing re-stripped the entire report to change two rows' tint.

Measured on a copy of the operator's 156 MB ledger, real `OperatorApp` under the production stylesheet at 120x45, loop-thread CPU:

| | stock | this PR |
|---|---|---|
| one row-crossing pointer move (n=30) | **243.28 ms mean / 244.47 median / 319.83 max** | 7.78–8.55 mean / 6.08–6.56 median / 49–68 max |
| row-to-row, warmed (n=12, `bench_events`) | 238.71 mean | **8.73 mean** |
| same row, x shifting (n=20) | 18.70 mean | 3.76 mean |
| pointer off the table (n=20) | 20.03 mean | 3.87 mean |
| wheel 1 line, pointer resting on a row (n=20) | 173.81 mean / 238.21 max | **9.05 mean / 7.42 median** / 53.38 max |
| body strip conversions per crossing | 846 (`Visual.to_strips` = 1,850 ms of the 3,006 ms a 12-step run spent) | **2** (4.0 ms over the same 12 steps) |
| no-analytics-screen floor, same harness | — | 6.6 mean / 13.6 max |

## The fix

Two halves, both needed (virtualizing alone measures 40 ms per crossing; with row patching it is 4–8 ms):

1. **Virtualize the render.** `ReportView(ScrollView)` (`local_operator/tui/widgets/report_view.py`) owns its `virtual_size` and implements `render_line(y)`, building one `Strip` per line the compositor actually asks for, cached per line. This is the `RichLog`/`OptionList` idiom already used at `session_sidebar.py:463`. It does reach ONE private: `Widget._scroll_update(size)` to publish the content size (`OptionList` does exactly the same at `_option_list.py:838`), and publishing it from the subclass is not optional — `ScrollView._size_updated` discards the layout-computed size and reuses `virtual_size`, so a line-API subclass owns that number and the framework's own documented line-API widgets reach for the same method. Render becomes O(viewport) instead of O(report).
2. **Patch only the rows that changed.** A hover change alters two rows — the one the pointer left and the one it entered — so `_apply_hover` recomposes exactly those and calls `set_line`/`refresh_line` instead of re-entering `build_report`. `_move_cursor` uses the same path, which also removes the per-arrow-key full repaint.

`ReportView` and the screen's `_scroll` are now the same widget, so the hit-test basis (viewport + live `scroll_offset`, not a second widget's lagging `region`) is a single object's geometry.

## The trap that must not be repeated

The table's `tokens`/`cost`/`calls` columns are **maxima over every row**. A patch that recomposes one row against **that row's own figures** gets a narrower column and shifts the row sideways — measured by the architect on the real ledger: 24 of 26 patched rows differed from a full recompose. So `_session_row_line(layout, index, row, …)` takes the **layout**, never a row list: the signature is what keeps the trap out of reach of a future caller. With the widths hoisted, 26 of 26 rows were byte-identical.

That trap is what `test_a_recomposed_row_equals_the_full_rebuild` exists for, and finding it took a second fixture: the operator-shaped fixture's **first twelve rows are all the same width** (six-cell cost, calls at the four-cell floor), so the naive mutation *survived* there and is caught only by a deliberately ragged table. Both facts are recorded in the fixture's docstring.

## Deviations from the design, each with a measurement

1. **`build_report` still returns blocks; the split happens at the widget boundary** (`_flatten_blocks` in `_repaint`). The design said to flatten inside `build_report`. Doing that moved **11** existing tests' premise rather than the one the design predicted: the plain-text tests index a *section* block (`text[start].split("\n")[1:]`), so a flat list empties them. Flattening at the renderer buys the reader nothing; the widget is where line addressing actually starts. Verified both ways.
2. **`_apply_hover` patches `{previous, index}` even when one of them is absent** (design: fall back to a full repaint when either index is missing). Measured: entering the table with the pointer costs **71 ms** and leaving it **40 ms** under the fallback rule, against 2–4 ms patched — and the row to un-tint when no hover is painted is exactly the one `previous` names, so nothing is skipped. Guarded by `test_entering_and_leaving_the_table_touch_one_row_each` (mutation-proven below).
3. **`ReportView` pins `overflow-x: hidden` and sizes its content to `max(composed width, widest line, content region)`; `_make_strip` strips at `max(widget width, line length)`.** Neither is in the design, and without them the frame comparison at **90x40** caught two real differences: a totals row is 77 cells inside a 74-cell box, so stripping it at the widget width wrapped it and the frame **lost its last five cells** where the replaced `width: auto` body cropped them; and `ScrollView`'s inherited `overflow-x: auto` put a horizontal scrollbar on the screen, costing the body a row of height (25 → 24) that the `VerticalScroll` it replaces never cost. Both are invisible at 120x45, which is why the design's frame check passed.

## Testing evidence

New: `tests/unit/tui/test_analytics_repaint.py` — **5 passed**. These assert the WORK, not the clock (no laptop-calibrated CPU ceiling; the structural invariants carry the guard).

| test | on the unfixed tree | mutation |
|---|---|---|
| `…_a_hover_crossing_does_not_recompose_the_report` | `build_report` runs **once per crossing** (measured through the stock surface) | always-`_repaint` mutant → **FAIL** "a hover crossing recomposed the whole report" |
| `…_a_hover_crossing_converts_only_the_lines_that_changed` | **1,692 body lines** converted (2 calls x 846) vs the ≤4 budget | always-`_repaint` mutant → passes, because `set_lines` reuses unchanged strips — the test's teeth are a body that renders every line (option 1 alone: 31), recorded in the docstring |
| `…_a_recomposed_row_equals_the_full_rebuild` | n/a — no per-line body exists to address | per-row-width mutant → **FAIL** "row 1 as painted differs from a full recompose" |
| `…_the_hover_adds_no_cell_to_the_row_it_lands_on` | n/a (same) | drop-the-tint mutant → **FAIL** (no span change) |
| `…_entering_and_leaving_the_table_touch_one_row_each` | n/a (same) | design's fallback mutant → **FAIL** "entering the table recomposed the whole report" |

The tests cannot import on the unfixed tree (there is no per-line model to address), so "fails on the unfixed tree" for the last three is an ImportError rather than a behavioural proof; that is why each has a **mutation proof on the fixed tree** with the observed failure quoted above, and why the first two were also run through the stock surface directly (`prove_stock.py`: `build_report` calls = 1, body lines stripped = 1692).

Existing tests: **one** premise changed, as predicted — `test_a_click_below_the_viewport_is_not_a_row`. The overhang it asserted is gone by construction (body and viewport are one widget), so the premise is re-derived rather than deleted: the coordinate is still outside the viewport, **and** the row arithmetic alone now resolves a real row there, so the viewport guard is the only thing rejecting the click. The guard itself is unchanged and still asserted.

Suites: `test_analytics_panel.py` + `test_analytics_mouse.py` + `test_analytics_repaint.py` = **108 passed** (`-n0`, `env -u NO_COLOR TERM=xterm-256color`).

**Full unit tree: 18162 passed, 18 skipped in 18:23** — with one file excluded, and here is why, because an excluded file is not a pass:

```
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q \
    --ignore=tests/unit/providers/test_oauth_flows.py
```

`tests/unit/providers/test_oauth_flows.py::test_pinned_port_fails_before_browser_when_busy` **wedges** — it starts and never finishes (found with a `pytest_runtest_logstart/logfinish` trace plugin: 18294 of 18295 tests finished, this one in flight for 35+ minutes, and it has no internal timeout — unlike its neighbour `test_port_fallback_when_allowed`, which wraps its drive in `asyncio.wait_for(..., timeout=10)`). It is a loopback-port arbitration test in `local_operator/providers/oauth`, which this diff does not touch.

Settled by the pair, same venv, `-n0`, hard `timeout 300`, nothing else of mine running:

| tree | command | result |
|---|---|---|
| this branch | `timeout 300 … pytest 'tests/unit/providers/test_oauth_flows.py::test_pinned_port_fails_before_browser_when_busy' -n0` | **rc=124 (hangs)** |
| base `05784120f` (throwaway worktree) | same command, `PYTHONPATH` at the base tree | **rc=124 (hangs)** |

A `faulthandler` dump of the base-ref run shows the coroutine parked in the event loop's `select()` under `flow.run()` — the awaited call simply never returns. **Conclusion: environmental/pre-existing, not this change.** CI's own `test` shards ran that file green on this head (see below), which is the same conclusion from the other side. Several peer sessions were running this same suite on this host at the time (one with `-p lopdiag` in `/private/tmp/lo-qa-s4-suites`, another in `lo-edit-suggestions`), which is what a port-bound test collides with; it is reported here rather than papered over with an exclusion inside the repo.

Gates, run the way CI runs them: `flake8 .` clean; `uvx --from black==26.1.0 black --check .` clean (1222 files unchanged); `uvx isort==5.13.2 --check .` clean; `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` **0 errors, 0 warnings, 0 informations**. `tests/e2e -m e2e -n0 -q`: **107 passed, 7 skipped in 3:11** (no watchdog trip).

### Performance, measured on the real-ledger copy

```sh
cd /private/tmp/lo-ana-hover \
  && env HOME=/private/tmp/ana-bench/home LOCAL_OPERATOR_CONFIG_DIR=/private/tmp/ana-bench/cfg \
         TERM=xterm-256color .venv/bin/python /private/tmp/ana-bench/bench_hover.py
```

The bar this work was given is **≤15 ms mean and ≤25 ms max per row-crossing move** (stock 243/320 here; 205/261 when the defect was first measured on a quieter host) and **≤25 ms per wheel line** (stock 174).

- **Mean: cleared, twice over — 6.4 ms (median 4.7) after round 1, 7.8–8.6 ms before it.** The
  selection work costs nothing while nothing is selected: the hooks only run when a drag exists.
- **Wheel with the pointer resting: 7.5 ms mean / 4.9 median per line** (9.1/7.4 before round 1),
  against a bar of ≤25 ms.
- **A drag with the button held** (the gesture round 1 restored, so it needed its own number — a
  selection change drops the visible lines' strips): **4.28 ms mean / 3.31 median / 12.85 max per
  move** after the round-2 paint fix (5.75 before it), against **274.4 ms mean / 323.6 max on the
  base** (`bench_drag.py`, same protocol).
  Restoring the affordance did not restore the freeze that made it unusable.
- **Max: NOT cleared in a single run** (34–38 ms after round 1; 49–68 ms before it; wheel 34.2 ms).
  Reported rather than massaged, and **independently reproduced and attributed by QA and the
  reviewer, both of whom measured the same band and the same cause**: per-crossing instrumentation
  (`probe_crossings.py`) shows `_repaint 0`, `build_report 0` and **≤2 body strip conversions on
  every crossing**, and with `gc.disable()` the loop's max falls to **8.6–14.8 ms** at an unchanged
  mean. The residual spike is an interpreter GC pause on the loop thread, not repaint work; the
  no-analytics-screen control (`bench_control.py`) measures 6.6 mean / 13.6 max on the same host.
  QA and the reviewer both judged this **not a blocker and no code change argued** (the stock path
  allocates far more per crossing, so it pays more GC), and the disclosure stays here rather than
  being smoothed over. The GC is deliberately not touched.

**CI on `73a7f2025` (the reviewed head) is green**: lint, type-check, test shards 0-4, tui-e2e (macos-latest + ubuntu-latest), filesystem-boundaries-windows, pip-audit, context-budget, version-bump-guard.

## Visual evidence

Frames captured with `scripts.visual_capture.save_capture` on the real `OperatorApp` + production stylesheet, driving the real ledger, at **120x45, 90x40 and 200x45**, in two states (session table scrolled in with three rows hovered and the caret set; and the top of the report). BEFORE frames come from a throwaway worktree at the pre-fix ref (`git worktree add --detach /private/tmp/lo-ana-before 05784120f`), never from the shared checkout.

Rendered with `rsvg-convert` and **looked at** (not just saved): the table, the hover tint on the row under the pointer, the caret on a different row, the `% cache` column shed at 90 columns, and the scrollbar chrome all as before.

**Paint equality with stock**, same state both trees:

- 120x45 (table hovered) — SVG byte-identical (93,654 bytes), PNG byte-identical
- 90x40 (table hovered) — byte-identical
- 90x40 (top of report) — byte-identical
- 200x45 (top of report) — byte-identical
- 120x45 (top of report) — differs only by one **zero-width** rect (a segment-splitting artefact; a rect of width 0 paints nothing)
- 200x45 (table hovered) — differs only in how adjacent same-fill rects are split at one column

For the last two, `frame_diff.py` rasterises every rect onto the cell grid and compares the painted field plus the text rows with their foreground classes: **identical**. Geometry agrees too (`view.size`, `scrollable_content_region`, `virtual_size`, `max_scroll_y`, scrollbar flags) — e.g. 90x40 is `box 75x25, content 74x25, virtual 86x846, max_scroll_y 821, h=False` on both trees.

Frame files (evidence, not committed): `/private/tmp/ana-bench-coder/{before,after}-{120x45,90x40,200x45}-{table,top}.{svg,png}`.

**After the round-1 fixes, re-verified**: the same six pairs were re-captured and re-compared — three
byte-identical, three paint-identical at cell level — so the selection and cache work moved no pixel.
The drag-selected state is its own pair: `{before,after}-selection.{svg,png}`, **byte-identical**,
captured by performing the same drag on both trees (the base `Static` body paints the selection, the
`ReportView` now paints the same one) and rendering the "before" by driving the pre-fix ref — and that
holds for a **wide-glyph** label too (`{before,after}w-wide-selection.svg`, byte-identical), which
round 2 (UX's U3) correctly showed was NOT true before the round-2 fix: the band then painted a
cell-window and the copy a character-window. Both sides now use the character span.

**Not a pixel moved by the round-2 fixes either**: the six `{120x45,90x40,200x45}-{table,top}` pairs
re-captured byte/paint-identical, and the four selection states the designer measured for the band
regression re-measured against their own control frames — the band is back to the base's cell count and
row run in every one (numbers in the round-2 remediation section).

## Round-1 review remediation (`1965c569f`)

> Head note: the round's fixes landed as `d29c37463`, amended to `3153ee36f`, then to `1965c569f` — the last two amendments are a docstring rewording and a `black` reformat of the new test file, with no behaviour change. CI `lint` on `3153ee36f` is what caught the second one (my local `black --check` had run before the test was appended); the full lint set is green locally on `1965c569f`.

Four streams reviewed `73a7f2025`: reviewer (0 blocker / 0 major), QA (0 FAIL of 36 rows), design
(terminal, 0 blocker / 0 major), UX (**1 MAJOR** — one round, answered). The MAJOR, and what changed:

- **U1 (MAJOR) — drag-select and ctrl+c were dead on the new body.** On the base a drag across three
  rows paints a selection and ctrl+c copies them; on `73a7f2025` the drag registered a selection on
  `ReportView`, painted nothing, and `Screen.get_selected_text()` returned `''`. Both halves of the
  `Log` idiom were missing — `get_selection`/`selection_updated` (a line-API widget returns no
  `Text`/`Content` from `_render()`, so `Widget.get_selection` extracts nothing) **and**
  `Strip.apply_offsets` in `render_line`, without which the compositor cannot recover the pointer's
  content offset and the drag resolves a start with no end ("select to the end of everything" — which
  is why the symptom was a whole-report selection rather than an empty one). The highlighted span is
  converted from cells to characters, because the offsets arrive by terminal column and this table's
  labels are free text. Asserted by `test_a_drag_across_the_rows_selects_them_and_copies_them` (fails
  on `73a7f2025`: *"the drag selected nothing"*).
- **R-1** — `notify_style_update` drops the strip cache (`test_a_style_update_drops_the_cached_strips`;
  fails on `73a7f2025`).
- **U2** — `on_resize` republishes `virtual_size`, because `set_lines` reads the content box before
  layout settles on a resize and left the pre-resize width published (101 after a live 120x45 →
  90x40). Small and self-contained, so it is fixed and tested
  (`test_a_live_resize_republishes_the_width_it_composed_for`; fails on `73a7f2025`).
- **R-3** — the strip-budget test now asserts the patch path itself (`set_line` called, `set_lines`
  not). Its budget alone passed under an always-`_repaint` mutant, because `set_lines` reuses the
  strips of byte-identical lines; the docstring now says what the budget does and does not prove.
  Re-verified: under that mutant it now fails with *"the crossing rebuilt the whole body instead of
  patching rows"*.
- **R-2 / R-4 / R-5** — the two comments still describing a `Static` body in a `VerticalScroll`, and
  `_styled`'s backwards claim about rich's `Text.__eq__`, are corrected; the "without touching Textual
  privates" claim above is replaced with what the widget actually reaches for.
- **Deferred, with the evidence, not fixed here:** **Q2** (`_card_width()` drifts 2 cells from the
  paintable box at 50 and ≥157 columns; byte-identical to the base, frames pixel-identical at both
  extremes) — `deferred — pre-existing, unrelated to this change`. **D1** (the hover tint pair is
  ~1.16:1 on this card's ground, below a 3:1 state-indicator bar; pre-existing, and changing it would
  move the very frames this PR proves unchanged) — `deferred — pre-existing, needs its own
  design-driven change`. **Q1** (the max clause) is accepted with the disclosure above, no code
  change. **D2/D3/Q3** are deliberate / pre-existing / rasterisation-only, acknowledged in the
  round-1 remediation comments.

## Round-2 review remediation (`06256ebac`)

Round 2 reviewed `1965c569f`. Reviewer: R-6 MAJOR + R-7/R-8 MINOR + R-9/R-10 NIT. QA: Q3 FAIL
(the same defect as R-6, independently reproduced on a CJK label) + Q4 recorded. Designer: D1 MAJOR.
UX: terminal, one NIT (U3) bounding a claim this body made. All of it is in the selection paint this PR
added, and all of it is fixed in one commit.

- **R-6 / Q3 (MAJOR, one defect, found twice) — the band and the clipboard disagreed.** `_cell_to_char`
  read the selection offsets as CELL columns and converted them a second time; they are CHARACTER
  offsets end to end (`Strip.apply_offsets` advances by `len(segment.text)`, the compositor counts
  characters into the segment the pointer landed on, `Selection.extract` — i.e. what ctrl+c uses —
  slices the plain string with the same numbers). The conversion is the identity for 1-cell text, which
  is every row of the operator's real ledger and of every fixture in this PR, which is exactly why it
  hid. **Fix: the conversion is deleted; the span is used raw, as `Log._render_line_strip` does.**
  QA's own repro (`/private/tmp/qa956r2-h/repro_wide_mismatch.py`, run with `NO_COLOR` unset — with it
  set the app paints a monochrome ramp and the script's extraction finds no band at all) now prints
  `paint==copy: True` for the ASCII control **and** the CJK row (`PAINTED == COPIED == 'セッション番号'`).
- **D1 (MAJOR) — a selection starting on body line 0 banded every body line.** `Visual.to_strips`
  re-resolves the selection against the visual it is handed, and this widget hands it ONE line, so every
  strip read body line 0's span. `/analytics` opens at line 0 and an upward drag normalises to start
  there, so the gesture is the first one available. **Fix: the per-line visual is told
  `apply_selection=False`; the span is applied by the only code that knows the line index.** Re-measured
  with the designer's own frames and `cells.py` (selection cells / rows against the matching control
  frame, my new frames prefixed `after2-`):

  | frame | base | `1965c569f` | fixed |
  |---|---|---|---|
  | ledger 120x45 `sel_top` | 214 / 4 rows | 1394 / 28 rows | **214 / 4** |
  | ledger 120x45 `sel_toplong` | 1074 / 20 | 1426 / 28 | **1074 / 20** |
  | ledger 90x40 `sel_top` | 211 / 4 | 1215 / 24 | **211 / 4** |
  | ledger 200x45 `sel_top` | 214 / 4 | 1394 / 28 | **214 / 4** |
  | row-less 120x45 `sel_top` | 184 / 4 | 1350 / 28 | **184 / 4** |

- **U3 (NIT) — the "byte-identical selection frame" claim held only for 1-cell text.** It now holds for
  wide glyphs too: the same drag over CJK-labelled rows produces a frame **byte-identical** to the base
  tree's (`{before,after}w-wide-selection.svg`), and per-row `paint == copy` on both trees. The claim
  above is scoped to what is measured rather than to what was hoped for.
- **R-7** — the comments named `RichLog` for hooks it does not have; they now name `Log` (which has all
  three: `get_selection`, `selection_updated`, `apply_offsets`), and `RichLog` only where it really does
  clear its line cache on `notify_style_update`.
- **R-8** — the tcss header said `/usage`'s body is a `Static` in a `VerticalScroll`; it is
  `UsagePanel` (itself a `Static`) scrolling in a plain container with a hand-painted bar. Corrected.
- **R-9** — the dead `rows` assignment in the drag test is gone.
- **R-10** — `apply_offsets`' docstring now records that its x is `scroll_offset.x` only because the
  strip is served uncropped and `overflow-x` is pinned, so enabling that axis would silently shift every
  offset; `Log` crops-then-stamps and this would have to as well.
- **Two tests added, both proven red on `1965c569f`**: a wide-glyph label whose band text must equal the
  copied text (`the band highlights '本語セッション +1 subagen' while ctrl+c copies '語セッション +1
  subagent    40.'`), and a selection from body line 0 that must band only its own rows (`banded rows
  outside it: [12, 13, 14, …36]`). Both use a paint-vs-copy comparison rather than a fixture equality,
  because a fixture that agrees in every attribute cannot see this class of defect.
- **Found while writing them, and fixed:** the drag test's `_drag_to` helper passed `0,0` as the pointer
  position. The compositor resolves the selection's end offset by hit-testing that position, so the drag
  silently selected **to the end of the whole report** and every assertion in the round-1 test still
  passed. The helper now sends the real position, and that test additionally asserts the copy spans no
  more lines than the drag covered.
- **Q2/D2/D3** stay deferred (pre-existing, out of scope, with their evidence in the round-1/round-2
  threads); **Q4** (a drag that ends below the body now selects into the hint) is Textual's ordinary
  cross-widget selection and is accepted as recorded, no action.

## Not in this PR

- **`session_panel.py` and `info_panel.py` are NOT converted.** They have the same `Static`-in-`VerticalScroll` shape and **no hover** (`grep on_mouse_move` → nothing), so they repaint once per key/resize, not per mouse event; the defect is analytics-specific. `ReportView` lives in `widgets/report_view.py` so their conversion is a mechanical ~3-line change each, and the CSS rule they depend on is untouched (the analytics `color: $lo-fg` was moved to its own `#analytics-scroll` rule rather than into the shared selector list, so no sibling style moved).
- No version bump (`pyproject.toml` stays at the last released version).
- No GitHub issues created; the deferred findings (Q2, D1) are recorded in the thread with the reason and the evidence, per the standing rule.
- Not touched: the cursor/wheel split, the hint ladder, the rollup arithmetic, `render_lines_for_test`, and `_card_width`'s arithmetic (its docstring records that the gutter now belongs to the view).

## How to review / run it

```sh
cd <worktree>
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui/test_analytics_panel.py \
    tests/unit/tui/test_analytics_mouse.py tests/unit/tui/test_analytics_repaint.py -q -n0
```

Then open `/analytics` (`/analytics` in the TUI), `pagedown` to the session table and move the pointer down the rows: the frame should follow the pointer without the stall, `enter` should still expand the row under the caret, and the wheel with the pointer resting on a row should move the viewport without a pause.


