### PR TITLE
fix(secrets): register the runtime, not the viewer, as the broker session

### DIFF
--- a/docs/design/secret-store.md
+++ b/docs/design/secret-store.md
@@ -568,7 +568,10 @@ has authenticated to session `S`, it notifies `S` over the same socket
 (`retrieved: {id, value}` on the session's own registration connection). The
 session registers the value with its redactor **before** the child's output can
 be read, because the broker's reply to the child and the notification to the
-session are both written before the child can print anything. The existing
+session are both written before the child can print anything. **`S` is the
+process that OWNS the filter, which in the attached architecture is the session
+runtime rather than the terminal a human is looking at** — see §13's amendment
+on registrants for the defect that distinction caused. The existing
 `_PipeRedactor` (`builtin.py:1298`) then scrubs the stream bytes, including a
 secret split across two reads, which it already handles.
 
@@ -1104,10 +1107,26 @@ lifeline — it is consulted per retrieval. So:
 >   audited and cost a geometric backoff (0.25 s → 8 s), since this verb is now
 >   reachable without lineage and scrypt's ~180 ms alone is a thin defence
 >   against an online oracle.
-> - **Interactive sessions register themselves** (`local_operator/secrets/
->   session.py`, wired into `run_tui`). Without this, authenticating `register`
->   would have converted the bypass into a permanent lockout. Closing the
->   channel deregisters, which is what revokes descendants promptly.
+> - **Sessions register themselves** (`local_operator/secrets/
+>   session.py`). Without this, authenticating `register` would have converted
+>   the bypass into a permanent lockout. Closing the channel deregisters, which
+>   is what revokes descendants promptly.
+>
+>   **Amended (runtime registration): the REGISTRANT is the process that owns
+>   the `VariableStore`, which is not always the terminal.** The original wiring
+>   registered inside `run_tui`, which was correct while the TUI process ran an
+>   in-process `Session`. Once the attached facade landed (#937) an interactive
+>   TUI held only an `AttachedSession` view over a separate runtime process, so
+>   its sink had no store to scrub through, every notice went unacked, and the
+>   fail-closed rule below denied EVERY descendant retrieval in EVERY attached
+>   session. The runtime now registers from its own handle
+>   (`ServingSessionHandle`, `session/runtime/serving.py`), the single seam
+>   behind both `spawn_owned_session` (phone and TUI runtime spawn) and `lop
+>   exec --control`, and deregisters on the handle's disposal and on the exec
+>   control surface's own teardown. `run_tui` keeps its registration for the
+>   case it is actually right for — a TUI that OWNS the session, where the
+>   store really is in that process. A registration is also skipped when no
+>   store exists yet, since there is nothing a descendant could be served.
 > - **Unlocking grants the operator's terminal standing for this boot.** `lop
 >   secret get` typed at a prompt has no lop session among its ancestors and is
 >   denied by construction — in `keyfile` mode the key-file fallback hides

--- a/docs/design/secret-store.md
+++ b/docs/design/secret-store.md
@@ -1120,13 +1120,41 @@ lifeline — it is consulted per retrieval. So:
 >   its sink had no store to scrub through, every notice went unacked, and the
 >   fail-closed rule below denied EVERY descendant retrieval in EVERY attached
 >   session. The runtime now registers from its own handle
->   (`ServingSessionHandle`, `session/runtime/serving.py`), the single seam
->   behind both `spawn_owned_session` (phone and TUI runtime spawn) and `lop
+>   (`ServingSessionHandle`, `session/runtime/serving.py`), the seam behind
+>   both `spawn_owned_session` (phone and TUI runtime spawn) and `lop
 >   exec --control`, and deregisters on the handle's disposal and on the exec
 >   control surface's own teardown. `run_tui` keeps its registration for the
 >   case it is actually right for — a TUI that OWNS the session, where the
->   store really is in that process. A registration is also skipped when no
->   store exists yet, since there is nothing a descendant could be served.
+>   store really is in that process — and, for an ATTACHED TUI, its sink now
+>   FORWARDS the notice to the runtime over the control channel
+>   (`register_secret_redaction`) instead of failing, so the viewer's entry is
+>   the broker's working fallback when the runtime registered nothing. A
+>   registration is also skipped when no store exists yet, since there is
+>   nothing a descendant could be served.
+>
+>   **Amended (the hardened-tier lineage limit on that seam, review round 1
+>   MAJOR-2).** The handle is the seam for a runtime that HAS lineage — one
+>   that descends from the terminal that unlocked the store, or from an
+>   already-registered session. It is NOT the seam for a daemon-spawned
+>   runtime: in the **hardened tier** a runtime started by launchd (ppid 1,
+>   which is how a wake or a phone-triggered runtime with no viewer in its
+>   ancestry runs) has no granted terminal and no registered ancestor, so
+>   `_handle_register` refuses it (`broker.py`, "registering a session also
+>   requires descending from an unlocked terminal or a registered session").
+>   Nothing registers, the runtime's descendants are denied
+>   (`no lop session is registered with the broker`), and — because
+>   `access.retrieve_secret` degrades to the local decrypt on that refusal in
+>   the keyfile tier — the failure is only visible there as a denied
+>   `lop secret get`, not as a served value. This is NOT a regression (a phone
+>   session registered nothing before either) and it is **not a hole in the
+>   keyfile tier**, where the ticket alone admits a registrant; it is a limit
+>   of the hardened tier that needs a lineage story for the daemon, not a
+>   weaker register gate. The shape that would work is an `unlock` grant for
+>   the daemon's SUPERVISOR (the process launchd owns), so a runtime it spawns
+>   descends from a granted terminal like any other — recorded as DEFERRED on
+>   the PR rather than half-built here. The refusal is at least no longer
+>   silent: `client.register_session` logs a WARNING naming the tier and the
+>   broker's reason.
 > - **Unlocking grants the operator's terminal standing for this boot.** `lop
 >   secret get` typed at a prompt has no lop session among its ancestors and is
 >   denied by construction — in `keyfile` mode the key-file fallback hides

--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -58,6 +58,15 @@ from local_operator.session.runtime.types import DESKTOP_WATCH_CAPABILITY
 #: surfaces as an error rather than a hang.
 ACK_TIMEOUT_S = 15.0
 
+#: The whole viewer-side budget for one §6 redaction forward (viewer → owner,
+#: ``register_secret_redaction``). Sized well under the broker's
+#: ``NOTIFY_ACK_TIMEOUT_S`` (2 s) on purpose: the broker denies the child when
+#: the session does not acknowledge in time, so a hop that stalls must give up
+#: and fail closed BEFORE that deadline rather than eating it and turning the
+#: denial into an ambiguous timeout. The TUI's notice thread bounds its wait on
+#: this same constant, so both sides of the hop share one budget.
+REDACTION_FORWARD_TIMEOUT_S = 1.0
+
 #: How long to wait for ``complete_aside`` — a full provider round trip, not a
 #: control-plane op. Matched to ``providers/clients.py`` ``STREAM_READ_TIMEOUT_S
 #: = 180.0``, the layer below's own budget for silence from a stream in flight:
@@ -1364,6 +1373,29 @@ class AttachClient:
         carefully — nothing echoes, logs, or transcribes this field.
         """
         return await self._request_payload("credential", action=action, key=key, value=value)
+
+    async def register_secret_redaction(self, value: str) -> None:
+        """Ask the owner to register ONE §6 value with its own redactor.
+
+        This is the attached viewer's half of §6: the broker's notice reaches
+        the nearest REGISTERED session above the retrieving child, which is
+        normally the runtime itself (``ServingSessionHandle``) — but not when
+        the runtime registered nothing (it booted before a store existed at its
+        config root, §13). There the viewer's own registration is the one that
+        answers, and the ``VariableStore`` the value must reach is the owner's,
+        not this process's — so the value is forwarded over the same
+        viewer→runtime control route ``credential`` already rides, in its own
+        named field with a single consumer. It is deliberately NOT a
+        ``/credential`` verb: the owner registers a redaction, it does not
+        store a credential, and the op must stay out of that verb table.
+
+        ``value`` never appears in any log, journal, announcement, audit row
+        or event stream on either side of the wire; the owner's handler writes
+        it only into its ``VariableStore`` redaction set.
+        """
+        await self._request_payload(
+            "register_secret_redaction", value=value, deadline_s=REDACTION_FORWARD_TIMEOUT_S
+        )
 
     async def adopt_aside(self, messages: list[dict[str, Any]]) -> str:
         """Fork an aside exchange into the conversation on the authoritative owner."""

--- a/local_operator/mobile/types.py
+++ b/local_operator/mobile/types.py
@@ -216,6 +216,13 @@ def validate_control_frame(frame: dict[str, Any]) -> None:
             raise ValueError("key must be a string")
         if not isinstance(frame.get("value", ""), str):
             raise ValueError("value must be a string")
+    elif op == "register_secret_redaction":
+        # The other op that carries a secret's value, and it carries ONLY that:
+        # the value has one named home and one consumer (the owner's redactor).
+        # Typed so a non-string is refused rather than coerced to its repr and
+        # registered as a redaction that would never match the real secret.
+        if not isinstance(frame.get("value"), str):
+            raise ValueError("value must be a string")
     elif op == "adopt_aside":
         messages = frame.get("messages")
         if not isinstance(messages, list) or not all(isinstance(item, dict) for item in messages):

--- a/local_operator/secrets/client.py
+++ b/local_operator/secrets/client.py
@@ -28,6 +28,7 @@ error in ``passphrase`` mode, never to a plausible wrong answer (§13).
 from __future__ import annotations
 
 import fcntl
+import logging
 import os
 import socket
 import subprocess
@@ -53,6 +54,8 @@ from local_operator.secrets.protocol import (
     send_frame,
     socket_path,
 )
+
+logger = logging.getLogger(__name__)
 
 #: Hard ceiling on reaching the broker. §13 requires a retrieval attempted
 #: while the broker is down to return a clear error and NEVER to hang.
@@ -367,6 +370,29 @@ def register_session(
         connection.close()
         return None
     if not reply.get("ok"):
+        # **A refusal is not the same as "no store this boot", and it used to be
+        # invisible (review round 1, MAJOR-2).** In the hardened tier the broker
+        # refuses a registrant with no lineage — the shape a daemon-spawned
+        # (launchd, ppid 1) runtime has, §13 — and returning ``None`` without a
+        # line made that limit unreportable at every level: the callers' own
+        # ``except`` branches never fire because nothing is raised. Name the
+        # tier and the broker's own reason once, here, where every caller — the
+        # runtime handle and ``register_variable_store_session`` alike — passes
+        # through. The reason names the tier for the hardened case; ``key_mode``
+        # is the local corroboration, read defensively so logging can never
+        # raise out of the registration path.
+        from local_operator.secrets.keys import key_mode
+
+        try:
+            tier = key_mode(base)
+        except Exception:  # noqa: BLE001 — a log line must not break registration
+            tier = "unknown"
+        logger.warning(
+            "the %s-tier secret broker refused to register this session (%s): %s",
+            tier,
+            reply.get("code", "unknown"),
+            reply.get("error", "no reason given"),
+        )
         connection.close()
         return None
     # No timeout on the channel afterwards: it is long-lived and mostly idle,

--- a/local_operator/secrets/session.py
+++ b/local_operator/secrets/session.py
@@ -94,8 +94,24 @@ class SessionRegistration:
                 return
 
     def close(self) -> None:
-        """Deregister this session and stop answering notices."""
+        """Deregister this session and stop answering notices.
+
+        **``shutdown`` before ``close``, and that ordering is the whole of this
+        method's correctness.** The reader thread is parked in ``recv`` on this
+        socket, and ``close()`` alone does not send the peer its EOF while that
+        read holds the file description — measured on CI (Linux): the broker's
+        session table still held the pid for the whole 5 s the new guards polled
+        for, twice, while the same code deregistered in under a second on
+        macOS, whose ``close`` does revoke the descriptor. ``shutdown`` acts on
+        the socket rather than the descriptor, so it both makes the broker's
+        liveness peek see ``b""`` immediately and wakes the parked read; the
+        ``close`` afterwards only releases the descriptor.
+        """
         self._stopping.set()
+        try:
+            self._channel.shutdown(socket.SHUT_RDWR)
+        except OSError:  # pragma: no cover - already gone
+            pass
         try:
             self._channel.close()
         except OSError:  # pragma: no cover - already gone

--- a/local_operator/secrets/session.py
+++ b/local_operator/secrets/session.py
@@ -33,7 +33,7 @@ import logging
 import socket
 import threading
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 
 logger = logging.getLogger(__name__)
 
@@ -126,3 +126,50 @@ def register_session(
     if channel is None:
         return None
     return SessionRegistration(channel, on_secret)
+
+
+def register_variable_store_session(
+    session: Any,
+    *,
+    session_id: str | None = None,
+    base: Path | None = None,
+) -> SessionRegistration | None:
+    """Register the process that HOLDS ``session``'s ``VariableStore`` (§6).
+
+    **Why the store's process and not the front end a human is typing into.**
+    The §6 notice asks the notified session to add a child's
+    ``$(lop secret get X)`` value to the filter that scrubs its own streamed
+    output, and to the value set the bash/eval redactors re-read per chunk.
+    Both live in the ``VariableStore`` of the process that RUNS the session
+    (``Session.variables``). In the attached architecture that process is the
+    session runtime, and the TUI holds only an ``AttachedSession`` facade —
+    which has no store at all — so a registration made by the viewer could
+    only refuse, and the broker (correctly) denied the descendant. Registering
+    from the runtime's handle is what makes the notice land on the process that
+    can actually honour it.
+
+    The sink resolves the store per notice rather than capturing it, and RAISES
+    when there is none: ``SessionRegistration._read_loop`` deliberately does not
+    ack a failed redaction, so the broker fails closed and denies the child
+    instead of serving a value nothing can scrub. That is the required
+    direction — do not soften it into a log-and-continue.
+
+    ``None`` on the same terms as :func:`register_session` — no broker, no
+    readable ticket, refused — plus one more: a runtime that boots before a
+    secret store exists has nothing any descendant could retrieve, and skipping
+    the registration there keeps a session that never touches the store from
+    starting a broker daemon of its own. A store created later is picked up on
+    the next session boot.
+    """
+    from local_operator.secrets.keys import store_path
+
+    if not store_path(base).is_file():
+        return None
+
+    def on_secret(_name: str, value: bytes) -> None:
+        store = getattr(session, "variables", None)
+        if store is None:
+            raise RuntimeError("the session has no variable store to redact through")
+        store.register_redaction(value.decode("utf-8", errors="replace"))
+
+    return register_session(on_secret, session_id=session_id, base=base)

--- a/local_operator/secrets/session.py
+++ b/local_operator/secrets/session.py
@@ -131,6 +131,12 @@ def register_session(
     started, the registration ticket is unreadable, the broker refused — and is
     never an error the caller has to handle: a session boots and runs normally
     without a secret store.
+
+    **A REFUSAL is logged before returning ``None`` (review round 1, MAJOR-2).**
+    "Nothing to register" and "the broker said no" both end here, but only the
+    second is a limit the operator should be able to see: in the hardened tier
+    a registrant with no lineage — a daemon-spawned runtime, §13 — is refused,
+    and that refusal used to be silent at every level because nothing raised.
     """
     try:
         from local_operator.secrets import client
@@ -176,6 +182,24 @@ def register_variable_store_session(
     the registration there keeps a session that never touches the store from
     starting a broker daemon of its own. A store created later is picked up on
     the next session boot.
+
+    **The base is the caller's, on purpose (MINOR-3, NIT-2).** ``base`` is the
+    root this session was built from, passed by the caller
+    (``ServingSessionHandle``), never re-read from ``config_dir()`` here: the
+    store-existence check below and the registration itself must agree about
+    WHICH store this session owns, or a handle rooted at a different store
+    could check one and register against another.
+
+    **A session with no ``variables`` still registers, and that is not an
+    oversight (NIT-2).** Skipping it would leave a descendant with no
+    registered ancestor at all, and the broker's ancestry refusal is not the end
+    of that path: ``access.retrieve_secret`` catches ``BrokerDenied`` and, in
+    the keyfile tier, falls through to an UNNOTIFIED local decrypt, so the
+    child is SERVED the value with nothing registered to scrub it — the exact
+    §6 leak. Registering anyway keeps the broker's fail-closed denial, and the
+    sink raises per notice so the child is denied rather than served raw. That
+    deny path is pinned by
+    ``tests/unit/secrets/test_runtime_session_registration.py``.
     """
     from local_operator.secrets.keys import store_path
 

--- a/local_operator/session/attached.py
+++ b/local_operator/session/attached.py
@@ -5542,6 +5542,30 @@ class AttachedSession:
             return {"ok": False, "reason": "disconnected"}
         return answer if isinstance(answer, dict) else {"ok": False, "reason": "unavailable"}
 
+    async def register_secret_redaction(self, value: str) -> None:
+        """Hand one §6 value to the owner so IT registers it for redaction.
+
+        The viewer's registration is the broker's fallback for a runtime that
+        registered nothing (``ServingSessionHandle`` skips its own registration
+        when no store existed at its boot, §13). The ``VariableStore`` the notice
+        must reach lives in the owner's process — the one whose bash and eval
+        redactors read it — so this is a forward, not a local write.
+
+        It RAISES rather than reporting an "unavailable" result when the owner
+        cannot be reached, REFUSES, or does not answer inside the forward budget:
+        the caller is a §6 sink, and a sink that cannot register the value must
+        not acknowledge, so the broker fails closed and denies the child instead
+        of serving a value nothing can scrub. A silent success here would BE that
+        leak. The value is never logged, journalled, announced or streamed on
+        either side; this method only carries it.
+        """
+        client = self._client
+        if client is None or self._recovering or not client.connected:
+            raise ConnectionError(
+                "the runtime is not attached, so it cannot register this redaction"
+            )
+        await client.register_secret_redaction(value)
+
     def cancel_subagents(self, reason: str = "interrupted") -> int:
         """Optimistic cancel: returns the running count the offer promised.
 

--- a/local_operator/session/runtime/exec_control.py
+++ b/local_operator/session/runtime/exec_control.py
@@ -134,6 +134,16 @@ class ExecControl:
             await self.runtime.aclose()
         except Exception:  # noqa: BLE001 — teardown must not fail the run
             logger.warning("exec control: runtime shutdown failed", exc_info=True)
+        # Deregister the handle's secret session as part of the same teardown.
+        # ``ServingSessionHandle.dispose`` would do it, but this path never
+        # disposes the handle — the run's owner disposes the session and the
+        # process exits — so without this the socket-close backstop would be the
+        # only revocation, and a supervisor that reuses the process would leave
+        # descendants of a finished agent authorized (§2.1).
+        try:
+            self.handle.close_secret_registration()
+        except Exception:  # noqa: BLE001 — teardown must not fail the run
+            logger.debug("exec control: secret deregistration failed", exc_info=True)
 
 
 async def start_exec_control(

--- a/local_operator/session/runtime/exec_control.py
+++ b/local_operator/session/runtime/exec_control.py
@@ -185,6 +185,7 @@ async def start_exec_control(
     )
 
     loop = asyncio.get_running_loop()
+    config_directory = config_dir()
     handle = ServingSessionHandle(
         session,
         loop,
@@ -192,9 +193,12 @@ async def start_exec_control(
         auto_approve=yolo,
         approval_pinned=yolo,
         install_gates=supervised,
+        # Declared so the §6 registration's store-existence check and the
+        # registration itself share this run's root (MINOR-3).
+        config_dir=config_directory,
     )
     if supervised:
-        attach_gate_config_watch(handle, config_dir())
+        attach_gate_config_watch(handle, config_directory)
     # The ``stop`` control op (and therefore `lop stop`, which can now see this
     # run because it publishes a record) reaches ``request_stop`` -> this hook.
     # Without one the handle falls back to disposing in place, UNDER the prompt

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -332,6 +332,13 @@ _PAYLOAD_OPS = {
     "job_trajectory",
     "fork_snapshot",
     "credential",
+    # The §6 redaction forward: the ONE other op that carries a secret's value,
+    # and only in its own named field. It is a distinct op from ``credential``
+    # on purpose — the handler registers the value with the runtime's redactor,
+    # it does not store a credential — so it must never be reachable through
+    # that verb table. Old runtimes answer unknown-op, which the viewer's sink
+    # treats as a failure and (correctly) fails closed on.
+    "register_secret_redaction",
     "history_page",
     "frontend_sync",
     "record_shell",
@@ -2623,6 +2630,29 @@ class RuntimeServer:
             if inspect.isawaitable(result):
                 result = await result
             return result
+        if op == "register_secret_redaction":
+            # The viewer→runtime half of §6: the viewer's registration answered
+            # the broker's notice because this runtime registered nothing (it
+            # booted before a store existed at its config root, §13), and the
+            # value has to land in THIS process's VariableStore — the one the
+            # bash and eval redactors read. Validated for the same reason
+            # ``credential`` is: the payload path skips the control-frame
+            # validator, and this op carries a secret's value.
+            from local_operator.mobile.types import validate_control_frame
+
+            validate_control_frame(frame)
+            # getattr-probed like every optional capability: a reduced or older
+            # handle answers the unknown-op error rather than silently accepting
+            # a value it will not scrub. The handler only writes the value into
+            # the redaction set — never a credential, never an announcement,
+            # never a log line, never the event stream.
+            register = getattr(h, "register_secret_redaction", None)
+            if not callable(register):
+                raise ValueError("this owner cannot register a redaction")
+            outcome = register(str(frame.get("value", "")))
+            if inspect.isawaitable(outcome):
+                await outcome
+            return True
         if op == "cancel_subagents":
             cancel = getattr(h, "cancel_subagents_count", None)
             if not callable(cancel):

--- a/local_operator/session/runtime/serving.py
+++ b/local_operator/session/runtime/serving.py
@@ -333,6 +333,13 @@ class ServingSessionHandle(SessionHandle):
             effort_ladder=_ladder(session),
         )
         self._fold = ProjectionFold(self._projection)
+        #: The broker registration that authorizes THIS process's descendants to
+        #: retrieve secrets, or ``None`` (§6). Held so teardown can deregister
+        #: promptly rather than waiting for the process's socket to close: a
+        #: runtime can outlive the session it served — a stopped ``exec`` run
+        #: returning to its supervisor — and a session that is gone must stop
+        #: authorizing its descendants (§2.1).
+        self._secret_registration: Any = None
         # Conversation naming is a TUI-only errand today (OperatorApp owns the
         # naming worker), so a phone-started session used to stay "mobile
         # session" forever — the session list and the header both read the
@@ -405,6 +412,9 @@ class ServingSessionHandle(SessionHandle):
         self._gates_installed = install_gates
         if install_gates:
             self._install_gates()
+        # Last, so a handle that could not be fully built never leaves a live
+        # registration behind (see :meth:`_register_secret_session`).
+        self._register_secret_session()
 
     # -- gates -----------------------------------------------------------------
 
@@ -697,6 +707,53 @@ class ServingSessionHandle(SessionHandle):
         self._mcp_reload_tasks.add(task)
         task.add_done_callback(self._mcp_reload_tasks.discard)
 
+    def _register_secret_session(self) -> None:
+        """Register THIS process as the session the broker notifies (§6).
+
+        **The notice has to reach the process that owns the output filter and
+        the transcript**, and in the attached architecture that is this
+        runtime: ``Session.variables`` here is the store the bash and eval
+        redactors read, while the TUI holds only an ``AttachedSession`` facade
+        with no store at all. Registering from the viewer instead made the
+        notice unanswerable by construction, so the broker (correctly) denied
+        every descendant retrieval in every attached session.
+
+        Best-effort by contract, exactly like the TUI's own registration: the
+        store is an optional capability and never a boot dependency (§13), so a
+        session starts and runs normally with no broker to reach.
+
+        Runs on the runtime's loop, so the one blocking step — starting a
+        broker that is not up yet — is a bounded, one-time stall
+        (``STARTUP_TIMEOUT_S``, 5 s) before the runtime serves anyone. That is
+        the cost the TUI already pays at its own boot, and it is paid only when
+        a store exists and no daemon is listening.
+        """
+        from local_operator.secrets.session import register_variable_store_session
+
+        try:
+            self._secret_registration = register_variable_store_session(
+                self._session, session_id=getattr(self._session, "session_id", None)
+            )
+        except Exception:  # noqa: BLE001 — the store is optional; boot must not fail on it
+            logger.debug("secret session registration failed", exc_info=True)
+            self._secret_registration = None
+
+    def close_secret_registration(self) -> None:
+        """Deregister this process, so its descendants stop being authorized.
+
+        Idempotent and non-raising. The socket closing on process exit is the
+        backstop; this is the plan (§2.1), and it is what covers a runtime that
+        outlives the session it served — an ``exec`` run whose control surface
+        closes while the process lives on to be reused.
+        """
+        registration = self._secret_registration
+        self._secret_registration = None
+        if registration is not None:
+            try:
+                registration.close()
+            except Exception:  # noqa: BLE001 — teardown must not fail on a deregistration
+                logger.debug("secret session deregistration failed", exc_info=True)
+
     async def dispose(self) -> None:
         """Dispose the underlying session (release the claim, flush, abort).
 
@@ -704,6 +761,10 @@ class ServingSessionHandle(SessionHandle):
         to ``self._session`` so the ordering (deny gates first) stays in one
         place and hosts cannot forget the claim release."""
         self._disposing = True
+        # Revoke the broker registration along with the session: descendants of
+        # a session that is going away must not stay authorized behind it
+        # (§2.1). Bounded and non-raising, so it cannot delay or break teardown.
+        self.close_secret_registration()
         if self._goal_loop is not None:
             await self._goal_loop.cancel()
         if self._unsubscribe_config_watch is not None:

--- a/local_operator/session/runtime/serving.py
+++ b/local_operator/session/runtime/serving.py
@@ -41,6 +41,7 @@ from local_operator.harness.types import AgentEvent, ModelChangeEvent
 
 if TYPE_CHECKING:
     from local_operator.harness.types import ImageContent
+    from local_operator.secrets.session import SessionRegistration
 
 from local_operator.mobile.command_reservation import CommandReservations
 from local_operator.mobile.projection import ProjectionFold
@@ -237,6 +238,7 @@ class ServingSessionHandle(SessionHandle):
         auto_approve: bool = False,
         approval_pinned: bool = False,
         install_gates: bool = True,
+        config_dir: Path | None = None,
     ) -> None:
         self._session = session
         self._goal_loop: Any = None
@@ -339,7 +341,18 @@ class ServingSessionHandle(SessionHandle):
         #: runtime can outlive the session it served — a stopped ``exec`` run
         #: returning to its supervisor — and a session that is gone must stop
         #: authorizing its descendants (§2.1).
-        self._secret_registration: Any = None
+        self._secret_registration: SessionRegistration | None = None
+        #: The config root this handle's session was built from, when the spawn
+        #: site knows it (``spawn_owned_session``/``start_exec_control`` both
+        #: do). Passed rather than re-read from ``config_dir()`` at registration
+        #: time so the store-existence check and the registration share ONE
+        #: base (MINOR-3): a handle whose session is rooted elsewhere can no
+        #: longer check one store and register against another. ``None`` means
+        #: the spawn site did not declare one; registration then falls back to
+        #: this process's own ``config_dir()``, which is the same root the
+        #: session was built from because the runtime is spawned with it in the
+        #: environment.
+        self._config_dir = config_dir
         # Conversation naming is a TUI-only errand today (OperatorApp owns the
         # naming worker), so a phone-started session used to stay "mobile
         # session" forever — the session list and the header both read the
@@ -413,7 +426,13 @@ class ServingSessionHandle(SessionHandle):
         if install_gates:
             self._install_gates()
         # Last, so a handle that could not be fully built never leaves a live
-        # registration behind (see :meth:`_register_secret_session`).
+        # registration behind (see :meth:`_register_secret_session`). The call
+        # is synchronous and can stall the loop for up to ``STARTUP_TIMEOUT_S``
+        # (5 s) while a cold broker starts — bounded, one-time, and paid only
+        # when a store exists at this handle's root and no daemon is listening
+        # (MINOR-1). It mirrors the TUI's own boot cost deliberately, because
+        # the alternative (registering off-loop) would let the handle serve
+        # turns before it can authorize the descendants those turns spawn.
         self._register_secret_session()
 
     # -- gates -----------------------------------------------------------------
@@ -726,17 +745,48 @@ class ServingSessionHandle(SessionHandle):
         broker that is not up yet — is a bounded, one-time stall
         (``STARTUP_TIMEOUT_S``, 5 s) before the runtime serves anyone. That is
         the cost the TUI already pays at its own boot, and it is paid only when
-        a store exists and no daemon is listening.
+        a store exists at this handle's root AND no daemon is already
+        listening; a warm daemon makes the poll return on its first check.
+
+        The base is the handle's own ``self._config_dir``, not a re-read of
+        ``config_dir()``: the spawn sites declare the root they built the
+        session from, so the store-existence check inside
+        ``register_variable_store_session`` and the registration itself cannot
+        disagree about WHICH store this session owns (MINOR-3, NIT-2).
         """
         from local_operator.secrets.session import register_variable_store_session
 
         try:
             self._secret_registration = register_variable_store_session(
-                self._session, session_id=getattr(self._session, "session_id", None)
+                self._session,
+                session_id=getattr(self._session, "session_id", None),
+                base=self._config_dir,
             )
         except Exception:  # noqa: BLE001 — the store is optional; boot must not fail on it
             logger.debug("secret session registration failed", exc_info=True)
             self._secret_registration = None
+
+    def register_secret_redaction(self, value: str) -> None:
+        """Add ONE value the §6 notice asked this process to scrub.
+
+        The owner side of ``AttachedSession.register_secret_redaction``: the
+        viewer forwards a value here when ITS registration, not this runtime's,
+        is the one that answered the broker's notice — which happens when this
+        runtime registered nothing because no store existed at its base at boot
+        (see :meth:`_register_secret_session`). The value has to reach the store
+        the bash and eval redactors read, which is ``self._session.variables``,
+        so that is the only thing this method touches.
+
+        It writes the value into the redaction set and nothing else: never a
+        credential, never an announcement, never a log line, never an audit row
+        or an event. It RAISES when there is no store, so the viewer's sink
+        declines to acknowledge and the broker denies the child rather than
+        serving a value nothing can scrub — the fail-closed direction §6 requires.
+        """
+        variables = getattr(self._session, "variables", None)
+        if variables is None:
+            raise RuntimeError("this runtime has no variable store to redact through")
+        variables.register_redaction(value)
 
     def close_secret_registration(self) -> None:
         """Deregister this process, so its descendants stop being authorized.
@@ -4196,7 +4246,15 @@ async def spawn_owned_session(
     # the running one; the guard mirrors that seam's "boot must not depend on
     # the watcher" degrade.
     handle = ServingSessionHandle(
-        session, loop, cwd=cwd, auto_approve=auto_approve, approval_pinned=False
+        session,
+        loop,
+        cwd=cwd,
+        auto_approve=auto_approve,
+        approval_pinned=False,
+        # Declared so the §6 registration's store-existence check and the
+        # registration itself share the config root this session was built
+        # from (MINOR-3).
+        config_dir=config_directory,
     )
     attach_gate_config_watch(handle, config_directory)
     return handle

--- a/local_operator/tui/__init__.py
+++ b/local_operator/tui/__init__.py
@@ -19,43 +19,129 @@ logger = logging.getLogger(__name__)
 def _register_secret_session(app: Any) -> Any:
     """Register this process with the secret broker; ``None`` when there is none.
 
-    **This covers the TUI only when the TUI OWNS the session.** With an
-    in-process ``Session`` this process holds the ``VariableStore`` the §6
-    notice has to reach, so this registration is the one that answers it. An
-    ATTACHED TUI — the interactive default, where ``app._session`` is an
-    ``AttachedSession`` facade over a separate runtime process — has no store
-    at all, and the registration that matters there is the RUNTIME's own
-    (``ServingSessionHandle``), made in the process whose bash and eval
-    redactors read the store. Do not "fix" the sink below by reaching for the
-    viewer's session state looking for a store: there is nothing to reach.
+    **This process is registered in every shape, and that is deliberate.** The
+    §6 notice reaches the nearest REGISTERED ancestor of the retrieving child,
+    which in the attached architecture is normally the runtime that owns the
+    value's filter (``ServingSessionHandle``). But a runtime that booted before
+    a store existed at its root registers nothing (§13), and then this viewer's
+    entry is the only ancestor the broker can notify. Closing this channel
+    instead would leave no registered ancestor at all: the broker refuses the
+    retrieval for lacking ancestry, ``access.retrieve_secret`` then falls
+    through to its keyfile-tier local decrypt (``except BrokerDenied: if
+    hardened: raise``), and the value lands in the transcript with nothing
+    having been notified — the very leak §6 exists to prevent. So the entry is
+    kept, and the sink below makes it do real work rather than being a slot the
+    broker wastes.
 
-    The redaction sink is resolved LAZILY, per notice, rather than captured
-    here: the session is constructed inside the app after this runs, so its
-    ``VariableStore`` does not exist yet. A notice that arrives before it does
-    is dropped rather than acked, which the broker treats as "cannot be
-    scrubbed" and denies — the correct direction, since there is genuinely no
-    filter to catch that value at that moment (§6, review R3).
+    The sink resolves the redaction target LAZILY, per notice, in order:
+
+    1. ``app._session.variables`` — the TUI OWNS the session, so this process
+       holds the store the bash and eval redactors read and answers directly.
+    2. a forward to the attached runtime (``register_secret_redaction``) over
+       the same viewer→runtime control channel ``/credential store`` already
+       uses, so the value reaches the process that owns the filter.
+    3. RAISE — there is genuinely no filter anywhere this process can reach, so
+       the notice is not acknowledged and the broker fails closed.
+
+    The target is resolved per notice rather than captured here because the
+    session is constructed inside the app after this runs, and /new, /resume
+    and /reload replace it; a captured store would be stale.
+
+    **Budget (review round 1, MAJOR-1).** Registered entries are one per TUI
+    window (this one, made once at boot for the process's whole life) plus one
+    per runtime that HAS a store at its root — a no-store runtime does not
+    register at all, so a machine full of store-less sessions adds nothing.
+    Against the broker's ``MAX_SESSIONS`` (32) that is one entry per window and
+    per store-owning runtime rather than the unbounded per-retrieval growth the
+    cap was added for; the viewer entry is no longer inert, which is why it is
+    kept rather than closed. It is registered unconditionally (no store check,
+    unlike the runtime path), because gating it on a store existing at boot
+    loses the entry in exactly the case it exists for — a store created after
+    the runtime booted — and then NO ancestor registers: the broker refuses for
+    lack of ancestry and the keyfile fallback serves the value unnotified. A
+    store-less window therefore pays one broker start and keeps a fail-closed
+    entry, and that is the deliberate trade.
     """
     from local_operator.secrets.session import register_session as register
 
     def on_secret(name: str, value: bytes) -> None:
+        text = value.decode("utf-8", errors="replace")
         session = getattr(app, "_session", None)
         variables = getattr(session, "variables", None) if session is not None else None
-        if variables is None:
-            # The LAST-RESORT fail-closed path, not the primary one. An attached
-            # viewer has no store to redact through, so the runtime's own
-            # registration is what should have answered this notice; reach here
-            # only when there is genuinely no filter in this process. Logged
-            # because a silent denial is invisible in the agent's transcript.
-            logger.warning(
-                "%r could not be registered for redaction: no variable store in this "
-                "process, so the retrieval is denied rather than served unscrubbed",
-                name,
-            )
-            raise RuntimeError("no variable store is available to redact through yet")
-        variables.register_redaction(value.decode("utf-8", errors="replace"))
+        if variables is not None:
+            # (1) In-process session: the store is here, so the notice is
+            # answered here. Unchanged behaviour.
+            variables.register_redaction(text)
+            return
+        forward = (
+            getattr(session, "register_secret_redaction", None) if session is not None else None
+        )
+        if forward is not None:
+            # (2) Attached session: hand the value to the runtime that owns the
+            # filter. Raises on any failure, which is the fail-closed direction.
+            _forward_redaction_to_runtime(app, forward, text)
+            return
+        # (3) The LAST-RESORT fail-closed path. Logged because a silent denial
+        # is invisible in the agent's transcript; the raise is what stops
+        # ``SessionRegistration._read_loop`` from acknowledging, so the broker
+        # denies rather than serving a value nothing can scrub.
+        logger.warning(
+            "%r could not be registered for redaction: no variable store in this "
+            "process and no runtime to forward to, so the retrieval is denied "
+            "rather than served unscrubbed",
+            name,
+        )
+        raise RuntimeError("no variable store is available to redact through yet")
 
     return register(on_secret)
+
+
+def _forward_redaction_to_runtime(app: Any, forward: Any, value: str) -> None:
+    """Hand one §6 value to the attached runtime, bounded; raise on failure.
+
+    **Why the hop.** The broker's notice arrives on
+    ``SessionRegistration._read_loop``, a plain thread; the viewer's RPC to the
+    runtime runs on the app's event loop, so the call has to hop there.
+
+    **Why it is bounded on THIS side.** The broker denies the retrieval when no
+    acknowledgement arrives within ``NOTIFY_ACK_TIMEOUT_S`` (2 s). A
+    ``call_from_thread``-style hop blocks the notice thread with no timeout, so
+    a wedged loop would park here past that window and turn a fail-closed
+    denial into an ambiguous hang. Instead the coroutine is scheduled with
+    ``run_coroutine_threadsafe`` and the thread waits with an explicit timeout
+    (the transport's own ``REDACTION_FORWARD_TIMEOUT_S``, well under 2 s), so
+    the hop gives up, the sink raises, and the broker denies — fail closed.
+
+    **Why no Textual context is needed.** The forwarded coroutine touches only
+    the attach client's socket and its store; it never reads or mutates widgets,
+    so it does not need ``App._context()`` that ``call_from_thread`` would set.
+    """
+    import asyncio
+    from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+    from local_operator.mobile.attach_client import REDACTION_FORWARD_TIMEOUT_S
+
+    loop = getattr(app, "_loop", None)
+    if loop is None:
+        # The app has not started its loop yet (a notice before the first turn,
+        # or a session constructed in the gap). There is nothing to forward to.
+        raise RuntimeError(
+            "the TUI is not running yet, so no attached runtime can be asked to redact"
+        )
+    try:
+        future = asyncio.run_coroutine_threadsafe(forward(value), loop)
+    except RuntimeError as exc:  # loop closed, or scheduling refused
+        raise RuntimeError(
+            f"the attached runtime cannot be reached to register this redaction: {exc}"
+        ) from exc
+    try:
+        future.result(timeout=REDACTION_FORWARD_TIMEOUT_S)
+    except FuturesTimeoutError as exc:
+        future.cancel()
+        raise RuntimeError(
+            "the attached runtime did not confirm the redaction within the forward "
+            "budget, so the value cannot be kept out of the transcript"
+        ) from exc
 
 
 async def run_tui(
@@ -103,11 +189,13 @@ async def run_tui(
         # notice must reach (QA Q2 — nothing in shipping code registered a
         # session before, which left the broker's table permanently empty and
         # `lop secret harden` unable to unlock its own store). An ATTACHED TUI
-        # is covered by the RUNTIME's registration instead (serving.py), since
-        # its `app._session` facade holds no store this sink could scrub
-        # through. Registration is deliberately best-effort: `register` returns
-        # None when no broker can be started, and the store is an optional
-        # capability rather than a boot dependency (§13).
+        # keeps the same registration as the broker's fallback for a runtime
+        # that registered nothing (it booted before a store existed), and its
+        # sink FORWARDS the notice to that runtime rather than being inert —
+        # see `_register_secret_session`. Registration is deliberately
+        # best-effort: `register` returns None when no broker can be started,
+        # and the store is an optional capability rather than a boot dependency
+        # (§13).
         registration = _register_secret_session(app)
         try:
             await app.run_async()

--- a/local_operator/tui/__init__.py
+++ b/local_operator/tui/__init__.py
@@ -7,14 +7,27 @@ Import hygiene: ``cli.py`` imports this module ONLY in interactive mode, and
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Awaitable, Callable
 
 from local_operator.logger import file_logging
 from local_operator.session.protocol import SessionProtocol
 
+logger = logging.getLogger(__name__)
+
 
 def _register_secret_session(app: Any) -> Any:
     """Register this process with the secret broker; ``None`` when there is none.
+
+    **This covers the TUI only when the TUI OWNS the session.** With an
+    in-process ``Session`` this process holds the ``VariableStore`` the §6
+    notice has to reach, so this registration is the one that answers it. An
+    ATTACHED TUI — the interactive default, where ``app._session`` is an
+    ``AttachedSession`` facade over a separate runtime process — has no store
+    at all, and the registration that matters there is the RUNTIME's own
+    (``ServingSessionHandle``), made in the process whose bash and eval
+    redactors read the store. Do not "fix" the sink below by reaching for the
+    viewer's session state looking for a store: there is nothing to reach.
 
     The redaction sink is resolved LAZILY, per notice, rather than captured
     here: the session is constructed inside the app after this runs, so its
@@ -29,6 +42,16 @@ def _register_secret_session(app: Any) -> Any:
         session = getattr(app, "_session", None)
         variables = getattr(session, "variables", None) if session is not None else None
         if variables is None:
+            # The LAST-RESORT fail-closed path, not the primary one. An attached
+            # viewer has no store to redact through, so the runtime's own
+            # registration is what should have answered this notice; reach here
+            # only when there is genuinely no filter in this process. Logged
+            # because a silent denial is invisible in the agent's transcript.
+            logger.warning(
+                "%r could not be registered for redaction: no variable store in this "
+                "process, so the retrieval is denied rather than served unscrubbed",
+                name,
+            )
             raise RuntimeError("no variable store is available to redact through yet")
         variables.register_redaction(value.decode("utf-8", errors="replace"))
 
@@ -74,14 +97,17 @@ async def run_tui(
             warm_session_imports=warm_session_imports,
         )
         # Register THIS process as a live lop session with the secret broker.
-        # Interactive TUI processes are the sessions the broker's ancestry
-        # check is about — an agent's `bash` and the eval worker are their
-        # descendants — and nothing in shipping code registered one before
-        # (QA Q2), which left the broker's session table permanently empty and
-        # `lop secret harden` unable to unlock its own store. Registration is
-        # deliberately best-effort: `register` returns None when no broker can
-        # be started, and the store is an optional capability rather than a
-        # boot dependency (§13).
+        # It covers the session the TUI OWNS: an in-process session's `bash`
+        # and eval workers are this process's descendants, and its
+        # `VariableStore` is here, so this registration is the one the §6
+        # notice must reach (QA Q2 — nothing in shipping code registered a
+        # session before, which left the broker's table permanently empty and
+        # `lop secret harden` unable to unlock its own store). An ATTACHED TUI
+        # is covered by the RUNTIME's registration instead (serving.py), since
+        # its `app._session` facade holds no store this sink could scrub
+        # through. Registration is deliberately best-effort: `register` returns
+        # None when no broker can be started, and the store is an optional
+        # capability rather than a boot dependency (§13).
         registration = _register_secret_session(app)
         try:
             await app.run_async()

--- a/tests/unit/secrets/test_runtime_session_registration.py
+++ b/tests/unit/secrets/test_runtime_session_registration.py
@@ -100,12 +100,16 @@ def _sessions(config_root: Path) -> set[int]:
     return set(status.get("sessions") or ())
 
 
-def _await_absent(config_root: Path, pid: int, timeout: float = 5.0) -> set[int]:
+def _await_absent(config_root: Path, pid: int, timeout: float = 10.0) -> set[int]:
     """Poll until ``pid`` leaves the broker's session table, or the deadline.
 
-    The broker notices a closed channel on its own liveness poll, so a
+    The broker notices a closed channel on its own 1 s liveness poll, so a
     deregistration is prompt but not instantaneous; asserting immediately would
-    test the poll interval rather than the deregistration.
+    test the poll interval rather than the deregistration. The bound matches the
+    one the existing deregistration test uses
+    (``test_a_dead_sessions_descendants_stop_being_authorized``) — a loaded CI
+    runner is slower than a workstation, and a tight bound there fails the
+    window rather than the behaviour.
     """
     deadline = time.monotonic() + timeout
     sessions = _sessions(config_root)

--- a/tests/unit/secrets/test_runtime_session_registration.py
+++ b/tests/unit/secrets/test_runtime_session_registration.py
@@ -1,0 +1,252 @@
+"""The RUNTIME registers the session the §6 notice has to reach (design §2.1, §6).
+
+**The defect these tests pin.** The broker notifies the registered session that
+OWNS the requesting peer and denies the retrieval when that session does not
+acknowledge in time. The registration used to be made by the TUI process, whose
+sink read ``app._session.variables`` — and once the attached facade landed
+(#937) ``app._session`` was an ``AttachedSession`` with no store at all, so the
+sink raised, nothing was ever acked, and EVERY descendant retrieval in EVERY
+attached session was denied ("session <pid> did not acknowledge the redaction
+notice within 2s"). The registrant has to be the process that holds the
+``VariableStore`` the bash and eval redactors read, which is the session
+runtime, not the viewer — hence ``ServingSessionHandle``.
+
+These tests spawn REAL descendant processes rather than faking a peer identity,
+for the reason ``test_broker.py`` states for its own: the mechanism is what the
+kernel reports about the process on the other end of the socket, so a mocked pid
+would prove nothing about the boundary that broke.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+import textwrap
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import local_operator
+from local_operator.secrets import client
+from local_operator.secrets.broker import SecretBroker
+from local_operator.secrets.keys import key_path, write_private_file
+from local_operator.secrets.store import SecretStore
+from local_operator.session.runtime.serving import ServingSessionHandle
+from local_operator.variables import VariableStore
+
+_SUPPORTED = sys.platform == "darwin" or sys.platform.startswith("linux")
+pytestmark = pytest.mark.skipif(
+    not _SUPPORTED, reason="the broker is implemented for macOS and Linux"
+)
+
+SECRET_NAME = "RUNTIME_SINK_TOKEN"
+SECRET_VALUE = "runtime-sink-7c1f0b2a"
+
+
+class RuntimeSessionDouble:
+    """The slice of ``Session`` the handle's construction and teardown touch.
+
+    Local and deliberately minimal rather than shared with the runtime suite's
+    fake: this file's subject is the secret registration, so the double only
+    carries the ``VariableStore`` the §6 sink reads plus the handful of
+    attributes the projection and the command reservations read while the
+    handle is built. ``variables`` is the ONE field under test — a store here
+    models the runtime, ``None`` models a session with nothing to scrub
+    through.
+    """
+
+    def __init__(self, variables: VariableStore | None) -> None:
+        self.session_id = "runtime-session-under-test"
+        self.conversation_name = ""
+        self.model = None
+        self.variables = variables
+        self.disposed = False
+
+    def history(self) -> list[Any]:
+        return []
+
+    def set_approval_handler(self, handler: Any) -> None:
+        self.approval_handler = handler
+
+    def set_ask_handler(self, handler: Any) -> None:
+        self.ask_handler = handler
+
+    async def dispose(self) -> None:
+        self.disposed = True
+
+
+@pytest.fixture
+def running_broker(config_root: Path, master_key: bytes) -> Iterator[SecretBroker]:
+    """A live keyfile-tier broker over the isolated config dir."""
+    store = SecretStore(master_key, base=config_root)
+    store.initialize()
+    store.set(SECRET_NAME, SECRET_VALUE.encode(), description="runtime sink")
+    write_private_file(key_path(config_root), master_key)
+    instance = SecretBroker(config_root, key_provider=lambda: master_key, idle_shutdown_s=0)
+    instance.start()
+    try:
+        yield instance
+    finally:
+        instance.stop(timeout=5)
+
+
+def _sessions(config_root: Path) -> set[int]:
+    status = client.broker_status(config_root) or {}
+    return set(status.get("sessions") or ())
+
+
+def _await_absent(config_root: Path, pid: int, timeout: float = 5.0) -> set[int]:
+    """Poll until ``pid`` leaves the broker's session table, or the deadline.
+
+    The broker notices a closed channel on its own liveness poll, so a
+    deregistration is prompt but not instantaneous; asserting immediately would
+    test the poll interval rather than the deregistration.
+    """
+    deadline = time.monotonic() + timeout
+    sessions = _sessions(config_root)
+    while pid in sessions and time.monotonic() < deadline:
+        time.sleep(0.05)
+        sessions = _sessions(config_root)
+    return sessions
+
+
+def _retrieve_in_child(config_root: Path, name: str) -> subprocess.CompletedProcess[str]:
+    """A REAL descendant process retrieving ``name`` through the broker.
+
+    The child imports the tree UNDER TEST rather than whatever ``lop`` is
+    installed on this machine — without PYTHONPATH pointing at the worktree it
+    would silently exercise the released runtime and report on the wrong code.
+    """
+    tree = str(Path(local_operator.__file__).resolve().parent.parent)
+    script = textwrap.dedent(f"""
+        import sys
+        from pathlib import Path
+        from local_operator.secrets import client
+
+        try:
+            value = client.retrieve({name!r}, Path({str(config_root)!r}))
+        except Exception as error:
+            print(f"{{type(error).__name__}}: {{error}}", file=sys.stderr)
+            raise SystemExit(2)
+        print(value.decode())
+        """)
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        env={**os.environ, "PYTHONPATH": tree},
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_descendant_retrieval_is_served_when_the_runtime_registered(
+    config_root: Path, running_broker: SecretBroker
+) -> None:
+    """The regression: the handle's registration is what lets a child be served.
+
+    On the pre-fix tree ``ServingSessionHandle`` registered nothing, so this
+    process was never in the broker's session table and the child below was
+    denied for having no registered session ancestor at all. With the fix the
+    runtime is the registered session, its ``VariableStore`` answers the §6
+    notice, and the value is served — registered for redaction BEFORE the ack
+    that released it to the child.
+    """
+    variables = VariableStore()
+    session = RuntimeSessionDouble(variables)
+    handle = ServingSessionHandle(session, asyncio.get_running_loop(), cwd=str(config_root))
+    try:
+        assert os.getpid() in _sessions(config_root), (
+            "the runtime handle did not register this process as the session the "
+            "broker notifies; a descendant retrieval would be denied"
+        )
+
+        result = _retrieve_in_child(config_root, SECRET_NAME)
+
+        assert result.returncode == 0, f"the child was refused: {result.stderr}"
+        assert result.stdout.strip() == SECRET_VALUE, "the child was not served the value"
+        # Registered by the time the child could print: the sink ran before the
+        # ack, which is the whole §6 ordering.
+        assert (
+            SECRET_VALUE in variables.redaction_values()
+        ), "the value was served without reaching the store that owns the filter"
+        assert variables.redact(f"token={SECRET_VALUE}") == "token=[redacted]"
+    finally:
+        handle.close_secret_registration()
+        assert os.getpid() not in _await_absent(
+            config_root, os.getpid()
+        ), "the closed registration still authorized this process"
+
+
+@pytest.mark.asyncio
+async def test_a_runtime_with_no_store_registers_nothing(config_root: Path) -> None:
+    """A store-less runtime registers nothing, and starts no broker doing it.
+
+    The registration is skipped when no store exists at this base: there is
+    nothing any descendant could be served from it, and the skip is what keeps
+    a session that never uses the store — most sessions, and every test double
+    that builds a handle — from spawning a broker daemon. No ``running_broker``
+    fixture here on purpose: the assertion is that none appears.
+    """
+    handle = ServingSessionHandle(
+        RuntimeSessionDouble(VariableStore()), asyncio.get_running_loop(), cwd=str(config_root)
+    )
+    try:
+        assert (
+            client.broker_status(config_root) is None
+        ), "a runtime with no secret store started a broker anyway"
+    finally:
+        handle.close_secret_registration()
+
+
+@pytest.mark.asyncio
+async def test_a_sink_that_cannot_register_denies_and_names_the_runtime_pid(
+    config_root: Path, running_broker: SecretBroker
+) -> None:
+    """Fail-closed is preserved, and the denial names THIS process.
+
+    A session with no ``VariableStore`` — the shape the attached TUI's facade
+    had — must not be served a value nothing can scrub. The broker denies, and
+    the message names the runtime whose sink could not register, which is what
+    makes the failure diagnosable instead of a silent empty substitution.
+    """
+    handle = ServingSessionHandle(
+        RuntimeSessionDouble(None), asyncio.get_running_loop(), cwd=str(config_root)
+    )
+    try:
+        assert os.getpid() in _sessions(
+            config_root
+        ), "the registration itself must succeed; the sink, not the session, is what is missing"
+
+        result = _retrieve_in_child(config_root, SECRET_NAME)
+
+        assert result.returncode == 2, f"the child was served: {result.stdout!r}"
+        assert SECRET_VALUE not in result.stdout
+        assert SECRET_VALUE not in result.stderr
+        assert "did not acknowledge the redaction notice" in result.stderr
+        assert f"session {os.getpid()}" in result.stderr
+    finally:
+        handle.close_secret_registration()
+
+
+@pytest.mark.asyncio
+async def test_disposing_the_handle_deregisters_the_session(
+    config_root: Path, running_broker: SecretBroker
+) -> None:
+    """Teardown revokes: a session that is gone must stop authorizing (§2.1)."""
+    session = RuntimeSessionDouble(VariableStore())
+    handle = ServingSessionHandle(session, asyncio.get_running_loop(), cwd=str(config_root))
+    assert os.getpid() in _sessions(config_root)
+
+    await handle.dispose()
+
+    assert session.disposed
+    assert os.getpid() not in _await_absent(config_root, os.getpid()), (
+        "the disposed handle left this process registered, so its descendants "
+        "would stay authorized behind a session that has ended"
+    )

--- a/tests/unit/secrets/test_runtime_session_registration.py
+++ b/tests/unit/secrets/test_runtime_session_registration.py
@@ -20,6 +20,7 @@ would prove nothing about the boundary that broke.
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import subprocess
 import sys
@@ -36,7 +37,9 @@ from local_operator.secrets import client
 from local_operator.secrets.broker import SecretBroker
 from local_operator.secrets.keys import key_path, write_private_file
 from local_operator.secrets.store import SecretStore
+from local_operator.session.runtime.server import RuntimeServer
 from local_operator.session.runtime.serving import ServingSessionHandle
+from local_operator.tui import _register_secret_session
 from local_operator.variables import VariableStore
 
 _SUPPORTED = sys.platform == "darwin" or sys.platform.startswith("linux")
@@ -46,6 +49,10 @@ pytestmark = pytest.mark.skipif(
 
 SECRET_NAME = "RUNTIME_SINK_TOKEN"
 SECRET_VALUE = "runtime-sink-7c1f0b2a"
+
+#: A second value used by the forwarding tests, so a failure cannot be
+#: explained by the registry test having leaked the first one.
+FORWARDED_VALUE = "viewer-forward-4d9e1c"
 
 
 class RuntimeSessionDouble:
@@ -69,6 +76,16 @@ class RuntimeSessionDouble:
 
     def history(self) -> list[Any]:
         return []
+
+    def subscribe(self, handler: Any) -> Any:
+        """The event subscription ``RuntimeServer.start_in_process`` installs.
+
+        Only the wire test starts a server; the rest of this file never does, so
+        this hook exists purely so a REAL ``RuntimeServer`` can be driven over a
+        real socket against this double.
+        """
+        self._event_handler = handler
+        return lambda: None
 
     def set_approval_handler(self, handler: Any) -> None:
         self.approval_handler = handler
@@ -254,3 +271,198 @@ async def test_disposing_the_handle_deregisters_the_session(
         "the disposed handle left this process registered, so its descendants "
         "would stay authorized behind a session that has ended"
     )
+
+
+@pytest.mark.asyncio
+async def test_the_runtime_handler_registers_a_forwarded_value(config_root: Path) -> None:
+    """The owner side of the forward writes to its store — and nowhere else.
+
+    This is what ``AttachedSession.register_secret_redaction`` reaches over the
+    control channel: the value goes into the ``VariableStore`` the bash and eval
+    redactors read, and the handler raises when there is no store, so the
+    viewer's sink declines to acknowledge and the broker denies.
+    """
+    variables = VariableStore()
+    handle = ServingSessionHandle(
+        RuntimeSessionDouble(variables), asyncio.get_running_loop(), cwd=str(config_root)
+    )
+    try:
+        handle.register_secret_redaction(FORWARDED_VALUE)
+        assert FORWARDED_VALUE in variables.redaction_values()
+        assert variables.redact(f"x={FORWARDED_VALUE}") == "x=[redacted]"
+        # Registered as a REDACTION, never as a credential: the value must not
+        # become readable back out of the store's credential surface.
+        assert FORWARDED_VALUE not in variables.credential_names()
+        # And the op must NOT be reachable through the ``/credential`` verb
+        # table: a verb whose only job is to scrub a value must never be able to
+        # store one, and the table's own unknown-action reply is the proof.
+        refusal = await handle.credential_op("register_secret_redaction", "", "x")
+        assert refusal.get("ok") is False and refusal.get("reason") == "unknown-action"
+    finally:
+        handle.close_secret_registration()
+
+    storeless = ServingSessionHandle(
+        RuntimeSessionDouble(None), asyncio.get_running_loop(), cwd=str(config_root)
+    )
+    try:
+        with pytest.raises(RuntimeError):
+            storeless.register_secret_redaction(FORWARDED_VALUE)
+    finally:
+        storeless.close_secret_registration()
+
+
+@pytest.mark.asyncio
+async def test_the_wire_op_registers_the_value_in_the_runtime_store(config_root: Path) -> None:
+    """The viewer→runtime forward really crosses the control channel.
+
+    A real ``RuntimeServer`` over a real handle, driven by a real authenticated
+    socket: the payload op registers the value with the runtime's redactor and
+    answers ``True``. An OLD owner would answer unknown-op here, which the
+    viewer's sink turns into a raise (fail closed), so the seam degrades safely.
+    """
+    variables = VariableStore()
+    handle = ServingSessionHandle(
+        RuntimeSessionDouble(variables), asyncio.get_running_loop(), cwd=str(config_root)
+    )
+    runtime = RuntimeServer(handle, kind="daemon")
+    await runtime.start_in_process()
+    writer = None
+    try:
+        record = runtime._record
+        reader, writer = await asyncio.open_connection(
+            "127.0.0.1", record.control_port, limit=1 << 20
+        )
+        writer.write(json.dumps({"key": record.control_key, "client": "attach"}).encode() + b"\n")
+        await writer.drain()
+        welcome = json.loads(await asyncio.wait_for(reader.readline(), timeout=5))
+        assert welcome.get("op") == "projection"
+
+        writer.write(
+            json.dumps(
+                {"op": "register_secret_redaction", "req": 1, "value": FORWARDED_VALUE}
+            ).encode()
+            + b"\n"
+        )
+        await writer.drain()
+        for _ in range(30):
+            frame = json.loads(await asyncio.wait_for(reader.readline(), timeout=5))
+            if frame.get("op") == "result" and frame.get("req") == 1:
+                break
+        else:  # pragma: no cover - only on a broken server
+            raise AssertionError("no result frame for register_secret_redaction")
+        assert frame["data"] is True
+        assert FORWARDED_VALUE in variables.redaction_values()
+    finally:
+        if writer is not None:
+            writer.close()
+        await runtime.aclose()
+
+
+@pytest.mark.asyncio
+async def test_an_attached_viewer_forwards_the_notice_and_the_child_is_served(
+    config_root: Path, running_broker: SecretBroker
+) -> None:
+    """The viewer's registration is NOT inert: it forwards to the runtime.
+
+    The shape shipping ``lop`` has when a runtime booted before its store
+    existed: the VIEWER is the only registered session, so the broker's notice
+    lands on the viewer's sink on a plain thread. The sink resolves
+    ``app._session.variables`` (absent on an attached facade), then forwards
+    the value to the attached runtime over the control channel — the loop hop is
+    exercised for real here — and only then acknowledges, so the child is served
+    AND the value is in the filter before the value can be printed.
+    """
+    filtered = VariableStore()
+
+    class AttachedDouble:
+        async def register_secret_redaction(self, value: str) -> None:
+            filtered.register_redaction(value)
+
+    class AppDouble:
+        _session = AttachedDouble()
+        _loop = asyncio.get_running_loop()
+
+    registration = _register_secret_session(AppDouble())
+    assert registration is not None, "the viewer registration did not reach a broker"
+    try:
+        # Off the loop on purpose: the notice has to be answered by a coroutine
+        # scheduled on THIS loop, so a synchronous subprocess.run here would
+        # block the very loop the forward needs — and the timeout this test
+        # would then see is a test artefact, not the production shape.
+        result = await asyncio.to_thread(_retrieve_in_child, config_root, SECRET_NAME)
+
+        assert result.returncode == 0, f"the child was refused: {result.stderr}"
+        assert result.stdout.strip() == SECRET_VALUE
+        assert SECRET_VALUE in filtered.redaction_values(), (
+            "the value was served before the forwarded redaction reached the "
+            "runtime's store, so the notice was not honoured"
+        )
+    finally:
+        registration.close()
+        _await_absent(config_root, os.getpid())
+
+
+class _ForwardFails:
+    """An attached runtime whose forward refuses (a lost owner, a full queue)."""
+
+    async def register_secret_redaction(self, value: str) -> None:
+        raise ConnectionError("runtime gone")
+
+
+@pytest.mark.asyncio
+async def test_an_attached_viewer_that_cannot_forward_denies_the_child(
+    config_root: Path, running_broker: SecretBroker
+) -> None:
+    """A forward that fails must fail CLOSED, not serve the value unredacted.
+
+    A noisy "log and continue" here would acknowledge the notice, let the broker
+    serve the child, and leave the session's redactor unaware of the value — the
+    §6 leak. The sink must raise instead, so the broker denies and the value
+    never reaches the transcript.
+    """
+
+    class AppDouble:
+        _session = _ForwardFails()
+        _loop = asyncio.get_running_loop()
+
+    registration = _register_secret_session(AppDouble())
+    assert registration is not None
+    try:
+        result = await asyncio.to_thread(_retrieve_in_child, config_root, SECRET_NAME)
+
+        assert result.returncode == 2, f"the child was served anyway: {result.stdout!r}"
+        assert SECRET_VALUE not in result.stdout
+        assert SECRET_VALUE not in result.stderr
+        assert "did not acknowledge the redaction notice" in result.stderr
+    finally:
+        registration.close()
+        _await_absent(config_root, os.getpid())
+
+
+@pytest.mark.asyncio
+async def test_the_viewer_sink_with_no_target_at_all_denies_the_child(
+    config_root: Path, running_broker: SecretBroker
+) -> None:
+    """The last-resort branch: nowhere to scrub → deny, never serve.
+
+    A session facade with neither a ``VariableStore`` nor a forwarding method
+    has no filter anywhere the viewer can reach, so the sink raises and the
+    broker denies. This is the branch that keeps the viewer entry fail-closed
+    rather than a silent pass-through.
+    """
+
+    class AppDouble:
+        _session = object()
+        _loop = asyncio.get_running_loop()
+
+    registration = _register_secret_session(AppDouble())
+    assert registration is not None
+    try:
+        result = await asyncio.to_thread(_retrieve_in_child, config_root, SECRET_NAME)
+
+        assert result.returncode == 2, f"the child was served anyway: {result.stdout!r}"
+        assert SECRET_VALUE not in result.stdout
+        assert "did not acknowledge the redaction notice" in result.stderr
+    finally:
+        registration.close()
+        _await_absent(config_root, os.getpid())


### PR DESCRIPTION
# PR Description

## Summary of Changes

Fixes a live defect: **in an attached session every `$(lop secret get NAME)` run
by an agent was denied**, with

```
session <pid> did not acknowledge the redaction notice within 2s, so this value
cannot be kept out of its transcript and was not served
```

The §6 rule in `secrets/broker.py` notifies the REGISTERED session that owns the
requesting peer and fails closed when that session does not ack in 2 s. The only
registration shipping code made was the TUI's, whose sink read
`app._session.variables` — and since the attached facade landed (#937)
`app._session` is an `AttachedSession` with **no `VariableStore` at all**, so the
sink raised, `SessionRegistration._read_loop` deliberately did not ack, and the
broker denied. Observed 60 times in the operator's live log. **The registrant has
to be the process that owns the output filter and the transcript, which is the
session runtime, not the viewer.**

- `local_operator/secrets/session.py` — `register_variable_store_session(session)`
  builds the §6 sink over `session.variables`, resolving it per notice and
  **raising** when it is absent so the broker still fails closed; returns `None`
  when no store exists at the base, so a session that never uses the store starts
  no broker daemon.
- `local_operator/session/runtime/serving.py` — `ServingSessionHandle.__init__`
  registers, the single seam behind `spawn_owned_session` (phone and TUI runtime
  spawn) and `lop exec --control`; `dispose` deregisters, via a new idempotent
  `close_secret_registration`, so descendants of a session that has ended stop
  being authorized promptly (§2.1) instead of waiting for the socket to close.
- `local_operator/session/runtime/exec_control.py` — `ExecControl.aclose`
  deregisters too: that path never disposes the handle, so the socket-close
  backstop would otherwise be its only revocation.
- `local_operator/tui/__init__.py` — the TUI registration is kept in every shape
  and is no longer inert. The sink resolves per notice: `app._session.variables`
  when the TUI OWNS the session (there the store really is in that process); else
  it FORWARDS the value to the attached runtime over the control channel; else it
  raises so the broker still fails closed. The forward is bounded thread-side at
  `REDACTION_FORWARD_TIMEOUT_S` (1 s, under the broker's 2 s ack window) and any
  timeout or transport failure propagates as a non-acknowledgement.
- `local_operator/session/attached.py`, `local_operator/mobile/attach_client.py`,
  `local_operator/session/runtime/server.py`, `local_operator/mobile/types.py` —
  the viewer→runtime forward: `AttachedSession.register_secret_redaction(value)` →
  the `register_secret_redaction` payload op on the existing control channel →
  `ServingSessionHandle.register_secret_redaction`, which writes the value only
  into `session.variables.register_redaction` (never a credential, never an
  announcement, never a log, audit row or event). It RAISES rather than returning
  an "unavailable" result, so the sink fails closed. The op is typed in
  `mobile/types.py` and is deliberately not reachable through the `/credential`
  verb table.
- `local_operator/secrets/client.py` — a refused `register_session` now logs a
  WARNING naming the tier and the broker's reason, instead of returning `None`
  silently.
- `tests/unit/secrets/test_runtime_session_registration.py` — four new guards
  (below), spawning real descendant processes, plus five more from review round 1
  (a real-broker + real-descendant end-to-end forward, the wire op, the fail-closed
  forward, the no-target sink, and the handler/verb-table separation).
- `docs/design/secret-store.md` — §6 names the owning process; §13's amendment
  records the defect, the corrected registrant, and the hardened-tier lineage
  limit on the handle seam. No version bump: `pyproject.toml` is untouched.

**One new payload op on the EXISTING control channel**, additive and with no
`PROTOCOL_VERSION` bump (an old owner answers unknown-op, which the sink turns
into a fail-closed raise). No new channel and no new input surface: the value
rides the same authenticated loopback socket `/credential store` already uses,
and the child's own retrieval reply is still the only other place it crosses.

## Related Issue(s)

Related: no issue was filed; the reporter was the operator's own log, where the
warning + `RuntimeError` pair repeats 60 times through
`tui/__init__.py::on_secret`.

## Impact

- **Restores a documented capability.** The credentials guidance tells agents to
  read stored credentials with `$(lop secret get NAME)`; in an attached session
  (the interactive default, and the phone's runtime) that was impossible.
- **Security posture is unchanged, deliberately.** A sink that cannot register
  still raises, so the broker still DENIES rather than serving an unredactable
  value; no "serve anyway after timeout" was added, and no bypass path exists for
  a descendant that cannot be scrubbed.
- **Cost:** one broker registration per runtime process that HAS a store, plus
  one per TUI window (the viewer entry is kept because it is the broker's working
  fallback rather than an inert slot), against the broker's `MAX_SESSIONS` (32);
  and at most one bounded cold-broker start on the boot path
  (`STARTUP_TIMEOUT_S`, 5 s) when a store exists and no daemon is listening — the
  same cost `run_tui` already pays. No dependency change, no breaking change.
- **Deliberate limit (hardened tier only).** A runtime spawned by launchd (ppid 1)
  has no lineage, so the hardened tier refuses its registration and its
  descendants are denied; the refusal is now logged as a WARNING naming the tier
  and the broker's reason, and §13 states the limit instead of implying the handle
  always works. The keyfile tier is unaffected — the ticket alone admits a
  registrant. The handle is the seam for a runtime WITH lineage; a runtime that
  boots before a store exists at its root still registers nothing, but in an
  attached session the VIEWER's registration now forwards the notice to it, so
  that retrieval is served and scrubbed rather than denied.

## Testing Details

### 1. The real path, before and after — real broker, real store, real `bash` child

An isolated config dir, a synthetic secret, and the documented
`$(lop secret get EVIDENCE_TOKEN)` executed through `execute_bash` in a real
child process. Identical command in both runs; only the registration differs.

**Before** — the registration that shipped (`run_tui`'s sink over an
attached-style facade, no store):

```
[tui-sink] this pid            : 16258
[tui-sink] broker sessions    : [16258]
could not register secret 'EVIDENCE_TOKEN' for redaction
Traceback (most recent call last):
  File ".../secrets/session.py", line 83, in _read_loop
    self._on_secret(name, value)
  File ".../tui/__init__.py", line 32, in on_secret
    raise RuntimeError("no variable store is available to redact through yet")
[tui-sink] --- bash tool result ---
exit=2 len=0
printed:
--- stderr ---
session 16258 did not acknowledge the redaction notice within 2s, so this value cannot be kept out of its transcript and was not served
```

**After** — the runtime handle, over a real `VariableStore`:

```
[runtime-handle] broker sessions    : [15890]
exit=0 len=15
printed: [redacted]
[runtime-handle] redaction set: ['evid-2b8f41d0c9']
[runtime-handle] is_error: False
[runtime-handle] session disposed: True
[runtime-handle] broker sessions after teardown: [] (this pid still present: False)
```

`exit=0 len=15` is the child being SERVED (a denied CLI leaves the value empty);
`printed: [redacted]` is the value already in the filter by the time the child
could emit it — the §6 ordering — and the store's own `redact()` returns
`token=[redacted]`.

### 2. The same handle path on the pre-fix tree registered nothing

Same script against `origin/main` (`be41663ed`), with the broker up as it was in
the live system:

```
broker reachable before the handle: True
broker status   : {'ok': True, ..., 'sessions': [], 'protocol': 1}
handle attribute _secret_registration: False
child exit      : 2
child stderr    : 'BrokerDenied: no lop session is registered with the broker'
```

### 3. The REAL runtime child registers itself

`python -m local_operator.session.runtime.process` (the production daemon child
that `spawn_owned_session` builds the handle in), isolated config dir, dummy
provider key so construction succeeds (no model call is made):

```
runtime child pid: 16893
broker sessions while the child runs: [16893]
runtime child pid registered        : True
child exit code: 0
broker sessions after the child exits: []
```

### 4. New tests: red on the base, green here

`tests/unit/secrets/test_runtime_session_registration.py` — served-once-registered,
fail-closed-names-the-runtime-pid, deregistered-on-teardown, and
no-store-registers-nothing.

```
# pre-fix tree, same file (only the not-yet-existing close call neutralised)
3 failed in 1.81s
  test_a_descendant_retrieval_is_served_when_the_runtime_registered
    AssertionError: the runtime handle did not register this process as the session the broker notifies; a descendant retrieval would be denied — assert 20376 in set()
# head
4 passed in 6.59s
```

The deny-path guard asserts the broker's own message names THIS runtime pid
(`session <pid> did not acknowledge the redaction notice`), which is what makes a
future failure diagnosable rather than silent.

### 5. Gates (worktree `.venv`, CI-pinned tools)

```
# head c5d28c7a0, and the bounded-scope re-check below
.venv/bin/python -m flake8 .                     -> clean
black==26.1.0 --check .                          -> 1224 files unchanged
isort==5.13.2 --check .                          -> clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .   -> 0 errors
.venv/bin/python -m pytest tests/unit/secrets tests/unit/tui -q \
                                                 -> 7195 passed, 12 skipped in 777 s
.venv/bin/python -m pytest tests/unit/secrets -q  -> 245 passed
# full-tree runs
.venv/bin/python -m pytest tests/unit -q         -> 18425 passed, 18 skipped in 892 s
                                                    (at c5d28c7a0)
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
                                                 -> 107 passed, 7 skipped in 167 s
                                                    (at 1bdc119d1)
```

### 6. The CI run this PR produced, and the real defect it caught

The first head (`1bdc119d1`) failed `test (3.12, 0)` on exactly the two new
deregistration guards, and the failure was a product defect rather than a flake:

```
E AssertionError: the closed registration still authorized this process
E assert 2385 not in {2385}
...
2 failed, 3336 passed, 14 skipped, 30 warnings in 650.42s (0:10:50)
```

`SessionRegistration.close()` closed the socket while its own reader thread was
parked in `recv` on it. **On Linux that does not deliver the peer's EOF** — the
parked read still holds the file description — so the broker's liveness peek
never saw `b""` and its session table kept the pid for the whole window the
guards polled. macOS revokes the descriptor on `close`, so the same code
deregistered in under a second locally: a CI-only failure, visible only because
the guards poll the table instead of asserting immediately.

`c5d28c7a0` makes `close()` `shutdown(SHUT_RDWR)` first. `shutdown` acts on the
socket rather than the descriptor, so the broker's peek sees the EOF immediately
and the parked read wakes; the `close` after it only releases the descriptor.
This is the *shared* close path, so the same hazard had left the TUI's own
registration revocable only by process exit. The guards keep their poll, raised
to the 10 s bound the existing
`test_a_dead_sessions_descendants_stop_being_authorized` already uses (the broker
notices on its own 1 s poll; a tight bound fails the window, not the behaviour).

### 7. Review round 1 remediation — the forwarding path, executed

Five new guards in `tests/unit/secrets/test_runtime_session_registration.py`.
Every number below is from a run on the remediation head, `1c0a1461b`.

**Red on the base, green here.** The same test file against `c5d28c7a0` (the
round-1 head) with that tree's own sources:

```
# base c5d28c7a0, new tests copied in
3 failed, 6 passed in 21.90s
  test_the_runtime_handler_registers_a_forwarded_value
    AttributeError: 'ServingSessionHandle' object has no attribute 'register_secret_redaction'
  test_the_wire_op_registers_the_value_in_the_runtime_store
    TimeoutError: owner did not answer 'register_secret_redaction'
  test_an_attached_viewer_forwards_the_notice_and_the_child_is_served
    AssertionError: the child was refused: session <pid> did not acknowledge the redaction notice within 2s
      (the base sink: "no variable store in this process, so the retrieval is denied rather than served unscrubbed")
# head 1c0a1461b
9 passed in 14.62s
```

**The forwarding path: four probes, a real broker and real child processes**
(isolated `HOME`/`LOCAL_OPERATOR_CONFIG_DIR`, synthetic secret, every `CMUX_*`
unset; nothing of the operator's config, sessions or workspaces touched):

```
[PASS] A forward->serve: rc=0 stdout='token=evidence-5b3c1a9d7e' value_in_runtime_store=True forwarded=True
[PASS] B stream guard: raw='token=evidence-5b3c1a9d7e' after_filter='token=[redacted]'
[PASS] C fail-closed: rc=2 stdout='' stderr='...session 60010 did not acknowledge the redaction notice within 2s...'
[PASS] D Q3 control (no ancestor): rc=0 stdout='token=evidence-5b3c1a9d7e' = served un-notified by the keyfile local decrypt
```

- **A** — the attached viewer's notice is forwarded to the runtime and the child
  is served, with the value already in the runtime's redaction set at serve time.
- **B** — the §6 guard scrubs the value out of the streamed line
  (`after_filter='token=[redacted]'`); the mutation-verified stream tests in
  `tests/unit/secrets/test_agent_surfaces.py` show the guard is load-bearing.
- **C** — a forward that fails leaves the child DENIED, not served.
- **D** — the control that justifies KEEPING the viewer entry instead of closing
  it: with no registered ancestor the broker refuses for lack of ancestry and
  `access.retrieve_secret` falls through to its keyfile-tier local decrypt
  (`except BrokerDenied: if hardened: raise` → `open_store(base).get(...)`),
  serving the value UNNOTIFIED — the Q3 leak, reproduced.

**Gates on the remediation head:**

```
.venv/bin/python -m flake8 <changed .py files>               -> clean
black --check <changed .py files>                            -> 10 files unchanged
isort --check-only <changed .py files>                       -> clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .  -> 0 errors, 0 warnings
.venv/bin/python -m pytest tests/unit -q                     -> 18430 passed, 18 skipped
```

### 8. Review round 2 and QA round 2 — deferred findings

Round 2 is TERMINAL on `1c0a1461b` (0 BLOCKER / 0 MAJOR) and QA round 2 PASSED
with no Q-findings, so the items below are the only open ones. Each is left
unaddressed on purpose: editing this head for them would move a reviewed and
QA'd commit for non-blocking findings, and none of them can turn a serve into a
leak — every fail-closed direction still ends in a denial.

#### Not addressed (deferred)

- **MINOR-1 — the at-cap half of the viewer entry's budget consequence is
  untested.** The diagnosability half is already on this head: a refused
  `register_session` logs a WARNING naming the tier and the broker's reason
  (`local_operator/secrets/client.py`). The residual — a test pinning the
  refuse-at-cap path, plus a cap-arithmetic guard for the 2×-per-window shape
  against `MAX_SESSIONS = 32` — is deferred because a refusal denies rather
  than leaks.
- **NIT-1 — `docs/design/secret-store.md:1145-1148` reads as if the keyfile
  tier denies, while that path serves.** Deferred: a docs-only edit would move
  a reviewed + QA'd head. Recorded as the first item for the next PR touching
  `secret-store.md`; the reviewer's suggested wording (name the tier) is on the
  round-2 thread.
- **NIT-2 — `tui/__init__.py:79` probes the forward with a truthiness check
  rather than `callable(forward)`.** Deferred, and assessed as non-defective: a
  non-callable attribute of that name raises `TypeError` out of the sink, which
  `SessionRegistration._read_loop` catches and does not ack, so the broker
  denies — fail-closed, cosmetic only.
- **NIT-3 — no test pins the new refusal WARNING or the real-app sink.**
  Deferred for the same reason; the mechanism is verified by reading and by the
  round-2 review's log-surface probe (0 records carry the value).
- **QA round 2 observation (a) — late registration after a wedged loop.**
  Deferred observation: when the viewer's loop is wedged past the 1 s forward
  budget but the process survives, the queued forward still lands in the
  runtime's store after the child was already denied. Safe direction — more
  redaction, never a serve; nothing was served or leaked.
- **QA round 2 observation (c) — `_forward_redaction_to_runtime` on the loop
  thread.** Deferred observation: called from the loop thread rather than the
  broker's notice thread it self-times-out at the 1 s budget and raises.
  Fail-closed, never a hang; a latent trap for a future caller only — the
  production caller is the plain notice thread.

## Not addressed (found on the way, deliberately out of this slice)

- **A store created mid-session is not registered until the next boot** (see the
  deliberate limit above). Re-registering live would need a re-arm path on the
  handle for a case that requires the operator to harden a store while an agent
  is running.
- **A hardened-tier runtime whose launcher is neither a granted terminal nor a
  registered session still cannot register** (the broker's lineage rule for
  `register`), so its descendants stay denied. This is the phone/wake/automation
  shape: a launchd-spawned runtime has no lineage to borrow. **DEFERRED** — the
  fix is a lineage story for the daemon (an `unlock` grant for the supervisor
  launchd owns), not a weaker register gate, and it is out of this slice. What
  landed here is the visibility (§13 states the limit; the refusal is a WARNING)
  and the keyfile-tier behaviour is unchanged. The TUI path is fine: its
  registration runs before it spawns the runtime, so the child has lineage.
- **`TuiSessionHandle` (the TUI-OWNED, `kind="tui"` runtime) does not register,
  and does not need to:** in that shape the TUI process holds the `Session`, so
  `run_tui`'s registration is the correct one and its sink resolves the store.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required. (§6 and §13 of
      `docs/design/secret-store.md`; the mechanism and its constraint are in the
      docstrings of `register_variable_store_session`,
      `ServingSessionHandle._register_secret_session` and the TUI sink.)
- [x] Security considerations are addressed (especially for code execution features). (Fail-closed is preserved and asserted, including the new forward; ONE additive payload op on the EXISTING authenticated control channel, no new channel or input surface; the value crosses only in a single named field on the child's own retrieval reply and on the viewer→runtime forward, and is never logged, journalled, announced, audited or streamed.)
- [x] I have linked all related issues. (None filed; the report is the log line above.)


