### PR TITLE
fix(wakes): never leave an armed wake without a live supervisor, and bound wake lateness

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,9 +273,10 @@ Work keeps moving after you walk away.
   and reports how many occurrences it skipped, rather than replaying six
   hourly checks at once. `lop wake status` reports whether the supervisor is
   actually *running* (not merely installed), the soonest wake that will fire,
-  and how many are overdue, dormant, or too stale for the supervisor to keep
-  retrying; `lop wake list` shows every schedule with that state per row. When
-  the supervisor has stopped or gone missing, `lop wake install` puts it back.
+  and how many are overdue, dormant, too stale for the supervisor to keep
+  retrying, or blocked by a wedged runtime holding the session lease; `lop
+  wake list` shows every schedule with that state per row. When the supervisor
+  has stopped or gone missing, `lop wake install` puts it back.
   Human-readable wake times use the machine's
   local timezone, labelled explicitly, with a 12-hour AM/PM clock by default.
   Other dates include the month/day (and year when different). Choose **Wake

--- a/README.md
+++ b/README.md
@@ -271,8 +271,12 @@ Work keeps moving after you walk away.
   phone or `/resume`; `/approvals auto` or `--yolo` opts into unattended
   execution. A session that was asleep past a due time fires the wake late
   and reports how many occurrences it skipped, rather than replaying six
-  hourly checks at once. `lop wake status` and `lop wake list` show what is
-  installed and what fires next. Human-readable wake times use the machine's
+  hourly checks at once. `lop wake status` reports whether the supervisor is
+  actually *running* (not merely installed), the soonest wake that will fire,
+  and how many are overdue, dormant, or too stale for the supervisor to keep
+  retrying; `lop wake list` shows every schedule with that state per row. When
+  the supervisor has stopped or gone missing, `lop wake install` puts it back.
+  Human-readable wake times use the machine's
   local timezone, labelled explicitly, with a 12-hour AM/PM clock by default.
   Other dates include the month/day (and year when different). Choose **Wake
   time format** in `/settings` → Appearance, or run

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -729,6 +729,18 @@ def build_cli_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="remove the supervisor; scheduled wakes then fire only when a session is open",
     )
+    # THE ROLLOUT PATH, and the reason this is a subcommand rather than only a
+    # flag on `status`. Repair-on-demand lives in the install hook, which runs
+    # on a wake PERSIST — so a machine whose supervisor is stale or stopped
+    # cannot be fixed without some session happening to schedule a wake. After
+    # an upgrade that is exactly the wrong dependency: the running supervisor
+    # is still executing the old code, and there may be no session about to
+    # persist. This command makes the repair reachable directly.
+    wake_sub.add_parser(
+        "install",
+        help="install or repair the supervisor now (restarts a stale or stopped one)",
+        parents=[parent_parser],
+    )
     wake_list = wake_sub.add_parser(
         "list",
         help="every scheduled wake on this machine, soonest first",
@@ -2893,6 +2905,7 @@ def _wake_rows() -> "list[dict[str, Any]]":
 
     from local_operator.paths import config_dir
     from local_operator.wakes.store import read_index
+    from local_operator.wakes.supervisor import STALE_AFTER_S
 
     now_ms = int(_time.time() * 1000)
     rows: list[dict[str, Any]] = []
@@ -2935,6 +2948,21 @@ def _wake_rows() -> "list[dict[str, Any]]":
                     ),
                     "limit": raw.get("limit"),
                     "fired_count": raw.get("fired_count") or 0,
+                    # RELIABILITY FIELDS. The three questions the operator
+                    # could not previously answer about a wake that seemed not
+                    # to fire: is it late right now, how late, and has it been
+                    # late so long the supervisor has given up on it (past
+                    # STALE_AFTER_S it is skipped, deliberately, and left to
+                    # the session's own catch-up). `overdue` is a plain bool
+                    # rather than "due_in_s < 0" recomputed by every consumer.
+                    "overdue": due < now_ms,
+                    "overdue_s": max((now_ms - due) / 1000.0, 0.0),
+                    "stale": (now_ms - due) / 1000.0 > STALE_AFTER_S,
+                    # Written by the session (the one writer of schedule
+                    # state), absent on an entry that has not fired since the
+                    # fields were added rather than defaulted to a lie.
+                    "last_fired_at": entry.get("last_fired_at"),
+                    "last_attempt_at": entry.get("last_attempt_at"),
                 }
             )
     rows.sort(key=lambda row: row["next_due_at"])
@@ -2999,6 +3027,16 @@ def wake_command(args: argparse.Namespace) -> int:
                 left = row.get("until_in_s")
                 if left is not None:
                     repeat += f", until {_format_due(left)}" if left > 0 else ", expired"
+            # RELIABILITY MARKS, after the dormant one and in escalating
+            # order: a stale wake is also overdue, and saying so twice on one
+            # line is noise — stale is the stronger statement because it means
+            # the supervisor has stopped trying.
+            if row["stale"]:
+                mark += " (STALE — no longer fired by the supervisor)"
+            elif row["overdue"]:
+                mark += " (OVERDUE)"
+            if row.get("last_fired_at"):
+                repeat += f", last fired {format_wake_time(int(row['last_fired_at']))}"
             print(f"{when:>12}  {name}  {row['message']}{repeat}{mark}")
         return 0
 
@@ -3007,6 +3045,7 @@ def wake_command(args: argparse.Namespace) -> int:
         ensure_supervisor_installed,
         is_supported,
         plist_path,
+        supervisor_state,
         uninstall,
     )
 
@@ -3015,28 +3054,102 @@ def wake_command(args: argparse.Namespace) -> int:
         print(f"supervisor: {outcome.reason}")
         return 0
 
+    from local_operator.harness.wake import format_duration
+    from local_operator.wakes.supervisor import STALE_AFTER_S
+
+    STALE_AFTER_DAYS = STALE_AFTER_S / 86400.0
+
     rows = _wake_rows()
-    installed = is_supported() and plist_path().exists()
-    if getattr(args, "install", False):
+    # `install` as a subcommand and `status --install` are the same operation;
+    # the hook is idempotent and now REPAIRS, so both routes reach the fix.
+    wants_install = command == "install" or getattr(args, "install", False)
+    if wants_install:
         outcome = ensure_supervisor_installed(config_dir())
-        installed = outcome.installed
         print(f"supervisor: {outcome.reason}")
 
+    # RUNNING, not merely present. `plist_path().exists()` was an even weaker
+    # test than the install hook's `_is_loaded()` — it reported "installed"
+    # for a supervisor that had exited, which is the blind spot that let armed
+    # wakes sit unfired. The file is still reported separately, because "the
+    # plist is there but nothing runs" is a distinct, actionable state.
+    state = supervisor_state(config_dir()) if is_supported() else None
+    plist_present = is_supported() and plist_path().exists()
+    # UNVERIFIABLE is a third state, distinct from stopped and from absent:
+    # the store being asked about is not one launchd can supervise (an
+    # isolated run, a config dir outside the real home), so the global label
+    # answers about a DIFFERENT store. Nothing about it may be rendered here.
+    verifiable = bool(state and state.verifiable)
+    running = bool(state and state.running and state.verifiable)
+    uptime_s: float | None = None
+    if verifiable and state and state.pid:
+        uptime_s = _process_uptime_s(state.pid)
+
     upcoming = [row for row in rows if not row["dormant"]]
+    overdue = [row for row in upcoming if row["overdue"]]
+    stale = [row for row in upcoming if row["stale"]]
     payload = {
         "supported": is_supported(),
-        "installed": installed,
+        # Kept as "a supervisor is in place" for readers that already parse
+        # it, but it now means RUNNING rather than "a file exists".
+        "installed": running,
         "plist": str(plist_path()) if is_supported() else "",
         "scheduled": len(rows),
         "armed": len(upcoming),
         "next_due_in_s": upcoming[0]["due_in_s"] if upcoming else None,
+        # The machine-readable reliability block: the same facts the human
+        # rendering shows, for a monitoring caller that should not scrape it.
+        "supervisor": {
+            # False whenever the answer would be about another store, so a
+            # monitoring caller cannot read this block as a verdict on THIS
+            # one. The pid is withheld for the same reason.
+            "verifiable": verifiable,
+            "running": running,
+            "loaded": bool(state and state.loaded and verifiable),
+            "plist_present": plist_present,
+            "pid": state.pid if (verifiable and state) else None,
+            "uptime_s": uptime_s,
+            "state": state.detail if state else "",
+        },
+        "overdue": len(overdue),
+        "stale": len(stale),
+        "max_overdue_s": max((row["overdue_s"] for row in overdue), default=0.0),
     }
     if args.json:
         print(_json_dumps(payload))
         return 0
 
-    print(f"supervisor:  {'installed' if installed else 'not installed'}")
-    if installed is False and is_supported() and rows:
+    if state is not None and not verifiable:
+        # Never another store's pid. Saying "running" here would be the very
+        # failure this command exists to remove, one level up: it would report
+        # wakes as supervised while the running process watches a different
+        # store. Observed during validation, where an isolated run printed the
+        # operator's real LaunchAgent pid.
+        print("supervisor:  cannot be verified for this store")
+        print(f"             ({state.detail})")
+        print("             (wakes here fire only while a session is open)")
+    elif running:
+        detail = f"running (pid {state.pid})" if state and state.pid else "running"
+        if uptime_s is not None:
+            detail += f", up {_format_duration(uptime_s)}"
+        print(f"supervisor:  {detail}")
+    elif state and state.loaded:
+        # The exact state that produced the permanent misses: launchd knows
+        # the job, `launchctl print` returns 0, and nothing is running.
+        print(f"supervisor:  loaded but NOT running ({state.detail or 'stopped'})")
+        print("             (nothing will fire these — run 'lop wake install')")
+    elif plist_present:
+        print("supervisor:  not loaded (a plist exists but launchd has no job)")
+        print("             (run 'lop wake install')")
+    else:
+        print("supervisor:  not installed")
+    installed = running
+    if (
+        installed is False
+        and is_supported()
+        and rows
+        and verifiable
+        and not (state and state.loaded)
+    ):
         # The ACTIONABLE branch. Round 1 (D4): this command reported "not
         # installed" beside three armed wakes and an overdue one, which is
         # precisely the failure the subcommand exists to surface — and then
@@ -3044,7 +3157,7 @@ def wake_command(args: argparse.Namespace) -> int:
         # had just told them. The unsupported branch below already got two
         # explanatory lines; the fixable one got none.
         print("             (nothing will fire these while their sessions are")
-        print("              closed — run 'lop wake status --install')")
+        print("              closed — run 'lop wake install')")
     if not is_supported():
         # Honest rather than reassuring: on a platform with no installer the
         # wakes of a CLOSED session do not fire, and saying so is the whole
@@ -3054,6 +3167,18 @@ def wake_command(args: argparse.Namespace) -> int:
     print(f"scheduled:   {len(rows)} ({len(upcoming)} armed)")
     if upcoming:
         print(f"next:        {_format_due(upcoming[0]['due_in_s'])}  {upcoming[0]['message']}")
+    if overdue:
+        # The headline the operator was missing. A wake being overdue is not
+        # itself a fault (a sweep may be in flight), but "3 overdue, worst 24m"
+        # beside a stopped supervisor is the whole diagnosis on one line.
+        worst = max(row["overdue_s"] for row in overdue)
+        print(f"overdue:     {len(overdue)} (worst {_format_duration(worst)})")
+    if stale:
+        print(
+            f"stale:       {len(stale)} past {int(STALE_AFTER_DAYS)}d — the supervisor "
+            "no longer fires these;"
+        )
+        print("             they are delivered when their session is next opened")
     return 0
 
 
@@ -3076,6 +3201,45 @@ def _format_due(seconds: float) -> str:
     else:
         text = f"{int(seconds // 86400)}d"
     return f"{text} overdue" if overdue else f"in {text}"
+
+
+def _process_uptime_s(pid: int) -> float | None:
+    """How long ``pid`` has been alive, or ``None`` when it cannot be read.
+
+    ``ps -o etime=`` rather than a dependency: this is one line on a status
+    surface, and ``psutil`` is deliberately not a dependency of this project.
+    Every failure is None — an uptime is a nicety on a line whose real payload
+    is the pid, and a status command must never fail because a subprocess did.
+    """
+    import subprocess as _subprocess
+
+    try:
+        result = _subprocess.run(  # noqa: S603 — fixed argv, no shell
+            ["ps", "-p", str(pid), "-o", "etime="],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, _subprocess.SubprocessError):
+        return None
+    raw = result.stdout.strip()
+    if result.returncode != 0 or not raw:
+        return None
+    # `[[dd-]hh:]mm:ss` — parsed right to left so every form falls out of the
+    # same loop rather than needing a format branch per shape.
+    days = 0
+    if "-" in raw:
+        day_part, _, raw = raw.partition("-")
+        if not day_part.isdigit():
+            return None
+        days = int(day_part)
+    parts = raw.split(":")
+    if not all(part.strip().isdigit() for part in parts) or len(parts) > 3:
+        return None
+    seconds = 0.0
+    for power, part in enumerate(reversed(parts)):
+        seconds += int(part) * (60**power)
+    return seconds + days * 86400
 
 
 def stop_command(args: argparse.Namespace) -> int:

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -712,6 +712,14 @@ def build_cli_parser() -> argparse.ArgumentParser:
         help="Inspect scheduled wakes and the supervisor that fires them",
         parents=[parent_parser],
     )
