### PR TITLE
fix(tui): repaint the tool ledger whenever its shared name column moves

### DIFF
--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -1514,11 +1514,15 @@ class ToolCard(ExpandableActionBlock):
         # command" instead of the call's life. The withheld clock survives
         # re-entry; only a card that can date itself restarts.
         clockless = self._state == "running" and self._started is None
+        # Whether this call PROMOTES the row: the two things that decide whether
+        # the spine may move because of it (see the invalidation at the end).
+        was_composing = self._state == "composing"
         # The name comes from the EXECUTION, not from the announcement. The first
         # compose event fires on the first name fragment — deliberately, so the
         # row appears immediately — and a provider that splits `write` into `wr`
         # and `ite` would otherwise leave `wr` on the settled row forever, in the
         # ledger, on the icon, and in the summary built from it.
+        renamed = tool_name != self.tool_name
         self.tool_name = _strip_control_sequences(tool_name)
         # The duration clock RESTARTS here. `_started` was set when the row was
         # mounted, which for an adopted row is when the model began dictating —
@@ -1575,6 +1579,25 @@ class ToolCard(ExpandableActionBlock):
         # would only burn a repaint per second.
         if not clockless:
             self._start_clock()
+        # A promotion can move the ledger's shared name column, and nothing else
+        # here will say so. `contributes_name` is False while the row is
+        # dictating and True once the call it names has started, so THIS is the
+        # moment a long MCP name starts counting towards the spine — the exact
+        # inverse of the transition `set_composing` already answers, and for the
+        # same reason: without it the row keeps the column it did NOT earn (the
+        # card is mounted and dictated at the floor) and paints its own name
+        # truncated (`list_va…`) for the rest of the session. A hover cannot
+        # repair it either — `_refresh_row` re-fits the row at the stale
+        # column — so the only cure would be an unrelated later resync.
+        #
+        # After every field above, so the derivation sees the RUNNING row and
+        # the broadcast repaints it from its final state: this runs inside the
+        # one event that promotes the card, so no frame is composited between
+        # the column moving and the rows being told.
+        if was_composing or renamed:
+            parent = self.parent
+            if isinstance(parent, TranscriptView):
+                parent.invalidate_name_col()
         self._refresh_row()
 
     def set_partial_detail(self, detail: str) -> None:

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -1954,7 +1954,7 @@ class PeerMessageBlock(ExpandableActionBlock):
         #: ONCE here rather than on every repaint.
         #:
         #: `_refresh_row` runs on hover, focus, expand/collapse, `retheme`,
-        #: `on_resize` AND `_invalidate_name_col` — and that last one repaints
+        #: `on_resize` AND the name-column resync — and that last one repaints
         #: every ledger block when the shared name column moves, so one peer
         #: card's cost is paid by the whole ledger. The strip is a regex plus a
         #: per-character `unicodedata.category` scan, and it runs over the
@@ -3095,6 +3095,14 @@ class TranscriptView(ScrollableContainer):
         # is read once per card per repaint and only changes when the set of tool
         # names on screen does.
         self._name_col_cache: int | None = None
+        # The width the ledger's ROWS were last published with — what their
+        # summaries were actually laid out against. Deliberately separate from
+        # the cache: every path that can move the column DROPS the cache, so the
+        # cache cannot answer "did this actually change", and a resync comparing
+        # against it would read `None` as "nothing to do" while rows sat at the
+        # old offset. `None` here means no row has been painted under a published
+        # column yet, so there is nobody to be stale.
+        self._name_col_applied: int | None = None
         #: The block held at the BOTTOM as later blocks arrive (the working
         #: line). Pinned rather than re-appended so it is never unmounted and
         #: remounted mid-turn, which would restart its timer and its clock.
@@ -3279,6 +3287,12 @@ class TranscriptView(ScrollableContainer):
         was_at_tail = self._tail_anchor.following or self.is_near_bottom()
         release_revision = self._tail_anchor.release_revision
         self.mount_all(blocks)
+        # A batch arrives as ONE ledger change, so it gets one resync rather than
+        # the per-append fast path's reading of it: the newcomers were held out
+        # of the container while they were appended, and the column their names
+        # imply has to be published to the rows already on screen in the same
+        # breath.
+        self._resync_name_col()
         self.call_after_refresh(self._settle_gaps, blocks)
         self._remeasure_empty_state()
         # Then land on the tail, AFTER the settle pass above.
@@ -3453,7 +3467,12 @@ class TranscriptView(ScrollableContainer):
         else:
             self.mount(*additions, before=before)
         self._blocks[index:index] = additions
-        self._name_col_cache = None
+        # Revealed rows are part of the ledger now, and a page can carry tool
+        # names longer than anything already on screen. Re-derive and repaint in
+        # the same pass as the mount: dropping the cache alone left the rows
+        # already painted at the old offset while the first newcomer to paint
+        # derived the wider column, which is the tear a reader saw on scroll-up.
+        self._resync_name_col()
         # The mount itself may not have triggered a resize yet; correct now so
         # no frame can be painted at the displaced offset even once.
         self._reanchor_insert()
@@ -3561,10 +3580,14 @@ class TranscriptView(ScrollableContainer):
         is the ledger's size that decides whether it matters). The two ways the
         column can SHRINK keep the full re-derivation, because only a re-scan
         can say how far: a rename, through :meth:`invalidate_name_col`, and a
