### PR TITLE
fix(tui): a transient owner loss no longer latches the sidebar or /resume

### DIFF
--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -722,6 +722,39 @@ def find_runtime_record(
     return None, owner
 
 
+def dialable_record_exists(config_dir: Path, pid: int) -> bool | None:
+    """Whether ``pid`` publishes a LIVE record this build could dial.
+
+    `find_runtime_record` collapses two very different states into
+    ``(None, pid)``: an owner that publishes no usable record at all (an older
+    binary, or a registrant that failed to start), and the rebind race — a
+    record for that pid that is ``live`` and dialable but is still stamped with
+    the PREVIOUS ``session_id``, which that function's own docstring describes
+    as a state whose record "is returned anyway and the welcome projection's
+    identity check ... arbitrates". A caller about to tell the user the process
+    is an old one must therefore ask this rather than infer it from the tuple;
+    otherwise it reports a cause the code has not established and skips the
+    pacing the race asks for (review m3).
+
+    The threshold is ``2``, the same floor `find_runtime_record` uses to decide
+    a record is usable — deliberately NOT `FRONTEND_ATTACH_MIN_PROTOCOL`: the
+    question here is only "could this pid's record be dialled at all", and a
+    record below the frontend attach protocol is a case
+    `frontend_attach_refusal` already answers with its own sentence.
+
+    ``None`` when the registry could not be read at all. Not a plain bool on
+    purpose: a failed read is not evidence of absence, so the caller must pace
+    rather than refuse on it.
+    """
+    try:
+        for record, state in scan(config_dir):
+            if state == "live" and record.pid == pid and record.protocol >= 2:
+                return True
+    except OSError:
+        return None
+    return False
+
+
 class AttachClient:
     """One authenticated ``attach`` connection to a live session's registrant.
 

--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -723,18 +723,29 @@ def find_runtime_record(
 
 
 def dialable_record_exists(config_dir: Path, pid: int) -> bool | None:
-    """Whether ``pid`` publishes a LIVE record this build could dial.
+    """Whether ``pid`` publishes a record this build could dial.
 
     `find_runtime_record` collapses two very different states into
     ``(None, pid)``: an owner that publishes no usable record at all (an older
     binary, or a registrant that failed to start), and the rebind race — a
-    record for that pid that is ``live`` and dialable but is still stamped with
-    the PREVIOUS ``session_id``, which that function's own docstring describes
-    as a state whose record "is returned anyway and the welcome projection's
+    record for that pid that is dialable but is still stamped with the
+    PREVIOUS ``session_id``, which that function's own docstring describes as a
+    state whose record "is returned anyway and the welcome projection's
     identity check ... arbitrates". A caller about to tell the user the process
     is an old one must therefore ask this rather than infer it from the tuple;
     otherwise it reports a cause the code has not established and skips the
     pacing the race asks for (review m3).
+
+    A WEDGED RECORD ANSWERS ``True``, because that is the whole of "could this
+    pid's record be dialled" (review round 3, MINOR-2). The registry has a
+    third state — the pid is alive and the heartbeat is older than
+    ``HEARTBEAT_TIMEOUT_S``, i.e. the owner is stuck — and `scan` keeps that
+    record for exactly the reason the redial exists: a stuck owner may recover
+    on its own, which is the transient the budget is sized to outlast. Asking
+    only for ``live`` made a wedged owner answer ``False``, so it earned the
+    older-process sentence AND skipped the pacing: a cause the code had not
+    established, on the one state a redial could have healed. ``stale`` (the
+    pid is gone) is the state that is genuinely absent, and it stays ``False``.
 
     The threshold is ``2``, the same floor `find_runtime_record` uses to decide
     a record is usable — deliberately NOT `FRONTEND_ATTACH_MIN_PROTOCOL`: the
@@ -748,7 +759,7 @@ def dialable_record_exists(config_dir: Path, pid: int) -> bool | None:
     """
     try:
         for record, state in scan(config_dir):
-            if state == "live" and record.pid == pid and record.protocol >= 2:
+            if state in ("live", "wedged") and record.pid == pid and record.protocol >= 2:
                 return True
     except OSError:
         return None

--- a/local_operator/session/attached.py
+++ b/local_operator/session/attached.py
@@ -651,6 +651,41 @@ def _validated_ask_question(pending: PendingRequest) -> AskQuestion:
     )
 
 
+#: The oldest attach protocol that carries the whole frontend state: below it
+#: there is no canonical full-TUI attach, and the degraded projection view was
+#: deliberately deleted, so the refusal below is the whole story rather than a
+#: fallback.
+FRONTEND_ATTACH_MIN_PROTOCOL = 5
+
+
+def frontend_attach_refusal(record: SessionRecord) -> str | None:
+    """Why ``connect`` would refuse this record, or ``None`` if it would dial.
+
+    ONE RULE, TWO CALLERS. ``connect`` refuses on it; a caller that has to
+    decide whether a failed connect is worth RETRYING must ask the same
+    question of the same record. The question matters because the two failure
+    classes want opposite handling: a capability or protocol gap is a STATIC
+    property of the owner, so every redial raises the identical refusal and a
+    budget spent on it is a longer way to the same sentence, while the
+    transient failures (a socket that is not there yet, an owner that is not
+    answering) are exactly what a budget is for.
+
+    Extracted rather than restated at the far side, because a copy of this
+    version test is one protocol bump away from disagreeing with the guard it
+    mirrors — and the disagreement would be silent, since both spellings would
+    keep compiling.
+    """
+    if (
+        record.protocol < FRONTEND_ATTACH_MIN_PROTOCOL
+        or FRONTEND_CAPABILITY not in record.capabilities
+    ):
+        return (
+            f"owner lacks {FRONTEND_CAPABILITY}; canonical full-TUI attach needs "
+            f"protocol >= {FRONTEND_ATTACH_MIN_PROTOCOL}"
+        )
+    return None
+
+
 class AttachedSession:
     """A SessionProtocol facade backed by one owner's v5 attach socket.
 
@@ -1033,10 +1068,9 @@ class AttachedSession:
         display_window: bool = False,
         surface: str = "terminal",
     ) -> "AttachedSession":
-        if record.protocol < 5 or FRONTEND_CAPABILITY not in record.capabilities:
-            raise ConnectionError(
-                f"owner lacks {FRONTEND_CAPABILITY}; canonical full-TUI attach needs protocol >= 5"
-            )
+        refusal = frontend_attach_refusal(record)
+        if refusal is not None:
+            raise ConnectionError(refusal)
         self = cls(
             config_dir=config_dir,
             session_id=session_id,

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -321,8 +321,18 @@ _EVENT_QUEUE_MAX = 64
 #: OTHER reason means the runtime removed a client that had not asked to leave —
 #: an attach-cap eviction, a queue overflow, a send timeout — which is exactly
 #: the event a viewer learns about only as a cold facade, so those are logged at
-#: WARNING. Derived from the call sites rather than guessed: see the six
+#: WARNING. Derived from the call sites rather than guessed: see the eleven
 #: ``_drop_client`` callers, and keep this list beside any new one.
+#:
+#: ``frontend requested but unsupported`` is deliberately NOT in this set, and
+#: the call is a decision rather than an oversight (review n1). It reads like a
+#: client-caused drop, but the level is chosen by what the user sees, and what
+#: they see is identical to an eviction: a viewer that asked to be kept live is
+#: cut off and reads cold next. The cause is also permanent rather than
+#: transient — a runtime whose handler has no ``subscribe_frontend`` refuses
+#: every reconnect the same way — so burying it at INFO would make the one
+#: recurring reason a viewer keeps going cold the one reason the log does not
+#: show without turning INFO on for the whole runtime.
 _GRACEFUL_DROP_REASONS = frozenset(
     {"runtime shutdown", "reader eof", "reader reset", "daemon replaced"}
 )

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -315,6 +315,18 @@ _TUI_SEND_TIMEOUT_S = 5.0
 # reconnect through durable history + canonical frontend_sync instead of drift.
 _EVENT_QUEUE_MAX = 64
 
+#: Drop reasons that are an ordinary part of a client's life, kept at INFO: a
+#: close the runtime itself was asked for (``runtime shutdown``), a peer that
+#: closed first, and a daemon dial that superseded its own predecessor. Every
+#: OTHER reason means the runtime removed a client that had not asked to leave —
+#: an attach-cap eviction, a queue overflow, a send timeout — which is exactly
+#: the event a viewer learns about only as a cold facade, so those are logged at
+#: WARNING. Derived from the call sites rather than guessed: see the six
+#: ``_drop_client`` callers, and keep this list beside any new one.
+_GRACEFUL_DROP_REASONS = frozenset(
+    {"runtime shutdown", "reader eof", "reader reset", "daemon replaced"}
+)
+
 # Ops whose answer is structured data (a typed slash result, a cancel count)
 # rather than a one-line receipt: they reply with a ``result`` frame so the
 # invoker renders the outcome locally instead of the owner's transcript
@@ -1586,11 +1598,25 @@ class RuntimeServer:
         # SERVER-GLOBAL state has to honour that contract, or the late second
         # call reaches across to whatever connection replaced this one.
         was_registered = self._clients.pop(id(conn.writer), None) is not None
-        # One INFO per actual removal. The reader loop's ``finally`` always
-        # calls again after a send-path drop; that second call is a no-op and
-        # must not look like a second failure (DEBUG only).
+        # One line per actual removal, at ONE level chosen by WHY it happened.
+        #
+        # A view that went cold and was told to reselect used to leave nothing
+        # in the log to read: the removal was recorded at INFO beside every
+        # routine close, so the reason a watching terminal lost its owner — the
+        # attach cap evicting it, an event queue overflowing, a send timing out
+        # — could not be found without turning INFO on for the whole runtime.
+        # The reasons below that mean "we dropped a client that did not ask to
+        # leave" are therefore WARNING, and the ones that are an ordinary part
+        # of a client's life stay INFO. The reader loop's `finally` always calls
+        # again after a send-path drop; that second call is a no-op and must not
+        # look like a second failure (DEBUG only).
         peer = conn.writer.get_extra_info("peername")
-        log = logger.info if was_registered else logger.debug
+        if not was_registered:
+            log = logger.debug
+        elif reason in _GRACEFUL_DROP_REASONS:
+            log = logger.info
+        else:
+            log = logger.warning
         log(
             "session runtime: dropped %s client %s (events=%s frontend=%s surface=%s): %s",
             conn.kind,

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1637,6 +1637,49 @@ def _sidebar_connect_attempts() -> int:
 #: cover it would buy nothing and cost every click path a longer wait.
 SIDEBAR_CONNECT_ATTEMPTS = _sidebar_connect_attempts()
 
+
+def _resume_connect_attempts() -> int:
+    """How many times `/resume` re-dials before the user is told it failed.
+
+    THE SAME RULE AS `_sidebar_connect_attempts`, APPLIED TO THE OTHER BOUND.
+    The quantity a redial budget has to outlast is the give-up bound of the
+    facade it is building, and that bound is selected by `_can_go_cold`.
+    `/resume` reaches `AttachedSession.connect`, which builds a TERMINAL
+    surface — so `_can_go_cold` is False and the bound that governs it is
+    `RECOVERY_GIVE_UP_S`, not `COLD_FALLBACK_S`. Reusing the sidebar's count
+    here would be sizing one facade's budget from another facade's bound,
+    which is the mistake this derivation exists to prevent.
+
+    `RECOVERY_GIVE_UP_S` is also the RIGHT question for this seam rather than
+    merely the wider one: it is scoped to "a record has been seen", which is
+    exactly the shape of a failed `/resume` — the loop re-reads the record
+    before every attempt, so a record that is present and an owner that will
+    not answer are both established facts, and the bound answers precisely
+    "an owner is there and will not answer". The same 50% margin as the
+    sidebar's: the last attempt must land clearly past the owner's give-up on
+    a loaded machine, not tie with it.
+    """
+    from local_operator.session.attached import RECOVERY_GIVE_UP_S
+
+    return _attempts_outlasting(RECOVERY_GIVE_UP_S * 1.5)
+
+
+#: Attempts `/resume` may spend re-dialling an owner that is being republished,
+#: before the user is told the session is unreachable.
+#:
+#: The pre-#883 shape at this seam was ONE-SHOT: any exception from
+#: `AttachedSession.connect` printed the error and returned, so a runtime that
+#: was mid-restart — the ordinary case, since a `kill -9` republishes a record
+#: within a second or two — was reported to the user as a permanent failure to
+#: be retyped by hand. Bounded rather than immediate, and bounded rather than
+#: infinite: every attempt re-reads the runtime record, so a republished owner
+#: under a NEW pid is picked up instead of dialling a dead socket, and the
+#: budget is what stops that from becoming a hang.
+#:
+#: NOT `SIDEBAR_CONNECT_ATTEMPTS`. Derivation and its reasoning live on
+#: `_resume_connect_attempts` above.
+RESUME_CONNECT_ATTEMPTS = _resume_connect_attempts()
+
 #: The chord that lifts the aside's full text to the clipboard.
 #:
 #: `omp`, the reference implementation this surface is modelled on, ships copy
@@ -5216,6 +5259,56 @@ class OperatorApp(App[None]):
             and not card.settled
         )
 
+    def _abandon_sidebar_frame(self, error: Exception) -> bool:
+        """Fail a pending sidebar frame with ``error``; report whether one was armed.
+
+        The one seam through which a caller that has PROVEN this frame can never
+        paint releases the connect body's ``await ready`` early, instead of
+        leaving it to sit out ``_await_sidebar_frame``'s 15 s timer. Both
+        points that can learn the answer (the display hook, and the bind->commit
+        half of the same window) go through here so the pending tuple is cleared
+        exactly once and in one place — a second clearer is how a future edit
+        ends up resolving a frame whose future the connect body has already
+        stopped waiting on.
+
+        ``False`` means the frame had already settled, so the caller owns the
+        error: returning success there would publish the very state this exists
+        to refuse.
+        """
+        pending = getattr(self, "_sidebar_ready_frame", None)
+        if pending is None:
+            return False
+        self._sidebar_ready_frame = None
+        future = pending[2]
+        if future.done():
+            return False
+        future.set_exception(error)
+        return True
+
+    def _sidebar_live_frame_owner_gone(self, source: SessionInteraction) -> bool:
+        """Whether this pending frame is a LIVE commit whose owner went cold.
+
+        The gate's first check is ``is_cold``, so this is the one state whose
+        verdict is already known before a single frame is painted: no relayout
+        can ever make it pass, and buying one per frame is what turned a
+        transient owner loss into a 15 s hot spin (measured pre-fix: 1,820
+        refusals, every one of them a recovery relayout, ~127/s).
+
+        ``display_only`` frames are excluded deliberately — their gate branch
+        does not consult ``is_cold`` at all (a saved excerpt is ALLOWED to
+        paint over a cold session), so failing them here would break the
+        preview path rather than the state this guards.
+
+        ``getattr`` for the same reason the gate uses it: the source's session
+        is typed as the general viewer protocol, and only the owner-backed
+        facade declares ``is_cold``.
+        """
+        return (
+            not source.display_only
+            and self._is_current(source)
+            and bool(getattr(source.session, "is_cold", False))
+        )
+
     def _await_sidebar_frame(
         self, source: SessionInteraction, generation: int
     ) -> asyncio.Future[None]:
@@ -5310,6 +5403,46 @@ class OperatorApp(App[None]):
             # update. Only now are the target frame and its input surface ready.
             self._sidebar_ready_frame = None
             future.set_result(None)
+        elif (
+            generation == self._sidebar_navigation.generation
+            and self._sidebar_live_frame_owner_gone(source)
+        ):
+            # A LIVE COMMIT WHOSE OWNER WENT COLD CAN NEVER PAINT, so the one
+            # thing this state must not do is wait out the gate's 15 s timer.
+            # `_sidebar_gate_surface_ready`'s FIRST check is `is_cold`, so the
+            # verdict is already known; the branch below would buy a forced
+            # full-screen relayout for it on every frame (measured pre-fix on
+            # the architect's rig: 15.1 s, 1,820 refusals, every one of them a
+            # recovery, ~127/s) and the timer would then raise
+            # `SurfaceNotReady`, which is terminal-on-first by #883's design —
+            # latching a transient owner loss the reselect healed in 0.17 s.
+            #
+            # THE BOUND IS THE CONNECT BODY'S, NOT THIS CALL SITE'S. The
+            # exception is NOT a `SurfaceNotReady` (it subclasses
+            # `ConnectionError`, see `OwnerWentCold`), so it lands in
+            # `_connect_sidebar_source`'s generic arm — the one that increments
+            # `connect_attempts` and re-arms through the backoff, latching only
+            # when the budget is EXHAUSTED. That is the whole reason it is a
+            # distinct type rather than a faster timer: an arm that re-armed
+            # without spending the budget is the infinite reconnect loop this
+            # codebase already measured once (the `connect_attempts` reset that
+            # made the retry's own re-arm refill it). The cold condition is
+            # bounded by the facade's own recovery (`COLD_FALLBACK_S`), and
+            # `SIDEBAR_CONNECT_ATTEMPTS` is derived to outlast it — so the
+            # budget is spent on a condition that really does end, and a
+            # genuinely unreachable owner still latches with the honest copy.
+            #
+            # Through the shared abandon seam rather than a second `set_exception`
+            # here: ``future`` is provably unsettled at this point (the chain
+            # opens on `if future.done()`), so the helper cannot report a settled
+            # frame, and having ONE clearer is what keeps a future edit from
+            # resolving a frame the connect body has stopped waiting on.
+            from local_operator.tui.session_navigation import (
+                UNREACHABLE_OWNER_MESSAGE,
+                OwnerWentCold,
+            )
+
+            self._abandon_sidebar_frame(OwnerWentCold(UNREACHABLE_OWNER_MESSAGE))
         elif (
             generation == self._sidebar_navigation.generation
             and self._is_current(source)
@@ -6400,6 +6533,39 @@ class OperatorApp(App[None]):
 
         source.connection_task.add_done_callback(settled)
 
+    def _sidebar_connect_failure_fields(
+        self, source: SessionInteraction, *, error: BaseException, elapsed: float
+    ) -> str:
+        """The one diagnostics line for a terminal/latched sidebar connect arm.
+
+        Shared by both arms so a future edit cannot enrich one and leave the
+        other blind, which is how this path ended up with NO log line at all
+        while the user was being told to reselect: everything needed to explain
+        the verdict was already in memory, on the source and its viewer.
+
+        Every field answers a question the investigation had to ask by hand:
+        WHICH arm (named by the caller), WHICH session, how long THIS ROUND
+        waited, how much budget was spent, whether the app still believed it was
+        showing a saved excerpt, and the three pieces of facade state the three
+        falsifiable causes map onto — ``is_cold`` (the owner is gone), ``_recovering``
+        (it is on its way back), ``display_history_current`` (the app can still
+        paint what it holds). ``getattr`` with a default because the source's
+        session is the general viewer protocol and only some facades declare
+        these.
+
+        No secret content: ids, counters, booleans and an exception message.
+        """
+        session = source.session
+        session_id = getattr(session, "session_id", None) or "?"
+        return (
+            f"session={session_id} elapsed={elapsed:.2f}s "
+            f"attempts={source.connect_attempts} display_only={source.display_only} "
+            f"is_cold={bool(getattr(session, 'is_cold', False))!r} "
+            f"recovering={getattr(session, '_recovering', None)!r} "
+            f"display_history_current={getattr(session, 'display_history_current', None)!r} "
+            f"error={type(error).__name__}: {error}"
+        )
+
     async def _connect_sidebar_source(self, source: SessionInteraction) -> None:
         """Reconcile a saved view without holding the navigation coordinator.
 
@@ -6424,6 +6590,8 @@ class OperatorApp(App[None]):
         published false around the wait instead of only in `finally`.
         """
         from local_operator.tui.session_navigation import (
+            UNREACHABLE_OWNER_MESSAGE,
+            OwnerWentCold,
             PreparationInvalidated,
             SurfaceNotReady,
         )
@@ -6431,6 +6599,17 @@ class OperatorApp(App[None]):
         prepared = None
         retry = False
         cancelled = False
+        loop = asyncio.get_running_loop()
+        # THIS ATTEMPT ROUND's own clock, not the sequence's. The retry is
+        # re-armed as a NEW task each round, so that is the only span a round can
+        # measure about itself — and it is the informative one at the arms that
+        # log: the paint arm's elapsed IS the 15 s gate wait. The sequence's size
+        # is carried beside it as `connect_attempts`.
+        started = loop.time()
+        # Snapshotted for the paint arm's deltas: the gate counters are
+        # app-global, so only a delta says how many refusals THIS connect spent.
+        gate_reached_at_entry = self._sidebar_gate_reached
+        gate_recoveries_at_entry = self._sidebar_gate_recoveries
         try:
             session = source.session
             if not _is_viewer(session):
@@ -6466,7 +6645,7 @@ class OperatorApp(App[None]):
                 # The message is the sentence the sync-failure path already
                 # uses, so the two ways a connect can fail read identically to
                 # the user and no new copy is introduced.
-                raise ConnectionError("the runtime is not responding")
+                raise OwnerWentCold(UNREACHABLE_OWNER_MESSAGE)
             await session.ensure_display_current()
             if source.retired or not self._is_current(source):
                 return
@@ -6496,6 +6675,25 @@ class OperatorApp(App[None]):
             ready = self._commit_sidebar_session(session.session_id, prepared, generation)
             prepared = None
             if ready is not None:
+                # THE BELT FOR THE OTHER HALF OF THE WINDOW. `post_display_hook`
+                # closes the commit->paint half; an owner lost between the bind
+                # postcondition above and this commit is already cold BY THE
+                # TIME the frame is armed, so re-check it before waiting rather
+                # than hoping a display arrives to notice. Cheap and exact: one
+                # property read on the same session the bind just checked.
+                #
+                # Raising here (rather than only failing the frame) is what
+                # keeps the bound: this is a `ConnectionError`, so it falls to
+                # the generic arm below, which spends `connect_attempts` and
+                # re-arms through the backoff. `_abandon_sidebar_frame` must
+                # run first so the pending tuple is cleared and the connect
+                # body is not left waiting on a frame nothing will resolve —
+                # and if it reports no armed frame, the raise is the only way
+                # left to refuse a cold commit.
+                if _is_viewer(session) and session.is_cold:
+                    error = OwnerWentCold(UNREACHABLE_OWNER_MESSAGE)
+                    if not self._abandon_sidebar_frame(error):
+                        raise error
                 await ready
             # REFILL THE BUDGET ONLY ON A COMPLETED CONNECT, and only here at
             # the very end of the success path. Resetting earlier — beside
@@ -6528,6 +6726,21 @@ class OperatorApp(App[None]):
             # firing is itself a signal. The budget exists to outlast
             # `COLD_FALLBACK_S`; a gate timeout is not a thing `COLD_FALLBACK_S`
             # bounds, so spending the budget on it is category error.
+            #
+            # Logged because this path used to be silent in the total: a user
+            # reporting "the session just said Reconnect failed" left nothing to
+            # read, and the ONE number that explains the wait (how many frames
+            # the gate refused, each buying a full-screen relayout) existed only
+            # in the counters.
+            logger.warning(
+                "sidebar connect failed terminally (paint gate did not open): %s "
+                "gate_reached=%d gate_recoveries=%d",
+                self._sidebar_connect_failure_fields(
+                    source, error=error, elapsed=loop.time() - started
+                ),
+                self._sidebar_gate_reached - gate_reached_at_entry,
+                self._sidebar_gate_recoveries - gate_recoveries_at_entry,
+            )
             source.display_only = True
             source.connection_error = str(error) or "Connection unavailable"
             source.connect_attempts = 0
@@ -6588,6 +6801,26 @@ class OperatorApp(App[None]):
                     cancelled = True
                     raise
             else:
+                # THE LATCH, and the only arm the user ever sees as a verdict.
+                # Logged with the same fields as the paint arm: this is the
+                # other half of "the session said Reconnect failed and the logs
+                # say nothing", and the reason it latched (budget spent versus
+                # the source leaving the screen) is a property of THIS arm's
+                # condition, not of the error.
+                why = []
+                if source.connect_attempts > SIDEBAR_CONNECT_ATTEMPTS:
+                    why.append("retry budget exhausted")
+                if source.retired:
+                    why.append("source retired")
+                if not self._is_current(source):
+                    why.append("source left the screen")
+                logger.warning(
+                    "sidebar connect latched (%s): %s",
+                    ", ".join(why) or "not retryable",
+                    self._sidebar_connect_failure_fields(
+                        source, error=error, elapsed=loop.time() - started
+                    ),
+                )
                 source.connection_error = str(error) or "Connection unavailable"
                 # Surrendered, so the counter goes back to zero: the status now
                 # reads "Reselect to retry", and that affordance has to mean a
@@ -11525,34 +11758,99 @@ class OperatorApp(App[None]):
         Protocol <4 has no full event stream. The degraded projection view was
         deliberately deleted, so a mixed-version owner gets a precise upgrade
         refusal rather than silently falling back to a divergent UI.
+
+        THE DIAL IS BOUNDED-RETRIED, which this seam was not (#883 fixed the
+        sidebar's connect and left this one one-shot). `AttachedSession.connect`
+        raising used to be printed to the user and accepted as a verdict, so a
+        runtime that was being restarted — the ordinary case, since a `kill -9`
+        republishes its record within a second or two — read as a permanent
+        failure and the user re-typed `/resume` to try again. The record is
+        therefore RE-READ BEFORE EVERY ATTEMPT rather than captured once: a
+        runtime that retired between attempts publishes a new record under a
+        NEW pid, and redialling the dead one would spend the whole budget on a
+        socket that cannot answer.
         """
         from local_operator.mobile.attach_client import find_runtime_record
-        from local_operator.session.attached import AttachedSession
+        from local_operator.session.attached import (
+            AttachedSession,
+            frontend_attach_refusal,
+        )
+        from local_operator.tui.session_navigation import UNREACHABLE_OWNER_MESSAGE
 
-        record, found_owner = await asyncio.to_thread(find_runtime_record, config_root, concrete)
-        if record is None or found_owner != owner or record.protocol < 4:
-            self._system_notice(
-                f"session {concrete} is open in an older Local Operator process "
-                f"(pid {owner}) — update or close that process, then resume again",
-                "warning",
-            )
-            return
         assert self._resume_factory is not None
 
         async def takeover_factory() -> Any:
             assert self._resume_factory is not None
             return await self._resume_factory(concrete)
 
