### PR TITLE
chore(release): bump version to 0.54.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.15"
+version = "0.54.16"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release lock for the post-`v0.54.15` window. `pyproject.toml` only, one line, per the combined-release rule.

**Owner:** pid 17851 (`Audit session vs remotes…`). Window opens at `v0.54.15` (`ee3ceceb7`); contents are re-derived immediately before tagging.

**Status: DRAFT until the window closes.** Merges only when the owner cuts the release; a draft lock consumes nothing.