### PR TITLE
fix: eliminate the surviving test-suite flakiness (record-directory clobber, listing-test cold window)

### DIFF
--- a/local_operator/session/runtime/exec_control.py
+++ b/local_operator/session/runtime/exec_control.py
@@ -215,7 +215,12 @@ async def start_exec_control(
         session_id=record.session_id,
         pid=record.pid,
         port=record.control_port,
-        record_path=str(registry.record_path(record.pid, config_dir())),
+        # The SAME root this run resolved above, not a second `config_dir()`
+        # call: the path printed as the supervisor's correlation handle has to
+        # be the file this run actually published, and a re-resolved
+        # environment could name another directory's `<pid>.json` — the same
+        # "resolve it once" rule `RecordPublisher` now holds for its own writes.
+        record_path=str(registry.record_path(record.pid, config_directory)),
         supervised=supervised,
     )
 

--- a/local_operator/session/runtime/exec_control.py
+++ b/local_operator/session/runtime/exec_control.py
@@ -177,7 +177,6 @@ async def start_exec_control(
     import asyncio
 
     from local_operator.paths import config_dir
-    from local_operator.session.runtime import registry
     from local_operator.session.runtime.server import RuntimeServer
     from local_operator.session.runtime.serving import (
         ServingSessionHandle,
@@ -215,12 +214,14 @@ async def start_exec_control(
         session_id=record.session_id,
         pid=record.pid,
         port=record.control_port,
-        # The SAME root this run resolved above, not a second `config_dir()`
-        # call: the path printed as the supervisor's correlation handle has to
-        # be the file this run actually published, and a re-resolved
-        # environment could name another directory's `<pid>.json` — the same
-        # "resolve it once" rule `RecordPublisher` now holds for its own writes.
-        record_path=str(registry.record_path(record.pid, config_directory)),
+        # The file this run ACTUALLY published, read off the runtime rather than
+        # recomputed from a second `config_dir()` read: the record's directory
+        # is fixed when the runtime starts, but `_serve` yields at
+        # `asyncio.start_server` before it builds the publisher, so a config dir
+        # that moves during that window makes a recomputed path name a
+        # `<pid>.json` no runtime wrote — and this path is the correlation
+        # handle a supervisor is handed (QA round 2, Q2).
+        record_path=str(runtime.record_path),
         supervised=supervised,
     )
 

--- a/local_operator/session/runtime/registry.py
+++ b/local_operator/session/runtime/registry.py
@@ -199,8 +199,25 @@ class RecordPublisher:
 
     def __init__(self, record: SessionRecord, root: Path | None = None) -> None:
         self.record = record
-        self._root = root
-        self.path = publish(record, root)
+        # RESOLVE THE DIRECTORY ONCE, HERE, and use that resolution for the
+        # rest of this publisher's life. ``root=None`` means "whatever
+        # ``config_dir()`` says now", and ``config_dir()`` deliberately reads
+        # the environment on every call (see its docstring: tests re-point it
+        # after import) — so leaving ``self._root`` as None made every later
+        # ``heartbeat``/``close`` re-resolve it. A runtime that outlived its
+        # own config dir then rewrote its record into whatever directory was
+        # current at that moment, and deleted THAT file on close, leaving its
+        # own record behind: records are keyed by pid alone, so the file it
+        # clobbered belonged to a different session. Measured in this suite,
+        # where the autouse fixture hands every test a fresh HOME: a runtime
+        # whose shutdown landed after the NEXT test had started removed that
+        # test's record, which is how two unrelated tests read "no session
+        # matches <name>" and "the record still says started=False".
+        #
+        # Pin the CONFIG dir rather than the run dir so ``root`` keeps meaning
+        # what every caller already passes.
+        self._root = root if root is not None else config_dir()
+        self.path = publish(record, self._root)
 
     def heartbeat(self, **updates: object) -> None:
         """Rewrite the record with fresh liveness plus any changed fields

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -764,7 +764,7 @@ class RuntimeServer:
         #: then — another session's, under a pid-keyed filename. Left as None
         #: until a start path runs, so a server that is never started keeps the
         #: publisher's own default.
-        self._run_root: Path | None = None
+        self._config_root: Path | None = None
         self._server: asyncio.AbstractServer | None = None
         self._unsubscribe_events: Callable[[], None] | None = None
         # Strong references to the one event writer per subscribed client. A
@@ -856,7 +856,7 @@ class RuntimeServer:
         # already moved on from, publishing — and then deleting — a record in
         # a directory this runtime never started in. See
         # ``RecordPublisher.__init__`` for the other half of this invariant.
-        self._run_root = config_dir()
+        self._config_root = config_dir()
         # The thread name is a runtime-observable diagnostic (py-spy, thread
         # dumps, `ps -M`) and deliberately keeps its mobile-era spelling: this
         # move changes no behaviour, and renaming it would silently invalidate
@@ -871,7 +871,14 @@ class RuntimeServer:
         call through a cross-thread hop for no benefit."""
         if self._server is not None:
             return
-        self._run_root = config_dir()
+        # Same pin as `start`, and here it is defence in depth rather than a
+        # closed race: this path reaches `_serve` through a direct `await` on
+        # the caller's own task, with no scheduling point in between, so today
+        # nothing can re-point the config dir first. The pin is still the
+        # invariant — the record's directory is decided when the runtime is
+        # asked to start, never when the publisher is built — and it is what
+        # keeps that true if `_serve` ever gains a yield before the publisher.
+        self._config_root = config_dir()
         self._loop = asyncio.get_running_loop()
         await self._serve()
 
@@ -1089,7 +1096,7 @@ class RuntimeServer:
         )
         port = self._server.sockets[0].getsockname()[1]
         self._record.control_port = port
-        self._publisher = RecordPublisher(self._record, self._run_root)
+        self._publisher = RecordPublisher(self._record, self._config_root)
         self._unsubscribe = self._handle.subscribe(self._schedule_push)
         # v4: hosts that can serialize their event stream feed the relay.
         # Probed, not required — a handle without the capability leaves attach

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -52,10 +52,13 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Protocol, cast
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from local_operator.harness.types import ImageContent
 
 from local_operator.mobile.projection import ProjectionFold
 from local_operator.mobile.types import SessionProjection
+from local_operator.paths import config_dir
 from local_operator.session.frontend_state import FRONTEND_CAPABILITY
 from local_operator.session.runtime.registry import RecordPublisher
 from local_operator.session.runtime.types import (
@@ -753,6 +756,15 @@ class RuntimeServer:
             self._started = True
             self._record.started = True
         self._publisher: RecordPublisher | None = None
+        #: The config dir this runtime was STARTED in, captured by ``start`` /
+        #: ``start_in_process`` and handed to the publisher. The record path is
+        #: ``<config dir>/run/mobile/<pid>.json``, so resolving it when the
+        #: worker thread eventually reaches ``_serve`` lets a thread the OS did
+        #: not schedule promptly publish into whatever directory is current by
+        #: then — another session's, under a pid-keyed filename. Left as None
+        #: until a start path runs, so a server that is never started keeps the
+        #: publisher's own default.
+        self._run_root: Path | None = None
         self._server: asyncio.AbstractServer | None = None
         self._unsubscribe_events: Callable[[], None] | None = None
         # Strong references to the one event writer per subscribed client. A
@@ -835,6 +847,16 @@ class RuntimeServer:
         event feed — on a dedicated thread with its own loop. Idempotent."""
         if self._thread is not None:
             return
+        # PIN THE DISCOVERY DIRECTORY HERE, at the moment the caller asks this
+        # runtime to announce itself. ``start`` only hands the work to a thread,
+        # so this is the last point at which the answer is still the caller's:
+        # a runner loaded enough to delay that thread past ``start``'s return
+        # (and past the runtime's own ``close``, whose join is bounded) had
+        # ``_serve`` create its publisher against a config dir the process had
+        # already moved on from, publishing — and then deleting — a record in
+        # a directory this runtime never started in. See
+        # ``RecordPublisher.__init__`` for the other half of this invariant.
+        self._run_root = config_dir()
         # The thread name is a runtime-observable diagnostic (py-spy, thread
         # dumps, `ps -M`) and deliberately keeps its mobile-era spelling: this
         # move changes no behaviour, and renaming it would silently invalidate
@@ -849,6 +871,7 @@ class RuntimeServer:
         call through a cross-thread hop for no benefit."""
         if self._server is not None:
             return
+        self._run_root = config_dir()
         self._loop = asyncio.get_running_loop()
         await self._serve()
 
@@ -1066,7 +1089,7 @@ class RuntimeServer:
         )
         port = self._server.sockets[0].getsockname()[1]
         self._record.control_port = port
-        self._publisher = RecordPublisher(self._record)
+        self._publisher = RecordPublisher(self._record, self._run_root)
         self._unsubscribe = self._handle.subscribe(self._schedule_push)
         # v4: hosts that can serialize their event stream feed the relay.
         # Probed, not required — a handle without the capability leaves attach

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -871,13 +871,13 @@ class RuntimeServer:
         call through a cross-thread hop for no benefit."""
         if self._server is not None:
             return
-        # Same pin as `start`, and here it is defence in depth rather than a
-        # closed race: this path reaches `_serve` through a direct `await` on
-        # the caller's own task, with no scheduling point in between, so today
-        # nothing can re-point the config dir first. The pin is still the
-        # invariant — the record's directory is decided when the runtime is
-        # asked to start, never when the publisher is built — and it is what
-        # keeps that true if `_serve` ever gains a yield before the publisher.
+        # The pin is LOAD-BEARING on this path too, not defence in depth:
+        # `_serve` reaches its first yield — `await asyncio.start_server` —
+        # BEFORE it builds the publisher, so a config dir that moves while this
+        # await is suspended is otherwise resolved by `RecordPublisher` inside
+        # `_serve`, and the record lands in a directory this runtime never
+        # started in. (The caller-visible half of the same rule is
+        # `RuntimeServer.record_path`.)
         self._config_root = config_dir()
         self._loop = asyncio.get_running_loop()
         await self._serve()
@@ -3310,6 +3310,28 @@ class RuntimeServer:
         authorization model, so nothing should be encouraged to copy it out.
         """
         return self._record
+
+    @property
+    def record_path(self) -> Path:
+        """The file this runtime published its discovery record to.
+
+        Read off the PUBLISHER, never recomputed from the config dir. The two
+        only agree by circumstance: the record's directory is pinned when the
+        runtime is asked to start, while ``_serve`` reaches its first yield —
+        ``await asyncio.start_server`` — before it builds the publisher. A
+        config dir that moves during that yield therefore leaves a
+        ``config_dir()`` recomputation naming a ``<pid>.json`` no runtime ever
+        wrote, and a caller that prints or dials this path has to have the file
+        that exists (QA round 2, Q2 forced exactly that window).
+
+        Raises rather than returning ``None``, like :attr:`record`'s habit of
+        answering directly: asking an unstarted runtime where its record is has
+        no useful answer, and a caller cannot print ``None`` as a path.
+        """
+        publisher = self._publisher
+        if publisher is None:
+            raise RuntimeError("this runtime has not published a record yet")
+        return publisher.path
 
     @property
     def projection_sink(self) -> ProjectionSink | None:

--- a/tests/unit/session/runtime/test_exec_control.py
+++ b/tests/unit/session/runtime/test_exec_control.py
@@ -26,6 +26,7 @@ from local_operator.session.runtime.exec_control import (
     maybe_start_exec_control,
     start_exec_control,
 )
+from local_operator.session.runtime.server import RuntimeServer
 
 
 class FakeSession:
@@ -164,6 +165,65 @@ async def test_start_publishes_an_exec_record(isolated_config: Path) -> None:
         assert str(control.port) in control.endpoint_line
         assert control.record_path in control.endpoint_line
         assert control.runtime.record.control_key not in control.endpoint_line
+    finally:
+        await control.aclose()
+
+
+@pytest.mark.asyncio
+async def test_the_printed_record_path_is_the_file_this_run_published(
+    isolated_config: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """QA round 2, Q2: the correlation handle names a file that EXISTS.
+
+    `start_exec_control` resolves the run's root once, but the file is written
+    later — and the environment can move in either of two windows between the
+    two:
+
+    * the pin is taken inside `start_in_process`, so a move BEFORE it lands the
+      record in a different directory than the one this function resolved; and
+    * `_serve` reaches its first yield (`await asyncio.start_server`) BEFORE it
+      builds the publisher, so a move during that await is resolved by the
+      publisher itself.
+
+    Both are forced here, so the printed path must be the file the publisher
+    holds rather than anything recomputed from the environment. It fails under
+    both earlier spellings — `registry.record_path(record.pid, config_dir())`
+    (a second read) and the run's own pre-resolved `config_directory` — which
+    is the point: only asking the runtime cannot disagree with it.
+    """
+    moved_to = tmp_path / "moved-to"
+    third = tmp_path / "third"
+    original_start_in_process = RuntimeServer.start_in_process
+    original_serve = RuntimeServer._serve
+
+    async def start_after_the_config_dir_moved(server: RuntimeServer) -> None:
+        # Window 1: after `start_exec_control` resolved its root, before the
+        # pin the runtime actually publishes under.
+        monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(moved_to))
+        await original_start_in_process(server)
+
+    async def serve_after_the_config_dir_moved(server: RuntimeServer) -> None:
+        # Window 2: `_serve`'s first yield, after the pin was taken.
+        monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(third))
+        await original_serve(server)
+
+    monkeypatch.setattr(RuntimeServer, "start_in_process", start_after_the_config_dir_moved)
+    monkeypatch.setattr(RuntimeServer, "_serve", serve_after_the_config_dir_moved)
+    control = await start_exec_control(FakeSession(), cwd="/tmp")
+    try:
+        printed = Path(control.record_path)
+        # Compared against the PUBLISHER's own file rather than the runtime's
+        # accessor, which the product itself now reads: going through the same
+        # property on both sides could not catch a wrong path.
+        publisher = control.runtime._publisher
+        assert publisher is not None, "start_exec_control publishes before it returns"
+        assert printed == publisher.path
+        assert (
+            printed.is_file()
+        ), "the path a supervisor is handed must name the record this run published"
+        # Specifically neither of the directories a recomputation would pick.
+        assert not (tmp_path / "run" / "mobile" / printed.name).exists()
+        assert not (third / "run" / "mobile" / printed.name).exists()
     finally:
         await control.aclose()
 