-        try:
-            remote = await AttachedSession.connect(
-                record,
-                concrete,
-                config_dir=config_root,
-                takeover_factory=takeover_factory,
+        # ONE live row for the redial, restated in place rather than stacked.
+        # The budget spans the facade's whole give-up bound, so a notice per
+        # attempt would write a hundred rows into a durable transcript to say
+        # one thing — the same reason `NoticeBlock.restate` exists.
+        retry_notice: NoticeBlock | None = None
+
+        def narrate(text: str) -> None:
+            nonlocal retry_notice
+            if retry_notice is None or not retry_notice.is_attached:
+                retry_notice = NoticeBlock(text, "warning")
+                self._append_block(retry_notice, ends_empty_state=False)
+            else:
+                retry_notice.restate(text, "warning")
+
+        attempt = 0
+        remote: Any = None
+        while True:
+            record, found_owner = await asyncio.to_thread(
+                find_runtime_record, config_root, concrete
             )
-        except Exception as error:
-            self._system_notice(str(error), "warning")
-            return
+            # The pid the user named is honoured on the FIRST attempt only.
+            # After that a record for the SAME session id under a new pid is
+            # the owner coming back, which is what `/resume` asked for; the
+            # mixed-version refusal stays exact because it is a property of
+            # the record in hand, re-read like everything else here.
+            if attempt == 0 and (record is None or found_owner != owner or record.protocol < 4):
+                self._system_notice(
+                    f"session {concrete} is open in an older Local Operator process "
+                    f"(pid {owner}) — update or close that process, then resume again",
+                    "warning",
+                )
+                return
+            if record is None or record.protocol < 4:
+                # An owner that is not there THIS MOMENT. A restarting runtime
+                # has no record between the old pid retiring and the new one
+                # publishing, which is the window the redial exists for — so
+                # this is paced and retried, not reported.
+                error: Exception = ConnectionError(UNREACHABLE_OWNER_MESSAGE)
+            else:
+                try:
+                    remote = await AttachedSession.connect(
+                        record,
+                        concrete,
+                        config_dir=config_root,
+                        takeover_factory=takeover_factory,
+                    )
+                    break
+                except Exception as caught:  # noqa: BLE001 — classified below
+                    error = caught
+            attempt += 1
+            # A CAPABILITY/PROTOCOL GAP IS STATIC, so it is never retried:
+            # every redial would raise the identical refusal and only make the
+            # user wait for a sentence already known. Read off the SAME record
+            # `connect` just refused, so the two cannot disagree.
+            static = frontend_attach_refusal(record) if record is not None else None
+            if static is not None or attempt > RESUME_CONNECT_ATTEMPTS:
+                self._system_notice(str(error), "warning")
+                return
+            narrate(
+                f"reconnecting to session {concrete} — the owner is not answering "
+                f"(retry {attempt} of {RESUME_CONNECT_ATTEMPTS})"
+            )
+            await asyncio.sleep(sidebar_connect_backoff_s(attempt))
+
+        # The retry row described a dial that is now over; leaving it up would
+        # have the transcript promise a reconnect that already happened.
+        if retry_notice is not None and retry_notice.is_attached:
+            self._transcript_view().remove_block(retry_notice)
 
         detach_gates = getattr(self._session, "detach_viewer_gates", None)
         if callable(detach_gates):

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1670,6 +1670,15 @@ def _resume_connect_limits() -> tuple[float, float]:
     already in flight when it expires can spend one more. Stated rather than
     rounded down, because the defect this replaces was an understated span —
     49 x 15 s of dials described as "135.75 s" of backoff.
+
+    IT IS NOT EXACT, AND THE SURFACE DOES NOT PRETEND IT IS (review n4). Every
+    pass re-reads the runtime record at the top of the loop and is charged for
+    that read only after the dial that follows it, so the true worst case is
+    this bound plus one record read; the envelope a connect may spend after its
+    own sync window is not charged either. That is why the row says "about ... s
+    in total" rather than asserting the number: folding the read into the
+    deadline check would narrow the gap by one slice and still not make the
+    figure exact, while the hedge costs one word.
     """
     from local_operator.session.attached import (
         COLD_FALLBACK_S,
@@ -3053,6 +3062,19 @@ class OperatorApp(App[None]):
         #: being LEFT, and naming it would be a false statement about which
         #: session the app is reconnecting to.
         self._resume_retry_target = ""
+        #: The row a refused Enter is currently speaking through, or None.
+        #:
+        #: THE ROW THE REFUSAL OWNS, so that the NEXT refusal can restate it
+        #: instead of appending a second one. A durable notice per refused Enter
+        #: was the shape this replaces, and Enter is the user's response to
+        #: silence, so the accumulation was unbounded by construction (UX U1:
+        #: three Enters during one redial put six lines of stale present-tense
+        #: text under the verdict). Retired by `_retire_composer_refusal` the
+        #: moment the state it describes ends — the redial's own exits, and a
+        #: sidebar connect that completed — because the sentence is
+        #: present-progressive about a state the app owns, not a timestamped
+        #: event like a chat message.
+        self._composer_refusal_notice: NoticeBlock | None = None
         #: Session ids that have run `eval`, so a `/move` restarting the
         #: runtime destroys the namespace they built up. Recorded when the call
         #: is drawn rather than re-derived from the transcript, because
@@ -6777,6 +6799,17 @@ class OperatorApp(App[None]):
             # and crediting it would hand the next real failure a budget it did
             # not earn.
             source.connect_attempts = 0
+            # THE COMPOSER'S OWN ROW ENDS WHEN THIS STATE DOES. A refused Enter
+            # during the connect wrote "Send unavailable until connected." —
+            # false the moment the commit above lands, and it was durable
+            # (UX U1). Retired only on a COMPLETED connect, for the same reason
+            # the budget is refilled only here: an attempt that returned early
+            # proved nothing about the owner, so the refusal it answered still
+            # describes the state. The block is removed from its own parent, not
+            # from `_transcript_view()`, because the row was written into the
+            # INCOMING session's view and this commit is what made that view
+            # current.
+            self._retire_composer_refusal()
         except asyncio.CancelledError:
             cancelled = True
             raise
@@ -11518,7 +11551,7 @@ class OperatorApp(App[None]):
                 # Discovery scans the filesystem; run it as a worker so the
                 # UI thread never blocks on it, and settle attach-vs-refuse
                 # when the record is in hand.
-                self._run_session_transition(self._attach_or_refuse(config_dir(), concrete, owner))
+                self._run_session_transition(self._attach_or_refuse(config_dir(), concrete))
                 return
         # A navigation entered during /fork must not queue a stop behind its
         # snapshot RPC. The original's ownership guarantee lasts through that
@@ -11800,19 +11833,35 @@ class OperatorApp(App[None]):
         and the composer said nothing at all for the whole wait (UX U1) — see
         `composer_submission_refused`. It names the session it is reconnecting
         TO, because a user who retyped `/resume <other>` mid-wait is owed the
-        difference, and states the bound, because a wait with no stated end is
-        what made a bounded window read as a hang.
+        difference. It does NOT restate the bound: the retry row above is
+        already saying one number, and a second spelling of the same wait on the
+        same screen is what design D3 found.
+
+        ASKED FIRST IN THE CHAIN, deliberately. `self._interaction` is, for the
+        current session, the very object the sidebar connect writes (the app
+        assigns the same instance to `self._interaction` and to
+        `self._sidebar_sources[session_id]`), so a latched `connection_error` or
+        a spent `connect_attempts` can sit on the object a live redial is asking
+        about. Ordering by specificity is what keeps the answer true: a redial
+        in flight is a state the app ITSELF set for exactly the life of its
+        loop, and while it is set the honest advice is the redial's —
+        "reselection" is precisely what the retry row above contradicts. UX U3
+        could not drive that combination (both of its attempts healed), so the
+        reachability stayed unstated; the precedence is fixed by construction
+        here and pinned by
+        `test_the_redial_outranks_a_latched_source_in_the_hint` rather than
+        left to the order two fields happen to be tested in.
         """
         source = self._interaction
+        if self._session_transition_pending and self._resume_retry_target:
+            return (
+                f" Reconnecting to session {self._resume_retry_target} — "
+                "switching session stops the wait."
+            )
         if source.connection_error:
             return " Select this session again to retry."
         if source.connect_attempts:
             return " Reconnecting — it will keep trying for a few more seconds."
-        if self._session_transition_pending and self._resume_retry_target:
-            return (
-                f" Reconnecting to {self._resume_retry_target} — it will keep trying "
-                f"for up to {RESUME_CONNECT_BOUND_S:g} s; switching session stops the wait."
-            )
         return ""
 
     def composer_submission_refused(self) -> None:
@@ -11827,13 +11876,60 @@ class OperatorApp(App[None]):
         both dropped without a word — measured for 136 s, which is precisely long
         enough for the user to conclude the app had ignored them (UX U1). One
         branch, reusing the sidebar seam's copy and register.
+
+        ONE ROW, AND NOT A DURABLE ONE. The notice answers a gesture, but its
+        sentence is about a state the app owns, so it is restated by the next
+        refusal instead of stacked and retired by `_retire_composer_refusal`
+        when that state ends — the discipline the redial's own row already
+        follows. The alternative was measured: three Enters during one redial
+        left three two-line blocks of present-tense text under the verdict,
+        each one retracting the sentence above it (UX U1).
         """
         if (
             self._interaction.display_only
             or self._interaction.command_frame_pending
             or (self._session_transition_pending and self._resume_retry_target)
         ):
-            self._notice(f"Send unavailable until connected.{self._unavailable_hint()}", "warning")
+            text = f"Send unavailable until connected.{self._unavailable_hint()}"
+            held = self._composer_refusal_notice
+            if held is not None and held.is_attached:
+                # ONE ROW PER STATE, not one row per Enter. Appending a durable
+                # notice made the count unbounded by construction, because Enter
+                # is the user's response to silence: three Enters during one
+                # redial put six lines of stale present-tense text on screen,
+                # and they outlived the verdict (UX U1). Same mechanism as the
+                # redial's own row — restate in place while the state lasts,
+                # retire it when it ends — rather than a second one.
+                held.restate(text, "warning")
+            else:
+                notice = NoticeBlock(text, "warning")
+                self._composer_refusal_notice = notice
+                self._append_block(notice)
+
+    def _retire_composer_refusal(self) -> None:
+        """Take the refusal row down once the state it describes has ended.
+
+        The sentence is present-progressive about a state the app OWNS
+        ("Reconnecting to…"), so it may not outlive that state the way a chat
+        message can: left standing, a refused Enter goes on promising a
+        reconnect beneath the verdict that retires it, which is the reading
+        order UX U1 measured (the stale claim was the LAST thing read). The
+        slot is enough to retire because `composer_submission_refused` restates
+        in place, so there is at most one such row.
+
+        Called from the redial's every exit and from a sidebar connect that
+        COMPLETED — the two ways the state the row describes ends.
+        """
+        notice = self._composer_refusal_notice
+        self._composer_refusal_notice = None
+        if notice is None or not notice.is_attached:
+            return
+        # The block's OWN parent, not `self._transcript_view()`: for a sidebar
+        # connect the row is written into the INCOMING session's view, which by
+        # the time the connect commits is no longer the current one.
+        parent = notice.parent
+        if isinstance(parent, TranscriptView):
+            parent.remove_block(notice)
 
     def composer_submission_blocked(
         self, text: str | None = None, *, shell: bool | None = None
@@ -11852,7 +11948,7 @@ class OperatorApp(App[None]):
         entry = slash_command_for(editor.text if text is None else text)
         return entry is None or f"/{entry.name}" not in self._SAVED_LOCAL_COMMANDS
 
-    async def _attach_or_refuse(self, config_root, concrete: str, owner: int) -> None:
+    async def _attach_or_refuse(self, config_root, concrete: str) -> None:
         """Build a AttachedSession and adopt it like any ordinary resume.
 
         An owner below `FRONTEND_ATTACH_MIN_PROTOCOL` has no full event stream.
@@ -11879,7 +11975,10 @@ class OperatorApp(App[None]):
         attempts was ~58x longer than it read. See `_resume_connect_limits` for
         the derivation and for the bound the user is told.
         """
-        from local_operator.mobile.attach_client import find_runtime_record
+        from local_operator.mobile.attach_client import (
+            dialable_record_exists,
+            find_runtime_record,
+        )
         from local_operator.session.attached import (
             FRONTEND_ATTACH_MIN_PROTOCOL,
             AttachedSession,
@@ -11893,11 +11992,30 @@ class OperatorApp(App[None]):
             assert self._resume_factory is not None
             return await self._resume_factory(concrete)
 
-        # EVERY PATH OUT OF THE REDIAL ENDS ON ONE ROW, restated in place
-        # rather than stacked. The budget spans tens of seconds, so a notice
-        # per attempt would write a hundred rows into a durable transcript to
-        # say one thing — the same reason `NoticeBlock.restate` exists.
+        # EVERY PATH OUT OF THE REDIAL SETTLES ITS ROW, and there are THREE of
+        # them, not two. A notice per attempt would write a hundred rows into a
+        # durable transcript to say one thing — the same reason
+        # `NoticeBlock.restate` exists — so the row is restated in place rather
+        # than stacked, and the exits are:
+        #
+        #   * give-up and the static refusal — `verdict()` restates it;
+        #   * a successful dial — the adopt below REMOVES it;
+        #   * CANCELLATION, which is the one that used to be missed.
+        #
+        # The sidebar's switch cancels this worker group
+        # (`_select_sidebar_session`), so the loop unwinds on `CancelledError`
+        # straight to `finally` — which cleared the target and left the row
+        # standing: the user came back to a session reading "still trying for up
+        # to 42 s" under a loop that was already dead, one more stranded row per
+        # abandoned run, on the very exit the new composer copy teaches (design
+        # D1 / review m4 / QA Q2 found it independently and it falsified this
+        # comment's claim). A settled flag is what closes it: `verdict()` and the
+        # successful adopt both set it, so the `finally` restates only a row
+        # nothing else has settled. A flag rather than `except CancelledError`,
+        # because the invariant is about exits rather than about one exception
+        # class — any unwind out of the loop owes the row the same ending.
         retry_notice: NoticeBlock | None = None
+        settled = False
 
         def narrate(text: str) -> None:
             nonlocal retry_notice
@@ -11917,10 +12035,12 @@ class OperatorApp(App[None]):
             stale pair frozen at `retry 48 of 48` — design D1, UX U3).
             Restating in place is the mirror of what the success path already
             does by removing the row, and it is what keeps the verdict the
-            BOTTOM row: nothing is left underneath it that still claims the
-            dial is running.
+            BOTTOM row — with the `finally`'s retirement of the composer's own
+            refusal row (see below), which is appended BELOW this one and used
+            to leave a present-tense claim under the outcome (UX U1).
             """
-            nonlocal retry_notice
+            nonlocal retry_notice, settled
+            settled = True
             if retry_notice is not None and retry_notice.is_attached:
                 retry_notice.restate(text, "warning")
                 retry_notice = None
@@ -11935,9 +12055,62 @@ class OperatorApp(App[None]):
             U4). An exhaustion that never saw a record at all reports the app's
             ONE sentence for an unreachable owner; the older-process advice
             next door belongs to the older-process case only (design D5).
