### PR TITLE
fix(tui): the aside doesn't take the keyboard's guard rails with it when it closes

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -29535,8 +29535,9 @@ class OperatorApp(App[None]):
         self._interaction.draft.aside = None
         panel.close()
         panel._on_height = None
-        # Give the transcript its own last rows back, and land the reader at
-        # the end of the conversation they came back to.
+        # Give the transcript its own last rows back, and land the reader
+        # back where THEY were — the tail only if that is where they already
+        # were (see the `is_following_tail` guard below).
         #
         # DROP the inline rule rather than write a number back. The sheet's own
         # bottom padding is the conversation's trailing row of ground (1 in the
@@ -29548,8 +29549,31 @@ class OperatorApp(App[None]):
         # which is the only place that knows which layout is up.
         transcript = self._transcript_view()
         if transcript is not None:
+            # `follow_tail()` ONLY when the reader was already at the end —
+            # not unconditionally. The unconditional call was itself a
+            # defect: a reader who scrolled BACK to re-read something before
+            # opening the aside (the exact gesture the docstring at
+            # `_reserve_ground_for_aside` names — "re-reading is a thing
+            # people do WHILE asking an aside about it") got yanked to the
+            # tail the moment they closed the card, landing on unrelated
+            # content and one click away from the D2/D3 defects this same
+            # change fixes elsewhere. Measured: parked at `scroll_y=3` of 15,
+            # `/btw` opened and closed with no scroll gesture in between —
+            # `scroll_y` came back as `15`, not `3`. Clearing the padding
+            # rule alone (no `follow_tail()`) already lands the SAME row at
+            # the SAME offset, because the padding is the only thing that
+            # moved: the conversation's own rows never did.
+            #
+            # `is_following_tail()`, not `is_near_bottom()`: the anchor is the
+            # authority on INTENT (did the reader ask to be at the end),
+            # which is what a re-acquire on close should honour, and it is
+            # already resynced against the padded extent by
+            # `_reserve_ground_for_aside`'s own `follow_tail()` call when the
+            # aside opened at the tail.
+            was_following = transcript.is_following_tail
             transcript.styles.clear_rule("padding")
-            transcript.follow_tail()
+            if was_following:
+                transcript.follow_tail()
         draft = self._aside_draft
         images = self._aside_draft_images
         self._aside_draft = None

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -66,6 +66,7 @@ from local_operator.harness.intent import ACTIVITY_THINKING
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.composer_focus import (
     composer_may_take_focus,
+    focus_is_claimed,
     return_focus_to_composer,
 )
 
@@ -2976,6 +2977,48 @@ class TranscriptView(ScrollableContainer):
     #: full suite finds it.
     can_focus = True
 