--- a/tests/unit/session/runtime/test_registry.py
+++ b/tests/unit/session/runtime/test_registry.py
@@ -9,6 +9,8 @@ import stat
 import time
 from pathlib import Path
 
+import pytest
+
 from local_operator.session.runtime import registry
 from local_operator.session.runtime.types import HEARTBEAT_TIMEOUT_S, SessionRecord
 
@@ -229,7 +231,9 @@ def test_the_heartbeat_republishes_the_subagent_counts(tmp_path: Path) -> None:
         registry.unpublish(record.pid, root=tmp_path)
 
 
-def test_the_publisher_rewrites_the_file_it_created(tmp_path: Path, monkeypatch) -> None:
+def test_the_publisher_rewrites_the_file_it_created(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A publisher's directory is decided when it publishes, not per call.
 
     ``root=None`` means "whatever ``config_dir()`` says", and ``config_dir()``
@@ -265,7 +269,9 @@ def test_the_publisher_rewrites_the_file_it_created(tmp_path: Path, monkeypatch)
         publisher.close()
 
 
-def test_the_publisher_removes_only_the_file_it_created(tmp_path: Path, monkeypatch) -> None:
+def test_the_publisher_removes_only_the_file_it_created(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """The exit path, where the damage inverts from clobbering to deleting.
 
     Needs its own test because the two directions fail differently: a stray

--- a/tests/unit/session/runtime/test_registry.py
+++ b/tests/unit/session/runtime/test_registry.py
@@ -229,6 +229,71 @@ def test_the_heartbeat_republishes_the_subagent_counts(tmp_path: Path) -> None:
         registry.unpublish(record.pid, root=tmp_path)
 
 
+def test_the_publisher_rewrites_the_file_it_created(tmp_path: Path, monkeypatch) -> None:
+    """A publisher's directory is decided when it publishes, not per call.
+
+    ``root=None`` means "whatever ``config_dir()`` says", and ``config_dir()``
+    reads the environment on every call on purpose. Resolving it again inside
+    ``heartbeat`` therefore let a runtime that outlived its own config dir
+    rewrite its record into whatever directory was current at that moment — a
+    different session's file, because records are keyed by pid alone, and an
+    xdist worker keeps one pid for every test it runs. This is the shape a
+    shard runner produced: a runtime from the previous test, whose heartbeat
+    had not been cancelled yet, landed its own ``started=False`` copy on the
+    next test's record.
+    """
+    started_in = tmp_path / "started-in"
+    moved_to = tmp_path / "moved-to"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(started_in))
+    record = make_record()
+    publisher = registry.RecordPublisher(record)
+    own = registry.run_dir(started_in) / f"{record.pid}.json"
+    try:
+        assert publisher.path == own, "the publisher's own record is the one it names"
+        # The config dir moves under a live runtime. Every test boundary in this
+        # suite does exactly this to HOME, which is what makes it the shape that
+        # bit, rather than a hypothetical.
+        monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(moved_to))
+        publisher.heartbeat(conversation_name="renamed")
+        assert own.exists(), "the record must stay where this publisher put it"
+        stray = registry.run_dir(moved_to) / f"{record.pid}.json"
+        assert not stray.exists(), (
+            "a heartbeat must not write into a directory this publisher never "
+            "published into — that filename belongs to another session"
+        )
+    finally:
+        publisher.close()
+
+
+def test_the_publisher_removes_only_the_file_it_created(tmp_path: Path, monkeypatch) -> None:
+    """The exit path, where the damage inverts from clobbering to deleting.
+
+    Needs its own test because the two directions fail differently: a stray
+    ``heartbeat`` overwrites a stranger's record, a stray ``close`` unlinks it,
+    and the suite's own runs showed the second — a leaked runtime's shutdown
+    resolving the NEXT test's directory and taking that test's record with it.
+    """
+    started_in = tmp_path / "started-in"
+    moved_to = tmp_path / "moved-to"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(started_in))
+    publisher = registry.RecordPublisher(make_record())
+    own = publisher.path
+    assert own.exists()
+    # Another session's record in the directory the config dir moves to, keyed
+    # by the SAME pid — the pid keying is what makes this a wrong-FILE hazard
+    # rather than a missing-file one.
+    other = make_record()
+    registry.publish(other, root=moved_to)
+    other_path = registry.run_dir(moved_to) / f"{other.pid}.json"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(moved_to))
+    try:
+        publisher.close()
+        assert not own.exists(), "a publisher removes the record it created"
+        assert other_path.exists(), "and must leave a different session's record alone"
+    finally:
+        registry.unpublish(other.pid, root=moved_to)
+
+
 def test_the_protocol_version_did_not_move_for_the_subagent_counts() -> None:
     """Pinned WITH ITS REASON, because the tempting change is to bump it.
 

--- a/tests/unit/session/runtime/test_server.py
+++ b/tests/unit/session/runtime/test_server.py
@@ -1424,6 +1424,46 @@ async def test_the_record_directory_is_fixed_when_the_runtime_starts(tmp_path, m
 
 
 @pytest.mark.asyncio
+async def test_the_record_directory_is_fixed_for_an_in_process_runtime(
+    tmp_path, monkeypatch
+) -> None:
+    """The same invariant on the in-process start path.
+
+    ``start_in_process`` reaches ``_serve`` through a direct ``await`` on the
+    caller's own task, so today nothing can re-point the config dir in between
+    and this half is defence in depth rather than a closed race. It is still the
+    invariant both start paths share — the record's directory is decided when
+    the runtime is asked to START, never when the publisher is built — and this
+    fails if that pin is dropped, which is what makes it worth asserting rather
+    than assuming: `_serve` is made to observe a moved config dir, and the
+    record must land where this runtime started anyway.
+    """
+
+    started_in = tmp_path / "started-in"
+    moved_to = tmp_path / "moved-to"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(started_in))
+    original_serve = RuntimeServer._serve
+
+    async def serve_after_the_world_moved(server: RuntimeServer) -> None:
+        monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(moved_to))
+        await original_serve(server)
+
+    monkeypatch.setattr(RuntimeServer, "_serve", serve_after_the_world_moved)
+    server = RuntimeServer(FakeHandle(), kind="tui")
+    await server.start_in_process()
+    try:
+        live = [rec for rec, state in registry.scan(started_in) if state == "live"]
+        assert live, "the runtime must publish into the config dir it started in"
+        stray = registry.run_dir(moved_to) / f"{server._record.pid}.json"
+        assert not stray.exists(), (
+            "an in-process runtime must not publish where the config dir has "
+            "since moved — that filename belongs to another session"
+        )
+    finally:
+        await server.aclose()
+
+
+@pytest.mark.asyncio
 async def test_desktop_watch_lease_separates_visibility_and_notification_delivery() -> None:
     from local_operator.mobile.attach_client import AttachClient
     from local_operator.session.runtime.types import DESKTOP_WATCH_LEASE_S

--- a/tests/unit/session/runtime/test_server.py
+++ b/tests/unit/session/runtime/test_server.py
@@ -1376,6 +1376,54 @@ class TestLiveStateReachesTheRecord:
 
 
 @pytest.mark.asyncio
+async def test_the_record_directory_is_fixed_when_the_runtime_starts(tmp_path, monkeypatch) -> None:
+    """The record belongs to the config dir the runtime was STARTED in.
+
+    ``start`` only hands the work to a thread, so a runner loaded enough to
+    delay that thread past the caller's own teardown had ``_serve`` resolve
+    ``config_dir()`` at the worst possible moment, publish its record into the
+    NEXT test's directory, and then delete it there on the way out — ``close``
+    re-resolved the same way. Records are keyed by pid alone and an xdist
+    worker keeps one pid, so that file belonged to a different session. Both
+    shapes need the thread to be late, which is why this pins the DIRECTORY
+    rather than trying to reproduce the scheduling delay: the answer must be
+    settled at ``start`` no matter when the thread eventually runs.
+    """
+
+    started_in = tmp_path / "started-in"
+    moved_to = tmp_path / "moved-to"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(started_in))
+    original_serve = RuntimeServer._serve
+
+    async def serve_after_the_world_moved(server: RuntimeServer) -> None:
+        # Stand in for a worker thread the OS did not schedule promptly: by the
+        # time it reaches `_serve`, the process is on another config dir.
+        monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(moved_to))
+        await original_serve(server)
+
+    monkeypatch.setattr(RuntimeServer, "_serve", serve_after_the_world_moved)
+    server = RuntimeServer(FakeHandle(), kind="tui")
+    server.start()
+    try:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + 5
+        found: list[registry.SessionRecord] = []
+        while loop.time() < deadline:
+            found = [rec for rec, state in registry.scan(started_in) if state == "live"]
+            if found:
+                break
+            await asyncio.sleep(0.02)
+        assert found, "the runtime must publish into the config dir it started in"
+        stray = registry.run_dir(moved_to) / f"{server._record.pid}.json"
+        assert not stray.exists(), (
+            "a thread that runs late must not publish where the config dir has "
+            "since moved — that filename belongs to another session"
+        )
+    finally:
+        server.close()
+
+
+@pytest.mark.asyncio
 async def test_desktop_watch_lease_separates_visibility_and_notification_delivery() -> None:
     from local_operator.mobile.attach_client import AttachClient
     from local_operator.session.runtime.types import DESKTOP_WATCH_LEASE_S