-        removal, which drops the cache outright.
+        removal, which goes through :meth:`_resync_name_col`.
+
+        Whether it widened is asked of :attr:`_name_col_applied` — the width the
+        rows HOLD — not of the cache. This runs while the cache may be unset, and
+        the early return that read `None` as "nothing to do" is exactly the
+        defect: rows already painted kept the narrow offset while whichever row
+        painted next derived the wider one.
         """
-        if self._name_col_cache is None:
-            return  # nothing cached to widen; `tool_name_col` will derive it
         # The same two exclusions `tool_name_col` applies, and for the reasons
         # argued there: a pending approval and a call the model is still
         # dictating are not rows the spine is measured against.
@@ -3578,11 +3601,60 @@ class TranscriptView(ScrollableContainer):
         from local_operator.tui.glyphs import display_name
 
         width = max(TOOL_NAME_COL, min(cell_len(display_name(name)), TOOL_NAME_COL_MAX))
-        if width <= self._name_col_cache:
+        # `None` published means no row is holding a column yet, so the floor is
+        # the widest any of them can be showing.
+        applied = self._name_col_applied
+        if width <= (TOOL_NAME_COL if applied is None else applied):
             return
         self._name_col_cache = width
-        for existing in self._blocks:
-            repaint = getattr(existing, "refresh_row", None)
+        self._name_col_applied = width
+        self._repaint_ledger_rows()
+
+    def _resync_name_col(self) -> None:
+        """Re-derive the shared name column and repaint the ledger if it moved.
+
+        THE one funnel for every path that can move the column: an append's
+        growth (through :meth:`_widen_name_col`, which keeps its O(1) fast path),
+        pagination, a rename, a removal, a clear, and a batch mount. Each of
+        those used to carry its own idea of what to do — most dropped the derived
+        width and repainted nobody, and the append's growth path returned early
+        whenever the width was unset, which is exactly the state those drops
+        leave — so rows kept the old offset until a pointer happened to hover
+        them. That is the tear a reader saw moving the cursor down the ledger,
+        and again on revealing an older page.
+
+        The comparison is against the width the rows were actually published
+        with, :attr:`_name_col_applied` — never against the cache, which the
+        caller has just dropped and which would therefore read as "unchanged".
+        """
+        previous = self._name_col_applied
+        self._name_col_cache = None
+        width = self.tool_name_col
+        if previous == width:
+            return
+        self._name_col_applied = width
+        self._repaint_ledger_rows()
+
+    def _repaint_ledger_rows(self) -> None:
+        """Re-render every ledger row against the current column.
+
+        Every ``LEDGER_ROW``, not only the ones on screen: a row is rebuilt from
+        the data it holds rather than from the frame it is on, so one scrolled
+        out of view is already correct when the reader reveals it. Repainting
+        just what is visible would move the same tear one page further out.
+        """
+        for block in self._blocks:
+            if not getattr(block, "LEDGER_ROW", False):
+                continue
+            if block.parent is not self:
+                # A row that has not been mounted has not been painted, so it
+                # holds no stale offset — and rebuilding it here, with no parent
+                # to ask for the shared column, would fit it to the console rung
+                # and paint one frame at the old width before its own layout
+                # pass corrected it. It derives the column on that pass, like
+                # any other newcomer.
+                continue
+            repaint = getattr(block, "refresh_row", None)
             if callable(repaint):
                 repaint()
 
@@ -3684,6 +3756,13 @@ class TranscriptView(ScrollableContainer):
                 if isinstance(name, str) and name:
                     longest = max(longest, cell_len(display_name(name)))
             self._name_col_cache = max(TOOL_NAME_COL, min(longest, TOOL_NAME_COL_MAX))
+            # Deriving IS publishing: this is the width every row paints with
+            # from here on, so it is also what a later resync has to compare
+            # against. Recorded at the derivation rather than only at a repaint
+            # broadcast so a resync can skip the repaint when the column did not
+            # move — a fresh ledger's first derivation has nobody to repaint, and
+            # a reveal that changes nothing must not walk every row.
+            self._name_col_applied = self._name_col_cache
         return self._name_col_cache
 
     def invalidate_name_col(self) -> None:
@@ -3693,21 +3772,7 @@ class TranscriptView(ScrollableContainer):
         column is derived from those names — without this the first fragment's
         width outlived it for the rest of the session.
         """
-        self._invalidate_name_col()
-
-    def _invalidate_name_col(self) -> None:
-        """Forget the cached column and repaint the ledger if it moved.
-
-        Only the cards repaint, and only when the number actually changed: a
-        ledger that reflowed on every append would undo the point of a spine.
-        """
-        previous = self._name_col_cache
-        self._name_col_cache = None
-        if previous is not None and previous != self.tool_name_col:
-            for block in self._blocks:
-                repaint = getattr(block, "refresh_row", None)
-                if callable(repaint):
-                    repaint()
+        self._resync_name_col()
 
     def refresh_gap_after(self, block: TranscriptBlock) -> None:
         """Re-decide the gap for the first real block below ``block``.
@@ -3820,10 +3885,12 @@ class TranscriptView(ScrollableContainer):
         if self._tail is block:
             self._tail = None
         block.remove()
-        # Same reason `clear_blocks` does it: the name column is derived FROM the
-        # blocks, so a removal can only ever make it too wide.
+        # The name column is derived FROM the blocks, so removing one can only
+        # make it too wide — but it is the rows LEFT BEHIND that have to hear
+        # about it. Dropping the cache alone let them keep the wide offset until
+        # something else repainted them.
         if getattr(block, "LEDGER_ROW", False):
-            self._name_col_cache = None
+            self._resync_name_col()
         # Whatever fell into the removed block's place now has a different
         # neighbour above it — most visibly the very first block, which must
         # never carry a gap once the boot hint is lifted off the top.
@@ -3868,10 +3935,12 @@ class TranscriptView(ScrollableContainer):
         self._blocks.clear()
         # Every derived measurement goes with them. The name column is computed
         # FROM the blocks, so a stale one made the next ledger inherit the width
-        # of a transcript the user just cleared. The pin goes too — the block it
-        # named was just removed, and the hook below is where a live turn's
-        # working line is mounted again.
-        self._name_col_cache = None
+        # of a transcript the user just cleared — re-deriving here publishes the
+        # floor of the empty ledger instead of leaving the answer to whichever
+        # row paints next. The pin goes too — the block it named was just
+        # removed, and the hook below is where a live turn's working line is
+        # mounted again.
+        self._resync_name_col()
         self._tail = None
         # An insert settling into the transcript that just went away has no
         # reader to hold. `_reanchor_insert` would notice the anchor is

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -3097,11 +3097,22 @@ class TranscriptView(ScrollableContainer):
         self._name_col_cache: int | None = None
         # The width the ledger's ROWS were last published with — what their
         # summaries were actually laid out against. Deliberately separate from
-        # the cache: every path that can move the column DROPS the cache, so the
+        # the cache: a path that invalidates the column drops the cache, so the
         # cache cannot answer "did this actually change", and a resync comparing
         # against it would read `None` as "nothing to do" while rows sat at the
         # old offset. `None` here means no row has been painted under a published
         # column yet, so there is nobody to be stale.
+        #
+        # PRECISELY what this is, because it is compared as an EQUALITY and an
+        # over-stated invariant here would be a tear later: it is the shared
+        # column's value in force, NOT the cell count every row literally painted
+        # with. A row fits itself inside it — `ToolCard._name_col` answers the
+        # floor below `NAME_GROWTH_MIN_ROW`, and `name_budget` shrinks it further
+        # on a narrow frame — and those clamps are functions of the ROW's own
+        # width, so every row at one frame width agrees on them without the
+        # column moving. That is why the comparison stays sound: a row can hold
+        # less than this number, but no row holds a DIFFERENT one because of a
+        # missed repaint, which is the only thing this field exists to detect.
         self._name_col_applied: int | None = None
         #: The block held at the BOTTOM as later blocks arrive (the working
         #: line). Pinned rather than re-appended so it is never unmounted and
@@ -3613,15 +3624,20 @@ class TranscriptView(ScrollableContainer):
     def _resync_name_col(self) -> None:
         """Re-derive the shared name column and repaint the ledger if it moved.
 