+    def focus_on_click(self) -> bool:
+        """Refuse the MouseDown focus-steal while a surface has a real claim.
+
+        THE DEFECT THIS EXISTS TO PREVENT. Textual's own click-to-focus is not
+        this widget's :meth:`on_click` — it runs a step earlier, INSIDE
+        ``Screen._forward_event`` on ``MouseDown``: ``get_focusable_widget_at``
+        walks up from whatever is under the pointer, and because most rows
+        have no document position of their own (``UserBlock``,
+        ``AssistantBlock``, a settled ``ToolCard`` with nothing to expand),
+        that walk lands HERE, on the container, and Textual calls
+        ``self.app.set_focus(self)`` before ``on_click`` ever runs — before
+        this widget or the app has any say. A click on ordinary conversation
+        text was silently taking the keyboard away from a live tool approval,
+        an unsettled ``ask`` picker, or the ``/btw`` aside: none of those
+        surfaces stop the click (they have no reason to — a click did not use
+        to reach past them), and by the time :meth:`on_click` runs and
+        consults :func:`composer_focus.focus_is_claimed`, the damage is done —
+        focus is already here, not on the surface the user was trying to
+        answer.
+
+        Measured on a real approval: click a plain ``UserBlock`` while
+        ``rm -rf /tmp/x`` is unanswered, and ``app.focused`` became
+        ``TranscriptView`` with the prompt still up and unanswered underneath
+        it. The same click while the ``/btw`` aside is open leaves the
+        composer un-focusable for the rest of the gesture — see
+        :meth:`on_key`'s guard, which refuses to rescue a keystroke for
+        exactly this reason, and which this method is the other half of. One
+        predicate, two doors: :meth:`on_key` guards what happens to a
+        keystroke arriving AFTER focus lands here; this guards whether focus
+        is allowed to land here AT ALL.
+
+        Read-only where it can be. ``focus_is_claimed`` is the exact question
+        Textual is here answering "yes, focus me" to on its own — the widget
+        is not stealing the claim's OWN say, only declining Textual's default
+        one when nothing else has agreed to give the keyboard up. When
+        nothing claims it (the ordinary case, no approval/ask/aside/etc. up),
+        this returns True and the container still becomes the fallback focus
+        target exactly as before — :meth:`on_click` then redirects it to the
+        composer.
+        """
+        return not focus_is_claimed(self.app)
+
     def on_key(self, event) -> None:  # type: ignore[no-untyped-def]
         """Typing at the transcript goes to the COMPOSER, not into the void.
 
@@ -3148,7 +3191,8 @@ class TranscriptView(ScrollableContainer):
         self.vertical_scrollbar.styles.pointer = "grab"
 
     def on_click(self, event) -> None:  # type: ignore[no-untyped-def]
-        """A click on blank transcript returns focus to the composer.
+        """A click that lands on THIS container, and not on a descendant,
+        returns focus to the composer.
 
         Measured: with a card holding focus, clicking the empty column beside
         it left the card focused and the composer dark. The gesture said "I am
@@ -3158,17 +3202,41 @@ class TranscriptView(ScrollableContainer):
         scrolling surface, not an input, and focus resting there is the state
         :meth:`on_key` exists to rescue. Sending it to the composer is.
 
-        Only the blank column reaches this. A row's own handler runs first
-        (:meth:`ExpandableActionBlock.on_click` stops the event when it
-        expands), and the ``TranscriptBlock`` test below leaves a click that hit
-        a row alone, so clicking a card still focuses and expands it.
+        ``self.has_focus``, not ``isinstance(event.widget, TranscriptBlock)``.
+        The isinstance test was trying to ask "did a row's own handler already
+        deal with this?", but Textual answers that question directly:
+        ``Click`` bubbles from the widget under the pointer, a row that
+        legitimately takes the click stops it (:meth:`ExpandableActionBlock.
+        on_click` on activation), and a stopped event never reaches here at
+        all. So the only clicks this method ever SEES are ones nothing
+        claimed — except that MouseDown's own focus walk runs before any of
+        that: Textual focuses the nearest FOCUSABLE ancestor under the
+        pointer, and a row with no document position of its own
+        (``UserBlock``, ``AssistantBlock``, a settled ``ToolCard`` with
+        nothing to expand) has none, so the walk lands on this container.
+        ``event.widget`` is that row — a ``TranscriptBlock`` — and the old
+        guard bailed out on exactly that widget, leaving focus stranded here
+        with no rescue. Measured: click a plain conversation row (no aside, no
+        approval, nothing else open) and ``app.focused`` stays
+        ``TranscriptView`` — the same class of defect
+        :meth:`OperatorApp._focus_is_claimed` exists to prevent on the Esc
+        path, reopened here on the click path for every row that cannot take
+        focus itself.
+
+        ``self.has_focus`` reads the ANSWER to "did something else end up
+        holding it", which is true regardless of whether that something was a
+        row, blank padding, or nothing at all: a row that DID take focus
+        (``ToolCard.can_focus`` is True even when :meth:`ToolCard.can_expand`
+        is False) leaves ``self.has_focus`` False, and this correctly leaves
+        it alone. A row that could not take focus leaves the container
+        holding it by default, and this correctly redirects.
 
         ``event.stop()`` is deliberately NOT called: ``Click`` bubbles up from
         children, and stopping it at the container would swallow an event a
         descendant already owned. The rule is "focus the composer if nothing
         claimed the click", not "claim the click".
         """
