### PR TITLE
chore(release): bump version to 0.54.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.13"
+version = "0.54.14"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release lock for the post-0.54.13 window. `pyproject.toml` only, one line.

## Window

Derived from `origin/main` at this branch's base (`0e3102811`). In the terms the review rules use, the base is `origin/main` itself, so the window is linear over it:

| PR | Merge SHA | Impact |
| --- | --- | --- |
| [#956](https://github.com/damianvtran/local-operator/pull/956) | `0e3102811` | `perf(tui)`: the `/analytics` session table stops re-rendering its whole 846-line body per hovered row — a row-crossing mouse move went from ~190–243 ms of blocked event loop to ~6 ms, a wheel line from ~133–174 ms to ~6–7 ms, painted frames unchanged |

`git log --oneline --merges v0.54.13..origin/main` returns exactly that one merge; its four non-merge commits (`2b73ab48a`, `73a7f2025`, `1965c569f`, `06256ebac`) are all inside #956.

## Bump class

**PATCH → 0.54.14.** A performance fix on an existing surface with no interface change, no visual change (the PR's own design round recorded 46/46 rendered frames identical to the base tree) and no new API. It does not clear the step-function bar a minor requires.

## Scope

One file, one line, `version = "0.54.13"` → `"0.54.14"`. No dependency, constraint, script or entry-point line is touched. CI for this PR is the version-bump guard plus the usual suite.

## Review record for the window PR

#956 carried four clean rounds fresh on its merged head `06256ebac` — agent review r3 terminal, QA r3 PASS with 0 FAIL, design r3 terminal (46/46 frames identical), UX r3 terminal — plus the remediations answering rounds 1 and 2. CI was 16/16 green on that head and the merge completed on the code-owner path via `--admin` (no human clicked approve); that is disclosed here rather than left implicit.
