### PR TITLE
fix(tui): keep the insert settle's promise so a resume page cannot wedge the paging gate

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1119,15 +1119,44 @@ class _PagingLease:
     will never complete — a wedged owner socket that no disconnect event
     reaches — so the next such request retires it rather than standing down
     against a gate that nothing will ever release. A holder that HAS mounted
-    is merely settling, and keeps its gate (F1): a dropped ``insert_blocks``
-    settle is a TranscriptView defect outside this path, and breaking that
-    lease would re-consume a cursor whose rows are already painted. A fetch
-    that has not yet returned is indistinguishable from a wedge, so the
-    request is also the reader's way out of a hung wait.
+    is merely settling, and keeps its gate (F1): breaking that lease would
+    re-consume a cursor whose rows are already painted. A fetch that has not
+    yet returned is indistinguishable from a wedge, so the request is also
+    the reader's way out of a hung wait.
+
+    ``mounted_view`` is what makes "merely settling" a CHECKABLE claim rather
+    than an assumption. A settling lease is released by the callback
+    ``insert_blocks`` scheduled on that view; if the view's message pump is
+    gone, that callback can never run and the lease is unsettleable — the
+    live-lock this field exists to make recoverable. ``insert_blocks`` now
+    honours its ``on_settled`` contract even on a closing pump, so no
+    first-party path should reach that state; this is the total answer for
+    the state machine rather than a second implementation of the release,
+    and it is why the escape reads the VIEW's liveness instead of a timeout.
     """
 
     source_token: str
     mounted: bool = False
+    mounted_view: Any | None = None
+
+    def can_settle(self) -> bool:
+        """Whether the callback that would release this lease can still run.
+
+        An unmounted lease is a fetch in flight: its release comes from the
+        fetch's own completion, not from a view, so it is never declared
+        unsettleable here (``_break_abandoned_paging_lease`` owns that case).
+        A mounted lease is answered by the view it painted into: a widget
+        whose pump is closed will never deliver another callback, so a gate
+        waiting on one is waiting forever.
+        """
+        if not self.mounted:
+            return True
+        view = self.mounted_view
+        if view is None:
+            return True
+        return bool(getattr(view, "is_mounted", True)) and not (
+            getattr(view, "_closing", False) or getattr(view, "_closed", False)
+        )
 
 
 def _resume_tail_start(history: list[Any], bound: int) -> int:
@@ -8829,6 +8858,17 @@ class OperatorApp(App[None]):
                 # including one started before a switch away and back. Filling
                 # resumes from that transaction's own settle callback rather
                 # than sending a second request against the same cursor (F1).
+                #
+                # Not a silent return, though: this attempt is over, and
+                # leaving `_resume_fill_active` set would tell
+                # `_reconcile_head_notice` a fill is still on its way to a
+                # better frame, which is the R6 skip — so the row keeps
+                # whatever copy it had rather than describing the geometry it
+                # actually has. The holder's own settle re-enters the fill
+                # (that is why filling is not restarted here); what this owes
+                # is an honest row in the meantime (AC3).
+                self._resume_fill_active = False
+                self._reconcile_head_notice()
                 return
             self.run_worker(
                 self._fetch_older_display_page(source, lease, on_settled=settled),
@@ -8919,8 +8959,12 @@ class OperatorApp(App[None]):
             # geometry (UX U1) and "click to load" looks idle while a load is
             # already underway (UX U3 / D2). Loading copy until a page mounts
             # is the honest state; a second click or ctrl+home may still
-            # retire the lease. A holder that HAS mounted is merely settling
-            # and falls through so R6's skip still applies.
+            # retire the lease. A holder that HAS mounted falls through so
+            # R6's skip still applies — either it is settling (its release is
+            # on its way) or its view is gone, in which case the ordinary
+            # "scroll up"/"click to load" copy is once again TRUE: an explicit
+            # ask retires an unsettleable lease (`_PagingLease.can_settle`)
+            # and proceeds to a real fetch rather than standing down.
             self._restate_head_notice(
                 notice,
                 RESUME_AUDIT_LOADING_NOTICE if audit else RESUME_LOADING_NOTICE,
@@ -9615,8 +9659,28 @@ class OperatorApp(App[None]):
         the gesture should now proceed to a fresh fetch.
         """
         lease = self._paging_leases.get(source.token)
-        if lease is None or lease.mounted:
+        if lease is None:
             return False
+        if lease.mounted and lease.can_settle():
+            # Merely settling, and its release can still arrive. Standing down
+            # is correct here and retiring would re-consume a cursor whose
+            # rows are already painted (F1).
+            return False
+        # Either nothing was ever mounted (the wedged-fetch case above), or a
+        # page WAS mounted into a view whose pump is gone, so the callback
+        # that releases this lease can never run. The second is the live-lock
+        # AC1 forbids: without this the gate stayed shut for the life of the
+        # app, `_resume_paging` stood every gesture down, and the head notice
+        # went on advertising a control that could not answer. The lease is
+        # keyed by SOURCE TOKEN, which outlives any one view, so a reader
+        # returning to that conversation inherited the dead gate too.
+        #
+        # Safe for the same reason the unmounted case is: the retired lease
+        # loses ownership, so a late completion releases nothing and publishes
+        # nothing. It is not a lost page either — the rows this lease mounted
+        # are already in `_resume_mounted_ids`, and the id dedupe in
+        # `_mount_older_resume_page` drops any that a re-issue delivers twice.
+        #
         # Cancel the wedged fetch's worker so its coroutine unwinds through
         # its own `finally` (which now releases nothing, having lost the gate)
         # rather than lingering against the retired lease.
@@ -9834,11 +9898,24 @@ class OperatorApp(App[None]):
             # are still answering must see a working transaction, not a
             # wedge. Mutated on this object so identity (F1) is unchanged.
             lease.mounted = True
+            # WHICH view owes this lease its release, so "still settling" can
+            # be checked rather than assumed. `insert_blocks` schedules the
+            # releasing callback on this widget; a later ask asserting the
+            # lease is merely settling is only entitled to stand down while
+            # that widget can still deliver it (`_PagingLease.can_settle`).
+            lease.mounted_view = transcript
             transcript.insert_blocks(index, blocks, on_settled=release_gate)
         else:
             # Hidden-only pages still yield; otherwise initial fill projects
             # several raw pages synchronously without letting input run.
-            transcript.call_after_refresh(release_gate)
+            #
+            # The SAME unkept promise as the insert path: `call_after_refresh`
+            # refuses on a closing pump and returns False rather than raising,
+            # so a hidden-only page mounted against a view that is going away
+            # left this source's lease held forever. Yield when the pump can
+            # still yield; release inline when it cannot.
+            if not transcript.call_after_refresh(release_gate):
+                release_gate()
 
     def _collect_resume_page_blocks(self, page: list[Any]) -> list[Any]:
         """Build the blocks for one deferred page WITHOUT mounting them.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1128,11 +1128,24 @@ class _PagingLease:
     than an assumption. A settling lease is released by the callback
     ``insert_blocks`` scheduled on that view; if the view's message pump is
     gone, that callback can never run and the lease is unsettleable — the
-    live-lock this field exists to make recoverable. ``insert_blocks`` now
-    honours its ``on_settled`` contract even on a closing pump, so no
-    first-party path should reach that state; this is the total answer for
-    the state machine rather than a second implementation of the release,
-    and it is why the escape reads the VIEW's liveness instead of a timeout.
+    live-lock this field exists to make recoverable.
+
+    NOT DEFENCE-IN-DEPTH FOR AN UNREACHABLE STATE — a first-party path
+    reaches it. ``insert_blocks`` honours its ``on_settled`` contract when
+    the post is REFUSED, which closes the route where the pump is already
+    closing at post time. It cannot close the other one: a post that
+    SUCCEEDS is forwarded to the screen's callback list and invoked on a
+    later refresh, so a teardown that lands between the post and that flush
+    drops the callback silently and strands the lease in exactly the same
+    state (review round 1, MAJOR-3). That race is accepted rather than
+    guarded, because the honest guard would be a second implementation of
+    the release racing the first. What makes it acceptable is this field:
+    ``can_settle()`` answers False there, so one further explicit ask
+    retires the lease and the reader is out — inconvenienced by one click,
+    never wedged. So this escape is the PRIMARY mechanism for that race, and
+    anyone tempted to delete it as dead code should read this paragraph
+    first. Reading the VIEW's liveness rather than a timeout is what keeps
+    the answer deterministic.
     """
 
     source_token: str