--- a/tests/unit/session/runtime/test_server.py
+++ b/tests/unit/session/runtime/test_server.py
@@ -1429,14 +1429,14 @@ async def test_the_record_directory_is_fixed_for_an_in_process_runtime(
 ) -> None:
     """The same invariant on the in-process start path.
 
-    ``start_in_process`` reaches ``_serve`` through a direct ``await`` on the
-    caller's own task, so today nothing can re-point the config dir in between
-    and this half is defence in depth rather than a closed race. It is still the
-    invariant both start paths share — the record's directory is decided when
-    the runtime is asked to START, never when the publisher is built — and this
-    fails if that pin is dropped, which is what makes it worth asserting rather
-    than assuming: `_serve` is made to observe a moved config dir, and the
-    record must land where this runtime started anyway.
+    Here the window is REAL, not manufactured: ``_serve`` reaches its first
+    yield — ``await asyncio.start_server`` — before it builds the publisher, so
+    a config dir that moves while ``start_in_process`` is suspended in that
+    await is exactly what a dropped pin lets the publisher resolve inside
+    ``_serve``. The wrapper below moves it at that point, and the record must
+    still land where this runtime started; removing the pin fails this test
+    (``assert []``) while the thread-path test still passes, so the two halves
+    are separately caught.
     """
 
     started_in = tmp_path / "started-in"

