### PR TITLE
feat(tui): open the skill picker inside a prompt command's argument

### DIFF
--- a/local_operator/tui/widgets/command_picker.py
+++ b/local_operator/tui/widgets/command_picker.py
@@ -55,6 +55,7 @@ from textual.widgets import Static
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.autocomplete import (
     ArgumentChoice,
+    ArgumentMode,
     SlashCommand,
     match_choices,
     match_commands,
@@ -310,6 +311,91 @@ def _claiming_command(line: str, commands: frozenset[str] = frozenset()) -> int 
     return None
 
 
+def _skill_argument_floor(
+    line: str,
+    claim: int,
+    prompt_commands: frozenset[str],
+    name_commands: frozenset[str],
+) -> int | None:
+    """Column at or after which a boundary ``$`` may open inside a claim, else ``None``.
+
+    THE one definition of "past the name slot", read both by :func:`skill_token`
+    (deciding whether a token opens at all) and by
+    :func:`_skill_argument_region` (deciding what a reassembly rebuilds), for
+    the same non-drift reason :func:`skill_token_is_leading` is one definition:
+    two copies of this rule is how the gate and the edit end up disagreeing
+    about which half of a line belongs to the command.
+
+    The claim in :func:`_claiming_command` is now PARTIAL. It is lifted only
+    where the argument is free text destined for the model
+    (``consumes_prompt``), and only PAST the name slot, which is what keeps the
+    three picker phases mutually exclusive: while a name is still being typed
+    (``/team del``) there is no skill token at all, so the roster list owns the
+    caret unopposed. ``None`` means the claim stands WHOLE — an enum-tail
+    argument (``/model``, ``/theme``), any non-prompt command, or a name slot
+    still open.
+
+    ``claim`` is the index :func:`_claiming_command` returned; the caller has
+    already established it is not ``None``.
+    """
+    word, _sep, argument = line[claim + 1 :].partition(" ")
+    word = word.lower()
+    if word not in prompt_commands:
+        # Enum-tail and every non-prompt command: a `$` here is plain argument
+        # text, exactly as before this rule existed.
+        return None
+    arg_start = claim + 1 + len(word) + 1
+    if word not in name_commands:
+        # `/goal`, `/loop`, `/btw`, `/fork` — no name slot, so the whole
+        # argument is the request and the boundary is where it starts.
+        return arg_start
+    first, first_sep, _rest = argument.partition(" ")
+    if not first_sep:
+        # The name slot is still open: the roster list owns this caret.
+        return None
+    if word in ("team", "teams") and first.lower() == "chart":
+        # `/team chart <name>`'s second slot is another name list, not free
+        # text, so the claim stands whole through both levels.
+        return None
+    return arg_start + len(first) + 1
+
+
+def _skill_argument_region(
+    text: str,
+    cursor: int | None,
+    commands: frozenset[str],
+    prompt_commands: frozenset[str],
+    name_commands: frozenset[str],
+) -> tuple[int, int] | None:
+    """Buffer span a ``$`` reassembly rebuilds inside a claim, or ``None``.
+
+    The buffer-offset projection of :func:`_skill_argument_floor`, shaped like
+    :func:`slash_token_span`. ``[region_start, region_end)`` STARTS at the floor
+    so it cannot drift from the gate that let the token open in the first place
+    — one helper answers both questions — and ENDS at the line end per the
+    inline contract stated verbatim in :func:`slash_argument_context`'s own
+    docstring: "the argument is the text from the word-terminating space to the
+    END OF THE LINE the command is on".
+
+    Deliberately does NOT use :func:`slash_argument_context`. That parser is
+    gated on ``ArgumentMode``, which states whether a command offers a VALUE
+    LIST and says nothing about whether its argument is free text;
+    ``consumes_prompt`` is that statement. Reading the wrong flag would leave
+    the four prompt commands that offer no list — ``/goal``, ``/loop``,
+    ``/btw``, ``/fork`` — with a token that opens but no region to rebuild, and
+    they would fall through to the whole-buffer reassembly that puts the skill
+    in FRONT of the command word.
+    """
+    line, line_start, column = _line_of_cursor(text, cursor)
+    claim = _claiming_command(line, commands)
+    if claim is None or column <= claim:
+        return None
+    floor = _skill_argument_floor(line, claim, prompt_commands, name_commands)
+    if floor is None:
+        return None
+    return line_start + floor, line_start + len(line)
+
+
 def slash_context(
     text: str, cursor: int | None = None, commands: frozenset[str] = frozenset()
 ) -> SlashContext | None:
@@ -470,7 +556,11 @@ def slash_argument(
 
 
 def skill_token(
-    text: str, cursor: int | None = None, commands: frozenset[str] = frozenset()
+    text: str,
+    cursor: int | None = None,
+    commands: frozenset[str] = frozenset(),
+    prompt_commands: frozenset[str] = frozenset(),
+    name_commands: frozenset[str] = frozenset(),
 ) -> SlashContext | None:
     """The ``$skill`` token being typed at the caret, or ``None``.
 
@@ -502,6 +592,21 @@ def skill_token(
     lists would fight over one caret. Empty ``commands`` (the pure-parser
     default) disables claiming, matching every other parser here.
 
+    That claim is PARTIALLY lifted by ``prompt_commands`` and ``name_commands``.
+    A command whose argument is free text destined for the model
+    (``consumes_prompt``) is exactly where reaching for a skill makes sense —
+    ``/team delivery $research explain the MR`` — so a boundary ``$`` there
+    opens the picker, but only AT OR AFTER the argument's name-slot boundary
+    (:func:`_skill_argument_floor`). That floor is what keeps the relaxation
+    from costing disjointness: while the name is still being typed (``/team ``,
+    ``/team del``, ``/team $``) there is no skill token, so the roster list
+    answers alone and ``/team $`` cannot hijack it. At most one of the three
+    phases can answer for any caret, by construction, exactly as before.
+
+    BOTH default to ``frozenset()``, which keeps the claim TOTAL — the
+    behaviour every parser-level test and every caller outside the composer
+    relies on. Only the composer, which has the registry, passes them.
+
     ``query`` is ``""`` for a bare ``$``, which opens the list on the full set.
     The caret must be INSIDE the token; moving it out into the request closes
     the list, which is what makes the picker phase a property of the parse.
@@ -517,10 +622,19 @@ def skill_token(
     # through `_active_slash`, so the two sigils cannot disagree about who owns
     # the caret.
     claim = _claiming_command(line, commands)
+    floor = 0
     if claim is not None and column > claim:
-        return None
+        argument_floor = _skill_argument_floor(line, claim, prompt_commands, name_commands)
+        if argument_floor is None:
+            return None
+        floor = argument_floor
     dollar = _active_sigil(line, column, "$")
     if dollar is None:
+        return None
+    # The floor is tested on the RESOLVED `$`, not on the caret: the caret can
+    # sit anywhere inside the token, so a token opened before the floor stays
+    # closed however far right the user has typed.
+    if dollar < floor:
         return None
     end = dollar + 1
     while end < len(line) and not line[end].isspace():
@@ -590,6 +704,8 @@ def completion_for(
     row_name: str,
     commands: tuple[str, ...],
     known: frozenset[str] = frozenset(),
+    prompt_commands: frozenset[str] = frozenset(),
+    name_commands: frozenset[str] = frozenset(),
 ) -> tuple[str, int] | None:
     """The buffer and caret that accepting ``row_name`` produces — pure.
 
@@ -614,9 +730,23 @@ def completion_for(
     parse the caller would otherwise have had to repeat.
     """
     if mode is CompletionMode.SKILL:
-        token = skill_token(text, caret, known)
+        token = skill_token(text, caret, known, prompt_commands, name_commands)
         if token is None:
             return None
+        # INSIDE a prompt command's argument the token must become the
+        # ARGUMENT's prefix, not the buffer's. The submit-side parser is
+        # anchored at offset 0 of the ARGUMENT string, and `_reassembled_skill`
+        # below moves to the BUFFER start, which here would produce
+        # `$gitlab /team delivery …` — a line neither parser can read. So when
+        # a region exists and holds the token, that path is the only one
+        # allowed to run: a `None` from it falls through to the span
+        # replacement, never to the whole-buffer reassembly.
+        region = _skill_argument_region(text, caret, known, prompt_commands, name_commands)
+        if region is not None and region[0] <= token.start < region[1]:
+            reassembled = _reassembled_skill_argument(text, token, row_name, region)
+            if reassembled is not None:
+                return reassembled
+            return _skill_span_replacement(text, token, row_name)
         # INLINE ENGAGE, modelled exactly as NAME_ARGUMENT models it below. A
         # `$` is inline now, so a draft can survive OUTSIDE the token — either
         # before it (`fix this $res`) or on another line — and the submit-side
@@ -636,16 +766,7 @@ def completion_for(
         reassembled = _reassembled_skill(text, token, row_name)
         if reassembled is not None:
             return reassembled
-        # Same trailing-space contract as the command word: it terminates the
-        # token, closes the list, and opens the request. The suffix beyond the
-        # token is preserved because a user can complete a `$skill` typed in
-        # front of a request they already wrote.
-        # `token.start` is the `$`, which is not column 0 when the draft is
-        # indented; the leading run is preserved rather than normalised away so
-        # completing never silently reformats what the user typed.
-        lead = text[: token.start]
-        completed = f"{lead}${row_name} {text[token.end :].lstrip()}"
-        return completed, token.start + len(row_name) + 2
+        return _skill_span_replacement(text, token, row_name)
     if mode is CompletionMode.COMMAND:
         context = slash_context(text, caret, known)
         if context is None:
@@ -687,6 +808,87 @@ def completion_for(
         if outside:
             return _reassembled_completion(filled, caret_after, known)
     return filled, caret_after
+
+
+def _skill_span_replacement(text: str, token: SlashContext, row_name: str) -> tuple[str, int]:
+    """Replace just the ``$`` token's span with ``row_name`` \u2014 the plain path.
+
+    Factored out because :func:`completion_for` now reaches it from TWO places:
+    the ordinary inline case, and the argument case where the token already
+    leads its region and :func:`_reassembled_skill_argument` declines. One
+    definition so the two cannot drift into producing different buffers for
+    what the user experiences as the same keystroke.
+
+    Same trailing-space contract as the command word: it terminates the token,
+    closes the list, and opens the request. The suffix beyond the token is
+    preserved because a user can complete a ``$skill`` typed in front of a
+    request they already wrote. ``token.start`` is the ``$``, which is not
+    column 0 when the draft is indented; the leading run is preserved rather
+    than normalised away so completing never silently reformats what the user
+    typed.
+    """
+    lead = text[: token.start]
+    completed = f"{lead}${row_name} {text[token.end :].lstrip()}"
+    return completed, token.start + len(row_name) + 2
+
+
+def _reassembled_skill_argument(
+    text: str, token: SlashContext, row_name: str, region: tuple[int, int]
+) -> tuple[str, int] | None:
+    """Move a ``$`` token to the front of a prompt command's ARGUMENT.
+
+    The argument-scoped mirror of :func:`_reassembled_skill`, and it exists
+    because that one moves the token to the BUFFER start. Inside a command
+    argument that is the wrong destination: the submit-side parser
+    (:mod:`local_operator.skills.invoke`) is anchored at offset 0 of the
+    ARGUMENT string, so the token has to become the ARGUMENT's prefix.
+    Reassembling to the buffer start instead would produce
+    ``$gitlab /team delivery \u2026``, which neither the command dispatcher nor the
+    skill parser can read.
+
+    The command word and any name slot sit BEFORE ``region[0]`` by
+    construction \u2014 the region starts at :func:`_skill_argument_floor`, which is
+    past the name slot \u2014 so ``/team delivery`` is untouched here rather than
+    preserved by an extra rule. ``region`` comes from
+    :func:`_skill_argument_region`, which deliberately does not consult
+    :func:`slash_argument_context`; see there for why ``ArgumentMode`` is the
+    wrong flag to gate this on.
+
+    ``None`` whenever nothing but whitespace precedes the token INSIDE the
+    region, which is the only case this is for: the token already leads the
+    argument, so the caller's span replacement is the whole and correct answer
+    for both sub-cases — ``/team delivery $gi`` gains the separator the user
+    has not typed yet, and ``/team delivery $gi fix this`` does NOT gain a
+    trailing one, because the separator before the request is already there and
+    a space after the user's own sentence is a stray character no other
+    completion in this codebase appends.
+
+    The caret parks immediately after the ``$<name> `` separator rather than at
+    the end of the text, which is where :func:`_reassembled_skill` parks. Two
+    completion paths reach THIS slot — span replacement when no prose precedes
+    the ``$``, reassembly when some does — and which one runs depends on
+    something the user cannot see; parking them differently would move Tab's
+    caret by the length of their own prose for no visible reason. Consistency
+    within the slot outranks consistency across slots, and in the bare case the
+    two conventions coincide anyway.
+    """
+    region_start, region_end = region
+    if not text[region_start : token.start].strip():
+        return None
+    # One adjoining separator goes with the token, the same rule
+    # :func:`_reassembled_skill` and :func:`_reassembled_completion` use, so the
+    # gap the token used to occupy does not survive the move. The PRECEDING
+    # separator is preferred; the following one is taken only when the token
+    # opens the rebuilt region.
+    start, end = token.start, token.end
+    if start > region_start and text[start - 1] in " \t\n":
+        start -= 1
+    elif end < region_end and text[end] in " \t\n":
+        end += 1
+    rest = (text[region_start:start] + text[end:region_end]).strip()
+    assembled = f"${row_name} {rest} " if rest else f"${row_name} "
+    new_text = text[:region_start] + assembled + text[region_end:]
+    return new_text, region_start + len(row_name) + 2
 
 
 def _reassembled_skill(text: str, token: SlashContext, row_name: str) -> tuple[str, int] | None:
@@ -1046,6 +1248,8 @@ class CommandPicker(Static):
         self._suppress_report = False
         self._commands: list[SlashCommand] = []
         self._command_names: frozenset[str] = frozenset()
+        self._prompt_command_names: frozenset[str] = frozenset()
+        self._name_prompt_commands: frozenset[str] = frozenset()
         #: Whether the ``$`` token the SKILL list is showing for sits INLINE
         #: rather than at the buffer start. Latched by ``sync_skills`` so the
         #: app's one-tick-later ``set_choices`` refill re-derives under the same
@@ -1093,6 +1297,24 @@ class CommandPicker(Static):
         # claimed the rest of the line. Cached so it is not rebuilt per keystroke.
         self._command_names = frozenset(
             name.lower() for command in commands for name in command.names
+        )
+        # The `$` arbitration's two halves, cached beside the vocabulary above
+        # and for the same reason. A command whose argument is free text bound
+        # for the model gives up its claim PAST the name slot, so a skill can be
+        # reached from inside the request; `_skill_argument_floor` reads both
+        # sets to find that boundary. Derived from the registry so they cannot
+        # drift from the flag they describe.
+        self._prompt_command_names = frozenset(
+            name.lower()
+            for command in commands
+            if command.consumes_prompt
+            for name in command.names
+        )
+        self._name_prompt_commands = frozenset(
+            name.lower()
+            for command in commands
+            if command.consumes_prompt and command.arguments is not ArgumentMode.NONE
+            for name in command.names
         )
 
     def set_choices(self, choices: list[ArgumentChoice], highlight: str | None = None) -> None:
@@ -1387,7 +1609,13 @@ class CommandPicker(Static):
         inside an engaged command's argument reads as plain text here for the
         same reason it does there.
         """
-        token = skill_token(text, cursor, self._command_names)
+        token = skill_token(
+            text,
+            cursor,
+            self._command_names,
+            self._prompt_command_names,
+            self._name_prompt_commands,
+        )
         if token is None:
             self._dismissed_query = None
             self._mode = PickerMode.SKILL

--- a/local_operator/tui/widgets/command_picker.py
+++ b/local_operator/tui/widgets/command_picker.py
@@ -350,8 +350,11 @@ def _skill_argument_floor(
         # argument is the request and the boundary is where it starts.
         return arg_start
     first, first_sep, _rest = argument.partition(" ")
-    if not first_sep:
-        # The name slot is still open: the roster list owns this caret.
+    if not first_sep or not first:
+        # The name slot is still open: the roster list owns this caret. An EMPTY
+        # `first` is the doubled-space case (`/team  $x`), where `partition`
+        # splits on the first of two spaces and reports a terminated name that
+        # was never typed; a blank token is an open slot, not a finished name.
         return None
     if word in ("team", "teams") and first.lower() == "chart":
         # `/team chart <name>`'s second slot is another name list, not free

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -2040,6 +2040,8 @@ class Editor(TextArea):
         # derive-from-registry reason as the tuples above; read during the
         # inline run to decide reassemble-to-front vs splice-and-run.
         self._prompt_commands: tuple[str, ...] = ()
+        self._prompt_command_names: frozenset[str] = frozenset()
+        self._name_prompt_commands: frozenset[str] = frozenset()
         # The team/agent NAMES the open argument list is offering, pushed by the
         # app in ``on_argument_query_opened`` (see :meth:`set_name_choices`).
         # A frozenset so the render pass tests membership in O(1): the render
@@ -2559,6 +2561,28 @@ class Editor(TextArea):
         # included) so the set cannot drift from the flag it reads.
         self._prompt_commands = tuple(
             name for command in commands if command.consumes_prompt for name in command.names
+        )
+        # The same flag as a lower-cased SET, for the `$` parsers: inside one of
+        # these commands the argument is free text destined for the model, which
+        # is exactly where reaching for a skill makes sense, so the command's
+        # claim on its line is partially lifted there. Kept separate from the
+        # tuple above rather than repointing its readers, because that one
+        # answers a different question (which command to reassemble) and its
+        # callers depend on the ordering.
+        self._prompt_command_names = frozenset(
+            name.lower()
+            for command in commands
+            if command.consumes_prompt
+            for name in command.names
+        )
+        # Those of the above that also offer a NAME list, so the `$` floor knows
+        # a name slot has to be passed first. Derived from the registry, not
+        # spelled out, so it cannot drift from `NAME_ARGUMENT_COMMANDS`.
+        self._name_prompt_commands = frozenset(
+            name.lower()
+            for command in commands
+            if command.consumes_prompt and command.arguments is not ArgumentMode.NONE
+            for name in command.names
         )
         # Lower-cased vocabulary (primaries AND aliases), shared by the
         # highlighter's "is this a real command?" oracle and the inline
@@ -7182,11 +7206,19 @@ class Editor(TextArea):
         """Which list the caret is currently inside, or ``None``.
 
         ``"argument"`` while :func:`slash_argument` matches, ``"command"``
-        while :func:`slash_context` matches, ``None`` otherwise. The three
-        answers are mutually exclusive by construction (the space that
-        opens an argument closes the command word). Used by
+        while :func:`slash_context` matches, ``None`` otherwise. Used by
         :meth:`_sync_picker_if_phase_changed` so a caret move that stays
         inside one phase does not re-open an Esc-dismissed list.
+
+        The three answers are still mutually exclusive, but the claim alone no
+        longer delivers that. A prompt command's claim is now PARTIAL: a ``$``
+        inside ``/team delivery …`` does open a skill token. What keeps the
+        phases disjoint is ``_skill_argument_floor``, which refuses the NAME
+        SLOT — while ``/team del`` is being typed there is no skill token at
+        all, so the roster list answers alone and cannot be hijacked. Past the
+        name the argument is free text, where the roster list has nothing to
+        say. The order below therefore still decides only who is ASKED first,
+        never who wins.
         """
         cursor = self._caret_offset()
         # Checked FIRST and short-circuiting, but the reason is no longer "a `$`
@@ -7197,7 +7229,16 @@ class Editor(TextArea):
         # `slash_argument` resolve their own nested slashes with. The two answers
         # are therefore disjoint by construction, and this order only decides who
         # is asked first — not who wins.
-        if skill_token(self.text, cursor, self._command_names) is not None:
+        if (
+            skill_token(
+                self.text,
+                cursor,
+                self._command_names,
+                self._prompt_command_names,
+                self._name_prompt_commands,
+            )
+            is not None
+        ):
             return "skill"
         if (
             slash_argument(self.text, self._argument_commands, cursor, self._command_names)
@@ -7308,7 +7349,16 @@ class Editor(TextArea):
         # engaged command's argument is claimed by that command and never
         # answers here. The rows themselves are pushed by the app
         # (SkillQueryOpened), exactly as an argument list's are.
-        if skill_token(self.text, cursor, self._command_names) is not None:
+        if (
+            skill_token(
+                self.text,
+                cursor,
+                self._command_names,
+                self._prompt_command_names,
+                self._name_prompt_commands,
+            )
+            is not None
+        ):
             if not self._skill_choices_requested:
                 self._skill_choices_requested = True
                 self.post_message(SkillQueryOpened())
@@ -7788,6 +7838,8 @@ class Editor(TextArea):
             name,
             self._argument_commands,
             self._command_names,
+            self._prompt_command_names,
+            self._name_prompt_commands,
         )
 
     def _completion_mode(self) -> CompletionMode | None:

--- a/tests/unit/tui/test_skill_in_command_argument.py
+++ b/tests/unit/tui/test_skill_in_command_argument.py
@@ -105,6 +105,17 @@ class TestTheFloorDecidesWhereATokenOpens:
         """`/team del$` is still inside the unterminated name token."""
         assert _token("/team del$") is None
 
+    @pytest.mark.parametrize("text", ["/team  $x", "/team   $x", "/agent  $x"])
+    def test_skill_token_declines_on_doubled_space_before_name(self, text: str):
+        """Extra spaces before the name still leave the name slot OPEN.
+
+        `partition(" ")` splits on the FIRST of two spaces, so a doubled space
+        reports an empty-but-"terminated" name. Reading that as a finished name
+        handed the caret to the skill picker and dropped the roster list the
+        floor exists to protect.
+        """
+        assert _token(text) is None
+
     def test_skill_token_opens_in_goal_argument(self):
         """`/goal` offers no name list, so its argument starts at the request."""
         token = _token("/goal $cte")

--- a/tests/unit/tui/test_skill_in_command_argument.py
+++ b/tests/unit/tui/test_skill_in_command_argument.py
@@ -1,0 +1,437 @@
+"""`$skill` inside a PROMPT-carrying slash command's argument.
+
+The composer half of the contract. A command whose argument is free text bound
+for the model (``consumes_prompt``) gives up its claim on that argument PAST the
+name slot, so ``/team delivery $cte-explainer explain the MR`` opens the picker
+and accepting a row rewrites the ARGUMENT rather than the buffer.
+
+Three properties carry it and regress independently, so they are asserted apart:
+WHICH carets open a token (the floor), WHAT the picker offers there (the inline
+lowercase gate, which applies unchanged in this position), and WHERE an accepted
+row lands (the argument's front, not the buffer's — the submit parser is anchored
+at offset 0 of the argument string).
+
+The negative half — where the claim still holds totally — stays in
+`test_skill_invocation.py::test_a_sigil_stays_plain_text_where_the_claim_holds`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from local_operator.slash_commands import SLASH_COMMANDS
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.autocomplete import ArgumentChoice, ArgumentMode
+from local_operator.tui.widgets.command_picker import (
+    CompletionMode,
+    PickerMode,
+    _skill_argument_floor,
+    _skill_argument_region,
+    completion_for,
+    ghost_for,
+    skill_suggestions,
+    skill_token,
+)
+from local_operator.tui.widgets.editor import Editor
+
+from .test_app_pilot import FakeSession, _factory
+from .test_skill_invocation import skill_root  # noqa: F401  (pytest fixture)
+
+# The registry-derived vocabularies the composer passes. Built here exactly as
+# `Editor.set_commands` builds them, so a drift between the two shows up as a
+# failure rather than as a test that quietly stops describing the product.
+COMMAND_NAMES = frozenset(name.lower() for c in SLASH_COMMANDS for name in c.names)
+PROMPT_COMMANDS = frozenset(
+    name.lower() for c in SLASH_COMMANDS if c.consumes_prompt for name in c.names
+)
+NAME_COMMANDS = frozenset(
+    name.lower()
+    for c in SLASH_COMMANDS
+    if c.consumes_prompt and c.arguments is not ArgumentMode.NONE
+    for name in c.names
+)
+ARGUMENT_COMMANDS = tuple(
+    name for c in SLASH_COMMANDS if c.arguments is not ArgumentMode.NONE for name in c.names
+)
+
+
+def _token(text: str, caret: int | None = None):
+    """``skill_token`` as the COMPOSER asks it, with both vocabularies."""
+    return skill_token(
+        text,
+        len(text) if caret is None else caret,
+        COMMAND_NAMES,
+        PROMPT_COMMANDS,
+        NAME_COMMANDS,
+    )
+
+
+def _complete(text: str, row_name: str, caret: int | None = None):
+    """``completion_for`` in SKILL mode as the composer asks it."""
+    return completion_for(
+        text,
+        len(text) if caret is None else caret,
+        CompletionMode.SKILL,
+        row_name,
+        ARGUMENT_COMMANDS,
+        COMMAND_NAMES,
+        PROMPT_COMMANDS,
+        NAME_COMMANDS,
+    )
+
+
+class TestTheFloorDecidesWhereATokenOpens:
+    """Which carets inside a claimed line may open a `$` token at all."""
+
+    def test_skill_token_opens_in_team_request_slot(self):
+        """The case the slice exists for: past the name, the rest is a request."""
+        token = _token("/team delivery $cte")
+        assert token is not None and token.query == "cte"
+
+    def test_skill_token_declines_in_team_name_slot(self):
+        """`/team $cte` must not hijack the roster list.
+
+        The ordering answer: while the name slot is open there is no skill token,
+        so `slash_argument` resolves first and the roster owns the caret.
+        """
+        assert _token("/team $cte") is None
+
+    def test_skill_token_declines_on_bare_team_space(self):
+        assert _token("/team $") is None
+
+    def test_skill_token_declines_in_partial_team_name(self):
+        """`/team del$` is still inside the unterminated name token."""
+        assert _token("/team del$") is None
+
+    def test_skill_token_opens_in_goal_argument(self):
+        """`/goal` offers no name list, so its argument starts at the request."""
+        token = _token("/goal $cte")
+        assert token is not None and token.query == "cte"
+
+    @pytest.mark.parametrize("text", ["/btw $cte", "/loop $cte", "/fork $cte"])
+    def test_skill_token_opens_in_btw_and_loop_arguments(self, text: str):
+        """The other three no-name-slot prompt commands behave as `/goal` does."""
+        token = _token(text)
+        assert token is not None and token.query == "cte"
+
+    @pytest.mark.parametrize("text", ["/model $cte", "/theme $cte", "/login $cte"])
+    def test_skill_token_declines_in_enum_tail_argument(self, text: str):
+        """An enum-tail argument is a fixed vocabulary, so the claim stands whole."""
+        assert _token(text) is None
+
+    def test_skill_token_declines_in_team_chart_slot(self):
+        """`/team chart <name>`'s second slot is another name list, not free text."""
+        assert _token("/team chart $cte") is None
+
+    def test_skill_token_opens_after_agent_name(self):
+        token = _token("/agent reviewer $cte")
+        assert token is not None and token.query == "cte"
+
+    def test_skill_token_claim_total_without_prompt_sets(self):
+        """Omitting the new sets keeps the claim TOTAL — the parser-level default.
+
+        The guarantee every caller outside the composer relies on, including the
+        two `app.py` slash-argument sites and every pure-parser test: the
+        relaxation is opt-in, carried by the vocabularies the composer passes.
+        """
+        assert skill_token("/team delivery $cte", None, COMMAND_NAMES) is None
+
+
+class TestTheInlineGateAppliesUnchanged:
+    """A `$` in an argument is never buffer-leading, so the inline gate applies.
+
+    No code makes this true: `skill_token_is_leading` is already False in this
+    position, so `sync_skills` sets `_skill_inline` and the lowercase-evidence
+    rule holds for free. Asserted here because it is load-bearing for the
+    founding money case — `/team delivery review the $5 invoice` must stay prose.
+    """
+
+    CHOICES = [
+        ArgumentChoice("cte-explainer", "Explain a CTE."),
+        ArgumentChoice("gitlab", "Work a merge request."),
+    ]
+
+    def _rows(self, text: str) -> list[str]:
+        token = _token(text)
+        if token is None:
+            return []
+        return [name for name, _ in skill_suggestions(token.query, self.CHOICES, inline=True)]
+
+    def test_bare_dollar_in_command_argument_offers_nothing(self):
+        assert self._rows("/team delivery $") == []
+
+    def test_money_in_command_argument_offers_nothing(self):
+        assert self._rows("/team delivery review the $5 invoice") == []
+
+    def test_shell_variable_in_command_argument_offers_nothing(self):
+        """`$PATH` carries no lowercase evidence, so it stays prose."""
+        assert self._rows("/goal deploy with $PATH") == []
+
+    def test_lowercase_prefix_in_command_argument_offers_rows(self):
+        assert "cte-explainer" in self._rows("/team delivery $ct")
+
+
+class TestAcceptingARowRewritesTheArgument:
+    """An accepted row becomes the ARGUMENT's prefix, never the buffer's.
+
+    The submit-side parser is anchored at offset 0 of the argument string, so a
+    reassembly to the buffer start would produce `$gitlab /team delivery …` —
+    a line neither the dispatcher nor the skill parser can read.
+    """
+
+    def test_completion_moves_skill_to_argument_front(self):
+        assert _complete("/team delivery explain this $git", "gitlab") == (
+            "/team delivery $gitlab explain this ",
+            23,
+        )
+
+    def test_completion_preserves_tail_when_skill_leads_argument(self):
+        """No trailing space here: the separator before the request already exists.
+
+        The token already leads the region, so the plain span replacement is the
+        whole answer and a space appended after the user's own sentence would be
+        a stray character no other completion in this codebase adds.
+        """
+        assert _complete("/team delivery $gi fix this", "gitlab", caret=18) == (
+            "/team delivery $gitlab fix this",
+            23,
+        )
+
+    def test_completion_in_goal_argument(self):
+        """The case that could not work while the region came from `ArgumentMode`."""
+        assert _complete("/goal ship it $git", "gitlab") == ("/goal $gitlab ship it ", 14)
+
+    @pytest.mark.parametrize(
+        "text,expected,caret",
+        [
+            ("/btw ask it $git", "/btw $gitlab ask it ", 13),
+            ("/loop drive it $git", "/loop $gitlab drive it ", 14),
+            ("/fork start on $git", "/fork $gitlab start on ", 14),
+        ],
+    )
+    def test_completion_in_btw_loop_fork_arguments(self, text: str, expected: str, caret: int):
+        """The three remaining no-name-slot prompt commands rebuild in place."""
+        assert _complete(text, "gitlab") == (expected, caret)
+
+    def test_completion_outside_command_still_reassembles_buffer(self):
+        """The pre-existing whole-buffer path, unregressed."""
+        assert _complete("fix this $git", "gitlab") == ("$gitlab fix this ", 17)
+
+    def test_dollar_on_second_line_of_goal_draft_is_unchanged(self):
+        """LOCKED AS UNCHANGED, not as desirable.
+
+        Line 2 carries no claiming `/`, so the floor is never consulted and the
+        token takes the whole-buffer path from 92fe6402. The result is odd, and
+        it is odd on origin/main too; fixing it is out of this slice's scope.
+        """
+        assert _complete("/goal ship it\nfix the $git", "gitlab") == (
+            "$gitlab /goal ship it\nfix the ",
+            30,
+        )
+
+    @pytest.mark.parametrize(
+        "text,caret",
+        [
+            ("/team delivery explain this $git", None),
+            ("/goal ship it $git", None),
+            ("/agent reviewer look at this $git", None),
+            ("/btw ask it $git", None),
+            ("/loop drive it $git", None),
+            ("/fork start on $git", None),
+            ("/team delivery $gi fix this", 18),
+        ],
+    )
+    def test_argument_reassembly_never_precedes_the_command_word(
+        self, text: str, caret: int | None
+    ):
+        """The command word stays at index 0 in every rebuild case."""
+        completed = _complete(text, "gitlab", caret=caret)
+        assert completed is not None, text
+        new_text, _ = completed
+        assert new_text.startswith("/")
+        assert new_text.index("$") > new_text.index(" ")
+
+    def test_completion_after_agent_name(self):
+        assert _complete("/agent reviewer look at this $git", "gitlab") == (
+            "/agent reviewer $gitlab look at this ",
+            24,
+        )
+
+    def test_ghost_withheld_for_argument_reassembly(self):
+        """The result is not an append, so `ghost_for`'s startswith rule withholds it."""
+        text = "/team delivery explain this $git"
+        assert ghost_for(_complete(text, "gitlab"), text) == ""
+
+
+class TestTheRegionCannotDriftFromTheFloor:
+    """One helper answers "where does the argument start", for gate and edit alike."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "/team delivery explain this $git",
+            "/goal ship it $git",
+            "/agent reviewer look at this $git",
+            "/btw ask it $git",
+            "/loop drive it $git",
+            "/fork start on $git",
+        ],
+    )
+    def test_region_start_equals_floor(self, text: str):
+        region = _skill_argument_region(
+            text, len(text), COMMAND_NAMES, PROMPT_COMMANDS, NAME_COMMANDS
+        )
+        assert region is not None
+        floor = _skill_argument_floor(text, 0, PROMPT_COMMANDS, NAME_COMMANDS)
+        assert floor is not None
+        # Single-line buffers, so line_start is 0 and the two are directly comparable.
+        assert region[0] == floor
+        assert region[1] == len(text)
+
+
+class TestPhaseDisjointness:
+    """At most one picker phase may answer for any caret — the highest risk here.
+
+    Before this slice the CLAIM delivered disjointness. It is now partial, so the
+    floor delivers it instead: the phases stay mutually exclusive by construction
+    and `_picker_phase`'s order still decides only who is ASKED first.
+    """
+
+    def _editor(self) -> Editor:
+        editor = Editor()
+        editor.set_commands(list(SLASH_COMMANDS))
+        return editor
+
+    async def _phase(self, buffer: str) -> str | None:
+        """``_picker_phase()`` with the caret at the END of ``buffer``.
+
+        Driven through a mounted app rather than a bare ``Editor``: the phase
+        reads ``_caret_offset()``, which is 0 until the widget is mounted and
+        the caret actually moved, so an unmounted editor would answer for column
+        0 — the ``/`` — and every case here would pass for the wrong reason.
+        """
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = app.query_one(Editor)
+            editor.focus()
+            await pilot.pause()
+            editor.load_text(buffer)
+            editor.move_cursor(editor._end_of_buffer())
+            await pilot.pause()
+            return editor._picker_phase()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("buffer", ["/team ", "/team del"])
+    async def test_picker_phase_is_argument_in_team_name_slot(self, buffer: str):
+        assert await self._phase(buffer) == "argument"
+
+    @pytest.mark.asyncio
+    async def test_picker_phase_is_skill_in_team_request_slot(self):
+        assert await self._phase("/team delivery $ct") == "skill"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "buffer",
+        [
+            "/team ",
+            "/team del",
+            "/team $",
+            "/team delivery $ct",
+            "/team chart $ct",
+            "/model $ct",
+            "/goal $ct",
+            "/agent reviewer $ct",
+        ],
+    )
+    async def test_picker_phase_never_two_answers(self, buffer: str):
+        """Exactly one phase owns the caret, and a name slot is never the skill.
+
+        NOTE ON FORMULATION — this deliberately does NOT assert that at most one
+        of `skill_token` / `slash_argument` / `slash_context` is non-None, which
+        is how the property was first written. That version cannot hold, and its
+        failure is the slice working as designed: `slash_argument` answers for
+        the WHOLE argument tail of a name-list command, `$` or no `$`
+        (`/team delivery hello` already answers it on origin/main). It was alone
+        there only because the total claim suppressed `skill_token`; relaxing
+        that claim past the name slot — the entire point of this slice —
+        necessarily makes both answer for `/team delivery $ct`. Asserting raw
+        exclusivity would mean un-building the feature.
+
+        What must actually hold, and what this asserts, is the user-visible
+        contract D2 is about: `_picker_phase` resolves to exactly ONE phase, and
+        a `$` is never allowed to open inside a still-open NAME slot. The
+        short-circuit order then decides only who is asked first among parsers
+        that may legitimately overlap — never whether a roster list can be
+        hijacked, which the floor decides and the name-slot cases above pin.
+        """
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = app.query_one(Editor)
+            editor.focus()
+            await pilot.pause()
+            editor.load_text(buffer)
+            editor.move_cursor(editor._end_of_buffer())
+            await pilot.pause()
+            phase = editor._picker_phase()
+            assert phase in (None, "skill", "argument", "command"), (buffer, phase)
+            caret = editor._caret_offset()
+            token = _token(buffer, caret)
+            if token is not None:
+                # A token that opened must own the phase outright...
+                assert phase == "skill", (buffer, phase)
+                # ...and must sit at or past the floor, never in the name slot.
+                region = _skill_argument_region(
+                    buffer, caret, COMMAND_NAMES, PROMPT_COMMANDS, NAME_COMMANDS
+                )
+                assert region is None or region[0] <= token.start, (buffer, region)
+
+    def test_name_prompt_commands_match_name_argument_commands(self):
+        """The registry-derived set must equal the hand-written one it describes.
+
+        A guard, not a tautology: if a `consumes_prompt` command grows an argument
+        list that is not a team/agent roster, the two-set formulation stops
+        describing the registry and the floor's name-slot rule needs rethinking.
+        """
+        editor = self._editor()
+        assert editor._name_prompt_commands == frozenset(Editor.NAME_ARGUMENT_COMMANDS)
+
+
+class TestTheComposerOpensTheListInARequestSlot:
+    """The composer-level half: the picker really opens, end to end in the app."""
+
+    async def _draft(self, app, pilot, text: str) -> Editor:
+        """Type ``text`` into a focused composer with the caret at its end."""
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        editor.load_text(text)
+        editor.move_cursor(editor._end_of_buffer())
+        for _ in range(50):
+            await pilot.pause()
+            if editor.picker.is_open():
+                break
+        return editor
+
+    @pytest.mark.asyncio
+    async def test_a_sigil_in_a_prompt_command_request_opens_the_skill_list(
+        self, skill_root: Path  # noqa: F811
+    ) -> None:
+        """The inverse of the enum-tail case.
+
+        Past a terminated name slot the request is free text, so `$res` is an
+        invocation and not prose. This is the coverage the old
+        `test_a_sigil_inside_an_engaged_command_is_plain_text` gave up when its
+        buffer became the very case the slice exists to open.
+        """
+        session = FakeSession()
+        app = OperatorApp(lambda: _factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            editor = await self._draft(app, pilot, "/team ops $res")
+            assert editor.picker.mode is PickerMode.SKILL

--- a/tests/unit/tui/test_skill_invocation.py
+++ b/tests/unit/tui/test_skill_invocation.py
@@ -591,17 +591,26 @@ class TestInlineInvocation:
             assert not editor.picker.is_open()
 
     @pytest.mark.asyncio
-    async def test_a_sigil_inside_an_engaged_command_is_plain_text(self, skill_root) -> None:
-        """`/team ops $research` is a request about a skill, not an invocation.
+    async def test_a_sigil_stays_plain_text_where_the_claim_holds(self, skill_root) -> None:
+        """A `$` is plain text wherever a command's argument is NOT free text.
 
-        The arbitration case that only became possible when `$` went inline.
+        The arbitration case, narrowed to what survives the argument-slot floor.
+        A terminated recognised command still claims its line, but that claim is
+        now PARTIAL: it yields past a terminated NAME slot, because the request
+        after a team/agent name is free text destined for the model and a
+        `$skill` there is an invocation (see `_skill_argument_floor`). It holds
+        totally in the two shapes below — an enum-tail argument, whose values are
+        a fixed vocabulary, and a NAME slot still being typed, where the roster
+        list owns the caret. The positive half of this contract is asserted in
+        `test_skill_in_command_argument.py`.
         """
         session = FakeSession()
         app = OperatorApp(lambda: _factory(session))
         async with app.run_test(size=(100, 30)) as pilot:
             await pilot.pause()
-            editor = await self._draft(app, pilot, "/team ops $res")
-            assert editor.picker.mode is not PickerMode.SKILL
+            for buffer in ("/model $res", "/team $res"):
+                editor = await self._draft(app, pilot, buffer)
+                assert editor.picker.mode is not PickerMode.SKILL, buffer
 
     @pytest.mark.asyncio
     async def test_enter_reassembles_the_draft_and_stages_it(self, skill_root) -> None:


### PR DESCRIPTION
Release: patch — `$` inside a prompt-carrying command's argument opens the skill picker and rewrites the argument rather than the whole buffer

# PR Description

## Summary of Changes

Feature plus a review-found fix. Typing `$` inside a prompt-carrying slash command's argument now opens the skill picker, and accepting a row rewrites the **argument** rather than the whole buffer — so the line reads `/team delivery $cte-explainer explain the MR pipeline`.

This is the composer-side half of the `$skill`-in-a-command problem; #965 is the submit-side half. They are independent and merge in either order.

- The command's claim on its line becomes **partial** rather than total. It is lifted only where the argument is free text destined for the model (`consumes_prompt`), and only past the argument's name-slot boundary.
- `_skill_argument_floor` is the single definition of "past the name slot", read both by the gate that opens the token and by the reassembly that rewrites the argument, so the two cannot drift.
- While a name is still being typed (`/team `, `/team del`, `/team $`) there is no skill token at all, so the roster list keeps the caret and cannot be hijacked. Enum-tail arguments (`/model`, `/theme`), non-prompt commands and the reserved `/team chart <name>` form keep the claim whole.
- `_reassembled_skill_argument` rebuilds only the argument region. The existing `_reassembled_skill` moves the token to the buffer start, which inside a command argument would produce `$gitlab /team delivery …` — unreadable to both the dispatcher and the skill parser.
- Both new vocabularies default to empty, so the claim stays total for every caller that does not pass them; the pure-parser tests and the two `app.py` slash-argument sites are unaffected by construction.

**Defect found in review and fixed here.** `_skill_argument_floor` split the argument with `partition(" ")` and read a non-empty separator as "the name has been typed and terminated". With two spaces after the command word (`/team  $x`) the split lands on the *first* of the two, so `first` is the empty string and an unwritten name was reported as a finished one: the floor returned a column, the skill picker opened, and `completion_for` then dropped the team name entirely (`/team  $gitlab `). A blank first token is now treated identically to an unterminated one, so the name slot stays open across any run of spaces.

## Related Issue(s)

- Related: none filed; reported in session use.
- Companion (independent, either order): #965 — the submit-side expansion.

## Impact

- No breaking changes. No dependency updates.
- Scope is the composer's picker gating. A `$` on a later line of a multi-line draft is unchanged: that line carries no claiming `/`, so the floor is never consulted and the pre-existing whole-buffer path applies. Locked by test as unchanged behaviour.

## Testing Details

Verified on the branch merged with `origin/main` at `5dd5e57e` (merge commit `1ca0119b`), not on the stale base:

```
tests/unit/tui/test_skill_in_command_argument.py
tests/unit/tui/test_skill_invocation.py     124 passed
flake8                                      0
black --check                               1227 files unchanged
isort --check-only                          clean
pyright                                     0 errors, 0 warnings
```

`tests/unit/tui/test_skill_in_command_argument.py` is new (448 lines) and covers:
- The picker opens past the name slot and stays shut inside it — `/team `, `/team del` and `/team $` are each asserted to keep the roster list.
- Acceptance rewrites the argument region, not the buffer; the `$gitlab /team …` inversion is asserted against directly.
- The doubled-space regression (`/team  $x`) that review caught, pinned so the dropped team name cannot come back.
- `/team chart <name>`, enum-tail commands and non-prompt commands keep a whole claim.
- The multi-line `$`-on-line-2 fallback is locked as unchanged.

End-to-end, the original report reproduces clean: `/team delivery $cte-explainer explain the MR pipeline` opens the picker, reassembles to the full line, and the submit-side parser resolves `skill='cte-explainer'`.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [ ] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.