@@ -1148,15 +1161,35 @@ class _PagingLease:
         A mounted lease is answered by the view it painted into: a widget
         whose pump is closed will never deliver another callback, so a gate
         waiting on one is waiting forever.
+
+        THE TERM IS THE PUMP'S OWN, and deliberately NOT ``is_mounted``.
+        ``Widget._is_mounted`` is set in the pump's ``_pre_process``, which
+        runs a tick AFTER ``mount()`` — so a freshly mounted, fully live view
+        reports ``is_mounted=False`` while ``post_message`` still returns
+        True. Reading it here answered "unsettleable" for a view that would
+        in fact deliver the callback, which errs in the F1-VIOLATING
+        direction: an explicit ask landing in that window would retire a
+        lease whose settle was still coming and let a second fetch re-consume
+        the cursor (review round 1, MAJOR-2). The id dedupe covers duplicate
+        rows, not a duplicate request.
+
+        ``_closing``/``_closed`` are the exact flags ``post_message`` itself
+        tests, so this predicate and the refusal it reasons about read the
+        same state. ``parent is None`` covers a view detached without its
+        pump having closed yet. Both are private to Textual (pinned
+        ``textual>=8.0.0``, verified against 8.2.8); the ``getattr`` defaults
+        mean a rename degrades to "assume live", which is the FAIL-SAFE
+        direction — it restores the pre-fix stand-down rather than inventing
+        an F1 violation (review round 1, NIT-1).
         """
         if not self.mounted:
             return True
         view = self.mounted_view
         if view is None:
             return True
-        return bool(getattr(view, "is_mounted", True)) and not (
-            getattr(view, "_closing", False) or getattr(view, "_closed", False)
-        )
+        if getattr(view, "_closing", False) or getattr(view, "_closed", False):
+            return False
+        return getattr(view, "parent", object()) is not None
 
 
 def _resume_tail_start(history: list[Any], bound: int) -> int:
@@ -8779,7 +8812,22 @@ class OperatorApp(App[None]):
             if self._resume_fill_active:
                 self._fill_resume_until_scrollable(target=target)
 
-        view.call_after_refresh(start)
+        if not view.call_after_refresh(start):
+            # SAME UNKEPT PROMISE as the insert seam, one screen away: the
+            # flag above is raised BEFORE the post, and `call_after_refresh`
+            # returns False on a closing pump rather than raising. A refused
+            # post therefore stranded `_resume_fill_active = True` with no
+            # fill in flight, which is exactly the R6 skip inverted —
+            # `_reconcile_head_notice` is told a better frame is on its way
+            # and keeps stale copy forever (review round 1, MAJOR-4).
+            #
+            # Cleared rather than run inline: `start` exists to measure
+            # geometry AFTER a refresh, and a pump that will not deliver it
+            # will not paint either, so there is no frame to fill. Standing
+            # the fill down and restating the row from the geometry that
+            # actually exists is the honest answer.
+            self._resume_fill_active = False
+            self._reconcile_head_notice()
 
     def _fill_resume_until_scrollable(
         self, _attempt: int = 0, *, target: float | None = None
@@ -8856,17 +8904,28 @@ class OperatorApp(App[None]):
             if lease is None:
                 # A prior transaction for this source is still outstanding —
                 # including one started before a switch away and back. Filling
-                # resumes from that transaction's own settle callback rather
-                # than sending a second request against the same cursor (F1).
+                # must not send a second request against the same cursor (F1).
                 #
-                # Not a silent return, though: this attempt is over, and
-                # leaving `_resume_fill_active` set would tell
-                # `_reconcile_head_notice` a fill is still on its way to a
-                # better frame, which is the R6 skip — so the row keeps
-                # whatever copy it had rather than describing the geometry it
-                # actually has. The holder's own settle re-enters the fill
-                # (that is why filling is not restarted here); what this owes
-                # is an honest row in the meantime (AC3).
+                # DEFENSIVE, AND CURRENTLY UNREACHABLE. `_resume_paging` is
+                # `token in self._paging_leases`, which is the exact condition
+                # `_acquire_paging_lease` refuses on, and the guard at the top
+                # of this method has already returned on it. There is no
+                # `await` and no lease mutation in between, so today this
+                # cannot be None (review round 1, MINOR-1). It is kept rather
+                # than deleted because the guard and the acquire are separated
+                # by ~80 lines and a future yield between them would make the
+                # window real — a total state machine should not depend on
+                # that distance.
+                #
+                # If it is ever reached, it stands the fill down and restates
+                # the row rather than returning silently: leaving
+                # `_resume_fill_active` set would tell `_reconcile_head_notice`
+                # a better frame is on its way (the R6 skip) and the copy would
+                # go stale. Deliberately NOT claiming the holder's settle
+                # re-enters the fill — an earlier version of this comment did,
+                # and it was wrong: `settled()` guards on `_resume_fill_active`,
+                # which this branch has just cleared, so the demand ends here
+                # and the reader's next gesture re-arms it.
                 self._resume_fill_active = False
                 self._reconcile_head_notice()
                 return
@@ -9641,8 +9700,14 @@ class OperatorApp(App[None]):
         from this side of the gate, so the ask is also the way out of a hung
         wait. A holder that HAS mounted is merely settling, and keeping that
         gate is F1: retiring it would let a second fetch re-consume the same
-        cursor. A dropped ``insert_blocks`` settle is a TranscriptView defect
-        outside this path and is deliberately not retired here.
+        cursor. That deference is conditional on the settle being ABLE to
+        arrive — a lease mounted into a view whose pump is gone is retired
+        here, because nothing will ever release it (see
+        ``_PagingLease.can_settle``). This docstring used to say such a
+        settle was "a TranscriptView defect outside this path"; it is now
+        handled at that seam AND recoverable here, and the stale sentence is
+        removed rather than left to justify reverting the fix (review round
+        1, MINOR-2).
 
         The replacement inherits ``_older_page_retries`` for this source: the
         budget is against a moving window, not a particular transaction, so a
@@ -9727,14 +9792,37 @@ class OperatorApp(App[None]):
             if self._sidebar_navigation.generation == generation:
                 self._check_resume_page()
 
+        def post_check() -> bool:
+            """Queue ``run_check``, reporting whether the pump accepted it."""
+            return view.call_after_refresh(run_check)
+
+        def defer_check() -> None:
+            # The inner hop can be refused on its own, once the outer one has
+            # already been delivered, so it carries the same clear.
+            if not post_check():
+                self._resume_check_pending = False
+
         if upward is not None:
             # Keyboard scroll helpers enqueue their actual motion after the
             # refresh too. Our input hook runs first to release tail-follow;
             # checking in that same callback batch would retire the demand
             # before Home/PageUp had even installed its animation target.
-            view.call_after_refresh(lambda: view.call_after_refresh(run_check))
+            queued = view.call_after_refresh(defer_check)
         else:
-            view.call_after_refresh(run_check)
+            queued = post_check()
+        if not queued:
+            # THE WORST OF THE THREE, because it needs no lease at all.
+            # `_resume_check_pending` is raised before the post and cleared
+            # only inside `run_check`; a refused post latched it True, and the
+            # guard above then returned early on EVERY subsequent scroll — the
+            # wheel dead permanently while the notice click still worked,
+            # which is the operator's reported symptom reached without any
+            # paging lease being involved (review round 1, MAJOR-4; QA Q1).
+            #
+            # A demand that cannot be scheduled is not retained: the reader's
+            # next gesture re-arms it, which is the same contract a delivered
+            # `run_check` honours when it finds the view superseded.
+            self._resume_check_pending = False
 
     def _check_resume_page(self, *, force: bool = False) -> None:
         """Spend one demand only after motion settles in the prefetch zone.

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -2587,6 +2587,26 @@ class SubagentView(Vertical):
                 # the insert even mounted) makes the window match
                 # `_resume_paging`'s on the parent view, which is held by the
                 # same callback.