--- a/tests/unit/test_procname.py
+++ b/tests/unit/test_procname.py
@@ -198,10 +198,19 @@ class TestStaleness:
     def test_unreadable_libpython_parent_does_not_raise(self, branded, tmp_path):
         """QA round 2, Q3: `_needs_replant` is contractually no-raise.
 
-        `Path.exists()` is not total — an unreadable parent directory makes it
-        raise `PermissionError` (reproduced), which escaped a function this
+        An unreadable parent directory made `Path.exists()` raise
+        `PermissionError` (reproduced on 3.12), which escaped a function this
         module documents as never raising. "Replant" is the safe answer: a
         libpython we cannot stat is not one to assume correct.
+
+        The wall is asserted with `os.stat` rather than `Path.exists` because
+        the stdlib changed underneath the original precondition: 3.14 routes
+        `exists()` through `os.path.exists`/`_stat(ignore_errors=True)`, so
+        EACCES becomes `False` instead of propagating (3.12 raises). The route
+        this test is named for is still exercised wherever the stdlib still has
+        it — `_needs_replant` calls `exists()` itself, so an unguarded raise
+        there fails this test on 3.12 — while the property being pinned, "must
+        not raise on a path it cannot stat", holds on every interpreter.
         """
         walled = tmp_path / "lib" / "sub"
         walled.mkdir(parents=True)
@@ -211,12 +220,12 @@ class TestStaleness:
         try:
             # PRECONDITION, not decoration. `True` is ALSO reachable through the
             # `resolve()` identity mismatch below, so asserting it alone would
-            # not prove this test exercised the `exists()` path it is named for
+            # not prove this test exercised the unreadable path it is named for
             # — and on a host where `chmod 0o000` does not block (root, some
             # container runtimes) it would stay green with the guard deleted.
             # Review round 3, M3-2: the R2-1 failure mode in embryo.
             with pytest.raises(PermissionError):