-        THE one funnel for every path that can move the column: an append's
-        growth (through :meth:`_widen_name_col`, which keeps its O(1) fast path),
-        pagination, a rename, a removal, a clear, and a batch mount. Each of
-        those used to carry its own idea of what to do — most dropped the derived
-        width and repainted nobody, and the append's growth path returned early
-        whenever the width was unset, which is exactly the state those drops
-        leave — so rows kept the old offset until a pointer happened to hover
-        them. That is the tear a reader saw moving the cursor down the ledger,
-        and again on revealing an older page.
+        The one funnel for every path that can move the column EXCEPT an
+        append's growth: pagination, a rename, a composing row's promotion to
+        running, a removal, a clear, and a batch mount. Growth keeps
+        :meth:`_widen_name_col`, which is a deliberate second path because an
+        append can only ever widen and can answer that in O(1) (see its
+        docstring); everything else goes through here, because only a re-scan
+        can say which way the width moved.
+
+        Each of those paths used to carry its own idea of what to do — most
+        dropped the derived width and repainted nobody, and the append's growth
+        path returned early whenever the width was unset, which is exactly the
+        state those drops leave — so rows kept the old offset until a pointer
+        happened to hover them. That is the tear a reader saw moving the cursor
+        down the ledger, and again on revealing an older page.
 
         The comparison is against the width the rows were actually published
         with, :attr:`_name_col_applied` — never against the cache, which the