-        if isinstance(event.widget, TranscriptBlock):
+        if not self.has_focus:
             return
         from local_operator.tui.widgets.editor import Editor
 

--- a/tests/unit/tui/test_aside.py
+++ b/tests/unit/tui/test_aside.py
@@ -437,6 +437,73 @@ async def test_the_card_rests_on_the_end_of_the_chat_not_on_top_of_it() -> None:
 
 
 @pytest.mark.asyncio
+async def test_a_reader_scrolled_back_is_not_yanked_to_the_tail_on_close() -> None:
+    """Closing the aside must not move a reader who was not at the end.
+
+    ``_reserve_ground_for_aside``'s own docstring makes the promise this test
+    pins: "yanking someone who had scrolled back to re-read something is what
+    this must not do, and re-reading is a thing people do WHILE asking an
+    aside about it." ``_close_aside`` broke exactly that promise on the way
+    out — it called ``transcript.follow_tail()`` unconditionally, so a reader
+    who opened `/btw` from a scrolled-back position landed back at the newest
+    message the instant they dismissed the card, with no scroll gesture of
+    their own in between.
+
+    Measured before this fix, at ``scroll_y=3`` of a 15-row scrollback: opening
+    and closing `/btw` with no scroll gesture between the two moved
+    ``scroll_y`` to `15`. The row the reader was looking at is still on
+    screen after the fix — clearing the padding rule alone repositions the
+    SAME rows correctly, because the conversation's own content never moved;
+    only the reserved ground under the card did.
+    """
+    from local_operator.tui.widgets.transcript import UserBlock
+
+    session = AsideSession(answer="\n\n".join(f"para {i} " * 20 for i in range(20)))
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 24)) as pilot:
+        await pilot.pause()
+        for i in range(40):
+            app._append_block(UserBlock(f"question number {i:02d} about the codebase"))
+        await pilot.pause()
+        transcript = app._transcript_view()
+
+        # Scroll back to re-read something, the gesture the docstring names.
+        transcript.note_user_scroll()
+        transcript.scroll_to(y=3, animate=False, immediate=True)
+        await pilot.pause()
+        parked = transcript.scroll_y
+        assert parked < transcript.max_scroll_y, "premise: not at the tail"
+        assert not transcript.is_following_tail, "premise: the anchor released"
+
+        await _open_with_question(pilot, app, "why is this long?")
+        await pilot.press("escape")
+        await pilot.pause()
+
+        assert transcript.scroll_y == parked, (
+            f"closing the aside moved the reader from {parked} to "
+            f"{transcript.scroll_y} with no scroll gesture of their own"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_reader_at_the_tail_still_lands_at_the_tail_on_close() -> None:
+    """The other half: a reader who WAS following still is, after the round trip."""
+    session = AsideSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 24)) as pilot:
+        await pilot.pause()
+        transcript = app._transcript_view()
+        assert transcript.is_following_tail
+
+        await _open_with_question(pilot, app, "are the subagents stuck?")
+        await pilot.press("escape")
+        await pilot.pause()
+
+        assert transcript.is_following_tail
+        assert transcript.scroll_y == transcript.max_scroll_y
+
+
+@pytest.mark.asyncio
 async def test_an_aside_question_never_enters_the_prompt_history() -> None:
     """ "esc discards it" has to be true of UP as well as of the transcript.
 

--- a/tests/unit/tui/test_composer_focus_claims.py
+++ b/tests/unit/tui/test_composer_focus_claims.py
@@ -261,7 +261,17 @@ async def test_tab_from_a_row_does_not_steal_focus_from_a_live_prompt() -> None:
 
 @pytest.mark.asyncio
 async def test_a_blank_transcript_click_does_not_steal_focus_from_a_live_prompt() -> None:
-    """The third unguarded route: ``TranscriptView.on_click``."""
+    """The third unguarded route: ``TranscriptView.on_click``.
+
+    Two claims, not one. ``editor.has_focus is False`` alone passed even before
+    this route was guarded, because Textual's own ``MouseDown`` handling (see
+    :meth:`TranscriptView.focus_on_click`) moved focus to ``TranscriptView``
+    itself rather than to the composer — the picker's OWN focus was still
+    stolen, just not handed to the field the old assertion checked. The
+    stronger claim (``app.focused is picker``) is the one the report is
+    actually about: the question must still be answerable, which means the
+    ask picker, not merely "not the composer", holds the keyboard.
+    """
     from local_operator.tui.widgets.transcript import TranscriptView
 
     app = _app()
@@ -282,6 +292,54 @@ async def test_a_blank_transcript_click_does_not_steal_focus_from_a_live_prompt(
         assert (
             not editor.has_focus
         ), "a click on blank transcript took the keyboard off a live multi-select"
+        assert app.focused is picker, (
+            f"a click on blank transcript moved focus to {type(app.focused).__name__} "
+            "instead of leaving it on the multi-select picker"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_transcript_row_click_does_not_steal_focus_from_a_live_prompt() -> None:
+    """The MouseDown focus-walk, not just ``on_click``.
+
+    A click on a row with no document position of its own (``UserBlock``,
+    ``AssistantBlock``) never reaches a row's ``on_click`` at all before this
+    fix — Textual's ``get_focusable_widget_at`` walks up from the widget under
+    the pointer on ``MouseDown``, finds no focusable ancestor short of
+    ``TranscriptView``, and calls ``set_focus`` on it directly, one step
+    before any handler in this codebase gets to run. A live approval sits
+    behind the SAME dock the transcript is nowhere near, so this is not a
+    contrived gesture: "click the conversation to see what led to this" is
+    the ordinary thing a user does while deciding how to answer a prompt.
+    """
+    from local_operator.tui.widgets.transcript import TranscriptView, UserBlock
+
+    app = _app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        app._append_block(UserBlock("run the migration"))
+        await pilot.pause()
+        app.run_worker(
+            app.request_tool_approval("bash", "rm -rf /Users/me/project/data"), thread=False
+        )
+        for _ in range(8):
+            await pilot.pause()
+        prompt = app._approval
+        assert prompt is not None, "premise: the approval card is up"
+        assert app.focused is prompt, "premise: the approval holds the keyboard"
+
+        view = app.query_one(TranscriptView)
+        block = view.blocks()[-1]
+        assert isinstance(block, UserBlock) and block.can_focus is False
+        site = _clamped(app, (block.region.x + 2, block.region.y))
+        await pilot.click(offset=site)
+        for _ in range(3):
+            await pilot.pause()
+
+        assert app.focused is prompt, (
+            f"clicking a plain conversation row moved focus to "
+            f"{type(app.focused).__name__}, off a live unanswered `rm -rf`"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_transcript_focus.py
+++ b/tests/unit/tui/test_transcript_focus.py
@@ -30,6 +30,7 @@ from local_operator.tui.widgets.transcript import (
     PeerMessageBlock,
     TranscriptBlock,
     TranscriptView,
+    UserBlock,
     WakeBlock,
 )
 
@@ -491,3 +492,52 @@ async def test_clicking_a_row_still_focuses_and_expands_it() -> None:
 
         assert cards[0].expanded is True
         assert app.focused is cards[0]
+
+
+@pytest.mark.asyncio
+async def test_clicking_a_row_with_no_focus_of_its_own_reaches_the_composer() -> None:
+    """A click on a row that CANNOT take focus must not strand it on the
+    container either.
+
+    ``UserBlock`` (and ``AssistantBlock``, and a settled ``ToolCard`` with
+    nothing to expand) has ``can_focus = False`` and no document position of
+    its own, so Textual's own click-to-focus walk — ``MouseDown`` in
+    ``Screen._forward_event``, which runs BEFORE any ``on_click`` handler —
+    finds no focusable ancestor short of ``TranscriptView`` itself and lands
+    focus there. The old guard in ``TranscriptView.on_click``
+    (``isinstance(event.widget, TranscriptBlock): return``) bailed out on
+    exactly this case, on the theory that a click hitting a
+    ``TranscriptBlock`` had already been handled by that block's own
+    ``on_click`` — true for a card that activates (it calls ``event.stop()``,
+    which keeps the click from ever bubbling here at all), false for a block
+    with no click handler of its own. Measured on ``origin/main`` before this
+    fix: clicking a plain ``UserBlock`` left ``app.focused`` as
+    ``TranscriptView``, with the composer dark and unreachable by a second
+    click on the same spot.
+    """
+    app = _app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        app._append_block(UserBlock("hello there"))
+        await pilot.pause()
+
+        view = app.query_one(TranscriptView)
+        block = view.blocks()[-1]
+        assert block.can_focus is False, "premise: UserBlock cannot take focus"
+        offset = (block.region.x + 2, block.region.y)
+        hit, _ = app.screen.get_widget_at(*offset)
+        assert isinstance(hit, UserBlock), f"click site hit a {type(hit).__name__}"
+
+        # `widget=` matters: `Pilot.click`'s `event.widget` is the WIDGET
+        # PASSED IN, not the one Textual would resolve for a real click at
+        # that offset (that resolution — `get_widget_at` at `MouseDown` time —
+        # is exactly the mechanism this test exists to exercise). Omitting it
+        # defaults to the screen and never reaches the code path under test.
+        await pilot.click(widget=block, offset=(2, 0))
+        await pilot.pause()
+
+        assert app.focused is editor
+        assert app.query_one("#input-dock").has_class(COMPOSER_FOCUSED_CLASS)


### PR DESCRIPTION
Release: patch — the `/btw` aside keeps its claim on the keyboard while it is open, so closing it no longer strands clicks and keys on the receded transcript

## Summary

Follow-up to #927. That fix closed the dead frame around the composer and
the click/Tab routes that ignored a live claimant, but it introduced its own
gap — `TranscriptView` became focusable to make Tab-return and the click-to-
composer rescue work, and two of the paths it opened were never checked
against the same claim predicate. Reported as "the `/btw` aside doesn't
scroll when the text is long, and closing it leaves clicking/highlighting
skewed" — the aside's own wheel and keyboard scroll were never actually
broken; the symptom is that once a click lands on the receded transcript
while the aside is open, the keyboard is stranded on a scrolling container
that answers nothing, so nothing after that click *looks* like it works,
scroll included. Reproduced against `origin/main` before any change, one
mechanism at a time.

### Defect A — a click can steal focus from a live claim before any handler runs

Textual's own click-to-focus fires on `MouseDown`, one step before
`TranscriptView.on_click` ever executes: `get_focusable_widget_at` walks up
from whatever is under the pointer, and most rows carry no document
position of their own (`UserBlock`, `AssistantBlock`, a settled `ToolCard`
with nothing to expand). That walk lands on the container, and Textual
calls `set_focus(self)` directly — before this codebase's own
`composer_focus.focus_is_claimed()` guard is ever consulted. Measured on a
real approval:

```
approval up: True answered: False
clicking UserBlock can_focus=False at y=8
focused after click: TranscriptView
approval still unanswered: True
```

`rm -rf /Users/me/project/data` sat unanswered underneath a container that
does nothing with a keypress, and the click that produced this needs no
aside at all — a live tool approval is enough.

Fixed with `TranscriptView.focus_on_click()`, the hook Textual calls
*before* its own `set_focus`, consulting the exact predicate `on_key`
already does. One rule at its two entry points: `on_key` guards a keystroke
arriving *after* focus lands here, `focus_on_click` guards whether focus is
*allowed* to land here at all.

### Defect B — the click guard bailed on the wrong signal

`TranscriptView.on_click`'s guard, `isinstance(event.widget, TranscriptBlock):
return`, assumed a click on a row had already been handled by that row's
own `on_click`. True for a card that activates — `ExpandableActionBlock.
on_click` calls `event.stop()`, so the click never bubbles here at all —
false for a row with no click handler of its own (`UserBlock`,
`AssistantBlock`). Those rows leave the click unclaimed, the `isinstance`
guard bails anyway, and focus is stranded on the container with **no
aside, no approval, nothing else open**:

```
NO ASIDE EVER OPENED. Clicking a UserBlock (can_focus=False):
  focused: TranscriptView -- composer stranded: True
```

Replaced with `self.has_focus`, read at `on_click` time — the actual
question this method needs answered ("did something else end up holding
it"), true regardless of whether that something was a row, blank padding,
or nothing at all. A row that legitimately took focus (`ToolCard.can_focus`
is `True` even with nothing to expand) leaves `has_focus` `False` and this
correctly leaves it alone; a row that could not take focus leaves the
container holding it by default, and this now redirects to the composer.

### Defect C — closing the aside yanked a scrolled-back reader to the tail

`_close_aside` called `transcript.follow_tail()` **unconditionally**. A
reader who scrolled back to re-read something before opening `/btw` — the
exact gesture `_reserve_ground_for_aside`'s own docstring names as the
reason the aside must not disturb the transcript's offset while it's open
— got yanked to the newest message the instant they dismissed the card,
with no scroll gesture of their own in between:

```
parked at scroll_y=3.0 (max 15)
aside open : scroll_y=3.0  (preserved on open — correct)
after esc  : scroll_y=15   (YANKED — wrong)
```

Clearing the padding rule the aside reserved is enough on its own: the
conversation's rows never moved, only the ground reserved under the card
did. `follow_tail()` now runs only when `transcript.is_following_tail` was
already `True` — the anchor's own record of intent, not a re-derived guess.

## What's still just the pre-existing rule working correctly

The aside's own wheel and `ctrl+pageup`/`ctrl+pagedown` keyboard scroll were
swept across every size (120x40, 100x30, 80x24, 60x18, 40x12) and both the
todo-band and no-band layouts — no dead rows, no dead columns, both gestures
reach every offset from 0 to `_max_scroll_back()`. The wheel over the
composer dock (the aside's own input) is correctly a no-op — there is
nothing there for a wheel to scroll, and the keyboard chord is the
documented no-mouse substitute for exactly that case.

## Testing

`tests/unit/tui/test_composer_focus_claims.py`:
- `test_a_transcript_row_click_does_not_steal_focus_from_a_live_prompt`
  (new) — proven to fail on `origin/main`, passes here.
- `test_a_blank_transcript_click_does_not_steal_focus_from_a_live_prompt`
  strengthened: it previously only asserted `editor.has_focus is False`,
  which passed even pre-fix because Textual moved focus to `TranscriptView`
  rather than the composer — the picker's *own* focus was still stolen, the
  old assertion just didn't check for it. Now asserts `app.focused is
  picker`.

`tests/unit/tui/test_transcript_focus.py`:
- `test_clicking_a_row_with_no_focus_of_its_own_reaches_the_composer` (new)
  — the no-claimant case; proven to fail pre-fix, passes here.

`tests/unit/tui/test_aside.py`:
- `test_a_reader_scrolled_back_is_not_yanked_to_the_tail_on_close` (new) —
  proven to fail on `origin/main` (`3` → `68` with nothing to explain the
  jump), passes here.
- `test_a_reader_at_the_tail_still_lands_at_the_tail_on_close` (new) — the
  case that must keep working: a reader following the tail still is after
  the round trip.

Full suites, this branch:
- `tests/unit/tui` — **6855 passed, 12 skipped**, 0 failed (~12 min).
- `tests/e2e -m e2e` — **107 passed, 7 skipped**, 0 failed (the
  resume-liveness / deadlock regression guard from `AGENTS.md`).
- `tests/unit/server` — **338 passed, 2 skipped**, 0 failed.
- `flake8`, `black --check`, `isort --check`, `pyright` — all clean.

**Not fully settled:** a full `tests/unit` run (18k+ tests) on this shared
development host repeatedly stalled at 93–99% under `xdist` regardless of
`--dist worksteal` vs `--dist load`, reproducing identically whether or not
`tests/unit/tui` was included and independent of worker count — killing the
coordinator process always unblocked the remaining workers immediately,
which points at host contention (many concurrent sibling worktree runs) or
an xdist coordination quirk on this specific machine rather than a defect
in the changed code. Every suite that *did* complete relevant to this
change — the entire TUI suite, the e2e deadlock guard, and the server suite
— passed clean. CI runs on a dedicated runner without that contention
(`AGENTS.md`'s own note on why the CPU-share cap is skipped there).