+                # RAISED BEFORE THE INSERT, not after it. `insert_blocks`
+                # keeps its `on_settled` promise even when the pump refuses
+                # the callback it would normally schedule, in which case the
+                # callback runs INLINE, before this call returns. Setting the
+                # flag afterwards therefore re-raised it on top of
+                # `_finish_history_mount`'s clear and left the page wedged on
+                # "loading earlier…" with no read in flight and no gesture
+                # able to re-open it (`_history_loading` gates both
+                # `_maybe_load_history` and `_note_history_gesture`).
+                #
+                # Hoisting is order-preserving for every other reader: the
+                # flag was already True on entry from `_maybe_load_history`
+                # and is cleared by `_apply_history_page` a few frames above,
+                # so the only window this moves is the synchronous span
+                # between here and the insert — during which nothing repaints.
+                # The ordering constraint in `_finish_history_mount`'s
+                # docstring still holds: the flag is continuously True from
+                # before the insert until the settle clears it, so
+                # `_history_state_text` can never observe it down mid-mount.
+                self._history_loading = True
                 self._body.insert_blocks(
                     prefix,
                     new_blocks,
@@ -2611,15 +2631,19 @@ class SubagentView(Vertical):
                         )
                     ),
                 )
-                # Re-raised for the duration of the insert: see the comment
-                # above. Cleared again by `_finish_history_mount`.
-                # NOTE: this MUST NOT be visible to `_history_state_text`
-                # before the reconcile below has run — `show()` repaints the
-                # hint from `_history_loading` and a True here paints
-                # "loading earlier…" over the just-settled "transcript
-                # start". `_finish_history_mount` re-paints on clear, so the
-                # hint always ends at the settled text.
-                self._history_loading = True
+                # The flag is raised ABOVE the insert (see there). It must not
+                # be re-raised here: on the inline-settle path
+                # `_finish_history_mount` has already run and cleared it, and
+                # writing True back over that clear is the wedge this ordering
+                # exists to avoid.
+                #
+                # The constraint the old comment recorded is unchanged and
+                # still satisfied: the flag MUST NOT be visible to
+                # `_history_state_text` before the reconcile below has run —
+                # `show()` repaints the hint from `_history_loading` and a
+                # True here paints "loading earlier…" over the just-settled
+                # "transcript start". `_finish_history_mount` re-paints on
+                # clear, so the hint always ends at the settled text.
                 self._blocks[prefix:prefix] = new_blocks
                 self._entries[prefix:prefix] = new_entries
                 self._pending = entries

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -3607,6 +3607,18 @@ class TranscriptView(ScrollableContainer):
             # are already mounted and `_reanchor_insert` above has already
             # taken the offset correction that matters for a frame anyone can
             # still see.
+            #
+            # INLINE MAKES THE RESUME FILL CHAIN SYNCHRONOUS, and what keeps
+            # that safe is `RESUME_FILL_MAX_PAGES`. `release_gate` → the
+            # fill's `on_settled` → the next `_mount_older_resume_page` then
+            # runs in one stack instead of one page per refresh (measured with
+            # every settle refused: 16 mounts, max depth 154, no
+            # `RecursionError`). That is the unbounded mid-interaction render
+            # cost the one-page-per-gesture bound exists to prevent — but it
+            # is only reachable once the pump is dead, i.e. when no frame will
+            # be painted and nobody is waiting on one, and the page cap bounds
+            # it regardless (review round 1, MINOR-3). Anyone raising that cap
+            # should re-measure this path.
             if on_settled is not None:
                 on_settled()
 

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -3574,9 +3574,41 @@ class TranscriptView(ScrollableContainer):
                     if on_settled is not None:
                         on_settled()
 
-            self.call_after_refresh(restore_anchor)
+            if not self.call_after_refresh(restore_anchor):
+                # The pump closed between the settle and the restore. Same
+                # contract as below: `on_settled` is owed unconditionally, and
+                # the offset correction it would have followed is moot on a
+                # view that will never paint again.
+                if on_settled is not None:
+                    on_settled()
 
-        self.call_after_refresh(settle_then_restore)
+        if not self.call_after_refresh(settle_then_restore):
+            # `call_after_refresh` POSTS A MESSAGE, and `post_message` returns
+            # False for a pump that is closing or closed — it does not raise
+            # and it does not queue. Ignoring that return made `on_settled` a
+            # promise this method could silently fail to keep, and its one
+            # production caller (`_mount_older_resume_page`) hands it the
+            # release of a single-flight paging lease that has ALREADY been
+            # flagged mounted. A dropped settle therefore stranded that lease
+            # in `_paging_leases` forever: `_resume_paging` stayed True for
+            # the source token (which outlives this view), every later scroll
+            # and click stood down against it, and
+            # `_break_abandoned_paging_lease` refuses a mounted lease by
+            # design — a permanently dead "older messages above" control.
+            #
+            # Reached without any fault of the caller's: `_release_sidebar_
+            # preparation` awaits `view.remove()` on a presentation the
+            # navigation did not keep, which closes the pump under an
+            # in-flight page.
+            #
+            # Called INLINE rather than dropped, because the callback's own
+            # purpose — gaps settled, anchor restored — is unreachable on a
+            # dead pump, while the caller's gate still has to open. The blocks
+            # are already mounted and `_reanchor_insert` above has already
+            # taken the offset correction that matters for a frame anyone can
+            # still see.
+            if on_settled is not None:
+                on_settled()
 
     def append_block(self, block: TranscriptBlock) -> None:
         """Mount ``block`` at the bottom.

--- a/scripts/resume_paging_shot.py
+++ b/scripts/resume_paging_shot.py
@@ -23,6 +23,13 @@ FRAME is one of:
                  observation, so the ``mount-*`` frames show a displaced paint
                  as though it never happened. Pre-fix, ``paint-1`` sits a page
                  below ``paint-0``; post-fix every paint is identical.
+    wedged       the head notice after a page whose insert settle was DROPPED
+                 and five subsequent clicks. ``call_after_refresh`` is
+                 ``post_message``, which returns False on a closing pump, so a
+                 view removed under an in-flight page left its paging lease
+                 mounted and unreleasable. Pre-fix this frame is frozen — the
+                 row still reads "older messages above" and the five clicks
+                 moved nothing; post-fix the gate reopens and the clicks page.
 """
 
 from __future__ import annotations
@@ -41,6 +48,7 @@ from scripts.visual_capture import isolate_capture, save_capture  # noqa: E402
 isolate_capture()
 
 from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.session_presentation import OlderHistoryNotice  # noqa: E402
 from local_operator.tui.widgets.transcript import TranscriptView  # noqa: E402
 from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
 
@@ -49,7 +57,14 @@ FRAMES = [
     "scrolled",
     *[f"mount-{i}" for i in range(4)],
     *[f"paint-{i}" for i in range(4)],
+    "wedged",
 ]
+
+#: How many times the ``wedged`` frame activates the head notice before the
+#: capture. The operator's report was "clicked it and nothing happened", so
+#: one click would not distinguish a slow page from a dead control; five
+#: establishes that no number of asks recovers the pre-fix state.
+_WEDGED_CLICKS = 5
 
 
 def _history(steps: int = 200, followups: int = 1) -> list[Any]:
@@ -152,6 +167,42 @@ async def capture(path: Path, frame: str, size: tuple[int, int]) -> None:
         view = app.query_one(TranscriptView)
 
         if frame == "scrolled":
+            view.note_user_scroll()
+            view.scroll_home(animate=False)
+            for _ in range(12):
+                await pilot.pause()
+        elif frame == "wedged":
+            # Refuse EXACTLY the settle `insert_blocks` schedules, once. That
+            # is not a contrivance: it is the same False Textual's
+            # `post_message` returns when `_release_sidebar_preparation`
+            # removes a transcript under a page that has already flagged its
+            # lease mounted. Arming it this way keeps the capture in one
+            # process and off the sidebar's whole navigation path.
+            real = view.call_after_refresh
+            armed = {"hit": False}
+
+            def refuse(callback, *callback_args, **callback_kwargs):
+                name = getattr(callback, "__name__", "")
+                if not armed["hit"] and name == "settle_then_restore":
+                    armed["hit"] = True
+                    return False
+                return real(callback, *callback_args, **callback_kwargs)
+
+            view.call_after_refresh = refuse  # type: ignore[method-assign]
+            app._mount_older_resume_page()
+            view.call_after_refresh = real  # type: ignore[method-assign]
+            for _ in range(60):
+                await pilot.pause()
+            if not armed["hit"]:
+                raise SystemExit("the settle was never refused; the hazard was not armed")
+            notice = app._resume_head_notice
+            for _ in range(_WEDGED_CLICKS):
+                if isinstance(notice, OlderHistoryNotice):
+                    notice.post_message(OlderHistoryNotice.Requested(notice))
+                for _ in range(60):
+                    await pilot.pause()
+            # At the top, where the notice is, so the frame shows the row the
+            # reader was clicking rather than the tail they never left.
             view.note_user_scroll()
             view.scroll_home(animate=False)
             for _ in range(12):