+
+            THE NEXT STEP IS ITS OWN AUTHORED ROW (design D2). As one flowing
+            paragraph the wrap fell wherever the cells landed, and at 80 columns
+            — a width the original rig never filmed — that put `/resume` and the
+            id the user must type on different lines: the actionable half, split
+            from its own argument (measured 71.4 cells then 23.1). Two authored
+            rows cost nothing at the widths where the text already wrapped, and
+            render exactly as before at 44 columns.
             """
             detail = str(error).strip() or UNREACHABLE_OWNER_MESSAGE
-            return f"could not resume {concrete} — {detail}. Run /resume {concrete} again to retry."
+            return (
+                f"could not resume {concrete} — {detail}.\n"
+                f"Run /resume {concrete} again to retry."
+            )
+
+        def stopped_text(unwound: BaseException | None) -> str:
+            """The sentence for a redial that ended WITHOUT running to a verdict.
+
+            Reachable by cancellation — the sidebar switch, which is the exit the
+            composer copy recommends as the way to stop the wait — and by any
+            unexpected exception unwinding the loop. Only the row this loop
+            actually narrated is settled by it, so a `/resume` abandoned during
+            its first silent envelope (no row yet) gains no row here.
+
+            The copy names the cause it can name rather than a diagnosis it
+            cannot: a `CancelledError` here IS the user switching away — the
+            sidebar cancels this worker group and nothing else does — and the way
+            back is a fresh `/resume`. Anything else gets the give-up sentence,
+            which is true of it: the wait is over and no dial is pending.
+            """
+            if isinstance(unwound, asyncio.CancelledError):
+                return (
+                    f"resume of {concrete} stopped — the wait ended when you switched "
+                    f"session.\nRun /resume {concrete} again to retry."
+                )
+            return gave_up_text(unwound if isinstance(unwound, Exception) else ConnectionError())
+
+        def static_text() -> str:
+            """The terminal sentence for a gap no redial can change (UX U2).
+
+            This arm used to pass `str(error)` straight through, so the user was
+            handed the owner's own internal refusal — `owner lacks tui_state_v1;
+            canonical full-TUI attach needs protocol >= 5` — with no session
+            named and no next step, one arm over from the sibling fix that added
+            both. The token is dropped rather than translated because it is not
+            something the user can act on; what they can act on is the process,
+            named in the neighbouring arm's own register. Deliberately NOT a
+            "Run /resume … again to retry": the refusal is a STATIC property of
+            the owner, so a redial would reproduce it identically — which is why
+            this arm does not retry at all.
+            """
+            return (
+                f"could not resume {concrete} — the process hosting it does not serve "
+                "the full TUI session state. Update or restart that process, then "
+                "resume again."
+            )
 
         # The bound the user is told, in whole seconds: the wall-clock cap plus
         # the envelope of a dial that may already be in flight when it expires.
@@ -11981,6 +12154,20 @@ class OperatorApp(App[None]):
                 # record — an older binary, or a registrant that failed to
                 # start.
                 #
+                # ...AND THAT ABSENCE, TOO, IS ESTABLISHED RATHER THAN INFERRED
+                # (review m3). `(None, pid)` is ALSO what the rebind race looks
+                # like: a record for that pid that is live, protocol-5 and
+                # perfectly dialable, still stamped with the PREVIOUS
+                # `session_id` — the shape `find_runtime_record`'s own docstring
+                # describes as a race whose welcome-projection identity check
+                # arbitrates. Refusing there claimed an age the code never
+                # checked and invited the user to close a healthy
+                # current-version runtime. So the refusal is taken only when a
+                # scan says this pid publishes NO dialable record at all;
+                # anything else — a dialable record, or a registry that could
+                # not be read — is paced, and the timeout's own honest sentence
+                # is the outcome.
+                #
                 # A MOVED OWNER PID IS PACED, NOT REFUSED. `find_runtime_record`
                 # derives its own owner from the same `.session.pid` marker the
                 # caller read, so a mismatch can only mean the marker changed
@@ -11997,7 +12184,13 @@ class OperatorApp(App[None]):
                 if attempt == 0:
                     older_pid: int | None = None
                     if record is None:
-                        older_pid = found_owner
+                        if found_owner is not None and (
+                            await asyncio.to_thread(
+                                dialable_record_exists, config_root, found_owner
+                            )
+                            is False
+                        ):
+                            older_pid = found_owner
                     elif record.protocol < FRONTEND_ATTACH_MIN_PROTOCOL:
                         older_pid = record.pid
                     if older_pid is not None:
@@ -12020,6 +12213,10 @@ class OperatorApp(App[None]):
                             config_dir=config_root,
                             takeover_factory=takeover_factory,
                         )
+                        # SETTLED BEFORE THE BREAK: the adopt below is the
+                        # row's other resolution (it REMOVES the row), so the
+                        # `finally` must not restate this as a cancellation.
+                        settled = True
                         break
                     except Exception as caught:  # noqa: BLE001 — classified below
                         error = caught
@@ -12028,25 +12225,56 @@ class OperatorApp(App[None]):
                 # every redial would raise the identical refusal and only make
                 # the user wait for a sentence already known. Read off the SAME
                 # record `connect` just refused, so the two cannot disagree.
+                #
+                # ONE DIAL IS STILL SPENT on the capability half of this (QA
+                # Q3: `connect_calls=1 socket_dials=0` on this head and on the
+                # base — `frontend_attach_refusal` is consulted only after the
+                # call). Only a record below the attach protocol is refused
+                # before any dial, at the first-attempt guard above.
                 static = frontend_attach_refusal(record) if record is not None else None
                 remaining = deadline - _resume_redial_clock()
                 if static is not None:
-                    verdict(str(error))
+                    verdict(static_text())
                     return
                 if attempt >= RESUME_CONNECT_ATTEMPTS or remaining <= 0:
                     verdict(gave_up_text(error))
                     return
                 # STATED AS A BOUND, and in the composer's register for the same
                 # wait: no denominator the user cannot act on, no diagnosis the
-                # app has not established, and short enough to sit on one line in
-                # the notice's 75-cell measure (design D2, D3, D4).
-                narrate(f"reconnecting to session {concrete} — still trying for up to {bound_s} s")
+                # app has not established, and short enough not to split in the
+                # notice's 75-cell measure with a typical id (design D2). The
+                # bound is anchored as the WHOLE wait's and hedged so it cannot
+                # be read as exact (UX U4, review n4 — see `bound_s`), and the
+                # non-breaking space keeps `42 s` from splitting across a wrap in
+                # the narrower block a sidebar-open layout leaves (design D2).
+                narrate(
+                    f"reconnecting to session {concrete} — still trying, about "
+                    f"{bound_s}\u00a0s in total"
+                )
                 await _resume_redial_pause(min(sidebar_connect_backoff_s(attempt), remaining))
         finally:
             self._resume_retry_target = ""
+            # THE CANCELLATION EXIT OWES THE ROW THE SAME ENDING. The sidebar's
+            # switch cancels this worker group, so the loop unwinds on
+            # `CancelledError` without reaching any verdict: without this, the
+            # row the user left behind still promises a dial that is over, in
+            # the session they return to, one more stranded row per abandoned
+            # run (design D1 / review m4 / QA Q2). Restating rather than
+            # removing keeps the one-row-per-run guarantee, and `settled` keeps
+            # this out of the two exits that already resolved the row. An
+            # unwind that delivered no dial at all has no row and gains none.
+            if not settled and retry_notice is not None and retry_notice.is_attached:
+                retry_notice.restate(stopped_text(sys.exc_info()[1]), "warning")
+                retry_notice = None
+            # The composer's refusal row describes the same state, so it ends
+            # with the operation on every exit too.
+            self._retire_composer_refusal()
 
         # The retry row described a dial that is now over; leaving it up would
-        # have the transcript promise a reconnect that already happened.
+        # have the transcript promise a reconnect that already happened. The
+        # refusal row was retired in the `finally` above, before this point, so
+        # what is left on screen after a successful adopt is the adopted session
+        # and nothing that still speaks in the present tense.
         if retry_notice is not None and retry_notice.is_attached:
             self._transcript_view().remove_block(retry_notice)
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1638,47 +1638,88 @@ def _sidebar_connect_attempts() -> int:
 SIDEBAR_CONNECT_ATTEMPTS = _sidebar_connect_attempts()
 
 
-def _resume_connect_attempts() -> int:
-    """How many times `/resume` re-dials before the user is told it failed.
+def _resume_connect_limits() -> tuple[float, float]:
+    """`/resume`'s redial budget: (wall-clock cap, outer bound stated to the user).
 
-    THE SAME RULE AS `_sidebar_connect_attempts`, APPLIED TO THE OTHER BOUND.
-    The quantity a redial budget has to outlast is the give-up bound of the
-    facade it is building, and that bound is selected by `_can_go_cold`.
-    `/resume` reaches `AttachedSession.connect`, which builds a TERMINAL
-    surface — so `_can_go_cold` is False and the bound that governs it is
-    `RECOVERY_GIVE_UP_S`, not `COLD_FALLBACK_S`. Reusing the sidebar's count
-    here would be sizing one facade's budget from another facade's bound,
-    which is the mistake this derivation exists to prevent.
+    THE PRIMARY CAP IS WALL CLOCK, and this derivation exists because the
+    budget it replaces reasoned about the BACKOFF ALONE. A dial of a
+    live-but-silent owner costs the full `FRONTEND_SYNC_FOREGROUND_S`
+    envelope before `AttachedSession.connect` raises
+    `RuntimeUnresponsiveError` — the type whose own docstring says the runtime
+    is still running and the retry is free — so a budget written as an attempt
+    COUNT was really that count times 15 s plus its own backoff. Measured from
+    the shipped numbers: 49 dials and ~14.5 minutes for one `/resume`, against
+    the single 15 s failure the same owner produced before the retry existed,
+    for the one failure mode a redial cannot fix (a wedged runtime stays
+    wedged). The count was measuring the wrong quantity.
 
-    `RECOVERY_GIVE_UP_S` is also the RIGHT question for this seam rather than
-    merely the wider one: it is scoped to "a record has been seen", which is
-    exactly the shape of a failed `/resume` — the loop re-reads the record
-    before every attempt, so a record that is present and an owner that will
-    not answer are both established facts, and the bound answers precisely
-    "an owner is there and will not answer". The same 50% margin as the
-    sidebar's: the last attempt must land clearly past the owner's give-up on
-    a loaded machine, not tie with it.
+    Sized from the transients this loop EXISTS for, not from a round number:
+    a record moving between `live_runtime_pid` and `find_runtime_record`
+    (milliseconds to seconds — a `kill -9` republishes within a second or
+    two), an attach refusal, and a facade mid-recovery for up to
+    `COLD_FALLBACK_S`. The first term is the sidebar's own rule for that
+    window — its paced schedule must outlast `COLD_FALLBACK_S` with a 50%
+    margin — and the second is ONE full attempt envelope, so that a single
+    silent dial cannot spend the whole budget before any paced retry has run.
+    The sum lands in the tens of seconds, and ATTEMPT TIME IS SUBTRACTED from
+    it: an owner that burns a full envelope per dial ends the loop after two
+    of them, not after `RESUME_CONNECT_ATTEMPTS`.
+
+    The SECOND number is what the user is told, and it is the cap plus one
+    envelope: the deadline bounds when a NEW dial may start, while the dial
+    already in flight when it expires can spend one more. Stated rather than
+    rounded down, because the defect this replaces was an understated span —
+    49 x 15 s of dials described as "135.75 s" of backoff.
     """
-    from local_operator.session.attached import RECOVERY_GIVE_UP_S
+    from local_operator.session.attached import (
+        COLD_FALLBACK_S,
+        FRONTEND_SYNC_FOREGROUND_S,
+    )
 
-    return _attempts_outlasting(RECOVERY_GIVE_UP_S * 1.5)
+    wall = COLD_FALLBACK_S * 1.5 + FRONTEND_SYNC_FOREGROUND_S
+    return wall, wall + FRONTEND_SYNC_FOREGROUND_S
 
 
-#: Attempts `/resume` may spend re-dialling an owner that is being republished,
-#: before the user is told the session is unreachable.
-#:
-#: The pre-#883 shape at this seam was ONE-SHOT: any exception from
-#: `AttachedSession.connect` printed the error and returned, so a runtime that
-#: was mid-restart — the ordinary case, since a `kill -9` republishes a record
-#: within a second or two — was reported to the user as a permanent failure to
-#: be retyped by hand. Bounded rather than immediate, and bounded rather than
-#: infinite: every attempt re-reads the runtime record, so a republished owner
-#: under a NEW pid is picked up instead of dialling a dead socket, and the
-#: budget is what stops that from becoming a hang.
-#:
-#: NOT `SIDEBAR_CONNECT_ATTEMPTS`. Derivation and its reasoning live on
-#: `_resume_connect_attempts` above.
-RESUME_CONNECT_ATTEMPTS = _resume_connect_attempts()
+#: Wall-clock budget for one `/resume`'s redial: the PRIMARY cap, and the one
+#: the loop subtracts each attempt's own duration from. Derivation, the ~14.5
+#: minute regression it closes, and the outer bound below all live on
+#: `_resume_connect_limits`.
+RESUME_CONNECT_WALL_S, RESUME_CONNECT_BOUND_S = _resume_connect_limits()
+
+#: SECONDARY cap: the number of dials the same budget allows when every dial
+#: fails INSTANTLY. A count survives at all only so a schedule retuned to (or a
+#: test patched to) a tiny backoff cannot spin the loop as fast as the CPU
+#: allows before the wall clock is consulted; derived from the SAME span so the
+#: two caps cannot disagree about how long the redial may take. That it lands
+#: well under the old 48 is the point: the old count was sized to outlast
+#: `RECOVERY_GIVE_UP_S` (90 s) of backoff, which is a bound `/resume` does not
+#: have to survive — the transient it must survive is `COLD_FALLBACK_S`.
+RESUME_CONNECT_ATTEMPTS = _attempts_outlasting(RESUME_CONNECT_WALL_S)
+
+
+def _resume_redial_clock() -> float:
+    """The redial's clock reading, as a SEAM rather than a direct call.
+
+    `RESUME_CONNECT_WALL_S` is a wall-clock bound, and a bound like that is
+    only testable if the clock can be moved without sleeping: the test patches
+    this and `_resume_redial_pause`, drives a virtual clock past the deadline,
+    and asserts the loop stopped for the right reason. AGENTS.md's
+    "Timing, flakes" section forbids asserting a duration, and this is the
+    structural alternative — the same shape `session_picker`'s cadence test
+    uses when it patches that widget's own module clock.
+    """
+    return asyncio.get_running_loop().time()
+
+
+async def _resume_redial_pause(seconds: float) -> None:
+    """The redial's ONE sleep point, for the same reason as the clock above.
+
+    Also what makes the backoff's clamp observable: the loop passes
+    `min(backoff, time left in the budget)`, and a test records what this was
+    asked to wait for instead of measuring how long it waited.
+    """
+    await asyncio.sleep(seconds)
+
 
 #: The chord that lifts the aside's full text to the clipboard.
 #:
@@ -3001,6 +3042,17 @@ class OperatorApp(App[None]):
         # Keep the existing composer visually unchanged, but make its submit
         # boundary atomic so text cannot land in the conversation being left.
         self._session_transition_pending = False
+        #: The session a `/resume` redial is currently reconnecting TO, or "".
+        #:
+        #: Set for exactly the life of `_attach_or_refuse`'s retry loop and
+        #: cleared in its `finally`. It exists because that loop is the ONE
+        #: transition whose source is neither `display_only` nor frame-pending,
+        #: so `composer_submission_refused` had nothing to answer with and a
+        #: typed Enter was silently dropped for the whole window (UX U1). Held
+        #: here rather than on the source because the source is the session
+        #: being LEFT, and naming it would be a false statement about which
+        #: session the app is reconnecting to.
+        self._resume_retry_target = ""
         #: Session ids that have run `eval`, so a `/move` restarting the
         #: runtime destroys the namespace they built up. Recorded when the call
         #: is drawn rather than re-derived from the transcript, because
@@ -6674,26 +6726,44 @@ class OperatorApp(App[None]):
             source.command_frame_pending = True
             ready = self._commit_sidebar_session(session.session_id, prepared, generation)
             prepared = None
+            # THE BELT FOR THE OTHER HALF OF THE WINDOW, AND IT IS NOT
+            # CONDITIONAL ON A FRAME. `post_display_hook` closes the
+            # commit->paint half; an owner lost between the bind postcondition
+            # above and this commit is already cold BY THE TIME the frame is
+            # armed, so re-check it before waiting rather than hoping a display
+            # arrives to notice. Cheap and exact: one property read on the same
+            # session the bind just checked.
+            #
+            # `ready is None` USED TO SKIP THIS ENTIRELY (review m2). That is
+            # `_commit_sidebar_session`'s early return for a prepared replay
+            # that already IS the current transcript view, and it leaves
+            # `display_only = False` set with no frame and no hook left to
+            # refuse a cold body: the commit reports success and
+            # `connect_attempts` is reset below. The return is NOT reachable
+            # from this connect path — both of `_prepare_sidebar_session`'s
+            # early returns are guarded on `not refresh` and this call passes
+            # `refresh=True`, so the prepared view is always a freshly mounted
+            # one and never `self._transcript_view()`, which is what the early
+            # return compares against — and that is pinned by
+            # `test_the_connect_prepares_with_refresh_so_no_frame_return_is_unreachable`.
+            # Kept unconditional anyway, because the cost is one read and the
+            # failure it would otherwise hide is silent: the postcondition this
+            # whole file exists for is "after a connect commits, the session is
+            # not cold", and a belt with a hole in it is not a postcondition.
+            #
+            # Raising here (rather than only failing the frame) is what
+            # keeps the bound: this is a `ConnectionError`, so it falls to
+            # the generic arm below, which spends `connect_attempts` and
+            # re-arms through the backoff. `_abandon_sidebar_frame` must
+            # run first so the pending tuple is cleared and the connect
+            # body is not left waiting on a frame nothing will resolve —
+            # and if it reports no armed frame (the `ready is None` case), the
+            # raise is the only way left to refuse a cold commit.
+            if _is_viewer(session) and session.is_cold:
+                error = OwnerWentCold(UNREACHABLE_OWNER_MESSAGE)
+                if not self._abandon_sidebar_frame(error):
+                    raise error
             if ready is not None:
-                # THE BELT FOR THE OTHER HALF OF THE WINDOW. `post_display_hook`
-                # closes the commit->paint half; an owner lost between the bind
-                # postcondition above and this commit is already cold BY THE
-                # TIME the frame is armed, so re-check it before waiting rather
-                # than hoping a display arrives to notice. Cheap and exact: one
-                # property read on the same session the bind just checked.
-                #
-                # Raising here (rather than only failing the frame) is what
-                # keeps the bound: this is a `ConnectionError`, so it falls to
-                # the generic arm below, which spends `connect_attempts` and
-                # re-arms through the backoff. `_abandon_sidebar_frame` must
-                # run first so the pending tuple is cleared and the connect
-                # body is not left waiting on a frame nothing will resolve —
-                # and if it reports no armed frame, the raise is the only way
-                # left to refuse a cold commit.
-                if _is_viewer(session) and session.is_cold:
-                    error = OwnerWentCold(UNREACHABLE_OWNER_MESSAGE)
-                    if not self._abandon_sidebar_frame(error):
-                        raise error
                 await ready
             # REFILL THE BUDGET ONLY ON A COMPLETED CONNECT, and only here at
             # the very end of the success path. Resetting earlier — beside
@@ -6774,8 +6844,8 @@ class OperatorApp(App[None]):
             ):
                 retry = True
                 # Empty, so the status renders "Connecting…" rather than
-                # "Connection unavailable · Reselect to retry": the app has not
-                # given up, and telling the user to act while it is still
+                # "Saved · Reconnect failed · Select again to retry": the app
+                # has not given up, and telling the user to act while it is still
                 # working asks them to fix something that is fixing itself.
                 source.connection_error = ""
                 if prepared is not None:
@@ -6823,10 +6893,10 @@ class OperatorApp(App[None]):
                 )
                 source.connection_error = str(error) or "Connection unavailable"
                 # Surrendered, so the counter goes back to zero: the status now
-                # reads "Reselect to retry", and that affordance has to mean a
-                # FULL budget, not one last single-shot attempt. Nothing re-arms
-                # automatically from here (`retry` stays False), so the only
-                # reader of a fresh count is the user's own next selection.
+                # reads "Select again to retry", and that affordance has to mean
+                # a FULL budget, not one last single-shot attempt. Nothing
+                # re-arms automatically from here (`retry` stays False), so the
+                # only reader of a fresh count is the user's own next selection.
                 source.connect_attempts = 0
         finally:
             if prepared is not None:
@@ -11723,16 +11793,46 @@ class OperatorApp(App[None]):
         retry is in flight is not what the user should do); nothing had replaced
         it. Now the retry window says the app is working and no action is owed,
         which is the answer, and a spent budget keeps the actionable advice.
+
+        THE FOURTH STATE IS A `/resume` REDIAL, and it is the one the source's
+        own fields cannot describe. That redial runs over a session that is
+        still live, so `connection_error` and `connect_attempts` are both empty
+        and the composer said nothing at all for the whole wait (UX U1) — see
+        `composer_submission_refused`. It names the session it is reconnecting
+        TO, because a user who retyped `/resume <other>` mid-wait is owed the
+        difference, and states the bound, because a wait with no stated end is
+        what made a bounded window read as a hang.
         """
         source = self._interaction
         if source.connection_error:
             return " Select this session again to retry."
         if source.connect_attempts:
             return " Reconnecting — it will keep trying for a few more seconds."
+        if self._session_transition_pending and self._resume_retry_target:
+            return (
+                f" Reconnecting to {self._resume_retry_target} — it will keep trying "
+                f"for up to {RESUME_CONNECT_BOUND_S:g} s; switching session stops the wait."
+            )
         return ""
 
     def composer_submission_refused(self) -> None:
-        if self._interaction.display_only or self._interaction.command_frame_pending:
+        """Speak on every Enter this app refuses, or the refusal is a swallow.
+
+        `composer_submission_blocked` answers "may this go through"; this answers
+        "then say so". The `/resume` redial is the third state that owes an
+        answer and the one that used to give none: its source is neither
+        `display_only` nor frame-pending (`_attach_or_refuse` is redialling over
+        the still-live previous session), so the guard below was False for the
+        entire window and a typed draft plus a RE-TYPED `/resume target` were
+        both dropped without a word — measured for 136 s, which is precisely long
+        enough for the user to conclude the app had ignored them (UX U1). One
+        branch, reusing the sidebar seam's copy and register.
+        """
+        if (
+            self._interaction.display_only
+            or self._interaction.command_frame_pending
+            or (self._session_transition_pending and self._resume_retry_target)
+        ):
             self._notice(f"Send unavailable until connected.{self._unavailable_hint()}", "warning")
 
     def composer_submission_blocked(
@@ -11755,9 +11855,12 @@ class OperatorApp(App[None]):
     async def _attach_or_refuse(self, config_root, concrete: str, owner: int) -> None:
         """Build a AttachedSession and adopt it like any ordinary resume.
 
-        Protocol <4 has no full event stream. The degraded projection view was
-        deliberately deleted, so a mixed-version owner gets a precise upgrade
-        refusal rather than silently falling back to a divergent UI.
+        An owner below `FRONTEND_ATTACH_MIN_PROTOCOL` has no full event stream.
+        The degraded projection view was deliberately deleted, so a
+        mixed-version owner gets a precise upgrade refusal rather than silently
+        falling back to a divergent UI — and the threshold is NAMED rather than
+        restated, because a literal here is a second version test for one
+        concept (review n3).
 
         THE DIAL IS BOUNDED-RETRIED, which this seam was not (#883 fixed the
         sidebar's connect and left this one one-shot). `AttachedSession.connect`
@@ -11769,9 +11872,16 @@ class OperatorApp(App[None]):
         runtime that retired between attempts publishes a new record under a
         NEW pid, and redialling the dead one would spend the whole budget on a
         socket that cannot answer.
+
+        THE BUDGET IS WALL CLOCK, NOT AN ATTEMPT COUNT, and every attempt is
+        charged for its own duration — a dial of a live-but-silent owner costs
+        a full `FRONTEND_SYNC_FOREGROUND_S` envelope, so a budget counted in
+        attempts was ~58x longer than it read. See `_resume_connect_limits` for
+        the derivation and for the bound the user is told.
         """
         from local_operator.mobile.attach_client import find_runtime_record
         from local_operator.session.attached import (
+            FRONTEND_ATTACH_MIN_PROTOCOL,
             AttachedSession,
             frontend_attach_refusal,
         )
@@ -11783,10 +11893,10 @@ class OperatorApp(App[None]):
             assert self._resume_factory is not None
             return await self._resume_factory(concrete)
 
-        # ONE live row for the redial, restated in place rather than stacked.
-        # The budget spans the facade's whole give-up bound, so a notice per
-        # attempt would write a hundred rows into a durable transcript to say
-        # one thing — the same reason `NoticeBlock.restate` exists.
+        # EVERY PATH OUT OF THE REDIAL ENDS ON ONE ROW, restated in place
+        # rather than stacked. The budget spans tens of seconds, so a notice
+        # per attempt would write a hundred rows into a durable transcript to
+        # say one thing — the same reason `NoticeBlock.restate` exists.
         retry_notice: NoticeBlock | None = None
 
         def narrate(text: str) -> None:
@@ -11797,55 +11907,143 @@ class OperatorApp(App[None]):
             else:
                 retry_notice.restate(text, "warning")
 
+        def verdict(text: str) -> None:
+            """End the redial by RESTATING the row it narrated into the outcome.
+
+            The give-up arm used to post the verdict and `return`, leaving the
+            live row above it still in the present tense: the transcript
+            promised a reconnect that would never happen, and every later
+            `/resume` stranded one more (measured: two runs, four rows, the
+            stale pair frozen at `retry 48 of 48` — design D1, UX U3).
+            Restating in place is the mirror of what the success path already
+            does by removing the row, and it is what keeps the verdict the
+            BOTTOM row: nothing is left underneath it that still claims the
+            dial is running.
+            """
+            nonlocal retry_notice
+            if retry_notice is not None and retry_notice.is_attached:
+                retry_notice.restate(text, "warning")
+                retry_notice = None
+            else:
+                self._system_notice(text, "warning")
+
+        def gave_up_text(error: Exception) -> str:
+            """The terminal sentence: what failed, WHICH session, and what next.
+
+            The bare `str(error)` this replaces was a state with no session and
+            no next step, for a command the user typed with an explicit id (UX
+            U4). An exhaustion that never saw a record at all reports the app's
+            ONE sentence for an unreachable owner; the older-process advice
+            next door belongs to the older-process case only (design D5).
+            """
+            detail = str(error).strip() or UNREACHABLE_OWNER_MESSAGE
+            return f"could not resume {concrete} — {detail}. Run /resume {concrete} again to retry."
+
+        # The bound the user is told, in whole seconds: the wall-clock cap plus
+        # the envelope of a dial that may already be in flight when it expires.
+        bound_s = f"{RESUME_CONNECT_BOUND_S:g}"
+
         attempt = 0
         remote: Any = None
-        while True:
-            record, found_owner = await asyncio.to_thread(
-                find_runtime_record, config_root, concrete
-            )
-            # The pid the user named is honoured on the FIRST attempt only.
-            # After that a record for the SAME session id under a new pid is
-            # the owner coming back, which is what `/resume` asked for; the
-            # mixed-version refusal stays exact because it is a property of
-            # the record in hand, re-read like everything else here.
-            if attempt == 0 and (record is None or found_owner != owner or record.protocol < 4):
-                self._system_notice(
-                    f"session {concrete} is open in an older Local Operator process "
-                    f"(pid {owner}) — update or close that process, then resume again",
-                    "warning",
+        # TAKEN ONCE, AND CHARGED FOR EVERYTHING THE LOOP SPENDS. Each attempt's
+        # own duration comes off this deadline as it is spent and each backoff
+        # is clamped to what is left, so a silent owner cannot buy more dials by
+        # making the loop's own attempts expensive (review M1: the budget that
+        # counted only the waits was 49 dials and ~14.5 minutes, not 135.75 s).
+        deadline = _resume_redial_clock() + RESUME_CONNECT_WALL_S
+        # THE COMPOSER NEEDS A TARGET FOR THE WHOLE OF THIS LOOP. A `/resume`
+        # redials over a session that is still live, so its source is neither
+        # `display_only` nor frame-pending and `composer_submission_refused`
+        # had nothing to say: Enter was silently swallowed for the entire
+        # window (UX U1, measured at 136 s — draft kept, no notice, no band
+        # change, no toast, and a retyped `/resume target` left sitting in the
+        # buffer). Published for exactly the life of the loop and cleared in
+        # `finally`, so a later transition cannot inherit this session's name.
+        self._resume_retry_target = concrete
+        try:
+            while True:
+                record, found_owner = await asyncio.to_thread(
+                    find_runtime_record, config_root, concrete
                 )
-                return
-            if record is None or record.protocol < 4:
-                # An owner that is not there THIS MOMENT. A restarting runtime
-                # has no record between the old pid retiring and the new one
-                # publishing, which is the window the redial exists for — so
-                # this is paced and retried, not reported.
-                error: Exception = ConnectionError(UNREACHABLE_OWNER_MESSAGE)
-            else:
-                try:
-                    remote = await AttachedSession.connect(
-                        record,
-                        concrete,
-                        config_dir=config_root,
-                        takeover_factory=takeover_factory,
-                    )
-                    break
-                except Exception as caught:  # noqa: BLE001 — classified below
-                    error = caught
-            attempt += 1
-            # A CAPABILITY/PROTOCOL GAP IS STATIC, so it is never retried:
-            # every redial would raise the identical refusal and only make the
-            # user wait for a sentence already known. Read off the SAME record
-            # `connect` just refused, so the two cannot disagree.
-            static = frontend_attach_refusal(record) if record is not None else None
-            if static is not None or attempt > RESUME_CONNECT_ATTEMPTS:
-                self._system_notice(str(error), "warning")
-                return
-            narrate(
-                f"reconnecting to session {concrete} — the owner is not answering "
-                f"(retry {attempt} of {RESUME_CONNECT_ATTEMPTS})"
-            )
-            await asyncio.sleep(sidebar_connect_backoff_s(attempt))
+                # THE FIRST ATTEMPT IS THE ONLY ONE THAT MAY REFUSE OUTRIGHT,
+                # and only for a condition no later dial can change.
+                #
+                # `record is None` IS DELIBERATELY NOT ONE OF THEM. An owner
+                # being restarted publishes no record between the old pid
+                # retiring and the new one arriving — `find_runtime_record`
+                # returns `(None, None)` — which is the exact window this redial
+                # exists for, and refusing there told the user the session was
+                # "open in an older Local Operator process" when nothing was
+                # open at all, then returned without trying again: a `/resume`
+                # typed inside the republish gap got a false sentence and no
+                # retry (review m1). The absence worth naming is `(None, pid)`,
+                # an owner whose marker is live but which publishes no dialable
+                # record — an older binary, or a registrant that failed to
+                # start.
+                #
+                # A MOVED OWNER PID IS PACED, NOT REFUSED. `find_runtime_record`
+                # derives its own owner from the same `.session.pid` marker the
+                # caller read, so a mismatch can only mean the marker changed
+                # between the two reads — a republish, which the next attempt
+                # re-reads anyway. The suggested `found_owner != owner` refusal
+                # was implemented and rejected for that reason: it reproduced
+                # m1's own defect (a sentence about a pid, and no retry) for a
+                # different input.
+                #
+                # The threshold is `FRONTEND_ATTACH_MIN_PROTOCOL`, the same one
+                # `frontend_attach_refusal` applies, so one concept has one
+                # version test rather than a literal beside the canonical one
+                # (review n3).
+                if attempt == 0:
+                    older_pid: int | None = None
+                    if record is None:
+                        older_pid = found_owner
+                    elif record.protocol < FRONTEND_ATTACH_MIN_PROTOCOL:
+                        older_pid = record.pid
+                    if older_pid is not None:
+                        self._system_notice(
+                            f"session {concrete} is open in an older Local Operator "
+                            f"process (pid {older_pid}) — update or close that "
+                            "process, then resume again",
+                            "warning",
+                        )
+                        return
+                if record is None:
+                    # An owner that is not there THIS MOMENT: paced and retried,
+                    # never reported (see the first-attempt block above).
+                    error: Exception = ConnectionError(UNREACHABLE_OWNER_MESSAGE)
+                else:
+                    try:
+                        remote = await AttachedSession.connect(
+                            record,
+                            concrete,
+                            config_dir=config_root,
+                            takeover_factory=takeover_factory,
+                        )
+                        break
+                    except Exception as caught:  # noqa: BLE001 — classified below
+                        error = caught
+                attempt += 1
+                # A CAPABILITY/PROTOCOL GAP IS STATIC, so it is never retried:
+                # every redial would raise the identical refusal and only make
+                # the user wait for a sentence already known. Read off the SAME
+                # record `connect` just refused, so the two cannot disagree.
+                static = frontend_attach_refusal(record) if record is not None else None
+                remaining = deadline - _resume_redial_clock()
+                if static is not None:
+                    verdict(str(error))
+                    return
+                if attempt >= RESUME_CONNECT_ATTEMPTS or remaining <= 0:
+                    verdict(gave_up_text(error))
+                    return
+                # STATED AS A BOUND, and in the composer's register for the same
+                # wait: no denominator the user cannot act on, no diagnosis the
+                # app has not established, and short enough to sit on one line in
+                # the notice's 75-cell measure (design D2, D3, D4).
+                narrate(f"reconnecting to session {concrete} — still trying for up to {bound_s} s")
+                await _resume_redial_pause(min(sidebar_connect_backoff_s(attempt), remaining))
+        finally:
+            self._resume_retry_target = ""
 
         # The retry row described a dial that is now over; leaving it up would
         # have the transcript promise a reconnect that already happened.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -6931,6 +6931,16 @@ class OperatorApp(App[None]):
                 # re-arms automatically from here (`retry` stays False), so the
                 # only reader of a fresh count is the user's own next selection.
                 source.connect_attempts = 0
+                # THE LATCH IS A STATE END, SO THE COMPOSER'S ROW ENDS WITH IT
+                # (UX U1, round 3). This arm is the one that resolves the
+                # connect as a verdict for the user — the band reads "Reconnect
+                # failed · Select again to retry" — and a refusal row left
+                # saying "Reconnecting … it will keep trying" above it makes the
+                # app contradict itself at the exact moment the original defect
+                # is on screen. Called AFTER the two field writes above so the
+                # hint it restates from is the post-latch one.
+                if source is self._interaction:
+                    self._restate_composer_refusal()
         finally:
             if prepared is not None:
                 await self._release_sidebar_preparation(prepared)
@@ -11918,7 +11928,9 @@ class OperatorApp(App[None]):
         in place, so there is at most one such row.
 
         Called from the redial's every exit and from a sidebar connect that
-        COMPLETED — the two ways the state the row describes ends.
+        COMPLETED — two of the three ways the state the row describes ends; the
+        third is the sidebar's latch, which restates rather than retires (see
+        `_restate_composer_refusal`).
         """
         notice = self._composer_refusal_notice
         self._composer_refusal_notice = None
@@ -11930,6 +11942,59 @@ class OperatorApp(App[None]):
         parent = notice.parent
         if isinstance(parent, TranscriptView):
             parent.remove_block(notice)
+
+    def _restate_composer_refusal(self) -> None:
+        """Settle the refusal row into the state a sidebar LATCH published.
+
+        The latch is the third end of the state the row describes (UX U1,
+        round 3), beside the redial's exits and a completed connect. It is the
+        arm that resolves the connect as a verdict for the user — the band
+        reads "Reconnect failed · Select again to retry" and `connect_attempts`
+        goes back to zero — so a row still saying "Reconnecting … it will keep
+        trying for a few more seconds" above it made the app contradict itself
+        at the exact moment the original defect was on screen. The old bug
+        report is about that moment, which is why the contradiction matters
+        more than the row's grade.
+
+        Restated rather than retired, and through the row's own writer so the
+        two spellings cannot drift: the NEXT Enter already refreshes the row
+        into exactly this register (`Select this session again to retry.`), so
+        going through `composer_submission_refused` is what makes the surface
+        agree whether or not the user presses it. A latch with no row on screen
+        invents none — it is a state end, not a gesture, and only
+        `composer_submission_refused` speaks for gestures.
+        """
+        held = self._composer_refusal_notice
+        if held is None or not held.is_attached:
+            return
+        self.composer_submission_refused()
+
+    def _absorb_into_settled_notice(self, notice: NoticeBlock, text: str) -> bool:
+        """Settle into an identical settled sentence already in the same view.
+
+        Returns True when `notice`'s own view already holds `text`, having
+        retired `notice` in its favour. The redial's cancellation sentence names
+        only the session, so a second abandoned run settled its fresh row into a
+        byte-identical copy of the one already there: two adjacent identical
+        blocks in the current view (design D1, round 3). The sentence already on
+        screen says exactly what this run would have said, so the run
+        contributes no second copy — and the block that goes is this run's own
+        LIVE row, the only thing still promising a dial.
+
+        ONLY the cancellation arm calls it, because that is the sentence with no
+        per-run information: the fall-through for an unexpected raise reuses the
+        give-up sentence, and absorbing a repeat of that would collapse two
+        runs' verdicts into one (the one-row-per-run policy rounds 1-2 approved).
+        The match is therefore on one arm's text and never crosses registers.
+        """
+        parent = notice.parent
+        if not isinstance(parent, TranscriptView):
+            return False
+        for block in parent.blocks():
+            if block is not notice and isinstance(block, NoticeBlock) and block.text() == text:
+                parent.remove_block(notice)
+                return True
+        return False
 
     def composer_submission_blocked(
         self, text: str | None = None, *, shell: bool | None = None
@@ -12073,22 +12138,29 @@ class OperatorApp(App[None]):
         def stopped_text(unwound: BaseException | None) -> str:
             """The sentence for a redial that ended WITHOUT running to a verdict.
 
-            Reachable by cancellation — the sidebar switch, which is the exit the
-            composer copy recommends as the way to stop the wait — and by any
-            unexpected exception unwinding the loop. Only the row this loop
-            actually narrated is settled by it, so a `/resume` abandoned during
-            its first silent envelope (no row yet) gains no row here.
+            Reachable by cancellation and by any unexpected exception unwinding
+            the loop. Only the row this loop actually narrated is settled by it,
+            so a `/resume` abandoned during its first silent envelope (no row
+            yet) gains no row here.
 
-            The copy names the cause it can name rather than a diagnosis it
-            cannot: a `CancelledError` here IS the user switching away — the
-            sidebar cancels this worker group and nothing else does — and the way
-            back is a fresh `/resume`. Anything else gets the give-up sentence,
-            which is true of it: the wait is over and no dial is pending.
+            THE COPY NAMES NO CAUSE, because the cancellation arm has two and
+            the code cannot tell them apart (review round 3, MINOR-1): the
+            sidebar's switch cancels this worker group, and Textual cancels
+            EVERY worker when the message loop ends (`workers.cancel_all()` in
+            `_process_messages_loop`'s `finally`), so a quit or Ctrl+C mid-redial
+            lands on the same line. The row is durable, so a sentence claiming a
+            switch could be read on the next launch beside a session the user
+            never left. What is true of both is that the resume never completed —
+            said here as a fact rather than as a cause — and the way back is a
+            fresh `/resume`. (Design D2's `switched session` also read as a
+            dropped article, which a cause-neutral sentence does not have to
+            carry.) Anything else gets the give-up sentence, which is true of it:
+            the wait is over and no dial is pending.
             """
             if isinstance(unwound, asyncio.CancelledError):
                 return (
-                    f"resume of {concrete} stopped — the wait ended when you switched "
-                    f"session.\nRun /resume {concrete} again to retry."
+                    f"resume of {concrete} stopped — the wait ended without "
+                    f"connecting.\nRun /resume {concrete} again to retry."
                 )
             return gave_up_text(unwound if isinstance(unwound, Exception) else ConnectionError())
 
@@ -12167,6 +12239,15 @@ class OperatorApp(App[None]):
                 # anything else — a dialable record, or a registry that could
                 # not be read — is paced, and the timeout's own honest sentence
                 # is the outcome.
+                #
+                # A WEDGED OWNER IS PACED FOR THE SAME REASON (review round 3,
+                # MINOR-2). The registry's third state — pid alive, heartbeat
+                # older than `HEARTBEAT_TIMEOUT_S`, i.e. the owner is stuck — is
+                # a current-version process that may recover, and `scan` keeps
+                # its record for exactly that hope, so `dialable_record_exists`
+                # answers `True` for it. Asking only for `live` printed this
+                # sentence for a merely stuck owner and skipped the very wait
+                # that could have healed it.
                 #
                 # A MOVED OWNER PID IS PACED, NOT REFUSED. `find_runtime_record`
                 # derives its own owner from the same `.session.pid` marker the
@@ -12259,12 +12340,36 @@ class OperatorApp(App[None]):
             # `CancelledError` without reaching any verdict: without this, the
             # row the user left behind still promises a dial that is over, in
             # the session they return to, one more stranded row per abandoned
-            # run (design D1 / review m4 / QA Q2). Restating rather than
-            # removing keeps the one-row-per-run guarantee, and `settled` keeps
-            # this out of the two exits that already resolved the row. An
-            # unwind that delivered no dial at all has no row and gains none.
+            # run (design D1 / review m4 / QA Q2). Textual's own shutdown
+            # cancels every worker the same way (`workers.cancel_all()`), which
+            # is why the sentence below names no cause — see `stopped_text`.
+            # Restating rather than removing keeps the one-row-per-run
+            # guarantee, and `settled` keeps this out of the two exits that
+            # already resolved the row. An unwind that delivered no dial at all
+            # has no row and gains none.
             if not settled and retry_notice is not None and retry_notice.is_attached:
-                retry_notice.restate(stopped_text(sys.exc_info()[1]), "warning")
+                unwound = sys.exc_info()[1]
+                settled_text = stopped_text(unwound)
+                # ONE SETTLED SENTENCE PER CONVERSATION (design D1, round 3):
+                # the cancellation sentence carries no per-run information, so a
+                # SECOND abandoned redial settled its fresh row into a
+                # byte-identical copy of the one already there — two identical
+                # blocks adjacent in the current view. When the view already
+                # holds that exact sentence, it IS this run's outcome, and the
+                # block that goes is this run's own live row.
+                #
+                # Scoped to the CANCELLATION arm on purpose. The fall-through
+                # for an unexpected raise reuses the give-up sentence, and
+                # absorbing a repeat of THAT would collapse two runs' verdicts
+                # into one — the one-row-per-run policy rounds 1-2 approved and
+                # this round was told not to reopen (`_absorb_into_settled_notice`
+                # is the mechanism, called only here).
+                is_cancellation = isinstance(unwound, asyncio.CancelledError)
+                absorbed = is_cancellation and self._absorb_into_settled_notice(
+                    retry_notice, settled_text
+                )
+                if not absorbed:
+                    retry_notice.restate(settled_text, "warning")
                 retry_notice = None
             # The composer's refusal row describes the same state, so it ends
             # with the operation on every exit too.

--- a/local_operator/tui/session_navigation.py
+++ b/local_operator/tui/session_navigation.py
@@ -41,6 +41,39 @@ class SurfaceNotReady(RuntimeError):
     """
 
 
+class OwnerWentCold(ConnectionError):
+    """A LIVE commit whose owner went cold before its first frame could paint.
+
+    The other half of the split above, and the reason both are named rather
+    than matched on text. ``SurfaceNotReady`` is a LOCAL paint failure of a
+    session that is bound and reachable, so it is terminal on the first
+    occurrence (#883). This one is the TRANSIENT shape and must spend the
+    reconnect budget instead: the frame was armed against a session that had
+    passed the bind postcondition, and the owner was lost in the window after
+    it — the facade is ``_recovering`` and clears itself within
+    ``COLD_FALLBACK_S``, so a reselect heals in milliseconds while a latch
+    makes the user perform that reselect by hand.
+
+    Raised from ``post_display_hook`` rather than by a timer because the gate's
+    FIRST check is ``is_cold``: for as long as the session is cold the gate
+    can never pass, so every frame it waits out is spent buying full-screen
+    relayouts for a verdict that is already known (measured pre-fix: 1,820
+    refusals, every one of them a relayout, over the 15 s timer).
+
+    Subclasses ``ConnectionError`` — the same type the bind postcondition in
+    ``_connect_sidebar_source`` raises for this exact condition, carrying the
+    same sentence — so the arms that already classify "the runtime is not
+    responding" as connectivity keep classifying this as connectivity, and no
+    second terminal wording is introduced.
+    """
+
+
+#: The one sentence both arms that detect an unreachable owner report, so the
+#: bind postcondition and the cold-frame failure are indistinguishable to the
+#: user and neither can drift into a second vocabulary for one condition.
+UNREACHABLE_OWNER_MESSAGE = "the runtime is not responding"
+
+
 class SessionNavigation(Generic[Prepared]):
     def __init__(
         self,

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -140,12 +140,12 @@ PAGE_ROWS_MAX = 10
 #:
 #: Sized against what the markers can actually say, not against taste: the
 #: states they report come from heartbeat recency, whose own resolution is
-#: 45 s (``HEARTBEAT_TIMEOUT_S``), so a 1 s refresh is two orders of magnitude
-#: finer than the signal and no transition can be shown late at a scale a
-#: reader could notice. It still bounds the cost — 12.5 scans/s became 1 — and
-#: it keeps the repaint-on-change guard (`_tick`) working, which is what makes
-#: a row that REORDERS (a session parking on a gate, with nothing animating)
-#: reach the screen.
+#: 45 s (``HEARTBEAT_TIMEOUT_S``), so a 1 s refresh is 45× finer than that
+#: signal and no transition can be shown late at a scale a reader could
+#: notice. It still bounds the cost — 12.5 scans/s became 1 — and it keeps the
+#: repaint-on-change guard (`_tick`) working, which is what makes a row that
+#: REORDERS (a session parking on a gate, with nothing animating) reach the
+#: screen.
 LIVE_REFRESH_INTERVAL_S = 1.0
 
 #: Name/id matches at which the picker stops consulting the bounded soft tier
@@ -1415,9 +1415,9 @@ class SessionPickerScreen(ModalScreen[str | None]):
         animating. So it is BOUNDED rather than dropped, and the bound is what
         keeps a frozen marker from claiming to be live: the picker's own
         freshness is now a stated number instead of an accident of the frame
-        rate, and at 1 s it is two orders of magnitude finer than the 45 s
-        heartbeat the live states are derived from, which is the resolution
-        they actually change at.
+        rate, and at 1 s it is 45× finer than the 45 s heartbeat the live
+        states are derived from, which is the resolution they actually change
+        at.
         """
         before = self._marker_signature()
         refresh = self._refresh_live_state

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -62,6 +62,7 @@ footer (which is the only place the card says how to get out).
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Callable, Sequence
 from collections.abc import Set as AbstractSet
 
@@ -131,6 +132,21 @@ RESUME_EMPTY_NOTICE = "no conversations of yours to resume — subagent runs are
 #: than a popup; ten is enough to scan. A CEILING, not the page size — see
 #: :meth:`SessionPickerScreen._page_rows`.
 PAGE_ROWS_MAX = 10
+
+#: How stale a live marker may be while the picker is open. The spinner keeps
+#: advancing at ``SPINNER_INTERVAL_S`` (motion), but the DATA behind the markers
+#: — `registry.scan()` plus `read_index()` — is re-read at this cadence instead
+#: of on every frame.
+#:
+#: Sized against what the markers can actually say, not against taste: the
+#: states they report come from heartbeat recency, whose own resolution is
+#: 45 s (``HEARTBEAT_TIMEOUT_S``), so a 1 s refresh is two orders of magnitude
+#: finer than the signal and no transition can be shown late at a scale a
+#: reader could notice. It still bounds the cost — 12.5 scans/s became 1 — and
+#: it keeps the repaint-on-change guard (`_tick`) working, which is what makes
+#: a row that REORDERS (a session parking on a gate, with nothing animating)
+#: reach the screen.
+LIVE_REFRESH_INTERVAL_S = 1.0
 
 #: Name/id matches at which the picker stops consulting the bounded soft tier
 #: (see ``SessionPickerScreen._soft_tier_wanted``). Three, not one: a single
@@ -929,6 +945,11 @@ class SessionPickerScreen(ModalScreen[str | None]):
         self._body: Static
         #: Spinner phase for the running marker, advanced by ``_tick``.
         self._frame = 0
+        #: ``time.monotonic()`` of the last liveness refresh, or ``-inf`` so the
+        #: first tick always refreshes. The picker's data freshness is a stated
+        #: bound (``LIVE_REFRESH_INTERVAL_S``) rather than a side effect of the
+        #: frame rate; see ``_tick``.
+        self._live_refreshed_at = float("-inf")
         #: Has this picker EVER shown an exec row? Latched, never cleared while
         #: the screen lives — see :meth:`_exec_column_latched` for why the
         #: column may widen but must not narrow.
@@ -1371,21 +1392,38 @@ class SessionPickerScreen(ModalScreen[str | None]):
         self._timer = self.set_interval(SPINNER_INTERVAL_S, self._tick)
 
     def _tick(self) -> None:
-        """Advance the spinner and re-read what it is claiming.
+        """Advance the spinner, and re-read what the live markers claim.
 
-        Cheap by construction: the refresh is the same one `registry.scan()` +
-        `read_index()` pair the picker already budgets for as a per-open cost,
-        and the repaint is one `Static.update`. It runs only while the picker
-        is on screen — the timer dies with the screen.
+        TWO RATES, deliberately, because they answer different questions.
 
-        Skipped entirely when no row is animating, so a store of cold sessions
-        costs nothing: without a running session there is no motion to drive,
-        and re-scanning the registry ten times a second to discover that would
-        be the picker's own idle cost.
+        The FRAME advances at ``SPINNER_INTERVAL_S`` (12.5 Hz) while a row is
+        busy: that is motion, and motion is what makes the running marker read
+        as running rather than as a static bullet.
+
+        The DATA is re-read at ``LIVE_REFRESH_INTERVAL_S`` — the refresh is
+        `registry.scan()` (a glob, a JSON parse per record, a `ps` per
+        quiet-heartbeat record) plus `read_index()`, and `_tick` used to run it
+        unconditionally on every frame, so an idle picker re-scanned the whole
+        store 12.5 times a second. That is not a per-open cost and the previous
+        docstring's claim that it was "skipped entirely when no row is
+        animating" described a guard that did not exist.
+
+        The refresh is NOT skipped outright, because two things it feeds are
+        real while nothing spins: the repaint-on-visible-change guard below and
+        the rows themselves, which REORDER when a session parks on a
+        gate — this release's headline event, and one that arrives with no row
+        animating. So it is BOUNDED rather than dropped, and the bound is what
+        keeps a frozen marker from claiming to be live: the picker's own
+        freshness is now a stated number instead of an accident of the frame
+        rate, and at 1 s it is two orders of magnitude finer than the 45 s
+        heartbeat the live states are derived from, which is the resolution
+        they actually change at.
         """
         before = self._marker_signature()
         refresh = self._refresh_live_state
-        if refresh is not None:
+        now = time.monotonic()
+        if refresh is not None and now - self._live_refreshed_at >= LIVE_REFRESH_INTERVAL_S:
+            self._live_refreshed_at = now
             try:
                 self._all = list(refresh(self._all))
                 # The filter cache is keyed on the query, which has not

--- a/tests/e2e/test_sidebar_reconnect_e2e.py
+++ b/tests/e2e/test_sidebar_reconnect_e2e.py
@@ -258,6 +258,117 @@ async def test_an_evicted_viewer_reconnects_without_ever_looking_connected(
 
 
 @pytest.mark.asyncio
+async def test_a_loss_in_the_bind_to_paint_window_heals_instead_of_latching(
+    headless_tui_env: Path,
+) -> None:
+    """THE WINDOW ITSELF, which the two tests above only approach.
+
+    ``during`` reselects a session that is ALREADY cold, so the connect body's
+    bind postcondition refuses it before anything is committed. The operator's
+    report is the other ordering: the session was live when the bind check ran
+    and the owner was lost in the gap between that check and the first painted
+    frame — the window ``post_display_hook``'s readiness gate owns. A cold
+    session committed in that window satisfies no frame the gate can ever
+    accept (its FIRST check is ``is_cold``), so pre-fix the gate refused every
+    frame for 15 s, each refusal buying a forced full-screen relayout (measured
+    on the architect's rig: 15.10 s, 1,820 refusals, all recoveries), and the
+    timer's ``SurfaceNotReady`` — terminal on first by #883's design — latched a
+    loss the user's reselect healed in 0.17 s.
+
+    The injection is deterministic rather than raced: ``ensure_display_current``
+    is the first await AFTER the bind postcondition and BEFORE presentation, so
+    evicting the viewer inside it puts a REAL ``ATTACH_MAX_CLIENTS`` eviction
+    exactly in the window while every other line of the real connect body runs.
+    Racing it (as the architect's offset sweep does) is load-dependent: on a
+    fast host the connect's fast path lands first and no frame is ever armed.
+    """
+    config = headless_tui_env
+    servers = {name: await _runtime(config, name) for name in ("origin", "target")}
+
+    def find_owner(_config_dir, session_id):
+        server = servers.get(session_id)
+        return (server._record, server._record.pid) if server else (None, None)
+
+    async def resume(session_id):
+        return await AttachedSession.connect(
+            servers[session_id]._record,
+            session_id,
+            config_dir=config,
+            takeover_factory=_never_take_over,
+            display_window=True,
+        )
+
+    app = OperatorApp(lambda: resume("origin"), resume_factory=resume)
+    hogs: list[AttachedSession] = []
+    with patch("local_operator.mobile.attach_client.find_runtime_record", find_owner):
+        async with app.run_test(size=(120, 36)) as pilot:
+            await wait_for_adoption(app, pilot)
+            await asyncio.wait_for(app._sidebar_navigation.select("target"), 30)
+            source = app._sidebar_sources["target"]
+            if source.connection_task is not None:
+                await asyncio.wait_for(asyncio.shield(source.connection_task), 30)
+            await pilot.pause()
+            viewer = source.session
+            assert isinstance(viewer, AttachedSession)
+            assert not source.display_only
+            assert not viewer.is_cold
+
+            original_display = AttachedSession.ensure_display_current
+
+            async def evicting_display(self) -> None:
+                await original_display(self)
+                if self is viewer and not hogs:
+                    # REAL eviction: the same number of genuine attach clients
+                    # as the cap, so the LRU drop is the runtime's own.
+                    hogs.extend(
+                        [
+                            await AttachedSession.connect(
+                                servers["target"]._record,
+                                "target",
+                                config_dir=config,
+                                takeover_factory=_never_take_over,
+                                display_window=True,
+                            )
+                            for _ in range(ATTACH_MAX_CLIENTS)
+                        ]
+                    )
+
+            try:
+                with patch.object(AttachedSession, "ensure_display_current", evicting_display):
+                    # The state the connect task is always entered from: the
+                    # saved excerpt is on screen, and the user asks for the
+                    # session again.
+                    source.display_only = True
+                    recoveries_before = app._sidebar_gate_recoveries
+                    app._start_sidebar_connection(source)
+                    seen = await _settle(app, pilot, source)
+
+                # PRECONDITION: the eviction really landed in the window, so a
+                # pass cannot mean "nothing was ever lost".
+                assert hogs, "the eviction never fired; this test proves nothing"
+                assert (
+                    viewer.is_cold is False
+                ), "the reconnect did not heal: the owner was never recovered"
+                assert source.display_only is False
+                assert source.connection_error == ""
+                # THE HEADLINE: the transient loss healed with NO user action,
+                # and a cold session was never presented as LIVE on the way.
+                #
+                # Only `(False, cold)` is forbidden. `(True, True)` — the saved
+                # excerpt on screen while the owner is gone — is the HONEST
+                # state (that is what "Saved · Connecting…" means), and the
+                # point of this fix is that it is a state the app RETRIES out
+                # of rather than a verdict it latches.
+                assert (False, True) not in seen
+                # NO SPIN: the commit->paint window is where the 15 s refusal
+                # storm lived, so its counter is the sharpest reading here.
+                assert app._sidebar_gate_recoveries - recoveries_before <= _GATE_RECOVERY_CEILING
+            finally:
+                for hog in hogs:
+                    await hog.dispose()
+
+
+@pytest.mark.asyncio
 async def test_a_plain_socket_loss_reconnects_with_no_attach_pressure(
     headless_tui_env: Path,
 ) -> None:

--- a/tests/unit/mobile/test_attach_client.py
+++ b/tests/unit/mobile/test_attach_client.py
@@ -11,11 +11,13 @@ from pathlib import Path
 
 import pytest
 
+from local_operator.mobile import attach_client
 from local_operator.mobile.attach_client import (
     ACK_TIMEOUT_S,
     ASIDE_DEADLINE_S,
     AttachClient,
     OwnerAckTimeout,
+    dialable_record_exists,
     find_runtime_record,
 )
 from local_operator.mobile.types import SessionProjection, TranscriptEntry
@@ -593,3 +595,67 @@ async def test_a_late_reply_for_an_abandoned_request_is_logged(
         await client.detach()
     finally:
         r.close()
+
+
+def _synthetic(pid: int, session_id: str, protocol: int = 5) -> registry.SessionRecord:
+    return registry.SessionRecord(
+        pid=pid,
+        kind="tui",
+        session_id=session_id,
+        conversation_name="",
+        cwd="/tmp",
+        model_label="",
+        control_port=1,
+        control_key="k",
+        protocol=protocol,
+    )
+
+
+@pytest.mark.parametrize(
+    ("records", "expected"),
+    [
+        # The m3 case: a LIVE, dialable record for this pid under ANOTHER
+        # session_id — the rebind race `find_runtime_record` reports as
+        # `(None, pid)`. It is dialable, so no caller may call the process old.
+        ([(_synthetic(91234, "sess-previous"), "live")], True),
+        # A v1 record is not dialable at all, whatever it names.
+        ([(_synthetic(91234, "sess-other", protocol=1), "live")], False),
+        # Not live: the pid holds no record this build could talk to.
+        ([(_synthetic(91234, "sess-other"), "stale")], False),
+        # A live record for a DIFFERENT pid says nothing about this one.
+        ([(_synthetic(1, "sess-other"), "live")], False),
+        ([], False),
+    ],
+)
+def test_dialable_record_exists_answers_for_the_pid_not_the_session(
+    monkeypatch, tmp_path: Path, records, expected
+) -> None:
+    """The question `(None, pid)` cannot answer, asked where it can be.
+
+    `find_runtime_record` collapses "no usable record" and "a live dialable
+    record stamped with the previous session_id" into the same tuple, so the
+    `/resume` refusal has to ask the registry itself before it names a cause
+    (review m3). The session_id is deliberately NOT part of the question: the pid
+    is what a caller refuses about.
+    """
+    monkeypatch.setattr(attach_client, "scan", lambda _root: list(records))
+
+    assert dialable_record_exists(tmp_path, 91234) is expected
+
+
+def test_dialable_record_exists_is_unknown_when_the_registry_cannot_be_read(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """A failed read is not evidence of absence, so it is not a `bool`.
+
+    The refusal it gates names a cause ("open in an older Local Operator
+    process"); a scan that raised has established nothing about the process, so
+    the tri-state is what keeps the caller from printing that sentence anyway.
+    """
+
+    def unreadable(_root: Path):
+        raise OSError("registry unreadable")
+
+    monkeypatch.setattr(attach_client, "scan", unreadable)
+
+    assert dialable_record_exists(tmp_path, 91234) is None

--- a/tests/unit/mobile/test_attach_client.py
+++ b/tests/unit/mobile/test_attach_client.py
@@ -618,6 +618,10 @@ def _synthetic(pid: int, session_id: str, protocol: int = 5) -> registry.Session
         # session_id — the rebind race `find_runtime_record` reports as
         # `(None, pid)`. It is dialable, so no caller may call the process old.
         ([(_synthetic(91234, "sess-previous"), "live")], True),
+        # A WEDGED record is dialable as well (review round 3, MINOR-2): the pid
+        # is alive and `scan` keeps the record for the recovery the redial exists
+        # to outlast, so a caller must pace this owner rather than age it.
+        ([(_synthetic(91234, "sess-previous"), "wedged")], True),
         # A v1 record is not dialable at all, whatever it names.
         ([(_synthetic(91234, "sess-other", protocol=1), "live")], False),
         # Not live: the pid holds no record this build could talk to.

--- a/tests/unit/session/runtime/test_server.py
+++ b/tests/unit/session/runtime/test_server.py
@@ -2280,8 +2280,19 @@ async def test_push_skips_full_tui_clients_but_keeps_welcome_and_daemon() -> Non
 
 
 @pytest.mark.asyncio
-async def test_every_drop_logs_reason_once_at_info(caplog: pytest.LogCaptureFixture) -> None:
-    """Test 21: one INFO line per actual removal, naming the reason."""
+async def test_every_drop_logs_its_reason_once_at_one_level(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test 21: one line per actual removal, naming the reason.
+
+    At the level the reason EARNS: a close the runtime asked for, or one a peer
+    asked for by closing first, is part of a client's ordinary life and stays
+    INFO. Every other reason means a client was removed without asking to
+    leave, and those are WARNING — see `_GRACEFUL_DROP_REASONS` and
+    `test_an_unrequested_drop_is_logged_at_warning`. Both used to be INFO
+    beside every routine close, which is how "the sidebar went cold" ended up
+    with no findable cause in the runtime log.
+    """
     import logging
 
     handle = FakeHandle()
@@ -2294,7 +2305,7 @@ async def test_every_drop_logs_reason_once_at_info(caplog: pytest.LogCaptureFixt
         conns = list(runtime._clients.values())
         assert len(conns) == 1
         caplog.set_level(logging.INFO, logger="local_operator.session.runtime.server")
-        runtime._drop_client(conns[0], reason="test")
+        runtime._drop_client(conns[0], reason="reader eof")
         infos = [
             rec
             for rec in caplog.records
@@ -2303,8 +2314,9 @@ async def test_every_drop_logs_reason_once_at_info(caplog: pytest.LogCaptureFixt
         assert len(infos) == 1, [rec.getMessage() for rec in infos]
         assert "dropped attach client" in infos[0].getMessage()
         assert "events=" in infos[0].getMessage()
-        assert infos[0].getMessage().endswith(": test")
-        # Second call (reader-loop finally) must not INFO again.
+        assert infos[0].getMessage().endswith(": reader eof")
+        assert not [rec for rec in caplog.records if rec.levelno == logging.WARNING]
+        # Second call (reader-loop finally) must not log again.
         runtime._drop_client(conns[0], reason="reader eof")
         infos_after = [
             rec
@@ -2312,6 +2324,52 @@ async def test_every_drop_logs_reason_once_at_info(caplog: pytest.LogCaptureFixt
             if rec.levelno == logging.INFO and "dropped" in rec.getMessage()
         ]
         assert len(infos_after) == 1
+    finally:
+        if writer is not None:
+            writer.close()
+        runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_an_unrequested_drop_is_logged_at_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Why the client went is the one thing that must not be buried.
+
+    A viewer dropped for a reason IT did not choose — the attach cap evicting
+    it, an event queue overflowing, a send timing out — learns what happened
+    only as a cold facade. The runtime's own record of the reason is therefore
+    the only place the cause exists at all, and at INFO beside every routine
+    close it was invisible in practice: the operator's report of "Reconnect
+    failed — select again to retry" had nothing to read.
+    """
+    import logging
+
+    handle = FakeHandle()
+    runtime = RuntimeServer(handle, kind="tui")
+    runtime.start()
+    writer = None
+    try:
+        record = await _wait_record()
+        _reader, writer = await _dial(record, client="attach")
+        conns = list(runtime._clients.values())
+        assert len(conns) == 1
+        caplog.set_level(logging.INFO, logger="local_operator.session.runtime.server")
+        runtime._drop_client(conns[0], reason="attach cap")
+        warnings = [
+            rec
+            for rec in caplog.records
+            if rec.levelno == logging.WARNING and "dropped" in rec.getMessage()
+        ]
+        assert len(warnings) == 1, [rec.getMessage() for rec in warnings]
+        assert "dropped attach client" in warnings[0].getMessage()
+        assert warnings[0].getMessage().endswith(": attach cap")
+        # The reason is still ONE line, not a warning plus an info.
+        assert not [
+            rec
+            for rec in caplog.records
+            if rec.levelno == logging.INFO and "dropped" in rec.getMessage()
+        ]
     finally:
         if writer is not None:
             writer.close()
@@ -2336,7 +2394,7 @@ async def test_attach_cap_drop_reason_is_logged(caplog: pytest.LogCaptureFixture
         messages = [
             rec.getMessage()
             for rec in caplog.records
-            if rec.levelno == logging.INFO and "dropped" in rec.getMessage()
+            if rec.levelno == logging.WARNING and "dropped" in rec.getMessage()
         ]
         assert any(msg.endswith(": attach cap") for msg in messages), messages
     finally:

--- a/tests/unit/tui/test_resume_connect_retry.py
+++ b/tests/unit/tui/test_resume_connect_retry.py
@@ -25,12 +25,14 @@ the real budget is asserted as a RELATIONSHIP in
 
 from __future__ import annotations
 
+import asyncio
 import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
 import pytest
+from rich.text import Text
 
 from local_operator.session.attached import (
     COLD_FALLBACK_S,
@@ -42,6 +44,7 @@ from local_operator.session.frontend_state import FRONTEND_CAPABILITY
 from local_operator.session.runtime.types import SessionRecord
 from local_operator.tui import app as app_module
 from local_operator.tui.app import OperatorApp
+from local_operator.tui.session_navigation import UNREACHABLE_OWNER_MESSAGE
 from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
@@ -97,15 +100,69 @@ def _notices(app: OperatorApp) -> list[str]:
     return [block._text for block in views[0].blocks() if isinstance(block, NoticeBlock)]
 
 
+def _rendered_text(app: OperatorApp) -> str:
+    """Every notice row the view paints, as one whitespace-normalised string."""
+    return " ".join(" ".join(_rendered_notice_rows(app)).split())
+
+
+def _rendered_notice_rows(app: OperatorApp) -> list[str]:
+    """What the notices actually PAINT, one entry per rendered row.
+
+    Distinct from `_notices`, which reads the authored string: these rows are
+    the block's own `_build` output, so a claim that a row is gone is a claim
+    about the surface rather than about a list the app happens to hold. The two
+    disagree exactly when a block is still ATTACHED — which is the defect class
+    here: QA's repro read a correct-looking `pending=False` beside a row that was
+    still on screen when the user returned to the session (QA Q2).
+    """
+    views = list(app.query(TranscriptView))
+    if not views:
+        return []
+    rows: list[str] = []
+    for block in views[0].blocks():
+        if not isinstance(block, NoticeBlock):
+            continue
+        # `_build` IS the renderable the block paints; asking it here rather than
+        # reading `_text` is what makes these rows the surface's own, and the
+        # isinstance is what tells pyright which renderable it is.
+        renderable = block._build()
+        if isinstance(renderable, Text):
+            rows.extend(renderable.plain.split("\n"))
+    return rows
+
+
 def _gave_up(detail: str, *, session_id: str = "remote-1") -> str:
     """The terminal sentence, spelled the way the app spells it.
 
     ONE concept, two spellings would drift: the app's copy names the session and
     the next step (UX U4) around whatever the last failure's own text was, so
     the test builds it from the same two pieces rather than pasting the whole
-    string twice.
+    string twice. The next step is its OWN authored row (design D2) — as one
+    flowing paragraph the 80-column wrap split `/resume` from the id beside it.
     """
-    return f"could not resume {session_id} — {detail}. Run /resume {session_id} again to retry."
+    return (
+        f"could not resume {session_id} — {detail}.\n" f"Run /resume {session_id} again to retry."
+    )
+
+
+def _stopped(*, session_id: str = "remote-1") -> str:
+    """The sentence a redial that never reached a verdict leaves behind.
+
+    The cancellation exit — the sidebar switch — which is the exit the
+    composer copy teaches as the way to stop the wait.
+    """
+    return (
+        f"resume of {session_id} stopped — the wait ended when you switched session.\n"
+        f"Run /resume {session_id} again to retry."
+    )
+
+
+def _static_refused(*, session_id: str = "remote-1") -> str:
+    """The terminal sentence for a capability gap no redial can change (UX U2)."""
+    return (
+        f"could not resume {session_id} — the process hosting it does not serve the "
+        "full TUI session state. Update or restart that process, then resume again."
+    )
 
 
 class _RedialClock:
@@ -229,7 +286,7 @@ async def test_a_transient_connect_failure_is_retried_rather_than_reported(monke
 
     async with _running(app):
         with pytest.raises(_Stranded):
-            await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+            await app._attach_or_refuse(tmp_path, "remote-1")
 
         assert len(dials) == 2, "a transient failure was not retried"
         notices = _notices(app)
@@ -246,6 +303,11 @@ async def test_a_transient_connect_failure_is_retried_rather_than_reported(monke
         # ...and once the dial SUCCEEDS the row is retired, rather than left
         # claiming a reconnect that has already happened.
         assert not [n for n in notices if n.startswith("reconnecting to session")]
+        # NOTHING AT ALL, which is the sharper form of the same claim: a row
+        # restated into "the wait ended when you switched session" also stops
+        # starting with "reconnecting", and it would be FALSE here — the attach
+        # succeeded. That is what the settled flag at the break is for.
+        assert notices == [], notices
 
 
 @pytest.mark.asyncio
@@ -272,7 +334,7 @@ async def test_only_exhaustion_latches_and_it_says_so_honestly(monkeypatch, tmp_
     monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
 
     async with _running(app):
-        await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+        await app._attach_or_refuse(tmp_path, "remote-1")
 
         assert len(dials) == _SHIPPED_ATTEMPTS, "the redial did not spend its budget"
         # THE ROW IS RESTATED INTO THE VERDICT, so the transcript holds exactly
@@ -305,9 +367,9 @@ async def test_a_second_resume_does_not_strand_the_first_ones_row(monkeypatch, t
     monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
 
     async with _running(app):
-        await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+        await app._attach_or_refuse(tmp_path, "remote-1")
         first = _notices(app)
-        await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+        await app._attach_or_refuse(tmp_path, "remote-1")
 
         assert first == [_gave_up("attach refused")]
         assert _notices(app) == [_gave_up("attach refused")] * 2
@@ -349,7 +411,7 @@ async def test_the_runtime_record_is_re_read_before_every_attempt(monkeypatch, t
 
     async with _running(app):
         with pytest.raises(_Stranded):
-            await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+            await app._attach_or_refuse(tmp_path, "remote-1")
 
         assert len(lookups) == 2, "the record was captured once and reused"
         assert [r.pid for r in dialled] == [
@@ -365,9 +427,20 @@ async def test_a_static_refusal_is_not_retried(monkeypatch, tmp_path):
     Every redial would raise the identical refusal, so a budget spent on it is
     just a longer way to the same sentence — and since `frontend_attach_refusal`
     already answers the question `connect` refuses on (its docstring's "ONE
-    RULE, TWO CALLERS"), the refusal is taken BEFORE spending even one dial.
-    The expected sentence is built by that function rather than pasted, so the
-    two cannot drift apart.
+    RULE, TWO CALLERS"), the arm reads the answer off the same record rather
+    than inferring it from the exception.
+
+    ONE DIAL IS SPENT FIRST, and that is the behaviour (review n5, QA Q3):
+    `frontend_attach_refusal` is consulted only AFTER `connect` raises —
+    `connect_calls=1 socket_dials=0`, on this head and on the pre-delta base —
+    so the assertion is `len(dials) == 1`, not zero. Zero is the record
+    BELOW the attach protocol, which the first-attempt guard refuses before any
+    dial (see the neighbouring test). This docstring used to claim the refusal
+    was taken "BEFORE spending even one dial" three lines above that assertion.
+
+    The sentence is the app's own (UX U2), not the owner's internal one: the
+    token it used to print (`owner lacks tui_state_v1; … protocol >= 5`) is not
+    something the user can act on, and the arm had no session and no next step.
     """
     app = _app(monkeypatch, tmp_path)
     record = _record(90909, "the remote", capabilities=[])
@@ -386,10 +459,13 @@ async def test_a_static_refusal_is_not_retried(monkeypatch, tmp_path):
     monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
 
     async with _running(app):
-        await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+        await app._attach_or_refuse(tmp_path, "remote-1")
 
         assert len(dials) == 1, "a static refusal was retried"
-        assert _notices(app) == [frontend_attach_refusal(record)]
+        assert _notices(app) == [_static_refused()]
+        assert not [
+            n for n in _notices(app) if "tui_state_v1" in n
+        ], "the owner's internal capability token reached the transcript"
 
 
 @pytest.mark.asyncio
@@ -430,7 +506,7 @@ async def test_an_empty_record_on_the_first_attempt_is_paced_not_refused(monkeyp
 
     async with _running(app):
         with pytest.raises(_Stranded):
-            await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+            await app._attach_or_refuse(tmp_path, "remote-1")
 
         assert len(dials) == 1, "the empty first attempt did not reach the republished record"
         assert lookups == ["remote-1", "remote-1"]
@@ -451,6 +527,13 @@ async def test_an_owner_that_publishes_no_record_is_refused_by_its_own_pid(monke
     it — an older binary, or a registrant that failed to start. That IS the case
     the upgrade advice belongs to, and the pid it names must be the live owner's
     rather than the (possibly stale) one the command was invoked with.
+
+    THE ABSENCE IS ESTABLISHED HERE, NOT ASSUMED FROM THE TUPLE (review m3):
+    this test's registry really is empty, so `dialable_record_exists` answers
+    `False` and the refusal is the established one. Its sibling
+    `test_an_owner_with_a_live_record_under_another_session_id_is_paced_not_refused`
+    is the same `(None, pid)` input with a live record behind it, and it must NOT
+    reach this sentence.
     """
     app = _app(monkeypatch, tmp_path)
     dials: list[Any] = []
@@ -466,7 +549,7 @@ async def test_an_owner_that_publishes_no_record_is_refused_by_its_own_pid(monke
     monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
 
     async with _running(app):
-        await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+        await app._attach_or_refuse(tmp_path, "remote-1")
 
         assert dials == []
         assert _notices(app)[-1] == (
@@ -502,7 +585,7 @@ async def test_a_record_below_the_attach_protocol_is_refused_with_the_older_proc
     monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
 
     async with _running(app):
-        await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+        await app._attach_or_refuse(tmp_path, "remote-1")
 
         assert dials == []
         assert _notices(app)[-1] == (
@@ -542,7 +625,7 @@ async def test_an_owner_pid_that_moved_between_the_reads_is_paced_not_refused(
 
     async with _running(app):
         with pytest.raises(_Stranded):
-            await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+            await app._attach_or_refuse(tmp_path, "remote-1")
 
         assert len(dials) == 1, "the redial refused a record whose owner pid had moved"
         assert not [
@@ -560,9 +643,17 @@ async def test_the_in_flight_row_states_the_bound_and_fits_the_notice_measure(
     app had not established ("the owner is not answering" — wrong whenever there
     is no record at all), use a noun this TUI uses nowhere else ("owner"), and
     restate an implementation counter the user cannot act on (`retry 48 of 48`)
-    while the wait itself had no stated end (design D2/D3/D4, UX U2). It is now
-    62 cells for a typical id — inside the 75-cell notice measure, so it fits on
-    one line instead of splitting its own parenthetical.
+    while the wait itself had no stated end (design D2/D3/D4, UX U2).
+
+    THE BOUND IS ANCHORED AS THE WHOLE WAIT'S, not a countdown (UX U4): said
+    verbatim, "still trying for up to 42 s" at t=13.3 s of a 24.86 s wait reads
+    as "42 s from now". "about … s in total" cannot be read that way, and the
+    hedge is also what keeps the number true — one loop-top record read per pass
+    is charged only after the dial that follows it, so the real worst case is
+    the stated bound plus that read (review n4). The non-breaking space keeps
+    `42 s` from splitting across a wrap in the narrower block a sidebar-open
+    layout leaves (design D2); it is asserted so a copy edit cannot quietly
+    drop it.
     """
     app = _app(monkeypatch, tmp_path)
     record = _record(90909, "the remote")
@@ -581,15 +672,20 @@ async def test_the_in_flight_row_states_the_bound_and_fits_the_notice_measure(
     monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
 
     async with _running(app):
-        await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+        await app._attach_or_refuse(tmp_path, "remote-1")
 
         rows = [n for n in seen[1] if n.startswith("reconnecting to session")]
         assert rows == [
-            f"reconnecting to session remote-1 — still trying for up to " f"{_SHIPPED_BOUND_S:g} s"
+            f"reconnecting to session remote-1 — still trying, about "
+            f"{_SHIPPED_BOUND_S:g}\u00a0s in total"
         ]
         assert len(rows[0]) <= _NOTICE_MEASURE_CELLS, "the row splits in the notice measure"
         assert "owner" not in rows[0]
         assert "retry" not in rows[0]
+        # The whole-operation anchor, and the unit that must not break from its
+        # own number.
+        assert "in total" in rows[0]
+        assert f"{_SHIPPED_BOUND_S:g}\u00a0s" in rows[0]
 
 
 def test_the_budget_outlasts_the_transient_window_and_stays_in_tens_of_seconds():
@@ -654,7 +750,7 @@ async def test_the_redial_stops_when_the_wall_clock_is_spent_not_when_attempts_r
     monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
 
     async with _running(app):
-        await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+        await app._attach_or_refuse(tmp_path, "remote-1")
 
         assert len(dials) == 2, "a silent owner spent more than two full envelopes"
         assert len(dials) < _SHIPPED_ATTEMPTS, "the ATTEMPT cap ended the loop, not the budget"
@@ -692,7 +788,7 @@ async def test_the_backoff_is_clamped_to_what_is_left_of_the_budget(monkeypatch,
     monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
 
     async with _running(app):
-        await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+        await app._attach_or_refuse(tmp_path, "remote-1")
 
         # 5, then 5, then the 2 s that were left — never the 5 the schedule asked
         # for, and never a wait that outlives the deadline.
@@ -721,6 +817,7 @@ async def test_the_composer_says_what_is_happening_during_a_resume_redial(monkey
         seen["target"] = app._resume_retry_target
         seen["blocked"] = app.composer_submission_blocked("/resume other")
         app.composer_submission_refused()
+        seen["during"] = list(_notices(app))
         raise ConnectionError("the runtime is not responding")
 
     monkeypatch.setattr(
@@ -732,15 +829,354 @@ async def test_the_composer_says_what_is_happening_during_a_resume_redial(monkey
     async with _running(app):
         app._session_transition_pending = True
         try:
-            await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+            await app._attach_or_refuse(tmp_path, "remote-1")
         finally:
             app._session_transition_pending = False
 
         assert seen["target"] == "remote-1", "the redial never published its target"
         assert seen["blocked"] is True, "a submit the redial swallows was not refused"
         assert (
-            "Send unavailable until connected. Reconnecting to remote-1 — it will keep "
-            f"trying for up to {_SHIPPED_BOUND_S:g} s; switching session stops the wait."
-        ) in _notices(app), "the refused submit was silent"
+            "Send unavailable until connected. Reconnecting to session remote-1 — "
+            "switching session stops the wait."
+        ) in seen["during"], "the refused submit was silent"
+        # The TARGET is named one way and the bound is NOT restated: the retry row
+        # directly above is already carrying the number, and naming the session
+        # two ways (`session <id>` / bare `<id>`) is what design D3 found.
+        assert not [n for n in seen["during"] if "42" in n and n.startswith("Send")]
         # Cleared when the loop ends, so a later transition cannot inherit it.
         assert app._resume_retry_target == ""
+        # AND THE REFUSAL ROW DID NOT OUTLIVE IT. The refusal speaks for a state
+        # the loop owns, so the transcript after the verdict holds the verdict —
+        # nothing underneath still claiming the dial is running (UX U1).
+        assert _notices(app) == [_gave_up("the runtime is not responding")]
+        assert app._composer_refusal_notice is None
+
+
+@pytest.mark.asyncio
+async def test_a_redial_cancelled_by_a_sidebar_switch_settles_its_row(monkeypatch, tmp_path):
+    """The THIRD exit: a switch away leaves no live promise behind (D1/m4/Q2).
+
+    Three independent round-2 streams found this one: `verdict()` restated the
+    row on the give-up and static arms only, while the sidebar's switch cancels
+    this worker group (`_select_sidebar_session`) — so the loop died on
+    `CancelledError`, `finally` cleared `_resume_retry_target`, and the row went
+    on saying "still trying" in the session the user returned to. One more stuck
+    row per abandoned run, on the exit the new composer copy TEACHES.
+
+    Driven the way the key drives it — `cancel_group(app, "session")`, the same
+    edge the sidebar uses — with the loop parked inside a real dial, which is
+    where a silent owner holds it for a full 15 s envelope.
+
+    Asserted on the RENDERED notice, not only on the block list: QA's round-2
+    repro showed a correct-looking `pending=False`/`retry_target=''` beside a row
+    that was still on screen when the user came back (`repro_r3_stranded.py`,
+    `stranded-back-in-origin.png`).
+    """
+    app = _app(monkeypatch, tmp_path)
+    record = _record(90909, "the remote")
+    parked = asyncio.Event()
+    dials: list[Any] = []
+
+    async def connect(*_args, **_kwargs):
+        dials.append(1)
+        if len(dials) == 1:
+            raise ConnectionError("attach refused")
+        # The envelope of a live-but-silent owner: the loop is parked HERE when
+        # the user switches away.
+        parked.set()
+        await asyncio.sleep(3600)
+
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_runtime_record",
+        lambda _root, _concrete: (record, 90909),
+    )
+    monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
+
+    async with _running(app) as pilot:
+        app._run_session_transition(app._attach_or_refuse(tmp_path, "remote-1"))
+        for _ in range(200):
+            await pilot.pause()
+            if parked.is_set():
+                break
+        assert parked.is_set(), "the redial never reached its second dial"
+        assert _notices(app) == [
+            f"reconnecting to session remote-1 — still trying, about "
+            f"{_SHIPPED_BOUND_S:g}\u00a0s in total"
+        ]
+        # And a refused Enter mid-wait, which writes the composer's own row: the
+        # same abandon falsifies its forward-looking clause too, so BOTH rows
+        # have to end with the wait (design D1 — "the composer's refusal row
+        # needs the same treatment on that exit").
+        app.composer_submission_refused()
+        assert len(_notices(app)) == 2, "the refusal did not speak"
+
+        # The sidebar's own abort. `cancel_group` is what a switch calls before
+        # the navigation starts, so this is the real edge rather than a
+        # hand-raised CancelledError.
+        app.workers.cancel_group(app, "session")
+        for _ in range(200):
+            await pilot.pause()
+            if not app._session_transition_pending:
+                break
+
+        assert len(dials) == 2, "the cancelled redial kept dialling"
+        assert app._resume_retry_target == ""
+        assert app._session_transition_pending is False
+        # ONE settled statement, in the past tense: the row the loop narrated,
+        # restated — not a second row under it and not the live one.
+        assert _notices(app) == [_stopped()]
+        rendered = _rendered_text(app)
+        assert "still trying" not in rendered, "a dead redial is still promising a dial"
+        # The AUTHORED statement, whitespace-collapsed: what the view paints is
+        # the same sentence wrapped to the block's own measure, so the claim is
+        # about the words on screen rather than about where the fold landed.
+        assert " ".join(_stopped().split()) in " ".join(rendered.split())
+        # Nothing here is a live promise: the composer answers as it does with no
+        # redial running, because none is.
+        assert app._unavailable_hint() == ""
+
+
+@pytest.mark.asyncio
+async def test_a_redial_cancelled_during_its_first_dial_invents_no_row(monkeypatch, tmp_path):
+    """The settle restates the row the loop NARRATED; it never invents one.
+
+    A `/resume` abandoned inside its very first silent envelope has nothing on
+    screen yet, so there is nothing to correct — and the copy that would
+    otherwise be written ("the wait ended when you switched session") describes
+    a wait the user never saw. The invariant is about promises made, not about
+    exits taken.
+    """
+    app = _app(monkeypatch, tmp_path)
+    record = _record(90909, "the remote")
+    parked = asyncio.Event()
+    dials: list[Any] = []
+
+    async def connect(*_args, **_kwargs):
+        dials.append(1)
+        parked.set()
+        await asyncio.sleep(3600)
+
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_runtime_record",
+        lambda _root, _concrete: (record, 90909),
+    )
+    monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
+
+    async with _running(app) as pilot:
+        app._run_session_transition(app._attach_or_refuse(tmp_path, "remote-1"))
+        for _ in range(200):
+            await pilot.pause()
+            if parked.is_set():
+                break
+        assert parked.is_set()
+        assert _notices(app) == [], "the first envelope narrated a row already"
+
+        app.workers.cancel_group(app, "session")
+        for _ in range(200):
+            await pilot.pause()
+            if not app._session_transition_pending:
+                break
+
+        assert len(dials) == 1
+        assert _rendered_notice_rows(app) == []
+
+
+@pytest.mark.asyncio
+async def test_a_refused_enter_restates_one_row_and_never_outlives_the_verdict(
+    monkeypatch, tmp_path
+):
+    """U1: the composer's row is ONE row, and it ends with the operation.
+
+    Enter is the user's response to silence, so a durable notice per refusal made
+    the count unbounded by construction: three Enters during one redial put
+    three two-line blocks of present-tense text on screen, each retracting the
+    sentence above it — and because `verdict()` restates the retry row IN PLACE,
+    a refusal in the redial's last second was left BELOW the verdict, making the
+    stale claim the last thing read. Seven refusals here, not three, so the check
+    is about the mechanism rather than about a count that happened to fit.
+    """
+    app = _app(monkeypatch, tmp_path)
+    record = _record(90909, "the remote")
+    during: list[list[str]] = []
+    refusals: list[int] = []
+
+    async def connect(*_args, **_kwargs):
+        if len(refusals) < 7:
+            refusals.append(1)
+            app.composer_submission_refused()
+            during.append(_notices(app))
+        raise ConnectionError("the runtime is not responding")
+
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_runtime_record",
+        lambda _root, _concrete: (record, 90909),
+    )
+    monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
+
+    async with _running(app):
+        app._session_transition_pending = True
+        try:
+            await app._attach_or_refuse(tmp_path, "remote-1")
+        finally:
+            app._session_transition_pending = False
+
+        assert len(refusals) == 7, "the refusals did not all land in the redial"
+        assert (
+            len([n for n in during[-1] if n.startswith("Send unavailable")]) == 1
+        ), f"one Enter, one row — got {during[-1]}"
+        # THE VERDICT IS THE LAST THING READ, and the only notice left at all.
+        assert _notices(app) == [_gave_up("the runtime is not responding")]
+        assert "Send unavailable" not in "\n".join(_rendered_notice_rows(app))
+        assert app._composer_refusal_notice is None
+
+
+@pytest.mark.asyncio
+async def test_an_owner_with_a_live_record_under_another_session_id_is_paced_not_refused(
+    monkeypatch, tmp_path
+):
+    """review m3: `(None, pid)` is not only the publishes-no-record case.
+
+    `find_runtime_record` also returns it for the rebind race — a record for that
+    pid that is live, protocol-5 and perfectly dialable, still stamped with the
+    PREVIOUS `session_id` (its own docstring calls the welcome projection the
+    arbiter of that race). The first-attempt guard used to read the tuple as
+    "this owner is an old binary", which claimed an age the code never checked
+    and invited the user to close a healthy current-version runtime.
+
+    Paced, not dialled: the loop re-reads the record each pass and the timeout's
+    own sentence is the outcome, which is what a refusal that cannot name a
+    cause should degrade to. The pause list is asserted, so this pins the PACING
+    rather than merely the absence of the sentence.
+    """
+    app = _app(monkeypatch, tmp_path)
+    clock = _RedialClock()
+    clock.install(monkeypatch, wall_s=12.0)
+    monkeypatch.setattr(app_module, "sidebar_connect_backoff_s", lambda _attempt: 5.0)
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_runtime_record",
+        lambda _root, _concrete: (None, 91234),
+    )
+    # A live, dialable record for that pid exists under ANOTHER session_id.
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.dialable_record_exists",
+        lambda _root, _pid: True,
+    )
+
+    async def explode(*_args, **_kwargs):  # pragma: no cover - must not be reached
+        raise AssertionError("a paced absence dialled a record it never got")
+
+    monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", explode)
+
+    async with _running(app):
+        await app._attach_or_refuse(tmp_path, "remote-1")
+
+        assert clock.pauses == [5.0, 5.0, 2.0], "the refusal's pacing was skipped"
+        assert not [
+            n for n in _notices(app) if "older Local Operator process" in n
+        ], "the older-process sentence was printed for an owner the code never aged"
+        assert _notices(app) == [_gave_up(UNREACHABLE_OWNER_MESSAGE)]
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_registry_is_paced_rather_than_refused(monkeypatch, tmp_path):
+    """A failed read is not evidence of absence — so it cannot be a refusal.
+
+    `dialable_record_exists` answers `None` when the registry cannot be read at
+    all, which is why it is not a plain bool: the refusal's sentence names a
+    cause ("open in an older Local Operator process"), and a scan that raised has
+    established nothing about the process. The redial ends on the timeout's own
+    honest sentence instead.
+    """
+    app = _app(monkeypatch, tmp_path)
+    clock = _RedialClock()
+    clock.install(monkeypatch, wall_s=12.0)
+    monkeypatch.setattr(app_module, "sidebar_connect_backoff_s", lambda _attempt: 5.0)
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_runtime_record",
+        lambda _root, _concrete: (None, 91234),
+    )
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.dialable_record_exists",
+        lambda _root, _pid: None,
+    )
+
+    async with _running(app):
+        await app._attach_or_refuse(tmp_path, "remote-1")
+
+        assert clock.pauses == [5.0, 5.0, 2.0]
+        assert not [n for n in _notices(app) if "older Local Operator process" in n]
+        assert _notices(app) == [_gave_up(UNREACHABLE_OWNER_MESSAGE)]
+
+
+def test_the_redial_outranks_a_latched_source_in_the_hint(monkeypatch, tmp_path):
+    """UX U3: the composer answers for the state the app is actually in.
+
+    `_unavailable_hint` is an ordered chain, and `self._interaction` is — for the
+    current session — the very object `_connect_sidebar_session` writes, so a
+    latched `connection_error` or a spent `connect_attempts` can sit on the
+    object a live redial is asking about. Behind those two fields, a refusal
+    mid-redial would answer "Select this session again to retry." while the retry
+    row directly above says the app is already retrying and that reselection is
+    not what is owed.
+
+    UX could not DRIVE that combination (both attempts healed), so the failure
+    itself stays unreproduced; what is pinned here is that the precedence no
+    longer depends on the order two fields happen to be tested in. The retry is
+    the more specific state — the app sets it for exactly the life of its loop.
+    """
+    app = _app(monkeypatch, tmp_path)
+    app._session_transition_pending = True
+    app._resume_retry_target = "remote-1"
+    app._interaction.connection_error = "the runtime is not responding"
+    app._interaction.connect_attempts = 3
+
+    assert app._unavailable_hint() == (
+        " Reconnecting to session remote-1 — switching session stops the wait."
+    )
+
+    # With no redial live, the latched state answers exactly as it did before.
+    app._resume_retry_target = ""
+    assert app._unavailable_hint() == " Select this session again to retry."
+
+    app._interaction.connection_error = ""
+    assert app._unavailable_hint() == " Reconnecting — it will keep trying for a few more seconds."
+
+
+@pytest.mark.asyncio
+async def test_the_verdict_keeps_its_next_step_on_one_row_at_eighty_columns(monkeypatch, tmp_path):
+    """design D2: the actionable half must not be split from its argument.
+
+    As one flowing paragraph the wrap fell wherever the cells landed, and at 80
+    columns — a width the original rig never filmed — it broke between `/resume`
+    and the session id the user has to type (measured 71.4 cells then 23.1),
+    i.e. the half they must act on was the half that got split. A newline before
+    the final sentence costs nothing at the widths where the row already wraps,
+    and this pins the rendered result rather than the authored string: the whole
+    sentence has to survive as ONE row of the block.
+    """
+    app = _app(monkeypatch, tmp_path)
+    record = _record(90909, "the remote")
+
+    async def connect(*_args, **_kwargs):
+        raise ConnectionError("the runtime is not responding")
+
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_runtime_record",
+        lambda _root, _concrete: (record, 90909),
+    )
+    monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
+
+    async with app.run_test(size=(80, 24)) as pilot:  # type: ignore[attr-defined]
+        for _ in range(40):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        await app._attach_or_refuse(tmp_path, "remote-1")
+
+        rows = [row.strip() for row in _rendered_notice_rows(app)]
+        assert (
+            "Run /resume remote-1 again to retry." in rows
+        ), f"the next step was split across rows: {rows}"
+        # And it is still TWO authored statements, so the wider widths cannot
+        # silently rejoin it into the paragraph this replaced.
+        assert _gave_up("the runtime is not responding").count("\n") == 1

--- a/tests/unit/tui/test_resume_connect_retry.py
+++ b/tests/unit/tui/test_resume_connect_retry.py
@@ -1,0 +1,310 @@
+"""`/resume`'s dial is bounded-retried, not one-shot.
+
+THE DEFECT THESE PIN. `_attach_or_refuse` called `AttachedSession.connect` once
+and handed any exception straight to the user, which is the pre-#883 shape at
+the other seam: #883 gave the SIDEBAR's connect a budget so a transient owner
+loss heals by itself, and left `/resume` — the path a user reaches for when the
+sidebar has already failed them — reporting a permanent verdict for what is
+usually a runtime that is mid-restart (a `kill -9` republishes its record within
+a second or two). The visible cost was the operator re-typing `/resume`.
+
+What is asserted here is the POLICY — retried, bounded, record re-read per
+attempt, static refusals not retried — driven through the real `_attach_or_refuse`
+with only its two seams (`find_runtime_record`, `AttachedSession.connect`)
+stubbed, exactly as `test_stop_command.py` drives it.
+
+NO WALL-CLOCK ASSERTIONS. The budget is a COUNT of dials against
+`RESUME_CONNECT_ATTEMPTS`, and the backoff is collapsed to zero so the policy is
+testable at speed; the derivation that sizes the real schedule is asserted as a
+RELATIONSHIP in `test_the_retry_budget_outlasts_the_facade_give_up_bound`.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.session.attached import RECOVERY_GIVE_UP_S
+from local_operator.session.frontend_state import FRONTEND_CAPABILITY
+from local_operator.session.runtime.types import SessionRecord
+from local_operator.tui import app as app_module
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+#: The shipped schedule, captured at import BEFORE any test patches it for
+#: speed: the property under test is what a user's next `/resume` actually gets.
+_SHIPPED_BACKOFF_S = app_module.SIDEBAR_CONNECT_BACKOFF_S
+_SHIPPED_CEILING_S = app_module.SIDEBAR_CONNECT_BACKOFF_CEILING_S
+_SHIPPED_ATTEMPTS = app_module.RESUME_CONNECT_ATTEMPTS
+
+
+class _Stranded(Exception):
+    """Raised in the swap window to stop a test at the point it asserts."""
+
+
+@pytest.fixture(autouse=True)
+def isolate(tmp_path, monkeypatch):
+    # An inherited CMUX_* variable lets a headless app rename the operator's
+    # real multiplexer workspaces; HOME is redirected too because the cache
+    # root is derived from it independently of LOCAL_OPERATOR_CONFIG_DIR.
+    for key in tuple(os.environ):
+        if key.startswith("CMUX_"):
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_NOTIFICATIONS", "1")
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_TERMINAL_TITLE", "1")
+    monkeypatch.setattr(OperatorApp, "_check_for_update", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_update_check", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_terminal_title", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_multiplexer_broadcast", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_herdr_reporter", lambda _self: None)
+
+
+def _notices(app: OperatorApp) -> list[str]:
+    """Notices on screen, tolerating a transcript that has not been built yet.
+
+    The modal boot composition mounts no `TranscriptView` until the app is
+    booted, and a notice written before that lands on the screen rather than in
+    the view — which is a state these tests should not depend on either way.
+    """
+    views = list(app.query(TranscriptView))
+    if not views:
+        return []
+    return [block._text for block in views[0].blocks() if isinstance(block, NoticeBlock)]
+
+
+def _record(
+    pid: int, name: str, *, protocol: int = 5, capabilities: list[str] | None = None
+) -> SessionRecord:
+    return SessionRecord(
+        pid=pid,
+        kind="tui",
+        session_id=f"sid-{pid}",
+        conversation_name=name,
+        cwd="/tmp",
+        model_label="test/model",
+        control_port=1,
+        control_key="k",
+        protocol=protocol,
+        capabilities=[FRONTEND_CAPABILITY] if capabilities is None else capabilities,
+    )
+
+
+def _app(monkeypatch, tmp_path: Path) -> OperatorApp:
+    """A booted-independent app whose `/resume` seams the caller stubs."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    app._resume_factory = lambda _sid: _factory(FakeSession())  # type: ignore[assignment]
+    monkeypatch.setattr(app_module, "sidebar_connect_backoff_s", lambda _attempt: 0.0)
+    return app
+
+
+@asynccontextmanager
+async def _running(app: OperatorApp):
+    """An app with a built transcript, yielded so the dialog can be driven.
+
+    Booted before yielding because the notices these tests read are rendered
+    into the transcript view, which the modal boot composition has not mounted
+    yet — and kept OPEN across the assertions, because the view goes with the
+    app the moment `run_test` exits.
+    """
+    async with app.run_test(size=(100, 30)) as pilot:  # type: ignore[attr-defined]
+        for _ in range(40):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        yield pilot
+
+
+@pytest.mark.asyncio
+async def test_a_transient_connect_failure_is_retried_rather_than_reported(monkeypatch, tmp_path):
+    """The pre-#883 shape: one dial, then the exception as a verdict.
+
+    The retry is what makes a runtime that is mid-restart (a republished record
+    a second later) invisible to the user, so the assertion is that the SECOND
+    dial happened — and that the user was shown a live retry rather than an
+    error in the meantime.
+    """
+    app = _app(monkeypatch, tmp_path)
+    record = _record(90909, "the remote")
+    dials: list[Any] = []
+    # RECORDED, never raised: anything raised inside the stub is caught by the
+    # connect body's own handler and read as one more transient failure, so an
+    # assertion here would turn into a retry instead of a failure (the sidebar
+    # file learned this the hard way).
+    seen_between_attempts: list[list[str]] = []
+
+    async def connect(record_arg, *_args, **_kwargs):
+        dials.append(record_arg)
+        if len(dials) == 1:
+            raise ConnectionError("attach refused")
+        seen_between_attempts.append(_notices(app))
+        return FakeSession()
+
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_runtime_record",
+        lambda _root, _concrete: (record, 90909),
+    )
+    monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
+    # The swap window's first step, so the test stops where it was going to
+    # assert rather than stepping into a real adoption.
+    monkeypatch.setattr(
+        OperatorApp, "_reset_ledger_for_swap", lambda _self: (_ for _ in ()).throw(_Stranded())
+    )
+
+    async with _running(app):
+        with pytest.raises(_Stranded):
+            await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+
+        assert len(dials) == 2, "a transient failure was not retried"
+        notices = _notices(app)
+        assert not [
+            n for n in notices if n == "attach refused"
+        ], "the user was shown a verdict for a dial that was already being retried"
+        # BETWEEN the attempts the user is told a redial is running, which is
+        # the whole point of narrating it: the alternative they used to get was
+        # an error for a dial that was about to succeed.
+        assert seen_between_attempts, "the second dial never ran"
+        assert [
+            n for n in seen_between_attempts[0] if n.startswith("reconnecting to session")
+        ], seen_between_attempts[0]
+        # ...and once the dial SUCCEEDS the row is retired, rather than left
+        # claiming a reconnect that has already happened.
+        assert not [n for n in notices if n.startswith("reconnecting to session")]
+
+
+@pytest.mark.asyncio
+async def test_only_exhaustion_latches_and_it_says_so_honestly(monkeypatch, tmp_path):
+    """A genuinely unreachable owner still reaches the user — after the budget.
+
+    The terminal state is what the budget is FOR, not an alternative to it. The
+    count is asserted against the derived constant rather than a literal, so a
+    retuned schedule cannot turn this into a permanently-failing loop or into a
+    one-shot by accident.
+    """
+    app = _app(monkeypatch, tmp_path)
+    record = _record(90909, "the remote")
+    dials: list[Any] = []
+
+    async def connect(record_arg, *_args, **_kwargs):
+        dials.append(record_arg)
+        raise ConnectionError("attach refused")
+
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_runtime_record",
+        lambda _root, _concrete: (record, 90909),
+    )
+    monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
+
+    async with _running(app):
+        await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+
+        assert len(dials) == _SHIPPED_ATTEMPTS + 1
+        notices = _notices(app)
+        assert notices[-1] == "attach refused"
+        # ONE live row for the whole redial, restated in place: the budget can
+        # run for the facade's entire give-up bound, and a notice per attempt
+        # would write a hundred durable rows to say one thing.
+        assert len([n for n in notices if n.startswith("reconnecting to session")]) == 1
+
+
+@pytest.mark.asyncio
+async def test_the_runtime_record_is_re_read_before_every_attempt(monkeypatch, tmp_path):
+    """A retired runtime republishes under a NEW pid.
+
+    Reusing the first record would spend the whole budget redialling a socket
+    that cannot answer, so the lookup is per attempt — the same reason
+    `AttachedSession._recover_runtime` re-reads. The second dial must therefore
+    be handed the SECOND record, not the first.
+    """
+    app = _app(monkeypatch, tmp_path)
+    first = _record(90909, "the remote")
+    republished = _record(91555, "the remote")
+    lookups: list[str] = []
+    dialled: list[Any] = []
+
+    def lookup(_root, concrete):
+        lookups.append(concrete)
+        return (first, 90909) if len(lookups) == 1 else (republished, 91555)
+
+    async def connect(record_arg, *_args, **_kwargs):
+        dialled.append(record_arg)
+        if len(dialled) == 1:
+            raise ConnectionError("attach refused")
+        return FakeSession()
+
+    monkeypatch.setattr("local_operator.mobile.attach_client.find_runtime_record", lookup)
+    monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
+    monkeypatch.setattr(
+        OperatorApp, "_reset_ledger_for_swap", lambda _self: (_ for _ in ()).throw(_Stranded())
+    )
+
+    async with _running(app):
+        with pytest.raises(_Stranded):
+            await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+
+        assert len(lookups) == 2, "the record was captured once and reused"
+        assert [r.pid for r in dialled] == [
+            90909,
+            91555,
+        ], "the redial was pointed at the retired pid instead of the republished one"
+
+
+@pytest.mark.asyncio
+async def test_a_static_refusal_is_not_retried(monkeypatch, tmp_path):
+    """A capability gap is a property of the owner, not of the moment.
+
+    Every redial would raise the identical refusal, so a budget spent on it is
+    just a longer way to the same sentence. Read off the same record `connect`
+    refused, so the two can never disagree.
+    """
+    app = _app(monkeypatch, tmp_path)
+    record = _record(90909, "the remote", capabilities=[])
+    dials: list[Any] = []
+
+    async def connect(*_args, **_kwargs):
+        dials.append(1)
+        raise ConnectionError(
+            f"owner lacks {FRONTEND_CAPABILITY}; canonical full-TUI attach needs protocol >= 5"
+        )
+
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_runtime_record",
+        lambda _root, _concrete: (record, 90909),
+    )
+    monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
+
+    async with _running(app):
+        await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+
+        assert len(dials) == 1, "a static refusal was retried"
+        assert _notices(app)[-1] == (
+            f"owner lacks {FRONTEND_CAPABILITY}; canonical full-TUI attach needs protocol >= 5"
+        )
+
+
+def test_the_retry_budget_outlasts_the_facade_give_up_bound():
+    """THE RELATIONSHIP, not the number — the way this fix regresses quietly.
+
+    `/resume` builds a TERMINAL facade, whose give-up bound is
+    `RECOVERY_GIVE_UP_S` rather than the sidebar viewer's `COLD_FALLBACK_S`, so
+    that is what the budget has to outlast. Pinned as an inequality between the
+    two constants because that is the property: asserting either number instead
+    would go green on a tree where the bound had grown past the budget — which
+    is the original defect, silently restored.
+    """
+    schedule = [
+        app_module.sidebar_connect_backoff_s(attempt) for attempt in range(1, _SHIPPED_ATTEMPTS + 1)
+    ]
+    assert sum(schedule) > RECOVERY_GIVE_UP_S
+    # Not merely wider by a rounding error: the last attempt must land clearly
+    # past the bound on a loaded machine, not tie with it.
+    assert sum(schedule) > RECOVERY_GIVE_UP_S * 1.25
+    # One attempt fewer must NOT clear the bound, which is what makes the
+    # derived count minimal rather than an arbitrary large number.
+    assert sum(schedule[:-1]) <= RECOVERY_GIVE_UP_S * 1.5

--- a/tests/unit/tui/test_resume_connect_retry.py
+++ b/tests/unit/tui/test_resume_connect_retry.py
@@ -10,13 +10,17 @@ a second or two). The visible cost was the operator re-typing `/resume`.
 
 What is asserted here is the POLICY — retried, bounded, record re-read per
 attempt, static refusals not retried — driven through the real `_attach_or_refuse`
-with only its two seams (`find_runtime_record`, `AttachedSession.connect`)
-stubbed, exactly as `test_stop_command.py` drives it.
+with only its seams (`find_runtime_record`, `AttachedSession.connect`, the redial
+clock) stubbed, exactly as `test_stop_command.py` drives it.
 
-NO WALL-CLOCK ASSERTIONS. The budget is a COUNT of dials against
-`RESUME_CONNECT_ATTEMPTS`, and the backoff is collapsed to zero so the policy is
-testable at speed; the derivation that sizes the real schedule is asserted as a
-RELATIONSHIP in `test_the_retry_budget_outlasts_the_facade_give_up_bound`.
+THE BOUND IS WALL CLOCK, SO THE CLOCK IS A SEAM. `_attach_or_refuse` reads its
+time through `_resume_redial_clock` and waits through `_resume_redial_pause`;
+those two exist so a test can drive a VIRTUAL clock past the deadline instead of
+measuring a duration, which AGENTS.md's "Timing, flakes" section forbids and
+which would be a bet on machine load in any case. The backoff is collapsed to
+zero (or replaced outright) for the same reason, and the derivation that sizes
+the real budget is asserted as a RELATIONSHIP in
+`test_the_budget_outlasts_the_transient_window_and_stays_in_tens_of_seconds`.
 """
 
 from __future__ import annotations
@@ -28,7 +32,12 @@ from typing import Any
 
 import pytest
 
-from local_operator.session.attached import RECOVERY_GIVE_UP_S
+from local_operator.session.attached import (
+    COLD_FALLBACK_S,
+    FRONTEND_ATTACH_MIN_PROTOCOL,
+    FRONTEND_SYNC_FOREGROUND_S,
+    frontend_attach_refusal,
+)
 from local_operator.session.frontend_state import FRONTEND_CAPABILITY
 from local_operator.session.runtime.types import SessionRecord
 from local_operator.tui import app as app_module
@@ -41,6 +50,15 @@ from tests.unit.tui.test_app_pilot import FakeSession, _factory
 _SHIPPED_BACKOFF_S = app_module.SIDEBAR_CONNECT_BACKOFF_S
 _SHIPPED_CEILING_S = app_module.SIDEBAR_CONNECT_BACKOFF_CEILING_S
 _SHIPPED_ATTEMPTS = app_module.RESUME_CONNECT_ATTEMPTS
+_SHIPPED_WALL_S = app_module.RESUME_CONNECT_WALL_S
+_SHIPPED_BOUND_S = app_module.RESUME_CONNECT_BOUND_S
+
+
+#: The notice measure the retry row has to fit: `resume-after.geometry.json`
+#: reports the `NoticeBlock` at `[75, 2]` at 100 columns, and it stays 75 at
+#: every wider terminal — so a row longer than this always wraps and splits its
+#: own parenthetical (design D3, where the 77-78 cell row did exactly that).
+_NOTICE_MEASURE_CELLS = 75
 
 
 class _Stranded(Exception):
@@ -77,6 +95,58 @@ def _notices(app: OperatorApp) -> list[str]:
     if not views:
         return []
     return [block._text for block in views[0].blocks() if isinstance(block, NoticeBlock)]
+
+
+def _gave_up(detail: str, *, session_id: str = "remote-1") -> str:
+    """The terminal sentence, spelled the way the app spells it.
+
+    ONE concept, two spellings would drift: the app's copy names the session and
+    the next step (UX U4) around whatever the last failure's own text was, so
+    the test builds it from the same two pieces rather than pasting the whole
+    string twice.
+    """
+    return f"could not resume {session_id} — {detail}. Run /resume {session_id} again to retry."
+
+
+class _RedialClock:
+    """A VIRTUAL clock for the redial's two seams, measured in loop turns.
+
+    `RESUME_CONNECT_WALL_S` is a wall-clock bound, so the property under test is
+    "this loop stops when its budget is spent" — and AGENTS.md's "Timing,
+    flakes" section forbids asserting that with a duration: a test that sleeps
+    then asserts is a bet on machine load. This drives the deadline past itself
+    with no sleeping at all, the same shape `session_picker`'s cadence test uses
+    when it patches that widget's own module clock.
+
+    `dial_s` is what ONE attempt costs, so the interesting case — an owner that
+    is alive and silent, spending a full `FRONTEND_SYNC_FOREGROUND_S` envelope
+    per dial — is expressible as a number the test chooses rather than as a
+    machine speed it hopes for.
+    """
+
+    def __init__(self, *, dial_s: float = 0.0, start: float = 1_000.0) -> None:
+        self.started = start
+        self.now = start
+        self.dial_s = dial_s
+        #: What each backoff was asked to wait for, in order. The clamp is
+        #: asserted against this rather than against elapsed time.
+        self.pauses: list[float] = []
+
+    def clock(self) -> float:
+        return self.now
+
+    async def pause(self, seconds: float) -> None:
+        self.pauses.append(seconds)
+        self.now += seconds
+
+    def spend_dial(self) -> None:
+        self.now += self.dial_s
+
+    def install(self, monkeypatch, *, wall_s: float | None = None) -> None:
+        monkeypatch.setattr(app_module, "_resume_redial_clock", self.clock)
+        monkeypatch.setattr(app_module, "_resume_redial_pause", self.pause)
+        if wall_s is not None:
+            monkeypatch.setattr(app_module, "RESUME_CONNECT_WALL_S", wall_s)
 
 
 def _record(
@@ -204,13 +274,46 @@ async def test_only_exhaustion_latches_and_it_says_so_honestly(monkeypatch, tmp_
     async with _running(app):
         await app._attach_or_refuse(tmp_path, "remote-1", 90909)
 
-        assert len(dials) == _SHIPPED_ATTEMPTS + 1
-        notices = _notices(app)
-        assert notices[-1] == "attach refused"
-        # ONE live row for the whole redial, restated in place: the budget can
-        # run for the facade's entire give-up bound, and a notice per attempt
-        # would write a hundred durable rows to say one thing.
-        assert len([n for n in notices if n.startswith("reconnecting to session")]) == 1
+        assert len(dials) == _SHIPPED_ATTEMPTS, "the redial did not spend its budget"
+        # THE ROW IS RESTATED INTO THE VERDICT, so the transcript holds exactly
+        # ONE statement about the redial and it is in the past tense (design D1,
+        # UX U3). Asserted as the whole list because the old shape left the live
+        # row ABOVE the verdict — "reconnecting to session … (retry 48 of 48)"
+        # over "the runtime is not responding" — and a second run stacked a
+        # second pair on top of it.
+        assert _notices(app) == [_gave_up("attach refused")]
+
+
+@pytest.mark.asyncio
+async def test_a_second_resume_does_not_strand_the_first_ones_row(monkeypatch, tmp_path):
+    """Two `/resume`s leave two verdicts, not four rows (design D1, UX U3).
+
+    The give-up arm used to post the verdict and leave its live row standing, so
+    every later run inherited the previous one's — measured on the PR's own
+    frame: `notice rows on screen: 4` after a second run.
+    """
+    app = _app(monkeypatch, tmp_path)
+    record = _record(90909, "the remote")
+
+    async def connect(*_args, **_kwargs):
+        raise ConnectionError("attach refused")
+
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_runtime_record",
+        lambda _root, _concrete: (record, 90909),
+    )
+    monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
+
+    async with _running(app):
+        await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+        first = _notices(app)
+        await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+
+        assert first == [_gave_up("attach refused")]
+        assert _notices(app) == [_gave_up("attach refused")] * 2
+        assert not [
+            n for n in _notices(app) if n.startswith("reconnecting to session")
+        ], "a retry row survived the run it belonged to"
 
 
 @pytest.mark.asyncio
@@ -260,8 +363,11 @@ async def test_a_static_refusal_is_not_retried(monkeypatch, tmp_path):
     """A capability gap is a property of the owner, not of the moment.
 
     Every redial would raise the identical refusal, so a budget spent on it is
-    just a longer way to the same sentence. Read off the same record `connect`
-    refused, so the two can never disagree.
+    just a longer way to the same sentence — and since `frontend_attach_refusal`
+    already answers the question `connect` refuses on (its docstring's "ONE
+    RULE, TWO CALLERS"), the refusal is taken BEFORE spending even one dial.
+    The expected sentence is built by that function rather than pasted, so the
+    two cannot drift apart.
     """
     app = _app(monkeypatch, tmp_path)
     record = _record(90909, "the remote", capabilities=[])
@@ -269,9 +375,9 @@ async def test_a_static_refusal_is_not_retried(monkeypatch, tmp_path):
 
     async def connect(*_args, **_kwargs):
         dials.append(1)
-        raise ConnectionError(
-            f"owner lacks {FRONTEND_CAPABILITY}; canonical full-TUI attach needs protocol >= 5"
-        )
+        # The SAME sentence `connect` refuses with, taken from the canonical
+        # function rather than spelled out, so the two cannot drift apart.
+        raise ConnectionError(frontend_attach_refusal(record))
 
     monkeypatch.setattr(
         "local_operator.mobile.attach_client.find_runtime_record",
@@ -283,28 +389,358 @@ async def test_a_static_refusal_is_not_retried(monkeypatch, tmp_path):
         await app._attach_or_refuse(tmp_path, "remote-1", 90909)
 
         assert len(dials) == 1, "a static refusal was retried"
+        assert _notices(app) == [frontend_attach_refusal(record)]
+
+
+@pytest.mark.asyncio
+async def test_an_empty_record_on_the_first_attempt_is_paced_not_refused(monkeypatch, tmp_path):
+    """THE REPUBLISH GAP: `(None, None)` is what the redial exists for.
+
+    A runtime that has just been restarted publishes no record between the old
+    pid retiring and the new one arriving, and a `/resume` typed inside that
+    window used to be told the session was "open in an older Local Operator
+    process" — a statement about a process that did not exist — and returned
+    without trying again (review m1). It is paced now, and the FIRST attempt
+    doing so is the assertion: the lookup returns nothing, and the second one
+    gets a record and is dialled.
+    """
+    app = _app(monkeypatch, tmp_path)
+    record = _record(90909, "the remote")
+    lookups: list[str] = []
+    dials: list[Any] = []
+    seen: list[list[str]] = []
+
+    def lookup(_root, concrete):
+        lookups.append(concrete)
+        return (None, None) if len(lookups) == 1 else (record, 90909)
+
+    async def connect(record_arg, *_args, **_kwargs):
+        dials.append(record_arg)
+        # Sampled on the dial that FOLLOWS the paced attempt, which is the only
+        # place the row exists on this path: the success path removes it (by
+        # design — see the give-up tests for the arm that restates it instead).
+        seen.append(_notices(app))
+        return FakeSession()
+
+    monkeypatch.setattr("local_operator.mobile.attach_client.find_runtime_record", lookup)
+    monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
+    monkeypatch.setattr(
+        OperatorApp, "_reset_ledger_for_swap", lambda _self: (_ for _ in ()).throw(_Stranded())
+    )
+
+    async with _running(app):
+        with pytest.raises(_Stranded):
+            await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+
+        assert len(dials) == 1, "the empty first attempt did not reach the republished record"
+        assert lookups == ["remote-1", "remote-1"]
+        assert not [
+            n for n in _notices(app) if "older Local Operator process" in n
+        ], "an absence was reported as an older process running the session"
+        # The wait is narrated while it happens rather than staying silent until
+        # it succeeds, and the row is gone once it HAS succeeded.
+        assert [n for n in seen[0] if n.startswith("reconnecting to session")]
+        assert not [n for n in _notices(app) if n.startswith("reconnecting to session")]
+
+
+@pytest.mark.asyncio
+async def test_an_owner_that_publishes_no_record_is_refused_by_its_own_pid(monkeypatch, tmp_path):
+    """`(None, pid)`: an owner is there, and it is one no dial can reach.
+
+    The marker names a live process and the scan finds no dialable record for
+    it — an older binary, or a registrant that failed to start. That IS the case
+    the upgrade advice belongs to, and the pid it names must be the live owner's
+    rather than the (possibly stale) one the command was invoked with.
+    """
+    app = _app(monkeypatch, tmp_path)
+    dials: list[Any] = []
+
+    async def connect(*_args, **_kwargs):
+        dials.append(1)
+        raise AssertionError("an owner with no dialable record was dialled")
+
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_runtime_record",
+        lambda _root, _concrete: (None, 91234),
+    )
+    monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
+
+    async with _running(app):
+        await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+
+        assert dials == []
         assert _notices(app)[-1] == (
-            f"owner lacks {FRONTEND_CAPABILITY}; canonical full-TUI attach needs protocol >= 5"
+            "session remote-1 is open in an older Local Operator process (pid 91234) — "
+            "update or close that process, then resume again"
         )
 
 
-def test_the_retry_budget_outlasts_the_facade_give_up_bound():
+@pytest.mark.asyncio
+async def test_a_record_below_the_attach_protocol_is_refused_with_the_older_process_advice(
+    monkeypatch, tmp_path
+):
+    """One version concept, one threshold: `FRONTEND_ATTACH_MIN_PROTOCOL`.
+
+    The guard this replaces compared against a literal `4` while the canonical
+    refusal used `5`, so a protocol-4 record was dialled and then refused by the
+    very rule the guard was duplicating (review n3). A record below the current
+    build has no full-TUI attach, so the user is told to update the process —
+    the advice that belongs to this case and only this one (design D5).
+    """
+    app = _app(monkeypatch, tmp_path)
+    record = _record(90909, "the remote", protocol=FRONTEND_ATTACH_MIN_PROTOCOL - 1)
+    dials: list[Any] = []
+
+    async def connect(*_args, **_kwargs):
+        dials.append(1)
+        raise AssertionError("an owner below the attach protocol was dialled")
+
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_runtime_record",
+        lambda _root, _concrete: (record, 90909),
+    )
+    monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
+
+    async with _running(app):
+        await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+
+        assert dials == []
+        assert _notices(app)[-1] == (
+            "session remote-1 is open in an older Local Operator process (pid 90909) — "
+            "update or close that process, then resume again"
+        )
+
+
+@pytest.mark.asyncio
+async def test_an_owner_pid_that_moved_between_the_reads_is_paced_not_refused(
+    monkeypatch, tmp_path
+):
+    """A moved marker is a republish, which is the case the retry is FOR.
+
+    `find_runtime_record` derives its owner from the same `.session.pid` marker
+    the caller read, so a mismatch can only mean the marker moved between the
+    two reads. Refusing there — as the suggested guard did — would reproduce
+    m1's own defect (a sentence about a pid, and no retry) for a different
+    input, so the second attempt's record is dialled instead.
+    """
+    app = _app(monkeypatch, tmp_path)
+    record = _record(91555, "the remote")
+    dials: list[Any] = []
+
+    async def connect(record_arg, *_args, **_kwargs):
+        dials.append(record_arg)
+        return FakeSession()
+
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_runtime_record",
+        lambda _root, _concrete: (record, 91555),
+    )
+    monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
+    monkeypatch.setattr(
+        OperatorApp, "_reset_ledger_for_swap", lambda _self: (_ for _ in ()).throw(_Stranded())
+    )
+
+    async with _running(app):
+        with pytest.raises(_Stranded):
+            await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+
+        assert len(dials) == 1, "the redial refused a record whose owner pid had moved"
+        assert not [
+            n for n in _notices(app) if "older Local Operator process" in n
+        ], "the moved pid was reported as an older process"
+
+
+@pytest.mark.asyncio
+async def test_the_in_flight_row_states_the_bound_and_fits_the_notice_measure(
+    monkeypatch, tmp_path
+):
+    """The row's copy, pinned: bounded, no denominator, no internal noun.
+
+    Three findings land on this one string. It used to assert a diagnosis the
+    app had not established ("the owner is not answering" — wrong whenever there
+    is no record at all), use a noun this TUI uses nowhere else ("owner"), and
+    restate an implementation counter the user cannot act on (`retry 48 of 48`)
+    while the wait itself had no stated end (design D2/D3/D4, UX U2). It is now
+    62 cells for a typical id — inside the 75-cell notice measure, so it fits on
+    one line instead of splitting its own parenthetical.
+    """
+    app = _app(monkeypatch, tmp_path)
+    record = _record(90909, "the remote")
+    seen: list[list[str]] = []
+
+    async def connect(*_args, **_kwargs):
+        # Sampled on the SECOND dial: the row is narrated after the first one
+        # fails, which is why `seen[1]` is the first frame that can hold it.
+        seen.append(_notices(app))
+        raise ConnectionError("attach refused")
+
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_runtime_record",
+        lambda _root, _concrete: (record, 90909),
+    )
+    monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
+
+    async with _running(app):
+        await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+
+        rows = [n for n in seen[1] if n.startswith("reconnecting to session")]
+        assert rows == [
+            f"reconnecting to session remote-1 — still trying for up to " f"{_SHIPPED_BOUND_S:g} s"
+        ]
+        assert len(rows[0]) <= _NOTICE_MEASURE_CELLS, "the row splits in the notice measure"
+        assert "owner" not in rows[0]
+        assert "retry" not in rows[0]
+
+
+def test_the_budget_outlasts_the_transient_window_and_stays_in_tens_of_seconds():
     """THE RELATIONSHIP, not the number — the way this fix regresses quietly.
 
-    `/resume` builds a TERMINAL facade, whose give-up bound is
-    `RECOVERY_GIVE_UP_S` rather than the sidebar viewer's `COLD_FALLBACK_S`, so
-    that is what the budget has to outlast. Pinned as an inequality between the
-    two constants because that is the property: asserting either number instead
-    would go green on a tree where the bound had grown past the budget — which
-    is the original defect, silently restored.
+    What the budget has to outlast is the TRANSIENT WINDOW this loop exists for,
+    not the facade's `RECOVERY_GIVE_UP_S`: a record moving between
+    `live_runtime_pid` and `find_runtime_record`, an attach refusal, and a facade
+    mid-recovery for up to `COLD_FALLBACK_S` — the same window the sidebar's
+    budget is sized against, and the derivation that grew to ~14.5 minutes was
+    sizing for 90 s of a bound this command never has to survive (review M1).
+
+    Pinned as inequalities between the constants rather than as literals, and
+    deliberately with NO duration in it: a test that sleeps and asserts is a bet
+    on machine load (AGENTS.md, "Timing, flakes"). The wall-clock behaviour
+    itself is driven on a virtual clock in the tests below.
     """
-    schedule = [
-        app_module.sidebar_connect_backoff_s(attempt) for attempt in range(1, _SHIPPED_ATTEMPTS + 1)
-    ]
-    assert sum(schedule) > RECOVERY_GIVE_UP_S
-    # Not merely wider by a rounding error: the last attempt must land clearly
-    # past the bound on a loaded machine, not tie with it.
-    assert sum(schedule) > RECOVERY_GIVE_UP_S * 1.25
-    # One attempt fewer must NOT clear the bound, which is what makes the
-    # derived count minimal rather than an arbitrary large number.
-    assert sum(schedule[:-1]) <= RECOVERY_GIVE_UP_S * 1.5
+    # 50% margin over the recovery bound, the sidebar's own rule: the last paced
+    # attempt must land clearly after `_go_cold`, not tie with it on a loaded
+    # machine.
+    assert _SHIPPED_WALL_S > COLD_FALLBACK_S * 1.5
+    # ...and the fence on the OTHER side, which is the actual regression: the
+    # budget is a small number of full-envelope dials, not 49 of them.
+    envelopes = _SHIPPED_WALL_S / FRONTEND_SYNC_FOREGROUND_S
+    assert envelopes <= 2, "the wall-clock cap allows more than a couple of full-envelope dials"
+    assert _SHIPPED_BOUND_S == _SHIPPED_WALL_S + FRONTEND_SYNC_FOREGROUND_S
+    assert _SHIPPED_BOUND_S < 60, "a user-initiated command should not wait a minute"
+    # The secondary cap is the SAME span, so the two caps cannot disagree: a dial
+    # that fails instantly cannot buy more dials than the paced schedule itself
+    # would have spent the budget on.
+    assert _SHIPPED_ATTEMPTS == app_module._attempts_outlasting(_SHIPPED_WALL_S)
+
+
+@pytest.mark.asyncio
+async def test_the_redial_stops_when_the_wall_clock_is_spent_not_when_attempts_run_out(
+    monkeypatch, tmp_path
+):
+    """M1, stated as behaviour: attempt time comes off the budget.
+
+    The measured regression this closes: each dial of a live-but-silent owner
+    costs a full `FRONTEND_SYNC_FOREGROUND_S` envelope before it raises, and the
+    budget that counted only the backoff was therefore 49 dials and ~14.5
+    minutes for one `/resume`. On a virtual clock where every dial spends that
+    envelope the loop must end after TWO of them — well before
+    `RESUME_CONNECT_ATTEMPTS` — so what stopped it was the clock, not the count.
+    """
+    app = _app(monkeypatch, tmp_path)
+    record = _record(90909, "the remote")
+    clock = _RedialClock(dial_s=FRONTEND_SYNC_FOREGROUND_S)
+    clock.install(monkeypatch)
+    dials: list[Any] = []
+
+    async def connect(record_arg, *_args, **_kwargs):
+        dials.append(record_arg)
+        clock.spend_dial()
+        raise ConnectionError("the runtime is not responding")
+
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_runtime_record",
+        lambda _root, _concrete: (record, 90909),
+    )
+    monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
+
+    async with _running(app):
+        await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+
+        assert len(dials) == 2, "a silent owner spent more than two full envelopes"
+        assert len(dials) < _SHIPPED_ATTEMPTS, "the ATTEMPT cap ended the loop, not the budget"
+        # The promise the row makes to the user holds on this path: the span is
+        # the deadline plus at most the one envelope already in flight.
+        assert clock.now - clock.started <= _SHIPPED_BOUND_S
+        assert _notices(app) == [_gave_up("the runtime is not responding")]
+
+
+@pytest.mark.asyncio
+async def test_the_backoff_is_clamped_to_what_is_left_of_the_budget(monkeypatch, tmp_path):
+    """The paced wait is measured against the REMAINING budget, not against itself.
+
+    A schedule that slept its own backoff regardless would push the loop past
+    its own deadline by up to one full backoff, which is how a "bounded" loop
+    ends up unbounded in practice. Read off the pause the loop actually asked
+    for, so no duration is measured.
+    """
+    app = _app(monkeypatch, tmp_path)
+    record = _record(90909, "the remote")
+    wall_s = 12.0
+    clock = _RedialClock()
+    clock.install(monkeypatch, wall_s=wall_s)
+    # Instant dials and a backoff LONGER than the whole budget, so every pause
+    # has to be the clamp rather than the schedule.
+    monkeypatch.setattr(app_module, "sidebar_connect_backoff_s", lambda _attempt: 5.0)
+
+    async def connect(*_args, **_kwargs):
+        raise ConnectionError("the runtime is not responding")
+
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_runtime_record",
+        lambda _root, _concrete: (record, 90909),
+    )
+    monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
+
+    async with _running(app):
+        await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+
+        # 5, then 5, then the 2 s that were left — never the 5 the schedule asked
+        # for, and never a wait that outlives the deadline.
+        assert clock.pauses == [5.0, 5.0, 2.0]
+        assert clock.now - clock.started == wall_s
+        assert max(clock.pauses) <= wall_s
+
+
+@pytest.mark.asyncio
+async def test_the_composer_says_what_is_happening_during_a_resume_redial(monkeypatch, tmp_path):
+    """U1: a refused Enter speaks, and names the session it is reconnecting to.
+
+    Enter is refused for the whole redial — `composer_submission_blocked` decides
+    that and is unchanged — but the refusal used to say NOTHING, because it only
+    spoke when the source was `display_only` or frame-pending and a `/resume`
+    redial runs over a still-live session. Measured for 136 s: draft kept, no
+    notice, no band change, no toast, and a retyped `/resume target` left sitting
+    in the buffer. Read from INSIDE the real loop, so this pins live state rather
+    than a state the test assembled by hand.
+    """
+    app = _app(monkeypatch, tmp_path)
+    record = _record(90909, "the remote")
+    seen: dict[str, Any] = {}
+
+    async def connect(*_args, **_kwargs):
+        seen["target"] = app._resume_retry_target
+        seen["blocked"] = app.composer_submission_blocked("/resume other")
+        app.composer_submission_refused()
+        raise ConnectionError("the runtime is not responding")
+
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_runtime_record",
+        lambda _root, _concrete: (record, 90909),
+    )
+    monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
+
+    async with _running(app):
+        app._session_transition_pending = True
+        try:
+            await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+        finally:
+            app._session_transition_pending = False
+
+        assert seen["target"] == "remote-1", "the redial never published its target"
+        assert seen["blocked"] is True, "a submit the redial swallows was not refused"
+        assert (
+            "Send unavailable until connected. Reconnecting to remote-1 — it will keep "
+            f"trying for up to {_SHIPPED_BOUND_S:g} s; switching session stops the wait."
+        ) in _notices(app), "the refused submit was silent"
+        # Cleared when the loop ends, so a later transition cannot inherit it.
+        assert app._resume_retry_target == ""

--- a/tests/unit/tui/test_resume_connect_retry.py
+++ b/tests/unit/tui/test_resume_connect_retry.py
@@ -26,8 +26,11 @@ the real budget is asserted as a RELATIONSHIP in
 from __future__ import annotations
 
 import asyncio
+import json
 import os
+import time
 from contextlib import asynccontextmanager
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -41,7 +44,8 @@ from local_operator.session.attached import (
     frontend_attach_refusal,
 )
 from local_operator.session.frontend_state import FRONTEND_CAPABILITY
-from local_operator.session.runtime.types import SessionRecord
+from local_operator.session.runtime import registry
+from local_operator.session.runtime.types import HEARTBEAT_TIMEOUT_S, SessionRecord
 from local_operator.tui import app as app_module
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.session_navigation import UNREACHABLE_OWNER_MESSAGE
@@ -105,6 +109,19 @@ def _rendered_text(app: OperatorApp) -> str:
     return " ".join(" ".join(_rendered_notice_rows(app)).split())
 
 
+def _notice_blocks(app: OperatorApp) -> list[NoticeBlock]:
+    """The notice BLOCKS on screen, by identity, in visual order.
+
+    `_notices` compares authored strings, which cannot tell one identical block
+    from two. A claim that a run settled INTO an existing row rather than beside
+    it is a claim about identity, so it has to read the widgets.
+    """
+    blocks: list[NoticeBlock] = []
+    for view in app.query(TranscriptView):
+        blocks.extend(block for block in view.blocks() if isinstance(block, NoticeBlock))
+    return blocks
+
+
 def _rendered_notice_rows(app: OperatorApp) -> list[str]:
     """What the notices actually PAINT, one entry per rendered row.
 
@@ -148,11 +165,14 @@ def _gave_up(detail: str, *, session_id: str = "remote-1") -> str:
 def _stopped(*, session_id: str = "remote-1") -> str:
     """The sentence a redial that never reached a verdict leaves behind.
 
-    The cancellation exit — the sidebar switch — which is the exit the
-    composer copy teaches as the way to stop the wait.
+    The cancellation exit. It names NO cause, on purpose: the sidebar's switch
+    and Textual's own shutdown (`workers.cancel_all()` when the message loop
+    ends) take the same arm, so a sentence claiming a switch can be false for a
+    quit (review round 3, MINOR-1) — and the row is durable, so a false cause
+    can outlive the process that wrote it.
     """
     return (
-        f"resume of {session_id} stopped — the wait ended when you switched session.\n"
+        f"resume of {session_id} stopped — the wait ended without connecting.\n"
         f"Run /resume {session_id} again to retry."
     )
 
@@ -304,7 +324,7 @@ async def test_a_transient_connect_failure_is_retried_rather_than_reported(monke
         # claiming a reconnect that has already happened.
         assert not [n for n in notices if n.startswith("reconnecting to session")]
         # NOTHING AT ALL, which is the sharper form of the same claim: a row
-        # restated into "the wait ended when you switched session" also stops
+        # restated into "the wait ended without connecting" also stops
         # starting with "reconnecting", and it would be FALSE here — the attach
         # succeeded. That is what the settled flag at the break is for.
         assert notices == [], notices
@@ -937,14 +957,140 @@ async def test_a_redial_cancelled_by_a_sidebar_switch_settles_its_row(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_a_redial_cancelled_by_a_shutdown_names_no_cause(monkeypatch, tmp_path):
+    """MINOR-1 (round 3): Textual's shutdown takes the same arm as a switch.
+
+    `workers.cancel_all()` — which `_process_messages_loop`'s `finally` calls
+    when the message loop ends — cancels this worker on a quit exactly as the
+    sidebar's switch does, so the sentence that used to read "the wait ended when
+    you switched session" was false for every shutdown. The row is durable, so a
+    false cause could be read on the next launch beside a session the user never
+    left. What is true of both is that the resume never completed, and the row
+    now says that instead.
+
+    Driven on the real shutdown edge (`cancel_all`, the call Textual itself
+    makes) rather than by hand-raising a `CancelledError`, so the equivalence
+    the copy now rests on is executed. The how-to-retry half is asserted too: a
+    neutral cause must not cost the user their next step.
+    """
+    app = _app(monkeypatch, tmp_path)
+    record = _record(90909, "the remote")
+    parked = asyncio.Event()
+    dials: list[Any] = []
+
+    async def connect(*_args, **_kwargs):
+        dials.append(1)
+        if len(dials) == 1:
+            raise ConnectionError("attach refused")
+        parked.set()
+        await asyncio.sleep(3600)
+
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_runtime_record",
+        lambda _root, _concrete: (record, 90909),
+    )
+    monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
+
+    async with _running(app) as pilot:
+        app._run_session_transition(app._attach_or_refuse(tmp_path, "remote-1"))
+        for _ in range(200):
+            await pilot.pause()
+            if parked.is_set():
+                break
+        assert parked.is_set(), "the redial never reached its second dial"
+
+        app.workers.cancel_all()
+        for _ in range(200):
+            await pilot.pause()
+            if not app._session_transition_pending:
+                break
+
+        assert _notices(app) == [_stopped()]
+        # The cause is not asserted, because the code cannot establish one: no
+        # `switch`/`switched` anywhere on the rendered surface.
+        assert "switch" not in _rendered_text(app).lower()
+        assert "Run /resume remote-1 again to retry." in _rendered_text(app)
+
+
+@pytest.mark.asyncio
+async def test_a_second_abandonment_does_not_repeat_the_first_ones_sentence(monkeypatch, tmp_path):
+    """D1 (round 3): one settled sentence per conversation, because the words
+    carry no per-run information.
+
+    The cancellation sentence names only the session, so a SECOND abandoned
+    redial settled its fresh row into a byte-identical copy of the one already
+    in the view — measured on the round-3 head as `notice rows on screen: 2`,
+    regions `(12,14,75,3)` and `(12,18,75,3)`. Two adjacent identical blocks
+    say nothing the first one did not, so the run contributes no second copy
+    and the block that goes is its own live row.
+
+    NOT the verdict case: `test_a_second_resume_does_not_strand_the_first_ones_row`
+    keeps two identical VERDICTS (approved in rounds 1-2), and this narrowing
+    matches on the settle text only.
+    """
+    app = _app(monkeypatch, tmp_path)
+    record = _record(90909, "the remote")
+    parked: list[asyncio.Event] = []
+    dials: list[Any] = []
+
+    async def connect(*_args, **_kwargs):
+        dials.append(1)
+        # Odd dials fail, so every run narrates a row before its wait; even ones
+        # park where a switch finds the loop — the shape the `cancel2` rig drove.
+        if len(dials) % 2:
+            raise ConnectionError("attach refused")
+        event = asyncio.Event()
+        parked.append(event)
+        event.set()
+        await asyncio.sleep(3600)
+
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_runtime_record",
+        lambda _root, _concrete: (record, 90909),
+    )
+    monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", connect)
+
+    async with _running(app) as pilot:
+        previous: NoticeBlock | None = None
+        for run in (1, 2):
+            app._run_session_transition(app._attach_or_refuse(tmp_path, "remote-1"))
+            for _ in range(200):
+                await pilot.pause()
+                if len(parked) == run:
+                    break
+            assert len(parked) == run, f"run {run} never reached its parked dial"
+            assert _notices(app)[-1].startswith("reconnecting to session remote-1")
+            app.workers.cancel_group(app, "session")
+            for _ in range(200):
+                await pilot.pause()
+                if not app._session_transition_pending:
+                    break
+            if run == 1:
+                # The row the first abandonment leaves behind. The second run
+                # must settle INTO this block, not append a copy beside it
+                # (design D1) — hence the identity check below.
+                previous = _notice_blocks(app)[0]
+
+        assert len(parked) == 2, "the second run never started, so D1 is untested"
+        assert previous is not None, "the first run's settled row was never captured"
+        rows = _rendered_notice_rows(app)
+        # ONE settled sentence for the conversation, and it is the FIRST run's
+        # own row, kept and restated rather than a second copy appended.
+        assert _notice_blocks(app) == [previous]
+        assert sum(1 for row in rows if "resume of remote-1 stopped" in row) == 1
+        assert _notices(app) == [_stopped()]
+        assert "still trying" not in _rendered_text(app)
+
+
+@pytest.mark.asyncio
 async def test_a_redial_cancelled_during_its_first_dial_invents_no_row(monkeypatch, tmp_path):
     """The settle restates the row the loop NARRATED; it never invents one.
 
     A `/resume` abandoned inside its very first silent envelope has nothing on
     screen yet, so there is nothing to correct — and the copy that would
-    otherwise be written ("the wait ended when you switched session") describes
-    a wait the user never saw. The invariant is about promises made, not about
-    exits taken.
+    otherwise be written ("the wait ended without connecting") describes a wait
+    the user never saw. The invariant is about promises made, not about exits
+    taken.
     """
     app = _app(monkeypatch, tmp_path)
     record = _record(90909, "the remote")
@@ -1105,6 +1251,63 @@ async def test_an_unreadable_registry_is_paced_rather_than_refused(monkeypatch, 
 
         assert clock.pauses == [5.0, 5.0, 2.0]
         assert not [n for n in _notices(app) if "older Local Operator process" in n]
+        assert _notices(app) == [_gave_up(UNREACHABLE_OWNER_MESSAGE)]
+
+
+@pytest.mark.asyncio
+async def test_a_wedged_owner_is_paced_rather_than_told_it_is_an_older_process(
+    monkeypatch, tmp_path
+):
+    """review round 3 MINOR-2: `wedged` is not `absent`.
+
+    The registry has a third state — the pid is alive and the heartbeat is older
+    than `HEARTBEAT_TIMEOUT_S`, i.e. the owner is stuck — and it keeps that
+    record for exactly the reason the redial exists: a stuck owner may recover
+    on its own, which is the transient the budget outlasts. `dialable_record_exists`
+    asked only for `live`, so a wedged owner answered `False` and earned the
+    older-process sentence with the pacing skipped: a cause the code had not
+    established, printed for a current-version process that a redial could have
+    healed.
+
+    Driven through the REAL registry and the REAL `.session.pid` marker rather
+    than a stubbed classification of them, so the state under test is the one
+    `scan` actually produces — and the instrument is asserted first, because a
+    test that quietly drove the `live` branch would say nothing about this
+    finding.
+    """
+    app = _app(monkeypatch, tmp_path)
+    clock = _RedialClock()
+    clock.install(monkeypatch, wall_s=12.0)
+    monkeypatch.setattr(app_module, "sidebar_connect_backoff_s", lambda _attempt: 5.0)
+
+    # A record for a REAL, live pid — this test process — aged past the
+    # heartbeat timeout, plus the claim marker naming it. Both are the files
+    # `find_runtime_record` reads in production.
+    record = replace(_record(os.getpid(), "the remote"), session_id="remote-1")
+    registry.publish(record, root=tmp_path)
+    published = registry.record_path(record.pid, root=tmp_path)
+    payload = json.loads(published.read_text())
+    payload["heartbeat_at"] = time.time() - (HEARTBEAT_TIMEOUT_S + 5.0)
+    published.write_text(json.dumps(payload))
+    marker = tmp_path / "sessions" / "remote-1"
+    marker.mkdir(parents=True, exist_ok=True)
+    (marker / ".session.pid").write_text(str(record.pid))
+
+    states = [state for found, state in registry.scan(tmp_path) if found.pid == record.pid]
+    assert states == ["wedged"], "the record is not wedged, so nothing below is about MINOR-2"
+
+    async def explode(*_args, **_kwargs):  # pragma: no cover - must not be reached
+        raise AssertionError("a wedged owner's record is never handed to a dial")
+
+    monkeypatch.setattr("local_operator.session.attached.AttachedSession.connect", explode)
+
+    async with _running(app):
+        await app._attach_or_refuse(tmp_path, "remote-1")
+
+        assert clock.pauses == [5.0, 5.0, 2.0], "the wedged owner's pacing was skipped"
+        assert not [
+            n for n in _notices(app) if "older Local Operator process" in n
+        ], "the older-process sentence was printed for a process the code never aged"
         assert _notices(app) == [_gave_up(UNREACHABLE_OWNER_MESSAGE)]
 
 

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -1985,8 +1985,92 @@ def test_a_marker_change_with_nothing_busy_still_repaints() -> None:
     assert repaints["n"] == 0, "an unchanged settled store must stay cheap"
 
     state["live"] = "wedged"
+    # The live-marker read is on a BOUNDED cadence now (`LIVE_REFRESH_INTERVAL_S`
+    # in the widget), so this test drives the refresh explicitly instead of
+    # assuming the frame rate is it. What is pinned here is the
+    # repaint-on-visible-change property; the cadence has its own test
+    # (`test_the_overlay_is_not_re_run_on_every_tick`).
+    screen._live_refreshed_at = float("-inf")
     screen._tick()
     assert repaints["n"] == 1, "a marker transition must reach the screen"
+
+
+def test_the_overlay_is_not_re_run_on_every_tick(monkeypatch) -> None:
+    """The overlay's cost was per FRAME; the design says per visible change.
+
+    `_tick` runs at `SPINNER_INTERVAL_S` (12.5 Hz) and called `refresh`
+    unconditionally — one `registry.scan()` (a glob, a JSON parse per record, a
+    `ps` per quiet-heartbeat record) plus `read_index()` — while its own
+    docstring claimed the refresh was "skipped entirely when no row is
+    animating". An open picker over a store of cold sessions therefore
+    re-scanned the whole store twelve times a second to discover that nothing
+    had changed.
+
+    Driven with a fake clock so the cadence is asserted EXACTLY rather than
+    inferred from how fast the test machine happened to run: the property is a
+    ratio of refreshes to frames, and nothing here measures a duration.
+    """
+    import time as real_time
+
+    from local_operator.resume import SessionRow
+    from local_operator.tui.widgets import session_picker as picker_module
+    from local_operator.tui.widgets.session_picker import (
+        LIVE_REFRESH_INTERVAL_S,
+        SPINNER_INTERVAL_S,
+        SessionPickerScreen,
+    )
+
+    clock = {"t": 0.0}
+
+    class _Clock:
+        # Patched onto the widget's own module reference, not onto `time`
+        # itself: only this picker sees it, and pytest's own timing is untouched.
+        @staticmethod
+        def monotonic() -> float:
+            return clock["t"]
+
+    monkeypatch.setattr(picker_module, "time", _Clock)
+
+    now = real_time.time()
+    rows = [SessionRow(id="aaaaaaaaaaa1", mtime=now, name="only", live_state="idle")]
+    refreshes = {"n": 0}
+
+    def refresh(current: list[SessionRow]) -> list[SessionRow]:
+        refreshes["n"] += 1
+        return list(current)
+
+    screen = SessionPickerScreen(rows, now, refresh_live_state=refresh)
+
+    class _Body:
+        is_mounted = True
+
+        def update(self, _text: object) -> None:
+            return None
+
+    screen._body = _Body()  # type: ignore[assignment]
+
+    # One second of frames (0.00 through 0.96 s) — one refresh, not thirteen.
+    for tick in range(13):
+        clock["t"] = tick * SPINNER_INTERVAL_S
+        screen._tick()
+    assert refreshes["n"] == 1, "the overlay was re-run once per frame"
+
+    # A CADENCE, not a one-off: the next interval refreshes again, which is what
+    # keeps a row that REORDERS (a session parking on a gate, nothing animating)
+    # from freezing on screen — the property the D10 tests above pin.
+    clock["t"] += LIVE_REFRESH_INTERVAL_S
+    screen._tick()
+    assert refreshes["n"] == 2
+
+    # ...and the frame counter still runs at the FRAME rate while a row is
+    # busy, because that is motion and it is the honest thing for a running
+    # marker to show. The data stays on the slower cadence.
+    screen._all = [row._replace(live_state="busy") for row in screen._all]
+    before_frames = screen._frame
+    for _ in range(5):
+        clock["t"] += SPINNER_INTERVAL_S
+        screen._tick()
+    assert screen._frame == before_frames + 5, "the spinner stopped animating"
 
 
 def test_a_pure_reorder_with_identical_content_still_repaints() -> None:

--- a/tests/unit/tui/test_sidebar_connect_retry.py
+++ b/tests/unit/tui/test_sidebar_connect_retry.py
@@ -47,6 +47,7 @@ from local_operator.tui import app as app_module
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.session_interaction import SessionInteraction
 from local_operator.tui.session_navigation import OwnerWentCold, SurfaceNotReady
+from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
 #: The shipped schedule, captured at import BEFORE any test patches it for
@@ -1028,38 +1029,58 @@ async def test_guidance_answers_wait_or_act_in_every_disconnected_state(monkeypa
     async with app.run_test(size=(100, 30)) as pilot:
         source = await _current_source(app, pilot, session)
         source.display_only = True
-        notices: list[str] = []
-        monkeypatch.setattr(app, "_notice", lambda text, kind="info": notices.append(text))
+
+        def composer_notice() -> str:
+            """The text of the row a refused Enter is speaking through.
+
+            The composer's refusal OWNS its row now — one block per state,
+            restated in place and retired when the state ends (UX U1) — so this
+            reads the block it holds rather than the last block in the view:
+            the slash-command refusal below appends its own row AFTER it, and a
+            restated row is not the newest one on screen. `latest_notice` is the
+            probe for that second path.
+            """
+            notice = app._composer_refusal_notice
+            assert notice is not None and notice.is_attached, "the refused Enter said nothing"
+            return notice.text()
+
+        def latest_notice() -> str:
+            """The text of the LAST notice in the transcript."""
+            views = list(app.query(TranscriptView))
+            blocks = [b for b in views[0].blocks() if isinstance(b, NoticeBlock)]
+            assert blocks, "nothing was said at all"
+            return blocks[-1].text()
 
         # Mid-retry: the app is working and the user need not act.
         source.connect_attempts = 2
         source.connection_error = ""
         app.composer_submission_refused()
-        assert "Reconnecting" in notices[-1]
-        assert "Select this session again" not in notices[-1]
+        assert "Reconnecting" in composer_notice()
+        assert "Select this session again" not in composer_notice()
         # The SLASH-COMMAND refusal carries the same three-state guidance. It is
         # a second caller of `_unavailable_hint` with eight call sites of its
         # own, and it reads the hint through a different guard — so the composer
         # assertions above do not cover it, and the inverted-guidance bug was
         # fixed here separately.
         assert app._allow_source_command() is False, "a cold source must refuse the command"
-        assert "Reconnecting" in notices[-1]
-        assert "Select this session again" not in notices[-1]
+        assert "Reconnecting" in latest_notice()
+        assert "Select this session again" not in latest_notice()
 
         # Exhausted: the app has stopped, and reselecting is the right advice.
         source.connection_error = "the runtime is not responding"
         app.composer_submission_refused()
-        assert "Select this session again to retry." in notices[-1]
+        assert "Select this session again to retry." in composer_notice()
         assert app._allow_source_command() is False, "a cold source must refuse the command"
-        assert "Select this session again to retry." in notices[-1]
+        assert "Select this session again to retry." in latest_notice()
 
-        # Never-attempted: nothing to say beyond the refusal itself.
+        # NEVER-ATTEMPTED: the composer's row is RESTATED, not stacked, so the
+        # second refusal leaves one row where it had one before (UX U1).
         source.connect_attempts = 0
         source.connection_error = ""
         app.composer_submission_refused()
-        assert notices[-1] == "Send unavailable until connected."
+        assert composer_notice() == "Send unavailable until connected."
         assert app._allow_source_command() is False, "a cold source must refuse the command"
-        assert notices[-1] == "Commands unavailable until connected."
+        assert latest_notice() == "Commands unavailable until connected."
 
 
 def test_the_derivation_refuses_a_backoff_it_cannot_solve(monkeypatch):
@@ -1192,3 +1213,40 @@ async def test_the_connect_prepares_with_refresh_so_no_frame_return_is_unreachab
         # And a bound, cold-free connect with no frame still settles as connected.
         assert source.display_only is False
         assert session.is_cold is False
+
+
+@pytest.mark.asyncio
+async def test_a_refused_enter_stops_speaking_once_the_connect_lands(monkeypatch):
+    """UX U1's other half: the refusal row ends when the state it describes does.
+
+    `Send unavailable until connected.` is present-progressive about a state the
+    app owns, so it may not survive the connect that ended it — a durable row
+    would have the transcript say "until connected" directly above a session that
+    IS connected, and it accumulated one row per refused Enter while the wait
+    lasted. Retired on the COMPLETED connect only (same condition as the budget
+    refill): an attempt that returned early proved nothing about the owner.
+    """
+    session = UnreachableRemote("blipping", heals_after=3)
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        source = await _current_source(app, pilot, session)
+        prepared: Any = (source, object())
+        monkeypatch.setattr(app, "_prepare_sidebar_session", _always(prepared))
+        monkeypatch.setattr(app, "_commit_sidebar_session", Mock(return_value=None))
+        _instant_backoff(monkeypatch)
+
+        app._start_sidebar_connection(source)
+        # Mid-connect, the state the composer refuses to send in.
+        assert source.display_only is True
+        app.composer_submission_refused()
+        app.composer_submission_refused()
+        assert app._composer_refusal_notice is not None, "the refusal said nothing"
+        assert app._composer_refusal_notice.is_attached
+
+        await _drain_retries(app, source)
+
+        assert source.connect_attempts == 0, "the connect did not land"
+        assert app._composer_refusal_notice is None, "the refusal outlived the connect"
+        views = list(app.query(TranscriptView))
+        rows = [b for b in views[0].blocks() if isinstance(b, NoticeBlock)]
+        assert [b.text() for b in rows if b.text().startswith("Send unavailable")] == []

--- a/tests/unit/tui/test_sidebar_connect_retry.py
+++ b/tests/unit/tui/test_sidebar_connect_retry.py
@@ -364,7 +364,7 @@ async def test_the_status_stays_on_connecting_while_the_retry_is_live(monkeypatc
     """Mid-retry the app has not given up, so it must not tell the user it has.
 
     ``connection_error`` is what flips the status from ``Saved · Connecting…``
-    to ``Saved · Connection unavailable · Reselect to retry``. Asking the user
+    to ``Saved · Reconnect failed · Select again to retry``. Asking the user
     to act while the app is still working asks them to fix something that is
     fixing itself.
     """
@@ -1094,3 +1094,101 @@ def _always(value: Any) -> Any:
         return value
 
     return prepare
+
+
+class _LostDuringPreparation(RecoveringRemote):
+    """Binds cleanly, then loses its owner inside the prepare→commit window.
+
+    The state the belt's unconditional form exists for: the bind postcondition
+    sees a reachable owner, the owner is gone by the time the commit returns, and
+    the commit returned ``None`` (no frame to fail and no ``post_display_hook`` to
+    notice) — see `test_a_cold_session_whose_commit_returns_no_frame_is_still_refused`.
+    """
+
+    def __init__(self, session_id: str) -> None:
+        super().__init__(session_id)
+        self._cold = False
+
+    async def _ensure_bound(self, *, foreground: bool = True) -> None:
+        self.bind_calls += 1
+
+    async def ensure_display_current(self) -> None:
+        # The loss lands HERE, between the bind postcondition and the commit.
+        self._cold = True
+
+
+@pytest.mark.asyncio
+async def test_a_cold_session_whose_commit_returns_no_frame_is_still_refused(monkeypatch):
+    """F/m2: the postcondition is not conditional on there being a frame.
+
+    ``ready is None`` is ``_commit_sidebar_session``'s early return for a
+    prepared replay that already IS the current transcript view. With the belt
+    gated on ``ready is not None`` the body fell straight through it having
+    already set ``display_only = False``, so an owner lost in this window was
+    published live with no frame to refuse and no hook left to notice — the
+    ``connect_attempts`` reset below then credited the round with a connect it
+    never made.
+    """
+    session = _LostDuringPreparation("lost")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        source = await _current_source(app, pilot, session)
+        prepared: Any = (source, object())
+        monkeypatch.setattr(app, "_prepare_sidebar_session", _always(prepared))
+        monkeypatch.setattr(app, "_commit_sidebar_session", Mock(return_value=None))
+        # Observed rather than allowed to run, so this test sees ONE refusal
+        # rather than the whole chain (the chain is pinned elsewhere).
+        rearmed = Mock()
+        monkeypatch.setattr(app, "_start_sidebar_connection", rearmed)
+        _instant_backoff(monkeypatch, attempts=2)
+
+        await app._connect_sidebar_source(source)
+        await asyncio.sleep(0)  # the re-arm is a `call_soon` callback
+
+        assert session.is_cold is True
+        assert source.display_only is True, "a cold session was published with no frame to refuse"
+        assert source.connect_attempts == 1, "the cold commit was counted as a completed connect"
+        rearmed.assert_called_once_with(source, continues_retry=True)
+
+
+@pytest.mark.asyncio
+async def test_the_connect_prepares_with_refresh_so_no_frame_return_is_unreachable(monkeypatch):
+    """F/m2: WHY that return cannot be reached from the sidebar connect path.
+
+    Two things together, rather than a prose claim. (1) The trigger that return
+    compares against is a presentation whose replay view already IS the current
+    transcript — demonstrated below on the real helper, so the premise is
+    executed rather than asserted. (2) The ONLY way to be handed that
+    presentation is `_prepare_sidebar_session`'s two shortcuts, and both are
+    guarded on ``not refresh``; the connect body passes ``refresh=True``, which
+    is what this pins. So the belt's extension above is defensive on this path —
+    it is kept because one property read is cheaper than a silent hole in the
+    postcondition this whole file exists for.
+    """
+    session = RecoveringRemote("fresh", heals_after=1)
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        source = await _current_source(app, pilot, session)
+        prepared: Any = (source, object())
+        seen: list[dict[str, Any]] = []
+
+        async def prepare(*_args: Any, **kwargs: Any) -> Any:
+            seen.append(kwargs)
+            return prepared
+
+        monkeypatch.setattr(app, "_prepare_sidebar_session", prepare)
+        monkeypatch.setattr(app, "_commit_sidebar_session", Mock(return_value=None))
+
+        await app._connect_sidebar_source(source)
+        await asyncio.sleep(0)
+
+        # (1) the trigger, on the real helper.
+        assert app._capture_sidebar_presentation().replay.view is app._transcript_view()
+        # (2) the connect never asks for it.
+        assert seen == [{"refresh": True}], (
+            "the connect prepared without `refresh`, which re-opens the "
+            "current-view shortcuts `_commit_sidebar_session`'s early return needs"
+        )
+        # And a bound, cold-free connect with no frame still settles as connected.
+        assert source.display_only is False
+        assert session.is_cold is False

--- a/tests/unit/tui/test_sidebar_connect_retry.py
+++ b/tests/unit/tui/test_sidebar_connect_retry.py
@@ -46,7 +46,7 @@ from local_operator.session.attached import COLD_FALLBACK_S, AttachedSession
 from local_operator.tui import app as app_module
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.session_interaction import SessionInteraction
-from local_operator.tui.session_navigation import SurfaceNotReady
+from local_operator.tui.session_navigation import OwnerWentCold, SurfaceNotReady
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
 #: The shipped schedule, captured at import BEFORE any test patches it for
@@ -443,6 +443,217 @@ def test_the_retry_budget_outlasts_the_recovery_give_up_bound():
     # One attempt fewer must NOT clear the bound, which is what makes the
     # derived count minimal rather than an arbitrary large number.
     assert sum(schedule[:-1]) <= COLD_FALLBACK_S * 1.5
+
+
+class BindsThenLosesItsOwner(RecoveringRemote):
+    """A viewer that BINDS, then loses its owner before its frame paints.
+
+    The window the defect lives in, in one object: the bind postcondition
+    passes and the owner disappears in the gap between that check and the first
+    painted frame — which is where a real ``ATTACH_MAX_CLIENTS`` LRU eviction
+    landed for the user (the architect's rig reproduced it at 15.1 s with 1,820
+    refusals).
+
+    ``heals_after`` is deliberately unused: this double never comes back, so
+    the arms under test are the refusal and the BOUND, not the heal. The heal
+    is asserted against real runtimes in
+    ``tests/e2e/test_sidebar_reconnect_e2e.py``.
+    """
+
+    def __init__(self, session_id: str) -> None:
+        super().__init__(session_id, heals_after=None)
+        self._cold = False
+
+    async def _ensure_bound(self, *, foreground: bool = True) -> None:
+        self.bind_calls += 1
+
+    def go_cold(self) -> None:
+        self._cold = True
+
+
+async def _drain_with_paints(app: OperatorApp, pilot: Any, source: SessionInteraction) -> None:
+    """``_drain_retries``, but pumping the pilot so the app actually PAINTS.
+
+    A cold pending frame is decided by ``post_display_hook``, and that only runs
+    when Textual renders. A drain that merely awaits the task leaves the
+    compositor idle, so the readiness gate's own 15 s timer becomes the only
+    thing that can settle the frame — which IS the pre-fix behaviour, and the
+    reason every assertion below is on the exception TYPE and the counters
+    rather than on how long anything took.
+
+    ``wait_for`` is a runaway backstop, never an assertion: a chain that has
+    settled breaks out immediately.
+    """
+    for _ in range(40):
+        task = source.connection_task
+        if task is None:
+            return
+        try:
+            await asyncio.wait_for(asyncio.shield(task), 30)
+        except asyncio.CancelledError:
+            return
+        await pilot.pause()
+        if source.connection_task is task or source.connection_task is None:
+            return
+    raise AssertionError("the retry chain never settled")
+
+
+def _cold_frame_rig(
+    app: OperatorApp,
+    source: SessionInteraction,
+    session: Any,
+    monkeypatch: Any,
+    *,
+    deferred: bool = True,
+):
+    """Arm a REAL frame, then lose the owner before it can paint.
+
+    Returned as the recorder for what the frame finally settled with.
+
+    ``deferred`` selects WHICH HALF of the window is exercised, and the two are
+    not interchangeable — they are the two places this PR closes it:
+
+    * ``True`` (the hook's half): the loss is scheduled with ``call_soon``, so
+      it lands while the connect body is suspended on ``await ready`` and the
+      next paint is what notices. Inline would be caught by the belt instead,
+      because the belt is SYNCHRONOUS between ``_commit_sidebar_session``
+      returning and its ``is_cold`` read — the test would then prove nothing
+      about the hook.
+    * ``False`` (the belt's half): the loss is applied inline, i.e. before the
+      commit returns, which is what an owner lost during preparation looks
+      like. The belt refuses it before the body ever waits.
+    """
+    outcomes: list[BaseException | None] = []
+    loop = asyncio.get_running_loop()
+
+    def commit(*_args: Any, **_kwargs: Any) -> Any:
+        future = app._await_sidebar_frame(source, app._sidebar_navigation.generation)
+        future.add_done_callback(lambda settled: outcomes.append(settled.exception()))
+        if deferred:
+            loop.call_soon(session.go_cold)
+        else:
+            session.go_cold()
+        return future
+
+    monkeypatch.setattr(app, "_commit_sidebar_session", commit)
+    prepared: Any = (source, object())
+    monkeypatch.setattr(app, "_prepare_sidebar_session", _always(prepared))
+    return outcomes
+
+
+@pytest.mark.asyncio
+async def test_a_cold_frame_does_not_wait_out_the_readiness_gate(monkeypatch):
+    """THE CORE FIX: a cold committed frame fails at once, and spends the budget.
+
+    ``_sidebar_gate_surface_ready``'s first check is ``is_cold``, so for as long
+    as the owner is gone the gate's verdict is already known. Waiting it out is
+    not a longer check — it is 15 s of refusals, each buying a forced
+    full-screen relayout (measured pre-fix: 1,820 of them, ~127/s), ending in
+    ``SurfaceNotReady``, which #883 made terminal-on-first for the good reason
+    that a PAINT failure should not be retried. That latched a TRANSIENT owner
+    loss and told the user to reselect the session the reselect healed in 0.17 s.
+
+    Asserted as the exception the frame settled with plus a COUNT of attempts —
+    the defect is "the wrong arm decided this: the timer instead of the cold
+    check, and no retry", which is a fact about types and counts, not durations.
+    """
+    monkeypatch_setup = monkeypatch
+    session = BindsThenLosesItsOwner("cold-at-paint")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        source = await _current_source(app, pilot, session)
+        outcomes = _cold_frame_rig(app, source, session, monkeypatch_setup)
+        # A SHORT budget: the property is that this arm SPENDS it and latches
+        # only on exhaustion, not the shipped length of it.
+        _instant_backoff(monkeypatch, attempts=3)
+
+        app._start_sidebar_connection(source)
+        await _drain_with_paints(app, pilot, source)
+
+        assert outcomes, "no frame was ever armed"
+        assert isinstance(outcomes[0], OwnerWentCold), (
+            f"the cold frame settled as {outcomes[0]!r}: a SurfaceNotReady means the "
+            "gate's 15 s timer decided it, not the cold branch"
+        )
+        # THE BOUND HOLDS: attempts are spent per round, and only exhaustion
+        # latches — one bind that succeeded, then one per refusing round.
+        assert session.bind_calls == app_module.SIDEBAR_CONNECT_ATTEMPTS + 1
+        assert source.display_only is True
+        assert source.connection_error == "the runtime is not responding"
+        # Surrendering hands the user a full budget for their reselect.
+        assert source.connect_attempts == 0
+
+
+@pytest.mark.asyncio
+async def test_a_loss_during_preparation_is_refused_before_the_wait(monkeypatch):
+    """THE BELT: an owner lost between the bind check and the commit.
+
+    The commit->paint half is the hook's; this is the other half, and it is
+    closed by re-reading ``is_cold`` once between the commit and the ``await``.
+    Without it the frame is armed against a session that is already cold, and
+    the only thing that can settle it is the gate's 15 s timer.
+
+    Its signature is DISTINCT from the hook's, which is why both are pinned:
+    the gate is consulted ZERO times here, because nothing was ever painted
+    before the refusal, where the hook's half consults it exactly once.
+    """
+    session = BindsThenLosesItsOwner("cold-at-commit")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        source = await _current_source(app, pilot, session)
+        outcomes = _cold_frame_rig(app, source, session, monkeypatch, deferred=False)
+        _instant_backoff(monkeypatch, attempts=3)
+        reached_before = app._sidebar_gate_reached
+
+        app._start_sidebar_connection(source)
+        await _drain_with_paints(app, pilot, source)
+
+        assert outcomes, "no frame was ever armed"
+        assert isinstance(outcomes[0], OwnerWentCold), (
+            f"the cold commit settled as {outcomes[0]!r}: the frame was waited on "
+            "instead of refused"
+        )
+        assert (
+            app._sidebar_gate_reached - reached_before == 0
+        ), "the gate was consulted for a commit the belt can already refuse"
+        # Spends the budget like every other transient arm, and latches only on
+        # exhaustion — the whole reason it is not routed at the terminal one.
+        assert session.bind_calls == app_module.SIDEBAR_CONNECT_ATTEMPTS + 1
+        assert source.display_only is True
+        assert source.connection_error == "the runtime is not responding"
+
+
+@pytest.mark.asyncio
+async def test_a_cold_frame_buys_no_relayout(monkeypatch):
+    """NO GATE SPIN, for the commit->paint window this time.
+
+    #856's counters are the sharpest instrument here: ``_sidebar_gate_reached``
+    "reached the gate" and ``_sidebar_gate_recoveries`` "bought a full-screen
+    relayout chasing it". A cold frame that waits can only ever produce the
+    second — the gate refuses on ``is_cold`` before it can pass — so the fix's
+    signature is one consultation and ZERO recoveries, against 1,820 before it.
+
+    Counts, not rates: a busy machine changes how long the frames take, not how
+    many the gate refuses.
+    """
+    session = BindsThenLosesItsOwner("cold-at-paint")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        source = await _current_source(app, pilot, session)
+        _cold_frame_rig(app, source, session, monkeypatch)
+        _instant_backoff(monkeypatch, attempts=3)
+        reached_before = app._sidebar_gate_reached
+        recoveries_before = app._sidebar_gate_recoveries
+
+        app._start_sidebar_connection(source)
+        await _drain_with_paints(app, pilot, source)
+
+        assert (
+            app._sidebar_gate_reached - reached_before == 1
+        ), "the gate was consulted for a frame that was already refused"
+        assert (
+            app._sidebar_gate_recoveries - recoveries_before == 0
+        ), "a relayout was bought for a verdict the gate had already reached"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_sidebar_connect_retry.py
+++ b/tests/unit/tui/test_sidebar_connect_retry.py
@@ -41,6 +41,7 @@ from typing import Any
 from unittest.mock import Mock
 
 import pytest
+from rich.text import Text
 
 from local_operator.session.attached import COLD_FALLBACK_S, AttachedSession
 from local_operator.tui import app as app_module
@@ -239,6 +240,26 @@ def _instant_backoff(monkeypatch, *, attempts: int | None = None) -> None:
     monkeypatch.setattr(app_module, "SIDEBAR_CONNECT_BACKOFF_CEILING_S", 0.0)
     if attempts is not None:
         monkeypatch.setattr(app_module, "SIDEBAR_CONNECT_ATTEMPTS", attempts)
+
+
+def _notice_rows(app: OperatorApp) -> list[str]:
+    """What the notices on screen actually PAINT, one entry per row.
+
+    `NoticeBlock.text()` is the authored string; `_build()` is what the surface
+    shows. The claim these tests make is about the surface — a row that still
+    promises a dial is a rendered sentence, and a restate that changed nothing
+    on screen would pass a check on the authored list and fail the user.
+    """
+    rows: list[str] = []
+    for view in app.query(TranscriptView):
+        for block in view.blocks():
+            if not isinstance(block, NoticeBlock):
+                continue
+            # `_build` is typed as any renderable; these blocks build `Text`,
+            # and `plain` is the string the surface shows.
+            built = block._build()
+            rows.extend((built if isinstance(built, Text) else Text(str(built))).plain.split("\n"))
+    return rows
 
 
 @pytest.mark.asyncio
@@ -1250,3 +1271,66 @@ async def test_a_refused_enter_stops_speaking_once_the_connect_lands(monkeypatch
         views = list(app.query(TranscriptView))
         rows = [b for b in views[0].blocks() if isinstance(b, NoticeBlock)]
         assert [b.text() for b in rows if b.text().startswith("Send unavailable")] == []
+
+
+@pytest.mark.asyncio
+async def test_a_refused_enter_does_not_survive_the_latch(monkeypatch):
+    """UX U1's third exit: the LATCH is a state end too (round 3).
+
+    The row ends on the redial's exits and on a COMPLETED connect, but a
+    sidebar connect that LATCHES left it speaking in the present tense under the
+    band's own verdict — measured on the round-3 head at 14.23s:
+
+        LATCHED: status='Saved · Reconnect failed · Select again to retry'
+        notices at the latch: ['Send unavailable until connected. Reconnecting —
+                              it will keep trying for a few more seconds.']
+
+    The band had retracted the retry while the transcript still promised one,
+    in exactly the state the original bug report was about. Restated into the
+    register the user's next Enter already produced, so the two surfaces agree
+    whether or not they press it — and asserted on the PAINTED rows, because
+    the defect is what the user reads.
+    """
+    session = RecoveringRemote("gone")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        source = await _current_source(app, pilot, session)
+        # NOT the collapsed backoff here: the Enter has to land in the mid-retry
+        # register ("Reconnecting — it will keep trying …"), which only exists
+        # while a round is PARKED. With a zeroed backoff the whole chain latches
+        # inside one `pilot.pause()` and the row is written in the
+        # pre-first-dial register instead — which would make this test pass on
+        # the very defect it exists to catch.
+        monkeypatch.setattr(app_module, "SIDEBAR_CONNECT_ATTEMPTS", 3)
+        monkeypatch.setattr(app_module, "sidebar_connect_backoff_s", lambda _attempt: 0.2)
+
+        app._start_sidebar_connection(source)
+        assert source.display_only is True
+        # Pump until the first attempt has failed, so the Enter lands in the
+        # register the user actually sees mid-retry (the `connect_attempts`
+        # hint) rather than in the pre-first-dial state.
+        for _ in range(400):
+            await pilot.pause()
+            if source.connect_attempts >= 1:
+                break
+        assert source.connect_attempts >= 1, "the connect never attempted a dial"
+        app.composer_submission_refused()
+        assert app._composer_refusal_notice is not None, "the refusal said nothing"
+        # The state the row describes, while it is still true.
+        assert any("will keep trying" in row for row in _notice_rows(app))
+
+        await _drain_retries(app, source)
+
+        assert source.connect_attempts == 0, "the connect did not latch"
+        assert app._status is not None
+        status = app._status.render_text(120).plain
+        assert "Reconnect failed" in status
+        assert "Select again to retry" in status
+
+        rows = _notice_rows(app)
+        assert "will keep trying" not in " ".join(
+            rows
+        ), "the refusal row outlived the latch and kept promising a dial"
+        assert any("Select this session again to retry." in row for row in rows)
+        # One row, not two: the restate replaces rather than stacks.
+        assert sum(1 for row in rows if "Send unavailable" in row) == 1

--- a/tests/unit/tui/test_stop_command.py
+++ b/tests/unit/tui/test_stop_command.py
@@ -1231,7 +1231,7 @@ async def test_a_strand_mid_swap_leaves_the_kill_switch_armed(
         app._resume_factory = fake_find  # type: ignore[assignment]
 
         with pytest.raises(RuntimeError):
-            await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+            await app._attach_or_refuse(tmp_path, "remote-1")
 
         assert app._session is None, "the viewer really is unbound"
         assert app._adopted_session_id == "sess", "the only lever the user has must survive"

--- a/tests/unit/tui/test_stop_command.py
+++ b/tests/unit/tui/test_stop_command.py
@@ -1196,8 +1196,17 @@ async def test_a_strand_mid_swap_leaves_the_kill_switch_armed(
         # that reproduces the shape by hand would step straight over it. Its
         # imports are function-local, so the record lookup and the connect are
         # patched at their source modules and everything else is the real path.
+        #
+        # The record must be one `_attach_or_refuse` will actually DIAL. It used
+        # to be pinned to protocol 4, which was goalless even then — the guard
+        # refused below 4, so 4 was simply the oldest dialable value — and is
+        # now refused before the dial: the first-attempt guard applies
+        # `FRONTEND_ATTACH_MIN_PROTOCOL` (the canonical check) instead of a
+        # literal, so anything below the current build gets the upgrade refusal
+        # rather than a doomed connect. A refusal here would step over the swap
+        # window this test is about, which is why the field is left at its
+        # current-protocol default.
         remote_record = _record(90909, "the remote")
-        remote_record.protocol = 4
 
         async def fake_find(_root: Any, _concrete: str):
             return remote_record, 90909


### PR DESCRIPTION
## Summary

Release: patch — a transient runtime-owner loss no longer latches the sidebar or /resume; the sidebar connect stops burning forced full-screen relayouts, /resume gets a bounded redial, and the resume picker's live-state scan drops from 12.5 Hz to ~1 Hz.

The operator selected a running session in the TUI sidebar and got
`Saved · Reconnect failed · Select again to retry`. Selecting the *same*
session again a moment later worked. The cause is an `ATTACH_MAX_CLIENTS` (4)
LRU eviction on a multiplexed runtime landing in the narrow window between the
sidebar connect's bind postcondition (`tui/app.py`, "A BIND THAT DID NOT BIND
IS A FAILURE") and the first painted frame: the facade goes cold, and
`_sidebar_gate_surface_ready`'s FIRST check is `is_cold`, so the readiness gate
can never pass. Waiting it out is not a longer check — `post_display_hook`'s
recovery branch bought a forced full-screen relayout on every refused frame
(~127/s) for the full 15 s timer, and the timer's `SurfaceNotReady` then latched
the transient loss, because #883 deliberately made a PAINT failure terminal on
its first occurrence. The user was told to do the one thing that works, and the
thing that works is not supposed to be necessary.

Four parts, one PR: the cold-frame refusal, diagnostics for the path (which
logged nothing at all), the same resilience for `/resume`'s one-shot dial, and
the `/resume` picker's per-frame registry scan.

## Reproduction, before and after

Deterministic rig (`~/workspace/lo-connect-investigation/pilot_bindpaint.py`,
developed from the architect's `pilot_window.py`): real in-process
`RuntimeServer`, a real `ATTACH_MAX_CLIENTS` eviction of the viewer, injected at
the one point the window lives at — the first await after the bind
postcondition and before presentation. Racing it (the architect's offset sweep)
is load-dependent: on a fast host the connect's fast path lands first and no
frame is ever armed, which is why the injection is deterministic here.

```sh
# BEFORE (any checkout at the base commit)
cd ~/workspace/lo-connect-investigation
env -u NO_COLOR TERM=xterm-256color LO_RIG_REPO=<base checkout> \
  <base checkout>/.venv/bin/python pilot_bindpaint.py