--- a/scripts/ledger_names_shot.py
+++ b/scripts/ledger_names_shot.py
@@ -1,0 +1,164 @@
+"""Capture the tool ledger's shared name column against every row that shares it.
+
+Run from the worktree root:
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/ledger_names_shot.py OUT.svg [COLSxROWS] [CASE]
+
+``CASE`` selects the event that MOVES the column, because the defect was that
+one event moved it for some rows and left the others where they were:
+
+    append  (default)  a longer-named row appended while older rows are already
+                       painted. Reached the way a live session reaches it: the
+                       derived column is invalidated first by a block paged in
+                       from older history, which is the state the growth path
+                       read as "nothing to do".
+    reveal             an older page carrying a longer MCP tool name paged in
+                       above rows already on screen.
+
+The fixture is the SAME in both cases, so the two frames differ in the event and
+not in the data. Every row is a settled receipt, and the names are chosen so the
+column has to grow: `bash` and `read` sit at the floor, `list_variables` and
+`create_initiative` (from `mcp__linear_create_initiative`) do not.
+
+The property to read off the frame is that every row's summary starts in the
+SAME cell — that is the shared spine. A frame where one row's text starts two or
+more cells right of its neighbours' is the tear the pointer used to repair one
+row at a time.
+
+Capture the BEFORE frame from a checkout that predates the fix with this same
+script and the same fixture; no provider request, live session or operator
+config is used (``isolate_capture`` redirects HOME, config and caches first).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+# Clear every multiplexer identifier BEFORE any application import: a headless
+# pilot must not rename the operator's real workspace through inherited CMUX IDs.
+for _key in tuple(os.environ):
+    if _key.startswith("CMUX_"):
+        os.environ.pop(_key)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.visual_capture import isolate_capture, save_capture  # noqa: E402
+
+isolate_capture()
+
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.tool_card import ToolCard  # noqa: E402
+from local_operator.tui.widgets.transcript import TranscriptView  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+#: The rows already painted when the column moves. Short names, so the ledger
+#: sits at the floor of the column and the growth is entirely the newcomer's.
+SEEDED_ROWS = [
+    ("t1", "bash", "rg -n 'name_col' local_operator/ | head -9", "9 matches"),
+    ("t2", "read", "local_operator/tui/widgets/transcript.py", "4308 lines"),
+]
+
+#: An older LOAD-BEARING row paged in first. Its own name is short — the point
+#: is not that it widens the column but that paging history in invalidates the
+#: derived width, which is the state the append lands in.
+OLDER_SHORT_ROW = ("old1", "bash", "git log --oneline -3", "3 commits")
+
+#: An older row whose name DOES widen the column: the `reveal` case.
+OLDER_WIDE_ROW = ("old2", "mcp__linear_create_initiative", "release window", "created")
+
+#: The newcomer. `list_variables` is longer than every name above it.
+APPENDED_ROW = ("t3", "list_variables", "list_variables {}", "4 variables")
+
+
+def _tool(app: OperatorApp, rows: list[tuple[str, str, str, str]]) -> list[ToolCard]:
+    """Append FINISHED tool rows, so the ledger is settled ink rather than the
+    live-turn accent. ``mark_done`` runs after the mount because a card settles
+    in place (the pattern ``peer_message_shot.py`` uses)."""
+    cards = []
+    for call_id, name, command, result in rows:
+        card = ToolCard(call_id, name, {"command": command})
+        app._append_block(card)
+        card.mark_done(result)
+        cards.append(card)
+    return cards
+
+
+#: call id -> the text its summary starts with, so the frame's own geometry can
+#: be read back: the cell the summary starts in IS the shared name column's far
+#: edge, and every row has to agree on it.
+SUMMARIES = {
+    SEEDED_ROWS[0][0]: SEEDED_ROWS[0][2],
+    SEEDED_ROWS[1][0]: SEEDED_ROWS[1][2],
+    OLDER_SHORT_ROW[0]: OLDER_SHORT_ROW[2],
+    OLDER_WIDE_ROW[0]: OLDER_WIDE_ROW[2],
+    APPENDED_ROW[0]: APPENDED_ROW[2],
+}
+
+
+def _report_geometry(app: OperatorApp, view: TranscriptView) -> None:
+    """Print the summary column each painted row starts in, straight off the
+    compositor. The stills show the tear; these numbers say which rows were in
+    which column, and the two together are the evidence."""
+    strips = list(app.screen._compositor.render_strips())
+    for block in view.blocks():
+        call_id = getattr(block, "tool_call_id", "")
+        marker = SUMMARIES.get(call_id)
+        if marker is None:
+            continue
+        row = strips[block.region.y].text
+        print(f"  {call_id:>6} summary@{row.index(marker)}", file=sys.stderr)
+
+
+async def main() -> None:
+    out = sys.argv[1]
+    size = (100, 30)
+    if len(sys.argv) > 2:
+        cols, rows = sys.argv[2].split("x")
+        size = (int(cols), int(rows))
+    case = sys.argv[3] if len(sys.argv) > 3 else "append"
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        view = app.query_one(TranscriptView)
+        painted = _tool(app, SEEDED_ROWS)
+        await pilot.pause()
+
+        if case == "reveal":
+            blocks = [
+                ToolCard("old1", OLDER_SHORT_ROW[1], {"command": OLDER_SHORT_ROW[2]}),
+                ToolCard("old2", OLDER_WIDE_ROW[1], {"command": OLDER_WIDE_ROW[2]}),
+            ]
+            for block, result in zip(blocks, (OLDER_SHORT_ROW[3], OLDER_WIDE_ROW[3])):
+                block.mark_done(result)
+            view.insert_blocks(0, blocks)
+        else:
+            # Page one older block in, then append the longer-named row: the
+            # column is invalidated by the page and moved by the append.
+            older_block = ToolCard(
+                OLDER_SHORT_ROW[0], OLDER_SHORT_ROW[1], {"command": OLDER_SHORT_ROW[2]}
+            )
+            older_block.mark_done(OLDER_SHORT_ROW[3])
+            view.insert_blocks(0, [older_block])
+            painted.extend(_tool(app, [APPENDED_ROW]))
+
+        # Two settled frames: a first paint that differs from this one is a
+        # reflow the user sees as motion (AGENTS.md, "Animation and multi-frame
+        # changes"). The pointer never enters the frame in either case — the
+        # rows have to be right without it.
+        await pilot.pause()
+        await pilot.pause()
+        screen = app.screen
+        print(
+            f"case={case} size={screen.size} virtual={screen.virtual_size} "
+            f"vscroll={screen.show_vertical_scrollbar} col={view.tool_name_col}",
+            file=sys.stderr,
+        )
+        _report_geometry(app, view)
+        save_capture(app, out)
+
+
+asyncio.run(main())

--- a/scripts/ledger_names_shot.py
+++ b/scripts/ledger_names_shot.py
@@ -15,6 +15,9 @@ one event moved it for some rows and left the others where they were:
                        read as "nothing to do".
     reveal             an older page carrying a longer MCP tool name paged in
                        above rows already on screen.
+    promote            a call that STARTS: a row dictated under its announce name
+                       is promoted to `running` with the execution's name, which
+                       is the moment its name starts counting towards the spine.
 
 The fixture is the SAME in both cases, so the two frames differ in the event and
 not in the data. Every row is a settled receipt, and the names are chosen so the
@@ -50,6 +53,7 @@ from scripts.visual_capture import isolate_capture, save_capture  # noqa: E402
 isolate_capture()
 
 from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.glyphs import display_name  # noqa: E402
 from local_operator.tui.widgets.tool_card import ToolCard  # noqa: E402
 from local_operator.tui.widgets.transcript import TranscriptView  # noqa: E402
 from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
@@ -71,6 +75,10 @@ OLDER_WIDE_ROW = ("old2", "mcp__linear_create_initiative", "release window", "cr
 
 #: The newcomer. `list_variables` is longer than every name above it.
 APPENDED_ROW = ("t3", "list_variables", "list_variables {}", "4 variables")
+
+#: The promoted row of the `promote` case: dictated as `list_variables` while it
+#: was composing, then started. Its summary is the one the execution carries.
+PROMOTED_ROW = ("live", "list_variables", "list them")
 
 
 def _tool(app: OperatorApp, rows: list[tuple[str, str, str, str]]) -> list[ToolCard]:
@@ -95,7 +103,30 @@ SUMMARIES = {
     OLDER_SHORT_ROW[0]: OLDER_SHORT_ROW[2],
     OLDER_WIDE_ROW[0]: OLDER_WIDE_ROW[2],
     APPENDED_ROW[0]: APPENDED_ROW[2],
+    PROMOTED_ROW[0]: PROMOTED_ROW[2],
 }
+
+
+def _summary_column(row: str, label: str, marker: str) -> str:
+    """Where this row's summary starts, measured off the frame's own text.
+
+    The marker is the direct answer while the frame is wide enough to paint it.
+    A narrower frame clips the summary — and that frame is exactly what this
+    script exists to document, so raising there wrote no frame at all. The
+    fallback measures the same number off the NAME field instead: the label
+    ends and the padding that follows belongs to the name column, so the first
+    cell of the summary is the first non-space after the label. A row narrow
+    enough to clip the label as well is reported as exactly that, rather than as
+    a number nothing backs.
+    """
+    at = row.find(marker)
+    if at >= 0:
+        return f"summary@{at}"
+    name_at = row.find(label)
+    if name_at < 0:
+        return f"name clipped at this width (neither {marker!r} nor {label!r} painted)"
+    tail = row[name_at + len(label) :]
+    return f"summary@{name_at + len(label) + len(tail) - len(tail.lstrip(' '))}"
 
 
 def _report_geometry(app: OperatorApp, view: TranscriptView) -> None:
@@ -108,8 +139,9 @@ def _report_geometry(app: OperatorApp, view: TranscriptView) -> None:
         marker = SUMMARIES.get(call_id)
         if marker is None:
             continue
-        row = strips[block.region.y].text
-        print(f"  {call_id:>6} summary@{row.index(marker)}", file=sys.stderr)
+        label = display_name(getattr(block, "tool_name", ""))
+        column = _summary_column(strips[block.region.y].text, label, marker)
+        print(f"  {call_id:>6} {column}", file=sys.stderr)
 
 
 async def main() -> None:
@@ -135,6 +167,15 @@ async def main() -> None:
             for block, result in zip(blocks, (OLDER_SHORT_ROW[3], OLDER_WIDE_ROW[3])):
                 block.mark_done(result)
             view.insert_blocks(0, blocks)
+        elif case == "promote":
+            # Dictate first, then start: the two events a real turn produces, in
+            # the order that moves the column on the SECOND one.
+            call_id, name, summary = PROMOTED_ROW
+            live = ToolCard(call_id, "bash", {})
+            view.append_block(live)
+            live.set_composing(12, name)
+            await pilot.pause()
+            live.begin_running(name, {"command": summary}, None)
         else:
             # Page one older block in, then append the longer-named row: the
             # column is invalidated by the page and moved by the append.

--- a/tests/unit/tui/test_peer_message.py
+++ b/tests/unit/tui/test_peer_message.py
@@ -1005,7 +1005,7 @@ async def test_a_repaint_does_not_rescan_the_whole_body() -> None:
     """The snippet is sanitized once at construction, not per repaint.
 
     `_refresh_row` runs on hover, focus, expand, retheme, resize and — through
-    `_invalidate_name_col` — on every ledger block when the shared name column
+    the name-column resync — on every ledger block when the shared name column
     moves. The strip is a regex plus a per-character `unicodedata.category`
     scan; run over a body at the 256 KiB wire cap it measured 23.9 ms of
     loop-thread CPU *per repaint*, so one card taxed the whole ledger.

--- a/tests/unit/tui/test_transcript_name_col.py
+++ b/tests/unit/tui/test_transcript_name_col.py
@@ -21,6 +21,12 @@ In every case hovering a row repaired that row alone (``on_enter`` →
 ``refresh_row``), so the ledger visibly re-aligned under the pointer one row at
 a time. The assertions here are on the frame the compositor painted, with no
 pointer anywhere in the sequence.