--- a/scripts/resume_paging_shot.py
+++ b/scripts/resume_paging_shot.py
@@ -30,6 +30,20 @@ FRAME is one of:
                  mounted and unreleasable. Pre-fix this frame is frozen — the
                  row still reads "older messages above" and the five clicks
                  moved nothing; post-fix the gate reopens and the clicks page.
+    loading      the head notice while an UNMOUNTED lease holds the gate, i.e.
+                 ``loading older messages…``. It exists because that copy is
+                 the state this fix is most about and it had never been seen
+                 on a painted frame: a synthetic session settles inside one
+                 paint, so exporting "during" a real load captures the settled
+                 row instead (design review round 1, D4). The lease is taken
+                 and HELD here rather than the fetch being slowed, so the row
+                 is painted from the same ``_reconcile_head_notice`` branch a
+                 real in-flight fetch drives.
+    unreachable  the head notice in its ``— click to load`` state: more
+                 history exists and the frame cannot scroll to it, so the row
+                 offers itself as the control. Reached by suppressing the
+                 geometry fill, which is what the tall-viewport case does in
+                 practice (design review round 1, D3).
 """
 
 from __future__ import annotations
@@ -58,6 +72,8 @@ FRAMES = [
     *[f"mount-{i}" for i in range(4)],
     *[f"paint-{i}" for i in range(4)],
     "wedged",
+    "loading",
+    "unreachable",
 ]
 
 #: How many times the ``wedged`` frame activates the head notice before the
@@ -203,10 +219,92 @@ async def capture(path: Path, frame: str, size: tuple[int, int]) -> None:
                     await pilot.pause()
             # At the top, where the notice is, so the frame shows the row the
             # reader was clicking rather than the tail they never left.
+            #
+            # ASK REPEATEDLY, AND ASSERT. One `scroll_home` is enough on the
+            # broken branch (nothing loads, so nothing moves) and NOT enough
+            # on the fixed one: reaching the head reopens the gate, every
+            # recovered page mounts above the reader, and the anchor restore
+            # holds their rows — which puts the offset back where it was. The
+            # single-shot version therefore captured the "after" frame with
+            # the notice 46 rows above the viewport, so the evidence for a
+            # fix to a ROW did not contain that row and a reader could not
+            # tell repair from removal (design review round 1, D1).
             view.note_user_scroll()
-            view.scroll_home(animate=False)
-            for _ in range(12):
+            for _ in range(60):
+                view.scroll_home(animate=False)
                 await pilot.pause()
+                head = app._resume_head_notice
+                if view.scroll_y <= 0.5 and head is not None and head.region.y >= 0:
+                    break
+            for _ in range(4):
+                await pilot.pause()
+            head = app._resume_head_notice
+            # The script must never again silently produce a frame without its
+            # subject: a capture that cannot show the row is a failed capture,
+            # not a frame to be published with a caption explaining it away.
+            if head is None or head.region.y < 0:
+                where = None if head is None else head.region.y
+                raise SystemExit(
+                    f"the head notice is not in the viewport (y={where}); "
+                    f"the frame would not show its subject"
+                )
+        elif frame in ("loading", "unreachable"):
+            # Both states are decided by `_reconcile_head_notice` from the
+            # CURRENT lease and geometry, so each is reached by establishing
+            # that state and letting the production funnel restate the row —
+            # never by writing the copy onto the widget, which would prove
+            # only that the string exists.
+            if frame == "loading":
+                # An UNMOUNTED lease is the "a fetch is in flight" state. Held
+                # for the capture instead of racing a real fetch: on a
+                # synthetic session the round trip settles within one paint,
+                # so every attempt to export mid-load exported the settled row.
+                lease = app._acquire_paging_lease(app._interaction)
+                if lease is None:
+                    raise SystemExit("the paging gate was already held; cannot stage `loading`")
+            else:
+                # `RESUME_UNREACHABLE_NOTICE` needs more-exists AND an
+                # unscrollable frame AND no fill in flight. The fill is what
+                # normally prevents it, so stand it down and shrink the
+                # content back to fit — the same end state a very tall
+                # viewport reaches with the fill capped.
+                # Strip everything below the notice so the content no longer
+                # exceeds the viewport, which is the `not scrollable` half of
+                # the state. The deferred head is untouched, so "more exists"
+                # stays true — exactly the combination a very tall viewport
+                # produces when the fill cannot outgrow the screen.
+                for block in list(view.blocks())[1:]:
+                    view.remove_block(block)
+                # Let the extent shrink before anything reads it. The offset
+                # follows on its own once the canvas is one viewport tall;
+                # scrolling here instead would move against the OLD extent.
+                for _ in range(20):
+                    await pilot.pause()
+                # Cleared last, so a fill in flight cannot re-arm it while the
+                # rows are being taken out from under it.
+                app._resume_fill_active = False
+            if frame == "loading":
+                # The `loading` frame keeps its full transcript, so the notice
+                # has to be scrolled back into view. `unreachable` deliberately
+                # skips this: its canvas is already one viewport tall (nothing
+                # to scroll), and `note_user_scroll` would re-arm the demand
+                # this state is defined by the absence of.
+                view.note_user_scroll()
+                view.scroll_home(animate=False)
+                for _ in range(8):
+                    await pilot.pause()
+            app._reconcile_head_notice()
+            for _ in range(8):
+                await pilot.pause()
+            head = app._resume_head_notice
+            # Assert the state actually painted: a frame captioned with a copy
+            # it does not contain is worse than no frame (D1's lesson).
+            wanted = "loading older messages" if frame == "loading" else "click to load"
+            if head is None or wanted not in head.text() or head.region.y < 0:
+                raise SystemExit(
+                    f"expected {wanted!r} on screen, got "
+                    f"{None if head is None else (head.text(), head.region.y)}"
+                )
         elif frame.startswith("paint-"):
             # Same parking as `mount-*`, but the SVG is exported from inside
             # the compositor refresh — the moment the terminal is written —

--- a/tests/unit/tui/test_resume_render.py
+++ b/tests/unit/tui/test_resume_render.py
@@ -1749,3 +1749,129 @@ async def test_a_user_aborted_call_restores_the_duration_it_ran_for() -> None:
     assert cards[0]._state == "interrupted"
     assert cards[0]._duration == pytest.approx(2.5)
     assert "2.5s" in cards[0]._build_row(100).plain
+
+
+@pytest.mark.asyncio
+async def test_a_dropped_insert_settle_still_releases_the_paging_gate() -> None:
+    """``insert_blocks`` owes ``on_settled`` even when its refresh never comes.
+
+    THE DEFECT THIS PINS. ``call_after_refresh`` is ``post_message``, and
+    ``post_message`` RETURNS FALSE for a pump that is closing or closed — it
+    does not raise and it does not queue. ``insert_blocks`` ignored that
+    return, which made ``on_settled`` a promise it could silently fail to
+    keep. Its one production caller is ``_mount_older_resume_page``, which
+    hands it the release of the single-flight paging lease AFTER flagging
+    that lease ``mounted``. So a dropped settle stranded the lease in
+    ``_paging_leases`` permanently:
+
+    * ``_resume_paging`` stayed True for the source token, which outlives any
+      one view, so a reader returning to that conversation inherited it;
+    * ``_check_resume_page`` returned at ``not in_zone or _resume_paging``;
+    * ``_break_abandoned_paging_lease`` refused, by design, to retire a
+      MOUNTED lease;
+    * ``_reconcile_head_notice`` paints loading copy only for an UNMOUNTED
+      lease, so the row went on saying "older messages above".
+
+    The reader is then left with a control that answers nothing, for the life
+    of the app — reproduced against the operator's real 731-row journal, where
+    five clicks and ``ctrl+home`` all moved zero rows.
+
+    Reached here the way a real teardown reaches it: refuse exactly the settle
+    the insert schedules, once, which is the same False Textual returns when
+    ``_release_sidebar_preparation`` removes a view under an in-flight page.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(200, followups=1)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _wait_for_resume(pilot, app)
+        for _ in range(60):
+            await pilot.pause()
+        view = app.query_one(TranscriptView)
+        token = app._interaction.token
+        assert app._resume_pending_head, "nothing deferred: the gate cannot be armed"
+        assert token not in app._paging_leases
+
+        real = view.call_after_refresh
+        refused = {"hit": False}
+
+        def refuse(callback, *args, **kwargs):
+            if not refused["hit"] and getattr(callback, "__name__", "") == "settle_then_restore":
+                refused["hit"] = True
+                return False
+            return real(callback, *args, **kwargs)
+
+        view.call_after_refresh = refuse  # type: ignore[assignment]
+        app._mount_older_resume_page()
+        view.call_after_refresh = real  # type: ignore[assignment]
+        for _ in range(80):
+            await pilot.pause()
+
+        assert refused["hit"], "the settle was never refused; the hazard was not armed"
+        # THE INVARIANT: the gate is open. Pre-fix this held a mounted lease
+        # forever and every assertion below failed in sequence.
+        assert token not in app._paging_leases
+        assert app._resume_paging is False
+
+        # And the affordance still answers, which is the user-visible half:
+        # the head notice is a control, and activating it must make the head
+        # progress rather than stand down against a gate nothing will release.
+        notice = app._resume_head_notice
+        assert isinstance(notice, OlderHistoryNotice)
+        before = len(app._resume_pending_head)
+        blocks_before = len(view.blocks())
+        notice.post_message(OlderHistoryNotice.Requested(notice))
+        for _ in range(120):
+            await pilot.pause()
+        assert (
+            len(app._resume_pending_head) < before
+        ), "activating the head notice after a dropped settle loaded nothing"
+        assert len(view.blocks()) > blocks_before
+
+
+@pytest.mark.asyncio
+async def test_an_unsettleable_mounted_lease_is_recoverable_by_an_explicit_ask() -> None:
+    """AC1's other half: a gate whose release provably cannot arrive.
+
+    ``_break_abandoned_paging_lease`` refuses a MOUNTED lease because a holder
+    that has painted rows is normally just settling, and retiring it would let
+    a second fetch re-consume a cursor whose rows are already on screen (F1).
+    That reasoning is sound only while the settle can still run. A lease
+    mounted into a view whose pump is gone can never be released by it, and
+    the old predicate could not tell the two apart — so it stood the reader
+    down forever rather than for a frame.
+
+    ``_PagingLease.can_settle`` makes that a CHECKABLE question by recording
+    which view owes the release, so the state machine is total: every "no" is
+    either recoverable or honestly reported.
+
+    The F1 guarantee is pinned in the same breath — a mounted lease whose view
+    is alive is still refused, which is what
+    ``test_a_mounted_lease_survives_a_second_click`` asserts from the other
+    side.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(200, followups=1)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _wait_for_resume(pilot, app)
+        for _ in range(60):
+            await pilot.pause()
+        view = app.query_one(TranscriptView)
+        source = app._interaction
+
+        lease = app._acquire_paging_lease(source)
+        assert lease is not None
+        lease.mounted = True
+        lease.mounted_view = view
+        # A live view owes a release that can still arrive: refuse (F1).
+        assert lease.can_settle() is True
+        assert app._break_abandoned_paging_lease(source) is False
+        assert app._paging_leases.get(source.token) is lease
+
+        # The same lease against a view that can never deliver it again.
+        await view.remove()
+        assert lease.can_settle() is False
+        assert app._break_abandoned_paging_lease(source) is True
+        assert source.token not in app._paging_leases
+        assert app._resume_paging is False

--- a/tests/unit/tui/test_resume_render.py
+++ b/tests/unit/tui/test_resume_render.py
@@ -107,6 +107,29 @@ async def _press_and_settle(pilot, view: TranscriptView, key: str) -> None:
             return
 
 
+def _wheel_up_transcript(view: TranscriptView) -> None:
+    """One real upward wheel notch, through the widget's own input surface.
+
+    Posted rather than synthesised on the app so it routes through
+    `note_user_scroll` and the page-back latch exactly as a hand on a mouse
+    does — which is the whole point when the assertion is "the wheel still
+    pages".
+    """
+    view.post_message(
+        MouseScrollUp(
+            widget=view,
+            button=0,
+            shift=False,
+            meta=False,
+            ctrl=False,
+            x=10,
+            y=10,
+            delta_x=0,
+            delta_y=-1,
+        )
+    )
+
+
 async def _wait_for_resume(pilot, app: OperatorApp, *, min_blocks: int = 1) -> None:
     """Boot paints, then a worker adopts the session and replays history.
 
