### PR TITLE
fix(session): resolve attached-viewer images from the shared attachment store

### DIFF
--- a/local_operator/session/attached.py
+++ b/local_operator/session/attached.py
@@ -78,7 +78,7 @@ from local_operator.mobile.types import (
     PendingRequest,
     SessionRecord,
 )
-from local_operator.session.attachments import ATTACHMENTS_DIRNAME, AttachmentStore
+from local_operator.session.attachments import store_for_transcript_dir
 from local_operator.session.frontend_state import (
     FRONTEND_CAPABILITY,
     FRONTEND_CHECKPOINT_CUSTOM_TYPE,
@@ -3123,6 +3123,16 @@ class AttachedSession:
             if page.status == "full_required":
 
                 def replay() -> list[Any]:
+                    # ``Transcript``'s own store is the env default
+                    # (``AttachmentStore()`` == ``config_dir()/attachments``).
+                    # That is the same root ``store_for_transcript_dir``
+                    # derives for this session in every shipped caller — the
+                    # session's config dir comes from ``config_dir()`` (see the
+                    # AttachedSession construction sites) — so read root ==
+                    # write root here today. Left as the env default
+                    # deliberately: it is the write path's own expression, and
+                    # the construction sites, not this call, are what keep the
+                    # two equal.
                     transcript = Transcript(self._config_dir / "sessions" / self._session_id)
                     return (
                         transcript.build_llm_history(through_id=window.through_id)
@@ -3228,23 +3238,20 @@ class AttachedSession:
                 # the file START without meeting the cursor, so this is the
                 # same "id is not in the journal" the whole-file parse saw.
                 cut = None
-            # Resolve externalized media against the SAME shared store the
-            # write path puts it in: ``Transcript`` externalizes to
-            # ``config_dir()/attachments`` (attachments.AttachmentStore's
-            # default root), so that is the only root that can resolve a
-            # reference. The obvious-looking alternative — a per-session store
-            # at ``self._config_dir / "sessions" / self._session_id`` — was
-            # the bug: NOTHING ever writes there, so every digest resolved to
-            # None and a live, on-disk screenshot replayed as "image
-            # unavailable — no longer in the transcript". :meth:`_read_transcript`
-            # moved off ``Transcript.build_llm_history()`` (which used the
-            # shared store) and silently carried the wrong root with it.
-            # Mirrors ``server/utils/desktop_sessions.py`` and
-            # ``mobile/durable.py``, both of which deliberately read ONE
-            # cross-session store rather than a per-session copy.
+            # Resolve externalized media against the store that OWNED this
+            # journal (``<config>/attachments``), derived from the session
+            # directory rather than from this reader's environment — the
+            # sidebar's saved-preview reader and this cold replay both know
+            # the config dir that owns the transcript, and only the co-located
+            # root is the writer's root by construction. The obvious-looking
+            # alternative, a per-session store at ``<config>/sessions/<id>``,
+            # was the bug (#694): NOTHING ever writes there, so every digest
+            # resolved to None and a live, on-disk screenshot replayed as
+            # "image unavailable — no longer in the transcript".
+            # ``store_for_transcript_dir`` owns that rule for both readers.
             return replay_entries(
                 suffix.entries,
-                AttachmentStore(self._config_dir / ATTACHMENTS_DIRNAME),
+                store_for_transcript_dir(directory),
                 through_id=cut,
             )
 

--- a/local_operator/session/attached.py
+++ b/local_operator/session/attached.py
@@ -78,7 +78,7 @@ from local_operator.mobile.types import (
     PendingRequest,
     SessionRecord,
 )
-from local_operator.session.attachments import AttachmentStore
+from local_operator.session.attachments import ATTACHMENTS_DIRNAME, AttachmentStore
 from local_operator.session.frontend_state import (
     FRONTEND_CAPABILITY,
     FRONTEND_CHECKPOINT_CUSTOM_TYPE,
@@ -3228,7 +3228,25 @@ class AttachedSession:
                 # the file START without meeting the cursor, so this is the
                 # same "id is not in the journal" the whole-file parse saw.
                 cut = None
-            return replay_entries(suffix.entries, AttachmentStore(directory), through_id=cut)
+            # Resolve externalized media against the SAME shared store the
+            # write path puts it in: ``Transcript`` externalizes to
+            # ``config_dir()/attachments`` (attachments.AttachmentStore's
+            # default root), so that is the only root that can resolve a
+            # reference. The obvious-looking alternative — a per-session store
+            # at ``self._config_dir / "sessions" / self._session_id`` — was
+            # the bug: NOTHING ever writes there, so every digest resolved to
+            # None and a live, on-disk screenshot replayed as "image
+            # unavailable — no longer in the transcript". :meth:`_read_transcript`
+            # moved off ``Transcript.build_llm_history()`` (which used the
+            # shared store) and silently carried the wrong root with it.
+            # Mirrors ``server/utils/desktop_sessions.py`` and
+            # ``mobile/durable.py``, both of which deliberately read ONE
+            # cross-session store rather than a per-session copy.
+            return replay_entries(
+                suffix.entries,
+                AttachmentStore(self._config_dir / ATTACHMENTS_DIRNAME),
+                through_id=cut,
+            )
 
         return await asyncio.to_thread(_replay)
 

--- a/local_operator/session/attachments.py
+++ b/local_operator/session/attachments.py
@@ -183,9 +183,18 @@ class AttachmentStore:
         try:
             raw = self._content_path(digest).read_bytes()
             meta = json.loads(self._meta_path(digest).read_text(encoding="utf-8"))
-            mime_type = str(meta.get("mime_type", "image/png"))
         except (OSError, ValueError):
             return None
+        # A sidecar that PARSES but is not a JSON object (``[]``, ``null``, a
+        # bare number) has no ``mime_type`` key to read, so ``meta.get`` would
+        # raise AttributeError — straight through the callers whose contract is
+        # "degrade to a placeholder, never raise" (this method's own docstring,
+        # ``transcript._resolve_attachments``, and the readers built on them).
+        # Damaged sidecars are a hand-edited or interrupted write, i.e. the same
+        # class as a missing file, so they are treated the same way.
+        if not isinstance(meta, dict):
+            return None
+        mime_type = str(meta.get("mime_type", "image/png"))
         # The filename IS the digest. A bit-rotted or truncated file
         # that still has a sidecar would otherwise flow silently-wrong
         # bytes into the model; treat a mismatch as missing so replay

--- a/local_operator/session/attachments.py
+++ b/local_operator/session/attachments.py
@@ -76,6 +76,34 @@ def attachments_dir() -> Path:
     return config_dir() / ATTACHMENTS_DIRNAME
 
 
+def store_for_transcript_dir(directory: str | Path) -> AttachmentStore:
+    """The store that OWNED the journal in ``directory``, derived from its path.
+
+    ``directory`` is a session directory — the one holding ``transcript.jsonl``,
+    i.e. ``<cfg>/sessions/<id>``. A journal written there was written by a
+    process whose config dir was ``<cfg>``, because that is the only place
+    ``Transcript`` externalizes to (``AttachmentStore()`` ==
+    ``config_dir()/attachments``). So ``<cfg>/attachments`` is the writer's
+    store **by construction**, independent of what ``config_dir()`` resolves to
+    in the process doing the reading.
+
+    That independence is the whole point, and it is why this is a path
+    computation rather than the env default. Two readers know the config dir
+    that OWNS the transcript they are reading without being the writer: the
+    sidebar's saved-preview reader and the attached viewer's cold replay. For
+    them the env default happens to be the same directory in every shipped
+    caller today, which is exactly the kind of unstated coincidence that let a
+    second, wrong root live beside this one before (#694 — a per-session root
+    that nothing writes to, so every reference resolved to ``None`` and a
+    live screenshot replayed as "image unavailable"). One definition keeps the
+    readers and the write path from drifting apart again.
+
+    NEVER root this at the session directory itself: nothing ever writes under
+    ``<cfg>/sessions/<id>``, so a store there can only return ``None``.
+    """
+    return AttachmentStore(Path(directory).parent.parent / ATTACHMENTS_DIRNAME)
+
+
 class AttachmentStore:
     """Content-addressed binary store under the config dir.
 

--- a/local_operator/session/saved_preview.py
+++ b/local_operator/session/saved_preview.py
@@ -4,7 +4,15 @@ Only complete suffix rows are replayed. Prunes occur after their targets, so
 all prunes affecting these rows are in this same suffix. An incomplete final
 row, malformed row, or unresolved compaction cut makes the preview unavailable:
 we cannot prove that omitted bytes did not retract something we would display.
-No attachment is hydrated and this reader never starts an owner.
+
+Externalized attachments ARE hydrated, through the store that owned the journal
+(``store_for_transcript_dir``) rather than the reader's environment, because a
+preview that paints "image unavailable" for a picture the session actually has
+is the same false receipt this reader exists to avoid. The cost is bounded and
+paid off the loop: rows are still capped at ``PREVIEW_BYTES`` of journal, and
+each image reference is one file read whose size is that image (no decoding
+here — the widget decodes). What stays true from before: this reader never
+starts an owner.
 """
 
 from __future__ import annotations
@@ -13,6 +21,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from local_operator.session.attachments import store_for_transcript_dir
 from local_operator.session.history_window import DISPLAY_HISTORY_MESSAGES
 from local_operator.session.transcript import TranscriptEntry, replay_entries
 
@@ -66,7 +75,7 @@ def read_saved_preview(directory: Path) -> SavedPreview:
         (str(entry.payload.get("cwd", "")) for entry in entries if entry.type == "session"),
         "",
     )
-    messages = replay_entries(entries, None)
+    messages = replay_entries(entries, store_for_transcript_dir(directory))
     # The byte ceiling bounds disk/parse work; a separate row ceiling bounds
     # replay bookkeeping and Textual's preparation of many tiny messages. Apply
     # prunes/compaction BEFORE slicing, never truncate away their instructions.

--- a/local_operator/session/saved_preview.py
+++ b/local_operator/session/saved_preview.py
@@ -10,9 +10,10 @@ Externalized attachments ARE hydrated, through the store that owned the journal
 preview that paints "image unavailable" for a picture the session actually has
 is the same false receipt this reader exists to avoid. The cost is bounded and
 paid off the loop: rows are still capped at ``PREVIEW_BYTES`` of journal, and
-each image reference is one file read whose size is that image (no decoding
-here — the widget decodes). What stays true from before: this reader never
-starts an owner.
+each image reference costs one content read, one tiny sidecar read, and a
+full-digest re-hash (the store validates the file against its name) — all
+proportional to that image, with no decoding here: the widget decodes. What
+stays true from before: this reader never starts an owner.
 """
 
 from __future__ import annotations

--- a/tests/unit/session/test_remote_cold.py
+++ b/tests/unit/session/test_remote_cold.py
@@ -112,6 +112,73 @@ async def test_a_cold_viewer_renders_durable_history_without_an_owner(
 
 
 @pytest.mark.asyncio
+async def test_a_cold_viewer_rehydrates_a_pasted_image_from_the_shared_store(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """An externalized image must replay with its BYTES, not an empty block.
+
+    The cold replay used to resolve attachment digests against a per-session
+    store (``<config>/sessions/<id>``) that nothing ever writes to, so a user
+    screenshot that is on disk and intact replayed as the "image unavailable —
+    no longer in the transcript" receipt. The write path externalizes to the
+    SHARED ``<config>/attachments`` store (``AttachmentStore``'s default root),
+    and that is the only root a replay can resolve against.
+
+    Asserted through ``AttachedSession.cold`` — the real cold seam that boots a
+    viewer over a seeded journal — rather than ``replay_entries`` directly, so
+    the test fails if the viewer is ever wired to a third root.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    directory = _seed_transcript(tmp_path, SESSION_ID)
+
+    import base64
+    import json
+
+    from local_operator.harness.types import ImageContent, Message
+    from local_operator.session.transcript import Transcript
+
+    # Above the 1 KB externalization floor, so the row references the store
+    # rather than carrying the bytes inline — an inline row resolves with no
+    # store at all and would pass on the buggy tree.
+    image = ImageContent(
+        data=base64.b64encode(b"\x89PNG\r\n\x1a\n" + b"\x00" * 4096).decode("ascii"),
+        mime_type="image/png",
+    )
+    transcript = Transcript(directory)
+    await transcript.append_message(Message.user("look at this [Image #1]", images=[image]))
+
+    rows = [
+        json.loads(line)
+        for line in (directory / "transcript.jsonl").read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+    assert any(
+        block.get("attachment")
+        for row in rows
+        for block in (row.get("payload", {}).get("content") or [])
+        if isinstance(block, dict)
+    ), "precondition: the image row must be externalized to the store"
+
+    viewer = await AttachedSession.cold(
+        SESSION_ID, config_dir=tmp_path, cwd=str(tmp_path), takeover_factory=_never
+    )
+    try:
+        blocks = [
+            block
+            for message in viewer.history()
+            for block in (getattr(message, "content", None) or [])
+            if isinstance(block, ImageContent)
+        ]
+        assert len(blocks) == 1
+        # NON-EMPTY and byte-identical to the paste: a block that merely
+        # EXISTS is exactly what the bug produced.
+        assert blocks[0].data == image.data
+        assert len(blocks[0].data) > 0
+    finally:
+        await viewer.dispose()
+
+
+@pytest.mark.asyncio
 async def test_a_cold_viewer_shows_scheduled_wakes_from_the_index(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/unit/session/test_remote_cold.py
+++ b/tests/unit/session/test_remote_cold.py
@@ -201,6 +201,61 @@ async def test_a_cold_viewer_rehydrates_a_pasted_image_from_the_shared_store(
 
 
 @pytest.mark.asyncio
+async def test_a_cold_viewer_degrades_when_the_store_sidecar_is_not_an_object(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A damaged sidecar must degrade into the viewer, never raise.
+
+    ``AttachmentStore.get`` promises "degrade to a placeholder, never raise" —
+    and so does ``transcript._resolve_attachments``, which is the only caller on
+    this path. A sidecar that parses as JSON but is not an object (``[]``,
+    ``null``, a bare number) has no ``mime_type`` key, so an unguarded
+    ``meta.get`` raised AttributeError straight through the cold replay. It
+    needs a damaged or hand-edited store, which is why this is the guard rather
+    than a live defect: the property under test is that the replay survives the
+    same class of damage as a truncated sidecar already did.
+    """
+    import base64
+
+    from local_operator.harness.types import ImageContent, Message
+    from local_operator.session.transcript import Transcript
+
+    owner_cfg = tmp_path / "owner"
+    directory = _seed_transcript(owner_cfg, SESSION_ID)
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(owner_cfg))
+
+    image = ImageContent(
+        data=base64.b64encode(b"\x89PNG\r\n\x1a\n" + b"\x00" * 4096).decode("ascii"),
+        mime_type="image/png",
+    )
+    await Transcript(directory).append_message(
+        Message.user("look at this [Image #1]", images=[image])
+    )
+
+    sidecars = list((owner_cfg / "attachments").glob("*.json"))
+    assert len(sidecars) == 1, "precondition: the write path stored one sidecar"
+    sidecars[0].write_text("[]", encoding="utf-8")
+
+    viewer = await AttachedSession.cold(
+        SESSION_ID, config_dir=owner_cfg, cwd=str(tmp_path), takeover_factory=_never
+    )
+    try:
+        history = viewer.history()
+        blocks = [
+            block
+            for message in history
+            for block in (getattr(message, "content", None) or [])
+            if isinstance(block, ImageContent)
+        ]
+        assert len(blocks) == 1
+        # The honest receipt, not a raise and not a blanked transcript.
+        assert blocks[0].data == ""
+        assert any("look at this [Image #1]" in getattr(m, "text", "") for m in history)
+    finally:
+        await viewer.dispose()
+
+
+@pytest.mark.asyncio
 async def test_a_cold_viewer_shows_scheduled_wakes_from_the_index(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/unit/session/test_remote_cold.py
+++ b/tests/unit/session/test_remote_cold.py
@@ -120,22 +120,37 @@ async def test_a_cold_viewer_rehydrates_a_pasted_image_from_the_shared_store(
     The cold replay used to resolve attachment digests against a per-session
     store (``<config>/sessions/<id>``) that nothing ever writes to, so a user
     screenshot that is on disk and intact replayed as the "image unavailable —
-    no longer in the transcript" receipt. The write path externalizes to the
-    SHARED ``<config>/attachments`` store (``AttachmentStore``'s default root),
-    and that is the only root a replay can resolve against.
+    no longer in the transcript" receipt. The journal's own config dir is where
+    the write path externalizes to, and that is the only root a replay can
+    resolve against.
 
     Asserted through ``AttachedSession.cold`` — the real cold seam that boots a
-    viewer over a seeded journal — rather than ``replay_entries`` directly, so
-    the test fails if the viewer is ever wired to a third root.
+    viewer over a seeded journal — rather than ``replay_entries`` directly.
+
+    The reader's ENVIRONMENT deliberately differs from the owning config dir:
+    ``LOCAL_OPERATOR_CONFIG_DIR`` points at a second, empty directory while the
+    session is read with ``config_dir=<owner>``. A regression that resolved the
+    replay against ``AttachmentStore()`` (the env default) would therefore
+    resolve nothing and fail here, which is the wiring this pins — the bug's own
+    shape was a root that looked plausible and was not the writer's.
     """
-    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
-    directory = _seed_transcript(tmp_path, SESSION_ID)
+    owner_cfg = tmp_path / "owner"
+    reader_env = tmp_path / "reader-env"
+    directory = _seed_transcript(owner_cfg, SESSION_ID)
 
     import base64
     import json
 
     from local_operator.harness.types import ImageContent, Message
+    from local_operator.session.attachments import (
+        AttachmentStore,
+        store_for_transcript_dir,
+    )
     from local_operator.session.transcript import Transcript
+
+    # Write under the OWNING config dir, so the bytes land in
+    # <owner>/attachments — the store derived from the session directory.
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(owner_cfg))
 
     # Above the 1 KB externalization floor, so the row references the store
     # rather than carrying the bytes inline — an inline row resolves with no
@@ -159,8 +174,15 @@ async def test_a_cold_viewer_rehydrates_a_pasted_image_from_the_shared_store(
         if isinstance(block, dict)
     ), "precondition: the image row must be externalized to the store"
 
+    # Now hand the reader a DIFFERENT env config dir than the one that owns the
+    # journal. The roots must disagree, or the test cannot see a rewire.
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(reader_env))
+    assert store_for_transcript_dir(directory).root == owner_cfg / "attachments"
+    assert AttachmentStore().root == reader_env / "attachments"
+    assert store_for_transcript_dir(directory).root != AttachmentStore().root
+
     viewer = await AttachedSession.cold(
-        SESSION_ID, config_dir=tmp_path, cwd=str(tmp_path), takeover_factory=_never
+        SESSION_ID, config_dir=owner_cfg, cwd=str(tmp_path), takeover_factory=_never
     )
     try:
         blocks = [

--- a/tests/unit/session/test_saved_preview.py
+++ b/tests/unit/session/test_saved_preview.py
@@ -151,3 +151,92 @@ def test_oversized_last_row_reports_unavailable_instead_of_fake_content(tmp_path
     journal(tmp_path, [message("huge", "x" * (PREVIEW_BYTES * 2))])
     result = read_saved_preview(tmp_path)
     assert result.partial and result.messages == []
+
+
+async def _seeded_image_journal(tmp_path: Path, monkeypatch) -> tuple[Path, str]:
+    """A journal in its OWNER config dir whose image row is externalized.
+
+    Returns ``(session_dir, pasted_base64)``. The owning config dir is the env
+    config dir *at write time*, which is what ``Transcript`` externalizes
+    through; the caller relocates the env afterwards to prove the reader uses
+    the journal's own store rather than its environment.
+    """
+    import base64
+
+    from local_operator.harness.types import ImageContent, Message
+    from local_operator.session.transcript import Transcript
+
+    owner_cfg = tmp_path / "owner"
+    session_dir = owner_cfg / "sessions" / "preview01"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(owner_cfg))
+
+    # >1 KB base64 so the row references the store instead of carrying the
+    # bytes inline (an inline row resolves with no store at all).
+    pasted = base64.b64encode(b"\x89PNG\r\n\x1a\n" + b"\x00" * 4096).decode("ascii")
+    image = ImageContent(data=pasted, mime_type="image/png")
+    await Transcript(session_dir).append_message(
+        Message.user("previewed [Image #1]", images=[image])
+    )
+    return session_dir, pasted
+
+
+@pytest.mark.asyncio
+async def test_preview_hydrates_an_externalized_image_from_the_owning_store(tmp_path, monkeypatch):
+    """The sidebar's default surface must not paint a false "unavailable".
+
+    ``read_saved_preview`` is the sidebar's cold excerpt seam
+    (``AttachedSession.saved_preview``), so an unhydrated reference there paints
+    the unavailable receipt for a picture the session actually has.
+    """
+    from local_operator.harness.types import ImageContent
+    from local_operator.session.attachments import (
+        AttachmentStore,
+        store_for_transcript_dir,
+    )
+
+    session_dir, pasted = await _seeded_image_journal(tmp_path, monkeypatch)
+
+    # The reader's env config dir must NOT be the answer: point it at an empty
+    # directory, so a rewire to the env-default store fails this test.
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "reader-env"))
+    assert store_for_transcript_dir(session_dir).root == tmp_path / "owner" / "attachments"
+    assert store_for_transcript_dir(session_dir).root != AttachmentStore().root
+
+    blocks = [
+        block
+        for message in read_saved_preview(session_dir).messages
+        for block in (message.content or [])
+        if isinstance(block, ImageContent)
+    ]
+    assert len(blocks) == 1
+    assert blocks[0].data == pasted
+    assert len(blocks[0].data) > 0
+
+
+@pytest.mark.asyncio
+async def test_preview_degrades_to_the_receipt_when_the_store_blob_is_gone(tmp_path, monkeypatch):
+    """A genuinely missing blob still degrades — never raises, never blanks.
+
+    The hydration above must not be able to turn a pruned store into a failed
+    preview: the row keeps its prompt text and an empty image the widget renders
+    as the deliberate unavailable receipt.
+    """
+    from local_operator.harness.types import ImageContent
+
+    session_dir, _ = await _seeded_image_journal(tmp_path, monkeypatch)
+    blobs = list((tmp_path / "owner" / "attachments").glob("*.bin"))
+    assert blobs, "precondition: the write path must have stored the bytes"
+    for blob in blobs:
+        blob.unlink()
+
+    preview = read_saved_preview(session_dir)
+    blocks = [
+        block
+        for message in preview.messages
+        for block in (message.content or [])
+        if isinstance(block, ImageContent)
+    ]
+    assert len(blocks) == 1
+    assert blocks[0].data == ""
+    assert any("previewed [Image #1]" in message.text for message in preview.messages)

--- a/tests/unit/session/test_saved_preview.py
+++ b/tests/unit/session/test_saved_preview.py
@@ -240,3 +240,32 @@ async def test_preview_degrades_to_the_receipt_when_the_store_blob_is_gone(tmp_p
     assert len(blocks) == 1
     assert blocks[0].data == ""
     assert any("previewed [Image #1]" in message.text for message in preview.messages)
+
+
+@pytest.mark.asyncio
+async def test_preview_degrades_when_the_store_sidecar_is_not_an_object(tmp_path, monkeypatch):
+    """A JSON sidecar that is not an object must degrade, not raise.
+
+    ``AttachmentStore.get`` documents "Callers must treat that as ordinary and
+    degrade to a placeholder, never raise", and this reader reaches the store
+    only because it now hydrates. A sidecar of ``[]``/``null`` parses fine but
+    is not an object, so an unguarded ``meta.get`` raised AttributeError out
+    through ``read_saved_preview`` and into the sidebar's lease.
+    """
+    from local_operator.harness.types import ImageContent
+
+    session_dir, _ = await _seeded_image_journal(tmp_path, monkeypatch)
+    sidecars = list((tmp_path / "owner" / "attachments").glob("*.json"))
+    assert len(sidecars) == 1, "precondition: the write path stored one sidecar"
+    sidecars[0].write_text("null", encoding="utf-8")
+
+    preview = read_saved_preview(session_dir)
+    blocks = [
+        block
+        for message in preview.messages
+        for block in (message.content or [])
+        if isinstance(block, ImageContent)
+    ]
+    assert len(blocks) == 1
+    assert blocks[0].data == ""
+    assert any("previewed [Image #1]" in message.text for message in preview.messages)


### PR DESCRIPTION
# PR Description

## Summary of Changes

Fixes a live defect: **an image pasted into a session replayed as
`▨ image unavailable — no longer in the transcript` in an ATTACHED viewer** —
the TUI session sidebar, or `/resume` onto a session that is live in another
process (`AttachedSession`). The same image rendered live, and replayed
correctly on a plain local `--resume`.

- **Root cause.** `AttachedSession._read_transcript`'s inner `_replay()`
  resolved externalized attachment references against a **per-session** store at
  `<config>/sessions/<session_id>`, which *nothing ever writes to*. The write
  path (`Transcript.encode_message_payload` → `_externalize_attachments`) puts
  the bytes in the **shared** `<config>/attachments` store. The wrong root made
  every digest resolve to `None`, so `_resolve_attachments` logged
  `transcript references missing attachment <digest>`, set `data=""`, and
  `ImageBlock` painted the unavailable receipt for an image that was on disk and
  intact. Introduced by `bf7020399` (#694, the session sidebar), when this path
  moved off `Transcript.build_llm_history()` (which used the shared store) and
  silently carried the wrong root with it.
- **The root now has ONE definition** —
  `local_operator/session/attachments.py::store_for_transcript_dir(session_dir)`.
  A journal at `<cfg>/sessions/<id>/transcript.jsonl` was written by a process
  whose config dir was `<cfg>`, so `<cfg>/attachments` is the writer's store **by
  construction**, independent of what the *reader's* environment resolves to.
  That is the property that matters for a reader which is not the writer, and it
  is why the helper is a path computation rather than `AttachmentStore()`.
- **Both readers use it.** `session/attached.py::_read_transcript._replay` (the
  viewer's durable replay) and `session/saved_preview.py::read_saved_preview`
  (the sidebar's cold excerpt — `AttachedSession.saved_preview`, and the
  sidebar's *default* surface when no owner is live). The preview reader also
  hydrated **no** attachments before (`replay_entries(entries, None)`), so it
  painted the same false receipt; its docstring no longer claims attachments are
  not hydrated, and the stated bound is now rows ≤ `PREVIEW_BYTES` of journal
  plus one file read per referenced image, off the loop, still never starting an
  owner. Measured cost and the no-cap decision are in the remediation comments.
- `session/attached.py::materialize_history`'s `Transcript(...)` keeps its
  env-default store, now with a comment recording that it is the same root in
  every shipped caller — left unchanged deliberately.
- **Tests** — the cold-replay regression test now points
  `LOCAL_OPERATOR_CONFIG_DIR` at a **different** directory from `config_dir=`
  and asserts both store roots, so a rewire to the env default fails; two new
  tests cover the saved-preview seam (byte-identical hydration, and the
  missing-blob degrade). Each was proven to fail against the unfixed mechanism.
- **Sweep for sibling occurrences of the wrong root.** `grep -rn 'AttachmentStore(' local_operator/`
  — the per-session store was the only wrong one; the others read one shared
  store deliberately:

  | site | root | verdict |
  |---|---|---|
  | `session/transcript.py` (`Transcript.__init__`) | `AttachmentStore()` (shared) | correct — the write path |
  | `server/utils/desktop_sessions.py:532` | `self.root / ATTACHMENTS_DIRNAME` (shared) | correct |
  | `mobile/durable.py:590` | `AttachmentStore()` (shared) | correct |
  | `session/attached.py` `_read_transcript._replay` | `<config>/sessions/<id>` (per-session) | **wrong → fixed** |
  | `session/saved_preview.py` | `None` (**no** store) | **wrong → fixed** |
  | `scripts/migrate_transcript_attachments.py:151` | `AttachmentStore()` (shared) | correct |

  Test call sites under `tests/` pass an explicit `tmp_path` root on purpose and
  are unaffected.

No version bump: `pyproject.toml` stays at `0.54.14` on this branch.

Release: patch — a pasted image renders again in an attached viewer and in the sidebar's saved excerpt, instead of replaying as “image unavailable — no longer in the transcript”.

## Related Issue(s)

No issue was filed. Reported in-session against a real attachment
(`9316db10239230afc3887e63beb91696`, a 440x490 `image/png`) in
`~/.local-operator/sessions/45554e7ae7b7/transcript.jsonl`.

## Impact

- **Restores a documented capability in the attached viewer.** The transcript
  promises the picture is part of the ledger ("images ride the transcript as
  base64, so a resumed conversation replays them from the same bytes the model
  saw" — `tui/widgets/image_block.py`); in the viewer path that promise was
  broken for every externally-stored image.
- **Read-only change, no schema or on-disk format change.** Only the directory a
  replay *reads* from moves; the write path is untouched, and the rows on disk
  are unchanged. No migration, no dependency change, no breaking change.
- **No new failure mode.** A reference that resolves to nothing still degrades to
  the same unavailable receipt — the fix only stops that happening when the
  bytes are present.

## Testing Details

### 1. Real-data reproduction, before and after

The reported session is on this machine. `AttachmentStore(<session dir>)` is a
miss; `AttachmentStore()` (the shared store) hits; a fresh `read_replay_suffix`
+ `replay_entries` resolves the image **only** with the shared store.
`_resolve_attachments` pops the `attachment` key in place, so the script re-parses
per store — two stores replaying one parse would share (and consume) one another's
references.

```python
# /tmp/repro_attached_image.py  (run: <venv>/bin/python /tmp/repro_attached_image.py <repo-root>)
SESS = Path.home() / ".local-operator" / "sessions" / "45554e7ae7b7"
DIGEST = "9316db10239230afc3887e63beb91696"

def image_lengths(store, mode):
    suffix = read_replay_suffix(SESS)  # fresh parse per store: see above
    msgs = replay_entries(suffix.entries, store, mode=mode)
    return [len(b.data or "") for m in msgs for b in (m.content or []) if isinstance(b, ImageContent)]
```

**Before** — base commit `633baf258`:

```
$ cd /tmp/lo-before && .venv/bin/python /tmp/repro_attached_image.py "$PWD"
attachment digest: 9316db10239230afc3887e63beb91696
session-dir store .get(digest) -> None
config-dir  store .get(digest) -> HIT
transcript references missing attachment 9316db10239230afc3887e63beb91696
transcript references missing attachment 1e6f20b2362f8c513801c4c96f28236d
transcript references missing attachment 2f170b75bb33439c7204676e00abce59
[context] image data lengths, AttachmentStore(session_dir): [0, 0, 0]
[context] image data lengths, AttachmentStore(config_dir): [67448, 177520, 105612]
[audit]   image data lengths, AttachmentStore(session_dir): [0, 0, 0]
[audit]   image data lengths, AttachmentStore(config_dir): [67448, 177520, 105612]
```

`[context]` is the mode the production call in `_read_transcript` uses (the
default `replay_entries` mode); `[audit]` is the same seam through the other
replay mode. The production call is `AttachmentStore(<session dir>)`, i.e. the
`[0, 0, 0]` row — a live, intact 67,448-character image replayed empty.

**After** — this branch head. The production call in `_read_transcript` now
builds the shared root, so it resolves; the same seam is asserted directly by
the regression test below, and the capture run in §3 prints
`replayed image data lengths: [123556]` where the base commit printed `[0]`.
No `transcript references missing attachment` warning is emitted.

### 2. Regression tests, proven they can still fail

**`tests/unit/session/test_remote_cold.py::test_a_cold_viewer_rehydrates_a_pasted_image_from_the_shared_store`**
seeds a real journal whose image row is externalized (base64 above the 1 KB
floor, so the row references the store rather than inlining the bytes), boots
`AttachedSession.cold` over it, and asserts a **non-empty, byte-identical**
`ImageContent` in `viewer.history()` — a block that merely *exists* is exactly
what the bug produced. It writes the journal under one config dir and then
points `LOCAL_OPERATOR_CONFIG_DIR` at a **different** one, asserting both store
roots, so a rewire to the env-default store fails on the root rather than only
on the bytes.

**`tests/unit/session/test_saved_preview.py::test_preview_hydrates_an_externalized_image_from_the_owning_store`**
and **`…::test_preview_degrades_to_the_receipt_when_the_store_blob_is_gone`**
cover the sidebar's cold excerpt (`AttachedSession.saved_preview`): the first
asserts the preview returns byte-identical image data with the same env-vs-owner
split; the second deletes the blob and asserts the block still exists with empty
data, the prompt survives, and nothing raises.

Each was run against the unfixed mechanism, reverted in place, and restored:

```
# cold replay rewired to the env default
E   AssertionError: assert '' == 'iVBORw0KGgoA...AAAAAAAAAAAAA'
1 failed

# saved-preview seam back on replay_entries(entries, None)
E   AssertionError: assert '' == 'iVBORw0KGgoA...AAAAAAAAAAAAA'
1 failed

# degrade test against a resolver that raises instead of degrading
E   KeyError: '91745db03e2c43b8f6729ee1cba9eaf1'
FAILED ...::test_preview_degrades_to_the_receipt_when_the_store_blob_is_gone
```

Restored, `tests/unit/session/test_remote_cold.py` + `test_saved_preview.py` are
green (30 passed).

### 3. Visual evidence (user-visible change)

> **Capture path, stated plainly.** These are not frames of a full attach
> handshake (spawning a real owner runtime to attach to is out of scope for a
> still). They are the same state driven through the **real replay seams** — the
> cold viewer (`AttachedSession.cold`) and the sidebar's saved excerpt
> (`AttachedSession.saved_preview`) — and rendered through the **real
> `OperatorApp`** (the one that loads `local_operator.tcss`), with
> `scripts.visual_capture.save_capture` under an isolated HOME/config at
> `100x30`, `env -u NO_COLOR TERM=xterm-256color`. **Both runs of a pair execute
> from the same working directory** and the seeded journal is byte-identical, so
> the *only* variable is the tree imported (`sys.path[0]`): the before is base
> `633baf258` — the real bug, no edit to the tree — and the after is this head.
> Round 1's pair was not controlled (the two runs used different cwds, so the
> composer's directory row differed); this replaces it.

**Cold viewer** (the viewer's own durable replay):

![cold viewer before — the unavailable receipt](https://github.com/user-attachments/assets/9fe08520-6958-42b8-994c-2271ce5d4ecf)

![cold viewer after — the image painted](https://github.com/user-attachments/assets/3f15618f-7d63-4689-8003-b1f03b8e688f)

**Sidebar saved preview** (R1-1's surface, same journal and same tree pair):

![sidebar saved preview before — the unavailable receipt](https://github.com/user-attachments/assets/5172ad17-2a34-475f-8157-b2e7f93b5f81)

![sidebar saved preview after — the image painted](https://github.com/user-attachments/assets/ad66640a-12bf-4f52-b1b3-dbfa3e8df615)

The fixture is a **deterministic 440x490 PNG** (the reported case's dimensions)
of colour bands over a ramp — not random pixels — so the after frame shows *the*
image, and the run asserts it is byte-identical to the paste. It is synthetic on
purpose: the operator's real screenshot is not republished. The real case is
verified numerically in §1.

Cell geometry is **pinned in the shot** to the capture profile's cell
(`images._cell_cache = CellSize(8, 17)`), so the arithmetic and the still share
one geometry:

```
source: 440x490 png=1655 bytes  base64=2208 chars  (floor 1024)
expected grid at pinned cell 8x17: 34x18 cells
ImageBlock painted grid:           34x18 cells
```

| | before | after |
|---|---|---|
| replayed image data length | `0` | `2208` |
| replayed == pasted | `False` | `True` |
| `ImageBlock` rendered chars | `51` | `665` |
| `ImageBlock` half-cell glyphs (`▀`) | `0` | `612` |
| `ImageBlock` painted grid | receipt, 1 row | `34x18` cells |
| `ImageBlock` head | `'  ▨ image unavailable — no longer in the transcript'` | `'  ▀▀▀▀▀▀▀▀…'` |

Arithmetic in that one geometry: 440x490 px at an 8x17 px cell is 55.0 x 28.8
cells; `MAX_ROWS = 18` binds, scale 0.625, width 55 x 0.625 = 34.4 -> **34x18**.
Aspect `34*8 : 18*17` = 0.889 against the source `440:490` = 0.898 — the 1% cell
quantisation.

Cell-granular diff of each pair (800x510 raster, 8x17 px cells) — the change is
the image's own band and nothing else, the composer's cwd row included. The band
is **cell rows 5..22 (the 18-row block) plus the raster's 1-px straddle → rows
5..23**: the block region is `(2, 5, 96, 18)`, i.e. rows 5..22 = pixels 85..390,
and the last painted pixel row lands one pixel into cell row 23 (which is also
why the bbox's first differing pixel is x=31, one column of edge blend left of
the picture's own x=32). That is the capture pipeline's alignment, reproduced
identically by an independent capture, not a geometry error:

```
cold pair   : diff bbox px=(31, 86, 423, 392) -> cell rows 5..22 + 1-px straddle (5..23), cols 3..52
preview pair: diff bbox px=(31, 86, 423, 392) -> cell rows 5..22 + 1-px straddle (5..23), cols 3..52
before frames, cold vs preview seam: byte-identical (no differing cells)
```

### 4. Gates (over the whole tree, exactly as CI)

```
$ .venv/bin/python -m flake8 .
flake8 rc=0
$ uvx --from black==26.1.0 black --check .
All done! 1226 files would be left unchanged.
$ uvx isort==5.13.2 --check .
Skipped 2 files
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
18445 passed, 18 skipped, 710 warnings in 1889.50s (0:31:29)
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
107 passed, 7 skipped, 5 warnings in 207.90s (0:03:27)
```

This run is fully green. Round 1's suite carried one failure,
`tests/unit/tui/test_session_sidebar.py::test_hover_repaints_the_widget_at_most_once_per_move`
(`AssertionError: 7 repaints for 6 moves`) — a **pre-existing flake, not this
change**: a repaint-COUNT assertion on the sidebar's hover refresh, unrelated to
attachment resolution, which also fails on the **unmodified base commit** (10
serial runs on `633baf258` failed 1/10; 10 serial runs on the round-1 head
failed 1/10, same message; both under peer load average >100). It did not fire
on this head. Per AGENTS.md it is classified repo-wide rather than mine; fixing
the measurement is out of this slice's scope and is listed under "not
addressed".

## Not addressed

- **`tui/test_session_sidebar.py::test_hover_repaints_the_widget_at_most_once_per_move`**
  is a pre-existing repaint-count flake (1/10 on base, 1/10 on the round-1 head,
  same message, under peer load). Fixing the measurement is a separate change;
  recorded rather than fixed here.
- **Preview hydration has no byte cap.** Needed only by a crafted/imported
  journal whose 256 KB tail is ~120 megabyte-scale images (synthetic worst case
  160 M base64 chars / 8.3 s). Real sessions max out at 4.98 MB / 35.8 ms. A cap
  would change prune/compaction ordering to be honest about it, so it belongs in
  its own change — measurements are in the agent-review remediation comment.
- **`store_for_transcript_dir` trusts the journal's shape.** A caller passing a
  directory one level deeper would silently resolve `<cfg>/sessions/attachments`
  — **deferred — unreachable today; a nested-session caller must revisit.** Both
  callers pass `<cfg>/sessions/<id>` and ids are validated
  (`session_directory_name` rejects `/`, `\`, `..`; `resolve_resume_id` rejects
  `Path(id).name != id`), so no guard was added.
- **`_build_halfcell` has no `navigation_visible` guard**, so an offscreen
  presentation of a session with images now walks pixels (612 spans for a 34x18
  block). Raised as a design observation, out of this remediation's scope.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass. *(one pre-existing sidebar hover-repaint flake excluded, reproduced on the base commit)*
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required. *(no doc change needed: this is a wrong-root fix, and the code comment carries the constraint)*
- [x] Security considerations are addressed (especially for code execution features). *(read-only path change; no new input surface)*
- [x] I have linked all related issues. *(no issue filed; root cause named in the summary)*