+
+What is asserted is the COLUMN, never frame bytes or whole-row text: hover
+legitimately rewrites a row's own text (``_build_row`` lights the ``⟨expand⟩``
+offer when the row is hovered), so "the frame is unchanged" is the wrong
+instrument even where the alignment is right. The shared column is what must not
+move under any of these transitions.
 """
 
 from __future__ import annotations
@@ -30,7 +36,11 @@ from rich.text import Text
 from textual.app import App
 
 from local_operator.tui.widgets.tool_card import ToolCard
-from local_operator.tui.widgets.transcript import TranscriptBlock, TranscriptView
+from local_operator.tui.widgets.transcript import (
+    TOOL_NAME_COL,
+    TranscriptBlock,
+    TranscriptView,
+)
 from tests.unit.tui.conftest import StyledTranscriptApp
 
 #: A name long enough to widen the column past the floor. It renders through
@@ -232,3 +242,117 @@ async def test_a_row_scrolled_out_of_view_is_repainted_too() -> None:
         off_frame = composed_row(first).index("echo step0")
         assert off_frame > narrow
         assert off_frame == composed_row(rest[-1]).index("echo step13")
+
+
+@pytest.mark.asyncio
+async def test_a_call_that_starts_earns_the_column_for_its_row() -> None:
+    """The promotion out of ``composing`` is a path that moves the column.
+
+    ``contributes_name`` is False while a call is still being dictated and True
+    once the call it names has started, so a row's name begins counting towards
+    the spine at exactly this transition — the inverse of entering ``composing``,
+    which already invalidates the column. Without it the ledger stays on the
+    floor and the live row paints its own name truncated (``list_va…``), and
+    neither settling nor hovering repairs that: hover re-fits the row at the
+    stale column, so only some unrelated later resync would.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(100, 24)) as pilot:
+        view = app.query_one(TranscriptView)
+        settled = _bash("c1", "echo alpha")
+        view.append_block(settled)
+        await _settle(pilot)
+        narrow = summary_col(app, settled, "echo alpha")
+
+        live = ToolCard("live", "bash", {})
+        view.append_block(live)
+        live.set_composing(12, LONGER_TOOL)
+        await _settle(pilot)
+        # Dictated, not started: the name may not move the ledger's column yet.
+        assert summary_col(app, settled, "echo alpha") == narrow
+
+        live.begin_running(LONGER_TOOL, {"command": "list them"}, None)
+        await _settle(pilot)
+
+        shared = summary_col(app, live, "list them")
+        assert shared > narrow
+        assert summary_col(app, settled, "echo alpha") == shared
+        # The row the column grew FOR is painted in full, not ellipsised into a
+        # column that would have fitted it.
+        assert LONGER_TOOL in painted_row(app, live)
+
+
+@pytest.mark.asyncio
+async def test_removing_the_widest_row_brings_the_spine_back_down() -> None:
+    """The shrink half of the funnel: only a re-scan can say how far.
+
+    Growth can be answered by the newcomer's own name; a removal cannot, so it
+    keeps the full re-derivation — and the rows LEFT BEHIND are the ones that
+    have to be told, which is what dropping the cache alone failed to do.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(100, 24)) as pilot:
+        view = app.query_one(TranscriptView)
+        first = _bash("c1", "echo alpha")
+        second = _bash("c2", "echo beta")
+        view.append_block(first)
+        view.append_block(second)
+        await _settle(pilot)
+        floor = summary_col(app, first, "echo alpha")
+
+        wide = ToolCard("wide", WIDE_TOOL, {"command": "wide row"}, "")
+        view.append_block(wide)
+        await _settle(pilot)
+        grown = summary_col(app, wide, "wide row")
+        assert grown > floor
+        assert summary_col(app, first, "echo alpha") == grown
+        assert summary_col(app, second, "echo beta") == grown
+
+        view.remove_block(wide)
+        await _settle(pilot)
+
+        assert summary_col(app, first, "echo alpha") == floor
+        assert summary_col(app, second, "echo beta") == floor
+        assert view.tool_name_col == TOOL_NAME_COL
+
+
+@pytest.mark.asyncio
+async def test_every_row_agrees_on_the_column_rung_at_narrow_widths() -> None:
+    """Across the narrow threshold no row may diverge from its neighbours.
+
+    ``tool_name_col`` is the DERIVED column; what a row paints with is that value
+    clamped by the row's OWN frame — ``ToolCard._name_col`` answers the floor
+    below ``NAME_GROWTH_MIN_ROW``, and ``name_budget`` shrinks it further — so
+    the derived value and the painted one legitimately disagree there. The
+    property that has to hold is the one this file is about: at every rung all
+    rows agree, in both directions across the threshold. A rung where one row
+    disagrees is the tear, not the clamp.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(100, 24)) as pilot:
+        view = app.query_one(TranscriptView)
+        first = _bash("c1", "echo alpha")
+        second = _bash("c2", "echo beta")
+        wide = ToolCard("wide", WIDE_TOOL, {"command": "wide row"}, "")
+        for card in (first, second, wide):
+            view.append_block(card)
+        await _settle(pilot)
+
+        def rung(summary: str) -> int:
+            return summary_col(app, first, "echo alpha")
+
+        at_full_width = rung("echo alpha")
+        assert summary_col(app, wide, "wide row") == at_full_width
+
+        for width in (68, 50):
+            await pilot.resize_terminal(width, 24)
+            await _settle(pilot)
+            narrowed = rung("echo alpha")
+            assert narrowed < at_full_width, "the row clamp has to bite below the threshold"
+            assert summary_col(app, second, "echo beta") == narrowed
+            assert summary_col(app, wide, "wide row") == narrowed
+
+        await pilot.resize_terminal(100, 24)
+        await _settle(pilot)
+        assert rung("echo alpha") == at_full_width
+        assert summary_col(app, wide, "wide row") == at_full_width

--- a/tests/unit/tui/test_transcript_name_col.py
+++ b/tests/unit/tui/test_transcript_name_col.py
@@ -139,3 +139,45 @@ async def test_appending_a_longer_name_repaints_the_rows_already_painted() -> No
         assert expected > narrow
         assert summary_col(app, first, "echo alpha") == expected
         assert summary_col(app, second, "echo beta") == expected