# AFTER
env -u NO_COLOR TERM=xterm-256color LO_RIG_REPO=$HOME/workspace/repos/lo-resume-resilience \
  ~/workspace/repos/lo-resume-resilience/.venv/bin/python pilot_bindpaint.py
```

The rig asserts its own precondition (`injected=True`), so a pass cannot mean
"nothing was ever lost".

**Before (base tree):**

```
[bindpaint] connect settled after  15.13s  injected=True  cold=True  display_only=True  attempts=0  error='The conversation connected but its input surface did not become ready'
[bindpaint] STATUS LINE SHOWS: 'Saved · Reconnect failed · Select again to retry'
[bindpaint] gate reached=1766 recoveries=1766 (full-screen relayouts bought chasing the gate)
[bindpaint] VERDICT: LATCHED — the user was told to do the one thing that works
[bindpaint] RESELECT:   0.14s  cold=False  display_only=False  error=''  -> SHOWN
```

**After (this branch):**

```
[bindpaint] connect settled after  10.03s  injected=True  cold=False  display_only=False  attempts=0  error=''
[bindpaint] STATUS LINE SHOWS: ''
[bindpaint] gate reached=2 recoveries=1 (full-screen relayouts bought chasing the gate)
[bindpaint] VERDICT: HEALED
[bindpaint] RESELECT:   0.54s  cold=False  display_only=False  error=''  -> SHOWN
```

The relayout storm collapses from 1,766 to the healthy connect's own single
arming frame, nobody is told to reselect, and the session comes back by itself
(the 10.03 s is the facade's own recovery bound being waited out, which is what
the budget is derived to outlast — not a spin).

The same run also shows the new runtime-side log line, which is the whole of
part 2's second half:

```
session runtime: dropped attach client ('127.0.0.1', 56739) (events=True frontend=True surface=terminal): attach cap
```

## Part 1 — a cold frame fails immediately, bounded by the retry budget

`post_display_hook` gains one branch, ordered BEFORE the recovery branch that
buys the relayout: a pending frame whose source is a LIVE commit
(`not display_only`) and whose session `is_cold` is failed at once with a new
`OwnerWentCold` — instead of waiting for a gate whose verdict is already known.

The trap the investigation left unresolved is the bound, and it is why the new
outcome is a distinct TYPE rather than a shorter timer:

* `OwnerWentCold` subclasses `ConnectionError`, NOT `SurfaceNotReady`. So it
  lands in `_connect_sidebar_source`'s **generic** arm — the one that increments
  `connect_attempts` and re-arms through the backoff, latching only when the
  budget is exhausted. An arm that re-armed without spending the budget is the
  infinite reconnect loop this codebase already measured once (the
  `connect_attempts` reset that made the retry's own re-arm refill it), and
  `tests/unit/tui/test_sidebar_connect_retry.py` pins that the loop's own
  re-arm still spends it.
* `SurfaceNotReady` stays terminal-on-first, exactly as #883 settled:
  `test_a_readiness_gate_timeout_is_not_retried` is **unchanged and green**.
* The cold condition is bounded by the facade's own recovery
  (`COLD_FALLBACK_S`, 8 s), and `SIDEBAR_CONNECT_ATTEMPTS` is derived to
  outlast it — so the budget is spent on a condition that really ends, and a
  genuinely unreachable owner still latches, with the honest copy for an
  unreachable owner ("the runtime is not responding", the sentence the bind
  postcondition already uses).

Belt for the other half of the window: `is_cold` is re-read once between
`_commit_sidebar_session` returning and the `await`, which closes a loss that
lands during preparation (the commit->paint half is the hook's). It refuses
through the shared `_abandon_sidebar_frame` seam, so the pending frame is
cleared in exactly one place.

`display_only` frames are excluded deliberately: their gate branch does not
consult `is_cold` at all, so failing them here would break the preview path.

## Part 2 — the path is diagnosable

This path logged nothing at all — every fact needed to explain the verdict was
already in memory. Both terminal/latched arms of `_connect_sidebar_source` now
emit one `logger.warning` (`_sidebar_connect_failure_fields`) carrying the arm,
session id, this round's elapsed seconds, `connect_attempts`, `display_only`,
`is_cold`, `_recovering`, `display_history_current`, and the exception type and
message — plus the gate reached/recoveries DELTAS for the paint arm, which are
the two numbers that describe the storm. The mutation run below is that line
working.

Runtime side: `_drop_client`'s single line now chooses its level from WHY the
client went (`_GRACEFUL_DROP_REASONS` = shutdown, reader eof/reset, daemon
replaced → INFO; everything else — **attach cap**, queue overflow, send timeout,
send failure — WARNING), so "why did this viewer go cold" is findable without
turning INFO on for the whole runtime. The documented double drop is still
DEBUG only.

## Part 3 — `/resume` gets the same resilience

`_attach_or_refuse` built the facade with a ONE-SHOT `AttachedSession.connect`
and handed any exception to the user as a verdict — the pre-#883 shape at the
other seam, where the ordinary case (a runtime mid-restart, republished within a
second or two) reads as a permanent failure and the user retypes `/resume`.

* Bounded retry around the dial, with the **runtime record re-read before every
  attempt** (a retired runtime republishes under a new pid; the same reason
  `AttachedSession._recover_runtime` re-reads). The pid the user named is
  honoured on the first attempt only; after that a record for the same session
  id is the owner coming back.
* The budget is derived from the bound the facade is **actually on**:
  `AttachedSession.connect` builds a TERMINAL surface (`_can_go_cold=False`), so
  it is `RECOVERY_GIVE_UP_S`, not the sidebar viewer's `COLD_FALLBACK_S` — the
  distinction `app.py`'s own comment draws. That is also the right question at
  this seam rather than merely the wider one: `RECOVERY_GIVE_UP_S` is scoped to
  "a record has been seen", which is exactly the shape of a failed `/resume`,
  and it answers "an owner is there and will not answer".
  `RESUME_CONNECT_ATTEMPTS` = 48 (135.75 s of backoff).
* Narration: ONE transcript row, restated in place (the `NoticeBlock.restate`
  discipline) — the user sees a live retry instead of an immediate wrong
  verdict, and a hundred attempts do not write a hundred durable rows. The row
  is retired once a dial succeeds, so it never claims a reconnect that has
  already happened.
* A capability/protocol gap is a STATIC property of the record, so it is NOT
  retried: the new `frontend_attach_refusal` helper is the same predicate
  `connect` refuses on (extracted so the two cannot drift), read off the same
  record `connect` just refused.

The strand-window ordering `tests/unit/tui/test_stop_command.py` pins is
untouched — the record lookup and the dial became a loop, and everything after
a successful dial is byte-for-byte the same sequence.

## Part 4 — the picker's idle cost

`_tick` called `refresh` unconditionally at `SPINNER_INTERVAL_S` (12.5 Hz); the
refresh is `registry.scan()` (glob + a JSON parse per record + a `ps` per
quiet-heartbeat record) plus `read_index()`. Its own docstring claimed this was
"skipped entirely when no row is animating" — a guard that did not exist.

Two rates now, and the docstring describes them: the FRAME still advances at
12.5 Hz while a row is busy (that is motion), and the DATA is re-read at
`LIVE_REFRESH_INTERVAL_S = 1.0 s`. The refresh is bounded rather than dropped
because it feeds two things that are real while nothing spins: the
repaint-on-visible-change guard, and the rows themselves, which REORDER when a
session parks on a gate — this release's headline event, arriving with nothing
animating. 1 s is two orders of magnitude finer than the 45 s heartbeat the
live states are derived from, which is the resolution they actually change at,
so the markers stay honest rather than frozen.

## Testing

**Static gates, whole tree, exactly as CI** (from the worktree):

```
.venv/bin/python -m flake8 .                                -> clean
uvx --from black==26.1.0 black --check .                    -> 1227 files unchanged
uvx isort==5.13.2 --check .                                 -> clean (2 skipped)
.venv/bin/python -m pyright --pythonpath .venv/bin/python . -> 0 errors, 0 warnings
```

**Suites** (rebased head, on a development host running at load average 80-158
from sibling sessions, hence the wall times):

CI on head `2546a16e0`: **16 of 16 checks green** (`test` shards 0-4, `lint`,
`type-check`, `version-bump-guard`, `tui-e2e` on ubuntu and macos, `pip-audit`,
`context-budget`, `filesystem-boundaries-windows`).


* `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q`
  — **18543 passed, 18 skipped, 1 failed** (22:01). The one failure is
  `tests/unit/session/test_attach_frame_size.py::test_a_quiescent_follower_recovers_without_waiting_for_more_traffic[True]`,
  which is a PRE-EXISTING xdist-sensitive flake and not this PR's: the file is
  untouched here, the code path (degraded resync retry) is not on the diff, and
  the same file run under the same `-n auto` on a pristine `origin/main`
  checkout fails the same way (measured: 97 passed, then 1 failed / 96 passed)
  while passing 3/3 file-level runs with `-n0` on this head.
* `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q`
  — **108 passed, 7 skipped**, 0 failed (4:19), which includes the new
  bind->paint case and the macOS resume-liveness regression guard.

**New and changed tests**

* `tests/unit/tui/test_sidebar_connect_retry.py`
  * `test_a_cold_frame_does_not_wait_out_the_readiness_gate` — the core fix.
    Asserts the frame settles with `OwnerWentCold` (a `SurfaceNotReady` there
    means the 15 s timer decided it) and that the budget is SPENT, then latched:
    `bind_calls == SIDEBAR_CONNECT_ATTEMPTS + 1`, `connection_error` = the
    unreachable-owner sentence, `connect_attempts` back to 0 on surrender.
  * `test_a_loss_during_preparation_is_refused_before_the_wait` — the belt's
    half, and it has a DIFFERENT signature from the hook's: the gate is
    consulted ZERO times, because nothing is painted before the refusal.
  * `test_a_cold_frame_buys_no_relayout` — #856's counters: one consultation,
    ZERO recoveries (1,820 before).
* `tests/unit/tui/test_resume_connect_retry.py` (new)
  * a transient failure is retried and the user is shown a live retry row
    between attempts (recorded from inside the second dial, since anything
    raised in a stub is swallowed by the connect body's own handler);
  * exhaustion dials exactly `RESUME_CONNECT_ATTEMPTS + 1` times, reports the
    error, and leaves ONE retry row (no stacking);
  * the record is re-read per attempt and the redial is handed the REPUBLISHED
    pid, not the retired one;
  * a static capability refusal is never retried;
  * the budget OUTLASTS `RECOVERY_GIVE_UP_S` as a relationship between the two
    constants, with `attempts - 1` NOT clearing it.
* `tests/e2e/test_sidebar_reconnect_e2e.py`
  * `test_a_loss_in_the_bind_to_paint_window_heals_instead_of_latching` — the
    window, against a real `RuntimeServer` and a real eviction, asserting the
    reconnect heals with no user action, that `(display_only=False, cold)` never
    appears (a cold session is never shown as live), and that the gate's
    recovery count stays inside the healthy-connect ceiling.
* `tests/unit/tui/test_session_picker.py`
  * `test_the_overlay_is_not_re_run_on_every_tick` — a fake clock, because the
    property is a ratio of refreshes to frames rather than a duration: 13
    frames (one second) produce ONE refresh, the next interval refreshes again,
    and the frame counter still advances per frame while a row is busy.
* `tests/unit/session/runtime/test_server.py` — the drop-log level contract
  (the two tests that pinned "always INFO" now pin the level the reason earns,
  and a new one covers an unrequested drop being WARNING).

**Mutation checks — proof the new tests can fail**

* Removing the `post_display_hook` cold branch: both cold-frame unit tests fail,
  and the failure IS the pre-fix defect, printed by the new log line:

```
sidebar connect failed terminally (paint gate did not open): session=cold-at-paint
elapsed=15.00s attempts=0 display_only=False is_cold=True recovering=None
display_history_current=True error=SurfaceNotReady: The conversation connected
but its input surface did not become ready gate_reached=1608 gate_recoveries=1608
```

* Removing the belt: `test_a_loss_during_preparation_is_refused_before_the_wait`
  fails on `the gate was consulted for a commit the belt can already refuse`
  (1 != 0) — the hook covers the same loss one paint later, which is why both
  halves need their own test.

**Rendered frames, looked at (not just saved)** — `rsvg-convert` of
`scripts.visual_capture.save_capture` output; both trees run with the same venv
so the pair differs only in the code. Files live in
`~/workspace/lo-connect-investigation/frames/` (evidence, not committed):

* `sidebar-{before,after}.{svg,png}` — the outcome the operator reported.
  BEFORE: `Saved · Reconnect failed · Select again to retry` in the band, the
  placeholder still `Draft a message…`, no model/cwd row. AFTER: the band is
  gone, the composer is live (`Message Local Operator…`) and the
  `test/e2e-model › config` row is back — the session is genuinely attached.
  The band's copy is unchanged (`connection_error` is not printed by the band),
  which is why the pair is about the STATE and not the string.
* `resume-{before,after}.{svg,png}` — the new copy. BEFORE: `! the owner is not
  answering` immediately. AFTER: one row, `! reconnecting to session remote-1 —
  the owner is not answering (retry 48 of 48)`, followed by the terminal
  verdict — one row restated in place 48 times, not 48 rows.

## Not addressed, and things to flag

* **A pre-existing flake, found while verifying this branch and deliberately not
  fixed here:**
  `tests/unit/session/test_attach_frame_size.py::test_a_quiescent_follower_recovers_without_waiting_for_more_traffic[False]`
  and `[True]` fail intermittently under xdist on `origin/main` (97 passed,
  then 1 failed / 96 passed on a pristine checkout), while passing with `-n0`
  and passing on retry. Same file, same code path as main — reported rather
  than widened into this PR.

* **The `/resume` budget is generously sized (48 attempts, 135.75 s of backoff)
  and it is a count, not a wall-clock cap.** That is the sidebar's own shape,
  applied to the wider bound, and it satisfies the requirement (the span must
  outlast the facade's give-up bound) — but when a wedge makes each attempt cost
  the full 15 s frontend-sync envelope, the aggregate wait exceeds the span. The
  shipped sidebar budget has the same property at a smaller multiple. If a
  harder ceiling is wanted, the clean lever is a deadline checked alongside the
  attempt count; I did not invent a second bound without asking.
* The picker's `1.0 s` cadence is a stated freshness bound, not derived from
  anything. It is deliberately far below the 45 s heartbeat resolution of the
  states it reports.
* No version bump (per the repo's release protocol): the branch carries two
  commits on current `main` and `pyproject.toml` is untouched. The brief named
  `801d4d164` (the 0.54.13 merge) as the base; `main` has moved six commits
  since, so the branch was rebased onto the current head rather than a stale
  one. The rebase is content-identical — `git range-diff` reports `=` for the
  perf commit, the fix commit's only range-diff delta is blank-line context
  around the one hunk that needed hand-resolution (`local_operator/session/
  attached.py`, where main added two new module-level helpers at the same
  insertion point), and the NON-BLANK added-line sets are byte-identical while
  the only removed lines are the four-line guard the new helper replaces. Every
  gate and suite below was re-run on the rebased head.

