### PR TITLE
chore(release): bump version to 0.54.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.11"
+version = "0.54.12"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release lock for the post-v0.54.11 window. `pyproject.toml` only, one line.

## Window

Re-derived from `origin/main` at `142dc72ee`. Plain `git log v0.54.11..origin/main` (never `--merges`):

| PR | Merge SHA | Impact |
|---|---|---|
| [#946](https://github.com/damianvtran/local-operator/pull/946) | `0d6cde1f0` | `feat(evaluation)`: score agent-stop for decision exhaustion and unanswered asks. |
| [#950](https://github.com/damianvtran/local-operator/pull/950) | `47655cf60` | `ci(tests)`: regenerate the shard duration manifest from a full measured run. |
| [#954](https://github.com/damianvtran/local-operator/pull/954) | `bac601934` | `test(providers)`: release the port-squatter double's connections, which hung CI. |
| [#953](https://github.com/damianvtran/local-operator/pull/953) | `e8e977a24` | `fix(tui)`: apply the subagent page's Home offset at press time. |
| [#951](https://github.com/damianvtran/local-operator/pull/951) | `142dc72ee` | `ci(tests)`: name the test a shard stalls on instead of losing it to the cap. |

## Bump class

**PATCH → 0.54.12.** One user-visible bug fix (#953, subagent Home offset) plus evaluation-scoring, CI and test-only changes; no API addition, no migration. Does not clear the step-function bar for minor.

## Scope

This PR is one file, one line. C0.
