### PR TITLE
fix(tui): author a paged row at the width it will be given

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -9092,7 +9092,9 @@ class OperatorApp(App[None]):
                         # when the turn dies instead of returning a result.
                         live_cards[block.tool_call_id] = block
 
-    def _project_settled_rows(self, history: list[Any], *, bound: int | None = None) -> bool:
+    def _project_settled_rows(
+        self, history: list[Any], *, bound: int | None = None, fold_width: int = 0
+    ) -> bool:
         from local_operator.tui.session_presentation import project_settled_rows
 
         session = self._session
@@ -9104,7 +9106,7 @@ class OperatorApp(App[None]):
         # same subtracted question for a target that never seeded.
         self._projection_live_call_ids = live_projection_call_ids(session)
         try:
-            projected = project_settled_rows(self, history, bound=bound)
+            projected = project_settled_rows(self, history, bound=bound, fold_width=fold_width)
             # The visible transcript, so the app's own registry is the right
             # owner: a row this repaints live is one `_retire_live_tool_cards`
             # must be able to settle when the turn dies.
@@ -9858,7 +9860,20 @@ class OperatorApp(App[None]):
         collected: list[Any] = []
         self._block_sink = collected
         try:
-            self._project_settled_rows(page)
+            # The width this page's blocks are about to be given. These rows
+            # are built DETACHED — nothing is mounted until `insert_blocks` —
+            # so without this every one of them folds at the 80-column
+            # fallback and pins that fold as its height, and `insert_blocks`'
+            # own hint arrived too late to be read: the block authors its rows
+            # before it is handed over. Corrected by the first layout's resize,
+            # which costs a second build per block and paints one frame of
+            # narrow rows — and it is the frame right after the page mounts,
+            # the one the reader is looking at when they scroll up into it.
+            # Measured at 150x40: 192 of 288 folds in three page mounts were at
+            # the fallback. Supplying it here, where the destination is known,
+            # is what makes the fold right the first time (PR #971).
+            transcript = self._transcript_view()
+            self._project_settled_rows(page, fold_width=transcript.scrollable_content_region.width)
         finally:
             self._block_sink = None
             # A page can end on a bang user row whose assistant lives in the
@@ -9952,11 +9967,16 @@ class OperatorApp(App[None]):
         )
 
     def _replay_tool_call(
-        self, call: Any, results: dict[str, Any], *, user_run: bool = False
+        self,
+        call: Any,
+        results: dict[str, Any],
+        *,
+        user_run: bool = False,
+        fold_width: int = 0,
     ) -> None:
         from local_operator.tui.session_presentation import replay_tool_call
 
