### PR TITLE
refactor(session): make the session contract total and fix the last dead duck-probes

### DIFF
--- a/docs/design/history-fold-convergence.md
+++ b/docs/design/history-fold-convergence.md
@@ -14,8 +14,10 @@
 >
 > * **The §3 divergences are FIXED**, by #864 (`51c71ff6f`, `fix(mobile): stop
 >   the phone dropping refusals, failures and gate timeouts`), which is an
->   **ancestor of this file's PR base `633baf258`** — i.e. the present-tense
->   claims were already stale when the file was tracked. The worst case below
+>   **ancestor of this file's original PR base `633baf258`** — and therefore of
+>   the branch's current base `27466f669`, which the branch was rebased onto on
+>   2026-09-11 — i.e. the present-tense claims were already stale when the file
+>   was tracked. The worst case below
 >   (a hub/parent steer rendering as a clean `parent_message` card on a
 >   scrolled-up history page and as a raw `<parent-message>` XML envelope on
 >   attach) no longer reproduces: both phone folds emit the parent's own words,
@@ -44,12 +46,12 @@
 >
 > **What the file is still good for.** §1's pager-vs-fold correction, §5's
 > measured superset, §6's design and the "one fold, two renderers" decision are
-> the reasoning the code was written from, and four production comments cite
-> this file as the authority for those ( `harness/rows.py`,
-> `tui/session_presentation.py`, `mobile/projection.py`,
-> `tests/unit/mobile/test_fold_parity.py`). That citation is about the ROWS,
-> which is still current. Nothing below should be read as "these defects are
-> live today".
+> the reasoning the code was written from, and four comments cite this file as
+> the authority for those — three in production code (`harness/rows.py`,
+> `tui/session_presentation.py`, `mobile/projection.py`) and one in the parity
+> test (`tests/unit/mobile/test_fold_parity.py`). That citation is about the
+> ROWS, which is still current. Nothing below should be read as "these defects
+> are live today".
 
 **Author:** architect (lopdev team), task `arch-fold-convergence`
 **Date:** 2026-09-09

--- a/docs/design/history-fold-convergence.md
+++ b/docs/design/history-fold-convergence.md
@@ -1,11 +1,64 @@
 # Converging the duplicated history folds — scope, divergences, design
 
+> ## STATUS: HISTORICAL DESIGN RECORD — NOT A DESCRIPTION OF THE TREE
+>
+> **Read this before acting on any present-tense claim below.** This analysis was
+> written against `origin/main` @ `a8f98be3b` (2026-09-09) and is landed
+> unchanged, because its §6 recommendation and the reasoning behind it are the
+> record for how the folds were converged. Its findings are stated in the
+> present tense of **that** base; the divergences it calls live were fixed
+> before this file's own PR base, so a reader who sizes work from §0, §3 or §7
+> will be sizing a bug that no longer exists.
+>
+> **What has landed since, and what it means for each claim:**
+>
+> * **The §3 divergences are FIXED**, by #864 (`51c71ff6f`, `fix(mobile): stop
+>   the phone dropping refusals, failures and gate timeouts`), which is an
+>   **ancestor of this file's PR base `633baf258`** — i.e. the present-tense
+>   claims were already stale when the file was tracked. The worst case below
+>   (a hub/parent steer rendering as a clean `parent_message` card on a
+>   scrolled-up history page and as a raw `<parent-message>` XML envelope on
+>   attach) no longer reproduces: both phone folds emit the parent's own words,
+>   including on the live echo-reconcile path
+>   (`mobile/projection.py`, `ProjectionFold.absorb_user_event`), and
+>   `tests/unit/mobile/test_fold_parity.py` asserts row-for-row agreement between
+>   the two folds.
+> * **§6's recommendation is IMPLEMENTED.** "Converge the semantics into
+>   host-free shared helpers" is `local_operator/harness/rows.py`, which both
+>   folds now import (`mobile/projection.py` for the phone fold,
+>   `tui/session_presentation.py` for the TUI fold). The differential harness §6
+>   asks for as Stage 0 is `tests/unit/mobile/test_fold_parity.py`. §6's premise
+>   ("the phone silently omits refusals, failed turns, gate timeouts …") is now
+>   a list of passing parity assertions.
+> * **§0's own count contradicts §3 and §7 and is wrong.** §0 says "Nine
+>   divergence classes are enumerated in §3" while §3 enumerates D1–D12 and §7
+>   records "12 found, 11 real, 8 user-visible today". Twelve were found; those
+>   are the twelve the parity test now pins as AGREEING.
+> * **Every `file:line` anchor in §2.1 is stale against head.** They are
+>   line numbers on `a8f98be3b`, and the refactors in between moved them: e.g.
+>   `fold_messages_to_entries` is now at `mobile/projection.py:607` (not `:567`),
+>   `ProjectionFold.fold_history` at `:924` (not `:746`), and
+>   `session/history_window.py`'s `display_window` at `:254` (not `:46`), with
+>   `tui/session_presentation.py`'s two entries likewise moved. Treat them as
+>   pointers into the base; only the `mobile/durable.py` anchors still resolve.
+>
+> **What the file is still good for.** §1's pager-vs-fold correction, §5's
+> measured superset, §6's design and the "one fold, two renderers" decision are
+> the reasoning the code was written from, and four production comments cite
+> this file as the authority for those ( `harness/rows.py`,
+> `tui/session_presentation.py`, `mobile/projection.py`,
+> `tests/unit/mobile/test_fold_parity.py`). That citation is about the ROWS,
+> which is still current. Nothing below should be read as "these defects are
+> live today".
+
 **Author:** architect (lopdev team), task `arch-fold-convergence`
 **Date:** 2026-09-09
 **Base:** `origin/main` @ `a8f98be3b` (moved past the briefed `0cd3a9434` during
 this analysis), fresh worktree `/tmp/arch-fold/wt`, own venv
-**Status:** analysis and plan only. **No production code written.** Every probe
-below runs outside the worktree and is re-runnable.
+**Status:** analysis and plan only, as of the base above. **No production code
+was written by this analysis.** Every probe below runs outside the worktree and
+is re-runnable. See the banner at the top of this file: the defects it reports
+have since been fixed and the §2.1 anchors have moved.
 **Builds on:** `/tmp/arch2/wt/docs/design/session-unification-adjudication.md`
 §6 item 3 and §9, which established that the folds duplicate a contract and
 explicitly declined to size it.

--- a/docs/design/history-fold-convergence.md
+++ b/docs/design/history-fold-convergence.md
@@ -1,0 +1,805 @@
+# Converging the duplicated history folds — scope, divergences, design
+
+**Author:** architect (lopdev team), task `arch-fold-convergence`
+**Date:** 2026-09-09
+**Base:** `origin/main` @ `a8f98be3b` (moved past the briefed `0cd3a9434` during
+this analysis), fresh worktree `/tmp/arch-fold/wt`, own venv
+**Status:** analysis and plan only. **No production code written.** Every probe
+below runs outside the worktree and is re-runnable.
+**Builds on:** `/tmp/arch2/wt/docs/design/session-unification-adjudication.md`
+§6 item 3 and §9, which established that the folds duplicate a contract and
+explicitly declined to size it.
+
+---
+
+## 0. Summary
+
+The redundancy is real, it is **worse than the brief describes**, and it is
+already producing user-visible wrong output on `main` today.
+
+Four findings, each verified by execution:
+
+1. **The brief's table conflates a pager with a fold.**
+   `session/history_window.py::display_window` is **not** a row fold. It returns
+   `list[AgentMessage]` (`history_window.py:46`) — it selects and signs a page
+   of *messages* and never produces a row. Measured by AST statement, 25 of its
+   52 statements are paging/budget and **4** touch row semantics (§2). It is not
+   a third implementation of the fold; it is the transport under one of them.
+   Removing it from the comparison is the single biggest correction here,
+   because a plan that tried to merge it into a row fold would be merging a
+   cursor-signing pager into a renderer.
+
+2. **There are, however, still three row folds, not two** — the brief lists
+   two. `mobile/projection.py` contains **two independent folds over
+   `AgentMessage`**: `fold_messages_to_entries` (`:567`, history pages) and
+   `ProjectionFold.fold_history` (`:746`, attach seed). They are 62 and 50
+   statements, they are ~80% the same code, and their own docstrings
+   (`:777-787`) assert they must not diverge.
+
+3. **They already diverge, and the worst case is on the phone against
+   itself.** A hub/parent steer renders as a clean `parent_message` card on a
+   scrolled-up history page and as a **raw `<parent-message>` XML envelope** in
+   a `notice` row on attach — same session, same row, one scroll gesture apart
+   (§3, D1). Nine divergence classes are enumerated in §3; all nine are verified
+   by execution, six against a real on-disk `Transcript`.
+
+4. **The performance constraint the brief flags as hard is not binding on the
+   fold.** Measured (§4): `fold_messages_to_entries` over 3,000 messages costs
+   **5.3 ms**. The 90–900 ms in `durable.py:1-9` is the **file parse and
+   replay**, not the fold — and the cache already sits *above* the fold behind a
+   one-line seam (`durable.py:446-449`). Convergence of fold semantics therefore
+   does **not** touch the cache at all.
+
+**Recommendation (§6): converge the two PHONE folds into one total function
+now, keep all three caches exactly where they are, and do NOT merge
+`TranscriptEntry` with the TUI's block tree.** The TUI fold mounts Textual
+widgets and costs 1,061 ms where the phone fold costs 5.3 ms (§4) — a 200x gap
+that is entirely widget construction. They are one *contract* with two
+*renderers*, and the correct shared artifact is a declarative row model plus an
+exhaustiveness check, not a shared row type.
+
+The honest framing the brief invited: this is **"converge the semantics, keep
+the caches separate"** — and the evidence lands there decisively (§4, §6.4).
+
+---
+
+## 1. What I measured, and how to re-run it
+
+| Probe | Establishes |
+|---|---|
+| `/tmp/arch-fold/probe_diverge.py` | 18 synthetic conversations through the TUI fold and the phone fold side by side |
+| `/tmp/arch-fold/probe_e2e.py` | The same, but input is a **real `Transcript.build_llm_history()`** off disk |
+| `/tmp/arch-fold/probe_phone_pair.py` | The two phone folds against each other |
+| `/tmp/arch-fold/probe_buckets2.py` | Per-fold concern buckets over AST **statements** |
+| `/tmp/arch-fold/probe_perf.py` | Fold/replay/pager costs at 120 / 600 / 3,000 messages |
+| `/tmp/arch-fold/probe_rowspec.py` | **Prototype of the recommended design**: the closed union under real pyright, and a `RowSpec`-based phone fold reproducing today's output |
+
+**Two of my own findings I corrected mid-analysis**, recorded because the
+standard on this team is that a corrected finding is worth more than a confident
+one:
+
+- My first bucketing pass counted docstrings and comments as code and produced
+  an `other/plumbing` bucket of ~60%. In a file where comments outnumber code by
+  design, that made the table meaningless. `probe_buckets2.py` walks AST
+  statement nodes instead and skips docstring `Expr` nodes; §2 uses only that.
+- My first perf run measured a **128-byte journal**: `Transcript()` takes a
+  *directory*, not a file path (`transcript.py:508`), so my "cold parse" numbers
+  were parsing an empty file. Re-measured against real 108 KB / 543 KB / 2.7 MB
+  journals; §4 uses only the corrected run. The uncorrected numbers would have
+  understated cold replay by ~4x and I would have drawn the wrong conclusion
+  about where the 90–900 ms lives.
+
+---
+
+## 2. Ground truth on the overlap
+
+### 2.1 The four implementations, correctly classified
+
+| # | Implementation | Location | Stmts | Input → Output | What it actually is |
+|---|---|---|---:|---|---|
+| 1 | `project_settled_rows` (+ `replay_tool_call`) | `tui/session_presentation.py:471`, `:801` | 119 + 20 | `AgentMessage` → Textual widgets | **Row fold** (owner/TUI) |
+| 2 | `fold_messages_to_entries` | `mobile/projection.py:567` | 62 | `AgentMessage` → `TranscriptEntry` | **Row fold** (phone, history pages) |
+| 3 | `ProjectionFold.fold_history` | `mobile/projection.py:746` | 50 | `AgentMessage` → `TranscriptEntry` | **Row fold** (phone, attach seed) |
+| 4 | `_capture_display_window` | `session/history_window.py:223` | 52 | `AgentMessage` → `AgentMessage` | **Pager**, not a fold |
+
+### 2.2 Concern buckets (AST statements, `probe_buckets2.py`)
+
+```
+concern             TUI.rows  TUI.tool  PH.pagefold  PH.attachfold  OWN.pager
+tool pairing              13         1            8              9          4
+custom rows                7         0            5              4          0
+chrome suppress            3         0            1              1          0
+images                     4         2            2              1          0
+refusal/fail               6         4            2              2          0
+payload fields             1         4            4              4          0
+paging/budget              5         0            0              1         25
+host mount                11         1            6              7          0
+plumbing                  69         8           34             21         23
+TOTAL                    119        20           62             50         52
+```
+
+Shared **row-semantics** statements (the six meaning-bearing concerns, excluding
+paging, host mount and plumbing):
+
+```
+TUI.rows        34        PH.pagefold     22
+TUI.tool        11        PH.attachfold   21
+                          OWN.pager        4
+```
+
+Read three ways:
+
+- **The pager is not in this problem.** 25 of 52 statements are paging/budget;
+  4 touch row semantics, and all four are the tool-call/result *grouping* it
+  does to avoid splitting a group across a page boundary
+  (`history_window.py:282-297`). That is a genuinely paging concern that happens
+  to need one fact about rows. **Leave it alone.**
+- **The two phone folds are near-duplicates**: 22 vs 21 shared-semantics
+  statements over the same six concerns, differing by one. They are the same
+  function written twice.
+- **The TUI fold is a superset, not a duplicate.** 45 shared-semantics
+  statements against the phone's 22, and its extra weight is real behaviour
+  (refusal/fail 10 vs 2; custom rows 7 vs 5; chrome suppression 3 vs 1) — which
+  is exactly the divergence list in §3.
+
+### 2.3 The honest overlap number
+
+Genuinely-same-contract-implemented-more-than-once, by concern:
+
+| Concern | Contract | Implemented in | Verdict |
+|---|---|---|---|
+| tool call ↔ result pairing | index results by `tool_call_id`, render on the call's row | 1, 2, 3 (+ grouping only in 4) | **Duplicated 3x** |
+| custom-row dispatch | wake / peer / hub / gate-timeout / compaction-refused → their own row kinds | 1, 2, 3 | **Duplicated 3x, and disagreeing** |
+| harness-chrome suppression | LOOP_PROMPT, `_CONTINUATION_PROMPT`, connectivity prompt, `$skill` payload never render verbatim | 1, 2, 3 | **Duplicated 3x, and disagreeing** |
+| refusal / interrupt / failed turn | `stop_reason` → a visible notice | 1 only | **Missing from 2 and 3** |
+| payload fields (`details`, `duration_s`) | diff counts + elapsed off `provider_payload` | 1, 2, 3 | **Duplicated 3x** |
+| image attachment resolution | user rows carry attachments | 1, 2, 3 | Duplicated 3x, forms differ legitimately (bytes vs refs) |
+| wire budget / cursor signing | — | 4 only | **Host-specific, correctly isolated** |
+| cache strategy | — | 4 (`_DisplayWindowCache`), `durable.py` | **Host-specific, correctly isolated** |
+| row type / mount | — | each | **Host-specific, legitimately different** |
+
+**Five of six row-semantics concerns are implemented three times. Two host
+concerns (budget, cache) are correctly isolated already.** The duplication is
+entirely in row *meaning* and entirely absent from row *transport* — which is
+what makes this tractable: the thing to share is the part with no host
+dependencies.
+
+---
+
+## 3. The divergences that already exist
+
+**This is the payload of the report.** Every row below was produced by running
+both folds; the `E2E` column marks the ones reproduced against a real on-disk
+`Transcript` replayed through `build_llm_history()` rather than synthetic
+messages.
+
+`probe_e2e.py` on one real 8-message transcript: **TUI renders 9 rows, phone
+renders 6.** Three rows silently vanish on the phone.
+
+| # | Conversation fact | TUI renders | Phone renders | Impact | E2E |
+|---|---|---|---|---|---|
+| **D1** | Hub/parent steer (`hub_message`) | *nothing* (main transcript) | **attach seed: raw `<parent-message>` XML in a notice**; history page: clean `parent_message` card | **Phone contradicts itself across one scroll.** Leaks the model-facing envelope `extract_parent_message` exists to hide | ✅ |
+| **D2** | Assistant turn with `stop_reason="refusal"` | `NoticeBlock("content policy", error)` | **nothing** | User sees a truncated answer with no indication the provider cut it off | ✅ |
+| **D3** | Failed turn (`stop_reason="error"`, no text/calls) | `NoticeBlock("turn failed", error)` | **nothing** | Prompt followed by silence; looks like the agent ignored them | ✅ |
+| **D4** | Interrupted turn (`stop_reason="aborted"`) | `NoticeBlock("interrupted", error)` | **nothing** | Same as D3 | ✅ |
+| **D5** | Gate timed out unattended | `NoticeBlock("waited 2h for approval with nobody attached, then denied it — bash · rm -rf /x", warning)` | **nothing** | The most expensive event in the detached feature is invisible on the phone | ✅ |
+| **D6** | Wake delivery (`wake_prompt`) | `WakeBlock` (dedicated affordance, `catchup` aware) | generic `notice` | Wake receipts lose their identity | ✅ |
+| **D7** | Compaction refused (`compaction_refused`) | `NoticeBlock`, **`error` vs `warning` ink chosen from the detail text** (`session_presentation.py:666`) | **nothing** | The optimistic "compacting context…" receipt is never corrected on the phone | ✅ |
+| **D8** | `$skill` invocation | `UserBlock("$research the widget market")` via `_typed_line_of` | **the entire expanded SKILL.md payload as the user's bubble** | Phone shows a wall of skill body; also poisons any phone-side session titling | — |
+| **D9** | `LOOP_PROMPT` / `_CONTINUATION_PROMPT` | suppressed | **rendered as a user bubble** | Harness chrome shown as the user's own words. Note the phone *does* suppress the third prompt, `CONNECTIVITY_CONTINUATION_PROMPT` (`projection.py:635`, `:776`) — a **partially copied list**, which is the drift signature itself | — |
+| **D10** | Unanswered tool call | `ToolCard` state `interrupted` | `tool_state="done"` | A call that never returned is shown as **succeeded** | — |
+| **D11** | Bang-mode (`! cmd`) | card opens expanded (`user_run=True`) | ordinary collapsed row | Cosmetic; the user's own command does not self-open | — |
+| **D12** | `compaction_summary` marker | *nothing* | `notice` | Divergence, but **benign**: the phone's web renderer treats `compaction` and `notice` identically (`transcript.tsx:181-182`) | ✅ |
+
+Notes on scoping honesty:
+
+- **D1 is the headline.** It is the only one where the phone disagrees with
+  *itself*, it leaks model-facing markup to a user surface, and both call sites
+  carry comments claiming the opposite is guaranteed
+  (`projection.py:777-787`: *"the two folds must not diverge or an attaching
+  phone and a lazy-loaded page would disagree about the same row"*). The comment
+  is wrong on `main` today. Verified end-to-end:
+
+  ```
+  PHONE ATTACH SEED:      notice | '<parent-message> focus on the parser </parent-message>'
+  PHONE HISTORY PAGE:     parent_message | 'focus on the parser'
+  ```
+
+- **D2–D5, D7 are one class**: the phone fold has no `stop_reason` branch and no
+  custom-row branch beyond peer/hub/generic-notice. Confirmed absent: `grep -rn
+  "stop_reason" local_operator/mobile/` returns only the *live-event* aborted
+  flag (`projection.py:876`) and web types — **no history fold anywhere in the
+  mobile stack reads `stop_reason`.**
+- **D10 is the same bug class as the three shipped duration bugs** the brief
+  cites (#823 `4790838ce` and its two follow-ups): one path silently defaulting
+  where another is explicit. `TranscriptEntry.tool_state` defaults to `"done"`
+  (`mobile/types.py:370`), so an unpaired call is *asserted* successful rather
+  than left unknown. A default that means "success" is how this class keeps
+  recurring.
+- **D12 I initially wrote up as a bug and downgraded** after reading the web
+  renderer: `case "notice": case "compaction":` fall through to the same
+  element. It stays on the list as a latent divergence — the day those two kinds
+  render differently it becomes real — but it is **not** a user-visible defect
+  today and I am not counting it as one.
+
+### 3.1 Why this got worse over time, structurally
+
+`EntryKind` (`mobile/types.py:339-351`) has a `compaction` member emitted **only
+by the live event path** (`projection.py:1023`) and by neither history fold. So
+the phone already has a row kind reachable live and unreachable on replay. There
+is no exhaustiveness check anywhere: no test in `tests/unit/mobile/` or
+`tests/unit/tui/` compares the folds' output on one input (verified by grep;
+`test_projection.py` pins each fold *separately*, and its header even claims
+*"these tests pin the TUI-parity contract"* while never executing the TUI). The
+folds are kept in step by review attention alone, and review attention has
+already failed nine times.
+
+---
+
+## 4. Performance: the constraint is not where the brief expects
+
+Measured on this host (`probe_perf.py`, min of 7, real journals):
+
+| messages / journal | cold `build_llm_history` | warm replay | **`fold_messages_to_entries`** | **`project_settled_rows`** | `display_window` (cold) |
+|---|---:|---:|---:|---:|---:|
+| 120 / 108 KB | 0.77 ms | 0.26 ms | **0.19 ms** | **39.8 ms** | 2.9 ms |
+| 600 / 543 KB | 3.87 ms | 1.33 ms | **0.98 ms** | **205.5 ms** | 5.1 ms |
+| 3000 / 2.7 MB | 19.7 ms | 6.84 ms | **5.26 ms** | **1061.3 ms** | 11.1 ms |
+
+Three conclusions, and they largely decide §6:
+
+1. **The fold is not the cost. The file is.** `durable.py:1-9` attributes
+   90–900 ms to "construct a fresh `Transcript` per request"; my measurement
+   splits that into ~20 ms parse + ~5 ms fold at 3,000 messages (the operator's
+   52 MB transcripts scale the parse, not the fold). The module's own third
+   design fact already says this — *"Fold cost is O(history), not O(file)…
+   ~1 ms where the file parse measured hundreds"* — and my numbers confirm it
+   at 5.3 ms for 3,000 messages. **A semantics change to the fold has
+   approximately no performance consequence.** The cache exists to avoid the
+   parse, and nothing proposed here touches the parse.
+
+2. **The cache is already decoupled from the fold.** `durable.py:446-449` is a
+   four-line seam:
+   ```python
+   def _fold(history: list[AgentMessage]) -> list[Any]:
+       from local_operator.mobile.projection import fold_messages_to_entries
+       return fold_messages_to_entries(history)
+   ```
+   The incremental cache calls the fold through one function. Replacing what the
+   fold *does* requires changing nothing in `durable.py`. This is the single
+   most important structural fact in the report: **the caches and the semantics
+   are already separated, so "converge the semantics, keep the caches" is not a
+   compromise — it is the shape the code is already in.**
+
+3. **The TUI fold is 200x the phone fold and that gap is irreducible.** At 3,000
+   messages: 1,061 ms vs 5.3 ms. Profiling (`cProfile`, 600 messages) attributes
+   it to widget construction, not semantics — `AssistantBlock._flat_whole`
+   0.330 s of 0.723 s, `rich.markdown.Markdown.__init__` 0.160 s,
+   `ToolCard.__init__` 0.095 s. The TUI is not folding slowly; it is
+   *rendering*, eagerly, inside the fold. **Any design that gives the TUI and
+   the phone one shared row-producing function must not make the phone pay
+   Textual construction, and must not make the TUI fold twice.** This is what
+   kills the "single row type" option in §5.
+
+---
+
+## 5. Options
+
+### Option A — one shared fold core, host-specific adapters (visitor/emit)
+
+A pure `fold(history, emit)` where `emit` is a host-supplied sink receiving
+semantic row events (`emit.user(...)`, `emit.tool(...)`, `emit.notice(kind,
+text)`). The TUI's sink mounts widgets; the phone's builds `TranscriptEntry`.
+
+- **Pro:** every §3 divergence becomes structurally impossible — one dispatch,
+  one chrome-suppression list, one `stop_reason` branch. Adding a row kind is
+  one `emit` method that every sink must implement.
+- **Pro:** no shared row type, so the phone never constructs a widget and the
+  TUI never builds a `TranscriptEntry`.
+- **Con:** the TUI's fold is not purely row-emitting — it interleaves
+  `_painted_tool_card` / `_settle_painted_tool_card` reconciliation
+  (`session_presentation.py:550-553`), head/tail deferral into
+  `_resume_pending_head`, and `batch_append`. Those are 11 "host mount"
+  statements that must stay on the TUI side of the seam, and getting the seam
+  wrong reintroduces the #401-class risk in the most-contended file in the repo.
+- **Con (largest):** it touches `tui/app.py`'s replay path — 82 commits and
+  +36,737 lines in 7 days per the adjudication's measurement. Blast radius on
+  the TUI is the real cost here, not the design.
+
+### Option B — one row type (`TranscriptEntry`) with host-specific renderers
+
+Fold once to `TranscriptEntry`; TUI renders widgets *from* entries.
+
+- **Pro:** conceptually cleanest; one fold, provably one semantics.
+- **Con — disqualifying:** `TranscriptEntry` is a **lossy wire type** built for
+  a phone. It caps args to `TOOL_ARGS_CHARS`, truncates output to a tail
+  (`projection.py:684`), carries images as `{index, mime}` *references* while
+  the TUI needs the actual `ImageContent` blocks (`session_presentation.py:708-712`),
+  and has no representation for `user_run`, `completion_anchor_id`,
+  `navigation_anchor_part`, or the painted-card reconciliation. Making it
+  lossless for the TUI means growing it until it is no longer a wire type —
+  and it is serialized to the phone on **every streaming token**
+  (`mobile/types.py:378-385` explains why bytes must never be inlined). Widening
+  it directly regresses the SSE budget.
+- **Con:** forces the phone's caps into the TUI or forces two variants of the
+  type, which is the divergence again with extra steps.
+
+### Option C — converge the two PHONE folds only; share nothing with the TUI
+
+Merge `fold_messages_to_entries` and `ProjectionFold.fold_history` into one
+function. Leave the TUI alone.
+
+- **Pro:** kills D1 outright (the self-contradiction), and it is the only
+  divergence where one surface disagrees with itself.
+- **Pro:** zero blast radius on `tui/app.py` — the entire change is inside
+  `mobile/projection.py`, which no other in-flight PR is rewriting.
+- **Con:** does **not** fix D2–D5, D7–D11, which are TUI-vs-phone. The phone
+  stays silent about refusals, failed turns and gate timeouts.
+- **Con:** leaves the bug class alive — two folds becomes one fold, but the
+  *contract* is still asserted by comment rather than checked.
+
+### Option D — do nothing / fix forward case by case
+
+- **Pro:** honest baseline; each divergence is individually a small fix.
+- **Con:** nine divergences accumulated under exactly this policy, three
+  duration bugs shipped from the same class, and both prior architects
+  independently pointed at this seam. The evidence that "fix each one" does not
+  hold is the list in §3.
+
+### Option E — shared **declarative** semantics + exhaustiveness check (recommended core)
+
+Extract the *decisions* — not the rendering — into one pure, host-free module
+that maps one `AgentMessage` (plus fold-local pairing state) to a **closed
+union of semantic row descriptors**. Each host has a *total* renderer over that
+union, and totality is enforced by the type checker (`assert_never`) plus a
+property test that both renderers accept every variant.
+
+This is Option A with the seam drawn at the *decision* rather than at the
+*emit*, which keeps the TUI's mount mechanics entirely on the TUI side.
+
+---
+
+## 6. Recommendation
+
+**Adopt E, staged, starting with C. Keep all three caches exactly where they
+are. Do not converge `TranscriptEntry` with the TUI's block tree.**
+
+Concretely:
+
+1. **Source of truth for row semantics: the TUI fold** (`project_settled_rows`
+   + `replay_tool_call`). Not because it is prettier — because §2.2 measures it
+   as the strict superset (45 shared-semantics statements vs 22/21) and §3 shows
+   every divergence resolves in its favour except D12 (benign) and D1 (where
+   *neither* is right — the TUI renders nothing and the correct answer is the
+   history page's `parent_message`). Its behaviour is also the one with review
+   history attached: the comments cite review rounds and specific findings
+   (MAJOR-1/U7/D1, round 2 m2, round 5 U17), so its choices are adjudicated
+   rather than incidental.
+
+2. **Source of truth for the *type*: neither.** Introduce a new closed union of
+   row descriptors — `RowSpec` — in a host-free module (no Textual, no wire
+   types, no session import), mirroring how `compaction/marker.py` already sits
+   below hosts that "must not import the session" (`marker.py:11-14`). Both
+   `TranscriptEntry` and the TUI's blocks are *projections of* `RowSpec`, not
+   each other.
+
+3. **Caches stay put.** `_DisplayWindowCache` (owner paging),
+   `durable.py`'s incremental cache (daemon), and the TUI's
+   `_resume_pending_head` deferral solve three different problems at three
+   different layers, and §4 shows the fold is 0.5% of the cost the daemon cache
+   exists to avoid. Converging them would be a large change with no measured
+   benefit. **This is the part of the brief's framing I am pushing back on:
+   performance is a hard constraint, but it constrains the *cache*, and the
+   cache is not what is duplicated.**
+
+4. **The pager (`history_window.py`) is out of scope.** §2.1. Do not touch it.
+
+### 6.1 Arguing against my own recommendation
+
+**Attack 1: "E is A with extra ceremony — you invented a type to avoid drawing a
+seam."** Partly fair. The difference is load-bearing but narrow: A's `emit` sink
+must be *called from inside* the shared fold, which means the shared fold owns
+the loop, which means the TUI's painted-card reconciliation and head/tail
+deferral must either move into the shared code (wrong — they are host mount
+concerns) or be hoisted out of the loop (a real refactor of the most-contended
+function in the repo). E's `RowSpec` is a *value*, so each host keeps its own
+loop and its own mount mechanics and only the decisions are shared. If that
+distinction turns out not to survive contact with the TUI's `_resume_pending_*`
+slicing, **E degrades to C plus a checker** and I would take that outcome over
+forcing it.
+
+**Attack 2: "You are recommending a new abstraction beside two existing ones —
+the thing the role brief tells you to avoid."** The strongest attack. My defence
+is that the alternative is not "fix the existing thing" but "fix the existing
+thing nine times and then again next quarter", and §3.1 shows there is no
+mechanism that would catch the tenth. But I concede the shape of the risk, which
+is why the plan (§8) makes Stage 1 and Stage 2 **independently valuable and
+independently shippable**: if the team stops after Stage 2, the phone is
+self-consistent and the worst divergences are fixed, with no new abstraction
+landed at all.
+
+**Attack 3: "Just delete `ProjectionFold.fold_history` and call
+`fold_messages_to_entries`."** This is genuinely most of Stage 1 and I want it
+on the record as the cheapest real fix. It does not fully work as stated —
+`fold_history` also maintains `_tool_rows`/`_tool_args` correlation maps and
+prunes them to the surviving tail (`projection.py:846-859`), which the pure
+function cannot do — but the *row production* half can be replaced wholesale,
+with the state maintenance layered on top. That is exactly Stage 1.
+
+**Attack 4: "D12 shows you are inflating the list."** Fair challenge, which is
+why I downgraded it in place rather than dropping it. Eight of the twelve are
+user-visible today; D11 is cosmetic; D12 is latent-only.
+
+### 6.2 What would change my mind
+
+- If the TUI's `_resume_pending_head`/`_resume_pending_tail` slicing cannot be
+  expressed over a `RowSpec` list without a second pass over messages, the
+  message→row seam is in the wrong place and the answer is C + checker.
+  **Evidence that settles it:** a prototype of Stage 3 that produces
+  byte-identical mounted blocks for the `tests/unit/tui/test_resume_render.py`
+  corpus. I did not build this — it is the first thing Stage 3 should do, and
+  Stage 3 should be abandoned if it fails.
+- If a `RowSpec` variant needs a Textual-only or wire-only field, the union is
+  not host-free and E collapses to B's problem.
+
+---
+
+## 7. Proving the bug class dies
+
+The brief's bar: a future field added to `provider_payload`, or a new row kind,
+must become **impossible** to drop on one path and not the other. Four
+mechanisms, in decreasing strength.
+
+### 7.1 Exhaustiveness at the type level (kills the *new row kind* half)
+
+`RowSpec` is a closed discriminated union. Each host renderer dispatches with a
+terminal `assert_never`:
+
+```python
+def render(spec: RowSpec) -> None:
+    match spec:
+        case UserRow(): ...
+        case AssistantRow(): ...
+        case ToolRow(): ...
+        case NoticeRow(): ...
+        case WakeRow(): ...
+        case PeerRow(): ...
+        case ParentRow(): ...
+        case _ as unreachable:
+            assert_never(unreachable)   # pyright errors on a new variant
+```
+
+Adding a variant makes **pyright fail on every host that does not handle it** —
+and pyright is already a required gate. This is the mechanism that would have
+prevented D2–D7: each is a row kind one host knows about and the other silently
+falls through. Today the phone's fold ends its `if/elif` chain with no `else`,
+so an unhandled message is dropped in silence; that is precisely how five row
+kinds went missing.
+
+**Strength: strong — and this is EXECUTED, not argued.** I prototyped the union
+and two renderers (`/tmp/arch-fold/probe_rowspec.py`) and ran the repo's own
+pyright over them. A renderer that handles every variant passes; the identical
+renderer with the `NoticeRow` case deleted fails:
+
+```
+error line 107 :: Argument of type "NoticeRow" cannot be assigned to
+                  parameter "arg" of type "Never" in function "assert_never"
+```
+
+`NoticeRow` is precisely the variant carrying D2–D5 and D7 — the five rows the
+phone silently drops today. **Under this mechanism, the phone fold as it exists
+on `main` would not typecheck.** It is a compile-time failure in a gate the
+project already runs, not a test someone can forget to write.
+
+### 7.2 Totality of the payload projection (kills the *new field* half)
+
+The `provider_payload` → row-fields projection becomes **one function** in the
+shared module:
+
+```python
+def tool_payload(message: Message) -> ToolPayload:   # total, no host may re-read the dict
+    ...
+```
+
+with `ToolPayload` a frozen dataclass. The rule that makes it stick: **no host
+may read `message.provider_payload` directly** — enforceable by a ~15-line AST
+test asserting the string `provider_payload` appears in exactly one module
+outside `harness/`. Today it is read independently at
+`projection.py:671-673`, `projection.py:826-833` and inside the TUI's
+`replay_tool_call`, which is why the same `details`/`duration_s` keys PR #858 is
+repairing on one path are pre-loaded to break on the others.
+
+Adding a field then has exactly one edit site, and every host receives it or
+fails to typecheck.
+
+**Strength: strong for the intended class; it does not stop a host from
+*ignoring* a field it receives** — which §7.4 covers.
+
+I also prototyped the *other* half of the claim — that the phone fold can be
+rebuilt as `messages → [RowSpec] → [TranscriptEntry]` — and it reproduces
+today's output exactly on a non-divergent case:
+
+```
+today  : [('user','edit it',...), ('assistant','editing',...), ('tool','','edit','done',9.75,3,1)]
+RowSpec: [('user','edit it',...), ('assistant','editing',...), ('tool','','edit','done',9.75,3,1)]
+EQUAL: True
+```
+
+So Stage 3 is demonstrated, not merely designed. **Stage 4 (the TUI half)
+remains un-prototyped and stays gated** — see §6.2 and §10.
+
+### 7.3 Differential property test (catches semantic drift the types cannot)
+
+The test that does not exist today and should:
+
+> For every message shape in a generated corpus, `phone_rows(h)` and
+> `tui_rows(h)` produce the **same sequence of row kinds** and the same
+> per-row identity/text/state, modulo an explicitly declared and *asserted*
+> allowance list.
+
+`probe_diverge.py` and `probe_e2e.py` in this report are that test in
+prototype form; `PreparedReplay` (`session_presentation.py:216-283`) already
+makes the TUI fold drivable headless, so the harness cost is near zero. The
+allowance list is the key discipline: a divergence must be *named* to be
+legal, so D11 (bang-mode expansion) would be an explicit entry and D2–D7 could
+not be.
+
+**Strength: medium-strong.** It catches what types cannot (two hosts both
+handling a kind, differently), and it fails loudly. It is a test, so it can be
+skipped — but it fails on the corpus, not on a hand-written case, so it does not
+rot the way per-case tests do.
+
+### 7.4 Where the proof is honestly incomplete
+
+**A field that every host receives and one host chooses not to render is still
+representable.** No type stops a renderer from ignoring a `RowSpec` field. §7.3
+catches it only if the corpus exercises that field. So the claim I will defend
+is narrower than "the bug class is unrepresentable":
+
+- **new row kind dropped on one path** → impossible (7.1, compile-time)
+- **new payload field parsed on one path only** → impossible (7.2, single site)
+- **field carried everywhere but rendered differently** → *caught, not
+  prevented* (7.3)
+
+Option C alone achieves none of the three; Option B achieves the first two but
+at the wire-budget cost in §5. **That is the argument for E over C**, and it is
+the whole argument — if the team does not value the first two, C is cheaper and
+I would not fight for E.
+
+---
+
+## 8. Staged execution plan
+
+Sequenced by **correctness risk and blast radius**, not effort. Each stage is
+independently shippable and independently valuable; the plan can be stopped
+after any stage without leaving the tree half-converged.
+
+### Stage 0 — differential harness (no production code)
+
+Land `tests/unit/mobile/test_fold_parity.py` (or `tests/unit/tui/`) containing
+the §7.3 differential test **with today's divergences encoded as an explicit,
+commented allowance list**. It goes green on `main` immediately.
+
+- **Why first:** it is the regression net for every later stage, and it converts
+  §3 from a report into an executable artifact. Every subsequent stage's
+  evidence is "N allowances deleted".
+- **Blast radius:** zero — tests only.
+- **Parallelisable:** no (everything else depends on it).
+- **Reversible:** entirely.
+
+### Stage 1 — collapse the two phone folds (Option C)
+
+Make `ProjectionFold.fold_history` call `fold_messages_to_entries` for row
+production, keeping its correlation-map maintenance
+(`projection.py:846-859`) and `_cap_tail` layered on top.
+
+- **Fixes:** D1 (the self-contradiction, and the XML leak).
+- **Why here:** the highest-severity divergence, and it is entirely inside
+  `mobile/projection.py` — **no `tui/app.py` contact at all**.
+- **Blast radius:** small and phone-only.
+- **Parallelisable:** yes — independent of Stage 2.
+- **Evidence:** the D1 reproduction in §3 must flip; QA drives a real phone
+  session with a hub steer, opens it (attach seed) and scrolls up (history
+  page), and captures both.
+
+### Stage 2 — teach the phone the rows it is missing
+
+Add the `stop_reason` branch and the missing custom-row dispatch to the (now
+single) phone fold: refusal, failed turn, interrupted turn, gate timeout,
+compaction-refused, wake identity, `$skill` typed line, chrome suppression,
+unpaired-call `interrupted` state.
+
+- **Fixes:** D2–D11.
+- **Why here:** these are the user-visible ones, and they need **no new
+  abstraction** — they are additions to one function, checked by Stage 0's
+  harness with allowances deleted one per fix.
+- **Blast radius:** phone renderer needs a `tool_state="interrupted"` case and
+  possibly a notice severity; `mobile/web` is a real but contained surface.
+- **Parallelisable:** **yes, and this is where the fan-out is** — D2/D3/D4
+  (`stop_reason`), D5/D7 (custom notices), D6 (wake), D8/D9 (chrome), D10
+  (`tool_state`) are five independent slices over disjoint branches of one
+  `if/elif` chain. They must land as **one commit round** per the team's
+  batching rule, but they can be *written* concurrently.
+- **User-visible ⇒ designer round required** (new row kinds on the phone), and
+  D10's `interrupted` state needs a glyph decision.
+
+### Stage 3 — extract `RowSpec` and make the phone total (Option E, phone half)
+
+Introduce the host-free `RowSpec` union and the single `tool_payload`
+projection; rewrite the phone fold as `messages → [RowSpec] → [TranscriptEntry]`
+with `assert_never`.
+
+- **Delivers:** §7.1 and §7.2 for the phone, and the AST guard that
+  `provider_payload` is read in one place.
+- **Blast radius:** still phone-only. The TUI keeps its own fold, now checked
+  against the phone by Stage 0's harness.
+- **Irreversible-ish:** this is the first stage that adds a new module. It is
+  the decision point — **stop here if Stage 3 review finds the union awkward**,
+  and the tree is still strictly better than today.
+
+### Stage 4 — move the TUI onto `RowSpec` (Option E, TUI half) — *gated*
+
+Rewrite `project_settled_rows` as a `RowSpec` consumer, keeping
+`_painted_tool_card` reconciliation, head/tail deferral and `batch_append`
+on the TUI side.
+
+- **Gate:** do not start until the §6.2 prototype shows byte-identical mounted
+  blocks for the `test_resume_render.py` corpus. **If it does not, abandon
+  Stage 4** — the tree keeps Stages 0–3, which is a good outcome.
+- **Blast radius: the largest in the repo.** `tui/app.py` and
+  `session_presentation.py` are the most-contended files; the adjudication
+  measured 82 commits / +36,737 lines in 7 days on `app.py`.
+- **Not parallelisable with anything.** One worktree, one PR, serialised.
+- **Irreversible steps:** none technically (it is a refactor), but a regression
+  here is a frozen or wrongly-rendered TUI, which is the #401 class. Requires
+  the full visual-validation treatment in `AGENTS.md` — rendered before/after
+  SVG frames for resume, reconnect-gap replay, and bang-mode.
+
+### Concurrency and merge-conflict strategy
+
+- **Stages 0, 1, 2, 3 barely touch `tui/app.py`** — deliberately. The plan
+  front-loads all the value that can be delivered without entering the
+  contended file, and quarantines the contended work into a single gated stage
+  at the end.
+- **PR #858 interaction:** Stage 3's `tool_payload` is the natural home for
+  exactly what #858 makes total in `Message.tool_result`. **Stage 3 must rebase
+  onto a merged #858 and adopt its factory rather than duplicating the stamp** —
+  if #858 is still open when Stage 3 starts, Stage 3 waits. Stages 0–2 do not
+  touch `harness/types.py` and are unaffected. I have not read #858's diff and
+  am relying on the brief's description.
+- **Absorbing concurrent merges:** each stage begins by rebasing on
+  `origin/main` and **re-running Stage 0's differential harness before writing
+  any code**. New divergences introduced by other sessions show up as harness
+  failures against the allowance list, which is precisely the "periodically pull
+  in-flight work into the new pattern" the operator asked for — the harness *is*
+  the mechanism. A new allowance entry appearing without a comment is the review
+  signal that someone added a row kind on one side only.
+- **Rebase discipline:** per the team's rule, a rebase onto a moved base is
+  never re-pinnable — prove content unchanged with `git range-diff '='` plus
+  byte-identical ±line sets, then one convergence round scoped
+  `<old-head>..<new-head>` checking only files upstream also touched.
+
+### Roles per stage
+
+| Stage | coder | reviewer | qa-tester | designer | ux-reviewer |
+|---|---|---|---|---|---|
+| 0 | ✅ | ✅ | ✅ | — | — |
+| 1 | ✅ | ✅ | ✅ | — | — |
+| 2 | ✅ (fan-out, one commit round) | ✅ | ✅ | ✅ (new phone rows) | — |
+| 3 | ✅ | ✅ | ✅ | — | — |
+| 4 | ✅ | ✅ | ✅ | ✅ (TUI frames) | ✅ (resume flow) |
+
+---
+
+## 9. Risks to watch during rollout
+
+1. **Stage 2 makes the phone noisier.** Five row kinds that were invisible
+   become visible. On a long agent session, "turn failed"/"interrupted" notices
+   may be frequent. **Watch:** the designer round should decide severity ink and
+   whether interrupted turns collapse. This is a genuine product change, not
+   just a bug fix, and should be framed that way to the operator.
+2. **`_cap_tail` interaction (Stage 1/2).** The attach seed caps to a render
+   tail; the history page is uncapped. Adding rows changes what the cap keeps —
+   `_cap_tail` deliberately preserves the opening user message
+   (`projection.py:1630-1656`). **Watch:** a session whose tail is now mostly
+   notices could push real content out of the seed.
+3. **Stage 3 union churn.** If `RowSpec` needs a variant per custom type, it
+   grows with every new custom type, and `assert_never` then makes *every* new
+   custom type a multi-host change. That is the intended cost, but it is a real
+   tax. **Watch:** if variants exceed ~12, prefer a generic `NoticeRow(kind,
+   severity, text)` over per-type variants.
+4. **Stage 4 performance.** The TUI fold is 1,061 ms at 3,000 messages *today*;
+   a `RowSpec` intermediate adds an allocation per row. It should be noise
+   against widget construction (§4), but it must be **measured, not assumed** —
+   re-run `probe_perf.py` before and after.
+5. **The allowance list rotting.** Stage 0's value depends on entries being
+   deleted, not accumulated. **Watch:** any PR that *adds* an allowance without
+   an explicit reviewer-acknowledged reason is the failure mode this whole plan
+   exists to prevent.
+6. **`durable.py` cache invalidation is untouched but adjacent.** Stages 1–3
+   change fold output while the cache keys on file inode/size, not on fold
+   version. **Verified:** the cache is a process-local singleton owned by the
+   daemon (`daemon.py:112`, `_DURABLE_FOLD_CACHE = DurableFoldCache()`), so it
+   dies with the process and cannot outlive a restart. The residual risk is
+   therefore only that a **long-running daemon is not restarted** by
+   `lop-update` and keeps serving old-fold rows to the phone while a new TUI
+   renders new-fold rows. **Watch:** make the daemon restart part of each
+   stage's rollout, and have QA confirm `mobile` service restart before
+   validating phone output — otherwise a stage will appear not to have
+   landed.
+
+---
+
+## 10. Uncertainty, stated
+
+- **Stage 3 IS prototyped** (§7.1/§7.2, `probe_rowspec.py`): the union
+  typechecks, the missing-variant renderer fails pyright, and the
+  `RowSpec`-based phone fold reproduces today's rows. **Stage 4 is not.**
+- **I did not prototype Stage 4.** The claim that the TUI's mount mechanics can
+  sit above a `RowSpec` seam is reasoned from reading
+  `session_presentation.py:471-798`, not executed. §6.2 names the experiment
+  that settles it and §8 gates the stage on it.
+- **I did not read PR #858's diff** (instructed not to disturb it). Stage 3's
+  interaction with it is inferred from the brief.
+- **D8/D9/D10/D11 are verified on synthetic messages only**, not through a real
+  `Transcript` round-trip. The message shapes are taken from the code that
+  builds them, but a real skill invocation and a real bang-mode record should be
+  captured in Stage 0's corpus rather than trusted from here.
+- **The 200x TUI/phone fold gap is measured headless** via `PreparedReplay`,
+  which does not mount into a live `App`. Real mounting may be slower still;
+  it will not be faster, so the direction of the §5-B argument holds.
+- **`_message_text`'s hub behaviour** (§3 D1) depends on hub messages carrying a
+  `text` key in `details`. I verified this is what `comms.py:2065-2074` writes.
+  A hub message written by an older version without that key would degrade to a
+  dropped row rather than a leaked envelope — still a divergence, different
+  symptom.
+
+---
+
+## 11. Summary for the manager
+
+**Overlap:** five of six row-semantics concerns are implemented three times
+(TUI fold, phone history-page fold, phone attach-seed fold). The two host
+concerns that would be expensive to share — wire budget and cache strategy — are
+already correctly isolated. **The brief's third fold is a miscount:
+`display_window` is a pager (25 of 52 statements are paging; 4 touch rows) and
+should be left alone. The real third fold is `ProjectionFold.fold_history`,
+inside `mobile/projection.py`.**
+
+**Divergences:** 12 found, 11 real, 8 user-visible today. The worst is **D1**:
+the phone shows a hub steer as a clean card on a scrolled-up page and as a raw
+`<parent-message>` XML envelope on attach — the same row, one gesture apart,
+under comments that explicitly promise this cannot happen. **D2–D5 and D7** mean
+the phone silently omits refusals, failed turns, interrupted turns, gate
+timeouts and compaction refusals: on one real transcript the TUI renders 9 rows
+and the phone renders 6.
+
+**Performance:** not the constraint people think. The fold is **5.3 ms at 3,000
+messages**; the 90–900 ms in `durable.py` is file parsing. The cache already
+calls the fold through a four-line seam (`durable.py:446-449`), so **converging
+fold semantics requires no cache change at all.**
+
+**Recommendation:** converge the semantics, keep the caches separate — which is
+the option the brief invited and the evidence lands on. Source of truth for
+meaning is the TUI fold (measured superset); source of truth for the *type* is
+neither — a new host-free `RowSpec` union, because `TranscriptEntry` is a lossy
+wire type re-sent on every streaming token and widening it regresses the SSE
+budget. **Do not merge `TranscriptEntry` with the TUI's blocks. One fold, two
+renderers.**
+
+**Bug-class proof:** a closed union + `assert_never` makes a dropped row kind a
+**pyright failure** (kills D2–D7's class); a single `tool_payload` projection
+plus a one-site AST guard makes a dropped payload field impossible (kills the
+#823/#858 class). A field carried but rendered differently is *caught, not
+prevented*, by the differential test — I state that limit rather than overclaim.
+
+**Plan:** five stages, front-loaded to deliver all value reachable **without
+touching `tui/app.py`**, with the one high-blast-radius stage last and *gated*
+on a prototype. Stage 0 (differential harness, green on `main` today) is the
+mechanism that absorbs concurrent merges: every later stage re-runs it after
+rebase, and a new allowance entry is the review signal that someone changed one
+fold and not the other.
+
+**Stop-anywhere property:** stopping after Stage 2 leaves the phone
+self-consistent and the user-visible divergences fixed, with no new abstraction
+landed. That is the fallback if `RowSpec` does not survive review.

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -1033,14 +1033,20 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
     # desktop routes' ``bridge.remote``, and ``info/collect.py``'s ``session``
     # parameter.
     #
-    # The OWNER-side readers of these same members are NOT an exception to that,
-    # because they hold the concrete class: ``harness/subagent.py`` types its
-    # ``parent_session`` as ``Session`` and reads ``mcp_manager`` /
-    # ``mcp_startup`` / ``jobs`` off it, and ``session/runtime/serving.py`` reads
-    # ``self._session.jobs`` on the owner. Those reads are already checked by
-    # pyright against the real class, so a protocol declaration would buy them
-    # nothing — which is why the placement is a claim about the DUCK-TYPED
-    # population and not the claim "only a viewer has these".
+    # The OWNER-side readers of these same members are NOT an exception to that.
+    # ``harness/subagent.py`` types its ``parent_session`` as ``Session`` and
+    # reads ``mcp_manager`` / ``mcp_startup`` / ``jobs`` off it, so pyright is
+    # already checking those against the real class.
+    #
+    # ``session/runtime/serving.py`` reads ``self._session.jobs`` on the owner
+    # too, and those reads are UNCHECKED: ``ServingSessionHandle.__init__``
+    # takes ``session: Any``, so ``self._session`` is ``Any`` there and pyright
+    # verifies nothing — not against the real class, not against a protocol.
+    # Restating the difference matters because it is the reason a declaration on
+    # ``SessionProtocol`` would buy those readers nothing either: what would
+    # check them is typing the handle's constructor, not widening the protocol.
+    # Either way the placement is a claim about the DUCK-TYPED population and
+    # not the claim "only a viewer has these".
     #
     # Declaring them is deliberately NOT the same as making them safe for any
     # host to read. A snapshot member answers from the last sync, so a caller

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -27,6 +27,7 @@ from local_operator.harness.types import (
     ImageContent,
     Message,
     ModelSpec,
+    ToolResult,
     Usage,
 )
 from local_operator.session.naming import ConversationName
@@ -1016,4 +1017,142 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
 
     def set_recall_resolution(self, resolver: Callable[[str], None] | None) -> None:
         """The recall twin of :meth:`set_cancel_resolution`."""
+        ...
+
+    # --- engine state a viewer host renders --------------------------------
+    #
+    # The MCP status segment and its menus, the subagent and job views, the
+    # sidebar's gate identity, the wake panel, the ``/agent`` and ``/team``
+    # listings, and the saved-usage band. These live on THIS protocol rather
+    # than on ``SessionProtocol`` because that is the honest claim. BOTH
+    # classes implement them — the owner exposes the live manager, scheduler or
+    # registry, and a viewer a read-only SNAPSHOT the runtime published — but
+    # every host that reads them (the TUI, the desktop routes,
+    # ``info/collect.py``) holds an attached facade, so the viewer is where a
+    # reader actually lands.
+    #
+    # Declaring them is deliberately NOT the same as making them safe for any
+    # host to read. A snapshot member answers from the last sync, so a caller
+    # that needs the live object — or the owner-only extra argument, as
+    # ``subscribe_frontend``'s ``display_window`` is — must hold the concrete
+    # engine type. What the declaration buys is that a rename, a typo or a
+    # deletion is now a pyright error and a guard failure instead of the silent
+    # ``None`` that shipped a fabricated zero-subagent ``/info``.
+    #
+    # The wider-protocol claim is not hypothetical: declaring these on
+    # ``SessionProtocol`` put the whole ``tests/unit/tui`` double population off
+    # conformance (measured: 213 pyright errors across 19 files, from ~10 local
+    # ``FakeSession`` classes alone; 1996 when every member of the old exclusion
+    # list went there). A double that has to grow an MCP manager to keep
+    # compiling is a double describing an object the hosts never read. The
+    # viewer protocol is the narrower, true claim and costs the doubles nothing.
+
+    # Job, wake and subagent plumbing. Read by the subagent view, the wake
+    # panel and ``/fork``'s "cannot leave work running" check.
+
+    @property
+    def jobs(self) -> Any:
+        """Background-job ledger: the live manager, or the runtime's snapshot."""
+        ...
+
+    @property
+    def wake_scheduler(self) -> Any:
+        """Armed wakes: the live scheduler, or the runtime's snapshot."""
+        ...
+
+    @property
+    def subagent_comms(self) -> Any:
+        """Channel to launched subagents: live on an owner, a view on a viewer."""
+        ...
+
+    # MCP status and its menus. Both are optional by design: a session may
+    # carry no manager at all, and the startup outcome is None until one runs.
+
+    @property
+    def mcp_manager(self) -> Any | None:
+        """The MCP manager: live on an owner, a snapshot on a viewer, or ``None``."""
+        ...
+
+    @property
+    def mcp_startup(self) -> Any | None:
+        """The MCP startup outcome (discovery failures), or ``None``."""
+        ...
+
+    # The registries behind ``/agent`` and ``/team``. Each is the registry of
+    # the machine the VIEWER runs on, which is why a viewer is a real
+    # implementation and not a passthrough.
+
+    @property
+    def agent_registry(self) -> Any | None:
+        """The user's agent-profile registry, or ``None`` when none is wired."""
+        ...
+
+    @property
+    def team_registry(self) -> Any | None:
+        """The user's team registry, or ``None`` when none is wired."""
+        ...
+
+    # Per-frame reads with a narrow accessor, so a frame does not pay the
+    # whole-state clone ``frontend_state`` costs.
+
+    @property
+    def pending_gate(self) -> Any:
+        """The parked approval gate, read without the whole-state clone."""
+        ...
+
+    @property
+    def epoch(self) -> str:
+        """The runtime epoch, read without the whole-state clone."""
+        ...
+
+    def subscribe_frontend(self, handler: Callable[[Any], Any]) -> Any:
+        """Refresh, snapshot and subscribe to canonical state in one step.
+
+        Only the argument every session can honour is declared. The owner
+        version also accepts ``display_window`` (it can capture a signed page
+        of its own transcript); a host that needs that holds the owner type.
+        """
+        ...
+
+    # The status band and the transcript. ``record_shell`` is routed by a
+    # viewer and persisted by the owner; ``restored_usage`` is the provider's
+    # own last reading, so the band can seed a truthful zero-cost state.
+
+    def context_breakdown(self) -> dict[str, int]:
+        """On-demand token breakdown for the context the next request sends."""
+        ...
+
+    def restored_usage(self) -> Usage | None:
+        """The provider's own last usage reading for this conversation."""
+        ...
+
+    async def record_shell(self, command: str, result: ToolResult) -> None:
+        """Persist a user-typed bang-mode command into the conversation."""
+        ...
+
+    # The capability-style members. Each is a REAL operation on both classes,
+    # and each host reads it through ``getattr`` + a ``callable`` check even
+    # now; declaring them is what turns "the double quietly lacks it" into a
+    # static failure, which is the entire point of this block.
+
+    async def fork_snapshot(self, message: str = "") -> dict[str, Any]:
+        """Fork the committed prefix without interrupting the live loop."""
+        ...
+
+    async def refresh_attention(self) -> dict[str, Any]:
+        """Reconcile cross-process attention receipts."""
+        ...
+
+    async def acknowledge_attention(self, token: str) -> dict[str, Any]:
+        """Acknowledge one observed attention outcome."""
+        ...
+
+    @property
+    def active_agent(self) -> str:
+        """Display name of the ``/agent`` profile in force (``""`` when none)."""
+        ...
+
+    @property
+    def active_team_name(self) -> str:
+        """Name of the team this session manages (``""`` when none)."""
         ...

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -1024,12 +1024,23 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
     # The MCP status segment and its menus, the subagent and job views, the
     # sidebar's gate identity, the wake panel, the ``/agent`` and ``/team``
     # listings, and the saved-usage band. These live on THIS protocol rather
-    # than on ``SessionProtocol`` because that is the honest claim. BOTH
+    # than on ``SessionProtocol`` because that is where the duck-typed readers
+    # land. BOTH
     # classes implement them — the owner exposes the live manager, scheduler or
-    # registry, and a viewer a read-only SNAPSHOT the runtime published — but
-    # every host that reads them (the TUI, the desktop routes,
-    # ``info/collect.py``) holds an attached facade, so the viewer is where a
-    # reader actually lands.
+    # registry, and a viewer a read-only SNAPSHOT the runtime published — and
+    # every host that reaches them through a DUCK-TYPED binding holds an
+    # attached facade: the TUI's ``self._session`` / ``source.session``, the
+    # desktop routes' ``bridge.remote``, and ``info/collect.py``'s ``session``
+    # parameter.
+    #
+    # The OWNER-side readers of these same members are NOT an exception to that,
+    # because they hold the concrete class: ``harness/subagent.py`` types its
+    # ``parent_session`` as ``Session`` and reads ``mcp_manager`` /
+    # ``mcp_startup`` / ``jobs`` off it, and ``session/runtime/serving.py`` reads
+    # ``self._session.jobs`` on the owner. Those reads are already checked by
+    # pyright against the real class, so a protocol declaration would buy them
+    # nothing — which is why the placement is a claim about the DUCK-TYPED
+    # population and not the claim "only a viewer has these".
     #
     # Declaring them is deliberately NOT the same as making them safe for any
     # host to read. A snapshot member answers from the last sync, so a caller
@@ -1040,12 +1051,15 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
     # ``None`` that shipped a fabricated zero-subagent ``/info``.
     #
     # The wider-protocol claim is not hypothetical: declaring these on
-    # ``SessionProtocol`` put the whole ``tests/unit/tui`` double population off
-    # conformance (measured: 213 pyright errors across 19 files, from ~10 local
-    # ``FakeSession`` classes alone; 1996 when every member of the old exclusion
-    # list went there). A double that has to grow an MCP manager to keep
-    # compiling is a double describing an object the hosts never read. The
-    # viewer protocol is the narrower, true claim and costs the doubles nothing.
+    # ``SessionProtocol`` would add only conformance obligations — the duck-typed
+    # hosts read the same members either way — and it put the whole
+    # ``tests/unit/tui`` double population off conformance (measured: 213
+    # pyright errors across 19 files, from ~10 reduced local ``FakeSession``
+    # classes alone; 1996 when every member of the old exclusion list went
+    # there). A double that has to grow an MCP manager to keep compiling is a
+    # double describing an object the hosts never read. The viewer protocol is
+    # the narrower claim, it is true of every duck-typed reader above, and it
+    # costs the doubles nothing.
 
     # Job, wake and subagent plumbing. Read by the subagent view, the wake
     # panel and ``/fork``'s "cannot leave work running" check.

--- a/local_operator/slash_commands.py
+++ b/local_operator/slash_commands.py
@@ -405,10 +405,12 @@ SLASH_COMMANDS: list[SlashCommand] = [
     # command, and the prompt the turn later announces).
     SlashCommand(
         "loop",
-        # Advertises BOTH forms so the goal mode is discoverable from the palette
+        # Advertises all THREE forms so each is discoverable from the palette
         # without reading the source: free text is a goal a judge decides is met,
-        # a number is a bounded iteration count.
-        "Loop toward a goal: /loop <goal text>, or /loop <n> for n turns",
+        # a number is a bounded iteration count, and `stop` is the escape hatch —
+        # which used to appear only in a launch notice or an already-running
+        # refusal, i.e. after the user needed it (UX round 1, U6).
+        "Loop toward a goal: /loop <goal text>, /loop <n>, or /loop stop to cancel",
         consumes_prompt=True,
         desktop_destination="session.loop",
     ),

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -4728,6 +4728,52 @@ class OperatorApp(App[None]):
         self._exit_hint = None
         self._superseded_steer_controllers.clear()
 
+    async def _preview_cwd(self, directory: Path, session_id: str) -> str:
+        """Where the conversation about to be PREVIEWED was working, or ``""``.
+
+        The previewed ``session_id`` is a DIFFERENT conversation from the one
+        this terminal is attached to, so the value has to come from that
+        conversation's own record — never from ``self._session``. Handing over
+        the current session's directory made the preview band advertise one
+        conversation's project as another's, and it did not stay a label: the
+        connect leg binds a runtime in that directory.
+
+        Two honest sources, in the order of how much each knows: the live
+        runtime's discovery record (it is running, so its recorded ``cwd`` is
+        current), then the wake index, which keeps a ``cwd`` for a session no
+        process has open. This is the ladder ``tui/resume_click.py``'s
+        ``_session_cwd`` already uses, deliberately minus its ``~`` fallback:
+        a notification may put a user in a plausible default, but the band's
+        ``cwd`` rung renders as the conversation's own identity field, where a
+        guess cannot be told apart from a recorded fact.
+
+        ``""`` is the last resort, and it is deliberately the SAME value the
+        dead probe used to return: the band then shows its own unrecorded
+        placeholder, which reads as a placeholder. What it must never be is
+        this terminal's directory, which reads as an answer about a
+        conversation that was never in it.
+
+        ``find_runtime_record`` (not ``registry.scan``) is the reader for the
+        live half: it resolves the OWNER of this exact id, so a stale or
+        unrelated record cannot supply a third session's directory.
+        """
+        from local_operator.mobile.attach_client import find_runtime_record
+        from local_operator.wakes import store as wake_store
+
+        try:
+            record, _owner = await asyncio.to_thread(find_runtime_record, directory, session_id)
+            if record is not None and record.cwd:
+                return str(record.cwd)
+        except Exception:  # noqa: BLE001 — an unreadable registry is an ordinary "unknown"
+            logger.debug("could not read the previewed session's record", exc_info=True)
+        try:
+            entry = await asyncio.to_thread(wake_store.read_entry, directory, session_id) or {}
+        except Exception:  # noqa: BLE001 — same: absent is the answer, not an error
+            logger.debug("could not read the previewed session's wake entry", exc_info=True)
+            return ""
+        cwd = entry.get("cwd")
+        return cwd if isinstance(cwd, str) and cwd else ""
+
     async def _lease_sidebar_source(
         self, session_id: str, *, speculative: bool
     ) -> SessionInteraction:
@@ -4747,19 +4793,10 @@ class OperatorApp(App[None]):
             raise RuntimeError("a sidebar viewer never takes over a session")
 
         if not speculative:
-            # The fallback working directory a saved preview uses when its own
-            # journal records none: this session's REAL cwd, read through the
-            # declared ``frontend_state`` accessor. It used to be
-            # ``getattr(self._session, "cwd", "")`` — a name that exists on
-            # neither session class, so the fallback was always the empty
-            # string and a preview with no recorded cwd opened at the process
-            # default instead of the session's directory.
-            current = self._session
-            fallback_cwd = current.frontend_state.cwd if _is_viewer(current) else ""
             remote = await AttachedSession.saved_preview(
                 session_id,
                 config_dir=directory,
-                cwd=fallback_cwd,
+                cwd=await self._preview_cwd(directory, session_id),
                 takeover_factory=no_takeover,
             )
         else:
@@ -11374,27 +11411,6 @@ class OperatorApp(App[None]):
         except Exception:  # noqa: BLE001 — unprovable means "do not persist"
             logger.debug("could not decide whether the runtime is local", exc_info=True)
             return True
-
-    def _session_is_busy(self) -> bool:
-        """Whether the session is mid-turn, however that turn was started.
-
-        Deliberately asks the SESSION rather than this viewer's own state: the
-        turn may have been submitted by another terminal, or by the phone, and
-        the answer is still "yes, work is happening".
-
-        ``is_streaming`` is the declared predicate for exactly that question:
-        an owner holds it for the whole of ``_run_turn`` — tool execution
-        included — and clears it when the turn ends, and a viewer mirrors the
-        runtime's own ``streaming`` flag. It replaces a probe for
-        ``is_busy``/``busy``, names that exist on NEITHER class, so this always
-        returned ``False`` and the ``/loop stop`` notice that calls it was
-        unreachable code. ``runtime_idle`` would also fold in a running job and
-        a parked gate, but it is viewer-only (the app types its session as
-        ``SessionProtocol``) and it reads a COLD viewer as "not idle", which
-        would report an empty session as busy.
-        """
-        session = self._session
-        return session is not None and session.is_streaming
 
     def _overlay_live_state(self, rows: list[Any]) -> list[Any]:
         from local_operator.paths import config_dir
@@ -27998,24 +28014,33 @@ class OperatorApp(App[None]):
             if self._loop_running:
                 self._loop_cancelled = True
                 notice("loop will stop after the current turn")
-            elif self._session_is_busy():
+            else:
+                # Say only what THIS terminal knows, and nothing more.
+                #
                 # A loop DRIVES the session from the terminal that started it:
                 # each iteration is an ordinary turn submitted over the socket,
                 # which is what keeps it bounded, interruptible and visible in
                 # the transcript. So a second viewer of the same session has no
-                # loop to cancel even though it can see the turns arriving, and
-                # "no loop is running" would be a flat contradiction of what is
-                # on its screen.
+                # loop of its own to cancel even while it watches turns arrive,
+                # and it CANNOT tell a loop's turn from a plain prompt's —
+                # `_loop_running` is app-local state the owner never publishes.
                 #
-                # Say where the control actually is, and name the tool that
-                # works from here: `/stop` ends the runtime from any viewer.
-                notice(
-                    "no loop is running in THIS terminal — a loop is cancelled "
-                    "where it was started, or use /stop to end the session",
-                    "warning",
-                )
-            else:
-                notice("no loop is running")
+                # Two predecessors of this line were each wrong in a different
+                # direction, which is why the branch is one flat sentence now:
+                # a bare "no loop is running" reads as a flat contradiction of
+                # a viewer's own screen, while "a loop is cancelled where it
+                # was started, or use /stop to end the session" (guarded by the
+                # `_session_is_busy` probe) asserted a loop elsewhere and
+                # offered a SESSION-ENDING action as the remedy for a no-op —
+                # and fired in the owner's own terminal during an ordinary turn,
+                # where no loop exists at all. The scoped sentence is true in
+                # every one of those states: this terminal is not running a
+                # loop, and this terminal cannot answer for another one.
+                #
+                # The tint is the plain notice, not `warning`: the request is
+                # legitimate, the answer is an explanation, and nothing here
+                # says the user did anything wrong.
+                notice("no loop is running in THIS terminal")
             return
         if session is None:
             # A rejected command changed nothing, so the conversation has not
@@ -33122,9 +33147,13 @@ class OperatorApp(App[None]):
         The loop drives provider turns through the session, which lives here;
         a follower-local loop would either drive nothing (its own facade has
         no loop worker worth running — each iteration's prompt must cross the
-        socket anyway) or double-drive the session. Every stop/validation
-        branch mirrors ``_cmd_loop`` so the two UIs answer identically; only
-        the transport of the receipt differs.
+        socket anyway) or double-drive the session. The stop and validation
+        branches mirror ``_cmd_loop`` in SUBSTANCE but not word for word: this
+        path answers from the runtime's own published loop state, so it can
+        name what the loop is doing, while the local path may only speak for
+        its own terminal (see ``_cmd_loop``'s stop branch). Only the transport
+        of the receipt differs for the branches that DO agree — the launch and
+        validation notices.
         """
         session = self._session
         if arg.lower() in ("stop", "cancel", "abort"):

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -4748,10 +4748,14 @@ class OperatorApp(App[None]):
         guess cannot be told apart from a recorded fact.
 
         ``""`` is the last resort, and it is deliberately the SAME value the
-        dead probe used to return: the band then shows its own unrecorded
-        placeholder, which reads as a placeholder. What it must never be is
-        this terminal's directory, which reads as an answer about a
-        conversation that was never in it.
+        dead probe returned: the previewed session is then bound with no
+        recorded directory at all, so the runtime bound for it falls back to
+        the process default (``~`` — ``session/runtime/process.py``'s
+        child-cwd default) and the band renders that real bound directory,
+        exactly as the pre-PR tree did. There is no "unknown" rung to render,
+        which is why this is stated as "the same as before" rather than as an
+        absent value. What it must never be is THIS terminal's directory: that
+        reads as an answer about a conversation which was never in it.
 
         ``find_runtime_record`` (not ``registry.scan``) is the reader for the
         live half: it resolves the OWNER of this exact id, so a stale or
@@ -33149,11 +33153,14 @@ class OperatorApp(App[None]):
         no loop worker worth running — each iteration's prompt must cross the
         socket anyway) or double-drive the session. The stop and validation
         branches mirror ``_cmd_loop`` in SUBSTANCE but not word for word: this
-        path answers from the runtime's own published loop state, so it can
-        name what the loop is doing, while the local path may only speak for
-        its own terminal (see ``_cmd_loop``'s stop branch). Only the transport
-        of the receipt differs for the branches that DO agree — the launch and
-        validation notices.
+        handler runs on the AUTHORITATIVE host
+        (``OperatorApp.run_slash_authoritative``), so its ``_loop_running`` IS
+        the loop's own terminal-local state — nothing about it crosses a
+        process boundary, so the receipt may name what the loop is doing. The
+        local path cannot: there the flag belongs to whichever terminal asked
+        (see ``_cmd_loop``'s stop branch). Only the transport of the receipt
+        differs for the branches that DO agree — the launch and validation
+        notices.
         """
         session = self._session
         if arg.lower() in ("stop", "cancel", "abort"):

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -4747,10 +4747,19 @@ class OperatorApp(App[None]):
             raise RuntimeError("a sidebar viewer never takes over a session")
 
         if not speculative:
+            # The fallback working directory a saved preview uses when its own
+            # journal records none: this session's REAL cwd, read through the
+            # declared ``frontend_state`` accessor. It used to be
+            # ``getattr(self._session, "cwd", "")`` — a name that exists on
+            # neither session class, so the fallback was always the empty
+            # string and a preview with no recorded cwd opened at the process
+            # default instead of the session's directory.
+            current = self._session
+            fallback_cwd = current.frontend_state.cwd if _is_viewer(current) else ""
             remote = await AttachedSession.saved_preview(
                 session_id,
                 config_dir=directory,
-                cwd=str(getattr(self._session, "cwd", "")),
+                cwd=fallback_cwd,
                 takeover_factory=no_takeover,
             )
         else:
@@ -11372,19 +11381,20 @@ class OperatorApp(App[None]):
         Deliberately asks the SESSION rather than this viewer's own state: the
         turn may have been submitted by another terminal, or by the phone, and
         the answer is still "yes, work is happening".
+
+        ``is_streaming`` is the declared predicate for exactly that question:
+        an owner holds it for the whole of ``_run_turn`` — tool execution
+        included — and clears it when the turn ends, and a viewer mirrors the
+        runtime's own ``streaming`` flag. It replaces a probe for
+        ``is_busy``/``busy``, names that exist on NEITHER class, so this always
+        returned ``False`` and the ``/loop stop`` notice that calls it was
+        unreachable code. ``runtime_idle`` would also fold in a running job and
+        a parked gate, but it is viewer-only (the app types its session as
+        ``SessionProtocol``) and it reads a COLD viewer as "not idle", which
+        would report an empty session as busy.
         """
         session = self._session
-        if session is None:
-            return False
-        for probe in ("is_busy", "busy"):
-            value = getattr(session, probe, None)
-            try:
-                resolved = value() if callable(value) else value
-            except Exception:  # noqa: BLE001 — a probe must never break a command
-                continue
-            if isinstance(resolved, bool):
-                return resolved
-        return False
+        return session is not None and session.is_streaming
 
     def _overlay_live_state(self, rows: list[Any]) -> list[Any]:
         from local_operator.paths import config_dir

--- a/tests/unit/session/test_viewer_protocol.py
+++ b/tests/unit/session/test_viewer_protocol.py
@@ -31,18 +31,29 @@ members escaped typing in the first place.
 **What the derivation reaches, stated precisely — it is not "every access".**
 It sees ``<expr>.member`` and a two-or-more-argument call to any name in
 ``_PROBE_CALLS`` (``getattr``, ``hasattr``, and ``info/collect.py``'s ``_attr``
-wrapper) whose member name is a literal string, a variable bound by a
-``for probe in ("a", "b")`` loop, or a module-level string constant — where
-``<expr>`` is one of the bindings registered for that file in ``_SCANNED`` or a
-single-level local ALIAS of one (``session = source.session``, followed inside
-the scope that binds it and no further). It is blind to:
+wrapper) whose member name is any of:
+
+* a literal string;
+* a name bound by a ``for probe in ("a", "b")`` loop, INCLUDING a tuple-unpack
+target (``for probe, default in (("a", None),)``), which is read
+positionally off the literal rows;
+* a module-level string constant OR a local one bound to the same literal shape
+in the scope that reads it;
+
+where ``<expr>`` is one of the bindings registered for that file in ``_SCANNED``
+or a single-level local ALIAS of one (``session = source.session``). An alias is
+followed only while it is LIVE — from the binding that makes it a session to the
+next binding of the same name in the same scope — which is what stops a
+same-scope reuse (``previous = source.session`` … ``previous = rows[-1]``) from
+attributing the row's members to a session. It is blind to:
 
 * an alias chased through a second hop (``a = self._session; b = a``);
+* an alias read from a scope other than the one that binds it;
 * any other attribute or helper return holding a session
   (``self._current_session().member``);
-* a probe name computed at runtime by neither route — a dict lookup, a list
-  built incrementally, an f-string. ``_session_is_busy`` was the canonical
-  instance of the SHAPE this now covers: it looped
+* a probe name computed at runtime by none of the literal routes above — a dict
+  lookup, a list built incrementally, an f-string. ``_session_is_busy`` was the
+  canonical instance of the SHAPE this now covers: it looped
   ``for probe in ("is_busy", "busy")``, neither name exists on either class, so
   it returned a hard-coded ``False`` and its ``/loop stop`` caller took a dead
   branch. That loop is now recognized — and was removed rather than declared
@@ -105,11 +116,16 @@ _ROOT = Path(local_operator.__file__).resolve().parent
 #:
 #: These are the ROOT bindings, matched literally. A single-level local alias
 #: of one of them (``session = source.session``, then ``session.member``) IS
-#: followed — inside the scope that binds it and no further, which is the part
-#: that keeps it safe: resolving assignments ACROSS scopes is where the false
-#: positives that nearly killed this probe come from. See ``_scope_aliases``
-#: and ``_scope_nodes`` for the boundary. This list stays the thing to extend
-#: when a new root binding appears; a new alias needs no edit here.
+#: followed, but only while it is LIVE: inside the scope that binds it, from the
+#: statement that binds it to the next statement in that scope that rebinds the
+#: same name to something else. Both halves of that boundary are load-bearing.
+#: Resolving assignments ACROSS scopes is where the false positives that nearly
+#: killed this probe come from, and so is treating a name as an alias for the
+#: rest of the scope after it has been reused for a row or a widget — the same
+#: ``previous``/``current``/``remote`` reuse, one binding later. See
+#: ``_scope_bindings`` and ``_alias_live_at`` for the liveness rule. This list
+#: stays the thing to extend when a new root binding appears; a new alias needs
+#: no edit here.
 _SESSION_EXPRS = frozenset(
     {
         "self._session",
@@ -397,15 +413,21 @@ def _string_names(node: ast.AST | None) -> frozenset[str]:
     constructor is how a module probe set is usually written, and reading
     through the wrapper costs nothing while missing it would leave the shape
     half-covered — the exact "it looks watched" gap this file exists to avoid.
+
+    Nested sequences FLATTEN: ``(("a", None), ("b", None))`` reads as
+    ``{"a", "b"}``. That is the shape a loop unpacks positionally (see
+    ``_loop_probe_names``), and flattening is what makes the same literal
+    readable both as a whole set and row by row. Only string literals are ever
+    returned, so a row's non-name slots (the ``None`` default above) contribute
+    nothing.
     """
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
         return frozenset({node.value})
     if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
-        return frozenset(
-            elt.value
-            for elt in node.elts
-            if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
-        )
+        names: set[str] = set()
+        for elt in node.elts:
+            names |= _string_names(elt)
+        return frozenset(names)
     if (
         isinstance(node, ast.Call)
         and isinstance(node.func, ast.Name)
@@ -414,6 +436,26 @@ def _string_names(node: ast.AST | None) -> frozenset[str]:
     ):
         return _string_names(node.args[0])
     return frozenset()
+
+
+def _union_probe_names(bound: dict[str, frozenset[str]], name: str, names: frozenset[str]) -> None:
+    """Add ``names`` to whatever ``name`` already resolves to in this scope.
+
+    Deliberately a UNION rather than a replacement. One scope may reuse a single
+    variable across two probe loops (a bare ``for probe in (...)`` and later a
+    ``for probe, default in (...)``), and last-writer-wins silently dropped
+    whichever set came first — a coverage loss with no symptom, because the
+    guard then simply reads fewer names off the later ``getattr``. Measured, not
+    theoretical: a planted host with both shapes derived the loop names and
+    MISSED the unpacked ones entirely until this was a union.
+
+    Over-attributing a member NAME is the harmless direction here: the name
+    reached a ``getattr(session, …)``, so it is a probe name wherever it was
+    bound, and the names it is unioned with are all names some probe call in
+    this scope computes.
+    """
+    if names:
+        bound[name] = bound.get(name, frozenset()) | names
 
 
 def _module_probe_constants(tree: ast.Module) -> dict[str, frozenset[str]]:
@@ -436,8 +478,8 @@ def _module_probe_constants(tree: ast.Module) -> dict[str, frozenset[str]]:
             continue
         names = _string_names(value)
         for target in targets:
-            if isinstance(target, ast.Name) and names:
-                constants[target.id] = names
+            if isinstance(target, ast.Name):
+                _union_probe_names(constants, target.id, names)
     return constants
 
 
@@ -451,40 +493,174 @@ def _loop_probe_names(
     derivation recorded nothing — two names that exist on neither class stayed
     invisible behind a green guard while the function returned a hard-coded
     ``False``.
+
+    The tuple-unpack spelling of the same idea (``for probe, default in
+    (("is_busy", None),)``) is covered too, positionally, because the old
+    reader skipped every target that was not a bare ``Name`` and that is exactly
+    how a probe set with defaults is written.
     """
     bound: dict[str, frozenset[str]] = {}
     for node in _scope_nodes(scope):
-        if not (isinstance(node, ast.For) and isinstance(node.target, ast.Name)):
+        if not isinstance(node, (ast.For, ast.AsyncFor)):
             continue
         names = _string_names(node.iter)
         if not names and isinstance(node.iter, ast.Name):
             names = constants.get(node.iter.id, frozenset())
-        if names:
-            bound[node.target.id] = names
+        target = node.target
+        if isinstance(target, ast.Name):
+            _union_probe_names(bound, target.id, names)
+            continue
+        # The tuple-unpack target: `for probe, default in (("a", None),)`. Read
+        # POSITIONALLY off literal rows when the iterable is one — the target at
+        # index i takes the string at index i of each row — and otherwise give
+        # every name in the target the whole flattened set, which can only ever
+        # over-attribute a member NAME and never miss one.
+        if not isinstance(target, (ast.Tuple, ast.List)):
+            continue
+        rows: list[ast.expr] = []
+        if isinstance(node.iter, (ast.Tuple, ast.List)):
+            rows = list(node.iter.elts)
+        for index, elt in enumerate(target.elts):
+            if not isinstance(elt, ast.Name):
+                continue
+            collected: set[str] = set()
+            for row in rows:
+                if isinstance(row, (ast.Tuple, ast.List)) and index < len(row.elts):
+                    collected |= _string_names(row.elts[index])
+            collected |= names if not rows else set()
+            _union_probe_names(bound, elt.id, frozenset(collected))
     return bound
 
 
-def _scope_aliases(scope: ast.AST, exprs: frozenset[str]) -> frozenset[str]:
-    """Names this scope binds to a watched session expression.
+def _target_names(target: ast.AST) -> list[str]:
+    """Every ``Name`` a binding target introduces, unpacking tuples/lists.
 
-    ONE level, by construction: only an assignment whose VALUE is already a
-    watched expression qualifies, so an alias of an alias is not chased and an
-    expression that merely shares a spelling never becomes a session.
+    A tuple-unpack target binds more than one name, and the probe reader has to
+    see all of them: ``for probe, default in (...): getattr(session, probe,
+    default)`` was invisible to the old reader because it bailed on any target
+    that was not a bare ``Name``.
     """
-    aliases: set[str] = set()
+    if isinstance(target, ast.Name):
+        return [target.id]
+    if isinstance(target, (ast.Tuple, ast.List)):
+        names: list[str] = []
+        for elt in target.elts:
+            names.extend(_target_names(elt))
+        return names
+    if isinstance(target, ast.Starred):
+        return _target_names(target.value)
+    return []
+
+
+def _scope_bindings(scope: ast.AST, exprs: frozenset[str]) -> dict[str, list[tuple[int, bool]]]:
+    """Per name, the line-ordered points at which this scope makes it (not) a session.
+
+    WHY a sequence of points rather than a set of names. The earlier
+    ``_scope_aliases`` collected a name once it had been assigned a watched
+    expression and then treated it as an alias for the WHOLE scope. A same-scope
+    reassignment to an ordinary value therefore kept the name attributed, and
+    ``previous``/``current``/``remote`` — the exact names the TUI reuses for
+    rows, widgets and strings — are the false-positive class that nearly had
+    this probe deleted. Reproduced on the old rule: a scope binding
+    ``previous = source.session``, reading ``previous.session_id``, then
+    rebinding ``previous = rows[-1]`` and reading ``previous.label`` derived
+    ``{'label': [5], 'session_id': [3]}``, where ``label`` is a row's member.
+
+    Only the shapes an ordinary reassignment is written in are listed. A name
+    bound here is a session again only if the new value IS a watched expression,
+    so ``session = session`` and ``session = source.session`` both keep it live.
+    """
+    events: dict[str, list[tuple[int, bool]]] = {}
+
+    def bind(name: str, line: int, value: ast.expr | None) -> None:
+        events.setdefault(name, []).append((line, value is not None and _unparse(value) in exprs))
+
     for node in _scope_nodes(scope):
-        if isinstance(node, ast.Assign) and _unparse(node.value) in exprs:
+        line = getattr(node, "lineno", 0)
+        if isinstance(node, ast.Assign):
             for target in node.targets:
-                if isinstance(target, ast.Name):
-                    aliases.add(target.id)
-        elif (
-            isinstance(node, ast.AnnAssign)
-            and node.value is not None
-            and isinstance(node.target, ast.Name)
-            and _unparse(node.value) in exprs
-        ):
-            aliases.add(node.target.id)
-    return frozenset(aliases)
+                for name in _target_names(target):
+                    bind(name, line, node.value)
+        elif isinstance(node, ast.AnnAssign):
+            for name in _target_names(node.target):
+                bind(name, line, node.value)
+        elif isinstance(node, ast.AugAssign):
+            # `x += ...` only changes the VALUE; it cannot reintroduce a session.
+            for name in _target_names(node.target):
+                bind(name, line, None)
+        elif isinstance(node, (ast.For, ast.AsyncFor)):
+            # The target is bound from the iterable, so `for previous in rows`
+            # ends an alias the moment the loop's body starts.
+            for name in _target_names(node.target):
+                bind(name, line, node.iter)
+        elif isinstance(node, (ast.With, ast.AsyncWith)):
+            for item in node.items:
+                if item.optional_vars is not None:
+                    for name in _target_names(item.optional_vars):
+                        bind(name, line, item.context_expr)
+        elif isinstance(node, ast.NamedExpr):
+            for name in _target_names(node.target):
+                bind(name, line, node.value)
+        elif isinstance(node, ast.ExceptHandler) and node.name:
+            bind(node.name, line, None)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                if alias.name != "*":
+                    bind(alias.asname or alias.name.split(".")[0], line, None)
+        elif isinstance(node, ast.Delete):
+            for target in node.targets:
+                for name in _target_names(target):
+                    bind(name, line, None)
+    # A rebinding on the SAME line as the binding it shadows sorts LAST, so the
+    # read below is not credited: when one statement both reads an alias and
+    # rebinds the name, the conservative answer is "no longer a session".
+    return {
+        name: sorted(lines, key=lambda evt: (evt[0], not evt[1])) for name, lines in events.items()
+    }
+
+
+def _alias_live_at(events: list[tuple[int, bool]], line: int) -> bool:
+    """Whether a name still holds a session at ``line``.
+
+    The LAST binding at or before ``line`` decides. Read before the name is
+    bound at all, it is not a session (the caller has the scope's own root
+    expressions for those reads).
+    """
+    live = False
+    for bind_line, is_session in events:
+        if bind_line > line:
+            break
+        live = is_session
+    return live
+
+
+def _local_probe_names(scope: ast.AST) -> dict[str, frozenset[str]]:
+    """Names this scope binds to a literal probe-name string.
+
+    ``name = "x"`` followed by ``getattr(session, name, None)`` is the same
+    computation as the module-constant shape one scope down, and it was the one
+    shape left invisible beside the loop form the guard had just learned to read
+    (QA round 1, Q1). Scope-wide like ``_module_probe_constants`` and
+    ``_loop_probe_names``: a local that a probe name reaches through
+    ``getattr`` IS a probe name, which is why a same-scope reuse needs no
+    liveness rule the way an alias does — the wrong answer here would be a
+    member name, not an unrelated read.
+    """
+    bound: dict[str, frozenset[str]] = {}
+    for node in _scope_nodes(scope):
+        targets: list[ast.expr]
+        value: ast.expr | None
+        if isinstance(node, ast.Assign):
+            targets, value = list(node.targets), node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets, value = [node.target], node.value
+        else:
+            continue
+        names = _string_names(value)
+        for target in targets:
+            for name in _target_names(target):
+                _union_probe_names(bound, name, names)
+    return bound
 
 
 def _session_members_touched(source: str, exprs: frozenset[str]) -> dict[str, list[int]]:
@@ -493,24 +669,29 @@ def _session_members_touched(source: str, exprs: frozenset[str]) -> dict[str, li
     ``exprs`` is per-file because the binding that holds a session differs by
     host: the TUI has ``self._session``, the desktop bridge has ``self.remote``.
 
-    Three resolutions beyond the registered binding itself, each of which used
+    Four resolutions beyond the registered binding itself, each of which used
     to hide a member completely — the ceiling the class docstring used to
     record as permanent:
 
     * a local ALIAS of a watched expression (``session = source.session``),
-      followed for exactly one level and only inside the scope that binds it;
+      followed for exactly one level, inside the scope that binds it, and only
+      for as long as it stays LIVE (see ``_scope_bindings``);
     * a probe whose member name is a LOOP VARIABLE (``for probe in ("is_busy",
-      "busy")``), the shape that shipped ``_session_is_busy``;
+      "busy")``, or the tuple-unpack spelling), the shape that shipped
+      ``_session_is_busy``;
     * a probe whose member name is a MODULE CONSTANT (``getattr(session,
-      _PROBES, None)``).
+      _PROBES, None)``);
+    * a probe whose member name is a LOCAL NAME bound to a literal string
+      (``name = "x"; getattr(session, name, None)``).
 
-    Two limits are deliberate and stay. An alias is not chased through a
-    second hop, and a name computed at runtime that is neither a bound loop
-    variable nor a module-level string constant — a dict lookup, an f-string —
-    is still invisible. The probe strings reached by neither are also the ones
-    no rename can silently break, so the residual gap is the one that is
-    defensible; widening it is a change to THIS function, never to the
-    protocols it checks.
+    Limits that are deliberate and stay. An alias is not chased through a
+    second hop, nor read outside the scope that binds it, nor kept past the
+    statement that rebinds it. A name computed at runtime by none of the
+    literal routes above — a dict lookup, an f-string, a list built
+    incrementally — is still invisible. The probe strings reached by none of
+    them are also the ones no rename can silently break, so the residual gap is
+    the one that is defensible; widening it is a change to THIS function, never
+    to the protocols it checks.
     """
     tree = ast.parse(source)
     constants = _module_probe_constants(tree)
@@ -520,10 +701,18 @@ def _session_members_touched(source: str, exprs: frozenset[str]) -> dict[str, li
         touched.setdefault(name, []).append(line)
 
     for scope in _scopes(tree):
-        watch = exprs | _scope_aliases(scope, exprs)
+        bindings = _scope_bindings(scope, exprs)
         computed = dict(constants)
         computed.update(_loop_probe_names(scope, constants))
+        computed.update(_local_probe_names(scope))
         for node in _scope_nodes(scope):
+            # The scope's own root expressions are always a session; an alias is
+            # one only where its live range says so (R3's same-scope reuse).
+            watch = exprs | {
+                name
+                for name, events in bindings.items()
+                if _alias_live_at(events, getattr(node, "lineno", 0))
+            }
             # session.member / self._session.member, aliases included.
             if isinstance(node, ast.Attribute) and _unparse(node.value) in watch:
                 record(node.attr, node.lineno)
@@ -652,8 +841,13 @@ def test_every_session_member_a_host_touches_is_declared() -> None:
         + ", ".join(f"{name} ({', '.join(sites)})" for name, sites in sorted(offenders.items()))
         + ". A duck-typed member is invisible to pyright, so a rename or a typo "
         "in the probe string degrades it to a silent None instead of an error. "
-        "Declare it on SessionProtocol (both kinds of session have it) or on "
-        "ViewerSessionProtocol (only an attached facade has it). A name that "
+        "Declare it on ViewerSessionProtocol when every host that reads it "
+        "through a DUCK-TYPED binding holds an attached facade (the usual "
+        "case, and it covers a member BOTH classes implement); declare it on "
+        "SessionProtocol only when such a host may hold EITHER kind of "
+        "session and needs the member on both. An owner-side reader that "
+        "holds the concrete ``Session`` is checked by pyright against the real "
+        "class and needs no declaration either way. A name that "
         "reaches here from a local ALIAS (``session = source.session`` then "
         "``session.member``) or from a COMPUTED probe (``for probe in (...): "
         "getattr(session, probe, None)``, or a module-constant name) is a real "
@@ -682,11 +876,12 @@ def test_remote_session_satisfies_the_viewer_protocol_at_runtime() -> None:
 
     Four of the eight arrived with the engine-state block: declaring ``jobs``,
     ``wake_scheduler``, ``mcp_manager`` and ``mcp_startup`` on
-    ``SessionProtocol`` makes them contract members, and the contract is checked
-    HERE, on an instance, not only by pyright — a Protocol member that an
-    instance lacks fails ``isinstance`` even when the annotation is perfect.
-    They are built with the same no-argument snapshot constructors ``__init__``
-    uses, so the assignment states what production holds rather than a stand-in.
+    ``ViewerSessionProtocol`` makes them contract members of THAT protocol, and
+    the contract is checked HERE, on an instance, not only by pyright — a
+    Protocol member that an instance lacks fails ``isinstance`` even when the
+    annotation is perfect. They are built with the same no-argument snapshot
+    constructors ``__init__`` uses, so the assignment states what production
+    holds rather than a stand-in.
     """
     from local_operator.session.frontend_state import (
         SnapshotJobs,
@@ -1401,3 +1596,103 @@ def test_an_alias_is_not_followed_out_of_its_own_scope() -> None:
     exprs = frozenset({"source.session"})
     assert _derived_undeclared(source, exprs) == set()
     assert "label" not in _session_members_touched(source, exprs)
+
+
+def test_a_reassigned_alias_stops_being_a_session() -> None:
+    """An alias dies at the statement that rebinds the same name to a row.
+
+    The alias route was scope-WIDE: once a name had been bound to a watched
+    expression it stayed an alias until the scope ended, so a reuse of the same
+    spelling — ``previous = rows[-1]`` below — attributed the ROW's member to
+    the session. ``previous``/``current``/``remote`` are the names the TUI
+    reuses for rows, widgets and strings, so this was one refactor away from the
+    cry-wolf failure that nearly had this probe deleted (review round 1, R3).
+
+    Reproduced verbatim: the old rule derived ``{'label': [5], 'session_id':
+    [3]}`` here, where ``label`` is the row's member and not a session member.
+    """
+    source = (
+        "def view(source, rows):\n"
+        "    previous = source.session\n"
+        "    _ = previous.session_id\n"
+        "    previous = rows[-1]\n"
+        "    return previous.label\n"
+    )
+    exprs = frozenset({"source.session"})
+    touched = _session_members_touched(source, exprs)
+    # The alias's own read is still credited — the fix bounds the range, it does
+    # not abandon the route.
+    assert touched.get("session_id") == [3]
+    assert "label" not in touched
+    assert _derived_undeclared(source, exprs) == set()
+
+
+def test_an_alias_rebound_to_a_session_again_is_credited_again() -> None:
+    """The other side of the live range, so the rule is not "first binding wins".
+
+    ``previous = rows[-1]`` then ``previous = source.session`` makes the name a
+    session again: the liveness rule is about the LAST binding at or before the
+    read, not about the first one.
+    """
+    source = (
+        "def view(source, rows):\n"
+        "    previous = rows[-1]\n"
+        "    previous = source.session\n"
+        "    return previous.no_such_member\n"
+    )
+    assert _derived_undeclared(source, frozenset({"source.session"})) == {"no_such_member"}
+
+
+def test_the_guard_sees_a_locally_bound_literal_probe_name() -> None:
+    """``name = "x"; getattr(session, name, None)`` must fail as well.
+
+    The module-CONSTANT route covered a probe set declared at module scope, but
+    the same computation one scope down — an ordinary in-scope assignment of the
+    literal — derived ``set()``, so a probe written that way was invisible while
+    its loop spelling was covered (QA round 1, Q1).
+    """
+    source = (
+        "def probe(session):\n"
+        '    name = "qa_local_name"\n'
+        "    return getattr(session, name, None)\n"
+    )
+    assert _derived_undeclared(source, frozenset({"session"})) == {"qa_local_name"}
+
+
+def test_the_guard_sees_a_tuple_unpacked_loop_probe_name() -> None:
+    """``for probe, default in ((\"x\", None),)`` must fail as well.
+
+    The loop reader required ``isinstance(node.target, ast.Name)`` and skipped
+    every other target, so the spelling a probe set with defaults is written in
+    stayed invisible even after the bare-name loop form was covered (QA round 1,
+    Q1). The member name is read POSITIONALLY off each literal row.
+    """
+    source = (
+        "def probe(session):\n"
+        '    for probe, default in (("qa_unpack", None),):\n'
+        "        getattr(session, probe, default)\n"
+    )
+    assert _derived_undeclared(source, frozenset({"session"})) == {"qa_unpack"}
+
+
+def test_two_probe_loops_sharing_one_variable_keep_both_sets() -> None:
+    """A reused loop variable must not drop the first loop's names.
+
+    The probe-name tables are keyed by variable name, so a bare loop and a
+    tuple-unpack loop binding the SAME name in one scope used to overwrite each
+    other and only one set of members stayed derived. Reproduced against a real
+    scanned host before this was a union: the unpacked names were derived as
+    nothing at all. Which loop won depended on the traversal order, so the loss
+    was silent rather than stable.
+    """
+    source = (
+        "def probe(session):\n"
+        "    for entry in ('planted_loop_a',):\n"
+        "        getattr(session, entry, None)\n"
+        "    for entry, default in (('planted_unpack_b', None),):\n"
+        "        getattr(session, entry, default)\n"
+    )
+    assert _derived_undeclared(source, frozenset({"session"})) == {
+        "planted_loop_a",
+        "planted_unpack_b",
+    }

--- a/tests/unit/session/test_viewer_protocol.py
+++ b/tests/unit/session/test_viewer_protocol.py
@@ -31,25 +31,32 @@ members escaped typing in the first place.
 **What the derivation reaches, stated precisely — it is not "every access".**
 It sees ``<expr>.member`` and a two-or-more-argument call to any name in
 ``_PROBE_CALLS`` (``getattr``, ``hasattr``, and ``info/collect.py``'s ``_attr``
-wrapper) with a literal member name, where ``<expr>`` is one of the bindings
-registered for that file in ``_SCANNED``. It is blind to:
+wrapper) whose member name is a literal string, a variable bound by a
+``for probe in ("a", "b")`` loop, or a module-level string constant — where
+``<expr>`` is one of the bindings registered for that file in ``_SCANNED`` or a
+single-level local ALIAS of one (``session = source.session``, followed inside
+the scope that binds it and no further). It is blind to:
 
-* local aliases — ``s = self._session; s.member`` (see ``_SESSION_EXPRS``);
+* an alias chased through a second hop (``a = self._session; b = a``);
 * any other attribute or helper return holding a session
   (``self._current_session().member``);
-* computed probe names — ``getattr(session, probe, None)`` where ``probe`` is a
-  variable. ``_session_is_busy`` (``app.py:9313``) is a live example: it loops
+* a probe name computed at runtime by neither route — a dict lookup, a list
+  built incrementally, an f-string. ``_session_is_busy`` was the canonical
+  instance of the SHAPE this now covers: it looped
   ``for probe in ("is_busy", "busy")``, neither name exists on either class, so
-  it always returns ``False`` and its caller takes a dead branch. The guard
-  runs over that exact line and structurally cannot see it. That is the
-  syntactic approach's ceiling, recorded here so nobody reads a green run as
-  "no duck-probe is broken";
+  it returned a hard-coded ``False`` and its ``/loop stop`` caller took a dead
+  branch. That loop is now recognized — and was removed rather than declared
+  around — with ``test_the_guard_sees_a_loop_computed_probe_name`` proving the
+  loop shape still fails here if it comes back;
 * sessions arriving as differently-named parameters;
 * files outside ``_SCANNED``.
 
 A green run means "no *reachable-by-this-derivation* probe is undeclared", not
 "the front end is fully typed". Widening any of the above is a matter of adding
-an expression or a path — the machinery does not change.
+an expression or a path — the machinery does not change. What is NOT a way to
+widen it: an exclusion set. There is none for undeclared members any more (see
+the note where one used to live), so a new member reached by any of the routes
+above fails with its name and ``file:line``.
 
 **Do not narrow pyright's path to ``local_operator/``.** Half of the
 conformance claim is not in ``session/`` at all: it is carried by
@@ -64,6 +71,7 @@ alone, therefore disarms the static half silently and leaves the suite green.
 from __future__ import annotations
 
 import ast
+from collections.abc import Iterator
 from pathlib import Path
 
 import local_operator
@@ -95,12 +103,13 @@ _ROOT = Path(local_operator.__file__).resolve().parent
 #: ``test_every_registered_session_binding_still_matches_the_source`` (QA round
 #: 2, Q5), which is what makes that claim checkable instead of aspirational.
 #:
-#: These are BINDINGS, matched literally. ``s = self._session; s.member`` is
-#: not covered: a local alias is a different expression, and the guard does no
-#: dataflow. Following aliases means resolving assignments per scope, which is
-#: where the false positives that nearly killed this probe come from — so the
-#: boundary is deliberate, and this list is the thing to extend when a new
-#: session binding appears.
+#: These are the ROOT bindings, matched literally. A single-level local alias
+#: of one of them (``session = source.session``, then ``session.member``) IS
+#: followed — inside the scope that binds it and no further, which is the part
+#: that keeps it safe: resolving assignments ACROSS scopes is where the false
+#: positives that nearly killed this probe come from. See ``_scope_aliases``
+#: and ``_scope_nodes`` for the boundary. This list stays the thing to extend
+#: when a new root binding appears; a new alias needs no edit here.
 _SESSION_EXPRS = frozenset(
     {
         "self._session",
@@ -286,74 +295,35 @@ _OWNER_ONLY_CAPABILITY_PROBES = frozenset(
     }
 )
 
-#: Undeclared members that live on BOTH classes.
+#: There is deliberately NO "undeclared member" exclusion set any more.
 #:
-#: Not viewer-surface, so out of this PR's scope, but real: the TUI duck-probes
-#: them exactly like the viewer members and they are equally invisible to
-#: pyright. Listed rather than silently skipped so the debt is visible and the
-#: guard shrinks as they are declared. Declaring them belongs with the call-site
-#: migration (Stage 3), not with this additive change.
+#: Two sets used to sit here. ``_UNDECLARED_ON_BOTH_CLASSES`` held 18 members
+#: that exist on BOTH classes but on no protocol (``subagent_comms``, ``jobs``,
+#: ``wake_scheduler``, ``mcp_manager``, ``pending_gate``, ``epoch``, the
+#: attention pair, …), each reached by a duck-probe the guard could see and
+#: pyright could not. ``_KNOWN_MISSING_ON_BOTH_CLASSES`` held one name, ``cwd``,
+#: probed by ``app.py`` but present on NEITHER class, so the saved preview's
+#: working directory was ALWAYS ``""``. Both are closed: the 18 are declared on
+#: ``ViewerSessionProtocol`` — the protocol every host that reads them holds,
+#: and the one whose conformance the doubles already satisfy — and the ``cwd``
+#: read goes through the declared ``frontend_state`` accessor. The contract is
+#: TOTAL, so there is nothing left to exclude.
 #:
-#: Every name here is asserted to be present on both classes by
-#: ``test_the_exclusion_sets_state_true_facts`` — the set is a claim about the
-#: code, not a mute list, so an entry that stops being true fails rather than
-#: silently widening the guard's blind spot.
+#: Reinstating a name here would re-open the exact class of defect this file
+#: exists to close: an undeclared member whose ``getattr`` default reports a
+#: plausible wrong answer while pyright stays silent. A new undeclared member
+#: is therefore a FAILURE naming the member and its ``file:line`` — never a
+#: mute list. If a member is genuinely engine-internal, the fix is to move the
+#: host read onto the concrete type or an already-declared accessor, exactly as
+#: ``cwd`` was moved, and to say why in the comment beside that read.
 #:
-#: ``subagent_comms`` is the MOTIVATING member of this whole file and it sits
-#: here rather than on a protocol, which needs saying plainly. It is read by
-#: ``/info`` and lives on both classes, so declaring it is Stage 3's call-site
-#: work like every other name in this set. What matters for round 2 is that it
-#: is now DERIVED at all: until ``info/collect.py`` joined ``_SCANNED`` the
-#: reviewer could re-ship the original outage — rename it on the facade — with
-#: a green guard and zero pyright errors (review round 2, MAJOR-1). Being an
-#: entry in a checked set means a rename to a name that exists on NEITHER class
-#: now fails here, which is the shape the original bug had.
-_UNDECLARED_ON_BOTH_CLASSES = frozenset(
-    {
-        "acknowledge_attention",
-        "active_agent",
-        "active_team_name",
-        "agent_registry",
-        "context_breakdown",
-        "epoch",
-        "fork_snapshot",
-        "jobs",
-        "mcp_manager",
-        "mcp_startup",
-        "pending_gate",
-        "record_shell",
-        "refresh_attention",
-        "restored_usage",
-        "subagent_comms",
-        "subscribe_frontend",
-        "team_registry",
-        "wake_scheduler",
-    }
-)
-
-#: Probed by a host but present on NEITHER class — the probe is already dead.
-#:
-#: Kept apart from ``_UNDECLARED_ON_BOTH_CLASSES`` because that set's whole
-#: point is "this member exists, it is merely undeclared". Parking a name here
-#: records the opposite and worse fact: the call site reads a member that does
-#: not exist, so its ``getattr`` default is the only value it will ever see.
-#: Filing these as ordinary debt would let the guard built to surface
-#: silent-wrong-answers permanently silence one.
-#:
-#: * ``cwd`` — ``app.py`` passes ``getattr(self._session, "cwd", "")`` to
-#:   ``saved_preview(...)``, so the saved preview's working directory is
-#:   ALWAYS ``""``. Pre-existing (present at ``a8f98be3b``), behavioural, and
-#:   out of scope for this additive change: deferred to Stage 3, where that
-#:   call site is rewritten against a declared member. Cited by call SHAPE
-#:   rather than by line number on purpose — a line number in a moving file is
-#:   the rot this file eliminated elsewhere (review round 2, MINOR-3), and the
-#:   name itself is machine-checked below, so the prose carries no claim the
-#:   suite cannot verify.
-#:
-#: ``test_the_exclusion_sets_state_true_facts`` asserts these are absent from
-#: both classes, so a name here that someone later implements fails the suite
-#: and gets promoted rather than lingering as a false claim.
-_KNOWN_MISSING_ON_BOTH_CLASSES = frozenset({"cwd"})
+#: ``subagent_comms`` is worth naming because it was this file's MOTIVATING
+#: member. It is read by ``/info``, it lives on both classes, and until
+#: ``info/collect.py`` joined ``_SCANNED`` the reviewer could re-ship the
+#: original fabricated zero-subagent outage with a green guard and zero pyright
+#: errors (review round 2, MAJOR-1). Declaring it is what turns a rename to a
+#: name that exists on neither class into a failure HERE rather than in a
+#: user's terminal.
 
 #: Names that MUST NOT come back — neither read by a host nor defined on a class.
 #:
@@ -379,8 +349,8 @@ _KNOWN_MISSING_ON_BOTH_CLASSES = frozenset({"cwd"})
 #: cannot be re-added to ``AttachedSession`` and duck-probed), absent from BOTH
 #: protocols (so it cannot be laundered by declaring it), and read by NO scanned
 #: host (so a probe against a name that exists nowhere cannot sit there
-#: returning its default forever, which is the ``cwd`` defect in
-#: ``_KNOWN_MISSING_ON_BOTH_CLASSES``).
+#: returning its default forever — the ``cwd`` defect, closed by rewriting that
+#: read against a declared accessor.
 _RETIRED = frozenset({"is_remote"})
 
 
@@ -391,30 +361,188 @@ def _unparse(node: ast.AST) -> str:
         return ""
 
 
+def _scope_nodes(scope: ast.AST) -> Iterator[ast.AST]:
+    """Every node belonging to ``scope`` itself, nested scopes EXCLUDED.
+
+    A nested ``def``/``class``/``lambda`` body is a scope of its own (see
+    ``_scopes``), and the walk stops at that boundary. The boundary is what
+    makes alias following safe: a helper's ``own = self._session`` must not
+    turn every ``own.<attr>`` in the method around it into a session read, and
+    the TUI reuses names like ``previous``/``current``/``remote`` for rows,
+    widgets and strings. Cross-scope leakage of exactly that kind made an
+    earlier version of this probe report ``partition``, ``focus`` and ``label``
+    as session members and nearly got it deleted.
+    """
+    stack = list(ast.iter_child_nodes(scope))
+    while stack:
+        node = stack.pop()
+        yield node
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)):
+            continue
+        stack.extend(ast.iter_child_nodes(node))
+
+
+def _scopes(tree: ast.Module) -> Iterator[ast.AST]:
+    """The module scope, and every class and function scope inside it."""
+    yield tree
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield node
+
+
+def _string_names(node: ast.AST | None) -> frozenset[str]:
+    """The member names a literal string (or literal sequence of them) spells.
+
+    ``frozenset({"a", "b"})`` counts: wrapping a literal collection in its
+    constructor is how a module probe set is usually written, and reading
+    through the wrapper costs nothing while missing it would leave the shape
+    half-covered — the exact "it looks watched" gap this file exists to avoid.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return frozenset({node.value})
+    if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+        return frozenset(
+            elt.value
+            for elt in node.elts
+            if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+        )
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in {"frozenset", "tuple", "set", "list"}
+        and len(node.args) == 1
+    ):
+        return _string_names(node.args[0])
+    return frozenset()
+
+
+def _module_probe_constants(tree: ast.Module) -> dict[str, frozenset[str]]:
+    """Module-level names that hold probe member names.
+
+    ``getattr(session, _PROBES, None)`` is the second computed-probe shape: the
+    member name arrives as a constant, not a literal, so a literal-only
+    derivation reads nothing from the line at all. Only MODULE scope is read,
+    so a same-named local elsewhere cannot smuggle a probe past this.
+    """
+    constants: dict[str, frozenset[str]] = {}
+    for node in tree.body:
+        targets: list[ast.expr]
+        value: ast.expr | None
+        if isinstance(node, ast.Assign):
+            targets, value = list(node.targets), node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets, value = [node.target], node.value
+        else:
+            continue
+        names = _string_names(value)
+        for target in targets:
+            if isinstance(target, ast.Name) and names:
+                constants[target.id] = names
+    return constants
+
+
+def _loop_probe_names(
+    scope: ast.AST, constants: dict[str, frozenset[str]]
+) -> dict[str, frozenset[str]]:
+    """Names a ``for probe in ("is_busy", "busy")`` loop binds to probe names.
+
+    This is the shape ``_session_is_busy`` shipped: the member name is a loop
+    variable, so the probe call's second argument is a ``Name`` and the old
+    derivation recorded nothing — two names that exist on neither class stayed
+    invisible behind a green guard while the function returned a hard-coded
+    ``False``.
+    """
+    bound: dict[str, frozenset[str]] = {}
+    for node in _scope_nodes(scope):
+        if not (isinstance(node, ast.For) and isinstance(node.target, ast.Name)):
+            continue
+        names = _string_names(node.iter)
+        if not names and isinstance(node.iter, ast.Name):
+            names = constants.get(node.iter.id, frozenset())
+        if names:
+            bound[node.target.id] = names
+    return bound
+
+
+def _scope_aliases(scope: ast.AST, exprs: frozenset[str]) -> frozenset[str]:
+    """Names this scope binds to a watched session expression.
+
+    ONE level, by construction: only an assignment whose VALUE is already a
+    watched expression qualifies, so an alias of an alias is not chased and an
+    expression that merely shares a spelling never becomes a session.
+    """
+    aliases: set[str] = set()
+    for node in _scope_nodes(scope):
+        if isinstance(node, ast.Assign) and _unparse(node.value) in exprs:
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    aliases.add(target.id)
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and node.value is not None
+            and isinstance(node.target, ast.Name)
+            and _unparse(node.value) in exprs
+        ):
+            aliases.add(node.target.id)
+    return frozenset(aliases)
+
+
 def _session_members_touched(source: str, exprs: frozenset[str]) -> dict[str, list[int]]:
     """Session members one file reads, by name, with line numbers.
 
     ``exprs`` is per-file because the binding that holds a session differs by
     host: the TUI has ``self._session``, the desktop bridge has ``self.remote``.
+
+    Three resolutions beyond the registered binding itself, each of which used
+    to hide a member completely — the ceiling the class docstring used to
+    record as permanent:
+
+    * a local ALIAS of a watched expression (``session = source.session``),
+      followed for exactly one level and only inside the scope that binds it;
+    * a probe whose member name is a LOOP VARIABLE (``for probe in ("is_busy",
+      "busy")``), the shape that shipped ``_session_is_busy``;
+    * a probe whose member name is a MODULE CONSTANT (``getattr(session,
+      _PROBES, None)``).
+
+    Two limits are deliberate and stay. An alias is not chased through a
+    second hop, and a name computed at runtime that is neither a bound loop
+    variable nor a module-level string constant — a dict lookup, an f-string —
+    is still invisible. The probe strings reached by neither are also the ones
+    no rename can silently break, so the residual gap is the one that is
+    defensible; widening it is a change to THIS function, never to the
+    protocols it checks.
     """
     tree = ast.parse(source)
+    constants = _module_probe_constants(tree)
     touched: dict[str, list[int]] = {}
-    for node in ast.walk(tree):
-        # session.member / self._session.member
-        if isinstance(node, ast.Attribute) and _unparse(node.value) in exprs:
-            touched.setdefault(node.attr, []).append(node.lineno)
-        # getattr(session, "member", ...) / hasattr(session, "member") /
-        # _attr(session, "member", default) — see ``_PROBE_CALLS``.
-        if isinstance(node, ast.Call):
-            if (
-                isinstance(node.func, ast.Name)
+
+    def record(name: str, line: int) -> None:
+        touched.setdefault(name, []).append(line)
+
+    for scope in _scopes(tree):
+        watch = exprs | _scope_aliases(scope, exprs)
+        computed = dict(constants)
+        computed.update(_loop_probe_names(scope, constants))
+        for node in _scope_nodes(scope):
+            # session.member / self._session.member, aliases included.
+            if isinstance(node, ast.Attribute) and _unparse(node.value) in watch:
+                record(node.attr, node.lineno)
+            # getattr(session, "member", ...) / hasattr(session, "member") /
+            # _attr(session, "member", default) — see ``_PROBE_CALLS``.
+            elif (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
                 and node.func.id in _PROBE_CALLS
                 and len(node.args) >= 2
-                and _unparse(node.args[0]) in exprs
-                and isinstance(node.args[1], ast.Constant)
-                and isinstance(node.args[1].value, str)
+                and _unparse(node.args[0]) in watch
             ):
-                touched.setdefault(node.args[1].value, []).append(node.lineno)
+                literal = _string_names(node.args[1])
+                if literal:
+                    for name in literal:
+                        record(name, node.lineno)
+                elif isinstance(node.args[1], ast.Name):
+                    for name in sorted(computed.get(node.args[1].id, frozenset())):
+                        record(name, node.lineno)
     return touched
 
 
@@ -511,12 +639,7 @@ def test_every_session_member_a_host_touches_is_declared() -> None:
     # this test would pass. Reads of a retired name are failed by
     # ``test_a_retired_session_flag_cannot_be_reintroduced`` instead, with a
     # message that says why the name is gone rather than "declare it".
-    known = (
-        declared
-        | _OWNER_ONLY_CAPABILITY_PROBES
-        | _UNDECLARED_ON_BOTH_CLASSES
-        | _KNOWN_MISSING_ON_BOTH_CLASSES
-    )
+    known = declared | _OWNER_ONLY_CAPABILITY_PROBES
 
     offenders = {
         name: sites
@@ -530,7 +653,12 @@ def test_every_session_member_a_host_touches_is_declared() -> None:
         + ". A duck-typed member is invisible to pyright, so a rename or a typo "
         "in the probe string degrades it to a silent None instead of an error. "
         "Declare it on SessionProtocol (both kinds of session have it) or on "
-        "ViewerSessionProtocol (only an attached facade has it)."
+        "ViewerSessionProtocol (only an attached facade has it). A name that "
+        "reaches here from a local ALIAS (``session = source.session`` then "
+        "``session.member``) or from a COMPUTED probe (``for probe in (...): "
+        "getattr(session, probe, None)``, or a module-constant name) is a real "
+        "read like any other: declare the member, or move the read onto the "
+        "concrete type and say why beside it."
     )
 
 
@@ -543,24 +671,45 @@ def test_remote_session_satisfies_the_viewer_protocol_at_runtime() -> None:
     which is this guard's job, and pyright catches the signatures.
 
     What it does NOT catch, contrary to what this docstring claimed for two
-    rounds, is an ``__init__``-assigned attribute disappearing. The four below
+    rounds, is an ``__init__``-assigned attribute disappearing. The eight below
     are hand-assigned to satisfy ``__new__``, so the ``isinstance`` passes
     whether or not ``__init__`` still sets them — the reviewer deleted
     ``runtime_version`` from the class outright and got 7 tests passing against 2
-    pyright errors (review round 2, MINOR-2). For those four the division of
+    pyright errors (review round 2, MINOR-2). For those eight the division of
     labour runs the other way: **pyright is the guard and this test is
     structurally blind.** Stated here because a test believed to cover a case it
     cannot is worse than an uncovered case.
+
+    Four of the eight arrived with the engine-state block: declaring ``jobs``,
+    ``wake_scheduler``, ``mcp_manager`` and ``mcp_startup`` on
+    ``SessionProtocol`` makes them contract members, and the contract is checked
+    HERE, on an instance, not only by pyright — a Protocol member that an
+    instance lacks fails ``isinstance`` even when the annotation is perfect.
+    They are built with the same no-argument snapshot constructors ``__init__``
+    uses, so the assignment states what production holds rather than a stand-in.
     """
+    from local_operator.session.frontend_state import (
+        SnapshotJobs,
+        SnapshotMcpManager,
+        SnapshotWakeScheduler,
+    )
+
     session = AttachedSession.__new__(AttachedSession)
     # The instance attributes are assigned in ``__init__``, which dials a
     # socket. Set them directly: presence is what the protocol requires, and
     # constructing a real facade would make this a network test. See the
-    # docstring: this assignment is exactly why the four are pyright's to guard.
+    # docstring: this assignment is exactly why the eight are pyright's to guard.
     session.runtime_version = ""
     session.runtime_source_ref = ""
     session.degraded_reason = ""
     session.saved_preview_partial = False
+    # The engine-state snapshots, exactly as `AttachedSession.__init__` builds
+    # them (`attached.py`): a follower's read-only view of the runtime's jobs,
+    # wakes and MCP servers, and the startup outcome `None` until one is read.
+    session.jobs = SnapshotJobs()
+    session.wake_scheduler = SnapshotWakeScheduler()
+    session.mcp_manager = SnapshotMcpManager()
+    session.mcp_startup = None
 
     assert isinstance(session, ViewerSessionProtocol)
     assert isinstance(session, SessionProtocol)
@@ -844,10 +993,10 @@ def test_a_retired_session_flag_cannot_be_reintroduced() -> None:
       probes legitimate, which is the laundering route that test's ``known``
       union no longer offers.
     * **In a host.** A probe against a name that exists nowhere does not raise:
-      it returns the ``False`` default forever, silently, which is the exact
-      shape of the ``cwd`` defect recorded in
-      ``_KNOWN_MISSING_ON_BOTH_CLASSES``. A green suite is what that failure
-      looks like.
+      it returns the ``False`` default forever, silently — the shape of the
+      ``cwd`` defect this file now closes by rewriting that read against a
+      declared accessor, and of ``_session_is_busy``'s ``is_busy``/``busy``.
+      A green suite is what that failure looks like.
 
     This is deliberately an extension of the existing derivation rather than a
     parallel mechanism: it reuses ``_all_touched``/``_members``/``_declared``,
@@ -894,35 +1043,18 @@ def test_a_retired_session_flag_cannot_be_reintroduced() -> None:
 
 
 def test_the_exclusion_sets_state_true_facts() -> None:
-    """Each exclusion set asserts something about the classes; check it holds.
+    """Each remaining exclusion set asserts something about the classes.
 
     An exclusion set is a claim, and a false claim inside the guard is worse
     than no guard: it silences a member while telling the reader the silence is
     justified. ``cwd`` was listed as living on BOTH classes when it lives on
     neither, which converted an always-empty-value defect into permanently
-    silenced debt (review M2). Each set now has to be true.
+    silenced debt (review M2). The two sets that made those claims are gone —
+    their members are declared, and the ``cwd`` read is rewritten — so the only
+    set left to justify is the owner-only one, checked from BOTH sides below.
     """
     owner_members = _members(Session, "session.py", "Session")
     viewer_members = _members(AttachedSession, "attached.py", "AttachedSession")
-
-    missing = sorted(
-        n for n in _UNDECLARED_ON_BOTH_CLASSES if n not in owner_members or n not in viewer_members
-    )
-    assert not missing, (
-        f"_UNDECLARED_ON_BOTH_CLASSES claims these live on both classes: {missing}. "
-        "They do not. A name absent from both is a DEAD probe reading its own "
-        "default forever — move it to _KNOWN_MISSING_ON_BOTH_CLASSES, recording "
-        "the value it actually returns, or declare it."
-    )
-
-    resurrected = sorted(
-        n for n in _KNOWN_MISSING_ON_BOTH_CLASSES if n in owner_members or n in viewer_members
-    )
-    assert not resurrected, (
-        "_KNOWN_MISSING_ON_BOTH_CLASSES claims these exist on neither class: "
-        f"{resurrected}. They now exist, so the probe is live: declare them on a "
-        "protocol and drop them from this set."
-    )
 
     not_owner_only = sorted(n for n in _OWNER_ONLY_CAPABILITY_PROBES if n in viewer_members)
     assert not not_owner_only, (
@@ -942,9 +1074,10 @@ def test_the_exclusion_sets_state_true_facts() -> None:
     assert not not_on_owner, (
         "_OWNER_ONLY_CAPABILITY_PROBES justifies each name as an OWNER "
         f"capability, but these are absent from Session too: {not_on_owner}. A "
-        "name on neither class is a DEAD probe reading its own default forever "
-        "— move it to _KNOWN_MISSING_ON_BOTH_CLASSES, recording the value it "
-        "actually returns, rather than laundering it as an owner capability."
+        "name on neither class is a DEAD probe reading its own default forever. "
+        "Declare it if a class implements it, or rewrite the host read against "
+        "the concrete type or a declared accessor — the route ``cwd`` took — "
+        "rather than laundering it as an owner capability."
     )
 
 
@@ -1159,3 +1292,112 @@ def test_every_registered_session_binding_still_matches_the_source() -> None:
         "notice). Adding one is good news and needs this list updated too; "
         "either way, say which in the commit."
     )
+
+
+# --- the shapes that used to hide a member -----------------------------------
+#
+# Each test below plants ONE previously-invisible read and shows the REAL
+# predicate — the same one `test_every_session_member_a_host_touches_is_declared`
+# applies — reporting it as undeclared. They exist because the shapes were the
+# guard's stated ceiling, and a ceiling that is described in a docstring but
+# never exercised is how `_session_is_busy` shipped a hard-coded `False` behind
+# a green run for six releases.
+
+
+def _derived_undeclared(source: str, exprs: frozenset[str]) -> set[str]:
+    """Members ``source`` reads through ``exprs`` that no protocol declares.
+
+    Deliberately the guard's own predicate rather than a stand-in. A planted
+    violation judged by a separate rule could pass while the guard it is meant
+    to demonstrate stays blind, which is the failure mode these tests exist to
+    prevent in the first place.
+    """
+    touched = _session_members_touched(source, exprs)
+    known = _declared() | _OWNER_ONLY_CAPABILITY_PROBES
+    return {name for name in touched if not name.startswith("_") and name not in known}
+
+
+def test_the_guard_sees_an_undeclared_member_read_through_a_local_alias() -> None:
+    """A one-level local alias must not hide a member.
+
+    The derivation used to match only the registered expression itself, so
+    ``session = source.session`` followed by a read off ``session`` was
+    invisible. The live instance is the sidebar's gate identity, whose
+    ``session = source.session`` local reached ``pending_gate`` and ``epoch``
+    that no protocol declared.
+    """
+    source = (
+        "def view(source):\n" "    session = source.session\n" "    return session.no_such_member\n"
+    )
+    assert _derived_undeclared(source, frozenset({"source.session"})) == {"no_such_member"}
+
+
+def test_the_guard_credits_a_declared_member_reached_through_an_alias() -> None:
+    """The alias route must credit a DECLARED member too, or it is just noise."""
+    source = (
+        "def view(source):\n" "    session = source.session\n" "    return session.session_id\n"
+    )
+    assert _derived_undeclared(source, frozenset({"source.session"})) == set()
+
+
+def test_the_guard_sees_a_loop_computed_probe_name() -> None:
+    """The ``for probe in (...)`` shape ``_session_is_busy`` shipped must fail.
+
+    It looped over ``("is_busy", "busy")`` — neither name exists on either
+    class — so it returned ``False`` forever and its ``/loop stop`` caller took
+    a dead branch. The guard derived probe names from string literals only, ran
+    over that exact line, and saw nothing.
+    """
+    source = (
+        "def busy(session):\n"
+        "    for probe in ('is_busy', 'busy'):\n"
+        "        value = getattr(session, probe, None)\n"
+        "        if value:\n"
+        "            return True\n"
+        "    return value\n"
+    )
+    assert _derived_undeclared(source, frozenset({"session"})) == {"is_busy", "busy"}
+
+
+def test_the_guard_sees_a_module_constant_probe_name() -> None:
+    """A probe named by a module-level constant must fail as well.
+
+    ``getattr(session, _PROBES, None)`` hides every member behind a constant the
+    literal-only derivation never resolved. Both spellings a probe set is
+    written in are covered: a bare literal collection and the constructor form.
+    """
+    source = (
+        "_PROBES = ('also_not_real', 'nor_is_this')\n"
+        "_WRAPPED = frozenset({'nor_is_this_either'})\n"
+        "\n"
+        "def state(session):\n"
+        "    first = getattr(session, _PROBES, None)\n"
+        "    return getattr(session, _WRAPPED, first)\n"
+    )
+    assert _derived_undeclared(source, frozenset({"session"})) == {
+        "also_not_real",
+        "nor_is_this",
+        "nor_is_this_either",
+    }
+
+
+def test_an_alias_is_not_followed_out_of_its_own_scope() -> None:
+    """The alias route must stop at the scope boundary that binds it.
+
+    Without the boundary, an alias leaked between sibling scopes and names the
+    TUI reuses for rows, widgets and strings (``previous``, ``current``,
+    ``remote``) were read as sessions — the false-positive class that nearly had
+    this probe deleted. ``helper`` binds the same spelling to a plain row.
+    """
+    source = (
+        "def outer(source):\n"
+        "    previous = source.session\n"
+        "    return previous.session_id\n"
+        "\n"
+        "def helper(rows):\n"
+        "    previous = rows[-1]\n"
+        "    return previous.label\n"
+    )
+    exprs = frozenset({"source.session"})
+    assert _derived_undeclared(source, exprs) == set()
+    assert "label" not in _session_members_touched(source, exprs)

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -5711,6 +5711,43 @@ async def test_loop_no_goal_hint_surfaces_inline_form() -> None:
 
 
 @pytest.mark.asyncio
+async def test_loop_stop_says_where_the_control_is_when_a_turn_is_in_flight() -> None:
+    """`/loop stop` must ask a DECLARED predicate, not a dead probe.
+
+    ``_session_is_busy`` probed ``is_busy``/``busy`` — names that exist on
+    NEITHER session class — so it answered a hard-coded ``False`` and this
+    branch, the whole reason it exists, was unreachable: a second viewer
+    watching a turn arrive from another terminal was told "no loop is running",
+    a flat contradiction of its own screen. ``is_streaming`` is the declared
+    predicate for "a turn is in flight".
+    """
+    session = GoalSession()
+    session.streaming = True
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await _type_command(pilot, app, "loop stop")
+        # Collapse wrap so an 80-col break inside the notice does not matter.
+        text = " ".join(_transcript_text(app).split())
+    assert "no loop is running in THIS terminal" in text
+    assert session.prompts == []
+
+
+@pytest.mark.asyncio
+async def test_loop_stop_says_none_when_no_turn_is_running() -> None:
+    """The other side of the same predicate, so the fix is not a constant True."""
+    session = GoalSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await _type_command(pilot, app, "loop stop")
+        text = " ".join(_transcript_text(app).split())
+    assert "no loop is running" in text
+    assert "THIS terminal" not in text
+    assert session.prompts == []
+
+
+@pytest.mark.asyncio
 async def test_loop_stops_on_turn_error() -> None:
     session = GoalSession()
     session.set_goal("g")

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -5711,15 +5711,23 @@ async def test_loop_no_goal_hint_surfaces_inline_form() -> None:
 
 
 @pytest.mark.asyncio
-async def test_loop_stop_says_where_the_control_is_when_a_turn_is_in_flight() -> None:
-    """`/loop stop` must ask a DECLARED predicate, not a dead probe.
+async def test_loop_stop_says_this_terminal_while_a_turn_is_in_flight() -> None:
+    """`/loop stop` must not contradict the reader's own screen, or claim more.
 
-    ``_session_is_busy`` probed ``is_busy``/``busy`` — names that exist on
-    NEITHER session class — so it answered a hard-coded ``False`` and this
-    branch, the whole reason it exists, was unreachable: a second viewer
-    watching a turn arrive from another terminal was told "no loop is running",
-    a flat contradiction of its own screen. ``is_streaming`` is the declared
-    predicate for "a turn is in flight".
+    The branch used to be guarded by ``_session_is_busy``, which probed
+    ``is_busy``/``busy`` — names that exist on NEITHER session class — so it
+    answered a hard-coded ``False`` and this case was unreachable: a second
+    viewer watching a loop's turns arrive from another terminal was told "no
+    loop is running", a flat contradiction of what it could see.
+
+    Replacing the dead probe with ``is_streaming`` made the case reachable but
+    wrong in the other direction: ``is_streaming`` is true for ANY in-flight
+    turn, so it also fired in the OWNER's terminal during an ordinary prompt
+    where no loop exists anywhere, and it asserted where a loop was
+    ("a loop is cancelled where it was started") while offering ``/stop`` — a
+    session-ending action — as the remedy for a no-op (UX round 1, U1/U2;
+    design round 1, D2). One scoped sentence is true in every one of those
+    states, so the branch is flat again.
     """
     session = GoalSession()
     session.streaming = True
@@ -5730,20 +5738,28 @@ async def test_loop_stop_says_where_the_control_is_when_a_turn_is_in_flight() ->
         # Collapse wrap so an 80-col break inside the notice does not matter.
         text = " ".join(_transcript_text(app).split())
     assert "no loop is running in THIS terminal" in text
+    # Nothing may be suggested that ends the session, and nothing that names a
+    # place the reader cannot act on.
+    assert "/stop" not in text
+    assert "where it was started" not in text
     assert session.prompts == []
 
 
 @pytest.mark.asyncio
-async def test_loop_stop_says_none_when_no_turn_is_running() -> None:
-    """The other side of the same predicate, so the fix is not a constant True."""
+async def test_loop_stop_is_the_same_honest_no_op_when_nothing_is_running() -> None:
+    """Idle and in-flight answer identically, because the answer is scoped.
+
+    The message says only what THIS terminal knows, so there is no second copy
+    to keep in step and no state in which it asserts something false.
+    """
     session = GoalSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
         await _type_command(pilot, app, "loop stop")
         text = " ".join(_transcript_text(app).split())
-    assert "no loop is running" in text
-    assert "THIS terminal" not in text
+    assert "no loop is running in THIS terminal" in text
+    assert "/stop" not in text
     assert session.prompts == []
 
 

--- a/tests/unit/tui/test_saved_preview_cwd.py
+++ b/tests/unit/tui/test_saved_preview_cwd.py
@@ -1,12 +1,29 @@
-"""The sidebar's saved-preview fallback directory must be the session's REAL one.
+"""The saved-preview directory must be the PREVIEWED conversation's own.
 
-``_lease_sidebar_source`` hands ``AttachedSession.saved_preview`` a fallback
-``cwd`` for a conversation whose journal records none. It read that value as
-``getattr(self._session, "cwd", "")``, and ``cwd`` exists on neither session
-class — so the fallback was ALWAYS the empty string, and a conversation with no
-recorded directory opened its preview at the process default instead of the
-session's own working directory. The read now goes through the declared
-``frontend_state`` accessor; these tests pin both halves of that.
+``_lease_sidebar_source`` hands ``AttachedSession.saved_preview`` the working
+directory of the conversation it is about to preview, and that conversation is
+a DIFFERENT session id from the one this terminal is attached to. The preview
+band renders the value as the previewed session's identity field, and the
+connect leg binds a runtime in it, so a plausible-looking value that belongs to
+another conversation is a claim about someone else's project.
+
+Three wrong answers preceded this one, each fixed by the tests below:
+
+* ``getattr(self._session, "cwd", "")`` — ``cwd`` exists on neither session
+  class, so the read was ALWAYS ``""`` and a conversation with no recorded
+  directory opened at the process default.
+* this session's ``frontend_state.cwd`` — a real directory, but the WRONG one:
+  a preview of conversation A advertised the directory of conversation B (the
+  one on screen), and nothing ever restored the honest value because
+  ``read_saved_preview``'s ``cwd`` half scans for a ``session`` transcript entry
+  that no writer in the tree emits (design round 1, D1; UX round 1, U3).
+* the fix here — the previewed session's own record, then its wake-index entry,
+  and ``""`` as the honest last resort.
+
+Resolution is exercised through the app's real seam (``_lease_sidebar_source``
+into ``_preview_cwd``), not by calling the resolver on a private path: the point
+of D1 was that the value reaching ``saved_preview`` was wrong, so that is what
+the assertions read.
 """
 
 from __future__ import annotations
@@ -16,8 +33,10 @@ from typing import Any
 
 import pytest
 
+from local_operator.mobile import attach_client
 from local_operator.session.attached import AttachedSession
 from local_operator.tui.app import OperatorApp
+from local_operator.wakes import store as wake_store
 
 
 class _StopLease(Exception):
@@ -27,6 +46,14 @@ class _StopLease(Exception):
     ``try``/``except BaseException`` — so nothing downstream of the call under
     test has to be stood up for the assertion to be about the real code path.
     """
+
+
+class _Record:
+    """The two fields ``find_runtime_record``'s caller reads off a record."""
+
+    def __init__(self, session_id: str, cwd: str) -> None:
+        self.session_id = session_id
+        self.cwd = cwd
 
 
 async def _no_takeover() -> Any:
@@ -49,65 +76,143 @@ def _app_over(session: Any) -> OperatorApp:
     return app
 
 
+def _record_lookup(monkeypatch: pytest.MonkeyPatch, record: _Record | None) -> None:
+    """Make ``find_runtime_record`` answer with ``record`` (or no owner at all).
+
+    ``_preview_cwd`` imports the name inside the function, so patching it on the
+    module is what the call site resolves; the call itself goes through
+    ``asyncio.to_thread``, which is why the stub is an ordinary function.
+    """
+    monkeypatch.setattr(
+        attach_client,
+        "find_runtime_record",
+        lambda _config_dir, _session_id: (record, 4321 if record is not None else None),
+    )
+
+
+def _wake_entry(monkeypatch: pytest.MonkeyPatch, entry: dict[str, Any] | None) -> None:
+    monkeypatch.setattr(wake_store, "read_entry", lambda _config_dir, _session_id: entry)
+
+
+async def _cwd_handed_to_saved_preview(
+    app: OperatorApp, monkeypatch: pytest.MonkeyPatch, session_id: str
+) -> str:
+    """Run the real seam and return the ``cwd`` the launcher was given."""
+
+    async def spy(cls: Any, session_id: str, *, config_dir: Path, cwd: str, takeover_factory: Any):
+        seen["cwd"] = cwd
+        raise _StopLease
+
+    seen: dict[str, Any] = {}
+    monkeypatch.setattr(AttachedSession, "saved_preview", classmethod(spy))
+    with pytest.raises(_StopLease):
+        await app._lease_sidebar_source(session_id, speculative=False)
+    return seen["cwd"]
+
+
 @pytest.mark.asyncio
-async def test_saved_preview_fallback_cwd_is_the_sessions_real_directory(
+async def test_preview_cwd_is_the_previewed_sessions_record_directory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The live runtime's own record is the first source, and it is exact."""
+    _record_lookup(monkeypatch, _Record("previewed-session", "/work/previewed-project"))
+    _wake_entry(monkeypatch, {"cwd": "/work/stale-index-entry"})
+
+    app = _app_over(_Owner())
+    cwd = await _cwd_handed_to_saved_preview(app, monkeypatch, "previewed-session")
+
+    # The record wins over the index: a running session's record is current,
+    # the wake index is a projection that need not be.
+    assert cwd == "/work/previewed-project"
+
+
+@pytest.mark.asyncio
+async def test_preview_cwd_falls_back_to_the_previewed_sessions_wake_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A session nobody has open has no record, but may still have a wake entry.
+
+    The same ladder ``resume_click._session_cwd`` uses, and the reason the
+    resolver is not simply ``find_runtime_record``: a saved conversation that
+    carries wakes keeps a ``cwd`` in the index.
+    """
+    _record_lookup(monkeypatch, None)
+    _wake_entry(monkeypatch, {"cwd": "/work/cold-project"})
+
+    app = _app_over(_Owner())
+    cwd = await _cwd_handed_to_saved_preview(app, monkeypatch, "previewed-session")
+
+    assert cwd == "/work/cold-project"
+
+
+@pytest.mark.asyncio
+async def test_preview_cwd_is_empty_when_nothing_records_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``""`` is the honest last resort: the band's rung simply goes absent.
+
+    Deliberately NOT the process default or the home directory — those read as a
+    recorded fact in the band, which is the exact confusion D1 is about.
+    """
+    _record_lookup(monkeypatch, None)
+    _wake_entry(monkeypatch, None)
+
+    app = _app_over(_Owner())
+    cwd = await _cwd_handed_to_saved_preview(app, monkeypatch, "previewed-session")
+
+    assert cwd == ""
+
+
+@pytest.mark.asyncio
+async def test_preview_cwd_never_borrows_this_sessions_directory(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    known_cwd = tmp_path / "known-session-dir"
-    known_cwd.mkdir()
+    """The regression guard for D1: this terminal's own cwd must not leak in.
 
+    The viewing session HAS a real directory and the previewed one has none —
+    the state in which the old fallback handed over ``known_cwd``. The answer
+    must be the honest ``""``, not the directory of the conversation that
+    happens to be on screen.
+    """
+    known_cwd = tmp_path / "the-session-on-screen"
+    known_cwd.mkdir()
     current = await AttachedSession.cold(
         "current-session",
         config_dir=tmp_path,
         cwd=str(known_cwd),
         takeover_factory=_no_takeover,
     )
-    seen: dict[str, Any] = {}
-
-    async def spy(cls: Any, session_id: str, *, config_dir: Path, cwd: str, takeover_factory: Any):
-        seen["session_id"] = session_id
-        seen["cwd"] = cwd
-        raise _StopLease
-
-    monkeypatch.setattr(AttachedSession, "saved_preview", classmethod(spy))
+    _record_lookup(monkeypatch, None)
+    _wake_entry(monkeypatch, None)
 
     app = _app_over(current)
-    with pytest.raises(_StopLease):
-        await app._lease_sidebar_source("other-session", speculative=False)
+    cwd = await _cwd_handed_to_saved_preview(app, monkeypatch, "previewed-session")
 
-    assert seen["session_id"] == "other-session"
-    # Non-empty, and specifically the SESSION's directory — the two facts the
-    # dead probe could never supply.
-    assert seen["cwd"]
-    assert seen["cwd"] == str(known_cwd)
+    assert cwd == ""
+    assert cwd != str(known_cwd)
 
 
 @pytest.mark.asyncio
-async def test_saved_preview_fallback_cwd_is_empty_for_a_non_viewer(
+async def test_preview_cwd_is_the_record_directory_for_a_non_viewer_host(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A non-viewer host has no attached frontend state, so the fallback stands.
+    """The source does not depend on what KIND of session this host holds.
 
-    The old probe answered ``""`` for EVERY session, so this half looked right
-    for the wrong reason; asserting it separately is what keeps the fix from
-    being reverted into "read a member nobody declares" if a non-viewer host
-    ever mounts this seam.
+    A non-viewer host has no attached frontend state at all, which is why the
+    old fallback offered it ``""`` unconditionally. The previewed session's own
+    record is just as available, so it is still the answer.
     """
-
-    class _Owner:
-        owns_runtime = True
-        session_id = "owner-session"
-
-    seen: dict[str, Any] = {}
-
-    async def spy(cls: Any, session_id: str, *, config_dir: Path, cwd: str, takeover_factory: Any):
-        seen["cwd"] = cwd
-        raise _StopLease
-
-    monkeypatch.setattr(AttachedSession, "saved_preview", classmethod(spy))
+    _record_lookup(monkeypatch, _Record("previewed-session", "/work/previewed-project"))
+    _wake_entry(monkeypatch, None)
 
     app = _app_over(_Owner())
-    with pytest.raises(_StopLease):
-        await app._lease_sidebar_source("other-session", speculative=False)
+    cwd = await _cwd_handed_to_saved_preview(app, monkeypatch, "previewed-session")
 
-    assert seen["cwd"] == ""
+    assert cwd == "/work/previewed-project"
+
+
+class _Owner:
+    """A minimal non-viewer session: enough for the seam, no frontend state."""
+
+    owns_runtime = True
+    session_id = "owner-session"

--- a/tests/unit/tui/test_saved_preview_cwd.py
+++ b/tests/unit/tui/test_saved_preview_cwd.py
@@ -1,0 +1,113 @@
+"""The sidebar's saved-preview fallback directory must be the session's REAL one.
+
+``_lease_sidebar_source`` hands ``AttachedSession.saved_preview`` a fallback
+``cwd`` for a conversation whose journal records none. It read that value as
+``getattr(self._session, "cwd", "")``, and ``cwd`` exists on neither session
+class — so the fallback was ALWAYS the empty string, and a conversation with no
+recorded directory opened its preview at the process default instead of the
+session's own working directory. The read now goes through the declared
+``frontend_state`` accessor; these tests pin both halves of that.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.session.attached import AttachedSession
+from local_operator.tui.app import OperatorApp
+
+
+class _StopLease(Exception):
+    """Stop ``_lease_sidebar_source`` at the call under test.
+
+    Raised from the ``saved_preview`` spy, which runs BEFORE the method's own
+    ``try``/``except BaseException`` — so nothing downstream of the call under
+    test has to be stood up for the assertion to be about the real code path.
+    """
+
+
+async def _no_takeover() -> Any:
+    raise RuntimeError("a sidebar viewer never takes over a session")
+
+
+def _app_over(session: Any) -> OperatorApp:
+    """An app holding ``session``, constructed without ``run_test``.
+
+    ``_lease_sidebar_source`` touches only ``_sidebar_sources`` and ``_session``
+    before it calls ``saved_preview``, and both are set in ``__init__``, so the
+    pilot would add a mounted widget tree without changing what is exercised.
+    """
+
+    async def factory() -> Any:
+        return session
+
+    app = OperatorApp(factory)
+    app._session = session
+    return app
+
+
+@pytest.mark.asyncio
+async def test_saved_preview_fallback_cwd_is_the_sessions_real_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    known_cwd = tmp_path / "known-session-dir"
+    known_cwd.mkdir()
+
+    current = await AttachedSession.cold(
+        "current-session",
+        config_dir=tmp_path,
+        cwd=str(known_cwd),
+        takeover_factory=_no_takeover,
+    )
+    seen: dict[str, Any] = {}
+
+    async def spy(cls: Any, session_id: str, *, config_dir: Path, cwd: str, takeover_factory: Any):
+        seen["session_id"] = session_id
+        seen["cwd"] = cwd
+        raise _StopLease
+
+    monkeypatch.setattr(AttachedSession, "saved_preview", classmethod(spy))
+
+    app = _app_over(current)
+    with pytest.raises(_StopLease):
+        await app._lease_sidebar_source("other-session", speculative=False)
+
+    assert seen["session_id"] == "other-session"
+    # Non-empty, and specifically the SESSION's directory — the two facts the
+    # dead probe could never supply.
+    assert seen["cwd"]
+    assert seen["cwd"] == str(known_cwd)
+
+
+@pytest.mark.asyncio
+async def test_saved_preview_fallback_cwd_is_empty_for_a_non_viewer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-viewer host has no attached frontend state, so the fallback stands.
+
+    The old probe answered ``""`` for EVERY session, so this half looked right
+    for the wrong reason; asserting it separately is what keeps the fix from
+    being reverted into "read a member nobody declares" if a non-viewer host
+    ever mounts this seam.
+    """
+
+    class _Owner:
+        owns_runtime = True
+        session_id = "owner-session"
+
+    seen: dict[str, Any] = {}
+
+    async def spy(cls: Any, session_id: str, *, config_dir: Path, cwd: str, takeover_factory: Any):
+        seen["cwd"] = cwd
+        raise _StopLease
+
+    monkeypatch.setattr(AttachedSession, "saved_preview", classmethod(spy))
+
+    app = _app_over(_Owner())
+    with pytest.raises(_StopLease):
+        await app._lease_sidebar_source("other-session", speculative=False)
+
+    assert seen["cwd"] == ""


### PR DESCRIPTION
## Summary

Follow-up to the Session/`AttachedSession` consolidation (Stages 1–4). That work unified the architecture, but its **enforcement** half — a *total* session contract — landed only partially, and the gap was load-bearing.

`tests/unit/session/test_viewer_protocol.py` derives every session member a host reads and fails when one is not declared on a protocol. Two exclusion sets made that derivation advisory rather than total:

| Set | What it held | Why it mattered |
| --- | --- | --- |
| `_UNDECLARED_ON_BOTH_CLASSES` | 18 members read by hosts, implemented by **both** classes, declared on **no** protocol | pyright cannot see a duck-probe string, so a rename or a typo degrades the member to a silent `None` |
| `_KNOWN_MISSING_ON_BOTH_CLASSES` | `cwd` — read by `app.py`, present on **neither** class | already dead: the read returned its default forever |

Both sets are gone. The 18 are declared on `ViewerSessionProtocol`; the `cwd` read is rewritten against a declared accessor; and the guard's derivation now *sees* the shapes that let those defects hide.

## Round-1 remediation (this head)

One commit answers every finding from the four round-1 rounds. The disputed items are implemented as the manager settled them, not re-argued:

| Finding | Disposition |
| --- | --- |
| Review R1 — tracked design doc asserts fixed defects as live | **FIXED** — prominent staleness banner (see below) |
| Review R2 — placement comment's justification was false | **FIXED** — reason restated; placement unchanged |
| Review R3 — alias following is scope-wide, not flow-honest | **FIXED** — live-range bounded, with the reproduced case as a test |
| Review R4 / R5 — wrong protocol named; test count | **FIXED** |
| QA Q1 — plain literal assignment / tuple-unpack loop target invisible | **FIXED** — both shapes now derived, not just documented |
| Design D1 / UX U3 — preview advertises another session's directory | **FIXED** — resolves the *previewed* session's own directory |
| Design D2 / UX U1, U2, U4, U5, U6 — `/loop stop` copy | **FIXED** — dead predicate deleted, one scoped notice, plain kind, `/help` row |
| Design D3 — routed twin's docstring promise | **FIXED** — divergence stated |

### `/loop stop`: the predicate is deleted, not repaired

`_session_is_busy` probed `"is_busy"`/`"busy"` — names that exist on NEITHER class — so it always returned `False` and its `/loop stop` caller was dead code. Replacing it with `is_streaming` (the round-1 head) made the branch reachable but wrong in both directions at once, which is why it is **gone** rather than re-aimed:

* `is_streaming` is true for *any* in-flight turn, so the branch fired in the **owner's own terminal** during an ordinary prompt, where no loop exists anywhere (UX U2), and it asserted a loop *elsewhere* while offering `/stop` — a session-ending action — as the remedy for a no-op (design D2).
* Between two loop iterations the flag is **false**, so a viewer watching a loop advance was told a flat `no loop is running`, the same contradiction of its own screen the PR set out to remove (UX U1).

`_loop_running` is terminal-local state the owner never publishes, so no viewer can answer for another terminal's loop and no streaming flag can stand in for one. The branch is now one scoped sentence, in the plain (not `warning`) notice kind:

> `· no loop is running in THIS terminal`

It claims nothing about where a loop might be running, offers no session-ending action, and is true in every one of the four states — the owner's own terminal mid-turn, a second viewer mid-turn, a second viewer between iterations, and nothing running anywhere. One row at 100 cols, 80 cols and 60 cols (the replaced copy was 2 rows at 100 and 3 at 60), verified in the rendered frames rather than by counting characters. `/loop stop` is now also in the `/help` row, so the escape hatch is discoverable *before* a loop is running (UX U6).

### The saved preview resolves the previewed session's directory

`_lease_sidebar_source` handed `saved_preview(...)` the cwd of `self._session` — the conversation the user is **attached to** — as the fallback for a *different* session id, and `saved_preview` publishes it as facade state. The row therefore advertised another conversation's project as this one's, and it did not stay a label: the connect leg binds a runtime in that directory (design D1, UX U3).

It is now resolved from the previewed id's **own** sources — its live runtime record, then its wake-index entry, `""` as the honest last resort. That is `tui/resume_click.py::_session_cwd`'s ladder minus its `~` fallback: the notification path may put a user in a plausible default, but the band's `cwd` rung renders as the conversation's own identity field, where a guess is indistinguishable from a fact. When neither source exists the value is the same placeholder the pre-PR tree showed (`~/.`), which is the reviewer's stated bar — an obvious placeholder beats a confident wrong answer.

`read_saved_preview`'s cwd half is still dead (nothing in the tree writes the `session` transcript entry it scans for), so the resolver above is the only source in practice. That writer is out of this PR's scope: **deferred — `read_saved_preview`'s cwd half is dead (no writer emits the `session` entry); the picker now resolves via the record instead.**

### The guard is flow-honest about aliases, and sees two more probe shapes

* **Aliases now have a live range** (review R3). The old rule collected a name once it had been bound to a watched expression and treated it as an alias for the rest of the scope, so a same-scope reuse — `previous = source.session` … `previous = rows[-1]` … `previous.label` — attributed the *row's* member to the session (reproduced: `{'label': [5], 'session_id': [3]}`). A name is now a session only from the binding that makes it one to the next binding that makes it something else, which is the same false-positive class the scope boundary already guards.
* **Two more probe-name shapes are derived** (QA Q1): an in-scope assignment of the literal (`name = "x"; getattr(session, name, None)`) and a tuple-unpack loop target (`for probe, default in (("x", None),)`, read positionally off the literal rows). Both were invisible beside the loop form this PR already covered; the module docstring's "blind to" list now names only the shapes that genuinely remain (a dict lookup, a list built incrementally, an f-string, a second alias hop).

## Why the 18 are declared on `ViewerSessionProtocol` and not `SessionProtocol`

Both classes implement all 18 (the owner exposes the live manager/scheduler/registry, a viewer a snapshot the runtime published), so `SessionProtocol` is the tempting home. The reason it stays on the viewer protocol is the **duck-typed** population, not a claim that only a viewer has them: every host that reads them through a duck-typed binding holds an attached facade (the TUI's `self._session`/`source.session`, the desktop routes' `bridge.remote`, `info/collect.py`'s `session` parameter), while the **owner-side** readers of the same members hold the concrete `Session` and are already checked against the real class (`harness/subagent.py` types its `parent_session` as `Session` and reads `mcp_manager`/`mcp_startup`/`jobs` off it; `session/runtime/serving.py` reads `self._session.jobs`). Declaring them on the wider protocol would add no coverage for those readers — only conformance obligations for the reduced doubles:

| Placement | pyright result |
| --- | --- |
| All 18 on `SessionProtocol` | **1996 errors** across `tests/unit/tui`, `scripts/`, `tests/unit/test_exec_mode.py` |
| Only the 7 every *shared* double already implements (`jobs`, `agent_registry`, `team_registry`, `context_breakdown`, `record_shell`, `active_agent`, `active_team_name`) on `SessionProtocol` | **213 errors**, 19 files, from ~10 local `FakeSession` classes |
| All 18 on `ViewerSessionProtocol` | **0 errors** |

No fake was migrated, so nothing is deferred on this account.

## The tracked design record is history, and now says so

`docs/design/history-fold-convergence.md` is landed verbatim from the analysis that produced it (805 lines; its §3 is the section four production comments cite) — but it was written against `origin/main` @ `a8f98be3b` and states its findings in that base's present tense, while **#864 (`51c71ff6f`) fixed the §3 divergences and is an ancestor of this PR's base `633baf258`**, and its §6 recommendation is implemented (`harness/rows.py` + `tests/unit/mobile/test_fold_parity.py`). Every `file:line` anchor in §2.1 is also stale.

The earlier claim here — "no claim in it was found stale against the current tree" — was wrong, and the file now carries a prominent header banner stating the base SHA, what landed since, and which sections to read as history. The file is kept because it is the *reasoning* the convergence was built from and the four citing comments point at its row semantics; it is no longer presented as a description of the tree.

## Testing

Base: `origin/main` at `633baf258` (v0.54.14), rebased onto the current `origin/main` @ `27466f669` (#955/#960/#963/#965–968/#974/#952 landed). Head: `89d68dbaf`. `pyproject.toml` unchanged at `0.54.14` — no version bump. PR stays DRAFT.

### Static gates (whole tree, exactly as CI)

```
$ .venv/bin/python -m flake8 .                                     # no output, rc=0
$ uvx --from black==26.1.0 black --check .                         # 1228 files would be left unchanged.
$ uvx isort==5.13.2 --check .                                      # Skipped 2 files; rc=0
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .      # 0 errors, 0 warnings, 0 informations
```

### Suites

```
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
18593 passed, 18 skipped, 721 warnings in 980.40s (0:16:20)