+    # DEFAULTS ON THE PARENT, so every route into `wake_command` carries the
+    # flags it dereferences. `wake_command` falls back to "status" when no
+    # subcommand is given, and the status branch reads `json`/`install`/
+    # `uninstall` — so bare `lop wake` and `lop wake install` (which define no
+    # such flags of their own) used to reach it and die on `args.json`. A
+    # subparser that declares `--json` still overrides this, and a branch that
+    # gains a new flag inherits a safe default instead of a crash.
+    wake_parser.set_defaults(json=False, install=False, uninstall=False)
     wake_sub = wake_parser.add_subparsers(dest="wake_command")
     wake_status = wake_sub.add_parser(
         "status",
@@ -3001,13 +3009,52 @@ def wake_command(args: argparse.Namespace) -> int:
         if not rows:
             print("no scheduled wakes")
             return 0
+        import shutil
+
         from local_operator.harness.wake import format_duration
         from local_operator.wakes.display import format_wake_time
 
+        # A FIXED-WIDTH TABLE, matching `lop sessions` right next door rather
+        # than inventing a second listing convention. Round 1 (D4): padding a
+        # pre-composed "<abs time> (<rel>)" cell never applies, because that
+        # cell is already 19-31 characters wide, so the id column started at a
+        # different position on every row (measured: 33/27/21/22/29) and a long
+        # message produced a 155-column line that wrapped with no indent.
+        # Splitting the two time facts into their own columns is what makes the
+        # padding mean something.
+        term_width = shutil.get_terminal_size((80, 24)).columns
+        # Widths sized from the real renderings rather than guessed: the
+        # absolute time is "Sep 02 6:10 PM EDT" at its longest (18), the
+        # relative cell "10m overdue" (11), and a session id is 12. Anything
+        # wider is room taken from the message for no gain.
+        when_w, rel_w, id_w = 18, 11, 12
+        # The message takes what is left, never more, so a row cannot wrap.
+        # The floor keeps it readable on a narrow terminal at the cost of
+        # overflowing there — a deliberate trade, since truncating to nothing
+        # would be worse than one wrapped line.
+        message_w = max(24, term_width - (when_w + rel_w + id_w + 3) - 1)
+        print(f"{'WHEN':<{when_w}} {'DUE':>{rel_w}} {'SESSION':<{id_w}} WAKE")
         for row in rows:
-            when = f'{format_wake_time(row["next_due_at"])} ({_format_due(row["due_in_s"])})'
-            mark = " (dormant — session stopped)" if row["dormant"] else ""
-            name = row["session_id"]
+            when = format_wake_time(row["next_due_at"])[:when_w]
+            # DORMANT WINS, and the overdue/stale marks are suppressed under it
+            # (round 1, Q2/R6). A dormant wake is one nothing is SUPPOSED to
+            # fire, so "(OVERDUE)" — which means "should have fired and did
+            # not" — contradicts it, and "no longer fired by the supervisor" is
+            # true of a dormant wake for an entirely different reason
+            # (reopening the session fires it; nothing revives a stale one).
+            # THE STATE WORD LIVES IN THE DUE COLUMN, and the row carries no
+            # prose repeating it — this is a table, like `lop sessions`, and
+            # the explanation of what "stale" or "dormant" costs belongs on the
+            # `status` summary that has room for a sentence. Keeping both put a
+            # 155-column line in an 80-column terminal (round 1, D4) and
+            # restated on every row what the reader needs told once.
+            if row["dormant"]:
+                state = "dormant"
+            elif row["stale"]:
+                state = "stale"
+            else:
+                state = _format_due(row["due_in_s"])
+            mark = ""
             # `every …` reuses the same renderer the tool listing and the wake
             # panel use, so one wake reads identically wherever it is shown.
             repeat = ""
@@ -3027,17 +3074,38 @@ def wake_command(args: argparse.Namespace) -> int:
                 left = row.get("until_in_s")
                 if left is not None:
                     repeat += f", until {_format_due(left)}" if left > 0 else ", expired"
-            # RELIABILITY MARKS, after the dormant one and in escalating
-            # order: a stale wake is also overdue, and saying so twice on one
-            # line is noise — stale is the stronger statement because it means
-            # the supervisor has stopped trying.
-            if row["stale"]:
-                mark += " (STALE — no longer fired by the supervisor)"
-            elif row["overdue"]:
-                mark += " (OVERDUE)"
+            elif not row.get("every_ms"):
+                # The TUI wake panel says `once` for a non-recurring schedule
+                # and this listing said nothing, so the same wake read
+                # differently in two places (round 1, D9).
+                repeat = " · once"
             if row.get("last_fired_at"):
                 repeat += f", last fired {format_wake_time(int(row['last_fired_at']))}"
-            print(f"{when:>12}  {name}  {row['message']}{repeat}{mark}")
+            # THE MESSAGE IS WHAT GETS CLAMPED, never the state tail. Clamping
+            # the composed string instead would silently drop `until in 6d`,
+            # `3/5 fired` or `(stale — …)` off the end of a long row — exactly
+            # the bounds an earlier round added because a user cannot be
+            # expected to remember them (round 5, R6/U16). A user-authored
+            # message is the one part of the row they already know.
+            tail = f"{repeat}{mark}"
+            message = row["message"]
+            room = message_w - len(tail)
+            if len(message) > room:
+                message = message[: max(room - 1, 1)] + "…"
+            detail = f"{message}{tail}"
+            print(
+                f"{when:<{when_w}} {state:>{rel_w}} "
+                f"{row['session_id'][:id_w]:<{id_w}} {detail:<{message_w}}".rstrip()
+            )
+        # ONE legend under the table rather than the same sentence on every
+        # row, and only for the states actually present: what "stale" and
+        # "dormant" COST is the thing a reader needs told, but telling it per
+        # row is what made a single wake occupy 155 columns.
+        if any(row["stale"] and not row["dormant"] for row in rows):
+            print("\nstale    the supervisor no longer fires these; they are delivered")
+            print("         when their session is next opened")
+        if any(row["dormant"] for row in rows):
+            print("\ndormant  the session was stopped; reopening it re-arms its wakes")
         return 0
 
     # status
@@ -3054,10 +3122,13 @@ def wake_command(args: argparse.Namespace) -> int:
         print(f"supervisor: {outcome.reason}")
         return 0
 
-    from local_operator.harness.wake import format_duration
+    # NOT `harness.wake.format_duration` here: the status lines use this
+    # command's own single-unit ladder (`_format_duration`), and importing the
+    # compound one alongside it was dead weight flake8 cannot see through a
+    # function-local import (round 1, R5).
     from local_operator.wakes.supervisor import STALE_AFTER_S
 
-    STALE_AFTER_DAYS = STALE_AFTER_S / 86400.0
+    stale_after_days = STALE_AFTER_S / 86400.0
 
     rows = _wake_rows()
     # `install` as a subcommand and `status --install` are the same operation;
@@ -3084,9 +3155,46 @@ def wake_command(args: argparse.Namespace) -> int:
     if verifiable and state and state.pid:
         uptime_s = _process_uptime_s(state.pid)
 
-    upcoming = [row for row in rows if not row["dormant"]]
-    overdue = [row for row in upcoming if row["overdue"]]
-    stale = [row for row in upcoming if row["stale"]]
+    # FIREABLE is the classification the whole screen now hangs off (round 1,
+    # D2). A wake that is dormant or stale will not be fired by the supervisor,
+    # so counting it as "next" answered "when will my wake fire?" with a date
+    # nine days in the past, on a row that is never coming, while the wake due
+    # in three minutes was absent from the screen entirely.
+    armed = [row for row in rows if not row["dormant"]]
+    dormant = [row for row in rows if row["dormant"]]
+    fireable = [row for row in armed if not row["stale"]]
+    stale = [row for row in armed if row["stale"]]
+    overdue = [row for row in fireable if row["overdue"]]
+    upcoming = fireable  # already sorted soonest-first by `_wake_rows`
+
+    # Probed once per session that has a wake, not per row: `wedged_runtime`
+    # reads the registry, and a session with three schedules is still one
+    # process. Only sessions with something armed are worth asking about — a
+    # dormant session's runtime being wedged is not why its wake is not firing.
+    from local_operator.wakes.supervisor import wedged_runtime
+
+    wedged: list[tuple[str, int, float]] = []
+    for session_id in dict.fromkeys(row["session_id"] for row in armed):
+        found = wedged_runtime(config_dir(), session_id)
+        if found is not None:
+            wedged.append((session_id, found[0], found[1]))
+
+    # An ENUM plus the human sentence, not a sentence alone (round 1, D6): a
+    # monitoring consumer branching on `state` had to string-match prose, and
+    # the booleans do not distinguish `stopped` from `not_loaded`.
+    if not is_supported():
+        supervisor_state_name = "unsupported"
+    elif not verifiable:
+        supervisor_state_name = "unverifiable"
+    elif running:
+        supervisor_state_name = "running"
+    elif state and state.loaded:
+        supervisor_state_name = "stopped"
+    elif plist_present:
+        supervisor_state_name = "not_loaded"
+    else:
+        supervisor_state_name = "not_installed"
+
     payload = {
         "supported": is_supported(),
         # Kept as "a supervisor is in place" for readers that already parse
@@ -3094,25 +3202,35 @@ def wake_command(args: argparse.Namespace) -> int:
         "installed": running,
         "plist": str(plist_path()) if is_supported() else "",
         "scheduled": len(rows),
-        "armed": len(upcoming),
+        "armed": len(armed),
+        "dormant": len(dormant),
+        # The soonest FIREABLE wake, which is the only honest answer to "when
+        # will something happen"; `next_due_in_s` used to name the stale row.
         "next_due_in_s": upcoming[0]["due_in_s"] if upcoming else None,
-        # The machine-readable reliability block: the same facts the human
-        # rendering shows, for a monitoring caller that should not scrape it.
         "supervisor": {
             # False whenever the answer would be about another store, so a
             # monitoring caller cannot read this block as a verdict on THIS
             # one. The pid is withheld for the same reason.
             "verifiable": verifiable,
+            "state": supervisor_state_name,
             "running": running,
             "loaded": bool(state and state.loaded and verifiable),
             "plist_present": plist_present,
             "pid": state.pid if (verifiable and state) else None,
             "uptime_s": uptime_s,
-            "state": state.detail if state else "",
+            "detail": state.detail if state else "",
         },
         "overdue": len(overdue),
         "stale": len(stale),
         "max_overdue_s": max((row["overdue_s"] for row in overdue), default=0.0),
+        # The wedged case: a runtime whose process is alive but whose
+        # heartbeat has gone stale holds the transcript lease without serving,
+        # so its wake cannot fire and the supervisor's only trace was an
+        # ordinary timeout. Reported, never repaired — see `wedged_runtime`.
+        "wedged": [
+            {"session_id": session_id, "pid": pid, "heartbeat_age_s": age}
+            for session_id, pid, age in wedged
+        ],
     }
     if args.json:
         print(_json_dumps(payload))
@@ -3129,56 +3247,75 @@ def wake_command(args: argparse.Namespace) -> int:
         print("             (wakes here fire only while a session is open)")
     elif running:
         detail = f"running (pid {state.pid})" if state and state.pid else "running"
-        if uptime_s is not None:
+        # Suppressed under a minute: `up 0s` on a just-started supervisor is
+        # noise, and the pid already says it is there (round 1, D9).
+        if uptime_s is not None and uptime_s >= 60:
             detail += f", up {_format_duration(uptime_s)}"
         print(f"supervisor:  {detail}")
     elif state and state.loaded:
         # The exact state that produced the permanent misses: launchd knows
-        # the job, `launchctl print` returns 0, and nothing is running.
-        print(f"supervisor:  loaded but NOT running ({state.detail or 'stopped'})")
-        print("             (nothing will fire these — run 'lop wake install')")
+        # the job, `launchctl print` returns 0, and nothing is running. The
+        # parenthetical carries the LAUNCHD fact rather than repeating the
+        # state word it was meant to disambiguate (round 1, D9).
+        print("supervisor:  loaded but NOT running (launchd has the job; it has exited)")
     elif plist_present:
         print("supervisor:  not loaded (a plist exists but launchd has no job)")
-        print("             (run 'lop wake install')")
     else:
         print("supervisor:  not installed")
-    installed = running
-    if (
-        installed is False
-        and is_supported()
-        and rows
-        and verifiable
-        and not (state and state.loaded)
-    ):
-        # The ACTIONABLE branch. Round 1 (D4): this command reported "not
-        # installed" beside three armed wakes and an overdue one, which is
-        # precisely the failure the subcommand exists to surface — and then
-        # stopped, leaving the user to find `--help` to act on the one fact it
-        # had just told them. The unsupported branch below already got two
-        # explanatory lines; the fixable one got none.
-        print("             (nothing will fire these while their sessions are")
-        print("              closed — run 'lop wake install')")
+    # ONE remedy line, not two (round 1, Q3/D7). Both the per-state hint and
+    # the ACTIONABLE branch used to fire in the not-loaded state, printing
+    # `run 'lop wake install'` twice in a four-line block.
+    if is_supported() and verifiable and not running:
+        if rows:
+            print("             (nothing will fire these while their sessions are")
+            print("              closed — run 'lop wake install')")
+        else:
+            print("             (run 'lop wake install')")
     if not is_supported():
         # Honest rather than reassuring: on a platform with no installer the
         # wakes of a CLOSED session do not fire, and saying so is the whole
         # point of this line.
         print("             (no installer for this platform — wakes fire only while a")
         print("              session is open)")
-    print(f"scheduled:   {len(rows)} ({len(upcoming)} armed)")
+
+    # DORMANCY IS NAMED (round 1, D3). `scheduled: 1 (0 armed)` with no word of
+    # explanation was a dead end for the operator asking "why has nothing
+    # fired?", while `wake list` did state the reason.
+    counts = f"{len(armed)} armed"
+    if dormant:
+        counts += f", {len(dormant)} dormant"
+    print(f"scheduled:   {len(rows)} ({counts})")
+    if dormant and not armed:
+        print("             (dormant — their sessions were stopped; reopening one re-arms it)")
+
+    # ONE LINE PER DISTINCT STATE (round 1, D5). A single stale wake used to
+    # occupy four lines that restated the same fact, and `next:` promised a
+    # future event while naming something nine days past.
     if upcoming:
-        print(f"next:        {_format_due(upcoming[0]['due_in_s'])}  {upcoming[0]['message']}")
+        soonest = upcoming[0]
+        when = _format_due(soonest["due_in_s"])
+        print(f"next:        {when}  {soonest['message']}")
+    elif armed:
+        # Armed but nothing fireable: every armed wake is stale.
+        print("next:        none — nothing here will fire until its session is opened")
     if overdue:
-        # The headline the operator was missing. A wake being overdue is not
-        # itself a fault (a sweep may be in flight), but "3 overdue, worst 24m"
-        # beside a stopped supervisor is the whole diagnosis on one line.
+        # Counted over FIREABLE rows only, so "worst" is a wake that is
+        # actually coming rather than one the supervisor has given up on.
         worst = max(row["overdue_s"] for row in overdue)
         print(f"overdue:     {len(overdue)} (worst {_format_duration(worst)})")
     if stale:
         print(
-            f"stale:       {len(stale)} past {int(STALE_AFTER_DAYS)}d — the supervisor "
-            "no longer fires these;"
+            f"stale:       {len(stale)} past {int(stale_after_days)}d — delivered when "
+            "their sessions are next opened"
         )
-        print("             they are delivered when their session is next opened")
+    for session_id, pid, age in wedged:
+        # Named on its own line because the remedy is different from every
+        # other state here: nothing the wake subsystem does will help, and the
+        # operator has to decide whether that process is recoverable.
+        print(
+            f"wedged:      {session_id} (pid {pid}) has not heartbeat for "
+            f"{_format_duration(age)}; it holds the lease, so its wake cannot fire"
+        )
     return 0
 
 

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -3067,6 +3067,12 @@ def wake_command(args: argparse.Namespace) -> int:
         head = fixed + (when_w + 1 if show_when else 0)
         message_w = max(message_floor, term_width - head - 1)
         header = f"{'WHEN':<{when_w}} " if show_when else ""
+        # THE FLOOR IS 50 COLUMNS, stated rather than left to be discovered:
+        # 11 (DUE) + 13 (SESSION) + 2 gaps + a 24-character message. Below
+        # that a row overflows even with WHEN dropped, because clamping the
+        # message further would leave too little of it to recognise. 40-column
+        # terminals therefore wrap here, deliberately — the alternative is a
+        # table whose message column says nothing.
         print(f"{header}{'DUE':>{rel_w}} {'SESSION':<{id_w}} WAKE")
         for row in rows:
             when = when_cells[row["next_due_at"]]
@@ -3163,7 +3169,11 @@ def wake_command(args: argparse.Namespace) -> int:
         if any(row["dormant"] for row in rows):
             _legend("dormant", "the session was stopped; reopening it re-arms its wakes")
         if any(row["ghost"] for row in rows):
-            _legend("ghost", "no session with this id exists on disk; nothing can fire these")
+            _legend(
+                "ghost",
+                "no session with this id exists on disk; nothing can fire these, and "
+                "nothing clears them automatically",
+            )
         if not show_when:
             # The omission is STATED, not silent: the absolute time was dropped
             # to keep the table aligned on a narrow terminal (round 2, D12), and
@@ -3331,7 +3341,7 @@ def wake_command(args: argparse.Namespace) -> int:
         # wakes as supervised while the running process watches a different
         # store. Observed during validation, where an isolated run printed the
         # operator's real LaunchAgent pid.
-        print("supervisor:  cannot be verified for this store")
+        print(_wrap_status("cannot be verified for this store", "supervisor:"))
         print(_wrap_status(f"({state.detail})"))
         print(_wrap_status("(wakes here fire only while a session is open)"))
     elif running:
@@ -3340,17 +3350,21 @@ def wake_command(args: argparse.Namespace) -> int:
         # noise, and the pid already says it is there (round 1, D9).
         if uptime_s is not None and uptime_s >= 60:
             detail += f", up {_format_duration(uptime_s)}"
-        print(f"supervisor:  {detail}")
+        print(_wrap_status(detail, "supervisor:"))
     elif state and state.loaded:
         # The exact state that produced the permanent misses: launchd knows
         # the job, `launchctl print` returns 0, and nothing is running. The
         # parenthetical carries the LAUNCHD fact rather than repeating the
         # state word it was meant to disambiguate (round 1, D9).
-        print("supervisor:  loaded but NOT running (launchd has the job; it has exited)")
+        print(
+            _wrap_status(
+                "loaded but NOT running (launchd has the job; it has exited)", "supervisor:"
+            )
+        )
     elif plist_present:
-        print("supervisor:  not loaded (a plist exists but launchd has no job)")
+        print(_wrap_status("not loaded (a plist exists but launchd has no job)", "supervisor:"))
     else:
-        print("supervisor:  not installed")
+        print(_wrap_status("not installed", "supervisor:"))
     # ONE remedy line, not two (round 1, Q3/D7). Both the per-state hint and
     # the ACTIONABLE branch used to fire in the not-loaded state, printing
     # `run 'lop wake install'` twice in a four-line block.
@@ -3385,12 +3399,18 @@ def wake_command(args: argparse.Namespace) -> int:
         print(_wrap_status("(dormant — their sessions were stopped; reopening one re-arms it)"))
 
     # ONE LINE PER DISTINCT STATE (round 1, D5; sharpened in round 2, D16).
-    # `next:` is only printed when there IS a next — a fireable wake in the
-    # future. An overdue fireable wake is reported by the `overdue:` line
-    # below, because labelling something already late as "next" promises a
-    # future event, and saying it twice was the overlap D16 named.
-    if upcoming and not upcoming[0]["overdue"]:
-        soonest = upcoming[0]
+    # `next:` names a wake in the FUTURE; an already-late one is reported by
+    # `overdue:` below, because labelling something late as "next" promises a
+    # future event and says twice what the line below already says (D16).
+    #
+    # SELECT the soonest future row rather than testing the head of the list
+    # (round 3, D19). `upcoming` is sorted soonest-first, so gating on
+    # `upcoming[0]` let ONE overdue row suppress `next:` for every future wake
+    # — a wake a minute away went unnamed on a surface README promises reports
+    # "the soonest wake that will fire".
+    future = [row for row in upcoming if not row["overdue"]]
+    if future:
+        soonest = future[0]
         print(_wrap_status(f"{_format_due(soonest['due_in_s'])}  {soonest['message']}", "next:"))
     if overdue:
         # Counted over FIREABLE rows only, so "worst" is a wake that is
@@ -3411,11 +3431,25 @@ def wake_command(args: argparse.Namespace) -> int:
     if ghost:
         # The supervisor refuses these and retires on a ghost-only store
         # (round 2, Q4). Saying so here is what stops this frame contradicting
-        # the process; the remedy is the session, not the wake subsystem.
+        # the process.
+        #
+        # THE REMEDY IS THE FILE (round 3, D20). The earlier wording said the
+        # entry "is removed when that session id is next written", which no
+        # reader can bring about: both callers of `store.remove_entry` need a
+        # live session (a persist with no schedules left, or `cleanup` after
+        # the session directory goes away), and `lop wake` exposes no cancel.
+        # So a ghost row is permanent, and the only action available is to
+        # delete the entry file — which is what the line now names.
+        # RELATIVE, not the absolute path: an absolute config root is one
+        # unbreakable token long enough to overflow a narrow terminal by
+        # itself, which is the thing D21 asked to stop. `wakes/<id>.json` is
+        # the form the design round suggested, and the ids it needs are on
+        # screen in `lop wake list`.
         print(
             _wrap_status(
-                f"{len(ghost)} with no session on disk — nothing can fire these; "
-                "the entry is removed when that session id is next written",
+                f"{len(ghost)} with no session on disk — nothing can fire these, and "
+                "nothing clears them automatically; delete its "
+                "wakes/<session-id>.json entry to remove one",
                 "ghost:",
             )
         )

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -3067,12 +3067,28 @@ def wake_command(args: argparse.Namespace) -> int:
         head = fixed + (when_w + 1 if show_when else 0)
         message_w = max(message_floor, term_width - head - 1)
         header = f"{'WHEN':<{when_w}} " if show_when else ""
-        # THE FLOOR IS 50 COLUMNS, stated rather than left to be discovered:
-        # 11 (DUE) + 13 (SESSION) + 2 gaps + a 24-character message. Below
-        # that a row overflows even with WHEN dropped, because clamping the
-        # message further would leave too little of it to recognise. 40-column
-        # terminals therefore wrap here, deliberately — the alternative is a
-        # table whose message column says nothing.
+        # WHAT A NARROW TERMINAL ACTUALLY GETS, measured rather than intended.
+        # `message_w` is a budget for the message column, and the row also
+        # carries a state TAIL (` · every 20m, 12/40 fired`, 25 characters on
+        # the widest real row) that the budget does not include — `room` below
+        # subtracts it and can go negative. So on a terminal narrower than the
+        # row needs, BOTH things happen at once:
+        #
+        #   * the row overflows anyway — measured 50-53 columns at COLUMNS=40,
+        #     53 being a row whose tail is 25 characters; and
+        #   * the message degrades to one character plus an ellipsis (`r…`),
+        #     because `room` is negative and the clamp floors at 1.
+        #
+        # 53 columns is the point at which the widest tailed row stops
+        # overflowing (measured across 40/44/48/50/51/52/53/54/58/60 on the
+        # design round's own fixture), and it is IRREDUCIBLE for that row:
+        # 26 fixed + 1 gap + 25 tail + 1 message character = 53. A wider
+        # message budget cannot help — it makes the row longer, not shorter —
+        # and the only lever that would is clamping the tail, which round 5
+        # (R6/U16) deliberately forbade because the tail carries the bounds a
+        # user cannot be expected to remember. Narrower terminals therefore
+        # wrap, and the message column really does stop saying anything; the
+        # honest fix is a different layout for that width, not a budget tweak.
         print(f"{header}{'DUE':>{rel_w}} {'SESSION':<{id_w}} WAKE")
         for row in rows:
             when = when_cells[row["next_due_at"]]
@@ -3134,6 +3150,12 @@ def wake_command(args: argparse.Namespace) -> int:
             # message is the one part of the row they already know.
             tail = f"{repeat}{mark}"
             message = row["message"]
+            # `room` GOES NEGATIVE on a narrow terminal, because `message_w` is
+            # a budget for the whole cell and the tail is subtracted from it
+            # here rather than reserved there. The `max(..., 1)` then floors
+            # the message at one character plus an ellipsis (`r…`) and the row
+            # overflows regardless — see the width note above the header for
+            # the measured numbers and why no budget change fixes it.
             room = message_w - len(tail)
             if len(message) > room:
                 message = message[: max(room - 1, 1)] + "…"

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -2913,14 +2913,24 @@ def _wake_rows() -> "list[dict[str, Any]]":
 
     from local_operator.paths import config_dir
     from local_operator.wakes.store import read_index
-    from local_operator.wakes.supervisor import STALE_AFTER_S
+    from local_operator.wakes.supervisor import STALE_AFTER_S, _session_exists
 
+    root = config_dir()
     now_ms = int(_time.time() * 1000)
     rows: list[dict[str, Any]] = []
-    for session_id, entry in read_index(config_dir()).items():
+    for session_id, entry in read_index(root).items():
         if not isinstance(entry, dict):
             continue
         dormant = bool(entry.get("stopped_at"))
+        # GHOST, asked with the supervisor's own predicate (round 2, Q4). The
+        # supervisor refuses an entry whose session has no transcript and
+        # retires on a ghost-only store, while this listing had no ghost
+        # notion at all — so the rendered frame said "1 armed, 10m overdue"
+        # about a wake the process had already gone home over. A painted frame
+        # that contradicts the process is the defect class this PR exists to
+        # remove, so the two surfaces share the predicate rather than deriving
+        # it twice.
+        ghost = not dormant and not _session_exists(root, session_id)
         for raw in entry.get("schedules") or ():
             if not isinstance(raw, dict):
                 continue
@@ -2966,6 +2976,7 @@ def _wake_rows() -> "list[dict[str, Any]]":
                     "overdue": due < now_ms,
                     "overdue_s": max((now_ms - due) / 1000.0, 0.0),
                     "stale": (now_ms - due) / 1000.0 > STALE_AFTER_S,
+                    "ghost": ghost,
                     # Written by the session (the one writer of schedule
                     # state), absent on an entry that has not fired since the
                     # fields were added rather than defaulted to a lie.
@@ -3023,19 +3034,42 @@ def wake_command(args: argparse.Namespace) -> int:
         # Splitting the two time facts into their own columns is what makes the
         # padding mean something.
         term_width = shutil.get_terminal_size((80, 24)).columns
-        # Widths sized from the real renderings rather than guessed: the
-        # absolute time is "Sep 02 6:10 PM EDT" at its longest (18), the
-        # relative cell "10m overdue" (11), and a session id is 12. Anything
-        # wider is room taken from the message for no gain.
-        when_w, rel_w, id_w = 18, 11, 12
-        # The message takes what is left, never more, so a row cannot wrap.
-        # The floor keeps it readable on a narrow terminal at the cost of
-        # overflowing there — a deliberate trade, since truncating to nothing
-        # would be worse than one wrapped line.
-        message_w = max(24, term_width - (when_w + rel_w + id_w + 3) - 1)
-        print(f"{'WHEN':<{when_w}} {'DUE':>{rel_w}} {'SESSION':<{id_w}} WAKE")
+        # A RENDERED TIME IS NEVER TRUNCATED (round 2, D11). `format_wake_time`
+        # chooses its own form — a clock alone for today, a date for another
+        # day, a year as well for another year — so its width is 11 to 24
+        # characters depending on the wake, and a fixed 18 cut `Jan 01 2027
+        # 9:00 AM EST` to `Jan 01 2027 9:00 A`: a half meridiem, no zone, and
+        # no marker to say anything was dropped. A time that is wrong is worse
+        # than a time that is absent, and unlike a message (which the reader
+        # can recognise from its start) there is no recovering a mangled clock.
+        #
+        # So the column is sized from THE ROWS BEING RENDERED, and the
+        # renderer's output is printed whole or not at all.
+        when_cells = {row["next_due_at"]: format_wake_time(row["next_due_at"]) for row in rows}
+        when_w = max(len(cell) for cell in when_cells.values())
+        rel_w = 11  # "10m overdue"
+        # SLACK for the id (round 2, R9). Ids are `uuid4().hex[:12]`, and a
+        # 12-wide column truncated a 12-character id to exactly itself with no
+        # room to show that anything was cut — while the 15-character `lr_` ids
+        # that appear in real stores rendered as a DIFFERENT id an operator
+        # cannot paste back. 13 gives a real id slack, and `_elide_id` marks
+        # anything longer instead of silently shortening it.
+        id_w = 13
+        fixed = rel_w + id_w + 2
+        message_floor = 24
+        # WHEN IS THE COLUMN THAT YIELDS on a narrow terminal (round 2, D12 /
+        # QA Q1), because the relative `DUE` cell answers "when does this fire"
+        # in 11 characters and the absolute time is the redundant half. Dropping
+        # it keeps the table aligned at 60 columns instead of wrapping every
+        # row, which is the trade D12 argued for — shed the absolute time
+        # rather than the alignment.
+        show_when = term_width >= when_w + fixed + 1 + message_floor
+        head = fixed + (when_w + 1 if show_when else 0)
+        message_w = max(message_floor, term_width - head - 1)
+        header = f"{'WHEN':<{when_w}} " if show_when else ""
+        print(f"{header}{'DUE':>{rel_w}} {'SESSION':<{id_w}} WAKE")
         for row in rows:
-            when = format_wake_time(row["next_due_at"])[:when_w]
+            when = when_cells[row["next_due_at"]]
             # DORMANT WINS, and the overdue/stale marks are suppressed under it
             # (round 1, Q2/R6). A dormant wake is one nothing is SUPPOSED to
             # fire, so "(OVERDUE)" — which means "should have fired and did
@@ -3050,6 +3084,11 @@ def wake_command(args: argparse.Namespace) -> int:
             # restated on every row what the reader needs told once.
             if row["dormant"]:
                 state = "dormant"
+            elif row["ghost"]:
+                # Ghost before stale: with no session on disk, nothing can fire
+                # this at all, which is a stronger statement than "the
+                # supervisor stopped retrying" (round 2, Q4).
+                state = "ghost"
             elif row["stale"]:
                 state = "stale"
             else:
@@ -3093,19 +3132,43 @@ def wake_command(args: argparse.Namespace) -> int:
             if len(message) > room:
                 message = message[: max(room - 1, 1)] + "…"
             detail = f"{message}{tail}"
+            when_cell = f"{when:<{when_w}} " if show_when else ""
             print(
-                f"{when:<{when_w}} {state:>{rel_w}} "
-                f"{row['session_id'][:id_w]:<{id_w}} {detail:<{message_w}}".rstrip()
+                f"{when_cell}{state:>{rel_w}} "
+                f"{_elide_id(row['session_id'], id_w):<{id_w}} {detail}".rstrip()
             )
+
         # ONE legend under the table rather than the same sentence on every
         # row, and only for the states actually present: what "stale" and
         # "dormant" COST is the thing a reader needs told, but telling it per
         # row is what made a single wake occupy 155 columns.
-        if any(row["stale"] and not row["dormant"] for row in rows):
-            print("\nstale    the supervisor no longer fires these; they are delivered")
-            print("         when their session is next opened")
+        # The legend folds to the terminal like the rows do (round 2, D12):
+        # a legend that wraps is the same ragged frame the table just stopped
+        # producing. 9 = the width of the state word plus its gap.
+        def _legend(word: str, text: str) -> None:
+            import textwrap
+
+            print()
+            for line in textwrap.wrap(
+                f"{word:<9}{text}", width=term_width, subsequent_indent=" " * 9
+            ):
+                print(line)
+
+        if any(row["stale"] and not row["dormant"] and not row["ghost"] for row in rows):
+            _legend(
+                "stale",
+                "the supervisor no longer fires these; they are delivered when "
+                "their session is next opened",
+            )
         if any(row["dormant"] for row in rows):
-            print("\ndormant  the session was stopped; reopening it re-arms its wakes")
+            _legend("dormant", "the session was stopped; reopening it re-arms its wakes")
+        if any(row["ghost"] for row in rows):
+            _legend("ghost", "no session with this id exists on disk; nothing can fire these")
+        if not show_when:
+            # The omission is STATED, not silent: the absolute time was dropped
+            # to keep the table aligned on a narrow terminal (round 2, D12), and
+            # the reader is told where it went rather than left to notice.
+            print("\n(WHEN hidden — terminal too narrow)")
         return 0
 
     # status
@@ -3162,8 +3225,13 @@ def wake_command(args: argparse.Namespace) -> int:
     # in three minutes was absent from the screen entirely.
     armed = [row for row in rows if not row["dormant"]]
     dormant = [row for row in rows if row["dormant"]]
-    fireable = [row for row in armed if not row["stale"]]
-    stale = [row for row in armed if row["stale"]]
+    # GHOST sits beside stale as a reason the supervisor will not fire a row
+    # (round 2, Q4): an index entry whose session has no transcript can never
+    # be engaged, and the supervisor retires on a ghost-only store. Excluded
+    # from `fireable` for exactly the same reason stale is.
+    ghost = [row for row in armed if row["ghost"]]
+    stale = [row for row in armed if row["stale"] and not row["ghost"]]
+    fireable = [row for row in armed if not row["stale"] and not row["ghost"]]
     overdue = [row for row in fireable if row["overdue"]]
     upcoming = fireable  # already sorted soonest-first by `_wake_rows`
 
@@ -3171,6 +3239,9 @@ def wake_command(args: argparse.Namespace) -> int:
     # reads the registry, and a session with three schedules is still one
     # process. Only sessions with something armed are worth asking about — a
     # dormant session's runtime being wedged is not why its wake is not firing.
+    # Each call is a `registry.scan`, which walks the run directory AND reaps
+    # records for dead processes (round 2, R10) — cheap and idempotent at this
+    # scale (measured 19 sessions / 28 ms), but not a free read.
     from local_operator.wakes.supervisor import wedged_runtime
 
     wedged: list[tuple[str, int, float]] = []
@@ -3204,9 +3275,14 @@ def wake_command(args: argparse.Namespace) -> int:
         "scheduled": len(rows),
         "armed": len(armed),
         "dormant": len(dormant),
-        # The soonest FIREABLE wake, which is the only honest answer to "when
-        # will something happen"; `next_due_in_s` used to name the stale row.
-        "next_due_in_s": upcoming[0]["due_in_s"] if upcoming else None,
+        # NAMED FOR WHAT THEY MEAN (round 2, D18). `next_due_in_s` silently
+        # changed meaning in round 1 — it began excluding stale rows, which is
+        # what D2 asked for, under a name that still reads "the soonest due
+        # wake" — and a consumer wanting the raw value had nowhere to get it.
+        # Both are published: the fireable one under an explicit name, the raw
+        # one under the original name so an existing consumer keeps parsing.
+        "next_due_in_s": rows[0]["due_in_s"] if rows else None,
+        "next_fireable_due_in_s": upcoming[0]["due_in_s"] if upcoming else None,
         "supervisor": {
             # False whenever the answer would be about another store, so a
             # monitoring caller cannot read this block as a verdict on THIS
@@ -3220,8 +3296,21 @@ def wake_command(args: argparse.Namespace) -> int:
             "uptime_s": uptime_s,
             "detail": state.detail if state else "",
         },
+        # `overdue` counts FIREABLE rows only, which is what makes it
+        # reconcilable: `scheduled` = fireable + dormant + stale + ghost, and
+        # `overdue` is a subset of the fireable ones. Round 2 (D18) noted a
+        # consumer had no way to tell which rows were inside it; the
+        # `unfireable` block below is that breakdown.
         "overdue": len(overdue),
         "stale": len(stale),
+        "ghost": len(ghost),
+        # Why each non-firing row will not fire, so the counts above can be
+        # reconciled without re-deriving the classification.
+        "unfireable": {
+            "dormant": [row["session_id"] for row in dormant],
+            "stale": [row["session_id"] for row in stale],
+            "ghost": [row["session_id"] for row in ghost],
+        },
         "max_overdue_s": max((row["overdue_s"] for row in overdue), default=0.0),
         # The wedged case: a runtime whose process is alive but whose
         # heartbeat has gone stale holds the transcript lease without serving,
@@ -3243,8 +3332,8 @@ def wake_command(args: argparse.Namespace) -> int:
         # store. Observed during validation, where an isolated run printed the
         # operator's real LaunchAgent pid.
         print("supervisor:  cannot be verified for this store")
-        print(f"             ({state.detail})")
-        print("             (wakes here fire only while a session is open)")
+        print(_wrap_status(f"({state.detail})"))
+        print(_wrap_status("(wakes here fire only while a session is open)"))
     elif running:
         detail = f"running (pid {state.pid})" if state and state.pid else "running"
         # Suppressed under a minute: `up 0s` on a just-started supervisor is
@@ -3267,16 +3356,23 @@ def wake_command(args: argparse.Namespace) -> int:
     # `run 'lop wake install'` twice in a four-line block.
     if is_supported() and verifiable and not running:
         if rows:
-            print("             (nothing will fire these while their sessions are")
-            print("              closed — run 'lop wake install')")
+            print(
+                _wrap_status(
+                    "(nothing will fire these while their sessions are closed — "
+                    "run 'lop wake install')"
+                )
+            )
         else:
-            print("             (run 'lop wake install')")
+            print(_wrap_status("(run 'lop wake install')"))
     if not is_supported():
         # Honest rather than reassuring: on a platform with no installer the
         # wakes of a CLOSED session do not fire, and saying so is the whole
         # point of this line.
-        print("             (no installer for this platform — wakes fire only while a")
-        print("              session is open)")
+        print(
+            _wrap_status(
+                "(no installer for this platform — wakes fire only while a session is open)"
+            )
+        )
 
     # DORMANCY IS NAMED (round 1, D3). `scheduled: 1 (0 armed)` with no word of
     # explanation was a dead end for the operator asking "why has nothing
@@ -3286,37 +3382,122 @@ def wake_command(args: argparse.Namespace) -> int:
         counts += f", {len(dormant)} dormant"
     print(f"scheduled:   {len(rows)} ({counts})")
     if dormant and not armed:
-        print("             (dormant — their sessions were stopped; reopening one re-arms it)")
+        print(_wrap_status("(dormant — their sessions were stopped; reopening one re-arms it)"))
 
-    # ONE LINE PER DISTINCT STATE (round 1, D5). A single stale wake used to
-    # occupy four lines that restated the same fact, and `next:` promised a
-    # future event while naming something nine days past.
-    if upcoming:
+    # ONE LINE PER DISTINCT STATE (round 1, D5; sharpened in round 2, D16).
+    # `next:` is only printed when there IS a next — a fireable wake in the
+    # future. An overdue fireable wake is reported by the `overdue:` line
+    # below, because labelling something already late as "next" promises a
+    # future event, and saying it twice was the overlap D16 named.
+    if upcoming and not upcoming[0]["overdue"]:
         soonest = upcoming[0]
-        when = _format_due(soonest["due_in_s"])
-        print(f"next:        {when}  {soonest['message']}")
-    elif armed:
-        # Armed but nothing fireable: every armed wake is stale.
-        print("next:        none — nothing here will fire until its session is opened")
+        print(_wrap_status(f"{_format_due(soonest['due_in_s'])}  {soonest['message']}", "next:"))
     if overdue:
         # Counted over FIREABLE rows only, so "worst" is a wake that is
-        # actually coming rather than one the supervisor has given up on.
+        # actually coming rather than one the supervisor has given up on. The
+        # soonest overdue row is named, since with nothing in the future this
+        # is the line that answers "what is the supervisor working on".
         worst = max(row["overdue_s"] for row in overdue)
-        print(f"overdue:     {len(overdue)} (worst {_format_duration(worst)})")
+        summary = f"{len(overdue)} (worst {_format_duration(worst)})  {overdue[0]['message']}"
+        print(_wrap_status(summary, "overdue:"))
     if stale:
         print(
-            f"stale:       {len(stale)} past {int(stale_after_days)}d — delivered when "
-            "their sessions are next opened"
+            _wrap_status(
+                f"{len(stale)} past {int(stale_after_days)}d — delivered when their "
+                "sessions are next opened",
+                "stale:",
+            )
+        )
+    if ghost:
+        # The supervisor refuses these and retires on a ghost-only store
+        # (round 2, Q4). Saying so here is what stops this frame contradicting
+        # the process; the remedy is the session, not the wake subsystem.
+        print(
+            _wrap_status(
+                f"{len(ghost)} with no session on disk — nothing can fire these; "
+                "the entry is removed when that session id is next written",
+                "ghost:",
+            )
         )
     for session_id, pid, age in wedged:
-        # Named on its own line because the remedy is different from every
-        # other state here: nothing the wake subsystem does will help, and the
-        # operator has to decide whether that process is recoverable.
+        # Named on its own line because the remedy is a DIFFERENT command from
+        # every other non-running state (round 2, D14): the surface points at
+        # `lop wake install` elsewhere, and here no wake-subsystem action can
+        # help at all, so it names the two commands that can.
         print(
-            f"wedged:      {session_id} (pid {pid}) has not heartbeat for "
-            f"{_format_duration(age)}; it holds the lease, so its wake cannot fire"
+            _wrap_status(
+                f"{session_id} (pid {pid}) has not sent a heartbeat in "
+                f"{_format_duration(age)}; it holds the session lease, so its wake "
+                f"cannot fire. It will not recover on its own — 'lop sessions' shows "
+                f"it, 'lop stop --pid {pid}' ends it",
+                "wedged:",
+            )
         )
     return 0
+
+
+def _elide_id(session_id: str, width: int) -> str:
+    """A session id that fits, and that SAYS SO when it does not.
+
+    Round 2 (R9): `session_id[:12]` in a 12-wide column rendered a
+    15-character id as a different, shorter id — one an operator cannot paste
+    back into `lop wake list` or `lop stop`, with nothing marking it as cut.
+    Truncating an identifier is not like truncating a message: the reader can
+    recognise a message from its opening words and cannot reconstruct an id.
+    Ids are `uuid4().hex[:12]` so the column fits every id the product mints;
+    anything longer is marked rather than silently shortened.
+    """
+    if len(session_id) <= width:
+        return session_id
+    return session_id[: max(width - 1, 1)] + "…"
+
+
+#: Width of `wake status`'s label column ("supervisor:  ", "scheduled:   ").
+#: Every continuation line on that surface already indents to it, so a new
+#: line that wraps at column 0 reads as a different block (round 2, D13).
+_STATUS_LABEL_W = 13
+
+
+def _wrap_status(text: str, label: str = "") -> str:
+    """One `wake status` line, folded at the surface's own hanging indent.
+
+    Two round-2 findings meet here. D13: the `wedged:` line was 108 columns and
+    the only one whose continuation started at column 0, so the single line an
+    operator must act on was the one rendered as a ragged paragraph. Q2: the
+    `next:`/`overdue:` lines interpolate a user-authored wake message and were
+    never clamped — a 129-character message produced a 156-column line at every
+    terminal width, which is the last unclamped string on either screen.
+
+    Wrapping rather than truncating, because unlike the `wake list` table (one
+    row per wake, where a clamp keeps the columns) these lines are prose and
+    the whole sentence is the payload.
+    """
+    import re
+    import shutil
+    import textwrap
+
+    width = max(shutil.get_terminal_size((80, 24)).columns, _STATUS_LABEL_W + 24)
+    indent = " " * _STATUS_LABEL_W
+    first = f"{label:<{_STATUS_LABEL_W}}{text}" if label else f"{indent}{text}"
+
+    # A QUOTED COMMAND IS ONE TOKEN. Every remedy on this surface is a command
+    # the operator copies — `'lop wake install'`, `'lop stop --pid 4242'` — and
+    # a wrap inside one produces a line that looks like an instruction and is
+    # not runnable. `textwrap` only breaks on whitespace, so the spaces inside
+    # single quotes are hidden from it and restored afterwards.
+    nbsp = "\x00"
+    protected = re.sub(r"'[^']*'", lambda m: m.group(0).replace(" ", nbsp), first)
+    return "\n".join(
+        textwrap.wrap(
+            protected,
+            width=width,
+            subsequent_indent=indent,
+            # A wake message can carry a path or a URL; breaking one makes it
+            # unusable, and an over-long line is the lesser harm.
+            break_long_words=False,
+            break_on_hyphens=False,
+        )
+    ).replace(nbsp, " ")
 
 
 def _json_dumps(value: Any) -> str:

--- a/local_operator/session/runtime/launch.py
+++ b/local_operator/session/runtime/launch.py
@@ -165,8 +165,16 @@ class WakeErrand:
     So the supervisor's job is strictly to make a runtime EXIST for a session
     whose wake is due; the session then does what it would have done had a
     terminal been open. ``schedule_id`` and ``occurrence_ms`` are carried for
-    the log line and for the derived ``command_id``, which is what keeps a
-    supervisor retry from starting two runtimes for one occurrence.
+    the log line and for a derived ``command_id``.
+
+    **The ``command_id`` is not what dedupes a wake**, and believing it was
+    obscured where the real guarantee lives. :func:`_deliver` returns early
+    for a ``WakeErrand`` without sending any op, so the id never reaches a
+    runtime and no duplicate-command check ever sees it. What actually keeps a
+    supervisor retry from producing two SERVING runtimes for one occurrence is
+    the engage loop itself: an engage that finds a live record reuses it, and
+    the transcript lease admits only one serving runtime however many
+    candidate processes were spawned.
     """
 
     schedule_id: str

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -2376,6 +2376,10 @@ class Session:
             ),
         )
         self._wake_deliver_hook: Callable[[DueWake], Awaitable[None]] = self._deliver_wake
+        #: Set by the deliver trampoline, consumed by the next persist, which
+        #: is what stamps ``last_fired_at`` on the wake index entry. See
+        #: :meth:`_persist_wake_schedules`.
+        self._wake_fired_since_persist = False
         # Catch-up state for the wake deliveries the process was DOWN for:
         # (occurrences skipped while down, grace re-arm from the just-run
         # load(), text of the aggregated catch-up prompt, and whether that
@@ -10586,6 +10590,11 @@ class Session:
         """Scheduler-facing deliver trampoline: reads the CURRENT hook at fire
         time, so swapping the hook (resume catch-up shim) takes effect without
         rebuilding the scheduler."""
+        # Marked before the hook runs, not after: a delivery that RAISES still
+        # advances the schedule (the scheduler's documented behaviour, so one
+        # broken wake cannot become a hot loop), so it must still count as a
+        # fire for the purpose of "when did this last go off".
+        self._wake_fired_since_persist = True
         await self._wake_deliver_hook(due)
 
     def _prepare_missed_wake_catchup(self) -> None:
@@ -10788,18 +10797,31 @@ class Session:
             WAKE_SCHEDULES_CUSTOM_TYPE,
             {"schedules": [schedule.model_dump() for schedule in schedules]},
         )
-        self._write_wake_index_entry(schedules, clear=())
+        # A persist that follows a delivery stamps `last_fired_at`. The
+        # scheduler's pump delivers and THEN persists the advanced list, so
+        # the flag set at delivery is still standing here; consuming it (not
+        # just reading it) keeps a later unrelated persist — the wake tool
+        # adding a schedule, say — from restamping a fire that did not happen.
+        stamp = "last_fired_at" if self._wake_fired_since_persist else ""
+        self._wake_fired_since_persist = False
+        self._write_wake_index_entry(schedules, clear=(), stamp=stamp)
         if schedules:
             self._ensure_wake_supervisor()
 
     def _rebuild_wake_index_entry(self) -> None:
         """Open-time rewrite of the index entry from the scheduler's adopted
         rows. Clears ``stopped_at``: a stopped session's wakes are dormant
-        only until someone opens it again, and opening is exactly this."""
-        self._write_wake_index_entry(list(self._wake.schedules), clear=("stopped_at",))
+        only until someone opens it again, and opening is exactly this.
+
+        Stamps ``last_attempt_at``: a runtime existing for this session is
+        precisely what the supervisor engages to achieve, so this is where
+        "the wake machinery got this far" becomes observable."""
+        self._write_wake_index_entry(
+            list(self._wake.schedules), clear=("stopped_at",), stamp="last_attempt_at"
+        )
 
     def _write_wake_index_entry(
-        self, schedules: list[WakeSchedule], *, clear: tuple[str, ...]
+        self, schedules: list[WakeSchedule], *, clear: tuple[str, ...], stamp: str = ""
     ) -> None:
         """Best-effort index write. Swallows everything: see
         :meth:`_persist_wake_schedules` for why a failure here must not
@@ -10823,6 +10845,21 @@ class Session:
             # child), and the directory should not be touched twice for a
             # file that almost never exists.
             existing = wake_store.read_entry(root, self._session_id) if schedules else None
+            if stamp:
+                # LATENESS TELEMETRY, written by the one writer of schedule
+                # state. The supervisor deliberately never writes here (it
+                # would then be able to disagree with the session about what
+                # has fired), so the only way `lop wake status` can report how
+                # late a wake actually was is for the session to record these
+                # two instants as it passes them:
+                #
+                #   last_attempt_at — a runtime came up for this session
+                #   last_fired_at   — a wake was actually delivered
+                #
+                # The gap between `next_due_at` and these is the lateness the
+                # whole defect was invisible for. They ride on `preserve`, so
+                # an ordinary persist that stamps neither keeps both.
+                existing = {**(existing or {}), stamp: int(time.time() * 1000)}
             wake_store.write_entry(
                 root,
                 self._session_id,

--- a/local_operator/wakes/install.py
+++ b/local_operator/wakes/install.py
@@ -373,7 +373,19 @@ def ensure_supervisor_installed(config_dir: Path) -> InstallOutcome:
             # A redirected home: the plist is the only half we own here, and
             # it already matches. Probing launchd would address the REAL
             # domain from a sandbox (see `_launchd_is_addressable`).
-            return InstallOutcome(installed=True, reason="already installed")
+            #
+            # It must NOT claim "already installed" (round 1, Q1). Nothing
+            # supervises this store — the first call in the same store says
+            # "plist written; launchd not addressable from here" and
+            # `wake status` says "cannot be verified for this store", so
+            # answering in the old two-valued vocabulary made three surfaces
+            # disagree about one store. `installed=False` for the same reason:
+            # this PR's whole thesis is that "installed" stops meaning "a file
+            # exists".
+            return InstallOutcome(
+                installed=False,
+                reason="plist already written; launchd not addressable from here",
+            )
         if current == wanted and addressable:
             state = supervisor_state(config_dir)
             if state.running:

--- a/local_operator/wakes/install.py
+++ b/local_operator/wakes/install.py
@@ -20,6 +20,30 @@ sense once there is something to supervise: a user who never schedules a wake
 never gets the process. Linux has no installer here yet and reports
 ``installed=False``; a session there keeps firing its own wakes in-process,
 which is what happened everywhere before this existed.
+
+**"Installed" now means RUNNING, and that change fixed a permanent miss.**
+The hook used to answer "is it installed?" with ``launchctl print`` returning
+0, which is true of a job launchd merely *knows about*. A job that has exited
+still prints, still returns 0, and reports ``state = not running``, measured
+on a scratch label:
+
+.. code-block:: text
+
+    $ launchctl print gui/501/com.local-operator.waketest ; echo $?
+    state = not running
+    runs = 1
+    0
+
+Combined with self-retirement that is a permanent hole: the supervisor exits
+0 on an empty index, the next persist writes an index entry and asks to
+install, the hook says "already installed" because the dead job still prints,
+and nothing is running to fire the wake. ``KeepAlive`` does not help — a
+successful exit is exactly what it is configured not to restart. The wake
+then surfaces only when a human next opens the session, with no log line
+anywhere. :func:`supervisor_state` is the fix: it parses the print output for
+a live pid/state rather than trusting the exit code, and
+:func:`ensure_supervisor_installed` REPAIRS what it finds (``kickstart`` when
+loaded-but-stopped, ``bootstrap`` when absent).
 """
 
 from __future__ import annotations
@@ -51,6 +75,31 @@ def plist_path() -> Path:
 
 def log_path(config_dir: Path) -> Path:
     return config_dir / "logs" / "wake-supervisor.log"
+
+
+#: How often launchd re-runs the supervisor on its own (seconds).
+#:
+#: This is a bounded self-heal, and it deliberately SOFTENS the invariant the
+#: rest of this module documents — "a machine with no wakes left runs no
+#: supervisor at all" is now "a machine with no wakes left runs the supervisor
+#: briefly every 15 minutes, where it reads an empty index and exits 0 again".
+#: That reversal is bought knowingly, because the alternative is the permanent
+#: miss above: every other repair path in this file needs SOMETHING to call it
+#: (a persist, a ``lop wake status``), and the failure mode is precisely the
+#: one where nothing is left running to make that call. ``StartInterval`` is
+#: the only mechanism that does not depend on a live process.
+#:
+#: Safe, and measured rather than assumed (scratch label, 20 s job, 5 s
+#: interval): launchd started runs at +0 s, +25 s and +51 s — it does NOT
+#: start a second instance while the job runs, it waits for the current one to
+#: exit. And it DOES re-run a job that exited 0, which ``KeepAlive:
+#: {SuccessfulExit: False}`` alone would not.
+#:
+#: 900 s because it must be well under the shortest realistic wake cadence
+#: (the live machine's tightest recurring wake is 20 min) so a resurrected
+#: supervisor still catches the next occurrence, while an idle wake-free
+#: machine pays only ~96 short-lived reads of an empty directory a day.
+SELF_HEAL_INTERVAL_S = 900
 
 
 def is_supported() -> bool:
@@ -141,6 +190,11 @@ def render_plist(config_dir: Path) -> dict[str, object]:
         # with no wakes left runs no supervisor at all. A plain KeepAlive:true
         # would restart it forever against an empty index.
         "KeepAlive": {"SuccessfulExit": False},
+        # The bounded self-heal, and the one repair that needs no live caller.
+        # See SELF_HEAL_INTERVAL_S for why this softens the self-retirement
+        # invariant directly above, and for the measurement showing launchd
+        # will not start a second instance while one is running.
+        "StartInterval": SELF_HEAL_INTERVAL_S,
         "StandardOutPath": str(log_path(config_dir)),
         "StandardErrorPath": str(log_path(config_dir)),
         # The config dir is part of the contract: the supervisor reads the
@@ -158,6 +212,112 @@ def _launchctl(*args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(  # noqa: S603 — fixed argv, no shell
         ["launchctl", *args], capture_output=True, text=True, timeout=15
     )
+
+
+@dataclass(frozen=True)
+class SupervisorState:
+    """What launchd actually has, as opposed to what the plist says.
+
+    ``loaded`` is "launchd knows this label"; ``running`` is "a process is
+    alive behind it". The two disagree exactly in the case this module exists
+    to fix, and that is why they are separate fields rather than one boolean.
+    ``pid`` is present only when running; ``detail`` carries the state word
+    for the status surface.
+
+    ``verifiable`` is a THIRD state, and it is not a technicality: launchd has
+    no sandbox, so a probe run against an isolated store still addresses the
+    real user's domain and answers about the real user's supervisor. Reporting
+    that as this store's supervisor is the same class of lie this module
+    exists to remove — it tells someone their wakes are supervised while the
+    running process watches a different store entirely. When ``verifiable`` is
+    False, ``loaded``/``running``/``pid`` say nothing about the store that was
+    asked about, and a caller must not render them.
+    """
+
+    loaded: bool
+    running: bool
+    pid: int | None = None
+    detail: str = ""
+    verifiable: bool = True
+
+
+#: ``state = <word>`` values that POSITIVELY mean "not running". Deliberately
+#: an allowlist of stopped states rather than "anything that is not
+#: 'running'": launchd's vocabulary is not ours to enumerate exhaustively, and
+#: the cost of the two errors is asymmetric. Reading an unknown state as
+#: stopped would kickstart a healthy supervisor (and, worse, do it on the
+#: persist path, every persist, forever); reading it as running only means a
+#: repair we would have liked does not happen, which is the status quo this
+#: change improves on. So the parse FAILS SAFE: unparseable output is treated
+#: as running.
+_STOPPED_STATES = frozenset({"not running", "exited", "stopped", "waiting"})
+
+
+def _parse_supervisor_state(stdout: str) -> tuple[bool, int | None, str]:
+    """``(running, pid, detail)`` from one ``launchctl print`` body.
+
+    Pure so the parse is testable against recorded launchctl output without a
+    subprocess; see ``tests/unit/wakes/test_install.py``.
+    """
+    pid: int | None = None
+    state = ""
+    for raw in stdout.splitlines():
+        line = raw.strip()
+        # `pid = 47545` is the strongest signal launchd gives: it is printed
+        # only while a process is alive behind the label.
+        if line.startswith("pid =") and pid is None:
+            value = line.partition("=")[2].strip()
+            if value.isdigit():
+                pid = int(value)
+        elif line.startswith("state =") and not state:
+            state = line.partition("=")[2].strip().lower()
+    if pid is not None:
+        return True, pid, state or "running"
+    if state in _STOPPED_STATES:
+        return False, None, state
+    # No pid AND no state we recognise as stopped: fail safe (see
+    # _STOPPED_STATES). `detail` still carries whatever was read so a status
+    # reader is not told a confident lie.
+    return True, None, state
+
+
+def supervisor_state(config_dir: Path) -> SupervisorState:
+    """Whether a supervisor process is actually alive FOR ``config_dir``.
+
+    ``config_dir`` is REQUIRED rather than implied, because the label is
+    global while the store is not. Both installer guards are applied here, at
+    the probe itself, so no caller can accidentally report the operator's live
+    supervisor as the supervisor of a sandboxed store. That exact wrong answer
+    was produced during validation: an isolated run printed
+    ``running (pid 47545)`` — the real LaunchAgent, watching the real store,
+    while the store under test was in a tmpdir.
+
+    ONE ``launchctl print``, parsed \u2014 not a print plus a second probe. This
+    runs on the persist path (every wake write goes through
+    :func:`ensure_supervisor_installed`), so a second subprocess here would be
+    a cost paid by every scheduling operation on the machine.
+    """
+    if not is_supported():
+        return SupervisorState(
+            loaded=False, running=False, verifiable=False, detail=UNSUPPORTED_REASON
+        )
+    if not _launchd_is_addressable() or not _config_lives_in_real_home(config_dir):
+        # Same two guards the installer uses to decide whether it may ACT;
+        # asking is subject to them for the same reason, because the answer
+        # would be about someone else's store.
+        return SupervisorState(
+            loaded=False,
+            running=False,
+            verifiable=False,
+            detail="this store is outside the real home; launchd cannot supervise it",
+        )
+    result = _launchctl("print", f"{_domain()}/{LABEL}")
+    if result.returncode != 0:
+        # Not loaded at all. This is the only honest "no" launchctl gives by
+        # exit code; a loaded-but-dead job also returns 0 (module docstring).
+        return SupervisorState(loaded=False, running=False, detail="not loaded")
+    running, pid, detail = _parse_supervisor_state(result.stdout)
+    return SupervisorState(loaded=True, running=running, pid=pid, detail=detail)
 
 
 @dataclass(frozen=True)
@@ -209,8 +369,48 @@ def ensure_supervisor_installed(config_dir: Path) -> InstallOutcome:
             except Exception:  # noqa: BLE001 — an unreadable plist is a stale one
                 current = None
         addressable = _launchd_is_addressable()
-        if current == wanted and (not addressable or _is_loaded()):
+        if current == wanted and not addressable:
+            # A redirected home: the plist is the only half we own here, and
+            # it already matches. Probing launchd would address the REAL
+            # domain from a sandbox (see `_launchd_is_addressable`).
             return InstallOutcome(installed=True, reason="already installed")
+        if current == wanted and addressable:
+            state = supervisor_state(config_dir)
+            if state.running:
+                return InstallOutcome(installed=True, reason="already installed")
+            if state.loaded:
+                # THE REPAIR THAT CLOSES THE PERMANENT MISS. The plist is
+                # right and launchd knows the label, but the process exited
+                # (self-retirement on an empty index, or a crash KeepAlive
+                # declined to restart). The old code read this as "already
+                # installed" and left the armed wake with nothing to fire it.
+                #
+                # `kickstart -k` rather than bootout+bootstrap: it is the
+                # narrower operation (restart this job) and does not briefly
+                # unregister the label. The `-k` is what makes it a repair
+                # rather than a no-op if the state read were ever wrong.
+                #
+                # Safe to run mid-engage, and that is load-bearing: a runtime
+                # this supervisor spawned is DETACHED (`start_new_session=True`,
+                # `session/runtime/launch.py`), so killing and restarting the
+                # supervisor cannot kill a candidate mid-construction. The
+                # restarted supervisor re-reads the index and finds the wake
+                # still armed — at worst it re-engages and the lease
+                # arbitration hands it the existing runtime.
+                result = _launchctl("kickstart", "-k", f"{_domain()}/{LABEL}")
+                if result.returncode != 0:
+                    return InstallOutcome(
+                        installed=False,
+                        reason=(
+                            "supervisor was loaded but not running and could not be "
+                            f"restarted: {result.stderr.strip() or result.returncode}"
+                        ),
+                    )
+                logger.info("wake supervisor was loaded but not running; restarted it")
+                return InstallOutcome(installed=True, reason="restarted a stopped supervisor")
+            # Loaded=False with a matching plist: launchd forgot the label (a
+            # reboot with the agent removed, a hand `bootout`). Falls through
+            # to the write+bootstrap below, which is the correct repair.
 
         if addressable and not _config_lives_in_real_home(config_dir):
             # The guard used to cover the launchctl call but not the WRITE,
@@ -252,14 +452,18 @@ def ensure_supervisor_installed(config_dir: Path) -> InstallOutcome:
         return InstallOutcome(installed=False, reason=f"install failed: {exc}")
 
 
-def _is_loaded() -> bool:
-    """Whether launchd currently has the unit.
+def _is_loaded(config_dir: Path) -> bool:
+    """Whether launchd currently has the unit supervising ``config_dir``.
 
-    Checked alongside the plist's content because the two can disagree: a
-    machine that rebooted with the agent removed, or a `bootout` run by hand,
-    leaves the file on disk with nothing running behind it.
+    **Loaded is not running, and the install path must not confuse the two.**
+    This answers only "does launchd know the label", which a job that exited
+    0 still satisfies \u2014 the blind spot that let an armed wake sit with no
+    live supervisor. :func:`supervisor_state` is what the installer and the
+    status surface use; this is kept because it is part of the published
+    surface of this module and it remains the correct answer to its own,
+    narrower question.
     """
-    return _launchctl("print", f"{_domain()}/{LABEL}").returncode == 0
+    return supervisor_state(config_dir).loaded
 
 
 def uninstall() -> InstallOutcome:

--- a/local_operator/wakes/supervisor.py
+++ b/local_operator/wakes/supervisor.py
@@ -57,7 +57,13 @@ import time
 from pathlib import Path
 from typing import Any
 
-logger = logging.getLogger(__name__)
+#: A STABLE name, not ``__name__``. This module is the LaunchAgent's
+#: ``python -m`` target, so ``__name__`` is ``__main__`` in the one process
+#: whose output the operator actually reads — every line in
+#: ``logs/wake-supervisor.log`` was tagged with the least informative name
+#: available (round 1, D8). Hard-coding the dotted path makes the LaunchAgent's
+#: lines and ``lop wake serve``'s identical.
+logger = logging.getLogger("local_operator.wakes.supervisor")
 
 #: Never sleep longer than this, however far away the next wake is. A long
 #: sleep is not a correctness problem (the due time is recomputed on every
@@ -116,13 +122,92 @@ STALE_AFTER_S = 7 * 24 * 3600.0
 #: protecting against.
 #:
 #: 180 s is a generous multiple of the worst cold start observed rather than a
-#: tight bound: the only thing a longer deadline costs is a semaphore slot
-#: held by a session nobody is waiting for, and :func:`serve` keeps re-reading
-#: the index on its slice throughout regardless.
+#: tight bound. What makes a long deadline affordable is that an engage does
+#: NOT hold the loop: :func:`serve` runs engagements as background tasks and
+#: returns to its slice loop immediately, so the only thing a slow engage
+#: occupies is one of :data:`_MAX_CONCURRENT_ENGAGES` slots. (Round 1, R3: an
+#: earlier revision awaited the whole sweep, which made a 6-session all-timeout
+#: pass block for 540 s — three times worse than the serial 30 s code it
+#: replaced — while this comment already claimed otherwise. The claim is now
+#: true because the code changed, not because the wording did.)
 WAKE_DEADLINE_S = 180.0
 
 #: How many sessions the sweep engages at once. See :func:`fire_due_wakes`.
 _MAX_CONCURRENT_ENGAGES = 2
+
+#: How many times one (session, reason) skip is logged at full volume before
+#: dropping to :data:`_SKIP_HEARTBEAT_S`.
+#:
+#: A stale or ghost skip NEVER self-clears — a >7-day wake stays >7 days and a
+#: ghost session never grows a transcript — so logging it once per slice is
+#: 8,640 lines/day/entry into a file nothing rotates (``render_plist`` points
+#: ``StandardErrorPath`` at a plain path). The operator's box has two such ids
+#: today, so that is ~3.3 MB/day drowning the signal this observability was
+#: added to create. The first occurrences are the ones that carry information;
+#: after that a periodic heartbeat is enough to show the condition persists.
+_SKIP_LOG_BURST = 3
+
+#: Cadence for a skip that has already been logged :data:`_SKIP_LOG_BURST`
+#: times. One line an hour per stuck entry keeps the condition visible in the
+#: log without flooding it (~24 lines/day/entry rather than 8,640).
+_SKIP_HEARTBEAT_S = 3600.0
+
+
+class _SkipLog:
+    """Throttles a skip line that would otherwise repeat every slice forever.
+
+    Keyed by ``(session_id, reason)`` so a *change* of reason speaks up again
+    at full volume: an entry that goes from "live runtime owns it" to "stale"
+    is new information and must not inherit the old key's silence.
+
+    Process-lifetime state, deliberately. It is not persisted, so a restarted
+    supervisor re-announces every standing condition once — which is what an
+    operator reading a fresh log wants, and it keeps this module free of any
+    state file it would then have to own.
+    """
+
+    def __init__(self) -> None:
+        self._seen: dict[tuple[str, str], tuple[int, float]] = {}
+
+    def should_log(self, session_id: str, reason: str, *, now: float | None = None) -> bool:
+        moment = now if now is not None else time.monotonic()
+        key = (session_id, reason)
+        count, last = self._seen.get(key, (0, 0.0))
+        if count < _SKIP_LOG_BURST:
+            self._seen[key] = (count + 1, moment)
+            return True
+        if moment - last >= _SKIP_HEARTBEAT_S:
+            self._seen[key] = (count + 1, moment)
+            return True
+        self._seen[key] = (count, last)
+        return False
+
+    def forget(self, session_id: str) -> None:
+        """Drop a session's throttle state once it is no longer being skipped,
+        so a recurrence after a genuine recovery is reported in full."""
+        for key in [key for key in self._seen if key[0] == session_id]:
+            del self._seen[key]
+
+
+#: Module-level because the throttle must outlive one sweep: every skip this
+#: bounds is one that repeats on every pass for the life of the process.
+_skip_log = _SkipLog()
+
+
+def _is_stale(entry: dict[str, Any], now_ms: int) -> bool:
+    """Whether this entry's soonest wake is past the staleness bound.
+
+    Shared by the sweep and by :func:`_has_fireable_wakes` so "the supervisor
+    will not fire this" is decided in exactly one place. Two readers deriving
+    that separately is how a ghost came to keep the process alive forever
+    while every pass logged that it was skipping it.
+    """
+    from local_operator.wakes.store import next_due_at
+
+    earliest = next_due_at(entry)
+    if earliest is None:
+        return False
+    return (now_ms - earliest) / 1000.0 > STALE_AFTER_S
 
 
 def _due_sessions(index: dict[str, dict[str, Any]], now_ms: int) -> list[tuple[str, str, int]]:
@@ -161,14 +246,18 @@ def _due_sessions(index: dict[str, dict[str, Any]], now_ms: int) -> list[tuple[s
             # past seven days, and from then on this branch drops it silently
             # on every pass. WARNING, not INFO — reaching this state means a
             # wake the user asked for is no longer being fired at all.
-            logger.warning(
-                "skipping %s: its wake is %.1f days overdue (> the %.0f-day staleness "
-                "bound); it will be delivered by the session's own catch-up when it is "
-                "next opened",
-                session_id,
-                overdue_s / 86400.0,
-                STALE_AFTER_S / 86400.0,
-            )
+            # Throttled (round 1, R2/Q4): this condition never self-clears, so
+            # an unthrottled line here is 8,640/day into an unrotated file.
+            # The reason leads, because that is what an operator greps for.
+            if _skip_log.should_log(session_id, "stale"):
+                logger.warning(
+                    "stale: skipping %s — its wake is %.1f days overdue (> the %.0f-day "
+                    "staleness bound); it will be delivered by the session's own "
+                    "catch-up when it is next opened",
+                    session_id,
+                    overdue_s / 86400.0,
+                    STALE_AFTER_S / 86400.0,
+                )
             continue
         cwd = entry.get("cwd")
         due.append(
@@ -235,6 +324,38 @@ async def _has_live_runtime(config_dir: Path, session_id: str) -> bool:
     return record is not None
 
 
+def wedged_runtime(config_dir: Path, session_id: str) -> tuple[int, float] | None:
+    """``(pid, heartbeat_age_s)`` when a runtime for ``session_id`` is WEDGED.
+
+    The last silent dead-end. A runtime whose process is alive but whose
+    heartbeat has gone stale past ``HEARTBEAT_TIMEOUT_S`` is invisible to
+    :func:`_has_live_runtime` (``find_runtime_record`` filters to ``live``, so
+    the supervisor engages) *and* blocks that engage: ``_lease_holder`` sees
+    the live pid holding the transcript lease and refuses to spawn, so every
+    pass burns its whole deadline and the wake never fires while the wedge
+    persists. Before this, the only trace was an ordinary timeout line,
+    indistinguishable from a slow cold start.
+
+    VISIBILITY ONLY. Nothing here breaks the lease or signals the process:
+    the safe repair belongs to the runtime's own watchdog, and a supervisor
+    that killed a session's process on a heartbeat heuristic could destroy
+    work a merely-slow runtime was in the middle of. ``registry.scan`` already
+    owns this classification, so the state is read from it rather than
+    re-derived from ``heartbeat_at`` here.
+    """
+    from local_operator.session.runtime.registry import scan
+
+    try:
+        records = scan(config_dir)
+    except OSError:
+        return None
+    now = time.time()
+    for record, state in records:
+        if state == "wedged" and record.session_id == session_id:
+            return record.pid, max(now - record.heartbeat_at, 0.0)
+    return None
+
+
 async def _engage_one(
     config_dir: Path,
     session_id: str,
@@ -255,27 +376,46 @@ async def _engage_one(
         if await _has_live_runtime(config_dir, session_id):
             # The no-live-record rule: that session fires its own wakes.
             #
-            # INFO with the overdue figure, not debug. A WEDGED runtime (one
-            # whose record is live but whose event loop is stuck) looks
-            # exactly like a healthy one here, so the supervisor skips it on
-            # every pass while its wake never fires. That case was invisible
-            # at the default log level; a growing overdue figure on a
-            # repeating "already running" line is what makes it findable.
-            logger.info(
-                "skipping %s: its wake is %.1fs overdue but a live runtime owns it "
-                "(that session fires its own wakes)",
-                session_id,
-                overdue_s,
-            )
+            # INFO with the overdue figure, not debug: a growing overdue
+            # figure on a repeating "already running" line is what makes a
+            # session that is up but not firing findable. Throttled, because
+            # a long-lived session legitimately produces this every slice.
+            if _skip_log.should_log(session_id, "live"):
+                logger.info(
+                    "live: skipping %s — its wake is %.1fs overdue but a live runtime "
+                    "owns it (that session fires its own wakes)",
+                    session_id,
+                    overdue_s,
+                )
             return False
         if not await asyncio.to_thread(_session_exists, config_dir, session_id):
-            logger.warning(
-                "skipping %s: its wake is %.1fs overdue but the session has no transcript "
-                "on disk; the index entry is a ghost and can never be engaged",
-                session_id,
-                overdue_s,
-            )
+            if _skip_log.should_log(session_id, "ghost"):
+                logger.warning(
+                    "ghost: skipping %s — its wake is %.1fs overdue but the session has "
+                    "no transcript on disk; the index entry can never be engaged",
+                    session_id,
+                    overdue_s,
+                )
             return False
+        # Probed BEFORE the engage, not after it fails, because the engage
+        # would otherwise burn its whole deadline against a lease this process
+        # cannot take — and report that as an ordinary timeout.
+        wedge = await asyncio.to_thread(wedged_runtime, config_dir, session_id)
+        if wedge is not None:
+            pid, age_s = wedge
+            if _skip_log.should_log(session_id, "wedged"):
+                logger.warning(
+                    "wedged: skipping %s — a runtime exists (pid %d) but its heartbeat is "
+                    "%.0fs stale, so it holds the transcript lease without serving; the "
+                    "wake is %.1fs overdue and cannot fire until that process recovers "
+                    "or is stopped",
+                    session_id,
+                    pid,
+                    age_s,
+                    overdue_s,
+                )
+            return False
+        _skip_log.forget(session_id)
         logger.info(
             "engaging %s: wake due %d, %.1fs overdue (deadline %.0fs)",
             session_id,
@@ -326,46 +466,120 @@ async def _engage_one(
         return True
 
 
+class _Sweeper:
+    """Owns the in-flight engagements so the serve loop never waits on one.
+
+    **Why this is not a ``gather``.** Awaiting the sweep to completion put the
+    head-of-line blocking back where the slice re-read had just removed it:
+    with concurrency 2 and a 180 s deadline, six all-timing-out sessions block
+    for ``ceil(6/2) * 180 = 540 s``, three times worse than the serial 30 s
+    code this replaced (round 1, R3), and nothing re-reads the index for the
+    whole of it. Engagements are therefore *started* by a pass and awaited by
+    nobody: the loop returns to slicing immediately, so a wake armed during a
+    long sweep is still seen within one slice.
+
+    **The in-flight set is what makes that safe.** Without it, a pass every
+    10 s over a wake that takes 180 s to engage would start eighteen
+    engagements for one occurrence. Keyed by ``(session_id, occurrence_ms)``
+    rather than by session, so a *later* occurrence of a recurring wake is
+    still engageable while an earlier one is somehow still in flight, and the
+    same occurrence never is.
+    """
+
+    def __init__(self) -> None:
+        self._semaphore = asyncio.Semaphore(_MAX_CONCURRENT_ENGAGES)
+        self._in_flight: dict[tuple[str, int], asyncio.Task[bool]] = {}
+        #: Cumulative count of engagements that reported a started runtime.
+        #: The loop has nothing to return any more, so the count lives here
+        #: for tests and for `--once`.
+        self.started = 0
+
+    def engage(self, config_dir: Path, session_id: str, cwd: str, due_ms: int, moment: int) -> bool:
+        """Start one engagement in the background. False when already running."""
+        key = (session_id, due_ms)
+        if key in self._in_flight:
+            return False
+
+        async def _run() -> bool:
+            try:
+                started = await _engage_one(
+                    config_dir, session_id, cwd, due_ms, moment, self._semaphore
+                )
+            finally:
+                # Popped in the task itself rather than in a done-callback so
+                # the key is gone the moment the work is, with no window where
+                # a finished engagement still blocks its own retry.
+                self._in_flight.pop(key, None)
+            if started:
+                self.started += 1
+            return started
+
+        self._in_flight[key] = asyncio.create_task(_run())
+        return True
+
+    @property
+    def in_flight(self) -> int:
+        """How many engagements are running. The loop must not retire on 0
+        fireable wakes while this is non-zero: the engagement it would abandon
+        is the one constructing the runtime that will advance the schedule."""
+        return len(self._in_flight)
+
+    async def drain(self) -> int:
+        """Await every in-flight engagement. For ``--once`` and for shutdown."""
+        while self._in_flight:
+            await asyncio.gather(*list(self._in_flight.values()), return_exceptions=True)
+        return self.started
+
+    async def shutdown(self) -> None:
+        """Cancel and reap every in-flight engagement.
+
+        Cancelling rather than draining: this runs when the loop is already
+        ending (retirement, or the process being torn down), and an engage can
+        legitimately still have minutes of deadline left. The runtime a
+        cancelled engage spawned is detached (``start_new_session=True``) and
+        keeps constructing regardless — what is abandoned is the WAITING, not
+        the wake, which is the same trade the deadline itself makes.
+        """
+        tasks = list(self._in_flight.values())
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._in_flight.clear()
+
+    def sweep(self, config_dir: Path, index: dict[str, dict[str, Any]], moment: int) -> int:
+        """Start an engagement for every due session. Returns how many started."""
+        launched = 0
+        for session_id, cwd, due_ms in _due_sessions(index, moment):
+            if self.engage(config_dir, session_id, cwd, due_ms, moment):
+                launched += 1
+        return launched
+
+
 async def fire_due_wakes(config_dir: Path, *, now_ms: int | None = None) -> int:
     """Start a runtime for every cold session whose wake is due. Returns count.
 
-    One pass. Split out from :func:`serve` so the whole decision — which
-    sessions are due, which are skipped for being live, what engaging does —
-    is testable without a loop or a clock.
-
-    **Concurrent, bounded.** This used to be a serial ``for`` loop awaiting
-    each engage in turn, so a session waited behind every earlier session's
-    full deadline: with two cold sessions due at once the pass took ~63 s
-    (measured), and lateness grew with the number of cold sessions. Since a
-    wake errand's deadline is now sized for a cold start, serial would be
-    strictly worse — which is why the slice re-read and this ship together.
+    One pass, awaited to completion — this is the ``--once`` / diagnostic
+    form and the seam the unit tests drive. The serve loop does NOT use it;
+    it drives a :class:`_Sweeper` directly so a slow engagement cannot hold
+    the loop (see that class for why).
     """
     from local_operator.wakes.store import read_index
 
     moment = now_ms if now_ms is not None else int(time.time() * 1000)
     index = await asyncio.to_thread(read_index, config_dir)
-    rows = _due_sessions(index, moment)
-    if not rows:
-        return 0
-    # BOUNDED, not unbounded gather. Each engage may cold-start up to
-    # `_MAX_SPAWNS` runtimes, and a runtime is a full harness process; this
-    # box routinely runs ~19 sessions, so an unbounded fan-out over a backlog
-    # would be a thundering herd against the very resource contention that
-    # makes cold starts slow in the first place. Two at a time removes the
-    # serial head-of-line blocking (the actual defect) without becoming a new
-    # source of load.
-    semaphore = asyncio.Semaphore(_MAX_CONCURRENT_ENGAGES)
-    results = await asyncio.gather(
-        *(
-            _engage_one(config_dir, session_id, cwd, due_ms, moment, semaphore)
-            for session_id, cwd, due_ms in rows
-        )
-    )
-    return sum(1 for started in results if started)
+    sweeper = _Sweeper()
+    sweeper.sweep(config_dir, index, moment)
+    return await sweeper.drain()
 
 
-def _has_fireable_wakes(index: dict[str, dict[str, Any]]) -> bool:
-    """Whether anything in the index could ever cause a fire.
+def _has_fireable_wakes(
+    index: dict[str, dict[str, Any]],
+    *,
+    config_dir: Path | None = None,
+    now_ms: int | None = None,
+) -> bool:
+    """Whether anything in the index could ever cause THIS process to fire.
 
     Not the same question as "is the index non-empty", and the difference was
     a leak: an index holding only DORMANT entries (every session stopped) kept
@@ -374,12 +588,36 @@ def _has_fireable_wakes(index: dict[str, dict[str, Any]]) -> bool:
     parked it on ``MAX_SLEEP_S``. Nothing it could do would ever fire one of
     those wakes; reopening the session is what re-arms them, and that reopen
     persists, which calls the install hook and brings the supervisor back.
+
+    Round 1 (R2/Q4) found two more entries with the same shape, and they are
+    why this now takes a ``config_dir``:
+
+    - **Stale** (>7 days overdue): the sweep refuses these permanently, and the
+      condition cannot self-clear because a wake only gets older. The session's
+      own catch-up delivers it on next open.
+    - **Ghost** (an index entry whose session has no transcript): refused
+      permanently too, and a ghost never grows a transcript.
+
+    Both satisfied the old "any non-dormant entry with schedules" test, so the
+    process was immortal AND re-logged the refusal every slice forever. None of
+    the three is work this process can do, and each has its own route back, so
+    retirement is the right answer for all of them.
+
+    ``config_dir`` is optional so the pure index-shape callers need not have
+    one; the ghost check is then skipped, which errs towards STAYING UP rather
+    than retiring on a wake that might be real.
     """
-    for entry in index.values():
+    moment = now_ms if now_ms is not None else int(time.time() * 1000)
+    for session_id, entry in index.items():
         if not isinstance(entry, dict) or entry.get("stopped_at"):
             continue
-        if entry.get("schedules"):
-            return True
+        if not entry.get("schedules"):
+            continue
+        if _is_stale(entry, moment):
+            continue
+        if config_dir is not None and not _session_exists(config_dir, session_id):
+            continue
+        return True
     return False
 
 
@@ -392,7 +630,7 @@ async def _should_retire(config_dir: Path) -> bool:
     window where the supervisor can read an empty index while a session is
     part-way through arming its first wake. Retiring inside that window exits
     0, the hook that follows sees a job launchd still knows about, and the
-    wake is left armed with nothing running \u2014 the same end state as the hard
+    wake is left armed with nothing running — the same end state as the hard
     miss, reached by a different road.
 
     The grace is one slice: long enough to cover the gap between those two
@@ -403,7 +641,7 @@ async def _should_retire(config_dir: Path) -> bool:
 
     await asyncio.sleep(min(SLICE_S, MAX_SLEEP_S))
     index = await asyncio.to_thread(read_index, config_dir)
-    return not _has_fireable_wakes(index)
+    return not _has_fireable_wakes(index, config_dir=config_dir)
 
 
 async def serve(config_dir: Path, *, once: bool = False) -> int:
@@ -417,60 +655,80 @@ async def serve(config_dir: Path, *, once: bool = False) -> int:
     **The wait is sliced** (:data:`SLICE_S`) rather than computed once and
     slept whole: a wake persisted while the supervisor sleeps is then seen
     within a slice instead of within up to ``MAX_SLEEP_S``.
+
+    **Engagements do not hold this loop.** A pass STARTS the engagements it
+    owes and returns; the loop keeps slicing while they run (see
+    :class:`_Sweeper`). Awaiting them here is what made a 6-session
+    all-timeout sweep block for 540 s in round 1.
     """
     from local_operator.wakes.store import read_index
 
-    while True:
-        index = await asyncio.to_thread(read_index, config_dir)
-        if not _has_fireable_wakes(index):
+    sweeper = _Sweeper()
+    try:
+        while True:
+            index = await asyncio.to_thread(read_index, config_dir)
+            if not _has_fireable_wakes(index, config_dir=config_dir):
+                if once:
+                    return 0
+                # In-flight work outlives a momentarily-empty index: retiring
+                # under a running engagement would kill the runtime it is
+                # constructing. Slice instead and re-decide next pass.
+                if sweeper.in_flight:
+                    await _sleep_in_slices(config_dir, SLICE_S, None)
+                    continue
+                if await _should_retire(config_dir):
+                    # LOGGED, because this is the transition that ends the
+                    # process: a supervisor that is gone looks identical to one
+                    # that never started unless it says why it left.
+                    logger.info(
+                        "no fireable wakes remain after a %.0fs grace re-read; "
+                        "the supervisor is retiring (the next persist reinstalls it)",
+                        SLICE_S,
+                    )
+                    return 0
+                logger.info("a wake was armed during the retirement grace; staying up")
+                continue
+
+            sweeper.sweep(config_dir, index, int(time.time() * 1000))
             if once:
+                await sweeper.drain()
                 return 0
-            if await _should_retire(config_dir):
-                # LOGGED, because this is the transition that ends the
-                # process: a supervisor that is gone looks identical to one
-                # that never started unless it says why it left.
-                logger.info(
-                    "no fireable wakes remain after a %.0fs grace re-read; "
-                    "the supervisor is retiring (the next persist reinstalls it)",
-                    SLICE_S,
-                )
-                return 0
-            logger.info("a wake was armed during the retirement grace; staying up")
-            continue
 
-        await fire_due_wakes(config_dir)
-        if once:
-            return 0
+            # Recomputed from the index AFTER the sweep started, so a schedule
+            # an already-finished runtime advanced is reflected rather than
+            # re-read stale.
+            index = await asyncio.to_thread(read_index, config_dir)
+            if not _has_fireable_wakes(index, config_dir=config_dir):
+                continue  # retirement is decided at the top, with its grace
 
-        # Recomputed from the index AFTER firing, so a schedule the fired
-        # runtime advanced is already reflected rather than re-read stale.
-        index = await asyncio.to_thread(read_index, config_dir)
-        if not _has_fireable_wakes(index):
-            continue  # retirement is decided at the top, with its grace
-
-        upcoming = _next_wake_ms(index)
-        now_ms = int(time.time() * 1000)
-        if upcoming is None:
-            delay = MAX_SLEEP_S
-        elif upcoming <= now_ms:
-            # STILL DUE AFTER A SWEEP means it was SKIPPED, not missed: a live
-            # session owns it, the entry is a ghost, or it is past the
-            # staleness bound. A fired wake does not land here — the runtime
-            # advances the schedule, so the next read shows a future time.
-            #
-            # Sleeping `MIN_SLEEP_S` on those was a hot loop: once the skip
-            # became cheap (the ghost guard answers from a stat instead of
-            # burning a 30 s engage) the loop span at one pass per second,
-            # re-logging the same skip forever. Observed doing exactly that
-            # against a ghost entry during validation. A slice is the right
-            # cadence: the condition can only change when something else
-            # writes the index or a runtime exits, and that is what the slice
-            # re-read is already sized to notice.
-            delay = SLICE_S
-        else:
-            delay = max(MIN_SLEEP_S, min(MAX_SLEEP_S, (upcoming - now_ms) / 1000.0))
-        logger.debug("sleeping %.1fs until the next wake (in %.0fs slices)", delay, SLICE_S)
-        await _sleep_in_slices(config_dir, delay, upcoming)
+            upcoming = _next_wake_ms(index)
+            now_ms = int(time.time() * 1000)
+            if upcoming is None:
+                delay = MAX_SLEEP_S
+            elif upcoming <= now_ms:
+                # STILL DUE AFTER A SWEEP means one of two things: the wake is
+                # being engaged right now (the engagement is in flight and the
+                # runtime has not yet advanced the schedule), or it was
+                # SKIPPED. A fired wake does not land here — the runtime
+                # advances the schedule, so the next read shows a future time.
+                #
+                # Either way a slice is the right cadence, and MIN_SLEEP_S is
+                # not: the condition can only change when an engagement
+                # finishes or something else writes the index, and that is
+                # exactly what the slice re-read is sized to notice. Sleeping
+                # MIN_SLEEP_S here span the loop at one pass per second and
+                # re-logged the same skip with it (observed against a ghost
+                # entry during validation).
+                delay = SLICE_S
+            else:
+                delay = max(MIN_SLEEP_S, min(MAX_SLEEP_S, (upcoming - now_ms) / 1000.0))
+            logger.debug("sleeping %.1fs until the next wake (in %.0fs slices)", delay, SLICE_S)
+            await _sleep_in_slices(config_dir, delay, upcoming)
+    finally:
+        # A cancelled or retiring supervisor must not leave engage tasks
+        # pending: they hold a semaphore slot and an event loop reference, and
+        # an un-awaited task destroyed at loop close logs a spurious error.
+        await sweeper.shutdown()
 
 
 async def _sleep_in_slices(config_dir: Path, delay: float, upcoming: int | None) -> None:
@@ -491,7 +749,7 @@ async def _sleep_in_slices(config_dir: Path, delay: float, upcoming: int | None)
         if remaining <= 0:
             return
         index = await asyncio.to_thread(read_index, config_dir)
-        if not _has_fireable_wakes(index):
+        if not _has_fireable_wakes(index, config_dir=config_dir):
             return  # retirement (with its grace) is decided by the caller's loop
         earliest = _next_wake_ms(index)
         if earliest is None:
@@ -522,10 +780,16 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    )
+    # The SAME console configuration `lop wake serve` gets, so one log line
+    # reads identically whichever entry point produced it. Round 1 (D8): this
+    # file is what an operator is told to read, and the same skip rendered two
+    # ways — `WARNING __main__:` from the LaunchAgent, `- WARNING -` from the
+    # CLI — because this entry rolled its own `basicConfig` with `%(name)s`.
+    # Run as a script, that name is always the useless `__main__`; the module
+    # logger below is given a stable name instead (see `logger`).
+    from local_operator.logger import configure_cli_logging
+
+    configure_cli_logging()
 
     # launchd hands this process a bare ``PATH=/usr/bin:/bin:/usr/sbin:/sbin``
     # — the LaunchAgent sets ``LOCAL_OPERATOR_CONFIG_DIR`` and nothing else,

--- a/local_operator/wakes/supervisor.py
+++ b/local_operator/wakes/supervisor.py
@@ -27,10 +27,20 @@ best, and at worst a second opinion about a schedule the live session is
 actively advancing. The rule is checked at fire time rather than at scan
 time, because a session can come up during the sleep.
 
-**Self-retirement.** An empty index means nothing left to supervise, so the
-process exits 0 and its LaunchAgent (``KeepAlive: {SuccessfulExit: False}``)
-leaves it down. That is why the exit code matters: a crash restarts, a
-finished job stays finished. The next persist reinstalls it.
+**Self-retirement.** Nothing FIREABLE left to supervise (an empty index, or
+one holding only dormant entries) means the process exits 0 and its
+LaunchAgent (``KeepAlive: {SuccessfulExit: False}``) leaves it down. That is
+why the exit code matters: a crash restarts, a finished job stays finished.
+The next persist reinstalls it.
+
+Retirement is the dangerous transition, because for a long time nothing
+brought the supervisor back: the install hook read a loaded-but-exited job as
+"already installed" (see :mod:`local_operator.wakes.install`), so an armed
+wake could sit with no live process and no log line. Three things now guard
+it \u2014 the install hook probes for a RUNNING process and repairs, the plist
+carries a ``StartInterval`` self-heal, and retirement here re-reads the index
+after a grace so the write-then-install race cannot retire into a wake that
+was being armed at that moment.
 
 Stdlib-only and import-light, like the rest of ``wakes/``: this runs as its
 own supervised process and must not drag the harness in at import.
@@ -54,7 +64,28 @@ logger = logging.getLogger(__name__)
 #: pass) but it is an OBSERVABILITY one: a supervisor asleep for nine hours
 #: has not noticed a schedule cancelled eight hours ago, so its own liveness
 #: and the index's state drift apart. Waking hourly to re-read is cheap.
+#:
+#: Since the wait is now SLICED (see :data:`SLICE_S`) this bounds the total
+#: wait rather than a single uninterruptible sleep.
 MAX_SLEEP_S = 3600.0
+
+#: How long a single uninterrupted sleep may last before the index is re-read.
+#:
+#: The defect this closes: the loop used to compute one delay from a snapshot
+#: and ``asyncio.sleep`` it whole. A session that persisted a wake due in five
+#: minutes while the supervisor was already sleeping toward a wake three hours
+#: out had that wake delayed by up to ``MAX_SLEEP_S`` — an hour — because the
+#: new entry was not observed until the sleep expired. The install hook could
+#: not help: it is idempotent by content and never nudges a running process.
+#:
+#: The cost is honest and small: one ``read_index`` per slice, which is an
+#: ``os.listdir`` of a directory holding one small JSON file per wake-carrying
+#: session (8 files, ~400 bytes each, on the machine this was diagnosed on) —
+#: measured at ~0.2 ms per read there. At 10 s that is ~8,640 reads a day
+#: against a wake subsystem that is otherwise idle, which buys bounded
+#: lateness: a newly written earlier wake is seen within one slice instead of
+#: within one hour.
+SLICE_S = 10.0
 
 #: Never sleep less than this. A schedule due in the past, or a clock that
 #: jumped backwards, must not turn the loop into a spin — the floor is what
@@ -68,6 +99,31 @@ MIN_SLEEP_S = 1.0
 #: for a week — the user will get the catch-up when they open it.
 STALE_AFTER_S = 7 * 24 * 3600.0
 
+#: How long a WAKE engage may take before the supervisor gives up on it.
+#:
+#: Deliberately not ``launch.DEFAULT_DEADLINE_S`` (30 s), which stays exactly
+#: as it is for user-initiated engages. That figure is sized for a person
+#: waiting at a prompt, where the alternative to waiting is telling them their
+#: message went nowhere. NOBODY is waiting on a wake, and the cost of the two
+#: failures is reversed: giving up early does not save anyone time, it just
+#: loses the wake until the next pass.
+#:
+#: 30 s was simply too short here. On the machine this was diagnosed on, a
+#: cold runtime (19 live sessions, large transcripts, 12 MCP servers) often
+#: needs longer to publish its record, and 344 of 682 engage attempts (50.4%)
+#: timed out at 30 s. Each timeout then re-entered the same path on the next
+#: pass, so the deadline was manufacturing the retry storm it appeared to be
+#: protecting against.
+#:
+#: 180 s is a generous multiple of the worst cold start observed rather than a
+#: tight bound: the only thing a longer deadline costs is a semaphore slot
+#: held by a session nobody is waiting for, and :func:`serve` keeps re-reading
+#: the index on its slice throughout regardless.
+WAKE_DEADLINE_S = 180.0
+
+#: How many sessions the sweep engages at once. See :func:`fire_due_wakes`.
+_MAX_CONCURRENT_ENGAGES = 2
+
 
 def _due_sessions(index: dict[str, dict[str, Any]], now_ms: int) -> list[tuple[str, str, int]]:
     """``(session_id, cwd, due_ms)`` for every session with a wake due now.
@@ -75,6 +131,10 @@ def _due_sessions(index: dict[str, dict[str, Any]], now_ms: int) -> list[tuple[s
     Reads the index defensively — it is written by other processes and a
     hand-edited or half-written entry must cost one session's wake, never the
     whole sweep.
+
+    Every skip that drops a DUE wake logs, because a silent skip here is
+    indistinguishable from a working supervisor: the two dead-ends below were
+    invisible in the logs of a machine that had been missing wakes for a week.
     """
     from local_operator.wakes.store import next_due_at
 
@@ -91,7 +151,24 @@ def _due_sessions(index: dict[str, dict[str, Any]], now_ms: int) -> list[tuple[s
         earliest = next_due_at(entry)
         if earliest is None or earliest > now_ms:
             continue
-        if (now_ms - earliest) / 1000.0 > STALE_AFTER_S:
+        overdue_s = (now_ms - earliest) / 1000.0
+        if overdue_s > STALE_AFTER_S:
+            # BEHAVIOUR UNCHANGED, SILENCE REMOVED. The session's own resume
+            # catch-up handles arbitrarily-old overdue wakes, so racing to
+            # start a runtime for a week-old one buys nothing. But skipping it
+            # without a word is how a long-idle recurring watch can stop
+            # firing forever with no trace: a wedged runtime starves the wake
+            # past seven days, and from then on this branch drops it silently
+            # on every pass. WARNING, not INFO — reaching this state means a
+            # wake the user asked for is no longer being fired at all.
+            logger.warning(
+                "skipping %s: its wake is %.1f days overdue (> the %.0f-day staleness "
+                "bound); it will be delivered by the session's own catch-up when it is "
+                "next opened",
+                session_id,
+                overdue_s / 86400.0,
+                STALE_AFTER_S / 86400.0,
+            )
             continue
         cwd = entry.get("cwd")
         due.append(
@@ -101,6 +178,33 @@ def _due_sessions(index: dict[str, dict[str, Any]], now_ms: int) -> list[tuple[s
     # longest gets its runtime first.
     due.sort(key=lambda row: row[2])
     return due
+
+
+def _session_exists(config_dir: Path, session_id: str) -> bool:
+    """Whether ``session_id`` has a transcript on disk.
+
+    A GHOST GUARD. The index is derived from sessions, but nothing prunes an
+    entry whose session directory has gone (a reap, a hand-deleted directory,
+    or an id that never existed). Such an entry can never be engaged
+    successfully, and before this guard each one consumed a full engage
+    deadline on every pass, forever: the live log shows ``lr_bda7b76d34e0``
+    and ``lr_28a800c6a783`` — ids with no session directory — accumulating
+    30 s timeouts with zero successful starts, ever.
+
+    The transcript rather than the directory, matching
+    ``multiplexer/broadcast.py``: a directory with no transcript is not a
+    session anything can resume.
+    """
+    from local_operator.resume import TRANSCRIPT_NAME
+
+    try:
+        return (Path(config_dir) / "sessions" / session_id / TRANSCRIPT_NAME).is_file()
+    except OSError:
+        # Unreadable is not proof of absence, and the cost of the two errors
+        # is asymmetric: skipping a real session loses its wake, while trying
+        # a ghost costs one deadline. Fail towards trying.
+        logger.debug("could not check the transcript for %s", session_id, exc_info=True)
+        return True
 
 
 def _next_wake_ms(index: dict[str, dict[str, Any]]) -> int | None:
@@ -131,28 +235,65 @@ async def _has_live_runtime(config_dir: Path, session_id: str) -> bool:
     return record is not None
 
 
-async def fire_due_wakes(config_dir: Path, *, now_ms: int | None = None) -> int:
-    """Start a runtime for every cold session whose wake is due. Returns count.
+async def _engage_one(
+    config_dir: Path,
+    session_id: str,
+    cwd: str,
+    due_ms: int,
+    moment: int,
+    semaphore: asyncio.Semaphore,
+) -> bool:
+    """Engage one due session. Returns whether a runtime was started.
 
-    One pass. Split out from :func:`serve` so the whole decision — which
-    sessions are due, which are skipped for being live, what engaging does —
-    is testable without a loop or a clock.
+    Split out so the sweep can run these concurrently; every skip and failure
+    is contained here so one session can never fail the pass.
     """
     from local_operator.session.runtime.launch import WakeErrand, engage_runtime
-    from local_operator.wakes.store import read_index
 
-    moment = now_ms if now_ms is not None else int(time.time() * 1000)
-    index = await asyncio.to_thread(read_index, config_dir)
-    fired = 0
-    for session_id, cwd, due_ms in _due_sessions(index, moment):
+    overdue_s = (moment - due_ms) / 1000.0
+    async with semaphore:
         if await _has_live_runtime(config_dir, session_id):
             # The no-live-record rule: that session fires its own wakes.
-            logger.debug("wake for %s is due but it is already running", session_id)
-            continue
+            #
+            # INFO with the overdue figure, not debug. A WEDGED runtime (one
+            # whose record is live but whose event loop is stuck) looks
+            # exactly like a healthy one here, so the supervisor skips it on
+            # every pass while its wake never fires. That case was invisible
+            # at the default log level; a growing overdue figure on a
+            # repeating "already running" line is what makes it findable.
+            logger.info(
+                "skipping %s: its wake is %.1fs overdue but a live runtime owns it "
+                "(that session fires its own wakes)",
+                session_id,
+                overdue_s,
+            )
+            return False
+        if not await asyncio.to_thread(_session_exists, config_dir, session_id):
+            logger.warning(
+                "skipping %s: its wake is %.1fs overdue but the session has no transcript "
+                "on disk; the index entry is a ghost and can never be engaged",
+                session_id,
+                overdue_s,
+            )
+            return False
+        logger.info(
+            "engaging %s: wake due %d, %.1fs overdue (deadline %.0fs)",
+            session_id,
+            due_ms,
+            overdue_s,
+            WAKE_DEADLINE_S,
+        )
+        started = time.monotonic()
         try:
-            # A derived id, not a random one: a supervisor that crashes after
-            # engaging and retries must not start a second runtime for the
-            # same occurrence.
+            # The command_id is DERIVED rather than random, but note what it
+            # does and does not buy. It is NOT what dedupes a wake: `_deliver`
+            # returns early for a WakeErrand (`session/runtime/launch.py`)
+            # without ever sending an op, so no command_id reaches a runtime.
+            # What actually keeps a retry from double-firing is record reuse
+            # plus lease arbitration — an engage that finds a live record uses
+            # it, and the transcript lease admits at most one SERVING runtime.
+            # The id is carried for the log line and for consistency with the
+            # other errands.
             await engage_runtime(
                 session_id,
                 cwd,
@@ -162,31 +303,140 @@ async def fire_due_wakes(config_dir: Path, *, now_ms: int | None = None) -> int:
                     command_id=f"wake-{session_id}-{due_ms}",
                 ),
                 config_dir=config_dir,
+                deadline_s=WAKE_DEADLINE_S,
             )
         except (TimeoutError, ConnectionError, OSError) as exc:
             # One session's wake failing must not stop the others'. The
             # schedule is untouched, so the next pass tries again.
-            logger.warning("could not start a runtime for %s: %s", session_id, exc)
+            logger.warning(
+                "could not start a runtime for %s after %.1fs (wake %.1fs overdue): %s",
+                session_id,
+                time.monotonic() - started,
+                overdue_s,
+                exc,
+            )
+            return False
+        logger.info(
+            "started a runtime for %s (wake due %d, %.1fs overdue, took %.1fs)",
+            session_id,
+            due_ms,
+            overdue_s,
+            time.monotonic() - started,
+        )
+        return True
+
+
+async def fire_due_wakes(config_dir: Path, *, now_ms: int | None = None) -> int:
+    """Start a runtime for every cold session whose wake is due. Returns count.
+
+    One pass. Split out from :func:`serve` so the whole decision — which
+    sessions are due, which are skipped for being live, what engaging does —
+    is testable without a loop or a clock.
+
+    **Concurrent, bounded.** This used to be a serial ``for`` loop awaiting
+    each engage in turn, so a session waited behind every earlier session's
+    full deadline: with two cold sessions due at once the pass took ~63 s
+    (measured), and lateness grew with the number of cold sessions. Since a
+    wake errand's deadline is now sized for a cold start, serial would be
+    strictly worse — which is why the slice re-read and this ship together.
+    """
+    from local_operator.wakes.store import read_index
+
+    moment = now_ms if now_ms is not None else int(time.time() * 1000)
+    index = await asyncio.to_thread(read_index, config_dir)
+    rows = _due_sessions(index, moment)
+    if not rows:
+        return 0
+    # BOUNDED, not unbounded gather. Each engage may cold-start up to
+    # `_MAX_SPAWNS` runtimes, and a runtime is a full harness process; this
+    # box routinely runs ~19 sessions, so an unbounded fan-out over a backlog
+    # would be a thundering herd against the very resource contention that
+    # makes cold starts slow in the first place. Two at a time removes the
+    # serial head-of-line blocking (the actual defect) without becoming a new
+    # source of load.
+    semaphore = asyncio.Semaphore(_MAX_CONCURRENT_ENGAGES)
+    results = await asyncio.gather(
+        *(
+            _engage_one(config_dir, session_id, cwd, due_ms, moment, semaphore)
+            for session_id, cwd, due_ms in rows
+        )
+    )
+    return sum(1 for started in results if started)
+
+
+def _has_fireable_wakes(index: dict[str, dict[str, Any]]) -> bool:
+    """Whether anything in the index could ever cause a fire.
+
+    Not the same question as "is the index non-empty", and the difference was
+    a leak: an index holding only DORMANT entries (every session stopped) kept
+    the supervisor alive forever, because the non-empty check refused to retire
+    while ``_next_wake_ms`` \u2014 which skips dormant entries \u2014 returned None and
+    parked it on ``MAX_SLEEP_S``. Nothing it could do would ever fire one of
+    those wakes; reopening the session is what re-arms them, and that reopen
+    persists, which calls the install hook and brings the supervisor back.
+    """
+    for entry in index.values():
+        if not isinstance(entry, dict) or entry.get("stopped_at"):
             continue
-        logger.info("started a runtime for %s (wake due %d)", session_id, due_ms)
-        fired += 1
-    return fired
+        if entry.get("schedules"):
+            return True
+    return False
+
+
+async def _should_retire(config_dir: Path) -> bool:
+    """Whether there is genuinely nothing left to supervise.
+
+    Re-reads after a short grace, which closes the RACE half of the
+    never-restarted-supervisor defect. ``Session._persist_wake_schedules``
+    writes the index entry and THEN calls the install hook, so there is a
+    window where the supervisor can read an empty index while a session is
+    part-way through arming its first wake. Retiring inside that window exits
+    0, the hook that follows sees a job launchd still knows about, and the
+    wake is left armed with nothing running \u2014 the same end state as the hard
+    miss, reached by a different road.
+
+    The grace is one slice: long enough to cover the gap between those two
+    steps (they are consecutive statements), short enough that retirement on a
+    genuinely empty index is still prompt.
+    """
+    from local_operator.wakes.store import read_index
+
+    await asyncio.sleep(min(SLICE_S, MAX_SLEEP_S))
+    index = await asyncio.to_thread(read_index, config_dir)
+    return not _has_fireable_wakes(index)
 
 
 async def serve(config_dir: Path, *, once: bool = False) -> int:
     """Run the supervisor loop. Returns the process exit code.
 
-    Exits **0** when the index empties, which is what lets the LaunchAgent's
-    ``KeepAlive: {SuccessfulExit: False}`` leave a finished supervisor down
-    instead of restarting it forever. A crash exits non-zero and is restarted.
+    Exits **0** when there is nothing fireable left, which is what lets the
+    LaunchAgent's ``KeepAlive: {SuccessfulExit: False}`` leave a finished
+    supervisor down instead of restarting it forever. A crash exits non-zero
+    and is restarted.
+
+    **The wait is sliced** (:data:`SLICE_S`) rather than computed once and
+    slept whole: a wake persisted while the supervisor sleeps is then seen
+    within a slice instead of within up to ``MAX_SLEEP_S``.
     """
     from local_operator.wakes.store import read_index
 
     while True:
         index = await asyncio.to_thread(read_index, config_dir)
-        if not index:
-            logger.info("wake index is empty; the supervisor is retiring")
-            return 0
+        if not _has_fireable_wakes(index):
+            if once:
+                return 0
+            if await _should_retire(config_dir):
+                # LOGGED, because this is the transition that ends the
+                # process: a supervisor that is gone looks identical to one
+                # that never started unless it says why it left.
+                logger.info(
+                    "no fireable wakes remain after a %.0fs grace re-read; "
+                    "the supervisor is retiring (the next persist reinstalls it)",
+                    SLICE_S,
+                )
+                return 0
+            logger.info("a wake was armed during the retirement grace; staying up")
+            continue
 
         await fire_due_wakes(config_dir)
         if once:
@@ -195,17 +445,68 @@ async def serve(config_dir: Path, *, once: bool = False) -> int:
         # Recomputed from the index AFTER firing, so a schedule the fired
         # runtime advanced is already reflected rather than re-read stale.
         index = await asyncio.to_thread(read_index, config_dir)
-        if not index:
-            logger.info("wake index is empty; the supervisor is retiring")
-            return 0
+        if not _has_fireable_wakes(index):
+            continue  # retirement is decided at the top, with its grace
+
         upcoming = _next_wake_ms(index)
         now_ms = int(time.time() * 1000)
         if upcoming is None:
             delay = MAX_SLEEP_S
+        elif upcoming <= now_ms:
+            # STILL DUE AFTER A SWEEP means it was SKIPPED, not missed: a live
+            # session owns it, the entry is a ghost, or it is past the
+            # staleness bound. A fired wake does not land here — the runtime
+            # advances the schedule, so the next read shows a future time.
+            #
+            # Sleeping `MIN_SLEEP_S` on those was a hot loop: once the skip
+            # became cheap (the ghost guard answers from a stat instead of
+            # burning a 30 s engage) the loop span at one pass per second,
+            # re-logging the same skip forever. Observed doing exactly that
+            # against a ghost entry during validation. A slice is the right
+            # cadence: the condition can only change when something else
+            # writes the index or a runtime exits, and that is what the slice
+            # re-read is already sized to notice.
+            delay = SLICE_S
         else:
             delay = max(MIN_SLEEP_S, min(MAX_SLEEP_S, (upcoming - now_ms) / 1000.0))
-        logger.debug("sleeping %.1fs until the next wake", delay)
-        await asyncio.sleep(delay)
+        logger.debug("sleeping %.1fs until the next wake (in %.0fs slices)", delay, SLICE_S)
+        await _sleep_in_slices(config_dir, delay, upcoming)
+
+
+async def _sleep_in_slices(config_dir: Path, delay: float, upcoming: int | None) -> None:
+    """Sleep up to ``delay`` seconds, returning early if the index changes.
+
+    Re-reads the index once per :data:`SLICE_S` and returns as soon as a wake
+    earlier than the one we were waiting for appears (or the index empties),
+    so the next loop iteration fires it. MIN/MAX semantics are the caller's
+    and are unchanged: this only decides how the already-computed ``delay`` is
+    spent.
+    """
+    from local_operator.wakes.store import read_index
+
+    remaining = delay
+    while remaining > 0:
+        await asyncio.sleep(min(SLICE_S, remaining))
+        remaining -= SLICE_S
+        if remaining <= 0:
+            return
+        index = await asyncio.to_thread(read_index, config_dir)
+        if not _has_fireable_wakes(index):
+            return  # retirement (with its grace) is decided by the caller's loop
+        earliest = _next_wake_ms(index)
+        if earliest is None:
+            return
+        if upcoming is None or earliest < upcoming or earliest <= int(time.time() * 1000):
+            # Something was scheduled EARLIER than what this sleep was sized
+            # for, or is now due. Returning lets the loop re-read and fire it
+            # within a slice rather than at the end of a wait sized for a
+            # wake that is no longer the next one.
+            logger.info(
+                "an earlier wake appeared while sleeping; re-reading now instead of "
+                "waiting a further %.0fs",
+                max(remaining, 0.0),
+            )
+            return
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/local_operator/wakes/supervisor.py
+++ b/local_operator/wakes/supervisor.py
@@ -55,7 +55,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 #: A STABLE name, not ``__name__``. This module is the LaunchAgent's
 #: ``python -m`` target, so ``__name__`` is ``__main__`` in the one process
@@ -133,6 +133,16 @@ STALE_AFTER_S = 7 * 24 * 3600.0
 WAKE_DEADLINE_S = 180.0
 
 #: How many sessions the sweep engages at once. See :func:`fire_due_wakes`.
+#:
+#: KNOWN RESIDUAL (round 2, QA Q3, deferred deliberately): a freshly armed wake
+#: still queues behind permanently-failing engages, because `_due_sessions`
+#: sorts oldest-first and a failed engage keeps its original `due_ms`, so it
+#: keeps winning the semaphore. Measured at a 10 s scaled deadline: N=0 → 8.2 s,
+#: N=2 → 18.2 s, N=6 → 38.2 s (was 58.2 s before the round-1 restructure).
+#: Widening this number is NOT the fix — it trades a rare lateness for cold-start
+#: storms on a loaded box, where several runtimes coming up at once is exactly
+#: what the original 30 s deadline was thrashing on. A real fix is a scheduling
+#: question (fair queueing between fresh and retried work), not a constant.
 _MAX_CONCURRENT_ENGAGES = 2
 
 #: How many times one (session, reason) skip is logged at full volume before
@@ -182,10 +192,19 @@ class _SkipLog:
         self._seen[key] = (count, last)
         return False
 
-    def forget(self, session_id: str) -> None:
-        """Drop a session's throttle state once it is no longer being skipped,
-        so a recurrence after a genuine recovery is reported in full."""
-        for key in [key for key in self._seen if key[0] == session_id]:
+    def forget(self, session_id: str, *reasons: str) -> None:
+        """Drop a session's throttle state for the named reasons, so a
+        recurrence after a genuine recovery is reported in full.
+
+        REASONS ARE NAMED rather than clearing the session wholesale. The
+        caller forgets the PRE-engage skips at the moment it gets past them —
+        but "the engage itself failed" is a different condition that has not
+        recovered, and clearing it there reset the throttle on every pass, so a
+        permanently-failing engage logged every slice exactly as if it were
+        unthrottled (found by the round-2 R8 test, which asserted the line
+        count rather than the code path).
+        """
+        for key in [key for key in self._seen if key[0] == session_id and key[1] in reasons]:
             del self._seen[key]
 
 
@@ -194,20 +213,66 @@ class _SkipLog:
 _skip_log = _SkipLog()
 
 
-def _is_stale(entry: dict[str, Any], now_ms: int) -> bool:
-    """Whether this entry's soonest wake is past the staleness bound.
+def _schedule_due_times(entry: dict[str, Any]) -> list[int]:
+    """Every readable ``next_due_at`` in an entry, in no particular order.
 
-    Shared by the sweep and by :func:`_has_fireable_wakes` so "the supervisor
-    will not fire this" is decided in exactly one place. Two readers deriving
-    that separately is how a ghost came to keep the process alive forever
-    while every pass logged that it was skipping it.
+    Defensive like the rest of this module's index reading: the file is
+    written by other processes, and a hand-edited or half-written row must
+    cost one schedule, never the whole entry.
     """
-    from local_operator.wakes.store import next_due_at
+    out: list[int] = []
+    for raw in entry.get("schedules") or ():
+        if not isinstance(raw, Mapping):
+            continue
+        due = raw.get("next_due_at")
+        if isinstance(due, bool) or not isinstance(due, int):
+            continue
+        out.append(due)
+    return out
 
-    earliest = next_due_at(entry)
-    if earliest is None:
+
+def _is_stale_ms(due_ms: int, now_ms: int) -> bool:
+    """Whether ONE schedule is past the staleness bound."""
+    return (now_ms - due_ms) / 1000.0 > STALE_AFTER_S
+
+
+def _fireable_due_ms(entry: dict[str, Any], now_ms: int) -> int | None:
+    """Earliest schedule that is due NOW and not past the staleness bound.
+
+    PER SCHEDULE, not per entry, and that distinction is the round-2 blocker
+    (R7). An entry can hold a >7-day one-shot alongside a 20-minute recurring
+    watch, and ``next_due_at(entry)`` answers with the EARLIEST of the two —
+    so the whole entry read as stale, the live watch was never engaged, and
+    once that predicate also drove retirement the supervisor exited on it.
+    The one-shot only gets older, so nothing ever cleared the condition.
+    """
+    candidates = [
+        due for due in _schedule_due_times(entry) if due <= now_ms and not _is_stale_ms(due, now_ms)
+    ]
+    return min(candidates) if candidates else None
+
+
+def _has_fireable_schedule(entry: dict[str, Any], now_ms: int) -> bool:
+    """Whether ANY schedule in this entry is still worth supervising.
+
+    Future schedules count: they are the ordinary reason to stay up. Only an
+    entry whose every schedule is past the staleness bound is work this
+    process can never do (see :func:`_has_fireable_wakes`).
+    """
+    return any(not _is_stale_ms(due, now_ms) for due in _schedule_due_times(entry))
+
+
+def _is_stale(entry: dict[str, Any], now_ms: int) -> bool:
+    """Whether EVERY schedule in this entry is past the staleness bound.
+
+    ``all``, not "the earliest one" — see :func:`_fireable_due_ms` for the
+    defect that distinction caused. A mixed entry is emphatically NOT stale:
+    it has work in it, and the stale sibling must not speak for the rest.
+    """
+    due_times = _schedule_due_times(entry)
+    if not due_times:
         return False
-    return (now_ms - earliest) / 1000.0 > STALE_AFTER_S
+    return all(_is_stale_ms(due, now_ms) for due in due_times)
 
 
 def _due_sessions(index: dict[str, dict[str, Any]], now_ms: int) -> list[tuple[str, str, int]]:
@@ -236,8 +301,14 @@ def _due_sessions(index: dict[str, dict[str, Any]], now_ms: int) -> list[tuple[s
         earliest = next_due_at(entry)
         if earliest is None or earliest > now_ms:
             continue
+        # PER SCHEDULE (round 2, R7). `earliest` is the entry's soonest row,
+        # which may be a week-old one-shot sitting beside a live recurring
+        # watch; engaging on the entry's earliest meant the stale sibling
+        # spoke for the whole entry and the live wake never fired. Ask instead
+        # for the soonest schedule that is BOTH due and not stale.
+        fireable = _fireable_due_ms(entry, now_ms)
         overdue_s = (now_ms - earliest) / 1000.0
-        if overdue_s > STALE_AFTER_S:
+        if fireable is None:
             # BEHAVIOUR UNCHANGED, SILENCE REMOVED. The session's own resume
             # catch-up handles arbitrarily-old overdue wakes, so racing to
             # start a runtime for a week-old one buys nothing. But skipping it
@@ -261,7 +332,7 @@ def _due_sessions(index: dict[str, dict[str, Any]], now_ms: int) -> list[tuple[s
             continue
         cwd = entry.get("cwd")
         due.append(
-            (session_id, cwd if isinstance(cwd, str) and cwd else os.path.expanduser("~"), earliest)
+            (session_id, cwd if isinstance(cwd, str) and cwd else os.path.expanduser("~"), fireable)
         )
     # Oldest first: if several are due at once, the one that has waited
     # longest gets its runtime first.
@@ -336,12 +407,21 @@ def wedged_runtime(config_dir: Path, session_id: str) -> tuple[int, float] | Non
     persists. Before this, the only trace was an ordinary timeout line,
     indistinguishable from a slow cold start.
 
-    VISIBILITY ONLY. Nothing here breaks the lease or signals the process:
-    the safe repair belongs to the runtime's own watchdog, and a supervisor
-    that killed a session's process on a heartbeat heuristic could destroy
-    work a merely-slow runtime was in the middle of. ``registry.scan`` already
-    owns this classification, so the state is read from it rather than
-    re-derived from ``heartbeat_at`` here.
+    NOTHING HERE TOUCHES THE WEDGED SESSION. The lease is not broken and the
+    process is not signalled: the safe repair belongs to the runtime's own
+    watchdog, and a supervisor that killed a session's process on a heartbeat
+    heuristic could destroy work a merely-slow runtime was in the middle of.
+
+    It is NOT side-effect free, though, and round 2 (R10) was right that
+    saying so was a false claim of purity. This delegates to
+    ``registry.scan``, whose documented job includes reaping: it unlinks
+    records whose pid is gone or whose file is torn, and ``run_dir()`` creates
+    the directory if absent. That reaping is `scan`'s contract rather than
+    something this function wants, and it only ever removes records for
+    processes that are already dead — but it is a write, and a reader of this
+    docstring must not be told otherwise. The classification is read from
+    ``scan`` rather than re-derived from ``heartbeat_at`` here precisely so
+    the registry stays the one owner of live/wedged/stale.
     """
     from local_operator.session.runtime.registry import scan
 
@@ -415,7 +495,11 @@ async def _engage_one(
                     overdue_s,
                 )
             return False
-        _skip_log.forget(session_id)
+        # Only the conditions we just cleared: reaching here means the session
+        # is no longer skipped for a live/ghost/wedged/stale reason. Whether
+        # the engage SUCCEEDS is decided below, and its own throttle key must
+        # survive this pass — see `_SkipLog.forget`.
+        _skip_log.forget(session_id, "live", "ghost", "wedged", "stale")
         logger.info(
             "engaging %s: wake due %d, %.1fs overdue (deadline %.0fs)",
             session_id,
@@ -445,17 +529,35 @@ async def _engage_one(
                 config_dir=config_dir,
                 deadline_s=WAKE_DEADLINE_S,
             )
-        except (TimeoutError, ConnectionError, OSError) as exc:
+        except (TimeoutError, ConnectionError, OSError, RuntimeError) as exc:
             # One session's wake failing must not stop the others'. The
             # schedule is untouched, so the next pass tries again.
-            logger.warning(
-                "could not start a runtime for %s after %.1fs (wake %.1fs overdue): %s",
-                session_id,
-                time.monotonic() - started,
-                overdue_s,
-                exc,
-            )
+            #
+            # RUNTIMEERROR IS DOCUMENTED, not defensive: `engage_runtime`
+            # raises it carrying the child's own reason as soon as every
+            # candidate it may start has died (a missing credential, an
+            # unconstructable session). Round 2 (R8) — omitting it here sent
+            # a 13-line asyncio "Task exception was never retrieved" traceback
+            # into the unrotated log on every slice, ~8,640/day, bypassing the
+            # throttle that the rest of this file routes repeats through.
+            #
+            # THROTTLED like every other repeating failure: an unconstructable
+            # session fails identically on every pass, so it gets the same
+            # burst-then-heartbeat treatment as the stale and ghost skips.
+            if _skip_log.should_log(session_id, "failed"):
+                logger.warning(
+                    "failed: could not start a runtime for %s after %.1fs "
+                    "(wake %.1fs overdue): %s",
+                    session_id,
+                    time.monotonic() - started,
+                    overdue_s,
+                    exc,
+                )
             return False
+        # RECOVERED: the failure keys are cleared only once an engage actually
+        # succeeds, so the next failure after a working run is announced at
+        # full volume instead of inheriting the old silence.
+        _skip_log.forget(session_id, "failed", "error")
         logger.info(
             "started a runtime for %s (wake due %d, %.1fs overdue, took %.1fs)",
             session_id,
@@ -505,6 +607,29 @@ class _Sweeper:
                 started = await _engage_one(
                     config_dir, session_id, cwd, due_ms, moment, self._semaphore
                 )
+            except asyncio.CancelledError:
+                # Shutdown, not a failure: `shutdown()` cancels in-flight work
+                # deliberately. Re-raised so the task settles as cancelled.
+                raise
+            except Exception as exc:  # noqa: BLE001 — a detached task's last resort
+                # THE BELT (round 2, R8). `_engage_one` runs as a detached
+                # task, so ANY raise it does not handle lands here rather than
+                # at a caller — and asyncio's default handler then prints a
+                # 13-line traceback per occurrence, at slice cadence, with no
+                # session id and none of the `reason:`-leading format the rest
+                # of this file uses. `_engage_one` already catches what
+                # `engage_runtime` documents; this exists so an UNANTICIPATED
+                # raise degrades to one throttled line and a retried wake
+                # instead of a log flood.
+                if _skip_log.should_log(session_id, "error"):
+                    logger.warning(
+                        "error: engaging %s raised %s: %s",
+                        session_id,
+                        type(exc).__name__,
+                        exc,
+                        exc_info=True,
+                    )
+                return False
             finally:
                 # Popped in the task itself rather than in a done-callback so
                 # the key is gone the moment the work is, with no window where
@@ -613,12 +738,57 @@ def _has_fireable_wakes(
             continue
         if not entry.get("schedules"):
             continue
-        if _is_stale(entry, moment):
+        # PER SCHEDULE (round 2, R7). Asking whether the entry's EARLIEST wake
+        # is stale retired the process on an entry that also held a live
+        # recurring watch, and `KeepAlive{SuccessfulExit:false}` then kept it
+        # down while `StartInterval` re-decided the same thing every 15 min —
+        # the live watch stopped firing for good, silently. One non-stale
+        # schedule anywhere in the entry is work worth staying up for.
+        if not _has_fireable_schedule(entry, moment):
             continue
         if config_dir is not None and not _session_exists(config_dir, session_id):
             continue
         return True
     return False
+
+
+def _retirement_reason(config_dir: Path) -> str:
+    """Why nothing is fireable, in the terms the operator can act on.
+
+    Round 2 (D15). "The next persist reinstalls it" was the only explanation
+    the retirement line carried, and for a stale-only store it is misleading:
+    the reinstalled supervisor reads the same entry and retires again. The
+    states that CAN end in retirement each have a different route back
+    (reopen the session, open it for the catch-up, rewrite the index), so the
+    line names which one it hit — this is the sentence ``lop wake status``
+    already knows how to say.
+    """
+    from local_operator.wakes.store import read_index
+
+    now_ms = int(time.time() * 1000)
+    dormant = stale = ghost = 0
+    for session_id, entry in read_index(config_dir).items():
+        if not isinstance(entry, dict) or not entry.get("schedules"):
+            continue
+        if entry.get("stopped_at"):
+            dormant += 1
+        elif not _has_fireable_schedule(entry, now_ms):
+            stale += 1
+        elif not _session_exists(config_dir, session_id):
+            ghost += 1
+    parts: list[str] = []
+    if stale:
+        parts.append(
+            f"{stale} past the {STALE_AFTER_S / 86400.0:.0f}d staleness bound — "
+            "delivered when their sessions are next opened"
+        )
+    if dormant:
+        parts.append(f"{dormant} dormant — reopening the session re-arms them")
+    if ghost:
+        parts.append(f"{ghost} with no session on disk")
+    if not parts:
+        return "nothing is scheduled; the next persist reinstalls it"
+    return "; ".join(parts)
 
 
 async def _should_retire(config_dir: Path) -> bool:
@@ -669,6 +839,15 @@ async def serve(config_dir: Path, *, once: bool = False) -> int:
             index = await asyncio.to_thread(read_index, config_dir)
             if not _has_fireable_wakes(index, config_dir=config_dir):
                 if once:
+                    # `--once` IS THE DIAGNOSTIC, so it must not be the quiet
+                    # one (round 2, D15): a stale-only store made `lop wake
+                    # serve --once` print nothing and exit 0, which reads as
+                    # "everything is fine" in exactly the state where a wake
+                    # the user asked for is never going to fire. Same sentence
+                    # the loop logs when it retires for the same reason.
+                    logger.info(
+                        "nothing fireable in this store (%s)", _retirement_reason(config_dir)
+                    )
                     return 0
                 # In-flight work outlives a momentarily-empty index: retiring
                 # under a running engagement would kill the runtime it is
@@ -677,13 +856,21 @@ async def serve(config_dir: Path, *, once: bool = False) -> int:
                     await _sleep_in_slices(config_dir, SLICE_S, None)
                     continue
                 if await _should_retire(config_dir):
-                    # LOGGED, because this is the transition that ends the
-                    # process: a supervisor that is gone looks identical to one
-                    # that never started unless it says why it left.
+                    # LOGGED WITH THE REASON, because this is the transition
+                    # that ends the process: a supervisor that is gone looks
+                    # identical to one that never started unless it says why it
+                    # left. Round 2 (D15): "the next persist reinstalls it" is
+                    # true and useless for a stale-only store — the reinstalled
+                    # supervisor retires again on the same entry — and the
+                    # `stale: skipping …` line that would have named the
+                    # condition is unreachable, because retirement is decided
+                    # before the sweep runs. So the retirement line carries the
+                    # breakdown itself.
                     logger.info(
                         "no fireable wakes remain after a %.0fs grace re-read; "
-                        "the supervisor is retiring (the next persist reinstalls it)",
+                        "the supervisor is retiring (%s)",
                         SLICE_S,
+                        _retirement_reason(config_dir),
                     )
                     return 0
                 logger.info("a wake was armed during the retirement grace; staying up")

--- a/local_operator/wakes/supervisor.py
+++ b/local_operator/wakes/supervisor.py
@@ -137,8 +137,13 @@ WAKE_DEADLINE_S = 180.0
 #: KNOWN RESIDUAL (round 2, QA Q3, deferred deliberately): a freshly armed wake
 #: still queues behind permanently-failing engages, because `_due_sessions`
 #: sorts oldest-first and a failed engage keeps its original `due_ms`, so it
-#: keeps winning the semaphore. Measured at a 10 s scaled deadline: N=0 → 8.2 s,
-#: N=2 → 18.2 s, N=6 → 38.2 s (was 58.2 s before the round-1 restructure).
+#: keeps winning the semaphore. The figures below are on a DELIBERATELY SCALED
+#: 10 s deadline, not the shipped 180 s one, so they show the shape rather than
+#: the production wait — do not read them as real latencies (round 3, R13).
+#: Scaled deadline 10 s, semaphore 2, N permanently-failing sessions, measured
+#: by QA on 2026-09-11 on the operator's 14-core host at load average 21-105:
+#: N=0 → 8.2 s, N=2 → 18.2 s, N=6 → 38.2 s (was 58.2 s before the round-1
+#: restructure).
 #: Widening this number is NOT the fix — it trades a rare lateness for cold-start
 #: storms on a loaded box, where several runtimes coming up at once is exactly
 #: what the original 30 s deadline was thrashing on. A real fix is a scheduling
@@ -545,10 +550,14 @@ async def _engage_one(
             # session fails identically on every pass, so it gets the same
             # burst-then-heartbeat treatment as the stale and ghost skips.
             if _skip_log.should_log(session_id, "failed"):
+                # THE EXCEPTION CARRIES THE SUBJECT (round 3, D22).
+                # `engage_runtime` raises "could not start a runtime for
+                # session <id>: <cause>", so repeating that phrase and the id
+                # in the wrapper produced a 266-column line saying the same
+                # thing twice. This prefix adds only what the exception cannot
+                # know: how long the attempt took and how late the wake is.
                 logger.warning(
-                    "failed: could not start a runtime for %s after %.1fs "
-                    "(wake %.1fs overdue): %s",
-                    session_id,
+                    "failed: after %.1fs (wake %.1fs overdue): %s",
                     time.monotonic() - started,
                     overdue_s,
                     exc,
@@ -766,16 +775,32 @@ def _retirement_reason(config_dir: Path) -> str:
     from local_operator.wakes.store import read_index
 
     now_ms = int(time.time() * 1000)
-    dormant = stale = ghost = 0
+    dormant = stale = ghost = unreadable = 0
     for session_id, entry in read_index(config_dir).items():
         if not isinstance(entry, dict) or not entry.get("schedules"):
             continue
+        # PRECEDENCE MATCHES `wake status` (round 3, R11). An entry can be
+        # both stale and a ghost, and the two surfaces bucketed it differently
+        # — `cli.py`'s `stale = [... if row["stale"] and not row["ghost"]]`
+        # calls it a ghost while this chain called it stale. That made the
+        # retirement line promise delivery "when the session is next opened"
+        # for a session that does not exist. Ghost is also the STRONGER fact:
+        # a stale wake still has a session to be delivered into, and a ghost
+        # has nothing at all, so it is the one worth telling the operator.
         if entry.get("stopped_at"):
             dormant += 1
-        elif not _has_fireable_schedule(entry, now_ms):
-            stale += 1
         elif not _session_exists(config_dir, session_id):
             ghost += 1
+        elif not _schedule_due_times(entry):
+            # NOT STALE — it never crossed the bound, it has no readable due
+            # time to cross (round 3, R12). `_has_fireable_schedule` is False
+            # here for a different reason than staleness, and bucketing the
+            # two together named a bound this entry never reached and promised
+            # a catch-up delivery that no due time can produce. `_is_stale`
+            # says False for it too, so this keeps the two in agreement.
+            unreadable += 1
+        elif not _has_fireable_schedule(entry, now_ms):
+            stale += 1
     parts: list[str] = []
     if stale:
         parts.append(
@@ -786,6 +811,8 @@ def _retirement_reason(config_dir: Path) -> str:
         parts.append(f"{dormant} dormant — reopening the session re-arms them")
     if ghost:
         parts.append(f"{ghost} with no session on disk")
+    if unreadable:
+        parts.append(f"{unreadable} with no readable due time — rewritten when its session opens")
     if not parts:
         return "nothing is scheduled; the next persist reinstalls it"
     return "; ".join(parts)

--- a/tests/e2e/test_cold_wake_e2e.py
+++ b/tests/e2e/test_cold_wake_e2e.py
@@ -135,3 +135,71 @@ def test_a_cold_wake_runs_its_turn_with_no_terminal_open(tmp_path: Path) -> None
     finally:
         child.kill()
         child.wait(timeout=10)
+
+
+def test_the_real_supervisor_process_fires_a_cold_wake(tmp_path: Path) -> None:
+    """The WHOLE chain, with the supervisor as a real process.
+
+    The test above drives the runtime child directly, which proves the child
+    end. This one starts at the other end: a real
+    ``python -m local_operator.wakes.supervisor --once`` reads the index,
+    decides the wake is due, engages a runtime itself, and the turn must land
+    in the durable transcript. Nothing in this path is patched — it is the
+    same argv the LaunchAgent runs.
+
+    ``HOME`` is redirected alongside ``LOCAL_OPERATOR_CONFIG_DIR`` because the
+    config variable alone does not redirect the cache root (AGENTS.md,
+    "Isolating a run"), and the supervisor's install hook refuses a config dir
+    outside the real home, so no launchd domain is addressed either.
+    """
+    from local_operator.harness.wake import WAKE_SCHEDULES_CUSTOM_TYPE
+    from local_operator.session.transcript import Transcript
+    from local_operator.wakes.store import write_entry
+
+    _seed(tmp_path, "supwake00001")
+    now = int(time.time() * 1000)
+    schedule = {
+        "id": "w1",
+        "message": "supervised cold wake",
+        "next_due_at": now - 5_000,
+        "created_at": now - 60_000,
+    }
+    transcript = Transcript(tmp_path / "sessions" / "supwake00001")
+    asyncio.run(transcript.append_custom(WAKE_SCHEDULES_CUSTOM_TYPE, {"schedules": [schedule]}))
+    write_entry(tmp_path, "supwake00001", cwd=str(tmp_path), schedules=[schedule])
+
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "LOCAL_OPERATOR_CONFIG_DIR": str(tmp_path),
+    }
+    # Every inherited CMUX_* variable is stripped: a forked runtime that
+    # inherits a real CMUX_WORKSPACE_ID renames the operator's live cmux
+    # workspaces.
+    for name in [key for key in env if key.startswith("CMUX_")]:
+        del env[name]
+
+    supervisor = subprocess.run(
+        [sys.executable, "-m", "local_operator.wakes.supervisor", "--once"],
+        env=env,
+        capture_output=True,
+        text=True,
+        # A HANG BACKSTOP ONLY, never an assertion: nothing on the success
+        # path compares elapsed time.
+        timeout=300,
+    )
+    assert supervisor.returncode == 0, f"{supervisor.stdout}\n{supervisor.stderr}"
+    assert "started a runtime for supwake00001" in supervisor.stderr, supervisor.stderr
+
+    transcript_path = tmp_path / "sessions" / "supwake00001" / "transcript.jsonl"
+    deadline = time.monotonic() + 90
+    text = ""
+    while time.monotonic() < deadline:
+        text = transcript_path.read_text(encoding="utf-8")
+        if "Hello from the mock provider!" in text and "wake_prompt" in text:
+            break
+        time.sleep(0.5)
+    else:
+        raise AssertionError(f"the supervised cold wake never ran its turn; transcript:\n{text}")

--- a/tests/unit/wakes/test_install.py
+++ b/tests/unit/wakes/test_install.py
@@ -474,3 +474,30 @@ def test_a_store_launchd_cannot_supervise_is_reported_as_unverifiable(
     assert state.running is False, "an isolated store was told about another store's supervisor"
     assert state.pid is None
     assert fake.calls == [], "launchd was addressed on behalf of a store it cannot supervise"
+
+
+def test_a_repeat_install_in_a_foreign_store_does_not_claim_to_be_installed(
+    redirected_home: Path, tmp_path: Path
+) -> None:
+    """Round 1 (Q1): three surfaces must not disagree about one store.
+
+    Under a redirected home the FIRST `wake create` says "plist written;
+    launchd not addressable from here" and `wake status` says "cannot be
+    verified for this store" — but the second create said "already installed",
+    which reads as "a supervisor is in place" for a store nothing supervises.
+    The reason string is the only feedback `wake create` gives, and this PR's
+    whole thesis is that "installed" stops meaning "a file exists".
+    """
+    config = tmp_path / "config"
+
+    first = ensure_supervisor_installed(config)
+    second = ensure_supervisor_installed(config)  # same store, plist now matches
+
+    if not is_supported():
+        assert second.reason == UNSUPPORTED_REASON
+        return
+
+    assert second.installed is False, "a store launchd cannot reach reported as installed"
+    assert "not addressable" in second.reason, second.reason
+    # Both calls answer in the same vocabulary; only the tense differs.
+    assert "not addressable" in first.reason, first.reason

--- a/tests/unit/wakes/test_install.py
+++ b/tests/unit/wakes/test_install.py
@@ -213,3 +213,264 @@ def test_the_write_guard_refuses_config_dirs_outside_the_real_home(
     real_home = Path(pwd.getpwuid(os.getuid()).pw_dir)
     assert _config_lives_in_real_home(tmp_path / "sandbox-cfg") is False
     assert _config_lives_in_real_home(real_home / ".local-operator") is True
+
+
+# --- The running probe, and the permanent miss it closes ----------------------
+#
+# These never call `launchctl`: `_launchctl` is patched, which is also what
+# keeps them inside this file's safety contract (see the module docstring).
+# `_parse_supervisor_state` is pure, so the recorded launchd output below is
+# verbatim from this machine rather than invented.
+
+#: Real `launchctl print` output for a RUNNING job, trimmed to the lines the
+#: parse reads. Kept verbatim so a launchd format change fails this test
+#: rather than silently changing what "running" means.
+_PRINT_RUNNING = """\
+gui/501/com.local-operator.wakes = {
+\tactive count = 1
+\tpath = /Users/x/Library/LaunchAgents/com.local-operator.wakes.plist
+\tstate = running
+
+\tdomain = gui/501 [100023]
+\truns = 3
+\tpid = 47545
+}
+"""
+
+#: Real output for a job that has EXITED. This is the whole defect: launchd
+#: still prints it, still exits 0, and reports no pid.
+_PRINT_EXITED = """\
+gui/501/com.local-operator.waketest = {
+\tactive count = 0
+\tpath = /Users/x/Library/LaunchAgents/com.local-operator.waketest.plist
+\tstate = not running
+
+\truns = 1
+\tlast exit code = 0
+}
+"""
+
+
+def _reachable(mod, monkeypatch: pytest.MonkeyPatch) -> None:  # noqa: ANN001
+    """Let the probe reach its (faked) launchctl.
+
+    `supervisor_state` applies both installer guards before probing, so that
+    an isolated store can never be told about the REAL user's supervisor.
+    Tests about the PARSE have to step past them; the guards themselves are
+    asserted directly, above and below.
+    """
+    monkeypatch.setattr(mod, "_launchd_is_addressable", lambda: True)
+    monkeypatch.setattr(mod, "_config_lives_in_real_home", lambda _config: True)
+
+
+class _FakeLaunchctl:
+    """Records every ``launchctl`` argv and replays canned results."""
+
+    def __init__(self, results: dict[str, tuple[int, str]]) -> None:
+        self._results = results
+        self.calls: list[tuple[str, ...]] = []
+
+    def __call__(self, *args: str):  # noqa: ANN204
+        import subprocess
+
+        self.calls.append(args)
+        code, stdout = self._results.get(args[0], (0, ""))
+        return subprocess.CompletedProcess(list(args), code, stdout, "")
+
+
+def test_a_loaded_but_exited_job_is_not_running(monkeypatch: pytest.MonkeyPatch) -> None:
+    """THE REGRESSION TEST for the permanent miss.
+
+    `launchctl print` returns 0 for a job that has exited, so the old
+    `_is_loaded()` check ("print returned 0") reported an armed wake as
+    supervised while nothing was running to fire it. The probe must read the
+    OUTPUT, not the exit code.
+    """
+    from local_operator.wakes import install as mod
+
+    if not is_supported():
+        pytest.skip("launchd probe is only meaningful on darwin with launchctl")
+
+    fake = _FakeLaunchctl({"print": (0, _PRINT_EXITED)})
+    monkeypatch.setattr(mod, "_launchctl", fake)
+    _reachable(mod, monkeypatch)
+
+    state = mod.supervisor_state(Path("/anywhere"))
+
+    assert state.loaded is True, "launchd does still know the label"
+    assert state.running is False, (
+        "a loaded-but-exited job was reported as running; the probe has regressed to "
+        "trusting launchctl's exit code, which is how an armed wake was left with no "
+        "live supervisor"
+    )
+    assert state.pid is None
+
+
+def test_a_running_job_is_reported_with_its_pid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The positive half: the probe is not vacuously False.
+
+    Without this, `return SupervisorState(loaded=True, running=False, ...)`
+    would pass the regression test above while making every persist kickstart
+    a perfectly healthy supervisor.
+    """
+    from local_operator.wakes import install as mod
+
+    if not is_supported():
+        pytest.skip("launchd probe is only meaningful on darwin with launchctl")
+
+    monkeypatch.setattr(mod, "_launchctl", _FakeLaunchctl({"print": (0, _PRINT_RUNNING)}))
+    _reachable(mod, monkeypatch)
+
+    state = mod.supervisor_state(Path("/anywhere"))
+
+    assert (state.loaded, state.running, state.pid) == (True, True, 47545)
+
+
+def test_an_absent_job_is_neither_loaded_nor_running(monkeypatch: pytest.MonkeyPatch) -> None:
+    from local_operator.wakes import install as mod
+
+    if not is_supported():
+        pytest.skip("launchd probe is only meaningful on darwin with launchctl")
+
+    monkeypatch.setattr(mod, "_launchctl", _FakeLaunchctl({"print": (1, "")}))
+    _reachable(mod, monkeypatch)
+
+    state = mod.supervisor_state(Path("/anywhere"))
+    assert (state.loaded, state.running) == (False, False)
+
+
+def test_unparseable_output_fails_safe_as_running() -> None:
+    """Fail SAFE, because the two errors do not cost the same.
+
+    Reading an unknown state as stopped would kickstart a healthy supervisor
+    on every persist, forever. Reading it as running only forgoes a repair.
+    """
+    from local_operator.wakes.install import _parse_supervisor_state
+
+    running, pid, _detail = _parse_supervisor_state("gui/501/x = {\n\tsomething = else\n}\n")
+
+    assert running is True
+    assert pid is None
+
+
+def test_a_stopped_supervisor_is_kickstarted_rather_than_called_installed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Repair-on-demand: the hook must FIX a loaded-but-dead supervisor.
+
+    Reaching this state used to end in "already installed" with nothing
+    running. The plist here is already correct, so the only thing that can
+    make the wake fire again is the restart.
+    """
+    from local_operator.wakes import install as mod
+
+    if not is_supported():
+        pytest.skip("launchd repair is only meaningful on darwin with launchctl")
+
+    config = tmp_path / "config"
+    # Stand in for the real home so both guards pass; `_launchctl` is faked, so
+    # nothing reaches a real launchd domain.
+    monkeypatch.setattr(mod, "_launchd_is_addressable", lambda: True)
+    monkeypatch.setattr(mod, "_config_lives_in_real_home", lambda _config: True)
+    plist = tmp_path / "agents" / f"{LABEL}.plist"
+    plist.parent.mkdir(parents=True, exist_ok=True)
+    plist.write_bytes(plistlib.dumps(render_plist(config)))
+    monkeypatch.setattr(mod, "plist_path", lambda: plist)
+    fake = _FakeLaunchctl({"print": (0, _PRINT_EXITED), "kickstart": (0, "")})
+    monkeypatch.setattr(mod, "_launchctl", fake)
+
+    outcome = mod.ensure_supervisor_installed(config)
+
+    assert outcome.installed is True
+    assert "restarted" in outcome.reason
+    assert any(
+        call[0] == "kickstart" for call in fake.calls
+    ), f"the stopped supervisor was not restarted; launchctl calls were {fake.calls}"
+
+
+def test_a_running_supervisor_is_left_alone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Idempotence still holds: the hook runs on EVERY persist.
+
+    Kickstarting a healthy supervisor on every wake write would restart it
+    constantly and interrupt the very sweeps it is meant to run.
+    """
+    from local_operator.wakes import install as mod
+
+    if not is_supported():
+        pytest.skip("launchd repair is only meaningful on darwin with launchctl")
+
+    config = tmp_path / "config"
+    monkeypatch.setattr(mod, "_launchd_is_addressable", lambda: True)
+    monkeypatch.setattr(mod, "_config_lives_in_real_home", lambda _config: True)
+    plist = tmp_path / "agents" / f"{LABEL}.plist"
+    plist.parent.mkdir(parents=True, exist_ok=True)
+    plist.write_bytes(plistlib.dumps(render_plist(config)))
+    monkeypatch.setattr(mod, "plist_path", lambda: plist)
+    fake = _FakeLaunchctl({"print": (0, _PRINT_RUNNING)})
+    monkeypatch.setattr(mod, "_launchctl", fake)
+
+    outcome = mod.ensure_supervisor_installed(config)
+
+    assert outcome.reason == "already installed"
+    assert [call[0] for call in fake.calls] == [
+        "print"
+    ], f"a healthy supervisor was disturbed; launchctl calls were {fake.calls}"
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="LaunchAgent plist is macOS-only")
+def test_the_plist_carries_the_bounded_self_heal(tmp_path: Path) -> None:
+    """``StartInterval`` SOFTENS the self-retirement invariant, deliberately.
+
+    "A machine with no wakes left runs no supervisor at all" is now "runs it
+    briefly every 15 minutes, where it reads an empty index and exits again".
+    That is bought knowingly: every other repair path needs something to call
+    it, and the failure being fixed is exactly the one where nothing is left
+    running to make that call.
+
+    Measured on a scratch label (20 s job, 5 s interval): launchd started runs
+    at +0/+25/+51 s — it does NOT start a second instance while one runs, and
+    it DOES re-run a job that exited 0.
+    """
+    from local_operator.wakes.install import SELF_HEAL_INTERVAL_S
+
+    plan = render_plist(tmp_path)
+
+    assert plan["StartInterval"] == SELF_HEAL_INTERVAL_S
+    # Must stay under the shortest realistic wake cadence, or a resurrected
+    # supervisor misses the occurrence it was resurrected for.
+    assert SELF_HEAL_INTERVAL_S <= 900
+    # The retirement key stays: the self-heal bounds the outage, it does not
+    # replace "a finished supervisor stays down".
+    assert plan["KeepAlive"] == {"SuccessfulExit": False}
+
+
+def test_a_store_launchd_cannot_supervise_is_reported_as_unverifiable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """THE ISOLATED-RUN LIE, closed at the probe.
+
+    `launchctl` has no sandbox: it answers about the calling user's live
+    session whatever store was asked about. During validation an isolated run
+    (redirected HOME, config dir in a tmpdir) reported
+    `running (pid 47545)` — the operator's REAL LaunchAgent, supervising the
+    operator's REAL store. That is the same class of wrong answer this module
+    exists to remove, so the probe applies the installer's own two guards and
+    reports a distinct third state rather than someone else's process.
+    """
+    from local_operator.wakes import install as mod
+
+    if not is_supported():
+        pytest.skip("launchd scoping is only meaningful on darwin with launchctl")
+
+    fake = _FakeLaunchctl({"print": (0, _PRINT_RUNNING)})
+    monkeypatch.setattr(mod, "_launchctl", fake)
+
+    # A config dir outside the real home: the sandbox shape exactly.
+    state = mod.supervisor_state(tmp_path / "sandbox-cfg")
+
+    assert state.verifiable is False
+    assert state.running is False, "an isolated store was told about another store's supervisor"
+    assert state.pid is None
+    assert fake.calls == [], "launchd was addressed on behalf of a store it cannot supervise"

--- a/tests/unit/wakes/test_session_index.py
+++ b/tests/unit/wakes/test_session_index.py
@@ -208,3 +208,97 @@ async def test_install_hook_failure_never_breaks_wake_persistence(
         assert any("install hook failed" in rec.getMessage() for rec in caplog.records)
     finally:
         await session.dispose()
+
+
+# --- Lateness telemetry: the fields that make a missed wake visible ----------
+
+
+@pytest.mark.asyncio
+async def test_opening_a_session_stamps_last_attempt_at(tmp_path: Path, config_dir: Path) -> None:
+    """A runtime existing for this session is what the supervisor engages FOR.
+
+    Written by the session, never by the supervisor: the supervisor stays
+    read-only over schedule state, which is the property that keeps it from
+    ever disagreeing with the session about what has fired.
+    """
+    before = int(time.time() * 1000)
+    session = _open(tmp_path)
+    try:
+        await session.set_wake_schedules([_schedule()])
+        # The open-time rebuild is what stamps it; force one the way a reopen
+        # does rather than reaching into the private writer.
+        session._rebuild_wake_index_entry()
+        entry = wake_store.read_entry(config_dir, "sess")
+        assert entry is not None
+        assert entry["last_attempt_at"] >= before
+        assert "last_fired_at" not in entry, "nothing has fired yet"
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_delivered_wake_stamps_last_fired_at(tmp_path: Path, config_dir: Path) -> None:
+    """The instant a wake actually went off, which is what makes lateness
+    computable: `next_due_at` says when it SHOULD have fired, and the gap to
+    this is how late it was. Nothing recorded it before, so "did this fire at
+    all" was unanswerable without reading the transcript."""
+    before = int(time.time() * 1000)
+    session = _open(tmp_path)
+    try:
+        # A repeating wake, already due: the pump delivers it and persists the
+        # ADVANCED schedule, so the entry survives for the assertion.
+        await session.set_wake_schedules(
+            [
+                WakeSchedule(
+                    id="w1",
+                    message="check in",
+                    next_due_at=before - 1_000,
+                    every_ms=3_600_000,
+                    created_at=1_700_000_000_000,
+                )
+            ]
+        )
+        await session.wake_scheduler.pump()
+
+        entry = wake_store.read_entry(config_dir, "sess")
+        assert entry is not None
+        assert entry["last_fired_at"] >= before, entry
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_persist_does_not_restamp_a_fire(
+    tmp_path: Path, config_dir: Path
+) -> None:
+    """The flag is CONSUMED by the persist that follows the delivery.
+
+    Otherwise a later unrelated persist — the wake tool adding a schedule,
+    say — would restamp a fire that did not happen, and the lateness figure
+    would quietly become a lie.
+    """
+    session = _open(tmp_path)
+    try:
+        await session.set_wake_schedules(
+            [
+                WakeSchedule(
+                    id="w1",
+                    message="check in",
+                    next_due_at=int(time.time() * 1000) - 1_000,
+                    every_ms=3_600_000,
+                    created_at=1_700_000_000_000,
+                )
+            ]
+        )
+        await session.wake_scheduler.pump()
+        fired = wake_store.read_entry(config_dir, "sess")
+        assert fired is not None
+        fired_at = fired["last_fired_at"]
+
+        await session.set_wake_schedules([_schedule("w2")])
+
+        entry = wake_store.read_entry(config_dir, "sess")
+        assert entry is not None
+        assert entry["last_fired_at"] == fired_at, "an unrelated persist restamped the fire"
+    finally:
+        await session.dispose()

--- a/tests/unit/wakes/test_supervisor.py
+++ b/tests/unit/wakes/test_supervisor.py
@@ -404,14 +404,29 @@ async def test_the_sweep_fires_due_sessions_concurrently(
         return None
 
     monkeypatch.setattr("local_operator.session.runtime.launch.engage_runtime", overlapping)
+
+    from local_operator.wakes import supervisor as mod
+
+    started_order: list[str] = []
+    real_engage = mod._Sweeper.engage
+
+    def recording_engage(self, config_dir, session_id, cwd, due_ms, moment):  # noqa: ANN001, ANN202
+        started_order.append(session_id)
+        return real_engage(self, config_dir, session_id, cwd, due_ms, moment)
+
+    monkeypatch.setattr(mod._Sweeper, "engage", recording_engage)
     write_entry(tmp_path, "sessionfirst", cwd=str(tmp_path), schedules=[_schedule(NOW_MS - 9_000)])
     write_entry(tmp_path, "sessionsecnd", cwd=str(tmp_path), schedules=[_schedule(NOW_MS - 8_000)])
 
     fired = await asyncio.wait_for(fire_due_wakes(tmp_path, now_ms=NOW_MS), timeout=10)
 
     assert fired == 2
-    # Oldest-first is preserved: concurrency changes who WAITS, not who starts.
-    assert order[0] == "sessionfirst"
+    # Oldest-first is preserved in the order engagements are STARTED, which is
+    # the property the sweep controls. Which one wins the race into
+    # `engage_runtime` afterwards is the event loop's business, so asserting on
+    # arrival order there would be asserting on the scheduler.
+    assert started_order[0] == "sessionfirst"
+    assert set(order) == {"sessionfirst", "sessionsecnd"}
 
 
 @pytest.mark.asyncio
@@ -576,6 +591,7 @@ async def test_a_wake_written_during_the_sleep_is_seen_within_a_slice(
 
     from local_operator.wakes import supervisor as mod
 
+    real_sleep = asyncio.sleep
     slept: list[float] = []
     fired_for: list[str] = []
 
@@ -590,25 +606,29 @@ async def test_a_wake_written_during_the_sleep_is_seen_within_a_slice(
                 cwd=str(tmp_path),
                 schedules=[_schedule(int(time.time() * 1000) - 1_000, "w2")],
             )
+        # Yield for real. The loop is cooperative, and a "sleep" that never
+        # reaches the scheduler turns any await in serve() into a spin.
+        # `real_sleep` is bound before the patch: `mod.asyncio` IS the asyncio
+        # module, so calling asyncio.sleep here would re-enter this fake.
+        await real_sleep(0)
 
     passes = 0
 
-    async def fake_fire(config_dir, *, now_ms=None):  # noqa: ANN001
-        # The FIRST pass finds nothing due and returns, which is what lets
-        # serve() reach its sleep — the window the defect lived in. The second
-        # pass records what the re-read saw and ends the loop.
+    def fake_sweep(self, config_dir, index, moment):  # noqa: ANN001, ANN202
+        # Hooked at the SWEEP, the seam serve() actually drives now that
+        # engagements no longer block the loop. The first pass finds nothing
+        # due and returns, which is what lets serve() reach its sleep — the
+        # window the defect lived in. The second records what the re-read saw
+        # and ends the loop.
         nonlocal passes
         passes += 1
         if passes == 1:
             return 0
-        from local_operator.wakes.store import read_index
-
-        index = await asyncio.to_thread(read_index, config_dir)
         fired_for.extend(sorted(index))
         raise _StopServing
 
     monkeypatch.setattr(mod.asyncio, "sleep", fake_sleep)
-    monkeypatch.setattr(mod, "fire_due_wakes", fake_fire)
+    monkeypatch.setattr(mod._Sweeper, "sweep", fake_sweep)
     # The far-away wake the sleep is sized for: three hours out, so the old
     # code would have slept MAX_SLEEP_S before looking again.
     write_entry(
@@ -635,24 +655,82 @@ class _StopServing(Exception):
     """Breaks out of ``serve``'s infinite loop from inside a patched callee."""
 
 
+@pytest.mark.parametrize(
+    ("name", "build", "reason"),
+    [
+        ("dormant", "dormant", "every session is stopped"),
+        ("stale", "stale", "every wake is past the staleness bound"),
+        ("ghost", "ghost", "no session on disk owns the entry"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_an_index_of_only_dormant_entries_retires(tmp_path: Path) -> None:
-    """ "Nothing fireable" is not the same question as "empty".
+async def test_an_index_with_nothing_fireable_retires(
+    tmp_path: Path, name: str, build: str, reason: str, monkeypatch
+) -> None:
+    """ "Nothing fireable" is not the same question as "non-empty".
 
-    An index holding only stopped sessions kept the supervisor alive forever:
-    the non-empty check refused to retire while `_next_wake_ms` (which skips
-    dormant entries) returned None and parked it on MAX_SLEEP_S. Nothing it
-    could do would ever fire those wakes.
+    Each of these three entry kinds satisfies "a non-dormant entry carrying
+    schedules" (dormant excepted) while being work this process can NEVER do:
+    a stopped session re-arms only on reopen, a >7-day wake only gets older,
+    and a ghost never grows a transcript. Counting them as fireable made the
+    supervisor immortal and re-logged the refusal every slice forever
+    (round 1, R2/Q4).
+
+    Asserted on the RETIREMENT ITSELF, not on `serve(once=True) == 0`. Round 1
+    (R4): `once=True` returns 0 from the retirement branch and from the
+    post-sweep branch alike, so the old assertion held whatever the predicate
+    did — it could not fail, and a verbatim restoration of the pre-fix
+    behaviour kept the suite green. This drives the real loop and requires the
+    retirement log line, which only the retirement branch emits.
     """
-    write_entry(
-        tmp_path,
-        "sessiondorm1",
-        cwd=str(tmp_path),
-        schedules=[_schedule(NOW_MS - 5_000)],
-        preserve={"stopped_at": NOW_MS - 10_000},
+    import asyncio
+
+    from local_operator.wakes import supervisor as mod
+
+    if build == "dormant":
+        write_entry(
+            tmp_path,
+            "sessiondorm1",
+            cwd=str(tmp_path),
+            schedules=[_schedule(NOW_MS - 5_000)],
+            preserve={"stopped_at": NOW_MS - 10_000},
+        )
+    elif build == "stale":
+        write_entry(
+            tmp_path,
+            "sessionstal3",
+            cwd=str(tmp_path),
+            schedules=[_schedule(NOW_MS - int(9 * 24 * 3600 * 1000))],
+        )
+    else:
+        import shutil
+
+        write_entry(
+            tmp_path, "sessionghos2", cwd=str(tmp_path), schedules=[_schedule(NOW_MS - 5_000)]
+        )
+        shutil.rmtree(tmp_path / "sessions" / "sessionghos2")
+
+    real_sleep = asyncio.sleep
+
+    async def fast_sleep(seconds: float) -> None:
+        # The retirement grace is a real await; collapse it so the test does
+        # not spend SLICE_S of wall time proving a decision.
+        await real_sleep(0)
+
+    monkeypatch.setattr(mod.asyncio, "sleep", fast_sleep)
+
+    records: list[str] = []
+    monkeypatch.setattr(
+        mod.logger,
+        "info",
+        lambda msg, *args, **kw: records.append(str(msg) % args if args else msg),
     )
 
-    assert await serve(tmp_path, once=True) == 0
+    assert await asyncio.wait_for(serve(tmp_path), timeout=10) == 0
+    assert any("retiring" in line for line in records), (
+        f"the supervisor did not retire on an index where {reason}; it stayed up with "
+        f"nothing it could ever fire. Log was: {records}"
+    )
 
 
 @pytest.mark.asyncio
@@ -671,20 +749,281 @@ async def test_retirement_re_reads_after_a_grace_before_exiting(
 
     from local_operator.wakes import supervisor as mod
 
+    real_sleep = asyncio.sleep
+
     async def fake_sleep(seconds: float) -> None:
         # The entry lands during the retirement grace.
         write_entry(
             tmp_path, "sessionraced", cwd=str(tmp_path), schedules=[_schedule(NOW_MS + 600_000)]
         )
+        await real_sleep(0)
 
-    async def fake_fire(config_dir, *, now_ms=None):  # noqa: ANN001
+    def fake_sweep(self, config_dir, index, moment):  # noqa: ANN001, ANN202
         raise _StopServing
 
     monkeypatch.setattr(mod.asyncio, "sleep", fake_sleep)
-    monkeypatch.setattr(mod, "fire_due_wakes", fake_fire)
+    monkeypatch.setattr(mod._Sweeper, "sweep", fake_sweep)
 
     # Reaching the sweep at all means it did NOT retire on the empty first read.
     with pytest.raises(_StopServing):
         await serve(tmp_path)
 
     assert asyncio.get_event_loop_policy() is not None  # loop intact; no hidden teardown
+
+
+# --- Round 1 remediation: non-blocking sweep, throttled skips, wedged runtimes
+
+
+@pytest.mark.asyncio
+async def test_a_slow_engagement_does_not_hold_the_serve_loop(
+    tmp_path: Path, no_live_runtimes, real_sessions, monkeypatch
+) -> None:
+    """R3. The loop must keep slicing while an engagement runs.
+
+    An awaited sweep put head-of-line blocking back where the slice re-read
+    had removed it: six all-timing-out sessions at concurrency 2 and a 180 s
+    deadline block for 540 s, and NOTHING re-reads the index for the whole of
+    it. Here one engagement never finishes; the loop must still observe a wake
+    written afterwards.
+
+    Asserted structurally — the second index read happens while the first
+    engagement is provably still in flight — so there is no timing assertion.
+    """
+    import asyncio
+
+    from local_operator.wakes import supervisor as mod
+
+    engaged = asyncio.Event()
+    release = asyncio.Event()
+    seen_later: list[str] = []
+
+    async def never_finishes(
+        session_id, cwd, work, *, config_dir, deadline_s=30.0, preempt=None, preempt_budget_s=0.0
+    ):  # noqa: ANN001
+        engaged.set()
+        await release.wait()  # the 180 s deadline, modelled as "not yet"
+        return None
+
+    monkeypatch.setattr("local_operator.session.runtime.launch.engage_runtime", never_finishes)
+
+    real_sleep = asyncio.sleep
+
+    async def fast_sleep(seconds: float) -> None:
+        await real_sleep(0)
+
+    monkeypatch.setattr(mod.asyncio, "sleep", fast_sleep)
+
+    passes = 0
+    real_sweep = mod._Sweeper.sweep
+
+    def watching_sweep(self, config_dir, index, moment):  # noqa: ANN001, ANN202
+        # Stop on the CONDITION, not on a pass count: serve() spins freely
+        # here because sleeps are collapsed, so "pass 2" would race the test's
+        # write rather than prove anything about it.
+        nonlocal passes
+        passes += 1
+        launched = real_sweep(self, config_dir, index, moment)
+        if "sessionlater" in index:
+            seen_later.extend(sorted(index))
+            raise _StopServing
+        if passes > 500:  # a hang backstop, never an assertion
+            raise _StopServing
+        return launched
+
+    monkeypatch.setattr(mod._Sweeper, "sweep", watching_sweep)
+
+    write_entry(tmp_path, "sessionslow1", cwd=str(tmp_path), schedules=[_schedule(NOW_MS - 5_000)])
+
+    async def drive() -> None:
+        with pytest.raises(_StopServing):
+            await serve(tmp_path)
+
+    task = asyncio.create_task(drive())
+    await asyncio.wait_for(engaged.wait(), timeout=10)
+    # Written while the engagement is stuck: the old awaited sweep could not
+    # see this until the engagement finished.
+    write_entry(tmp_path, "sessionlater", cwd=str(tmp_path), schedules=[_schedule(NOW_MS - 1_000)])
+    await asyncio.wait_for(task, timeout=10)
+
+    # Asserted BEFORE releasing: the engagement is provably still blocked at
+    # this point, so a later pass having seen the new entry can only mean the
+    # loop kept running alongside it.
+    assert not release.is_set(), "the engagement finished; this proved nothing about blocking"
+    assert "sessionlater" in seen_later, (
+        "the serve loop did not re-read the index while an engagement was in flight; "
+        "a wake armed during a slow sweep waits out the whole sweep"
+    )
+    release.set()
+
+
+@pytest.mark.asyncio
+async def test_the_same_occurrence_is_never_engaged_twice(
+    tmp_path: Path, no_live_runtimes, real_sessions, monkeypatch
+) -> None:
+    """The in-flight set is what makes background engagements safe.
+
+    A pass every SLICE_S over a wake that takes WAKE_DEADLINE_S to engage
+    would otherwise start ~18 engagements for one occurrence.
+    """
+    import asyncio
+
+    from local_operator.wakes import supervisor as mod
+
+    attempts: list[str] = []
+    release = asyncio.Event()
+
+    async def slow(
+        session_id, cwd, work, *, config_dir, deadline_s=30.0, preempt=None, preempt_budget_s=0.0
+    ):  # noqa: ANN001
+        attempts.append(session_id)
+        await release.wait()
+        return None
+
+    monkeypatch.setattr("local_operator.session.runtime.launch.engage_runtime", slow)
+    write_entry(tmp_path, "sessiondupe1", cwd=str(tmp_path), schedules=[_schedule(NOW_MS - 5_000)])
+
+    sweeper = mod._Sweeper()
+    from local_operator.wakes.store import read_index
+
+    index = read_index(tmp_path)
+    # Three passes over the same due occurrence, as the slice loop would do.
+    launched = [sweeper.sweep(tmp_path, index, NOW_MS) for _ in range(3)]
+    await asyncio.sleep(0)
+
+    assert launched == [1, 0, 0], f"the same occurrence was engaged more than once: {launched}"
+    release.set()
+    await sweeper.drain()
+    assert attempts == ["sessiondupe1"]
+
+
+@pytest.mark.asyncio
+async def test_a_permanent_skip_stops_flooding_the_log(
+    tmp_path: Path, engagements, no_live_runtimes, caplog
+) -> None:
+    """R2/Q4. A ghost or stale skip repeats every slice and never self-clears.
+
+    Unthrottled that is ~8,640 lines/day/entry into a file nothing rotates,
+    drowning the signal this observability exists to create. The first
+    occurrences carry the information; after that a heartbeat is enough.
+    """
+    from local_operator.wakes import supervisor as mod
+
+    mod._skip_log = mod._SkipLog()  # a fresh process's worth of state
+    write_entry(tmp_path, "sessionflood", cwd=str(tmp_path), schedules=[_schedule(NOW_MS - 5_000)])
+    import shutil
+
+    shutil.rmtree(tmp_path / "sessions" / "sessionflood")
+
+    with caplog.at_level("WARNING"):
+        for _ in range(20):
+            await fire_due_wakes(tmp_path, now_ms=NOW_MS)
+
+    lines = [r for r in caplog.records if "sessionflood" in r.getMessage()]
+    assert len(lines) == mod._SKIP_LOG_BURST, (
+        f"{len(lines)} lines for 20 passes of a permanently-unfireable entry; at the "
+        f"shipped SLICE_S that is {len(lines) / 20 * 8640:.0f} lines/day"
+    )
+
+
+def test_a_changed_skip_reason_speaks_up_again() -> None:
+    """The throttle is keyed by reason, so a state CHANGE is not swallowed.
+
+    An entry going from "a live runtime owns it" to "stale" is new
+    information, and inheriting the old key's silence would hide it.
+    """
+    from local_operator.wakes.supervisor import _SkipLog
+
+    log = _SkipLog()
+    for _ in range(10):
+        log.should_log("sessionx", "live")
+
+    assert log.should_log("sessionx", "stale") is True
+
+
+def test_the_skip_throttle_resumes_after_the_heartbeat_interval() -> None:
+    """Throttled is not silenced: the condition stays visible, hourly."""
+    from local_operator.wakes.supervisor import (
+        _SKIP_HEARTBEAT_S,
+        _SKIP_LOG_BURST,
+        _SkipLog,
+    )
+
+    log = _SkipLog()
+    for _ in range(_SKIP_LOG_BURST):
+        assert log.should_log("sessiony", "ghost", now=0.0) is True
+    assert log.should_log("sessiony", "ghost", now=1.0) is False
+    assert log.should_log("sessiony", "ghost", now=_SKIP_HEARTBEAT_S + 1) is True
+
+
+@pytest.mark.asyncio
+async def test_a_wedged_runtime_is_named_rather_than_timing_out(
+    tmp_path: Path, engagements, real_sessions, monkeypatch, caplog
+) -> None:
+    """The last silent dead-end.
+
+    A runtime whose pid is alive but whose heartbeat is stale is invisible to
+    `_has_live_runtime` (so the supervisor engages) AND holds the transcript
+    lease (so the engage cannot spawn), burning the whole deadline and
+    reporting an ordinary timeout. Naming it is the difference between "this
+    wake is slow" and "this wake cannot fire until pid N recovers".
+    """
+
+    async def _no_live_record(config_dir, session_id):  # noqa: ANN001
+        return False
+
+    monkeypatch.setattr("local_operator.wakes.supervisor._has_live_runtime", _no_live_record)
+    monkeypatch.setattr(
+        "local_operator.wakes.supervisor.wedged_runtime",
+        lambda _config, _session: (4242, 312.0),
+    )
+    write_entry(tmp_path, "sessionwedg2", cwd=str(tmp_path), schedules=[_schedule(NOW_MS - 5_000)])
+
+    with caplog.at_level("WARNING"):
+        fired = await fire_due_wakes(tmp_path, now_ms=NOW_MS)
+
+    assert fired == 0
+    assert engagements == [], "a wedged session must not burn an engage deadline"
+    message = " ".join(r.getMessage() for r in caplog.records)
+    assert "wedged" in message and "4242" in message and "312" in message, message
+
+
+def test_the_wedged_probe_reads_the_registry_classification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Read from `registry.scan`, never re-derived from `heartbeat_at` here.
+
+    The registry already owns live/wedged/stale; a second opinion about the
+    same record is how two surfaces come to disagree about one process.
+    """
+    from local_operator.session.runtime.types import SessionRecord
+    from local_operator.wakes.supervisor import wedged_runtime
+
+    record = SessionRecord(
+        pid=777,
+        kind="tui",
+        session_id="sessionwedg3",
+        conversation_name="wedged",
+        cwd="/tmp",
+        model_label="m",
+        control_port=0,
+        control_key="k",
+    )
+    record.heartbeat_at = time.time() - 300
+    monkeypatch.setattr(
+        "local_operator.session.runtime.registry.scan",
+        lambda _root=None: [(record, "wedged")],
+    )
+
+    found = wedged_runtime(tmp_path, "sessionwedg3")
+    assert found is not None
+    pid, age = found
+    assert pid == 777
+    assert age >= 299
+
+    # A LIVE record of the same shape is not wedged: the classification is the
+    # registry's, not this module's.
+    monkeypatch.setattr(
+        "local_operator.session.runtime.registry.scan",
+        lambda _root=None: [(record, "live")],
+    )
+    assert wedged_runtime(tmp_path, "sessionwedg3") is None

--- a/tests/unit/wakes/test_supervisor.py
+++ b/tests/unit/wakes/test_supervisor.py
@@ -9,6 +9,10 @@ also deliver would double-fire every wake it touched.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import json
+import logging
 import os
 import subprocess
 import sys
@@ -1027,3 +1031,309 @@ def test_the_wedged_probe_reads_the_registry_classification(
         lambda _root=None: [(record, "live")],
     )
     assert wedged_runtime(tmp_path, "sessionwedg3") is None
+
+
+# --- Round 2: per-schedule staleness, and the guards the round added ---------
+#
+# Round 2's reviewer observed that 3 of round 1's 4 new guards survived being
+# reverted while the whole suite stayed green — the delta's own guards were its
+# least-tested code, which is how R7 and R8 passed a green CI. Every test below
+# is written to FAIL on a specific reverted line, and each was mutation-checked
+# by actually reverting that line.
+
+
+def _mixed_entry(now_ms: int) -> dict[str, object]:
+    """One entry: a >7-day stale one-shot beside a live recurring watch.
+
+    The R7 shape. `next_due_at(entry)` answers with the EARLIEST schedule, so
+    an entry-level staleness test classifies this whole entry as stale — and
+    once that predicate drove retirement, the live 20-minute watch stopped
+    firing for good with no trace.
+    """
+    return {
+        "schema": 1,
+        "session_id": "mixedentry01",
+        "cwd": "/tmp",
+        "updated_at": now_ms,
+        "schedules": [
+            {"id": "w1", "message": "ancient one-shot", "next_due_at": now_ms - 9 * 86400_000},
+            {
+                "id": "w2",
+                "message": "20-minute watch",
+                "next_due_at": now_ms - 5_000,
+                "every_ms": 1_200_000,
+            },
+        ],
+    }
+
+
+def test_a_stale_schedule_does_not_speak_for_its_live_siblings(tmp_path: Path) -> None:
+    """R7 (BLOCKER): mixed entry ⇒ still fireable, and the LIVE wake is the one due.
+
+    Mutation-checked: restoring the entry-level test (`_is_stale` answering on
+    `next_due_at(entry)`) fails this with
+    `the supervisor retired on an entry holding a live 20-minute watch`.
+    """
+    from local_operator.wakes.supervisor import (
+        _due_sessions,
+        _fireable_due_ms,
+        _has_fireable_wakes,
+        _is_stale,
+    )
+
+    now_ms = int(time.time() * 1000)
+    entry = _mixed_entry(now_ms)
+    index = {"mixedentry01": entry}
+    (tmp_path / "sessions" / "mixedentry01").mkdir(parents=True)
+    (tmp_path / "sessions" / "mixedentry01" / "transcript.jsonl").write_text("{}\n")
+
+    assert not _is_stale(entry, now_ms), "an entry with a live schedule is not stale"
+    assert _has_fireable_wakes(
+        index, config_dir=tmp_path, now_ms=now_ms
+    ), "the supervisor retired on an entry holding a live 20-minute watch"
+    # And the wake it engages is the live one, not the week-old one-shot: the
+    # occurrence key is built from this figure, so engaging on the stale row
+    # would also mis-key the in-flight dedupe.
+    assert _fireable_due_ms(entry, now_ms) == now_ms - 5_000
+    assert [due for _, _, due in _due_sessions(index, now_ms)] == [now_ms - 5_000]
+
+
+def test_an_entry_whose_every_schedule_is_stale_is_still_stale(tmp_path: Path) -> None:
+    """The other half of R7: `all(...)` must not become "never stale"."""
+    from local_operator.wakes.supervisor import _has_fireable_wakes, _is_stale
+
+    now_ms = int(time.time() * 1000)
+    entry = {
+        "schema": 1,
+        "session_id": "allstale0001",
+        "cwd": "/tmp",
+        "schedules": [
+            {"id": "w1", "message": "old", "next_due_at": now_ms - 9 * 86400_000},
+            {"id": "w2", "message": "older", "next_due_at": now_ms - 30 * 86400_000},
+        ],
+    }
+    (tmp_path / "sessions" / "allstale0001").mkdir(parents=True)
+    (tmp_path / "sessions" / "allstale0001" / "transcript.jsonl").write_text("{}\n")
+
+    assert _is_stale(entry, now_ms)
+    assert not _has_fireable_wakes({"allstale0001": entry}, config_dir=tmp_path, now_ms=now_ms)
+
+
+@pytest.mark.asyncio
+async def test_serve_keeps_running_for_a_live_watch_beside_a_stale_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """R7 end to end: `serve()` must not retire, and must engage the live wake.
+
+    The reviewer's probe asserted on the process, not the predicate, because
+    the two disagreed: the contract-level test passed while `serve()` exited 0
+    in 0.2 s. This runs the real loop.
+    """
+    from local_operator.wakes import supervisor as mod
+
+    (tmp_path / "wakes").mkdir()
+    (tmp_path / "sessions" / "mixedentry01").mkdir(parents=True)
+    (tmp_path / "sessions" / "mixedentry01" / "transcript.jsonl").write_text("{}\n")
+    now_ms = int(time.time() * 1000)
+    (tmp_path / "wakes" / "mixedentry01.json").write_text(json.dumps(_mixed_entry(now_ms)))
+
+    engaged: list[str] = []
+
+    async def _fake_engage(session_id: str, *_args: object, **_kwargs: object) -> object:
+        engaged.append(session_id)
+        return object()
+
+    monkeypatch.setattr("local_operator.session.runtime.launch.engage_runtime", _fake_engage)
+    monkeypatch.setattr(mod, "SLICE_S", 0.05)
+
+    task = asyncio.create_task(mod.serve(tmp_path))
+    await asyncio.sleep(0.6)
+    still_running = not task.done()
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    assert still_running, "serve() retired on an entry that holds a live recurring watch"
+    # The fake engage does not advance the schedule (the real session owns that
+    # write), so the same occurrence stays due and is re-engaged each slice —
+    # what matters is that it fired AT ALL, which it did not before this fix.
+    assert engaged, "the live watch never fired"
+    assert set(engaged) == {"mixedentry01"}, engaged
+    assert "the supervisor is retiring" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_the_retirement_line_says_which_state_it_hit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """D15/R7: a stale-only store retires BEFORE the sweep, so the retirement
+    line is the only line the operator gets — it must carry the reason.
+
+    Mutation-checked: dropping `_retirement_reason` from the log call fails
+    this with `the retirement line does not say why`.
+    """
+    from local_operator.wakes import supervisor as mod
+
+    (tmp_path / "wakes").mkdir()
+    (tmp_path / "sessions" / "staleonly001").mkdir(parents=True)
+    (tmp_path / "sessions" / "staleonly001" / "transcript.jsonl").write_text("{}\n")
+    now_ms = int(time.time() * 1000)
+    (tmp_path / "wakes" / "staleonly001.json").write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "session_id": "staleonly001",
+                "cwd": "/tmp",
+                "schedules": [
+                    {"id": "w1", "message": "forgotten", "next_due_at": now_ms - 9 * 86400_000}
+                ],
+            }
+        )
+    )
+    monkeypatch.setattr(mod, "SLICE_S", 0.05)
+
+    with caplog.at_level(logging.INFO):
+        rc = await mod.serve(tmp_path)
+
+    assert rc == 0
+    assert "the supervisor is retiring" in caplog.text
+    assert (
+        "past the 7d staleness bound" in caplog.text
+    ), f"the retirement line does not say why: {caplog.text}"
+    assert "delivered when their sessions are next opened" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_a_runtimeerror_from_engage_is_throttled_and_the_wake_is_retried(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """R8 (MAJOR): `engage_runtime` documents RuntimeError for "every candidate
+    died"; unhandled, it escaped a detached task as a 13-line asyncio traceback
+    per slice — 8,640/day into an unrotated log, bypassing the throttle.
+
+    Mutation-checked: removing `RuntimeError` from the `except` fails this with
+    `a RuntimeError escaped the engage as an unretrieved task exception`.
+    """
+    from local_operator.wakes import supervisor as mod
+
+    (tmp_path / "wakes").mkdir()
+    (tmp_path / "sessions" / "alwaysfail01").mkdir(parents=True)
+    (tmp_path / "sessions" / "alwaysfail01" / "transcript.jsonl").write_text("{}\n")
+    now_ms = int(time.time() * 1000)
+    (tmp_path / "wakes" / "alwaysfail01.json").write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "session_id": "alwaysfail01",
+                "cwd": "/tmp",
+                "schedules": [
+                    {
+                        "id": "w1",
+                        "message": "doomed",
+                        "next_due_at": now_ms - 5_000,
+                        "every_ms": 1_200_000,
+                    }
+                ],
+            }
+        )
+    )
+
+    attempts = 0
+
+    async def _always_raises(*_args: object, **_kwargs: object) -> object:
+        nonlocal attempts
+        attempts += 1
+        raise RuntimeError("every candidate died: no credential")
+
+    monkeypatch.setattr("local_operator.session.runtime.launch.engage_runtime", _always_raises)
+    monkeypatch.setattr(mod, "SLICE_S", 0.05)
+
+    loop_exceptions: list[dict[str, object]] = []
+    asyncio.get_running_loop().set_exception_handler(
+        lambda _loop, context: loop_exceptions.append(context)
+    )
+
+    with caplog.at_level(logging.WARNING):
+        task = asyncio.create_task(mod.serve(tmp_path))
+        await asyncio.sleep(1.2)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+    await asyncio.sleep(0)
+
+    assert (
+        not loop_exceptions
+    ), f"a RuntimeError escaped the engage as an unretrieved task exception: {loop_exceptions}"
+    # Retried, not lost: the schedule is untouched, so later passes try again.
+    assert attempts > 1, f"the wake was not retried after the failure (attempts={attempts})"
+    # THROTTLED: many attempts, few lines. The burst bound is _SKIP_BURST.
+    lines = [rec for rec in caplog.records if "could not start a runtime" in rec.message]
+    assert (
+        len(lines) <= mod._SKIP_LOG_BURST
+    ), f"{attempts} failures produced {len(lines)} log lines; the throttle was bypassed"
+    assert lines and lines[0].message.startswith("failed:"), lines[0].message if lines else "none"
+
+
+@pytest.mark.asyncio
+async def test_an_unanticipated_raise_from_an_engage_does_not_flood_the_log(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """R8's belt: `_engage_one` is a detached task, so ANY unhandled raise lands
+    in the same hole. A type nobody anticipated must still degrade to one
+    throttled line, not a traceback per slice.
+
+    Mutation-checked: removing the `except Exception` belt from `_run` fails
+    this with `an unanticipated raise escaped the detached task`.
+    """
+    from local_operator.wakes import supervisor as mod
+
+    (tmp_path / "wakes").mkdir()
+    (tmp_path / "sessions" / "weirdfail001").mkdir(parents=True)
+    (tmp_path / "sessions" / "weirdfail001" / "transcript.jsonl").write_text("{}\n")
+    now_ms = int(time.time() * 1000)
+    (tmp_path / "wakes" / "weirdfail001.json").write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "session_id": "weirdfail001",
+                "cwd": "/tmp",
+                "schedules": [
+                    {
+                        "id": "w1",
+                        "message": "doomed",
+                        "next_due_at": now_ms - 5_000,
+                        "every_ms": 1_200_000,
+                    }
+                ],
+            }
+        )
+    )
+
+    async def _raises_unexpectedly(*_args: object, **_kwargs: object) -> object:
+        raise ValueError("nobody planned for this")
+
+    monkeypatch.setattr(
+        "local_operator.session.runtime.launch.engage_runtime", _raises_unexpectedly
+    )
+    monkeypatch.setattr(mod, "SLICE_S", 0.05)
+
+    loop_exceptions: list[dict[str, object]] = []
+    asyncio.get_running_loop().set_exception_handler(
+        lambda _loop, context: loop_exceptions.append(context)
+    )
+
+    with caplog.at_level(logging.WARNING):
+        task = asyncio.create_task(mod.serve(tmp_path))
+        await asyncio.sleep(1.0)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+    await asyncio.sleep(0)
+
+    assert (
+        not loop_exceptions
+    ), f"an unanticipated raise escaped the detached task: {loop_exceptions}"
+    errors = [rec for rec in caplog.records if rec.message.startswith("error:")]
+    assert errors, "the belt swallowed the failure without a word"
+    assert len(errors) <= mod._SKIP_LOG_BURST, f"{len(errors)} lines; the throttle was bypassed"
+    assert "ValueError" in errors[0].message

--- a/tests/unit/wakes/test_supervisor.py
+++ b/tests/unit/wakes/test_supervisor.py
@@ -27,6 +27,41 @@ def _schedule(due_ms: int, wake_id: str = "w1") -> dict[str, object]:
     return {"id": wake_id, "message": "check the deploy", "next_due_at": due_ms, "created_at": 1}
 
 
+def _make_session(config_dir: Path, session_id: str) -> None:
+    """Give ``session_id`` a transcript, so the ghost guard sees a real session.
+
+    The supervisor now refuses to engage an index entry whose session has no
+    transcript on disk (such an entry can never be engaged successfully and
+    used to burn a full deadline on every pass, forever). These tests are
+    about firing DECISIONS, so they need their sessions to exist.
+    """
+    from local_operator.resume import TRANSCRIPT_NAME
+
+    directory = config_dir / "sessions" / session_id
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / TRANSCRIPT_NAME).write_text("", encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def _sessions_exist(monkeypatch):  # noqa: ANN201
+    """Every ``write_entry`` in this file also lays down a transcript.
+
+    Wrapping the writer rather than annotating twenty call sites: the ghost
+    guard is asserted directly in its own test, and everywhere else a session
+    having a transcript is background, not the property under test.
+    """
+    import local_operator.wakes.store as store_mod
+
+    real = store_mod.write_entry
+
+    def writing(config_dir, session_id, **kwargs):  # noqa: ANN001, ANN202
+        _make_session(Path(config_dir), session_id)
+        return real(config_dir, session_id, **kwargs)
+
+    monkeypatch.setattr(store_mod, "write_entry", writing)
+    monkeypatch.setattr("tests.unit.wakes.test_supervisor.write_entry", writing)
+
+
 @pytest.fixture
 def engagements(monkeypatch):  # noqa: ANN201
     """Record every engage the supervisor makes, without starting a process."""
@@ -315,3 +350,341 @@ def test_wake_serve_primes_the_login_shell_path(tmp_path: Path) -> None:
 
     marker = str(tmp_path / "marker-bin")
     assert marker in observed.split(os.pathsep), observed
+
+
+# --- Bounded lateness, concurrency, and the dead-ends that used to be silent --
+
+
+@pytest.fixture
+def real_sessions(monkeypatch):  # noqa: ANN201
+    """Treat every session id as having a transcript.
+
+    The ghost guard is asserted on its own below; the other tests are about
+    firing decisions and would otherwise all have to build session dirs.
+    """
+    monkeypatch.setattr(
+        "local_operator.wakes.supervisor._session_exists", lambda _config, _session: True
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_sweep_fires_due_sessions_concurrently(
+    tmp_path: Path, no_live_runtimes, real_sessions, monkeypatch
+) -> None:
+    """The serial loop was the lateness amplifier, and this is what proves the fix.
+
+    Before: `for ... await engage_runtime` meant a session waited behind every
+    earlier session's FULL deadline — measured at ~63 s per pass for two cold
+    sessions. Since a wake's deadline is now sized for a cold start (180 s),
+    staying serial would have made lateness worse, not better.
+
+    Asserted structurally (overlap actually happened), never on wall-clock
+    duration: each engage blocks on an event that only a LATER engage can set,
+    so a serial implementation deadlocks its way to a timeout failure while a
+    concurrent one completes. No sleep, no timing assertion.
+    """
+    import asyncio
+
+    first_entered = asyncio.Event()
+    second_entered = asyncio.Event()
+    order: list[str] = []
+
+    async def overlapping(
+        session_id, cwd, work, *, config_dir, deadline_s=30.0, preempt=None, preempt_budget_s=0.0
+    ):  # noqa: ANN001
+        order.append(session_id)
+        if session_id == "sessionfirst":
+            first_entered.set()
+            # Only satisfiable if the SECOND engage runs while this one is
+            # still in flight.
+            await second_entered.wait()
+        else:
+            await first_entered.wait()
+            second_entered.set()
+        return None
+
+    monkeypatch.setattr("local_operator.session.runtime.launch.engage_runtime", overlapping)
+    write_entry(tmp_path, "sessionfirst", cwd=str(tmp_path), schedules=[_schedule(NOW_MS - 9_000)])
+    write_entry(tmp_path, "sessionsecnd", cwd=str(tmp_path), schedules=[_schedule(NOW_MS - 8_000)])
+
+    fired = await asyncio.wait_for(fire_due_wakes(tmp_path, now_ms=NOW_MS), timeout=10)
+
+    assert fired == 2
+    # Oldest-first is preserved: concurrency changes who WAITS, not who starts.
+    assert order[0] == "sessionfirst"
+
+
+@pytest.mark.asyncio
+async def test_the_sweep_bounds_its_concurrency(
+    tmp_path: Path, no_live_runtimes, real_sessions, monkeypatch
+) -> None:
+    """Bounded, because each engage may cold-start a full harness process.
+
+    An unbounded gather over a backlog would be a thundering herd against the
+    resource contention that makes cold starts slow in the first place.
+    """
+    import asyncio
+
+    from local_operator.wakes.supervisor import _MAX_CONCURRENT_ENGAGES
+
+    live = 0
+    peak = 0
+
+    async def counting(
+        session_id, cwd, work, *, config_dir, deadline_s=30.0, preempt=None, preempt_budget_s=0.0
+    ):  # noqa: ANN001
+        nonlocal live, peak
+        live += 1
+        peak = max(peak, live)
+        await asyncio.sleep(0)  # a real await point, so overlap is possible
+        live -= 1
+        return None
+
+    monkeypatch.setattr("local_operator.session.runtime.launch.engage_runtime", counting)
+    for n in range(6):
+        write_entry(
+            tmp_path, f"sessionbulk{n}", cwd=str(tmp_path), schedules=[_schedule(NOW_MS - 5_000)]
+        )
+
+    await fire_due_wakes(tmp_path, now_ms=NOW_MS)
+
+    assert peak <= _MAX_CONCURRENT_ENGAGES, f"{peak} engages ran at once"
+
+
+@pytest.mark.asyncio
+async def test_a_wake_errand_gets_a_cold_start_budget(
+    tmp_path: Path, no_live_runtimes, real_sessions, monkeypatch
+) -> None:
+    """The 30 s default is sized for a USER waiting at a prompt.
+
+    Nobody waits on a wake, and 344 of 682 engages (50.4%) timed out at 30 s
+    on the machine this was diagnosed on. The shared default must be left
+    alone for prompt/steer; only the wake path takes the longer budget.
+    """
+    from local_operator.session.runtime.launch import DEFAULT_DEADLINE_S
+    from local_operator.wakes.supervisor import WAKE_DEADLINE_S
+
+    seen: list[float] = []
+
+    async def record_deadline(
+        session_id, cwd, work, *, config_dir, deadline_s=30.0, preempt=None, preempt_budget_s=0.0
+    ):  # noqa: ANN001
+        seen.append(deadline_s)
+        return None
+
+    monkeypatch.setattr("local_operator.session.runtime.launch.engage_runtime", record_deadline)
+    write_entry(tmp_path, "sessioncold9", cwd=str(tmp_path), schedules=[_schedule(NOW_MS - 5_000)])
+
+    await fire_due_wakes(tmp_path, now_ms=NOW_MS)
+
+    assert seen == [WAKE_DEADLINE_S]
+    assert WAKE_DEADLINE_S >= 120, "a cold start on a loaded box needs more than two minutes"
+    assert DEFAULT_DEADLINE_S == 30.0, "the USER-facing deadline must not have moved"
+
+
+@pytest.mark.asyncio
+async def test_a_ghost_index_entry_is_skipped_and_logged(
+    tmp_path: Path, engagements, no_live_runtimes, caplog
+) -> None:
+    """An entry whose session has no transcript can never be engaged.
+
+    The live log shows two such ids accumulating 30 s timeouts with zero
+    successful starts, ever — each one consuming a sweep slot on every pass.
+    """
+    import shutil
+
+    write_entry(tmp_path, "sessionghost", cwd=str(tmp_path), schedules=[_schedule(NOW_MS - 5_000)])
+    # THE GHOST: the index entry stays, the session it describes does not.
+    # That is the real shape on disk — a reap or a hand-deleted directory
+    # leaves the entry behind, and nothing prunes it.
+    shutil.rmtree(tmp_path / "sessions" / "sessionghost")
+
+    with caplog.at_level("WARNING"):
+        fired = await fire_due_wakes(tmp_path, now_ms=NOW_MS)
+
+    assert fired == 0
+    assert engagements == [], "a session with no transcript must not be engaged"
+    assert any("ghost" in record.getMessage() for record in caplog.records), [
+        record.getMessage() for record in caplog.records
+    ]
+
+
+@pytest.mark.asyncio
+async def test_the_stale_skip_is_logged_with_how_overdue_it_is(
+    tmp_path: Path, engagements, no_live_runtimes, real_sessions, caplog
+) -> None:
+    """Behaviour unchanged, silence removed.
+
+    A wake past STALE_AFTER_S is still left to the session's own catch-up —
+    but skipping it without a word is how a wedged-runtime starvation becomes
+    permanent and invisible.
+    """
+    ancient = NOW_MS - int((9 * 24 * 3600) * 1000)
+    write_entry(tmp_path, "sessionstal2", cwd=str(tmp_path), schedules=[_schedule(ancient)])
+
+    with caplog.at_level("WARNING"):
+        fired = await fire_due_wakes(tmp_path, now_ms=NOW_MS)
+
+    assert fired == 0, "the skip BEHAVIOUR is deliberately unchanged"
+    message = " ".join(record.getMessage() for record in caplog.records)
+    assert "sessionstal2" in message
+    assert "9.0 days overdue" in message, message
+
+
+@pytest.mark.asyncio
+async def test_the_live_session_skip_reports_how_overdue_it_is(
+    tmp_path: Path, engagements, real_sessions, monkeypatch, caplog
+) -> None:
+    """A WEDGED runtime looks exactly like a healthy one here.
+
+    Its record is live, so the supervisor skips it on every pass while the
+    wake never fires. At debug level that case was invisible; a repeating
+    "already running" line with a GROWING overdue figure is what makes it
+    findable.
+    """
+
+    async def _always_live(config_dir, session_id):  # noqa: ANN001
+        return True
+
+    monkeypatch.setattr("local_operator.wakes.supervisor._has_live_runtime", _always_live)
+    write_entry(tmp_path, "sessionwedge", cwd=str(tmp_path), schedules=[_schedule(NOW_MS - 90_000)])
+
+    with caplog.at_level("INFO"):
+        await fire_due_wakes(tmp_path, now_ms=NOW_MS)
+
+    message = " ".join(record.getMessage() for record in caplog.records)
+    assert "sessionwedge" in message
+    assert "90.0s overdue" in message, message
+
+
+@pytest.mark.asyncio
+async def test_a_wake_written_during_the_sleep_is_seen_within_a_slice(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """THE LATENESS BOUND. A single computed sleep could hide a new wake for an hour.
+
+    The loop used to compute `delay` once from a snapshot and sleep it whole,
+    so a wake persisted while it slept was invisible until that sleep expired
+    (up to MAX_SLEEP_S = 3600 s). Here the supervisor starts out sleeping
+    toward a wake three hours away and a nearer one is written behind its
+    back; the sliced re-read must notice.
+
+    Time is driven by a fake `asyncio.sleep`, so this asserts on the ORDER of
+    events and never on the clock — no real waiting, no timing flake.
+    """
+    import asyncio
+
+    from local_operator.wakes import supervisor as mod
+
+    slept: list[float] = []
+    fired_for: list[str] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        slept.append(seconds)
+        # The new wake lands DURING the first slice, which is exactly the race
+        # the old single-sleep could not see.
+        if len(slept) == 1:
+            write_entry(
+                tmp_path,
+                "sessionurgent",
+                cwd=str(tmp_path),
+                schedules=[_schedule(int(time.time() * 1000) - 1_000, "w2")],
+            )
+
+    passes = 0
+
+    async def fake_fire(config_dir, *, now_ms=None):  # noqa: ANN001
+        # The FIRST pass finds nothing due and returns, which is what lets
+        # serve() reach its sleep — the window the defect lived in. The second
+        # pass records what the re-read saw and ends the loop.
+        nonlocal passes
+        passes += 1
+        if passes == 1:
+            return 0
+        from local_operator.wakes.store import read_index
+
+        index = await asyncio.to_thread(read_index, config_dir)
+        fired_for.extend(sorted(index))
+        raise _StopServing
+
+    monkeypatch.setattr(mod.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(mod, "fire_due_wakes", fake_fire)
+    # The far-away wake the sleep is sized for: three hours out, so the old
+    # code would have slept MAX_SLEEP_S before looking again.
+    write_entry(
+        tmp_path,
+        "sessiondistnt",
+        cwd=str(tmp_path),
+        schedules=[_schedule(int(time.time() * 1000) + 3 * 3600_000)],
+    )
+
+    with pytest.raises(_StopServing):
+        await serve(tmp_path)
+
+    # First pass fires (nothing due), then sleeps in SLICES rather than one
+    # 3600 s block, and the second sweep sees the urgent wake.
+    assert slept, "the supervisor did not sleep at all"
+    assert max(slept) <= mod.SLICE_S, (
+        f"slept {max(slept)}s in one uninterrupted block; a wake written during that "
+        "window is invisible for its whole duration (the defect this closes)"
+    )
+    assert "sessionurgent" in fired_for
+
+
+class _StopServing(Exception):
+    """Breaks out of ``serve``'s infinite loop from inside a patched callee."""
+
+
+@pytest.mark.asyncio
+async def test_an_index_of_only_dormant_entries_retires(tmp_path: Path) -> None:
+    """ "Nothing fireable" is not the same question as "empty".
+
+    An index holding only stopped sessions kept the supervisor alive forever:
+    the non-empty check refused to retire while `_next_wake_ms` (which skips
+    dormant entries) returned None and parked it on MAX_SLEEP_S. Nothing it
+    could do would ever fire those wakes.
+    """
+    write_entry(
+        tmp_path,
+        "sessiondorm1",
+        cwd=str(tmp_path),
+        schedules=[_schedule(NOW_MS - 5_000)],
+        preserve={"stopped_at": NOW_MS - 10_000},
+    )
+
+    assert await serve(tmp_path, once=True) == 0
+
+
+@pytest.mark.asyncio
+async def test_retirement_re_reads_after_a_grace_before_exiting(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The RACE half of the never-restarted-supervisor defect.
+
+    `_persist_wake_schedules` writes the index entry and THEN calls the
+    install hook, so the supervisor can read an empty index while a session is
+    part-way through arming its first wake. Retiring inside that window exits
+    0, the hook that follows sees a job launchd still knows about, and the
+    wake is left armed with nothing running.
+    """
+    import asyncio
+
+    from local_operator.wakes import supervisor as mod
+
+    async def fake_sleep(seconds: float) -> None:
+        # The entry lands during the retirement grace.
+        write_entry(
+            tmp_path, "sessionraced", cwd=str(tmp_path), schedules=[_schedule(NOW_MS + 600_000)]
+        )
+
+    async def fake_fire(config_dir, *, now_ms=None):  # noqa: ANN001
+        raise _StopServing
+
+    monkeypatch.setattr(mod.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(mod, "fire_due_wakes", fake_fire)
+
+    # Reaching the sweep at all means it did NOT retire on the empty first read.
+    with pytest.raises(_StopServing):
+        await serve(tmp_path)
+
+    assert asyncio.get_event_loop_policy() is not None  # loop intact; no hidden teardown

--- a/tests/unit/wakes/test_supervisor.py
+++ b/tests/unit/wakes/test_supervisor.py
@@ -1267,11 +1267,22 @@ async def test_a_runtimeerror_from_engage_is_throttled_and_the_wake_is_retried(
     # Retried, not lost: the schedule is untouched, so later passes try again.
     assert attempts > 1, f"the wake was not retried after the failure (attempts={attempts})"
     # THROTTLED: many attempts, few lines. The burst bound is _SKIP_BURST.
-    lines = [rec for rec in caplog.records if "could not start a runtime" in rec.message]
+    # Matched on the `failed:` prefix rather than the wrapper's old prose: the
+    # subject now comes from the exception itself, which already names the
+    # session (round 3, D22).
+    lines = [rec for rec in caplog.records if rec.message.startswith("failed:")]
     assert (
         len(lines) <= mod._SKIP_LOG_BURST
     ), f"{attempts} failures produced {len(lines)} log lines; the throttle was bypassed"
-    assert lines and lines[0].message.startswith("failed:"), lines[0].message if lines else "none"
+    assert lines, "the engage failure was never reported"
+    # THE WRAPPER ADDS ONLY TIMING (round 3, D22). The real `engage_runtime`
+    # raises "could not start a runtime for session <id>: <cause>", so the
+    # prefix must not restate the subject — asserted as "the session id
+    # appears at most once", which holds whatever the cause says. (This test's
+    # fake raises a bare message, so asserting on the phrase itself would pin
+    # the fixture rather than the format.)
+    assert lines[0].message.count("alwaysfail01") <= 1, lines[0].message
+    assert lines[0].message.startswith("failed: after "), lines[0].message
 
 
 @pytest.mark.asyncio

--- a/tests/unit/wakes/test_wake_status_cli.py
+++ b/tests/unit/wakes/test_wake_status_cli.py
@@ -604,3 +604,45 @@ def test_a_remedy_command_is_never_split_across_lines(
 
     out = capsys.readouterr().out
     assert "'lop wake install'" in out, out
+
+
+def test_a_future_wake_is_named_even_when_another_is_overdue(
+    tmp_path: Path, stopped_supervisor, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """D19: one late wake must not hide the next one.
+
+    `upcoming` is sorted soonest-first and the `next:` line was gated on its
+    HEAD, so a single overdue row suppressed `next:` for every future wake —
+    a wake a minute away went unnamed on the surface README promises reports
+    "the soonest wake that will fire". D16 (no `next:` when there is nothing
+    in the future) is asserted by
+    `test_status_reports_overdue_and_stale_counts`; this is the other half.
+    """
+    from local_operator.cli import wake_command
+
+    _arm(
+        tmp_path,
+        "d19late0001",
+        cwd=str(tmp_path),
+        schedules=[{"id": "w1", "message": "late watch", "next_due_at": NOW_MS - 600_000}],
+    )
+    _arm(
+        tmp_path,
+        "d19soon0001",
+        cwd=str(tmp_path),
+        schedules=[{"id": "w1", "message": "release-owner check", "next_due_at": NOW_MS + 60_000}],
+    )
+
+    assert wake_command(_args()) == 0
+
+    out = capsys.readouterr().out
+    next_line = next(
+        (line for line in out.splitlines() if line.startswith("next:")),
+        "",
+    )
+    assert next_line, f"a wake one minute away went unnamed: {out}"
+    assert "release-owner check" in next_line, next_line
+    # And the late one is still reported, on its own line, exactly once.
+    overdue_line = next(line for line in out.splitlines() if line.startswith("overdue:"))
+    assert "late watch" in overdue_line, overdue_line
+    assert "late watch" not in next_line, next_line

--- a/tests/unit/wakes/test_wake_status_cli.py
+++ b/tests/unit/wakes/test_wake_status_cli.py
@@ -1,0 +1,259 @@
+"""``lop wake status`` / ``list`` — is the thing that fires wakes alive?
+
+The command reported ``installed`` from ``plist_path().exists()``, which is an
+even weaker test than the install hook's own: a supervisor that had exited
+still has its plist on disk, so the one surface an operator would check to
+answer "why did my wake not fire" confidently answered "installed" while
+nothing was running. It also reported no per-schedule state at all — not when
+a wake last fired, not whether it is overdue now, not whether it has gone past
+the staleness bound the supervisor silently stops firing at.
+
+These tests never touch launchd: ``supervisor_state`` is patched, which is what
+keeps them inside the safety contract in ``test_install.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from local_operator.wakes.install import SupervisorState
+from local_operator.wakes.store import write_entry
+
+NOW_MS = int(time.time() * 1000)
+
+
+def _args(**kwargs: object) -> argparse.Namespace:
+    base: dict[str, object] = {
+        "wake_command": "status",
+        "json": False,
+        "install": False,
+        "uninstall": False,
+    }
+    base.update(kwargs)
+    return argparse.Namespace(**base)
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def stopped_supervisor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Loaded, exited — the state that produced the permanent misses."""
+    monkeypatch.setattr(
+        "local_operator.wakes.install.supervisor_state",
+        lambda _config: SupervisorState(loaded=True, running=False, detail="not running"),
+    )
+
+
+@pytest.fixture
+def running_supervisor(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "local_operator.wakes.install.supervisor_state",
+        lambda _config: SupervisorState(loaded=True, running=True, pid=4242, detail="running"),
+    )
+    monkeypatch.setattr("local_operator.cli._process_uptime_s", lambda _pid: 3600.0)
+
+
+def test_a_stopped_supervisor_is_not_reported_as_installed(
+    tmp_path: Path, stopped_supervisor, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """THE BLIND SPOT, on the surface an operator actually reads.
+
+    ``plist_path().exists()`` is true of a supervisor that exited hours ago.
+    Reporting that as "installed" beside an overdue wake is precisely the
+    reassurance that kept the misses invisible.
+    """
+    from local_operator.cli import wake_command
+
+    write_entry(
+        tmp_path,
+        "statussess01",
+        cwd=str(tmp_path),
+        schedules=[{"id": "w1", "message": "watch prod", "next_due_at": NOW_MS - 60_000}],
+    )
+
+    assert wake_command(_args()) == 0
+
+    out = capsys.readouterr().out
+    assert "loaded but NOT running" in out, out
+    assert "lop wake install" in out, "the actionable repair must be named"
+
+
+def test_a_running_supervisor_reports_its_pid_and_uptime(
+    tmp_path: Path, running_supervisor, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The positive half: "running" must be distinguishable from "present"."""
+    from local_operator.cli import wake_command
+
+    assert wake_command(_args()) == 0
+
+    out = capsys.readouterr().out
+    assert "running (pid 4242)" in out, out
+    assert "up 1h" in out, out
+
+
+def test_status_reports_overdue_and_stale_counts(
+    tmp_path: Path, running_supervisor, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A wake past ``STALE_AFTER_S`` is skipped by the supervisor FOREVER.
+
+    That is deliberate — the session's own catch-up owns it — but it must be
+    visible, because it is indistinguishable from a working wake otherwise.
+    """
+    from local_operator.cli import wake_command
+
+    write_entry(
+        tmp_path,
+        "statussess02",
+        cwd=str(tmp_path),
+        schedules=[{"id": "w1", "message": "late watch", "next_due_at": NOW_MS - 600_000}],
+    )
+    write_entry(
+        tmp_path,
+        "statussess03",
+        cwd=str(tmp_path),
+        schedules=[{"id": "w1", "message": "forgotten", "next_due_at": NOW_MS - 9 * 24 * 3600_000}],
+    )
+
+    assert wake_command(_args()) == 0
+
+    out = capsys.readouterr().out
+    assert "overdue:     2" in out, out
+    assert "stale:       1 past 7d" in out, out
+
+
+def test_the_json_form_carries_the_machine_readable_state(
+    tmp_path: Path, stopped_supervisor, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A monitoring caller must not have to scrape the human rendering."""
+    from local_operator.cli import wake_command
+
+    write_entry(
+        tmp_path,
+        "statussess04",
+        cwd=str(tmp_path),
+        schedules=[{"id": "w1", "message": "watch prod", "next_due_at": NOW_MS - 120_000}],
+    )
+
+    assert wake_command(_args(json=True)) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["supervisor"]["running"] is False
+    assert payload["supervisor"]["loaded"] is True
+    # The legacy key keeps its name but now means RUNNING, which is the only
+    # reading of "installed" that answers "will my wake fire".
+    assert payload["installed"] is False
+    assert payload["overdue"] == 1
+    assert payload["max_overdue_s"] >= 120
+
+
+def test_list_marks_overdue_and_stale_schedules(
+    tmp_path: Path, running_supervisor, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from local_operator.cli import wake_command
+
+    write_entry(
+        tmp_path,
+        "statussess05",
+        cwd=str(tmp_path),
+        schedules=[{"id": "w1", "message": "late watch", "next_due_at": NOW_MS - 600_000}],
+    )
+    write_entry(
+        tmp_path,
+        "statussess06",
+        cwd=str(tmp_path),
+        schedules=[{"id": "w1", "message": "forgotten", "next_due_at": NOW_MS - 9 * 24 * 3600_000}],
+    )
+
+    assert wake_command(_args(wake_command="list", json=True)) == 0
+    rows = {row["session_id"]: row for row in json.loads(capsys.readouterr().out)}
+
+    assert rows["statussess05"]["overdue"] is True
+    assert rows["statussess05"]["stale"] is False
+    assert rows["statussess06"]["stale"] is True
+
+    assert wake_command(_args(wake_command="list", json=False)) == 0
+    out = capsys.readouterr().out
+    assert "(OVERDUE)" in out
+    # Stale is the STRONGER statement (the supervisor has stopped trying), so
+    # it replaces the overdue mark rather than doubling up on one line.
+    assert "(STALE" in out
+    assert out.count("(OVERDUE)") == 1
+
+
+def test_the_install_subcommand_reaches_the_repair_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """THE ROLLOUT PATH.
+
+    Repair-on-demand otherwise runs only on a wake PERSIST, so a machine whose
+    supervisor is stale cannot be fixed without some session happening to
+    schedule a wake — exactly the wrong dependency after an upgrade, when the
+    running supervisor is still executing the old code.
+    """
+    from local_operator.cli import wake_command
+    from local_operator.wakes.install import InstallOutcome
+
+    called: list[Path] = []
+
+    def fake_install(config_dir: Path) -> InstallOutcome:
+        called.append(config_dir)
+        return InstallOutcome(installed=True, reason="restarted a stopped supervisor")
+
+    monkeypatch.setattr("local_operator.wakes.install.ensure_supervisor_installed", fake_install)
+    monkeypatch.setattr(
+        "local_operator.wakes.install.supervisor_state",
+        lambda _config: SupervisorState(loaded=True, running=True, pid=7, detail="running"),
+    )
+
+    assert wake_command(_args(wake_command="install")) == 0
+
+    assert called, "the install subcommand did not reach the repair hook"
+    assert "restarted a stopped supervisor" in capsys.readouterr().out
+
+
+def test_an_unsupervisable_store_never_reports_another_stores_supervisor(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """THE ISOLATED-RUN CASE, end to end through the command.
+
+    No patching of the probe: this drives the real `supervisor_state` against
+    a config dir outside the real home — the shape every isolated run has —
+    and the command must report a state of its own rather than the operator's
+    live LaunchAgent. Before this, the same invocation printed
+    `running (pid 47545)`, which is a different store's process.
+    """
+    from local_operator.cli import wake_command
+    from local_operator.wakes.install import is_supported
+
+    if not is_supported():
+        pytest.skip("launchd scoping is only meaningful on darwin with launchctl")
+
+    write_entry(
+        tmp_path,
+        "statussess07",
+        cwd=str(tmp_path),
+        schedules=[{"id": "w1", "message": "watch prod", "next_due_at": NOW_MS - 60_000}],
+    )
+
+    assert wake_command(_args()) == 0
+    out = capsys.readouterr().out
+
+    assert "cannot be verified for this store" in out, out
+    assert "running" not in out.split("scheduled:")[0].replace("not running", ""), out
+    assert "pid" not in out, "another store's pid was printed"
+
+    assert wake_command(_args(json=True)) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["supervisor"]["verifiable"] is False
+    assert payload["supervisor"]["running"] is False
+    assert payload["supervisor"]["pid"] is None
+    assert payload["installed"] is False

--- a/tests/unit/wakes/test_wake_status_cli.py
+++ b/tests/unit/wakes/test_wake_status_cli.py
@@ -620,17 +620,25 @@ def test_a_future_wake_is_named_even_when_another_is_overdue(
     """
     from local_operator.cli import wake_command
 
+    # NOT the module-level `NOW_MS`, which is captured at IMPORT: a CI shard
+    # can run for 17 minutes, and a wake armed "one minute from import" is
+    # long overdue by the time this executes — which lands in the very branch
+    # the test exists to distinguish from. An hour off a fresh reading is
+    # future under any plausible shard duration.
+    now_ms = int(time.time() * 1000)
     _arm(
         tmp_path,
         "d19late0001",
         cwd=str(tmp_path),
-        schedules=[{"id": "w1", "message": "late watch", "next_due_at": NOW_MS - 600_000}],
+        schedules=[{"id": "w1", "message": "late watch", "next_due_at": now_ms - 600_000}],
     )
     _arm(
         tmp_path,
         "d19soon0001",
         cwd=str(tmp_path),
-        schedules=[{"id": "w1", "message": "release-owner check", "next_due_at": NOW_MS + 60_000}],
+        schedules=[
+            {"id": "w1", "message": "release-owner check", "next_due_at": now_ms + 3_600_000}
+        ],
     )
 
     assert wake_command(_args()) == 0

--- a/tests/unit/wakes/test_wake_status_cli.py
+++ b/tests/unit/wakes/test_wake_status_cli.py
@@ -140,8 +140,15 @@ def test_status_reports_overdue_and_stale_counts(
     assert wake_command(_args()) == 0
 
     out = capsys.readouterr().out
-    assert "overdue:     2" in out, out
+    # ONE overdue, not two: the stale row is counted as stale and excluded
+    # from overdue, so "worst" describes a wake that is actually coming
+    # (round 1, D2). Counting it both ways let a wake the supervisor has given
+    # up on dominate the figure an operator reads as "how late am I".
+    assert "overdue:     1" in out, out
     assert "stale:       1 past 7d" in out, out
+    # And `next:` names the FIREABLE wake, never the stale one.
+    next_line = next(line for line in out.splitlines() if line.startswith("next:"))
+    assert "late watch" in next_line, next_line
 
 
 def test_the_json_form_carries_the_machine_readable_state(
@@ -196,11 +203,15 @@ def test_list_marks_overdue_and_stale_schedules(
 
     assert wake_command(_args(wake_command="list", json=False)) == 0
     out = capsys.readouterr().out
-    assert "(OVERDUE)" in out
+    # The DUE column carries the state word now that the listing is a
+    # fixed-width table (round 1, D4): an overdue row reads "10m overdue"
+    # there, and only the stale row needs the explanatory tail.
+    overdue_line = next(line for line in out.splitlines() if "statussess05" in line)
+    stale_line = next(line for line in out.splitlines() if "statussess06" in line)
+    assert "overdue" in overdue_line, overdue_line
     # Stale is the STRONGER statement (the supervisor has stopped trying), so
     # it replaces the overdue mark rather than doubling up on one line.
-    assert "(STALE" in out
-    assert out.count("(OVERDUE)") == 1
+    assert "stale" in stale_line and "overdue" not in stale_line, stale_line
 
 
 def test_the_install_subcommand_reaches_the_repair_path(
@@ -274,3 +285,73 @@ def test_an_unsupervisable_store_never_reports_another_stores_supervisor(
     assert payload["supervisor"]["running"] is False
     assert payload["supervisor"]["pid"] is None
     assert payload["installed"] is False
+
+
+# --- The REAL parser ---------------------------------------------------------
+#
+# Every test above hand-builds an `argparse.Namespace`, which is why round 1's
+# blocker (`lop wake install` and bare `lop wake` dying on `args.json`) was
+# invisible to the whole file: a hand-built namespace supplies exactly the
+# attributes the test author remembered, so it can never catch the dispatcher
+# reading one the PARSER does not define. These walk
+# `build_cli_parser().parse_args(...)` and then run the command, which is the
+# only arrangement that exercises the parser/dispatcher contract.
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["wake"],  # bare: `wake_command` defaults to "status"
+        ["wake", "status"],
+        ["wake", "status", "--json"],
+        ["wake", "install"],
+        ["wake", "list"],
+        ["wake", "list", "--json"],
+    ],
+)
+def test_every_wake_entry_point_survives_the_real_parser(
+    tmp_path: Path, argv: list[str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The regression test for the round-1 blocker, across the whole surface.
+
+    Not just the reported command: `lop wake status` PRINTS `run 'lop wake
+    install'` as its remedy in several states, so the crash was reachable from
+    the surface's own advice. Parametrised over every route into
+    `wake_command` so a future subcommand that forgets a flag fails here.
+    """
+    from local_operator.cli import build_cli_parser, wake_command
+
+    write_entry(
+        tmp_path,
+        "realparser1",
+        cwd=str(tmp_path),
+        schedules=[{"id": "w1", "message": "watch prod", "next_due_at": NOW_MS + 600_000}],
+    )
+
+    args = build_cli_parser().parse_args(argv)
+
+    # The assertion is that this does not raise. `install` reaches the real
+    # install hook, which under a redirected home writes a plist and declines
+    # to address launchd (see `test_install.py`'s safety contract).
+    assert wake_command(args) == 0
+    assert capsys.readouterr().out, f"{argv} produced no output"
+
+
+def test_the_parser_defines_every_flag_the_dispatcher_reads(tmp_path: Path) -> None:
+    """The structural form of the same bug, stated once.
+
+    `wake_command` reads `json`, `install` and `uninstall` off the namespace
+    for any route that lands in the status branch. Asserting on the parsed
+    namespace rather than on behaviour means a flag added to the dispatcher
+    without a parser default fails here with a message naming it.
+    """
+    from local_operator.cli import build_cli_parser
+
+    parser = build_cli_parser()
+    for argv in (["wake"], ["wake", "status"], ["wake", "install"], ["wake", "list"]):
+        args = parser.parse_args(argv)
+        for flag in ("json", "install", "uninstall"):
+            assert hasattr(args, flag), (
+                f"`lop {' '.join(argv)}` parses without `{flag}`, which `wake_command` "
+                f"dereferences — this is the round-1 blocker's exact shape"
+            )

--- a/tests/unit/wakes/test_wake_status_cli.py
+++ b/tests/unit/wakes/test_wake_status_cli.py
@@ -45,7 +45,21 @@ def _isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 @pytest.fixture
-def stopped_supervisor(monkeypatch: pytest.MonkeyPatch) -> None:
+def _installer_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pretend this platform has an installer.
+
+    The status RENDERING is platform-independent, but the command asks
+    `is_supported()` before probing at all — so on Linux (where there is no
+    installer and the honest answer is "wakes fire only while a session is
+    open") these fixtures would never be consulted and every assertion below
+    would be about the unsupported branch instead. Patching the capability
+    keeps the rendering under test on every runner rather than only on macOS.
+    """
+    monkeypatch.setattr("local_operator.wakes.install.is_supported", lambda: True)
+
+
+@pytest.fixture
+def stopped_supervisor(monkeypatch: pytest.MonkeyPatch, _installer_available: None) -> None:
     """Loaded, exited — the state that produced the permanent misses."""
     monkeypatch.setattr(
         "local_operator.wakes.install.supervisor_state",
@@ -54,7 +68,7 @@ def stopped_supervisor(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture
-def running_supervisor(monkeypatch: pytest.MonkeyPatch) -> None:
+def running_supervisor(monkeypatch: pytest.MonkeyPatch, _installer_available: None) -> None:
     monkeypatch.setattr(
         "local_operator.wakes.install.supervisor_state",
         lambda _config: SupervisorState(loaded=True, running=True, pid=4242, detail="running"),
@@ -190,7 +204,10 @@ def test_list_marks_overdue_and_stale_schedules(
 
 
 def test_the_install_subcommand_reaches_the_repair_path(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    _installer_available: None,
 ) -> None:
     """THE ROLLOUT PATH.
 

--- a/tests/unit/wakes/test_wake_status_cli.py
+++ b/tests/unit/wakes/test_wake_status_cli.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import time
 from pathlib import Path
 
@@ -25,6 +26,23 @@ from local_operator.wakes.install import SupervisorState
 from local_operator.wakes.store import write_entry
 
 NOW_MS = int(time.time() * 1000)
+
+
+def _arm(config_dir: Path, session_id: str, **kwargs: object) -> None:
+    """Index entry PLUS the session it belongs to.
+
+    Round 2 (QA Q4) taught `wake status` the supervisor's ghost predicate: an
+    index entry whose session has no transcript can never be engaged, so it is
+    no longer rendered as an armed, overdue wake. A bare ``write_entry`` builds
+    exactly that shape, which the product never produces — the session writes
+    its own transcript before it ever persists a schedule — so these fixtures
+    would all be ghosts and would test the ghost branch by accident. Tests that
+    WANT a ghost call ``write_entry`` directly and say so.
+    """
+    session = config_dir / "sessions" / session_id
+    session.mkdir(parents=True, exist_ok=True)
+    (session / "transcript.jsonl").write_text("{}\n", encoding="utf-8")
+    write_entry(config_dir, session_id, **kwargs)  # type: ignore[arg-type]
 
 
 def _args(**kwargs: object) -> argparse.Namespace:
@@ -87,7 +105,7 @@ def test_a_stopped_supervisor_is_not_reported_as_installed(
     """
     from local_operator.cli import wake_command
 
-    write_entry(
+    _arm(
         tmp_path,
         "statussess01",
         cwd=str(tmp_path),
@@ -124,13 +142,13 @@ def test_status_reports_overdue_and_stale_counts(
     """
     from local_operator.cli import wake_command
 
-    write_entry(
+    _arm(
         tmp_path,
         "statussess02",
         cwd=str(tmp_path),
         schedules=[{"id": "w1", "message": "late watch", "next_due_at": NOW_MS - 600_000}],
     )
-    write_entry(
+    _arm(
         tmp_path,
         "statussess03",
         cwd=str(tmp_path),
@@ -146,9 +164,14 @@ def test_status_reports_overdue_and_stale_counts(
     # up on dominate the figure an operator reads as "how late am I".
     assert "overdue:     1" in out, out
     assert "stale:       1 past 7d" in out, out
-    # And `next:` names the FIREABLE wake, never the stale one.
-    next_line = next(line for line in out.splitlines() if line.startswith("next:"))
-    assert "late watch" in next_line, next_line
+    # The FIREABLE wake is the one named, never the stale one — and it is named
+    # on `overdue:`, not `next:`. Round 2 (D16): with nothing in the future,
+    # `next:` was labelling an already-late wake as a coming event and saying
+    # the same fact the line below it said. `next:` now appears only when there
+    # genuinely is a next.
+    overdue_line = next(line for line in out.splitlines() if line.startswith("overdue:"))
+    assert "late watch" in overdue_line, overdue_line
+    assert not [line for line in out.splitlines() if line.startswith("next:")], out
 
 
 def test_the_json_form_carries_the_machine_readable_state(
@@ -157,7 +180,7 @@ def test_the_json_form_carries_the_machine_readable_state(
     """A monitoring caller must not have to scrape the human rendering."""
     from local_operator.cli import wake_command
 
-    write_entry(
+    _arm(
         tmp_path,
         "statussess04",
         cwd=str(tmp_path),
@@ -181,13 +204,13 @@ def test_list_marks_overdue_and_stale_schedules(
 ) -> None:
     from local_operator.cli import wake_command
 
-    write_entry(
+    _arm(
         tmp_path,
         "statussess05",
         cwd=str(tmp_path),
         schedules=[{"id": "w1", "message": "late watch", "next_due_at": NOW_MS - 600_000}],
     )
-    write_entry(
+    _arm(
         tmp_path,
         "statussess06",
         cwd=str(tmp_path),
@@ -265,7 +288,7 @@ def test_an_unsupervisable_store_never_reports_another_stores_supervisor(
     if not is_supported():
         pytest.skip("launchd scoping is only meaningful on darwin with launchctl")
 
-    write_entry(
+    _arm(
         tmp_path,
         "statussess07",
         cwd=str(tmp_path),
@@ -321,7 +344,7 @@ def test_every_wake_entry_point_survives_the_real_parser(
     """
     from local_operator.cli import build_cli_parser, wake_command
 
-    write_entry(
+    _arm(
         tmp_path,
         "realparser1",
         cwd=str(tmp_path),
@@ -355,3 +378,229 @@ def test_the_parser_defines_every_flag_the_dispatcher_reads(tmp_path: Path) -> N
                 f"`lop {' '.join(argv)}` parses without `{flag}`, which `wake_command` "
                 f"dereferences — this is the round-1 blocker's exact shape"
             )
+
+
+# --- Round 2: the rendering guards ------------------------------------------
+
+
+def test_a_wake_in_another_year_renders_its_whole_time(
+    tmp_path: Path, stopped_supervisor, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """D11 (MAJOR): `format_wake_time` widens to 24 characters for an off-year
+    wake, and a fixed 18-wide column cut `Jan 01 2027 9:00 AM EST` to
+    `Jan 01 2027 9:00 A` — a half meridiem, no zone, no marker. `wake create`
+    printed the full form one line earlier, so the same wake read two ways.
+
+    Mutation-checked: restoring `format_wake_time(...)[:18]` fails this with
+    `the rendered time was truncated mid-token`.
+    """
+    from local_operator.cli import wake_command
+    from local_operator.wakes.display import format_wake_time
+
+    due = NOW_MS + 400 * 86400_000  # comfortably into the next calendar year
+    _arm(
+        tmp_path,
+        "nextyear0001",
+        cwd=str(tmp_path),
+        schedules=[{"id": "w1", "message": "annual renewal: TLS cert", "next_due_at": due}],
+    )
+
+    assert wake_command(_args(wake_command="list", json=False)) == 0
+
+    out = capsys.readouterr().out
+    expected = format_wake_time(due)
+    assert "2027" in expected or "2026" in expected, expected
+    row = next(line for line in out.splitlines() if "nextyear0001" in line)
+    assert expected in row, f"the rendered time was truncated mid-token: {row!r}"
+
+
+def test_a_session_id_is_never_silently_shortened(
+    tmp_path: Path, stopped_supervisor, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """R9: a 12-wide column rendered a longer id as a DIFFERENT id — one an
+    operator cannot paste into `lop wake list` or `lop stop`. A real id fits
+    whole; anything longer is marked.
+
+    Mutation-checked: restoring `row['session_id'][:id_w]` fails this with
+    `a truncated id is indistinguishable from a real one`.
+    """
+    from local_operator.cli import wake_command
+
+    real = "00264921d0d9"  # uuid4().hex[:12], the shape the product mints
+    longer = "lr_bda7b76d34e0"
+    for session_id in (real, longer):
+        _arm(
+            tmp_path,
+            session_id,
+            cwd=str(tmp_path),
+            schedules=[{"id": "w1", "message": "watch", "next_due_at": NOW_MS + 60_000}],
+        )
+
+    assert wake_command(_args(wake_command="list", json=False)) == 0
+
+    out = capsys.readouterr().out
+    assert real in out, f"a real 12-character id must render whole: {out}"
+    # The longer id does not fit; it must be MARKED, never silently shortened
+    # into a different, real-looking id.
+    assert (
+        longer[:12] not in out or longer in out or "…" in out
+    ), f"a truncated id is indistinguishable from a real one: {out!r}"
+    ghosty = [line for line in out.splitlines() if "lr_bda7b76d" in line]
+    assert ghosty and ("…" in ghosty[0] or longer in ghosty[0]), ghosty
+
+
+def test_a_narrow_terminal_keeps_the_columns_aligned(
+    tmp_path: Path, stopped_supervisor, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """D12 / QA Q1: at 60 columns every row wrapped (68-71 chars), so the
+    alignment this table exists for was gone in a split pane. The absolute
+    time is the redundant half — `DUE` answers "when" in 11 characters — so it
+    is what yields, and the omission is stated rather than silent.
+
+    Mutation-checked: forcing `show_when = True` fails this with
+    `row exceeds the terminal width`.
+    """
+    import shutil
+
+    from local_operator.cli import wake_command
+
+    monkeypatch.setattr(
+        shutil, "get_terminal_size", lambda _default=None: os.terminal_size((60, 24))
+    )
+    _arm(
+        tmp_path,
+        "narrowsess01",
+        cwd=str(tmp_path),
+        schedules=[
+            {
+                "id": "w1",
+                "message": "cluster watch: aws-prod-2 node rotation",
+                "next_due_at": NOW_MS + 400 * 86400_000,
+            }
+        ],
+    )
+
+    assert wake_command(_args(wake_command="list", json=False)) == 0
+
+    out = capsys.readouterr().out
+    for line in out.splitlines():
+        assert len(line) <= 60, f"row exceeds the terminal width ({len(line)}): {line!r}"
+    assert "WHEN hidden" in out, out
+
+
+def test_status_and_the_supervisor_agree_about_a_ghost(
+    tmp_path: Path, stopped_supervisor, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """QA Q4: a ghost-only store made the two halves contradict each other —
+    the supervisor retired ("no fireable wakes remain") while this frame said
+    `1 armed`, `overdue: 1`. A painted frame that disagrees with the process is
+    the defect class this PR exists to remove.
+
+    `write_entry` directly, not `_arm`: the whole point is an index entry with
+    no session on disk.
+
+    Mutation-checked: removing the `ghost` predicate from `_wake_rows` fails
+    this with `status claims a wake is coming that the supervisor has retired
+    over`.
+    """
+    from local_operator.cli import wake_command
+    from local_operator.wakes.store import read_index
+    from local_operator.wakes.supervisor import _has_fireable_wakes
+
+    write_entry(
+        tmp_path,
+        "ghostsess001",
+        cwd=str(tmp_path),
+        schedules=[{"id": "w1", "message": "orphaned watch", "next_due_at": NOW_MS - 600_000}],
+    )
+
+    # The supervisor's verdict on this exact store.
+    assert not _has_fireable_wakes(read_index(tmp_path), config_dir=tmp_path)
+
+    assert wake_command(_args()) == 0
+    out = capsys.readouterr().out
+    assert "ghost:       1 with no session on disk" in out, out
+    assert (
+        "overdue:" not in out
+    ), f"status claims a wake is coming that the supervisor has retired over: {out}"
+
+    assert wake_command(_args(json=True)) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ghost"] == 1
+    assert payload["overdue"] == 0
+    assert payload["next_fireable_due_in_s"] is None
+    assert payload["unfireable"]["ghost"] == ["ghostsess001"]
+
+
+def test_a_long_status_line_folds_at_the_surfaces_indent(
+    tmp_path: Path, stopped_supervisor, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """D13 + QA Q2: the `wedged:` line was 108 columns and the only one whose
+    continuation started at column 0, and `next:`/`overdue:` interpolate a
+    user-authored message that was never clamped (156 columns measured).
+
+    Mutation-checked: bypassing `_wrap_status` fails this with
+    `status line exceeds the terminal width`.
+    """
+    import shutil
+
+    from local_operator.cli import wake_command
+
+    monkeypatch.setattr(
+        shutil, "get_terminal_size", lambda _default=None: os.terminal_size((80, 24))
+    )
+    _arm(
+        tmp_path,
+        "verbosewake1",
+        cwd=str(tmp_path),
+        schedules=[
+            {
+                "id": "w1",
+                "message": (
+                    "prod watch: NER backfill completion across every shard, then "
+                    "reconcile the ledger and post the summary to the release thread"
+                ),
+                "next_due_at": NOW_MS - 600_000,
+            }
+        ],
+    )
+
+    assert wake_command(_args()) == 0
+
+    out = capsys.readouterr().out
+    for line in out.splitlines():
+        assert len(line) <= 80, f"status line exceeds the terminal width ({len(line)}): {line!r}"
+    # Continuations align with the label column rather than starting at 0.
+    continuations = [
+        line
+        for line in out.splitlines()
+        if line.startswith(" ") and line.strip() and not line.startswith(" " * 13)
+    ]
+    assert not continuations, f"a continuation broke the 13-column indent: {continuations}"
+
+
+def test_a_remedy_command_is_never_split_across_lines(
+    tmp_path: Path, stopped_supervisor, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """Every remedy on this surface is a command the operator copies; a wrap
+    inside one produces a line that looks like an instruction and is not
+    runnable. Folding must treat a quoted command as one token.
+    """
+    import shutil
+
+    from local_operator.cli import wake_command
+
+    monkeypatch.setattr(
+        shutil, "get_terminal_size", lambda _default=None: os.terminal_size((62, 24))
+    )
+    _arm(
+        tmp_path,
+        "remedysess01",
+        cwd=str(tmp_path),
+        schedules=[{"id": "w1", "message": "watch", "next_due_at": NOW_MS + 60_000}],
+    )
+
+    assert wake_command(_args()) == 0
+
+    out = capsys.readouterr().out
+    assert "'lop wake install'" in out, out


### PR DESCRIPTION
Release: patch — scheduled wakes fire for closed sessions instead of being missed or arriving minutes late

# PR Description

## Summary of Changes

Background sessions were MISSING scheduled wakes, or getting them minutes late. This fixes the five defects behind that, all in the wake subsystem, plus one found while validating.

Measured on the operator's machine from `~/.local-operator/logs/wake-supervisor.log` (682 engage attempts since 2026-09-04):

```
attempts: 682   "could not start a runtime ... within 30s": 344 (50.4%)   started: 338
worst observed lateness: 24.5 min
```

## Problem

### 1. A retired supervisor was never restarted — the PERMANENT miss

The supervisor deliberately exits 0 when the wake index empties, and `KeepAlive: {SuccessfulExit: False}` leaves a finished job down. But `ensure_supervisor_installed` decided "already installed" from `_is_loaded()`, which was only `launchctl print` returning 0 — and **a loaded-but-exited job still returns 0**:

```
$ launchctl print gui/501/com.local-operator.wakescratch52337 ; echo $?
        state = not running
        runs = 1
0
```

So after any retirement the next persist wrote the index, asked to install, was told "already installed", and nothing was running to fire the wake. `KeepAlive` will not restart it either — a successful exit is exactly what it is configured to leave alone. The session's windows stayed armed on disk, so the wake appeared only when a human next opened the session. **No log line anywhere.**

The same hole has a racy form: the supervisor reads an empty index and exits 0 while a session is concurrently writing its first entry (persist writes the entry, *then* calls the install hook).

### 2. A wake scheduled while the supervisor slept was invisible for up to an hour

`serve()` computed `delay` once from an index snapshot and `asyncio.sleep(delay)` with no re-read, `MAX_SLEEP_S = 3600`. A session persisting a wake due in 5 minutes while the supervisor slept toward one three hours out had it delayed by up to an hour.

### 3. Serial firing on a deadline sized for a human

`serve()` fired due sessions serially, each burning up to `DEFAULT_DEADLINE_S = 30 s`. Two cold sessions due at once made a pass take ~63 s (measured from retry spacing), so a wake waited behind other sessions' failures. And 30 s is simply the wrong budget for a wake: it is sized for a **user waiting at a prompt**, where the alternative to waiting is telling them their message went nowhere. Nobody waits on a wake, and a cold runtime on this box (19 live sessions, 12 MCP servers) often needs longer — hence the 50.4% timeout rate, which then re-entered the same path on the next pass.

### 4. The state was invisible

`lop wake status` reported `installed` from `plist_path().exists()` — weaker still than `_is_loaded()`, and the same blind spot. It never reported whether a process was running, when a schedule last fired, or whether one was overdue now.

### 5. Two silent dead-ends

A wake more than `STALE_AFTER_S` (7 days) overdue was skipped forever with no log. A **wedged but alive** runtime is invisible to `_has_live_runtime` (it skips) *and* blocks the engage, so the wake never fires while the wedge persists — and the skip was `logger.debug`.

### 6. Ghost index entries (found during this work)

Two ids in the live log, `lr_bda7b76d34e0` and `lr_28a800c6a783`, have **no session directory on disk** and **zero successful starts, ever** — they burned an engage deadline on every pass indefinitely.

## What changed

| # | Change | File |
|---|---|---|
| 1 | `supervisor_state()` parses `launchctl print` for a live pid/state instead of trusting rc; repair-on-demand (`kickstart -k` when loaded-but-stopped, `bootstrap` when absent) | `wakes/install.py` |
| 1 | `StartInterval` (900 s) in `render_plist` as a bounded self-heal | `wakes/install.py` |
| 1 | Retirement re-reads the index after a grace, and logs | `wakes/supervisor.py` |
| 1 | `lop wake install` — reaches the repair without needing a persist | `cli.py` |
| 2 | The wait is spent in ~10 s slices that re-read the index | `wakes/supervisor.py` |
| 3 | Bounded concurrent sweep (`asyncio.gather`, semaphore 2) + `WAKE_DEADLINE_S = 180 s` | `wakes/supervisor.py` |
| 4 | `status`/`list` report running vs loaded-but-stopped (pid + uptime), overdue, stale; `--json` block | `cli.py` |
| 5 | Stale skip → WARNING, live-record skip → INFO, both naming how overdue | `wakes/supervisor.py` |
| 6 | Ghost guard: an entry whose session has no transcript is skipped and logged | `wakes/supervisor.py` |
| — | `last_fired_at` / `last_attempt_at` on the index entry, written by the session | `session/session.py` |

### Design notes

**`StartInterval` reverses a documented invariant, knowingly.** `install.py` documents "a machine with no wakes left runs no supervisor at all"; it is now "runs it briefly every 15 minutes, where it reads an empty index and exits again". That is bought deliberately: every *other* repair path needs something to call it (a persist, a `lop wake status`), and the failure being fixed is precisely the one where nothing is left running to make that call. The docstring records the reversal.

**The supervisor stays read-only over schedule state.** `last_fired_at`/`last_attempt_at` are written by `Session._persist_wake_schedules` — the single writer — which is the property that keeps the supervisor from ever disagreeing with the session about what has fired.

**The 30 s deadline for user-initiated engages is unchanged.** Only the wake path takes the longer budget; a test pins `DEFAULT_DEADLINE_S == 30.0`.

**Two comments corrected.** `supervisor.py` and `launch.py` both claimed the derived `command_id` is what keeps a retry from double-firing. It is not: `_deliver` returns early for a `WakeErrand` without ever sending an op, so no `command_id` reaches a runtime. The real guarantee is record reuse plus lease arbitration (at most one *serving* runtime). Relatedly, the diagnosis's claim that each retry spawns a fresh candidate does **not** hold: `engage_runtime` waits when `_lease_holder` reports a live holder (`launch.py:605-611`) rather than spawning.

**The probe is scoped to the store being asked about.** `launchctl` has no sandbox, so an early version of this change reported the operator's real LaunchAgent (`running (pid 47545)`) for an *isolated* store in a tmpdir — the same class of lie this PR removes, one level up. `supervisor_state(config_dir)` now applies both installer guards at the probe and reports a distinct third state instead of another store's process.

## Evidence

### (a) The launchd blind spot and its repair — scratch label, cleaned up

```
=== BEFORE: what the OLD check saw ===
launchctl print exit code: 0   <-- the old _is_loaded() said 'loaded' on this
        state = not running
        runs = 1
runs so far: 1

=== the NEW probe, parsing that same output ===
running=False  pid=None  state='not running'
probe correctly reports NOT running -> the repair path would kickstart

=== AFTER: the repair this drives (kickstart -k) ===
kickstart rc=0
runs after kickstart: 2  (was 1)
cleanup: scratch label gone
operator's real unit untouched:
        state = running
        pid = 47545
```

### `StartInterval` is safe — measured, not assumed

Scratch label, 20 s job, `StartInterval` 5 s (cleaned up):

```
START pid=52345 1789152404
END   pid=52345 1789152424     <- 20s job
START pid=52804 1789152429     <- +25s, NOT +5s: launchd waited for the running instance
END   pid=52804 1789152449
START pid=53457 1789152455     <- and it DOES re-run a job that exited 0
```

Both halves of the claim: launchd does **not** start a second instance while one runs, and it **does** re-run after a successful exit (which `KeepAlive{SuccessfulExit:false}` alone would not).

### (b) Real cold session, real supervisor process, isolated HOME

`HOME` and `LOCAL_OPERATOR_CONFIG_DIR` both redirected, every `CMUX_*` unset:

```
=== lop wake status (before the supervisor runs) ===
scheduled:   1 (1 armed)
next:        5s overdue  supervised cold wake
overdue:     1 (worst 5s)

=== the REAL supervisor, same argv the LaunchAgent runs ===
  INFO __main__: engaging e2ewake00001: wake due 1789153717484, 5.4s overdue (deadline 180s)
  INFO __main__: started a runtime for e2ewake00001 (wake due 1789153717484, 5.4s overdue, took 0.8s)

=== the wake turn in the durable transcript ===
  message    user      [{'type': 'text', 'text': 'seed'}]
  custom               {'schedules': [{'id': 'w1', 'message': 'supervised cold wake', ...
  message              {'wake_catchup': True, 'text': '(alarm) The session resumed after being closed; ...
  message    assistant [{'text': 'Hello from the mock provider!'}]
```

The wake turn lands in the transcript, driven by `python -m local_operator.wakes.supervisor --once` as a real process. Also pinned as an e2e test.

### (c) The slice re-read, observed live

A wake 3 h out (pre-fix: `delay = 3600 s`, slept whole), then a nearer wake written 12 s into that sleep:

```
15:12:33  wrote an overdue wake
15:12:41  INFO: an earlier wake appeared while sleeping; re-reading now instead of
                waiting a further 3580s
```

Noticed in **8.8 s** instead of up to 3580 s.

This run also exposed a defect in my own change: a due-but-unfireable entry pinned the loop at `MIN_SLEEP_S = 1 s`, re-logging the same skip every second. Fixed (a still-due wake after a sweep was *skipped*, not missed, so it waits a slice) and re-verified — **2 log lines in 25 s, was 25**.

### (d) Live before-numbers, per session (read-only from the operator's log)

```
session        starts  timeouts    median      worst
4140ee201ce1       37        36      4.5s       2.0m
8fb040f25a12        2         0    337.1s       5.6m
9f8e5b652ac7       87        79      6.2s      18.9m
bda7b76d34e0      167       219      7.2s      24.5m

ghost ids: lr_bda7b76d34e0 timeouts=2, lr_28a800c6a783 timeouts=1, successful starts=0
```

After-numbers for these same sessions can only come from the deployed fix (the supervisor is the operator's live unit); the mechanism is proven in (a)-(c) above.

### The isolated-store state, end to end

```
=== isolated store, the same command that printed 'pid 47545' ===
supervisor:  cannot be verified for this store
             (this store is outside the real home; launchd cannot supervise it)
             (wakes here fire only while a session is open)
scheduled:   1 (1 armed)
overdue:     1 (worst 1m)
```

while the real store still reports honestly: `supervisor:  running (pid 47545), up 2d`.

### Mutation checks — the tests can still fail

Headline regression test, fix reverted in the worktree:

```
FAILED test_a_loaded_but_exited_job_is_not_running - AssertionError: a loaded-but-exited
  job was reported as running; the probe has regressed to trusting launchctl's exit code,
  which is how an armed wake was left with no live supervisor
FAILED test_a_stopped_supervisor_is_kickstarted_rather_than_called_installed
  - AssertionError: assert 'restarted' in 'already installed'
```

That second message is the defect verbatim. Slice test, `_sleep_in_slices` reverted to `asyncio.sleep(delay)`:

```
FAILED test_a_wake_written_during_the_sleep_is_seen_within_a_slice - AssertionError:
  slept 3600.0s in one uninterrupted block; a wake written during that window is
  invisible for its whole duration (the defect this closes)
```

Both restored and green after.

## Test matrix

| Surface | Test | Result |
|---|---|---|
| Loaded-but-exited job → not running | `test_a_loaded_but_exited_job_is_not_running` | PASS (fails on mutation) |
| Running job → pid reported | `test_a_running_job_is_reported_with_its_pid` | PASS |
| Unparseable output → fails safe as running | `test_unparseable_output_fails_safe_as_running` | PASS |
| Stopped supervisor → kickstarted | `test_a_stopped_supervisor_is_kickstarted_rather_than_called_installed` | PASS (fails on mutation) |
| Healthy supervisor → untouched (idempotence) | `test_a_running_supervisor_is_left_alone` | PASS |
| Isolated store → never another store's unit | `test_a_store_launchd_cannot_supervise_is_reported_as_unverifiable` | PASS |
| `StartInterval` present + bounded | `test_the_plist_carries_the_bounded_self_heal` | PASS |
| Concurrent sweep (structural overlap) | `test_the_sweep_fires_due_sessions_concurrently` | PASS |
| Concurrency bounded | `test_the_sweep_bounds_its_concurrency` | PASS |
| Wake budget ≥120 s, user deadline unchanged | `test_a_wake_errand_gets_a_cold_start_budget` | PASS |
| Slice sees an earlier wake | `test_a_wake_written_during_the_sleep_is_seen_within_a_slice` | PASS (fails on mutation) |
| Dormant-only index retires | `test_an_index_of_only_dormant_entries_retires` | PASS |
| Retirement grace re-read | `test_retirement_re_reads_after_a_grace_before_exiting` | PASS |
| Stale skip logged with overdue | `test_the_stale_skip_is_logged_with_how_overdue_it_is` | PASS |
| Live-record skip logged with overdue | `test_the_live_session_skip_reports_how_overdue_it_is` | PASS |
| Ghost entry skipped + logged | `test_a_ghost_index_entry_is_skipped_and_logged` | PASS |
| Status: stopped not reported as installed | `test_a_stopped_supervisor_is_not_reported_as_installed` | PASS |
| Status: pid + uptime when running | `test_a_running_supervisor_reports_its_pid_and_uptime` | PASS |
| Status: overdue/stale counts, `--json` | `test_status_reports_overdue_and_stale_counts`, `..._machine_readable_state` | PASS |
| List: overdue/stale marks | `test_list_marks_overdue_and_stale_schedules` | PASS |
| `lop wake install` reaches the repair | `test_the_install_subcommand_reaches_the_repair_path` | PASS |
| Index stamps (`last_fired_at`, no restamp) | 3 tests in `test_session_index.py` | PASS |
| Real supervisor fires a cold wake | `test_the_real_supervisor_process_fires_a_cold_wake` (e2e) | PASS |

## Quality gates

```
.venv/bin/python -m flake8 .                                    clean
uvx --from black==26.1.0 black --check .                        1228 files unchanged
uvx isort==5.13.2 --check .                                     clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .      0 errors, 0 warnings
.venv/bin/python -m pytest tests/unit -q                        18599 passed, 18 skipped (32:41)
pytest tests/e2e/test_cold_wake_e2e.py -m e2e -n0 -q            3 passed
```

No version bump: `pyproject.toml` is untouched.

## Safety

Every test and every experiment ran against an isolated `HOME` + `LOCAL_OPERATOR_CONFIG_DIR`, or against a **scratch launchd label** that was booted out and removed. The operator's live `com.local-operator.wakes` (pid 47545) was never booted out, and `~/.local-operator` was read-only throughout. Confirmed after each experiment.

## CI and rebase record

Rebased onto `152afe440` (main, post-#969). The rebase is content-preserving — `git range-diff` reports `=` for both commits, and the diff-of-diffs against the two bases is byte-identical:

```
1:  9531c1659 =  8:  a8f39a178 fix(wakes): never leave an armed wake ...
2:  ba7b7b357 =  9:  0165f5cd9 test(wakes): keep the status rendering ...
IDENTICAL: the rebase changed no content
```

Two CI failures on the way, both diagnosed rather than re-run:

1. **Mine.** `test_wake_status_cli.py` asserted against the status rendering, but `wake_command` checks `is_supported()` before probing — so on the Linux runners the tests were exercising the "no installer for this platform" branch instead of the states they name. Fixed by patching the capability, and verified under the exact CI condition locally (`shutil.which` → None: 6 passed, 1 skipped) rather than only on macOS.
2. **Pre-existing.** `test_stream_anchor.py::test_paging_the_subagent_body_by_its_hint_arrow_releases_the_anchor` (`assert 17.0 == 19.0`) — untouched by this diff, green locally, and fixed on main by #969. It passes after the rebase.

Final: **17/17 checks green** on `0165f5cd9`.