-        return replay_tool_call(self, call, results, user_run=user_run)
+        return replay_tool_call(self, call, results, user_run=user_run, fold_width=fold_width)
 
     def _on_boot_failed(self, error: Exception) -> None:
         """Report a session that never constructed, WITHOUT retiring the splash.
@@ -23476,11 +23496,15 @@ class OperatorApp(App[None]):
             self._sync_boot_layout()
 
     def _append_image_blocks(
-        self, images: list[ImageContent], *, marker_text: str | None = None
+        self,
+        images: list[ImageContent],
+        *,
+        marker_text: str | None = None,
+        fold_width: int = 0,
     ) -> list[ImageBlock]:
         from local_operator.tui.session_presentation import append_image_blocks
 
-        return append_image_blocks(self, images, marker_text=marker_text)
+        return append_image_blocks(self, images, marker_text=marker_text, fold_width=fold_width)
 
     # -- slash commands -----------------------------------------------------
     def _notice(self, body: str, kind: NoticeKind = "info") -> None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -9104,13 +9104,35 @@ class OperatorApp(App[None]):
         # (`:8512`), the reconnect gap replay (`on_history_rows_settled`), the
         # sidebar commit's top-up (`:6113`/`:6127`) and the older-page collect —
         # so the destination is one question with one answer, and a caller left
-        # to remember it is a caller that can forget it. It is also knowable
-        # HERE: the transcript is laid out before the first block is built, so
-        # this is the eventual destination and not a pre-layout zero (measured
-        # at 100x30 during the boot projection: `transcript_cw=142` against
-        # `fold_width=0`).
+        # to remember it is a caller that can forget it.
         #
-        # Without it the whole tail projection is folded at the 80-column
+        # Knowable HERE only while the transcript is LAID OUT, which is the case
+        # this exists for: the view is laid out before the first block is built,
+        # so the region is the eventual destination and not a pre-layout zero.
+        # Measured by spying on this method at boot — 96 at 100x30, 142 at
+        # 146x40, 146 at 150x40 — with the previous cut of this comment having
+        # quoted the 146x40 figure against the 100x30 label (review round 2,
+        # M5): a number in a comment has to be traceable to the run that read
+        # it, or the next reader cannot tell a measurement from a guess.
+        #
+        # OFF-LAYOUT the region is 0, and that is deliberate, not overlooked
+        # (QA round 2, Q2): with `display = False` — the subagent view and the
+        # org chart — the view reports `region=0 view=0` (measured at every grid
+        # above, restored to 96/142/146 on the way back), so a
+        # `HistoryRowsSettled` that lands in that state still authors at the 80
+        # column fallback and is repaired by the restore's resize. That is a
+        # wasted build, not a painted frame: measured on the base revision and
+        # this one alike, the first paint after the restore carries no
+        # fallback-authored block.
+        #
+        # NOT repaired with a cached last-known width, which is the obvious next
+        # idea and is worse than the zero: a cache outlives the pane that set
+        # it, and a width from a WIDE pane pinned as a fold inside a NARROW one
+        # clips rows that can no longer re-wrap — missing text, where the zero
+        # costs one off-screen build of rows that are then re-authored before
+        # anything is painted.
+        #
+        # Without any of this the whole tail projection is folded at the
         # fallback and the FIRST PAINT of a resumed conversation is a narrow
         # one: prose wrapped at 78 cells inside a 96-cell pane, with blank space
         # to its right — the operator's reported frame, and the reason the
@@ -9125,8 +9147,14 @@ class OperatorApp(App[None]):
         # `_mark_pending_tool_rows` below; the fold's own fallback re-asks the
         # same subtracted question for a target that never seeded.
         self._projection_live_call_ids = live_projection_call_ids(session)
-        fold_width = self._transcript_view().scrollable_content_region.width
         try:
+            # Inside the guard, with the projection it serves. `_transcript_view()`
+            # raises `NoMatches` once `#transcript` is gone — the shutdown reachable
+            # with a session-adoption worker in flight (`:18416`) — and the `finally`
+            # below resets the projection bookkeeping, so a read placed ahead of the
+            # `try` would skip those resets for a projection that never ran (review
+            # round 2, N4).
+            fold_width = self._transcript_view().scrollable_content_region.width
             projected = project_settled_rows(self, history, bound=bound, fold_width=fold_width)
             # The visible transcript, so the app's own registry is the right
             # owner: a row this repaints live is one `_retire_live_tool_cards`
@@ -9886,12 +9914,13 @@ class OperatorApp(App[None]):
             # page and the tail cannot disagree about the destination, and the
             # hint reaches each block before it authors its rows — the half
             # `insert_blocks` cannot do for rows that already exist. Measured at
-            # 150x40 over three wheel-driven page mounts on `633baf258`:
-            # `scripts/resume_paging_probe.py fold ordinary 150x40` reported 108
-            # authoring folds with 72 of them at the 80-column fallback, and 6
-            # painted frames with a fallback-folded block inside the viewport;
-            # on this branch the same command reports 72 folds, 0 at the
-            # fallback, 0 frames.
+            # 150x40 over three wheel-driven page mounts on base `633baf258`:
+            # this branch's `scripts/resume_paging_probe.py fold ordinary 150x40`
+            # (the `fold` mode is part of this change, so it is run against that
+            # tree rather than checked out with it) reported 108 authoring folds
+            # with 72 of them at the 80-column fallback, and 6 painted frames
+            # with a fallback-folded block inside the viewport; on this branch
+            # the same command reports 72 folds, 0 at the fallback, 0 frames.
             self._project_settled_rows(page)
         finally:
             self._block_sink = None

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -9092,12 +9092,32 @@ class OperatorApp(App[None]):
                         # when the turn dies instead of returning a result.
                         live_cards[block.tool_call_id] = block
 
-    def _project_settled_rows(
-        self, history: list[Any], *, bound: int | None = None, fold_width: int = 0
-    ) -> bool:
+    def _project_settled_rows(self, history: list[Any], *, bound: int | None = None) -> bool:
         from local_operator.tui.session_presentation import project_settled_rows
 
         session = self._session
+        # The width every block this pass builds is about to be GIVEN, asked of
+        # the view they are about to be mounted into.
+        #
+        # Derived HERE rather than at each call site because every caller of
+        # this method projects into the live transcript — cold resume's tail
+        # (`:8512`), the reconnect gap replay (`on_history_rows_settled`), the
+        # sidebar commit's top-up (`:6113`/`:6127`) and the older-page collect —
+        # so the destination is one question with one answer, and a caller left
+        # to remember it is a caller that can forget it. It is also knowable
+        # HERE: the transcript is laid out before the first block is built, so
+        # this is the eventual destination and not a pre-layout zero (measured
+        # at 100x30 during the boot projection: `transcript_cw=142` against
+        # `fold_width=0`).
+        #
+        # Without it the whole tail projection is folded at the 80-column
+        # fallback and the FIRST PAINT of a resumed conversation is a narrow
+        # one: prose wrapped at 78 cells inside a 96-cell pane, with blank space
+        # to its right — the operator's reported frame, and the reason the
+        # paging fix alone did not close the report. Measured on `87240c118` at
+        # 100x30: one paint carrying 80 blocks at `box=96 built=80`, rows ending
+        # at cell 81 of 96 (QA round 1, Q1). The same paint on this branch
+        # carries no fallback-authored block.
         # Snapshot the in-flight calls BEFORE the fold: the answer can change
         # mid-projection, and replay reads only this set. The seed is the
         # gate-free set (`live_projection_call_ids` documents the pending
@@ -9105,6 +9125,7 @@ class OperatorApp(App[None]):
         # `_mark_pending_tool_rows` below; the fold's own fallback re-asks the
         # same subtracted question for a target that never seeded.
         self._projection_live_call_ids = live_projection_call_ids(session)
+        fold_width = self._transcript_view().scrollable_content_region.width
         try:
             projected = project_settled_rows(self, history, bound=bound, fold_width=fold_width)
             # The visible transcript, so the app's own registry is the right
@@ -9860,20 +9881,18 @@ class OperatorApp(App[None]):
         collected: list[Any] = []
         self._block_sink = collected
         try:
-            # The width this page's blocks are about to be given. These rows
-            # are built DETACHED — nothing is mounted until `insert_blocks` —
-            # so without this every one of them folds at the 80-column
-            # fallback and pins that fold as its height, and `insert_blocks`'
-            # own hint arrived too late to be read: the block authors its rows
-            # before it is handed over. Corrected by the first layout's resize,
-            # which costs a second build per block and paints one frame of
-            # narrow rows — and it is the frame right after the page mounts,
-            # the one the reader is looking at when they scroll up into it.
-            # Measured at 150x40: 192 of 288 folds in three page mounts were at
-            # the fallback. Supplying it here, where the destination is known,
-            # is what makes the fold right the first time (PR #971).
-            transcript = self._transcript_view()
-            self._project_settled_rows(page, fold_width=transcript.scrollable_content_region.width)
+            # The width these blocks are about to be given is NOT passed here:
+            # `_project_settled_rows` asks the live transcript for it, so the
+            # page and the tail cannot disagree about the destination, and the
+            # hint reaches each block before it authors its rows — the half
+            # `insert_blocks` cannot do for rows that already exist. Measured at
+            # 150x40 over three wheel-driven page mounts on `633baf258`:
+            # `scripts/resume_paging_probe.py fold ordinary 150x40` reported 108
+            # authoring folds with 72 of them at the 80-column fallback, and 6
+            # painted frames with a fallback-folded block inside the viewport;
+            # on this branch the same command reports 72 folds, 0 at the
+            # fallback, 0 frames.
+            self._project_settled_rows(page)
         finally:
             self._block_sink = None
             # A page can end on a bang user row whose assistant lives in the

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -9149,11 +9149,28 @@ class OperatorApp(App[None]):
         self._projection_live_call_ids = live_projection_call_ids(session)
         try:
             # Inside the guard, with the projection it serves. `_transcript_view()`
-            # raises `NoMatches` once `#transcript` is gone — the shutdown reachable
-            # with a session-adoption worker in flight (`:18416`) — and the `finally`
-            # below resets the projection bookkeeping, so a read placed ahead of the
-            # `try` would skip those resets for a projection that never ran (review
-            # round 2, N4).
+            # raises `NoMatches` once `#transcript` is gone — the case `_shutdown`'s
+            # own docstring records (`_adopt_session` → `_render_resumed_history` →
+            # `_transcript_view()`, the crash the pre-prune worker cancel closed) —
+            # and the `finally` below resets the projection bookkeeping, so a read
+            # placed ahead of the `try` skipped those resets for a projection that
+            # never ran.
+            #
+            # The read is DEFENSIVE, not a live path. QA round 3 drove the teardown
+            # 8 times per tree and never entered it: 0 projection entries during
+            # teardown, with the painter workers cancelled before Textual prunes
+            # the tree. What is observable is the leak on the previous head,
+            # reached through the same raise: there `_projection_message_id` and
+            # `_projection_skipped_live` survived it, and the NEXT appended block
+            # inherited the stale anchor; on this head all three fields reset and
+            # the next block gets none.
+            #
+            # Named by FUNCTION, not by line, and the other citations in this
+            # comment were re-resolved against this tree on the way past: adding
+            # 29 comment lines above shifted the case this sentence is about, which
+            # is how the previous citation came to point at
+            # `_stop_multiplexer_broadcast` instead. A line number in a comment
+            # survives only until the next edit above it.
             fold_width = self._transcript_view().scrollable_content_region.width
             projected = project_settled_rows(self, history, bound=bound, fold_width=fold_width)
             # The visible transcript, so the app's own registry is the right

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -852,9 +852,18 @@ def project_settled_rows(
         # The width goes to construction here for the same reason every other
         # block in this pass gets it: a notice wraps itself in `__init__`, and
         # this one is authored and mounted in the same pass as the rows below
-        # it, so a fallback fold here is a painted frame with a 36-cell
-        # sentence wrapped inside a 96-cell pane (QA round 1, Q1 caught exactly
-        # this row: `OlderHistoryNotice box=96 authored at 80`).
+        # it, so without it the row is folded at the 80-column fallback before
+        # any hint can reach it (QA round 1, Q1 caught exactly this row:
+        # `OlderHistoryNotice box=96 authored at 80`).
+        #
+        # The pane where that is VISIBLE is a narrow one, not the 96-cell pane
+        # the `box=` readout above happens to carry (design round 2, D6): the
+        # sentence is 36 cells and fits on one row at every pane above ~44, so
+        # at 100x30 and 60x20 this notice paints identically before and after.
+        # Measured at 40x20 (pane 36): the fallback build is one row ending
+        # `…scroll up`, and this one wraps to a second, hanging-indented row —
+        # `…scroll` / `up to load`. Below the fallback the width is the
+        # difference between the whole sentence and a truncated one.
         notice = OlderHistoryNotice(RESUME_OLDER_NOTICE, fold_width=fold_width)
         self._resume_head_notice = notice
         self._append_block(notice)

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -182,8 +182,8 @@ class OlderHistoryNotice(NoticeBlock, can_focus=True):
             super().__init__()
             self.notice = notice
 
-    def __init__(self, text: str) -> None:
-        super().__init__(text, "note")
+    def __init__(self, text: str, *, fold_width: int = 0) -> None:
+        super().__init__(text, "note", fold_width=fold_width)
         self._interactive = True
         self.add_class("interactive-notice")
 
@@ -494,6 +494,9 @@ class PreparedReplay(ReplayState):
         if self._resume_pending_head:
             from local_operator.tui.app import RESUME_OLDER_NOTICE
 
+            # No width: a prepared replay is authored offscreen for a parked
+            # view (see `project_settled_rows`' `fold_width` note), and this
+            # notice is folded when that view is laid out.
             self._resume_head_notice = OlderHistoryNotice(RESUME_OLDER_NOTICE)
             self.blocks.insert(0, self._resume_head_notice)
         if self._resume_pending_tail:
@@ -724,16 +727,30 @@ def project_settled_rows(
     rows no frontend painted and bounding it could hide one.
 
     ``fold_width`` is the width every block this pass BUILDS will be given.
-    Zero is "not supplied", which is right for a pass that mounts where it
-    authors (the tail) and wrong for a PAGE collected for insertion above
-    the viewport: those blocks are built detached, so every one of them folds
-    at the 80-column fallback, pins that fold as its height, and is then
-    re-authored by the first layout's resize — a second build per block and a
-    painted frame whose rows wrap at 80 inside a 146-cell pane. The caller
-    that knows the destination (``OperatorApp._collect_resume_page_blocks``)
-    supplies it here so the rows are authored at the right width the first
-    and only time. It is threaded to CONSTRUCTION rather than applied after,
-    because a block that wraps in ``__init__`` never reads a later hint.
+    Zero means "not supplied", and it is only right where there is no
+    destination to name: a prepared replay authors offscreen for a parked view
+    and is laid out inside it before that view is revealed.
+
+    Every other caller has a destination and must name it, because a block
+    built without one folds at the 80-column fallback, pins that fold as its
+    height, and is re-authored by the first layout's resize — a second build
+    per block and a painted frame whose rows wrap at 78 cells inside a 96 or
+    146-cell pane. `OperatorApp._project_settled_rows` derives it from the live
+    transcript for the tail, the reconnect gap replay, the sidebar commit's
+    top-up and the older-page collect, so those four cannot disagree about the
+    destination. It is threaded to CONSTRUCTION rather than applied after,
+    because a block that wraps in ``__init__`` never reads a hint set later.
+
+    The one authoring seam on a live transcript that still has no width is
+    ``TranscriptView.append_block`` / ``OperatorApp._append_block``: a live
+    prompt, notice or running card is built first and mounted second, so its
+    rows come out of the fallback too and are saved only by that same resize.
+    Deliberately not part of this seam: no painted narrow frame was observed on
+    it (the append's mount and resize both complete before the paint; measured
+    at 150x40 and 160x40 by review round 1 and the design round), so it is a
+    wasted build rather than a visible defect — recorded in the PR's "not
+    addressed" list, and it cannot be fixed from here because a hint applied at
+    append arrives after the rows exist.
     """
     from contextlib import nullcontext
 
