### PR TITLE
chore(release): bump version to 0.54.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.14"
+version = "0.54.15"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window claimed. Owner session pid: **63400** (session `80efe201ea61`, "Show closest matches for failed edits").

Lock per ~/local-operator/AGENTS.md "One release owner per window" — this PR is the lock, and it becomes the bump once the window's number is decided.

**Window** (everything on `main` since `v0.54.14`; tick as each is confirmed in the notes):

- [x] #952 — the `edit` tool's not-found refusal now names every failing hunk's closest file text; tolerant matcher reseeded from an inverted line index
- [x] #955 — dual-alias history pages accepted, stale module references retired, owner→runtime copy migration finished
- [x] #960 — the `/btw` aside no longer strands the keyboard on the receded transcript when it closes
- [x] #963 — release-record documentation only
- [x] #965 — `$skill` leading a slash command's argument now loads the skill instead of being sent as literal text
- [x] #966 — `$` inside a prompt-carrying command's argument opens the skill picker and rewrites the argument
- [x] #967 — `recommended`/`persist` survive the ask wire to a real interactive session
- [x] #968 — the ask picker's question is bounded by the terminal budget and the badge gets its own line
- [x] #974 — the aggregator router declares prompt-cache support, so a router request carries its sticky-routing key and cache marker

Bump argued: **patch** → `0.54.15`. No single PR in this window clears the step-function bar on its own (all are fixes or small, contained features), and several patches in a window are still one patch.

The window will be re-derived from `git log v0.54.14..origin/main` immediately before tagging, per the release-mechanics warnings; anything that merges while this window is open is listed.

`Release:` lines added by the window owner from each PR's own summary where a merged PR carried none (#960, #965, #966, #967, #968, #974), and #952's malformed `Release: none` corrected to the documented shape — no impact is invented from commit subjects.
