### PR TITLE
chore(release): bump version to 0.54.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.12"
+version = "0.54.13"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release lock for the post-v0.54.12 window. `pyproject.toml` only, one line.

## Window

Derived from `origin/main` at this branch's base (`e3a09a5f7`) with plain `git log v0.54.12..origin/main` (never `--merges`). Two PRs landed after the `v0.54.12` tag (tagged 06:47Z) and are unreleased:

| PR | Merge SHA | Impact |
|---|---|---|
| [#942](https://github.com/damianvtran/local-operator/pull/942) | `be41663ed` | `feat(session)`: refresh a conversation's title on demand with `/title refresh`. Merged 07:39Z, after the tag, and absent from the 0.54.12 notes. |
| [#959](https://github.com/damianvtran/local-operator/pull/959) | `e3a09a5f7` | `fix(secrets)`: register the runtime, not the viewer, as the broker session. Repairs the denial on every attached session's `$(lop secret get NAME)`. |

## Bump class

**PATCH → 0.54.13.** One bug fix that removes a hard failure on a primary workflow (secret retrieval from an agent's `bash` in an attached session) plus one small on-demand title refresh; no API addition, no migration, no breaking change. Neither clears the step-function bar for a minor — note that #942's own description proposes minor, and by the owner's materiality rule a convenience verb hung on the existing `/rename` row does not clear that bar, so the window takes PATCH.

## Release-window ownership

Window announced and claimed via the lop-dev protocol: `lop sessions` → peer `71978` (PR #956) confirmed it does not own this window, is not ready, and agreed PATCH is right for #959. No other lop-dev peer is live. #956 rides the next window.

## Scope

This PR is one file, one line. C0.