@@ -832,7 +849,13 @@ def project_settled_rows(
     # #451/#452 exist to prevent. One extra mount of a one-line notice is
     # not the cost this bound is avoiding.
     if self._block_sink is None and self._resume_pending_head and self._resume_head_notice is None:
-        notice = OlderHistoryNotice(RESUME_OLDER_NOTICE)
+        # The width goes to construction here for the same reason every other
+        # block in this pass gets it: a notice wraps itself in `__init__`, and
+        # this one is authored and mounted in the same pass as the rows below
+        # it, so a fallback fold here is a painted frame with a 36-cell
+        # sentence wrapped inside a 96-cell pane (QA round 1, Q1 caught exactly
+        # this row: `OlderHistoryNotice box=96 authored at 80`).
+        notice = OlderHistoryNotice(RESUME_OLDER_NOTICE, fold_width=fold_width)
         self._resume_head_notice = notice
         self._append_block(notice)
         appended = True

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -857,13 +857,22 @@ def project_settled_rows(
         # `OlderHistoryNotice box=96 authored at 80`).
         #
         # The pane where that is VISIBLE is a narrow one, not the 96-cell pane
-        # the `box=` readout above happens to carry (design round 2, D6): the
-        # sentence is 36 cells and fits on one row at every pane above ~44, so
-        # at 100x30 and 60x20 this notice paints identically before and after.
-        # Measured at 40x20 (pane 36): the fallback build is one row ending
-        # `…scroll up`, and this one wraps to a second, hanging-indented row —
-        # `…scroll` / `up to load`. Below the fallback the width is the
-        # difference between the whole sentence and a truncated one.
+        # the `box=` readout above happens to carry (design round 2, D6). The
+        # sentence is 40 cells and the body budget is `width - 6` (`body_budget`:
+        # the 2-cell spine indent plus the 4-cell glyph column), so the row stops
+        # wrapping at pane 46 — one row from 46 up, two rows at 44 and below.
+        # Measured by building the notice at fold widths 36..54 and reading each
+        # row's cell length: pane 44 → `[39, 8]` cells, pane 46 → `[44]`. An
+        # earlier cut of this comment carried the 40x20 PANE (36) as though it
+        # were the sentence's length — the sentence is 40, and a figure no
+        # reader can re-derive is worse than no figure.
+        #
+        # At 100x30 and 60x20 this notice therefore paints identically before
+        # and after, and the observable case is 40x20 (pane 36): the fallback
+        # build is one row ending `…scroll up`, and this one wraps to a second,
+        # hanging-indented row — `…scroll` / `up to load`. Below the wrap
+        # threshold the width is the difference between the whole sentence and
+        # a truncated one.
         notice = OlderHistoryNotice(RESUME_OLDER_NOTICE, fold_width=fold_width)
         self._resume_head_notice = notice
         self._append_block(notice)

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -379,7 +379,11 @@ class ReplayTarget(Protocol):
     ) -> None: ...
 
     def _append_image_blocks(
-        self, images: list[ImageContent], *, marker_text: str | None = None
+        self,
+        images: list[ImageContent],
+        *,
+        marker_text: str | None = None,
+        fold_width: int = 0,
     ) -> list[ImageBlock]: ...
 
     def _painted_tool_card(self, call_id: str) -> Any: ...
@@ -387,7 +391,12 @@ class ReplayTarget(Protocol):
     def _settle_painted_tool_card(self, card: Any, result: Any) -> None: ...
 
     def _replay_tool_call(
-        self, call: Any, results: dict[str, Any], *, user_run: bool = False
+        self,
+        call: Any,
+        results: dict[str, Any],
+        *,
+        user_run: bool = False,
+        fold_width: int = 0,
     ) -> None: ...
 
 
@@ -415,9 +424,23 @@ class PreparedReplay(ReplayState):
         self.blocks.append(block)
 
     def _append_image_blocks(
-        self, images: list[ImageContent], *, marker_text: str | None = None
+        self,
+        images: list[ImageContent],
+        *,
+        marker_text: str | None = None,
+        fold_width: int = 0,
     ) -> list[ImageBlock]:
-        return append_image_blocks(self, images, marker_text=marker_text, navigation_visible=False)
+        # ``fold_width`` is accepted to satisfy ``ReplayTarget``: a prepared
+        # replay is built OFFSCREEN, so there is no laid-out destination to
+        # name and the caller passes nothing (its blocks are folded when the
+        # presentation is committed into a mounted view).
+        return append_image_blocks(
+            self,
+            images,
+            marker_text=marker_text,
+            navigation_visible=False,
+            fold_width=fold_width,
+        )
 
     def _painted_tool_card(self, call_id: str) -> None:
         return None
@@ -426,9 +449,15 @@ class PreparedReplay(ReplayState):
         raise AssertionError("a prepared replay cannot contain a live tool card")
 
     def _replay_tool_call(
-        self, call: Any, results: dict[str, Any], *, user_run: bool = False
+        self,
+        call: Any,
+        results: dict[str, Any],
+        *,
+        user_run: bool = False,
+        fold_width: int = 0,
     ) -> None:
-        replay_tool_call(self, call, results, user_run=user_run)
+        # Zero for a prepared replay — see `_append_image_blocks` above.
+        replay_tool_call(self, call, results, user_run=user_run, fold_width=fold_width)
 
     def prepare(
         self,
@@ -663,7 +692,12 @@ class SessionPresentation:
 
 
 def project_settled_rows(
-    self: ReplayTarget, history: list[Any], *, bound: int | None = None, end: int | None = None
+    self: ReplayTarget,
+    history: list[Any],
+    *,
+    bound: int | None = None,
+    end: int | None = None,
+    fold_width: int = 0,
 ) -> bool:
     """Mount settled transcript rows through the ONE role-aware renderer.
 
@@ -688,6 +722,18 @@ def project_settled_rows(
     projection — never sees the split at all. The gap-replay caller passes
     no bound, because a reconnect gap is by definition the small set of
     rows no frontend painted and bounding it could hide one.
+
+    ``fold_width`` is the width every block this pass BUILDS will be given.
+    Zero is "not supplied", which is right for a pass that mounts where it
+    authors (the tail) and wrong for a PAGE collected for insertion above
+    the viewport: those blocks are built detached, so every one of them folds
+    at the 80-column fallback, pins that fold as its height, and is then
+    re-authored by the first layout's resize — a second build per block and a
+    painted frame whose rows wrap at 80 inside a 146-cell pane. The caller
+    that knows the destination (``OperatorApp._collect_resume_page_blocks``)
+    supplies it here so the rows are authored at the right width the first
+    and only time. It is threaded to CONSTRUCTION rather than applied after,
+    because a block that wraps in ``__init__`` never reads a later hint.
     """
     from contextlib import nullcontext
 
@@ -817,7 +863,13 @@ def project_settled_rows(
                     # Skip a receipt this session already painted live —
                     # replaying it would double the line (round 2, m2).
                     if key not in self._live_wake_receipts:
-                        self._append_block(WakeBlock(str(details.get("text", "")), catchup=False))
+                        self._append_block(
+                            WakeBlock(
+                                str(details.get("text", "")),
+                                catchup=False,
+                                fold_width=fold_width,
+                            )
+                        )
                         appended = True
                 continue
             # A peer message (`lop send` from another session) is also a
@@ -833,6 +885,7 @@ def project_settled_rows(
                         PeerMessageBlock(
                             str(details.get("body", "")),
                             details.get("sender") or {},
+                            fold_width=fold_width,
                         )
                     )
                     appended = True
@@ -851,7 +904,9 @@ def project_settled_rows(
             # distinction the transcript row itself exists to preserve.
             if getattr(message, "custom_type", None) == GATE_TIMEOUT_CUSTOM_TYPE:
                 details = getattr(message, "details", None) or {}
-                self._append_block(NoticeBlock(gate_timeout_notice(details), kind="warning"))
+                self._append_block(
+                    NoticeBlock(gate_timeout_notice(details), kind="warning", fold_width=fold_width)
+                )
                 appended = True
                 continue
             # A compaction that did NOT run. Rendered here for the same
@@ -863,7 +918,7 @@ def project_settled_rows(
             if getattr(message, "custom_type", None) == COMPACTION_REFUSED_TYPE:
                 details = getattr(message, "details", None) or {}
                 text, kind = compaction_refused_notice(details)
-                self._append_block(NoticeBlock(text, kind=kind))
+                self._append_block(NoticeBlock(text, kind=kind, fold_width=fold_width))
                 appended = True
                 continue
             # The compaction boundary itself. The replay layer has always
@@ -883,7 +938,11 @@ def project_settled_rows(
             # error — the rows below are real history, they are simply outside
             # what the agent can still see.
             if getattr(message, "custom_type", None) == COMPACTION_MARKER_TYPE:
-                self._append_block(CompactionMarkerBlock(COMPACTION_MARKER_NOTICE, kind="note"))
+                self._append_block(
+                    CompactionMarkerBlock(
+                        COMPACTION_MARKER_NOTICE, kind="note", fold_width=fold_width
+                    )
+                )
                 appended = True
                 continue
             role = getattr(message, "role", None)
@@ -931,8 +990,10 @@ def project_settled_rows(
                     if isinstance(block, ImageContent)
                 ]
                 if text or replay_images:
-                    self._append_block(UserBlock(text, len(replay_images)))
-                    self._append_image_blocks(replay_images, marker_text=text)
+                    self._append_block(UserBlock(text, len(replay_images), fold_width=fold_width))
+                    self._append_image_blocks(
+                        replay_images, marker_text=text, fold_width=fold_width
+                    )
                     appended = True
                 # A bang-mode receipt replays as open as it lived: the
                 # user row is `! <command>` and the assistant message that
@@ -958,6 +1019,10 @@ def project_settled_rows(
             if assistant_row_text(text):
                 block = AssistantBlock()
                 block.completion_anchor_id = str(getattr(message, "id", ""))
+                # Before `update_text`: this block authors its rows through the
+                # fold ladder on every update, and a hint set afterwards would
+                # only reach a rebuild that has already happened.
+                block.set_fold_hint(fold_width)
                 block.update_text(text)
                 block.finalize_text()
                 self._append_block(block)
@@ -971,7 +1036,7 @@ def project_settled_rows(
                 user_run = bool(
                     bang_pending and tool_calls[0] is call and getattr(call, "name", "") == "bash"
                 )
-                self._replay_tool_call(call, results, user_run=user_run)
+                self._replay_tool_call(call, results, user_run=user_run, fold_width=fold_width)
                 appended = True
             # A refused, failed or interrupted turn needs a notice the prose
             # alone does not carry — a refusal fires even when the model
@@ -988,7 +1053,7 @@ def project_settled_rows(
             )
             if notice is not None:
                 reason, severity = notice
-                self._append_block(NoticeBlock(reason, severity))
+                self._append_block(NoticeBlock(reason, severity, fold_width=fold_width))
                 appended = True
     # Every message this pass rendered, by stable id — the dedupe key a
     # later backward page is filtered through.
@@ -1013,7 +1078,12 @@ def project_settled_rows(
 
 
 def replay_tool_call(
-    self: ReplayTarget, call: Any, results: dict[str, Any], *, user_run: bool = False
+    self: ReplayTarget,
+    call: Any,
+    results: dict[str, Any],
+    *,
+    user_run: bool = False,
+    fold_width: int = 0,
 ) -> None:
     """Mount one settled tool row for a call from a previous session.
 
@@ -1094,6 +1164,12 @@ def replay_tool_call(
         getattr(call, "arguments", None) or {},
         user_run=user_run,
     )
+    # Before the `restore`/`mark_*` calls below re-author the row: the
+    # constructor's own build is the throwaway one (a detached card has no
+    # width to ask and falls to the console fallback), and every state call
+    # that follows rebuilds through the fold ladder — so this is the moment
+    # the card can be told the width its rows should be authored at.
+    card.set_fold_hint(fold_width)
     self._append_block(card)
     if result is None:
         # No result recorded: the session ended between the call and its
@@ -1188,6 +1264,7 @@ def append_image_blocks(
     *,
     marker_text: str | None = None,
     navigation_visible: bool = True,
+    fold_width: int = 0,
 ) -> list[ImageBlock]:
     """Mount one :class:`ImageBlock` per image, in order.
 
@@ -1232,6 +1309,7 @@ def append_image_blocks(
                 image.mime_type,
                 label=label,
                 navigation_visible=navigation_visible,
+                fold_width=fold_width,
             )
         except Exception:
             logger.debug("image block construction failed", exc_info=True)

--- a/local_operator/tui/widgets/assistant.py
+++ b/local_operator/tui/widgets/assistant.py
@@ -617,14 +617,18 @@ class AssistantBlock(TranscriptBlock):
         Spacing only needs "one row or more"; a full render of a message
         that may be thousands of lines long to learn that is waste. Any
         embedded newline settles it; otherwise the single line is multi-row
-        exactly when it is wider than the block.
+        exactly when it is wider than the block — measured at the LADDER's
+        width, so a block whose destination is already named is judged at it
+        rather than at the 80-column fallback
+        (`TranscriptBlock.spans_multiple_rows` records why that matters to the
+        gaps an insert settles before its mount).
         """
         text = self._full_text.strip()
         if not text:
             return False
         if "\n" in text:
             return True
-        return cell_len(text) > max(self.size.width or 80, 10)
+        return cell_len(text) > max(self.fold_width(80), 10)
 
     def text(self) -> str:
         """The accumulated message text (for tests and export)."""

--- a/local_operator/tui/widgets/image_block.py
+++ b/local_operator/tui/widgets/image_block.py
@@ -140,10 +140,16 @@ class ImageBlock(TranscriptBlock):
         *,
         label: str = "",
         navigation_visible: bool = True,
+        fold_width: int = 0,
     ) -> None:
         super().__init__()
         self.add_class("image-block")
         self._navigation_visible = navigation_visible
+        # Before the first `_build`/`_grid`: the grid is chosen from the width
+        # (see `UserBlock.__init__` for why a hint supplied later is a width
+        # nothing reads). Zero keeps construction's 80-column guess, which
+        # `on_mount` corrects.
+        self.set_fold_hint(fold_width)
         #: Short human name for the unavailable receipt (marker text or file
         #: name). Never rendered while the image itself is on screen — the
         #: caption already lives on the tool card or in the prompt text.
@@ -193,7 +199,7 @@ class ImageBlock(TranscriptBlock):
         (possibly downscaled) copy: the fit's job is the true aspect ratio
         and the no-upscale rule, both properties of the source image.
         """
-        width = self.size.width or 80
+        width = self.fold_width(80)
         avail = max(8, width - SPINE_INDENT)
         return images_mod.fit_cells(
             self._px_width,
@@ -428,7 +434,7 @@ class ImageBlock(TranscriptBlock):
 
         style = Style(color=theme_mod.semantic_color("muted"))
         lead = f"{glyph} "
-        room = max(8, (self.size.width or 80) - SPINE_INDENT - cell_len(lead))
+        room = max(8, self.fold_width(80) - SPINE_INDENT - cell_len(lead))
         if cell_len(message) > room:
             from rich.cells import set_cell_size
 

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -1030,11 +1030,11 @@ class InstructionBlock(UserBlock):
         Binding("enter", "toggle_brief", "Expand instruction", show=False),
     ]
 
-    def __init__(self, text: str) -> None:
+    def __init__(self, text: str, *, fold_width: int = 0) -> None:
         #: Set before `super().__init__`, which builds immediately.
         self._expanded = False
         self._hidden_rows = 0
-        super().__init__(text)
+        super().__init__(text, fold_width=fold_width)
         self.add_class("instruction-block")
 
     def _rows(self, body: int) -> list[str]:
@@ -1158,9 +1158,14 @@ def entry_block(
     its paragraph breaks, until the child eventually exits.
     """
     if entry.kind == "prompt":
-        return InstructionBlock(entry.text)
+        # The width goes to CONSTRUCTION for the three kinds below, not through
+        # `set_fold_hint` afterwards: these wrap inside `__init__`, so a hint set
+        # after they are built is a width nothing will read (see
+        # `UserBlock.__init__`). The streaming/ledger kinds above and below author
+        # through the ladder and take the hint instead.
+        return InstructionBlock(entry.text, fold_width=fold_width)
     if entry.kind in ("user", "parent_message"):
-        return UserBlock(entry.text)
+        return UserBlock(entry.text, fold_width=fold_width)
     if entry.kind in ("text", "subagent_message"):
         block = AssistantBlock()
         if fold_width:
@@ -1172,8 +1177,8 @@ def entry_block(
     if entry.kind == "notice":
         if entry.key == "__working__":
             activity = entry.text or "thinking"
-            return WorkingBlock(activity, activity)
-        return NoticeBlock(entry.text, entry.notice_kind)
+            return WorkingBlock(activity, activity, fold_width=fold_width)
+        return NoticeBlock(entry.text, entry.notice_kind, fold_width=fold_width)
     card = ToolCard("", entry.tool_name, entry.tool_args, entry.intent)
     if fold_width:
         card.set_fold_hint(fold_width)

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -1158,18 +1158,20 @@ def entry_block(
     its paragraph breaks, until the child eventually exits.
     """
     if entry.kind == "prompt":
-        # The width goes to CONSTRUCTION for the three kinds below, not through
-        # `set_fold_hint` afterwards: these wrap inside `__init__`, so a hint set
-        # after they are built is a width nothing will read (see
-        # `UserBlock.__init__`). The streaming/ledger kinds above and below author
-        # through the ladder and take the hint instead.
+        # The width goes to CONSTRUCTION for the kinds that wrap inside
+        # `__init__` (`InstructionBlock`/`UserBlock`/`NoticeBlock`/`WorkingBlock`)
+        # — a hint set after they are built is a width nothing will read (see
+        # `UserBlock.__init__`) — and through `set_fold_hint` for the kinds that
+        # author through the ladder on a later call (`AssistantBlock`,
+        # `ToolCard`). Every constructor clamps a zero itself, so the value is
+        # passed unconditionally rather than guarded here: two spellings of
+        # "no width" in one function is how the two drift apart.
         return InstructionBlock(entry.text, fold_width=fold_width)
     if entry.kind in ("user", "parent_message"):
         return UserBlock(entry.text, fold_width=fold_width)
     if entry.kind in ("text", "subagent_message"):
         block = AssistantBlock()
-        if fold_width:
-            block.set_fold_hint(fold_width)
+        block.set_fold_hint(fold_width)
         block.update_text(entry.text)
         if entry.complete or settled:
             block.finalize_text()
@@ -1180,8 +1182,7 @@ def entry_block(
             return WorkingBlock(activity, activity, fold_width=fold_width)
         return NoticeBlock(entry.text, entry.notice_kind, fold_width=fold_width)
     card = ToolCard("", entry.tool_name, entry.tool_args, entry.intent)
-    if fold_width:
-        card.set_fold_hint(fold_width)
+    card.set_fold_hint(fold_width)
     if entry.outcome == "error":
         card.restore(
             state="error",

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -599,10 +599,14 @@ class TranscriptBlock(Static):
         state (a tool card knows; a streaming message knows from its source
         text) never pays for a full render just to be spaced correctly.
         The default measures whatever renderable is applied, memoized per
-        content revision.
+        content revision. The width comes from the fold LADDER like every other
+        authoring site: a block a builder has already told where it is going
+        (`set_fold_hint`, e.g. a page settled before its mount) must not be
+        judged at the 80-column fallback, or `_settle_gaps` decides spacing for
+        a fold the block is never painted at.
         """
         if self._multirow_cache is None:
-            self._multirow_cache = _count_rows(self._content, self.size.width or 80) > 1
+            self._multirow_cache = _count_rows(self._content, self.fold_width(80)) > 1
         return self._multirow_cache
 
     # -- text selection (TUI-021) -------------------------------------------
@@ -1089,7 +1093,18 @@ class UserBlock(TranscriptBlock):
     #: is most crowded and the reader needs it most.
     MIN_BODY = 8
 
-    def __init__(self, text: str, attachments: int = 0) -> None:
+    def __init__(self, text: str, attachments: int = 0, *, fold_width: int = 0) -> None:
+        """``fold_width`` is the width this prompt is about to be given.
+
+        This block wraps in ``__init__``, so unlike a streaming row there is no
+        later authoring pass a caller could hint after: either the width is
+        known HERE or the rows are authored at the 80-column fallback and pin
+        that fold as their height until the first layout's resize lands — the
+        narrow-then-wide flash on a page mounted above the viewport, which is
+        the one place the reader is looking when a page arrives. Supplied by a
+        builder that knows the destination (`session_presentation`'s replay
+        fold, `entry_block` on the subagent page); zero keeps the fallback.
+        """
         super().__init__()
         self.add_class("user-block")
         self._text = text
@@ -1101,6 +1116,9 @@ class UserBlock(TranscriptBlock):
         #: by `_build` at the width it actually wrapped at, so `copy_row_is_chrome`
         #: never has to re-derive it and cannot disagree with the frame.
         self._receipt_row: int | None = None
+        # BEFORE `_build`: a hint supplied after the rows exist is a width
+        # nothing will read (the ladder is only consulted while authoring).
+        self.set_fold_hint(fold_width)
         self.set_content(self._build())
         self.finalize()
 
@@ -1241,7 +1259,11 @@ class UserBlock(TranscriptBlock):
         """
         rule_style = Style(color=theme_mod.semantic_color(self.RULE_TOKEN))
         text_style = Style(color=theme_mod.semantic_color(self.TEXT_TOKEN))
-        body = max((self.size.width or 80) - self.RULE_COLS, self.MIN_BODY)
+        # The LADDER, not `size.width or 80`: before this block has a size the
+        # ladder can still answer with the width it is about to be given (its
+        # parent's content region, or the hint a builder supplied). Reading the
+        # size alone is what made a detached prompt unable to receive one.
+        body = max(self.fold_width(80) - self.RULE_COLS, self.MIN_BODY)
         gutter = self.RULE + " " * (self.RULE_COLS - cell_len(self.RULE))
         rows = self._rows(body)
         self._set_authored_height(len(rows))
@@ -1314,12 +1336,22 @@ class NoticeBlock(TranscriptBlock):
         "error": "danger",
     }
 
-    def __init__(self, text: str, kind: NoticeKind = "info") -> None:
+    def __init__(self, text: str, kind: NoticeKind = "info", *, fold_width: int = 0) -> None:
+        """``fold_width``: the width this notice is about to be given.
+
+        Same reason ``UserBlock.__init__`` documents at length — a notice wraps
+        itself in ``_build``, so the hint has to be set before the rows exist or
+        the wrap is authored at the fallback and the height pin measures it.
+        The boot-column notice is the one place a wrong fold is not merely a
+        flash: the app hands it the card's width, and a build folded for the
+        terminal wraps again inside it.
+        """
         super().__init__()
         self.add_class("notice-block")
         self._text = text
         self._token = self._KIND_TOKENS.get(kind, "dim")
         self._glyph = NOTICE_GLYPHS.get(kind, "·")
+        self.set_fold_hint(fold_width)
         self.set_content(self._build())
         self.finalize()
 
@@ -1533,7 +1565,9 @@ class NoticeBlock(TranscriptBlock):
         style = Style(color=theme_mod.semantic_color(self._token))
         indent = " " * SPINE_INDENT
         hanging = " " * (SPINE_INDENT + 2)
-        body = self.body_budget(self.size.width or 80)
+        # The ladder, for the reason `UserBlock._build` records: a detached
+        # notice must be able to fold for the destination its builder named.
+        body = self.body_budget(self.fold_width(80))
         rows = self._rows(body)
         # PINNED to the authored row count, for the reason ``UserBlock._build``
         # gives: under ``auto`` the engine measures this block, and the first
@@ -1600,7 +1634,7 @@ class WakeBlock(ExpandableActionBlock):
     #: of row. Catch-up vs live is the SUMMARY, not the name.
     tool_name = "wake"
 
-    def __init__(self, text: str, *, catchup: bool = False) -> None:
+    def __init__(self, text: str, *, catchup: bool = False, fold_width: int = 0) -> None:
         super().__init__()
         self._text = text
         self._catchup = catchup
@@ -1613,6 +1647,9 @@ class WakeBlock(ExpandableActionBlock):
         self._row_count = 1
         self._applied_rows = -1
         self._built_width = -1
+        # Before the first row build: a hint set afterwards is never read
+        # (see `UserBlock.__init__`).
+        self.set_fold_hint(fold_width)
         self._refresh_row()
         self.finalize()
 
@@ -1961,11 +1998,15 @@ class PeerMessageBlock(ExpandableActionBlock):
     #: alone is a floor on half the arithmetic.
     MIN_BODY = 8
 
-    def __init__(self, body: str, sender: dict[str, object] | None = None) -> None:
+    def __init__(
+        self, body: str, sender: dict[str, object] | None = None, *, fold_width: int = 0
+    ) -> None:
         super().__init__()
         self.add_class("peer-message-block")
         self._text = body
         self._sender = sender or {}
+        # Before the first row build (see `UserBlock.__init__`).
+        self.set_fold_hint(fold_width)
         self._expanded = False
         self._hovered = False
         self._focused = False
@@ -2610,6 +2651,7 @@ class WorkingBlock(TranscriptBlock):
         *,
         clock: bool = True,
         clock_from: float | None = None,
+        fold_width: int = 0,
     ) -> None:
         super().__init__()
         self.add_class("working-block")
@@ -2636,6 +2678,9 @@ class WorkingBlock(TranscriptBlock):
         # :meth:`set_activity`; ``None`` means the phase's zero is correct.
         self._clock_from = clock_from
         self._clock = ""
+        # Before the first `_paint`: the row's truncation point is a function of
+        # the width, so a hint supplied after construction is never read.
+        self.set_fold_hint(fold_width)
         self._paint()
 
     @property
@@ -2856,7 +2901,7 @@ class WorkingBlock(TranscriptBlock):
         # model-supplied and of no bounded length. The clock's cells are
         # reserved rather than measured, so the clip point holds still.
         width = max(
-            (self.size.width or 80) - SPINE_INDENT - cell_len(head) - self._CLOCK_COL,
+            self.fold_width(80) - SPINE_INDENT - cell_len(head) - self._CLOCK_COL,
             8,
         )
         label = truncate_cells(self._activity, width)

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -1116,6 +1116,9 @@ class UserBlock(TranscriptBlock):
         #: by `_build` at the width it actually wrapped at, so `copy_row_is_chrome`
         #: never has to re-derive it and cannot disagree with the frame.
         self._receipt_row: int | None = None
+        #: The width `_build` last authored the rows at; `on_resize` compares
+        #: against it so a height-only resize does not re-wrap a prompt.
+        self._built_width: int = -1
         # BEFORE `_build`: a hint supplied after the rows exist is a width
         # nothing will read (the ladder is only consulted while authoring).
         self.set_fold_hint(fold_width)
@@ -1167,11 +1170,26 @@ class UserBlock(TranscriptBlock):
         then settles — the second pass produces the same rows, so it converges
         rather than oscillating). A HEIGHT-only terminal resize costs none: the
         block's width is unchanged, so it is never sent a resize at all.
+
+        Guarded on the WIDTH, the same short-circuit `AssistantBlock.on_resize`
+        and `ToolCard.on_resize` document at length, and this block needs it for
+        one more case than they do: a page mounted above the viewport is
+        authored at its destination width (see `UserBlock.__init__`), so the
+        mount's own 0→W resize — which every pinned height raises — now
+        reproduces rows it has already been given. Measured for one page:
+        `UserBlock` authored 18 times before the ladder fix, 12 after it, and 6
+        with this guard, i.e. the guard removes the last build per block per
+        mount. Safe because the rows are a pure function of the text, the
+        attachment count and the width, all three fixed at construction — a
+        prompt whose body changed is a new block — and `retheme` rebuilds
+        directly without consulting this. The gap re-ask below stays OUTSIDE
+        the guard: it answers a spacing question the width did not settle.
         """
         was_finalized = self._finalized
         self._finalized = False
         try:
-            self.set_content(self._build())
+            if self.fold_width(80) != self._built_width:
+                self.set_content(self._build())
         finally:
             self._finalized = was_finalized
         parent = self.parent
@@ -1264,6 +1282,7 @@ class UserBlock(TranscriptBlock):
         # parent's content region, or the hint a builder supplied). Reading the
         # size alone is what made a detached prompt unable to receive one.
         body = max(self.fold_width(80) - self.RULE_COLS, self.MIN_BODY)
+        self._built_width = self.fold_width(80)
         gutter = self.RULE + " " * (self.RULE_COLS - cell_len(self.RULE))
         rows = self._rows(body)
         self._set_authored_height(len(rows))
@@ -1351,6 +1370,9 @@ class NoticeBlock(TranscriptBlock):
         self._text = text
         self._token = self._KIND_TOKENS.get(kind, "dim")
         self._glyph = NOTICE_GLYPHS.get(kind, "·")
+        #: The width `_build` last authored the rows at; `on_resize` compares
+        #: against it so a height-only resize does not re-wrap the notice.
+        self._built_width: int = -1
         self.set_fold_hint(fold_width)
         self.set_content(self._build())
         self.finalize()
@@ -1455,11 +1477,18 @@ class NoticeBlock(TranscriptBlock):
         A re-wrap is a HEIGHT change, so the spacing rule has to be asked again:
         the same notice is one row at 90 columns and three at 40, and adaptive
         spacing gaps a multi-row block where it packs single-row ones.
+
+        Guarded on the WIDTH like ``UserBlock.on_resize``: a notice built at
+        the width it is about to be given is re-authored identically by the
+        mount's own 0→W resize, and a notice whose text is replaced goes
+        through :meth:`restate`, which rebuilds directly. The gap re-ask stays
+        outside the guard, for the reason recorded there.
         """
         was_finalized = self._finalized
         self._finalized = False
         try:
-            self.set_content(self._build())
+            if self.fold_width(80) != self._built_width:
+                self.set_content(self._build())
         finally:
             self._finalized = was_finalized
         parent = self.parent
@@ -1568,6 +1597,7 @@ class NoticeBlock(TranscriptBlock):
         # The ladder, for the reason `UserBlock._build` records: a detached
         # notice must be able to fold for the destination its builder named.
         body = self.body_budget(self.fold_width(80))
+        self._built_width = self.fold_width(80)
         rows = self._rows(body)
         # PINNED to the authored row count, for the reason ``UserBlock._build``
         # gives: under ``auto`` the engine measures this block, and the first
@@ -2678,6 +2708,9 @@ class WorkingBlock(TranscriptBlock):
         # :meth:`set_activity`; ``None`` means the phase's zero is correct.
         self._clock_from = clock_from
         self._clock = ""
+        #: The width the row was last authored at; `on_resize` compares against
+        #: it so a height-only resize does not re-truncate a one-row line.
+        self._built_width: int = -1
         # Before the first `_paint`: the row's truncation point is a function of
         # the width, so a hint supplied after construction is never read.
         self.set_fold_hint(fold_width)
@@ -2813,8 +2846,17 @@ class WorkingBlock(TranscriptBlock):
         self._paint()
 
     def on_resize(self, event: object) -> None:
-        """Re-truncate at the new width (the label is clipped, never wrapped)."""
-        self._paint()
+        """Re-truncate at the new width (the label is clipped, never wrapped).
+
+        Guarded on the WIDTH like ``UserBlock.on_resize``: the row is the
+        label's truncation point, one spinner cell and a clock the cadence
+        repaints anyway, so a resize that did not move the width reproduces the
+        row already held. Nothing else reaches this row without a paint either
+        (`set_activity`, `sync_animation_rate` and `_tick` all call
+        :meth:`_paint` directly), so the guard can only ever remove a duplicate.
+        """
+        if self.fold_width(80) != self._built_width:
+            self._paint()
 
     def _tick(self) -> None:
         from local_operator.tui.shimmer import shimmer_enabled
@@ -2905,6 +2947,7 @@ class WorkingBlock(TranscriptBlock):
             8,
         )
         label = truncate_cells(self._activity, width)
+        self._built_width = self.fold_width(80)
         line = Text(" " * SPINE_INDENT)
         line.append(head, style=dim)
         if animated:

--- a/scripts/resume_paging_probe.py
+++ b/scripts/resume_paging_probe.py
@@ -15,6 +15,7 @@ Usage:
     python scripts/resume_paging_probe.py geometry [SHAPE] [COLSxROWS]
     python scripts/resume_paging_probe.py jitter   [SHAPE] [COLSxROWS]
     python scripts/resume_paging_probe.py reader   [SHAPE] [COLSxROWS]
+    python scripts/resume_paging_probe.py fold     [SHAPE] [COLSxROWS] [OUTDIR]
 
 ``reader`` is the one to show a human: it prints, for every painted frame of a
 page mount, the TEXT of the block at the top of the viewport. A correct insert
@@ -46,6 +47,10 @@ from local_operator.tui.app import (  # noqa: E402
     RESUME_PAGE_MESSAGES,
     RESUME_PAGE_TRIGGER_ROWS,
     OperatorApp,
+)
+from local_operator.tui.widgets.assistant import (  # noqa: E402
+    FALLBACK_WIDTH,
+    AssistantBlock,
 )
 from local_operator.tui.widgets.transcript import (  # noqa: E402
     NoticeBlock,
@@ -437,6 +442,96 @@ async def run_reader(shape: str, size: tuple[int, int]) -> None:
         )
 
 
+async def run_fold(shape: str, size: tuple[int, int], outdir: str | None = None) -> None:
+    """Every fold a page mount performs, and every frame that showed one.
+
+    The width a transcript block authors its rows at is BAKED IN: the rows carry
+    the fold and the height is pinned to the count of them. A page is projected
+    detached, so a block that cannot ask for its destination folds at the
+    80-column fallback and is re-authored by the first layout's resize — a
+    second build per block, and a painted frame whose rows wrap at 78 cells
+    inside a wide pane. This mode prints both halves: the fold widths the mount
+    performed (a value of 80 while the pane is wider is the defect) and the
+    frames in which a fallback-folded block intersected the viewport, which is
+    the half a reader sees. ``OUTDIR`` saves each such frame through the
+    faithful capture helper, so the still can be looked at rather than trusted.
+    """
+    history = SHAPES[shape]()
+    app, _session = await _boot(history, size)
+    folds: list[tuple[str, int]] = []
+    frames: list[str] = []
+    watching = {"on": False}
+    real_apply = AssistantBlock._apply_rows
+
+    def record_apply(self: AssistantBlock, text: Any) -> Any:
+        if watching["on"]:
+            folds.append(("AssistantBlock", self._flat_width()))
+        return real_apply(self, text)
+
+    AssistantBlock._apply_rows = record_apply  # type: ignore[method-assign]
+    try:
+        async with app.run_test(size=size) as pilot:
+            view = await _settle(pilot, app, {})
+            pane = view.scrollable_content_region.width
+            refresh = app.screen._compositor_refresh
+            counter = {"frame": 0, "saved": 0}
+
+            def capture() -> None:
+                refresh()
+                counter["frame"] += 1
+                top, bottom = view.scroll_y, view.scroll_y + view.size.height
+                for block in view.blocks():
+                    if block.size.width <= FALLBACK_WIDTH:
+                        continue
+                    if getattr(block, "_built_width", None) != FALLBACK_WIDTH:
+                        continue
+                    if block.virtual_region.bottom <= top or block.virtual_region.y >= bottom:
+                        continue
+                    line = (
+                        f"frame {counter['frame']}: {type(block).__name__} "
+                        f"box={block.size.width} authored at {FALLBACK_WIDTH}"
+                    )
+                    frames.append(line)
+                    if outdir and counter["saved"] < 4:
+                        counter["saved"] += 1
+                        from scripts.visual_capture import save_capture
+
+                        path = f"{outdir}/fold-frame-{counter['saved']}.svg"
+                        save_capture(app, path)
+                        frames.append(f"  saved {path}")
+
+            app.screen._compositor_refresh = capture
+            watching["on"] = True
+            try:
+                for _ in range(3):
+                    # Park at the top, then post one REAL notch: the trigger
+                    # zone is the top of the travel, so a notch from anywhere
+                    # else is a scroll this probe would misread as no demand.
+                    view.scroll_to(y=0, animate=False, immediate=True)
+                    await pilot.pause()
+                    _wheel_to_trigger(view)
+                    await pilot.pause()
+                    for _ in range(30):
+                        await pilot.pause()
+                    for _ in range(4):
+                        _wheel_to_trigger(view)
+                        await pilot.pause()
+            finally:
+                watching["on"] = False
+                app.screen._compositor_refresh = refresh
+    finally:
+        AssistantBlock._apply_rows = real_apply  # type: ignore[method-assign]
+
+    print(f"shape={shape} grid={size[0]}x{size[1]} pane={pane}")
+    at_fallback = sum(1 for _, width in folds if width == FALLBACK_WIDTH)
+    print(f"folds performed while a page mounted: {len(folds)}")
+    print(f"  at the {FALLBACK_WIDTH}-column fallback: {at_fallback}")
+    print(f"  widths seen: {sorted({w for _, w in folds})}")
+    print(f"frames showing a fallback-folded block inside the viewport: {len(frames)}")
+    for line in frames:
+        print(f"  {line}")
+
+
 def main() -> None:
     mode = sys.argv[1] if len(sys.argv) > 1 else "geometry"
     shape = sys.argv[2] if len(sys.argv) > 2 else "agentic"
@@ -448,6 +543,9 @@ def main() -> None:
         asyncio.run(run_jitter(shape, (columns, rows)))
     elif mode == "reader":
         asyncio.run(run_reader(shape, (columns, rows)))
+    elif mode == "fold":
+        outdir = sys.argv[4] if len(sys.argv) > 4 else None
+        asyncio.run(run_fold(shape, (columns, rows), outdir))
     else:
         raise SystemExit(f"unknown mode {mode!r}")
 

--- a/tests/unit/tui/test_rendered_history_paging.py
+++ b/tests/unit/tui/test_rendered_history_paging.py
@@ -1790,9 +1790,72 @@ async def test_a_paged_block_is_folded_at_its_destination_width_not_the_fallback
 
     assert folds, "the paging path performed no authoring fold to check"
     at_fallback = [kind for kind, width in folds if width == FALLBACK_WIDTH]
+    # The PAINTED half is asserted FIRST, deliberately. Both halves describe the
+    # same defect, but only this one is read off the compositor — it says a
+    # frame was put in front of the reader with rows authored at another width —
+    # and an assertion that never executes on the tree it indicts proves
+    # nothing. Review round 1, M3: with the fold half first, this one was
+    # unreachable pre-fix, because the earlier assert always fired.
+    assert not painted_at_fallback, (
+        "a paged block was painted from rows authored at the "
+        f"{FALLBACK_WIDTH}-column fallback inside a {pane}-cell pane: {painted_at_fallback}"
+    )
     assert not at_fallback, (
         f"{len(at_fallback)} of {len(folds)} folds during paging were at the "
         f"{FALLBACK_WIDTH}-column fallback while the pane was wide: {sorted(set(folds))}"
     )
     assert all(width == pane for _, width in folds), sorted(set(folds))
+
+
+@pytest.mark.asyncio
+async def test_the_first_paint_of_a_resumed_conversation_is_not_folded_at_the_fallback() -> None:
+    """Cold resume's tail projection owes the frame the same width a page does.
+
+    The operator's reported frame is THIS one: the paint that reveals a resumed
+    conversation. `_render_resumed_history` projects the tail through the same
+    renderer, and before the width reached that seam every block in it was
+    authored at the 80-column fallback, so the frame carried prose wrapped at 78
+    cells inside a 96 or 146-cell pane with blank space to its right — and the
+    layout's resize re-authored all of it one hop later, which is why the
+    SETTLED frame looked correct and the report was hard to place (QA round 1,
+    Q1: one paint at 100x30, 80 blocks at `box=96 built=80`, rows ending at cell
+    81 of 96).
+
+    Asserted over every paint of the boot settle, not just the first, because
+    the reveal is one frame among several and a reader cannot tell which one
+    they arrived on.
+    """
+    session = FakeSession()
+    session._history = _wrapping_history(count=140)
+    app = OperatorApp(lambda: _factory(session))
+    painted_at_fallback: list[str] = []
+    paints = 0
+    async with app.run_test(size=(100, 30)) as pilot:
+        view = app._transcript_view()
+        refresh = app.screen._compositor_refresh
+
+        def capture() -> None:
+            nonlocal paints
+            refresh()
+            paints += 1
+            pane = view.scrollable_content_region.width
+            if not pane:
+                return
+            for block in view.blocks():
+                if block.size.width <= FALLBACK_WIDTH:
+                    continue
+                if getattr(block, "_built_width", None) != FALLBACK_WIDTH:
+                    continue
+                painted_at_fallback.append(
+                    f"paint {paints}: {type(block).__name__} box={block.size.width} "
+                    f"authored at {FALLBACK_WIDTH}"
+                )
+
+        app.screen._compositor_refresh = capture
+        try:
+            await settled(app, pilot)
+        finally:
+            app.screen._compositor_refresh = refresh
+
+    assert paints, "no paint was observed"
     assert not painted_at_fallback, painted_at_fallback

--- a/tests/unit/tui/test_rendered_history_paging.py
+++ b/tests/unit/tui/test_rendered_history_paging.py
@@ -11,6 +11,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
+from rich.text import Text
 from textual.events import MouseScrollUp
 
 from local_operator.harness.types import Message, TextContent
@@ -20,8 +21,8 @@ from local_operator.session.runtime.serving import ServingSessionHandle
 from local_operator.tui.app import OperatorApp, _PagingLease
 from local_operator.tui.session_interaction import SessionInteraction
 from local_operator.tui.session_presentation import OlderHistoryNotice
-from local_operator.tui.widgets.assistant import AssistantBlock
-from local_operator.tui.widgets.transcript import GAP_CLASS, NoticeBlock
+from local_operator.tui.widgets.assistant import FALLBACK_WIDTH, AssistantBlock
+from local_operator.tui.widgets.transcript import GAP_CLASS, NoticeBlock, UserBlock
 from tests.e2e.harness import ScriptedStream, build_session, seed_transcript, text_turn
 from tests.unit.session.test_remote import _never_take_over
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
@@ -1667,3 +1668,131 @@ async def test_a_failed_fetch_on_an_unscrollable_frame_does_not_tell_the_reader_
             assert all("scroll up" not in text for text in faults)
             assert any("click" in text for text in faults)
             remote.load_older_display_page = real_load
+
+
+# --- the destination width is supplied BEFORE the rows are authored ---------
+
+
+def _wrapping_history(count: int = 90) -> list[Message]:
+    """Rows that all wrap differently at 80 and at 116 columns.
+
+    Both halves of the defect need covering, and they author differently: prose
+    and tool cards fold through the ladder, while a prompt wraps inside
+    ``UserBlock.__init__`` and never consults it. A shape with only one of them
+    would pass on a fix that had only reached the other.
+    """
+    prose = (
+        "The compaction marker is written by the summariser after the fold, and the "
+        "renderer reads it back on resume so the transcript can show where the "
+        "context boundary fell rather than silently rewriting the conversation."
+    )
+    rows: list[Message] = []
+    for index in range(count):
+        rows.append(
+            Message(
+                id=f"synthetic-row-{index:04}",
+                role="user" if index % 3 else "assistant",
+                content=[
+                    TextContent(text=f"row {index:04} — {prose}"),
+                ],
+                stop_reason="stop",
+            )
+        )
+    return rows
+
+
+@pytest.mark.asyncio
+async def test_a_paged_block_is_folded_at_its_destination_width_not_the_fallback() -> None:
+    """The width must be known to the BUILDER, not repaired by the resize.
+
+    A page is projected DETACHED — nothing is mounted until ``insert_blocks`` —
+    so a block that has no width to ask folds at the 80-column fallback, pins
+    that fold as its height, and is then re-authored by the first layout's
+    resize. Two costs, and the second is what the operator reported: a second
+    build per block, and a painted frame whose rows wrap at 78 cells inside a
+    146-cell pane. ``insert_blocks``' own fold hint cannot fix it, because it
+    arrives after the rows exist — the block that wraps in ``__init__`` never
+    reads a hint set later.
+
+    So the assertion is stated at the authoring seam, as the FALLBACK rather
+    than as "== pane", for the reason the subagent page's fold-parity test
+    gives: the failure should name the defect, and every other width the ladder
+    may legitimately report mid-layout (a container, a parent region) would
+    still be a width the block is about to be given.
+    """
+    session = FakeSession()
+    session._history = _wrapping_history()
+    app = OperatorApp(lambda: _factory(session))
+    folds: list[tuple[str, int]] = []
+    watching = False
+
+    real_apply = AssistantBlock._apply_rows
+    real_build = UserBlock._build
+
+    def record_apply(self: AssistantBlock, text: Text) -> None:
+        if watching:
+            folds.append(("AssistantBlock", self._flat_width()))
+        return real_apply(self, text)
+
+    def record_build(self: UserBlock) -> object:
+        if watching:
+            folds.append(("UserBlock", self.fold_width(80)))
+        return real_build(self)
+
+    app_pilot = pytest.MonkeyPatch()
+    app_pilot.setattr(AssistantBlock, "_apply_rows", record_apply)
+    app_pilot.setattr(UserBlock, "_build", record_build)
+    painted_at_fallback: list[str] = []
+    try:
+        async with app.run_test(size=(120, 40)) as pilot:
+            await settled(app, pilot)
+            view = app._transcript_view()
+            pane = view.scrollable_content_region.width
+            assert pane > FALLBACK_WIDTH, "the fixture needs a pane wider than the fallback"
+
+            refresh = app.screen._compositor_refresh
+
+            def capture() -> None:
+                # Visible-stale, read off the compositor: a frame that put a
+                # fallback-folded block in front of the reader. This is the
+                # half a reader sees, and it is why a one-frame repair is not
+                # good enough — the frame after a page mounts is the one the
+                # reader is looking at when they scroll up into it.
+                refresh()
+                top, bottom = view.scroll_y, view.scroll_y + view.size.height
+                for block in view.blocks():
+                    if block.size.width <= FALLBACK_WIDTH:
+                        continue
+                    if getattr(block, "_built_width", None) != FALLBACK_WIDTH:
+                        continue
+                    if block.virtual_region.bottom <= top or block.virtual_region.y >= bottom:
+                        continue
+                    painted_at_fallback.append(
+                        f"{type(block).__name__} painted at {block.size.width}"
+                    )
+
+            app.screen._compositor_refresh = capture
+            watching = True
+            try:
+                for _ in range(2):
+                    view.scroll_to(y=0, animate=False, immediate=True)
+                    await pilot.pause()
+                    view.post_message(MouseScrollUp(view, 1, 1, 0, -1, 0, False, False, False))
+                    await settled(app, pilot)
+                    for _ in range(5):
+                        view.post_message(MouseScrollUp(view, 1, 1, 0, -1, 0, False, False, False))
+                        await pilot.pause()
+            finally:
+                watching = False
+                app.screen._compositor_refresh = refresh
+    finally:
+        app_pilot.undo()
+
+    assert folds, "the paging path performed no authoring fold to check"
+    at_fallback = [kind for kind, width in folds if width == FALLBACK_WIDTH]
+    assert not at_fallback, (
+        f"{len(at_fallback)} of {len(folds)} folds during paging were at the "
+        f"{FALLBACK_WIDTH}-column fallback while the pane was wide: {sorted(set(folds))}"
+    )
+    assert all(width == pane for _, width in folds), sorted(set(folds))
+    assert not painted_at_fallback, painted_at_fallback


### PR DESCRIPTION
# PR Description

## Summary of Changes

**Bug:** a transcript block built for a live transcript is authored at the **80-column fallback width**, and only re-authored when the first layout's resize lands. Two faces, one cause:

1. **The resume reveal frame** (the one the operator screenshotted): `_render_resumed_history` projected the whole tail with no width, so the first paint of a resumed conversation carried prose wrapped at 78 cells inside a 96 or 146-cell pane, with blank space to its right. Measured at 100x30 on `87240c118`: one paint with 80 blocks at `box=96 built=80`, rows ending at cell 81 of 96.
2. **A paged-in page**: the same for every block in it, plus a second build per block for the resize to repair.

**Fix:** the destination width reaches **construction** — through the one role-aware renderer — from the seam that owns it: `OperatorApp._project_settled_rows` now derives it from the view it is about to mount into, for the tail, the reconnect gap replay, the sidebar commit's top-up and the older-page collect alike. Zero means "not supplied", which is right only for a prepared (offscreen) replay.

- `local_operator/tui/app.py` — `_project_settled_rows` derives `fold_width` from `self._transcript_view().scrollable_content_region.width`; `_collect_resume_page_blocks` no longer passes it (one owner, so the page and the tail cannot disagree); `_append_image_blocks`/`_replay_tool_call` forward it.
- `local_operator/tui/session_presentation.py` — `project_settled_rows`, `replay_tool_call`, `append_image_blocks` and `OlderHistoryNotice` take `fold_width` and pass it to every block they build **before** that block authors its rows.
- `local_operator/tui/widgets/transcript.py` — the blocks that wrap **inside `__init__`** (`UserBlock`, `NoticeBlock`, `WakeBlock`, `PeerMessageBlock`, `WorkingBlock`) accept `fold_width` and set the hint before their first build; `UserBlock._build`/`NoticeBlock._build` and the pre-mount spacing predicate read the fold **ladder** instead of `self.size.width or 80` (which is what made a detached block unable to receive a width at all); `UserBlock`/`NoticeBlock`/`WorkingBlock` resize handlers now short-circuit on an unchanged width, like `AssistantBlock`/`ToolCard` already did.
- `local_operator/tui/widgets/image_block.py` — same for `ImageBlock` (grid and receipt truncation are width-dependent).
- `local_operator/tui/widgets/subagent_view.py` — `entry_block` passes its existing `fold_width` to the kinds that wrap in `__init__`; it previously reached only the streaming and ledger kinds.
- `scripts/resume_paging_probe.py` — new `fold` mode: every fold a page mount performs, and every painted frame that showed a fallback-folded block in the viewport.
- `tests/unit/tui/test_rendered_history_paging.py` — two regression tests (the reveal frame, and the page).

Release: patch — Paged and resumed history now folds at the pane's real width instead of an 80-column fallback, so message text no longer stops short of the right edge.

## Reproduction

**The reveal frame** (Q1 of QA round 1; the operator's reported symptom). Every compositor paint is hooked, and per paint each block's box width, authored fold width and the painted rows' rightmost ink cell are recorded — so a later re-author cannot overwrite what a frame was drawn at:

```sh
# both trees, isolated HOME/config, synthetic session
env -u NO_COLOR TERM=xterm-256color .venv/bin/python /tmp/evidence_round2.py boot 150 40 out.svg
```

| | base `87240c118` | head `54c975373` |
|---|---|---|
| reveal paint at 150x40 (pane 146) | **40 blocks at `box=146 authored=80`** | **0** |
| painted rows' ink ends | `80, 79, 72, 73` of 146 | `148, 82, 73, 148` of 146 |
| reveal paint at 100x30 (pane 96) | 40 blocks at `box=96 authored=80`, rows end `80, 79, 72, 73` | 0 stale, rows end `97, 96, 38` |
| tool rows at 60x20 (pane 56) | **no ✓ painted at all** (the 80-cell row is 24 cells wider than the pane; the ✓ on that row is clipped off it), and the prose loses its last two rows — see caption (b) | `✓` painted at cell 48, every row, every authored row drawn |

**The page** (round 1's seam). `scripts/resume_paging_probe.py fold ordinary 150x40`, three real wheel-driven page mounts:

```sh
# base 633baf258
folds performed while a page mounted: 108
  at the 80-column fallback: 72
  widths seen: [80, 146]
frames showing a fallback-folded block inside the viewport: 6

# head
folds performed while a page mounted: 72
  at the 80-column fallback: 0
  widths seen: [146]
frames showing a fallback-folded block inside the viewport: 0
```

The 36 missing folds are the second build per block the resize used to perform.

## Root Cause

`TranscriptView.insert_blocks` computes the destination width and sets it as a **fold hint** — but after the blocks were built, and the hint is only consulted *while authoring* (`TranscriptBlock.fold_width`'s ladder). So:

1. a projection that runs DETACHED (nothing mounted yet: a page, or the boot tail before its first layout) falls through the ladder to `FALLBACK_WIDTH = 80` (measured: `size=0 container=0 parent=None hint=0 mounted=False`);
2. the rows are folded at 80 and the height is **pinned** to that fold (`AssistantBlock._apply_rows`, `UserBlock._set_authored_height`);
3. the mount's first layout sends `Resize`, whose handler re-authors at the real width — a second build per block, and a painted frame in between at the wrong width;
4. three kinds could not be reached by the hint at all: `UserBlock`, `NoticeBlock`, `ImageBlock` read `self.size.width or 80` and never consulted the ladder.

Not confined to the constant either: a detached `ToolCard` reaches `_refresh_row`'s console rung, and `App.console.width` measures **80** even on a 150-column terminal.

## Impact

- No API break: every `fold_width` parameter is keyword-only, defaulting to `0`, which preserves the previous behaviour for callers without a destination.
- Performance: a block is built **once** instead of twice (108 → 72 folds for three page mounts; `UserBlock` authoring 18 → 12 → 6 events for one page across the three fixes in this branch).
- Spacing: `_settle_gaps` runs before the mount and asks `spans_multiple_rows()`, which now measures at the ladder's width — a one-line row longer than 80 cells was previously judged multi-row and earned a gap it never painted.
- Invariants untouched: the frozen-prefix/height-pin streaming work, the insert anchor, one page per gesture, monotone gap settlement. This change moves a width, not a mount, an anchor or a gate.

## Testing Details

Two regression tests, both **failing on the base for the reason they name** (verified in a throwaway worktree at `87240c118`):

```
# base 87240c118
FAILED test_a_paged_block_is_folded_at_its_destination_width_not_the_fallback
  AssertionError: a paged block was painted from rows authored at the 80-column fallback inside a
  116-cell pane: ['AssistantBlock painted at 116']
FAILED test_the_first_paint_of_a_resumed_conversation_is_not_folded_at_the_fallback
  AssertionError: ['paint 1: AssistantBlock box=96 authored at 80', ...]

# head 54c975373 (frames captured on 60273bb79; the only code change since capture is the projection's width-read placement, which is frame-invisible)
2 passed
```

The painted assertion is now asserted **first** in the paging test (review M3: the fold assertion fired before it, so the half that reads what was in front of the reader never executed on the tree it indicts).

**Suites run on this head** (`.venv/bin/python`, `env -u NO_COLOR TERM=xterm-256color`, `-n0` serial selections — the host is at load ~78, so this round used focused selections rather than the whole tree):

`test_rendered_history_paging.py test_resume_render.py test_subagent_view.py test_peer_message.py test_wake_ui.py test_working_line.py test_image_block.py test_boot_layout.py test_transcript_selection.py test_copy_markdown.py test_config_change_notice.py tests/unit/mobile/test_fold_parity.py` → **all passed** (see the QA remediation comment for the exact tally).

**Gates:** `flake8` clean; `black --check` (pinned `26.1.0`) 1204 files unchanged; `isort --check-only` (pinned `5.13.2`) clean; `pyright` (pinned `1.1.411`, `--pythonpath .venv/bin/python`) → **0 errors, 0 warnings**.

## Evidence

Driven on the real `OperatorApp` via `run_test`, faithful capture (`scripts.visual_capture.save_capture`: native 8x17 px cells, no synthetic chrome), the frame saved on the compositor paint named below.

**Which pair demonstrates which face** — the pairs are not interchangeable demonstrations (design round 2):

- **Items 1–2 are the ink-extent demonstration**, and the headline: on base every transcript row stops short of the pane edge with blank space to its right; on head the rows reach it. This is the operator's symptom on the prose face.
- **Item 4 is a wrap-point demonstration, not an ink-extent one.** Its single differing row is the trailer's *last* row, short on **both** revisions (72 → 82 cells); what changes is where the paragraph breaks — `context boundary fell…` on base, `where the context boundary fell…` on head, 3 rows authored at 80 → 2 rows at 146. A reader looking for "ink reaching the edge" wants items 1–2.
- **Item 5 plus the `bootcard-60x20` frame carry the ledger face** — short → reaching at 150x40, and *absent from the frame entirely* → painted at cell 48 at 60x20.
- **Item 6 is not a pair but a run**: the subagent surface driven end to end with a real child job, because what was in question there was whether the surface works at all, not how wide it paints.

**1. The headline pair — the reveal frame of a resumed conversation (150x40, pane 146).** Base: every transcript row ends at ~80 cells with half the pane blank. Head: the same rows run to 148.

- base: https://gist.githubusercontent.com/damianvtran/a9bd5ca25f86e3229eba7ac769f6bde9/raw/base-frame-r2-boot-150x40.svg
- head: https://gist.githubusercontent.com/damianvtran/a9bd5ca25f86e3229eba7ac769f6bde9/raw/head-frame-r2-boot-150x40.svg

**2. The reveal frame at 100x30 (pane 96)** — the geometry that matches the operator's "~83% across": rows ending at 80 of 96 cells.

- base: https://gist.githubusercontent.com/damianvtran/a9bd5ca25f86e3229eba7ac769f6bde9/raw/base-frame-r2-boot-100x30.svg
- head: https://gist.githubusercontent.com/damianvtran/a9bd5ca25f86e3229eba7ac769f6bde9/raw/head-frame-r2-boot-100x30.svg

**3. The narrow pane (60x20, pane 56, and 40x20, pane 36)** — pre-fix the ledger row is authored 24 cells wider than the pane and its ✓ is clipped off the row entirely; post-fix it is painted at cell 48. Worse than the clipped glyph, the pinned height means base also *loses text* at these panes (caption (b)). Narrow terminals were the more damaged case, not an unaffected one.

- base: https://gist.githubusercontent.com/damianvtran/a9bd5ca25f86e3229eba7ac769f6bde9/raw/base-frame-r2-bootcard-60x20.svg
- head: https://gist.githubusercontent.com/damianvtran/a9bd5ca25f86e3229eba7ac769f6bde9/raw/head-frame-r2-bootcard-60x20.svg

**4. The paging seam, prose trailer (150x40)** — a page whose trailer is an assistant row, captured on the first compositor refresh after `insert_blocks`: base paints it as 3 rows authored at 80 (78/77/70 cells), head as 2 rows at 146 (146/82).

- base: https://gist.githubusercontent.com/damianvtran/a9bd5ca25f86e3229eba7ac769f6bde9/raw/base-frame-r2-page-150x40.svg
- head: https://gist.githubusercontent.com/damianvtran/a9bd5ca25f86e3229eba7ac769f6bde9/raw/head-frame-r2-page-150x40.svg

**5. The paged ledger row (150x40)** — the round-1 pair, kept: the trailing card's ✓ moves from cell 72 to cell 138 (137-cell row inside a 146-cell box).

- base: https://gist.githubusercontent.com/damianvtran/c50eab138727f93e53439909e2512ae0/raw/before-page-mount.svg
- head: https://gist.githubusercontent.com/damianvtran/c50eab138727f93e53439909e2512ae0/raw/after-page-mount.svg

**6. The subagent surface, driven end to end** (QA round 3). This is the one surface in the change whose evidence is a real run rather than a mounted-view substitute: a real `task`-tool child in the assembled app — real `OperatorApp`, real `Session`, the `task` tool called by a real parent turn, the real job manager and child runner, with a real `bash` call inside the child (scripted provider boundary only, `tests/e2e/harness.py`'s documented split).

The child registered as job `300c7742920b` (`type=task`, `label=qa-r3-child`, **completed**); its `bash printf painted > …/qa976-child-effect.txt` wrote the file with contents `painted` (one approval answered in the pilot, card `✓ 0.7s`); its final turn came back as `Child wrote the effect file (QA976-CHILD-9d3f).` Both surfaces painted it — the sidebar `Subagents` roster row (`• qa-r3-child ✓ 1s Child wrote the effect file (QA976-CHILD-9d3f).`) and the full page (`Subagent · qa-r3-child ✓ completed · 1s · 1 tool`, carrying the child's instruction row, its bash card and its final answer) — captured as rendered frames and inspected as images: QA's `subagent/{roster,subagent-view}.svg` + `.png`.

Two caveats from that run, kept because they cost the next reviewer time otherwise: **there is no `/subagent` slash command** in this app — the subagent surface is the `task` tool plus the `Subagents` roster / `ctrl+g` view, which is the path driven here; and **a child's tool call rides the approval gate even when the parent session is `yolo=True`** (QA's first attempt sat 2m32s on "the agent needs your approval" until the pilot answered).

**Captions that matter when reading the pairs.**

(a) Three differences in a pair are not three changes. The scrollbar's shade/thumb moves because the corrected page is shorter — **8** rows in the round-1 ledger pair (virtual 254 → 246) but **12** in the round-2 page pair here (273 → 261); the figure printed beside a pair belongs to that pair (design round 2, D8). The footer's right-hand checkout path also differs, because each revision was captured from its own worktree (`⌂ /private/tmp/lo-base976` on base, `⌂ /Users/damian/workspace/repos/lo-paging-fold` on head, truncating differently at 60x20) — an artifact of the harness, not of the fix (D7).

(b) **The narrow-pane frames show lost text, not merely a clipped glyph** (design round 2, D5). The fallback also pins the block's height to its 80-column fold, so at a pane *below* the fallback the rows the paint-time re-wrap needs are never drawn: on base's 60x20 frame the paragraph's tail — `transcript can show where the context boundary fell rather than silently rewriting the conversation.` — is simply absent, with no ellipsis, and at 40x20 (pane 36) the notice drops `to load` while the prompt loses `list and report the ones that fail`. Head draws every authored row. The missing ✓ on the ledger row is the milder half of that same frame.

(c) With the wheel gesture that pages a transcript, the paint carries only the page trailer's bottom row — the page's bottom edge lands at the viewport top — so the operator's still (several rows ending short) is this defect with the viewport a row or two lower, not a different one.

(d) The **boot-column** notice is the one place the ladder could bite without a hint: it is narrowed by `styles.width = card` while its parent rung reports the full lane, but its re-wrap arrives through `on_resize`, by which point rung 1 is the card width; no frame in the audit produced a block whose authored width differed from its box, and boot-column notices are unchanged in every captured frame (design review D4). The **head (`OlderHistoryNotice`)** change this PR makes, by contrast, is observable only below ~44 columns — at 100x30 and 60x20 it paints identically before and after, while at 40x20 base truncates it to `…scroll up` and head wraps it to `…scroll` / `up to load` (design round 2, D6).

All frames are additionally on the PR as SVG text (the two gists above, plus their `.geometry.json` axis records). Nothing is committed to the repository (AGENTS.md §7).

## Not addressed

- **The live-append seam.** `TranscriptView.append_block` / `OperatorApp._append_block` supplies no width, so a live prompt, notice or running card is still authored at the fallback and saved by the same resize. It cannot be fixed where the hint is applied (the rows already exist) — it needs the width at construction, which is what this PR now does for every projection. QA round 1 (S15: `live_narrow_frames=0`), QA round 2 and the design round (V7: a mounted append paints `_built_width=146` on its first frame, because rung 3 answers for a parented block) all measured **no painted narrow frame** on this seam, so it is a wasted build rather than a visible defect. Recorded rather than expanded into this slice.
- **The off-layout gap replay** (QA round 2, Q2). While the live transcript is not laid out — `display = False`, the subagent view and the org chart — `scrollable_content_region.width` measures `0` (`region=0 view=0`, at every grid from 60x20 to 150x40, restored to 56/96/142/146 on the way back), so a `HistoryRowsSettled` landing in that state still authors at the fallback and is repaired by the restore's resize. Wasted build, no painted frame: QA measured the post-restore paints at 0 mismatch on base, the previous head and this one. **Deliberately not repaired with a cached last-known width**: the cache outlives the pane that set it, and a width from a wide pane pinned as a fold inside a narrow one clips rows that can no longer re-wrap — missing text on screen is worse than a build off screen. The derivation's scope is now stated in `_project_settled_rows` itself.
- **`ImageBlock`'s resize guard.** The other three width-baking kinds now short-circuit on an unchanged width; `ImageBlock` is deliberately left rebuilding, because its rebuild also resolves the render mode and places a kitty image, and skipping it on a width match could withhold a placement. Its *authoring* width is fixed by this PR (hint honoured); only the redundant-rebuild removal is deferred.
- **Cross-module `:NNNN` citations with pre-existing drift** (QA round 4, C4-1) — untouched by this PR, deferred, **`deferred — pre-existing drift outside this change's scope`**. The examples, re-checked on this head where a read could confirm them: `app.py:2322` cites `AskPickerScreen.on_click` as `ask_picker.py:1117`, while the only `def on_click` in that file is at `1170`; `tools/builtin.py:1478`/`:1990` and `tools/eval.py:882` cite `_error(...)` producers that have moved under them (the `_error(` returns in `builtin.py` sit at 1786-1881). All of it pre-exists this branch, in blocks this branch does not touch. The rule this branch adopted for its own comments — **name the function, not the line** — is the fix for the class; applying it repo-wide is a separate sweep, so it is recorded here rather than done here.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required (comments record the constraint at every site).
- [x] Security considerations are addressed (behaviour is unchanged for any path that supplies no width).
- [x] I have linked all related issues. (No issue: reported by the operator from a live session.)

