### PR TITLE
feat(model): persist reasoning effort with the model default

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ with its title and age:
 | Command | What it does |
 | --- | --- |
 | `/model` | Switch model for this session; `/model default` saves the current one for new ones, `/model saved` reverts to it (`/settings` edits the boot default too) |
-| `/effort` | Show or set reasoning effort (`shift+tab` cycles) |
+| `/effort` | Show or set reasoning effort (`shift+tab` cycles; save a level for new conversations with `/model default`) |
 | `/fast` | Toggle fast mode where the provider sells one: the same answer sooner, at premium pricing |
 | `/approvals` | Set whether tools ask first (`ask`/`auto`; add `default` to keep it) |
 | `/resume` | Pick a past conversation and continue it |
@@ -768,7 +768,9 @@ lop config open        # open it in your editor
 lop config instructions  # which instruction files a session assembles, in order
 ```
 
-Commonly set values: `hosting` and `model_name` (skip the CLI flags),
+Commonly set values: `hosting`, `model_name` and `model_effort` (skip the CLI
+flags; `model_effort` sets the reasoning level new conversations start at, and a
+rung the chosen model lacks clamps to its nearest),
 `conversation_length` / `detail_length` (history kept verbatim vs
 summarized), `tui.theme` (any registered theme name, easier to set with
 `/theme`, which previews live), and `retry.fallbackChains` (the model

--- a/local_operator/bootstrap.py
+++ b/local_operator/bootstrap.py
@@ -35,6 +35,7 @@ from local_operator.credentials import CredentialManager
 from local_operator.env import EnvConfig
 from local_operator.logger import get_logger
 from local_operator.model.configure import ModelConfiguration, configure_model
+from local_operator.model.effort import configured_effort
 from local_operator.types import OperatorType
 
 if TYPE_CHECKING:
@@ -156,6 +157,14 @@ def resolve_model_configuration(
             model_name=model_name,
             credential_manager=credential_manager,
             env_config=env_config,
+            # The configured birth-default effort, so the spec the SERVER REPORTS
+            # agrees with the one the session will actually run (design D3).
+            # Clamped inside ``configure_model`` against this spec's ladder, so a
+            # level this model cannot express lands on its nearest rung rather
+            # than 400ing. A speech model has no ladder and must NOT pass this —
+            # see ``server/routes/speech.py``, which calls ``configure_model``
+            # directly and leaves the parameter at its ``None`` default.
+            reasoning_effort=configured_effort(config_manager),
             **chat_args,
         )
     except Exception as exc:

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1259,24 +1259,47 @@ def config_edit_command(args: argparse.Namespace) -> int:
     try:
         # Parse the value to the appropriate type
         value = args.value
-        # Try to convert to int
-        try:
-            if value.isdigit() or (value.startswith("-") and value[1:].isdigit()):
-                value = int(value)
-            # Try to convert to float
-            elif value.replace(".", "", 1).isdigit() or (
-                value.startswith("-") and value[1:].replace(".", "", 1).isdigit()
-            ):
-                value = float(value)
-            # Try to convert to boolean
-            elif value.lower() in ("true", "false"):
-                value = value.lower() == "true"
-            # Handle null/None values
-            elif value.lower() in ("null", "none"):
-                value = None
-        except (ValueError, AttributeError):
-            # Keep as string if conversion fails
-            pass
+        # An ENUM's displayed LABEL is not always its stored VALUE (D11).
+        # `model_effort auto` means the stored ``""``, and the guessed parse
+        # below would hand the literal string ``auto`` to ``validate`` and have
+        # it rejected — a documented choice unreachable from the documented
+        # command. A label is matched case-insensitively and, when it matches,
+        # wins OUTRIGHT: the chain below is skipped, which matters because it
+        # converts the literal word ``none`` to Python ``None`` and ``none`` is
+        # a real rung of ``EFFORT_ORDER``. Values matching no label fall through
+        # to the existing parse unchanged, so no other kind's behaviour moves.
+        matched_choice: settings_io.Choice | None = None
+        if setting.kind is settings_io.Kind.ENUM:
+            typed = str(value).strip().lower()
+            matched_choice = next(
+                (
+                    choice
+                    for choice in setting.resolved_choices
+                    if str(choice.label).strip().lower() == typed
+                ),
+                None,
+            )
+        if matched_choice is not None:
+            value = matched_choice.value
+        else:
+            # Try to convert to int
+            try:
+                if value.isdigit() or (value.startswith("-") and value[1:].isdigit()):
+                    value = int(value)
+                # Try to convert to float
+                elif value.replace(".", "", 1).isdigit() or (
+                    value.startswith("-") and value[1:].replace(".", "", 1).isdigit()
+                ):
+                    value = float(value)
+                # Try to convert to boolean
+                elif value.lower() in ("true", "false"):
+                    value = value.lower() == "true"
+                # Handle null/None values
+                elif value.lower() in ("null", "none"):
+                    value = None
+            except (ValueError, AttributeError):
+                # Keep as string if conversion fails
+                pass
 
         # Through the facade rather than ``update_config``: a dotted key needs
         # the merge-into-existing-sub-mapping rule (a whole-mapping write drops

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1315,8 +1315,20 @@ def config_edit_command(args: argparse.Namespace) -> int:
         # the raw input would tell the user their config holds a spelling it
         # does not — the same class of lie as a page displaying a key the
         # runtime never bound.
+        #
+        # An ENUM echoes the LABEL the typed word selected, when it selected one
+        # (D8). The stored form is a wire value, not vocabulary: ``model_effort
+        # auto`` stores ``""``, so the receipt read "Successfully updated
+        # model_effort to " — the user typed a word and the confirmation named
+        # nothing. The same blank met every other member whose value is empty
+        # (``providers.openrouter.* default``), and the label also restores the
+        # words for the members whose value is not their label at all
+        # (``display.nerd_icons auto`` stores ``None`` and used to echo
+        # ``None``). Values that matched no label fall through unchanged, so the
+        # echo of a normalised value is exactly what it was.
         stored = settings_io.read_setting(config_manager, setting)
-        print(f"Successfully updated {args.key} to {stored}")
+        echoed = matched_choice.label if matched_choice is not None else stored
+        print(f"Successfully updated {args.key} to {echoed}")
         return 0
     except settings_io.ConfigUnreadableError as e:
         # Distinct from the schema rejection below: the key and the value are

--- a/local_operator/config.py
+++ b/local_operator/config.py
@@ -142,6 +142,17 @@ DEFAULT_CONFIG = Config(
             "max_learnings_history": 50,
             "hosting": "",
             "model_name": "",
+            # The BIRTH-default reasoning effort for new conversations, alongside
+            # the model pair above. ``""`` means "no opinion" — the model's own
+            # documented default stands. Read at session build
+            # (``session_factory._prepare``, ``bootstrap.resolve_model_configuration``)
+            # and clamped to the chosen model's own ladder there: a rung the
+            # model cannot express lands on its nearest rung rather than reaching
+            # the wire, so a stored ``xhigh`` beside a model that stops at
+            # ``high`` is survivable and re-applies ``xhigh`` on a later switch
+            # back to a wider ladder. A BIRTH default only — a resumed
+            # conversation's own stored selection outranks it.
+            "model_effort": "",
             "auto_save_conversation": False,
             # The tool-approval mode a NEW interactive session opens in, written
             # by ``/approvals default <mode>`` and read by the TUI at mount.

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -42,7 +42,11 @@ from local_operator.harness.types import (
 )
 from local_operator.model.catalogue import DEFAULT_TTL_S
 from local_operator.model.defaults import DEFAULT_MODEL_NAMES as _DEFAULT_MODEL_NAMES
-from local_operator.model.effort import default_effort, supported_efforts
+from local_operator.model.effort import (
+    default_effort,
+    resolve_effort_in,
+    supported_efforts,
+)
 from local_operator.model.ids import normalised_id as _normalised_id
 from local_operator.model.registry import (
     ModelInfo,
@@ -2212,6 +2216,7 @@ def configure_model(
     presence_penalty: Optional[float] = None,
     stop: Optional[list[str]] = None,
     seed: Optional[int] = None,
+    reasoning_effort: str | None = None,
 ) -> ModelConfiguration:
     """Configure a model for ``hosting``.
 
@@ -2300,6 +2305,30 @@ def configure_model(
         sampling_overrides["top_p"] = top_p
     if sampling_overrides:
         spec = spec.model_copy(update=sampling_overrides)
+    # The CONFIGURED default effort (``model_effort``), clamped into THIS spec's
+    # ladder — the spec's, not ``model.effort``'s table, because an aggregator
+    # listing can NARROW the ladder below the table's (see ``resolve_effort_in``
+    # and ``build_model_spec``). A level the chosen model cannot express lands on
+    # its nearest rung rather than reaching the wire, where the client's
+    # membership re-check would drop it while the status band still named it —
+    # the split-brain ``resolve_effort_in``'s docstring documents.
+    #
+    # ``reasoning_default_effort`` is deliberately NOT touched: that is what
+    # ``/effort auto`` restores, and it must stay the MODEL's own documented
+    # default, not the configured one. Overwriting it here would make ``auto``
+    # mean "the configured default", which is the opposite of the withdrawal the
+    # command performs (D4).
+    #
+    # Only when the caller passed a truthy level: ``None`` is "no opinion" and
+    # leaves the spec builder's own seeding (Anthropic's ``high``) alone. The
+    # guard also skips a needless ``model_copy`` when the resolved value equals
+    # what the spec already carries.
+    if reasoning_effort:
+        clamped = resolve_effort_in(
+            spec.reasoning_efforts, spec.reasoning_default_effort, reasoning_effort
+        )
+        if clamped is not None and clamped != spec.reasoning_effort:
+            spec = spec.model_copy(update={"reasoning_effort": clamped})
     # Radient base URL is env-overridable (legacy EnvConfig behaviour).
     if canonical == "radient" and env_config is not None:
         base_url = env_config.radient_api_base_url

--- a/local_operator/model/effort.py
+++ b/local_operator/model/effort.py
@@ -322,7 +322,20 @@ def configured_effort(config_manager: object) -> str | None:
         # Any failure — a broken config.yml, a manager that cannot read — means
         # "no configured effort", which is exactly the pre-change behaviour.
         return None
-    return str(raw).strip().lower() or None
+    # A NON-STRING is "no opinion", checked BEFORE the strip/lower (B1).
+    # ``str(raw)`` mapped a YAML null — ``model_effort:`` with no value,
+    # ``model_effort: null``, ``model_effort: ~`` — onto the word ``"None"``,
+    # whose lowercase spelling ``none`` is a REAL rung of :data:`EFFORT_ORDER`.
+    # So the plainest spelling of "clear the key" turned reasoning off on every
+    # new conversation of any model whose ladder offers ``none``: silently,
+    # durably (D6's clause 2 reads the same value back for a later
+    # ``/model default``), and against this docstring's own promise that a
+    # non-string value reads as ``None``. ``none`` is the one wrong type that is
+    # also a rung, which is why this cannot be left to ``resolve_effort_in``'s
+    # vocabulary check below.
+    if not isinstance(raw, str):
+        return None
+    return raw.strip().lower() or None
 
 
 def next_effort(levels: tuple[str, ...], current: str | None) -> str | None:

--- a/local_operator/model/effort.py
+++ b/local_operator/model/effort.py
@@ -289,6 +289,42 @@ def resolve_effort_in(
     )
 
 
+def configured_effort(config_manager: object) -> str | None:
+    """The stored ``model_effort`` default, normalised; ``None`` means "no opinion".
+
+    A thin reader rather than a second config vocabulary: the key is resolved
+    through the registry (``settings_io.resolve_key``) so the NAME lives in one
+    place, and the value is normalised only as far as stripping and lowercasing.
+
+    An UNKNOWN word is passed through deliberately. ``resolve_effort_in``
+    answers an off-vocabulary request with the model's own default, so a
+    hand-edited typo degrades to the model default instead of raising. This
+    function sits on the BOOT path (``session_factory._prepare``,
+    ``bootstrap.resolve_model_configuration``), and a broken config must not be
+    able to fail a launch, so it never raises either: a missing key, an
+    unreadable file and a non-string value all read as ``None``.
+
+    Empty, absent and whitespace all read as ``None`` — the registry's own
+    "no opinion" is the empty string, and the two spellings must not diverge.
+
+    The import is function-local because this module is a deliberate LEAF
+    (``re``/``dataclasses`` only): ``settings_io`` is on the CLI path and must
+    not be dragged onto the import graph of every module that reads a ladder.
+    """
+    try:
+        from local_operator import settings_io
+
+        setting = settings_io.resolve_key("model_effort")
+        if setting is None:  # pragma: no cover - the row is registered
+            return None
+        raw = settings_io.read_setting(config_manager, setting)  # type: ignore[arg-type]
+    except Exception:
+        # Any failure — a broken config.yml, a manager that cannot read — means
+        # "no configured effort", which is exactly the pre-change behaviour.
+        return None
+    return str(raw).strip().lower() or None
+
+
 def next_effort(levels: tuple[str, ...], current: str | None) -> str | None:
     """The level one cycle step above ``current``, wrapping at the top.
 

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -11623,7 +11623,7 @@ class Session:
             if self._job_id is None:
                 self._web_tools_dirty = True
         if "hosting" in changed or "model_name" in changed or "model_effort" in changed:
-            self._on_configured_model_changed(values, local=source == "local")
+            self._on_configured_model_changed(values, local=source == "local", changed=changed)
 
     def _rebuild_effort_tier_tools(self) -> None:
         """Re-render the tools whose schema advertises the configured effort tiers.
@@ -11655,7 +11655,9 @@ class Session:
             return
         self.refresh_tools([rebuilt.get(tool.name, tool) for tool in self._tools])
 
-    def _on_configured_model_changed(self, values: Mapping[str, Any], *, local: bool) -> None:
+    def _on_configured_model_changed(
+        self, values: Mapping[str, Any], *, local: bool, changed: frozenset[str]
+    ) -> None:
         """Defaults seed NEW conversations; reloading them never selects a model.
 
         A watcher cannot identify which pane authored an edit. Local commands
@@ -11722,60 +11724,68 @@ class Session:
         saved`` adopts the configured effort here, so naming the change is
         naming the thing the user can act on.
 
-        The third member is compared against the session's DELIBERATE level
-        rather than the raw ``self.model.reasoning_effort`` (M2), because the
-        two do not mean the same thing when the key is unset: ``""`` on the
-        config side is "no opinion", while the spec's field carries the value
-        ``build_model_spec`` SEEDED for the model (``high`` on Anthropic) and
-        diverges from ``reasoning_default_effort`` only once the user picks a
-        level. Compared raw, the guard never short-circuited for any
-        seed-carrying model, so an unrelated external write of the SAME pair
-        printed a false "default changed" for it. The rule applied is the one
-        the persist side uses (D6): ``reasoning_effort ==
-        reasoning_default_effort`` is a seed, not a choice, and reads as ``""``.
+        The third member is detected as a CHANGE rather than inferred from values
+        (round-3 ruling). ``ConfigChange.changed_keys`` states which registry key
+        actually moved, so the rule is: the pair still matches this session's
+        model AND ``model_effort`` is one of the keys that moved. That is the
+        form that satisfies every case at once. A value comparison cannot: it has
+        to decide what the session's "own" level is, and each such rule
+        mis-fires in one direction — comparing against the raw spec field made
+        an unrelated delivery announce for every seed-carrying model (M2);
+        normalising a seed to ``""`` made an unrelated same-value write announce
+        for a session holding a DELIBERATE level (Q2); and it made a genuine
+        move to ``""`` (the user clearing the key) silent for a session on the
+        seeded level (Q3) — the one member of this section the effort term
+        exists to keep audible. A key that moved is a fact about the writer, not
+        a guess about the reader.
         """
         if self._job_id is not None:
             return
         if local:
             return
-        stored_effort = str(values.get("model_effort") or "")
-        live_effort = self.model.reasoning_effort or ""
-        if live_effort == (self.model.reasoning_default_effort or ""):
-            live_effort = ""
-        pair_matches = values.get("hosting") == self.model.provider and (
-            values.get("model_name") == self.model.model_id
-        )
-        if pair_matches and stored_effort == live_effort:
-            return
-        if pair_matches:
-            # An EFFORT-ONLY delivery (U6): headline and body both name the
-            # member that moved and the value it moved to. "Model unchanged"
-            # with an unnamed "a default changed" was literally true and still
-            # left the reader unable to tell WHICH default without opening
-            # `/settings`.
+        if values.get("hosting") != self.model.provider or (
+            values.get("model_name") != self.model.model_id
+        ):
+            # The model default itself moved: the #785 notice, unchanged.
             self._spawn_background(
                 self._emit(
                     NoticeEvent(
                         text=(
-                            f"keeping {self.model_label}; reasoning effort default changed "
-                            f"for new sessions ({stored_effort or 'auto'}); "
+                            f"keeping {self.model_label}; default changed for new sessions. "
                             "/model saved adopts it here"
                         ),
                         kind="info",
-                        headline="Effort default changed",
+                        headline="Model unchanged",
                     )
                 )
             )
             return
+        if "model_effort" not in changed:
+            # The pair still matches and no effort key moved: a delivery that
+            # changed nothing this session follows. The ordinary case is an
+            # unrelated rewrite of `model_name` to the SAME value (or a two-key
+            # save that re-states the pair) — announcing there was M2/Q2.
+            return
+        # An EFFORT-ONLY delivery: name the member that moved and the value it
+        # moved to. "Model unchanged" with an unnamed "a default changed" was
+        # literally true and still left the reader unable to tell WHICH default
+        # without opening `/settings` (U6).
+        #
+        # No model label on this row (U7): the pair MATCHES this session's model
+        # by construction here, so `keeping <label>` restated what the status band
+        # already shows — and the 24 cells it cost were what pushed a 120-cell
+        # row past the 110-cell budget at 120 columns, orphaning the pointer.
+        # The label belongs on the branch above, where the pair really moved.
+        stored_effort = str(values.get("model_effort") or "")
         self._spawn_background(
             self._emit(
                 NoticeEvent(
                     text=(
-                        f"keeping {self.model_label}; default changed for new sessions. "
-                        "/model saved adopts it here"
+                        "reasoning effort default changed for new sessions "
+                        f"({stored_effort or 'auto'}); /model saved adopts it here"
                     ),
                     kind="info",
-                    headline="Model unchanged",
+                    headline="Effort default changed",
                 )
             )
         )

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -11622,7 +11622,7 @@ class Session:
         if "web_search.enabled" in changed or "web_fetch.enabled" in changed:
             if self._job_id is None:
                 self._web_tools_dirty = True
-        if "hosting" in changed or "model_name" in changed:
+        if "hosting" in changed or "model_name" in changed or "model_effort" in changed:
             self._on_configured_model_changed(values, local=source == "local")
 
     def _rebuild_effort_tier_tools(self) -> None:
@@ -11711,14 +11711,32 @@ class Session:
         per-tick coalescing of the notice, which a source flag cannot express.
         The fix is scoped to ``local`` because ``source`` identifies that
         writer set exactly, not because tearing is impossible elsewhere.
+
+        ``model_effort`` is part of the SAME predicate, for the reason the pair
+        is: it is the third key of the same ``model`` section, it governs the
+        same birth defaults, and the TUI's own listener skips the whole
+        ``model`` section (a local write is the author's own receipt). Without
+        it an effort-only edit from ANOTHER process would change new sessions'
+        default with no signal anywhere — the one member of the section that
+        moved silently. The notice's advice is now literally true: ``/model
+        saved`` adopts the configured effort here, so naming the change is
+        naming the thing the user can act on. Compared NORMALISED (``str(...)
+        or ""``) because the spec's effort is a level or ``None`` while the
+        stored value is always a string, and ``None``/``""`` both mean "no
+        configured level".
         """
         if self._job_id is not None:
             return
         if local:
             return
-        if (values.get("hosting"), values.get("model_name")) == (
+        if (
+            values.get("hosting"),
+            values.get("model_name"),
+            str(values.get("model_effort") or ""),
+        ) == (
             self.model.provider,
             self.model.model_id,
+            self.model.reasoning_effort or "",
         ):
             return
         self._spawn_background(

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -11720,24 +11720,52 @@ class Session:
         default with no signal anywhere — the one member of the section that
         moved silently. The notice's advice is now literally true: ``/model
         saved`` adopts the configured effort here, so naming the change is
-        naming the thing the user can act on. Compared NORMALISED (``str(...)
-        or ""``) because the spec's effort is a level or ``None`` while the
-        stored value is always a string, and ``None``/``""`` both mean "no
-        configured level".
+        naming the thing the user can act on.
+
+        The third member is compared against the session's DELIBERATE level
+        rather than the raw ``self.model.reasoning_effort`` (M2), because the
+        two do not mean the same thing when the key is unset: ``""`` on the
+        config side is "no opinion", while the spec's field carries the value
+        ``build_model_spec`` SEEDED for the model (``high`` on Anthropic) and
+        diverges from ``reasoning_default_effort`` only once the user picks a
+        level. Compared raw, the guard never short-circuited for any
+        seed-carrying model, so an unrelated external write of the SAME pair
+        printed a false "default changed" for it. The rule applied is the one
+        the persist side uses (D6): ``reasoning_effort ==
+        reasoning_default_effort`` is a seed, not a choice, and reads as ``""``.
         """
         if self._job_id is not None:
             return
         if local:
             return
-        if (
-            values.get("hosting"),
-            values.get("model_name"),
-            str(values.get("model_effort") or ""),
-        ) == (
-            self.model.provider,
-            self.model.model_id,
-            self.model.reasoning_effort or "",
-        ):
+        stored_effort = str(values.get("model_effort") or "")
+        live_effort = self.model.reasoning_effort or ""
+        if live_effort == (self.model.reasoning_default_effort or ""):
+            live_effort = ""
+        pair_matches = values.get("hosting") == self.model.provider and (
+            values.get("model_name") == self.model.model_id
+        )
+        if pair_matches and stored_effort == live_effort:
+            return
+        if pair_matches:
+            # An EFFORT-ONLY delivery (U6): headline and body both name the
+            # member that moved and the value it moved to. "Model unchanged"
+            # with an unnamed "a default changed" was literally true and still
+            # left the reader unable to tell WHICH default without opening
+            # `/settings`.
+            self._spawn_background(
+                self._emit(
+                    NoticeEvent(
+                        text=(
+                            f"keeping {self.model_label}; reasoning effort default changed "
+                            f"for new sessions ({stored_effort or 'auto'}); "
+                            "/model saved adopts it here"
+                        ),
+                        kind="info",
+                        headline="Effort default changed",
+                    )
+                )
+            )
             return
         self._spawn_background(
             self._emit(

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -1859,11 +1859,33 @@ async def _prepare(
     # first so /new or /resume cannot retarget an in-flight factory at the await.
     args = argparse.Namespace(**vars(args))
 
+    # The configured birth-default effort (``model_effort``). Imported here, in
+    # the same local style as ``configure_model`` below, because this module is
+    # on the startup import path that ``test_import_graph`` guards and the
+    # reader is only needed once per session build.
+    from local_operator.model.effort import configured_effort
+
     def resolve_birth():
         agent = resolve_agent(args, agent_registry)
-        return agent, resolve_hosting_model_with_source(agent, args, config_manager)
+        hosting, model_name, model_source = resolve_hosting_model_with_source(
+            agent, args, config_manager
+        )
+        # Read in the same OFF-LOOP thread as the model resolution (a config read
+        # is cheap, but there is no reason to hop back to the loop for it). This
+        # is a BIRTH default only: the journal restore in ``Session.__init__``
+        # runs after the spec is built and re-derives it (clamping), so a
+        # conversation resumed on a stored selection outranks this value by
+        # design — ``model_effort`` must not fight the per-conversation journal
+        # (design §0.1).
+        return (
+            agent,
+            (hosting, model_name, model_source),
+            configured_effort(config_manager),
+        )
 
-    agent, (hosting, model_name, model_source) = await asyncio.to_thread(resolve_birth)
+    agent, (hosting, model_name, model_source), effort_default = await asyncio.to_thread(
+        resolve_birth
+    )
     yolo = bool(getattr(args, "yolo", False))
 
     transcript_dir, agent_id = _transcript_dir_and_agent_id(agent, args, agent_registry)
@@ -1937,6 +1959,12 @@ async def _prepare(
             model_name=model_name,
             credential_manager=credential_manager,
             env_config=get_env_config(),
+            # The standing config effort, CLAMPED inside ``configure_model``
+            # against this spec's own ladder. Carried unconditionally, even when
+            # ``model_source`` is ``"flag"``: a ``--model`` flag chooses a
+            # MODEL, not an effort, and the clamp makes it safe to keep the
+            # configured level across that choice (design D3).
+            reasoning_effort=effort_default,
             **chat_kwargs,
         )
     )

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -664,15 +664,16 @@ SETTINGS: tuple[Setting, ...] = (
         # An ENUM member rather than `empty_unsets` so the page shows `auto`
         # beside the real rungs as a peer to pick between.
         default="",
-        # 61 cells — the same ~76-cell footer budget as `hosting` above, and it
-        # has to hold the row's own meaning AND the resting state (design round
-        # 1, D4+D5). The clamp sentence the first cut carried is gone: at 61
-        # cells it cannot sit beside the fact that the row ships UNSET, and the
-        # resting cell renders that emptiness as `—`, so the one member a user
-        # cannot READ off the page was the one left unexplained. The clamp is
-        # documented where it happens instead — README, and the `/model default`
-        # receipt names the instance when a rung is dropped.
-        help="Effort for new conversations. Unset: the model's own default.",
+        # 57 cells, and that is the point (design round 1, D4+D5; round 2, D10):
+        # it has to hold the row's own meaning AND the resting state inside the
+        # 74-cell detail budget at 80 columns, which the off-default line spends
+        # as `<help> · default: —`. The first cut sat EXACTLY on 74 with zero
+        # headroom, so one more word anywhere would shed the whole sentence in the
+        # state a user reads it in. `the model's default` rather than `the
+        # model's own default` recovers 4 cells; the clamp sentence the original
+        # cut carried is documented in the README and named where it happens, on
+        # the `/model default` receipt.
+        help="Effort for new conversations. Unset: the model's default.",
         choices=_effort_choices(),
     ),
     # -- providers ----------------------------------------------------------

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -587,7 +587,12 @@ def _theme_choices() -> tuple[Choice, ...]:
 #: sentence. ``tests/unit/test_settings_io.py`` pins that no rung is missing one,
 #: which is the loud failure this avoids at runtime.
 _EFFORT_LEVEL_HELP: dict[str, str] = {
-    "none": "no reasoning — fastest, cheapest",
+    # `reasoning off`, not `no reasoning — fastest, cheapest` (review round 1,
+    # m2): every other rung's description names a DEPTH, and the two benefits
+    # named the one row that costs the least, in a picker where the row directly
+    # above it is `auto`. A description has one job here — say what the member
+    # means — and the ladder's cheapest end is not the place to sell.
+    "none": "reasoning off",
     "minimal": "the least reasoning the model offers",
     "low": "light reasoning",
     "medium": "moderate reasoning",
@@ -659,10 +664,15 @@ SETTINGS: tuple[Setting, ...] = (
         # An ENUM member rather than `empty_unsets` so the page shows `auto`
         # beside the real rungs as a peer to pick between.
         default="",
-        # 68 cells — the same ~76-cell footer budget as `hosting` above; the
-        # clamp sentence is the half that matters most (an unsupported rung is
-        # survivable rather than hidden, so it need not be mentioned as a limit).
-        help="Effort for new conversations. A rung the model lacks clamps nearest.",
+        # 61 cells — the same ~76-cell footer budget as `hosting` above, and it
+        # has to hold the row's own meaning AND the resting state (design round
+        # 1, D4+D5). The clamp sentence the first cut carried is gone: at 61
+        # cells it cannot sit beside the fact that the row ships UNSET, and the
+        # resting cell renders that emptiness as `—`, so the one member a user
+        # cannot READ off the page was the one left unexplained. The clamp is
+        # documented where it happens instead — README, and the `/model default`
+        # receipt names the instance when a rung is dropped.
+        help="Effort for new conversations. Unset: the model's own default.",
         choices=_effort_choices(),
     ),
     # -- providers ----------------------------------------------------------

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -57,6 +57,7 @@ from typing import TYPE_CHECKING, Any, Callable
 import yaml
 
 from local_operator import keymap as _keymap
+from local_operator.model.effort import EFFORT_ORDER
 from local_operator.providers.local import (
     DEFAULT_MODEL_OVERRIDES,
     LOCAL_PRESETS,
@@ -292,8 +293,8 @@ SECTIONS: tuple[Section, ...] = (
         "model",
         "Model",
         Scope.NEW_SESSIONS,
-        "Provider and model for new conversations. Existing sessions keep their model; "
-        "/model saved adopts the default here.",
+        "Provider, model and reasoning effort for new conversations. "
+        "Existing sessions keep their model; /model saved adopts the default here.",
     ),
     # Split out of ``model`` (review round 1, M3). The design left this key in
     # ``model`` and proposed documenting the discrepancy, which was defensible
@@ -577,6 +578,48 @@ def _theme_choices() -> tuple[Choice, ...]:
     return tuple(choices)
 
 
+#: One-line meaning for each rung of :data:`EFFORT_ORDER`, for the
+#: ``model_effort`` row's expanded list. Every member is a 3-argument
+#: :class:`Choice` here (value, label, description), so the descriptions live
+#: beside the ladder's own names rather than in the row. A rung with no entry
+#: falls back to an EMPTY description rather than raising: this table is built
+#: at import, and a KeyError there would take the whole CLI down for a missing
+#: sentence. ``tests/unit/test_settings_io.py`` pins that no rung is missing one,
+#: which is the loud failure this avoids at runtime.
+_EFFORT_LEVEL_HELP: dict[str, str] = {
+    "none": "no reasoning — fastest, cheapest",
+    "minimal": "the least reasoning the model offers",
+    "low": "light reasoning",
+    "medium": "moderate reasoning",
+    "high": "deep reasoning",
+    "xhigh": "very deep reasoning",
+    "max": "the model's deepest reasoning",
+}
+
+
+def _effort_choices() -> tuple[Choice, ...]:
+    """``model_effort``'s value space: the shared ladder plus the ``auto`` rung.
+
+    ``""`` leads as its own member rather than as an ``empty_unsets`` empty —
+    the same shape ``providers.openrouter.sort`` uses — so the page shows
+    ``auto`` BESIDE the real rungs as a peer to pick between (a bare empty
+    field would not), and the schema knows a stored empty string means "no
+    opinion" rather than a missing key.
+
+    The ladder comes from :data:`EFFORT_ORDER`, not a re-listing: the vocabulary
+    is the one place a rung is defined, and a second copy here would drift the
+    moment a level is added or removed. A rung the chosen model lacks is NOT
+    hidden — it is CLAMPED at use (``configure_model``), which is precisely what
+    makes offering the full ladder safe: the row needs no model to render, which
+    is required on the CLI path (a paint must not resolve a model) and in the
+    no-model setup state.
+    """
+    return (
+        Choice("", "auto", "the model's own default"),
+        *(Choice(level, level, _EFFORT_LEVEL_HELP.get(level, "")) for level in EFFORT_ORDER),
+    )
+
+
 SETTINGS: tuple[Setting, ...] = (
     # -- model --------------------------------------------------------------
     Setting(
@@ -604,6 +647,23 @@ SETTINGS: tuple[Setting, ...] = (
         # 72 cells — see the note on `hosting` above.
         help="Model for new conversations. /model saved adopts it here.",
         empty_unsets=True,
+    ),
+    Setting(
+        key="model_effort",
+        path=("model_effort",),
+        section="model",
+        label="Default reasoning effort",
+        kind=Kind.ENUM,
+        # "" is the unset member: the stored empty string means "no opinion"
+        # (the model's own default), exactly like `providers.openrouter.sort`.
+        # An ENUM member rather than `empty_unsets` so the page shows `auto`
+        # beside the real rungs as a peer to pick between.
+        default="",
+        # 68 cells — the same ~76-cell footer budget as `hosting` above; the
+        # clamp sentence is the half that matters most (an unsupported rung is
+        # survivable rather than hidden, so it need not be mentioned as a limit).
+        help="Effort for new conversations. A rung the model lacks clamps nearest.",
+        choices=_effort_choices(),
     ),
     # -- providers ----------------------------------------------------------
     Setting(

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -26312,11 +26312,19 @@ class OperatorApp(App[None]):
             # widowed the qualifier (U8). Two words bought the room back: `boot `
             # (5 cells; the command the user just typed already says what kind of
             # default this is) and `used by` (4, so the qualifier is
-            # `(new sessions)` — the same noun PERSIST_HINT prints). The row now
-            # fits every shipped direct label INCLUDING the longest rung the
-            # shared vocabulary can carry (110 at `claude-opus-5` with `minimal`).
-            # What it cannot fit is a selector long enough to spend the whole
-            # budget by itself — see NEW-3 in the round-3 comment:
+            # `(new sessions)` — the same noun PERSIST_HINT prints).
+            #
+            # The worst row is measured, not estimated, and it is EXACT rather
+            # than comfortable (review round 3, MINOR-1): over the ids
+            # `model.registry` can select, `anthropic/claude-opus-4-5-20251101`
+            # with `medium` is 110 (the budget, to the cell) and
+            # `anthropic/claude-3-5-sonnet-latest` is 108. The longest word the
+            # shared vocabulary carries belongs to a model no shipped ladder
+            # gives it to (`claude-opus-5` is `low…max`, 100 here), so the pair
+            # does not arise; the budget is what the longest REACHABLE row costs.
+            #
+            # What no copy of this receipt can fit is a selector long enough to
+            # spend the whole budget by itself — see NEW-3 in the round-3 comment:
             # `openrouter/deepseek/deepseek-chat-v3.1-terminus` is 47 cells of
             # model id against a 110-cell row that also carries a 28-cell path.
             notice(
@@ -26331,15 +26339,17 @@ class OperatorApp(App[None]):
                 # user just created, where the stored level silently differs from
                 # the one they were running.
                 #
-                # `reasoning effort:` rather than `model_effort` (U9): every
-                # other row in this feature opens with the user-facing name of
-                # the dial, and `model_effort` is the config KEY — the spelling a
-                # user only meets on the settings page's detail line. "to the
-                # nearest rung" rather than "to this model's nearest rung": the
-                # model is on the band one row above, and the 2 shorter words are
-                # what keep the row inside the 70-cell budget for the longest
-                # level words the vocabulary can carry (U9's own suggested
-                # wording measures 71 for a 7-cell rung).
+                # `reasoning effort:` rather than `model_effort` (U9): this row is
+                # about the LEVEL the boot will run, not about the key the file now
+                # holds — that half is the receipt's job one row above, where
+                # `model_effort <value>` names what was written. Every other row in
+                # this feature that speaks about a level opens with the dial's name
+                # (`/effort` set/auto/already, `/model saved`), and this is a row of
+                # that kind. "to the nearest rung" rather than "to this model's
+                # nearest rung": the model is on the band one row above, and the 2
+                # shorter words are what keep the row inside the 70-cell budget for
+                # the longest level words the vocabulary can carry (U9's own
+                # suggested wording measures 71 for a 7-cell rung).
                 notice(
                     f"reasoning effort: {saved_effort} "
                     f"({requested_effort} clamps to the nearest rung)",

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3766,14 +3766,24 @@ class OperatorApp(App[None]):
         self._effort_choice: str | None = None
         #: A ONE-SHOT effort the NEXT model activation must apply CLAMPED
         #: instead of consulting `_effort_choice`. Set by `_cmd_model_saved`
-        #: (adopt the configured default) and by the persist path of
-        #: `/model default` (so the saved rung and the running rung agree).
-        #: Consumed and cleared at the TOP of `_activate_resolved_model`, before
-        #: any early return, so it cannot leak onto a later, unrelated switch.
-        #: A tuple rather than `str | None` because "no override" and "override
-        #: to no opinion" are DIFFERENT: the second is how `/model saved` clears
-        #: a session level when the configured key is unset.
+        #: (adopt the configured default). Consumed and cleared at the TOP of
+        #: `_activate_resolved_model`, before any early return, so it cannot
+        #: leak onto a later, unrelated switch. A tuple rather than
+        #: `str | None` because "no override" and "override to no opinion" are
+        #: DIFFERENT: the second is how `/model saved` clears a session level
+        #: when the configured key is unset.
         self._pending_effort_override: tuple[bool, str | None] = (False, None)
+        #: One-shot handoff for the override above, set by `_cmd_model_saved`
+        #: immediately before it re-dispatches `/model <p>/<id>` and consumed by
+        #: the very next `_cmd_model` entry (B2). `_cmd_model_saved` has to arm
+        #: the override BEFORE the dispatch, because the dispatch is a string
+        #: through the general slash dispatcher and there is no argument to
+        #: carry it; without this marker the entry guard that clears a stale
+        #: override would eat the one just armed. With it, `_cmd_model` clears the
+        #: override on every entry EXCEPT the dispatch it was armed for, so an
+        #: early return of its own (the unknown-provider guard) can no longer
+        #: leave it armed to land on a later, unrelated switch.
+        self._effort_override_handoff: bool = False
         #: The user's fast-mode choice, kept on the APP so it survives a session
         #: being replaced under it (`/new`, `/reload`, `/resume` all rebuild
         #: one) — the same reason `_effort_choice` lives here. Defaults False:
@@ -25697,6 +25707,20 @@ class OperatorApp(App[None]):
         on screen says the next launch comes back on the old one — so the command
         that fixes that was reachable only by already knowing it existed.
         """
+        # Clear any armed effort override UNLESS this entry is the dispatch one
+        # was armed for (B2). `_cmd_model_saved` arms `_pending_effort_override`
+        # and then re-dispatches `/model <p>/<id>`; the override is consumed only
+        # deep inside `_activate_resolved_model`, so a return from ANY of the
+        # guards below it — the unknown-provider check is the reachable one —
+        # used to leave it armed for the next, unrelated switch, where the user
+        # silently landed on a level they never asked for. The handoff marker is
+        # the one thing that distinguishes "the dispatch this was armed for" from
+        # "any other entry", and it is cleared here either way, so the arming
+        # cannot outlive the single hop it was created for.
+        if self._effort_override_handoff:
+            self._effort_override_handoff = False
+        else:
+            self._pending_effort_override = (False, None)
         if arg and not self._allow_source_command():
             return
         session = self._session
@@ -25838,6 +25862,14 @@ class OperatorApp(App[None]):
             return
         provider = provider.lower()  # build_model_spec is case-insensitive
         if self._providers is None:
+            # An ARMED effort override goes with the dispatch that failed (B2):
+            # `_cmd_model_saved` arms one for exactly this call, and the two
+            # guards here are the only ways it can end without reaching
+            # `_activate_resolved_model`. Dropping it at the entry guard alone
+            # would leave the field reading `(True, 'none')` after the refusal
+            # below — harmless to the user, but a state that outlives the command
+            # it belonged to is what made the original leak hard to see.
+            self._pending_effort_override = (False, None)
             self._system_notice(
                 "provider controller unavailable — cannot infer model spec", "warning"
             )
@@ -25847,6 +25879,9 @@ class OperatorApp(App[None]):
         # typo would silently reconfigure the session and only fail on the next
         # turn, reading as a network/auth error instead of a typo.
         if self._providers.provider(provider) is None:
+            # Same rule as the guard above: the dispatch the override was armed
+            # for has failed, so it goes with it (B2).
+            self._pending_effort_override = (False, None)
             self._system_notice(f"unknown provider: {provider} — see /provider", "warning")
             return
         self._model_activation_generation += 1
@@ -25945,6 +25980,14 @@ class OperatorApp(App[None]):
         if session is not self._session or not self._allow_source_command():
             return
         old_label = session.model_label
+        # The level in force BEFORE this activation, for the `/model saved`
+        # receipt below (U1/design D7): that command's commonest shape resolves to
+        # the model already in force, where the effort is the only thing that
+        # moved and the old receipt printed an `X → X` model line saying nothing
+        # about it. Read off the session's own spec — the same source
+        # `_effort_label` paints the band from — so receipt and band cannot
+        # disagree.
+        old_effort = getattr(getattr(session, "model", None), "reasoning_effort", None)
         # The DESTINATION is derived from the spec this command resolved, never
         # re-read from ``session.model_label`` after ``set_model``. On a local
         # ``Session`` the two agree — ``set_model`` assigns synchronously — but
@@ -26050,6 +26093,10 @@ class OperatorApp(App[None]):
         # BOOT clamp, which must leave a wider ladder's `xhigh` recoverable on a
         # later switch; an explicit `/model default` re-saves deliberately.
         saved_effort: str | None = None
+        #: The level the user asked to make durable, BEFORE the clamp — kept so the
+        #: receipt can say that a rung was dropped rather than quietly showing a
+        #: different value than the one on the command they just ran (U4).
+        requested_effort: str | None = None
         if persist_default:
             choice = self._effort_choice
             if choice:
@@ -26060,6 +26107,7 @@ class OperatorApp(App[None]):
                 current = getattr(spec, "reasoning_effort", None)
                 default = getattr(spec, "reasoning_default_effort", None)
                 saved_effort = current if current and current != default else ""
+            requested_effort = saved_effort
             if saved_effort:
                 saved_effort = (
                     resolve_effort_in(
@@ -26119,13 +26167,22 @@ class OperatorApp(App[None]):
             # gate makes this a no-op when the row is already warm.
             self._warm_usage_background()
         # The remembered choice follows the value just put in force, so the band,
-        # the persisted key and `_effort_choice` agree (D7/D8). On the persist
-        # path `saved_effort` is the clamped rung (or `""` — remember nothing);
-        # on an override it is the level the live spec actually carries, read
-        # BACK from the spec so a target with no ladder clears the choice rather
-        # than remembering a level it cannot express. The ordinary switch leaves
-        # `_effort_choice` to `_spec_with_chosen_effort`, which owns it.
-        if persist_default:
+        # the persisted key and `_effort_choice` agree (D7/D8) — on the paths that
+        # actually PUT something in force. The write-only form (a bare
+        # `/model default` on the model already in force) switches nothing: it
+        # writes the config default for NEW sessions and leaves the running
+        # session exactly as it is, so it must not touch `_effort_choice` either.
+        # It used to assign `saved_effort` unconditionally, which fabricated a
+        # remembered choice the live spec never carried — so a later, unrelated
+        # `/model <other>` resurrected a level the user had explicitly withdrawn
+        # with `/effort auto` (M1), and the band and the key disagreed until it
+        # did (D7 violated). On the persist path `saved_effort` is the clamped
+        # rung (or `""` — remember nothing); on an override it is the level the
+        # live spec actually carries, read BACK from the spec so a target with no
+        # ladder clears the choice rather than remembering a level it cannot
+        # express. The ordinary switch leaves `_effort_choice` to
+        # `_spec_with_chosen_effort`, which owns it.
+        if persist_default and not write_only:
             self._effort_choice = saved_effort or None
         elif apply_effort_override:
             # The level the live spec actually carries, so a target with no
@@ -26224,10 +26281,16 @@ class OperatorApp(App[None]):
         if persist_result is not None:
             notice(persist_result, "warning")
         elif persist_default:
-            # Names both halves, the file and the keys. "saved" alone is a claim
-            # the user cannot check without quitting and relaunching, and the
-            # PROVIDER is the half that rides along silently — it is written from
-            # the selector's left side, never typed as its own setting.
+            # Names the file, the model pair and the third key, as one row
+            # (design review D3). The pair is joined the way the app names a model
+            # everywhere else (``provider/model_id``) rather than as the two
+            # registry keys ``hosting``/``model_name``: at 120 columns a notice
+            # row holds 110 cells, and the key-per-half spelling pushed this
+            # receipt from the base 109 to 128, orphaning ``(used by new
+            # sessions)`` on a second line. The new third key is the half that
+            # must NOT be cut — it is the only place the level just made durable
+            # is named — so the cells come out of the preamble and the pair, which
+            # carry the same information the file path and the label already show.
             #
             # "used by new sessions", the noun PERSIST_HINT already uses, not
             # "from the next launch" (design review D3): a user who ran this
@@ -26237,23 +26300,69 @@ class OperatorApp(App[None]):
             # there as well as at relaunch. The settings page keeps its own
             # "new launch" vocabulary; it is a different surface.
             notice(
-                f"boot default saved to {saved_to}: hosting {provider}, "
-                f"model_name {model_id}, model_effort {saved_effort or 'auto'} "
-                f"(used by new sessions){suffix}"
+                f"boot default: {saved_to} — {provider}/{model_id}, "
+                f"model_effort {saved_effort or 'auto'} (used by new sessions){suffix}"
             )
+            if requested_effort and saved_effort and saved_effort != requested_effort:
+                # The clamp dropped a rung on the way to durable (U4). On its own
+                # row rather than as a parenthetical, so the row above keeps the
+                # one-line budget D3 bought and this clause pays only when it is
+                # true. README documents the rule; this names the instance the
+                # user just created, where the stored level silently differs from
+                # the one they were running.
+                notice(
+                    f"model_effort {saved_effort} ({requested_effort} clamps to this "
+                    "model's nearest rung)",
+                    "info",
+                )
         else:
-            # "(next turn)" alone read as permanent — the complaint behind this
-            # wording. The scope and the one command that widens it belong on the
-            # line that announces the switch, not in documentation the user would
-            # have to already suspect exists.
-            #
-            # TWO clauses and no more. This carried four separators — a
-            # parenthetical with a comma in it, the access note's ` · `, then a
-            # ` — ` onto a sentence of its own — and wrapped at 80 columns into a
-            # run-on. "(this session)" is the half that answers "for how long";
-            # "from the next turn" answered "starting when", which nothing had
-            # asked and which the very next receipt demonstrates anyway.
-            notice(f"model: {old_label} → {new_label} (this session){suffix} — {PERSIST_HINT}")
+            # `/model saved` resolving to the model already in force: the model did
+            # not move and the EFFORT is the only thing that did (U1, design D7).
+            # The generic line below is the shape this codebase refuses to print
+            # on purpose — an arrow between two identical labels reads as "this
+            # moved" — and here it also advertised the command the user did NOT
+            # run while saying nothing about the dial that did move.
+            ladder = tuple(getattr(live_spec, "reasoning_efforts", ()) or ())
+            after_effort = getattr(live_spec, "reasoning_effort", None)
+            source = "the configured default" if override_effort else "the model's own default"
+            if apply_effort_override and old_label == new_label:
+                if not ladder:
+                    # No dial on this model, so there is no level to name: the
+                    # honest receipt is that nothing moved, without the `X → X`
+                    # shape (U1).
+                    notice(f"already on {new_label} — {PERSIST_HINT}")
+                elif (old_effort or None) == (after_effort or None):
+                    notice(f"reasoning effort: already {after_effort} ({source})")
+                else:
+                    notice(
+                        f"reasoning effort: {old_effort or 'auto'} → "
+                        f"{after_effort or 'auto'} ({source})"
+                    )
+            else:
+                # "(next turn)" alone read as permanent — the complaint behind this
+                # wording. The scope and the one command that widens it belong on the
+                # line that announces the switch, not in documentation the user would
+                # have to already suspect exists.
+                #
+                # TWO clauses and no more. This carried four separators — a
+                # parenthetical with a comma in it, the access note's ` · `, then a
+                # ` — ` onto a sentence of its own — and wrapped at 80 columns into a
+                # run-on. "(this session)" is the half that answers "for how long";
+                # "from the next turn" answered "starting when", which nothing had
+                # asked and which the very next receipt demonstrates anyway.
+                notice(f"model: {old_label} → {new_label} (this session){suffix} — {PERSIST_HINT}")
+                if (
+                    apply_effort_override
+                    and ladder
+                    and (old_effort or None) != (after_effort or None)
+                ):
+                    # The model moved AND the adopted baseline moved the dial. The
+                    # model line answers the command; this answers the level, on
+                    # its own row so neither sentence has to carry the other.
+                    notice(
+                        f"reasoning effort: {old_effort or 'auto'} → "
+                        f"{after_effort or 'auto'} ({source})"
+                    )
         # MID-TURN is the one moment "starting when" is a live question, and the
         # next receipt cannot answer it because the answer is visible before
         # then: the agent goes on working on the old model until the step in
@@ -26363,8 +26472,13 @@ class OperatorApp(App[None]):
         # default, not whatever was picked here. ONLY a local session arms it: a
         # follower's re-dispatch routes through its owner's canonical mutation,
         # and the owner decides the effort on its own copy.
+        #
+        # The handoff marker travels WITH it: `_cmd_model` clears an armed
+        # override at every entry except the dispatch this marker tags, so the
+        # override survives exactly the one hop below and cannot outlive it (B2).
         if not callable(getattr(session, "route_shared_slash", None)):
             self._pending_effort_override = (True, saved_effort)
+            self._effort_override_handoff = True
         self._run_slash_command(f"/model {provider}/{model_id}")
 
     def _recover_from_missing_model(self, target: str, notice: NoticeFn) -> None:
@@ -26408,6 +26522,14 @@ class OperatorApp(App[None]):
             manager.set_config_value("hosting", provider)
             manager.set_config_value("model_name", model_id)
             saved_to = _home_relative(str(manager.config_file))
+            # U5: a stored `model_effort` is left untouched by this write and
+            # rides into the boot below, clamped to the chosen model's ladder. The
+            # sibling `/model default` receipt names all three keys, so the one
+            # receipt a NEW user sets their first default through naming only two
+            # of them hid the half they never typed. Read through the same reader
+            # the boot path uses, so this cannot disagree with what actually
+            # applies.
+            stored_effort = configured_effort(manager)
         except Exception as error:  # noqa: BLE001 — a read-only config dir
             # Fatal HERE, unlike the ordinary `/model default` path where the
             # live switch already succeeded: with no session, an unwritten
@@ -26415,7 +26537,11 @@ class OperatorApp(App[None]):
             # and drop straight back into this state.
             self._system_notice(f"could not save the model: {error}", "error")
             return
-        notice(f"saved hosting {provider}, model_name {model_id} to {saved_to}", "info")
+        effort_clause = f", model_effort {stored_effort}" if stored_effort else ""
+        notice(
+            f"saved hosting {provider}, model_name {model_id}{effort_clause} to {saved_to}",
+            "info",
+        )
         self._leave_setup_state_and_boot(notice)
 
     def _leave_setup_state_and_boot(self, notice: NoticeFn) -> None:
@@ -26896,8 +27022,10 @@ class OperatorApp(App[None]):
         — by saving the model with ``/model default`` while it is in force —
         which is a separate, deliberate action about the DEFAULT rather than a
         side effect of turning a dial. So the SET receipt points at that
-        command (D10). The ``/effort auto`` receipt deliberately does not: auto
-        withdraws the preference, so there is nothing there to keep.
+        command (D10). The ``/effort auto`` receipt points at ``/settings``
+        instead: auto WITHDRAWS the preference, so ``/model default`` is not the
+        route that keeps it (a stored level survives a bare ``/model default`` by
+        design, D6) — the settings row is (U2).
         """
         session = self._session
         spec = _model_spec(session)
@@ -26925,6 +27053,13 @@ class OperatorApp(App[None]):
             # Restores the MODEL's documented default rather than blanking the
             # field, so the band goes on naming the level actually in force —
             # `high` on Anthropic — rather than only the fact that it reasons.
+            #
+            # ``/new`` returns to the CONFIGURED default, not to this — the
+            # NEW_SESSIONS contract, working as designed: `model_effort` is a
+            # birth default, so a withdrawal here is scoped to this conversation
+            # and the next one boots on the stored key again. The receipt says
+            # that out loud (U2, below) rather than leaving the user to discover
+            # it one `/new` later.
             #
             # Off the SPEC, not re-derived from the model name. That keeps this
             # command agreeing with the band by CONSTRUCTION, whatever the spec
@@ -26954,12 +27089,27 @@ class OperatorApp(App[None]):
             # for a level that was already the model's own default asserts a
             # change that did not happen. The sibling `already <level>` branch
             # below is the voice this codebase already uses for a no-op.
-            destination = restored or "the provider's default"
+            # `auto` rather than `the provider's default` for the no-restore case
+            # (U2/D2): it is the word the BAND shows for that state, and the
+            # 24-cell alternative pushed this receipt past the 70-cell row budget
+            # at 80 columns once the scope clause below joined it.
+            destination = restored or "auto"
             scope = "(the model's own default)" if restored else "(nothing sent)"
             if restored == current:
                 notice(f"reasoning effort: already {destination} {scope}")
                 return
-            notice(f"reasoning effort: {current or 'auto'} → {destination} {scope}")
+            # U2: the withdrawal is SESSION-scoped and the user is told the one
+            # route that makes it stick, because the key they set earlier still
+            # holds the level and the next `/new` boots on it. The origin clause
+            # (`(the model's own default)` / `(nothing sent)`) gives way to it:
+            # at 80 columns a notice row holds 70 cells (design review D2) and
+            # origin + `(this session)` + the pointer do not fit together, so the
+            # actionable half stays. What it dropped is on the band and in the
+            # `/settings` expansion beside the level this row names.
+            notice(
+                f"reasoning effort: {current or 'auto'} → {destination} "
+                f"(this session) — /settings sets auto"
+            )
             return
         if wanted not in levels:
             # The model is not named: the band names it one row below, and the
@@ -26990,9 +27140,16 @@ class OperatorApp(App[None]):
         # the standing default (D10); it is on this receipt and not on the bare
         # listing, whose budget is tight and whose "this session only" clause is
         # still exactly true of the command it describes.
+        #
+        # `{current or 'auto'}` is the BAND's word for "a ladder, no level set"
+        # (`_effort_label`), so the receipt and the band name one state one way.
+        # The old `provider default` was a second spelling of it and 12 cells
+        # longer, which is the whole budget the pointer gets (design review D2:
+        # a notice row holds 70 cells at 80 columns). `; /model default keeps it`
+        # rather than ` — /model default to keep it` is the 3 cells that fit.
         notice(
-            f"reasoning effort: {current or 'provider default'} → {wanted} "
-            f"(this session) — /model default to keep it"
+            f"reasoning effort: {current or 'auto'} → {wanted} "
+            f"(this session); /model default keeps it"
         )
 
     # -- theme --------------------------------------------------------------
@@ -32910,7 +33067,7 @@ class OperatorApp(App[None]):
                 return SlashResult(
                     kind="notice", text="session cannot change model settings", style="warning"
                 )
-            destination = restored or "the provider's default"
+            destination = restored or "auto"
             scope = "(the model's own default)" if restored else "(nothing sent)"
             # The no-op voice, for the reason the sibling site above spells out:
             # an arrow between two identical values reads as a change.
@@ -32920,9 +33077,17 @@ class OperatorApp(App[None]):
                     text=f"reasoning effort: already {destination} {scope}",
                     style="info",
                 )
+            # Word for word the sibling site above, including the session scope and
+            # the route to making the withdrawal stick (U2): the two surfaces exist
+            # so a phone and a terminal get the SAME answer from one set of rules,
+            # and an answer that omitted the durability clause here would be the one
+            # divergence a user could act on wrongly.
             return SlashResult(
                 kind="notice",
-                text=f"reasoning effort: {current or 'auto'} → {destination} {scope}",
+                text=(
+                    f"reasoning effort: {current or 'auto'} → {destination} "
+                    f"(this session) — /settings sets auto"
+                ),
                 style="info",
             )
         if wanted not in levels:
@@ -32949,7 +33114,7 @@ class OperatorApp(App[None]):
             )
         return SlashResult(
             kind="notice",
-            text=f"reasoning effort: {current or 'provider default'} → {wanted} (this session)",
+            text=f"reasoning effort: {current or 'auto'} → {wanted} (this session)",
             style="info",
         )
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -27124,8 +27124,17 @@ class OperatorApp(App[None]):
             )
             return
         if wanted == current:
+            # The no-op voice, under the same 70-cell row budget as the receipts
+            # beside it (design review D2: a notice row holds `width - 10` cells,
+            # 70 at 80 columns). `restores the default` rather than `restores the
+            # model's default` is the 8 cells that holds it there at the LONGEST
+            # level name the vocabulary can carry (`minimal`, 69 cells); the
+            # qualifier it drops is what the sibling `/effort auto` receipt spells
+            # out in full, so the shorter form still points at the state it means.
+            # Kept word for word in `_effort_slash_result`, or a phone and a
+            # terminal answer one command two ways.
             self._system_notice(
-                f"reasoning effort: already {wanted} — /effort auto restores the model's default"
+                f"reasoning effort: already {wanted} — /effort auto restores the default"
             )
             return
         if not self._apply_effort(wanted):
@@ -33100,12 +33109,11 @@ class OperatorApp(App[None]):
                 style="warning",
             )
         if wanted == current:
+            # Word for word the sibling site above, including its cell budget: the
+            # two surfaces exist so one command gets one answer whatever renders it.
             return SlashResult(
                 kind="notice",
-                text=(
-                    f"reasoning effort: already {wanted} — "
-                    "/effort auto restores the model's default"
-                ),
+                text=f"reasoning effort: already {wanted} — /effort auto restores the default",
                 style="info",
             )
         if not self._apply_effort(wanted):

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -26291,35 +26291,34 @@ class OperatorApp(App[None]):
             # everywhere else (``provider/model_id``) rather than as the two
             # registry keys ``hosting``/``model_name``: at 120 columns a notice
             # row holds 110 cells, and the key-per-half spelling pushed this
-            # receipt from the base 109 to 128, orphaning ``(used by new
-            # sessions)`` on a second line. The new third key is the half that
-            # must NOT be cut — it is the only place the level just made durable
-            # is named — so the cells come out of the preamble and the pair, which
-            # carry the same information the file path and the label already show.
+            # receipt from the base 109 to 128, orphaning the qualifier on a
+            # second line. The third key is the half that must NOT be cut — it is
+            # the only place the level just made durable is named — so the cells
+            # come out of the preamble and the pair, which carry the same
+            # information the file path and the label already show.
             #
-            # "for new sessions", the noun PERSIST_HINT already uses ("… saves
-            # this for new sessions"), not "from the next launch" (design review
-            # D3): a user who ran this after reading the footer met three
-            # phrasings of "when" within two rows. "New sessions" is also the
-            # fuller claim — `/new` reloads `hosting`/`model_name` before it
-            # builds, so the default applies there as well as at relaunch. The
-            # settings page keeps its own "new launch" vocabulary; it is a
-            # different surface.
+            # "new sessions" is the noun PERSIST_HINT itself uses ("… saves this
+            # for new sessions"), not "from the next launch" (D3): a user who ran
+            # this after reading the footer met three phrasings of "when" within
+            # two rows. "New sessions" is also the fuller claim — `/new` reloads
+            # `hosting`/`model_name` before it builds, so the default applies
+            # there as well as at relaunch. The settings page keeps its own "new
+            # launch" vocabulary; it is a different surface.
             #
-            # The 110-cell budget at 120 columns is measured against the path a
-            # DEFAULT install renders — `~/.local-operator/config.yml` (28 cells
-            # home-relative), not the 19-cell `~/config/config.yml` a redirected
-            # test home produces, which is the 9 cells that took this row to 111
-            # and widowed the qualifier (U8). Two words bought the room back:
-            # `boot ` (5 cells) and `used by` (4). "new sessions" is the noun
-            # PERSIST_HINT itself uses, so the shorter qualifier keeps the
-            # vocabulary the sibling receipt already prints, and the row now fits
-            # every shipped direct label INCLUDING the longest rung the shared
-            # vocabulary can carry. What it cannot fit is a selector long enough
-            # to spend the whole budget by itself — see NEW-3 in the round-3
-            # comment: `openrouter/deepseek/deepseek-chat-v3.1-terminus` is 47
-            # cells of model id against a 110-cell row that also carries a 28-cell
-            # path, and no copy of this receipt holds that.
+            # The 110-cell budget is measured against the path a DEFAULT install
+            # renders — `~/.local-operator/config.yml` (28 cells home-relative),
+            # not the 19-cell `~/config/config.yml` a redirected test home
+            # produces, which is the 9 cells that took this row to 111 and
+            # widowed the qualifier (U8). Two words bought the room back: `boot `
+            # (5 cells; the command the user just typed already says what kind of
+            # default this is) and `used by` (4, so the qualifier is
+            # `(new sessions)` — the same noun PERSIST_HINT prints). The row now
+            # fits every shipped direct label INCLUDING the longest rung the
+            # shared vocabulary can carry (110 at `claude-opus-5` with `minimal`).
+            # What it cannot fit is a selector long enough to spend the whole
+            # budget by itself — see NEW-3 in the round-3 comment:
+            # `openrouter/deepseek/deepseek-chat-v3.1-terminus` is 47 cells of
+            # model id against a 110-cell row that also carries a 28-cell path.
             notice(
                 f"default: {saved_to} — {provider}/{model_id}, "
                 f"model_effort {saved_effort or 'auto'} (new sessions){suffix}"

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -111,7 +111,11 @@ from local_operator.mcp.verbs import _home_relative
 
 # A leaf table (`re` and `dataclasses` only), so importing it here costs the
 # boot path nothing the lazy-import discipline above is protecting.
-from local_operator.model.effort import next_effort
+from local_operator.model.effort import (
+    configured_effort,
+    next_effort,
+    resolve_effort_in,
+)
 from local_operator.session import naming
 from local_operator.session.frontend_state import MCP_SUBCOMMANDS as _MCP_SUBCOMMANDS
 
@@ -3760,6 +3764,16 @@ class OperatorApp(App[None]):
         # and dropped by `_spec_with_chosen_effort` when a model arrives that
         # cannot take it.
         self._effort_choice: str | None = None
+        #: A ONE-SHOT effort the NEXT model activation must apply CLAMPED
+        #: instead of consulting `_effort_choice`. Set by `_cmd_model_saved`
+        #: (adopt the configured default) and by the persist path of
+        #: `/model default` (so the saved rung and the running rung agree).
+        #: Consumed and cleared at the TOP of `_activate_resolved_model`, before
+        #: any early return, so it cannot leak onto a later, unrelated switch.
+        #: A tuple rather than `str | None` because "no override" and "override
+        #: to no opinion" are DIFFERENT: the second is how `/model saved` clears
+        #: a session level when the configured key is unset.
+        self._pending_effort_override: tuple[bool, str | None] = (False, None)
         #: The user's fast-mode choice, kept on the APP so it survives a session
         #: being replaced under it (`/new`, `/reload`, `/resume` all rebuild
         #: one) — the same reason `_effort_choice` lives here. Defaults False:
@@ -25887,6 +25901,27 @@ class OperatorApp(App[None]):
             if self._model_activation_pending == generation:
                 self._model_activation_pending = None
 
+    def _configured_default_effort(self) -> str | None:
+        """The stored ``model_effort``, or ``None`` when unset (D6's clause 2).
+
+        Reads through the ONE registry reader rather than a second config
+        vocabulary of its own, so the key NAME and its normalisation stay in
+        ``model.effort.configured_effort``. This exists — instead of the caller
+        opening a ``ConfigManager`` inline — because `/model default` needs the
+        stored value BEFORE its persist block builds the manager it writes
+        with, and because a read failure must mean "no configured level" rather
+        than a half-saved default. Deliberately NOT the session's live spec: on
+        this path the spec is the freshly RESOLVED target, which the session
+        factories' config application never touched (D6's whole point).
+        """
+        try:
+            from local_operator.config import ConfigManager
+            from local_operator.paths import config_dir
+
+            return configured_effort(ConfigManager(config_dir()))
+        except Exception:  # noqa: BLE001 — a read failure means "no opinion"
+            return None
+
     def _activate_resolved_model(
         self,
         session: Any,
@@ -25896,6 +25931,14 @@ class OperatorApp(App[None]):
         persist_default: bool,
         notice: NoticeFn,
     ) -> None:
+        # Consume the ONE-SHOT effort override FIRST, before any early return.
+        # `_cmd_model_saved` and the persist path leave it here so the NEXT
+        # activation applies the configured default CLAMPED; clearing it
+        # up-front means an early return (wrong session, refused source, a cold
+        # viewer) discards it rather than letting it leak onto a later, unrelated
+        # switch.
+        apply_effort_override, override_effort = self._pending_effort_override
+        self._pending_effort_override = (False, None)
         # Resolution can yield across a view switch. Recheck the captured
         # session, then the shared readiness boundary, immediately before any
         # setter or cold-bind task can be created.
@@ -25984,6 +26027,52 @@ class OperatorApp(App[None]):
         # form was derived from, so the two halves cannot disagree by case,
         # spacing, or a hosting alias the spec canonicalises.
         write_only = persist_default and new_label == old_label
+        # The reasoning effort to PERSIST alongside the model pair, and to put in
+        # force below (D6/D7). Computed here, before the live switch, so the saved
+        # rung and the running rung come from one value rather than from two
+        # derivations that can disagree.
+        #
+        # D6: persist the DELIBERATE effort, never an inferred one. The order is
+        # (1) the level the user picked this session, (2) the standing configured
+        # default — which the freshly resolved `spec` below does NOT carry, since
+        # only the session factories apply it, so this read is what keeps a bare
+        # `/model default` from ERASING a configured key — then (3) the spec's own
+        # level ONLY when it is not simply the model's documented default.
+        # Persisting that last case would freeze an inference into every future
+        # launch and, across a model change, silently deepen the new model's
+        # reasoning — a cost change arriving from a command about model
+        # IDENTITY. `""` is the registry's own "no opinion".
+        #
+        # The rung is then CLAMPED into the target's ladder: a level the target
+        # cannot express is saved as its NEAREST rung (or `""` when the target
+        # has no ladder at all), so what is saved is what will actually run — the
+        # whole point of D7. §4's "the stored key is not rewritten" is about the
+        # BOOT clamp, which must leave a wider ladder's `xhigh` recoverable on a
+        # later switch; an explicit `/model default` re-saves deliberately.
+        saved_effort: str | None = None
+        if persist_default:
+            choice = self._effort_choice
+            if choice:
+                saved_effort = choice
+            elif stored := self._configured_default_effort():
+                saved_effort = stored
+            else:
+                current = getattr(spec, "reasoning_effort", None)
+                default = getattr(spec, "reasoning_default_effort", None)
+                saved_effort = current if current and current != default else ""
+            if saved_effort:
+                saved_effort = (
+                    resolve_effort_in(
+                        tuple(getattr(spec, "reasoning_efforts", ()) or ()),
+                        getattr(spec, "reasoning_default_effort", None),
+                        saved_effort,
+                    )
+                    or ""
+                )
+        # Bound to ``spec`` so the override branch below can read the level the
+        # live switch actually applied even though the switch is skipped on the
+        # write-only path; that branch only runs when the switch DID run.
+        live_spec: Any = spec
         if not write_only:
             # The chosen effort rides along when the new model accepts it: a
             # user who dropped to `low` for cost did not mean "until I switch
@@ -25991,8 +26080,27 @@ class OperatorApp(App[None]):
             # pinned fallback route is withdrawn even when the choice
             # re-selects the model the fallback displaced — see
             # ``Session.set_model``.
+            #
+            # Two sibling paths, and which one runs is the D2/D7 split:
+            #   * the persist form carries the CLAMPED saved rung, so saved and
+            #     running agree (an Anthropic session whose `high` is only the
+            #     seeded default must not store `high` while the band reads
+            #     `auto`);
+            #   * an override (from `/model saved`) carries the configured
+            #     default CLAMPED, because the command means "put me back on my
+            #     configured baseline";
+            #   * the ordinary switch keeps the REMEMBERED-choice path, which
+            #     deliberately FORGETS a pick the new model cannot take — that
+            #     behaviour is pinned, and the clamp is a sibling for the case
+            #     where dropping the value silently is the failure.
+            if persist_default:
+                live_spec = self._spec_with_clamped_effort(spec, saved_effort or None)
+            elif apply_effort_override:
+                live_spec = self._spec_with_clamped_effort(spec, override_effort)
+            else:
+                live_spec = self._spec_with_chosen_effort(spec)
             session.set_model(
-                self._spec_with_chosen_fast_mode(self._spec_with_chosen_effort(spec)),
+                self._spec_with_chosen_fast_mode(live_spec),
                 explicit=True,
             )
             self._probe_quota_after_switch(session)
@@ -26010,6 +26118,24 @@ class OperatorApp(App[None]):
             # `/usage` right after the switch answers from disk too. The age
             # gate makes this a no-op when the row is already warm.
             self._warm_usage_background()
+        # The remembered choice follows the value just put in force, so the band,
+        # the persisted key and `_effort_choice` agree (D7/D8). On the persist
+        # path `saved_effort` is the clamped rung (or `""` — remember nothing);
+        # on an override it is the level the live spec actually carries, read
+        # BACK from the spec so a target with no ladder clears the choice rather
+        # than remembering a level it cannot express. The ordinary switch leaves
+        # `_effort_choice` to `_spec_with_chosen_effort`, which owns it.
+        if persist_default:
+            self._effort_choice = saved_effort or None
+        elif apply_effort_override:
+            # The level the live spec actually carries, so a target with no
+            # ladder clears the choice instead of remembering a level it cannot
+            # express — and an UNSET configured key clears it outright (D8), even
+            # though the spec then carries the model's own seeded default, which
+            # is not a choice anybody made.
+            self._effort_choice = (
+                getattr(live_spec, "reasoning_effort", None) if override_effort else None
+            )
         persist_result: str | None = None
         saved_to = ""
         if persist_default:
@@ -26035,24 +26161,35 @@ class OperatorApp(App[None]):
             # names only the key that happened to differ, and says "when" a
             # second time in a third phrasing.
             #
-            # Two facade calls, because the registry holds the pair as two
-            # settings — and each notifies the watcher separately, so this
-            # loop delivers TWO changes and the first carries a torn pair (new
-            # provider, old model name). Both arrive as ``local``, which is
-            # what keeps them silent: ``_on_config_change`` above returns
-            # early, and ``Session._on_configured_model_changed`` now reads
-            # the same flag. Until #785 the session did NOT, and printed a
-            # ``keeping ...`` notice off that torn pair, contradicting the
-            # receipt written below it.
+            # Three facade calls, because the registry holds the model pair as
+            # two settings and the effort as a third — and each notifies the
+            # watcher separately, so this loop delivers THREE changes and the
+            # first carries a torn pair (new provider, old model name). All
+            # arrive as ``local``, which is what keeps them silent:
+            # ``_on_config_change`` above returns early, and
+            # ``Session._on_configured_model_changed`` now reads the same flag.
+            # Until #785 the session did NOT, and printed a ``keeping ...``
+            # notice off that torn pair, contradicting the receipt written
+            # below it.
             try:
                 from local_operator import settings_io
                 from local_operator.config import ConfigManager
                 from local_operator.paths import config_dir
 
                 manager = ConfigManager(config_dir())
-                for key, value in (("hosting", provider), ("model_name", model_id)):
+                # The model pair first, then the effort LAST (design §4, "torn
+                # triple"): a mid-loop failure on the third write leaves the
+                # model pair exactly as durable as it was before this command,
+                # which is the pre-change semantics. Each key is one facade call,
+                # so each notifies; all three arrive as `local` and stay silent.
+                writes: list[tuple[str, Any]] = [
+                    ("hosting", provider),
+                    ("model_name", model_id),
+                    ("model_effort", saved_effort or ""),
+                ]
+                for key, value in writes:
                     setting = settings_io.resolve_key(key)
-                    if setting is None:  # pragma: no cover - both keys are registered
+                    if setting is None:  # pragma: no cover - all three are registered
                         raise KeyError(f"{key} is not a registered setting")
                     settings_io.write_setting(manager, setting, value)
                 saved_to = _home_relative(str(manager.config_file))
@@ -26101,7 +26238,8 @@ class OperatorApp(App[None]):
             # "new launch" vocabulary; it is a different surface.
             notice(
                 f"boot default saved to {saved_to}: hosting {provider}, "
-                f"model_name {model_id} (used by new sessions){suffix}"
+                f"model_name {model_id}, model_effort {saved_effort or 'auto'} "
+                f"(used by new sessions){suffix}"
             )
         else:
             # "(next turn)" alone read as permanent — the complaint behind this
@@ -26195,6 +26333,9 @@ class OperatorApp(App[None]):
             manager = ConfigManager(config_dir())
             provider = str(manager.get_config_value("hosting", "") or "").strip().lower()
             model_id = str(manager.get_config_value("model_name", "") or "").strip()
+            # The configured effort the baseline carries (D8). Read from the same
+            # manager; ARMED below, immediately before the re-dispatch.
+            saved_effort = configured_effort(manager)
         except Exception as error:  # noqa: BLE001 — reported, never fatal
             self._system_notice(f"could not read the saved default: {error}", "error")
             return
@@ -26210,6 +26351,20 @@ class OperatorApp(App[None]):
         # Re-enter the normal selector dispatch: local Sessions still use the
         # local activation path, while viewers await their owner and use its
         # canonical mutation/receipt rather than a fire-and-forget raw setter.
+        #
+        # The effort override is armed HERE, immediately before the dispatch,
+        # rather than up with the read: it is consumed and cleared only at the
+        # top of `_activate_resolved_model`, so an armed-but-undispatched
+        # override would survive the guards above and leak onto the next,
+        # unrelated activation. Adopting the configured BASELINE includes its
+        # effort (D8), so the activation puts the CLAMPED configured default in
+        # force — or clears this session's level when the key is unset, because
+        # "back to the baseline" with no configured level means the model's own
+        # default, not whatever was picked here. ONLY a local session arms it: a
+        # follower's re-dispatch routes through its owner's canonical mutation,
+        # and the owner decides the effort on its own copy.
+        if not callable(getattr(session, "route_shared_slash", None)):
+            self._pending_effort_override = (True, saved_effort)
         self._run_slash_command(f"/model {provider}/{model_id}")
 
     def _recover_from_missing_model(self, target: str, notice: NoticeFn) -> None:
@@ -26644,6 +26799,34 @@ class OperatorApp(App[None]):
             _forget_fast_refusal(session)
         self._system_notice(_fast_receipt(label, target))
 
+    def _spec_with_clamped_effort(self, spec: Any, requested: str | None) -> Any:
+        """``spec`` carrying ``requested`` CLAMPED into its own ladder.
+
+        The difference from :meth:`_spec_with_chosen_effort` is the whole point:
+        a person's PICK is theirs to re-make, so the remembered-choice path
+        FORGETS one the new model cannot take. A level the CONFIGURATION states
+        must survive the swap — it is the standing default that was carried
+        across, and dropping it silently is the failure ``resolve_effort_in``
+        exists to prevent. So an unsupported rung here lands on the target's
+        NEAREST rung (ties downward) instead of being discarded, and a target
+        with no ladder at all leaves the spec unchanged.
+
+        ``requested=None`` is a no-op in practice: on every route that reaches
+        this with no value, ``reasoning_default_effort == reasoning_effort`` at
+        build time, so the resolver returns the level the spec already carries
+        and the identity return below is taken. It is not special-cased because
+        the resolver's own answer is the correct one when a caller does pass a
+        ``None`` onto a spec whose two fields disagree.
+        """
+        resolved = resolve_effort_in(
+            tuple(getattr(spec, "reasoning_efforts", ()) or ()),
+            getattr(spec, "reasoning_default_effort", None),
+            requested,
+        )
+        if resolved is None or resolved == getattr(spec, "reasoning_effort", None):
+            return spec
+        return spec.model_copy(update={"reasoning_effort": resolved})
+
     def _spec_with_chosen_effort(self, spec: Any) -> Any:
         """``spec`` carrying the level the user picked, when the model takes it.
 
@@ -26703,13 +26886,18 @@ class OperatorApp(App[None]):
         in one keystroke, so the listing names that key instead of competing
         with it.
 
-        The level is SESSION-scoped and deliberately not persistable, which is
-        where this parts company with ``PERSIST_HINT``. The model is a standing
-        preference — you want the same one next launch — while effort is a
-        per-task dial: raised for a hard refactor, dropped for chat. Freezing
+        The level is SESSION-scoped: ``/effort`` has no durable form of its own,
+        which is where this parts company with ``PERSIST_HINT``. The model is a
+        standing preference — you want the same one next launch — while effort is
+        a per-task dial: raised for a hard refactor, dropped for chat. Freezing
         one task's dial into every future session is the failure mode, so there
-        is no ``/effort default`` to write one, and the receipt says how long
-        the choice lasts instead of pointing at a command that would extend it.
+        is still no ``/effort default``. What changed with the ``model_effort``
+        key is that a level CAN be made the BIRTH default for new conversations
+        — by saving the model with ``/model default`` while it is in force —
+        which is a separate, deliberate action about the DEFAULT rather than a
+        side effect of turning a dial. So the SET receipt points at that
+        command (D10). The ``/effort auto`` receipt deliberately does not: auto
+        withdraws the preference, so there is nothing there to keep.
         """
         session = self._session
         spec = _model_spec(session)
@@ -26798,7 +26986,14 @@ class OperatorApp(App[None]):
             return
         # `notice`, not `_system_notice`: this one CHANGED something, so it is a
         # receipt for an action rather than an answer about the app's settings.
-        notice(f"reasoning effort: {current or 'provider default'} → {wanted} (this session)")
+        # The pointer is the one place the app tells the user a level can be made
+        # the standing default (D10); it is on this receipt and not on the bare
+        # listing, whose budget is tight and whose "this session only" clause is
+        # still exactly true of the command it describes.
+        notice(
+            f"reasoning effort: {current or 'provider default'} → {wanted} "
+            f"(this session) — /model default to keep it"
+        )
 
     # -- theme --------------------------------------------------------------
     def _cmd_theme(self, arg: str, notice: NoticeFn) -> None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -25863,12 +25863,17 @@ class OperatorApp(App[None]):
         provider = provider.lower()  # build_model_spec is case-insensitive
         if self._providers is None:
             # An ARMED effort override goes with the dispatch that failed (B2):
-            # `_cmd_model_saved` arms one for exactly this call, and the two
-            # guards here are the only ways it can end without reaching
-            # `_activate_resolved_model`. Dropping it at the entry guard alone
-            # would leave the field reading `(True, 'none')` after the refusal
-            # below — harmless to the user, but a state that outlives the command
-            # it belonged to is what made the original leak hard to see.
+            # `_cmd_model_saved` arms one for exactly this call, and this guard
+            # plus the unknown-provider check below are the ways THAT dispatch
+            # ends without reaching `_activate_resolved_model`. (It is not the
+            # only way the pair can end un-consumed: `_run_slash_command` has an
+            # early return of its own, ABOVE this method entirely. That path is
+            # closed where it opens — in `_cmd_model_saved`, after the dispatch
+            # returns — because nothing in here runs on it at all; see NEW-1.)
+            # Dropping it at the entry guard alone would leave the field reading
+            # `(True, 'none')` after the refusal below — harmless to the user,
+            # but a state that outlives the command it belonged to is what made
+            # the original leak hard to see.
             self._pending_effort_override = (False, None)
             self._system_notice(
                 "provider controller unavailable — cannot infer model spec", "warning"
@@ -26292,16 +26297,32 @@ class OperatorApp(App[None]):
             # is named — so the cells come out of the preamble and the pair, which
             # carry the same information the file path and the label already show.
             #
-            # "used by new sessions", the noun PERSIST_HINT already uses, not
-            # "from the next launch" (design review D3): a user who ran this
-            # after reading the footer met three phrasings of "when" within two
-            # rows. "New sessions" is also the fuller claim — `/new` reloads
-            # `hosting`/`model_name` before it builds, so the default applies
-            # there as well as at relaunch. The settings page keeps its own
-            # "new launch" vocabulary; it is a different surface.
+            # "for new sessions", the noun PERSIST_HINT already uses ("… saves
+            # this for new sessions"), not "from the next launch" (design review
+            # D3): a user who ran this after reading the footer met three
+            # phrasings of "when" within two rows. "New sessions" is also the
+            # fuller claim — `/new` reloads `hosting`/`model_name` before it
+            # builds, so the default applies there as well as at relaunch. The
+            # settings page keeps its own "new launch" vocabulary; it is a
+            # different surface.
+            #
+            # The 110-cell budget at 120 columns is measured against the path a
+            # DEFAULT install renders — `~/.local-operator/config.yml` (28 cells
+            # home-relative), not the 19-cell `~/config/config.yml` a redirected
+            # test home produces, which is the 9 cells that took this row to 111
+            # and widowed the qualifier (U8). Two words bought the room back:
+            # `boot ` (5 cells) and `used by` (4). "new sessions" is the noun
+            # PERSIST_HINT itself uses, so the shorter qualifier keeps the
+            # vocabulary the sibling receipt already prints, and the row now fits
+            # every shipped direct label INCLUDING the longest rung the shared
+            # vocabulary can carry. What it cannot fit is a selector long enough
+            # to spend the whole budget by itself — see NEW-3 in the round-3
+            # comment: `openrouter/deepseek/deepseek-chat-v3.1-terminus` is 47
+            # cells of model id against a 110-cell row that also carries a 28-cell
+            # path, and no copy of this receipt holds that.
             notice(
-                f"boot default: {saved_to} — {provider}/{model_id}, "
-                f"model_effort {saved_effort or 'auto'} (used by new sessions){suffix}"
+                f"default: {saved_to} — {provider}/{model_id}, "
+                f"model_effort {saved_effort or 'auto'} (new sessions){suffix}"
             )
             if requested_effort and saved_effort and saved_effort != requested_effort:
                 # The clamp dropped a rung on the way to durable (U4). On its own
@@ -26310,9 +26331,19 @@ class OperatorApp(App[None]):
                 # true. README documents the rule; this names the instance the
                 # user just created, where the stored level silently differs from
                 # the one they were running.
+                #
+                # `reasoning effort:` rather than `model_effort` (U9): every
+                # other row in this feature opens with the user-facing name of
+                # the dial, and `model_effort` is the config KEY — the spelling a
+                # user only meets on the settings page's detail line. "to the
+                # nearest rung" rather than "to this model's nearest rung": the
+                # model is on the band one row above, and the 2 shorter words are
+                # what keep the row inside the 70-cell budget for the longest
+                # level words the vocabulary can carry (U9's own suggested
+                # wording measures 71 for a 7-cell rung).
                 notice(
-                    f"model_effort {saved_effort} ({requested_effort} clamps to this "
-                    "model's nearest rung)",
+                    f"reasoning effort: {saved_effort} "
+                    f"({requested_effort} clamps to the nearest rung)",
                     "info",
                 )
         else:
@@ -26476,10 +26507,33 @@ class OperatorApp(App[None]):
         # The handoff marker travels WITH it: `_cmd_model` clears an armed
         # override at every entry except the dispatch this marker tags, so the
         # override survives exactly the one hop below and cannot outlive it (B2).
+        #
+        # The cleanup below is the OTHER half of that invariant, and it is what
+        # makes it an invariant rather than a property of the happy path
+        # (NEW-1). The dispatch is a string through the general slash
+        # dispatcher, which has an early return of its own ABOVE `_cmd_model`:
+        # when the source is not ready and the command is not in
+        # `_SAVED_LOCAL_COMMANDS` (and `/model` is not) it answers
+        # `_allow_source_command()` and returns without entering the handler at
+        # all. Nothing in there would then clear either field, and the stranded
+        # marker would EAT the next entry's clear — so a later, unrelated
+        # `/model` switch would land on the stored level. That window is
+        # reachable: `_cmd_model_saved` has a caller that does not
+        # readiness-check first (the `local_setup` login continuation), and a
+        # mid-retry/cold-bind source can be un-ready at this instant.
+        #
+        # So: armed, dispatched, and whatever is still armed afterwards belonged
+        # to no dispatch. The marker is the record of "the handler consumed it",
+        # and only `_cmd_model` clears it — an asynchronous activation (a local
+        # provider's capacity check) leaves it consumed while the override is
+        # still in flight, which is why this checks the MARKER and not the pair.
         if not callable(getattr(session, "route_shared_slash", None)):
             self._pending_effort_override = (True, saved_effort)
             self._effort_override_handoff = True
         self._run_slash_command(f"/model {provider}/{model_id}")
+        if self._effort_override_handoff:
+            self._effort_override_handoff = False
+            self._pending_effort_override = (False, None)
 
     def _recover_from_missing_model(self, target: str, notice: NoticeFn) -> None:
         """Write a model into config from the setup state, then BOOT the session.
@@ -27154,12 +27208,19 @@ class OperatorApp(App[None]):
         # (`_effort_label`), so the receipt and the band name one state one way.
         # The old `provider default` was a second spelling of it and 12 cells
         # longer, which is the whole budget the pointer gets (design review D2:
-        # a notice row holds 70 cells at 80 columns). `; /model default keeps it`
-        # rather than ` — /model default to keep it` is the 3 cells that fit.
-        notice(
-            f"reasoning effort: {current or 'auto'} → {wanted} "
-            f"(this session); /model default keeps it"
-        )
+        # a notice row holds 70 cells at 80 columns).
+        #
+        # `(session)` rather than `(this session)` is what makes that budget
+        # INVARIANT rather than spot-checked (round-2 D9/NEW-2/Q1). The row's size
+        # is a function of two rung words, and both vary: `high → xhigh` (the pair
+        # D2 was measured on) is 70, but `medium → xhigh` is 71 and
+        # `minimal → medium` — reachable through a provider's own ladder — is 73.
+        # Dropping the one word buys 5 cells, so every ordered pair the shared
+        # vocabulary can form now fits. The scope is still named — that half is
+        # load-bearing, or the pointer reads as if the level were already durable.
+        # The string lives in `EFFORT_SET_RECEIPT` so its budget can be tested
+        # against the shipped copy rather than a copy of it.
+        notice(EFFORT_SET_RECEIPT.format(current=current or "auto", wanted=wanted))
 
     # -- theme --------------------------------------------------------------
     def _cmd_theme(self, arg: str, notice: NoticeFn) -> None:
@@ -33122,7 +33183,7 @@ class OperatorApp(App[None]):
             )
         return SlashResult(
             kind="notice",
-            text=f"reasoning effort: {current or 'auto'} → {wanted} (this session)",
+            text=EFFORT_SET_RECEIPT.format(current=current or "auto", wanted=wanted),
             style="info",
         )
 
@@ -36715,6 +36776,18 @@ def mode_word(auto: bool) -> str:
     describing the same setting.
     """
     return "auto" if auto else "ask"
+
+
+#: The `/effort <level>` set receipt: the level that was in force (or ``auto``)
+#: and the one now applied. A module constant because its width is a PROPERTY of
+#: the copy rather than of the pair it was last measured on — every ordered pair
+#: of rungs the shared vocabulary can form has to fit one 70-cell notice row at
+#: 80 columns (design review round 2, D9 / review NEW-2 / QA Q1) — and the test
+#: that proves that has to measure the SHIPPED string rather than a copy of it
+#: kept in the test file. `(session)`, one word shorter than the sibling
+#: receipts' `(this session)`, is the 5 cells that buy the invariant: 18 + 3 +
+#: rungs + 30 ≤ 70 holds for the longest two words in the vocabulary.
+EFFORT_SET_RECEIPT = "reasoning effort: {current} → {wanted} (session); /model default keeps it"
 
 
 def _effort_unavailable(label: str) -> str:

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -4075,3 +4075,93 @@ async def test_a_fast_mode_refusal_is_narrated_once_and_forwarded_to_the_session
 
     stream.forget_fast_refusal()
     assert not state.fast_refused_for("anthropic/claude-opus-5")
+
+
+class TestTheConfiguredEffortClamp:
+    """``configure_model(reasoning_effort=…)`` — the config default, clamped.
+
+    The clamp belongs on the spec builder because that is the one place a
+    session spec is BORN: the status band, the wire client's membership
+    re-check and the failover driver then all read a single value rather than
+    re-deriving one. It clamps against the SPEC's own ladder rather than the
+    effort table's, because an aggregator listing can narrow the ladder below
+    the table's — the split brain ``resolve_effort_in``'s docstring documents.
+    """
+
+    def test_a_supported_level_is_applied(self, mock_credential_manager) -> None:
+        config = configure_model(
+            "anthropic", "claude-opus-5", mock_credential_manager, reasoning_effort="low"
+        )
+        assert config.spec.reasoning_effort == "low"
+
+    def test_an_unsupported_level_lands_on_the_nearest_rung(self, mock_credential_manager) -> None:
+        """`claude-opus-4-6` offers low/medium/high/max, so `xhigh` is one rung
+        from `high` and one from `max`; a tie goes DOWN (``resolve_effort_in``).
+        Reaching the wire unclamped would be a silent drop beneath a band that
+        still named the level."""
+        config = configure_model(
+            "anthropic", "claude-opus-4-6", mock_credential_manager, reasoning_effort="xhigh"
+        )
+        assert config.spec.reasoning_effort == "high"
+
+    def test_the_clamp_can_move_upward_too(self, mock_credential_manager) -> None:
+        """`gpt-6-astra`'s ladder starts at `low`, so the vocabulary's `none`
+        has only one rung to land on and it is ABOVE the request."""
+        config = configure_model(
+            "openai", "gpt-6-astra", mock_credential_manager, reasoning_effort="none"
+        )
+        assert config.spec.reasoning_effort == "low"
+
+    def test_a_model_with_no_ladder_ignores_the_level(self, mock_credential_manager) -> None:
+        """A non-reasoning model must not acquire a level it would silently
+        drop — and no warning either, since a standing config value the model
+        simply cannot express is not an error, only a level out of reach."""
+        config = configure_model(
+            "deepseek", "deepseek-chat", mock_credential_manager, reasoning_effort="high"
+        )
+        assert config.spec.reasoning_efforts == ()
+        assert config.spec.reasoning_effort is None
+
+    def test_the_models_own_default_is_never_overwritten(self, mock_credential_manager) -> None:
+        """``/effort auto`` RESTORES ``reasoning_default_effort``, so it has to
+        stay the MODEL's documented default and not the configured one (D4).
+        Overwriting it would make "auto" mean the configured level, the exact
+        opposite of the withdrawal the command performs."""
+        config = configure_model(
+            "anthropic", "claude-opus-5", mock_credential_manager, reasoning_effort="low"
+        )
+        assert config.spec.reasoning_default_effort == "high"
+
+    def test_a_level_already_in_force_is_left_alone(self, mock_credential_manager) -> None:
+        """Anthropic seeds `high` directly, so asking for `high` must resolve to
+        what the spec already carries. The observable guard is the value; the
+        point of the ``!=`` in the implementation is to skip the copy."""
+        config = configure_model(
+            "anthropic", "claude-opus-5", mock_credential_manager, reasoning_effort="high"
+        )
+        assert config.spec.reasoning_effort == "high"
+
+    def test_no_argument_leaves_the_builders_seed(self, mock_credential_manager) -> None:
+        """``None`` is "no opinion": an absent key must not disturb the spec
+        builder's own seeding, which for a direct Anthropic route is `high`."""
+        config = configure_model("anthropic", "claude-opus-5", mock_credential_manager)
+        assert config.spec.reasoning_effort == "high"
+
+    def test_a_listing_narrowed_ladder_is_the_clamp_target(self, mock_credential_manager) -> None:
+        """The split-brain case made concrete: a listing can offer
+        medium/high/xhigh while the table for the same id offers
+        none/low/medium/high/xhigh. Clamping against the TABLE would keep a
+        ``low`` the route rejects; the clamp must read the SPEC's ladder, which
+        ``build_model_spec`` installed from the listing."""
+        widened = build_model_spec("openai", "gpt-5.4")
+        narrowed = widened.model_copy(
+            update={
+                "reasoning_efforts": ("medium", "high", "xhigh"),
+                "reasoning_default_effort": "medium",
+            }
+        )
+        with patch("local_operator.model.configure.build_model_spec", return_value=narrowed):
+            config = configure_model(
+                "openai", "gpt-5.4", mock_credential_manager, reasoning_effort="low"
+            )
+        assert config.spec.reasoning_effort == "medium"

--- a/tests/unit/model/test_effort.py
+++ b/tests/unit/model/test_effort.py
@@ -10,11 +10,15 @@ outlive the model it was chosen for.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
+from local_operator.config import ConfigManager
 from local_operator.model.configure import build_model_spec
 from local_operator.model.effort import (
     EFFORT_ORDER,
+    configured_effort,
     default_effort,
     next_effort,
     resolve_effort,
@@ -380,3 +384,53 @@ class TestClampingAgainstAnExplicitLadder:
             assert resolve_effort("claude-opus-5", requested) == resolve_effort_in(
                 supported_efforts("claude-opus-5"), default_effort("claude-opus-5"), requested
             )
+
+
+class TestConfiguredEffort:
+    """``configured_effort`` — the one reader of the ``model_effort`` key.
+
+    The registered key is the only vocabulary; this function just resolves it
+    and normalises the value. What matters most here is the property a rewrite
+    is most likely to lose: it sits on the BOOT path (``_prepare`` and
+    ``bootstrap.resolve_model_configuration``), so it must NEVER raise. A
+    broken, missing or hand-edited config degrades to "no opinion" — exactly
+    the behaviour before the key existed — rather than failing a launch.
+    """
+
+    @staticmethod
+    def _stored(tmp_path, value: Any) -> ConfigManager:
+        """A manager holding ``value`` at the key, as a hand-edit would.
+
+        ``set_config_value`` rather than the ``write_setting`` facade, because
+        the facade VALIDATES: a mis-cased or off-vocabulary value can only get
+        into the file by hand, which is the case this reader has to survive.
+        """
+        manager = ConfigManager(tmp_path)
+        manager.set_config_value("model_effort", value)
+        return manager
+
+    def test_absent_key_is_no_opinion(self, tmp_path) -> None:
+        assert configured_effort(ConfigManager(tmp_path)) is None
+
+    def test_empty_and_whitespace_are_no_opinion(self, tmp_path) -> None:
+        """The registry's own "no opinion" is the empty string, and the reader
+        must agree with the schema rather than inventing a second spelling."""
+        assert configured_effort(self._stored(tmp_path, "")) is None
+        assert configured_effort(self._stored(tmp_path, "   ")) is None
+
+    def test_a_level_is_normalised_to_lowercase(self, tmp_path) -> None:
+        assert configured_effort(self._stored(tmp_path, "High")) == "high"
+
+    def test_an_unknown_word_is_passed_through(self, tmp_path) -> None:
+        """Deliberately NOT validated away: ``resolve_effort_in`` answers an
+        off-vocabulary request with the model's own default, so a typo degrades
+        to the model default instead of raising on the boot path — and the
+        settings page can still show the user the odd token they stored."""
+        assert configured_effort(self._stored(tmp_path, "turbo")) == "turbo"
+
+    def test_it_never_raises(self) -> None:
+        """A manager that cannot answer, and the crudest wrong type, both mean
+        "no configured effort". This is the one property a boot path cannot
+        compromise on."""
+        assert configured_effort(None) is None
+        assert configured_effort(object()) is None

--- a/tests/unit/model/test_effort.py
+++ b/tests/unit/model/test_effort.py
@@ -434,3 +434,55 @@ class TestConfiguredEffort:
         compromise on."""
         assert configured_effort(None) is None
         assert configured_effort(object()) is None
+
+    def test_a_yaml_null_is_no_opinion_not_the_none_rung(self, tmp_path) -> None:
+        """B1: ``model_effort:`` with no value, ``model_effort: null`` and
+        ``model_effort: ~`` all parse to Python ``None``, and ``str(None)``
+        lowercases to ``"none"`` — a REAL rung of ``EFFORT_ORDER``.
+
+        So the plainest spelling of "clear the key" silently turned reasoning
+        OFF for every new conversation of any model whose ladder offers it, and
+        durably: D6's clause 2 reads the same value back, so a later
+        ``/model default`` re-persists it. This docstring's own promise — "a
+        missing key, an unreadable file and a non-string value all read as
+        ``None``" — was exactly the case that failed. Read through the FILE,
+        because a YAML null is how a hand edit spells it.
+        """
+        for stored in ("model_effort:\n", "model_effort: null\n", "model_effort: ~\n"):
+            (tmp_path / "config.yml").write_text(
+                "version: 0.0.0\nvalues:\n  hosting: anthropic\n"
+                "  model_name: claude-opus-5\n  " + stored
+            )
+            assert configured_effort(ConfigManager(tmp_path)) is None, stored
+
+    def test_a_null_stored_effort_leaves_the_boot_on_the_model_default(self, tmp_path) -> None:
+        """The consequence, composed the way ``session_factory._prepare``
+        composes it: the reader's answer goes through ``resolve_effort_in``
+        against the model's own ladder.
+
+        A null used to arrive there as the literal REQUEST ``none``, which clamps
+        onto the nearest rung instead of degrading to the documented default —
+        ``low`` on ``claude-opus-5``, reasoning at its floor, with no warning
+        anywhere (the boot clamp is silent by design and the band names the rung
+        in force, which is why nothing contradicted it on screen)."""
+        (tmp_path / "config.yml").write_text(
+            "version: 0.0.0\nvalues:\n  hosting: anthropic\n"
+            "  model_name: claude-opus-5\n  model_effort:\n"
+        )
+        spec = build_model_spec("anthropic", "claude-opus-5")
+        resolved = resolve_effort_in(
+            spec.reasoning_efforts,
+            spec.reasoning_default_effort,
+            configured_effort(ConfigManager(tmp_path)),
+        )
+        assert resolved == "high"
+
+    def test_other_non_string_types_are_no_opinion(self, tmp_path) -> None:
+        """The mirror half of B1: an ``int`` read as ``'3'`` and a ``bool`` as
+        ``'true'``/``'false'``. Both were harmless only by accident — they are
+        off-vocabulary, so ``resolve_effort_in`` happened to reject them — and
+        neither is a level this key should answer with. ``none`` was the one
+        wrong type that is also in the vocabulary, which is why the guard has to
+        be a TYPE check rather than the vocabulary check downstream."""
+        assert configured_effort(self._stored(tmp_path, 3)) is None
+        assert configured_effort(self._stored(tmp_path, True)) is None

--- a/tests/unit/session/test_config_live.py
+++ b/tests/unit/session/test_config_live.py
@@ -48,6 +48,18 @@ from local_operator.spawn.policy import fork_cmux_placement, fork_mode
 
 MODEL = ModelSpec(provider="test", model_id="m", context_window=100_000)
 
+#: A spec of the shape ``build_model_spec`` produces for a model with a
+#: documented default: the level is SEEDED (both fields equal) and becomes a
+#: choice only once the user picks one. The M2 probe needs this shape, because
+#: ``MODEL`` seeds nothing and the seed-versus-choice rule is the whole point.
+SEEDED = ModelSpec(
+    provider="test",
+    model_id="m",
+    context_window=100_000,
+    reasoning_effort="high",
+    reasoning_default_effort="high",
+)
+
 
 @pytest.fixture(autouse=True)
 def _fresh_registry():
@@ -123,8 +135,12 @@ def make_session(tmp_path, stream, **kwargs) -> Session:
             enabled=("web_search", "web_fetch"),
         ),
     )
+    # ``model`` is overridable so a probe can seat a spec that SEEDS an effort
+    # (``build_model_spec`` sets ``reasoning_effort`` ==
+    # ``reasoning_default_effort``), which is the shape M2 is about; ``MODEL``
+    # seeds nothing and would leave the seed/choice distinction untested.
     return Session(
-        model=MODEL,
+        model=kwargs.pop("model", MODEL),
         stream_fn=stream,
         tools=tools,
         transcript=Transcript(tmp_path / "sess"),
@@ -1362,5 +1378,95 @@ async def test_an_external_effort_edit_says_so_once(tmp_path, monkeypatch) -> No
         # model and level are untouched.
         assert session.model.model_id == "chosen"
         assert session.model.reasoning_effort == MODEL.reasoning_effort
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_an_external_write_of_the_same_pair_says_nothing(tmp_path, monkeypatch) -> None:
+    """M2: a delivery carrying the SAME model pair must stay silent even when the
+    session's spec SEEDS a level.
+
+    ``build_model_spec`` sets ``reasoning_effort`` to ``reasoning_default_effort``
+    at build time and "they diverge as soon as the user picks a level" — so a
+    spec whose two fields are equal carries a SEED, not a choice, while a stored
+    ``""`` means "no opinion". Comparing the stored string against the raw field
+    made the guard fail to short-circuit for every seed-carrying model (Anthropic
+    seeds ``high``), so a write that changed nothing about the effective default
+    printed "someone changed your default" — on the exact surface the session
+    uses to tell the user that.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    manager = ConfigManager(config_dir)
+    manager.set_config_value("hosting", SEEDED.provider)
+    session = make_session(
+        tmp_path, RebindableStream({}), model=SEEDED, compaction_settings=CompactionSettings()
+    )
+    _capture_events(session)
+    watcher = process_watcher(config_dir)
+    subscribe(session, watcher)
+    try:
+        await _settle(session)
+        _EVENTS[id(session)].clear()
+
+        # The model name arriving on disk under a session already on that model:
+        # one key changes, and the pair it lands on is the pair in force.
+        write_from_another_process(config_dir, "model_name", SEEDED.model_id)
+        change = watcher.poll_now()
+        assert change is not None and change.source == "disk"
+        assert change.changed_keys == frozenset({"model_name"})
+        await _settle(session)
+
+        assert _notices(session) == [], _notices(session)
+        assert session.model.model_id == SEEDED.model_id
+        assert session.model.reasoning_effort == "high"
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_an_effort_only_external_edit_names_the_effort(tmp_path, monkeypatch) -> None:
+    """U6: with the model pair unchanged, the notice names the member that moved
+    AND its value.
+
+    "keeping <model>; default changed for new sessions" is literally true for an
+    effort edit, and it left the reader unable to tell whether the model default,
+    the effort default or both had moved — short of opening ``/settings``. The
+    value shown is the stored one, in the registry's vocabulary (``auto`` for the
+    empty string).
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    manager = ConfigManager(config_dir)
+    manager.set_config_value("hosting", SEEDED.provider)
+    manager.set_config_value("model_name", SEEDED.model_id)
+    session = make_session(
+        tmp_path, RebindableStream({}), model=SEEDED, compaction_settings=CompactionSettings()
+    )
+    _capture_events(session)
+    watcher = process_watcher(config_dir)
+    subscribe(session, watcher)
+    try:
+        await _settle(session)
+        _EVENTS[id(session)].clear()
+
+        write_from_another_process(config_dir, "model_effort", "medium")
+        change = watcher.poll_now()
+        assert change is not None and change.source == "disk"
+        assert change.changed_keys == frozenset({"model_effort"})
+        await _settle(session)
+
+        events = [e for e in _EVENTS[id(session)] if e.type == "notice"]
+        assert len(events) == 1, events
+        assert events[0].headline == "Effort default changed"
+        assert events[0].text == (
+            "keeping test/m; reasoning effort default changed for new sessions (medium); "
+            "/model saved adopts it here"
+        )
+        # The birth default moved; the running session did not.
+        assert session.model.reasoning_effort == "high"
     finally:
         await session.dispose()

--- a/tests/unit/session/test_config_live.py
+++ b/tests/unit/session/test_config_live.py
@@ -1462,11 +1462,147 @@ async def test_an_effort_only_external_edit_names_the_effort(tmp_path, monkeypat
         events = [e for e in _EVENTS[id(session)] if e.type == "notice"]
         assert len(events) == 1, events
         assert events[0].headline == "Effort default changed"
+        # No `keeping <label>` clause: the pair MATCHES this session's model by
+        # construction on this branch, so the label restated the band and the 24
+        # cells it cost are what pushed this row over budget (U7).
         assert events[0].text == (
-            "keeping test/m; reasoning effort default changed for new sessions (medium); "
+            "reasoning effort default changed for new sessions (medium); "
             "/model saved adopts it here"
         )
         # The birth default moved; the running session did not.
         assert session.model.reasoning_effort == "high"
     finally:
         await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_model_default_notice_is_change_based(tmp_path, monkeypatch) -> None:
+    """The round-3 ruling: announce iff the pair still matches AND
+    ``model_effort`` is one of the keys that MOVED.
+
+    A value comparison cannot express that, which is what three rounds of
+    findings on this predicate amount to. It has to decide what the session's
+    "own" level is, and every version of that rule mis-fires in one direction:
+    comparing against the raw spec field announced for every seed-carrying model
+    (M2); normalising the seed to ``""`` announced for a session holding a
+    DELIBERATE level (Q2); and it made a genuine move to ``""`` silent for a
+    session on the seeded level (Q3) — the one member of this section the effort
+    term exists to keep audible. ``ConfigChange.changed_keys`` states which
+    registry key really moved, which is a fact about the writer rather than a
+    guess about the reader.
+
+    Every row below is driven through a real ``Session`` on the real
+    config-directory watcher, with a fresh config dir per case. The disk rows
+    write a key whose value is genuinely new (a matching pair that was not on
+    disk before), so each delivery is real rather than an unchanged-file no-op.
+    """
+
+    async def drive(
+        name: str,
+        *,
+        config: dict[str, Any],
+        spec: ModelSpec,
+        write: tuple[str, Any],
+        local: bool = False,
+    ) -> tuple[Any, list[str]]:
+        case = tmp_path / name
+        config_dir = case / "config"
+        config_dir.mkdir(parents=True)
+        monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+        manager = ConfigManager(config_dir)
+        for key, value in config.items():
+            manager.set_config_value(key, value)
+        session = make_session(
+            case, RebindableStream({}), model=spec, compaction_settings=CompactionSettings()
+        )
+        _capture_events(session)
+        watcher = process_watcher(config_dir)
+        subscribe(session, watcher)
+        try:
+            await _settle(session)
+            _EVENTS[id(session)].clear()
+            key, value = write
+            change = None
+            if local:
+                setting = settings_io.resolve_key(key)
+                assert setting is not None, key
+                settings_io.write_setting(manager, setting, value)
+            else:
+                write_from_another_process(config_dir, key, value)
+                change = watcher.poll_now()
+            await _settle(session)
+            return change, _notices(session)
+        finally:
+            await session.dispose()
+
+    pair = {"hosting": MODEL.provider, "model_name": MODEL.model_id}
+    #: A spec in the M2/Q2 shape: the level it CARRIES is not the one it was
+    #: seeded with, i.e. the session holds a deliberate pick.
+    deliberate = MODEL.model_copy(
+        update={
+            "reasoning_effort": "low",
+            "reasoning_default_effort": "high",
+            "reasoning_efforts": ("low", "medium", "high"),
+        }
+    )
+
+    # 1. An unrelated write: the pair is re-stated (the key was not on disk
+    #    before) and no effort key moved. Silent.
+    change, notices = await drive(
+        "unrelated", config={"hosting": MODEL.provider}, spec=MODEL, write=("model_name", "m")
+    )
+    assert change is not None and change.changed_keys == frozenset({"model_name"})
+    assert notices == [], notices
+
+    # 2. The same write against a session holding a DELIBERATE level: still
+    #    silent. This is Q2 exactly — the round-1 rule compared values and
+    #    announced here because "low" != "".
+    change, notices = await drive(
+        "deliberate",
+        config={"hosting": MODEL.provider},
+        spec=deliberate,
+        write=("model_name", "m"),
+    )
+    assert change is not None and change.changed_keys == frozenset({"model_name"})
+    assert notices == [], notices
+
+    # 3. Effort-only, to a rung: announced, naming the member and the value.
+    change, notices = await drive(
+        "rung",
+        config={**pair, "model_effort": ""},
+        spec=MODEL,
+        write=("model_effort", "medium"),
+    )
+    assert change is not None and change.changed_keys == frozenset({"model_effort"})
+    assert notices == [
+        "reasoning effort default changed for new sessions (medium); /model saved adopts it here"
+    ], notices
+
+    # 4. Effort-only, to auto (the stored empty string), on a session sitting on
+    #    the SEEDED level: announced, and named `auto`. This is Q3 — the round-1
+    #    rule was silent here, which is the direction that loses a change.
+    change, notices = await drive(
+        "auto",
+        config={**pair, "model_effort": "medium"},
+        spec=MODEL,
+        write=("model_effort", ""),
+    )
+    assert change is not None and change.changed_keys == frozenset({"model_effort"})
+    assert notices == [
+        "reasoning effort default changed for new sessions (auto); /model saved adopts it here"
+    ], notices
+
+    # 5. The same change written by THIS process's facade: silent, because the
+    #    surface that wrote it printed its own receipt (#785's source gate).
+    _change, notices = await drive(
+        "local", config=pair, spec=MODEL, write=("model_effort", "high"), local=True
+    )
+    assert notices == [], notices
+
+    # 6. The model pair itself moved: the #785 notice, unchanged — the session
+    #    keeps its model and hears that new conversations will not.
+    change, notices = await drive("pair", config=pair, spec=MODEL, write=("model_name", "other"))
+    assert change is not None
+    assert notices == [
+        "keeping test/m; default changed for new sessions. /model saved adopts it here"
+    ], notices

--- a/tests/unit/session/test_config_live.py
+++ b/tests/unit/session/test_config_live.py
@@ -1089,8 +1089,15 @@ async def test_saving_the_default_here_never_reports_the_torn_pair(tmp_path, mon
         _EVENTS[id(session)].clear()
 
         # Exactly the loop in ``OperatorApp._activate_resolved_model``: the
-        # facade, one call per key, each notifying this process's watcher.
-        for key, value in (("hosting", "openai"), ("model_name", "gpt-x")):
+        # facade, one call per key, each notifying this process's watcher. The
+        # third key is the effort the persist path now writes LAST (D7); it
+        # notifies on its own, and must be silent for the same reason the pair
+        # is — the command printed its own receipt.
+        for key, value in (
+            ("hosting", "openai"),
+            ("model_name", "gpt-x"),
+            ("model_effort", "low"),
+        ):
             setting = settings_io.resolve_key(key)
             assert setting is not None, key
             settings_io.write_setting(manager, setting, value)
@@ -1102,6 +1109,7 @@ async def test_saving_the_default_here_never_reports_the_torn_pair(tmp_path, mon
         saved = ConfigManager(config_dir)
         assert saved.get_config_value("hosting") == "openai"
         assert saved.get_config_value("model_name") == "gpt-x"
+        assert saved.get_config_value("model_effort") == "low"
     finally:
         await session.dispose()
 
@@ -1309,5 +1317,50 @@ async def test_a_re_enabled_web_tool_returns_to_its_registry_position(
         assert DEFAULT_TOOL_NAMES.index("web_search") < DEFAULT_TOOL_NAMES.index("web_fetch")
         assert after.index("web_search") < after.index("web_fetch"), after
         assert after[-1] != "web_search", "the re-enabled tool was appended"
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_an_external_effort_edit_says_so_once(tmp_path, monkeypatch) -> None:
+    """D9: the model-default notice covers an ``model_effort``-only edit too.
+
+    The TUI's own listener SKIPS the whole ``model`` section — a local write is
+    the author's own receipt — so without the effort in this predicate an edit
+    made in another process would move new conversations' birth default with no
+    signal anywhere: the one member of the section that changed silently. The
+    notice's advice is now literally true, because ``/model saved`` adopts the
+    configured effort here (D8) — so naming the change names the remedy.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    manager = ConfigManager(config_dir)
+    manager.set_config_value("hosting", MODEL.provider)
+    manager.set_config_value("model_name", MODEL.model_id)
+    session = make_session(tmp_path, RebindableStream({}), compaction_settings=CompactionSettings())
+    _capture_events(session)
+    watcher = process_watcher(config_dir)
+    subscribe(session, watcher)
+    try:
+        session.set_model(MODEL.model_copy(update={"model_id": "chosen"}), explicit=True)
+        await _settle(session)
+        _EVENTS[id(session)].clear()
+
+        write_from_another_process(config_dir, "model_effort", "high")
+        change = watcher.poll_now()
+        assert change is not None and change.source == "disk"
+        # One key, so the delivery cannot tear; the predicate's third member is
+        # what makes it differ from the spec's level and print.
+        assert change.changed_keys == frozenset({"model_effort"})
+        await _settle(session)
+
+        notices = _notices(session)
+        assert len(notices) == 1, notices
+        assert "keeping test/chosen" in notices[0] and "new sessions" in notices[0]
+        # The key is a birth default for NEW conversations: a running session's
+        # model and level are untouched.
+        assert session.model.model_id == "chosen"
+        assert session.model.reasoning_effort == MODEL.reasoning_effort
     finally:
         await session.dispose()

--- a/tests/unit/session/test_model_ownership.py
+++ b/tests/unit/session/test_model_ownership.py
@@ -464,3 +464,45 @@ async def test_cold_viewer_birth_and_resume_use_same_selection(tmp_path):
         assert resumed.model.model_id == A.model_id
     finally:
         await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_resumed_journal_outranks_the_configured_birth_effort(tmp_path):
+    """`model_effort` is a BIRTH default, so a conversation's own stored
+    selection — the journal row every `/model` writes — outranks it on resume.
+
+    The two keys answer different questions: "what should NEW conversations
+    start on" versus "what was THIS conversation running". A config effort that
+    overrode a restored row would silently move a conversation the user had
+    deliberately left somewhere else, and would do it on the one path
+    (`--resume`) where they most expect their state back.
+    """
+    from local_operator.model.configure import build_model_spec
+    from local_operator.session.transcript import Transcript as _Transcript
+
+    directory = tmp_path / "sessions" / "effort-journal"
+    transcript = _Transcript(directory)
+    # A version-2 row, i.e. one that carries an effort (the writer only emits
+    # `effort` from v2 on), naming a model whose ladder can express `low`.
+    await transcript.append_custom(
+        "selected_model",
+        {"version": 2, "selector": "anthropic/claude-opus-5", "effort": "low"},
+    )
+    # The BIRTH spec a configured `model_effort: high` would have produced.
+    birth = build_model_spec("anthropic", "claude-opus-5").model_copy(
+        update={"reasoning_effort": "high"}
+    )
+    stream = ScriptedStream([text_turn("ok")])
+    owner = Session(
+        model=birth,
+        model_source="config",
+        stream_fn=stream,
+        tools=[],
+        transcript=_Transcript(directory),
+        system_blocks_provider=lambda: [],
+        cwd=str(directory.parent),
+    )
+    try:
+        assert owner.model.reasoning_effort == "low"
+    finally:
+        await owner.dispose()

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -3785,3 +3785,71 @@ async def test_a_raising_revalidation_never_kills_the_poller(monkeypatch) -> Non
             break
     assert calls["n"] >= 3, "the poller stopped after a raising tick"
     await session.dispose()
+
+
+# --- The configured birth-default effort (model_effort) -----------------------
+
+
+async def _prepare_effort_plan(config_manager, tmp_config_dir: Path, **arg_overrides):
+    """Drive the real ``_prepare`` for a model whose ladder is the shipped one.
+
+    ``_prepare`` is the ONE funnel every launch path shares — TUI boot, /new,
+    /reload, /resume, ``lop exec``, the server and the scheduler — so the
+    configured effort is read there rather than mutated post-hoc by each
+    caller. Anthropic's `claude-opus-5` is used because its ladder is a real
+    one (low/medium/high/xhigh/max) and resolves offline from the registry.
+    """
+    from local_operator.session_factory import _prepare
+
+    registry = FakeRegistry(tmp_config_dir)
+    credential_manager = MagicMock()
+    credential_manager.get_credential.return_value = None
+    args = _args(**{"hosting": "anthropic", "model": "claude-opus-5", **arg_overrides})
+    return await _prepare(
+        args,
+        cast("ConfigManager", config_manager),
+        credential_manager,
+        cast("AgentRegistry", registry),
+        has_ui=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_configured_effort_reaches_the_spec_picked_by_the_flag(
+    tmp_config_dir: Path,
+) -> None:
+    """Carried unconditionally on ``model_source``: a ``--model`` flag chooses a
+    MODEL, not an effort, so the standing configured level rides across it — and
+    the clamp in ``configure_model`` is what makes that safe for a weaker ladder."""
+    config_manager = FakeConfigManager(
+        {"hosting": "anthropic", "model_name": "claude-opus-5", "model_effort": "low"}
+    )
+    plan = await _prepare_effort_plan(config_manager, tmp_config_dir)
+    assert plan.session_kwargs["model"].reasoning_effort == "low"
+
+
+@pytest.mark.asyncio
+async def test_a_configured_effort_reaches_the_spec_taken_from_config(
+    tmp_config_dir: Path,
+) -> None:
+    """The same read serves the no-flag path, so a plain launch gets the level
+    without the operator re-running `/effort` every time."""
+    config_manager = FakeConfigManager(
+        {"hosting": "anthropic", "model_name": "claude-opus-5", "model_effort": "medium"}
+    )
+    plan = await _prepare_effort_plan(config_manager, tmp_config_dir, hosting=None, model=None)
+    assert plan.session_kwargs["model"].reasoning_effort == "medium"
+
+
+@pytest.mark.asyncio
+async def test_no_configured_effort_leaves_the_builders_seed(tmp_config_dir: Path) -> None:
+    """``""`` is "no opinion", so the spec builder's own seeding must survive —
+    for a direct Anthropic route that is the documented ``high``. A regression
+    that read the empty string as a level would blank or move it."""
+    config_manager = FakeConfigManager(
+        {"hosting": "anthropic", "model_name": "claude-opus-5", "model_effort": ""}
+    )
+    plan = await _prepare_effort_plan(config_manager, tmp_config_dir)
+    spec = plan.session_kwargs["model"]
+    assert spec.reasoning_effort == "high"
+    assert spec.reasoning_default_effort == "high"

--- a/tests/unit/test_settings_io.py
+++ b/tests/unit/test_settings_io.py
@@ -1417,4 +1417,17 @@ class TestTheModelRowsHelpBudget:
     def test_the_effort_help_says_what_the_resting_cell_means(self) -> None:
         setting = settings_io.resolve_key("model_effort")
         assert setting is not None
-        assert "Unset" in setting.help and "model's own default" in setting.help, setting.help
+        assert "Unset" in setting.help and "model's default" in setting.help, setting.help
+
+    def test_the_effort_help_keeps_headroom_for_another_word(self) -> None:
+        """D10: the first cut sat EXACTLY on the 74-cell detail budget, so one
+        more word anywhere — in the help, in the ladder's ` · default: —`
+        suffix — would shed the whole sentence in the state the sentence exists
+        for, with no warning on the frame.
+
+        Three cells of margin is the floor this pins: enough that a later edit
+        has to notice, not so much that the sentence has to lose a word it needs.
+        """
+        setting = settings_io.resolve_key("model_effort")
+        assert setting is not None
+        assert len(f"{setting.help} · default: —") <= 71, setting.help

--- a/tests/unit/test_settings_io.py
+++ b/tests/unit/test_settings_io.py
@@ -20,6 +20,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from rich.cells import cell_len
+
 from local_operator import keymap, settings_io
 from local_operator.config import DEFAULT_CONFIG, ConfigManager
 from local_operator.model.effort import EFFORT_ORDER
@@ -1412,7 +1414,7 @@ class TestTheModelRowsHelpBudget:
         setting = settings_io.resolve_key(key)
         assert setting is not None
         assert setting.help
-        assert len(f"{setting.help} · default: —") <= 74, setting.help
+        assert cell_len(f"{setting.help} · default: —") <= 74, setting.help
 
     def test_the_effort_help_says_what_the_resting_cell_means(self) -> None:
         setting = settings_io.resolve_key("model_effort")
@@ -1430,4 +1432,7 @@ class TestTheModelRowsHelpBudget:
         """
         setting = settings_io.resolve_key("model_effort")
         assert setting is not None
-        assert len(f"{setting.help} · default: —") <= 71, setting.help
+        # `cell_len`, like every other width in this round: the composed line
+        # carries an em dash and a middot, so a character count is not a cell
+        # count (review round 3, NIT-1). It measures the same today.
+        assert cell_len(f"{setting.help} · default: —") <= 71, setting.help

--- a/tests/unit/test_settings_io.py
+++ b/tests/unit/test_settings_io.py
@@ -1327,3 +1327,94 @@ class TestConfigEditAcceptsAnEnumLabel:
         code = config_edit_command(argparse.Namespace(key="model_effort", value=typed))
         assert code == 0, capsys.readouterr()
         assert ConfigManager(tmp_path).get_config_value("model_effort") == stored
+
+
+class TestConfigEditEchoesTheTypedLabel:
+    """``lop config edit <enum key> <label>`` reports the word the user used.
+
+    The receipt printed the STORED value, which for an ENUM is a wire form, not
+    vocabulary: ``model_effort auto`` stores ``""``, so the confirmation read
+    "Successfully updated model_effort to " — the user typed a word and the
+    answer named nothing (design review D8). The same blank met every other
+    member whose value is empty (the ``providers.openrouter.*`` "default" rows),
+    and members whose label is not their value at all proposed a third spelling
+    (``display.nerd_icons auto`` stores ``None``).
+    """
+
+    @pytest.mark.parametrize(
+        ("key", "typed", "echoed"),
+        [
+            ("model_effort", "auto", "auto"),
+            ("model_effort", "none", "none"),
+            ("model_effort", "HIGH", "high"),
+            ("display.nerd_icons", "auto", "auto"),
+        ],
+    )
+    def test_the_label_is_what_comes_back(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        key: str,
+        typed: str,
+        echoed: str,
+    ) -> None:
+        import argparse
+
+        from local_operator.cli import config_edit_command
+
+        monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+        code = config_edit_command(argparse.Namespace(key=key, value=typed))
+        out = capsys.readouterr().out
+        assert code == 0, out
+        assert f"Successfully updated {key} to {echoed}" in out, out
+
+    def test_a_value_that_matched_no_label_still_echoes_what_was_stored(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """The other half: a value the schema accepts WITHOUT being a label is
+        echoed as stored, so nothing about the normalising path moved.
+
+        ``display.time_format`` stores ``12h`` while its label is ``12-hour``, so
+        the typed word matches no label and must fall through to the stored form
+        (a label lookup that swallowed this case would print ``12-hour`` for a
+        config that holds ``12h`` — the same class of lie the stored-value echo
+        exists to prevent, mirrored)."""
+        import argparse
+
+        from local_operator.cli import config_edit_command
+
+        monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+        code = config_edit_command(argparse.Namespace(key="display.time_format", value="12h"))
+        out = capsys.readouterr().out
+        assert code == 0, out
+        assert "Successfully updated display.time_format to 12h" in out, out
+
+
+class TestTheModelRowsHelpBudget:
+    """The three ``model`` rows' help must survive an 80-column footer.
+
+    The detail line for a row that is not at its default is
+    ``<help> · default: —``, measured at 74 usable cells at 80 columns, and the
+    ladder SHEDS the whole sentence rather than trimming it — so a help one cell
+    too long disappears entirely in exactly the state (an off-default row) where
+    the user is reading it. The new ``model_effort`` row shipped at 68 and was
+    the only one of the three to shed (design review D4); the cells went to the
+    row's own meaning instead, because the cell renders the unset value as ``—``
+    and the word ``auto`` is otherwise visible only inside the expansion (D5).
+    """
+
+    @pytest.mark.parametrize("key", ["hosting", "model_name", "model_effort"])
+    def test_the_help_fits_with_the_default_clause(self, key: str) -> None:
+        setting = settings_io.resolve_key(key)
+        assert setting is not None
+        assert setting.help
+        assert len(f"{setting.help} · default: —") <= 74, setting.help
+
+    def test_the_effort_help_says_what_the_resting_cell_means(self) -> None:
+        setting = settings_io.resolve_key("model_effort")
+        assert setting is not None
+        assert "Unset" in setting.help and "model's own default" in setting.help, setting.help

--- a/tests/unit/test_settings_io.py
+++ b/tests/unit/test_settings_io.py
@@ -22,6 +22,7 @@ import yaml
 
 from local_operator import keymap, settings_io
 from local_operator.config import DEFAULT_CONFIG, ConfigManager
+from local_operator.model.effort import EFFORT_ORDER
 from local_operator.providers import local as local_providers
 from local_operator.settings_io import Kind
 
@@ -1224,3 +1225,105 @@ def test_write_boundary_refuses_every_alternate_overlap(tmp_path, existing, cand
     with pytest.raises(ValueError, match=r"already uses ctrl\+g"):
         settings_io.write_setting(manager, settings_io.BY_KEY["keymap.resume"], candidate)
     assert settings_io.read_setting(manager, settings_io.BY_KEY["keymap.resume"]) == "ctrl+s"
+
+
+class TestTheModelEffortRow:
+    """The ``model_effort`` row: the birth-default reasoning level for new sessions.
+
+    Registered rather than read-only because ``/settings`` is where a user
+    discovers what is configurable and ``lop config edit`` resolves names out of
+    the same registry (AGENTS.md, "Adding a configuration key"). Its value space
+    is the shared FIXED vocabulary rather than anything model-derived — a paint
+    must not resolve a model, and the CLI must work with no model configured —
+    and an unsupported rung is exactly what the clamp at session build is for,
+    not a reason to hide rungs.
+    """
+
+    def test_the_row_is_a_fixed_vocabulary_enum(self) -> None:
+        setting = settings_io.resolve_key("model_effort")
+        assert setting is not None
+        assert setting.kind is Kind.ENUM
+        assert setting.path == ("model_effort",)
+        assert setting.section == "model"
+        assert setting.default == ""
+        # Deliberately NOT a `choices_source` (which would need a model) and NOT
+        # `empty_unsets` ("" is a real choice here — `auto`, the model's own
+        # default — rather than a deletion).
+        assert setting.choices_source is None
+        assert setting.empty_unsets is False
+        labels = [choice.label for choice in setting.resolved_choices]
+        assert labels[0] == "auto"
+        assert labels[1:] == list(EFFORT_ORDER)
+        assert setting.resolved_choices[0].value == ""
+
+    def test_every_rung_carries_a_description(self) -> None:
+        """The page's expanded list wants a three-argument Choice per member.
+
+        The help dict's lookup falls back to an empty description on purpose
+        (a KeyError at import would take the whole CLI down for a missing
+        sentence), so the loud failure for a rung added without one belongs
+        HERE."""
+        setting = settings_io.resolve_key("model_effort")
+        assert setting is not None
+        for choice in setting.resolved_choices:
+            assert choice.description, choice
+
+    def test_a_level_round_trips_through_the_facade(self, manager: ConfigManager) -> None:
+        setting = settings_io.resolve_key("model_effort")
+        assert setting is not None
+        settings_io.write_setting(manager, setting, "high")
+        assert settings_io.read_setting(manager, setting) == "high"
+
+    def test_the_empty_value_is_accepted_as_no_opinion(self, manager: ConfigManager) -> None:
+        setting = settings_io.resolve_key("model_effort")
+        assert setting is not None
+        settings_io.write_setting(manager, setting, "high")
+        settings_io.write_setting(manager, setting, "")
+        assert settings_io.read_setting(manager, setting) == ""
+
+    def test_an_off_vocabulary_value_is_refused(self, manager: ConfigManager) -> None:
+        setting = settings_io.resolve_key("model_effort")
+        assert setting is not None
+        with pytest.raises(ValueError):
+            settings_io.write_setting(manager, setting, "turbo")
+
+
+class TestConfigEditAcceptsAnEnumLabel:
+    """``lop config edit`` must accept a choice's displayed LABEL.
+
+    It matched the typed text against the choice VALUES only, which left two
+    documented words unreachable: ``model_effort auto`` (the stored ``""``) was
+    rejected outright, and ``model_effort none`` — a real rung of
+    ``EFFORT_ORDER`` — was converted to Python ``None`` by the generic value
+    guess before ``write_setting`` ever saw it. The guard maps a label to its
+    value before that guess, and only for ENUM settings.
+
+    It lives in this file because it is really about the registry's
+    LABEL→VALUE pair, which is this module's subject; the command is just the
+    keyboard for it.
+    """
+
+    @pytest.mark.parametrize(
+        ("typed", "stored"),
+        [
+            ("auto", ""),
+            ("none", "none"),
+            ("HIGH", "high"),
+        ],
+    )
+    def test_a_label_is_stored_as_its_value(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        typed: str,
+        stored: str,
+    ) -> None:
+        import argparse
+
+        from local_operator.cli import config_edit_command
+
+        monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+        code = config_edit_command(argparse.Namespace(key="model_effort", value=typed))
+        assert code == 0, capsys.readouterr()
+        assert ConfigManager(tmp_path).get_config_value("model_effort") == stored

--- a/tests/unit/test_settings_io.py
+++ b/tests/unit/test_settings_io.py
@@ -19,7 +19,6 @@ from pathlib import Path
 
 import pytest
 import yaml
-
 from rich.cells import cell_len
 
 from local_operator import keymap, settings_io

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -9175,11 +9175,11 @@ async def test_model_default_alone_prints_one_row_not_a_relaunch_echo(
             await pilot.pause()
             await pilot.pause()
             notices = [block.text() or "" for block in app.query(NoticeBlock)]
-        receipts = [n for n in notices if "boot default:" in n]
+        receipts = [n for n in notices if "default:" in n]
         assert len(receipts) == 1, notices
         assert not [n for n in notices if "config.yml changed" in n], notices
         # The receipt is the LAST row: nothing followed it.
-        assert "boot default:" in notices[-1], notices
+        assert "default:" in notices[-1], notices
     finally:
         _reset_for_tests()
 
@@ -10085,7 +10085,7 @@ async def test_model_default_on_a_cold_viewer_still_saves(
         app._run_slash_command("/model default anthropic/claude-fable-5-1")
         await pilot.pause()
         text = _unwrapped(_transcript_text(app))
-    assert _unwrapped("boot default:") in text, text
+    assert _unwrapped("default:") in text, text
     assert _unwrapped("no runtime is running") not in text, text
     assert "model_name: claude-fable-5-1" in (tmp_path / "config.yml").read_text()
 
@@ -10134,7 +10134,7 @@ async def test_model_default_mid_turn_also_says_when_it_applies(
     assert _unwrapped(MODEL_SWITCH_MID_TURN_NOTICE) in text, text
     # Still the persistence receipt, not the session one: this asserts the row
     # was ADDED to that branch rather than the branch being changed.
-    assert _unwrapped("used by new sessions") in text, text
+    assert _unwrapped("(new sessions)") in text, text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -9175,11 +9175,18 @@ async def test_model_default_alone_prints_one_row_not_a_relaunch_echo(
             await pilot.pause()
             await pilot.pause()
             notices = [block.text() or "" for block in app.query(NoticeBlock)]
-        receipts = [n for n in notices if "default:" in n]
+        # `startswith`, not a substring (review round 3, MINOR-2): three
+        # FAILURE notices contain `default:` — `could not save default:`,
+        # `model switched, but could not save default:` and `could not read the
+        # saved default:` — so the substring form would also have passed had the
+        # success receipt been replaced by a save failure, which is the one
+        # substitution this assertion exists to catch. The sibling budget test in
+        # `test_effort.py` uses the same shape against the same receipt.
+        receipts = [n for n in notices if n.startswith("default: ")]
         assert len(receipts) == 1, notices
         assert not [n for n in notices if "config.yml changed" in n], notices
         # The receipt is the LAST row: nothing followed it.
-        assert "default:" in notices[-1], notices
+        assert notices[-1].startswith("default: "), notices
     finally:
         _reset_for_tests()
 

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -982,6 +982,11 @@ async def test_repaired_config_boots_into_an_escapable_state(
     seed = ConfigManager(tmp_path)
     seed.set_config_value("hosting", "anthropicxyq")
     seed.set_config_value("model_name", "claude-sonnet-4-5")
+    # A stored effort this recovery does NOT touch but which rides into the boot
+    # it is about to start, clamped to whatever the chosen model takes (U5). The
+    # receipt names it, because a default is host + model + effort and this is
+    # the one receipt a first-run user sets one through.
+    seed.set_config_value("model_effort", "xhigh")
 
     # The repair the app performs on a successful `/login`, through the real
     # planner rather than a hand-written config: the point is that this exact
@@ -1049,7 +1054,8 @@ async def test_repaired_config_boots_into_an_escapable_state(
 
         # THE SUBSTANCE: the state must be escapable. A setup state you cannot
         # leave is the same bug wearing a different colour.
-        app._cmd_model("deepseek/deepseek-chat", lambda body, kind="info": None)
+        receipts: list[str] = []
+        app._cmd_model("deepseek/deepseek-chat", lambda body, kind="info": receipts.append(body))
         for _ in range(200):
             await pilot.pause()
             if app._session is not None:
@@ -1058,6 +1064,10 @@ async def test_repaired_config_boots_into_an_escapable_state(
 
         assert app._session is session, "the recovery command must BUILD the session"
         assert app._setup_state is False
+        # U5: the stored effort is named beside the pair it will govern. It is
+        # not rewritten here and it IS what the new boot runs on, so a receipt
+        # that stopped at host + model described two thirds of the default.
+        assert any("model_effort xhigh" in body for body in receipts), receipts
 
     # The escape persisted the pair, so the next launch does not return here.
     recovered = ConfigManager(tmp_path)
@@ -8815,8 +8825,11 @@ async def test_model_default_confirms_both_keys_and_the_file_it_wrote(
     written = yaml.safe_load((tmp_path / "config.yml").read_text())["values"]
     assert written["hosting"] == "anthropic", written
     assert written["model_name"] == "claude-opus-5", written
-    # What it wrote, under the names the config file uses…
-    assert _unwrapped("hosting anthropic, model_name claude-opus-5") in _unwrapped(text), text
+    # What it wrote, named the way the app names a model everywhere else (the
+    # joined label) with the third key under its registry name (design D3: at
+    # 120 columns a row holds 110 cells, so the pair is joined rather than
+    # spelled as the two config keys).
+    assert _unwrapped("anthropic/claude-opus-5, model_effort") in _unwrapped(text), text
     # …and where, so the user can go and read or undo it.
     assert str(tmp_path / "config.yml") in _unwrapped(text), text
 
@@ -8869,7 +8882,7 @@ async def test_model_default_alone_saves_the_model_the_session_is_on(
     # the persist path's own `set_model` is a no-op re-selection.
     assert label_after == "anthropic/claude-opus-5", label_after
     # Same receipt vocabulary as the explicit spelling — one outcome, one wording.
-    assert _unwrapped("hosting anthropic, model_name claude-opus-5") in _unwrapped(text), text
+    assert _unwrapped("anthropic/claude-opus-5, model_effort auto") in _unwrapped(text), text
     assert str(tmp_path / "config.yml") in _unwrapped(text), text
 
 
@@ -9085,7 +9098,7 @@ async def test_model_default_alone_is_write_only(
         await pilot.pause()
     written = yaml.safe_load((tmp_path / "config.yml").read_text())["values"]
     # The bare form WROTE (its receipt names the pair) without the access note…
-    assert _unwrapped("hosting openrouter, model_name deepseek/deepseek-chat") in bare_receipt
+    assert _unwrapped("openrouter/deepseek/deepseek-chat, model_effort auto") in bare_receipt
     assert _unwrapped("openrouter logged in") not in bare_receipt, bare_receipt
     # …and the explicit form with a different model took the switch tail once.
     assert session.set_model_calls == [("anthropic/claude-opus-5", True)], session.set_model_calls
@@ -9162,11 +9175,11 @@ async def test_model_default_alone_prints_one_row_not_a_relaunch_echo(
             await pilot.pause()
             await pilot.pause()
             notices = [block.text() or "" for block in app.query(NoticeBlock)]
-        receipts = [n for n in notices if "boot default saved" in n]
+        receipts = [n for n in notices if "boot default:" in n]
         assert len(receipts) == 1, notices
         assert not [n for n in notices if "config.yml changed" in n], notices
         # The receipt is the LAST row: nothing followed it.
-        assert "boot default saved" in notices[-1], notices
+        assert "boot default:" in notices[-1], notices
     finally:
         _reset_for_tests()
 
@@ -10072,7 +10085,7 @@ async def test_model_default_on_a_cold_viewer_still_saves(
         app._run_slash_command("/model default anthropic/claude-fable-5-1")
         await pilot.pause()
         text = _unwrapped(_transcript_text(app))
-    assert _unwrapped("boot default saved to") in text, text
+    assert _unwrapped("boot default:") in text, text
     assert _unwrapped("no runtime is running") not in text, text
     assert "model_name: claude-fable-5-1" in (tmp_path / "config.yml").read_text()
 

--- a/tests/unit/tui/test_effort.py
+++ b/tests/unit/tui/test_effort.py
@@ -608,10 +608,15 @@ def test_the_set_receipt_fits_every_ordered_pair_the_ladders_can_form() -> None:
         if first != second
     ]
     assert pairs, "the shipped ladders must offer at least one transition"
-    # The longest words the vocabulary can carry, in both directions: the
-    # receipt's two rung words are independent of each other.
-    longest = max(EFFORT_ORDER, key=cell_len)
-    pairs.extend([(longest, "medium"), ("medium", longest)])
+    # The longest two words the vocabulary can carry, in both directions: the
+    # receipt's two rung words are independent of each other, so the pair that
+    # spends the most cells is the two longest, whichever they are. Derived
+    # rather than named `medium` (review round 3, NIT-2): that word is right
+    # today and would silently stop being the worst if the vocabulary gained a
+    # longer one.
+    by_length = sorted(EFFORT_ORDER, key=cell_len)
+    longest, runner_up = by_length[-1], by_length[-2]
+    pairs.extend([(longest, runner_up), (runner_up, longest)])
 
     def rendered(first: str, second: str) -> str:
         # The SHIPPED string, not a copy of it: the receipt lives in a module

--- a/tests/unit/tui/test_effort.py
+++ b/tests/unit/tui/test_effort.py
@@ -23,7 +23,13 @@ from local_operator.model.configure import build_model_spec
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView, UserBlock
-from tests.unit.tui.test_app_pilot import FakeSession, _band, _factory
+from tests.unit.tui.test_app_pilot import (
+    FakeProviderController,
+    FakeSession,
+    _band,
+    _factory,
+    _FakeDef,
+)
 
 
 class EffortSession(FakeSession):
@@ -48,6 +54,42 @@ class EffortSession(FakeSession):
 
     def set_model(self, model: Any, *, explicit: bool = False) -> None:
         self._spec = model
+
+
+class EffortProviderController(FakeProviderController):
+    """A controller that resolves a selector to a REAL, shipped ``ModelSpec``.
+
+    ``FakeProviderController.resolve_model`` answers with a bare ``FakeModel``
+    that carries no ladder at all, which would make every clamp assertion in
+    this file vacuous: a level would be cleared because there was nothing to
+    clamp INTO, not because the target lacks a knob. ``build_model_spec`` is
+    the same offline derivation the real controller lands on.
+    """
+
+    def login_providers(self):
+        return [
+            _FakeDef("anthropic", "Anthropic", None, ("claude",)),
+            _FakeDef("openai", "OpenAI", None, ("gpt",)),
+        ]
+
+    def provider(self, pid):
+        for definition in self.login_providers():
+            if definition.id == pid:
+                return definition
+        return None
+
+    def has_any_credential(self, provider):
+        return True
+
+    def is_usable(self, provider):
+        return True
+
+    # ``FakeProviderController.resolve_model`` is annotated to return a bare
+    # ``FakeModel``; a controller that answers with a REAL spec is the point of
+    # this subclass, so the return is widened to ``Any`` rather than narrowed
+    # to a type the base cannot promise.
+    def resolve_model(self, provider, model_id) -> Any:
+        return build_model_spec(provider.lower(), model_id)
 
 
 async def _boot(pilot, app: OperatorApp) -> None:
@@ -614,3 +656,165 @@ async def test_apply_frontend_state_preserves_auto_effort_label() -> None:
 
         assert app._status._effort == "auto"
         assert "auto" in _band(app)
+
+
+# ---------------------------------------------------------------------------
+# `/model default` persists the level, and `/model saved` adopts it back
+# ---------------------------------------------------------------------------
+
+
+def _config_file(tmp_path) -> None:
+    """A file on disk, so ConfigManager builds its own Config rather than
+    mutating the module-level DEFAULT_CONFIG singleton other tests share."""
+    (tmp_path / "config.yml").write_text(
+        "version: 0.0.0\nvalues:\n  hosting: anthropic\n  model_name: claude-opus-5\n"
+    )
+
+
+def _written(tmp_path) -> dict[str, Any]:
+    import yaml
+
+    return yaml.safe_load((tmp_path / "config.yml").read_text())["values"]
+
+
+@pytest.mark.asyncio
+async def test_model_default_saves_the_level_alongside_the_model(tmp_path, monkeypatch) -> None:
+    """`/model default` used to persist only the model pair, so the operator
+    re-ran `/effort` every launch. The remembered level now rides into the
+    birth default, written LAST so a mid-loop failure cannot leave the effort
+    pointing at a model the pair never reached (nothing else has moved yet)."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _config_file(tmp_path)
+    app = OperatorApp(
+        lambda: _factory(EffortSession()), provider_controller=EffortProviderController()
+    )
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/effort low")
+        await _submit(pilot, app, "/model default")
+        notices = _notices(app)
+    written = _written(tmp_path)
+    assert written["model_name"] == "claude-opus-5", written
+    assert written["model_effort"] == "low", written
+    # The receipt names the third key, in the registry's own vocabulary
+    # (`auto` for the empty value), so a user can see what was made durable.
+    assert any("model_effort low (used by new sessions)" in n for n in notices), notices
+
+
+@pytest.mark.asyncio
+async def test_model_default_with_no_chosen_level_saves_no_opinion(tmp_path, monkeypatch) -> None:
+    """The model's SEEDED default is not a deliberate choice (D6). Persisting
+    `high` here — which `build_model_spec` merely seeds for Anthropic — would
+    freeze an INFERENCE into every future launch and, on a later
+    `/model default <other>`, silently deepen that model's reasoning."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _config_file(tmp_path)
+    app = OperatorApp(
+        lambda: _factory(EffortSession()), provider_controller=EffortProviderController()
+    )
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/model default")
+        notices = _notices(app)
+    written = _written(tmp_path)
+    assert written["model_effort"] == "", written
+    assert any("model_effort auto (used by new sessions)" in n for n in notices), notices
+
+
+@pytest.mark.asyncio
+async def test_model_default_clamps_the_saved_rung_and_runs_it(tmp_path, monkeypatch) -> None:
+    """D7: on the persist path the SAVED rung and the RUNNING rung must agree.
+
+    `/effort xhigh` on `claude-opus-5`, then `/model default
+    anthropic/claude-opus-4-6` — whose ladder stops at `high`, one rung below
+    `xhigh` on both sides, so the tie goes down. Without the live clamp the key
+    would say `xhigh` while the band read the model's own default, and the next
+    launch would make that disagreement real.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _config_file(tmp_path)
+    app = OperatorApp(
+        lambda: _factory(EffortSession()), provider_controller=EffortProviderController()
+    )
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/effort xhigh")
+        await _submit(pilot, app, "/model default anthropic/claude-opus-4-6")
+        level = _level(app)
+        remembered = app._effort_choice
+        band = _band(app)
+    written = _written(tmp_path)
+    assert written["model_name"] == "claude-opus-4-6", written
+    assert written["model_effort"] == "high", written
+    assert level == "high"
+    assert remembered == "high"
+    assert "high" in band
+
+
+@pytest.mark.asyncio
+async def test_model_default_on_a_model_with_no_ladder_clears_the_level(
+    tmp_path, monkeypatch
+) -> None:
+    """A model that takes no effort knob has nothing to save: the key is cleared
+    rather than left holding a level the route would silently drop, and the
+    receipt says `auto`. No 400, and no band lying about a level in force."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _config_file(tmp_path)
+    app = OperatorApp(
+        lambda: _factory(EffortSession()), provider_controller=EffortProviderController()
+    )
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/effort low")
+        await _submit(pilot, app, "/model default openai/gpt-4.1")
+        level = _level(app)
+    written = _written(tmp_path)
+    assert written["model_name"] == "gpt-4.1", written
+    assert written["model_effort"] == "", written
+    assert level is None
+
+
+@pytest.mark.asyncio
+async def test_model_saved_adopts_the_configured_effort(tmp_path, monkeypatch) -> None:
+    """`/model saved` means "put me back on my configured baseline", and effort
+    is part of that baseline now (D8). Restored CLAMPED, so a configured level
+    the saved model cannot express lands on its nearest rung rather than
+    vanishing."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "config.yml").write_text(
+        "version: 0.0.0\nvalues:\n  hosting: anthropic\n  model_name: claude-opus-5\n"
+        "  model_effort: medium\n"
+    )
+    app = OperatorApp(
+        lambda: _factory(EffortSession()), provider_controller=EffortProviderController()
+    )
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/effort low")
+        await _submit(pilot, app, "/model saved")
+        level = _level(app)
+        remembered = app._effort_choice
+    assert level == "medium"
+    assert remembered == "medium"
+
+
+@pytest.mark.asyncio
+async def test_model_saved_clears_the_level_when_nothing_is_configured(
+    tmp_path, monkeypatch
+) -> None:
+    """The key unset means "the model's own default", so adopting the baseline
+    CLEARS a level chosen here — the opposite of leaving the pick in force, and
+    the reason the override is tri-state rather than a plain value."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _config_file(tmp_path)
+    app = OperatorApp(
+        lambda: _factory(EffortSession()), provider_controller=EffortProviderController()
+    )
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/effort low")
+        await _submit(pilot, app, "/model saved")
+        level = _level(app)
+        remembered = app._effort_choice
+    assert level == "high"  # the model's own documented default
+    assert remembered is None

--- a/tests/unit/tui/test_effort.py
+++ b/tests/unit/tui/test_effort.py
@@ -16,11 +16,13 @@ from __future__ import annotations
 from typing import Any, cast
 
 import pytest
+from rich.cells import cell_len
 from textual.geometry import Size
 from textual.widgets import Static
 
 from local_operator.model.configure import build_model_spec
-from local_operator.tui.app import OperatorApp
+from local_operator.paths import DEFAULT_CONFIG_DIRNAME
+from local_operator.tui.app import EFFORT_SET_RECEIPT, OperatorApp
 from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView, UserBlock
 from tests.unit.tui.test_app_pilot import (
@@ -30,6 +32,12 @@ from tests.unit.tui.test_app_pilot import (
     _factory,
     _FakeDef,
 )
+
+#: What a DEFAULT install's receipt prints for the file it wrote: the config
+#: lives at `~/.local-operator/config.yml` unless LOCAL_OPERATOR_CONFIG_DIR says
+#: otherwise. Receipt budgets are measured against THIS label rather than the
+#: shorter `~/config/config.yml` a redirected test home produces (U8).
+DEFAULT_CONFIG_LABEL = f"~/{DEFAULT_CONFIG_DIRNAME}/config.yml"
 
 
 class EffortSession(FakeSession):
@@ -238,9 +246,12 @@ async def test_effort_with_a_level_sets_it_and_says_what_changed() -> None:
     receipt = [n for n in notices if "reasoning effort" in n]
     assert receipt, notices
     # Names the old level and the new one, and how long the choice lasts: it is
-    # session-scoped by design and nothing else on screen would say so.
+    # session-scoped by design and nothing else on screen would say so. The scope
+    # word is `(session)`, one word shorter than the siblings' `(this session)`
+    # because this receipt's two rung words are both variable and this one has to
+    # hold every pair at 80 columns (round-2 D9).
     assert "high" in receipt[-1] and "low" in receipt[-1]
-    assert "this session" in receipt[-1]
+    assert "(session)" in receipt[-1]
 
 
 @pytest.mark.asyncio
@@ -552,10 +563,67 @@ async def test_the_effort_set_receipt_holds_one_row_at_eighty_columns() -> None:
         await _submit(pilot, app, "/effort high")
         await _submit(pilot, app, "/effort xhigh")
         receipt = [n for n in _notices(app) if "reasoning effort" in n][-1]
-    assert (
-        receipt == "reasoning effort: high → xhigh (this session); /model default keeps it"
-    ), receipt
-    assert len(receipt) <= 70, receipt
+    assert receipt == EFFORT_SET_RECEIPT.format(current="high", wanted="xhigh"), receipt
+    assert cell_len(receipt) <= 70, receipt
+
+
+def test_the_set_receipt_fits_every_ordered_pair_the_ladders_can_form() -> None:
+    """NEW-2 / D9 / Q1: the budget is a property of the RECEIPT, not of the pair
+    round 1 happened to measure.
+
+    The row's size is a function of two rung words and both vary. Pinning
+    `high → xhigh` (exactly 70) is what let `medium → xhigh` (71) and
+    `medium → minimal` (73) ship wrapping at 80 columns: `/effort medium` on the
+    DEFAULT model is an ordinary command, and `minimal` is reachable through a
+    provider's own ladder (the shared vocabulary carries it and discovery admits
+    any member of that vocabulary). So this walks every ordered pair the shipped
+    ladders can form plus the longest word in the vocabulary, in both directions,
+    and holds each to the real budget: `width - 10` cells, 70 at 80 columns,
+    measured with ``cell_len`` (the string carries an arrow and an em dash, so a
+    character count is not a cell count).
+
+    The template is built here rather than driven through the app because the
+    property is about the copy's SHAPE: a rung no table offers today still has to
+    fit, and no widget decides that.
+    """
+    from local_operator.model.effort import EFFORT_ORDER, default_effort, supported_efforts
+
+    ladders: list[tuple[str, ...]] = []
+    for model_id in (
+        "claude-opus-5",
+        "claude-opus-4-6",
+        "claude-opus-4-5-20251101",
+        "gpt-5.4",
+        "gpt-6-astra",
+        "o3",
+        "gpt-4.1",
+    ):
+        level = default_effort(model_id)
+        ladder = tuple(supported_efforts(model_id))
+        ladders.append(ladder if not level or level in ladder else (*ladder, level))
+    pairs = [
+        (first, second)
+        for ladder in ladders
+        for first in ladder
+        for second in ladder
+        if first != second
+    ]
+    assert pairs, "the shipped ladders must offer at least one transition"
+    # The longest words the vocabulary can carry, in both directions: the
+    # receipt's two rung words are independent of each other.
+    longest = max(EFFORT_ORDER, key=cell_len)
+    pairs.extend([(longest, "medium"), ("medium", longest)])
+
+    def rendered(first: str, second: str) -> str:
+        # The SHIPPED string, not a copy of it: the receipt lives in a module
+        # constant precisely so this measures what the app prints.
+        return EFFORT_SET_RECEIPT.format(current=first, wanted=second)
+
+    worst = max(pairs, key=lambda pair: cell_len(rendered(*pair)))
+    assert cell_len(rendered(*worst)) <= 70, rendered(*worst)
+    # The pair the round-2 gates measured: one ordinary `/effort medium` on the
+    # shipped default model, pinned as text as well as by width.
+    assert cell_len(rendered("medium", "xhigh")) <= 70, rendered("medium", "xhigh")
 
 
 # ---------------------------------------------------------------------------
@@ -740,7 +808,7 @@ async def test_model_default_saves_the_level_alongside_the_model(tmp_path, monke
     assert written["model_effort"] == "low", written
     # The receipt names the third key, in the registry's own vocabulary
     # (`auto` for the empty value), so a user can see what was made durable.
-    assert any("model_effort low (used by new sessions)" in n for n in notices), notices
+    assert any("model_effort low (new sessions)" in n for n in notices), notices
 
 
 @pytest.mark.asyncio
@@ -760,7 +828,7 @@ async def test_model_default_with_no_chosen_level_saves_no_opinion(tmp_path, mon
         notices = _notices(app)
     written = _written(tmp_path)
     assert written["model_effort"] == "", written
-    assert any("model_effort auto (used by new sessions)" in n for n in notices), notices
+    assert any("model_effort auto (new sessions)" in n for n in notices), notices
 
 
 @pytest.mark.asyncio
@@ -1005,20 +1073,28 @@ async def test_the_default_receipt_names_a_clamped_rung(tmp_path, monkeypatch) -
         await _boot(pilot, app)
         await _submit(pilot, app, "/model default anthropic/claude-opus-4-6")
         notices = _notices(app)
-    saved = [n for n in notices if n.startswith("boot default: ")]
+    saved = [n for n in notices if n.startswith("default: ")]
     assert len(saved) == 1, notices
-    assert "model_effort high (used by new sessions)" in saved[0], saved[0]
-    # The 110-cell budget is measured with the SHORT home-relative path the
-    # receipt prints in practice (`~/config/config.yml`), so the test's absolute
-    # temp path is normalised the same way before measuring.
-    normalised = saved[0].replace(str(tmp_path / "config.yml"), "~/config/config.yml")
+    assert "model_effort high (new sessions)" in saved[0], saved[0]
+    # The 110-cell budget is measured against the path a DEFAULT install
+    # renders, not against the shorter placeholder a temp-dir test happens to
+    # produce (U8): `_home_relative` prints `~/.local-operator/config.yml` (28
+    # cells) for a user who never set LOCAL_OPERATOR_CONFIG_DIR, which is 9 cells
+    # more than `~/config/config.yml` — the difference between this row fitting
+    # at 120 columns and widowing `(for new sessions)`.
+    normalised = saved[0].replace(str(tmp_path / "config.yml"), DEFAULT_CONFIG_LABEL)
+    assert DEFAULT_CONFIG_LABEL == "~/.local-operator/config.yml", DEFAULT_CONFIG_LABEL
     # Measured WITHOUT the access suffix: that clause (` · anthropic logged in`)
     # rides only when there is an access note to give, and it pushed this row
     # over the 120-column budget before this PR too — D3's finding is about the
     # receipt proper, which is the form the designer measured.
-    assert len(normalised.split(" · ")[0]) <= 110, normalised
+    assert cell_len(normalised.split(" · ")[0]) <= 110, normalised
+    # ...and for the LONGEST rung the vocabulary can carry, not just the one this
+    # command stored: `minimal` is two cells longer than `xhigh`.
+    worst = normalised.replace("model_effort high", "model_effort minimal")
+    assert cell_len(worst.split(" · ")[0]) <= 110, worst
     assert any(
-        n == "model_effort high (xhigh clamps to this model's nearest rung)" for n in notices
+        n == "reasoning effort: high (xhigh clamps to the nearest rung)" for n in notices
     ), notices
 
 
@@ -1078,3 +1154,52 @@ async def test_the_already_set_receipt_fits_for_the_longest_level_name() -> None
         receipt == "reasoning effort: already minimal — /effort auto restores the default"
     ), receipt
     assert len(receipt) <= 70, receipt
+
+
+@pytest.mark.asyncio
+async def test_model_saved_in_the_readiness_window_does_not_strand_the_override(
+    tmp_path, monkeypatch
+) -> None:
+    """NEW-1, the residual of B2: the dispatch has an early return of its OWN.
+
+    `_cmd_model_saved` arms the override and re-dispatches through
+    `_run_slash_command`, and that dispatcher refuses BEFORE `_cmd_model` is
+    entered when the source is not ready (`/model` is not in
+    `_SAVED_LOCAL_COMMANDS`). Nothing in `_cmd_model` runs on that path, so
+    neither its entry clear nor its guard clears can fire — and the stranded
+    handoff marker then EATS the next entry's clear, which is how a later,
+    unrelated `/model` switch lands on the stored level. The window is reachable:
+    `_cmd_model_saved` also has a caller that does not readiness-check first
+    (the `local_setup` login continuation), and a cold-bind/mid-retry source can
+    be un-ready at this instant.
+
+    The pair is cleared in `_cmd_model_saved` itself for exactly this path, so
+    the invariant is "an armed override cannot outlive the dispatch it was armed
+    for" rather than "it cannot outlive the dispatch that ENTERED `_cmd_model`".
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "config.yml").write_text(
+        "version: 0.0.0\nvalues:\n  hosting: anthropic\n  model_name: claude-opus-5\n"
+        "  model_effort: none\n"
+    )
+    app = OperatorApp(
+        lambda: _factory(EffortSession()), provider_controller=EffortProviderController()
+    )
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/effort high")
+        # The window: the source is un-ready at the instant of the re-dispatch.
+        monkeypatch.setattr(app, "_source_commands_ready", lambda *args, **kwargs: False)
+        app._cmd_model_saved(app._notice)
+        await pilot.pause()
+        stranded = (app._pending_effort_override, app._effort_override_handoff)
+        monkeypatch.delattr(app, "_source_commands_ready")
+        # The unrelated switch the stranded override used to land on.
+        await _submit(pilot, app, "/model openai/gpt-5.1")
+        level = _level(app)
+        band = _band(app)
+    assert stranded == ((False, None), False), stranded
+    # `gpt-5.1` seeds no level, so the correct answer is `auto` — not the `none`
+    # the stranded override would have clamped onto its ladder.
+    assert level is None, band
+    assert "▴ auto" in band

--- a/tests/unit/tui/test_effort.py
+++ b/tests/unit/tui/test_effort.py
@@ -21,6 +21,7 @@ from textual.geometry import Size
 from textual.widgets import Static
 
 from local_operator.model.configure import build_model_spec
+from local_operator.model.effort import EFFORT_ORDER, default_effort, supported_efforts
 from local_operator.paths import DEFAULT_CONFIG_DIRNAME
 from local_operator.tui.app import EFFORT_SET_RECEIPT, OperatorApp
 from local_operator.tui.widgets.editor import Editor
@@ -586,8 +587,6 @@ def test_the_set_receipt_fits_every_ordered_pair_the_ladders_can_form() -> None:
     property is about the copy's SHAPE: a rung no table offers today still has to
     fit, and no widget decides that.
     """
-    from local_operator.model.effort import EFFORT_ORDER, default_effort, supported_efforts
-
     ladders: list[tuple[str, ...]] = []
     for model_id in (
         "claude-opus-5",

--- a/tests/unit/tui/test_effort.py
+++ b/tests/unit/tui/test_effort.py
@@ -1020,3 +1020,61 @@ async def test_the_default_receipt_names_a_clamped_rung(tmp_path, monkeypatch) -
     assert any(
         n == "model_effort high (xhigh clamps to this model's nearest rung)" for n in notices
     ), notices
+
+
+class _MinimalSession(EffortSession):
+    """A session whose model offers ``minimal`` — the longest level name the
+
+    shared vocabulary can carry. No shipped ladder lists it today (the table
+    reserves the word for the day a model page names it, and OpenAI's listing is
+    the one that may), but a provider's own ladder reaches a spec through
+    discovery, and this receipt has to fit for the longest word it can be asked
+    to print. ``xhigh``/``medium`` are the only longer-than-``high`` names any
+    table ladder offers, so ``minimal`` is the worst case.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._spec = self._spec.model_copy(
+            update={
+                "reasoning_efforts": ("minimal", "low", "medium", "high"),
+                "reasoning_effort": "minimal",
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_effort_already_set_receipt_holds_one_row_at_eighty_columns() -> None:
+    """The no-op branch of `/effort <level>` measured 74 cells and wrapped at 80
+    columns, widowing `default` — raised by the coder in the round-1 report; no
+    gate round had flagged it, because the set receipt beside it was the finding.
+
+    Same budget as its siblings (design review D2: a notice row holds
+    `width - 10` cells, 70 at 80 columns), and the same voice: an `already` line
+    is the codebase's shape for "nothing moved", so it must not wrap into two
+    rows while claiming a no-op.
+    """
+    app = OperatorApp(lambda: _factory(EffortSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        # `high` is Anthropic's documented default, so this set is a no-op.
+        await _submit(pilot, app, "/effort high")
+        receipt = [n for n in _notices(app) if "reasoning effort" in n][-1]
+    assert receipt == "reasoning effort: already high — /effort auto restores the default", receipt
+    assert len(receipt) <= 70, receipt
+
+
+@pytest.mark.asyncio
+async def test_the_already_set_receipt_fits_for_the_longest_level_name() -> None:
+    """The worst case the budget has to hold for: `minimal`, three cells longer
+    than the shared ladder's other words. A level name is DATA (a provider's
+    listing can state one), so the row cannot be sized against `high` alone."""
+    app = OperatorApp(lambda: _factory(_MinimalSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/effort minimal")
+        receipt = [n for n in _notices(app) if "reasoning effort" in n][-1]
+    assert (
+        receipt == "reasoning effort: already minimal — /effort auto restores the default"
+    ), receipt
+    assert len(receipt) <= 70, receipt

--- a/tests/unit/tui/test_effort.py
+++ b/tests/unit/tui/test_effort.py
@@ -501,8 +501,14 @@ async def test_the_choice_rides_a_model_switch_and_is_dropped_by_one_that_cannot
 @pytest.mark.asyncio
 async def test_effort_auto_on_a_model_with_no_documented_default_sends_nothing() -> None:
     """The OpenAI half of `/effort auto`: there is no level to restore, so the
-    key leaves the wire entirely and the receipt says so rather than naming a
-    level."""
+    key leaves the wire entirely and the receipt names the state the band shows
+    — `auto` — rather than a level.
+
+    `auto` replaced the longer `the provider's default` in the receipt (U2), for
+    the cells the session scope and the durable pointer now take: at 80 columns a
+    notice row holds 70 (design review D2), and origin + scope + pointer do not
+    fit. What is left is the band's own word for this state, which is the half
+    the user can see."""
     app = OperatorApp(lambda: _factory(EffortSession("openai", "gpt-5.4")))
     async with app.run_test(size=(120, 40)) as pilot:
         await _boot(pilot, app)
@@ -512,8 +518,44 @@ async def test_effort_auto_on_a_model_with_no_documented_default_sends_nothing()
         receipt = [n for n in _notices(app) if "reasoning effort" in n][-1]
         band = _band(app)
     assert level is None
-    assert "nothing sent" in receipt
+    assert receipt == "reasoning effort: high → auto (this session) — /settings sets auto", receipt
     assert "▴ auto" in band
+
+
+@pytest.mark.asyncio
+async def test_effort_auto_says_the_withdrawal_is_for_this_session_only() -> None:
+    """U2: `/effort auto` withdraws the level for THIS conversation, and the
+    stored key still governs the next one — so the receipt has to say both, and
+    name the one route that changes the standing default (`/settings`; a stored
+    level survives a bare `/model default` by design, D6, so that command is not
+    that route)."""
+    app = OperatorApp(lambda: _factory(EffortSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/effort xhigh")
+        await _submit(pilot, app, "/effort auto")
+        receipt = [n for n in _notices(app) if "reasoning effort" in n][-1]
+    assert receipt == "reasoning effort: xhigh → high (this session) — /settings sets auto", receipt
+    assert len(receipt) <= 70, receipt
+
+
+@pytest.mark.asyncio
+async def test_the_effort_set_receipt_holds_one_row_at_eighty_columns() -> None:
+    """D2: the pointer is worth keeping and the row still has to fit. A notice
+    row holds `width - 10` cells, so at 80 columns the budget is 70 — the base
+    receipt was 45 and the added pointer took it to 73, which wrapped the row and
+    widowed the word `it`. Measured here as cells, because a wrapped row and a
+    fitting one render identically in a transcript block list."""
+    app = OperatorApp(lambda: _factory(EffortSession()))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/effort high")
+        await _submit(pilot, app, "/effort xhigh")
+        receipt = [n for n in _notices(app) if "reasoning effort" in n][-1]
+    assert (
+        receipt == "reasoning effort: high → xhigh (this session); /model default keeps it"
+    ), receipt
+    assert len(receipt) <= 70, receipt
 
 
 # ---------------------------------------------------------------------------
@@ -818,3 +860,163 @@ async def test_model_saved_clears_the_level_when_nothing_is_configured(
         remembered = app._effort_choice
     assert level == "high"  # the model's own documented default
     assert remembered is None
+
+
+@pytest.mark.asyncio
+async def test_model_saved_receipt_names_the_effort_it_adopts(tmp_path, monkeypatch) -> None:
+    """U1 / design D7: `/model saved` on the model already in force moves the
+    EFFORT dial, and its receipt used to be an `X → X` model line that said
+    nothing about the level — while pointing at `/model default saves this for
+    new sessions`, the command the user did NOT run.
+
+    The configured baseline is the only thing that moved here, so the receipt
+    names that move and drops the model line entirely."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "config.yml").write_text(
+        "version: 0.0.0\nvalues:\n  hosting: anthropic\n  model_name: claude-opus-5\n"
+        "  model_effort: medium\n"
+    )
+    app = OperatorApp(
+        lambda: _factory(EffortSession()), provider_controller=EffortProviderController()
+    )
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/effort low")
+        await _submit(pilot, app, "/model saved")
+        notices = _notices(app)
+    assert any(
+        "reasoning effort: low → medium (the configured default)" in n for n in notices
+    ), notices
+    assert not any(n.startswith("model: ") for n in notices), notices
+
+
+@pytest.mark.asyncio
+async def test_model_saved_with_no_configured_effort_names_the_model_default(
+    tmp_path, monkeypatch
+) -> None:
+    """The sibling clause when the key is UNSET: adopting a baseline with no
+    stored level clears the session's pick, so the receipt says the level in
+    force is the model's own rather than claiming a configured default that does
+    not exist."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    _config_file(tmp_path)
+    app = OperatorApp(
+        lambda: _factory(EffortSession()), provider_controller=EffortProviderController()
+    )
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/effort low")
+        await _submit(pilot, app, "/model saved")
+        notices = _notices(app)
+    assert any(
+        "reasoning effort: low → high (the model's own default)" in n for n in notices
+    ), notices
+    assert not any(n.startswith("model: ") for n in notices), notices
+
+
+@pytest.mark.asyncio
+async def test_model_saved_that_is_refused_does_not_arm_the_next_switch(
+    tmp_path, monkeypatch
+) -> None:
+    """B2, the exact repro: a saved default naming a provider that is no longer
+    known makes `/model saved` refuse — and the armed effort override used to
+    survive that refusal, landing on the next, unrelated `/model` switch. The
+    user asked for `high`, got a refusal notice, then switched models for an
+    unrelated reason and silently landed on `none`: reasoning OFF, with the band
+    as the only signal."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "config.yml").write_text(
+        "version: 0.0.0\nvalues:\n  hosting: deadprovider\n  model_name: ghost\n"
+        "  model_effort: none\n"
+    )
+    app = OperatorApp(
+        lambda: _factory(EffortSession()), provider_controller=EffortProviderController()
+    )
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/effort high")
+        await _submit(pilot, app, "/model saved")
+        refused = _notices(app)
+        armed_after_refusal = app._pending_effort_override
+        # The unrelated switch the leak used to land on.
+        await _submit(pilot, app, "/model openai/gpt-5.1")
+        level = _level(app)
+        remembered = app._effort_choice
+        band = _band(app)
+    assert any("unknown provider: deadprovider" in n for n in refused), refused
+    assert armed_after_refusal == (False, None), armed_after_refusal
+    # `gpt-5.1` seeds no level, so the correct answer is `auto` — not the `none`
+    # the leaked override would have clamped onto its ladder.
+    assert level is None, band
+    assert remembered is None
+    assert "▴ auto" in band
+
+
+@pytest.mark.asyncio
+async def test_a_write_only_default_leaves_the_session_level_alone(tmp_path, monkeypatch) -> None:
+    """M1: the write-only `/model default` (the model already in force) switches
+    NOTHING — it writes the birth default for new sessions. It used to
+    `_effort_choice = saved_effort` anyway, fabricating a preference the live
+    spec never carried, so the next, unrelated `/model <other>` resurrected a
+    level the user had explicitly withdrawn with `/effort auto`."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "config.yml").write_text(
+        "version: 0.0.0\nvalues:\n  hosting: anthropic\n  model_name: claude-opus-5\n"
+        "  model_effort: high\n"
+    )
+    app = OperatorApp(
+        lambda: _factory(EffortSession()), provider_controller=EffortProviderController()
+    )
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/effort auto")
+        await _submit(pilot, app, "/model default")
+        choice_after_write = app._effort_choice
+        written = _written(tmp_path)
+        # The unrelated switch the resurrected choice used to land on.
+        await _submit(pilot, app, "/model openai/gpt-5.1")
+        level = _level(app)
+    # The stored level is PRESERVED (D6 clause 2) — the write-only form still
+    # writes the config default for new sessions.
+    assert written["model_effort"] == "high", written
+    # ...and the session is untouched: no remembered choice, so the switch below
+    # carries nothing.
+    assert choice_after_write is None
+    assert level is None
+
+
+@pytest.mark.asyncio
+async def test_the_default_receipt_names_a_clamped_rung(tmp_path, monkeypatch) -> None:
+    """U4: `/model default <p>/<id>` clamps the stored level into the target's
+    ladder and SAVES the clamped value — the receipt has to say that a rung was
+    dropped, because the user asked for `xhigh` and the file now holds `high`.
+
+    D3's budget holds on both rows: the receipt is one row at 120 columns (110
+    cells) and the clamp note is on its own row rather than inside it."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "config.yml").write_text(
+        "version: 0.0.0\nvalues:\n  hosting: anthropic\n  model_name: claude-opus-5\n"
+        "  model_effort: xhigh\n"
+    )
+    app = OperatorApp(
+        lambda: _factory(EffortSession()), provider_controller=EffortProviderController()
+    )
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/model default anthropic/claude-opus-4-6")
+        notices = _notices(app)
+    saved = [n for n in notices if n.startswith("boot default: ")]
+    assert len(saved) == 1, notices
+    assert "model_effort high (used by new sessions)" in saved[0], saved[0]
+    # The 110-cell budget is measured with the SHORT home-relative path the
+    # receipt prints in practice (`~/config/config.yml`), so the test's absolute
+    # temp path is normalised the same way before measuring.
+    normalised = saved[0].replace(str(tmp_path / "config.yml"), "~/config/config.yml")
+    # Measured WITHOUT the access suffix: that clause (` · anthropic logged in`)
+    # rides only when there is an access note to give, and it pushed this row
+    # over the 120-column budget before this PR too — D3's finding is about the
+    # receipt proper, which is the form the designer measured.
+    assert len(normalised.split(" · ")[0]) <= 110, normalised
+    assert any(
+        n == "model_effort high (xhigh clamps to this model's nearest rung)" for n in notices
+    ), notices

--- a/tests/unit/tui/test_settings_view.py
+++ b/tests/unit/tui/test_settings_view.py
@@ -2652,8 +2652,11 @@ async def test_selecting_a_row_keeps_its_attached_explanation_on_screen(
         # The ceiling is generous, not tight: sections added above the cascade
         # (the OpenRouter routing section, design round 1 D1) push the
         # discovered height up, and the contract being pinned is about the
-        # scroll model, not about any one era's row count.
-        for height in range(48, 8, -1):
+        # scroll model, not about any one era's row count. It is the range END
+        # that a new row above the cascade moves, so it has to move WITH one:
+        # `model_effort` (the effort default) added a third `model` row and took
+        # the discovered height from 48 to 49, one past the old ceiling of 48.
+        for height in range(64, 8, -1):
             await pilot.resize_terminal(120, height)
             await pilot.pause()
             if view._body_rows() == wanted:

--- a/tests/unit/tui/test_settings_view.py
+++ b/tests/unit/tui/test_settings_view.py
@@ -23,6 +23,7 @@ from textual import events
 
 from local_operator import settings_io
 from local_operator.config import ConfigManager
+from local_operator.model.effort import EFFORT_ORDER
 from local_operator.settings_io import Kind
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.widgets.model_picker import ModelRow
@@ -5238,3 +5239,46 @@ async def test_a_coercion_error_with_no_message_still_shows_something(
 
         assert view._error, "a coercion failure left the error slot empty"
         assert view._error == "ValueError"
+
+
+@pytest.mark.asyncio
+async def test_the_effort_row_renders_expands_and_resets(tmp_path: Path) -> None:
+    """The ``model_effort`` row end to end, on the page that OWNS the registry.
+
+    It renders ``auto`` for the unset ``""``, expands to the shared ladder as
+    choice rows, stores a level through one of them, and ``r`` takes it back to
+    the unset default — the same contract every other ENUM row has. The value
+    space is the vocabulary itself, so this is also where "a rung the model
+    lacks" stays OFFERABLE: the clamp happens at session build, not by hiding
+    rows the page cannot resolve a model to hide.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 32)) as pilot:
+        await pilot.pause()
+        app._open_settings_view()
+        view = app.query_one(SettingsView)
+        await pilot.pause()
+
+        index = _select(view, "model_effort")
+        view.action_activate()
+        await pilot.pause()
+        assert view._expanded == "model_effort"
+        choices = [row.choice for row in view._rows if row.kind == "choice"]
+        assert choices[0].label == "auto"
+        assert [choice.value for choice in choices[1:]] == list(EFFORT_ORDER)
+
+        for offset, row in enumerate(view._rows[index + 1 :], start=index + 1):
+            if row.kind == "choice" and row.choice.value == "high":
+                view._selected = offset
+                break
+        else:
+            raise AssertionError("no `high` choice row")
+        view.action_activate()
+        await pilot.pause()
+        assert _values(tmp_path)["model_effort"] == "high"
+        assert view._expanded is None
+
+        _select(view, "model_effort")
+        view.action_reset()
+        await pilot.pause()
+        assert "model_effort" not in _values(tmp_path)


### PR DESCRIPTION
## What

`/model default` persisted only the model (`hosting` + `model_name`), so a reasoning level chosen with `/effort` had to be re-chosen on every launch. A new top-level **`model_effort`** key now rides with the model pair as the birth default for new conversations, and a level the (possibly changed) default model cannot express is **clamped to its nearest supported rung** instead of 400ing or being silently dropped.

The design decisions this implements are named inline below as D1–D11, each with the constraint that produced it.

## Why this shape

`configure_model` is the only place a session spec is born, so the clamp lives there — the status band, the wire client's membership re-check and the failover driver then all read one value. It clamps against the **spec's** ladder, never `model.effort`'s table, because an aggregator listing can narrow a ladder below the table's (the split brain `resolve_effort_in`'s own docstring documents for `gpt-5.4-pro`).

`_prepare` (the one funnel TUI boot, `/new`, `/reload`, `/resume`, `lop exec`, the server and the scheduler all pass through) and `bootstrap.resolve_model_configuration` read the key, so a launch's running spec and the spec the server reports agree. Subagents are untouched: they receive a spec built by the parent's tier resolution, and `_prepare` has exactly two callers.

## Decisions worth naming

**D6 — the DELIBERATE effort is persisted, never an inferred one.** The value saved is (1) the level picked this session, else (2) the standing configured key, else (3) the spec's own level *only when it differs from the model's documented default*. Clause 2 is load-bearing: the freshly resolved spec on the persist path does **not** carry the config effort (only the session factories apply it), so without it a bare `/model default` would *erase* a configured key. Clause 3 is the point of the decision: `build_model_spec` merely *seeds* `high` for a direct Anthropic route, and freezing that into every future launch — then deepening a later `/model default <other>` model's reasoning — is a cost change arriving from a command about model *identity*. `""` is the registry's own "no opinion".

**D7 — saved equals running, on the paths that SWITCH** (round-1 manager ruling). `/model default <p>/<id>` puts the clamped rung in force *and* persists it, so it cannot store `xhigh` while the band reads the model's own default. That is a deliberate, small behaviour change: the band can move on an action that used to be a pure config write. The **write-only** form — a bare `/model default` on the model already in force — is the other half of the ruling and moves nothing: it writes the birth default for new sessions and deliberately touches neither the live spec nor `_effort_choice`. Before the ruling it fabricated a remembered choice the live spec never carried, and a later unrelated `/model <other>` resurrected a level the user had withdrawn with `/effort auto`. The boot clamp (§4) is a third path and still does **not** rewrite the key — `model_effort: xhigh` beside a model that stops at `high` runs `high` and keeps `xhigh`, so a later switch to a wider ladder re-applies it.

**D8 — `/model saved` adopts the configured level clamped, and clears the session level when the key is unset.** The override is a one-shot armed immediately before the re-dispatch and is only armed for a local session; a follower's re-dispatch still routes through its owner's canonical mutation. The invariant is that an armed override cannot outlive the dispatch it was armed *for*: `_cmd_model` clears it on every entry that is not that dispatch, its two provider guards drop it, **and `_cmd_model_saved` drops it if it survives the dispatch** — the slash dispatcher has an early return of its own, above `_cmd_model`, so a dispatch can end without entering the handler at all.

**D9 — an external `model_effort` edit prints a one-line notice, decided by CHANGE** (round-2 ruling). The TUI's listener skips the whole `model` section, so without this the key would be the one member of that section that changed with no signal anywhere. The rule is `ConfigChange.changed_keys`-based: announce iff the hosting/model_name pair still matches the session's model **and** `model_effort` is one of the keys that moved, naming the stored value (`auto` for the empty one). A value comparison cannot express that — it has to decide what the session's own level is, and every version mis-fires in one direction: announcing for an unrelated write on a seed-carrying model, or on a session holding a deliberate level, or going silent on a genuine move to `""`, which is the one member of the section the effort term exists to keep audible. A key that moved is a fact about the writer, not a guess about the reader.

**D10 — `/effort` stays session-scoped** (no `/effort default`); its set-receipt carries the durable route — `reasoning effort: high → xhigh (session); /model default keeps it` — and the `/effort auto` receipt carries `(this session) — /settings sets auto`, because a stored level survives a bare `/model default` by design, so the settings row is the route that actually makes a withdrawal stick.

**D11 — `lop config edit` now accepts a choice's LABEL**, and echoes the label the typed word selected. A label match (case-insensitive) maps to the stored value before the type-guessing chain, and only for ENUM settings. Two documented words were previously unreachable: `model_effort auto` means the stored `""` and was rejected outright, and `model_effort none` — a real rung of `EFFORT_ORDER` — was turned into Python `None` by the guard on the line below and rejected too. The receipt echoed the stored value, so `auto` confirmed with `Successfully updated model_effort to ` — a blank. No other kind's parsing moves.

## Rounds

| Round | Gates | Outcome |
| --- | --- | --- |
| 1 | agent review (2 BLOCKER, 2 MAJOR, 2 minor), design (1 MAJOR, D2–D5 minor, D6–D8 nits), UX (2 MAJOR, U3–U6 minor), QA **PASS** (31 surfaces, 3 declared gaps) | Remediated in `4c1ea8240`: the YAML-null reader, the override leak at `_cmd_model`'s own guards, the write-only path, the seed-vs-choice predicate, and the receipt/help cell budgets. |
| 2 | agent review (1 MAJOR NEW-1 — the residual of round 1's B2 — 2 minor, 1 nit), design **TERMINAL** (D9 minor, D10/D11 nits), UX **TERMINAL** (U7/U8 minor, U9 nit), QA **FAIL** (Q1, Q2, Q3) | Remediated in `ded2fc97a`: the readiness-window strand, change-based notice detection, and the three cell budgets the round-2 gates measured on the REAL widths. Deferrals recorded below. |
| 3 | this change | One commit; the deferrals below carry their reasons in the round-3 remediation comments. |

## Files

| File | Change |
| --- | --- |
| `local_operator/model/effort.py` | `configured_effort(config_manager)` — the one reader of the key; a non-string (YAML null) reads as "no opinion"; never raises, because it is on the boot path |
| `local_operator/model/configure.py` | `configure_model(reasoning_effort=…)`, clamped against `spec.reasoning_efforts`; `reasoning_default_effort` deliberately untouched (so `/effort auto` still restores the MODEL's default) |
| `local_operator/session_factory.py` | `_prepare` reads the key off-loop and threads it into the spec build |
| `local_operator/bootstrap.py` | `resolve_model_configuration` passes it too, so the server-reported spec matches (`server/routes/speech.py` deliberately does not — a speech model has no ladder) |
| `local_operator/settings_io.py` | the `model_effort` ENUM row (section `model`, `Scope.NEW_SESSIONS`, `""` labelled `auto`, choices derived from `EFFORT_ORDER`), plus the section description |
| `local_operator/config.py` | `DEFAULT_CONFIG["model_effort"] = ""` (required by the anti-drift test and by `config edit`'s unknown-key guard) |
| `local_operator/tui/app.py` | persist + live clamp + `/model saved` adoption + receipts + the sibling `_spec_with_clamped_effort` helper + the one-shot override and its handoff cleanup |
| `local_operator/session/session.py` | `_on_configured_model_changed` covers the third key, change-based |
| `local_operator/cli.py` | the D11 ENUM label→value guard, and the label echo |
| `README.md` | `/effort` row notes the durable route; `model_effort` added to the commonly-set keys |

`slash_commands.py` is deliberately unchanged (its description has ~55 cells of budget; the pointer goes on the transcript receipt instead).

## Testing evidence

Machine-readable gate set, whole tree, exact CI commands, on a clean worktree (`~/workspace/repos/lo-effort-default`, own venv, branch `feat/model-default-effort`) at the head of this PR:

| Command | Result |
| --- | --- |
| `.venv/bin/python -m flake8 .` | rc=0 |
| `uvx --from black==26.1.0 black --check .` | `1226 files would be left unchanged` |
| `uvx isort==5.13.2 --check .` | rc=0 |
| `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | `0 errors, 0 warnings, 0 informations` |
| `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q` | `18507 passed, 18 skipped` — exit 0. Run as two halves on this host (`tests/unit/tui`: `6981 passed, 12 skipped` in 21:25; the rest: `11526 passed, 6 skipped` in 6:11) because the single whole-tree invocation was killed at 92% under sibling sessions' load; CI's `test (3.12, 0..4)` re-ran the whole tree in one invocation on this head and is green. |
| `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q` | `106 passed, 7 skipped, 1 failed` — the one failure is `test_exec_startup_e2e.py::test_exec_live_tui_attachment_and_settled_frames[None]`, a spawned-subprocess frame assertion that passes alone (`2 passed in 4.81s`) and is a load flake on this host (load average 30-135 from sibling sessions); CI's two `tui-e2e` legs are green on this head. |
| touched files together (`model/test_effort.py`, `model/test_configure.py`, `test_settings_io.py`, `session/test_config_live.py`, `session/test_model_ownership.py`, `tui/test_effort.py`, `tui/test_settings_view.py`, `tui/test_app_pilot.py`) | `1495 passed` in 2:32 |

The TUI leg is the `env -u NO_COLOR TERM=xterm-256color` form, and every pytest run above is with that environment. The root `conftest.py` real-config tripwire did not fire; `~/.local-operator/config.yml` is byte-identical before and after (`md5 51a9b2a0…`).

Manual run, real code paths, isolated `HOME` + `LOCAL_OPERATOR_CONFIG_DIR`:

1. `local-operator config list` → the row is discoverable, with the help the settings page shows.
2. `local-operator config edit model_effort auto` → `Successfully updated model_effort to auto`, stored `model_effort: ''`, `configured_effort(...) is None`.
3. `local-operator config edit model_effort xhigh` → `… to xhigh`; `… turbo` → rc=1, `Error: model_effort: expected one of: auto, none, minimal, low, medium, high, xhigh, max`.
4. Boot the **real** factory (`session_factory.create_session`) from that config and read the real status band through `OperatorApp.run_test`: `model_effort: low` on `anthropic/claude-opus-5` → spec `low`, band `▴ low`; `model_effort: xhigh` on `claude-opus-4-6` → spec `high` (nearest rung, tie down) with the stored key still `xhigh`; a ladder-less model → no effort key on the wire and no effort segment.
5. Receipts rendered from the real `OperatorApp` at 80×24, 100×30 and 120×40 and read back as frames: the `/effort` set receipt on the worst shipped pair (`high → medium`, one row at 80), `/model default` with the real `~/.local-operator/config.yml` label (one row at 120), the clamp row (one row at 100), and the settings help beside a stored level (one row at 80).

Unit tests added/extended across the three rounds, in the files the design named:

- `tests/unit/model/test_effort.py` — `configured_effort`: absent, `""`, whitespace, `High`, an unknown word passed through, a YAML null/`int`/`bool`, the composed boot path, and never raising.
- `tests/unit/model/test_configure.py` — the clamp: applied, both directions, a downward tie, `None` for a no-ladder model, the model's own default untouched, and a listing-narrowed ladder as the clamp target.
- `tests/unit/test_settings_io.py` — the row's shape, a level round-trip, an off-vocabulary value refused, every rung described, the D11 label→value round trip for `auto`/`none`/`HIGH`, the label echo, and the help's 74-cell budget with headroom.
- `tests/unit/test_session_factory.py` — the configured level reaches the built spec on the flag and config routes; `""` leaves the builder's seed.
- `tests/unit/session/test_model_ownership.py` — a restored journal row outranks the configured birth effort on resume.
- `tests/unit/session/test_config_live.py` — the notice rule as a truth table over an unrelated write, a deliberate-level session, an effort-only move to a rung, an effort-only move to `auto`, a local facade write, and a pair change.
- `tests/unit/tui/test_effort.py` — the persist/adopt/clear rules, the B2 and readiness-window leaks (both asserted through the exact repros), the write-only path touching nothing, the receipt shapes at their budgets (the set receipt as a property over every ordered pair the shipped ladders can form), and the clamp row.
- `tests/unit/tui/test_settings_view.py` — the row renders, expands to the shared ladder, stores a level and resets, plus the height-ladder ceiling noted below.
- `tests/unit/tui/test_app_pilot.py` — the write-only `/model default`, its single-row receipt, and the recovery receipt naming the stored effort.

## Deviations from the design, and why

1. **D11's test lives in `test_settings_io.py`** (as §5 asks), but the resume/journal bullet moved to `tests/unit/session/test_model_ownership.py` — that file owns the session+journal harness (`Transcript` + a v2 `selected_model` row); a copy of it in `test_session_factory.py` would have been a second, weaker way to build the same fixture.
2. **`_configured_default_effort` is a small app helper** rather than literally "read it back from the same `ConfigManager` the persist block builds": D7 needs the value *before* the live switch, and the persist block's manager is built after it. It reuses the one registry reader, and returns `None` on any read failure.
3. **`test_selecting_a_row_keeps_its_attached_explanation_on_screen` (test_settings_view.py)** needed its discovered terminal-height ladder widened from 48 to 64: the new `model_effort` row sits above `retry.fallbackChains`, so the height that ends the body exactly on the cascade row moved from 48 to 49 — one past the old range end. The behaviour it pins was intact; the comment now names the ceiling as the thing a new row above the cascade must move. This is the only pre-existing test this change alters.
4. **Copy trades the gate rounds measured, each with the cells it buys.** The `/effort` set receipt says `(session)` where its siblings say `(this session)`: the row's size is a function of two rung words, so the budget is only a property of the receipt if the longest pair fits too. The `/model default` receipt leads with `default:` and qualifies with `(new sessions)` rather than `boot default:` / `(used by new sessions)`: 9 cells, which is what holds 110 against the path a default install renders instead of a redirected test home's shorter one. The `/effort auto` receipt dropped the origin clause (`the model's own default`) in favour of the scope and the durable route the UX round required. The clamp row says `reasoning effort:` (the dial's name) rather than `model_effort` (the config key), and `the nearest rung` for the same budget reason. The effort-only notice drops `keeping <model>`: the pair matches by construction on that branch, so the label restated the band.
5. **The bare `/effort` listing string is unchanged** (only the set-receipt gains the pointer), a literal reading of §3. Its `— this session only` clause stays true of the command it describes; if the design round prefers the pointer on the listing too, it is a one-line change.

## Not addressed

- **An off-vocabulary stored value (`model_effort: bogus`) leaves the ENUM expansion with no marked member** (design round 2, D6): `deferred —` reachable only through a hand-edited value that `validate` refuses everywhere, and marking nothing rather than marking a lie is the page's shared ENUM behaviour.
- **The setup-recovery receipt is painted while the rebuild runs and is cleared by the session swap** (design round 2, D11): `deferred —` pre-existing on the base with identical behaviour there, and the durable evidence that a stored effort rode into the boot is the status band.
- **A `/model default` receipt for a very long aggregator selector** (review round 2, NEW-3): `deferred —` measured: `openrouter/deepseek/deepseek-chat-v3.1-terminus` is 47 cells of model id against a 110-cell row that must also carry the 28-cell default config path, the pair, the key name and the qualifier. No spelling of the receipt holds that without eliding the id (the half the receipt exists to name) or dropping the path (the half that says where to undo it).
- `_recover_from_missing_model` still writes `hosting`/`model_name` through `ConfigManager.set_config_value` (bypassing the facade) and leaves `model_effort` alone; the boot that follows clamps the stale value. Pre-existing facade inconsistency, out of scope per the design.
- `lop exec --effort` still **raises** on an unsupported level while a stored default degrades. Deliberate asymmetry: an explicit flag is validated loudly.

## Impact

No breaking change, no dependency change, no migration. `pyproject.toml` is untouched — no version bump in this PR.

Release: patch — a small self-contained feature (one registry key plus the plumbing that clamps it) with no new surface or subsystem.