+
+
+@pytest.mark.asyncio
+async def test_a_page_that_does_not_move_the_column_repaints_nothing() -> None:
+    """The repaint is driven by the WIDTH moving, not by the event happening.
+
+    A reveal must be able to hand the ledger a page without walking every row it
+    already painted, and the O(1) append fast path must stay O(1) — otherwise
+    this fix would have bought alignment with a per-event rescan, which is the
+    cost the ledger's growth path exists to avoid. Asserted as call COUNTS
+    rather than a duration: a threshold calibrated on this machine is not a
+    threshold on CI, and "how many rows were re-rendered" is a fact about work
+    rather than about the clock.
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(100, 24)) as pilot:
+        view = app.query_one(TranscriptView)
+        first = _bash("c1", "echo alpha")
+        second = _bash("c2", "echo beta")
+        view.append_block(first)
+        view.append_block(second)
+        await _settle(pilot)
+
+        repaints: list[str] = []
+        for card in (first, second):
+            original = card.refresh_row
+
+            def counting(card=card, original=original) -> None:
+                repaints.append(card.tool_call_id)
+                original()
+
+            card.refresh_row = counting  # type: ignore[method-assign]
+
+        # A page the column already fits: one derivation, no repaints.
+        view.insert_blocks(0, [_bash("old1", "echo old")])
+        await _settle(pilot)
+        assert repaints == []
+
+        # A page carrying a longer name: every row behind it re-renders, once.
+        view.insert_blocks(0, [ToolCard("old2", LONGER_TOOL, {"command": "list them"}, "")])
+        await _settle(pilot)
+        assert sorted(repaints) == ["c1", "c2"]

--- a/tests/unit/tui/test_transcript_name_col.py
+++ b/tests/unit/tui/test_transcript_name_col.py
@@ -1,0 +1,141 @@
+"""The ledger's shared name column: ONE spine, moved as one.
+
+``TranscriptView`` sizes a single column from the longest tool name in the
+ledger, and every row draws its summary after it. The growth is deliberate —
+two MCP tools sharing a seven-character prefix stay distinguishable wherever the
+frame can afford the width — so the property that has to hold is not "the
+column is a constant" but "a row is never painted on a column the other rows
+are not on".
+
+It stopped holding on three paths, all of which left painted rows behind:
+
+* ``insert_blocks`` dropped the derived width and repainted nobody, so the rows
+  already on screen kept the width they were given while the first revealed row
+  derived a wider one for itself. Paging history in tore the ledger.
+* ``remove_block`` and ``clear_blocks`` did the same, in the shrink direction.
+* ``append_block``'s growth path early-returned when the derived width was
+  unset, which is exactly the state those paths leave behind: the appended row
+  painted on a freshly derived column and the rows already painted kept theirs.
+
+In every case hovering a row repaired that row alone (``on_enter`` →
+``refresh_row``), so the ledger visibly re-aligned under the pointer one row at
+a time. The assertions here are on the frame the compositor painted, with no
+pointer anywhere in the sequence.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App
+
+from local_operator.tui.widgets.tool_card import ToolCard
+from local_operator.tui.widgets.transcript import TranscriptBlock, TranscriptView
+from tests.unit.tui.conftest import StyledTranscriptApp
+
+#: A name long enough to widen the column past the floor. It renders through
+#: ``display_name`` as a SHORTER label, so the tests measure what is painted
+#: rather than what was passed in.
+WIDE_TOOL = "mcp__linear_create_initiative"
+LONGER_TOOL = "list_variables"
+
+
+def painted_row(app: App[None], block: TranscriptBlock) -> str:
+    """The row the frame actually painted for ``block``.
+
+    Read from the compositor rather than from the widget's own renderable: the
+    claim under test is about what a reader sees, and a card holds content it
+    has not painted yet (`refresh_row` builds it whether or not the row is on
+    frame).
+    """
+    strips = list(app.screen._compositor.render_strips())
+    y = block.region.y
+    assert 0 <= y < len(strips), "the ledger row is not on the painted frame"
+    return strips[y].text
+
+
+def summary_col(app: App[None], block: TranscriptBlock, summary: str) -> int:
+    """Cell the row's SUMMARY starts in — the far edge of the shared name column."""
+    return painted_row(app, block).index(summary)
+
+
+def _bash(call_id: str, summary: str) -> ToolCard:
+    return ToolCard(call_id, "bash", {"command": summary}, "")
+
+
+async def _settle(pilot) -> None:
+    """Wait for the SETTLED frame, which is the one a reader is left with.
+
+    A card builds its row in its constructor, where it has no parent to ask for
+    the shared column, so the first paint after a mount can still be that build;
+    the ledger's own layout pass replaces it on the next. Two pauses is the same
+    settle the peer-card suite uses for the same reason.
+    """
+    await pilot.pause()
+    await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_paging_an_older_row_in_repaints_the_rows_already_on_screen() -> None:
+    """Scroll-up reveal: the newcomers may not paint on a wider spine alone."""
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(100, 24)) as pilot:
+        view = app.query_one(TranscriptView)
+        first = _bash("c1", "echo alpha")
+        second = _bash("c2", "echo beta")
+        view.append_block(first)
+        view.append_block(second)
+        await _settle(pilot)
+        narrow = summary_col(app, first, "echo alpha")
+        assert summary_col(app, second, "echo beta") == narrow
+
+        # An OLDER row, revealed above the viewport, whose name is longer than
+        # anything the ledger has drawn so far.
+        revealed = ToolCard("older", WIDE_TOOL, {"command": "reveal me"}, "")
+        view.insert_blocks(0, [revealed])
+        await _settle(pilot)
+
+        # The column grew, and all three rows moved with it — no hover anywhere.
+        shared = summary_col(app, revealed, "reveal me")
+        assert shared > narrow
+        assert summary_col(app, first, "echo alpha") == shared
+        assert summary_col(app, second, "echo beta") == shared
+
+
+@pytest.mark.asyncio
+async def test_appending_a_longer_name_repaints_the_rows_already_painted() -> None:
+    """Append growth has to reach the rows behind it, not only the newcomer.
+
+    The append is reached with the derived column already invalidated and rows
+    still painted — the state a removal or a page reveal leaves the ledger in,
+    and the one the growth path's guard on the (unset) cache read as "nothing to
+    do".
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(100, 24)) as pilot:
+        view = app.query_one(TranscriptView)
+        first = _bash("c1", "echo alpha")
+        second = _bash("c2", "echo beta")
+        view.append_block(first)
+        view.append_block(second)
+        await _settle(pilot)
+        narrow = summary_col(app, first, "echo alpha")
+
+        wide = ToolCard("wide", WIDE_TOOL, {"command": "wide row"}, "")
+        view.append_block(wide)
+        await _settle(pilot)
+        assert summary_col(app, wide, "wide row") > narrow
+
+        # Removing a ledger row invalidates the derived column — deliberately
+        # without asserting the frame here: this test is about what the append
+        # does with the ledger in that state.
+        view.remove_block(wide)
+        await _settle(pilot)
+
+        longer = ToolCard("longer", LONGER_TOOL, {"command": "list them"}, "")
+        view.append_block(longer)
+        await _settle(pilot)
+
+        expected = summary_col(app, longer, "list them")
+        assert expected > narrow
+        assert summary_col(app, first, "echo alpha") == expected
+        assert summary_col(app, second, "echo beta") == expected

--- a/tests/unit/tui/test_transcript_name_col.py
+++ b/tests/unit/tui/test_transcript_name_col.py
@@ -26,6 +26,7 @@ pointer anywhere in the sequence.
 from __future__ import annotations
 
 import pytest
+from rich.text import Text
 from textual.app import App
 
 from local_operator.tui.widgets.tool_card import ToolCard
@@ -181,3 +182,53 @@ async def test_a_page_that_does_not_move_the_column_repaints_nothing() -> None:
         view.insert_blocks(0, [ToolCard("old2", LONGER_TOOL, {"command": "list them"}, "")])
         await _settle(pilot)
         assert sorted(repaints) == ["c1", "c2"]
+
+
+def _on_frame(app: App[None], block: TranscriptBlock) -> bool:
+    """Whether the frame is currently painting ``block`` at all."""
+    return 0 <= block.region.y < len(list(app.screen._compositor.render_strips()))
+
+
+def composed_row(block: TranscriptBlock) -> str:
+    """The row text ``block`` is holding, for a row the frame is not painting.
+
+    The compositor cannot speak for a row outside the viewport, so the widget's
+    own composed content is the instrument there — and it is the honest one for
+    the claim: this is what the row will paint when it is revealed, unless the
+    reveal itself rebuilds it.
+    """
+    rendered = block.render()
+    # The row is a Rich ``Text`` in every renderable state the ledger has; the
+    # cast is for the union ``Widget.render`` declares.
+    return rendered.plain.splitlines()[0] if isinstance(rendered, Text) else str(rendered)
+
+
+@pytest.mark.asyncio
+async def test_a_row_scrolled_out_of_view_is_repainted_too() -> None:
+    """A row the frame is not showing is rebuilt as well.
+
+    Read from the row's own composed content, because that is the only thing a
+    cell outside the viewport can be judged by: the reader who scrolls back to
+    it is who this is for, and a pointer never reaches it (hovering is what used
+    to repair a row).
+    """
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(100, 20)) as pilot:
+        view = app.query_one(TranscriptView)
+        first = _bash("c0", "echo step0")
+        view.append_block(first)
+        rest = [_bash(f"c{index}", f"echo step{index}") for index in range(1, 14)]
+        for card in rest:
+            view.append_block(card)
+        await _settle(pilot)
+        assert not _on_frame(app, first), "the fixture has to push the row off the frame"
+        narrow = composed_row(rest[-1]).index("echo step13")
+
+        # The column moves while `first` is above the viewport.
+        view.insert_blocks(0, [ToolCard("old", LONGER_TOOL, {"command": "list them"}, "")])
+        await _settle(pilot)
+
+        assert view.tool_name_col > narrow
+        off_frame = composed_row(first).index("echo step0")
+        assert off_frame > narrow
+        assert off_frame == composed_row(rest[-1]).index("echo step13")


### PR DESCRIPTION
**Round-1 remediation landed at `b44cb0384`** — all three round-1 streams are answered above the fold of the thread: [agent review](https://github.com/damianvtran/local-operator/pull/977#issuecomment-5641687510) (R1–R4), [QA](https://github.com/damianvtran/local-operator/pull/977#issuecomment-5641687629) (Q1–Q5), [design](https://github.com/damianvtran/local-operator/pull/977#issuecomment-5641687727) (D1–D4; D2 deferred with its measured cost). The commit adds the one path that still moved the ledger's shared column without telling its rows — a call that STARTS (`ToolCard.begin_running`) — plus the shrink and narrow-rung tests, and fixes the capture script's narrow-width crash. Gates and CI at that head are recorded in each remediation comment.

Release: patch — a repaint fix on an existing surface. No new API and no new UI: the column's width is unchanged, only which rows are told it moved. `pyproject.toml` untouched (combined-release rule: PRs never carry a bump).

## What and why

**C1 — user-visible defect, reported by the operator:** the tool ledger's shared name column is inconsistent between the rows on screen. A newly appended tool call with a longer name widens the column for itself and for rows painted afterwards, but rows already painted keep the older, narrower padding until the pointer hovers them; paging older blocks in has the same effect. Hovering (`on_enter` → `refresh_row`) repairs one row at a time, so moving the mouse down the list visibly tears the alignment. A screenshot showed two `bash` rows at different summary offsets in one frame.

The column is owned by `TranscriptView.tool_name_col`, derived from the longest contributing `LEDGER_ROW` name and cached in `_name_col_cache`. Four paths could move it without telling the rows already painted, and the one path that did repaint compared against a value it had already dropped:

| path | what it did |
|---|---|
| `insert_blocks` (scroll-up pagination, `prepend_blocks`) | dropped the cache and repainted nobody |
| `remove_block` (a ledger row) | dropped the cache and repainted nobody |
| `clear_blocks` | dropped the cache and repainted nobody |
| `append_block` → `_widen_name_col` | **early-returned when the cache was unset** — which is exactly the state the three drops above leave — so a widen repainted nobody and the next row to paint derived the wider column for itself |
| `invalidate_name_col` (rename) | the only path that repainted, and it compared against a cache the other paths had already cleared |

The stale rows were only repaired by a pointer hover, which is why the tear survived until the cursor crossed each row.

## The fix

Every path that can move the column now goes through one funnel, `TranscriptView._resync_name_col` (append growth keeps its own O(1) fast path), which:

1. re-derives the width,
2. compares it against `_name_col_applied` — a **separate** "width the rows were actually published with" value, because the cache cannot answer this question: every caller has just dropped it, so a stale cache compares equal to its own absence,
3. repaints the ledger's `LEDGER_ROW`s only when the width actually moved.

`_name_col_applied` is published at the two places a width becomes the rows' width: the lazy derivation (which is the value the next paint uses) and each broadcast repaint.

Deliberate properties:

- **The append path stays O(1).** An append can only ever widen the column, so `_widen_name_col` asks the newcomer's own name rather than re-scanning the ledger. The rationale is unchanged: the general re-derivation was measured at **36 ms of an 815 ms session switch at 891 rows** (24k `display_name` calls), quadratic in the ledger's size. Removal and rename keep the full re-derivation, since only a scan can say how far the column shrinks.
- **No per-frame rescan.** The repaint is driven by the change, not by paint; a resync whose width did not move repaints nothing.
- **Rows scrolled out of view are repainted too** — a row is rebuilt from the data it holds, so it is already correct when revealed.
- **A row that has not been mounted is skipped.** It has never painted, so it holds no stale offset; building it in the broadcast fitted it to the console rung and painted one frame at the old width before its own layout pass corrected it.

## Testing evidence

New: `tests/unit/tui/test_transcript_name_col.py` — **4 passed**, asserting on the frame the compositor actually painted (the row text at the widget's `region.y`), with no pointer anywhere in any sequence:

- `test_paging_an_older_row_in_repaints_the_rows_already_on_screen` — the scroll-up reveal.
- `test_appending_a_longer_name_repaints_the_rows_already_painted` — the append, reached with the derived column invalidated and rows still painted.
- `test_a_page_that_does_not_move_the_column_repaints_nothing` — the cost guard: a page the column already fits costs **zero** re-renders, and a page that widens it re-renders each row **exactly once**. Asserted as call counts, not a duration.
- `test_a_row_scrolled_out_of_view_is_repainted_too` — the row above the viewport when the column moved, read from the content the widget holds (a cell outside the frame has no compositor row to point at).

**All three fail on the unfixed tree** (`git show 633baf258:…/transcript.py` written over the fixed file, tests kept):

```
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui/test_transcript_name_col.py -q -n0
FAILED test_paging_an_older_row_in_repaints_the_rows_already_on_screen
  E AssertionError: assert 14 == 23          # the row painted before the reveal keeps the old column
FAILED test_appending_a_longer_name_repaints_the_rows_already_painted
  E AssertionError: assert 23 == 20
FAILED test_a_page_that_does_not_move_the_column_repaints_nothing
  E AssertionError: assert [] == ['c1', 'c2'] # the widen repainted nobody
FAILED test_a_row_scrolled_out_of_view_is_repainted_too
  E AssertionError: assert 12 > 12          # the off-frame row never moved
4 failed
```

Deterministic in both directions (same four failures across repeated unfixed runs; 5 consecutive all-pass runs on the fixed head). Full log: `~/workspace/lo-namecol-evidence/prefix-test-failures.log`.

The funnel touches every path that can move the column, so the neighbouring surfaces are covered by the whole-tree run above rather than by a hand-picked subset.

Exact head (`7154e0b88`): the four new tests pass, and `flake8`, `black --check`, `isort --check-only` and `pyright` are clean.

**CI is green at this head** — lint, type-check, all five `test (3.12, N)` shards, `tui-e2e` (macos-latest + ubuntu-latest), cli-sanity, server-sanity, coverage-report, pip-audit, filesystem-boundaries-windows, context-budget, version-bump-guard.

**The one local failure is unrelated and pre-existing**, recorded rather than smoothed over: `tests/unit/tui/test_cold_slash_binds.py::test_listings_and_chart_stay_local_and_engage_nothing_extra` asserts that a `/team` / `/agent` listing never routes through the bind seam (`assert not any(c[0] == "run_slash_authoritative" …)`). That dispatch belongs to `mobile/tui_handle.py` / `session/runtime/serving.py` and nothing in this diff reaches it. It **passes 10/10 in isolation** on this head, passed in the complete 18443-test run on the identical tree at `8f794a98f`, and passes on all five CI shards at this head. The run that caught it was on a host swapping 8.5 GB of 10 GB with three sibling suites running, which is also why it was repeated with a bounded `-n 4`: the whole `tests/unit/tui` directory passes at this head — **6963 passed, 12 skipped** — that test included.

### Quality gates

| gate | result |
|---|---|
| `.venv/bin/python -m flake8 .` | clean |
| `uvx --from black==26.1.0 black --check .` | 1228 files unchanged |
| `uvx isort==5.13.2 --check .` | clean |
| `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | 0 errors, 0 warnings |
| `.venv/bin/python -m pytest tests/unit -q` (whole tree) | 18443 passed, 18 skipped — clean at `8f794a98f`, whose `local_operator/` tree is byte-identical to this head. Re-run at the final head `7154e0b88` with a bounded `-n 4`: **18443 passed, 18 skipped, 1 failed**, the failure being an unrelated, pre-existing flake (above) |
| `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q` | 107 passed, 7 skipped in 4:10 |

## Visual evidence

Captured with `scripts.visual_capture.save_capture` on the real `OperatorApp` under the production stylesheet (`scripts/ledger_names_shot.py`), rendered with `rsvg-convert` and **looked at**, not just saved. Before frames come from the same script with the `transcript.py` hunk stashed, so both trees use the identical fixture.

```
env -u NO_COLOR TERM=xterm-256color .venv/bin/python scripts/ledger_names_shot.py OUT.svg 100x30 append
env -u NO_COLOR TERM=xterm-256color .venv/bin/python scripts/ledger_names_shot.py OUT.svg 100x30 reveal
```

The shot prints each row's summary column off the compositor, which is the number the stills show:

**`append` case — a longer-named row (`list_variables`) appended behind short ones**

| row | before | after |
|---|---|---|
| `bash` (paged in first) | 20 | 20 |
| `bash` `rg -n 'name_col' …` | **14** | **20** |
| `read …/transcript.py` | **14** | **20** |
| `list_variables` (appended) | 20 | 20 |

**`reveal` case — an older page carrying `mcp__linear_create_initiative` paged in**

| row | before | after |
|---|---|---|
| `bash` (paged in) | 23 | 23 |
| `create_initiative` (paged in) | 23 | 23 |
| `bash` `rg -n 'name_col' …` | **14** | **23** |
| `read …/transcript.py` | **14** | **23** |

Frame files (evidence, not committed): `~/workspace/lo-namecol-evidence/{before,after}-{append,reveal}.{svg,png}` (also `/tmp/`), plus the two stacked comparisons `ledger-{append,reveal}-before-after.png`.

No frame shows a virtual size larger than the screen or a scrollbar: `size=98x28 virtual=98x28 vscroll=False` in both cases on both trees.

## Changed files (4, +498/−31)

`local_operator/tui/widgets/transcript.py` (the funnel, the applied-width value, and the four call sites it replaces), `tests/unit/tui/test_transcript_name_col.py` (new), `scripts/ledger_names_shot.py` (new — the frame capture, kept because it is the reusable part), `tests/unit/tui/test_peer_message.py` (one comment that named the removed internal).

## Not addressed

- **A composing row that begins running still does not grow the column.** `ToolCard.begin_running` flips `contributes_name` from `False` to `True` (the row earns the column "once the call it names has actually started") but never invalidates it, so a live `list_variables` call paints its name truncated (`list_va…`) even though the column would fit it. Same family — the column moved and the rows were not told — but a different symptom (a truncated name, not rows at different offsets) and a different transition from the five paths the report names, so it is left for its own change rather than folded in here. Reproduced: `card.set_composing(12, "list_variables")` then `card.begin_running(...)` on a ledger whose other rows are `bash` leaves `view.tool_name_col == 8` and the row painting `list_va…`.
- No GitHub issues were created; the finding above is recorded here with its reproduction.