$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
107 passed, 7 skipped, 6 warnings in 181.16s (0:03:01)
```

### `/loop stop` in all four states, before and after

Driven through two real `OperatorApp` instances over a real loopback socket (`Session` + `ServingSessionHandle` + `RuntimeServer` + `AttachedSession.connect`), the provider parked on a gate so each state is held rather than raced. Same harness on both trees; `before` = round-1 head `a3a49c5c5`:

```
before CASE1 B viewer mid-turn      -> ! no loop is running in THIS terminal — a loop is cancelled where it was started, or use /stop to end the session
after  CASE1 B viewer mid-turn      -> · no loop is running in THIS terminal
before CASE2 B between iterations   -> (same 110-char warning)   // · no loop is running
after  CASE2 B between iterations   -> · no loop is running in THIS terminal
before CASE4 B nothing running      -> · no loop is running
after  CASE4 B nothing running      -> · no loop is running in THIS terminal
before CASE5 A owner's own terminal, plain turn in flight -> (same 110-char warning)
after  CASE5 A owner's own terminal, plain turn in flight -> · no loop is running in THIS terminal
both   CASE3 A stops its OWN loop   -> · loop will stop after the current turn      (unchanged)
```

Frames (real `OperatorApp`, `scripts.visual_capture.save_capture`, native 8×17 cells, geometry JSON alongside): `/tmp/pr971-r1/shots/{before-r1,head-r1}-B-after-stop-inflight.svg`, `…-A-after-stop-plain-turn.svg`, and `head-narrow-*` at 60×20. The `before` frame is a two-row amber `!` block ending in `… or use /stop to end the session`; the `after` frame is one dim row.

### The previewed directory, before and after

Two phases through the app's own `_select_sidebar_session` on a real attached viewer whose own session works in `/tmp/pr971-ux/conv-b`, previewing a conversation that works in `/tmp/pr971-ux/conv-a`:

```
before  bare  preview_cwd='/tmp/pr971-ux/conv-b'          # another conversation's directory
after   bare  preview_cwd='<HOME>'                        # placeholder, as pre-PR
before  wake  preview_cwd='/tmp/pr971-ux/conv-b'          # the previewed session's own index entry was ignored
after   wake  preview_cwd='/tmp/pr971-ux/conv-a'          # the PREVIEWED session's own directory (PASS)
```

`bare` = the previewed conversation records no directory anywhere; `wake` = it has its own wake-index entry recording `conv-a` (written with the real `wakes.store.write_entry`). `before` was the session *on screen* in both phases. The record half (live runtime) is covered in `tests/unit/tui/test_saved_preview_cwd.py`: an in-process owner is excluded from `find_runtime_record` by design, so the frame cannot exercise it.

Band and picker frames: `/tmp/pr971-r1/shots/{before-r1,head-r1}-preview-selected.svg` and `…-preview-move-picker.svg`. Before, the band reads `⌂ /tmp/pr971-ux/conv-b` under the previewed conversation's title and `/move` offers `❯ /tmp/pr971-ux/conv-b current`; after, the band reads `⌂ ~/.` and `/move` offers `❯ ~ current`, with `/tmp/pr971-ux/conv-b` demoted to a `session` row.

### The guard hardening, both directions

The guard's predicate is applied to a verbatim copy of a real scanned host (`local_operator/info/collect.py`) with one instance of each newly-covered shape appended — no tracked file edited, so the experiment is re-runnable:

```
$ .venv/bin/python planted_shapes.py <tree>
planted members, this branch  : ['planted_alias_member', 'planted_local_literal', 'planted_loop_one',
                                 'planted_loop_two', 'planted_module_constant_one',
                                 'planted_module_constant_two', 'planted_unpack_one', 'planted_unpack_two']
