### PR TITLE
fix(model): the aggregator router is a route that caches, so stop withholding its cache key

### DIFF
--- a/local_operator/model/registry.py
+++ b/local_operator/model/registry.py
@@ -795,7 +795,30 @@ aggregator_router_model_info: ModelInfo = ModelInfo(
     max_tokens=-1,
     context_window=1_048_576,
     supports_images=True,
-    supports_prompt_cache=False,
+    # True, and the asymmetry is the whole argument. The router is a ROUTE, so
+    # whether caching applies depends on the model it selects; today every route
+    # caches (DeepSeek and Gemini both cache implicitly, and the aggregator
+    # keeps the conversation on one host once it has affinity), and a router
+    # that resolves to a non-caching model tomorrow pays almost nothing for this
+    # flag being True: `prompt_cache_key` is a routing hint the provider ignores
+    # if it does not cache, and `cache_control` is stripped by the aggregator for
+    # providers that do not honour it (see ``clients._message_cache_markers``).
+    #
+    # A wrong False is not symmetric — it is what made this a defect. Both
+    # emissions are gated on this flag, so False sent NO routing key and NO cache
+    # marker on the router route, and a long agentic session paid full input
+    # price on every turn after the first: the largest avoidable cost in the
+    # largest conversations. It also disabled OpenRouter's provider sticky
+    # routing for exactly the route least able to predict where it lands, since
+    # the fallback (hashing the opening messages) only starts pinning after a hit
+    # it may never get.
+    #
+    # The listing cannot supply the answer for us either: the synthetic "auto"
+    # entry quotes the aggregator's meta-route price sentinel rather than a
+    # cache-read price, so discovery derives False from it, and
+    # ``discovery._merge_one`` ORs the two — this flag is the only input that can
+    # turn it on.
+    supports_prompt_cache=True,
     input_price=0.0,
     output_price=0.0,
     cache_writes_price=0.0,

--- a/local_operator/model/registry.py
+++ b/local_operator/model/registry.py
@@ -800,9 +800,9 @@ aggregator_router_model_info: ModelInfo = ModelInfo(
     # caches (DeepSeek and Gemini both cache implicitly, and the aggregator
     # keeps the conversation on one host once it has affinity), and a router
     # that resolves to a non-caching model tomorrow pays almost nothing for this
-    # flag being True: `prompt_cache_key` is a routing hint the provider ignores
-    # if it does not cache, and `cache_control` is stripped by the aggregator for
-    # providers that do not honour it (see ``clients._message_cache_markers``).
+    # in `prompt_cache_key` is a routing hint the provider ignores if it does not
+    # cache, and a `cache_control` marker is inert on a provider that does not honour
+    # it (see ``clients._message_cache_markers``).
     #
     # A wrong False is not symmetric — it is what made this a defect. Both
     # emissions are gated on this flag, so False sent NO routing key and NO cache
@@ -813,11 +813,15 @@ aggregator_router_model_info: ModelInfo = ModelInfo(
     # the fallback (hashing the opening messages) only starts pinning after a hit
     # it may never get.
     #
-    # The listing cannot supply the answer for us either: the synthetic "auto"
-    # entry quotes the aggregator's meta-route price sentinel rather than a
-    # cache-read price, so discovery derives False from it, and
-    # ``discovery._merge_one`` ORs the two — this flag is the only input that can
-    # turn it on.
+    # The catalogue cannot supply the answer, and for this provider it does not even
+    # get a chance to try: `discovery._merge_one` ORs a listing row against a static
+    # registry row, and `discovery._static_rows("radient")` is empty, so the merge for
+    # this provider runs with no registry input at all and its rows stay False
+    # whatever this flag says. What reads this flag is
+    # ``configure.resolve_model_info`` (static registry first) and then
+    # ``build_model_spec``, which is the one path the request builder calls — so this
+    # row is the only input that can turn caching on for the router route, and a
+    # ``False`` here is what withheld the key and the marker.
     supports_prompt_cache=True,
     input_price=0.0,
     output_price=0.0,

--- a/tests/unit/model/test_discovery.py
+++ b/tests/unit/model/test_discovery.py
@@ -35,7 +35,7 @@ from local_operator.model.discovery import (
     fetch_models,
     merge_models,
 )
-from local_operator.model.registry import ModelInfo, get_model_info, static_models
+from local_operator.model.registry import ModelInfo, static_models
 from local_operator.providers.registry import PROVIDER_REGISTRY
 
 
@@ -2389,22 +2389,29 @@ def test_cached_available_models_falls_back_to_static_on_cache_miss(tmp_path) ->
     assert agg_models == []
 
 
-def test_a_router_row_keeps_cache_support_though_the_listing_cannot_state_it() -> None:
-    """The router is the one row a listing cannot answer for, so it must not be
-    allowed to answer "no".
+def test_a_router_listing_row_is_not_where_cache_support_comes_from() -> None:
+    """The router's cache support cannot arrive through the listing merge, and does not.
 
-    The synthetic `auto` entry in an aggregator listing quotes a meta-route price
-    sentinel rather than a cache-read price, and discovery derives cache support
-    from a positive cache-read price, so the live row always arrives as False. The
-    merge ORs it against the registry, which makes the registry the only input that
-    can turn this on — and losing it silently costs a router conversation its
-    prompt cache on every turn after the first.
+    Review finding R1-1. The first version of this test asserted the merge restores
+    the flag, which is a contract the shipped merge does not provide for this row:
+    `_merge_one` ORs a listing row against a static registry row, and
+    `discovery._static_rows("radient")` is empty — this provider bundles no rows —
+    so the merge runs with `info=None` and `bool(row or None)` stays False.
+
+    That is inert rather than broken, and the boundary is worth pinning in BOTH
+    directions: the flag the request builder reads comes from the registry row via
+    `configure.resolve_model_info` / `build_model_spec` (covered by
+    `test_registry.py::test_aggregator_router_rows_advertise_prompt_caching`), and
+    nothing reads this field on this row. If a future change starts reading it, the
+    router route silently loses its cache key again — the defect the registry change
+    fixed — so it should fail here first.
     """
-    router = {"auto": get_model_info("radient", "auto")}
+    assert discovery._static_rows("radient") == {}, (
+        "this test's premise is that this provider contributes no static rows to the "
+        "merge; if that changed, re-derive the test rather than editing the assertion"
+    )
+
     live = [DiscoveredModel(id="auto", supports_prompt_cache=False, cache_read_price=0.0)]
+    merged = merge_models(discovery._static_rows("radient"), live)
 
-    merged = merge_models(router, live)
-
-    assert (
-        merged[0].supports_prompt_cache is True
-    ), "a listing row that cannot express cache support must not downgrade the router"
+    assert merged[0].supports_prompt_cache is False

--- a/tests/unit/model/test_discovery.py
+++ b/tests/unit/model/test_discovery.py
@@ -35,7 +35,7 @@ from local_operator.model.discovery import (
     fetch_models,
     merge_models,
 )
-from local_operator.model.registry import ModelInfo, static_models
+from local_operator.model.registry import ModelInfo, get_model_info, static_models
 from local_operator.providers.registry import PROVIDER_REGISTRY
 
 
@@ -2387,3 +2387,24 @@ def test_cached_available_models_falls_back_to_static_on_cache_miss(tmp_path) ->
     agg_models, agg_status = discovery.cached_available_models("openrouter", cache_dir=tmp_path)
     assert agg_status == "static"
     assert agg_models == []
+
+
+def test_a_router_row_keeps_cache_support_though_the_listing_cannot_state_it() -> None:
+    """The router is the one row a listing cannot answer for, so it must not be
+    allowed to answer "no".
+
+    The synthetic `auto` entry in an aggregator listing quotes a meta-route price
+    sentinel rather than a cache-read price, and discovery derives cache support
+    from a positive cache-read price, so the live row always arrives as False. The
+    merge ORs it against the registry, which makes the registry the only input that
+    can turn this on — and losing it silently costs a router conversation its
+    prompt cache on every turn after the first.
+    """
+    router = {"auto": get_model_info("radient", "auto")}
+    live = [DiscoveredModel(id="auto", supports_prompt_cache=False, cache_read_price=0.0)]
+
+    merged = merge_models(router, live)
+
+    assert (
+        merged[0].supports_prompt_cache is True
+    ), "a listing row that cannot express cache support must not downgrade the router"

--- a/tests/unit/model/test_registry.py
+++ b/tests/unit/model/test_registry.py
@@ -582,3 +582,29 @@ def test_an_arbitrary_aggregator_model_keeps_the_unknown_sentinels(provider: str
     info = get_model_info(provider, "some-vendor/never-heard-of-it")
     assert info.context_window == -1
     assert info.supports_images is False
+
+
+@pytest.mark.parametrize("provider", ["radient", "openrouter"])
+def test_aggregator_router_rows_advertise_prompt_caching(provider: str) -> None:
+    """The router row must not claim its route cannot cache.
+
+    `supports_prompt_cache` gates two emissions on the chat-completions wire, and
+    both of them exist to keep a long conversation's prompt cache warm: the
+    `prompt_cache_key` OpenRouter uses as its sticky-routing key, and the
+    `cache_control` marker that asks a provider to cache the prefix. A False here
+    therefore did not mean "unknown" — it meant every router request was sent with
+    no routing key and no cache marker, so a session paid full input price on every
+    turn after the first, and OpenRouter fell back to an affinity it only
+    establishes after a hit it had no way to earn.
+
+    True is the honest value because the router is a route and today every route
+    caches; the asymmetry is what settles it, since a hint or a marker sent to a
+    model that does not cache is inert, while withholding them from one that does
+    costs the full prefix on every turn.
+    """
+    info = get_model_info(provider, "auto")
+
+    assert info.supports_prompt_cache is True
+
+    spec = build_model_spec(provider, "auto", info)
+    assert spec.supports_prompt_cache is True, "the spec the request builder reads must carry it"

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -5464,3 +5464,31 @@ def test_fast_mode_on_openrouter_uses_the_aggregator_dialect() -> None:
     )
     assert body["service_tier"] == "priority"
     assert "speed" not in body
+
+
+async def test_router_model_request_carries_the_sticky_routing_key_and_cache_marker():
+    """The router route must reach the wire with both cache emissions, built from
+    the real registry rather than a hand-set spec.
+
+    This is the consequence test for the router row: `aggregator_router_model_info`
+    used to report `supports_prompt_cache=False`, and the effect was not a missing
+    capability badge — it was a router conversation sent with no `prompt_cache_key`
+    (OpenRouter's sticky-routing key) and no `cache_control` marker, so every turn
+    after the first bought the whole prefix again at full input price. The unit
+    tests above set the spec by hand, which is exactly how that stayed invisible.
+    """
+    from local_operator.model.configure import build_model_spec
+    from local_operator.model.registry import get_model_info
+    from local_operator.providers.clients import OpenAICompatClient
+
+    spec = build_model_spec("radient", "auto", get_model_info("radient", "auto"))
+    body = OpenAICompatClient("https://api.radienthq.com/v1")._build_body(
+        ChatRequest(
+            model=spec,
+            messages=[Message.user("a"), Message.user("b")],
+            prompt_cache_key="lineage-123",
+        )
+    )
+
+    assert body["prompt_cache_key"] == "lineage-123"
+    assert body["messages"][-1]["content"][-1].get("cache_control") == {"type": "ephemeral"}


### PR DESCRIPTION
Release: patch — the aggregator router declares prompt-cache support, so an `auto`-routed request carries its sticky-routing key and cache-control marker

# PR Description

## Summary of Changes

`aggregator_router_model_info.supports_prompt_cache` is now `True`, which is what makes a router request carry the cache markers it needs.

The flag is not cosmetic. Both cache emissions in the OpenAI-compatible client are gated on it:

```python
# local_operator/providers/clients.py
if request.model.supports_prompt_cache and request.prompt_cache_key:
    body["prompt_cache_key"] = request.prompt_cache_key   # OpenRouter's sticky-routing key
```

so a router request went out with **no** `prompt_cache_key` — the key OpenRouter uses to keep a conversation pinned to the host whose prefix cache it warmed — and **no** `cache_control` marker. A long agentic session on `auto` bought the whole prefix again on every turn after the first, and OpenRouter was left to its fallback affinity, which only begins pinning *after* a cache hit it had no way to earn.

## Problem

The router row is the one row a listing cannot answer for. The synthetic `auto` entry quotes the aggregator's meta-route price sentinel rather than a cache-read price, discovery derives cache support from a positive cache-read price, and `_merge_one` ORs the two — so the registry row is the only input that can turn it on. Reproduced offline against the cached listing:

```
$ python -c "... merger for radient/auto ..."
row.supports_prompt_cache = False | cache_read_price = 0.0
registry info.supports_prompt_cache = False
MERGED.supports_prompt_cache = False
```

## Why `True`

The router is a ROUTE, and today every route caches — DeepSeek and Gemini both cache implicitly. The asymmetry decides the direction: `prompt_cache_key` is a routing hint that a non-caching provider ignores, and `cache_control` is stripped by the aggregator for providers that do not honour it, so a wrong `True` is inert; a wrong `False` costs the full prefix on every turn of the longest conversations, and disables affinity for exactly the route least able to predict where it lands.

## Evidence

### The body, before and after (real client, real spec, live Router)

Built with `OpenAICompatClient._build_body` for `radient/auto` and posted to `https://api.radienthq.com/v1/chat/completions`:

```
BEFORE  turn1 body keys: prompt_cache_key=False cache_control=False
AFTER   turn1 body keys: prompt_cache_key=True  cache_control=True
```

### Live cache behaviour, controlled

Four trials per arm, **unique conversation prefix per trial** so no trial inherits another's warmth, ~8.8k tokens, two turns, through production:

```
BEFORE (no key, no marker)     warm-turn hits 1/4
AFTER  (key + marker)          warm-turn hits 1/4
```

**The hit rate did not measurably change in this sample, and the reason is the finding**: what decides a warm turn on this route is *which host OpenRouter picks*, not what the client sends. Across all observations, warm turns report cached tokens on some hosts and never on others:

| host | warm-turn cached tokens | cold turn | warm turn |
|---|---|---:|---:|
| GMICloud | 8704/8850 | $0.00269 | **$0.000115** |
| Io Net | 8576/8630 | $0.00269 | **$0.000079** |
| SiliconFlow | 0 across every observation | $0.00269 | $0.00269 |
| Novita / Wafer | 0 across every observation | $0.00267 | $0.00267 |

So the emissions this change restores are necessary but not sufficient: they make affinity and cache markers present, and the host's own behaviour decides whether anything comes of it. Affinity is worth having for that reason alone — measured directly against OpenRouter with unique prefixes per trial (~7.2k token prefix, warm-turn hits out of 8): **no key 1/8** vs `prompt_cache_key` 5/8, `session_id` 5/8 and the `x-session-id` header 7/8; on a longer ~9.6k prefix, the derived key this server now stamps reached **5/12 against 0/12 with no key**.

### What would actually move the cost

Host eligibility, not affinity: `provider.only` / `provider.ignore` on the `deepseek` route, which both lop's provider-routing settings and the server's pass-through already support. Deliberately **not** set here — the table above is a handful of observations, and pinning an allowlist on it would be a guess. Recorded instead as the follow-up worth measuring properly.

## Testing

- **Consequence test** (`tests/unit/providers/test_clients.py`): builds the real body for `radient/auto` from the registry and asserts both `prompt_cache_key` and `cache_control`. The three client tests that already existed set `spec.supports_prompt_cache` by hand — which is exactly how this stayed invisible — so the new one goes through `build_model_spec` instead.
- **Registry test** (`tests/unit/model/test_registry.py`): both router rows (`radient/auto`, `openrouter/auto`) assert the flag *and* the spec built from it, since the spec is what the request builder reads.
- **Merge test** (`tests/unit/model/test_discovery.py`): a listing row that cannot express cache support must not downgrade the router.
- Full suite: `1911 passed` across `tests/unit/model/` and `tests/unit/providers/`; `flake8` clean; `black --check` clean.

A comment on this change also went in beside the flag, recording why the value is what it is, since "the router declares it caches" is the kind of line a future reader would otherwise flip back on a hunch.