@@ -1875,3 +1898,194 @@ async def test_an_unsettleable_mounted_lease_is_recoverable_by_an_explicit_ask()
         assert app._break_abandoned_paging_lease(source) is True
         assert source.token not in app._paging_leases
         assert app._resume_paging is False
+
+
+@pytest.mark.asyncio
+async def test_a_mounted_lease_on_a_live_view_is_never_retired() -> None:
+    """F1, pinned against the LIVE-VIEW evaluation of ``can_settle``.
+
+    ``test_a_mounted_lease_survives_a_second_click`` asserts the same refusal
+    but sets only ``mounted``, so it exits through ``can_settle``'s
+    ``view is None`` early return and never reaches the predicate that reads a
+    real widget. This one does, and it covers the window that made the first
+    version of that predicate wrong: ``Widget._is_mounted`` is set in the
+    pump's ``_pre_process``, a tick AFTER ``mount()``, so a freshly mounted
+    and fully live view reports ``is_mounted=False`` while ``post_message``
+    still returns True. Keying on it answered "unsettleable" for a view that
+    would deliver the callback — retiring a lease whose settle was still
+    coming, which is the F1 violation ``mounted_view`` exists to prevent
+    (review round 1, MAJOR-2).
+
+    The assertion is therefore tied to the pump's OWN terms: whenever the view
+    would still accept a post, the lease must be refused.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(200, followups=1)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _wait_for_resume(pilot, app)
+        for _ in range(60):
+            await pilot.pause()
+        source = app._interaction
+
+        # Mount WITHOUT awaiting: awaiting drains the pump and closes the very
+        # window under test. This is the state a caller sees between `mount()`
+        # and the pump's first `_pre_process`.
+        view = TranscriptView(id="probe-transcript")
+        app.screen.mount(view)
+        lease = app._acquire_paging_lease(source)
+        assert lease is not None
+        lease.mounted = True
+        lease.mounted_view = view
+
+        # The window under test: immediately after mount, BEFORE the pump's
+        # first `_pre_process`. The old predicate answered False here.
+        assert view.post_message(Key("ignored-probe", None)) is True
+        assert lease.can_settle() is True, (
+            "a view whose pump still accepts posts was reported unsettleable; "
+            "an explicit ask would retire a lease whose settle is still coming"
+        )
+        assert app._break_abandoned_paging_lease(source) is False
+        assert app._paging_leases.get(source.token) is lease
+
+        # And after it has fully settled, which the old predicate also allowed.
+        for _ in range(10):
+            await pilot.pause()
+        assert lease.can_settle() is True
+        assert app._break_abandoned_paging_lease(source) is False
+
+        # Only a pump that will genuinely never deliver flips it.
+        await view.remove()
+        assert lease.can_settle() is False
+        assert app._break_abandoned_paging_lease(source) is True
+
+
+@pytest.mark.asyncio
+async def test_a_refused_scroll_check_post_does_not_latch_the_wheel_dead() -> None:
+    """``_resume_check_pending`` must not survive a post that was refused.
+
+    The sibling of the insert-seam defect, and the worse one, because it needs
+    NO paging lease at all. ``_transcript_scrolled`` raises
+    ``_resume_check_pending`` and then posts ``run_check``, which is the only
+    thing that clears it. ``call_after_refresh`` returns False on a closing
+    pump, so a refused post latched the flag True — and the guard at the top
+    of the method then returned early on EVERY subsequent scroll. The wheel
+    was dead permanently while the notice click still worked, which is the
+    operator's reported symptom reached with an empty ``_paging_leases``
+    (review round 1, MAJOR-4; QA Q1).
+
+    A demand that cannot be scheduled is not retained; the reader's next
+    gesture re-arms it.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(200, followups=1)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _wait_for_resume(pilot, app)
+        for _ in range(60):
+            await pilot.pause()
+        view = app.query_one(TranscriptView)
+        view.note_user_scroll()
+        view.scroll_to(y=0, animate=False, immediate=True)
+        for _ in range(10):
+            await pilot.pause()
+        assert not app._paging_leases, "this defect must be shown with no lease held"
+
+        real = view.call_after_refresh
+        refused = {"n": 0}
+
+        def refuse(callback, *args, **kwargs):
+            # Refuse the scroll check's own posts (the outer deferral and the
+            # inner hop), and nothing else.
+            name = getattr(callback, "__name__", "")
+            if name in ("run_check", "defer_check", "post_check") or (
+                name == "<lambda>" and refused["n"] == 0
+            ):
+                refused["n"] += 1
+                return False
+            return real(callback, *args, **kwargs)
+
+        view.call_after_refresh = refuse  # type: ignore[assignment]
+        app._transcript_scrolled(True)
+        view.call_after_refresh = real  # type: ignore[assignment]
+        for _ in range(20):
+            await pilot.pause()
+
+        assert refused["n"], "the scroll check's post was never refused; hazard not armed"
+        # THE INVARIANT. Pre-fix this stayed True and every later scroll
+        # returned early at `_transcript_scrolled`'s own guard.
+        assert app._resume_check_pending is False
+        assert not app._paging_leases
+
+        # And the wheel still ARMS a check, which is what the latch killed.
+        # Deliberately asserted on the demand rather than on a loaded page:
+        # whether a given notch earns a page depends on the trigger zone
+        # (`RESUME_PAGE_TRIGGER_ROWS`), and the settled fill parks the reader
+        # below it — measured identically on an unarmed run, so asserting a
+        # page here would pin the trigger geometry, not this defect. The
+        # latch's signature is that `_transcript_scrolled` returns at its own
+        # guard before ever reaching `_check_resume_page`; that a later notch
+        # can still reach it is exactly what was lost.
+        reached = {"n": 0}
+        real_check = app._check_resume_page
+
+        def counting_check(*, force: bool = False) -> None:
+            reached["n"] += 1
+            real_check(force=force)
+
+        app._check_resume_page = counting_check  # type: ignore[assignment]
+        view.note_user_scroll()
+        view.scroll_to(y=0, animate=False, immediate=True)
+        for _ in range(10):
+            await pilot.pause()
+        for _ in range(3):
+            _wheel_up_transcript(view)
+            for _ in range(40):
+                await pilot.pause()
+        app._check_resume_page = real_check  # type: ignore[assignment]
+        assert reached["n"], (
+            "no scroll reached `_check_resume_page` after a refused post: "
+            "`_resume_check_pending` is still latching the wheel dead"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_refused_fill_start_post_does_not_strand_the_fill_flag() -> None:
+    """``_resume_fill_active`` must not survive a post that was refused.
+
+    ``_start_resume_fill`` raises the flag before posting ``start``, and only
+    a delivered ``start`` (or a fill exit it leads to) lowers it again. A
+    refused post therefore stranded it True with no fill in flight — which is
+    the R6 skip inverted: ``_reconcile_head_notice`` is told a better frame is
+    on its way and keeps stale copy indefinitely (review round 1, MAJOR-4).
+
+    The honest answer on a pump that will not deliver a callback, and
+    therefore will not paint, is to stand the fill down and restate the row
+    from the geometry that actually exists.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(200, followups=1)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _wait_for_resume(pilot, app)
+        for _ in range(60):
+            await pilot.pause()
+        view = app.query_one(TranscriptView)
+
+        real = view.call_after_refresh
+        refused = {"hit": False}
+
+        def refuse(callback, *args, **kwargs):
+            if not refused["hit"] and getattr(callback, "__name__", "") == "start":
+                refused["hit"] = True
+                return False
+            return real(callback, *args, **kwargs)
+
+        view.call_after_refresh = refuse  # type: ignore[assignment]
+        app._start_resume_fill()
+        view.call_after_refresh = real  # type: ignore[assignment]
+        for _ in range(20):
+            await pilot.pause()
+
+        assert refused["hit"], "the fill's start post was never refused; hazard not armed"
+        assert app._resume_fill_active is False

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -5189,3 +5189,80 @@ async def test_a_follower_renders_the_delegated_brief_once_not_twice(tmp_path, m
         page = " ".join(view.rendered_rows())
         assert "SYSTEM PREAMBLE" not in page
         assert page.count(concise) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_dropped_prepend_settle_does_not_wedge_the_history_gate(tmp_path) -> None:
+    """``_history_loading`` must not outlive an insert whose settle was dropped.
+
+    ``TranscriptView.insert_blocks`` keeps its ``on_settled`` promise even when
+    the pump refuses the callback it would normally schedule — in which case
+    the callback runs INLINE, before ``insert_blocks`` returns. The prepend
+    path used to raise ``_history_loading`` immediately AFTER that call, so on
+    the inline path the raise landed on top of ``_finish_history_mount``'s
+    clear and the flag stayed True forever.
+
+    That is unrecoverable, unlike the parent transcript's gate: the flag gates
+    both ``_maybe_load_history`` and ``_note_history_gesture``, so no gesture
+    re-opens it. The footer sits on "loading earlier…" with no read in flight
+    and ``action_home`` does nothing, however many times it is pressed
+    (review round 1, MAJOR-1).
+
+    The flag is now raised BEFORE the insert, which is order-preserving for
+    every other reader — it is already True on entry and continuously True
+    across the mount either way, so ``_history_state_text`` can still never
+    observe it down mid-mount.
+    """
+    transcript = Transcript(tmp_path / "child")
+    # Several PAGES deep (`HISTORY_PAGE_ROWS`), so history genuinely remains
+    # after the prepend under test. A child that fits in one page drains on
+    # the first read and the recovery assertion below could not distinguish a
+    # working gate from an exhausted one.
+    for index in range(HISTORY_PAGE_ROWS * 4):
+        await transcript.append_message(Message.assistant(f"durable {index}"))
+    job = _job_with(TRAJECTORY, status="completed")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    session._subagent_comms = type(
+        "Comms", (), {"session_dir_of": lambda self, _job_id: transcript.directory}
+    )()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(90, 28)) as pilot:
+        view = await _open(pilot, app, job)
+        await _wait_history(pilot, view)
+
+        body = view._body
+        real = body.call_after_refresh
+        refused = {"hit": False}
+
+        def refuse(callback, *args, **kwargs):
+            # Exactly the settle `insert_blocks` schedules, once — the same
+            # False Textual returns for a pump that is closing.
+            if not refused["hit"] and getattr(callback, "__name__", "") == "settle_then_restore":
+                refused["hit"] = True
+                return False
+            return real(callback, *args, **kwargs)
+
+        body.call_after_refresh = refuse  # type: ignore[assignment]
+        view.action_home()
+        await _wait_history(pilot, view)
+        for _ in range(40):
+            await pilot.pause()
+        body.call_after_refresh = real  # type: ignore[assignment]
+
+        assert refused["hit"], "the prepend's settle was never refused; hazard not armed"
+        # THE INVARIANT: the gate is down, so a further read is possible.
+        assert view._history_loading is False
+        assert "loading earlier" not in view._history_state_text()
+
+        # And the documented gesture still answers, which is what the reader
+        # experiences: pre-fix six presses moved nothing at all.
+        before = len(view._history_ids)
+        for _ in range(3):
+            view.action_home()
+            await _wait_history(pilot, view)
+            for _ in range(10):
+                await pilot.pause()
+        assert (
+            len(view._history_ids) > before
+        ), "no history loaded after a dropped prepend settle: the gate is wedged"


### PR DESCRIPTION
# PR Description

## Summary of Changes

Bug fix. A resumed transcript showed `older messages above — click to load` as its top row, and clicking it did nothing — no rows appeared, the copy never changed, no scrollbar. The control was dead for the life of the app, and `ctrl+home` (the documented keyboard recovery) was dead with it.

**Root cause: `insert_blocks` could silently fail to keep its `on_settled` promise.** The method ends with `self.call_after_refresh(settle_then_restore)`. `call_after_refresh` is `post_message`, and `post_message` **returns False** for a pump that is closing or closed — it does not raise and it does not queue. That return was ignored.

Its production caller is `_mount_older_resume_page`, which hands `on_settled` the release of the single-flight paging lease — *after* setting `lease.mounted = True`. So a dropped settle stranded the lease in `_paging_leases` permanently, and every guard downstream then did exactly what it was designed to do:

| guard | behaviour with a stranded lease |
|---|---|
| `_resume_paging` | True forever for the **source token**, which outlives any one view — so a reader returning to that conversation inherits the dead gate |
| `_check_resume_page` | returns at `not self._resume_in_zone or self._resume_paging` |
| `_break_abandoned_paging_lease` | refuses, **by design**, to retire a MOUNTED lease (F1: retiring one would re-consume a cursor whose rows are already painted) |
| `_reconcile_head_notice` | paints loading copy only for an **unmounted** lease, so the row keeps saying "click to load" |

Each of those is individually correct. Together they make the reader's only affordance a no-op with no diagnostic — the "silent dead affordance" the head notice exists to prevent, one state over.

The trigger requires no fault of the caller's: `_release_sidebar_preparation` awaits `view.remove()` on a presentation the navigation did not keep, which closes the pump under an in-flight page.

## The fix, at the source

Preference throughout was to make the state machine **total** — every guard's "no" answer either recoverable or honestly reported — rather than to add a special case.

- **`insert_blocks` honours `on_settled` unconditionally.** When the pump refuses the callback, the settle's own purpose (gap settlement, anchor restore) is unreachable anyway, while the caller's gate still has to open — so it is invoked inline. This matches the branch that already did exactly that for empty `additions`. The same repair covers the **forward**-paging gate (`_resume_tail_paging`) and the subagent view's `_history_loading`, which share the pattern and had the identical latent wedge.
- The **hidden-only page** branch of `_mount_older_resume_page` (`transcript.call_after_refresh(release_gate)`) carried the same unkept promise and is fixed the same way.
- **`_PagingLease` records which view owes it a release**, so "merely settling" becomes a *checkable* claim rather than an assumption. `can_settle()` answers it, and `_break_abandoned_paging_lease` may now retire a mounted lease whose view is gone. **The F1 identity guarantee is untouched** — a mounted lease on a live view is still refused — while a provably unsettleable holder becomes recoverable instead of permanent. It is not a lost page either: the rows that lease mounted are in `_resume_mounted_ids`, and the id dedupe drops anything a re-issue delivers twice.
- **`_fill_resume_attempt`'s refused-acquire branch no longer returns silently.** It left `_resume_fill_active` set, which tells `_reconcile_head_notice` a better frame is still on its way (the R6 skip) — so the row kept stale copy instead of describing the geometry it actually had. (Review round 1 established this branch is unreachable today; it is kept as defensive with that stated, and its comment no longer claims a guarantee the code does not provide.)

**Remediation round 1 (`3584f3533`) extended the same repair to three more sites and corrected one term.** All four were found by review, and the first is the most important finding of the round:

- **`_transcript_scrolled`'s `run_check` posts.** `_resume_check_pending` is raised before the post and cleared only inside `run_check`; a refused post latched it, and the guard then returned early on **every subsequent scroll** — the wheel dead permanently while the notice click still worked. This reaches the operator's reported symptom **with `_paging_leases` empty**, i.e. by a route that has nothing to do with a lease, which is why the original lease-focused investigation could not have found it. Reproduced independently by both review and QA.
- **`_start_resume_fill`'s `start` post.** Strands `_resume_fill_active`, which is the R6 skip inverted: reconcile is told a better frame is coming and keeps stale copy.
- **The subagent view's prepend gate.** Round 1 *claimed* this path was covered and it was not: the caller re-raised `_history_loading` **after** `insert_blocks` returned, so the new inline `on_settled` cleared it first and the raise landed on top. The flag is now hoisted above the call. That wedge is unrecoverable (the flag gates every gesture that could re-open it), so the claim mattered.
- **`can_settle()` keys on the pump's own terms, not `is_mounted`.** `Widget._is_mounted` is set a tick after `mount()`, so a freshly mounted, fully live view reported `is_mounted=False` while `post_message` still returned `True` — answering "unsettleable" for a view that *would* deliver the callback, which errs in the **F1-violating** direction. Now `_closing`/`_closed` (exactly what `post_message` tests) plus `parent is None`.

**One race is accepted rather than guarded, and the code says so.** A post that *succeeds* and is then dropped by a teardown racing the screen flush strands the lease identically, and `if not call_after_refresh(...)` cannot see it. The honest guard would be a second implementation of the release racing the first. `can_settle()` returns False there, so one further explicit ask recovers it — which makes `mounted_view` the **primary** mechanism for that race rather than defence-in-depth for an unreachable state, and the docstring now opens with that so nobody deletes it as dead code.

A deterministic signal (the holder's view can no longer deliver a callback) was chosen over a timeout heuristic deliberately: a timeout cannot distinguish a slow socket from a dead pump, and would reintroduce the duplicate-fetch class F1 exists to prevent.

## Testing evidence

### 1. Reproduced from the operator's real journal, not a synthetic shape

`~/.local-operator/sessions/9621ffc4ef89/transcript.jsonl` — 731 entries (695 `message`, 21 `prune`, 14 `custom`, 1 `compaction`), 2.7 MB — **copied** and driven through a real `RuntimeServer` + `AttachedSession`, so the display-window pager, the audit phase, the paging leases and the head notice are all production code. The live session was never touched.

First, the server side was cleared of suspicion — the backward chain is healthy end to end:

```
build_llm_history (the model replay / context phase): 224 messages
=== FIRST display window ===  messages: 120  start: 104  has_more: True  audit: False
  page  1: msgs=103 audit=False start=1   more=True
  page  2: msgs=  1 audit=False start=0   more=True   audit_avail=True
  page  3: msgs=120 audit=True  start=376 more=True
  page  4: msgs=120 audit=True  start=254 more=True
  page  5: msgs=121 audit=True  start=116 more=True
  page  6: msgs=111 audit=True  start=0   more=False
  chain terminated after 6 page(s); total rows delivered: 696
```

### 2. The instrumented click path, pre-fix

Every guard along `on_older_history_notice_requested` → `_check_resume_page` → `_fill_resume_until_scrollable`/`_fill_resume_attempt` → `_mount_older_resume_page` was instrumented. With a lease stranded by a dropped settle:

```
=== after a mount whose settle was refused ===
  settle refused : True
  lease          : _PagingLease(source_token='daabf647…', mounted=True)
  _resume_paging : True
  break_abandoned: False          <-- refuses a MOUNTED lease, by design
  notices        : ['older messages above — scroll up to load']

=== clicks against the wedged lease ===
  click 1: blocks 54->54  vh 108->108  pend 16->16  paging=True
  click 2: blocks 54->54  vh 108->108  pend 16->16  paging=True
  click 3: blocks 54->54  vh 108->108  pend 16->16  paging=True
  click 4: blocks 54->54  vh 108->108  pend 16->16  paging=True
  click 5: blocks 54->54  vh 108->108  pend 16->16  paging=True
  ctrl+home : paging=True blocks=54   <-- the documented recovery is dead too
```

Post-fix, same script, same journal, same geometry:

```
=== after a mount whose settle was refused ===
  lease          : None
  _resume_paging : False

  click 1: blocks 54->64   vh 108->128  pend 16->0    paging=False
  click 2: blocks 64->76   vh 128->152  pend 0->79    paging=False
  click 3: blocks 76->89   vh 152->178  pend 79->55   paging=False
  click 4: blocks 89->102  vh 178->204  pend 55->31   paging=False
  click 5: blocks 102->121 vh 204->257  pend 31->1    paging=False
  ctrl+home : paging=False blocks=135  notice='earlier history above — scroll up to load'
```

The copy crossing to the **audit twin** on the last step is the vocabulary change working: the reader has drained the context replay and the rows above are now pre-compaction history.

### 3. The same wedge with no monkeypatch at all

Removing the view under an in-flight page — what `_release_sidebar_preparation` really does — reaches the identical state through Textual's own refusal:

```
PRE-FIX                                   POST-FIX
  lease           : _PagingLease(mounted=True)    lease           : None
  _resume_paging  : True                          _resume_paging  : False
  break_abandoned : False                         view pump closed: True
  view pump closed: True
```

### 4. Rendered frames

`scripts/resume_paging_shot.py` gains a `wedged` frame (the reusable part lives in `scripts/`, per AGENTS.md §7 — the images are attached here, not committed). Identical script, identical geometry, pre-fix vs post-fix:

```
before:  blocks=105  virtual_h=209  scroll_y=0   paging=True
after :  blocks=249  virtual_h=497  scroll_y=0   paging=False   (max_scroll_y=466)
```

**`scripts/resume_paging_shot.py … wedged 120x40` — before / after.** Re-captured in remediation round 1: the original pair put the notice 46 rows above the viewport on the fixed branch, so the "after" cell showed a tool row instead of the row this PR is about (design review D1). Both cells are now at `scroll_y=0` with the notice at the identical cell `[2, 2, 116, 1]`, and the script raises rather than saving a frame without its subject.

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-980/frames/r2-before-wedged.png) | ![after](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-980/frames/r2-after-wedged.png) |
| 5 clicks · `paging=True` · 105 blocks · `max_scroll_y=178` · frozen at record 149 | same 5 clicks · `paging=False` · 249 blocks · `max_scroll_y=466` · at record 077 |

**The two states this fix most implicates, now rendered.** Neither had ever appeared on a painted frame (design review D3/D4). Each is reached through the production `_reconcile_head_notice` funnel — the state is staged, the copy is never written onto the widget — and each asserts its own copy before saving.

| `— click to load` (`unreachable`) | `loading older messages…` (`loading`) |
|---|---|
| ![unreachable](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-980/frames/r2-unreachable.png) | ![loading](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-980/frames/r2-loading.png) |
| `scrollbar=False`, `max_scroll_y=0` — scrolling genuinely cannot reach the history, so "click" is the only gesture the row can honestly name | an unmounted lease holds the gate, i.e. a fetch in flight; a synthetic session settles inside one paint, so the state is held rather than raced |

**The head notice over the operator's real journal, at 140x38.** Left: after a dropped settle and five clicks, still `older messages above — scroll up to load`, 54 blocks, no travel. Right: the gate reopened and history recovered.

| before — wedged, 5 clicks | after — recovered | after — one more click |
|---|---|---|
| ![before](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-980/frames/before-wedged.png) | ![after](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-980/frames/after-wedged.png) | ![after clicked](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-980/frames/after-clicked.png) |

Frames live on the orphan `evidence/pr-980` branch (never merged into `main`) rather than in the tree, per AGENTS.md §7 — GitHub needs a hosted URL to render them. SVG originals are beside each PNG there; the reusable capture path is the `wedged`, `loading` and `unreachable` frames in `scripts/resume_paging_shot.py`.

### 5. AC2 — the reserve is actually delivered

At the operator's measured geometry the first paint carries ~2 viewports of **reachable** history above the reader, so scrolling up trips the lazy load a full screen above:

| grid | viewport | virtual_h | scrollable | scrollbar | pending head |
|---|---|---|---|---|---|
| 130x34 | 25 | 86 | yes | yes | 40 |
| 140x38 | 29 | 86 | yes | yes | 40 |
| 145x40 | 31 | 86 | yes | yes | 40 |

### 6. Regression tests — proven to fail on the pre-fix tree

Two tests added beside `tests/unit/tui/test_resume_render.py`'s notice tests. Run against a throwaway `git worktree` of `origin/main` (never a `git stash` — this checkout is shared):

```
FAILED test_a_dropped_insert_settle_still_releases_the_paging_gate
  AssertionError: assert 'd732813e…' not in {'d732813e…': _PagingLease(mounted=True)}
FAILED test_an_unsettleable_mounted_lease_is_recoverable_by_an_explicit_ask
  AttributeError: '_PagingLease' object has no attribute 'can_settle'
2 failed
```

The first fails on the **invariant itself** (the lease is stranded), not merely on a missing symbol. Both pass on this branch.

**Remediation round 1 adds four more, each proven to fail at `45410e765` — the round-1 head, not merely at base — for its own invariant:**

```
FAILED test_a_mounted_lease_on_a_live_view_is_never_retired
  AssertionError: a view whose pump still accepts posts was reported unsettleable;
  an explicit ask would retire a lease whose settle is still coming
FAILED test_a_refused_scroll_check_post_does_not_latch_the_wheel_dead
  AssertionError: assert True is False        <- _resume_check_pending latched
FAILED test_a_refused_fill_start_post_does_not_strand_the_fill_flag
  AssertionError: assert True is False        <- _resume_fill_active stranded
FAILED test_a_dropped_prepend_settle_does_not_wedge_the_history_gate
  AssertionError: assert True is False        <- _history_loading latched
```

Two of these needed a second attempt to be honest, which is worth recording:

- the live-view F1 test **mounts without awaiting**, because awaiting drains the pump and closes the very window under test — the awaited version passed at the round-1 head, i.e. proved nothing;
- the wheel test asserts that a scroll **reaches `_check_resume_page`**, not that it loads a page. Asserting a page failed, and an *unarmed* control run produced identical output: the settled fill parks the reader outside `RESUME_PAGE_TRIGGER_ROWS`, so a notch there legitimately earns nothing. That assertion would have pinned the trigger geometry rather than this defect.

`test_a_mounted_lease_survives_a_second_click`, which pins the opposite (F1) behaviour, still passes. Review round 1 correctly noted it does **not** guard the new predicate — it sets `mounted` but not `mounted_view`, so it exits through the `view is None` early return; `test_a_mounted_lease_on_a_live_view_is_never_retired` is the one that evaluates against a real widget.

### 7. Full gate, exactly as CI runs it

```
.venv/bin/python -m flake8 .                              -> 0
uvx --from black==26.1.0 black --check .                  -> 1227 files unchanged
uvx isort==5.13.2 --check .                               -> clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python . -> 0 errors, 0 warnings
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
tests/unit/tui/test_rendered_history_paging.py            -> 40 passed
```

On the remediation head `3584f3533`, all four re-run clean, plus the whole TUI suite:

```
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui -q
-> 7048 passed, 12 skipped, 14 warnings in 854.29s
```

## Hypotheses that were wrong, and the evidence that killed them

Stated explicitly because each one looked plausible from the code alone:

- **"The click never mounts anything because the cursor has no page."** Disproved — the server chain delivers 696 rows across 6 pages (§1), and post-fix the same clicks page normally.
- **"A canonical `HistoryRowsSettled(reset=True)` strands the lease."** That handler resets every other piece of resume state and never touches `_paging_leases`, which looks damning. Measured: the reset **clears** the lease via the normal settle, and three subsequent clicks all paged. Not the cause.
- **"Parking the transcript on a sidebar switch drops the settle."** `_set_transcript_parked` sets `disabled`, but Textual's `Widget.check_message_enabled` only refuses **mouse** events for a disabled widget. Measured directly: `call_after_refresh` on a parked view returned `True` and the callback fired, and a real mount while parked released its lease normally. The mechanism is the closing pump, not `disabled`.
- **"The audit vocabulary was wrong for a compacted session."** Checked at the painted frame: `history_is_audit=False`, `window.audit=False`, `window.audit_available=False`, `_history_hydrated=False`, `_audit_exhausted=True`. The window is context-phase with audit rows not yet advertised, so the **non-audit** copy was correct there. Once the reader drains the context phase the copy does cross to "earlier history above" (§2). No second defect.

## What I could NOT verify

- **The operator's exact frame was not reproduced from their live session.** That session is running (pid 28218) and was deliberately never attached to or written; everything here runs against a *copy* of its journal. The frame they described (~14 rows) comes from the sidebar/prepared path's `bound=max(12, height // 2)`, which I reproduced at 23 blocks/viewport 15 — the same shape, not the same pixel count, since the exact terminal size and panel state at that moment are not recoverable.
- **Which route the operator's session actually took is NOT pinned, and cannot be.** Its `_paging_leases` state at the failing frame is not recoverable after the fact. Two routes to the reported symptom were proven reachable and both are now closed: a closing pump under an in-flight page (strands a mounted lease), and the sibling-flag latch added in remediation round 1 (`_resume_check_pending`, which kills the wheel permanently **with no lease held at all**). The reviewer rates the second the likelier candidate for that session precisely because a lease-focused investigation — mine — could not have seen it. Neither can be attributed to that frame post-hoc, and this PR does not claim otherwise.
- **One CI shard (`test (3.12, 4)`) failed on a pre-existing flake, not on this change.** The two failures are `tests/unit/mobile/test_tui_ask.py::test_phone_answer_first_takes_the_terminal_card_down` and `tests/unit/mcp/test_manager.py::TestCircuitBreaker::test_breaker_trips_after_five_failures_in_window` — neither is reachable from this diff (paging leases and the transcript insert seam). Both pass locally in 1.73s (`-n0`). The same shard fails on `main` itself at `27466f66`, in the same file, on a sibling test (`test_terminal_answer_first_makes_a_late_phone_answer_fail` — `assert 'already answered' in 'Event loop is closed'`), and 4 of the last 6 `main` runs are red. Re-run requested. I did **not** fix those flakes: they are outside this slice and fixing them here would put an unrequested change in front of the reviewer.

- **`tests/e2e` was not run** — it drives boot/turn/`/resume` and does not exercise a closing-pump insert, so it is not a surface this change can touch. Say the word and I will run the stage anyway.