planted members, origin/main  : []
count                         : 8 vs 0
baseline (unplanted) this tree: none

$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/session/test_viewer_protocol.py -q
21 passed in 6.15s
```

The comparison derivation is `origin/main`'s own copy of the test file — the PR is what changes it — so "8 vs 0" is one predicate over one planted source. Running it found a real gap in this round's first attempt, disclosed rather than quietly fixed: the probe-name tables are keyed by variable name, so a bare loop and a tuple-unpack loop binding the same name overwrote each other and one set vanished silently (which set survived depended on AST traversal order). All three tables now **union** instead of replace, and `test_two_probe_loops_sharing_one_variable_keep_both_sets` pins it. The section carries **ten** planted-shape tests, five of them added by this round.

### CI

Run [34650572905](https://github.com/damianvtran/local-operator/actions/runs/34650572905): **success** on head `89d68dbaf` — `test (3.12, 0..4)`, `type-check`, `lint`… plus `tui-e2e (ubuntu-latest)`, `tui-e2e (macos-latest)`, `server-sanity`, `version-bump-guard` all green.

## Deferred — deliberately not in this PR

- **flake8 `getattr`/`hasattr` ban (plan §5.2 / PR D)** — the AST guard now covers the TUI surface *including* the computed-probe and alias shapes where the shipped defects hid; the ban is the larger, lower-yield change.
- **fold `RowSpec` / `assert_never` / single `tool_payload` (fold stage 3)** — no live divergence is reachable after stages 0–2.
- **typing `SlashResult.kind` / `data` (shape B)** — the AST producer/consumer test plus the dead-producer fix is a defensible closure; the type change has renderer-wide blast radius.
- **the transcript memory fix (plan PR 3)** — orthogonal to centralization; stays on the perf backlog.
- **deleting `_stop_local_session` / `own_local` (audit C.4)** — `run_tui` still types its factory as `Callable[[], Awaitable[SessionProtocol]]` and its docstring contemplates local `Session` factories; `tests/unit/tui/test_stop_command.py` drives that contract. Retire the contract first.
- **the owner→runtime prose sweep in `tui/`** — peer PR #955 owns the user-visible copy pass in `tui/app.py`; those strings are deliberately untouched here.
- **the dual-read / disconnect-reason wire cleanup (audit C.6)** — separate wire PR.
- **`read_saved_preview`'s cwd half** — no writer emits the `session` transcript entry it scans for; the picker resolves via the record instead (see above).