-                dylib.exists()
+                os.stat(dylib)
             assert (
                 procname._needs_replant(branded, Path(os.path.realpath(sys.executable)), dylib)
                 is True

--- a/tests/unit/tui/test_cold_slash_binds.py
+++ b/tests/unit/tui/test_cold_slash_binds.py
@@ -106,19 +106,41 @@ class _RoutingHandle(FakeHandle):
         return {"ok": True}
 
 
-def _stub_engage(monkeypatch: pytest.MonkeyPatch, server: RuntimeServer) -> list[int]:
-    """Stand in for the runtime spawn: publish a live record for the session."""
+def _stub_engage(
+    monkeypatch: pytest.MonkeyPatch,
+    server: RuntimeServer,
+    *,
+    land: asyncio.Event | None = None,
+) -> list[int]:
+    """Stand in for the runtime spawn: publish a live record for the session.
+
+    ``land`` holds the runtime back until the test releases it, for a test that
+    needs the viewer to still be COLD while it works. The 1.0 s sleep below is
+    a wall-clock bet on the runner being fast enough for the caller's work to
+    finish first, and the listing test lost that bet on a loaded shard runner:
+    it dispatches its listings a few hundred ms after the mount engage starts,
+    so any stall that pushed them past the engage's own 1.0 s ran a LISTING
+    against a viewer that had already bound — where a bare listing is an
+    authoritative command by design — failing its "no listing routes"
+    assertion. A test that needs the engage not to have landed yet must say
+    when it may land rather than hope the clock agrees.
+    """
     engagements: list[int] = []
 
     async def fake_engage(
         session_id, cwd, work, *, config_dir, deadline_s=30.0, preempt=None, preempt_budget_s=0.0
     ):  # noqa: ANN001
         engagements.append(1)
-        # The measured engage takes 1.1–2.8 s. The race IS the test: at 0.2 s
-        # the mount engage (#622) usually won against the paste+Enter, and
-        # two of the three cold cells stayed green with the fix removed
-        # (review round 2, R6). One second makes all three red deterministically.
-        await asyncio.sleep(1.0)
+        if land is not None:
+            # The caller's own signal, so the cold window lasts exactly as long
+            # as the work that needs it and no longer.
+            await land.wait()
+        else:
+            # The measured engage takes 1.1–2.8 s. The race IS the test: at 0.2 s
+            # the mount engage (#622) usually won against the paste+Enter, and
+            # two of the three cold cells stayed green with the fix removed
+            # (review round 2, R6). One second makes all three red deterministically.
+            await asyncio.sleep(1.0)
         server.start()
         marker = config_dir / "sessions" / session_id / ".session.pid"
         marker.parent.mkdir(parents=True, exist_ok=True)
@@ -147,12 +169,15 @@ def _cold_app(config_dir: Path, session_id: str) -> OperatorApp:
 
 
 def _rig(
-    config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    config_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    land: asyncio.Event | None = None,
 ) -> tuple[OperatorApp, _RoutingHandle, RuntimeServer, list[int]]:
     session_id = uuid.uuid4().hex[:12]
     handle = _RoutingHandle(session_id)
     server = RuntimeServer(handle, kind="tui")
-    engagements = _stub_engage(monkeypatch, server)
+    engagements = _stub_engage(monkeypatch, server, land=land)
     return _cold_app(config_dir, session_id), handle, server, engagements
 
 
@@ -339,7 +364,16 @@ async def test_listings_and_chart_stay_local_and_engage_nothing_extra(
     TeamRegistry(isolated).create_team(
         TeamEditFields(name="lopdev", description="d", manager="manager")
     )
-    app, handle, server, engagements = _rig(isolated, monkeypatch)
+    # Held back so the listings below are dispatched against a viewer that is
+    # PROVABLY cold. That is the whole property: "a listing never routes through
+    # the bind seam" is a statement about a cold viewer, and a bare listing on a
+    # bound one is an authoritative command by design (the capability registry
+    # says so, and the owner-routed receipt is the intended warm behaviour) — so
+    # a runner slow enough to let the mount engage land first made this test
+    # assert the opposite of what it means. The viewer's coldness is
+    # unambiguous now: nothing can land until this event is set.
+    land = asyncio.Event()
+    app, handle, server, engagements = _rig(isolated, monkeypatch, land=land)
     try:
         async with app.run_test(size=(110, 30)) as pilot:
             session = await _boot(app, pilot)
@@ -352,7 +386,12 @@ async def test_listings_and_chart_stay_local_and_engage_nothing_extra(
                 await pilot.pause()
             # Rendered from local config immediately, while still cold.
             assert "lopdev" in _transcript_text(app)
+            land.set()
             await _until(pilot, lambda: not session.is_cold)
+            # Slack for the NEGATIVE assertion below rather than a settle for
+            # work this test needs: any authoritative call these listings could
+            # make would arrive on the owner's socket, and giving it time to
+            # land can only make "none did" harder to satisfy.
             await asyncio.sleep(0.3)
             await pilot.pause()
             assert engagements == [1], "only the mount engage; the listings added none"

--- a/tests/unit/tui/test_cold_slash_binds.py
+++ b/tests/unit/tui/test_cold_slash_binds.py
@@ -387,7 +387,14 @@ async def test_listings_and_chart_stay_local_and_engage_nothing_extra(
             # Rendered from local config immediately, while still cold.
             assert "lopdev" in _transcript_text(app)
             land.set()
-            await _until(pilot, lambda: not session.is_cold)
+            # ASSERTED, not merely awaited: `_until` gives up after its own
+            # timeout and the assertions below would then run against a still-cold
+            # viewer with no listing to have routed anything — the warm half of
+            # this test passing vacuously. A mutation that makes `fake_engage`
+            # return without landing the runtime must fail HERE.
+            assert await _until(
+                pilot, lambda: not session.is_cold
+            ), "the mount engage never landed; the warm half was never reached"
             # Slack for the NEGATIVE assertion below rather than a settle for
             # work this test needs: any authoritative call these listings could
             # make would arrive on the owner's socket, and giving it time to


### PR DESCRIPTION
## What this fixes

Three red `main` runs, from two defects (one product, one test).

| # | Test | CI run | Class |
| --- | --- | --- | --- |
| F1 | `tests/unit/tools/test_send_tool.py::test_self_send_is_refused_before_any_dial` | 34567356241 (3.12 shard 0) | product |
| F2 | `tests/unit/session/runtime/test_server.py::TestLiveStateReachesTheRecord::test_started_survives_the_republish` | 34552844468 (3.12 shard 1) | product |
| F3 | `tests/unit/tui/test_cold_slash_binds.py::test_listings_and_chart_stay_local_and_engage_nothing_extra` | 34575394385 (3.13 shard 3) | test |

## F1 + F2 — one root cause: a discovery record written into a directory its runtime never started in

The two failures read as unrelated symptoms. They are the same defect.

A session's discovery record is `<config dir>/run/mobile/<pid>.json`. Two things
resolved that directory later than the runtime's own lifetime allowed:

1. **`RecordPublisher` stored `root=None` verbatim** (`registry.py`), so
   `heartbeat()` and `close()` re-resolved `config_dir()` on *every* call.
   `config_dir()` deliberately reads the environment each time, so a publisher
   that outlived its config dir rewrote its record into whatever directory was
   current at that moment, and then deleted **that** file on close, leaving its
   own record behind. Records are keyed by pid alone, and an xdist worker keeps
   one pid for every test it runs, so the file it clobbered belonged to another
   test's session.
2. **`RuntimeServer.start()` only hands the work to a thread**, and `_serve`
   created the publisher whenever that thread first ran. A runner loaded enough
   to delay the thread past the caller's own teardown (`close`'s join is bounded
   at 2 s) published the record into — and deleted it from — a directory the
   runtime never started in.

F1 (`no session matches 'fake'`) is the **unlink**: the registrant's record was
gone by the time `resolve_peer_target` scanned. F2 (`started is False`) is the
**write**: a stale `started=False` copy of the same `FakeHandle` record landed on
top of the current test's record between `set_record_started(True)` and
`registry.scan()`. Both are the same file, written by a publisher that should
never have been able to name it.

### Proof of the mechanism (deterministic, on `main`)

A publisher that publishes into A and is then used under B:

```
$ .venv/bin/python /tmp/root_probe.py
after construction: A exists: True | B exists: False
after heartbeat under B: B written: True | ...
after close under B: B removed: True | A removed: False
```

i.e. the heartbeat creates a record in a directory it never published into, and
`close` removes *that* one while leaving its own behind.

The same shape occurs inside the suite, not just in a synthetic probe. A shard
run with a probe that compares the directory a publisher published into against
the directory it later wrote to:

```
$ env -u NO_COLOR TERM=xterm-256color PYTHONPATH=/tmp .venv/bin/python -m pytest \
    tests/unit/session/runtime/test_server.py tests/unit/tools/test_send_tool.py \
    -q -n0 -p no:randomly -s -p instprobe
................
[LEAK] 1 registrant thread(s) alive after tests/unit/session/runtime/test_server.py::test_nonreading_socket_cannot_block_active_ack_and_projection
[INSTANCE-CROSS-DIR close/unpublish] .../pytest-of-damian/pytest-33730/home15/.local-operator/run/mobile -> /Users/damian/.local-operator/run/mobile
......................................................................
86 passed in 16.21s
```

A leaked registrant thread's shutdown resolved **the operator's real
`~/.local-operator`** while its own record was in a test's tmp HOME: the same
late-write/late-delete that clobbers a neighbouring test on CI (where the
"neighbour" is the next test's own config dir).

What that probe wrote, on the record because the reach is the point: its leaked
publisher's `close()` resolved `/Users/damian/.local-operator/run/mobile` and
unlinked the file named for the **pytest worker's** pid — a file no live session
owned, since live sessions are keyed by their own runtime pids. Checked
afterwards: all 18 live sessions still had their `<pid>.json` (18 records, one
per live pid, `lop sessions --json` cross-checked against
`ls ~/.local-operator/run/mobile/*.json`), and the owning runtimes republish on
their 15 s heartbeat regardless. Nothing was lost. The fix is what makes that
class of write unreachable: a publisher can no longer name a directory it did
not publish into.

### Fix

The directory is settled once — at `RecordPublisher` construction, and at
`start`/`start_in_process` for the server's own half — so the file a publisher
names is the file it rewrites and the file it removes. `root` keeps its existing
meaning (a config dir, not a run dir).

### Which mechanism produces the CI message (and which does not)

Emulating each candidate record state immediately before the tool dispatches,
on the unmodified test:

```
$ F1_MODE=deleted          ... pytest tests/unit/tools/test_send_tool.py::test_self_send_is_refused_before_any_dial
E  assert 'this session' in "no session matches 'fake' (searched live and stored sessions)"
$ F1_MODE=wedged           ... (heartbeat aged past HEARTBEAT_TIMEOUT_S)
E  assert 'this session' in "the only match for 'fake' is not responding (pid 25724); try again shortly"
$ F1_MODE=clobbered_unstarted ... (a stale started=False copy of the same record)
E  assert 'this session' in "no session matches 'fake' (searched live and stored sessions)"
```

The failure's own wording is the *stored fallback* message, which only a record
that is **gone or broadcast-invisible** reaches. A wedged one answers
differently, which rules out the strongest competing hypothesis (the record
classified `wedged`/`stale` under load). The `started=False` clobber reaches the
same line as the unlink: the same defect written rather than deleted.

Neither test was made to fail naturally here — five repetitions of
`test_send_tool.py` plus `TestLiveStateReachesTheRecord` on 3.12 (28 passed
each) and several full-file runs on 3.14 — so the mechanism above is the
evidence, not a local red run.

### Guards (each fails without its half of the fix)

```
$ .venv/bin/python -m pytest tests/unit/session/runtime/test_registry.py::test_the_publisher_rewrites_the_file_it_created \
    tests/unit/session/runtime/test_registry.py::test_the_publisher_removes_only_the_file_it_created \
    "tests/unit/session/runtime/test_server.py::test_the_record_directory_is_fixed_when_the_runtime_starts" -q
# with the fix:
3 passed
# with the fix reverted:
3 failed in 5.55s
  - a heartbeat must not write into a directory this publisher never published into — that filename belongs to another session
  - a publisher removes the record it created
  - the runtime must publish into the config dir it started in
```

## F3 — the listing test's cold window was a wall-clock bet

`test_listings_and_chart_stay_local_and_engage_nothing_extra` asserts that no
listing routed to the owner. That is a statement about a **cold** viewer. On a
bound one a bare `/team` or `/agent` is an authoritative command by design — the
capability registry advertises `AUTHORITATIVE_SESSION` for them, and the app's
local pullbacks cover only `/team chart`, bare `/model`, bare `/mcp` — so the
app routes it:

```
$ .venv/bin/python -m pytest tests/unit/tui/test_zz_scratch_warmprobe.py -q -s   # (diagnostic, not committed)
BOUND=True caps=40
calls before=[]
after '/team': ['run_slash_authoritative']
after '/agent': ['run_slash_authoritative', 'run_slash_authoritative']
after '/team chart lopdev': ['run_slash_authoritative', 'run_slash_authoritative']
```

The test got its cold window from the mount engage's own 1.0 s delay. Measured
on an idle box: the listings run 50–150 ms after the engage starts and the bind
lands at ~1.03 s, so the loop normally finishes ~0.9 s before the viewer binds.
Any stall that pushes a listing past that 1.0 s dispatches it against a viewer
that has already bound — the authoritative call the assertion forbids. Forty
repetitions of the unmodified test on an idle box did not reproduce it, which is
why the reproduction below forces the condition instead of hoping for it.

### Reproduction of the exact CI signature

Injecting the CI condition (a 1.3 s stall between two listings) and reverting
the test fix reproduces the pipeline's own failure:

```
$ F3_MUTATE=1 PYTHONPATH=/tmp .venv/bin/python -m pytest \
    tests/unit/tui/test_cold_slash_binds.py::test_listings_and_chart_stay_local_and_engage_nothing_extra -q -n0 -p f3ci
E               assert not True
E                +  where True = any(<generator object test_listings_and_chart_stay_local_and_engage_nothing_extra.<locals>.<genexpr> ...>)
tests/unit/tui/test_cold_slash_binds.py:398: AssertionError
1 failed
```

with the fix in place, the same stall:

```
1 passed, 2 warnings in 9.22s
```

### Fix

`_stub_engage` takes an optional `land` event; this test holds the runtime back
until its listings have been dispatched, so the cold window lasts exactly as long
as the work that needs it instead of as long as the clock allowed. The three pins
are unchanged: listings must not route through `_needs_runtime_first`, must not
start their own engage, and must render from local config.

## Also fixed — two smaller instances of the same "resolve it once" rule

- `RuntimeServer._config_root` (renamed from `_run_root`: it holds a *config*
dir, not a run dir).
- `exec_control.py` built the `record_path` it prints as the supervisor's
  correlation handle by re-resolving the config dir, so the printed path could
  name a different directory's `<pid>.json` than the record this run published.
  It now reads the path off the runtime's own publisher through a new
  `RuntimeServer.record_path` accessor, which cannot disagree with the file that
  exists. QA proved the old form's risk by forcing a config-dir move in the
  window; `test_the_printed_record_path_is_the_file_this_run_published` forces
  both windows (before the pin, and at `_serve`'s first yield) and fails under
  either earlier spelling. Flagged: the diff is two files wider than the
  original five (`exec_control.py` and its test).

## Also fixed — the suite's only red on the 3.14 dev venv

`tests/unit/test_procname.py::TestStaleness::test_unreadable_libpython_parent_does_not_raise`
(not in CI's failure record; CI's matrix is 3.12/3.13, there is no 3.14 leg).

Its precondition asserted that `Path.exists()` raises `PermissionError` for an
unreadable parent. That was true on 3.12/3.13 and 3.14 made `exists()` total —
`pathlib/_os.py` routes it through `os.path.exists`/`_stat(ignore_errors=True)`,
so EACCES becomes `False`:

```
$ .venv/bin/python -c "...chmod 0o000 parent; print(f.exists())"
python 3.14.3 uid 501
exists() -> False          # (os.stat still raises PermissionError, errno 13)
$ .venv312/bin/python -c "...same..."
python 3.12.13
exists() raised PermissionError
```

The wall is now asserted with `os.stat`, which raises on every interpreter, and
the escape route is unchanged where it still exists — `_needs_replant` calls
`exists()` internally, so removing its `except OSError` guard still fails this
test on 3.12:

```
# mutation: `live = libpython.exists()` without the guard
3.12: 1 failed - PermissionError: [Errno 13] Permission denied: '.../libpython3.12.dylib'
3.14: 1 passed  (no raise occurs there at all)
$ .venv/bin/python -m pytest tests/unit/test_procname.py -q -n0
48 passed in 0.71s          # and 48 passed on 3.12
```

## Quality gates

Recorded on the remediation head of this branch (branch base `5dd5e57e3`; `main`
is `7b2858944`, and PR CI evaluates the merge of the two).

```
$ .venv/bin/python -m flake8 --extend-exclude .venv312 .      # clean
$ uvx --from black==26.1.0 black --check --extend-exclude '\.venv312|F401' .
All done! 1229 files would be left unchanged.
$ uvx isort==5.13.2 --check-only --extend-skip .venv312 .
(clean)
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations

$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
    tests/unit/session/runtime/test_registry.py tests/unit/session/runtime/test_server.py \
    tests/unit/session/runtime/test_exec_control.py tests/unit/session/test_remote_cold.py \
    tests/unit/tools/test_send_tool.py tests/unit/tui/test_cold_slash_binds.py \
    tests/unit/test_procname.py -q -n0
189 passed in 32.00s                      # 3.14
189 passed in 31.85s                      # 3.12 (.venv312)

$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
    tests/unit/session tests/unit/tools/test_send_tool.py tests/unit/test_procname.py -q
2078 passed in 160.40s                    # the delta's neighbours, 3.14
```

`--extend-exclude .venv312` is only about this worktree owning two venvs inside
itself (CI checks out clean, so `flake8 .` / `black --check .` see neither).

### The full-tree 3.14 runs this branch produced, in order

```
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
1 failed, 18450 passed, 18 skipped in 1413.52s
  # the one failure was the 3.14-only procname precondition fixed above

(re-run on the then-head, after that fix)
reached 99% with zero failures, then was killed by the host during the slow
tail: no summary line and no wrapper exit code, so the process group was
killed rather than exiting cleanly. Zero `F` markers in any of its 255
progress lines. This is why the numbers below are the run that finished.

(re-run, detached)
18451 passed, 18 skipped in 1693.15s
```

CI's five 3.12 legs on this head are the authoritative full-tree evidence for
the merge with `main`. This repo's matrix takes `python-version` from the event:
`["3.12"]` on a pull request and `["3.12", "3.13"]` only on `main`
(`.github/workflows/ci.yml`), so this SHA's check-runs are 3.12-only and the
local runs above are the only 3.14 evidence there is.

## Reproducing the evidence (the diagnostics were deliberately not committed)

**The defect in twenty lines** — a publisher that publishes into A and is then
used under B. Save as `/tmp/root_probe.py`:

```python
import os, tempfile, pathlib
from local_operator.session.runtime import registry
from local_operator.session.runtime.types import RUN_DIRNAME

A = pathlib.Path(tempfile.mkdtemp(prefix="probeA-"))
B = pathlib.Path(tempfile.mkdtemp(prefix="probeB-"))
os.environ["LOCAL_OPERATOR_CONFIG_DIR"] = str(A)
rec = registry.SessionRecord(pid=os.getpid(), kind="tui", session_id="s1",
                             conversation_name="fake", cwd="/tmp",
                             model_label="test/model", control_port=1, control_key="k")
pub = registry.RecordPublisher(rec)
os.environ["LOCAL_OPERATOR_CONFIG_DIR"] = str(B)
pub.heartbeat(started=False)      # must stay in A
pub.close()                       # must remove A/<pid>.json
print("B written:", (B / RUN_DIRNAME / f"{os.getpid()}.json").exists())
print("A removed:", not (A / RUN_DIRNAME / f"{os.getpid()}.json").exists())
```

Pre-fix it prints `B written: True` / `A removed: False`; post-fix
`B written: False` / `A removed: True`.

**The same shape inside the suite** (`-p instprobe`, a plugin on `PYTHONPATH`):
wrap `registry.RecordPublisher.__init__` to record the run dir it published
into, then wrap `heartbeat`/`close` to compare that against
`registry.run_dir(self._root)` and print on mismatch; add
`pytest_runtest_setup` that reports any live `lop-mobile-registrant` thread.
Run it over the two files whose tests failed:

```
$ env -u NO_COLOR TERM=xterm-256color PYTHONPATH=/tmp .venv/bin/python -m pytest \
    tests/unit/session/runtime/test_server.py tests/unit/tools/test_send_tool.py \
    -q -n0 -p no:randomly -s -p instprobe
```

**F1's message, per candidate mechanism** (`-p f1variants`, selected by
`F1_MODE`): wrap the test module's `execute_send` so that, when
`params["target"] == "fake"`, it either unlinks `registry.record_path(os.getpid())`
(`deleted`), ages that record's `heartbeat_at` past `HEARTBEAT_TIMEOUT_S`
(`wedged`), or rewrites it with `started=False` (`clobbered_unstarted`), then
calls the original.

```
$ for m in deleted wedged clobbered_unstarted; do F1_MODE=$m PYTHONPATH=/tmp \
    .venv/bin/python -m pytest "tests/unit/tools/test_send_tool.py::test_self_send_is_refused_before_any_dial" \
    -q -n0 -p no:randomly -p f1variants; done
```

**F3's stall** (`-p f3ci`): set a flag on the first `OperatorApp._run_slash_command`
and make `Pilot.pause` sleep 1.3 s once it is set (a loaded runner between two
listings); with `F3_MUTATE=1` also drop the `land` hold by wrapping
`_stub_engage` to ignore it — i.e. restore the pre-fix stub timing.

```
$ F3_MUTATE=1 PYTHONPATH=/tmp .venv/bin/python -m pytest \
    tests/unit/tui/test_cold_slash_binds.py::test_listings_and_chart_stay_local_and_engage_nothing_extra \
    -q -n0 -p no:randomly -p f3ci          # assert not True, on the pre-fix test
```

**Warm-viewer routing**, the fact F3's fix depends on: a scratch test (kept out
of the tree) that boots the same rig, waits for `not session.is_cold`, then
dispatches `/team`, `/agent`, `/team chart lopdev` one at a time and prints
`handle.calls` after each — 2 authoritative calls for the first two, none for
the chart form.

**F4 / shard reproduction:** the file list is
`python scripts/shard_tests.py --shard 1 --total 5`; each run is
`env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest <list> -n 4 -q`
with a post-run `ps -eo pid,ppid,comm,args | grep -i 'Local Operator'` for
survivors (filter by the worktree's venv path, since the operator's own 18
sessions are branded too).


## Not addressed

- **F4 (#958 shard hang / orphaned branded child).** Two claims, kept apart
  because only one of them is measured.

  *Measured, and well supported: a secret broker outlives its starter and can be
  orphaned.* It is spawned as `[sys.executable, "-m",
  "local_operator.secrets.brokerd"]` (`secrets/client.py:288`) with
  `start_new_session=True`, so it inherits the branded interpreter path as
  `argv[0]` and detaches from the process group that made it. Independent QA on
  a clean local run measured `tests/unit/secrets/test_cli.py` leaking **+27**
  live key-holding brokers and `test_agent_surfaces.py` **+15**, with **252**
  such processes alive on this machine and **228** of them reparented to pid 1;
  a broker spawned through the real `_spawn_broker` survives `killpg` SIGKILL of
  its own job's process group. The per-file findings (+27 / +15) are the stable
  part; the census is a *dated snapshot*, not a constant — QA re-read it later
  the same day at **184 alive / 133 reparented** against 252 / 228 when first
  counted, which is ordinary churn on a host with ~18 live sessions. The suite has an autouse sweep for exactly this
  (`stop_secret_brokers_started_by_this_test` in `tests/conftest.py`), and when
  `timeout-minutes: 20` kills a run mid-test that sweep never executes.

  *Inference, not established: that the #958 orphan IS one of those brokers.*
  The runner's name field cannot identify a spawn path — on Linux
  `set_process_name` truncates `comm` to 15 bytes, so *every* branded child,
  labelled or not, reports as `Local Operator` — and no orphan argv was captured
  in the affected runs. What would settle it: the orphan's argv (or
  `/proc/<pid>/cmdline`) at teardown, or a shard canary that logs broker pids
  when they are spawned and checks their survival after the job ends. I did not
  keep the claim that "the orphan is the broker, therefore no leak exists".

  *Reproduction attempt, with counts:* four shard-1 runs (its real file list
  from `scripts/shard_tests.py --shard 1 --total 5`, `-n 4`, CI-shaped) on both
  interpreters — `.venv` (3.14) 598 s and 451 s, `.venv312` (3.12) 499 s and
  488 s — all `rc=0` with `4135 passed, 1 skipped`, no 98%-then-timeout shape,
  and no process branded from this worktree's venv surviving any run
  (`grep -c flake-fix` over the post-run process lists: 0). No leaking test
  found in the affected shard; one branded child does appear in the pre-#954
  teardown list (`103181168087`: `(2161) pytest, (2162) python, (2165) Local
  Operator, (2168) python, (2171) python`), which that inference above is about.
  Note the teardown list is "what was still running when the cap killed the
  job", so it is a consequence of a cancelled run rather than independent
  evidence of a leaking test.
- **QA Q1 (out of scope here, follow-up PR this session): the autouse broker
  sweep misses brokers started by `tests/unit/secrets/test_cli.py` and
  `tests/unit/tui/test_agent_surfaces.py`** — the +27 / +15 measured above. Real,
  but it is a harness/process-reaping change with its own blast radius, so the
  code is untouched in this PR; the numbers and the mechanism are quoted above
  for whoever takes it.
- **Sweep of the rest of the recent failure record — three further flakes found,
  all left alone** (each needs a product decision, not a test tweak):
  - `tests/unit/secrets/test_concurrency.py::test_ten_processes_read_while_one_writes`
    (`sqlite3.OperationalError: database is locked` at `store.py:678`
    `BEGIN IMMEDIATE`), run 34612841933, **`main` at 15:02Z today**, 3.12 shard 2.
    The 10 s `busy_timeout` was exhausted by the writer while 10 reader processes
    hammered the store. The only fixes are widening that product bound or adding
    a retry, which `AGENTS.md` forbids doing to a number a real user's wait is
    calibrated on. Worth its own ticket: a real `lop` session taking a writer lock
    against 10 others has the same ceiling.
  - `tests/unit/tui/test_transcript_selection.py::test_a_double_click_that_drifts_one_cell_does_not_clear_the_draft`
    ("a 1-cell drift cleared the draft"), run 34549931882, 3.13. The click chain
    is armed by a *wall-clock* window over hand-posted `MouseDown`/`MouseUp`, so a
    stalled loop scores the pair as two singles and the draft rung arms. Fixing it
    means changing how the chain measures time, which is the mechanism that test
    intentionally pins.
  - `tests/unit/evaluation/runner/test_provider_client.py::test_an_eval_row_says_which_task_ran_when_the_runner_knows_it`
    (`assert None is not None`), run 34541238420, 3.13.
- **The two branch-only failures were already fixed on `main`; left alone.**
  Both failing heads predate `9ce0f2f01` (#953): `git merge-base --is-ancestor
  9ce0f2f01` returns false for `c62a973` (`fix/shard-stall-watchdog` 04:51Z) and
  `bf64a30` (`fix/shard-duration-manifest` 02:08Z), and the subagent-view failure
  (`test_history_prepend_preserves_anchor_and_home_dedupes_requests`) is exactly
  what #953's subject fixes.
- No version bump (`pyproject.toml` stays at the last released version).
