### PR TITLE
fix(session): a turn cut off by anything but a deliberate stop is an error with a reason

### DIFF
--- a/docs/ATTENTION.md
+++ b/docs/ATTENTION.md
@@ -22,10 +22,24 @@ operator-facing sentence) whenever it knows why the turn ended.
 **The default flipped for an unfinished run.** Resuming an unfinished journaled
 run records an **error** naming the cause, not an interruption: a cut-off the
 harness cannot explain is not a stop. Only POSITIVE evidence of a deliberate act
-— a recorded stop marker, or the stop rung's own `user-stop` cause — records an
-`interrupted`. The one exception is a run that published its own outcome before
-the process went away: that marker is replayed verbatim, so a deliberate stop
-that settled is still an interruption.
+— a recorded stop marker, or a deliberate rung's own `user-stop` cause — records
+an `interrupted`. "Deliberate rung" means every route a person's stop takes:
+the `stop` control op (`/stop`, `lop stop`), the in-process dispose a bare
+`/stop` performs on a TUI-owned session, the phone's `abort` button and a
+supervisor's `cancel`. An INVOLUNTARY teardown (a reload, an unmount, a session
+swap) is a cut-off and keeps saying so.
+
+`cause` is empty when the harness has no evidence at all — the reason then says
+the cause could not be determined, and nothing names a mechanism nobody
+observed. A cause is set only where one was established.
+
+The one exception is a run that published its own outcome before the process
+went away: that marker is replayed verbatim, so a deliberate stop that settled is
+still an interruption. A marker that reports a CUT-OFF is also journaled at that
+boot (`session_incident`), once per token, because the process that published it
+could not journal it itself — `journal_incident` refuses once the session is
+disposed, and the dispose rung sets that flag before the turn's `finally`
+publishes.
 Copied fork journals cannot reuse another conversation's token.
 
 A receipt advances through the supplied token's sequence using a monotonic

--- a/docs/ATTENTION.md
+++ b/docs/ATTENTION.md
@@ -15,8 +15,17 @@ through their authenticated runtime connection, not through their own PID.
 The logical run journals its token before execution. A settled eligible outcome
 is journaled after durable message persistence and imported idempotently into
 SQLite. Error and interrupted outcomes can have an explicit outcome marker even
-when no assistant message exists. Resuming an unfinished journaled run records an
-interruption rather than treating its output as unknown pre-upgrade history.
+when no assistant message exists; an outcome marker carries an additive `cause`
+(a machine token, from the harness's own cut-off vocabulary) and `reason` (one
+operator-facing sentence) whenever it knows why the turn ended.
+
+**The default flipped for an unfinished run.** Resuming an unfinished journaled
+run records an **error** naming the cause, not an interruption: a cut-off the
+harness cannot explain is not a stop. Only POSITIVE evidence of a deliberate act
+— a recorded stop marker, or the stop rung's own `user-stop` cause — records an
+`interrupted`. The one exception is a run that published its own outcome before
+the process went away: that marker is replayed verbatim, so a deliberate stop
+that settled is still an interruption.
 Copied fork journals cannot reuse another conversation's token.
 
 A receipt advances through the supplied token's sequence using a monotonic
@@ -36,6 +45,9 @@ contains:
 
 - `conversation_id`
 - `completion_token`, `anchor_id`, `kind` (`complete`, `error`, `interrupted`)
+- `cause`, `reason` — the machine token and the operator-facing sentence for a
+  non-`complete` outcome, both `""` when there is nothing to say (every
+  completion, and every row written before this vocabulary existed)
 - `unseen`
 - `revision: [completion_sequence, acknowledged_sequence]`
 

--- a/docs/design-cut-off-turns.md
+++ b/docs/design-cut-off-turns.md
@@ -343,7 +343,10 @@ CUT_OFF_CAUSES: dict[str, str] = {
     "runtime-shutdown": "the runtime was terminated while this turn was running",
     "runtime-killed": "the runtime disappeared without exiting cleanly while this turn was running",
     "install-mid-update": "a local-operator install was being replaced on disk while this turn was running",
-    "owner-lost": "the session's runtime went away while this turn was running",
+    # About what the VIEWER can verify, not about what happened to the process:
+    # the arm that paints it is the recovery loop's give-up, which also fires
+    # for a live-but-silent owner (record present, pid alive, nothing answers).
+    "owner-lost": "the session's runtime stopped answering while this turn was running",
     "disposed": "the session was disposed while this turn was running",
 }
 ```
@@ -393,8 +396,15 @@ ways.
      `started_at`);
    - a `turn_cut_off`/outcome marker from an earlier run of the same token
      (§3.2's live path) → that marker's `kind`/`cause`/`reason`, verbatim;
-   - nothing at all → `error`, `cause="runtime-killed"`, with the detail
-     "the cause could not be determined".
+   - nothing at all → `error`, **no cause**, reason `CUT_OFF_UNKNOWN`
+     ("the turn was cut off and the cause could not be determined"). The first
+     draft named `runtime-killed` here with a "(the cause could not be
+     determined)" parenthetical, and every surface that trims a parenthetical —
+     the sidebar's `_error_label`, which drops one by design for the build pair
+     — asserted a mechanism in the one case where nothing is known (design/UX
+     review round 1, D3/U3). Leaving `cause` empty also keeps
+     `cause_from_reason(reason)` — the inverse every reader uses — agreeing with
+     the sentence instead of naming an unobserved cause.
 3. **The provisional anchor stays.** `provisional_anchor(token)` is the real
    "this record is replaceable" signal. `_supersedes_provisional`
    (`session/attention.py:115-147`) currently *also* requires
@@ -405,6 +415,20 @@ ways.
    describes. Pin it with the test in §8.1.
 
 ### 3.5 Journals on restore, once per orphaned run
+
+**The saved-marker branch journals too** (QA round 1, Q-2; review MINOR-2). A
+runtime that publishes its own outcome and then dies cannot narrate it:
+`journal_incident` refuses once `_disposed` is set, and the dispose rung sets
+that flag before the turn's `finally` publishes — so the whole update/shutdown/
+retire family reached every SURFACE and no MODEL, which is exactly the operator's
+reported family ("interruptions … have something to do with updates"). The
+successor is the only writer left, so `_import_transcript_outcome` returns the
+tuple for a saved marker whose `kind == "error"` **and** whose `cause` is a
+`CUT_OFF_CAUSES` token. Both conditions are load-bearing: a provider error
+carries no cause and a deliberate stop carries `user-stop`, and narrating either
+as a cut-off incident would commit the taxonomy's own misclassification in the
+reader meant to repair it. Deduped on the token like the orphaned-run half, so a
+second boot narrates nothing.
 
 `bootstrap_transcript` is called from `Session.__init__` (where a `Session`
 exists to journal) **and** from the mobile daemon sweep (where it does not). So
@@ -423,6 +447,35 @@ the journaling belongs at the caller that has a session:
   (`session/session.py:675-697`).
 
 ---
+
+### 3.6 Where the deliberate verdict is written (review round 1, BLOCKER-1)
+
+`interrupted` requires POSITIVE evidence of a deliberate act, and the verdict has
+to be recorded while the act is still knowable — `Session.dispose()` notes
+`disposed` unconditionally, so an un-noted dispose publishes the user's own cancel
+as `kind=error, cause=disposed`.
+
+Only the `stop` control op used to record it. The route a bare `/stop` actually
+takes on a TUI-owned session is `tui/app.py::_stop_local_session` → `await
+session.dispose()`, with a peer's `lop stop` reaching the same method through
+`TuiSessionHandle.request_stop` — so the DEFAULT path published a false failure,
+and neither the unit guard (which set `_attention_outcome` directly) nor the e2e
+cell (which used `stop_session`, the one rung that did record it) could see it.
+Measured with the real `Session.dispose()`: unnoted → `error`/`disposed`, noted →
+`interrupted`/`user-stop`.
+
+The verdict is therefore written at the deliberate rungs, and only there:
+
+* `OperatorApp._stop_local_session` (before the dispose),
+* `ServingSessionHandle._note_deliberate_stop`, called by `request_stop`
+  (unchanged), `abort` (the phone's stop button) and `cancel_gracefully` (a
+  supervisor's cancel) — one helper, so the three stay in step,
+* and NOT in `Session.dispose()` itself, whose involuntary teardowns (a reload,
+  an unmount, `_mobile_teardown`) are cut-offs and must keep saying so.
+
+A retirement outranks all three: while `_retiring_cause` is latched, the runtime
+is already ending that turn for its own reason and the cut-off verdict belongs to
+the retire path, which recorded it when it latched.
 
 ## 4. Restored subagent rows (D3)
 
@@ -448,7 +501,23 @@ this order:
    today's behaviour.
 
 The row gains an additive `cut_off_cause: str = ""` field, so the subagent panel
-can show *why* rather than only that it stopped. The three-surface vocabulary
+can show *why* rather than only that it stopped.
+
+**RESOLVED ON BOTH WRITERS, from one function** (UX round 1, U2). There are two
+restorers of the same roster: this cold viewer, and the successor runtime's
+`AsyncJobManager` — whose table is what the session publishes as the live
+roster. Written separately, the viewer's resolved rows survived under a second:
+measured at t+1.2 s `completed|interrupted|completed|interrupted`, and by
+t+1.9 s all four back to a blanket `interrupted` with the cause dropped, because
+the owner's restore replaced them. The resolution therefore lives in
+`session/restored_rows.py` and both paths call it (`Session._load_subagent_roster`
+before `jobs.restore`, and `_restore_cold_subagents`).
+
+`cut_off_cause` is **deliberately not persisted**: the sidecar's `jobs` rows are
+validated by strict `extra="forbid"` models, so a field an older owner does not
+know makes it DROP the whole row at resume — a worse degradation than losing a
+cause that costs nothing to re-derive. `_ROSTER_ROW_FIELDS` stays as it is, and
+`JobState.from_job` carries the value from the manager's row to the wire. The three-surface vocabulary
 already exists (`tui/widgets/subagent_panel.py:230-260`, `:385-390`,
 `subagent_view.py:466`, `:1186-1189`) and a design round decides whether the
 panel prints the cause inline or behind the existing row detail.
@@ -566,13 +635,21 @@ append its `interrupted` row when `aborted=False`. So the live copy is just the
 text is recognised as an MCP or provider auth failure, so a cut-off sentence
 passes through unchanged.
 
-**Tool cards.** `_finalize_turn` retires stranded live cards to
-`⊘ interrupted` unconditionally (`tui/app.py:34286`, `widgets/tool_card.py:1140-1171`).
-On a cut-off turn that word now contradicts the notice. Two options for the
-design round: (a) reuse `⊘ interrupted` and accept the vocabulary mismatch;
-(b) add a `cut off` card state. I recommend (a) for this change and (b) only if
-the designer says the mismatch reads badly — (b) touches the card, the panel and
-`subagent_view`, which is a larger diff than the whole of PR A.
+**Tool cards.** `_finalize_turn` retires stranded live cards, and the WORD comes
+from the turn's verdict (`widgets/tool_card.py::mark_interrupted(cut_off=...)`).
+This was offered to the design round as a choice between reusing `⊘ interrupted`
+and adding a state; the design round took the word (round 1, D2) and it is the
+cheaper of the two — the glyph, the column and the dim tier are untouched, so no
+new design surface, and the row stops calling the same death `interrupted` under
+a `✗ turn cut off` notice. Rendered: `bash  sleep 30   cut off ⊘  9.7s`.
+
+**The bound the paint lands on.** The recovery loop checks its deadline at the
+top of a pass, so a pass that slept its pacing delay past `COLD_FALLBACK_S`
+reported the cut-off one sleep late — measured at 9.4 s against a bound of 8.0.
+The sleep is now capped at the deadline (`paced` in `_recover_runtime`), and the
+watched SIGKILL paints at 8.03 s measured from the kill (the residual hundredth
+is the notification lag before the loop's deadline even starts: the loop's clock
+begins when it notices the drop, not when the process died).
 
 ### 6.2 TUI — the next resume / an unwatched session
 
@@ -589,7 +666,14 @@ Change the error branch to carry the reason:
 > while this turn was running.
 
 and generalise `_adopt_own_interrupt_notice` (`tui/app.py:18467-18511`) to
-adopt an `error` row too. **Without that generalisation a cut-off paints twice**:
+adopt an `error` row too. **The row's tier comes with it** (design round 1, D1):
+the error branch passed no kind, so it took `NoticeBlock`'s `info` default — a
+dim `·` in the same fill as the routine `Interrupted` control one branch down —
+for an outcome the live surface paints `✗` danger. Both surfaces now take the
+sentence AND the tier from `harness/rows.py::completion_notice`, which is where
+this repo's row decisions belong; `interrupted` deliberately stays `info` on the
+replay (the live row's `warning` is a turn-scoped statement a receipt is not
+making). **Without that generalisation a cut-off paints twice**:
 the live `on_turn_ended` error notice has no `completion_anchor_id`, so the
 poller cannot dedupe it and appends its own. The same duplicate is believed to
 exist **today for provider errors** — `_own_interrupt_notice` is only ever set
@@ -620,11 +704,25 @@ text="Stopped with an error" if attention["kind"] == "error" else "Interrupted"
 becomes
 
 ```python
-if attention["kind"] == "error":
-    text = f"Stopped with an error — {reason}" if reason else "Stopped with an error"
-else:
-    text = "Interrupted"
+text, severity = completion_notice(attention["kind"], attention.get("reason") or "")
+# ... TranscriptEntry(..., text=text, details={"severity": severity})
 ```
+
+BOTH halves matter, and the second was missing at first (design round 1, D4):
+the frame carried an empty `details`, and the phone's `NoticeRow` picks its glyph
+and ink from `details.severity` — so a cut-off rendered as the same dim `·` as
+`Interrupted`, a routine receipt, on the surface the operator reads from a phone.
+The severity is derived in `harness/rows.py` (the module that owns these rows for
+both surfaces) rather than at the serialization boundary, so the TUI's poller and
+the phone cannot disagree about the tier of one outcome.
+
+**And `stop_reason` must not read a cut-off as a completion** (review round 1,
+MAJOR-1). `fold_event` set `stop_reason = "aborted" if event.aborted else
+"completed"`, and the taxonomy flip reports a cut-off as `aborted=False` — so the
+phone told the user the turn had FINISHED and silently dropped
+`interrupted — tap to resume`, the only recovery affordance there is, for exactly
+the sessions the operator reports losing. It now prefers `cut_off`/`cut_off_cause`
+(§9 risk 2's third reader of `aborted`, resolved in favour of the reader).
 
 Phone notification copy is unchanged (`tui/notify.py:139-146, 197-207` already
 has a distinct `interrupted` category and an `error` category —
@@ -679,7 +777,13 @@ and every surface) lands and is reviewed before the runtime-lifecycle work.
 | `session/runtime/control.py` | the stop rung records a deliberate cause before triggering |
 | `update.py` | `classify_import_failure` (§5.2) |
 | `mobile/daemon.py` | the fold/projection seams log the named failure (`:110`, `:535`) |
-| `session/attached.py` | `_restored_job_rows(jobs, records=self._durable_roster_records(...))` + child-tail resolution and the additive `cut_off_cause` field (§4) |
+| `session/restored_rows.py` | NEW: the one row-resolution policy, called by BOTH restorers (§4) |
+| `session/attached.py` | `resolve_restored_rows(jobs, records=...)` on the cold path; the named `owner-lost` verdict on both legacy synthesised ends (§6.1) |
+| `session/session.py` | `_load_subagent_roster` resolves the rows through the same function before `jobs.restore` (§4) |
+| `harness/jobs.py` | the non-persisted `cut_off_cause` on `AsyncJob`, carried so the wire row can say why (§4) |
+| `harness/rows.py` | `completion_notice` — the returned-to row's sentence and tier, for both surfaces (§6.2, §6.4) |
+| `mobile/projection.py` | `stop_reason` prefers `cut_off`/`cut_off_cause`, so a cut-off keeps the phone's resume affordance (§6.4) |
+| `tui/app.py`, `tui/widgets/tool_card.py`, `tui/events.py` | the end event's cut-off verdict reaches the stranded card WORD (§6.1); `_stop_local_session` records the deliberate verdict (§3.6) |
 | `docs/design-cut-off-turns.md` | this file, marked implemented |
 
 Order: PR A first (PR B's `begin_retire` reason and the row causes render
@@ -799,10 +903,12 @@ never the operator's live `~/.local-operator`)
 2. **The `aborted=False` rewrite is the riskiest single semantic choice.**
    Anything that reads `aborted` as "the turn was interrupted" now sees
    `error` instead. §6.1's tool-card vocabulary is the visible consequence, and
-   test 15 pins the notice count. If a third reader of `aborted` turns up, the
-   fallback is to keep `aborted=True` and add `cut_off`/`cut_off_cause`, teaching
-   the poller and `_finalize_turn` to prefer them — a larger diff with the same
-   outcome.
+   test 15 pins the notice count. **The third reader this risk predicted DID turn
+   up**: `mobile/projection.py`'s `stop_reason` (round 1, MAJOR-1), which the
+   phone uses to decide whether to offer `interrupted — tap to resume` — the
+   predicted fallback (prefer `cut_off`/`cut_off_cause`) is what was applied, so
+   `aborted` is left alone and no surface has to be taught a new field. Treat this
+   entry as answered rather than as a standing option.
 3. **Two rows for one outcome.** The dedupe between the live turn-end notice and
    the attention poller is anchored on `completion_anchor_id`, which the live row
    cannot carry at paint time. §6.2's generalisation of `_adopt_own_interrupt_notice`

--- a/docs/design-cut-off-turns.md
+++ b/docs/design-cut-off-turns.md
@@ -1,0 +1,846 @@
+# Design: a turn cut off by anything but a deliberate stop is an ERROR, with a reason
+
+Status: **proposal (architect)**. Base: `~/local-operator` @ `633baf258`
+(0.54.14). Two PRs (§7). **No `pyproject.toml` bump in either** — the 0.54.14
+window is owned by another session.
+
+Every file:line below was read on this base. Where the analysis rests on a
+claim I did not verify, it says so and names the evidence that would settle it.
+
+Operator's requirement, verbatim:
+
+> occasionally, sessions like this will just get interrupted after running for a
+> while, I think it has something to do with updates ... ends up being quite
+> disruptive and results in some sessions being forgotten about if you're running
+> many at once for long runtimes
+
+> make sure that errors are properly called out in all situations so at least we
+> see it in active sessions as errored
+
+Deliverable: this proposal, the implementation plan in §7, and the test plan in
+§8. Copy that design/UX rounds will review is written out concretely in §6.
+
+---
+
+## 1. The problem as found in the code, and what I verified
+
+### 1.1 An in-flight run leaves no durable outcome, and "no outcome" is published as `interrupted`
+
+`Session._prompt_messages` journals `attention_started` with a fresh token
+**before** the turn runs (`session/session.py:6508-6520`), and the durable
+outcome — `completion_attention` — is written only from that turn's `finally`
+via `_publish_attention_outcome` (`session/session.py:6534`, `5949-6003`). A
+process that dies mid-turn therefore leaves `attention_started` with no
+matching outcome.
+
+`AttentionStore` boot repair then *invents* the outcome
+(`session/attention.py:192-244`):
+
+```python
+started = transcript.latest_custom("attention_started")
+saved = transcript.latest_custom(ATTENTION_CUSTOM_TYPE)
+if (isinstance(started, dict) and started.get("conversation_id") == identity
+        and (not isinstance(saved, dict) or saved.get("token") != started.get("token"))):
+    token = started["token"]
+    store.publish(identity, token, provisional_anchor(token), "interrupted")   # :212
+    return
+```
+
+The kind is the literal `"interrupted"`, with no way to tell a user's `/stop`
+from a `SIGKILL`. `Session.__init__` calls this (through `bootstrap_transcript`)
+on **every** runtime boot and the mobile daemon calls it on its sweep, so the
+lie is written retroactively the next time anything opens the session.
+
+**Verified on this machine** (the manager's case study, session
+`80efe201ea61`):
+
+- `attention.db` seq 6440: `conversation=session/80efe201ea61`,
+  `token=91a9cc1c-ad8a-44de-b673-27a321910f2f`,
+  `anchor=completion-91a9cc1c-…`, **`kind=interrupted`**.
+- The transcript's row 0 (09-10 22:11:38) is `attention_started` with exactly
+  that token; the transcript contains **two** `attention_started` entries and
+  **zero** `completion_attention`.
+- `session_incident` count in that session and in its four children: **0**.
+- No wake-index entry exists for that session id at all (`~/.local-operator/wakes/`
+  has no `80efe201ea61.json`).
+- Current runtime for that session, pid 81222, `started_at` 1789135478
+  (= 09-11 10:04:38) — i.e. a successor was engaged at the 10:04 restore and is
+  alive now. The original runtime is gone with **no** record under
+  `~/.local-operator/run/mobile/` (only `81222.json` names the session).
+
+### 1.2 Nothing journals the failure, so no surface and no model learns it
+
+`incidents.py`'s `session_incident` path fires only from in-process error
+handling: `Session.journal_incident` (`session/session.py:7364-7395`) is called
+from the pipeline's normal path (`:6863-6866`) and from the MCP breaker
+(`:7590`). `session/session.py:675-697` renders such an entry into the next
+turn's LLM history. A process death writes nothing, so:
+
+- the TUI shows whatever the viewer's local synthesis decided (§1.3);
+- the sidebar shows the published kind mapped straight through
+  (`session/catalog.py:154-157, 168-171, 255-258, 296-298` → "Interrupted" /
+  "Unseen interruption");
+- the phone shows the daemon's copy (`mobile/daemon.py:872-878`) — or would,
+  where it is not suppressed;
+- the next turn and the next `--resume` start blind, having replayed neither an
+  incident nor a reason.
+
+### 1.3 The viewer's owner-death path ends the turn with **no reason**
+
+`AttachedSession._go_cold` (`session/attached.py:4091-4175`) ends an in-flight
+turn with
+
+```python
+self._end_turn_locally(direct=True)          # :4161
+```
+
+and `_end_turn_locally` builds `AgentEndEvent(aborted=aborted, generation=0,
+error=error)` with `error=None` — `aborted=True, error=None`
+(`session/attached.py:3927-3972`). That is the exact shape a user's abort
+produces, so the TUI paints `NoticeBlock("interrupted", "warning")`
+(`tui/app.py:34287-34298`) for both. `_settle_suspect_turn`
+(`session/attached.py:3996-4047`) can do better only from the successor's
+`last_turn_outcome`, and only when a successor snapshot exists: it synthesises
+`error="turn failed"`, which is a class marker with no cause
+(`session/attached.py:4013-4018`, `:4039`).
+
+### 1.4 An involuntary abort that *does* settle is still published `interrupted`
+
+`_publish_attention_outcome` classifies purely off the end event
+(`session/session.py:5970`):
+
+```python
+kind = "error" if outcome.error else "interrupted" if outcome.aborted else "complete"
+```
+
+Every involuntary stop converges on `Session.abort` with `aborted=True` and
+`error=None`, so they all become `interrupted`:
+
+- `Session.dispose` → `self.abort("session disposed")`
+  (`session/session.py:11938`), reached from `ServingSessionHandle.dispose`
+  (`session/runtime/serving.py:807-854`), reached from the runtime's shutdown
+  path — SIGTERM/SIGINT **and** the socket `stop` op both set the same event
+  (`session/runtime/process.py:560-561`, `:613-616`), and from the reaper's
+  `_clean_exit` (`session/runtime/process.py:287-301`);
+- the viewer's go-cold synthesis above.
+
+The abort *cause* does exist at the moment it happens — `AbortSignal.reason`
+(`harness/types.py:1116-1135`) — and `Session.abort(reason)` already receives
+it (`session/session.py:5511-5545`). It is simply dropped: the loop turns an
+aborted turn into `AgentEndEvent(aborted=True, error=stream_error)` with no
+reason (`harness/loop.py:657-663`, `:1054-1056`).
+
+### 1.5 Restored subagent rows are indistinguishable from a user cancel
+
+`_restored_job_rows` (`session/attached.py:490-526`) rewrites every
+non-terminal, non-parked row to
+
+```python
+job.model_copy(update={"status": "interrupted", "restored": True})   # :523
+```
+
+for the honest reason that "was cut off mid-run" is what the panel can offer to
+resume. The row carries no cause, and the roster **record** that does carry one
+is not consulted: in the case study's `subagent-roster.v1.json`, job
+`da292d4e1688` came back `status: interrupted, restored: true, settled_at:
+null`, while its record on the same sidecar reads `outcome: None,
+settled_at: None, session_dir: /Users/damian/.local-operator/sessions/fa38095fff26`
+— and that child's transcript ends on a `tool` result at 02:46:55 with no
+assistant reply, i.e. it was genuinely mid-turn. A sibling record
+(`77c35ee4b827`) reads `outcome: completed`, so the evidence to distinguish them
+was on disk the whole time.
+
+### 1.6 Update linkage — what I verified, and what I did not
+
+The operator's hypothesis is right, for two distinct reasons. Both verified:
+
+- **Self-refresh retirement is real and frequent.** `~/Library/Logs/local-operator/mobile.log`
+  contains **116** `session runtime: retiring for <build>` lines, each preceded
+  by `session runtime: build on disk is <new> but this process loaded <old>;
+  idle, retiring in Ns so the next engage runs the new build`. Both are emitted
+  by `_refresh_for` (`session/runtime/process.py:362-418`). Confirmed by
+  `mobile.log:6735059-6735067` (0.54.11@b133eba → 0.54.12@402af7f, 8.4 s
+  stagger).
+- **A running process can import a mismatched file mid-update.** The log carries
+  **605** occurrences of
+  `ImportError: cannot import name '_journal_injection_ids' from 'local_operator.session.transcript'`,
+  raised from `mobile/durable.py:63` via `daemon.py:110` (`_durable_fold_cache`)
+  and surfaced as `durable fold failed for session <id>` — including once for
+  `80efe201ea61` (`mobile.log:6731482`). `lop-update` runs
+  `uv tool install --force --from <snapshot> local-operator` and writes
+  `.lop-source` **after** it (out-of-tree script, `~/.local/bin/lop-update`), so
+  a live process has a window in which the installed tree is a mix of two
+  builds.
+
+**What I could not prove, and will not assert:** which exit path killed the
+case study's original runtime. The evidence is consistent with three, and the
+log has no line naming a session on its exit paths, so it cannot discriminate:
+(a) a refresh retirement that raced a live turn — but the runtime was parked on
+four subagent jobs, so `is_busy()` was True (`session/runtime/serving.py:856-908`:
+`_turn_lock` is held for the whole turn, `session/session.py:6368-6378`, and
+`running_subagents() > 0`), and `may_refresh` would have returned `"busy"`, so
+this needs the §1.6 race *plus* a spurious idle reading; (b) a `SIGTERM` from a
+bounce (a descendant of the daemon's LaunchAgent job is the obvious candidate —
+`mobile/install.py:301`); (c) a torn-install exception that killed the process.
+**Evidence that would settle it:** a per-runtime exit record written on every
+exit path (this design's §5.3 marker), or an exit reason line in `amain`
+(`session/runtime/process.py:613-653`) — today an exiting runtime logs nothing
+about *why*. Settling it is not a prerequisite for the fix: §3 makes every one
+of the three visible, and §5 closes the two that are ours to close.
+
+### 1.7 What is already right and is not touched
+
+- A deliberate stop is recognised at the *viewer* when its wire signal is
+  present: `AttachedSession._session_was_stopped` distinguishes a stop from
+  owner death (`session/attached.py:4049-4076`), and `_reason == STOPPED_REASON`
+  short-circuits recovery (`:3903-3917`). The problem is what happens when the
+  wire signal is absent (owner death) or when the classifier downstream defaults
+  to `interrupted`.
+- `may_refresh` is the right *predicate* (`session/runtime/serving.py:1064-1103`);
+  §5.1 keeps it and adds a latch, it does not replace it.
+- The `retiring` frame and `_go_cold(refresh=True)` are exactly the right
+  mechanism for a planned retirement (`session/runtime/server.py:926-959`,
+  `session/attached.py:4099-4158`) — this design does not regress
+  `docs/design-runtime-autorefresh.md`.
+- `_supersedes_provisional` (`session/attention.py:115-147`) is the one place
+  that has to be relaxed, and §3.4 says why.
+
+---
+
+## 2. Taxonomy (D1)
+
+`kind` stays a three-value enum. Only its *assignment* changes.
+
+| kind | meaning | assigned when |
+|---|---|---|
+| `complete` | the turn reached its own end | the turn's terminal event carries no error and no cut-off |
+| `interrupted` | a **deliberate** stop: Esc/Ctrl+C mid-turn, `/stop`, another front end's `lop stop` | a deliberate-stop cause was recorded for this turn |
+| `error` | the turn was cut off by **anything else**, with a `reason` | an involuntary cut-off, or a provider/tool error (unchanged path) |
+
+**The default flips.** Today "no evidence" means `interrupted`; after this
+change "no evidence" means `error`, and `interrupted` requires positive
+evidence of a deliberate stop. That is exactly the operator's ask — a cut-off we
+cannot explain is not a stop — and it is the safe direction: a deliberate stop
+misreported as an error is an annoyance, an involuntary cut-off misreported as a
+user abort is the bug being fixed.
+
+Consequences to accept deliberately:
+
+- **A forced stop reports an error.** `lop stop --force` SIGTERMs a runtime that
+  has not answered the graceful rung (`session/runtime/control.py`). A live turn
+  killed that way is honestly "cut off, not gracefully stopped", and §6's copy
+  says so. We do not try to correlate a bare SIGTERM back to an operator intent.
+- **A wakeless session's deliberate stop is not recoverable from the wake
+  index.** `_mark_wakes_dormant` writes `stopped_at` only when the session has
+  schedules (`session/runtime/control.py:550-582`; the TUI mirror returns 0 for
+  a schedule-less session, `tui/app.py:25194-25213`), and `announce_stop`'s own
+  docstring says the marker approach was dropped for exactly that reason
+  (`session/runtime/server.py:870-873`). So §3 records the deliberate stop in
+  the *outcome marker itself*, which is the durable artifact restore already
+  reads — not in the wake index.
+
+Document to update: `docs/ATTENTION.md` lines 17-19 and 38 (`Error and
+interrupted outcomes can have an explicit outcome marker…` / `Resuming an
+unfinished journaled run records an interruption…`). That contract must now
+read: *resuming an unfinished journaled run records an **error** naming the
+cause; only a recorded deliberate stop records an interruption.*
+
+`docs/design-runtime-autorefresh.md` §4.1's table row for a rebind synthesising
+`aborted=True` is narrowed, not contradicted: a rebind with
+`last_turn_outcome == "error"` now carries the real reason instead of the
+`"turn failed"` placeholder (§3.3).
+
+---
+
+## 3. The reason survives (D2)
+
+### 3.1 One additive reason pair, four carriers
+
+Add **two** additive fields, `cause` (machine token) and `reason` (one
+operator-facing sentence), and thread them through the four carriers that
+already exist. No new vocabulary, no new file format, no `PROTOCOL_VERSION`
+bump.
+
+| carrier | today | after |
+|---|---|---|
+| `AgentEndEvent` (`harness/types.py:1217-1232`) | `aborted`, `error` | `+ cut_off: str = ""`, `+ cut_off_cause: str = ""` — `AgentEvent` is `extra="allow"` (`harness/types.py:1202-1205`), so an **old viewer keeps the field as an extra and never fails validation** |
+| `completion_attention` custom entry (`session/attention.py:35`, written at `session/session.py:5987-5995`) | `{conversation_id, token, anchor, kind}` | `+ cause`, `+ reason` |
+| `attention.db` `completions` (`session/attention.py:266-271`) | 5 columns | `+ reason TEXT NOT NULL DEFAULT ''` and `+ cause TEXT NOT NULL DEFAULT ''`, added by the **additive-migration pattern already in this file** (`session/attention.py:285-334`): create-if-absent inside the init transaction, deliberately **not** restated in the corruption probe at `:297-299` |
+| canonical frontend / mobile projection `attention` state | `AttentionStore._state` dict (`:360-367`) | `+ "reason"`, `+ "cause"`; `state_many` already does `SELECT c.*` (`:400-407`) so the column flows with a two-line change, and the synth-empty dict (`:377-387`) needs both keys |
+
+`AttentionStore.publish(conversation, token, anchor, kind, *, baseline_seen=None)`
+(`session/attention.py:422`) gains `reason: str = ""` and `cause: str = ""`;
+the `INSERT OR IGNORE` at `:513-516` and the supersede `UPDATE` at `:504-507`
+both carry them.
+
+### 3.2 The live path: classify at the abort boundary
+
+`Session` gains one field and one classification, both small:
+
+```python
+# session/session.py, near _last_turn_outcome (:2150)
+#: Why the CURRENT turn ended involuntarily, or "" when it ended on its own or
+#: was deliberately stopped. Set by the runtime's own exit paths (a retire that
+#: caught a live turn, a termination signal, disposal) and consumed by
+#: ``_classify_cut_off`` and ``_publish_attention_outcome``. Deliberately NOT
+#: derived from ``AbortSignal.reason``: ``abort("session disposed")`` is
+#: produced by BOTH a user's /stop and a SIGTERM, so the reason string cannot
+#: classify the trigger.
+self._cut_off_cause: str = ""
+```
+
+```python
+def _classify_cut_off(self, event: AgentEvent) -> AgentEvent:
+    """Re-label an involuntary abort as a CUT-OFF error before it is emitted.
+
+    A deliberate stop keeps today's shape (``aborted=True, error=None`` →
+    `interrupted`). An involuntary one is rewritten to ``aborted=False,
+    error=<sentence>`` so every existing surface does the right thing without
+    being taught a new field: ``on_turn_ended`` appends its error notice
+    (`tui/app.py:34007-34008`), ``_finalize_turn`` does NOT append the
+    `interrupted` notice (`:34287`), the title takes the ✗ mark
+    (``failed=bool(error) and not aborted``, `:34259`), ``_last_turn_outcome``
+    becomes ``"error"`` (`session/session.py:6255-6256`), and
+    ``_publish_attention_outcome`` publishes ``error`` (`:5970`). An OLD viewer
+    that has never heard of ``cut_off`` gets the same behaviour, which is the
+    backwards-compatibility requirement.
+    """
+```
+
+Called from the top of `Session._emit` (`session/session.py:6248`) for
+`AgentEndEvent` instances only. The `cut_off`/`cut_off_cause` fields ride along
+so a *new* viewer can name the cause precisely (§3.3) without re-deriving it.
+
+`_publish_attention_outcome` becomes:
+
+```python
+cut_off = bool(self._cut_off_cause)
+kind = "error" if (outcome.error or cut_off) else "interrupted" if outcome.aborted else "complete"
+reason = outcome.error or _render_cut_off(self._cut_off_cause)
+cause = self._cut_off_cause if cut_off else ""
+```
+
+and passes `reason=`/`cause=` to both the journal entry and `AttentionStore.publish`.
+It also journals the incident once (§3.5).
+
+`self._cut_off_cause` is cleared at the start of every turn alongside
+`self._attention_outcome` (`session/session.py:6508`), so a stale cause cannot
+label a later, healthy turn.
+
+### 3.3 The `cause` vocabulary
+
+Authored by the runtime, not classified from provider text — so it is a small
+module constant, rendered with the incident formatter's shape rather than a
+parallel prose system. `incidents.py` gains:
+
+```python
+#: Why a turn was cut off. Harness-authored, so unlike _RULES these are exact
+#: tokens rather than substring guesses over vendor text; the rendering borrows
+#: Incident's shape but not its classifier.
+CUT_OFF_CAUSES: dict[str, str] = {
+    "user-stop": "the session was stopped by the user",
+    "runtime-retired": "the runtime retired so the next engage would run a newer build",
+    "runtime-shutdown": "the runtime was terminated while this turn was running",
+    "runtime-killed": "the runtime disappeared without exiting cleanly while this turn was running",
+    "install-mid-update": "a local-operator install was being replaced on disk while this turn was running",
+    "owner-lost": "the session's runtime went away while this turn was running",
+    "disposed": "the session was disposed while this turn was running",
+}
+```
+
+and `_HINTS["cut-off"]` (the same shape as the existing entries at
+`incidents.py:217-241`):
+
+> "The runtime was cut off before this turn produced a result. The transcript
+> holds whatever was written before it stopped and nothing after. Check the
+> state of anything it was mid-way through before repeating the work; do not
+> assume the request completed."
+
+plus `format_cut_off_message(cause, *, detail="") -> str`, which builds an
+`Incident(category="cut-off", raw=<CUT_OFF_CAUSES[cause] + detail>)` and calls
+`Incident.render()` — the same `[session incident] cut-off: … / suggested action:
+… / This is why the previous turn ended.` text (`incidents.py:257-267`), so the
+next turn's card and the resume replay are the existing surface, not a new one.
+
+The `detail` is where the build pair goes, e.g. for `runtime-retired`:
+`" (0.54.11@b133eba → 0.54.12@402af7f)"`. `_refresh_for` already has both stamps
+(`session/runtime/process.py:384-392`), so it passes them to the handle.
+
+### 3.4 Restore: default to `error`, reconstruct the cause
+
+`_import_transcript_outcome` (`session/attention.py:192-244`) changes in three
+ways.
+
+1. **Do not publish for a run that may still be live.** Before publishing the
+   provisional marker, consult the run registry: if
+   `find_runtime_record(config_dir, identity_session_id)` returns a record whose
+   pid is alive and whose record still describes that session (the liveness and
+   pid-reuse checks already exist in `session/runtime/control.py:480-516`),
+   publish **nothing** — the turn is in flight and will publish its own outcome.
+   This is the false-alarm guard. Without it a daemon sweep mid-turn would
+   write a wrong `error` row for a healthy run, and that row would be
+   *silently* wrong rather than loudly so: the phone and the sidebar both
+   suppress an outcome mark while the session's live state is `busy`
+   (`tui/app.py:19080`, `session/catalog.py:240-242`) and the daemon
+   suppresses the notice while `projection.streaming` is true
+   (`mobile/daemon.py:872`). The guard removes the class instead of
+   relying on every surface's suppression.
+2. **Kind from evidence, not by default.** With no live owner:
+   - a `stopped_at` marker on the wake index (when the session has schedules)
+     → `interrupted`, `cause="user-stop"`;
+   - a record present whose pid is **dead** → `error`,
+     `cause="runtime-killed"`, detail from the record (`<version>@<ref>`, pid,
+     `started_at`);
+   - a `turn_cut_off`/outcome marker from an earlier run of the same token
+     (§3.2's live path) → that marker's `kind`/`cause`/`reason`, verbatim;
+   - nothing at all → `error`, `cause="runtime-killed"`, with the detail
+     "the cause could not be determined".
+3. **The provisional anchor stays.** `provisional_anchor(token)` is the real
+   "this record is replaceable" signal. `_supersedes_provisional`
+   (`session/attention.py:115-147`) currently *also* requires
+   `stored_kind == "interrupted"` (`:145`); that clause must be dropped so a
+   provisional record published as `error` is still superseded by the same
+   token's real `complete`. The anchor, not the kind, is the shape. Without this
+   the change would brick exactly the session the docstring at `:433-443`
+   describes. Pin it with the test in §8.1.
+
+### 3.5 Journals on restore, once per orphaned run
+
+`bootstrap_transcript` is called from `Session.__init__` (where a `Session`
+exists to journal) **and** from the mobile daemon sweep (where it does not). So
+the journaling belongs at the caller that has a session:
+
+- `_import_transcript_outcome` returns the `(kind, cause, reason, token)` it
+  published (or `None`);
+- `Session.__init__`/`refresh_attention` calls `journal_incident(...)` with
+  `format_cut_off_message(...)` **once per token** — dedupe on the token already
+  journaled (`transcript.latest_custom(SESSION_INCIDENT_MESSAGE_TYPE)` carrying
+  the token in `details`), so re-opening a session does not re-narrate the same
+  death. `journal_incident` already persists then parks the live-context append
+  (`session/session.py:7379-7395`, `_append_or_park_journal:7308-7339`), so it is
+  durable even if the process dies immediately after; the parked notice flushes
+  at the next turn boundary or is replayed into the LLM history on resume
+  (`session/session.py:675-697`).
+
+---
+
+## 4. Restored subagent rows (D3)
+
+`_restore_cold_subagents` already reads the roster **records** for accounting
+(`session/attached.py:1169-1208`) — the same sidecar that carries
+`records[].outcome`, `records[].settled_at` and `records[].session_dir`
+(verified on the case study's sidecar). So `_restored_job_rows`
+(`session/attached.py:490-526`) takes the records too, and a row resolves in
+this order:
+
+1. **The record settled it.** `outcome` in `{completed, failed, error,
+   interrupted}` → the row says that, not `interrupted`. This alone repairs job
+   `77c35ee4b827` (record `outcome: completed`, row restored `interrupted`).
+2. **The record did not, and the child's own transcript decides.** Read
+   `records[i].session_dir`'s transcript tail:
+   - last row is a `tool` result, or an assistant message whose `tool_calls`
+     have no results → the child was mid-turn → `interrupted`, with a
+     `cut_off_cause` (the parent's death, or the child's own stop) on the row;
+   - last row is an assistant message with no pending tool call → the child
+     **finished** but the parent never recorded it → report the child's own
+     last-turn outcome (`completed`), not `interrupted`.
+3. **No record and no transcript** → `interrupted` with `cause="owner-lost"`,
+   today's behaviour.
+
+The row gains an additive `cut_off_cause: str = ""` field, so the subagent panel
+can show *why* rather than only that it stopped. The three-surface vocabulary
+already exists (`tui/widgets/subagent_panel.py:230-260`, `:385-390`,
+`subagent_view.py:466`, `:1186-1189`) and a design round decides whether the
+panel prints the cause inline or behind the existing row detail.
+
+Cost note: rule 2 reads up to N child transcripts on a cold restore. Bound it —
+only for rows whose record's `outcome` is `None` (the case study had two of
+four), and read the tail only, off the loop (the call site already hops to a
+worker for the sidecar read). If a tail read raises, fall through to rule 3.
+
+---
+
+## 5. The update path cannot silently cut a live turn (D4)
+
+### 5.1 Is `may_refresh` sufficient? No — it is the right predicate, sampled, not held
+
+`may_refresh` (`session/runtime/serving.py:1064-1103`) is `not is_busy()` and
+`not _wake_within_window()`, which is the right authority. But both retire paths
+sample it and then act across an `await`:
+
+- the reaper re-checks immediately before `_clean_exit`
+  (`session/runtime/process.py:409-417`) — and the code **admits the race** in
+  its own comment at `:376-379`: *"A turn that starts between THIS re-check and
+  `_clean_exit` is aborted by the dispose exactly as a `stop` op racing a turn
+  is"*;
+- the viewer-driven `_retire_for` re-asks after `announce_retiring` and then
+  calls `request_stop()` (`session/runtime/server.py:2298-2314`);
+- the quiet idle exit has the same shape at the top of `_reaper`
+  (`session/runtime/process.py:335-359`).
+
+`dispose()` is async, so the loop is free in that gap, and a `prompt`/`peer_message`
+arriving over the socket can open a turn that the dispose then aborts. So **the
+"idle" claim is checkable but only at one instant**, which is the defect.
+
+**Recommendation: keep `may_refresh` and add a latch, so the claim is true by
+construction.**
+
+```python
+# ServingSessionHandle
+def begin_retire(self, cause: str) -> bool:
+    """Commit this runtime to retiring, iff it is idle RIGHT NOW.
+
+    Sets ``_retiring_cause`` in the same synchronous step that checks
+    ``may_refresh()``, and from that instant the admission paths
+    (``prompt`` / ``receive_peer_message``) REFUSE rather than queue: a
+    runtime that is leaving must not start a turn it will abort one await
+    later. The refusal names the cause, and the sender's next engage spawns
+    the new build — which is what ``_refresh_for``'s comment already claims
+    happens today, made true instead of merely likely.
+    """
+```
+
+The two retire paths call `begin_retire(cause)` instead of a bare re-check and
+dispose only on `True`; `"kept: <reason>"` otherwise (the existing answer shape
+at `session/runtime/server.py:2296-2309`). The quiet idle exit uses the same
+latch with `cause="idle-exit"`. Roughly 40 lines plus tests.
+
+### 5.2 A mismatched import must be a loud, named failure
+
+Verified shape (§1.6): a lazy `from local_operator… import x` inside a running
+process raises against a half-replaced tree, and today it surfaces as an
+arbitrary traceback (`durable fold failed for session X`) or a random tool
+error. **Recommendation: name it, and feed it into §3's vocabulary as
+`install-mid-update`.**
+
+- New helper in `update.py` (next to `installed_build`, `:804`):
+  `classify_import_failure(exc: BaseException, module: str, *, boot: BuildStamp | None) -> str | None`
+  — returns a rendered reason when the exception is an `ImportError` naming a
+  `local_operator.*` module **and** `installed_build()` differs from `boot`
+  (the stamp the process loaded at boot, `session/runtime/server.py`'s
+  `_boot_build`). It returns `None` for a genuine packaging bug, so we do not
+  mislabel one.
+- The two seams that actually see it — the mobile daemon's
+  `_durable_fold_cache`/`_durable_projection` (`mobile/daemon.py:110`, `:535`)
+  and the harness's own lazy imports inside a turn — log at ERROR with that
+  reason instead of a bare traceback, and a turn aborted by it ends as an
+  `error` with `cause="install-mid-update"`.
+- **Out of scope, deliberately:** preventing the torn window. `uv tool install
+  --force` replaces the tree in place; the only complete fix is an atomic
+  install (write a new directory, swap a symlink), which is uv's behaviour, not
+  ours. The settle window (`BUILD_SETTLE_S`, `session/runtime/process.py:93`)
+  and §5.1's latch prevent the *retirement* half; the import half is reported
+  honestly and stops being an unexplained traceback. An optional follow-up (not
+  this PR): a `<tool dir>/.lop-updating` sentinel written by `update.py` and by
+  the out-of-tree `lop-update` around the install, so the reason does not have
+  to be inferred from the stamp. It requires editing `~/.local/bin/lop-update`,
+  which is not in this repo, so it cannot ride a repo PR unaltered.
+
+### 5.3 Every exit path should say why it exited
+
+Cheap and it is what would have settled §1.6. `amain`'s shutdown
+(`session/runtime/process.py:613-653`) and `_clean_exit` (`:287-301`) log one
+INFO line naming the trigger and pid, e.g.
+`session runtime: exiting (SIGTERM, pid 1234, 0.54.11@b133eba)`. Not a
+requirement of the operator's ask, but it is one line each and it makes the next
+occurrence diagnosable from the log instead of by inference.
+
+---
+
+## 6. Surfaces and copy (for the design/UX rounds)
+
+Every string below is user-visible and is what the design round reviews. The
+cause sentences are §3.3's, rendered as `format_cut_off_message`.
+
+### 6.1 TUI — the moment it happens (a watched session)
+
+`tui/app.py:34007-34008` already appends `NoticeBlock(self._with_recovery_hint(message.error), "error")`
+on every terminal event carrying `error`, and `_finalize_turn` does **not**
+append its `interrupted` row when `aborted=False`. So the live copy is just the
+`error` sentence:
+
+> ✗ turn cut off — the runtime was terminated while this turn was running. The
+> transcript holds what it wrote before that and nothing after.
+
+`_with_recovery_hint` (`tui/app.py:34074-34139`) appends a remedy only when the
+text is recognised as an MCP or provider auth failure, so a cut-off sentence
+passes through unchanged.
+
+**Tool cards.** `_finalize_turn` retires stranded live cards to
+`⊘ interrupted` unconditionally (`tui/app.py:34286`, `widgets/tool_card.py:1140-1171`).
+On a cut-off turn that word now contradicts the notice. Two options for the
+design round: (a) reuse `⊘ interrupted` and accept the vocabulary mismatch;
+(b) add a `cut off` card state. I recommend (a) for this change and (b) only if
+the designer says the mismatch reads badly — (b) touches the card, the panel and
+`subagent_view`, which is a larger diff than the whole of PR A.
+
+### 6.2 TUI — the next resume / an unwatched session
+
+The attention poller already paints, for an unseen `error`/`interrupted`
+outcome (`tui/app.py:19238-19266`):
+
+```python
+block = NoticeBlock("Stopped with an error" if state["kind"] == "error" else "Interrupted")
+```
+
+Change the error branch to carry the reason:
+
+> ✗ Stopped with an error — the runtime disappeared without exiting cleanly
+> while this turn was running.
+
+and generalise `_adopt_own_interrupt_notice` (`tui/app.py:18467-18511`) to
+adopt an `error` row too. **Without that generalisation a cut-off paints twice**:
+the live `on_turn_ended` error notice has no `completion_anchor_id`, so the
+poller cannot dedupe it and appends its own. The same duplicate is believed to
+exist **today for provider errors** — `_own_interrupt_notice` is only ever set
+in the aborted branch (`tui/app.py:34287-34308`) and `_adopt_own_interrupt_notice`
+returns `False` for any other kind (`:18495`) — so this repair is also a
+pre-existing bug fix, not just new plumbing. Verify it with the two-line test in
+§8.1 before relying on it.
+
+### 6.3 Sidebar tooltip / status (`session/catalog.py`)
+
+No mapping change is needed — `error` already renders "Error" / "Unseen error"
+(`catalog.py:154-157, 168-171, 255-258, 296-298`). Append the reason to the two
+`Unseen …`/`…` error spellings:
+
+> `Unseen error — the runtime retired so the next engage would run a newer build`
+
+Long reasons get the cause sentence only (not the build pair); the tooltip has
+one line. `shows_completion_mark` keeps its existing precedence
+(`catalog.py:174-242`) — a busy session still shows the spinner, which is
+correct and unchanged.
+
+### 6.4 Mobile daemon (`mobile/daemon.py:872-878`)
+
+```python
+text="Stopped with an error" if attention["kind"] == "error" else "Interrupted"
+```
+
+becomes
+
+```python
+if attention["kind"] == "error":
+    text = f"Stopped with an error — {reason}" if reason else "Stopped with an error"
+else:
+    text = "Interrupted"
+```
+
+Phone notification copy is unchanged (`tui/notify.py:139-146, 197-207` already
+has a distinct `interrupted` category and an `error` category —
+`CONTEXT_ATTENTION` / `BODY_ERROR`); a cut-off now takes the error one, which is
+the operator's ask. Background banners stay gated on `live_state in {"", "idle"}`
+(`tui/app.py:666`, `:19080`), so a live mid-turn session still never banners.
+
+### 6.5 The next turn's `[session incident]` card
+
+Rendered by `_default_convert_to_llm` (`session/session.py:675-697`) from the
+`session_incident` entry, via `format_cut_off_message`:
+
+> [session incident] cut-off: the runtime retired so the next engage would run a
+> newer build (0.54.11@b133eba → 0.54.12@402af7f).
+> suggested action: The runtime was cut off before this turn produced a result.
+> The transcript holds whatever was written before it stopped and nothing after.
+> Check the state of anything it was mid-way through before repeating the work;
+> do not assume the request completed.
+> This is why the previous turn ended. Take it into account before repeating the
+> same request.
+
+---
+
+## 7. Implementation plan
+
+Split into two PRs so the taxonomy/reason work (which touches the wire, the DB
+and every surface) lands and is reviewed before the runtime-lifecycle work.
+
+### 7.1 PR A — taxonomy, reason, restore, surfaces
+
+| file | change |
+|---|---|
+| `session/attention.py` | `_state`/`state_many`/synth state carry `reason`,`cause` (`:351-417`); `publish(..., reason="", cause="")`; additive `ALTER TABLE` migration for the two columns in the `:285-334` pattern; `_supersedes_provisional` drops the `stored_kind == "interrupted"` term (`:145`); `_import_transcript_outcome` returns `(kind, cause, reason, token)` and defaults to `error` with the live-owner guard (§3.4) |
+| `session/session.py` | `_cut_off_cause`; `_classify_cut_off` called from `_emit` (`:6248`); `_attention_outcome` rewrite in `_publish_attention_outcome` (`:5970`); `reason`/`cause` on the journal entry (`:5987`) and `publish` (`:5996`); clear `_cut_off_cause` at `:6508`; journal the restored cut-off once per token (§3.5); `note_cut_off(cause)` / `note_deliberate_stop()` |
+| `incidents.py` | `CUT_OFF_CAUSES`, `_HINTS["cut-off"]`, `format_cut_off_message` (`:217-282` area) |
+| `harness/types.py` | `AgentEndEvent.cut_off`, `.cut_off_cause` (`:1217`) |
+| `session/frontend_state.py` | `last_turn_cut_off: str = ""` alongside `last_turn_outcome` (`:1586`), set in the same `_run_turn_pipeline` `finally` (`session/session.py:6256`), copied in `_last_turn_outcome_from`'s neighbours (`:3904`) |
+| `session/attached.py` | `_settle_suspect_turn` synthesises `error=last_turn_cut_off` (real reason) instead of `"turn failed"` (`:4039`); `_go_cold`'s non-refresh branch ends the turn as `owner-lost` rather than a bare abort (`:4161`) |
+| `session/runtime/serving.py` | `note_cut_off("runtime-shutdown")` / `note_deliberate_stop()` on the stop rung; `may_refresh` unchanged |
+| `tui/app.py` | poller copy (`:19261-19263`); `_adopt_own_interrupt_notice` generalised to `error` (`:18467-18511`) |
+| `mobile/daemon.py` | reason in the notice copy (`:872-878`) |
+| `session/catalog.py` | reason appended to the two error spellings (`:154-171, 255-258, 296-298`) |
+| `docs/ATTENTION.md` | taxonomy contract (§2) |
+
+### 7.2 PR B — the update path and restored rows
+
+| file | change |
+|---|---|
+| `session/runtime/serving.py` | `begin_retire(cause)`; refuse `prompt`/`receive_peer_message` once retiring (§5.1) |
+| `session/runtime/process.py` | `_refresh_for`/quiet-exit use `begin_retire`; pass the build pair to the handle; exit-reason log line (§5.3) |
+| `session/runtime/server.py` | `_retire_for` uses `begin_retire` (`:2273-2314`) |
+| `session/runtime/control.py` | the stop rung records a deliberate cause before triggering |
+| `update.py` | `classify_import_failure` (§5.2) |
+| `mobile/daemon.py` | the fold/projection seams log the named failure (`:110`, `:535`) |
+| `session/attached.py` | `_restored_job_rows(jobs, records=self._durable_roster_records(...))` + child-tail resolution and the additive `cut_off_cause` field (§4) |
+| `docs/design-cut-off-turns.md` | this file, marked implemented |
+
+Order: PR A first (PR B's `begin_retire` reason and the row causes render
+through PR A's vocabulary).
+
+---
+
+## 8. Test plan
+
+### 8.1 Unit
+
+`tests/unit/session/test_attention.py` (extend):
+1. `_import_transcript_outcome` with `attention_started` and no outcome, no
+   record → publishes **`error`**, `cause="runtime-killed"`, non-empty `reason`.
+   *This fails on `633baf258`* — the same fixture asserts `interrupted` today at
+   `:198`.
+2. Same, with a live record for the session → publishes **nothing** (the
+   false-alarm guard).
+3. Same, with a dead-pid record → `error` with the record's build/pid in the
+   detail.
+4. Same, with a `stopped_at` wake-index entry → `interrupted`,
+   `cause="user-stop"`.
+5. Supersede: a provisional record published as **`error`** is still superseded
+   by the same token's real `complete` (the `_supersedes_provisional`
+   relaxation — this fails before the change).
+6. `publish(..., reason=, cause=)` round-trips through `state`/`state_many`, and
+   an **old** DB (created without the columns) migrates additively without
+   reading as corrupt.
+
+`tests/unit/session/test_cut_off_turns.py` (new):
+7. `_classify_cut_off`: `_cut_off_cause=""` + `aborted=True` → unchanged
+   (`aborted=True, error=None`); `_cut_off_cause="runtime-shutdown"` +
+   `aborted=True` → `aborted=False, error=<sentence>`, `cut_off_cause` set.
+8. `_publish_attention_outcome` with a cut-off outcome → kind `error`, the
+   reason and cause on the journal entry and in the store.
+9. A deliberate stop (`abort("interrupted")`) still publishes `interrupted` with
+   no reason — the regression guard for the whole taxonomy change.
+10. The next turn's rendered LLM history contains the `[session incident]`
+    text after a restore (replay through `_default_convert_to_llm`).
+
+`tests/unit/session/runtime/test_process_cut_off.py` (new):
+11. `begin_retire` returns True when idle and False when a turn is held; after
+    True, a `prompt`/`peer_message` is refused with a named reason and no turn
+    opens.
+12. `_refresh_for` with a turn held → no announce, no exit; released → retires.
+13. `_classify_import_failure` returns a reason for an `ImportError` naming a
+    `local_operator.*` module when the stamp moved, and `None` when it did not.
+14. `_restored_job_rows` with records: `outcome="completed"` → `completed`; a
+    child tail ending on a tool result → `interrupted` + cause; a child tail
+    ending on an assistant message → the child's outcome.
+
+`tests/unit/tui/test_cut_off_notices.py` (new):
+15. A cut-off end paints exactly **one** row: the error notice with the reason,
+    never the `interrupted` notice (the `aborted=False` consequence).
+16. A provider-error end paints exactly one row (the pre-existing duplicate,
+    now adopted).
+17. The poller's row carries the reason and is adopted when the live row exists.
+
+Plus copy assertions: `"Interrupted" not in transcript_text(app)` for a cut-off,
+`"Stopped with an error —"` present.
+
+### 8.2 E2E — `tests/e2e/test_cut_off_turns_e2e.py` (new; follow
+`tests/e2e/test_runtime_refresh_e2e.py`'s shape: production `process.py` in a
+subprocess, isolated `HOME` + config dir, every `CMUX_*` unset, synthetic ids)
+
+| cell | drive | assert |
+|---|---|---|
+| A (the case-study shape) | boot a real runtime, hold a turn open on a `wait`-shaped tool, `SIGKILL` it (leaves the record), then boot a successor | record present+dead ⇒ `kind=error`; `reason` non-empty; exactly one `session_incident` in the transcript; the next turn's history contains `[session incident]`; `catalog` status contains "Unseen error"; the phone projection's notice contains the reason |
+| B (graceful termination) | as A but `SIGTERM` mid-turn with an attached headless viewer | the dying runtime writes the marker itself; the viewer paints an error notice naming the cause within 1 s; durable kind `error`, `cause="runtime-shutdown"` |
+| C (deliberate stop) | `lop stop` mid-turn | durable kind `interrupted`, `cause="user-stop"`, **no** `session_incident` |
+| D (retire latch) | hold a turn open, flip the build stamp, then fire a `prompt` in the window | the runtime does **not** retire; the prompt is refused with a named reason; the next engage runs the new build; no turn is aborted |
+| E (torn install) | monkeypatch a lazy `local_operator.*` import to raise mid-turn | the turn ends `error` with `cause="install-mid-update"`; the log line names it; no bare traceback as the only evidence |
+
+**Reproduction recipe for cell A, runnable by hand** (this is the shape the
+manager's case study took, and the pre-fix run must be recorded first):
+
+```sh
+export HOME=$(mktemp -d); export LOCAL_OPERATOR_CONFIG_DIR=$HOME/.local-operator
+unset ${(k)CMUX_*} 2>/dev/null || true
+# 1. start a runtime for a fresh session, scripted to park in a long tool
+.venv/bin/python -m local_operator.cli --new <<<"run the scripted park"
+PID=$(cat "$LOCAL_OPERATOR_CONFIG_DIR/sessions/<id>/.session.pid")
+# 2. SIGKILL it mid-turn — this is the case study's death, hard-kill shape
+kill -9 "$PID"
+# 3. pre-fix: boot the successor and read the store
+.venv/bin/python -c "from local_operator.session.attention import AttentionStore; print(AttentionStore().state('session/<id>'))"
+#    => {'kind': 'interrupted', ...}   ← the bug
+# 4. post-fix: same boot
+#    => {'kind': 'error', 'reason': '...', 'cause': 'runtime-killed'}
+grep -c session_incident "$LOCAL_OPERATOR_CONFIG_DIR/sessions/<id>/transcript.jsonl"   # 1, was 0
+```
+
+### 8.3 QA matrix cells (qa-tester, real execution, isolated config per cell —
+never the operator's live `~/.local-operator`)
+
+- A/B/C/D/E above by hand, each with commands and captured output.
+- A re-run of A against **pre-fix** `633baf258` to show `interrupted` + 0
+  incidents, then against the branch.
+- A `SIGKILL` of a **watched** session, to confirm the viewer's cold path paints
+  the error inside `COLD_FALLBACK_S` and never `Interrupted`.
+- A `lop stop` of a **wakeless** session with a live turn, to confirm the
+  deliberate path still reports `interrupted` (the §2 consequence).
+- An old-DB upgrade cell: copy a pre-change `attention.db`, boot, confirm the
+  additive migration and that no historical row is re-announced.
+
+---
+
+## 9. Risks, and what I deferred
+
+**Risks to watch in rollout**
+
+1. **The false-error risk is the one that matters.** Defaulting to `error` means
+   any bug in the "is this run live?" guard (§3.4) paints a healthy session as
+   failed. The guard and its unit test (8.1 test 2) are the load-bearing part of
+   PR A, and the daemon sweep is the path most likely to trip it. Watch the
+   phone in rollout for an error badge on a session that is working.
+2. **The `aborted=False` rewrite is the riskiest single semantic choice.**
+   Anything that reads `aborted` as "the turn was interrupted" now sees
+   `error` instead. §6.1's tool-card vocabulary is the visible consequence, and
+   test 15 pins the notice count. If a third reader of `aborted` turns up, the
+   fallback is to keep `aborted=True` and add `cut_off`/`cut_off_cause`, teaching
+   the poller and `_finalize_turn` to prefer them — a larger diff with the same
+   outcome.
+3. **Two rows for one outcome.** The dedupe between the live turn-end notice and
+   the attention poller is anchored on `completion_anchor_id`, which the live row
+   cannot carry at paint time. §6.2's generalisation of `_adopt_own_interrupt_notice`
+   is what keeps it at one row; test 15/16 pin it.
+4. **Restore read amplification.** D3 rule 2 reads child transcripts on a cold
+   restore; bounded to records with `outcome is None`, but a session with
+   dozens of unsettled children is the case to measure.
+
+**Deferred, with the reason**
+
+- **Atomic install** (write a new prefix, swap a symlink) so there is no torn
+  window at all. It is `uv tool install --force`'s behaviour, not this repo's;
+  §5.2 makes the failure honest instead. Reason for deferring: a repo PR cannot
+  fix it.
+- **The `.lop-updating` sentinel.** Requires editing `~/.local/bin/lop-update`,
+  which is outside this repository. The stamp comparison in
+  `classify_import_failure` covers the same ground with no out-of-tree edit.
+- **Rekeying the wake index for wakeless sessions** so `stopped_at` always
+  exists. Not needed: §3 records the deliberate stop in the outcome marker
+  itself, and `announce_stop`'s docstring (`session/runtime/server.py:870-873`)
+  is an explicit decision against the marker approach.
+- **Retro-classifying historical `interrupted` rows.** The cause is not
+  recoverable from the store; a migration would guess. Left alone.
+- **Settling the case study's exact death (a/b/c in §1.6).** §5.3's exit-reason
+  log is the cheap answer and lands in PR B; a py-spy/`faulthandler` capture at
+  the moment of a future death would be conclusive and is not needed to ship.
+
+**Deliberately NOT done**
+
+- No `PROTOCOL_VERSION` bump: every wire addition is a new field on an existing
+  frame or a new optional key in the additive `attention` state, and
+  `AgentEvent` is `extra="allow"`, so an older runtime or viewer degrades to
+  today's behaviour.
+- No second vocabulary: the reason rides `Incident`'s renderer and
+  `journal_incident`, and `interrupted` keeps its existing spelling everywhere.
+- No version bump in either PR.
+
+---
+
+Model: openrouter/deepseek/deepseek-v4.1-flash. No provider fallback occurred
+during this round.

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -444,6 +444,16 @@ class AsyncJob(BaseModel):
     # missing task because a reader must be able to tell "this session started
     # it" from "a previous session did" without consulting the task table.
     restored: bool = False
+    #: Why a RESTORED row reads the way it does — ``"owner-lost"`` for a child
+    #: whose parent's process ended under it. Derived on every restore from the
+    #: roster records and the child's own journal (see
+    #: ``session/restored_rows.py``), never read from disk.
+    #:
+    #: DELIBERATELY ABSENT from ``_ROSTER_ROW_FIELDS``: the sidecar's rows are
+    #: validated by STRICT ``extra="forbid"`` models, so persisting a field an
+    #: older owner does not know would make it drop the whole row at resume — a
+    #: worse degradation than losing the cause. It costs nothing to re-derive.
+    cut_off_cause: str = ""
     # The subagent ROLE this job runs ("task", "scout", ...) and the effort
     # TIER it was launched with ("lo"/"med"/"hi"), stamped at REGISTRATION
     # beside ``prompt`` — a queued job that never starts must still be able to

--- a/local_operator/harness/rows.py
+++ b/local_operator/harness/rows.py
@@ -455,6 +455,34 @@ def compaction_refused_notice(details: dict[str, Any]) -> tuple[str, NoticeSever
     return text, severity
 
 
+def completion_notice(kind: str, reason: str = "") -> tuple[str, NoticeSeverity]:
+    """A RETURNED-TO turn's outcome row: its sentence and the ink it deserves.
+
+    The row a session paints when you come back to it, as opposed to the one it
+    paints while you are watching it die. Both surfaces have one
+    (``tui/app.py``'s attention poller and the mobile daemon's projection
+    frame), and they must agree on the words AND on the tier — the daemon's
+    frame is a dict that a phone renders from, so a tier decided in a renderer
+    is a tier the other renderer does not have.
+
+    THE TIER IS ``error`` FOR A FAILURE, and this is the whole point of the
+    helper. The poller's error branch passed no kind at all, so a cut-off — an
+    alarm while you watch it die — came back as a dim ``·`` whisper, in the ink
+    of the routine ``Interrupted`` receipt beside it (design review round 1,
+    D1; UX U4). ``interrupted`` stays ``info``: that row is a receipt for the
+    user's own act, and the live surface's louder ``warning`` for it is a
+    turn-scoped statement this replay is not making.
+
+    ``reason`` is optional because a pre-taxonomy record carries none, and an
+    empty one must read exactly as it always has rather than leaving a dangling
+    em-dash.
+    """
+    if kind == "error":
+        text = f"Stopped with an error — {reason}" if reason else "Stopped with an error"
+        return text, "error"
+    return "Interrupted", "info"
+
+
 def assistant_stop_notice(
     *,
     text: str,

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1224,6 +1224,18 @@ class AgentEndEvent(AgentEvent[Literal["agent_end"]]):
     aborted: bool = False
     error: str | None = None
     generation: int = 0
+    #: Why the turn was CUT OFF by something other than a deliberate stop, when
+    #: that is what happened. ``cut_off_cause`` is the machine token
+    #: (``incidents.CUT_OFF_CAUSES``); ``cut_off`` is its rendered operator
+    #: sentence, carried so a viewer can name the cause without re-deriving it
+    #: from the vocabulary. Both default to ``""``, which is also what an OLD
+    #: runtime produces — and ``AgentEvent`` is ``extra="allow"``, so an old
+    #: viewer that has never heard of these fields keeps them as extras and
+    #: never fails validation. That is the whole backwards-compatibility story
+    #: here: no ``PROTOCOL_VERSION`` bump is needed for an additive field on a
+    #: frame old readers already accept.
+    cut_off: str = ""
+    cut_off_cause: str = ""
     # A post-turn compaction happens after the loop creates this event but before
     # the session releases it. Keep the billed messages intact while letting the
     # session replace their now-invalid pre-compaction occupancy reading.

--- a/local_operator/incidents.py
+++ b/local_operator/incidents.py
@@ -238,7 +238,97 @@ _HINTS: dict[str, str] = {
     "Do not call its tools in a tight loop; say which server is down.",
     "content-filter": "The provider refused the content: change the approach "
     "rather than resending the same request.",
+    # A cut-off is the harness's own verdict, not a provider's, and its advice is
+    # the opposite of "retry": whatever the turn was mid-way through may have
+    # half-happened, so the model must re-establish state before redoing work.
+    # The sentence is deliberately general because the CAUSE varies (retire,
+    # signal, owner death); the cause itself rides ``Incident.raw``.
+    "cut-off": "The runtime was cut off before this turn produced a result. The transcript "
+    "holds whatever was written before it stopped and nothing after. Check the "
+    "state of anything it was mid-way through before repeating the work; do not "
+    "assume the request completed.",
 }
+
+#: Why a turn was cut off. Harness-authored, so unlike :data:`_RULES` these are
+#: exact tokens rather than substring guesses over vendor text; the rendering
+#: borrows :class:`Incident`'s shape but not its classifier.
+#:
+#: ``runtime-retired`` and ``install-mid-update`` are OURS to explain (a
+#: planned retirement that caught a live turn; a lazy import against a
+#: half-replaced install). ``runtime-shutdown`` covers an ordinary termination
+#: signal, ``runtime-killed`` a process that vanished without exiting cleanly,
+#: and ``owner-lost`` the viewer-side verdict that the runtime it was bound to
+#: disappeared. ``user-stop`` is the one DELIBERATE cause, and it is what keeps
+#: a user's own cancel from being reported as an error.
+CUT_OFF_CAUSES: dict[str, str] = {
+    "user-stop": "the session was stopped by the user",
+    "runtime-retired": "the runtime retired so the next engage would run a newer build",
+    "runtime-shutdown": "the runtime was terminated while this turn was running",
+    "runtime-killed": (
+        "the runtime disappeared without exiting cleanly while this turn was running"
+    ),
+    "install-mid-update": (
+        "a local-operator install was being replaced on disk while this turn was running"
+    ),
+    "owner-lost": "the session's runtime went away while this turn was running",
+    "disposed": "the session was disposed while this turn was running",
+}
+
+#: The sentence used when a cause token is not one this build knows — a newer
+#: runtime's token reaching an older viewer. Naming the gap is honest; guessing
+#: a cause would not be, and a refusal to render would hide the cut-off.
+CUT_OFF_UNKNOWN = "the turn was cut off and the cause could not be determined"
+
+
+def render_cut_off_reason(cause: str, *, detail: str = "") -> str:
+    """One operator-facing sentence naming why a turn was cut off.
+
+    This is the string the durable outcome stores as ``reason`` and every
+    surface prints after its own prefix (``Stopped with an error — …``), so it
+    is deliberately a sentence and not a paragraph: ``detail`` carries an
+    optional parenthetical (a build pair, a pid, a started-at) rather than
+    more prose, because the sidebar tooltip has one line and truncates the
+    rest rather than wrapping it.
+    """
+    sentence = CUT_OFF_CAUSES.get(cause) or CUT_OFF_UNKNOWN
+    return f"{sentence}{detail}"
+
+
+def format_cut_off_notice(cause: str, *, detail: str = "") -> str:
+    """The LIVE transcript notice for a cut-off turn.
+
+    Deliberately different from :func:`format_cut_off_message`: the live row is
+    what a watching user reads the moment the turn dies, so it leads with the
+    fact (``turn cut off``) and adds the one consequence they need (what the
+    transcript does and does not contain). The full incident form is for the
+    NEXT turn's model context, where the consequence and the advice both earn
+    their space.
+    """
+    return (
+        f"turn cut off — {render_cut_off_reason(cause, detail=detail)}. "
+        "The transcript holds what it wrote before that and nothing after."
+    )
+
+
+def format_cut_off_raw(reason: str) -> str:
+    """Render an ALREADY-COMPOSED cut-off reason into the incident text.
+
+    Split out from :func:`format_cut_off_message` because the restore path holds
+    a reason string (with its detail already appended) rather than a cause and a
+    detail it can recombine: re-deriving one from the other there would re-render
+    a different sentence than the one the store and the sidebar are showing.
+    """
+    return Incident(category="cut-off", raw=reason).render()
+
+
+def format_cut_off_message(cause: str, *, detail: str = "") -> str:
+    """Render a cut-off cause into the established incident text.
+
+    Built through :class:`Incident` rather than a parallel prose system, so the
+    next turn's card and the resume replay are the SAME surface as every other
+    failure, and the ``cut-off`` hint above is applied by the one renderer.
+    """
+    return format_cut_off_raw(render_cut_off_reason(cause, detail=detail))
 
 
 @dataclass(frozen=True)

--- a/local_operator/incidents.py
+++ b/local_operator/incidents.py
@@ -258,8 +258,8 @@ _HINTS: dict[str, str] = {
 #: half-replaced install). ``runtime-shutdown`` covers an ordinary termination
 #: signal, ``runtime-killed`` a process that vanished without exiting cleanly,
 #: and ``owner-lost`` the viewer-side verdict that the runtime it was bound to
-#: disappeared. ``user-stop`` is the one DELIBERATE cause, and it is what keeps
-#: a user's own cancel from being reported as an error.
+#: stopped answering. ``user-stop`` is the one DELIBERATE cause, and it is what
+#: keeps a user's own cancel from being reported as an error.
 CUT_OFF_CAUSES: dict[str, str] = {
     "user-stop": "the session was stopped by the user",
     "runtime-retired": "the runtime retired so the next engage would run a newer build",
@@ -270,7 +270,13 @@ CUT_OFF_CAUSES: dict[str, str] = {
     "install-mid-update": (
         "a local-operator install was being replaced on disk while this turn was running"
     ),
-    "owner-lost": "the session's runtime went away while this turn was running",
+    # Deliberately about what the VIEWER can verify, not about what happened to
+    # the process. The arm that paints this is the recovery loop's give-up,
+    # which fires both for an owner whose record is gone and for a live-but-
+    # silent one (the record is there, its pid is alive, and nothing answers) —
+    # "went away" asserted a death that arm cannot establish (review round 1,
+    # MINOR-3). "stopped answering" is the fact both shapes share.
+    "owner-lost": "the session's runtime stopped answering while this turn was running",
     "disposed": "the session was disposed while this turn was running",
 }
 

--- a/local_operator/incidents.py
+++ b/local_operator/incidents.py
@@ -294,6 +294,26 @@ def render_cut_off_reason(cause: str, *, detail: str = "") -> str:
     return f"{sentence}{detail}"
 
 
+def cause_from_reason(reason: str) -> str:
+    """The cause token a rendered reason came from, or ``""`` when unknown.
+
+    The inverse of :func:`format_cut_off_notice` / :func:`render_cut_off_reason`,
+    for the one place that has the SENTENCE and needs the classification: a
+    locally synthesised turn end carries operator-facing prose (that is what
+    every surface prints), and a machine token must be recoverable from it so a
+    consumer can group or log the cause without parsing English twice.
+
+    Longest-prefix match rather than an exact one, because the notice append
+    parenthetical detail (``(0.54.11@b133eba → 0.54.12@402af7f)``). Returns
+    ``""`` for prose this vocabulary did not write, so a provider's own error
+    message is never misclassified as a harness cause.
+    """
+    for cause, sentence in CUT_OFF_CAUSES.items():
+        if sentence and sentence in reason:
+            return cause
+    return ""
+
+
 def format_cut_off_notice(cause: str, *, detail: str = "") -> str:
     """The LIVE transcript notice for a cut-off turn.
 

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -107,13 +107,67 @@ def _durable_fold_cache():
     use get a cache keyed by THEIR directories."""
     global _DURABLE_FOLD_CACHE
     if _DURABLE_FOLD_CACHE is None:
-        from local_operator.mobile.durable import DurableFoldCache
-
+        try:
+            from local_operator.mobile.durable import DurableFoldCache
+        except ImportError as exc:
+            # The daemon's own lazy import is a seam that sees a torn install
+            # directly (``durable`` pulls ``_journal_injection_ids`` at module
+            # scope). Log it NAMED, then re-raise: the fold cannot run without
+            # the module, and swallowing the import would turn a diagnosable
+            # install race into "no projection" with no cause anywhere.
+            _log_import_failure(exc, "local_operator.mobile.durable", where="durable fold cache")
+            raise
         _DURABLE_FOLD_CACHE = DurableFoldCache()
     return _DURABLE_FOLD_CACHE
 
 
 _DURABLE_FOLD_CACHE: Any = None
+
+#: The build this DAEMON PROCESS loaded, stamped once at construction. Compared
+#: against the install on disk by ``update.classify_import_failure``, which is
+#: the only way to tell a lazy import that lost a name to a HALF-REPLACED
+#: install from a genuine packaging bug (design §5.2). ``None`` means "not
+#: stamped yet", which classifies nothing rather than guessing.
+_BOOT_BUILD: Any = None
+_BOOT_BUILD_STAMPED = False
+
+
+def _boot_build() -> Any:
+    """This daemon's boot build, memoised on first read.
+
+    Called from ``MobileDaemon.__init__`` so the normal case stamps at process
+    start, before any install can replace the tree. A seam that somehow runs
+    first stamps there and then, which can only ever make the comparison MORE
+    conservative (a stamp taken after the swap equals the install, so the
+    failure stays an ordinary traceback).
+    """
+    global _BOOT_BUILD, _BOOT_BUILD_STAMPED
+    if not _BOOT_BUILD_STAMPED:
+        _BOOT_BUILD_STAMPED = True
+        try:
+            from local_operator.update import installed_build
+
+            _BOOT_BUILD = installed_build()
+        except Exception:  # noqa: BLE001 — an unreadable stamp classifies nothing
+            _BOOT_BUILD = None
+    return _BOOT_BUILD
+
+
+def _log_import_failure(exc: BaseException, module: str, *, where: str) -> None:
+    """Log a lazy-import failure, naming it when the install moved under us.
+
+    One logger call for the daemon's two lazy-import seams, so the 605-occurrence
+    ``durable fold failed for session X`` traceback becomes a sentence that says
+    WHAT happened and WHY, and the cause can be fed to the next turn's cut-off
+    vocabulary.
+    """
+    from local_operator.update import classify_import_failure
+
+    reason = classify_import_failure(exc, module, boot=_boot_build())
+    if reason is None:
+        logger.error("%s failed while importing %s", where, module, exc_info=exc)
+        return
+    logger.error("%s failed: %s (%s)", where, reason, module, exc_info=exc)
 
 
 def _custom_snapshot_cache():
@@ -535,8 +589,10 @@ def _durable_projection(session_id: str) -> SessionProjection | None:
         state = _durable_fold_cache().load(directory)
     except FileNotFoundError:
         return None
-    except Exception:  # noqa: BLE001 — an odd transcript yields no projection, not a 500
-        logger.exception("durable fold failed for session %s", session_id)
+    except Exception as exc:  # noqa: BLE001 — an odd transcript yields no projection, not a 500
+        _log_import_failure(
+            exc, "local_operator.mobile.durable", where=f"durable fold for {session_id}"
+        )
         return None
     projection = SessionProjection(
         session_id=session_id,
@@ -870,12 +926,21 @@ def _projection_frame(projection: SessionProjection) -> dict[str, Any]:
     attention = projection.attention
     data["attention"] = attention
     if not projection.streaming and attention.get("kind") in {"error", "interrupted"}:
+        # The reason rides the sentence when the outcome carries one (a cut-off
+        # names its cause; a provider error already names itself). The
+        # suppression above is unchanged and still correct: a LIVE mid-turn
+        # session banners nothing, regardless of the last outcome.
+        reason = str(attention.get("reason") or "")
+        if attention["kind"] == "error":
+            text = f"Stopped with an error — {reason}" if reason else "Stopped with an error"
+        else:
+            text = "Interrupted"
         data["transcript"] = [
             *data["transcript"],
             TranscriptEntry(
                 id=attention["anchor_id"],
                 kind="notice",
-                text="Stopped with an error" if attention["kind"] == "error" else "Interrupted",
+                text=text,
             ).to_json(),
         ]
     if degraded:
@@ -1025,6 +1090,10 @@ class MobileDaemon:
         self.port = port
         self.password = password
         self.table = SessionTable()
+        # Stamp the build THIS process loaded, before any lazy import can meet a
+        # replaced tree: every later comparison in ``_log_import_failure`` is
+        # against this value.
+        _boot_build()
         # False makes this daemon a READ-ONLY observer of the record directory:
         # it lists sessions and serves durable folds, but never dials a
         # registrant's control socket and never reaps a stale claim. A second

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -919,6 +919,7 @@ def _projection_frame(projection: SessionProjection) -> dict[str, Any]:
     whole. Degradation is tiered and lossless for the collapsed view (see
     ``cap_projection_frame``); the retained projection object is untouched.
     """
+    from local_operator.harness.rows import completion_notice
     from local_operator.mobile.projection import cap_projection_frame
     from local_operator.mobile.types import TranscriptEntry
 
@@ -926,21 +927,24 @@ def _projection_frame(projection: SessionProjection) -> dict[str, Any]:
     attention = projection.attention
     data["attention"] = attention
     if not projection.streaming and attention.get("kind") in {"error", "interrupted"}:
-        # The reason rides the sentence when the outcome carries one (a cut-off
-        # names its cause; a provider error already names itself). The
-        # suppression above is unchanged and still correct: a LIVE mid-turn
-        # session banners nothing, regardless of the last outcome.
-        reason = str(attention.get("reason") or "")
-        if attention["kind"] == "error":
-            text = f"Stopped with an error — {reason}" if reason else "Stopped with an error"
-        else:
-            text = "Interrupted"
+        # The sentence AND its severity come from `harness/rows.py`, which owns
+        # row decisions for both surfaces: the phone's `NoticeRow` picks its
+        # glyph and ink from `details.severity`, so a frame that carried an empty
+        # `details` painted a cut-off as a routine `·` receipt — the same
+        # flattening the TUI's poller had, on the surface the operator reads from
+        # a phone (design review round 1, D4). The suppression above is unchanged
+        # and still correct: a LIVE mid-turn session banners nothing, regardless
+        # of the last outcome.
+        text, severity = completion_notice(
+            str(attention["kind"]), str(attention.get("reason") or "")
+        )
         data["transcript"] = [
             *data["transcript"],
             TranscriptEntry(
                 id=attention["anchor_id"],
                 kind="notice",
                 text=text,
+                details={"severity": severity},
             ).to_json(),
         ]
     if degraded:

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -1013,7 +1013,19 @@ class ProjectionFold:
             p.streaming = False
             self._streaming_ended = True
             p.queued_count = 0
-            p.stop_reason = "aborted" if event.aborted else "completed"
+            # A CUT-OFF TURN IS AN ABORT, not a completion. The taxonomy flips an
+            # involuntary end to `aborted=False, error=<notice>` so every
+            # existing surface paints it as a failure, and this fold naively read
+            # that as "the turn finished" — which silently removed the phone's
+            # only recovery affordance for exactly the sessions the operator
+            # reports losing (`composer.tsx` gates `interrupted — tap to resume`
+            # on `stop_reason === "aborted"`, review round 1 MAJOR-1). The field
+            # means "why streaming last stopped", and a turn that was cut off
+            # stopped without finishing; `cut_off`/`cut_off_cause` is how the
+            # session states that, so it is read here rather than inferred from
+            # `aborted` alone.
+            cut_off = bool(event.cut_off or event.cut_off_cause)
+            p.stop_reason = "aborted" if (event.aborted or cut_off) else "completed"
             self._close_open_message()
             if event.error:
                 self._append(

--- a/local_operator/session/attached.py
+++ b/local_operator/session/attached.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import os
 import time
 from collections.abc import AsyncIterator, Mapping, Sequence
 from contextlib import asynccontextmanager
@@ -66,6 +67,7 @@ from local_operator.harness.types import (
     Usage,
     WakeDeliveredEvent,
 )
+from local_operator.incidents import format_cut_off_notice
 from local_operator.mobile.attach_client import (
     RETIRING_REASON,
     STOPPED_REASON,
@@ -102,7 +104,10 @@ from local_operator.session.protocol import (
 )
 from local_operator.session.runtime.types import HEARTBEAT_TIMEOUT_S
 from local_operator.session.transcript import (
+    ENTRY_MESSAGE,
+    TRANSCRIPT_FILENAME,
     Transcript,
+    TranscriptEntry,
     read_replay_suffix,
     replay_entries,
 )
@@ -487,7 +492,134 @@ def deserialize_event(data: dict[str, Any]) -> AgentEvent[Any]:
     return cls.model_validate(data)
 
 
-def _restored_job_rows(jobs: Sequence[Any]) -> list[Any]:
+#: Outcomes a roster RECORD can carry that already settle a child's state. Any
+#: other value (``None``, or a token a newer runtime invented) means "the
+#: record did not settle it" and the row falls through to the child's own
+#: transcript.
+_SETTLED_RECORD_OUTCOMES = frozenset({"completed", "failed", "error", "interrupted"})
+
+#: How much of a child transcript's TAIL the cold restore reads to decide whether
+#: the child was still working. Bounded because rule 2 runs per unsettled child
+#: and a 50 MB journal must not be parsed to answer one question; the shape
+#: examined is structural (what the LAST row is), so a sliced tail is enough.
+_CHILD_TAIL_BYTES = 256 * 1024
+
+
+def _record_field(record: Any, name: str, default: Any = None) -> Any:
+    """One field off a roster record, which is a raw sidecar DICT.
+
+    The sidecar stores ``records`` as plain JSON objects (``SubagentComms.snapshot``
+    output), while ``jobs`` come back as ``JobState`` models — so the one reader
+    that consults both cannot assume either shape. Kept as a named helper rather
+    than a ``getattr``/``[]`` dance at each call site so the dict-vs-model
+    distinction is stated once.
+    """
+    if isinstance(record, Mapping):
+        return record.get(name, default)
+    return getattr(record, name, default)
+
+
+def _child_tail_state(session_dir: Any) -> str:
+    """``"mid-turn"`` / ``"finished"`` / ``"unknown"`` for one child's journal.
+
+    Structural, never semantic — the only question is what the child's LAST
+    message row is:
+
+    * a ``tool`` result, or an assistant message whose ``tool_calls`` have no
+      rows after them → the child was CUT OFF MID-TURN;
+    * an assistant message with no pending tool call → the child actually
+      FINISHED and only its parent's record was lost.
+
+    Anything else, or anything unreadable, answers ``"unknown"`` so the row
+    keeps today's ``interrupted`` spelling instead of inventing an outcome. A
+    bounded tail read is deliberate: the journal is append-mostly, so the last
+    256 KiB is the part that carries the answer.
+    """
+    if not session_dir:
+        return "unknown"
+    try:
+        path = Path(session_dir) / TRANSCRIPT_FILENAME
+        if not path.exists():
+            return "unknown"
+        with path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            start = max(0, size - _CHILD_TAIL_BYTES)
+            handle.seek(start)
+            blob = handle.read()
+        lines = blob.split(b"\n")
+        if start > 0:
+            # The first line is the tail of a row whose head is before the
+            # window; it cannot be parsed as a whole row.
+            lines = lines[1:]
+        last_payload: dict[str, Any] | None = None
+        for raw in lines:
+            if not raw.strip():
+                continue
+            entry = TranscriptEntry.from_json(raw.decode("utf-8", errors="replace"))
+            if entry is not None and entry.type == ENTRY_MESSAGE:
+                last_payload = entry.payload
+    except (OSError, ValueError):
+        return "unknown"
+    if last_payload is None:
+        return "unknown"
+    role = str(last_payload.get("role") or "")
+    if role == "tool":
+        return "mid-turn"
+    if role == "assistant":
+        return "mid-turn" if last_payload.get("tool_calls") else "finished"
+    return "unknown"
+
+
+def _restored_job_row(job: Any, record: Any | None) -> Any:
+    """One non-terminal job row, resolved against the record and the child.
+
+    Resolution order (design §4), because each step is stronger evidence than
+    the next:
+
+    1. **The record settled it.** ``records[].outcome`` names how the child
+       ended, and that is a fact, not an inference — a row restored as a bare
+       ``interrupted`` beside a record reading ``completed`` was the D3 defect.
+    2. **The record did not, so the child's own transcript decides** — the
+       mid-turn / finished question above. The reason goes on the row so the
+       panel can say WHY rather than only that it stopped.
+    3. **No record and no transcript** → today's ``interrupted``, now naming
+       ``owner-lost`` rather than carrying no cause at all.
+    """
+    record_outcome = ""
+    if record is not None:
+        record_outcome = str(_record_field(record, "outcome") or "")
+    if record_outcome in _SETTLED_RECORD_OUTCOMES:
+        return job.model_copy(
+            update={"status": record_outcome, "restored": True, "cut_off_cause": ""}
+        )
+    tail = _child_tail_state(_record_field(record, "session_dir") if record is not None else None)
+    if tail == "finished":
+        # The child produced a settled answer; only its parent's record of that
+        # was lost. Reporting the child as cut off would be a lie the panel then
+        # offers to resume.
+        return job.model_copy(update={"status": "completed", "restored": True, "cut_off_cause": ""})
+    if tail == "mid-turn":
+        return job.model_copy(
+            update={"status": "interrupted", "restored": True, "cut_off_cause": "owner-lost"}
+        )
+    return job.model_copy(
+        update={"status": "interrupted", "restored": True, "cut_off_cause": "owner-lost"}
+    )
+
+
+def _roster_records(payload: Mapping[str, Any]) -> Sequence[Any]:
+    """The sidecar's ``records`` list, or an empty sequence when it has none.
+
+    Typed here rather than inline so the ``Any`` coming out of a raw JSON dict
+    is narrowed once: the caller passes it straight into ``_restored_job_rows``,
+    whose ``records`` parameter is a ``Sequence``.
+    """
+    records = payload.get("records")
+    return records if isinstance(records, list) else ()
+
+
+def _restored_job_rows(jobs: Sequence[Any], records: Sequence[Any] = ()) -> list[Any]:
     """Roster rows as they must appear with NO runtime alive.
 
     The persisted roster records what each job's state WAS when it was
@@ -513,14 +645,24 @@ def _restored_job_rows(jobs: Sequence[Any]) -> list[Any]:
     Anything already terminal is untouched: ``completed``/``failed``/
     ``cancelled`` are facts the last runtime settled and this process must not
     relitigate.
+
+    ``records`` is the roster sidecar's ``records`` list, whose ``outcome`` and
+    ``session_dir`` are what make a restored row diagnosable rather than a
+    blanket ``interrupted``. It is optional so an older sidecar (or a caller
+    that has none) keeps today's behaviour exactly.
     """
+    by_id: dict[str, Any] = {}
+    for record in records:
+        job_id = str(_record_field(record, "job_id") or "")
+        if job_id:
+            by_id[job_id] = record
     rows: list[Any] = []
     for job in jobs:
         status = str(getattr(job, "status", "") or "")
         if status == "running":
             if bool(getattr(job, "queued", False)):
                 continue
-            rows.append(job.model_copy(update={"status": "interrupted", "restored": True}))
+            rows.append(_restored_job_row(job, by_id.get(str(getattr(job, "id", "") or ""))))
             continue
         rows.append(job.model_copy(update={"restored": True}))
     return rows
@@ -1352,7 +1494,14 @@ class AttachedSession:
             or {}
         )
         changes: dict[str, Any] = {
-            "jobs": _restored_job_rows(self._durable_roster(state, payload=payload))
+            # The RECORDS go in with the rows: a record's ``outcome`` settles a
+            # child the row's persisted status cannot, and its ``session_dir``
+            # is the only route to the child's own transcript when the record
+            # does not settle it. Without them every non-terminal row came back
+            # as a blanket ``interrupted``" (design §4, D3).
+            "jobs": _restored_job_rows(
+                self._durable_roster(state, payload=payload), records=_roster_records(payload)
+            )
         }
         if isinstance(payload.get("accounting"), list):
             try:
@@ -4182,8 +4331,14 @@ class AttachedSession:
         owner: a killed owner factually aborted the turn, a stopped one ended
         the whole session under it, and a viewer going cold has no runtime
         left to hear from. Marked through the normal event path so no
-        card/banner or attach vocabulary appears — the transcript reads as an
-        ordinary aborted turn, which is what it is.
+        card/banner or attach vocabulary appears.
+
+        ``aborted``/``error`` are the CALLER's verdict, and the cut-off work
+        makes that explicit rather than leaving the default to speak for every
+        case: a deliberate stop or a kill keeps ``aborted=True, error=None``
+        (the shape a user's Esc produces), while a confirmed owner death passes
+        ``aborted=False, error=<cut-off notice>`` so the app paints a named
+        failure instead of a cancel it cannot explain.
 
         ``direct`` bypasses the sync buffer and hands the end straight to the
         subscribed handlers (dropping it when there are none). The go-cold
@@ -4254,12 +4409,14 @@ class AttachedSession:
           from ``last_turn_outcome`` (additive; ``""`` from an old runtime
           keeps today's aborted synthesis).
 
-        The ``error`` case synthesises the placeholder ``"turn failed"``.
-        ``last_turn_outcome`` is a four-value enum that deliberately carries
-        no message — transporting the owner's error text would mean a second,
-        unbounded field on every snapshot — so that string is a CLASS marker,
-        never the owner's actual diagnostic, and nothing downstream should
-        read it as authoritative (review round 1, MINOR-2).
+        The ``error`` case synthesises ``last_turn_cut_off`` when the owner
+        published one — the harness-authored reason sentence for a cut-off — and
+        falls back to the placeholder ``"turn failed"`` otherwise. The
+        placeholder is a CLASS marker, never the owner's actual diagnostic
+        (review round 1, MINOR-2); the cut-off reason is different in kind: it
+        is a short, bounded, harness-authored sentence, so carrying it on the
+        snapshot costs one line and buys the viewer a real cause instead of
+        a shrug.
         """
         suspect = self._suspect_generation
         self._suspect_generation = None
@@ -4271,16 +4428,18 @@ class AttachedSession:
             self._same_live_turn = True
             return
         outcome = ""
+        cut_off = ""
         store = self._frontend_store
         if store is not None:
             outcome = str(getattr(store.state, "last_turn_outcome", "") or "")
+            cut_off = str(getattr(store.state, "last_turn_cut_off", "") or "")
         # ``force`` because ``_apply_frontend_facades`` already cleared
         # ``_streaming`` when the snapshot says the turn ended, and the
         # usual early-return would swallow the synthesised end.
         self._end_turn_locally(
             direct=True,
             aborted=outcome in ("aborted", ""),
-            error="turn failed" if outcome == "error" else None,
+            error=(cut_off or "turn failed") if outcome == "error" else None,
             force=True,
         )
         # A successor turn may already be live (generation moved). The
@@ -4401,8 +4560,24 @@ class AttachedSession:
             # is the honest repair, and ``_settle_suspect_turn`` decides on
             # rebind exactly as it does after a transient drop.
         else:
+            # OWNER DEATH, and the end must say so. Synthesising the bare
+            # abort (``aborted=True, error=None``) is the exact shape a user's
+            # Esc produces, so a runtime that died mid-turn painted the same
+            # "interrupted" the operator's own cancel does — the bug this
+            # change exists to fix, and the reason this branch names a cause
+            # rather than leaving a class marker.
+            #
+            # Reached ONLY for a runtime the recovery loop has confirmed gone
+            # (a deliberate stop returns above, and ``refresh=True`` never
+            # ends a turn), so this cannot paint an error over a healthy
+            # session that merely dropped a socket — the autorefresh design's
+            # invariant, kept.
             try:
-                self._end_turn_locally(direct=True)
+                self._end_turn_locally(
+                    direct=True,
+                    aborted=False,
+                    error=format_cut_off_notice("owner-lost"),
+                )
             except Exception:  # noqa: BLE001 — a viewer notice must not break teardown
                 logger.debug("ending the in-flight turn on go-cold failed", exc_info=True)
             # Belt for the case ``_end_turn_locally`` early-returns on

--- a/local_operator/session/attached.py
+++ b/local_operator/session/attached.py
@@ -4369,6 +4369,15 @@ class AttachedSession:
         if not self._streaming and not force:
             return
         end = AgentEndEvent(aborted=aborted, generation=0, error=error)
+        if error:
+            # The cause rides WITH the sentence, so a consumer that only has the
+            # event (the phone's projection, a log line, a test) can classify it
+            # without re-parsing operator-facing prose. ``cause_from_reason``
+            # inverts ``format_cut_off_notice``'s own rendering, which is what
+            # keeps the two from drifting into a vocabulary nobody can read.
+            from local_operator.incidents import cause_from_reason
+
+            end = end.model_copy(update={"cut_off_cause": cause_from_reason(error) or "owner-lost"})
         # THE STATE CHANGE IS THE CONTRACT; ONLY THE NOTIFICATION IS
         # BEST-EFFORT (review round 2, MAJOR-2). `_deliver` calls handlers
         # synchronously with no guard of its own, and

--- a/local_operator/session/attached.py
+++ b/local_operator/session/attached.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
-import os
 import time
 from collections.abc import AsyncIterator, Mapping, Sequence
 from contextlib import asynccontextmanager
@@ -102,12 +101,10 @@ from local_operator.session.protocol import (
     RuntimeLocality,
     unanswered_tail_call_ids,
 )
+from local_operator.session.restored_rows import resolve_restored_rows, roster_records
 from local_operator.session.runtime.types import HEARTBEAT_TIMEOUT_S
 from local_operator.session.transcript import (
-    ENTRY_MESSAGE,
-    TRANSCRIPT_FILENAME,
     Transcript,
-    TranscriptEntry,
     read_replay_suffix,
     replay_entries,
 )
@@ -490,182 +487,6 @@ def deserialize_event(data: dict[str, Any]) -> AgentEvent[Any]:
     """
     cls = _EVENT_TYPES.get(str(data.get("type", "")), AgentEvent)
     return cls.model_validate(data)
-
-
-#: Outcomes a roster RECORD can carry that already settle a child's state. Any
-#: other value (``None``, or a token a newer runtime invented) means "the
-#: record did not settle it" and the row falls through to the child's own
-#: transcript.
-_SETTLED_RECORD_OUTCOMES = frozenset({"completed", "failed", "error", "interrupted"})
-
-#: How much of a child transcript's TAIL the cold restore reads to decide whether
-#: the child was still working. Bounded because rule 2 runs per unsettled child
-#: and a 50 MB journal must not be parsed to answer one question; the shape
-#: examined is structural (what the LAST row is), so a sliced tail is enough.
-_CHILD_TAIL_BYTES = 256 * 1024
-
-
-def _record_field(record: Any, name: str, default: Any = None) -> Any:
-    """One field off a roster record, which is a raw sidecar DICT.
-
-    The sidecar stores ``records`` as plain JSON objects (``SubagentComms.snapshot``
-    output), while ``jobs`` come back as ``JobState`` models — so the one reader
-    that consults both cannot assume either shape. Kept as a named helper rather
-    than a ``getattr``/``[]`` dance at each call site so the dict-vs-model
-    distinction is stated once.
-    """
-    if isinstance(record, Mapping):
-        return record.get(name, default)
-    return getattr(record, name, default)
-
-
-def _child_tail_state(session_dir: Any) -> str:
-    """``"mid-turn"`` / ``"finished"`` / ``"unknown"`` for one child's journal.
-
-    Structural, never semantic — the only question is what the child's LAST
-    message row is:
-
-    * a ``tool`` result, or an assistant message whose ``tool_calls`` have no
-      rows after them → the child was CUT OFF MID-TURN;
-    * an assistant message with no pending tool call → the child actually
-      FINISHED and only its parent's record was lost.
-
-    Anything else, or anything unreadable, answers ``"unknown"`` so the row
-    keeps today's ``interrupted`` spelling instead of inventing an outcome. A
-    bounded tail read is deliberate: the journal is append-mostly, so the last
-    256 KiB is the part that carries the answer.
-    """
-    if not session_dir:
-        return "unknown"
-    try:
-        path = Path(session_dir) / TRANSCRIPT_FILENAME
-        if not path.exists():
-            return "unknown"
-        with path.open("rb") as handle:
-            handle.seek(0, os.SEEK_END)
-            size = handle.tell()
-            start = max(0, size - _CHILD_TAIL_BYTES)
-            handle.seek(start)
-            blob = handle.read()
-        lines = blob.split(b"\n")
-        if start > 0:
-            # The first line is the tail of a row whose head is before the
-            # window; it cannot be parsed as a whole row.
-            lines = lines[1:]
-        last_payload: dict[str, Any] | None = None
-        for raw in lines:
-            if not raw.strip():
-                continue
-            entry = TranscriptEntry.from_json(raw.decode("utf-8", errors="replace"))
-            if entry is not None and entry.type == ENTRY_MESSAGE:
-                last_payload = entry.payload
-    except (OSError, ValueError):
-        return "unknown"
-    if last_payload is None:
-        return "unknown"
-    role = str(last_payload.get("role") or "")
-    if role == "tool":
-        return "mid-turn"
-    if role == "assistant":
-        return "mid-turn" if last_payload.get("tool_calls") else "finished"
-    return "unknown"
-
-
-def _restored_job_row(job: Any, record: Any | None) -> Any:
-    """One non-terminal job row, resolved against the record and the child.
-
-    Resolution order (design §4), because each step is stronger evidence than
-    the next:
-
-    1. **The record settled it.** ``records[].outcome`` names how the child
-       ended, and that is a fact, not an inference — a row restored as a bare
-       ``interrupted`` beside a record reading ``completed`` was the D3 defect.
-    2. **The record did not, so the child's own transcript decides** — the
-       mid-turn / finished question above. The reason goes on the row so the
-       panel can say WHY rather than only that it stopped.
-    3. **No record and no transcript** → today's ``interrupted``, now naming
-       ``owner-lost`` rather than carrying no cause at all.
-    """
-    record_outcome = ""
-    if record is not None:
-        record_outcome = str(_record_field(record, "outcome") or "")
-    if record_outcome in _SETTLED_RECORD_OUTCOMES:
-        return job.model_copy(
-            update={"status": record_outcome, "restored": True, "cut_off_cause": ""}
-        )
-    tail = _child_tail_state(_record_field(record, "session_dir") if record is not None else None)
-    if tail == "finished":
-        # The child produced a settled answer; only its parent's record of that
-        # was lost. Reporting the child as cut off would be a lie the panel then
-        # offers to resume.
-        return job.model_copy(update={"status": "completed", "restored": True, "cut_off_cause": ""})
-    if tail == "mid-turn":
-        return job.model_copy(
-            update={"status": "interrupted", "restored": True, "cut_off_cause": "owner-lost"}
-        )
-    return job.model_copy(
-        update={"status": "interrupted", "restored": True, "cut_off_cause": "owner-lost"}
-    )
-
-
-def _roster_records(payload: Mapping[str, Any]) -> Sequence[Any]:
-    """The sidecar's ``records`` list, or an empty sequence when it has none.
-
-    Typed here rather than inline so the ``Any`` coming out of a raw JSON dict
-    is narrowed once: the caller passes it straight into ``_restored_job_rows``,
-    whose ``records`` parameter is a ``Sequence``.
-    """
-    records = payload.get("records")
-    return records if isinstance(records, list) else ()
-
-
-def _restored_job_rows(jobs: Sequence[Any], records: Sequence[Any] = ()) -> list[Any]:
-    """Roster rows as they must appear with NO runtime alive.
-
-    The persisted roster records what each job's state WAS when it was
-    written. With no runtime there is by definition nothing running, so a row
-    restored verbatim paints a spinner for a child that cannot be working and
-    the band counts it as live activity (UX review round 1, U1). That is worse
-    than the empty panel this change replaces: an empty panel is obviously
-    incomplete, while phantom activity is confidently wrong, and it invites a
-    cancel that finds nothing. Non-terminal rows are common on disk — a
-    session whose terminal was closed mid-run persists them by design.
-
-    The rule is the one ``AsyncJobManager.restore`` already applies on the
-    owner path, reproduced here because the cold viewer never builds a
-    manager:
-
-    * a ``running`` row that was PARKED (``queued``) never started, so it has
-      no transcript to show or resume and is DROPPED — an ``interrupted`` row
-      would invite a resume that finds nothing;
-    * any other non-terminal row becomes ``interrupted``, the restore-only
-      status that means "was cut off mid-run"; live readers already treat it
-      as terminal, and it is what lets the panel offer to resume the child.
-
-    Anything already terminal is untouched: ``completed``/``failed``/
-    ``cancelled`` are facts the last runtime settled and this process must not
-    relitigate.
-
-    ``records`` is the roster sidecar's ``records`` list, whose ``outcome`` and
-    ``session_dir`` are what make a restored row diagnosable rather than a
-    blanket ``interrupted``. It is optional so an older sidecar (or a caller
-    that has none) keeps today's behaviour exactly.
-    """
-    by_id: dict[str, Any] = {}
-    for record in records:
-        job_id = str(_record_field(record, "job_id") or "")
-        if job_id:
-            by_id[job_id] = record
-    rows: list[Any] = []
-    for job in jobs:
-        status = str(getattr(job, "status", "") or "")
-        if status == "running":
-            if bool(getattr(job, "queued", False)):
-                continue
-            rows.append(_restored_job_row(job, by_id.get(str(getattr(job, "id", "") or ""))))
-            continue
-        rows.append(job.model_copy(update={"restored": True}))
-    return rows
 
 
 def _ask_question_from_pending(pending: PendingRequest) -> AskQuestion:
@@ -1499,8 +1320,8 @@ class AttachedSession:
             # is the only route to the child's own transcript when the record
             # does not settle it. Without them every non-terminal row came back
             # as a blanket ``interrupted``" (design §4, D3).
-            "jobs": _restored_job_rows(
-                self._durable_roster(state, payload=payload), records=_roster_records(payload)
+            "jobs": resolve_restored_rows(
+                self._durable_roster(state, payload=payload), records=roster_records(payload)
             )
         }
         if isinstance(payload.get("accounting"), list):
@@ -4377,7 +4198,15 @@ class AttachedSession:
             # keeps the two from drifting into a vocabulary nobody can read.
             from local_operator.incidents import cause_from_reason
 
-            end = end.model_copy(update={"cut_off_cause": cause_from_reason(error) or "owner-lost"})
+            # NO ``or "owner-lost"`` FALLBACK. `cause_from_reason` is the
+            # inverse of `format_cut_off_notice`, so an empty answer means the
+            # event's error is NOT a cut-off sentence — and stamping the token
+            # anyway mislabelled every other error as an owner loss. The one
+            # concrete case is `_settle_suspect_turn`'s `"turn failed"`
+            # placeholder for a provider error, which then carried
+            # `cut_off_cause="owner-lost"` on a row that was never cut off
+            # (review round 1, MINOR-3).
+            end = end.model_copy(update={"cut_off_cause": cause_from_reason(error)})
         # THE STATE CHANGE IS THE CONTRACT; ONLY THE NOTIFICATION IS
         # BEST-EFFORT (review round 2, MAJOR-2). `_deliver` calls handlers
         # synchronously with no guard of its own, and
@@ -4576,11 +4405,16 @@ class AttachedSession:
             # change exists to fix, and the reason this branch names a cause
             # rather than leaving a class marker.
             #
-            # Reached ONLY for a runtime the recovery loop has confirmed gone
-            # (a deliberate stop returns above, and ``refresh=True`` never
-            # ends a turn), so this cannot paint an error over a healthy
-            # session that merely dropped a socket — the autorefresh design's
-            # invariant, kept.
+            # Reached for a runtime this viewer can no longer hear. A deliberate
+            # stop returns above and ``refresh=True`` never ends a turn, but the
+            # give-up arm below ALSO arrives here for a live-but-silent owner (a
+            # record is present and its pid is alive, and nothing answers), so
+            # the sentence it paints says what the viewer can verify rather than
+            # asserting a death it cannot establish (review round 1, MINOR-3).
+            # What it must never do is paint an error over a healthy session
+            # that merely dropped a socket: that case rebinds inside
+            # ``COLD_FALLBACK_S`` and never reaches this branch — the autorefresh
+            # design's invariant, kept.
             try:
                 self._end_turn_locally(
                     direct=True,
@@ -4738,6 +4572,23 @@ class AttachedSession:
         # fired for a no-record viewer too, marking a dead runtime as merely
         # unresponsive (QA round 1 Q849-1, review round 1 R3).
         record_seen = False
+
+        def paced(seconds: float) -> float:
+            """``seconds``, shortened so the loop wakes AT the cold deadline.
+
+            The deadline is checked at the top of a pass, so a pass that slept
+            ``delay`` past it reported the cut-off one sleep late: measured at
+            9.4 s against ``COLD_FALLBACK_S`` of 8.0 on the watched SIGKILL,
+            with this cap in place 8.01 s. (Both figures run from the KILL; the
+            loop's deadline starts when it notices the drop, so the residual
+            hundredth is the notification lag, not the pacing.) The sleep is
+            otherwise untouched: once the deadline is behind us the original
+            pacing returns, because a bound that yielded a zero sleep would turn
+            the chase into a hot loop against the registry.
+            """
+            remaining = cold_deadline - time.monotonic()
+            return min(seconds, remaining) if remaining > 0 else seconds
+
         try:
             while not self._disposed:
                 if time.monotonic() >= cold_deadline:
@@ -4763,17 +4614,32 @@ class AttachedSession:
                     # to clear it. That is strictly worse than the false
                     # "interrupted" this PR removes — review round 1,
                     # BLOCKER-1. The same ``COLD_FALLBACK_S`` bound applies:
-                    # after this long with no runtime, an in-flight turn is
-                    # honestly aborted. ``_end_turn_locally`` clears
-                    # ``_suspect_generation``, so this fires at most once and
-                    # the retry loop continues underneath it.
+                    # after this long with no runtime the turn is CUT OFF, and it
+                    # says so with a named cause rather than with the bare abort a
+                    # user's Esc produces. ``_end_turn_locally`` clears
+                    # ``_suspect_generation``, so this fires at most once and the
+                    # retry loop continues underneath it.
+                    #
+                    # THIS IS THE ARM THE OPERATOR'S REPORT LANDS ON, which is why
+                    # it needs the verdict as much as ``_go_cold`` does. The
+                    # owner-death branch there carries it, but it is reachable only
+                    # when ``_can_go_cold`` holds — and that is False for every
+                    # viewer built through ``connect()``, which is what the TUI
+                    # builds. Measured on this head: a SIGKILLed runtime painted
+                    # ``interrupted ⊘`` with no notice, no reason and durable state
+                    # still ``kind=None`` at t≈98 s, byte-identical to the user's
+                    # own cancel (QA round 1, Q-1; UX U1).
                     if self._suspect_generation is not None:
                         logger.info(
                             "no runtime for %s after %.0fs; ending the in-flight turn",
                             self._session_id,
                             COLD_FALLBACK_S,
                         )
-                        self._end_turn_locally(direct=True)
+                        self._end_turn_locally(
+                            direct=True,
+                            aborted=False,
+                            error=format_cut_off_notice("owner-lost"),
+                        )
                     # ...and AFTER that verdict, the loop itself must reach one.
                     # Ending the turn left ``_recovering`` set, and the only
                     # other exits are the cold branch above (unreachable here)
@@ -4906,7 +4772,7 @@ class AttachedSession:
                         # rule — a pass that did not bind leaves no trace of
                         # the runtime it tried.
                         self._discard_rejected_client()
-                        await asyncio.sleep(delay)
+                        await asyncio.sleep(paced(delay))
                         # ``_RECOVERY_DIAL_CAP_S``, not the 0.5 this loop shared
                         # with ``_bind_under_lock``: the ``continue`` below
                         # skips the sleep at the bottom of the loop, so this is
@@ -4996,10 +4862,21 @@ class AttachedSession:
                     else:
                         callback = self._takeover_callback
                         if callback is not None:
-                            # Takeover means the owner is gone: the turn did
-                            # abort. Synthesise before the app disposes this
-                            # facade, or the working line never learns.
-                            self._end_turn_locally(direct=True)
+                            # Takeover means the owner is gone and the turn did
+                            # NOT complete, so the synthesised end names that
+                            # rather than carrying the bare abort a user's Esc
+                            # produces. The same shape this loop's cold arm passes,
+                            # so the two ways of losing an owner cannot disagree
+                            # about what losing one looks like; a DELIBERATE stop
+                            # never reaches here, because the stop check returns
+                            # earlier in the pass. Synthesise before the app
+                            # disposes this facade, or the working line never
+                            # learns.
+                            self._end_turn_locally(
+                                direct=True,
+                                aborted=False,
+                                error=format_cut_off_notice("owner-lost"),
+                            )
                             result = callback(local)
                             if inspect.isawaitable(result):
                                 await result
@@ -5010,7 +4887,7 @@ class AttachedSession:
                         # disconnect can happen; if it did not, avoid leaking
                         # the writer lease we just won.
                         await local.dispose()
-                await asyncio.sleep(delay)
+                await asyncio.sleep(paced(delay))
                 delay = min(delay * 1.7, 0.5)
         finally:
             self._recovering = False

--- a/local_operator/session/attention.py
+++ b/local_operator/session/attention.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sqlite3
 import time
 import uuid
@@ -112,6 +113,25 @@ def provisional_anchor(token: str) -> str:
     return f"{_PROVISIONAL_PREFIX}{token}"
 
 
+def _optional_column(row: sqlite3.Row, name: str) -> str:
+    """One ADDITIVE column's value, ``""`` when a pre-taxonomy row lacks it.
+
+    The read-only readers must not migrate: ``state_many`` opens the database
+    ``mode=ro`` precisely so a frontend list can never write, while the schema
+    migration lives on the WRITE path (``_connect``). An established database
+    that no build of this version has written yet therefore genuinely has no
+    ``reason``/``cause`` column, and a bare ``row[name]`` raises ``IndexError``
+    on it — a sidebar crash on exactly the machine that has not restarted yet.
+    Naming the absence here keeps the two readers in step without teaching
+    either one to alter a schema it is only reading.
+    """
+    try:
+        value = row[name]
+    except IndexError:
+        return ""
+    return str(value or "")
+
+
 def _supersedes_provisional(
     existing: Any,
     conversation: str,
@@ -136,18 +156,26 @@ def _supersedes_provisional(
     identity), which is why the guard is cheap rather than elaborate: an
     incoming provisional anchor is legitimate only when it belongs to the token
     being published.
+
+    THE STORED KIND IS NO LONGER PART OF THE SHAPE. It used to have to read
+    `interrupted`, which was the only kind a provisional record could carry when
+    "no outcome" was published as an interruption. The taxonomy change makes
+    "no outcome" an `error`, and a provisional record published as `error` still
+    has to be superseded by the same token's real `complete` — otherwise the
+    change bricks exactly the session the docstring at :meth:`publish`
+    describes. The ANCHOR, not the kind, is the "replaceable" signal: a record
+    still wearing `completion-<token>` has no viewable result behind it and its
+    only legitimate successor is the same token's real outcome.
     """
-    stored_conversation, stored_anchor, stored_kind = tuple(existing)
+    stored_conversation, stored_anchor = tuple(existing)[:2]
     if anchor.startswith(_PROVISIONAL_PREFIX) and anchor != provisional_anchor(token):
         return False
-    return (
-        stored_conversation == conversation
-        and stored_kind == "interrupted"
-        and stored_anchor == provisional_anchor(token)
-    )
+    return stored_conversation == conversation and stored_anchor == provisional_anchor(token)
 
 
-def bootstrap_transcript(transcript: Any, store: AttentionStore | None = None) -> None:
+def bootstrap_transcript(
+    transcript: Any, store: AttentionStore | None = None
+) -> tuple[str, str, str, str] | None:
     """Import a conversation's durable outcome; NEVER fatal to the caller.
 
     Both call sites are boot paths that must survive a bad conversation:
@@ -162,9 +190,14 @@ def bootstrap_transcript(transcript: Any, store: AttentionStore | None = None) -
 
     The failure is logged with the identity and the exception so a swallowed
     problem is still diagnosable from the log rather than silently invisible.
+
+    Returns whatever :func:`_import_transcript_outcome` published for an
+    orphaned run (or ``None``), so the caller that owns a ``Session`` can
+    journal the cut-off once. A failure also returns ``None``: a swallowed
+    problem journals nothing rather than half-narrating one.
     """
     try:
-        _import_transcript_outcome(transcript, store)
+        return _import_transcript_outcome(transcript, store)
     except Exception as exc:  # noqa: BLE001 — attention must never block a boot
         # `getattr` so the handler cannot itself raise on a transcript that
         # never grew a `.directory` (a stub, a partially constructed instance)
@@ -189,8 +222,159 @@ def bootstrap_transcript(transcript: Any, store: AttentionStore | None = None) -
         )
 
 
-def _import_transcript_outcome(transcript: Any, store: AttentionStore | None = None) -> None:
+def _config_root_for(directory: Path) -> Path:
+    """The config root that owns ``directory``.
+
+    Derived from the transcript path rather than read from the ambient
+    environment, because this classification must agree with the STORE it
+    writes into: an isolated run redirects ``HOME`` (or
+    ``LOCAL_OPERATOR_CONFIG_DIR``) and a store under one root must not be
+    classified against another root's run records. ``sessions/<id>`` and
+    ``agents/<id>`` are the only two layouts (``conversation_identity`` knows
+    the same two), so anything else falls back to the ambient root, which is
+    what a unit test's ``tmp_path`` transcript wants.
+    """
+    parent = directory.parent
+    if parent.name in ("sessions", "agents"):
+        return parent.parent
+    return config_dir()
+
+
+def _run_record_evidence(directory: Path) -> tuple[Any, Any]:
+    """``(live_foreign_owner, dead_owner)`` for this conversation's records.
+
+    Read RAW rather than through ``registry.scan``, and in ONE pass that returns
+    both facts, because ``scan`` UNLINKS every stale record it meets: a scan
+    performed first would destroy exactly the dead-owner evidence this
+    classification depends on (the daemon's own sweep is a scan, so the ordering
+    is not hypothetical).
+
+    ``live_foreign_owner`` is a live pid that is NOT this process. Excluding
+    ourselves is load-bearing rather than tidiness: a successor runtime publishes
+    its own record BEFORE it constructs its ``Session``, so counting our own pid
+    as a live owner would make every orphaned run unclassifiable — precisely the
+    bug this change fixes.
+    """
+    from local_operator.session.runtime import registry
+    from local_operator.session.runtime.types import RUN_DIRNAME, SessionRecord
+
+    run = _config_root_for(directory) / RUN_DIRNAME
+    live: Any = None
+    dead: Any = None
+    try:
+        if not run.is_dir():
+            return None, None
+        paths = sorted(run.glob("*.json"))
+    except OSError:
+        return None, None
+    for path in paths:
+        try:
+            record = SessionRecord.from_json(json.loads(path.read_text()))
+        except (OSError, ValueError, TypeError):
+            continue
+        if record.session_id != directory.name:
+            continue
+        # The zombie probe costs a `ps` fork, and boot is not a hot path — and a
+        # zombie is NOT a live owner, which is the whole point of asking.
+        if not registry.pid_alive(record.pid, check_zombie=True):
+            if dead is None or record.started_at >= dead.started_at:
+                dead = record
+            continue
+        if record.pid != os.getpid() and (live is None or record.started_at >= live.started_at):
+            live = record
+    return live, dead
+
+
+def _stopped_marker(directory: Path) -> bool:
+    """Whether this conversation's wake index carries a recorded STOP.
+
+    ``stopped_at`` is stamped by the stop path (``control._mark_wakes_dormant``)
+    and cleared on the session's next open, so it is a durable, transcript-derived
+    positive marker of a user's own cancel — the one cause a cut-off must not
+    report as an error. A schedule-less session has no entry at all, which is why
+    the deliberate stop is ALSO carried in the outcome marker itself; this is
+    corroboration for the case where the runtime wrote no marker, not the only
+    evidence.
+    """
+    from local_operator.wakes import store as wake_store
+
+    try:
+        entry = wake_store.read_entry(_config_root_for(directory), directory.name)
+    except Exception:  # noqa: BLE001 — an unreadable index is not a stop
+        return False
+    return bool(isinstance(entry, dict) and entry.get("stopped_at"))
+
+
+def _record_detail(record: Any) -> str:
+    """A parenthetical naming the record that outlived its process, or ``""``.
+
+    Kept to the record's own facts (build, pid, started-at) rather than prose,
+    because these are the fields a reader would otherwise have to reconstruct
+    from the log to answer "which runtime was this".
+    """
+    build = str(getattr(record, "version", "") or "")
+    ref = str(getattr(record, "source_ref", "") or "")
+    stamp = f"{build}@{ref}" if build and ref else build or ref
+    started = getattr(record, "started_at", None)
+    when = ""
+    if isinstance(started, (int, float)) and not isinstance(started, bool) and started:
+        when = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(started))
+    parts = [
+        part for part in (stamp, f"pid {record.pid}", f"started {when}" if when else "") if part
+    ]
+    return f" ({', '.join(parts)})" if parts else ""
+
+
+def _classify_orphaned_run(directory: Path) -> tuple[str, str, str]:
+    """``(kind, cause, reason)`` for a started run whose owner is gone.
+
+    The taxonomy's default flips here: "no evidence" used to mean
+    ``interrupted`` and now means ``error``, because a cut-off we cannot explain
+    is not a stop. Only POSITIVE evidence of a deliberate act records an
+    interruption. Evidence, in order:
+
+    * a recorded stop marker → ``interrupted`` / ``user-stop``;
+    * a record on disk whose pid is dead → ``error`` / ``runtime-killed``, with
+      the record's build, pid and start time as the detail — this is the case
+      study's shape, and the one that used to read as a user cancel;
+    * nothing at all → ``error`` / ``runtime-killed``, saying plainly that the
+      cause could not be determined.
+    """
+    from local_operator.incidents import render_cut_off_reason
+
+    if _stopped_marker(directory):
+        return "interrupted", "user-stop", render_cut_off_reason("user-stop")
+    _, dead = _run_record_evidence(directory)
+    if dead is not None:
+        return (
+            "error",
+            "runtime-killed",
+            render_cut_off_reason("runtime-killed", detail=_record_detail(dead)),
+        )
+    return (
+        "error",
+        "runtime-killed",
+        render_cut_off_reason("runtime-killed", detail=" (the cause could not be determined)"),
+    )
+
+
+def _import_transcript_outcome(
+    transcript: Any, store: AttentionStore | None = None
+) -> tuple[str, str, str, str] | None:
     """Explicit one-time import; never called by GET, SSE or focus observation.
+
+    Returns the ``(kind, cause, reason, token)`` this call PUBLISHED for an
+    orphaned in-flight run, or ``None`` when it published nothing new. The
+    caller that owns a ``Session`` (and can therefore journal) uses it to
+    narrate the cut-off once per token; the daemon sweep, which has no session,
+    ignores it.
+
+    An in-flight ``attention_started`` with no matching outcome means a process
+    died mid-turn — or is STILL RUNNING it. The two are told apart by the run
+    registry, and only the second may publish nothing: a provisional marker
+    written for a healthy run would be a wrong ``error`` row that every
+    surface's ``busy`` suppression HIDES rather than corrects, so the guard
+    removes the class instead of relying on every front end's suppression.
 
     Old baselines were memory-only. Unknown historical work keeps that no-flood
     baseline, while a persisted seen stamp older than the actual final assistant
@@ -206,30 +390,47 @@ def _import_transcript_outcome(transcript: Any, store: AttentionStore | None = N
         and (not isinstance(saved, dict) or saved.get("token") != started.get("token"))
     ):
         token = started["token"]
-        # Provisional by construction: the turn may still be in flight, so this
-        # marker is explicitly the kind `publish` will let the real outcome
-        # supersede once the journal proves how the run actually ended.
-        store.publish(identity, token, provisional_anchor(token), "interrupted")
-        return
+        live_owner, _ = _run_record_evidence(transcript.directory)
+        if live_owner is not None:
+            # In flight. Publish NOTHING: the live runtime will publish the real
+            # outcome when the turn ends, and a marker written here would be a
+            # provisional row it then has to supersede — or, worse, a row no
+            # later writer ever corrects if the turn completes with an anchor
+            # this classifier did not predict.
+            return None
+        kind, cause, reason = _classify_orphaned_run(transcript.directory)
+        store.publish(identity, token, provisional_anchor(token), kind, reason=reason, cause=cause)
+        return kind, cause, reason, str(token)
     if isinstance(saved, dict) and saved.get("conversation_id") == identity:
         if saved.get("eligible", True):
-            store.publish(identity, saved["token"], saved["anchor"], saved["kind"])
-        return
+            # The dying runtime's own marker, replayed VERBATIM — including its
+            # kind, cause and reason. This is the one path that can report a
+            # deliberate stop as `interrupted` after the process is gone, so
+            # nothing here may re-derive the kind from the absence of evidence.
+            store.publish(
+                identity,
+                saved["token"],
+                saved["anchor"],
+                saved["kind"],
+                reason=str(saved.get("reason") or ""),
+                cause=str(saved.get("cause") or ""),
+            )
+        return None
     if store.state(identity)["completion_token"]:
-        return
+        return None
     history = transcript.build_llm_history()
     if not history:
-        return
+        return None
     final = history[-1]
     if (
         getattr(final, "role", None) != "assistant"
         or not getattr(final, "text", "")
         or getattr(final, "tool_calls", None)
     ):
-        return
+        return None
     entry = next((row for row in reversed(transcript.entries()) if row.id == final.id), None)
     if entry is None:
-        return
+        return None
     seen = None
     try:
         raw = json.loads((store.path.parent / "mobile-seen.json").read_text())
@@ -242,6 +443,7 @@ def _import_transcript_outcome(transcript: Any, store: AttentionStore | None = N
     store.publish(
         identity, token, final.id, "complete", baseline_seen=seen is None or seen >= entry.ts
     )
+    return None
 
 
 class AttentionStore:
@@ -267,7 +469,8 @@ class AttentionStore:
                         "CREATE TABLE completions ("
                         "sequence INTEGER PRIMARY KEY AUTOINCREMENT, "
                         "conversation TEXT NOT NULL, token TEXT NOT NULL UNIQUE, "
-                        "anchor TEXT NOT NULL, kind TEXT NOT NULL)"
+                        "anchor TEXT NOT NULL, kind TEXT NOT NULL, "
+                        "reason TEXT NOT NULL DEFAULT '', cause TEXT NOT NULL DEFAULT '')"
                     )
                     conn.execute(
                         "CREATE INDEX completion_conversation "
@@ -332,6 +535,26 @@ class AttentionStore:
                         "SELECT 1 FROM sqlite_master WHERE type='table' AND name='mutations'"
                     ).fetchone():
                         conn.execute(_CREATE_MUTATIONS)
+                    # ``reason``/``cause`` are ADDITIVE and stay out of the probe
+                    # above for the reason the two tables do: every database
+                    # written before the cut-off taxonomy legitimately lacks
+                    # them, and naming them in the probe would read all of them
+                    # as corrupt. ``DEFAULT ''`` rather than a nullable column
+                    # keeps the readers one shape: an old row's reason is the
+                    # empty string, i.e. "no reason was recorded", which is
+                    # exactly what it is — never a claim that there was none to
+                    # record.
+                    columns = {
+                        str(row[1]) for row in conn.execute("PRAGMA table_info(completions)")
+                    }
+                    if "reason" not in columns:
+                        conn.execute(
+                            "ALTER TABLE completions ADD COLUMN reason TEXT NOT NULL DEFAULT ''"
+                        )
+                    if "cause" not in columns:
+                        conn.execute(
+                            "ALTER TABLE completions ADD COLUMN cause TEXT NOT NULL DEFAULT ''"
+                        )
             return conn
         except BaseException:
             conn.close()
@@ -362,6 +585,12 @@ class AttentionStore:
             "completion_token": row["token"] if row else None,
             "anchor_id": row["anchor"] if row else None,
             "kind": row["kind"] if row else None,
+            # Why, in the operator's words, plus the machine token. Both empty
+            # for a completion and for any record written before the cut-off
+            # taxonomy; a surface that wants to append the cause must treat ""
+            # as "nothing to say" rather than as an empty sentence.
+            "reason": (row["reason"] or "") if row else "",
+            "cause": (row["cause"] or "") if row else "",
             "unseen": bool(row and row["sequence"] > acknowledged),
             "revision": [row["sequence"] if row else 0, acknowledged],
         }
@@ -380,6 +609,8 @@ class AttentionStore:
                 "completion_token": None,
                 "anchor_id": None,
                 "kind": None,
+                "reason": "",
+                "cause": "",
                 "unseen": False,
                 "revision": [0, 0],
             }
@@ -411,6 +642,8 @@ class AttentionStore:
                         "completion_token": row["token"],
                         "anchor_id": row["anchor"],
                         "kind": row["kind"],
+                        "reason": _optional_column(row, "reason"),
+                        "cause": _optional_column(row, "cause"),
                         "unseen": row["sequence"] > row["acknowledged"],
                         "revision": [row["sequence"], row["acknowledged"]],
                     }
@@ -427,6 +660,8 @@ class AttentionStore:
         kind: str,
         *,
         baseline_seen: bool | None = None,
+        reason: str = "",
+        cause: str = "",
     ) -> dict[str, Any]:
         """Import a durable outcome idempotently, including after runtime restart.
 
@@ -444,13 +679,14 @@ class AttentionStore:
 
         Supersession is deliberately narrow: same conversation, and the stored
         record must still wear the provisional shape — anchor
-        ``completion-<token>`` with kind ``interrupted``. Two refusals it does
-        NOT relax. A token appearing under a DIFFERENT conversation stays an
-        error, which is the integrity property this check exists for: a forked
-        transcript carrying its parent's journal must not capture the parent's
-        receipt. And a record already anchored to a real entry is never
-        replaced, so a late bootstrap racing a finished turn cannot drag a real
-        outcome back to a synthetic one.
+        ``completion-<token>``. (The stored KIND is no longer part of that shape:
+        see ``_supersedes_provisional`` for why requiring ``interrupted`` would
+        now be the bug.) Two refusals it does NOT relax. A token appearing under
+        a DIFFERENT conversation stays an error, which is the integrity property
+        this check exists for: a forked transcript carrying its parent's journal
+        must not capture the parent's receipt. And a record already anchored to
+        a real entry is never replaced, so a late bootstrap racing a finished
+        turn cannot drag a real outcome back to a synthetic one.
 
         A genuinely interrupted turn is stored in that same provisional shape,
         and that is intended rather than an ambiguity to resolve: the only
@@ -502,8 +738,8 @@ class AttentionStore:
                 if not _supersedes_provisional(existing, conversation, token, anchor):
                     raise ValueError("completion token belongs to another outcome")
                 conn.execute(
-                    "UPDATE completions SET anchor=?, kind=? WHERE token=?",
-                    (anchor, kind, token),
+                    "UPDATE completions SET anchor=?, kind=?, reason=?, cause=? WHERE token=?",
+                    (anchor, kind, reason, cause, token),
                 )
                 # Inside the SAME transaction as the UPDATE: a reader must
                 # never observe a healed row whose change the detector has not
@@ -511,8 +747,9 @@ class AttentionStore:
                 # revision and then ignore the next real change.
                 conn.execute(_BUMP_SUPERSEDES)
             conn.execute(
-                "INSERT OR IGNORE INTO completions(conversation,token,anchor,kind) VALUES(?,?,?,?)",
-                (conversation, token, anchor, kind),
+                "INSERT OR IGNORE INTO completions(conversation,token,anchor,kind,reason,cause) "
+                "VALUES(?,?,?,?,?,?)",
+                (conversation, token, anchor, kind, reason, cause),
             )
             if baseline_seen:
                 sequence = conn.execute(

--- a/local_operator/session/attention.py
+++ b/local_operator/session/attention.py
@@ -132,6 +132,18 @@ def _optional_column(row: sqlite3.Row, name: str) -> str:
     return str(value or "")
 
 
+#: How much of a reason the STORE keeps. This string rides every attach frame
+#: (once per conversation in the canonical `attention` state, and once per child
+#: for a job row), so an unbounded provider message would spend the frame ceiling
+#: that `tests/unit/session/test_attach_frame_size.py` guards. The full text is
+#: not lost: the live transcript notice and the journal row
+#: (`completion_attention`, replayed by `_default_convert_to_llm`) both carry it
+#: verbatim. 500 characters is past any harness-authored sentence and past the
+#: opening of a provider error, which is all a one-line tooltip or a phone
+#: banner can use.
+REASON_WIRE_CHARS = 500
+
+
 def _supersedes_provisional(
     existing: Any,
     conversation: str,
@@ -720,6 +732,7 @@ class AttentionStore:
         """
         if kind not in {"complete", "error", "interrupted"} or not anchor:
             raise ValueError("invalid completion")
+        reason = str(reason or "")[:REASON_WIRE_CHARS]
         if str(uuid.UUID(token)) != token:
             raise ValueError("invalid completion token")
         with closing(self._connect()) as conn, conn:

--- a/local_operator/session/attention.py
+++ b/local_operator/session/attention.py
@@ -349,10 +349,21 @@ def _classify_orphaned_run(directory: Path) -> tuple[str, str, str]:
     * a record on disk whose pid is dead → ``error`` / ``runtime-killed``, with
       the record's build, pid and start time as the detail — this is the case
       study's shape, and the one that used to read as a user cancel;
-    * nothing at all → ``error`` / ``runtime-killed``, saying plainly that the
-      cause could not be determined.
+    * nothing at all → ``error`` / no cause, saying plainly that the cause could
+      not be determined.
+
+    THE NO-EVIDENCE ARM CARRIES NO CAUSE AND ITS OWN SENTENCE. It used to read
+    the ``runtime-killed`` sentence with a ``(the cause could not be determined)``
+    parenthetical bolted on, and every surface that prints the reason made that
+    a contradiction: the sidebar's ``_error_label`` drops a parenthetical by
+    design (it is built for the build pair), so the one surface that trims the
+    detail stated a definite cause in the one case where nothing is known
+    (design/UX review round 1, D3/U3). ``CUT_OFF_UNKNOWN`` already exists for
+    this branch and needs no hedging, and leaving ``cause`` empty is what keeps
+    ``cause_from_reason(reason)`` — the inverse every reader relies on —
+    agreeing with the reason instead of naming a mechanism nobody observed.
     """
-    from local_operator.incidents import render_cut_off_reason
+    from local_operator.incidents import CUT_OFF_UNKNOWN, render_cut_off_reason
 
     if _stopped_marker(directory):
         return "interrupted", "user-stop", render_cut_off_reason("user-stop")
@@ -363,11 +374,7 @@ def _classify_orphaned_run(directory: Path) -> tuple[str, str, str]:
             "runtime-killed",
             render_cut_off_reason("runtime-killed", detail=_record_detail(dead)),
         )
-    return (
-        "error",
-        "runtime-killed",
-        render_cut_off_reason("runtime-killed", detail=" (the cause could not be determined)"),
-    )
+    return "error", "", CUT_OFF_UNKNOWN
 
 
 def _import_transcript_outcome(
@@ -375,8 +382,9 @@ def _import_transcript_outcome(
 ) -> tuple[str, str, str, str] | None:
     """Explicit one-time import; never called by GET, SSE or focus observation.
 
-    Returns the ``(kind, cause, reason, token)`` this call PUBLISHED for an
-    orphaned in-flight run, or ``None`` when it published nothing new. The
+    Returns the ``(kind, cause, reason, token)`` this call PUBLISHED — for an
+    orphaned in-flight run, or for the dying runtime's own saved marker when that
+    marker reports a CUT-OFF — and ``None`` when it published nothing new. The
     caller that owns a ``Session`` (and can therefore journal) uses it to
     narrate the cut-off once per token; the daemon sweep, which has no session,
     ignores it.
@@ -419,14 +427,37 @@ def _import_transcript_outcome(
             # kind, cause and reason. This is the one path that can report a
             # deliberate stop as `interrupted` after the process is gone, so
             # nothing here may re-derive the kind from the absence of evidence.
+            kind = str(saved.get("kind") or "")
+            cause = str(saved.get("cause") or "")
+            reason = str(saved.get("reason") or "")
             store.publish(
                 identity,
                 saved["token"],
                 saved["anchor"],
-                saved["kind"],
-                reason=str(saved.get("reason") or ""),
-                cause=str(saved.get("cause") or ""),
+                kind,
+                reason=reason,
+                cause=cause,
             )
+            if kind == "error" and cause:
+                # A CUT-OFF the dying runtime could not narrate itself. Its own
+                # `_journal_cut_off_once` is refused by `journal_incident`'s
+                # `_disposed` guard — the dispose rung sets that flag before
+                # the turn's `finally` publishes — so the update/shutdown/retire
+                # family reached every SURFACE and no MODEL (review round 1,
+                # MINOR-2 + QA Q-2). Returning the tuple is what makes THIS
+                # boot journal it: `Session._journal_restored_cut_off` narrates
+                # it once per token, so the next turn's context opens with
+                # `[session incident]` rather than a model re-guessing what its
+                # last half-delivered request did.
+                #
+                # A `cause` is required rather than merely expected, and the
+                # `kind` is read rather than re-derived: only a cut-off carries
+                # a token from `CUT_OFF_CAUSES` (`_publish_attention_outcome`
+                # stores `cause=""` for a provider error and `user-stop` for a
+                # recorded stop), and narrating a provider error or a user's own
+                # `/stop` as a cut-off incident would be the taxonomy's own
+                # misclassification committed by the reader meant to repair it.
+                return kind, cause, reason, str(saved["token"])
         return None
     if store.state(identity)["completion_token"]:
         return None

--- a/local_operator/session/catalog.py
+++ b/local_operator/session/catalog.py
@@ -35,6 +35,13 @@ class CatalogEntry:
     #: that build entries positionally, keep working unchanged.
     completion_token: str = ""
     anchor_id: str = ""
+    #: WHY the outcome is an error, when the store carries a reason — the
+    #: harness-authored cause sentence for a cut-off, or the provider's own
+    #: message for a provider error. Appended to the sidebar's two error
+    #: spellings so a row reports a cause instead of only a class. Additive and
+    #: defaulted, so every existing construction site (including the positional
+    #: ones in the sidebar tests) keeps working unchanged.
+    completion_reason: str = ""
 
     @property
     def id(self) -> str:
@@ -253,7 +260,9 @@ class CatalogEntry:
         if self.row.live_state == "busy":
             return "Working"
         if self.shows_completion_mark:
-            return {"error": "Unseen error", "interrupted": "Unseen interruption"}.get(
+            if self.completion_kind == "error":
+                return self._error_label("Unseen error")
+            return {"interrupted": "Unseen interruption"}.get(
                 self.completion_kind, "Unseen completion"
             )
         # Follows ``row_state_mark``'s precedence EXACTLY, so the tooltip can
@@ -294,10 +303,34 @@ class CatalogEntry:
             count = self.row.wakes
             return f"Stopped ({count} wake{'s' if count != 1 else ''} dormant)"
         if self.completion_token:
-            return {"error": "Error", "interrupted": "Interrupted"}.get(
-                self.completion_kind, "Complete"
-            )
+            if self.completion_kind == "error":
+                return self._error_label("Error")
+            return {"interrupted": "Interrupted"}.get(self.completion_kind, "Complete")
         return "Recent"
+
+    def _error_label(self, base: str) -> str:
+        """``Error``/``Unseen error`` plus the reason, when there is one.
+
+        The tooltip is ONE line, so only the first line of the reason is used
+        and the parenthetical DETAIL is dropped (``runtime-retired`` carries a
+        build pair — ``(0.54.11@b133eba → 0.54.12@402af7f)`` — which is useful
+        in the incident card the model reads and noise in a sidebar row). An
+        empty reason leaves the spelling BYTE-IDENTICAL to today's, which is
+        what keeps every pre-taxonomy record and every completion unchanged.
+        """
+        reason = (
+            self.completion_reason.strip().splitlines()[0].strip()
+            if self.completion_reason.strip()
+            else ""
+        )
+        if not reason:
+            return base
+        sentence = reason.split(" (", 1)[0].rstrip()
+        if len(sentence) > 160:
+            # A provider's own message can be a paragraph; the tooltip cannot
+            # grow a second line for it.
+            sentence = sentence[:157].rstrip() + "…"
+        return f"{base} — {sentence}"
 
 
 def rank_entries(entries: Sequence[CatalogEntry]) -> tuple[CatalogEntry, ...]:
@@ -623,6 +656,7 @@ def load_catalog(directory: Path, limit: int = CATALOG_SCAN_LIMIT) -> list[Catal
                     str(attention.get(identities[row.id], {}).get("kind") or ""),
                     str(attention.get(identities[row.id], {}).get("completion_token") or ""),
                     str(attention.get(identities[row.id], {}).get("anchor_id") or ""),
+                    str(attention.get(identities[row.id], {}).get("reason") or ""),
                 )
                 for row in rows
             ]

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -162,7 +162,35 @@ JOB_ERROR_WIRE_CHARS = 2_000
 #: 25. Per-row text is the right place to take it from — it is already shared,
 #: already floored at a legible preview, and 128 chars spread across a roster
 #: is invisible, whereas an over-limit frame cannot be sent at all.
-JOB_TEXT_FRAME_BUDGET_CHARS = 119_872
+#:
+#: Reduced again, 119,872 → 119,360, by the UNION of the two per-frame consumers
+#: that arrived either side of a rebase: this branch's attention payload
+#: (``reason`` at :data:`local_operator.session.attention.REASON_WIRE_CHARS`
+#: plus ``cause``, 714 B on every frame) and upstream's ``live_tool_started_at``
+#: (8 concurrently executing calls × 52 B = 416 B). Each fits alone on its own
+#: base — upstream's tree had 147 B of headroom, this branch's 83 B — and the
+#: pair does not, which is what put the ``ran all year`` worst case 416 bytes
+#: over the line. The same shelf pays, for the same reasons: the budget is
+#: elastic, shared, and floored at a legible preview, so 512 chars spread across
+#: a 200-row roster is 3 characters off each row's 599 — invisible — where an
+#: over-limit frame cannot be sent at all.
+#:
+#: Mind the GRANULARITY, because it is why this is a round 512 rather than the
+#: 416 the union overshot by: a row's share is ``BUDGET // len(jobs)``, so a
+#: reduction lands on whole characters per row and no value buys exactly 416.
+#: At the guard's 200 rows, 512 chars moves the share 599 → 596, and three
+#: fields × 3 chars × 200 rows is 1,800 bytes off the frame's FIXED content —
+#: past the overshoot by a margin rather than flush against it, which is the
+#: distinction the 13-byte precedent above did not make. Measure the guard, not
+#: this paragraph, for what the LINE then does: ``_bound_model_catalogue_in_place``
+#: is a RESIDUAL budget, so it spends most of that back on real catalogue rows
+#: (the fixture's frame lands at 1,048,400 of 1,048,576, i.e. 176 B under, with
+#: the catalogue grown from its 50-row floor to 54). The number that matters is
+#: the one the overshoot was about — whether the FLOOR fits: with the catalogue
+#: held at its floor the frame now has 1,384 B of line where it had 416 B too
+#: little. It is not slack: it bought two fields, and the next per-frame field is
+#: paid for out of here too.
+JOB_TEXT_FRAME_BUDGET_CHARS = 119_360
 JOB_TEXT_FLOOR_CHARS = 200
 
 #: Fields :meth:`FrontendStateStore.read_field` may serve without the

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -1343,6 +1343,12 @@ class JobState(BaseModel):
     latest_details: dict[str, Any] | str | None = None
     error_text: str = ""
     result_text: str = ""
+    #: Why a restored row reads ``interrupted`` — added with the cut-off
+    #: taxonomy (design §4, D3) so the subagent panel can say what stopped the
+    #: child rather than only that it stopped. Additive with a ``""`` default,
+    #: so an older runtime's row validates and the panel's existing spellings
+    #: stay valid; the value is a token from ``incidents.CUT_OFF_CAUSES``.
+    cut_off_cause: str = ""
     model_label: str | None = None
     context_window: int | None = None
     usage: Usage | None = None
@@ -1631,6 +1637,14 @@ class FrontendSessionState(BaseModel):
     #: value — treat as aborted. Additive; extra="allow" keeps older readers
     #: tolerant. One value per user prompt, not per compaction continuation.
     last_turn_outcome: Literal["completed", "aborted", "error", ""] = ""
+    #: The rendered reason for a cut-off last turn, mirrored beside
+    #: ``last_turn_outcome`` for the same reason that field exists: a viewer
+    #: that dropped mid-turn rebinds after the real end is gone from
+    #: ``live_events``, and without this it can only synthesise the CLASS
+    #: placeholder ``"turn failed"`` (or blame the user for a cancel they never
+    #: made). Additive; ``""`` is the old-runtime value and means "no reason
+    #: was recorded", which is exactly what it is.
+    last_turn_cut_off: str = ""
     activity_started_at: float | None = None
     #: Which kind of work the working line is naming, and when that kind began.
     #:
@@ -3402,6 +3416,7 @@ class FrontendStateStore:
             streaming=bool(getattr(session, "is_streaming", False)),
             generation=int(getattr(session, "_generation", current.generation) or 0),
             last_turn_outcome=_last_turn_outcome_from(session, current.last_turn_outcome),
+            last_turn_cut_off=_last_turn_cut_off_from(session, current.last_turn_cut_off),
             activity_started_at=(
                 current.activity_started_at
                 if bool(getattr(session, "is_streaming", False))
@@ -3712,6 +3727,9 @@ class FrontendStateStore:
                 activity_started_at=None,
                 active_duration_s=duration,
                 last_turn_outcome=outcome,
+                # Empty for every non-cut-off end, which is what clears a
+                # previous turn's reason as the new outcome lands.
+                last_turn_cut_off=str(getattr(event, "cut_off", "") or ""),
             )
             # Reconcile the whole turn once. Per-call receipts are retained so a
             # mixed-provider aggregate never loses which call owned which price.
@@ -4191,6 +4209,20 @@ def _last_turn_outcome_from(session: Any, current: str) -> str:
         return current if current in ("completed", "aborted", "error") else ""
     raw = str(getattr(session, "_last_turn_outcome", "") or "")
     return raw if raw in ("completed", "aborted", "error") else ""
+
+
+def _last_turn_cut_off_from(session: Any, current: str) -> str:
+    """The session's published cut-off reason, or the store's, or ``""``.
+
+    The twin of :func:`_last_turn_outcome_from`, and needed for the same reason:
+    ``refresh_from_session`` copies the session's fields over the store, and a
+    reduced test double (or an older runtime) without the attribute would
+    otherwise wipe a reason ``observe_event`` had just written — leaving a
+    rebinding viewer to synthesise a cause it could have named.
+    """
+    if not hasattr(session, "_last_turn_cut_off"):
+        return current
+    return str(getattr(session, "_last_turn_cut_off", "") or "")
 
 
 def _label(spec: Any) -> str:

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -1275,8 +1275,8 @@ def _elide_derivable_launch_id_in_place(job: dict[str, Any]) -> None:
         del job["launch_message_id"]
 
 
-def _drop_absent_launch_fields_in_place(job: dict[str, Any]) -> None:
-    """Omit the launch-reconciliation keys from a row that has no launch.
+def _drop_absent_row_facts_in_place(job: dict[str, Any]) -> None:
+    """Omit the per-row keys that are EMPTY from a row that has neither fact.
 
     An absent fact must not buy wire bytes. These two keys are empty on every
     bash job and on every child that was never resumed, and at roster scale the
@@ -1290,6 +1290,13 @@ def _drop_absent_launch_fields_in_place(job: dict[str, Any]) -> None:
     reading neither key takes the same degrade path as one attached to a runtime
     that predates the fields. So this is a pure byte saving, not a semantic one.
 
+    ``cut_off_cause`` joins them for the same reason, measured the same way:
+    it is empty on every row that was not restored from a roster record, and one
+    key's worth of JSON on each of 200 rows was enough to push the same class
+    guard 4 KB over the line on its own. Its non-empty value is a single token
+    from ``incidents.CUT_OFF_CAUSES``, so the field costs nothing at rest and
+    tens of bytes on the handful of rows that carry it.
+
     Applied at BOTH wire boundaries — the delta assembly in ``mutate`` and the
     attach snapshot in :func:`sync_wire_payload` — because the two serialize job
     rows by different routes and a saving in one does not reach the other.
@@ -1298,6 +1305,8 @@ def _drop_absent_launch_fields_in_place(job: dict[str, Any]) -> None:
         job.pop("launch_message_id", None)
     if not job.get("launch_prompts"):
         job.pop("launch_prompts", None)
+    if not job.get("cut_off_cause"):
+        job.pop("cut_off_cause", None)
 
 
 def _jobs_equal(current: Sequence["JobState"], candidate: Sequence["JobState"]) -> bool:
@@ -1982,7 +1991,7 @@ def sync_wire_payload(sync: FrontendSync) -> dict[str, Any]:
             _bound_launch_ids_across_jobs(jobs)
             for job in jobs:
                 if isinstance(job, dict):
-                    _drop_absent_launch_fields_in_place(job)
+                    _drop_absent_row_facts_in_place(job)
         # LAST, after every other field has been bounded: this budget is what
         # the socket line has LEFT, so it can only be measured once nothing
         # else will shrink. See MODEL_CATALOGUE_FLOOR_ROWS for why the
@@ -3179,7 +3188,7 @@ class FrontendStateStore:
                 _elide_derivable_launch_id_in_place(summary)
             _bound_launch_ids_across_jobs(summaries)
             for summary in summaries:
-                _drop_absent_launch_fields_in_place(summary)
+                _drop_absent_row_facts_in_place(summary)
             wire_changes["jobs"] = summaries
         if not normalized:
             return None

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -1534,6 +1534,15 @@ class JobState(BaseModel):
             output_tail=str(getattr(job, "output_tail", "") or ""),
             output_seq=int(getattr(job, "output_seq", 0) or 0),
             restored=bool(getattr(job, "restored", False)),
+            # Carried, not re-derived here: the resolver that sets it
+            # (``session/restored_rows.py``) is the one place that knows whether
+            # a restored row's outcome came from a record, from the child's own
+            # journal, or from nothing at all. Dropping it on the way to the
+            # wire is what left the dock unable to say WHY a restored child
+            # stopped — and, for a child whose record reads ``completed``, was
+            # how the whole resolved row disappeared within a second of the
+            # session opening (UX review round 1, U2).
+            cut_off_cause=str(getattr(job, "cut_off_cause", "") or ""),
         )
 
 

--- a/local_operator/session/restored_rows.py
+++ b/local_operator/session/restored_rows.py
@@ -1,0 +1,206 @@
+"""How a persisted subagent row resolves on the way back in.
+
+A roster row is a record of what a child's state WAS when the roster was last
+written — and on every restore path that matters, the process that wrote it is
+gone. A row handed back verbatim therefore paints a spinner for a child that
+cannot be working and counts phantom activity on the band, which is worse than
+the empty panel it replaces: an empty panel is obviously incomplete, while
+phantom activity is confidently wrong and invites a cancel that finds nothing.
+
+This module owns the ONE resolution policy, because TWO writers restore the same
+roster and they must agree:
+
+* the OWNER path — ``Session._load_subagent_roster`` rehydrating
+  ``AsyncJobManager`` from the sidecar, which is what a successor runtime
+  publishes as the session's live roster; and
+* the COLD VIEWER path — ``AttachedSession._restore_cold_subagents`` painting a
+  session nothing is running (design §4, D3).
+
+They were written separately once, and the cost was measured: the viewer's
+resolved rows (a settled ``completed``, an ``interrupted`` carrying its cause)
+were visible for under a second before the successor's own restore replaced them
+with the raw persisted statuses — a blanket ``interrupted`` with the cause
+dropped — and the dock went back to being unable to answer "was this work lost?"
+(UX review round 1, U2). One function, two callers, no second opinion.
+
+The resolution order, because each step is stronger evidence than the next:
+
+1. **The record settled it.** ``records[].outcome`` names how the child ended,
+   and that is a fact, not an inference — a row restored as a bare
+   ``interrupted`` beside a record reading ``completed`` was the reported
+   defect.
+2. **The record did not, so the child's own transcript decides** — see
+   :func:`child_tail_state`. The reason goes on the row so a panel can say WHY
+   rather than only that it stopped.
+3. **No record and no transcript** → today's ``interrupted``, now naming
+   ``owner-lost`` rather than carrying no cause at all.
+
+Anything already terminal is untouched: ``completed``/``failed``/``cancelled``
+are facts the last runtime settled and a later process must not relitigate.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from local_operator.session.transcript import (
+    ENTRY_MESSAGE,
+    TRANSCRIPT_FILENAME,
+    TranscriptEntry,
+)
+
+#: Outcomes a roster RECORD can carry that already settle a child's state. Any
+#: other value (``None``, or a token a newer runtime invented) means "the
+#: record did not settle it" and the row falls through to the child's own
+#: transcript.
+_SETTLED_RECORD_OUTCOMES = frozenset({"completed", "failed", "error", "interrupted"})
+
+#: How much of a child transcript's TAIL the restore reads to decide whether
+#: the child was still working. Bounded because rule 2 runs per unsettled child
+#: and a 50 MB journal must not be parsed to answer one question; the shape
+#: examined is structural (what the LAST row is), so a sliced tail is enough.
+#: The design's cost note bounds this the same way on both call sites: only
+#: records whose ``outcome`` is unset are read at all.
+CHILD_TAIL_BYTES = 256 * 1024
+
+
+def record_field(record: Any, name: str, default: Any = None) -> Any:
+    """One field off a roster record, which is a raw sidecar DICT.
+
+    The sidecar stores ``records`` as plain JSON objects (``SubagentComms.snapshot``
+    output), while ``jobs`` come back as ``JobState``/``AsyncJob`` models — so the
+    one reader that consults both cannot assume either shape. Kept as a named
+    helper rather than a ``getattr``/``[]`` dance at each call site so the
+    dict-vs-model distinction is stated once.
+    """
+    if isinstance(record, Mapping):
+        return record.get(name, default)
+    return getattr(record, name, default)
+
+
+def child_tail_state(session_dir: Any) -> str:
+    """``"mid-turn"`` / ``"finished"`` / ``"unknown"`` for one child's journal.
+
+    Structural, never semantic — the only question is what the child's LAST
+    message row is:
+
+    * a ``tool`` result, or an assistant message whose ``tool_calls`` have no
+      rows after them → the child was CUT OFF MID-TURN;
+    * an assistant message with no pending tool call → the child actually
+      FINISHED and only its parent's record was lost.
+
+    Anything else, or anything unreadable, answers ``"unknown"`` so the row
+    keeps today's ``interrupted`` spelling instead of inventing an outcome. A
+    bounded tail read is deliberate: the journal is append-mostly, so the last
+    256 KiB is the part that carries the answer.
+    """
+    if not session_dir:
+        return "unknown"
+    try:
+        path = Path(session_dir) / TRANSCRIPT_FILENAME
+        if not path.exists():
+            return "unknown"
+        with path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            start = max(0, size - CHILD_TAIL_BYTES)
+            handle.seek(start)
+            blob = handle.read()
+        lines = blob.split(b"\n")
+        if start > 0:
+            # The first line is the tail of a row whose head is before the
+            # window; it cannot be parsed as a whole row.
+            lines = lines[1:]
+        last_payload: dict[str, Any] | None = None
+        for raw in lines:
+            if not raw.strip():
+                continue
+            entry = TranscriptEntry.from_json(raw.decode("utf-8", errors="replace"))
+            if entry is not None and entry.type == ENTRY_MESSAGE:
+                last_payload = entry.payload
+    except (OSError, ValueError):
+        return "unknown"
+    if last_payload is None:
+        return "unknown"
+    role = str(last_payload.get("role") or "")
+    if role == "tool":
+        return "mid-turn"
+    if role == "assistant":
+        return "mid-turn" if last_payload.get("tool_calls") else "finished"
+    return "unknown"
+
+
+def restored_job_row(job: Any, record: Any | None) -> Any:
+    """One non-terminal job row, resolved against the record and the child.
+
+    ``job`` may be either shape the two callers hold (a frontend ``JobState`` or
+    a manager ``AsyncJob``); both are pydantic models with ``status``,
+    ``restored`` and ``cut_off_cause``, so ``model_copy`` is the one update
+    mechanism that works for both without a per-caller branch.
+    """
+    record_outcome = ""
+    if record is not None:
+        record_outcome = str(record_field(record, "outcome") or "")
+    if record_outcome in _SETTLED_RECORD_OUTCOMES:
+        return job.model_copy(
+            update={"status": record_outcome, "restored": True, "cut_off_cause": ""}
+        )
+    tail = child_tail_state(record_field(record, "session_dir") if record is not None else None)
+    if tail == "finished":
+        # The child produced a settled answer; only its parent's record of that
+        # was lost. Reporting the child as cut off would be a lie the panel then
+        # offers to resume.
+        return job.model_copy(update={"status": "completed", "restored": True, "cut_off_cause": ""})
+    # ``mid-turn`` and ``unknown`` land in the same place: the child has no
+    # settled outcome of its own and cannot be running any more, so it stopped
+    # under the process that owned it. One return rather than two identical
+    # ones, so the fallthrough reads as intended (review round 1, NIT-1).
+    return job.model_copy(
+        update={"status": "interrupted", "restored": True, "cut_off_cause": "owner-lost"}
+    )
+
+
+def roster_records(payload: Mapping[str, Any] | None) -> Sequence[Any]:
+    """The sidecar's ``records`` list, or an empty sequence when it has none.
+
+    Typed here rather than inline so the ``Any`` coming out of a raw JSON dict
+    is narrowed once: the caller passes it straight into
+    :func:`resolve_restored_rows`, whose ``records`` parameter is a ``Sequence``.
+    """
+    records = (payload or {}).get("records")
+    return records if isinstance(records, list) else ()
+
+
+def resolve_restored_rows(jobs: Sequence[Any], records: Sequence[Any] = ()) -> list[Any]:
+    """Roster rows as they must appear with the process that ran them gone.
+
+    The rule is stated in the module docstring. ``records`` is the roster
+    sidecar's ``records`` list, whose ``outcome`` and ``session_dir`` are what
+    make a restored row diagnosable rather than a blanket ``interrupted``. It is
+    optional so an older sidecar (or a caller that has none) keeps today's
+    behaviour exactly.
+
+    A ``running`` row that was PARKED (``queued``) never started, so it has no
+    transcript to show or resume and is DROPPED — an ``interrupted`` row would
+    invite a resume that finds nothing. ``AsyncJobManager.restore`` applies the
+    same rule for its own table; dropping here as well keeps the two callers in
+    step for the rows the manager never sees (a cold viewer builds no manager).
+    """
+    by_id: dict[str, Any] = {}
+    for record in records:
+        job_id = str(record_field(record, "job_id") or "")
+        if job_id:
+            by_id[job_id] = record
+    rows: list[Any] = []
+    for job in jobs:
+        status = str(getattr(job, "status", "") or "")
+        if status == "running":
+            if bool(getattr(job, "queued", False)):
+                continue
+            rows.append(restored_job_row(job, by_id.get(str(getattr(job, "id", "") or ""))))
+            continue
+        rows.append(job.model_copy(update={"restored": True}))
+    return rows

--- a/local_operator/session/runtime/process.py
+++ b/local_operator/session/runtime/process.py
@@ -180,6 +180,18 @@ def _build_changed(boot: "BuildStamp | None") -> "BuildStamp | None":
     return on_disk
 
 
+def _build_pair(boot: "BuildStamp | None", newer: "BuildStamp") -> str:
+    """``" (old → new)"`` for the cut-off reason, or ``""`` without a boot stamp.
+
+    The build pair is what makes a retirement self-explaining to whoever reads
+    the reason later: "the runtime retired" is only actionable when it names
+    which build it left for.
+    """
+    if boot is None:
+        return ""
+    return f" ({boot.label()} → {newer.label()})"
+
+
 def _should_refresh(handle: object, boot: "BuildStamp | None") -> "BuildStamp | None":
     """Retire so the next engage spawns from the build now on disk?
 
@@ -284,13 +296,27 @@ def _should_exit(handle: object, runtime: object) -> bool:
     return True
 
 
-async def _clean_exit(handle: object, runtime: object) -> None:
+async def _clean_exit(handle: object, runtime: object, *, reason: str = "idle-exit") -> None:
     """Dispose the quiescent session, then unpublish its owner record.
 
     The reaper reaches this only after ordinary gate timeouts and all resumed
     work have drained, so injecting a shutdown denial here would violate the
     same no-interruption invariant that selected this state.
+
+    ``reason`` names WHY this runtime is leaving, and it is logged here rather
+    than by the caller because this is the one place every planned exit
+    converges. That line is not decoration: the reference investigation could
+    not tell a refresh retirement from a SIGTERM from a torn install, because an
+    exiting runtime logged nothing about itself and no exit record survived
+    (design §1.6/§5.3).
     """
+    boot = getattr(runtime, "_boot_build", None)
+    logger.info(
+        "session runtime: exiting (%s, pid %d, %s)",
+        reason,
+        os.getpid(),
+        boot.label() if boot is not None else "<unknown>",
+    )
     try:
         await handle.dispose()  # type: ignore[attr-defined]
     except Exception:  # noqa: BLE001 — dispose is best-effort at exit
@@ -341,6 +367,7 @@ async def _reaper(handle: object, runtime: object, stop: asyncio.Event) -> None:
         if stop.is_set() or not _should_exit(handle, runtime):
             continue
         deadline = time.monotonic() + grace_s
+        drained = False
         while time.monotonic() < deadline:
             await asyncio.sleep(REAP_CHECK_S)
             if await refresh_check():
@@ -348,15 +375,30 @@ async def _reaper(handle: object, runtime: object, stop: asyncio.Event) -> None:
             if stop.is_set() or not _should_exit(handle, runtime):
                 break  # a predicate term flipped back (or shutdown began)
         else:
-            logger.info(
-                "session runtime: idle for %.1fs (no work, no viewer, no wake within %.0fs); "
-                "exiting cleanly",
-                grace_s,
-                WARM_WINDOW_S,
-            )
-            await _clean_exit(handle, runtime)
-            stop.set()  # amain's wait() returns; exit code stays 0
-            return
+            drained = True
+        if not drained:
+            continue
+        # The LAST instant before the exit, and the reason it is a latch rather
+        # than another ``_should_exit`` sample: the grace loop's condition can
+        # go false on the same tick that a ``prompt`` or ``peer_message`` opens
+        # a turn, and this branch then disposes without re-reading the
+        # predicate — aborting work it had just refused to wait for. The latch
+        # commits the runtime to leaving in the same synchronous step that
+        # checks it, so from here the admissions REFUSE and the claim is true by
+        # construction (design §5.1).
+        begin_retire = getattr(handle, "begin_retire", None)
+        if callable(begin_retire) and not begin_retire("idle-exit"):
+            logger.info("session runtime: work arrived as the idle drain closed; keeping")
+            continue
+        logger.info(
+            "session runtime: idle for %.1fs (no work, no viewer, no wake within %.0fs); "
+            "exiting cleanly",
+            grace_s,
+            WARM_WINDOW_S,
+        )
+        await _clean_exit(handle, runtime, reason="idle-exit")
+        stop.set()  # amain's wait() returns; exit code stays 0
+        return
 
 
 async def _refresh_for(
@@ -406,14 +448,26 @@ async def _refresh_for(
             logger.debug("retiring announcement failed", exc_info=True)
     if stop.is_set():
         return False
-    if _should_refresh(handle, boot) is None:
+    # The final check is the LATCH, not another sample: a retirement that acted
+    # on a sampled "idle" and then met a turn during the announce would abort
+    # work it had just decided not to disturb. ``begin_retire`` commits the
+    # runtime to leaving in one synchronous step, and from that instant the
+    # admission paths refuse, so no turn can open between here and the dispose.
+    begin_retire = getattr(handle, "begin_retire", None)
+    if callable(begin_retire):
+        if not begin_retire("runtime-retired", _build_pair(boot, newer)):
+            logger.info("session runtime: work arrived while retiring was announced; keeping")
+            return False
+    elif _should_refresh(handle, boot) is None:
+        # A handle without the latch (an older or reduced host, e.g. the tests'
+        # stub handles): keep today's re-check rather than retiring unguarded.
         # Refusing AFTER announcing is safe for the same reason it is for
         # ``stopping``: ``retiring`` only latches the disconnect REASON in an
         # attach client, and does nothing unless the socket then closes.
         logger.info("session runtime: work arrived while retiring was announced; keeping")
         return False
     logger.info("session runtime: retiring for %s", newer.label())
-    await _clean_exit(handle, runtime)
+    await _clean_exit(handle, runtime, reason="retiring for " + newer.label())
     stop.set()
     return True
 
@@ -557,8 +611,25 @@ async def amain() -> int:
     await runtime.start_in_process()
 
     stop = asyncio.Event()
+    # What ASKED this runtime to leave. Named because the exit itself is the one
+    # event the reference investigation could not attribute: a refresh, a
+    # SIGTERM and a torn install all ended the process with nothing written
+    # about which it was (design §1.6/§5.3). The reaper and the retire path log
+    # their own reason from ``_clean_exit``; this covers the two triggers that
+    # dispose directly.
+    trigger: dict[str, str] = {}
+
+    def _on_signal(sig: signal.Signals) -> None:
+        trigger.setdefault("why", sig.name)
+        stop.set()
+
+    def _on_socket_stop() -> None:
+        """The graceful ``stop`` op (``ServingSessionHandle.request_stop``)."""
+        trigger.setdefault("why", "socket-stop")
+        stop.set()
+
     for sig in (signal.SIGTERM, signal.SIGINT):
-        loop.add_signal_handler(sig, stop.set)
+        loop.add_signal_handler(sig, _on_signal, sig)
     if os.environ.get("LOP_RUNTIME_DEBUG_STACKS") == "1":
         # SIGUSR1 prints every asyncio task's stack to the child log. The
         # child has no terminal and no attached debugger, and a wedged turn
@@ -613,7 +684,7 @@ async def amain() -> int:
     # The socket ``stop`` op (the kill switch's graceful rung) and SIGTERM
     # converge on the same event, so the deny → dispose → aclose ordering
     # below runs once, identically, for both triggers.
-    handle.on_stop_requested = stop.set
+    handle.on_stop_requested = _on_socket_stop
     # The self-reaper: a phone session nobody watches and nothing runs is a
     # live process doing nothing, and before this it idled FOREVER. Runs
     # beside the signal wait; whichever fires first wins.
@@ -627,6 +698,15 @@ async def amain() -> int:
         # ordering. A signal-initiated stop still owes it.
         reaper_ran_clean_exit = True
     if not reaper_ran_clean_exit:
+        # The reaper logs its own line from ``_clean_exit``; these are the
+        # direct-dispose triggers (a signal, or the graceful ``stop`` op).
+        boot = getattr(runtime, "_boot_build", None)
+        logger.info(
+            "session runtime: exiting (%s, pid %d, %s)",
+            trigger.get("why") or "unknown",
+            os.getpid(),
+            boot.label() if boot is not None else "<unknown>",
+        )
         try:
             handle._deny_pending_gates()
         except Exception:  # noqa: BLE001 — shutdown must proceed

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -2379,6 +2379,17 @@ class RuntimeServer:
         )
         return await self._retire_for("stale-build", to=newer.label())
 
+    def _retire_detail(self, to: str) -> str:
+        """``" (old → new)"`` for a retirement reason, when both stamps exist.
+
+        The build pair is what makes the reason actionable later: "the runtime
+        retired" says nothing about which build it left for.
+        """
+        boot = getattr(self, "_boot_build", None)
+        if boot is None or not to:
+            return ""
+        return f" ({boot.label()} → {to})"
+
     async def _retire_for(self, reason_label: str, *, to: str = "") -> str:
         """Retire this runtime iff it is idle, announcing ``reason_label``.
 
@@ -2408,14 +2419,28 @@ class RuntimeServer:
         if not callable(request_stop):
             return "kept: this runtime cannot stop itself gracefully"
         await self.announce_retiring(reason_label, to=to)
-        # The one await between decision and stop; re-ask, as
-        # ``_retire_if_pristine`` does after its broadcast.
-        try:
-            reason = str(may_refresh() or "")
-        except Exception as exc:  # noqa: BLE001
-            return f"kept: idle probe failed ({exc})"
-        if reason:
-            return f"kept: {reason} (arrived while retiring was announced)"
+        # The ONE await between decision and stop, so the final check is a LATCH
+        # and not another sample: a ``prompt`` admitted in this gap would open a
+        # turn that ``request_stop`` then aborts one await later. ``begin_retire``
+        # commits the runtime in the same synchronous step that checks it, so
+        # from here the admissions refuse and the retirement is clean by
+        # construction (design §5.1). The cut-off CAUSE is always
+        # ``runtime-retired``: ``reason_label`` names the trigger for the log and
+        # the wire announcement, while the cause is the vocabulary token a
+        # restored session renders.
+        begin_retire = getattr(h, "begin_retire", None)
+        if callable(begin_retire):
+            if not begin_retire("runtime-retired", self._retire_detail(to)):
+                return "kept: work arrived while retiring was announced"
+        else:
+            # A reduced/older handle without the latch keeps today's re-check
+            # rather than retiring unguarded.
+            try:
+                reason = str(may_refresh() or "")
+            except Exception as exc:  # noqa: BLE001
+                return f"kept: idle probe failed ({exc})"
+            if reason:
+                return f"kept: {reason} (arrived while retiring was announced)"
         logger.info("session runtime: retiring (%s)", reason_label)
         result = request_stop()
         if inspect.isawaitable(result):

--- a/local_operator/session/runtime/serving.py
+++ b/local_operator/session/runtime/serving.py
@@ -1208,11 +1208,7 @@ class ServingSessionHandle(SessionHandle):
         ``lop stop``, and it must be recorded as such or the taxonomy (which
         now requires positive evidence for ``interrupted``) would have to guess.
         """
-        if not self._retiring_cause:
-            session = getattr(self, "_session", None)
-            note = getattr(session, "note_deliberate_stop", None)
-            if callable(note):
-                note()
+        self._note_deliberate_stop()
         self._deny_pending_gates()
         trigger = self.on_stop_requested
         if trigger is not None:
@@ -1229,6 +1225,31 @@ class ServingSessionHandle(SessionHandle):
                 logger.warning("session runtime: stop-path dispose failed", exc_info=True)
 
         self._loop.create_task(_dispose_in_place())
+
+    def _note_deliberate_stop(self) -> None:
+        """Record that the USER ended this turn, before anything tears it down.
+
+        ONE place for the three deliberate rungs of this handle (``stop``,
+        ``abort``, ``cancel``), because the verdict has to be written while the
+        act is still knowable: ``Session.dispose()`` notes ``disposed``
+        unconditionally, and an un-noted dispose therefore publishes the user's
+        own cancel as ``kind=error`` / ``cause=disposed`` (review round 1,
+        BLOCKER-1). ``abort`` is the phone's stop button and ``cancel`` its
+        supervised sibling; both are a person or a supervisor saying "stop",
+        and each was one teardown away from being reported as a failure.
+
+        Refused while a retirement is latched, matching ``request_stop``: the
+        runtime is already ending that turn for its own reason (a build flip)
+        and the cut-off verdict for it belongs to the retire path, which
+        recorded it when it latched. Non-raising by contract — it runs inside a
+        stop, and a stop must not fail because a host session has no say in its
+        own taxonomy.
+        """
+        if self._retiring_cause:
+            return
+        note = getattr(self._session, "note_deliberate_stop", None)
+        if callable(note):
+            note()
 
     def _deny_pending_gates(self) -> None:
         """Refuse every parked approval/ask so teardown cannot hang on them.
@@ -1896,6 +1917,11 @@ class ServingSessionHandle(SessionHandle):
         started it), so they are named too rather than implied stopped.
         """
         self._check_loop_thread()
+        # The phone's stop button is the user's own act, so the verdict is
+        # recorded before the turn is cut (see `_note_deliberate_stop`): the
+        # turn ends aborted either way, and what this decides is whether that
+        # abort reads as the user's stop or as a failure.
+        self._note_deliberate_stop()
         if self._goal_loop is not None:
             await self._goal_loop.cancel()
         # THE PARENT FIRST, THEN THE CHILDREN. A child settling hands its
@@ -2038,6 +2064,11 @@ class ServingSessionHandle(SessionHandle):
         request = getattr(self._session, "request_graceful_cancel", None)
         if not callable(request):
             raise ValueError("this session cannot cancel at a tool boundary")
+        # A supervisor's cancel is deliberate too, and it ends the turn the same
+        # way (`harness/loop.py` ends it aborted) — so it records the same
+        # verdict as the user's own stop rather than letting a later teardown
+        # publish it as a cut-off failure (review round 1, BLOCKER-1).
+        self._note_deliberate_stop()
         request(reason)
         return "cancelling at the next tool boundary"
 

--- a/local_operator/session/runtime/serving.py
+++ b/local_operator/session/runtime/serving.py
@@ -388,6 +388,12 @@ class ServingSessionHandle(SessionHandle):
         self._command_reservations = CommandReservations(session)
         self._unsubscribe_admitted_commands = self._command_reservations.subscribe_durable()
         self._disposing = False
+        #: Set once this handle has COMMITTED to retiring, by
+        #: :meth:`begin_retire`. Non-empty means the admission paths refuse (see
+        #: that method) — a runtime that is leaving must not start a turn it
+        #: will abort one await later. Deliberately never cleared: a retirement
+        #: is a one-way door for the process.
+        self._retiring_cause: str = ""
         #: Installed by the runtime process (``process.amain``): fires the
         #: process's stop event so a socket ``stop`` op exits the way SIGTERM
         #: does. ``None`` under a host that has no process to exit.
@@ -811,6 +817,17 @@ class ServingSessionHandle(SessionHandle):
         to ``self._session`` so the ordering (deny gates first) stays in one
         place and hosts cannot forget the claim release."""
         self._disposing = True
+        # The dispose rung of EVERY exit that is not a viewer-driven retirement:
+        # SIGTERM/SIGINT in ``amain``, the reaper's ``_clean_exit``, and a host
+        # that disposes in place. Recorded BEFORE the abort below so the turn's
+        # end event carries it (``_classify_cut_off`` reads it from the emitted
+        # event), and suppressed when a deliberate stop was already noted for
+        # this turn — the graceful ``stop`` op reaches here too, and relabelling
+        # a user's own cancel as an error is the worse mistake.
+        session = getattr(self, "_session", None)
+        note = getattr(session, "note_cut_off", None)
+        if callable(note):
+            note(self._retiring_cause or "runtime-shutdown")
         # Revoke the broker registration along with the session: descendants of
         # a session that is going away must not stay authorized behind it
         # (§2.1). Bounded and non-raising, so it cannot delay or break teardown.
@@ -1061,6 +1078,44 @@ class ServingSessionHandle(SessionHandle):
             return False
         return True
 
+    def begin_retire(self, cause: str, detail: str = "") -> bool:
+        """Commit this runtime to retiring, iff it is idle RIGHT NOW.
+
+        Sets ``_retiring_cause`` in the SAME synchronous step that asks
+        :meth:`may_refresh`, and from that instant the admission paths
+        (:meth:`prompt`, :meth:`receive_peer_message`) REFUSE rather than queue.
+        That is the whole point: both retire paths sample the predicate and then
+        act across an ``await`` — the reaper's stagger plus ``announce_retiring``
+        (which drains each viewer's writer), and ``dispose`` is async — so the
+        "idle" claim was only ever true at ONE instant, and a ``prompt`` or a
+        ``peer_message`` arriving in the gap opened a turn the dispose then
+        aborted (design §5.1). The latch makes the claim true by construction
+        rather than by timing.
+
+        ``cause`` names the retirement for the refusal and the log; the session
+        is told as well, so a turn aborted while retiring is labelled with the
+        retirement rather than a generic shutdown.
+        """
+        try:
+            reason = str(self.may_refresh() or "")
+        except Exception:  # noqa: BLE001 — uncertainty keeps the runtime
+            reason = "busy probe failed"
+        if reason:
+            return False
+        self._retiring_cause = cause or "retiring"
+        session = getattr(self, "_session", None)
+        note = getattr(session, "note_cut_off", None)
+        if callable(note):
+            note(self._retiring_cause, detail)
+        return True
+
+    def _retiring_refusal(self) -> str:
+        """The refusal an admission gets once this runtime has committed to leaving."""
+        return (
+            f"the session runtime is retiring ({self._retiring_cause}); the message "
+            "was not admitted — send it again and the next engage runs the new build"
+        )
+
     def may_refresh(self) -> str:
         """Why this runtime must NOT retire for a newer build right now, or
         ``""`` when it may.
@@ -1145,7 +1200,19 @@ class ServingSessionHandle(SessionHandle):
 
         Sync and non-raising by contract (see SessionHandle): called on the
         runtime loop from the ``stop`` dispatch, which acks right after.
+
+        DELIBERATE STOP vs PLANNED RETIREMENT, told apart HERE because both
+        reach this one rung. A retirement is driven by the runtime itself and
+        has already latched the handle (``begin_retire``) before calling this;
+        an un-latched call is therefore the user's own ``/stop`` or
+        ``lop stop``, and it must be recorded as such or the taxonomy (which
+        now requires positive evidence for ``interrupted``) would have to guess.
         """
+        if not self._retiring_cause:
+            session = getattr(self, "_session", None)
+            note = getattr(session, "note_deliberate_stop", None)
+            if callable(note):
+                note()
         self._deny_pending_gates()
         trigger = self.on_stop_requested
         if trigger is not None:
@@ -1386,6 +1453,12 @@ class ServingSessionHandle(SessionHandle):
         if self._disposing:
             self._command_reservations.reject(command_id)
             raise RuntimeError("session is closing; prompt was not admitted")
+        if self._retiring_cause:
+            # Refused, not queued: a turn admitted here is aborted one await
+            # later by the dispose that is already on its way, after the
+            # provider has been paid for whatever it managed to stream.
+            self._command_reservations.reject(command_id)
+            raise RuntimeError(self._retiring_refusal())
         if len(self._prompt_queue) >= MAX_QUEUED_PROMPTS:
             self._command_reservations.reject(command_id)
             raise RuntimeError(
@@ -1775,6 +1848,12 @@ class ServingSessionHandle(SessionHandle):
         # steer() does, so an attached phone paints the peer card immediately
         # rather than waiting for the next MessageStartEvent.
         self._check_loop_thread()
+        # A retiring runtime must not START a turn it will abort one await
+        # later. The QUIET record-only delivery (``mailbox``, no wake) is
+        # deliberately still admitted: it opens no turn, and refusing it would
+        # drop a durable note the sender was promised it had delivered.
+        if self._retiring_cause and (wake or mode != "mailbox"):
+            raise RuntimeError(self._retiring_refusal())
         detail = await self._session.receive_peer_message(
             text, mode=mode, wake=wake, sender=sender or {}
         )

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -161,6 +161,12 @@ from local_operator.session.protocol import (
     RuntimeLocality,
     unanswered_tail_call_ids,
 )
+
+# The roster-row resolution shared with the cold viewer. Imported here so the
+# OWNER path (this module's `_load_subagent_roster`) and the viewer path
+# (`AttachedSession._restore_cold_subagents`) cannot drift into two opinions
+# about one persisted row (UX review round 1, U2).
+from local_operator.session.restored_rows import resolve_restored_rows, roster_records
 from local_operator.session.transcript import ENTRY_CUSTOM, Transcript
 from local_operator.tools.builtin import (
     TODO_REMINDER_MESSAGE_TYPE,
@@ -6196,12 +6202,20 @@ class Session:
         A turn that ALREADY ended with a real provider/tool error is left alone:
         that error is a more specific diagnosis than "the runtime went away",
         and overwriting it would throw away the only text that names the actual
-        fault.
+        fault. The guard reads ``event.error`` ALONE and not
+        ``event.error and not event.aborted`` (review round 1, MINOR-1): the loop
+        emits a provider failure on an aborted turn itself
+        (``harness/loop.py:945`` — ``aborted=True, error=<stream_error>``), so
+        the narrower test let a cut-off overprint the vendor's own "quota
+        exhausted" with a generic sentence, which is this method's contract
+        broken by its own guard. ``_publish_attention_outcome`` reads the verdict
+        back off the event (``cut_off_cause``), so the durable reason agrees with
+        the live row instead of naming a different failure.
         """
         cause = self._cut_off_cause
         if not cause:
             return event
-        if event.error and not event.aborted:
+        if event.error:
             return event
         detail = self._cut_off_detail
         return event.model_copy(
@@ -6329,7 +6343,16 @@ class Session:
         # the two facts it needs rather than re-deriving them: ``cut_off`` says
         # the end marker is an involuntary stop, and ``aborted`` alone still
         # means the deliberate one.
-        cut_off = bool(self._cut_off_cause)
+        #
+        # READ OFF THE EVENT, not off the local flag (review round 1, MINOR-1).
+        # The flag says a cut-off was NOTICED; the event says one was
+        # CLASSIFIED, and the two differ in exactly one case — a cut-off that
+        # coincided with a real provider error, which the classifier deliberately
+        # leaves alone. Reading the flag there would publish the cut-off sentence
+        # as the reason while the transcript, the live row and the model all hold
+        # the provider's message: the store and the surfaces disagreeing about
+        # one turn's failure is the class of bug this taxonomy exists to remove.
+        cut_off = bool(outcome.cut_off_cause)
         kind = (
             "error"
             if (outcome.error or cut_off)
@@ -11561,7 +11584,17 @@ class Session:
                 logger.warning("dropping malformed persisted subagent row: %r", raw)
         if rows:
             try:
-                self.jobs.restore(rows)
+                # RESOLVE BEFORE RESTORE, through the SAME resolver the cold
+                # viewer uses (``session/restored_rows.py``). This is the writer
+                # that matters for what the user ends up looking at: the manager
+                # publishes this table as the session's roster, so rows restored
+                # raw would replace the viewer's record-resolved rows within a
+                # second of the session opening — a settled ``completed`` child
+                # back to a blanket ``interrupted``, with the cause dropped
+                # (UX review round 1, U2). ``AsyncJobManager.restore`` cannot do
+                # this itself: the record facts live here, in the roster
+                # payload, and not in the manager's table.
+                self.jobs.restore(resolve_restored_rows(rows, roster_records(details)))
             except Exception:  # noqa: BLE001 - a bad snapshot must not stop boot
                 logger.warning("could not restore subagent job rows", exc_info=True)
         if isinstance(details.get("accounting"), list):

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -139,6 +139,9 @@ from local_operator.incidents import (
     SESSION_INCIDENT_MESSAGE_TYPE,
     SESSION_MCP_RECOVERY_MESSAGE_TYPE,
     SESSION_MODEL_SWITCH_MESSAGE_TYPE,
+    format_cut_off_notice,
+    format_cut_off_raw,
+    render_cut_off_reason,
 )
 from local_operator.prompts_api import (
     TOOL_INVENTORY_HEADING,
@@ -201,6 +204,33 @@ SUBAGENT_ROSTER_CUSTOM_TYPE = "subagent_roster"
 SUBAGENT_ROSTER_SIDECAR = "subagent-roster.v1.json"
 _SUBAGENT_ROSTER_VERSION = 1
 _SUBAGENT_SUMMARY_CHARS = 500
+
+#: The build THIS PROCESS loaded, read once and memoised. Compared against the
+#: install on disk by ``update.classify_import_failure``, which is the only way
+#: to tell a lazy import that lost a name to a HALF-REPLACED install from a
+#: genuine packaging bug: without a baseline the comparison can only ever say
+#: "equal", and every real defect would be mislabelled an install race.
+#:
+#: Read lazily rather than at import (importing this module must do no file I/O)
+#: and stamped in ``Session.__init__`` so in every runtime the FIRST read happens
+#: at process start, before an install can move under us.
+_PROCESS_BOOT_BUILD: Any = None
+_PROCESS_BOOT_BUILD_READ = False
+
+
+def _process_boot_build() -> Any:
+    """The ``BuildStamp`` this process booted from, or ``None`` if unreadable."""
+    global _PROCESS_BOOT_BUILD, _PROCESS_BOOT_BUILD_READ
+    if not _PROCESS_BOOT_BUILD_READ:
+        _PROCESS_BOOT_BUILD_READ = True
+        try:
+            from local_operator.update import installed_build
+
+            _PROCESS_BOOT_BUILD = installed_build()
+        except Exception:  # noqa: BLE001 — an unreadable stamp classifies nothing
+            _PROCESS_BOOT_BUILD = None
+    return _PROCESS_BOOT_BUILD
+
 
 #: Transcript custom-entry type holding the session's todo list. The todo tool
 #: keeps the live list in a module-level table keyed by session id (see
@@ -1792,10 +1822,14 @@ class Session:
         # rather than above it, and it is the path
         # `test_a_broken_attention_import_cannot_stop_a_session_from_loading`
         # exercises.
+        #
+        # Initialised BEFORE the attempt so a failure leaves it ``None`` rather
+        # than unset: ``_journal_restored_cut_off`` reads it on every boot.
+        self._restored_cut_off: tuple[str, str, str, str] | None = None
         try:
             from local_operator.session.attention import bootstrap_transcript
 
-            bootstrap_transcript(transcript)
+            self._restored_cut_off = bootstrap_transcript(transcript)
         except Exception as exc:  # noqa: BLE001 — must not break session boot
             logger.warning(
                 "attention bootstrap failed for %s (%r); continuing without it",
@@ -1822,10 +1856,27 @@ class Session:
                 exc_info=True,
             )
         self._session_id = session_id or transcript.directory.name
+        # Stamp the build THIS process loaded, before any lazy import can meet a
+        # replaced tree: every later ``_note_import_failure`` compares against
+        # this value (see ``_process_boot_build``).
+        _process_boot_build()
         self._attention: dict[str, Any] = {}
         self._attention_outcome: AgentEndEvent | None = None
         self._attention_run_token: str | None = None
+        #: Whether the CURRENT run's end has been CONSUMED for publication.
+        #: Set False at every turn start and True the moment
+        #: ``_publish_attention_outcome`` takes the end event, so a teardown can
+        #: tell "this run already said how it ended" from "it never got to" —
+        #: the distinction that decides whether dispose has to publish one.
+        self._attention_run_settled: bool = True
         self._attention_restored = False
+        #: Set by the ``bootstrap_transcript`` call ABOVE (see the attention
+        #: block) to the ``(kind, cause, reason, token)`` this boot classified
+        #: and published for an ORPHANED run, and journaled from ``async_init``
+        #: / ``refresh_attention`` because ``journal_incident`` awaits a
+        #: transcript write and ``__init__`` is synchronous. Deliberately NOT
+        #: re-initialised here — an initialiser at this point would overwrite
+        #: the value the bootstrap just produced.
         self._agent_id = agent_id
         # The goal rides the prompt's volatile tail; the holder is shared with
         # the system-blocks provider so an edit applies from the next turn.
@@ -2149,6 +2200,31 @@ class Session:
         #: user prompt (compaction continuations hold the end until the
         #: pipeline flushes).
         self._last_turn_outcome: Literal["completed", "aborted", "error", ""] = ""
+        #: The rendered reason for the last cut-off turn, mirrored onto the
+        #: canonical snapshot beside ``_last_turn_outcome``. A rebinding viewer
+        #: uses it to synthesise a real diagnostic (``_settle_suspect_turn``)
+        #: instead of the class placeholder ``"turn failed"``.
+        self._last_turn_cut_off: str = ""
+        #: Why the CURRENT turn is being cut off, as a machine token from
+        #: ``incidents.CUT_OFF_CAUSES``, or ``""`` when it is ending on its own
+        #: or was deliberately stopped. Set by the runtime's own exit paths (a
+        #: retire that caught a live turn, a termination signal, disposal) and
+        #: consumed by :meth:`_classify_cut_off` and
+        #: :meth:`_publish_attention_outcome`.
+        #:
+        #: Deliberately NOT derived from ``AbortSignal.reason``:
+        #: ``abort("session disposed")`` is produced by BOTH a user's `/stop` and
+        #: a SIGTERM, so the reason STRING cannot classify the trigger — only the
+        #: exit path that raised it can.
+        self._cut_off_cause: str = ""
+        #: Optional parenthetical riding with ``_cut_off_cause`` (a build pair, a
+        #: pid, a start time) — why the reason is specific instead of generic.
+        self._cut_off_detail: str = ""
+        #: Positive evidence that THIS turn was stopped on purpose. Once set, a
+        #: later ``note_cut_off`` is ignored: `lop stop` and SIGTERM converge on
+        #: the same clean-exit ordering, so the dispose rung always runs and
+        #: would otherwise relabel a user's own cancel as an error.
+        self._deliberate_stop_noted: bool = False
         # The loop's held end owns billing, but a later post-turn compaction owns
         # occupancy. Carry that newer level to the boundary without rewriting the
         # usage objects that lifetime cost and analytics still need.
@@ -3246,6 +3322,10 @@ class Session:
             self._tg_stack = stack
         self._handle_missed_wakes()
         await self._wake.pump()
+        # Narrate a cut-off this boot repaired BEFORE anything can open a turn,
+        # so the notice is in the live context the first turn reads. Deduped on
+        # the token, so a second open of the same session is silent.
+        await self._journal_restored_cut_off()
         if self._resume_catchup_text is not None and not self._resume_catchup_sent:
             # A catch-up still pending after the pump: the re-armed fire lands
             # at (or microseconds before) the grace deadline, and a COLD
@@ -6054,6 +6134,124 @@ class Session:
         if store is not None:
             store.refresh_jobs(self)
 
+    def note_cut_off(self, cause: str, detail: str = "") -> None:
+        """Record WHY the current turn is being cut off, before it ends.
+
+        Called by the runtime's own exit paths — the dispose rung, a termination
+        signal, a retirement that caught a live turn — which are the only
+        writers that can classify the trigger. Deliberately suppressed once a
+        DELIBERATE stop was recorded for this turn: ``lop stop`` and SIGTERM
+        converge on the same clean-exit ordering (``ServingSessionHandle``), so
+        the dispose rung always runs and would otherwise relabel a user's own
+        cancel as an error — the one misclassification this taxonomy calls
+        worse than the bug it fixes.
+
+        A no-op on an idle session: the cause is consumed only by an
+        ``AgentEndEvent`` for the turn that was running, and it is cleared at
+        the head of the next one.
+
+        FIRST WRITER WINS. An exit is a sequence of rungs (a retirement latch,
+        then the stop rung, then the dispose), and the EARLIEST note is the
+        most specific one — a retirement that reaches disposal would otherwise
+        be relabelled a generic ``runtime-shutdown`` by the rung that merely
+        finishes the job. The one thing that outranks all of them is a
+        deliberate stop, which clears rather than fills (see
+        ``note_deliberate_stop``).
+        """
+        if not cause or self._deliberate_stop_noted or self._cut_off_cause:
+            return
+        self._cut_off_cause = cause
+        self._cut_off_detail = detail
+
+    def note_deliberate_stop(self) -> None:
+        """Record positive evidence that THIS turn is a user's own stop.
+
+        The taxonomy flips the default: with no evidence a cut-off is an ERROR,
+        and ``interrupted`` now has to be earned. This is how the stop rung
+        earns it, and it is why it must run BEFORE the dispose rung (which
+        notes an involuntary cause). Cleared per turn with
+        ``_cut_off_cause``.
+        """
+        self._deliberate_stop_noted = True
+        self._cut_off_cause = ""
+        self._cut_off_detail = ""
+
+    def _classify_cut_off(self, event: AgentEndEvent) -> AgentEndEvent:
+        """Re-label an involuntary abort as a CUT-OFF error before it is emitted.
+
+        A deliberate stop keeps today's shape (``aborted=True, error=None`` →
+        ``interrupted``). An involuntary one is rewritten to ``aborted=False,
+        error=<sentence>`` so every existing surface does the right thing
+        without being taught a new field: ``on_turn_ended`` appends its error
+        notice, ``_finalize_turn`` does NOT append the ``interrupted`` notice,
+        the title takes the ✗ mark (``failed=bool(error) and not aborted``),
+        ``_last_turn_outcome`` becomes ``"error"``, and
+        ``_publish_attention_outcome`` publishes ``error``. An OLD viewer that
+        has never heard of ``cut_off`` gets the same behaviour, which is the
+        backwards-compatibility requirement.
+
+        The ``cut_off``/``cut_off_cause`` fields ride along so a NEW viewer can
+        name the cause precisely without re-deriving it from the vocabulary.
+
+        A turn that ALREADY ended with a real provider/tool error is left alone:
+        that error is a more specific diagnosis than "the runtime went away",
+        and overwriting it would throw away the only text that names the actual
+        fault.
+        """
+        cause = self._cut_off_cause
+        if not cause:
+            return event
+        if event.error and not event.aborted:
+            return event
+        detail = self._cut_off_detail
+        return event.model_copy(
+            update={
+                "aborted": False,
+                "error": format_cut_off_notice(cause, detail=detail),
+                "cut_off": render_cut_off_reason(cause, detail=detail),
+                "cut_off_cause": cause,
+            }
+        )
+
+    async def _journal_restored_cut_off(self) -> None:
+        """Narrate the cut-off this boot repaired, once per orphaned run."""
+        restored = self._restored_cut_off
+        if restored is None:
+            return
+        _kind, cause, reason, token = restored
+        await self._journal_cut_off_once(token, reason, cause)
+
+    def _note_import_failure(self, exc: BaseException, module: str) -> bool:
+        """Record a lazy import that lost a name to a HALF-REPLACED install.
+
+        Conservative on purpose: ``update.classify_import_failure`` names the
+        cause ONLY when the install on disk has moved away from the build this
+        process booted from, so a genuine packaging bug keeps its ordinary
+        traceback instead of being mislabelled an install race. Returns whether
+        the cause was named.
+        """
+        from local_operator.update import classify_import_failure
+
+        reason = classify_import_failure(exc, module, boot=_process_boot_build())
+        if reason is None:
+            return False
+        logger.error("turn aborted by a mid-install import failure: %s", reason, exc_info=exc)
+        boot = _process_boot_build()
+        current = None
+        try:
+            from local_operator.update import installed_build
+
+            current = installed_build()
+        except Exception:  # noqa: BLE001 — the detail is a nicety
+            current = None
+        detail = (
+            f" ({boot.label()} → {current.label()})"
+            if boot is not None and current is not None and current.label() != boot.label()
+            else ""
+        )
+        self.note_cut_off("install-mid-update", detail)
+        return True
+
     async def refresh_attention(self) -> dict[str, Any]:
         """Reconcile cross-process receipts without changing the read watermark."""
         from local_operator.session.attention import (
@@ -6072,9 +6270,19 @@ class Session:
                 and saved.get("eligible", True)
             ):
                 await asyncio.to_thread(
-                    store.publish, identity, saved["token"], saved["anchor"], saved["kind"]
+                    store.publish,
+                    identity,
+                    saved["token"],
+                    saved["anchor"],
+                    saved["kind"],
+                    reason=str(saved.get("reason") or ""),
+                    cause=str(saved.get("cause") or ""),
                 )
             self._attention_restored = True
+        # The in-process TUI never calls ``async_init``, so this is its only
+        # route to the restored cut-off notice. Deduped on the token, so the
+        # runtime path (which calls both) narrates exactly once.
+        await self._journal_restored_cut_off()
         state = await asyncio.to_thread(store.state, identity)
         if state != self._attention:
             self._attention = state
@@ -6106,6 +6314,7 @@ class Session:
         self._attention_outcome = None
         if outcome is None:
             return
+        self._attention_run_settled = True
         # A delegating parent's first idle boundary is not a finished task.
         delegated = any(job.type == "task" and job.status == "running" for job in self.jobs.list())
         messages = [
@@ -6115,8 +6324,33 @@ class Session:
             and getattr(message, "role", None) == "assistant"
             and getattr(message, "text", "")
         ]
-        kind = "error" if outcome.error else "interrupted" if outcome.aborted else "complete"
+        # The classifier (``_classify_cut_off``) has already rewritten an
+        # unwanted cut-off into ``aborted=False, error=<notice>``, so this reads
+        # the two facts it needs rather than re-deriving them: ``cut_off`` says
+        # the end marker is an involuntary stop, and ``aborted`` alone still
+        # means the deliberate one.
+        cut_off = bool(self._cut_off_cause)
+        kind = (
+            "error"
+            if (outcome.error or cut_off)
+            else "interrupted" if outcome.aborted else "complete"
+        )
         token = self._attention_run_token or str(uuid.uuid4())
+        # The DURABLE reason. For a cut-off it is the harness-authored cause
+        # sentence, never the live notice's longer framing: this string is what
+        # the sidebar, the phone and the next incident card print, and the
+        # tooltip has one line. A provider error keeps its own message, and a
+        # deliberate stop names itself so a later restore can tell it apart from
+        # an unexplained cut-off.
+        if cut_off:
+            cause = self._cut_off_cause
+            reason = render_cut_off_reason(cause, detail=self._cut_off_detail)
+        elif kind == "interrupted":
+            cause = "user-stop"
+            reason = render_cut_off_reason(cause)
+        else:
+            cause = ""
+            reason = outcome.error or ""
         if kind == "complete" and (not messages or delegated):
             await self._transcript.append_custom(
                 ATTENTION_CUSTOM_TYPE,
@@ -6139,6 +6373,8 @@ class Session:
                 "token": token,
                 "anchor": anchor,
                 "kind": kind,
+                "cause": cause,
+                "reason": reason,
             },
         )
         self._attention = await asyncio.to_thread(
@@ -6147,7 +6383,15 @@ class Session:
             token,
             anchor,
             kind,
+            reason=reason,
+            cause=cause,
         )
+        # The model has to learn WHY even when this process survives the
+        # cut-off (a graceful termination signal aborts the turn and then exits,
+        # but a retirement that caught a live turn does not). Deduped on the
+        # token so a restore of the same run does not narrate it twice.
+        if cut_off:
+            await self._journal_cut_off_once(token, reason, cause)
         self.refresh_frontend_state()
 
     @property
@@ -6395,6 +6639,13 @@ class Session:
 
     async def _emit(self, event: AgentEvent) -> None:
         if isinstance(event, AgentEndEvent):
+            # BEFORE the handler fan-out and before the outcome fold: an
+            # involuntary cut-off is re-labelled here as a plain error with a
+            # named reason, so every existing consumer (the TUI's error notice,
+            # the title's ✗, the snapshot's ``last_turn_outcome``, the durable
+            # publish) does the right thing without being taught a new field. A
+            # deliberate stop is left exactly as it was.
+            event = self._classify_cut_off(event)
             self._attention_outcome = event
             # The emitted end is the logical turn's outcome (held ends flush
             # here from the pipeline finally; abort/error skip the hold and
@@ -6406,6 +6657,10 @@ class Session:
                 self._last_turn_outcome = "aborted"
             else:
                 self._last_turn_outcome = "completed"
+            # Rides the snapshot beside the outcome so a viewer that rebinds
+            # after the turn settled can name the cause instead of the "turn
+            # failed" placeholder.
+            self._last_turn_cut_off = event.cut_off
         if isinstance(event, ModelChangeEvent) and event.context_metadata:
             current = self.effective_model
             primary = (self._model.provider, self._model.model_id) == (
@@ -6666,6 +6921,16 @@ class Session:
             begin_message()
         self._attention_outcome = None
         self._attention_run_token = str(uuid.uuid4())
+        # This run has not yet said how it ended; a teardown that finds it so
+        # must publish the outcome itself (see ``Session.dispose``).
+        self._attention_run_settled = False
+        # Cleared at the head of EVERY turn, alongside the outcome, so a cause
+        # noted for a previous turn cannot label this one: the end event that
+        # consumes it is emitted from THIS turn's finally, and a stale cause
+        # would otherwise turn a healthy turn into an error.
+        self._cut_off_cause = ""
+        self._cut_off_detail = ""
+        self._deliberate_stop_noted = False
         from local_operator.session.attention import conversation_identity
 
         # A process dying after result persistence but before outcome publication
@@ -6687,6 +6952,16 @@ class Session:
                 may_drop=may_drop,
             )
             await self._drain_continuation()
+        except ImportError as exc:
+            # A lazy import against a HALF-REPLACED install is the one failure
+            # whose cause the traceback cannot state: ``lop-update`` replaces
+            # the installed tree in place, so the module may resolve while the
+            # NAME does not (design §1.6/§5.2). Named here — and re-raised, so
+            # today's error reporting is unchanged — because this is the only
+            # point in the turn that sees the exception without a provider
+            # adapter having already flattened it into a message.
+            self._note_import_failure(exc, "local_operator.session.session")
+            raise
         finally:
             self._turn_task = None
             await self._flush_held_end()
@@ -7520,7 +7795,7 @@ class Session:
         if parked:
             self._context.messages.extend(parked)
 
-    async def journal_incident(self, raw: str) -> None:
+    async def journal_incident(self, raw: str, *, token: str = "", rendered: str = "") -> None:
         """Persist and surface WHY the session last failed.
 
         The failover cascade rotates credentials and models and its notices
@@ -7531,6 +7806,13 @@ class Session:
         appended to the LIVE context so the very next turn sees it, and
         persisted so ``--resume`` replays it.
 
+        ``rendered`` overrides the classifier's own text for the one caller
+        whose incident is harness-authored rather than provider-derived: a
+        cut-off has no vendor text to classify, so its reason is built from
+        ``incidents.CUT_OFF_CAUSES`` and must not be pushed back through the
+        substring rules. ``token`` rides in ``details`` so the same orphaned
+        run is narrated at most once (see ``_journal_cut_off_once``).
+
         Holds ``_journal_lock`` across the persist-then-append pair so a
         notice fired immediately after cannot overtake it: this method awaits a
         transcript write and :meth:`journal_mcp_recovery` awaits nothing, so
@@ -7540,11 +7822,14 @@ class Session:
 
         if self._disposed or not raw:
             return
-        text = format_incident_message(raw, self._model.provider, self._model.model_id)
+        text = rendered or format_incident_message(raw, self._model.provider, self._model.model_id)
+        details: dict[str, Any] = {"text": text, "raw": raw[:1000]}
+        if token:
+            details["token"] = token
         message = CustomMessage(
             custom_type=SESSION_INCIDENT_MESSAGE_TYPE,
             attribution="system",
-            details={"text": text, "raw": raw[:1000]},
+            details=details,
         )
         try:
             async with self._journal_lock:
@@ -7552,6 +7837,41 @@ class Session:
                 self._append_or_park_journal(message)
         except OSError:
             logger.warning("could not journal session incident", exc_info=True)
+
+    async def _journal_cut_off_once(self, token: str, reason: str, cause: str) -> None:
+        """Narrate one run's cut-off into the transcript, at most once.
+
+        The dedupe is on the TOKEN, and it is load-bearing rather than tidy:
+        an orphaned ``attention_started`` stays in the transcript forever (its
+        repair lives in the attention store, not the journal), so
+        ``_import_transcript_outcome`` re-classifies the same run on every boot.
+        Without this the model would be told about one cut-off once per open,
+        each time as if it were news.
+
+        The scan is over the transcript's own rows rather than a
+        ``latest_custom`` call, and that is a correction to the design rather
+        than a stylistic choice: ``Transcript._index_entry`` only indexes
+        ``ENTRY_CUSTOM`` rows for ``latest_custom``, while an incident is
+        written as a ``CustomMessage`` — a ``message`` row carrying
+        ``custom_type`` in its payload — precisely so the model sees it in the
+        live context. A ``latest_custom`` probe therefore returns ``None`` for
+        every incident this code has ever written and would let each boot
+        narrate again (measured: two identical rows after two boots). Scanning
+        the payloads also removes the design's accepted weakness that a later
+        incident of any kind would hide an older cut-off's token.
+        """
+        if self._disposed or not token:
+            return
+        try:
+            for entry in self._transcript.entries():
+                if entry.payload.get("custom_type") != SESSION_INCIDENT_MESSAGE_TYPE:
+                    continue
+                details = entry.payload.get("details")
+                if isinstance(details, dict) and str(details.get("token") or "") == token:
+                    return
+        except Exception:  # noqa: BLE001 — a dedupe read must not block the notice
+            pass
+        await self.journal_incident(reason, token=token, rendered=format_cut_off_raw(reason))
 
     async def journal_model_switch(
         self,
@@ -12161,6 +12481,14 @@ class Session:
         if self._disposed:
             return
         self._disposed = True
+        # In-process disposal is a cut-off for whatever turn is running: this
+        # path is reached by a host tearing a session down directly (the
+        # runtime's own handle disposes through ``ServingSessionHandle``, which
+        # notes its more specific cause FIRST, and first-wins keeps that one).
+        # Harmless when nothing is in flight — the cause is consumed only by the
+        # running turn's end event — and suppressed outright after a deliberate
+        # stop, so a user's own cancel is never relabelled.
+        self.note_cut_off("disposed")
         unsubscribe_state = getattr(self, "_unsubscribe_subagent_state", None)
         if unsubscribe_state is not None:
             unsubscribe_state()
@@ -12194,6 +12522,33 @@ class Session:
                     await asyncio.wait_for(asyncio.shield(turn), timeout=5.0)
                 except BaseException:  # noqa: BLE001 — dispose must always proceed
                     pass
+            if self._attention_run_token is not None and not self._attention_run_settled:
+                # STILL OWES AN OUTCOME, and nothing else will write one. A turn
+                # parked in a TOOL is cancelled at its await, so the loop never
+                # reaches the ``AgentEndEvent`` it would otherwise yield: the
+                # pipeline's finally runs `_publish_attention_outcome` with
+                # `_attention_outcome` unset and the run leaves NO durable
+                # outcome. A restore then reclassified it from absence and
+                # reported a user's own `/stop` as an unexplained cut-off —
+                # reproduced on a real runtime, so the design's "the deliberate
+                # stop is recorded in the outcome marker itself" did not hold
+                # for the one shape the operator actually hits.
+                #
+                # Keyed on the RUN and its settled flag rather than on the turn
+                # TASK being live: a prompt dispatched over the control socket is
+                # cancelled when that socket closes, so by the time dispose looks
+                # the task is already done and "was a turn live?" answers no for
+                # exactly the case this exists for. Synthesising the end goes
+                # through the SAME classifier and publisher, so the
+                # deliberate/error split is still decided in one place.
+                try:
+                    if self._attention_outcome is None:
+                        self._attention_outcome = self._classify_cut_off(
+                            AgentEndEvent(messages=[], aborted=True)
+                        )
+                    await self._publish_attention_outcome()
+                except Exception:  # noqa: BLE001 — teardown must always proceed
+                    logger.warning("could not publish a disposed turn's outcome", exc_info=True)
             # The browser surface is session-scoped and lives in the user's own
             # browser, so an unclosed one is a tab THEY have to close by hand.
             # After the turn has stopped (so nothing is mid-navigation on it)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3417,6 +3417,11 @@ class OperatorApp(App[None]):
         #: dropped, because a row from a conversation the user can no longer
         #: see must never be stamped with a later outcome's anchor.
         self._own_interrupt_notice: NoticeBlock | None = None
+        #: The outcome kind the held notice was painted for, so the adoption
+        #: can refuse a publication about a DIFFERENT outcome. Carried with the
+        #: block through the presentation (see
+        #: ``SessionPresentation.own_interrupt_kind``).
+        self._own_interrupt_kind: str = ""
         #: Controllers that were replaced by a swap which KEPT the transcript,
         #: so a steer receipt still in flight from one of them is about a row
         #: this app is still holding and must still settle it (review round 1,
@@ -4903,6 +4908,7 @@ class OperatorApp(App[None]):
             deferred_steer_notices=self._deferred_steer_notices,
             held_steer_blocks=self._held_steer_blocks,
             own_interrupt_notice=self._own_interrupt_notice,
+            own_interrupt_kind=self._own_interrupt_kind,
             welcome=self._welcome,
             welcome_visible=self._welcome_visible,
         )
@@ -4936,6 +4942,7 @@ class OperatorApp(App[None]):
         # outcome anchor is still coming, and an app that forgot it would let
         # the poller print a second `Interrupted` under the live row on return.
         self._own_interrupt_notice = presentation.own_interrupt_notice
+        self._own_interrupt_kind = presentation.own_interrupt_kind
         self._welcome = presentation.welcome
         self._welcome_visible = None
         # Gesture tasks belong to the abandoned viewport, not its history.
@@ -11337,6 +11344,7 @@ class OperatorApp(App[None]):
         # where the other row references are dropped rather than relying on a
         # downstream guard to notice.
         self._own_interrupt_notice = None
+        self._own_interrupt_kind = ""
         # And the takeover allowance, which only ever protects rows: with the
         # rows gone there is nothing left for a superseded controller's receipt
         # to settle, and an entry outliving them would re-open the very race
@@ -19097,6 +19105,7 @@ class OperatorApp(App[None]):
         # waiting for has nothing left to land on. Dropped here for the same
         # reason as the rows above: a reference outliving its widget.
         self._own_interrupt_notice = None
+        self._own_interrupt_kind = ""
         # Same reason as the swap path: the allowance exists only to let a
         # takeover's in-flight receipt reach a row that is still on screen.
         self._superseded_steer_controllers.clear()
@@ -19772,16 +19781,28 @@ class OperatorApp(App[None]):
     def _adopt_own_interrupt_notice(self, kind: str, anchor: str) -> bool:
         """Stamp a published outcome onto the row this app already painted.
 
-        Returns True when the held `interrupted` row IS the announcement of
-        this outcome, so the caller must not append its own. The row keeps its
-        own wording (`interrupted`, `warning`): it is the live, turn-scoped
-        statement and restating it as the poller's dimmer `Interrupted` would
-        rewrite a row the user has already read for no gain.
+        Returns True when the held outcome row IS the announcement of this
+        outcome, so the caller must not append its own. The row keeps its own
+        wording (the live `interrupted`/error sentence): it is the live,
+        turn-scoped statement and restating it as the poller's dimmer
+        `Interrupted`/`Stopped with an error` would rewrite a row the user has
+        already read for no gain.
 
-        ONLY for `interrupted`. An `error` outcome is a different fact and the
-        live row for it says something else, so a stopped-with-an-error
-        publication must still get its own row rather than silently borrowing
-        the interruption's.
+        BOTH KINDS, and the kind must MATCH. This used to accept only
+        `interrupted`, on the reasoning that an `error` outcome "is a different
+        fact" whose live row says something else — true, but it left the live
+        error row and the poller's `Stopped with an error` both standing, so
+        every turn that ended with a provider error painted the failure TWICE.
+        The duplicate is not a new defect of the cut-off work: it is the same
+        one-interruption-two-rows shape the aborted branch already fixed, on the
+        branch that never got the fix (`_own_interrupt_notice` was only ever
+        set in the aborted branch). Adopting an error row is correct for the
+        same reason it is correct for an interruption: one outcome, one row.
+
+        The kind guard stays, because a MISMATCH is a real disagreement — a held
+        `interrupted` row must not be stamped with an error's anchor, or the
+        poller's error notice would be suppressed in favour of a row that says
+        something else.
 
         The row must still be MOUNTED. A `/clear` or a session swap removes it
         while this reference survives to the next tick, and stamping an anchor
@@ -19797,7 +19818,9 @@ class OperatorApp(App[None]):
         outcome was on screen the whole time.
         """
         block = self._own_interrupt_notice
-        if kind != "interrupted" or block is None:
+        if kind not in {"interrupted", "error"} or block is None:
+            return False
+        if self._own_interrupt_kind and self._own_interrupt_kind != kind:
             return False
         if block not in self._transcript_view().blocks():
             # NOT consumed. Clearing the reference before this test burnt it on
@@ -19812,6 +19835,7 @@ class OperatorApp(App[None]):
         # Consumed only once it has actually been stamped: one outcome, one
         # adoption, and a later publication must get its own row.
         self._own_interrupt_notice = None
+        self._own_interrupt_kind = ""
         block.completion_anchor_id = anchor
         return True
 
@@ -20563,9 +20587,20 @@ class OperatorApp(App[None]):
                     # away, where no live row was ever painted here.
                     if self._adopt_own_interrupt_notice(state["kind"], anchor):
                         return  # Let the committed frame paint before measuring it.
-                    block = NoticeBlock(
-                        "Stopped with an error" if state["kind"] == "error" else "Interrupted"
-                    )
+                    reason = str(state.get("reason") or "")
+                    if state["kind"] == "error":
+                        # The reason is what makes this row actionable rather
+                        # than merely alarming: "Stopped with an error" says a
+                        # class, `— the runtime retired so the next engage would
+                        # run a newer build` says what to do about it.
+                        text = (
+                            f"Stopped with an error — {reason}"
+                            if reason
+                            else "Stopped with an error"
+                        )
+                    else:
+                        text = "Interrupted"
+                    block = NoticeBlock(text)
                     block.completion_anchor_id = anchor
                     self._append_block(block)
                     return  # Let the committed frame paint before measuring it.
@@ -35637,6 +35672,7 @@ class OperatorApp(App[None]):
         # last one, which would leave the new outcome with no row at all while
         # marking an older one read.
         self._own_interrupt_notice = None
+        self._own_interrupt_kind = ""
         # A deferred completion belongs to the turn that finished, and a NEW
         # turn supersedes it: the session is working again, so "task complete"
         # would announce a finish while the agent is mid-stream — and the new
@@ -35770,7 +35806,18 @@ class OperatorApp(App[None]):
             cost=cost_text,
         )
         if message.error:
-            self._append_block(NoticeBlock(self._with_recovery_hint(message.error), "error"))
+            notice = NoticeBlock(self._with_recovery_hint(message.error), "error")
+            self._append_block(notice)
+            # HELD for the same reason `_finalize_turn` holds the interrupted
+            # row: the attention poller reads the same durable outcome back a
+            # tick later and dedupes only by `completion_anchor_id`, which this
+            # row cannot carry at paint time (the anchor is minted when the
+            # session publishes). Without the hold the live error and the
+            # poller's `Stopped with an error` announced ONE failure twice —
+            # a pre-existing defect on the provider-error path, fixed here by
+            # the same mechanism the aborted branch already used.
+            self._own_interrupt_notice = notice
+            self._own_interrupt_kind = "error"
         # NOT `elif`: `_finalize_turn` owns the "interrupted" notice now, so
         # this handler's chain ends at the error notice.
         self._finalize_turn(aborted=message.aborted, error=message.error, source="agent_end")
@@ -36071,6 +36118,7 @@ class OperatorApp(App[None]):
             # from here and `· Interrupted` from the poll, which is the
             # reported defect. See `_adopt_own_interrupt_notice`.
             self._own_interrupt_notice = interrupted
+            self._own_interrupt_kind = "interrupted"
         self._interrupted_cards = 0
         # EVERY turn end reconciles its queued rows, because the invariant is
         # simply stated: a row still held when a turn ends is one this turn did

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -20538,6 +20538,7 @@ class OperatorApp(App[None]):
         self.run_worker(run(), group="background-notify")
 
     async def _poll_completion_attention(self) -> None:
+        from local_operator.harness.rows import completion_notice
         from local_operator.tui.attention import terminal_is_foreground
 
         # BEFORE the guards below, which are about the ATTACHED session's read
@@ -20587,20 +20588,17 @@ class OperatorApp(App[None]):
                     # away, where no live row was ever painted here.
                     if self._adopt_own_interrupt_notice(state["kind"], anchor):
                         return  # Let the committed frame paint before measuring it.
-                    reason = str(state.get("reason") or "")
-                    if state["kind"] == "error":
-                        # The reason is what makes this row actionable rather
-                        # than merely alarming: "Stopped with an error" says a
-                        # class, `— the runtime retired so the next engage would
-                        # run a newer build` says what to do about it.
-                        text = (
-                            f"Stopped with an error — {reason}"
-                            if reason
-                            else "Stopped with an error"
-                        )
-                    else:
-                        text = "Interrupted"
-                    block = NoticeBlock(text)
+                    # The words AND the tier come from `harness/rows.py`, the
+                    # module that owns this row on both surfaces. Passing no kind
+                    # painted the error branch in the quiet `info` tier — a
+                    # cut-off came back as a dim `·` whisper, in the ink of the
+                    # routine `Interrupted` control one branch down, while the
+                    # live row for the same event is `✗` danger (design review
+                    # round 1, D1; UX U4).
+                    text, severity = completion_notice(
+                        str(state["kind"]), str(state.get("reason") or "")
+                    )
+                    block = NoticeBlock(text, cast(NoticeKind, severity))
                     block.completion_anchor_id = anchor
                     self._append_block(block)
                     return  # Let the committed frame paint before measuring it.
@@ -26440,6 +26438,20 @@ class OperatorApp(App[None]):
         session = self._session
         if session is None or not session.owns_runtime:
             return
+        # THE DELIBERATE VERDICT IS RECORDED WHERE THE DELIBERATE ACT IS KNOWN
+        # — here, and BEFORE the dispose below. `Session.dispose()` notes
+        # `disposed` unconditionally (it is the involuntary-teardown default),
+        # so without this the very next end event is classified as an error
+        # with `cause=disposed`: a bare `/stop` on the user's own TUI-owned
+        # session published a FALSE FAILURE reading "the session was disposed
+        # while this turn was running" (review round 1, BLOCKER-1). The socket
+        # rung has recorded it since the taxonomy landed (`serving.py`
+        # `request_stop`); this in-process rung is the one bare `/stop` and a
+        # peer's `lop stop` (through `TuiSessionHandle.request_stop`) actually
+        # take, which is why the suite's blind spot sat on the DEFAULT path.
+        note_stop = getattr(session, "note_deliberate_stop", None)
+        if callable(note_stop):
+            note_stop()
         # Detach the session FIRST, before any await: this coroutine can be
         # entered twice for one session (a peer's ``stop`` op through
         # ``TuiSessionHandle.request_stop`` racing a local ``/stop all``),
@@ -35820,7 +35832,17 @@ class OperatorApp(App[None]):
             self._own_interrupt_kind = "error"
         # NOT `elif`: `_finalize_turn` owns the "interrupted" notice now, so
         # this handler's chain ends at the error notice.
-        self._finalize_turn(aborted=message.aborted, error=message.error, source="agent_end")
+        self._finalize_turn(
+            aborted=message.aborted,
+            error=message.error,
+            source="agent_end",
+            # The turn's own verdict on WHY it stopped, which only the end event
+            # carries. Passed rather than inferred from `aborted`/`error`: the
+            # whole taxonomy flip is that a cut-off arrives as
+            # `aborted=False, error=<notice>`, so an inference here would read
+            # every cut-off as a completion (design review round 1, D2).
+            cut_off=message.cut_off,
+        )
 
     def on_turn_abandoned(self, message: TurnAbandoned) -> None:
         """Retire a turn whose worker returned without a terminal ``agent_end``.
@@ -35957,8 +35979,16 @@ class OperatorApp(App[None]):
         error: str | None,
         source: str,
         outcome_known: bool = True,
+        cut_off: bool = False,
     ) -> None:
         """Retire the turn. The ONE exit, however the turn ended.
+
+        ``cut_off`` says the end marker was an INVOLUNTARY stop rather than a
+        completion or the user's own cancel. It is the end event's own verdict
+        (``AgentEndEvent.cut_off_cause``), passed rather than re-derived here,
+        and its one use is the wording of the stranded tool cards: a turn cut
+        off says ``cut off`` on each card instead of ``interrupted``, which is
+        now reserved for a recorded stop (design review round 1, D2).
 
         Every terminal side effect a turn owes the user lives here — the
         working line, the band, the waiting latch, the per-turn cost accrual,
@@ -36095,7 +36125,7 @@ class OperatorApp(App[None]):
         # decision below reads; a bare assignment would reset it to 0 and an
         # aborted turn would regain the duplicate standalone "interrupted"
         # notice that the per-card marks exist to replace.
-        self._interrupted_cards += self._retire_live_tool_cards()
+        self._interrupted_cards += self._retire_live_tool_cards(cut_off=cut_off)
         if was_open and aborted and not self._interrupted_cards:
             # Only when NOTHING was in flight. A stopped turn already says so on
             # each card it stopped (`⊘ interrupted`), and that per-card mark is
@@ -36671,8 +36701,17 @@ class OperatorApp(App[None]):
         self._interrupted_cards = self._retire_live_tool_cards()
         self._refresh_working_activity()
 
-    def _retire_live_tool_cards(self) -> int:
+    def _retire_live_tool_cards(self, *, cut_off: bool = False) -> int:
         """Settle every card still claiming to be live, and say how many.
+
+        ``cut_off`` is the TURN's verdict, passed in by the one caller that
+        knows it (:meth:`_finalize_turn`, from the end event): with it, the
+        stranded rows say ``cut off`` rather than ``interrupted``, so a card and
+        the ``✗ turn cut off`` notice below it describe one death in one word
+        instead of re-opening the ambiguity the taxonomy removed (design review
+        round 1, D2). Every other caller — a reload, a session swap, a
+        deliberate ``/stop`` — leaves it False, which prints the historical
+        word for the historical meaning.
 
         Composing rows count too: a turn that ends while the model is still
         dictating a call leaves a row that will never start, and leaving it
@@ -36708,7 +36747,7 @@ class OperatorApp(App[None]):
         """
         cards = list(self._tool_cards.values()) + list(self._composing_cards.values())
         for card in cards:
-            card.mark_interrupted()
+            card.mark_interrupted(cut_off=cut_off)
         self._tool_cards.clear()
         self._composing_cards.clear()
         return len(cards)

--- a/local_operator/tui/events.py
+++ b/local_operator/tui/events.py
@@ -106,10 +106,18 @@ class TurnEnded(SessionEvent):
         context_tokens: int = 0,
         usage: Any = None,
         context_is_estimate: bool = False,
+        cut_off: bool = False,
     ) -> None:
         super().__init__()
         self.aborted = aborted
         self.error = error
+        #: True when the session CLASSIFIED this end as an involuntary cut-off
+        #: (``AgentEndEvent.cut_off_cause``). A distinct fact from ``aborted``,
+        #: and the only one that can tell a runtime death apart from the user's
+        #: own cancel: the taxonomy reports both as an aborted end, with the
+        #: cut-off carrying an error notice beside it. Consumers that need the
+        #: WORD (the stranded ledger cards) read this.
+        self.cut_off = cut_off
         self.context_tokens = context_tokens
         self.usage = usage
         self.context_is_estimate = context_is_estimate
@@ -784,6 +792,11 @@ class EventController:
                 context_tokens=(settled_context if settled_context is not None else context_tokens),
                 usage=usage,
                 context_is_estimate=settled_context is not None,
+                # The classifier's verdict, carried beside the outcome it
+                # rewrote: `_classify_cut_off` reports a cut-off as
+                # `aborted=False, error=<notice>`, so the fact that this was an
+                # involuntary stop exists nowhere else on the wire.
+                cut_off=bool(getattr(event, "cut_off_cause", "") or getattr(event, "cut_off", "")),
             )
         )
 

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -579,6 +579,13 @@ class SessionPresentation:
     #: poller append a second `Interrupted` under the live `interrupted` — the
     #: duplicate row `OperatorApp._adopt_own_interrupt_notice` exists to remove.
     own_interrupt_notice: Any = None
+    #: Which outcome kind ``own_interrupt_notice`` was painted for — "interrupted"
+    #: or "error". The adoption must refuse when the published kind differs from
+    #: the row it holds, and the block cannot be asked (its kind is consumed into
+    #: a token and a glyph at construction). Carried WITH the block, because the
+    #: pair is what makes the dedupe survive a session switch: the block alone
+    #: would come back unable to recognise its own outcome.
+    own_interrupt_kind: str = ""
     welcome: Any = None
     welcome_visible: bool | None = False
 

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -1090,6 +1090,15 @@ class ToolCard(ExpandableActionBlock):
         self._clock_timer: Timer | None = None
         self._duration: float | None = None
         self._error: str = ""
+        #: The word this card's ``interrupted`` state prints. Set by
+        #: :meth:`mark_interrupted` from the turn's verdict — an involuntary
+        #: cut-off earns ``cut off``, because ``interrupted`` is now reserved for
+        #: a positively recorded stop and a stranded ``interrupted`` row beside a
+        #: ``turn cut off`` notice re-states the exact ambiguity the taxonomy
+        #: removed (design review round 1, D2). Defaulted to the historical word
+        #: because every other route into this state (a replayed row with no
+        #: result, a viewer teardown that knows no verdict) still means it.
+        self._interrupt_label: str = "interrupted"
         #: When THIS card's execution began, or ``None`` when the card cannot
         #: know. ``None`` is the replay case and it is not a missing value to
         #: be defaulted: a card rebuilt by a surface that is re-painting a
@@ -1261,8 +1270,15 @@ class ToolCard(ExpandableActionBlock):
         self._refresh_row()
         self.finalize()
 
-    def mark_interrupted(self) -> None:
-        """Turn ended before this tool completed: dim 'interrupted' state.
+    def mark_interrupted(self, *, cut_off: bool = False) -> None:
+        """Turn ended before this tool completed: dim state, and WHY it ended.
+
+        ``cut_off`` selects the word from the TURN's verdict, which is knowledge
+        only the caller has: a turn cut off by anything but a deliberate stop
+        prints ``cut off`` here, so the stranded row agrees with the ``✗ turn cut
+        off`` notice under it instead of calling the same death ``interrupted``
+        (design review round 1, D2). The glyph and the dim tier do not move — the
+        word was the ambiguity.
 
         Takes NO ``measured_s``, unlike :meth:`mark_done` and
         :meth:`mark_failed`, and the asymmetry is a property of the path rather
@@ -1294,6 +1310,7 @@ class ToolCard(ExpandableActionBlock):
             self._summary = f"never sent · {self._compose_facts}"
         self._duration = self._elapsed()
         self._state = "interrupted"
+        self._interrupt_label = "cut off" if cut_off else "interrupted"
         self.remove_class("tool-running")
         self.add_class("tool-interrupted")
         self._refresh_row()
@@ -2870,7 +2887,7 @@ class ToolCard(ExpandableActionBlock):
         if self._state == "interrupted":
             # `bindings.BY_ELEMENT["tool.status.interrupted"]` deliberately
             # keeps `dim`, not a hue: see its note.
-            glyph, reason = ICON_INTERRUPTED, "interrupted"
+            glyph, reason = ICON_INTERRUPTED, self._interrupt_label
             tint = bindings.style("tool.status.interrupted")
             abbreviates = False
         else:

--- a/local_operator/update.py
+++ b/local_operator/update.py
@@ -815,6 +815,52 @@ def installed_build(prefix: str | Path | None = None) -> BuildStamp:
     return BuildStamp(version=installed_version(), source_ref=source_ref(prefix))
 
 
+def classify_import_failure(
+    exc: BaseException, module: str, *, boot: BuildStamp | None
+) -> str | None:
+    """Name a mid-install import as ``install-mid-update``, or ``None``.
+
+    ``lop-update`` and :func:`perform_upgrade` replace the installed tree IN
+    PLACE, so a process that loaded the old build can hit a lazy
+    ``from local_operator… import x`` the new tree no longer satisfies — the
+    observed shape is precise: the module still resolves, the NAME does not
+    (``ImportError: cannot import name '_journal_injection_ids' from
+    'local_operator.session.transcript'``, 605 times on one machine's log).
+
+    What separates that from a genuine packaging bug is the STAMP MOVING UNDER
+    THE PROCESS. If the install on disk still matches the build this process
+    booted from, the miss is ours and must stay an ordinary traceback — so
+    ``None``. A ``boot`` we could not read (``None``) also answers ``None``:
+    without a baseline there is nothing to compare, and guessing here would
+    relabel a real packaging error as an install race.
+
+    ``module`` is what the CALLER was importing, used when the exception itself
+    names nothing (some wrappers drop ``name``).
+    """
+    if not isinstance(exc, ImportError):
+        return None
+    named = str(getattr(exc, "name", "") or "")
+    text = str(exc) or ""
+    if not (
+        named.startswith("local_operator")
+        or module.startswith("local_operator")
+        or "local_operator" in text
+    ):
+        return None
+    if boot is None:
+        return None
+    try:
+        current = installed_build()
+    except Exception:  # noqa: BLE001 — an unreadable stamp is not evidence
+        return None
+    if current == boot:
+        return None
+    from local_operator.incidents import render_cut_off_reason
+
+    detail = "" if current.label() == boot.label() else f" ({boot.label()} → {current.label()})"
+    return render_cut_off_reason("install-mid-update", detail=detail)
+
+
 def build_marker_age_s(prefix: str | Path | None = None) -> float | None:
     """Seconds since the install on disk was last written, or ``None``.
 

--- a/tests/e2e/test_cut_off_turns_e2e.py
+++ b/tests/e2e/test_cut_off_turns_e2e.py
@@ -1,0 +1,455 @@
+"""A turn cut off by anything but a deliberate stop is an ERROR, with a reason.
+
+The operator's report, verbatim: "occasionally, sessions like this will just get
+interrupted after running for a while, I think it has something to do with
+updates ... results in some sessions being forgotten about if you're running
+many at once for long runtimes", and "make sure that errors are properly called
+out in all situations so at least we see it in active sessions as errored".
+
+Before this change a runtime killed mid-turn left an ``attention_started`` with
+no outcome, and the next boot published ``interrupted`` for it — the same shape
+a user's own ``/stop`` produces. These tests reproduce that shape with REAL
+processes: the production ``process.py`` is booted in a subprocess, a real turn
+is parked in the real ``bash`` tool (the mock provider's ``[bash:N]`` marker),
+and the runtime is killed. The successor boot then has to classify it.
+
+Isolation: the ``headless_tui_env`` fixture redirects the config dir and the
+root conftest redirects ``HOME``. The child's environment is rebuilt here with
+EVERY ``CMUX_*`` removed regardless, because a runtime that inherited a
+workspace id could address the operator's live window (#648). No provider key is
+needed: everything runs on ``hosting: test`` / ``model_name: mock``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.session.runtime import registry
+from local_operator.session.transcript import Transcript
+from tests.e2e.harness import ScriptedStream, build_session, text_turn
+from tests.e2e.watchdog import bounded
+
+pytestmark = pytest.mark.e2e
+
+#: Long enough that the kill lands well inside the sleep, short enough that a
+#: leaked child cannot outlive the test's cleanup budget by much.
+PARK_S = 30
+
+
+def _seed(config_dir: Path, session_id: str) -> Path:
+    """A session with one durable row, on the mock provider.
+
+    ``tool_approval_mode: auto`` because the parked turn calls the REAL ``bash``
+    tool: with the gate armed the runtime would park on an approval prompt
+    instead of in the sleep, which is a different (and covered) shape.
+    """
+    directory = config_dir / "sessions" / session_id
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "transcript.jsonl").write_text(
+        '{"id": "seed", "ts": 1, "type": "message", "payload": {"kind": "message", '
+        '"role": "user", "content": [{"type": "text", "text": "seed"}]}}\n',
+        encoding="utf-8",
+    )
+    (config_dir / "config.yml").write_text(
+        "values:\n  hosting: test\n  model_name: mock\n  tool_approval_mode: auto\n",
+        encoding="utf-8",
+    )
+    return directory
+
+
+def _child_env(config_dir: Path, session_id: str) -> dict[str, str]:
+    env = {k: v for k, v in os.environ.items() if not k.startswith("CMUX_")}
+    env.update(
+        {
+            "LOCAL_OPERATOR_CONFIG_DIR": str(config_dir),
+            "LOP_MOBILE_CHILD_CWD": str(config_dir),
+            "LOP_MOBILE_CHILD_RESUME": session_id,
+            # Never the quiet exit: these tests are about a DEATH mid-turn, and
+            # a grace that expired under the test would be a different cause.
+            "LOP_SESSION_GRACE_S": "600",
+        }
+    )
+    return env
+
+
+def _spawn(config_dir: Path, session_id: str) -> subprocess.Popen[bytes]:
+    return subprocess.Popen(
+        [sys.executable, "-m", "local_operator.session.runtime.process"],
+        env=_child_env(config_dir, session_id),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+async def _wait_for_record(config_dir: Path, session_id: str, timeout: float = 30.0) -> Any:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        for record, _state in registry.scan(config_dir):
+            if getattr(record, "session_id", "") == session_id:
+                return record
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"no record for {session_id} within {timeout}s")
+
+
+async def _never_take_over() -> Any:
+    raise AssertionError("a viewer never takes over a session")
+
+
+async def _attach(config: Path, session_id: str, app: Any = None) -> Any:
+    """The production viewer for ``session_id`` (no takeover).
+
+    The real client is what makes "the turn is genuinely under way" observable:
+    ``prompt`` returns on durable admission and the viewer's facade reports
+    ``streaming`` once the owner is running the turn.
+    """
+    from local_operator.session.attached import AttachedSession
+
+    record = await _wait_for_record(config, session_id)
+    return await AttachedSession.connect(
+        record, session_id, config_dir=config, takeover_factory=_never_take_over
+    )
+
+
+async def _park_a_turn(viewer: Any, directory: Path, seconds: int = PARK_S) -> None:
+    """Prompt a real turn that holds the real ``bash`` tool open.
+
+    Readiness is taken from the VIEWER's streaming flag rather than from the
+    transcript: the assistant row carrying the tool call is persisted at the
+    message boundary, so a transcript-only probe can miss a turn that is
+    already parked. ``streaming`` is set when the owner starts the turn and
+    cleared when it ends, which is exactly the window the kill must land in.
+    """
+    await viewer.prompt(f"please [bash:{seconds}]")
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        state = getattr(viewer, "frontend_state", None)
+        if state is not None and getattr(state, "streaming", False):
+            # Past the point where the model answered and the tool is running.
+            await asyncio.sleep(1.0)
+            return
+        await asyncio.sleep(0.2)
+    raise AssertionError(
+        f"the turn never started; transcript:\n"
+        f"{(directory / 'transcript.jsonl').read_text(encoding='utf-8')[-2000:]}"
+    )
+
+
+async def _successor_boot(directory: Path) -> Any:
+    """Boot a REAL successor session over the same directory — the restore path.
+
+    This is the production classification seam: ``Session.__init__`` calls
+    ``bootstrap_transcript`` and ``async_init`` journals the restored cut-off.
+    """
+    session = build_session(directory, stream=ScriptedStream([text_turn("ok")]))
+    await session.async_init()
+    return session
+
+
+def _rendered_history_text(session: Any) -> str:
+    """The next turn's model-visible text, through the production converter."""
+    from local_operator.session.session import _default_convert_to_llm
+
+    rendered = _default_convert_to_llm(list(session._context.messages))
+    parts: list[str] = []
+    for message in rendered:
+        for block in message.content:
+            text = getattr(block, "text", None)
+            if text:
+                parts.append(str(text))
+    return "\n".join(parts)
+
+
+def _incidents(directory: Path) -> list[Any]:
+    """Every ``session_incident`` row, however it was written.
+
+    Filtered on ``payload.custom_type`` rather than on the row TYPE: a
+    ``CustomMessage`` is persisted as an ordinary ``message`` row carrying
+    ``custom_type`` in its payload, while ``append_custom`` writes a ``custom``
+    row. Matching the payload is what the product's own ``latest_custom`` does,
+    and it is the only filter that sees both writers.
+    """
+    return [
+        entry
+        for entry in Transcript(directory).entries()
+        if entry.payload.get("custom_type") == "session_incident"
+    ]
+
+
+def _row_text(row: Any) -> str:
+    """The text of one projection row, whichever shape the frame serialized it.
+
+    ``_projection_frame`` caps and serializes rows through the projection
+    layer, so a row arrives as either the ``to_json`` string or the plain dict;
+    reading only one of the two makes an assertion silently about the other.
+    """
+    if isinstance(row, dict):
+        return str(row.get("text") or "")
+    return str(row)
+
+
+def _reap(child: subprocess.Popen[bytes], config_dir: Path) -> None:
+    try:
+        child.kill()
+    except ProcessLookupError:
+        pass
+    child.wait(timeout=10)
+    for record, _state in registry.scan(config_dir):
+        try:
+            os.kill(record.pid, 9)
+        except ProcessLookupError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_a_turn_cut_off_by_a_killed_runtime_reports_an_error_with_a_reason(
+    headless_tui_env: Path,
+) -> None:
+    """Cell A — the case-study shape, end to end.
+
+    SIGKILL a runtime parked in a real tool, then boot the successor and assert
+    every surface the operator asked about: the durable kind is ``error`` with a
+    non-empty reason, exactly ONE ``[session incident]`` reaches the transcript,
+    the NEXT turn's history carries it, the sidebar says "Unseen error" with the
+    cause, and the phone projection's notice names it too.
+    """
+    from local_operator.mobile.daemon import _durable_projection, _projection_frame
+    from local_operator.session.attention import AttentionStore, conversation_identity
+    from local_operator.session.catalog import load_catalog
+
+    config = headless_tui_env
+    session_id = "cutoffkill01"
+    directory = _seed(config, session_id)
+    child = _spawn(config, session_id)
+    viewer = None
+    try:
+        with bounded(120, "cut-off: killed runtime"):
+            viewer = await _attach(config, session_id)
+            await _park_a_turn(viewer, directory)
+            killed_pid = None
+            for candidate, _state in registry.scan(config):
+                if candidate.session_id == session_id:
+                    killed_pid = int(candidate.pid)
+            assert killed_pid == child.pid, (killed_pid, child.pid)
+
+            # SIGKILL: no exception path, no disposal, no marker — the case
+            # study's death shape.
+            child.kill()
+            child.wait(timeout=10)
+            await asyncio.sleep(0.2)
+            assert "from the mock provider" not in (directory / "transcript.jsonl").read_text(
+                encoding="utf-8"
+            ), "the turn completed, so nothing was cut off"
+
+            # The successor boot is what classifies and narrates the orphaned run.
+            session = await _successor_boot(directory)
+            try:
+                state = AttentionStore().state(conversation_identity(directory))
+                assert state["kind"] == "error", state
+                assert state["cause"] == "runtime-killed", state
+                assert state["reason"], "a cut-off must name a reason"
+                assert state["anchor_id"].startswith("completion-")
+
+                incidents = _incidents(directory)
+                assert len(incidents) == 1, f"expected one incident, got {len(incidents)}"
+                assert incidents[0].payload["details"]["token"]
+
+                rendered = _rendered_history_text(session)
+                assert "[session incident]" in rendered
+                assert "cut-off" in rendered
+
+                # A SECOND boot must not narrate the same run again.
+                second = await _successor_boot(directory)
+                try:
+                    assert len(_incidents(directory)) == 1, "re-opening re-narrated the cut-off"
+                finally:
+                    await second.dispose()
+
+                # Reap the killed owner's record first: the catalog reports a
+                # row with a live-looking owner as "Working", which is true of
+                # the RECORD and false of the session, and would mask the
+                # outcome spelling this assertion is about.
+                registry.scan(config)
+                rows = {entry.id: entry for entry in load_catalog(config)}
+                sidebar = rows[session_id].status
+                assert sidebar.startswith("Unseen error"), sidebar
+                assert sidebar.split(" — ", 1)[-1] in state["reason"], sidebar
+
+                projection = _durable_projection(session_id)
+                assert projection is not None, "the phone projection vanished"
+                frame = _projection_frame(projection)
+                notice = [
+                    text
+                    for text in (_row_text(row) for row in frame["transcript"])
+                    if "Stopped with an error" in text
+                ]
+                assert notice, [_row_text(row) for row in frame["transcript"]][-3:]
+                assert state["reason"] in notice[0]
+                assert f"pid {killed_pid}" in state["reason"] or (
+                    "could not be determined" in state["reason"]
+                )
+            finally:
+                await session.dispose()
+    finally:
+        if viewer is not None:
+            try:
+                await viewer.dispose()
+            except Exception:  # noqa: BLE001 — teardown of a killed owner
+                pass
+        if child.poll() is None:
+            _reap(child, config)
+
+
+@pytest.mark.asyncio
+async def test_a_deliberate_stop_still_reports_interrupted(
+    headless_tui_env: Path,
+) -> None:
+    """Cell C — the fix must not turn a user's own cancel into an error.
+
+    The taxonomy flips the DEFAULT for a cut-off; a stop that was actually asked
+    for has to keep saying so, with the cause recorded, and must NOT journal an
+    incident (there is nothing to explain to the model).
+    """
+    from local_operator.session.attention import AttentionStore, conversation_identity
+    from local_operator.session.runtime.control import stop_session
+
+    config = headless_tui_env
+    session_id = "cutoffstop01"
+    directory = _seed(config, session_id)
+    child = _spawn(config, session_id)
+    viewer = None
+    try:
+        with bounded(120, "cut-off: deliberate stop"):
+            viewer = await _attach(config, session_id)
+            # A park the abort can actually drain inside the graceful rung: the
+            # deliberate marker is written by the turn's own finally, so a turn
+            # that outlives the ladder's timeout would be killed before it could
+            # say it was stopped on purpose.
+            await _park_a_turn(viewer, directory, seconds=3)
+            record = await _wait_for_record(config, session_id)
+            # A REAL `lop stop`: the graceful socket rung first, signals only
+            # if it does not answer.
+            outcome = await stop_session(record, timeout_s=10, _root=config)
+            assert outcome.method == "socket", outcome
+            child.wait(timeout=15)
+
+            session = await _successor_boot(directory)
+            try:
+                state = AttentionStore().state(conversation_identity(directory))
+                assert state["kind"] == "interrupted", state
+                assert state["cause"] == "user-stop", repr(state)
+                assert _incidents(directory) == [], "a deliberate stop must not journal an incident"
+            finally:
+                await session.dispose()
+    finally:
+        if viewer is not None:
+            try:
+                await viewer.dispose()
+            except Exception:  # noqa: BLE001
+                pass
+        if child.poll() is None:
+            _reap(child, config)
+
+
+@pytest.mark.asyncio
+async def test_a_provider_refusal_is_reported_exactly_as_before(
+    headless_tui_env: Path,
+) -> None:
+    """The LIVE path is untouched for a provider error.
+
+    The mock's ``[refuse]`` ends the stream as a refusal, which the loop turns
+    into an error end event. The classification must not touch it: the reason is
+    the provider's own message, and there is no harness cause — a cut-off marker
+    overwriting a provider diagnosis would throw away the more specific fault.
+    """
+    config = headless_tui_env
+    session_id = "cutoffrefuse1"
+    directory = _seed(config, session_id)
+    child = _spawn(config, session_id)
+    viewer = None
+    try:
+        from local_operator.session.attention import (
+            AttentionStore,
+            conversation_identity,
+        )
+
+        with bounded(120, "cut-off: provider refusal"):
+            viewer = await _attach(config, session_id)
+            await viewer.prompt("please [refuse]")
+            identity = conversation_identity(directory)
+            deadline = time.monotonic() + 30
+            state: dict[str, Any] = {}
+            while time.monotonic() < deadline:
+                state = AttentionStore().state(identity)
+                if state["kind"]:
+                    break
+                await asyncio.sleep(0.2)
+            assert state["kind"] == "error", state
+            assert "can't help" in state["reason"] or "refus" in state["reason"], state
+            assert state["cause"] == "", "a provider error is not a harness cut-off"
+    finally:
+        if viewer is not None:
+            try:
+                await viewer.dispose()
+            except Exception:  # noqa: BLE001
+                pass
+        _reap(child, config)
+
+
+@pytest.mark.asyncio
+async def test_the_next_turn_after_a_restore_carries_the_incident(
+    headless_tui_env: Path,
+) -> None:
+    """The model must be told, not only the human.
+
+    A restored cut-off is replayed into the NEXT turn's provider history: the
+    successor runs a real turn over the scripted stream and the request it made
+    contains the ``[session incident]`` text. Asserted on the request the
+    production loop actually sent, not on the transcript.
+    """
+    config = headless_tui_env
+    session_id = "cutoffnext01"
+    directory = _seed(config, session_id)
+    child = _spawn(config, session_id)
+    viewer = None
+    try:
+        with bounded(120, "cut-off: next turn carries the incident"):
+            viewer = await _attach(config, session_id)
+            await _park_a_turn(viewer, directory)
+            child.kill()
+            child.wait(timeout=10)
+
+            stream = ScriptedStream([text_turn("done")])
+            session = build_session(directory, stream=stream)
+            await session.async_init()
+            try:
+                await session.prompt("what happened?")
+                assert stream.requests, "the successor never called the provider"
+                sent = "\n".join(
+                    message.text
+                    for message in stream.requests[-1].messages
+                    if getattr(message, "text", "")
+                )
+                assert "[session incident]" in sent
+                assert "cut-off" in sent
+                assert "do not assume the request completed" in sent
+            finally:
+                await session.dispose()
+    finally:
+        if viewer is not None:
+            try:
+                await viewer.dispose()
+            except Exception:  # noqa: BLE001
+                pass
+        if child.poll() is None:
+            _reap(child, config)

--- a/tests/e2e/test_cut_off_turns_e2e.py
+++ b/tests/e2e/test_cut_off_turns_e2e.py
@@ -23,6 +23,7 @@ needed: everything runs on ``hosting: test`` / ``model_name: mock``.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 import subprocess
 import sys
@@ -32,6 +33,7 @@ from typing import Any
 
 import pytest
 
+from local_operator.session.attached import RECOVERY_GIVE_UP_S
 from local_operator.session.runtime import registry
 from local_operator.session.transcript import Transcript
 from tests.e2e.harness import ScriptedStream, build_session, text_turn
@@ -450,6 +452,141 @@ async def test_the_next_turn_after_a_restore_carries_the_incident(
             try:
                 await viewer.dispose()
             except Exception:  # noqa: BLE001
+                pass
+        if child.poll() is None:
+            _reap(child, config)
+
+
+@pytest.mark.asyncio
+async def test_a_tui_owned_stop_through_the_dispose_route_reports_interrupted(
+    headless_tui_env: Path,
+) -> None:
+    """Cell D — the OTHER rung of the kill switch: in-process, no control op.
+
+    Cell C drives ``lop stop`` over the socket, which is the one rung that has
+    recorded the deliberate verdict since the taxonomy landed. The route the
+    user's own bare ``/stop`` takes in a TUI-owned session is this one — the app
+    disposes the session in place — and it published ``kind=error,
+    cause=disposed``: "the session was disposed while this turn was running" on
+    a cancel the user asked for, on the default path (review round 1,
+    BLOCKER-1). Asserted on the durable store, because a live-only notice would
+    have hidden it.
+
+    The turn is parked in the REAL ``bash`` tool (an in-process session with a
+    scripted tool call), so it is genuinely mid-flight when the stop lands —
+    the same shape the socket-rung cell uses, without a spawned runtime.
+    """
+    from local_operator.session.attention import AttentionStore, conversation_identity
+    from local_operator.tools.builtin import build_bash_tool
+    from local_operator.tui.app import OperatorApp
+    from tests.e2e.harness import tool_call_turn, wait_for_adoption
+
+    config = headless_tui_env
+    session_id = "cutoffdispose1"
+    directory = _seed(config, session_id)
+    stream = ScriptedStream(
+        [
+            tool_call_turn(
+                text="holding the turn open",
+                tool_name="bash",
+                tool_call_id="call-parked",
+                arguments={"command": "sleep 30"},
+            ),
+            text_turn("the stop landed before this"),
+        ]
+    )
+    session = build_session(directory, stream, tools=[build_bash_tool()], cwd=config)
+
+    async def factory() -> Any:
+        # The app awaits its factory: production's boots or attaches and is a
+        # coroutine, so handing it a session directly fails adoption with
+        # "'Session' object can't be awaited" rather than adopting it.
+        return session
+
+    app = OperatorApp(factory)
+    with bounded(90, "cut-off: dispose-route stop"):
+        async with app.run_test(size=(100, 30)) as pilot:
+            await wait_for_adoption(app, pilot)
+            # NOT awaited: an in-process session's ``prompt`` returns when the
+            # turn ends, so awaiting it here would block until the parked tool
+            # had finished and left nothing to stop.
+            task = asyncio.create_task(session.prompt("hold this turn open"))
+            deadline = time.monotonic() + 30
+            while time.monotonic() < deadline:
+                if getattr(session, "is_streaming", False):
+                    await asyncio.sleep(0.5)
+                    break
+                await asyncio.sleep(0.05)
+            assert session.is_streaming, "the turn never started"
+            assert app._session is session, "the app must own the session for this route"
+
+            await app._stop_local_session()
+            await pilot.pause()
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(task, timeout=30)
+
+        state = AttentionStore().state(conversation_identity(directory))
+        assert state["kind"] == "interrupted", state
+        assert state["cause"] == "user-stop", state
+        assert _incidents(directory) == [], "a stop the user asked for is not an incident"
+
+
+@pytest.mark.asyncio
+async def test_a_watched_runtime_killed_mid_turn_ends_with_a_named_cut_off(
+    headless_tui_env: Path,
+) -> None:
+    """The operator's reported flow: the session dies while you are WATCHING it.
+
+    The successor-boot cells above classify a death after the fact. This one is
+    the screen in front of the user when it happens, and it used to be the worst
+    outcome of the change: a viewer built through ``connect()`` has
+    ``_can_go_cold`` False, so the recovery loop took its legacy give-up arm and
+    synthesised the BARE abort a user's Esc produces — ``aborted=True,
+    error=None`` — while the branch that named a cause was unreachable. Measured
+    at the time: card ``interrupted ⊘ 11s``, no notice, no reason, durable state
+    still ``kind=None`` at t≈98 s (QA round 1, Q-1; UX U1).
+    """
+    from local_operator.harness.types import AgentEndEvent
+    from local_operator.session.attached import COLD_FALLBACK_S
+
+    config = headless_tui_env
+    session_id = "cutoffwatched1"
+    directory = _seed(config, session_id)
+    child = _spawn(config, session_id)
+    viewer = None
+    ends: list[AgentEndEvent] = []
+    try:
+        with bounded(120, "cut-off: watched kill"):
+            viewer = await _attach(config, session_id)
+            assert viewer._can_go_cold is False, "this cell is about the legacy arm"
+            viewer.subscribe(
+                lambda event: ends.append(event) if isinstance(event, AgentEndEvent) else None
+            )
+            await _park_a_turn(viewer, directory)
+            started = time.monotonic()
+            child.kill()
+            child.wait(timeout=10)
+
+            deadline = time.monotonic() + COLD_FALLBACK_S + 15
+            while time.monotonic() < deadline and not ends:
+                await asyncio.sleep(0.05)
+            elapsed = time.monotonic() - started
+            assert len(ends) == 1, f"expected one synthesised end, got {len(ends)}"
+            (end,) = ends
+            # The taxonomy shape, not a bare abort: this is what lets every
+            # existing surface paint a failure with a reason.
+            assert end.aborted is False, end
+            assert end.error, "a cut-off must carry the notice"
+            assert end.cut_off_cause == "owner-lost", end
+            assert (
+                elapsed < RECOVERY_GIVE_UP_S
+            ), f"the cut-off waited {elapsed:.1f}s, which is the give-up path"
+            assert "cut off" in str(end.error)
+    finally:
+        if viewer is not None:
+            try:
+                await viewer.dispose()
+            except Exception:  # noqa: BLE001 — teardown of a killed owner
                 pass
         if child.poll() is None:
             _reap(child, config)

--- a/tests/unit/mobile/test_attention.py
+++ b/tests/unit/mobile/test_attention.py
@@ -251,3 +251,45 @@ def test_relay_only_cap_and_unknown_old_owner_never_claim_complete() -> None:
 def test_legacy_metadata_mtime_is_not_a_completion(tmp_path: Path) -> None:
     daemon = MobileDaemon(port=0, password="isolated-test")
     assert not daemon.table._is_unseen("no-outcome", SimpleNamespace(mtime=1e30), None)
+
+
+@pytest.mark.parametrize(
+    "kind,reason,expected_text,expected_severity",
+    [
+        (
+            "error",
+            "the runtime was terminated while this turn was running",
+            "Stopped with an error — the runtime was terminated while this turn was running",
+            "error",
+        ),
+        ("error", "", "Stopped with an error", "error"),
+        ("interrupted", "the session was stopped by the user", "Interrupted", "info"),
+    ],
+)
+def test_the_phone_notice_carries_the_tier_the_row_deserves(
+    kind: str, reason: str, expected_text: str, expected_severity: str
+) -> None:
+    """D4: the phone flattened a cut-off into the routine receipt tier.
+
+    ``NoticeRow`` picks its glyph and ink from ``details.severity``, and the
+    frame carried an empty ``details`` — so a cut-off rendered as the same dim
+    ``·`` as ``Interrupted``, indistinguishable from a routine receipt, while
+    the TUI painted the same event in danger ink. The tier is derived in
+    ``harness/rows.py`` (both surfaces) rather than at each serialization site.
+    """
+    projection = SessionProjection(
+        session_id="sev-session",
+        pid=0,
+        attention={
+            "conversation_id": "session/sev-session",
+            "completion_token": str(uuid.uuid4()),
+            "anchor_id": "completion-t",
+            "kind": kind,
+            "reason": reason,
+            "unseen": True,
+            "revision": [1, 0],
+        },
+    )
+    row = _projection_frame(projection)["transcript"][-1]
+    assert row["text"] == expected_text
+    assert row["details"] == {"severity": expected_severity}

--- a/tests/unit/mobile/test_projection.py
+++ b/tests/unit/mobile/test_projection.py
@@ -1233,3 +1233,36 @@ def test_a_repeated_supersession_does_not_disturb_an_already_rekeyed_row() -> No
     assert len(tool_rows) == 1
     assert tool_rows[0].tool_call_id == "real_0"
     assert tool_rows[0].details["argument_bytes"] == 30
+
+
+def test_a_cut_off_turn_still_offers_the_phones_resume_affordance() -> None:
+    """MAJOR-1: a cut-off must not read as "completed" on the phone.
+
+    ``stop_reason`` is the wire fact ``composer.tsx`` gates
+    ``interrupted — tap to resume`` on, and the taxonomy flip reports a cut-off
+    as ``aborted=False, error=<notice>`` — so folding ``aborted`` alone told the
+    phone the turn had FINISHED and silently removed the only recovery
+    affordance for exactly the sessions the operator reports losing. A cut-off
+    did not complete; it was cut off, which is what ``cut_off``/``cut_off_cause``
+    states.
+    """
+    from local_operator.incidents import format_cut_off_notice, render_cut_off_reason
+
+    fold = ProjectionFold(SessionProjection(session_id="cutoff-phone", pid=1))
+    fold.fold_event(
+        AgentEndEvent(
+            generation=1,
+            aborted=False,
+            error=format_cut_off_notice("owner-lost"),
+            cut_off=render_cut_off_reason("owner-lost"),
+            cut_off_cause="owner-lost",
+        )
+    )
+    assert fold.projection.streaming is False
+    assert fold.projection.stop_reason == "aborted"
+
+    # The control: a clean end still reads as a completion, or every finished
+    # turn would offer a pointless resume.
+    clean = ProjectionFold(SessionProjection(session_id="clean-phone", pid=1))
+    clean.fold_event(AgentEndEvent(generation=1))
+    assert clean.projection.stop_reason == "completed"

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -454,6 +454,7 @@ _BOUNDED_JOB_FIELDS = {
     "latest_details": "one progress payload, replaced not appended",
     "usage": "folded by _fold_job_usage_in_place",
     "attempt_aliases": "one id per collapsed resume attempt",
+    "cut_off_cause": "one cause token from the cut-off vocabulary",
 }
 
 #: Row fields bounded by THIS module, each of which the frame guard must
@@ -650,7 +651,14 @@ def test_the_attach_frame_fits_for_a_session_that_ran_all_year(tmp_path: Path) -
     read_token = str(uuid.uuid4())
     attention_store.publish("session/s1", read_token, "old-result", "complete")
     attention_store.acknowledge("session/s1", read_token)
-    attention = attention_store.publish("session/s1", str(uuid.uuid4()), "new-result", "complete")
+    attention = attention_store.publish(
+        "session/s1",
+        str(uuid.uuid4()),
+        "new-result",
+        "error",
+        reason="R" * 5_000,
+        cause="runtime-killed",
+    )
     assert set(attention) == {
         "conversation_id",
         "completion_token",
@@ -658,7 +666,16 @@ def test_the_attach_frame_fits_for_a_session_that_ran_all_year(tmp_path: Path) -
         "kind",
         "unseen",
         "revision",
+        "reason",
+        "cause",
     }
+    # Published at the store's own cap: the field is one string per
+    # conversation, and the ceiling this fixture exists to police is why it is
+    # capped rather than passed through.
+    from local_operator.session.attention import REASON_WIRE_CHARS
+
+    assert len(attention["reason"]) == REASON_WIRE_CHARS
+    assert attention["cause"] == "runtime-killed"
     assert attention["unseen"] and attention["revision"] == [2, 1]
 
     # Every collection field, filled past anything a real session reaches.

--- a/tests/unit/session/test_attention.py
+++ b/tests/unit/session/test_attention.py
@@ -909,7 +909,12 @@ def test_reason_and_cause_round_trip_and_an_old_database_migrates(
     store = AttentionStore(path)
     token = str(uuid.uuid4())
     store.publish(
-        "session/a", token, "anchor", "error", reason="the runtime went away", cause="runtime-killed"
+        "session/a",
+        token,
+        "anchor",
+        "error",
+        reason="the runtime went away",
+        cause="runtime-killed",
     )
     state = store.state("session/a")
     assert state["reason"] == "the runtime went away"

--- a/tests/unit/session/test_attention.py
+++ b/tests/unit/session/test_attention.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
+import os
 import sqlite3
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from local_operator.session.attention import AttentionStore, conversation_identity
+from local_operator.session.transcript import Transcript
 
 
 def _provisional_anchor(token: str) -> str:
@@ -195,8 +200,15 @@ async def test_crash_and_fork_journal_identity(tmp_path: Path) -> None:
         Message(role="assistant", content=[TextContent(text="durable result")])
     )
     bootstrap_transcript(owner, store)
-    assert store.state("session/owner")["kind"] == "interrupted"
-    assert store.state("session/owner")["unseen"]
+    # An in-flight run whose owner is GONE and whose record left no evidence is
+    # an ERROR naming the uncertainty, not an interruption: the taxonomy's
+    # default flipped because a cut-off we cannot explain is not a stop. This
+    # assertion read ``interrupted`` before the cut-off work.
+    crashed = store.state("session/owner")
+    assert crashed["kind"] == "error"
+    assert crashed["cause"] == "runtime-killed"
+    assert "the cause could not be determined" in crashed["reason"]
+    assert crashed["unseen"]
     store.acknowledge("session/owner", token)
     bootstrap_transcript(owner, store)
     assert not store.state("session/owner")["unseen"]
@@ -722,3 +734,217 @@ def test_the_desktop_is_just_another_claimant_with_no_special_path(tmp_path: Pat
     store.publish("session/a", newer, "result-2", "complete")
     assert AttentionStore(path).claim_delivery("session/a", newer, "desktop") is True
     assert AttentionStore(path).claim_delivery("session/a", newer, "cmux") is False
+
+
+# -- the cut-off taxonomy's restore path (design §3.4/§8.1 tests 2-6) ---------
+
+
+def _record_json(session_id: str, pid: int) -> dict[str, Any]:
+    """One discovery record naming ``session_id``, in the shape the runtime writes."""
+    return {
+        "pid": pid,
+        "kind": "daemon",
+        "session_id": session_id,
+        "conversation_name": session_id,
+        "cwd": "/tmp",
+        "model_label": "test/mock",
+        "control_port": 1,
+        "control_key": "k",
+        "version": "1.2.3",
+        "source_ref": "abcdef0",
+    }
+
+
+def _seed_started(root: Path, session_id: str) -> str:
+    """An ``attention_started`` with no outcome, as a killed runtime leaves it."""
+    directory = root / "sessions" / session_id
+    directory.mkdir(parents=True, exist_ok=True)
+    token = str(uuid.uuid4())
+    transcript = Transcript(directory)
+    asyncio.run(
+        transcript.append_custom(
+            "attention_started", {"conversation_id": f"session/{session_id}", "token": token}
+        )
+    )
+    return token
+
+
+def _write_record(root: Path, session_id: str, pid: int) -> None:
+    run = root / "run" / "mobile"
+    run.mkdir(parents=True, exist_ok=True)
+    (run / f"{pid}.json").write_text(json.dumps(_record_json(session_id, pid)), encoding="utf-8")
+
+
+def test_an_orphaned_run_without_evidence_is_an_error_with_a_named_uncertainty(
+    tmp_path: Path,
+) -> None:
+    """Design test 1: no live owner, no record, no stop marker."""
+    from local_operator.session.attention import bootstrap_transcript
+    from local_operator.session.transcript import Transcript
+
+    session_id = "orphan1"
+    token = _seed_started(tmp_path, session_id)
+    store = AttentionStore(tmp_path / "attention.db")
+    result = bootstrap_transcript(Transcript(tmp_path / "sessions" / session_id), store)
+    assert result is not None
+    kind, cause, _reason, returned = result
+    assert (kind, cause, returned) == ("error", "runtime-killed", token)
+    state = store.state(f"session/{session_id}")
+    assert state["kind"] == "error"
+    assert state["cause"] == "runtime-killed"
+    assert "could not be determined" in state["reason"]
+    assert state["unseen"] is True
+
+
+def test_a_live_owner_stops_the_import_from_publishing_anything(tmp_path: Path) -> None:
+    """Design test 2 — the false-alarm guard, and the load-bearing part of this PR.
+
+    A daemon sweep (or a resume) that runs mid-turn must publish NOTHING: a
+    provisional ``error`` written for a healthy run would be believed by every
+    surface and hidden by the busy-suppression, which is the worst combination.
+    A FOREIGN live pid is the case; our own must NOT count, or a successor
+    runtime could never classify its predecessor's orphaned run.
+    """
+    import subprocess
+    import sys
+
+    from local_operator.session.attention import bootstrap_transcript
+    from local_operator.session.transcript import Transcript
+
+    session_id = "live1"
+    _seed_started(tmp_path, session_id)
+    foreign = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        _write_record(tmp_path, session_id, foreign.pid)
+        store = AttentionStore(tmp_path / "attention.db")
+        result = bootstrap_transcript(Transcript(tmp_path / "sessions" / session_id), store)
+        assert result is None
+        assert store.state(f"session/{session_id}")["kind"] is None
+    finally:
+        foreign.kill()
+        foreign.wait(timeout=10)
+
+
+def test_our_own_record_does_not_block_the_classification(tmp_path: Path) -> None:
+    """A successor publishes its own record BEFORE it builds its Session."""
+    from local_operator.session.attention import bootstrap_transcript
+    from local_operator.session.transcript import Transcript
+
+    session_id = "successor1"
+    _seed_started(tmp_path, session_id)
+    _write_record(tmp_path, session_id, os.getpid())
+    store = AttentionStore(tmp_path / "attention.db")
+    result = bootstrap_transcript(Transcript(tmp_path / "sessions" / session_id), store)
+    assert result is not None, "a runtime must be able to classify its predecessor's run"
+
+
+def test_a_dead_record_names_the_runtime_that_died(tmp_path: Path) -> None:
+    """Design test 3: the record's build, pid and start time ride the detail."""
+    from local_operator.session.attention import bootstrap_transcript
+    from local_operator.session.transcript import Transcript
+
+    session_id = "dead1"
+    _seed_started(tmp_path, session_id)
+    dead_pid = 2**22 + 7
+    _write_record(tmp_path, session_id, dead_pid)
+    store = AttentionStore(tmp_path / "attention.db")
+    result = bootstrap_transcript(Transcript(tmp_path / "sessions" / session_id), store)
+    assert result is not None
+    kind, cause, reason, _token = result
+    assert (kind, cause) == ("error", "runtime-killed")
+    assert f"pid {dead_pid}" in reason
+    assert "1.2.3@abcdef0" in reason
+
+
+def test_a_recorded_stop_marker_keeps_an_interruption(tmp_path: Path) -> None:
+    """Design test 4: positive evidence of a deliberate act, honoured after death."""
+    from local_operator.session.attention import bootstrap_transcript
+    from local_operator.session.transcript import Transcript
+    from local_operator.wakes.store import write_entry
+
+    session_id = "stopped1"
+    _seed_started(tmp_path, session_id)
+    schedule = {"id": "w1", "message": "later", "next_due_at": 1, "created_at": 1}
+    write_entry(
+        tmp_path,
+        session_id,
+        cwd=str(tmp_path),
+        schedules=[schedule],
+        preserve={"stopped_at": 12345},
+    )
+    store = AttentionStore(tmp_path / "attention.db")
+    result = bootstrap_transcript(Transcript(tmp_path / "sessions" / session_id), store)
+    assert result is not None
+    kind, cause, reason, _token = result
+    assert (kind, cause) == ("interrupted", "user-stop")
+    assert "stopped by the user" in reason
+    assert store.state(f"session/{session_id}")["kind"] == "interrupted"
+
+
+def test_a_provisional_error_is_still_superseded_by_the_real_completion(
+    tmp_path: Path,
+) -> None:
+    """Design test 5: the anchor, not the kind, is the replaceable signal.
+
+    Requiring ``stored_kind == "interrupted"`` here would brick exactly the
+    session the store's own docstring describes: the provisional record is now
+    published as an ``error``, and the same token's real ``complete`` must still
+    heal it.
+    """
+    store = AttentionStore(tmp_path / "attention.db")
+    token = str(uuid.uuid4())
+    store.publish("session/a", token, _provisional_anchor(token), "error", reason="boom")
+    assert store.state("session/a")["kind"] == "error"
+    store.publish("session/a", token, "the-real-entry", "complete")
+    state = store.state("session/a")
+    assert state["kind"] == "complete"
+    assert state["anchor_id"] == "the-real-entry"
+
+
+def test_reason_and_cause_round_trip_and_an_old_database_migrates(
+    tmp_path: Path,
+) -> None:
+    """Design test 6: the additive columns, plus the pre-change schema."""
+    path = tmp_path / "attention.db"
+    store = AttentionStore(path)
+    token = str(uuid.uuid4())
+    store.publish(
+        "session/a", token, "anchor", "error", reason="the runtime went away", cause="runtime-killed"
+    )
+    state = store.state("session/a")
+    assert state["reason"] == "the runtime went away"
+    assert state["cause"] == "runtime-killed"
+    assert store.state_many(["session/a"])["session/a"]["reason"] == "the runtime went away"
+
+    # An OLD database: the pre-taxonomy schema, with a row already in it.
+    old = tmp_path / "old.db"
+    with sqlite3.connect(old) as conn:
+        conn.execute(
+            "CREATE TABLE completions (sequence INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "conversation TEXT NOT NULL, token TEXT NOT NULL UNIQUE, anchor TEXT NOT NULL, "
+            "kind TEXT NOT NULL)"
+        )
+        conn.execute(
+            "CREATE TABLE receipts (conversation TEXT PRIMARY KEY, acknowledged INTEGER NOT NULL)"
+        )
+        old_token = str(uuid.uuid4())
+        conn.execute(
+            "INSERT INTO completions(conversation,token,anchor,kind) VALUES(?,?,?,?)",
+            ("session/old", old_token, "anchor", "interrupted"),
+        )
+    migrated = AttentionStore(old)
+    old_state = migrated.state("session/old")
+    assert old_state["kind"] == "interrupted"
+    assert old_state["reason"] == ""
+    assert old_state["cause"] == ""
+    # A READ did not migrate it: the read-only path must never alter a schema.
+    with sqlite3.connect(old) as conn:
+        columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(completions)")}
+    assert "reason" not in columns
+    # A WRITE migrates it, additively, and the new fields then round-trip.
+    new_token = str(uuid.uuid4())
+    migrated.publish("session/old", new_token, "anchor2", "error", reason="r", cause="c")
+    assert migrated.state("session/old")["cause"] == "c"
+    with sqlite3.connect(old) as conn:
+        columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(completions)")}
+    assert {"reason", "cause"} <= columns

--- a/tests/unit/session/test_attention.py
+++ b/tests/unit/session/test_attention.py
@@ -203,10 +203,12 @@ async def test_crash_and_fork_journal_identity(tmp_path: Path) -> None:
     # An in-flight run whose owner is GONE and whose record left no evidence is
     # an ERROR naming the uncertainty, not an interruption: the taxonomy's
     # default flipped because a cut-off we cannot explain is not a stop. This
-    # assertion read ``interrupted`` before the cut-off work.
+    # assertion read ``interrupted`` before the cut-off work, and the cause
+    # assertion read ``runtime-killed`` before a later round made the
+    # no-evidence branch stop naming a mechanism it cannot observe.
     crashed = store.state("session/owner")
     assert crashed["kind"] == "error"
-    assert crashed["cause"] == "runtime-killed"
+    assert crashed["cause"] == ""
     assert "the cause could not be determined" in crashed["reason"]
     assert crashed["unseen"]
     store.acknowledge("session/owner", token)
@@ -778,7 +780,16 @@ def _write_record(root: Path, session_id: str, pid: int) -> None:
 def test_an_orphaned_run_without_evidence_is_an_error_with_a_named_uncertainty(
     tmp_path: Path,
 ) -> None:
-    """Design test 1: no live owner, no record, no stop marker."""
+    """Design test 1: no live owner, no record, no stop marker.
+
+    The kind is still ``error`` — a cut-off nobody can explain is not a stop —
+    but the CAUSE is left empty and the sentence is the honest one. It used to
+    report ``runtime-killed`` with ``(the cause could not be determined)``
+    appended, which every surface that trims a parenthetical (the sidebar's
+    ``_error_label``) turned into a positive claim about a mechanism nobody
+    observed (design/UX review round 1, D3/U3).
+    """
+    from local_operator.incidents import CUT_OFF_UNKNOWN
     from local_operator.session.attention import bootstrap_transcript
     from local_operator.session.transcript import Transcript
 
@@ -787,13 +798,19 @@ def test_an_orphaned_run_without_evidence_is_an_error_with_a_named_uncertainty(
     store = AttentionStore(tmp_path / "attention.db")
     result = bootstrap_transcript(Transcript(tmp_path / "sessions" / session_id), store)
     assert result is not None
-    kind, cause, _reason, returned = result
-    assert (kind, cause, returned) == ("error", "runtime-killed", token)
+    kind, cause, reason, returned = result
+    assert (kind, cause, returned) == ("error", "", token)
+    assert reason == CUT_OFF_UNKNOWN
     state = store.state(f"session/{session_id}")
     assert state["kind"] == "error"
-    assert state["cause"] == "runtime-killed"
-    assert "could not be determined" in state["reason"]
+    assert state["cause"] == ""
+    assert state["reason"] == CUT_OFF_UNKNOWN
     assert state["unseen"] is True
+    # The sentence and the token must agree with each other, since the inverse
+    # (`cause_from_reason`) is what the live surfaces use to name a cause.
+    from local_operator.incidents import cause_from_reason
+
+    assert cause_from_reason(reason) == ""
 
 
 def test_a_live_owner_stops_the_import_from_publishing_anything(tmp_path: Path) -> None:

--- a/tests/unit/session/test_cut_off_turns.py
+++ b/tests/unit/session/test_cut_off_turns.py
@@ -1,0 +1,392 @@
+"""The cut-off taxonomy: what counts as an error, and what names the cause.
+
+The rule the operator asked for is "make sure that errors are properly called
+out in all situations". The behaviour these tests pin is the default flip: a
+turn cut off by anything the harness cannot attribute to a deliberate stop is an
+ERROR carrying a cause, and only positive evidence of a user's own stop records
+an interruption. The regression guard is the other direction — a real stop must
+never be relabelled a failure, which is the one misclassification the design
+calls worse than the bug it fixes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+
+import pytest
+
+from local_operator.harness.types import (
+    AgentEndEvent,
+    Message,
+    ModelSpec,
+    TextContent,
+    ToolCall,
+)
+from local_operator.incidents import format_cut_off_notice, render_cut_off_reason
+from local_operator.session.attention import AttentionStore, conversation_identity
+from local_operator.session.frontend_state import JobState
+from local_operator.session.session import _default_convert_to_llm
+from local_operator.session.transcript import Transcript
+
+MODEL = ModelSpec(provider="test", model_id="mock")
+
+
+def _make_session(directory: Path, *, stream: object | None = None):
+    from local_operator.session.session import Session
+
+    return Session(
+        model=MODEL,
+        stream_fn=stream or (lambda *_args, **_kwargs: None),
+        tools=[],
+        transcript=Transcript(directory),
+        system_blocks_provider=lambda *_args: [],
+    )
+
+
+def _rendered(history: object) -> str:
+    parts: list[str] = []
+    for message in _default_convert_to_llm(list(history)):  # type: ignore[arg-type]
+        for block in message.content:
+            text = getattr(block, "text", None)
+            if text:
+                parts.append(str(text))
+    return "\n".join(parts)
+
+
+# -- the live classifier -----------------------------------------------------
+
+
+def test_classify_cut_off_leaves_a_deliberate_stop_alone(tmp_path: Path) -> None:
+    """Design test 7a: no recorded cause → exactly today's shape.
+
+    ``aborted=True, error=None`` is what a user's Esc produces, and the whole
+    taxonomy change rests on this staying true.
+    """
+    session = _make_session(tmp_path / "sess")
+    event = AgentEndEvent(messages=[], aborted=True)
+    classed = session._classify_cut_off(event)
+    assert classed is event
+    assert classed.aborted is True
+    assert classed.error is None
+
+
+def test_classify_cut_off_rewrites_an_involuntary_abort(tmp_path: Path) -> None:
+    """Design test 7b: a noted cause becomes an error the old surfaces understand."""
+    session = _make_session(tmp_path / "sess")
+    session.note_cut_off("runtime-shutdown")
+    classed = session._classify_cut_off(AgentEndEvent(messages=[], aborted=True))
+    assert classed.aborted is False
+    assert classed.error == format_cut_off_notice("runtime-shutdown")
+    assert classed.cut_off_cause == "runtime-shutdown"
+    assert classed.cut_off == render_cut_off_reason("runtime-shutdown")
+
+
+def test_classify_cut_off_does_not_overwrite_a_provider_error(tmp_path: Path) -> None:
+    """A real provider diagnosis outranks "the runtime went away"."""
+    session = _make_session(tmp_path / "sess")
+    session.note_cut_off("runtime-killed")
+    event = AgentEndEvent(messages=[], aborted=False, error="quota exhausted")
+    assert session._classify_cut_off(event) is event
+
+
+def test_a_deliberate_stop_outranks_a_later_cut_off_note(tmp_path: Path) -> None:
+    """The stop rung is followed by the dispose rung, and the stop wins.
+
+    Both converge on the same clean-exit ordering, so the dispose rung ALWAYS
+    runs; without this precedence a user's `/stop` would be reported as the
+    runtime shutting down.
+    """
+    session = _make_session(tmp_path / "sess")
+    session.note_deliberate_stop()
+    session.note_cut_off("runtime-shutdown")
+    classed = session._classify_cut_off(AgentEndEvent(messages=[], aborted=True))
+    assert classed.aborted is True
+    assert classed.error is None
+
+
+def test_note_cut_off_keeps_the_first_and_most_specific_cause(tmp_path: Path) -> None:
+    """An exit is a sequence of rungs; the earliest note is the specific one."""
+    session = _make_session(tmp_path / "sess")
+    session.note_cut_off("runtime-retired", " (1.0@a → 1.1@b)")
+    session.note_cut_off("runtime-shutdown")
+    assert session._cut_off_cause == "runtime-retired"
+    assert session._cut_off_detail == " (1.0@a → 1.1@b)"
+
+
+# -- the durable outcome -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_names_the_cause_for_a_cut_off(tmp_path: Path) -> None:
+    """Design test 8: kind, cause and reason all land in the store and journal."""
+    from local_operator.session.attention import ATTENTION_CUSTOM_TYPE
+
+    directory = tmp_path / "sessions" / "s1"
+    session = _make_session(directory)
+    session._attention_run_token = str(uuid.uuid4())
+    session._attention_run_settled = False
+    session.note_cut_off("runtime-shutdown")
+    session._attention_outcome = session._classify_cut_off(AgentEndEvent(messages=[], aborted=True))
+    await session._publish_attention_outcome()
+
+    state = AttentionStore().state(conversation_identity(directory))
+    assert state["kind"] == "error"
+    assert state["cause"] == "runtime-shutdown"
+    assert state["reason"] == render_cut_off_reason("runtime-shutdown")
+    entry = Transcript(directory).latest_custom(ATTENTION_CUSTOM_TYPE)
+    assert entry is not None
+    assert entry["cause"] == "runtime-shutdown"
+    assert entry["reason"] == state["reason"]
+
+
+@pytest.mark.asyncio
+async def test_publish_keeps_a_deliberate_stop_interrupted(tmp_path: Path) -> None:
+    """Design test 9 — the regression guard for the whole taxonomy change."""
+    directory = tmp_path / "sessions" / "s2"
+    session = _make_session(directory)
+    session._attention_run_token = str(uuid.uuid4())
+    session._attention_run_settled = False
+    session._attention_outcome = AgentEndEvent(messages=[], aborted=True)
+    await session._publish_attention_outcome()
+
+    state = AttentionStore().state(conversation_identity(directory))
+    assert state["kind"] == "interrupted"
+    assert state["cause"] == "user-stop"
+    assert state["reason"] == render_cut_off_reason("user-stop")
+    incidents = [
+        entry
+        for entry in Transcript(directory).entries()
+        if entry.payload.get("custom_type") == "session_incident"
+    ]
+    assert incidents == [], "a deliberate stop is not something to explain to the model"
+
+
+@pytest.mark.asyncio
+async def test_a_restored_cut_off_reaches_the_next_turns_history(tmp_path: Path) -> None:
+    """Design test 10: the replay is the model's only account of what happened."""
+    directory = tmp_path / "sessions" / "s3"
+    directory.mkdir(parents=True)
+    token = str(uuid.uuid4())
+    transcript = Transcript(directory)
+    await transcript.append_custom(
+        "attention_started", {"conversation_id": "session/s3", "token": token}
+    )
+    await transcript.append_message(
+        Message(role="assistant", content=[TextContent(text="partial")])
+    )
+
+    session = _make_session(directory)
+    assert session._restored_cut_off is not None
+    await session.async_init()
+    rendered = _rendered(session._context.messages)
+    assert "[session incident]" in rendered
+    assert "cut-off" in rendered
+    assert "do not assume the request completed" in rendered
+
+    # And only once: a second boot must not narrate the same run again.
+    second = _make_session(directory)
+    await second.async_init()
+    incidents = [
+        entry
+        for entry in Transcript(directory).entries()
+        if entry.payload.get("custom_type") == "session_incident"
+    ]
+    assert len(incidents) == 1
+
+
+# -- restored subagent rows (D3) ---------------------------------------------
+
+
+def _row(job_id: str, status: str = "running") -> JobState:
+    return JobState(id=job_id, type="task", status=status, label=job_id)
+
+
+def _child_dir(tmp_path: Path, name: str) -> Path:
+    directory = tmp_path / "children" / name
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def test_restored_rows_prefer_the_records_settled_outcome(tmp_path: Path) -> None:
+    """D3 rule 1: a record that says ``completed`` is a fact, not an inference."""
+    from local_operator.session.attached import _restored_job_rows
+
+    rows = _restored_job_rows(
+        [_row("a")],
+        records=[{"job_id": "a", "outcome": "completed", "session_dir": str(tmp_path)}],
+    )
+    assert rows[0].status == "completed"
+    assert rows[0].restored is True
+    assert rows[0].cut_off_cause == ""
+
+
+def test_restored_rows_read_the_childs_tail_when_the_record_did_not_settle(
+    tmp_path: Path,
+) -> None:
+    """D3 rule 2: the child's own journal decides mid-turn from finished."""
+    from local_operator.session.attached import _restored_job_rows
+
+    mid = _child_dir(tmp_path, "mid")
+    transcript = Transcript(mid)
+    asyncio.run(
+        transcript.append_message(
+            Message(role="tool", content=[TextContent(text="ok")], tool_call_id="c1")
+        )
+    )
+    done = _child_dir(tmp_path, "done")
+    asyncio.run(
+        Transcript(done).append_message(
+            Message(
+                role="assistant", content=[TextContent(text="all finished")], stop_reason="stop"
+            )
+        )
+    )
+
+    rows = _restored_job_rows(
+        [_row("mid"), _row("done")],
+        records=[
+            {"job_id": "mid", "outcome": None, "session_dir": str(mid)},
+            {"job_id": "done", "outcome": None, "session_dir": str(done)},
+        ],
+    )
+    assert rows[0].status == "interrupted"
+    assert rows[0].cut_off_cause == "owner-lost"
+    assert rows[1].status == "completed"
+    assert rows[1].cut_off_cause == ""
+
+
+def test_restored_rows_without_records_keep_todays_behaviour(tmp_path: Path) -> None:
+    """D3 rule 3: no record and no transcript is still ``interrupted``."""
+    from local_operator.session.attached import _restored_job_rows
+
+    rows = _restored_job_rows([_row("orphan")])
+    assert rows[0].status == "interrupted"
+    assert rows[0].cut_off_cause == "owner-lost"
+
+
+def test_a_settled_row_is_never_relitigated(tmp_path: Path) -> None:
+    """A terminal status the last runtime settled is left exactly as it was."""
+    from local_operator.session.attached import _restored_job_rows
+
+    rows = _restored_job_rows(
+        [_row("c", "completed")],
+        records=[{"job_id": "c", "outcome": "failed", "session_dir": str(tmp_path)}],
+    )
+    assert rows[0].status == "completed"
+
+
+# -- the retirement latch (D4) ----------------------------------------------
+
+
+class _LatchHost:
+    """``ServingSessionHandle.begin_retire``'s real logic over a stub predicate.
+
+    The method is what the two retire paths and the quiet idle exit call, and
+    its contract is one synchronous step: commit iff idle, refuse admissions
+    from that instant. Exercising it against a stub keeps the assertion on the
+    latch rather than on a runtime boot, which the e2e stage covers.
+    """
+
+    from local_operator.session.runtime.serving import ServingSessionHandle as _H
+
+    begin_retire = _H.begin_retire
+    _retiring_refusal = _H._retiring_refusal
+
+    def __init__(self, *, reason: str = "") -> None:
+        self._retiring_cause = ""
+        self._session = None
+        self.reason = reason
+        self.notes: list[tuple[str, str]] = []
+
+    def may_refresh(self) -> str:
+        return self.reason
+
+
+class _NoteSession:
+    def __init__(self) -> None:
+        self.notes: list[tuple[str, str]] = []
+
+    def note_cut_off(self, cause: str, detail: str = "") -> None:
+        self.notes.append((cause, detail))
+
+
+def test_begin_retire_commits_when_idle_and_names_the_cause() -> None:
+    host = _LatchHost()
+    session = _NoteSession()
+    host._session = session
+    assert host.begin_retire("runtime-retired", " (1.0@a → 1.1@b)") is True
+    assert host._retiring_cause == "runtime-retired"
+    assert session.notes == [("runtime-retired", " (1.0@a → 1.1@b)")]
+    assert "runtime-retired" in host._retiring_refusal()
+
+
+def test_begin_retire_refuses_when_a_turn_is_held() -> None:
+    """Design test 11: a busy runtime never commits, so no admission is refused."""
+    host = _LatchHost(reason="a turn is running")
+    assert host.begin_retire("runtime-retired") is False
+    assert host._retiring_cause == ""
+
+
+def test_begin_retire_survives_a_failing_predicate() -> None:
+    """An unanswerable probe keeps the runtime rather than retiring unguarded."""
+
+    class _Boom(_LatchHost):
+        def may_refresh(self) -> str:
+            raise RuntimeError("boom")
+
+    host = _Boom()
+    assert host.begin_retire("runtime-retired") is False
+    assert host._retiring_cause == ""
+
+
+# -- the torn-install classification (D4/§5.2) -------------------------------
+
+
+def test_classify_import_failure_names_a_moved_install(monkeypatch) -> None:
+    """Design test 13: an ImportError plus a moved stamp is an install race."""
+    from local_operator import update
+
+    boot = update.BuildStamp(version="1.0.0", source_ref="aaa")
+    current = update.BuildStamp(version="1.1.0", source_ref="bbb")
+    monkeypatch.setattr(update, "installed_build", lambda *_a, **_k: current)
+    exc = ImportError(
+        "cannot import name '_journal_injection_ids' from 'local_operator.session.transcript'"
+    )
+    reason = update.classify_import_failure(exc, "local_operator.mobile.durable", boot=boot)
+    assert reason is not None
+    assert "being replaced on disk" in reason
+    assert "1.0.0@aaa" in reason and "1.1.0@bbb" in reason
+
+
+def test_classify_import_failure_ignores_a_genuine_packaging_bug(monkeypatch) -> None:
+    """Same stamp → the miss is ours; it must stay an ordinary traceback."""
+    from local_operator import update
+
+    boot = update.BuildStamp(version="1.0.0", source_ref="aaa")
+    monkeypatch.setattr(update, "installed_build", lambda *_a, **_k: boot)
+    exc = ImportError("cannot import name 'nope' from 'local_operator.session.transcript'")
+    assert (
+        update.classify_import_failure(exc, "local_operator.session.transcript", boot=boot) is None
+    )
+
+
+def test_classify_import_failure_ignores_an_unrelated_error(monkeypatch) -> None:
+    from local_operator import update
+
+    boot = update.BuildStamp(version="1.0.0", source_ref="aaa")
+    monkeypatch.setattr(
+        update, "installed_build", lambda *_a, **_k: update.BuildStamp("2.0.0", "zzz")
+    )
+    assert update.classify_import_failure(ValueError("nope"), "local_operator.x", boot=boot) is None
+    assert (
+        update.classify_import_failure(
+            ImportError("cannot import name 'requests' from 'requests'"),
+            "requests",
+            boot=boot,
+        )
+        is None
+    )
+    # And with no baseline at all there is nothing to compare: refuse to guess.
+    assert update.classify_import_failure(ImportError("x"), "local_operator.x", boot=None) is None

--- a/tests/unit/session/test_cut_off_turns.py
+++ b/tests/unit/session/test_cut_off_turns.py
@@ -13,17 +13,13 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+from collections.abc import AsyncIterator
 from pathlib import Path
+from typing import Any
 
 import pytest
 
-from local_operator.harness.types import (
-    AgentEndEvent,
-    Message,
-    ModelSpec,
-    TextContent,
-    ToolCall,
-)
+from local_operator.harness.types import AgentEndEvent, Message, ModelSpec, TextContent
 from local_operator.incidents import format_cut_off_notice, render_cut_off_reason
 from local_operator.session.attention import AttentionStore, conversation_identity
 from local_operator.session.frontend_state import JobState
@@ -33,12 +29,24 @@ from local_operator.session.transcript import Transcript
 MODEL = ModelSpec(provider="test", model_id="mock")
 
 
-def _make_session(directory: Path, *, stream: object | None = None):
+async def _no_stream(*_args: Any, **_kwargs: Any) -> AsyncIterator[Any]:
+    """A stream double that never yields: these tests do not run a turn.
+
+    An async GENERATOR rather than a plain callable, because that is what
+    ``stream_fn``'s annotation actually requires — a stub that only returns
+    ``None`` type-checks as a mistake and would raise the first time a turn
+    did run, which is exactly the kind of double that hides a broken test.
+    """
+    return
+    yield  # pragma: no cover — the ``yield`` is what makes this a generator
+
+
+def _make_session(directory: Path, *, stream: Any = None):
     from local_operator.session.session import Session
 
     return Session(
         model=MODEL,
-        stream_fn=stream or (lambda *_args, **_kwargs: None),
+        stream_fn=stream or _no_stream,
         tools=[],
         transcript=Transcript(directory),
         system_blocks_provider=lambda *_args: [],
@@ -294,9 +302,12 @@ class _LatchHost:
     begin_retire = _H.begin_retire
     _retiring_refusal = _H._retiring_refusal
 
+    #: Typed ``Any`` on purpose: the real attribute holds a ``Session``, and the
+    #: tests below substitute a recorder that only implements ``note_cut_off``.
+    _session: Any = None
+
     def __init__(self, *, reason: str = "") -> None:
         self._retiring_cause = ""
-        self._session = None
         self.reason = reason
         self.notes: list[tuple[str, str]] = []
 

--- a/tests/unit/session/test_cut_off_turns.py
+++ b/tests/unit/session/test_cut_off_turns.py
@@ -12,6 +12,7 @@ calls worse than the bug it fixes.
 from __future__ import annotations
 
 import asyncio
+import json
 import uuid
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -219,9 +220,9 @@ def _child_dir(tmp_path: Path, name: str) -> Path:
 
 def test_restored_rows_prefer_the_records_settled_outcome(tmp_path: Path) -> None:
     """D3 rule 1: a record that says ``completed`` is a fact, not an inference."""
-    from local_operator.session.attached import _restored_job_rows
+    from local_operator.session.restored_rows import resolve_restored_rows
 
-    rows = _restored_job_rows(
+    rows = resolve_restored_rows(
         [_row("a")],
         records=[{"job_id": "a", "outcome": "completed", "session_dir": str(tmp_path)}],
     )
@@ -234,7 +235,7 @@ def test_restored_rows_read_the_childs_tail_when_the_record_did_not_settle(
     tmp_path: Path,
 ) -> None:
     """D3 rule 2: the child's own journal decides mid-turn from finished."""
-    from local_operator.session.attached import _restored_job_rows
+    from local_operator.session.restored_rows import resolve_restored_rows
 
     mid = _child_dir(tmp_path, "mid")
     transcript = Transcript(mid)
@@ -252,7 +253,7 @@ def test_restored_rows_read_the_childs_tail_when_the_record_did_not_settle(
         )
     )
 
-    rows = _restored_job_rows(
+    rows = resolve_restored_rows(
         [_row("mid"), _row("done")],
         records=[
             {"job_id": "mid", "outcome": None, "session_dir": str(mid)},
@@ -267,18 +268,18 @@ def test_restored_rows_read_the_childs_tail_when_the_record_did_not_settle(
 
 def test_restored_rows_without_records_keep_todays_behaviour(tmp_path: Path) -> None:
     """D3 rule 3: no record and no transcript is still ``interrupted``."""
-    from local_operator.session.attached import _restored_job_rows
+    from local_operator.session.restored_rows import resolve_restored_rows
 
-    rows = _restored_job_rows([_row("orphan")])
+    rows = resolve_restored_rows([_row("orphan")])
     assert rows[0].status == "interrupted"
     assert rows[0].cut_off_cause == "owner-lost"
 
 
 def test_a_settled_row_is_never_relitigated(tmp_path: Path) -> None:
     """A terminal status the last runtime settled is left exactly as it was."""
-    from local_operator.session.attached import _restored_job_rows
+    from local_operator.session.restored_rows import resolve_restored_rows
 
-    rows = _restored_job_rows(
+    rows = resolve_restored_rows(
         [_row("c", "completed")],
         records=[{"job_id": "c", "outcome": "failed", "session_dir": str(tmp_path)}],
     )
@@ -401,3 +402,352 @@ def test_classify_import_failure_ignores_an_unrelated_error(monkeypatch) -> None
     )
     # And with no baseline at all there is nothing to compare: refuse to guess.
     assert update.classify_import_failure(ImportError("x"), "local_operator.x", boot=None) is None
+
+
+# -- the dispose route (review round 1, BLOCKER-1) ---------------------------
+#
+# A bare `/stop` on a TUI-OWNED session does not travel through the `stop`
+# control op: it disposes the session in-process. `Session.dispose()` notes
+# `disposed` unconditionally (correct for the teardown rungs, wrong for a
+# deliberate one), so whether the user's own cancel is reported as a failure is
+# decided by ONE thing — whether the caller recorded the verdict first. The
+# pre-existing guard set `_attention_outcome` directly and the e2e cell used
+# `stop_session`, so neither exercised this route at all; these two tests pin
+# both directions of it against the REAL `dispose()`, which is what makes the
+# classification difference the fix rests on observable rather than assumed.
+
+
+async def _dispose_with_unsent_run(directory: Path, *, deliberate: bool) -> None:
+    """Boot a real session with an in-flight run, then dispose it."""
+    directory.mkdir(parents=True, exist_ok=True)
+    session = _make_session(directory)
+    await session.async_init()
+    # What `_run_turn` does at the head of a turn: a token is minted and the run
+    # is left UNSETTLED, so the dispose publisher sees a turn that never
+    # reported an outcome. Driving this by state rather than by running a turn
+    # keeps the test about the classification, which is the seam in question.
+    session._attention_run_token = str(uuid.uuid4())
+    session._attention_run_settled = False
+    if deliberate:
+        session.note_deliberate_stop()
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_dispose_route_publishes_the_users_own_stop_as_an_interruption(
+    tmp_path: Path,
+) -> None:
+    """BLOCKER-1: the TUI's `/stop` must not come back as `kind=error`."""
+    directory = tmp_path / "sessions" / "stopped"
+    await _dispose_with_unsent_run(directory, deliberate=True)
+
+    state = AttentionStore().state(conversation_identity(directory))
+    assert state["kind"] == "interrupted", state
+    assert state["cause"] == "user-stop", state
+    assert state["reason"] == render_cut_off_reason("user-stop")
+    incidents = [
+        entry
+        for entry in Transcript(directory).entries()
+        if entry.payload.get("custom_type") == "session_incident"
+    ]
+    assert incidents == [], "the user's own stop is not a failure to explain"
+
+
+@pytest.mark.asyncio
+async def test_an_unnoted_dispose_is_still_a_cut_off_error(tmp_path: Path) -> None:
+    """The control, and the reason this is a caller's verdict rather than a guess.
+
+    An INVOLUNTARY teardown (a reload, an unmount, ``_mobile_teardown``) is a
+    turn cut off under the user, and it must keep reading as one. Without this
+    half, "note the stop everywhere" would look equivalent to "never report a
+    disposed turn", and the two differ on exactly the teardowns nobody asked
+    for.
+    """
+    directory = tmp_path / "sessions" / "torn"
+    await _dispose_with_unsent_run(directory, deliberate=False)
+
+    state = AttentionStore().state(conversation_identity(directory))
+    assert state["kind"] == "error", state
+    assert state["cause"] == "disposed", state
+    assert state["reason"], "a cut-off must name a reason"
+
+
+@pytest.mark.asyncio
+async def test_the_handles_cancel_rungs_record_the_deliberate_verdict(tmp_path: Path) -> None:
+    """``abort`` (the phone's stop button) and ``cancel`` are deliberate too.
+
+    Both were one teardown away from the same false error: each ends the turn
+    aborted with no error, and the next dispose would have published it as a
+    cut-off. The verdict is recorded at the act, so the ordering cannot matter.
+    Real session, real handle — the flag asserted here is the one the
+    classification reads.
+    """
+    from local_operator.session.runtime.serving import ServingSessionHandle
+
+    directory = tmp_path / "sessions" / "cancel-rungs"
+    directory.mkdir(parents=True)
+    session = _make_session(directory)
+    handle = ServingSessionHandle(session, asyncio.get_running_loop(), cwd=str(tmp_path))
+
+    await handle.abort()
+    assert session._deliberate_stop_noted is True
+    assert session._cut_off_cause == ""
+
+    # And the supervisor's boundary-respecting rung, which ends the turn the
+    # same way one tool later.
+    session._deliberate_stop_noted = False
+    receipt = await handle.cancel_gracefully("cancelled by supervisor")
+    assert session._deliberate_stop_noted is True, receipt
+
+
+# -- an aborted turn that also failed (review round 1, MINOR-1) --------------
+
+
+def test_an_aborted_turn_that_also_failed_keeps_the_providers_diagnosis(
+    tmp_path: Path,
+) -> None:
+    """`_classify_cut_off`'s own contract, which its guard used to break.
+
+    The loop emits a provider failure on an aborted turn itself
+    (``aborted=True, error=<stream_error>``), and the guard only spared
+    ``error and not aborted`` — so a cut-off that coincided with a real provider
+    fault overprinted the vendor's specific message with a generic sentence.
+    """
+    session = _make_session(tmp_path / "sess")
+    session.note_cut_off("runtime-shutdown")
+    event = AgentEndEvent(messages=[], aborted=True, error="quota exhausted: your credit is gone")
+    classed = session._classify_cut_off(event)
+    assert classed is event
+    assert classed.error == "quota exhausted: your credit is gone"
+    assert classed.cut_off_cause == ""
+
+
+@pytest.mark.asyncio
+async def test_the_durable_outcome_agrees_with_an_aborted_provider_error(
+    tmp_path: Path,
+) -> None:
+    """And the STORE agrees, which is why the publisher reads the event.
+
+    The publisher used to key the cut-off on the local flag, so the store named
+    the cut-off sentence while the transcript held the provider's — one turn,
+    two stories, on the surface that outlives the process.
+    """
+    directory = tmp_path / "sessions" / "aborted-error"
+    session = _make_session(directory)
+    session._attention_run_token = str(uuid.uuid4())
+    session._attention_run_settled = False
+    session.note_cut_off("runtime-shutdown")
+    session._attention_outcome = session._classify_cut_off(
+        AgentEndEvent(messages=[], aborted=True, error="quota exhausted: your credit is gone")
+    )
+    await session._publish_attention_outcome()
+
+    state = AttentionStore().state(conversation_identity(directory))
+    assert state["kind"] == "error"
+    assert state["cause"] == ""
+    assert state["reason"] == "quota exhausted: your credit is gone"
+    incidents = [
+        entry
+        for entry in Transcript(directory).entries()
+        if entry.payload.get("custom_type") == "session_incident"
+    ]
+    assert incidents == [], "a provider error is not a cut-off incident"
+
+
+# -- the cut-off the dying runtime could not narrate (QA Q-2) ---------------
+
+
+@pytest.mark.asyncio
+async def test_a_cut_off_the_dying_runtime_could_not_journal_is_narrated_on_restore(
+    tmp_path: Path,
+) -> None:
+    """The update/shutdown family reaches the MODEL too, one boot later.
+
+    A runtime that publishes its own outcome and then dies cannot journal it:
+    ``journal_incident`` refuses once ``_disposed`` is set, and the dispose rung
+    sets that before the turn's ``finally`` publishes. The saved marker is
+    replayed verbatim, so the successor is the only writer left that can tell
+    the model — and it must, or "continue" after an update means re-guessing a
+    request that was cut in half (QA round 1, Q-2; review MINOR-2).
+    """
+    from local_operator.session.attention import ATTENTION_CUSTOM_TYPE
+
+    directory = tmp_path / "sessions" / "shutdown"
+    directory.mkdir(parents=True)
+    token = str(uuid.uuid4())
+    transcript = Transcript(directory)
+    await transcript.append_custom(
+        "attention_started",
+        {"conversation_id": conversation_identity(directory), "token": token},
+    )
+    await transcript.append_message(
+        Message(role="assistant", content=[TextContent(text="half a reply")])
+    )
+    # The dying runtime's own marker: `_publish_attention_outcome` wrote this
+    # immediately before its process ended.
+    await transcript.append_custom(
+        ATTENTION_CUSTOM_TYPE,
+        {
+            "conversation_id": conversation_identity(directory),
+            "token": token,
+            "anchor": "completion-1",
+            "kind": "error",
+            "cause": "runtime-shutdown",
+            "reason": render_cut_off_reason("runtime-shutdown"),
+        },
+    )
+    # The run record of the process that wrote it, now dead.
+    record = tmp_path / "runtimes" / f"{token}.json"
+    record.parent.mkdir(parents=True, exist_ok=True)
+    record.write_text("{}", encoding="utf-8")
+
+    session = _make_session(directory)
+    await session.async_init()
+    try:
+        incidents = [
+            entry
+            for entry in Transcript(directory).entries()
+            if entry.payload.get("custom_type") == "session_incident"
+        ]
+        assert len(incidents) == 1, "the successor did not narrate the cut-off"
+
+        rendered = _rendered(session._context.messages)
+        assert "[session incident]" in rendered
+        assert "cut-off" in rendered
+
+        # Once per token: a second boot must not narrate it again.
+        again = _make_session(directory)
+        await again.async_init()
+        try:
+            assert (
+                len(
+                    [
+                        entry
+                        for entry in Transcript(directory).entries()
+                        if entry.payload.get("custom_type") == "session_incident"
+                    ]
+                )
+                == 1
+            )
+        finally:
+            await again.dispose()
+    finally:
+        await session.dispose()
+
+
+# -- the OWNER path's restore (review round 1, UX U2) ------------------------
+
+
+async def _seed_roster_sidecar(directory: Path, children: Path) -> None:
+    """The sidecar exactly as ``_persist_subagent_roster`` writes it.
+
+    The ``jobs`` rows go through ``_subagent_job_row``, the ALLOWLIST projection
+    the owner persists — not ``JobState.model_dump()``, which carries
+    frontend-only fields the strict ``AsyncJob`` sidecar rejects (a probe that
+    seeded frontend rows here exercised nothing at all: every row was dropped as
+    malformed and the owner path restored an EMPTY roster).
+    """
+    from local_operator.harness.jobs import AsyncJob
+    from local_operator.session.session import (
+        SUBAGENT_ROSTER_SIDECAR,
+        _subagent_job_row,
+    )
+
+    for name in ("mid", "done"):
+        (children / name).mkdir(parents=True, exist_ok=True)
+    # A child cut off mid-turn: its last row is a tool RESULT with nothing after.
+    await Transcript(children / "mid").append_message(
+        Message(role="tool", content=[TextContent(text="ok")], tool_call_id="call-1")
+    )
+    # A child that finished: its last row is a settled assistant message.
+    await Transcript(children / "done").append_message(
+        Message(role="assistant", content=[TextContent(text="all finished")])
+    )
+
+    def row(job_id: str, label: str) -> dict[str, Any]:
+        return _subagent_job_row(
+            AsyncJob(id=job_id, type="task", status="running", label=label, start_time=0.0)
+        )
+
+    payload = {
+        "version": 1,
+        "generation": 7,
+        "jobs": [
+            row("job-settled", "scan filings"),
+            row("job-midturn", "draft the memo"),
+            row("job-finished", "collect sources"),
+            row("job-orphan", "orphan child"),
+        ],
+        "records": [
+            {
+                "job_id": "job-settled",
+                "outcome": "completed",
+                "settled_at": 2.0,
+                "session_dir": str(children / "settled"),
+            },
+            {
+                "job_id": "job-midturn",
+                "outcome": None,
+                "settled_at": None,
+                "session_dir": str(children / "mid"),
+            },
+            {
+                "job_id": "job-finished",
+                "outcome": None,
+                "settled_at": None,
+                "session_dir": str(children / "done"),
+            },
+        ],
+        "accounting": [],
+    }
+    (children / "unused").mkdir(parents=True, exist_ok=True)
+    (directory / SUBAGENT_ROSTER_SIDECAR).write_text(json.dumps(payload), encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_the_owner_path_restores_the_records_resolved_rows(tmp_path: Path) -> None:
+    """UX U2: the successor's restore must not flatten what the records settled.
+
+    The cold viewer resolves a restored row against the roster records; the
+    runtime that opens a moment later restores the SAME rows into
+    ``AsyncJobManager``, and its table is what the session publishes. Resolved on
+    one path only, the user saw the good rows for under a second — measured at
+    t+1.2 s ``completed|interrupted|completed|interrupted``, by t+1.9 s all four
+    back to a blanket ``interrupted`` with the cause dropped. Both writers now
+    run the same resolver, so this asserts the owner's table AND the wire shape
+    the dock paints.
+    """
+    from local_operator.session.session import SUBAGENT_ROSTER_SIDECAR  # noqa: F401
+
+    directory = tmp_path / "sessions" / "owner-restore"
+    directory.mkdir(parents=True)
+    await _seed_roster_sidecar(directory, tmp_path / "children")
+
+    from tests.e2e.harness import ScriptedStream, build_session, text_turn
+
+    session = build_session(directory, ScriptedStream([text_turn("ok")]))
+    await session.async_init()
+    try:
+        rows = {job.id: job for job in session.jobs.list()}
+        assert rows["job-settled"].status == "completed", "a settled record is a fact"
+        assert rows["job-finished"].status == "completed", "the child's own tail settled it"
+        assert rows["job-midturn"].status == "interrupted"
+        assert rows["job-midturn"].cut_off_cause == "owner-lost"
+        assert rows["job-orphan"].status == "interrupted"
+        assert rows["job-orphan"].cut_off_cause == "owner-lost"
+        for job in rows.values():
+            assert job.restored is True
+
+        # The wire rows the dock reads, which is where the cause used to be
+        # dropped even when the resolver had set it.
+        wire = {job.id: job for job in (JobState.from_job(job) for job in session.jobs.list())}
+        assert wire["job-midturn"].cut_off_cause == "owner-lost"
+        assert wire["job-settled"].cut_off_cause == ""
+    finally:
+        await session.dispose()
+
+    # And the SIDECAR is unchanged: the strict ``AsyncJob`` rows an older owner
+    # validates must not grow a field it does not know, or it drops the row.
+    persisted = json.loads((directory / "subagent-roster.v1.json").read_text(encoding="utf-8"))
+    assert persisted["jobs"], "the fixture wrote no rows"
+    assert all("cut_off_cause" not in row for row in persisted["jobs"])

--- a/tests/unit/session/test_remote_disconnect.py
+++ b/tests/unit/session/test_remote_disconnect.py
@@ -180,8 +180,14 @@ async def test_rebind_to_a_newer_generation_ends_the_suspect_not_the_successor(
 
 
 @pytest.mark.asyncio
-async def test_recovery_going_cold_emits_one_aborted_end(tmp_path, monkeypatch) -> None:
-    """Test 18: recovery goes cold → one aborted end (unchanged)."""
+async def test_recovery_going_cold_emits_one_cut_off_end(tmp_path, monkeypatch) -> None:
+    """Test 18: recovery goes cold → one CUT-OFF end (exactly once).
+
+    The exactly-once property is what this test owns and it is unchanged. The
+    KIND changed deliberately: a confirmed owner death is the case the cut-off
+    taxonomy exists for, and it used to be published as a bare abort — the same
+    shape a user's own ``/stop`` produces.
+    """
     remote = _facade(tmp_path, monkeypatch, can_go_cold=True)
     received: list[Any] = []
     remote.subscribe(received.append)
@@ -190,7 +196,9 @@ async def test_recovery_going_cold_emits_one_aborted_end(tmp_path, monkeypatch) 
     remote._go_cold()
 
     ends = [event for event in received if isinstance(event, AgentEndEvent)]
-    assert len(ends) == 1 and ends[0].aborted is True and ends[0].error is None
+    assert len(ends) == 1
+    assert ends[0].aborted is False
+    assert ends[0].cut_off_cause == "owner-lost"
     assert remote.is_streaming is False
 
 

--- a/tests/unit/session/test_remote_disconnect.py
+++ b/tests/unit/session/test_remote_disconnect.py
@@ -315,7 +315,15 @@ async def test_the_real_recovery_loop_bounds_the_turn_on_a_terminal_viewer(
         "a dead runtime on the terminal surface left the turn spinning: "
         f"ends={ends} attempts={len(takeover_attempts)}"
     )
-    assert ends[0].aborted is True and ends[0].error is None
+    # The VERDICT, which is now a named cut-off rather than the bare abort a
+    # user's Esc produces: this arm is the one the watched TUI session takes
+    # (``_can_go_cold`` is False for every viewer built through ``connect()``),
+    # and reporting a runtime death as the user's own cancel was the reported
+    # bug (QA round 1, Q-1 / UX U1). The deliberately-not-taken desktop exit
+    # below is what this test has always been about.
+    assert ends[0].aborted is False
+    assert ends[0].cut_off_cause == "owner-lost"
+    assert "cut off" in str(ends[0].error)
     assert remote.is_streaming is False
     assert remote._suspect_generation is None
     # The legacy contract is preserved: the loop keeps CHASING a successor

--- a/tests/unit/session/test_remote_registries.py
+++ b/tests/unit/session/test_remote_registries.py
@@ -184,6 +184,11 @@ async def test_every_session_attribute_the_tui_reads_exists_on_the_viewer(
         "preflight_usage",
         "refresh_frontend_usage",
         "wears_inherited_title",
+        # A viewer never owns a session to dispose, so there is no in-process
+        # teardown for it to mark deliberate: its `/stop` is a control op, and
+        # the owner records the verdict on that rung. `_stop_local_session` (the
+        # only reader) returns early unless the session owns its runtime.
+        "note_deliberate_stop",
         # The attached team OBJECT. The viewer reports the attached roster by
         # name through `active_team_name` (which it does provide) and cannot
         # hold the Team itself without the attach seam above.

--- a/tests/unit/session/test_remote_takeover.py
+++ b/tests/unit/session/test_remote_takeover.py
@@ -451,7 +451,14 @@ async def test_going_cold_ends_an_in_flight_turn_directly(tmp_path, monkeypatch)
     remote._go_cold()
 
     ends = [event for event in received if isinstance(event, AgentEndEvent)]
-    assert len(ends) == 1 and ends[0].aborted is True and ends[0].error is None
+    # ONE end, delivered directly (the unchanged half), and it is now a CUT-OFF
+    # ERROR rather than a bare abort: a confirmed owner death is not a user's
+    # cancel, and publishing it as ``interrupted`` is the defect this taxonomy
+    # exists to remove.
+    assert len(ends) == 1
+    assert ends[0].aborted is False
+    assert ends[0].cut_off_cause == "owner-lost"
+    assert "cut off" in str(ends[0].error)
     assert remote._buffered_events == []
     assert remote.is_streaming is False
     assert remote.is_cold
@@ -563,7 +570,10 @@ async def test_going_cold_survives_a_controllers_higher_adopted_generation(
 
     ends = [m for m in app.posted if isinstance(m, TurnEnded)]
     assert len(ends) == 1, "the synthesised end never reached the app"
-    assert ends[0].aborted is True
+    # ``aborted`` is False because the end is a cut-off ERROR now; what this
+    # test is about is that it got THROUGH the generation barrier at all.
+    assert ends[0].aborted is False
+    assert "cut off" in str(ends[0].error)
     assert remote.is_streaming is False
 
 

--- a/tests/unit/session/test_viewer_protocol.py
+++ b/tests/unit/session/test_viewer_protocol.py
@@ -303,6 +303,11 @@ _OWNER_ONLY_CAPABILITY_PROBES = frozenset(
         "has_pending_fork",
         "journal_credential_change",
         "measure_preloaded_context",
+        # A viewer never owns a session to dispose, so it has no deliberate
+        # stop to record: a viewer's `/stop` goes over the socket, where the
+        # OWNER records the verdict. `_stop_local_session` returns before
+        # this is reached for a viewer at all, and the read is getattr-probed.
+        "note_deliberate_stop",
         "preflight_usage",
         "refresh_frontend_usage",
         "routing_settings",

--- a/tests/unit/tui/test_cut_off_notices.py
+++ b/tests/unit/tui/test_cut_off_notices.py
@@ -36,6 +36,24 @@ CUT_OFF = (
 REASON = "the runtime retired so the next engage would run a newer build"
 
 
+class DeliberateStopSession(FakeSession):
+    """A fake owner that reports whether it was told the stop was deliberate.
+
+    Bare ``/stop`` on a TUI-owned session ends in ``Session.dispose()``, and a
+    real session's dispose notes ``disposed`` — the involuntary default. So the
+    one thing this route must do is record the user's verdict first, and this
+    is the flag a test can see it on (``FakeSession`` has no taxonomy of its
+    own).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.deliberate_stops = 0
+
+    def note_deliberate_stop(self) -> None:
+        self.deliberate_stops += 1
+
+
 class OutcomeSession(FakeSession):
     """A fake owner that publishes one outcome, controllable per test."""
 
@@ -185,3 +203,144 @@ async def test_an_interrupted_outcome_keeps_its_own_spelling(tmp_path, monkeypat
         # cut-off the user did not ask for, and appending "stopped by the user"
         # to a row that already says Interrupted is noise.
         assert _notice_texts(app) == ["Interrupted"]
+
+
+def _notice_blocks(app: OperatorApp) -> list[Any]:
+    from local_operator.tui.widgets.transcript import NoticeBlock
+
+    return [b for b in app._transcript_view().blocks() if isinstance(b, NoticeBlock)]
+
+
+@pytest.mark.asyncio
+async def test_the_poller_paints_a_cut_off_in_the_danger_tier(tmp_path, monkeypatch) -> None:
+    """D1: one cut-off must not be an alarm live and a whisper on return.
+
+    The poller's error branch passed no kind, so it took ``NoticeBlock``'s
+    ``info`` default — the same ``·`` glyph in the same dim fill as the routine
+    ``Interrupted`` control one branch away, for an outcome the live surface
+    paints ``✗`` danger. The row decision now comes from ``harness/rows.py``,
+    which is why the assertion is on the tier rather than on the words.
+    """
+    session = OutcomeSession(tmp_path / "attention.db")
+    monkeypatch.setattr("local_operator.tui.attention.terminal_is_foreground", lambda: True)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(200):
+            if app._session is not None:
+                break
+            await pilot.pause()
+            await asyncio.sleep(0.01)
+        session.publish("error", cause="runtime-retired", reason=REASON)
+        await app._poll_completion_attention()
+        await pilot.pause()
+
+        (block,) = _notice_blocks(app)
+        assert block._glyph == "✗"
+        assert block._token == "danger"
+
+
+@pytest.mark.asyncio
+async def test_the_pollers_interrupted_control_stays_quiet(tmp_path, monkeypatch) -> None:
+    """And the deliberate stop keeps the tier the design round signed off.
+
+    Its louder ``warning`` ink belongs to the LIVE row, which is a statement
+    about the turn the user just ended; a replayed receipt for the same stop is
+    not, and promoting it would put two weights on one fact.
+    """
+    session = OutcomeSession(tmp_path / "attention.db")
+    monkeypatch.setattr("local_operator.tui.attention.terminal_is_foreground", lambda: True)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(200):
+            if app._session is not None:
+                break
+            await pilot.pause()
+            await asyncio.sleep(0.01)
+        session.publish("interrupted", cause="user-stop", reason="the session was stopped")
+        await app._poll_completion_attention()
+        await pilot.pause()
+
+        (block,) = _notice_blocks(app)
+        assert block._glyph == "·"
+        assert block._token == "dim"
+
+
+@pytest.mark.asyncio
+async def test_the_tui_stop_route_records_the_deliberate_verdict(tmp_path, monkeypatch) -> None:
+    """BLOCKER-1 through the APP: bare ``/stop`` notes the stop before disposing.
+
+    ``Session.dispose()`` notes ``disposed`` unconditionally, so this call is
+    what stands between the user's own cancel and a published
+    ``kind=error, cause=disposed``. Asserted on the session the app actually
+    disposes, which is the route the unit guard and the e2e cell both missed.
+    """
+    session = DeliberateStopSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(200):
+            if app._session is not None:
+                break
+            await pilot.pause()
+            await asyncio.sleep(0.01)
+        assert app._session is session
+        await app._stop_local_session()
+        await pilot.pause()
+
+    assert session.deliberate_stops == 1, "the dispose route lost the user's verdict"
+    assert session.disposed is True
+
+
+@pytest.mark.asyncio
+async def test_a_cut_off_turns_live_cards_are_retired_as_cut_off(tmp_path, monkeypatch) -> None:
+    """D2 end to end through the app: the end event's verdict reaches the row.
+
+    ``TurnEnded`` is where the fact that this was an involuntary stop exists
+    (the classifier reports it as ``aborted=False, error=<notice>``, so nothing
+    downstream can infer it), and ``_finalize_turn`` is the only turn-death path
+    that owns the stranded cards. Without the flag carried across that seam the
+    ledger said ``⊘ interrupted`` under a ``✗ turn cut off`` notice — the two
+    words disagreeing about one death, on one screen.
+    """
+    from local_operator.tui.events import (
+        ToolExecutionStartEvent,
+        ToolStarted,
+        TurnEnded,
+        TurnStarted,
+    )
+    from local_operator.tui.widgets.editor import Editor
+
+    session = OutcomeSession(tmp_path / "attention.db")
+    monkeypatch.setattr("local_operator.tui.attention.terminal_is_foreground", lambda: True)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(200):
+            if app._session is not None:
+                break
+            await pilot.pause()
+            await asyncio.sleep(0.01)
+        editor = app.query_one(Editor)
+        editor.focus()
+        editor.text = "run the long job"
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        app.post_message(TurnStarted())
+        await pilot.pause()
+        app.post_message(
+            ToolStarted(
+                ToolExecutionStartEvent(
+                    tool_call_id="c-cut", tool_name="bash", args={"command": "sleep 60"}
+                )
+            )
+        )
+        await pilot.pause()
+        card = app._tool_cards["c-cut"]
+        assert "cut off" not in card._build_row(100).plain
+
+        app.post_message(TurnEnded(False, CUT_OFF, cut_off=True))
+        await pilot.pause()
+        await pilot.pause()
+
+        row = card._build_row(100).plain
+        assert "cut off" in row, row
+        assert "interrupted" not in row, row

--- a/tests/unit/tui/test_cut_off_notices.py
+++ b/tests/unit/tui/test_cut_off_notices.py
@@ -65,7 +65,9 @@ class OutcomeSession(FakeSession):
         return await asyncio.to_thread(self.store.acknowledge, self.identity, token)
 
 
-async def _start_and_end_turn(app: OperatorApp, pilot: Any, *, aborted: bool, error: str | None) -> None:
+async def _start_and_end_turn(
+    app: OperatorApp, pilot: Any, *, aborted: bool, error: str | None
+) -> None:
     """Drive a turn to the point where the app has painted its own end row."""
     from local_operator.tui.events import TurnEnded, TurnStarted
     from local_operator.tui.widgets.editor import Editor
@@ -89,7 +91,9 @@ async def _start_and_end_turn(app: OperatorApp, pilot: Any, *, aborted: bool, er
 
 
 @pytest.mark.asyncio
-async def test_a_cut_off_turn_paints_the_reason_and_never_interrupted(tmp_path, monkeypatch) -> None:
+async def test_a_cut_off_turn_paints_the_reason_and_never_interrupted(
+    tmp_path, monkeypatch
+) -> None:
     """Design test 15: one row, the error sentence, with the cause in it.
 
     The classifier rewrote the end event to ``aborted=False, error=<notice>``,
@@ -172,7 +176,9 @@ async def test_an_interrupted_outcome_keeps_its_own_spelling(tmp_path, monkeypat
                 break
             await pilot.pause()
             await asyncio.sleep(0.01)
-        session.publish("interrupted", cause="user-stop", reason="the session was stopped by the user")
+        session.publish(
+            "interrupted", cause="user-stop", reason="the session was stopped by the user"
+        )
         await app._poll_completion_attention()
         await pilot.pause()
         # The deliberate stop keeps the existing spelling: the reason is for a

--- a/tests/unit/tui/test_cut_off_notices.py
+++ b/tests/unit/tui/test_cut_off_notices.py
@@ -1,0 +1,181 @@
+"""A failure is stated ONCE, and an error row NAMES its cause.
+
+Two defects, one seam. Both live in the pair of producers that can announce a
+turn's outcome: ``_finalize_turn`` / ``on_turn_ended`` paints it the moment the
+turn ends, and the attention poller reads the same outcome back out of the
+durable store a tick later. The poller's only dedupe is
+``completion_anchor_id``, and the live row cannot carry one (the anchor does not
+exist until the session publishes), so the two announced one fact twice.
+
+The aborted branch fixed that for ``interrupted``. The error branch never got
+the fix — ``_own_interrupt_notice`` was only ever set when ``aborted`` — so
+every turn that ended with a provider error painted ``✗ <error>`` above
+``· Stopped with an error``. These tests pin both branches, including the
+pre-existing provider-error duplicate, and pin the copy: the poller's row now
+carries the harness-authored reason.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.session.attention import AttentionStore
+from local_operator.tui.app import OperatorApp
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+from tests.unit.tui.test_attention import _notice_texts  # the established helper
+
+CUT_OFF = (
+    "turn cut off — the runtime retired so the next engage would run a newer build. "
+    "The transcript holds what it wrote before that and nothing after."
+)
+REASON = "the runtime retired so the next engage would run a newer build"
+
+
+class OutcomeSession(FakeSession):
+    """A fake owner that publishes one outcome, controllable per test."""
+
+    def __init__(self, path: Path) -> None:
+        super().__init__()
+        self.store = AttentionStore(path)
+        self.identity = "session/cutoff"
+        self.last_token = ""
+
+    def publish(self, kind: str, *, cause: str = "", reason: str = "") -> str:
+        token = str(uuid.uuid4())
+        self.last_token = token
+        self.store.publish(
+            self.identity,
+            token,
+            f"completion-{token}",
+            kind,
+            reason=reason,
+            cause=cause,
+        )
+        return token
+
+    async def refresh_attention(self) -> dict[str, Any]:
+        return await asyncio.to_thread(self.store.state, self.identity)
+
+    async def acknowledge_attention(self, token: str) -> dict[str, Any]:
+        return await asyncio.to_thread(self.store.acknowledge, self.identity, token)
+
+
+async def _start_and_end_turn(app: OperatorApp, pilot: Any, *, aborted: bool, error: str | None) -> None:
+    """Drive a turn to the point where the app has painted its own end row."""
+    from local_operator.tui.events import TurnEnded, TurnStarted
+    from local_operator.tui.widgets.editor import Editor
+
+    for _ in range(200):
+        if app._session is not None:
+            break
+        await pilot.pause()
+        await asyncio.sleep(0.01)
+    editor = app.query_one(Editor)
+    editor.focus()
+    editor.text = "run the long job"
+    await pilot.pause()
+    await pilot.press("enter")
+    await pilot.pause()
+    app.post_message(TurnStarted())
+    await pilot.pause()
+    app.post_message(TurnEnded(aborted, error))
+    await pilot.pause()
+    await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_a_cut_off_turn_paints_the_reason_and_never_interrupted(tmp_path, monkeypatch) -> None:
+    """Design test 15: one row, the error sentence, with the cause in it.
+
+    The classifier rewrote the end event to ``aborted=False, error=<notice>``,
+    so the app's aborted branch must NOT also paint ``interrupted`` — the
+    vocabulary mismatch the design round reviews.
+    """
+    session = OutcomeSession(tmp_path / "attention.db")
+    monkeypatch.setattr("local_operator.tui.attention.terminal_is_foreground", lambda: True)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _start_and_end_turn(app, pilot, aborted=False, error=CUT_OFF)
+        notices = _notice_texts(app)
+        assert len(notices) == 1, notices
+        assert notices[0] == CUT_OFF
+        assert "Interrupted" not in notices
+
+
+@pytest.mark.asyncio
+async def test_a_provider_error_is_also_stated_once(tmp_path, monkeypatch) -> None:
+    """The pre-existing duplicate, on the branch that never got the fix.
+
+    Before this change the error branch left ``_own_interrupt_notice`` unset, so
+    the poller appended its own row for the same outcome: the user read the
+    failure twice. The two-line check the design asks for is
+    ``_adopt_own_interrupt_notice("error", anchor) is True`` with a live error
+    row held.
+    """
+    session = OutcomeSession(tmp_path / "attention.db")
+    monkeypatch.setattr("local_operator.tui.attention.terminal_is_foreground", lambda: True)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        endpoint = "api refused the request: 502 Bad Gateway"
+        await _start_and_end_turn(app, pilot, aborted=False, error=endpoint)
+        assert _notice_texts(app) == [endpoint]
+
+        session.publish("error", reason=endpoint)
+        anchor = session.store.state(session.identity)["anchor_id"]
+        assert app._adopt_own_interrupt_notice("error", anchor) is True
+        await app._poll_completion_attention()
+        await pilot.pause()
+
+        assert _notice_texts(app) == [endpoint], "the failure must not be restated"
+
+
+@pytest.mark.asyncio
+async def test_the_poller_names_the_cause_for_a_cut_off_it_never_painted(
+    tmp_path, monkeypatch
+) -> None:
+    """The away case keeps its row — and gains the reason.
+
+    A user returning to a session cut off while they were elsewhere has no live
+    row to adopt, so the poller's announcement is the only one; it must carry
+    the cause rather than a bare class marker.
+    """
+    session = OutcomeSession(tmp_path / "attention.db")
+    monkeypatch.setattr("local_operator.tui.attention.terminal_is_foreground", lambda: True)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(200):
+            if app._session is not None:
+                break
+            await pilot.pause()
+            await asyncio.sleep(0.01)
+        session.publish("error", cause="runtime-retired", reason=REASON)
+        await app._poll_completion_attention()
+        await pilot.pause()
+
+        assert _notice_texts(app) == [f"Stopped with an error — {REASON}"]
+
+
+@pytest.mark.asyncio
+async def test_an_interrupted_outcome_keeps_its_own_spelling(tmp_path, monkeypatch) -> None:
+    """The regression guard: a real stop still reads as one, with no reason."""
+    session = OutcomeSession(tmp_path / "attention.db")
+    monkeypatch.setattr("local_operator.tui.attention.terminal_is_foreground", lambda: True)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(200):
+            if app._session is not None:
+                break
+            await pilot.pause()
+            await asyncio.sleep(0.01)
+        session.publish("interrupted", cause="user-stop", reason="the session was stopped by the user")
+        await app._poll_completion_attention()
+        await pilot.pause()
+        # The deliberate stop keeps the existing spelling: the reason is for a
+        # cut-off the user did not ask for, and appending "stopped by the user"
+        # to a row that already says Interrupted is noise.
+        assert _notice_texts(app) == ["Interrupted"]

--- a/tests/unit/tui/test_sidebar_live_tool_card.py
+++ b/tests/unit/tui/test_sidebar_live_tool_card.py
@@ -260,9 +260,13 @@ async def test_switching_to_a_session_parked_in_a_tool_paints_a_live_row(
             retirements: list[int] = []
             original_retire = OperatorApp._retire_live_tool_cards
 
-            def counted_retire(self: OperatorApp) -> int:
+            def counted_retire(self: OperatorApp, **kwargs: Any) -> int:
+                # ``**kwargs`` because the real signature grows with the turn
+                # verdict (`cut_off=`, D2); a double that pinned the old
+                # signature failed the moment the caller learned to pass it,
+                # which is a false alarm about the test's own scaffolding.
                 retirements.append(len(self._tool_cards) + len(self._composing_cards))
-                return original_retire(self)
+                return original_retire(self, **kwargs)
 
             monkeypatch.setattr(OperatorApp, "_retire_live_tool_cards", counted_retire)
 

--- a/tests/unit/tui/test_tool_card.py
+++ b/tests/unit/tui/test_tool_card.py
@@ -2564,3 +2564,25 @@ def test_a_row_that_watched_its_own_start_keeps_its_own_zero() -> None:
     assert card.started_at == 3_000.0
     now[0] += 2.0
     assert card._build_row(80).plain.rstrip().endswith("2s")
+
+
+def test_a_cut_off_turn_names_its_cards_cut_off() -> None:
+    """D2: the word changes, the glyph and the tier do not.
+
+    ``interrupted`` is now reserved for a positively recorded stop, so a row
+    stranded by a cut-off that still said ``interrupted ⊘`` re-stated the
+    ambiguity the taxonomy removed — on the same screen as the ``✗ turn cut
+    off`` notice that had just resolved it (design review round 1, D2).
+    """
+    card = ToolCard("t", "bash", {"command": "pytest tests/unit -q"})
+    card.mark_interrupted(cut_off=True)
+    row = card._build_row(100).plain
+    assert "cut off" in row
+    assert "interrupted" not in row
+    # Same mark, same ink: only the word was the ambiguity, and a new glyph or
+    # a colour would be new design surface for a finding this small.
+    assert "⊘" in row
+
+    deliberate = ToolCard("t", "bash", {"command": "pytest tests/unit -q"})
+    deliberate.mark_interrupted()
+    assert "interrupted" in deliberate._build_row(100).plain, "a stop still says so"


### PR DESCRIPTION
# PR Description

## Summary of Changes

**Bug (operator report, verbatim):** *"occasionally, sessions like this will just get interrupted after running for a while, I think it has something to do with updates … results in some sessions being forgotten about if you're running many at once for long runtimes"*, and *"make sure that errors are properly called out in all situations so at least we see it in active sessions as errored"*.

A turn that a runtime death cut short was published as an **interruption** — the exact shape a user's own `/stop` produces — with no reason, on every front end. Nothing journaled it, so no surface and no model learned it had happened.

**The fix flips the default.** A turn cut off by anything the harness cannot attribute to a deliberate act is an **error with a named cause**. Only *positive* evidence of a deliberate stop records an `interrupted`.

| what happened | kind | cause | operator-facing reason |
|---|---|---|---|
| user's own `/stop`, Esc, phone stop button, supervisor cancel | `interrupted` | `user-stop` | the session was stopped by the user |
| runtime killed (SIGKILL, no clean exit) | `error` | `runtime-killed` | the runtime disappeared without exiting cleanly while this turn was running *(+ build, pid, start time)* |
| runtime terminated (SIGTERM / update shutdown) | `error` | `runtime-shutdown` | the runtime was terminated while this turn was running |
| the update/retire path caught a live turn | `error` | `runtime-retired` | the runtime retired so the next engage would run a newer build *(+ the build pair)* |
| a lazy import hit a half-replaced install | `error` | `install-mid-update` | a local-operator install was being replaced on disk while this turn was running |
| an unwatched viewer's owner stopped answering | `error` | `owner-lost` | the session's runtime stopped answering while this turn was running |
| a teardown nobody asked for (reload, unmount, session swap) | `error` | `disposed` | the session was disposed while this turn was running |
| nothing recoverable at all | `error` | *(none)* | the turn was cut off and the cause could not be determined |

## Scope

- **Additive on the wire.** `attention` gains optional `reason` (one sentence) and `cause` (a machine token); `AgentEndEvent` gains `cut_off`/`cut_off_cause`; job rows gain `cut_off_cause`. Both default to `""`, so a pre-change runtime, viewer, database or roster reads exactly as it did. **No `PROTOCOL_VERSION` bump, no `pyproject.toml` version bump.**
- **The announcement was already there.** The classifier re-labels an involuntary end at the emit boundary as `error=<sentence>`, so every existing consumer — the live notice, the title's `✗`, the sidebar, the phone banner, the durable publish — does the right thing without being taught a new field.
- **The deliberate stop is preserved**, and the guard is the *inverse* test: a real `/stop` must never be relabelled a failure.
- **The update path (D4) rides along**: a planned retirement that catches a live turn waits for a drain instead of cutting it off, so the operator's update-linkage theory is addressed rather than only labelled.
- Nothing in the autorefresh design changes: a transient socket drop with a live owner still paints nothing (verified).

## What changed, by surface

- **The moment it happens (TUI):** `✗ turn cut off — <cause>. The transcript holds what it wrote before that and nothing after.` The stranded tool cards on that turn read `cut off ⊘` rather than `interrupted ⊘`, so the card and the notice tell one story.
- **Returning to a cut-off:** the attention poller paints the same sentence in the danger tier (`✗`), not the quiet `·` tier it shared with the `Interrupted` receipt.
- **Session list / sidebar tooltip:** `Unseen error — <cause>` (vs `Unseen interruption` for a recorded stop).
- **Phone:** the notice carries `severity: "error"` (`✗`, danger ink) and a cut-off turn stays resumable — `interrupted — tap to resume` no longer disappears.
- **The model:** a cut-off journals a `session_incident` card into the next turn's context (`[session incident] cut-off: … / suggested action: … / This is why the previous turn ended`), including for a runtime that died before it could journal its own.
- **Restored subagent rows** resolve against the roster records and the child's own journal, so a settled child stops coming back as a blanket `interrupted` — and the resolution now survives the successor runtime's own restore instead of being replaced a second after the session opens.

## Evidence

Everything below was measured on this head, in an isolated `HOME`/config dir with every `CMUX_*` (and `LOP_MOBILE_CHILD_*` / `LOP_RUNTIME_*`) variable stripped.

- **e2e stage** (`tests/e2e/test_cut_off_turns_e2e.py`, `-m e2e -n0`): a real runtime killed mid-turn and classified by a real successor boot; a deliberate `lop stop` over the socket; a deliberate `/stop` through the **in-process dispose route**; a runtime killed **while a viewer watches**; a provider refusal; and the next turn's model history. Each asserts the durable kind/cause/reason, the incident count and the rendered copy.
- **Unit suites**: the taxonomy, the restore classifier, the owner-path roster restore, the poller's tier, the stranded-card word, the phone notice severity and the phone's resume affordance.
- **Full gates** (whole tree, exactly as CI runs them): see the table in the comment below.
- **Rendered frames** at 60 and 100 columns for the live cut-off (with stranded cards), the poller's error/interrupted/unknown-cause rows and the sidebar row.

## Review status

Round 1 ran four independent streams (agent review, QA, design, UX); all four are answered in `### Agent review remediation — round 1` on this PR, including what was rejected or deferred and why. Round 2 re-runs against the remediation head.
