### PR TITLE
fix(tests): the copy-picker chain flake CI is red on, and the broker sweep pytest's tmp_path reclaim hid

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -366,6 +366,58 @@ def fresh_served_selectors(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(failover, "_SERVED_SELECTORS", set())
 
 
+#: Where `pytest_runtest_call` leaves the temp roots it saw while they existed.
+#: Read back by `_secret_config_dirs` in the sweep's teardown; see that function
+#: and the hook for why a path that can still be NAMED after its directory is
+#: gone is the whole trick.
+_SWEEP_ROOT_KEY: pytest.StashKey[tuple[Path, ...]] = pytest.StashKey()
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_runtest_call(item: pytest.Item) -> Iterator[None]:
+    """Record this test's temp roots BEFORE pytest deletes them.
+
+    `tmp_path` removes its own directory at ITS teardown whenever the retention
+    policy is ``failed`` and the test passed — unconditionally, in pytest's own
+    fixture generator (`_pytest/tmpdir.py`) — and it always tears down BEFORE an
+    autouse fixture declared here: those are finalised last, because they are set
+    up first. So by the time the broker sweep looked for its candidates, the
+    directories the test actually used were already gone and `rglob` found
+    nothing; measured on this machine, one run of `tests/unit/secrets/test_cli.py`
+    left 28 live key-holding brokers, one per store-touching test.
+
+    The paths are what the sweep needs, not the contents: `socket_path()` is a
+    pure function of the directory NAME, and a config dir deep enough to need
+    the fallback (pytest's tmp_path always is) puts the socket in
+    ``$TMPDIR/lop-secrets-<uid>-<digest>``, which removing the config dir does
+    not touch. So capturing during the CALL phase — after the test body, while
+    every fixture is still set up — is enough, and it is the only point where
+    both the paths and the environment that produced them still exist.
+    """
+    try:
+        yield
+    finally:
+        item.stash[_SWEEP_ROOT_KEY] = _temp_roots(item)
+
+
+def _temp_roots(item: pytest.Item) -> tuple[Path, ...]:
+    """``tmp_path`` and every directory under it, as they were at call time.
+
+    Every directory, rather than a list of the shapes the suite is known to use:
+    the module docstring of `_secret_config_dirs` records where a hardcoded list
+    already failed. `Exception`, not `OSError`, for the same reason the sweep
+    itself suppresses broadly — a test may have replaced the path machinery this
+    walk depends on, and discovering nothing is the right failure here.
+    """
+    tmp_path = getattr(item, "funcargs", {}).get("tmp_path")
+    if not isinstance(tmp_path, Path):
+        return ()
+    with suppress(Exception):
+        if tmp_path.is_dir():
+            return (tmp_path, *(child for child in tmp_path.rglob("*") if child.is_dir()))
+    return ()
+
+
 @pytest.fixture(autouse=True)
 def stop_secret_brokers_started_by_this_test(request, isolate_environment) -> Iterator[None]:
     """Kill any secret broker a test caused to start, and remove its runtime dir.
@@ -390,7 +442,9 @@ def stop_secret_brokers_started_by_this_test(request, isolate_environment) -> It
     down too.
 
     Teardown-only: each test gets fresh temporary directories, so there is
-    nothing to clean up beforehand.
+    nothing to clean up beforehand. The CANDIDATES are captured during the call
+    phase (`pytest_runtest_call` below), because pytest reclaims `tmp_path`
+    before this fixture is finalised — see `_temp_roots` for the measurement.
     """
     yield
 
@@ -406,9 +460,22 @@ def stop_secret_brokers_started_by_this_test(request, isolate_environment) -> It
     if not candidates:
         return
 
-    # Imported in the teardown rather than at module scope: this conftest is
-    # loaded for every test session, and the secrets client drags in
-    # fcntl/socket machinery a run that touches no store never needs.
+    _stop_brokers_in(candidates)
+
+
+def _stop_brokers_in(candidates: list[Path]) -> None:
+    """SIGTERM the broker in each candidate config dir, then drop its runtime dir.
+
+    A function rather than an in-fixture loop so the behaviour is reachable from
+    a test: `test_broker_sweep.py` drives it against a REAL broker, and against a
+    real broker it must NOT touch. The safety property is the caller's — the
+    candidate list is derived from the test's own temp roots, never from a
+    process-name sweep — and this function is what makes that property testable
+    rather than merely asserted in a docstring.
+    """
+    # Imported here rather than at module scope: this conftest is loaded for
+    # every test session, and the secrets client drags in fcntl/socket
+    # machinery a run that touches no store never needs.
     from local_operator.secrets import client
     from local_operator.secrets.keys import secrets_dir
     from local_operator.secrets.protocol import _runtime_fallback_dir, socket_path
@@ -458,6 +525,15 @@ def stop_secret_brokers_started_by_this_test(request, isolate_environment) -> It
 def _secret_config_dirs(request: pytest.FixtureRequest, home: Path) -> list[Path]:
     """Every directory this test could have used as a config dir.
 
+    Three sources, all of them the test's OWN temp roots:
+
+    * ``home/.local-operator`` — the config dir a test that leaves HOME alone
+      resolves to, since `isolate_environment` points HOME at a scratch dir.
+    * the roots `pytest_runtest_call` recorded while they existed, which is the
+      only way to see a config dir pytest has since reclaimed (see `_temp_roots`).
+    * whatever is still under ``tmp_path`` right now, for a test that failed
+      during setup and so never reached the call phase.
+
     Derived from the test's temporary directories rather than read back from
     ``LOCAL_OPERATOR_CONFIG_DIR``: ``monkeypatch`` has already undone the test's
     ``setenv`` by the time an autouse fixture declared here tears down, so the
@@ -476,15 +552,5 @@ def _secret_config_dirs(request: pytest.FixtureRequest, home: Path) -> list[Path
     store pay one ``getattr``.
     """
     candidates = [home / ".local-operator"]
-    tmp_path = getattr(request.node, "funcargs", {}).get("tmp_path")
-    if not isinstance(tmp_path, Path):
-        return candidates
-    # `Exception`, not `OSError`: this walk runs in the teardown of EVERY test,
-    # and a test that monkeypatched `Path.exists`/`is_dir` to raise has not had
-    # that undone yet. Discovering nothing is the right failure here — the
-    # sweep skips a directory, it does not fail the test that just passed.
-    with suppress(Exception):
-        if tmp_path.is_dir():
-            candidates.append(tmp_path)
-            candidates.extend(child for child in tmp_path.rglob("*") if child.is_dir())
-    return candidates
+    candidates.extend(request.node.stash.get(_SWEEP_ROOT_KEY, ()))
+    return candidates + [root for root in _temp_roots(request.node) if root not in set(candidates)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -375,29 +375,64 @@ _SWEEP_ROOT_KEY: pytest.StashKey[tuple[Path, ...]] = pytest.StashKey()
 
 @pytest.hookimpl(wrapper=True)
 def pytest_runtest_call(item: pytest.Item) -> Iterator[None]:
-    """Record this test's temp roots BEFORE pytest deletes them.
+    """Reap this test's brokers, and record its temp roots, while both still exist.
 
-    `tmp_path` removes its own directory at ITS teardown whenever the retention
-    policy is ``failed`` and the test passed — unconditionally, in pytest's own
-    fixture generator (`_pytest/tmpdir.py`) — and it always tears down BEFORE an
-    autouse fixture declared here: those are finalised last, because they are set
-    up first. So by the time the broker sweep looked for its candidates, the
-    directories the test actually used were already gone and `rglob` found
-    nothing; measured on this machine, one run of `tests/unit/secrets/test_cli.py`
-    left 28 live key-holding brokers, one per store-touching test.
+    Two jobs, and the sweep's own teardown can do neither of them:
 
-    The paths are what the sweep needs, not the contents: `socket_path()` is a
-    pure function of the directory NAME, and a config dir deep enough to need
-    the fallback (pytest's tmp_path always is) puts the socket in
-    ``$TMPDIR/lop-secrets-<uid>-<digest>``, which removing the config dir does
-    not touch. So capturing during the CALL phase — after the test body, while
-    every fixture is still set up — is enough, and it is the only point where
-    both the paths and the environment that produced them still exist.
+    * **Reap.** A config dir shallow enough that its socket lives INSIDE it —
+      ``sun_path`` is 104 bytes, and Linux CI runs with ``TMPDIR=/tmp``, where a
+      pytest basetemp is short enough to qualify — loses that socket file when
+      pytest's ``tmp_path`` fixture removes the directory at ITS teardown. From
+      then on nothing path-derived can reach the daemon, so a sweep running only
+      at teardown cannot stop it: measured with ``--basetemp=/tmp/...``, one run
+      of ``tests/unit/secrets/test_cli.py`` left 31 live key-holding brokers on
+      exactly that layout. This is the last moment the socket exists in EVERY
+      layout, so the reap for that case has to be here.
+
+    * **Record.** `tmp_path` removes its own directory at ITS teardown whenever
+      the retention policy is ``failed`` and the test passed — unconditionally,
+      in pytest's own fixture generator (`_pytest/tmpdir.py`) — and it always
+      tears down BEFORE an autouse fixture declared here: those are finalised
+      last, because they are set up first. So by the time the sweep looked for
+      its candidates, the directories a DEEP config dir's socket is derivable
+      from were gone and ``rglob`` found nothing; measured on this machine, one
+      run of ``tests/unit/secrets/test_cli.py`` left 28 live brokers that way.
+      ``socket_path()`` is a pure function of the directory NAME, so recording
+      the paths here lets the teardown sweep still reach a fallback-layout
+      socket — and catch a broker a fixture finaliser restarts after this point.
+
+    The teardown sweep stays: it is idempotent, and it is what covers that
+    restart. The two together cover both layouts.
     """
     try:
         yield
     finally:
         item.stash[_SWEEP_ROOT_KEY] = _temp_roots(item)
+        _reap_brokers_of_this_test(item)
+
+
+def _broker_daemon_is_available() -> bool:
+    """Is there a broker daemon on this platform to sweep at all?
+
+    A named seam rather than a bare ``os.name`` read inside the sweep, because the
+    one platform where this is False is the one a developer's box cannot run:
+    `test_broker_sweep.py` pins the guard by patching THIS and watching a real
+    broker survive, which the bare form cannot be asked without having `pathlib`
+    hand out `WindowsPath` objects on POSIX.
+    """
+    return os.name != "nt"
+
+
+def _reap_brokers_of_this_test(item: pytest.Item) -> None:
+    """Stop every broker reachable from this test's own temp roots.
+
+    The isolated HOME is read off the fixture's VALUE rather than the module
+    constant, because `isolate_environment` is what put it there; the candidate
+    set is built by the same `_sweep_candidates` the teardown sweep uses, so the
+    two can never drift into disagreeing about what this test owns.
+    """
+    home = getattr(item, "funcargs", {}).get("isolate_environment")
+    _stop_brokers_in(_sweep_candidates(item, home if isinstance(home, Path) else None))
 
 
 def _temp_roots(item: pytest.Item) -> tuple[Path, ...]:
@@ -448,14 +483,6 @@ def stop_secret_brokers_started_by_this_test(request, isolate_environment) -> It
     """
     yield
 
-    # The broker is a POSIX daemon (`client.py` imports `fcntl`, `peer.py`
-    # authenticates over a unix socket), so on Windows there is nothing to
-    # sweep and the import below would raise `ModuleNotFoundError` for every
-    # test in the run — which is exactly how the `filesystem-boundaries-windows`
-    # job caught this.
-    if os.name == "nt":
-        return
-
     candidates = _secret_config_dirs(request, isolate_environment)
     if not candidates:
         return
@@ -472,7 +499,19 @@ def _stop_brokers_in(candidates: list[Path]) -> None:
     candidate list is derived from the test's own temp roots, never from a
     process-name sweep — and this function is what makes that property testable
     rather than merely asserted in a docstring.
+
+    The platform guard lives HERE rather than in each caller: this runs for every
+    test, from the call phase and again from teardown, and the broker is a POSIX
+    daemon — `client.py` imports `fcntl` and `peer.py` authenticates over a unix
+    socket — so an unguarded call would raise `ModuleNotFoundError` for every
+    test in a Windows run. It did exactly that on the `filesystem-boundaries-windows`
+    job when the call-phase reap was added and this guard was still only in the
+    fixture, which is the argument for one guard at the bottom of the stack
+    rather than one per entry point.
     """
+    if not _broker_daemon_is_available():
+        return
+
     # Imported here rather than at module scope: this conftest is loaded for
     # every test session, and the secrets client drags in fcntl/socket
     # machinery a run that touches no store never needs.
@@ -501,7 +540,22 @@ def _stop_brokers_in(candidates: list[Path]) -> None:
         if status is None:
             continue
         pid = status.get("pid")
-        if not isinstance(pid, int):
+        # Three refusals, because the third one is how this sweep killed the run
+        # that was running it. `test_broker.py`'s `broker` fixture serves the
+        # broker IN-PROCESS (`threading.Thread(target=loop, daemon=True)`), so its
+        # status reports THIS test process's pid, and `kill(os.getpid(),
+        # SIGTERM)` takes down the xdist worker — "worker 'gw0' crashed while
+        # running ...", 17 failed across 3.12 shards 2 and 3, and a `-n0` run
+        # with it. The old teardown-only sweep never met it because the fixture's
+        # own teardown has already closed that socket by then; the call-phase
+        # reap runs while the socket is up, which is exactly why it works. An
+        # in-process broker dies with the process that owns it, so skipping it
+        # loses nothing.
+        #
+        # `pid <= 0` is not a process at all: `kill(0, ...)` signals this
+        # process's whole GROUP and `kill(-1, ...)` every process this user may
+        # signal, neither of which is ever a broker to reap.
+        if not isinstance(pid, int) or pid <= 0 or pid == os.getpid():
             continue
         with suppress(OSError):
             os.kill(pid, signal.SIGTERM)
@@ -525,14 +579,24 @@ def _stop_brokers_in(candidates: list[Path]) -> None:
 def _secret_config_dirs(request: pytest.FixtureRequest, home: Path) -> list[Path]:
     """Every directory this test could have used as a config dir.
 
+    See `_sweep_candidates` for the three sources; this wrapper exists because
+    the fixture has a `request` and the call-phase hook has an `item`.
+    """
+    return _sweep_candidates(request.node, home)
+
+
+def _sweep_candidates(node: pytest.Item, home: Path | None) -> list[Path]:
+    """Every directory this test could have used as a config dir.
+
     Three sources, all of them the test's OWN temp roots:
 
     * ``home/.local-operator`` — the config dir a test that leaves HOME alone
       resolves to, since `isolate_environment` points HOME at a scratch dir.
     * the roots `pytest_runtest_call` recorded while they existed, which is the
       only way to see a config dir pytest has since reclaimed (see `_temp_roots`).
-    * whatever is still under ``tmp_path`` right now, for a test that failed
-      during setup and so never reached the call phase.
+    * whatever is still under ``tmp_path`` right now — the only source that is
+      non-empty for a test that failed during setup and so never reached the call
+      phase, and the only one that is fresh when this runs IN the call phase.
 
     Derived from the test's temporary directories rather than read back from
     ``LOCAL_OPERATOR_CONFIG_DIR``: ``monkeypatch`` has already undone the test's
@@ -551,6 +615,6 @@ def _secret_config_dirs(request: pytest.FixtureRequest, home: Path) -> list[Path
     tmp_path holds a handful of entries; the ~16k tests that never touch a
     store pay one ``getattr``.
     """
-    candidates = [home / ".local-operator"]
-    candidates.extend(request.node.stash.get(_SWEEP_ROOT_KEY, ()))
-    return candidates + [root for root in _temp_roots(request.node) if root not in set(candidates)]
+    candidates = [home / ".local-operator"] if isinstance(home, Path) else []
+    candidates.extend(node.stash.get(_SWEEP_ROOT_KEY, ()))
+    return candidates + [root for root in _temp_roots(node) if root not in set(candidates)]

--- a/tests/unit/secrets/test_broker_sweep.py
+++ b/tests/unit/secrets/test_broker_sweep.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import os
 import shutil
 import signal
+import tempfile
+import time
 from contextlib import suppress
 from pathlib import Path
 from typing import cast
@@ -28,6 +30,7 @@ import pytest
 from local_operator.secrets import client
 from local_operator.secrets.keys import secrets_dir
 from local_operator.secrets.protocol import _runtime_fallback_dir, socket_path
+from local_operator.session.runtime.registry import pid_alive
 from tests.conftest import _SWEEP_ROOT_KEY, _secret_config_dirs, _stop_brokers_in
 
 
@@ -54,6 +57,59 @@ def _kill(base: Path) -> None:
             os.kill(pid, signal.SIGTERM)
 
 
+def _uses_the_fallback_socket(base: Path) -> bool:
+    """Which layout `socket_path` chose for ``base`` — asked, not assumed.
+
+    A deep config dir cannot fit its socket under ``sun_path`` (104 bytes) and
+    gets the ``$TMPDIR/lop-secrets-<uid>-<digest>`` runtime dir; a shallow one
+    keeps the socket INSIDE ``<base>/secrets``. Which one a test sees is a
+    property of the machine's tmp depth — ``TMPDIR=/tmp`` on Linux CI against the
+    long ``/var/folders`` path here — so a test asserting either layout is
+    asserting the box it runs on. Ask the code what it did, and assert that.
+    """
+    return socket_path(base).parent == _runtime_fallback_dir(secrets_dir(base))
+
+
+def _deep_config_dir(tmp_path: Path) -> Path:
+    """A config dir whose socket MUST take the ``$TMPDIR`` fallback layout.
+
+    For the tests whose SUBJECT is that layout: constructing it makes them valid
+    on every runner instead of only where the tmp depth happens to be enough,
+    which is what made an earlier version of this file pass locally and fail on
+    CI. The assert is the construction's own guard — without it, a later change
+    to the nesting could quietly hand the test the other layout instead.
+    """
+    deep = tmp_path / ("d" * 60) / ("e" * 60) / "config"
+    deep.mkdir(parents=True)
+    assert _uses_the_fallback_socket(
+        deep
+    ), "the construction failed: this config dir took the in-directory layout"
+    return deep
+
+
+def _wait_gone(pid: int, timeout: float = 5.0) -> bool:
+    """Wait for a signalled daemon to stop being a process at all.
+
+    `_stop_brokers_in` waits for the daemon to stop ANSWERING, which happens as
+    it closes its listener — a step before it exits. The zombie probe is what
+    tells those apart: signal-0 alone reports a zombie as alive (the trap
+    `registry.pid_alive` documents at length), and a daemon this process started
+    stays a zombie until this process reaps it. Asserting the kill without it
+    would flap on the scheduling of an exit already under way.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not pid_alive(pid, check_zombie=True):
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def _kill_pid(pid: int) -> None:
+    with suppress(OSError):
+        os.kill(pid, signal.SIGTERM)
+
+
 def test_the_sweep_reaps_a_broker_under_a_candidate(config_root: Path) -> None:
     """The happy path, against a real daemon and a real socket.
 
@@ -66,10 +122,16 @@ def test_the_sweep_reaps_a_broker_under_a_candidate(config_root: Path) -> None:
         assert client.is_running(config_root), "the broker is not reachable before the sweep"
         _stop_brokers_in([config_root])
         assert not client.is_running(config_root), "the sweep left the broker running"
-        assert not socket_path(config_root).exists(), "the socket outlived the broker"
-        assert not _runtime_fallback_dir(
-            secrets_dir(config_root)
-        ).exists(), "the runtime directory outlived the broker"
+        # What the sweep owes on the FILESYSTEM depends on the layout it was
+        # handed: with the socket in the runtime dir, that dir is the sweep's to
+        # remove; with the socket inside the config dir, the file lives in a
+        # directory that is not the sweep's to unlink (pytest's tmp_path fixture
+        # removes it, and the daemon's death is the contract asserted above).
+        if _uses_the_fallback_socket(config_root):
+            assert not socket_path(config_root).exists(), "the socket outlived the broker"
+            assert not _runtime_fallback_dir(
+                secrets_dir(config_root)
+            ).exists(), "the runtime directory outlived the broker"
     finally:
         _kill(config_root)
 
@@ -103,31 +165,161 @@ def test_the_sweep_leaves_a_broker_it_was_not_asked_about_alone(
         _kill(other)
 
 
-def test_a_broker_survives_the_removal_of_its_config_dir(config_root: Path) -> None:
-    """Why the sweep captures PATHS: the socket does not live in the config dir.
+def test_a_broker_survives_the_removal_of_its_config_dir(tmp_path: Path) -> None:
+    """Why the sweep records PATHS: a fallback socket does not live in the dir.
 
-    pytest reclaims ``tmp_path`` before the autouse sweep is finalised, so the
-    sweep runs with the directory gone. The socket it needs is in the fallback
-    runtime dir — a config dir deep enough to need one, which a pytest tmp_path
-    always is — and the fallback path is derived from the config dir's NAME, not
-    from anything on disk. So naming a deleted directory is still enough to find
-    and stop its broker, which is the property the call-phase capture relies on
-    and the one this test pins.
+    For the layout where a sweep running at teardown CAN still work: pytest has
+    just reclaimed the config directory, and the socket is in the runtime dir
+    derived from that directory's NAME rather than from anything on disk, so
+    naming a deleted directory is still enough to find and stop its broker.
+
+    The deep directory is CONSTRUCTED rather than inherited from ``tmp_path``:
+    on a runner whose tmp path is short enough (Linux CI runs ``TMPDIR=/tmp``)
+    the socket stays inside the config dir, dies with it, and this test's premise
+    is simply false there — which is what took CI red on this file. The other
+    layout is pinned by
+    `test_an_in_directory_socket_is_unreachable_once_its_config_dir_is_gone`.
     """
-    pid = _start(config_root)
+    base = _deep_config_dir(tmp_path)
+    pid = _start(base)
     try:
-        shutil.rmtree(config_root)
-        assert not config_root.exists(), "the config dir was expected to be gone"
+        shutil.rmtree(base)
+        assert not base.exists(), "the config dir was expected to be gone"
         assert socket_path(
-            config_root
+            base
         ).exists(), "the fallback socket must outlive the config dir it was derived from"
-        assert (client.broker_status(config_root) or {}).get("pid") == pid
-        _stop_brokers_in([config_root])
-        assert not client.is_running(
-            config_root
-        ), "a broker whose config dir is gone must still be reapable by name"
+        assert (client.broker_status(base) or {}).get("pid") == pid
+        _stop_brokers_in([base])
+        assert _wait_gone(pid), "a broker whose config dir is gone must still be reapable by name"
     finally:
-        _kill(config_root)
+        _kill(base)
+        _kill_pid(pid)
+
+
+def test_an_in_directory_socket_is_unreachable_once_its_config_dir_is_gone() -> None:
+    """The measurement behind the call-phase reap, pinned in-repo.
+
+    A SHORT config dir needs no fallback, so its socket lives inside its own
+    ``secrets`` directory. pytest's ``tmp_path`` fixture removes that directory at
+    its teardown, the socket file goes with it, and from then on no path-derived
+    lookup can reach the daemon — which is why a sweep running only at teardown
+    left 31 live key-holding brokers from one run of ``test_cli.py`` on exactly
+    this layout. That is why the reap happens while the socket still exists.
+
+    ``/tmp`` deliberately, not ``tmp_path``: the subject is a path short enough to
+    stay under ``sun_path`` (104 bytes), and a pytest tmp_path is not by
+    construction. The daemon is stopped by pid here — nothing in the suite can
+    reach it once the directory is gone, which is the point.
+    """
+    scratch = Path(tempfile.mkdtemp(prefix="lop-sweep-short-", dir="/tmp"))
+    try:
+        base = scratch / "config"
+        base.mkdir()
+        assert not _uses_the_fallback_socket(
+            base
+        ), "the test needs the in-directory layout, and /tmp is short enough for it"
+        pid = _start(base)
+        try:
+            shutil.rmtree(base)
+            assert not socket_path(
+                base
+            ).exists(), "the test's premise: the socket lived inside the config dir"
+            _stop_brokers_in([base])
+            assert pid_alive(pid, check_zombie=True), (
+                "a sweep can no longer reach this daemon, so the reap has to happen "
+                "while its socket exists — if this ever fails, the sweep got smarter "
+                "and the call-phase reap can be reconsidered"
+            )
+        finally:
+            _kill_pid(pid)
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+
+
+def test_the_sweep_does_nothing_where_the_broker_does_not_exist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The platform guard, driven by its effect.
+
+    The broker is a POSIX daemon — `local_operator.secrets.client` imports
+    `fcntl` at module scope — and the sweep now runs for every test from the call
+    phase as well as from teardown, so an unguarded call fails an entire Windows
+    run rather than one test: that is how the `filesystem-boundaries-windows` job
+    caught the first version of the call-phase reap, which had the guard only in
+    the fixture.
+
+    Pinned through the named seam rather than by mutating `os.name`, which would
+    have `pathlib` hand out `WindowsPath` objects on this host; a REAL broker under
+    a named candidate is what proves the guard: it survives, which it could not if
+    the import were reached (it raises there) or the kill were.
+    """
+    base = tmp_path / "config"
+    base.mkdir()
+    pid = _start(base)
+    try:
+        monkeypatch.setattr("tests.conftest._broker_daemon_is_available", lambda: False)
+        _stop_brokers_in([base])
+        assert client.is_running(base), "the sweep acted on a platform where it must not"
+    finally:
+        _kill(base)
+        _kill_pid(pid)
+
+
+def test_the_sweep_never_signals_its_own_pid_or_a_process_group(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The refusals that keep the reap from killing the run it is part of.
+
+    Driven through a spy on `os.kill` with the two things the sweep reads faked,
+    because the failure this pins is process death: `test_broker.py`'s `broker`
+    fixture serves the broker IN-PROCESS, so its status reports the test
+    process's own pid, and the first version of the call-phase reap signalled it
+    — `worker 'gw0' crashed while running ...`, 17 failed on the 3.12 shards, and
+    a whole `-n0` run dead with it. A test that actually delivered those signals
+    could only report its own disappearance, so the spy does the asserting.
+
+    `0` and `-1` are the other half: `kill(0, ...)` signals this process's entire
+    GROUP and `kill(-1, ...)` every process this user may signal, so a record
+    carrying one is never a broker to reap. The positive control (a pid far
+    outside any real range) proves the spy sees a signal when there is one to
+    send, so the three refusals are not passing by inertness.
+    """
+    base = tmp_path / "config"
+    base.mkdir()
+    decoy = tmp_path / "broker.sock"
+    decoy.touch()
+    sent: list[tuple[int, int]] = []
+    real_kill = os.kill
+
+    def spy(pid: int, sig: int) -> None:
+        sent.append((pid, sig))
+        if pid == 999_999_999:  # positive control: nothing to signal, don't try
+            raise ProcessLookupError
+        real_kill(pid, sig)
+
+    monkeypatch.setattr(os, "kill", spy)
+    monkeypatch.setattr("local_operator.secrets.protocol.socket_path", lambda base=None: decoy)
+    for pid in (os.getpid(), 0, -1):
+        monkeypatch.setattr(
+            "local_operator.secrets.client.broker_status",
+            lambda base=None, _pid=pid: {"ok": True, "pid": _pid},
+        )
+        sent.clear()
+        _stop_brokers_in([base])
+        assert sent == [], (
+            f"the sweep signalled {sent} for pid {pid} — its own process, or a whole "
+            "process group, instead of a separate broker"
+        )
+
+    monkeypatch.setattr(
+        "local_operator.secrets.client.broker_status",
+        lambda base=None: {"ok": True, "pid": 999_999_999},
+    )
+    sent.clear()
+    _stop_brokers_in([base])
+    assert sent == [
+        (999_999_999, signal.SIGTERM)
+    ], "the positive control sent nothing, so the refusals above prove nothing"
 
 
 class _StubNode:

--- a/tests/unit/secrets/test_broker_sweep.py
+++ b/tests/unit/secrets/test_broker_sweep.py
@@ -1,0 +1,184 @@
+"""The suite-wide broker sweep: what it must reap, and what it must never touch.
+
+These are not unit tests of a fixture but of the behaviour the fixture hides.
+The sweep in ``tests/conftest.py`` is the only thing standing between a test run
+and a key-holding daemon left alive on the operator's machine, and it silently
+stopped finding its candidates when it began running after pytest had already
+reclaimed ``tmp_path`` — measured: one run of ``tests/unit/secrets/test_cli.py``
+left 28 live brokers, one per store-touching test, each holding a master key in
+memory.
+
+They start REAL brokers, because what broke was the path arithmetic and not a
+mock's return value: `socket_path` is a pure function of the config dir NAME, so
+the sweep can still reach a broker whose directory pytest has deleted, and only
+a real daemon proves that.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+from contextlib import suppress
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from local_operator.secrets import client
+from local_operator.secrets.keys import secrets_dir
+from local_operator.secrets.protocol import _runtime_fallback_dir, socket_path
+from tests.conftest import _SWEEP_ROOT_KEY, _secret_config_dirs, _stop_brokers_in
+
+
+def _start(base: Path) -> int:
+    """Start a real broker for ``base`` and return its pid."""
+    assert client.ensure_broker(base), "the broker never came up"
+    status = client.broker_status(base) or {}
+    pid = status.get("pid")
+    assert isinstance(pid, int), status
+    return pid
+
+
+def _kill(base: Path) -> None:
+    """Stop a broker this test started, so the test never leaks one itself.
+
+    Deliberately the client's own status/pid route rather than `_stop_brokers_in`,
+    except where a test is *about* the sweep: a test that used the code under
+    test to clean up could not tell a broken sweep from a leaked broker.
+    """
+    status = client.broker_status(base) or {}
+    pid = status.get("pid")
+    if isinstance(pid, int):
+        with suppress(OSError):
+            os.kill(pid, signal.SIGTERM)
+
+
+def test_the_sweep_reaps_a_broker_under_a_candidate(config_root: Path) -> None:
+    """The happy path, against a real daemon and a real socket.
+
+    ``config_root`` is ``tmp_path/config`` with HOME redirected — the exact shape
+    ``test_cli.py`` uses — so this is the configuration whose broker the sweep
+    used to leave behind.
+    """
+    _start(config_root)
+    try:
+        assert client.is_running(config_root), "the broker is not reachable before the sweep"
+        _stop_brokers_in([config_root])
+        assert not client.is_running(config_root), "the sweep left the broker running"
+        assert not socket_path(config_root).exists(), "the socket outlived the broker"
+        assert not _runtime_fallback_dir(
+            secrets_dir(config_root)
+        ).exists(), "the runtime directory outlived the broker"
+    finally:
+        _kill(config_root)
+
+
+def test_the_sweep_leaves_a_broker_it_was_not_asked_about_alone(
+    tmp_path: Path, config_root: Path
+) -> None:
+    """The safety property: the sweep is scoped to the candidates it is given.
+
+    A broker under a config dir the candidate list does not name stands in for
+    the two processes the sweep must never kill — another agent's live session,
+    and the operator's own store under their real ``~/.local-operator``. Both are
+    reachable by name and neither is a candidate, which is the whole reason the
+    sweep takes a list instead of walking the process table. Driven against a
+    real daemon because that is the only way to catch a "reap" that goes looking
+    beyond its list.
+    """
+    other = tmp_path / "another-live-session"
+    other.mkdir()
+    _start(config_root)
+    _start(other)
+    try:
+        _stop_brokers_in([config_root])
+        assert not client.is_running(config_root), "the sweep missed its own candidate"
+        assert client.is_running(other), (
+            "the sweep killed a broker outside its candidate list — a live session's "
+            "store, or the operator's, is not this suite's to reap"
+        )
+    finally:
+        _kill(config_root)
+        _kill(other)
+
+
+def test_a_broker_survives_the_removal_of_its_config_dir(config_root: Path) -> None:
+    """Why the sweep captures PATHS: the socket does not live in the config dir.
+
+    pytest reclaims ``tmp_path`` before the autouse sweep is finalised, so the
+    sweep runs with the directory gone. The socket it needs is in the fallback
+    runtime dir — a config dir deep enough to need one, which a pytest tmp_path
+    always is — and the fallback path is derived from the config dir's NAME, not
+    from anything on disk. So naming a deleted directory is still enough to find
+    and stop its broker, which is the property the call-phase capture relies on
+    and the one this test pins.
+    """
+    pid = _start(config_root)
+    try:
+        shutil.rmtree(config_root)
+        assert not config_root.exists(), "the config dir was expected to be gone"
+        assert socket_path(
+            config_root
+        ).exists(), "the fallback socket must outlive the config dir it was derived from"
+        assert (client.broker_status(config_root) or {}).get("pid") == pid
+        _stop_brokers_in([config_root])
+        assert not client.is_running(
+            config_root
+        ), "a broker whose config dir is gone must still be reapable by name"
+    finally:
+        _kill(config_root)
+
+
+class _StubNode:
+    """The two attributes `_secret_config_dirs` reads off a pytest item."""
+
+    def __init__(self, funcargs: dict[str, object], stash: pytest.Stash) -> None:
+        self.funcargs = funcargs
+        self.stash = stash
+
+
+class _StubRequest:
+    """A stand-in for the `pytest.FixtureRequest` the sweep is handed.
+
+    `_secret_config_dirs` reads only `request.node.funcargs` and `request.node.stash`,
+    so a stub is what lets this test put the sweep in the exact teardown-time state
+    (recorded paths, directories gone) without running a nested pytest session.
+    """
+
+    def __init__(self, node: _StubNode) -> None:
+        self.node = node
+
+
+def test_the_candidates_keep_paths_whose_directories_are_already_gone(
+    tmp_path: Path, config_root: Path
+) -> None:
+    """The regression guard for the leak, at the level the leak actually happened.
+
+    A teardown-time walk of ``tmp_path`` finds nothing once pytest has reclaimed
+    it — which is what made the sweep a no-op for every test that redirects its
+    config dir into ``tmp_path``. The recorded paths are what carry the sweep
+    over that window, so the candidate list must contain a directory that no
+    longer exists.
+    """
+    gone = tmp_path / "test_something0"
+    gone.mkdir()
+    (gone / "config").mkdir()
+    candidate = gone / "config"
+
+    stash: pytest.Stash = pytest.Stash()
+    stash[_SWEEP_ROOT_KEY] = (gone, candidate)
+    # `funcargs` still names the path, as pytest's does, but the directory it
+    # points at is gone — exactly the teardown-time state.
+    node = _StubNode({"tmp_path": gone}, stash)
+    shutil.rmtree(gone)
+
+    candidates = _secret_config_dirs(
+        cast(pytest.FixtureRequest, _StubRequest(node)), tmp_path / "home"
+    )
+
+    assert candidate in candidates, (
+        "a candidate recorded while the test ran is missing from the list, so its "
+        "broker would never be reaped"
+    )
+    assert not gone.exists(), "the test's premise: the directories are gone by teardown"

--- a/tests/unit/tui/test_copy_picker_mouse.py
+++ b/tests/unit/tui/test_copy_picker_mouse.py
@@ -27,6 +27,8 @@ both arrive as ``chain=1`` and never double-click at all.
 
 from __future__ import annotations
 
+import time
+
 import pytest
 from rich.cells import cell_len
 from textual import events
@@ -147,6 +149,41 @@ def _wheel(screen: CopyPickerScreen, x: int, y: int, down: bool):
     )
 
 
+#: Spacing between hand-posted clicks, in seconds of *event* time.
+_CLICK_STEP_S = 0.12
+
+#: Event-time clock for `_full_click`, seeded from the real monotonic so the
+#: stamps stay plausible to anything that ever inspects them.
+_click_events_at = time.monotonic()
+
+
+def _next_click_time() -> float:
+    """The ``event.time`` to stamp the next hand-posted click with.
+
+    Textual decides whether two clicks are ONE gesture by comparing the two
+    events' own ``event.time`` values against ``CLICK_CHAIN_TIME_THRESHOLD``
+    (0.9 s in this app), and `_full_click` used to let those times come from the
+    wall clock at construction. That makes the fixture's verdict a measurement
+    of the machine: under a loaded shard runner the two clicks straddle the
+    window, Textual resets ``_chained_clicks`` to 1, the picker's double-click
+    branch is never reached, and a test asserting a copy fails with a message
+    that blames the REFUSAL instead — the frame it names really did not change.
+    Measured on red `main`: forcing a 1.2 s gap leaves ``app._chained_clicks``
+    at 1 and fails
+    `test_a_movement_that_moves_nothing_does_not_disarm_the_double_click` with
+    CI's own message, while the same pair stamped inside the window passes.
+
+    So the stamp is what pins the gesture the fixture MEANS — two clicks of one
+    double-click, not two clicks at whatever speed the box could post them —
+    and the picker's clamping and refusal logic stays under test. The spacing is
+    `_CLICK_STEP_S` against a 0.9 s window: an order of magnitude of margin, and
+    still a plausible human double-click.
+    """
+    global _click_events_at
+    _click_events_at += _CLICK_STEP_S
+    return _click_events_at
+
+
 async def _full_click(app, x: int, y: int) -> None:
     """A REAL press and release at ``(x, y)``, with Textual computing the chain.
 
@@ -156,26 +193,37 @@ async def _full_click(app, x: int, y: int) -> None:
     lives. The tests that assert on the CLIPBOARD need that path; the tests
     that assert on the picker's own row arithmetic do not, and keep using the
     posted `_click` for the no-loop-turn case it exists to reach.
+
+    Both events of the click are stamped by `_next_click_time`, so a pair of
+    consecutive calls is a chained double-click by construction rather than by
+    luck; see that helper for what the wall clock used to do here.
     """
+    at = _next_click_time()
     for kind in (events.MouseDown, events.MouseUp):
         # Spelled out per event rather than splatted from a shared dict: a
         # `dict(...)` literal widens every value to the union of its types, so
         # `**common` type-checks as `int | None` against every parameter.
-        await app.on_event(
-            kind(
-                widget=None,
-                x=x,
-                y=y,
-                delta_x=0,
-                delta_y=0,
-                button=1,
-                shift=False,
-                meta=False,
-                ctrl=False,
-                screen_x=x,
-                screen_y=y,
-            )
+        event = kind(
+            widget=None,
+            x=x,
+            y=y,
+            delta_x=0,
+            delta_y=0,
+            button=1,
+            shift=False,
+            meta=False,
+            ctrl=False,
+            screen_x=x,
+            screen_y=y,
         )
+        # `MouseEvent` takes no `time` argument — `Message.__init__` stamps
+        # construction time — so the stamp is set on the instance. That
+        # attribute is exactly what the chain comparison reads, and nothing
+        # else on this path reads it at all (the picker's own logic is
+        # position- and state-based), so an explicit stamp changes only the
+        # gesture's identity, never the code under test.
+        event.time = at
+        await app.on_event(event)
 
 
 async def _full_wheel(app, x: int, y: int, down: bool) -> None:
@@ -1904,6 +1952,16 @@ async def test_a_refused_click_leaves_the_clipboard_exactly_as_it_found_it() -> 
 
             clipboard = app._clipboard
             copied = got[0] if got else None
+            # The gesture's premise, asserted for the same reason the caller
+            # asserts its own below: a pair scored as two SEPARATE singles never
+            # reaches the picker's double-click branch, so `copied is None`
+            # would be a broken chain wearing the refusal's clothes. That is how
+            # a loaded runner reddened `main`; the stamp in `_full_click` makes
+            # it unreachable, and this is what makes it audible if it ever is.
+            assert app._chained_clicks >= 2, (
+                f"a {interlude} between the clicks was scored as two separate singles, "
+                "so nothing below is about a double-click"
+            )
             if screen.is_attached:
                 app.pop_screen()
                 await pilot.pause()
@@ -1946,6 +2004,12 @@ async def test_a_refused_click_leaves_the_clipboard_exactly_as_it_found_it() -> 
             await _full_click(app, x, y)
             await pilot.pause()
             await pilot.pause()
+            # Only a CHAINED click reaches `Widget._on_click`, which is where
+            # the select-all that leaked the chrome lives; two singles would
+            # satisfy the assertion below without ever exercising it.
+            assert (
+                app._chained_clicks >= 2
+            ), f"the two clicks on the {label} were scored as separate singles"
             assert app._clipboard == prior, (
                 f"double-clicking the {label} wrote {len(app._clipboard)} characters of "
                 f"card chrome to the clipboard: {app._clipboard[:60]!r}"
@@ -2042,6 +2106,17 @@ async def test_a_movement_that_moves_nothing_does_not_disarm_the_double_click() 
             await _full_click(app, x, y)
             await pilot.pause()
             await pilot.pause()
+            # The gesture's other premise, next to the caller's `noop` and for the
+            # same purpose: the two clicks above must have been scored as ONE
+            # double-click, or `copied is None` below would be a chain broken by
+            # the clock rather than the refusal this test is about — the exact
+            # mis-attribution that reddened `main` on a loaded runner. The stamp
+            # in `_full_click` is what keeps this true; this assert is what fails
+            # loudly if a future change re-opens it.
+            assert app._chained_clicks >= 2, (
+                f"{interlude!r} after {pre_key!r}: the two fixture clicks were scored "
+                "as separate singles, so nothing below is about a double-click"
+            )
 
             copied = got[0] if got else None
             if screen.is_attached:


### PR DESCRIPTION
Two slices of `main`'s remaining test flakiness/leaks, each with the mechanism measured rather than argued. No version bump.

---

## Slice A — `test_a_movement_that_moves_nothing_does_not_disarm_the_double_click` is live, not fixed

`main` is red on it: run [34638578398](https://github.com/damianvtran/local-operator/actions/runs/34638578398) (on `ee3ceceb7`, the v0.54.15 release commit), 3.13, shard 0 —

```
FAILED tests/unit/tui/test_copy_picker_mouse.py::test_a_movement_that_moves_nothing_does_not_disarm_the_double_click
  AssertionError: wheel up at the first row moved nothing, yet the double-click was refused against a frame that never changed
1 failed, 4006 passed, 61 skipped in 692.26s
```

Earlier, run [34563768974](https://github.com/damianvtran/local-operator/actions/runs/34563768974) (branch `fix/shard-stall-watchdog`), 3.12 shard 0, failed the same test at the same assertion with a different movement parameter (`'home' at the first row ...`, at `assert copied is not None`). We had written both off as fixed by #953 (`9ce0f2f01`); that was wrong for this test — it fails on `main` *with* #953 in it.

### Mechanism: the fixture's double-click was scored by the wall clock

`_full_click` hands real `MouseDown`/`MouseUp` pairs to `App.on_event`, which is the only entry point that synthesises a `Click` with a chain — the tests that assert on the clipboard need that path. Textual computes the chain from the events' own `event.time`:

```python
# .venv/lib/python3.14/site-packages/textual/app.py:4096
within_time_threshold = (
    self._click_chain_last_time is not None
    and event.time - self._click_chain_last_time <= self.CLICK_CHAIN_TIME_THRESHOLD
)
if same_offset and within_time_threshold:
    self._chained_clicks += 1
else:
    self._chained_clicks = 1
```

`event.time` is stamped at construction (`textual/message.py:53`), so the two clicks' verdict was the machine's speed: `CLICK_CHAIN_TIME_THRESHOLD` is 0.9 s here (`local_operator/tui/app.py:2492`). Let the runner stall longer than that between the two clicks and Textual resets `_chained_clicks` to 1, the picker never reaches `if chain >= 2 and not disturbed: self.action_choose()`, nothing is copied — and because the frame really was byte-identical at all three points, the fixture's own `noop` premise assertion passes and the failure message blames the REFUSAL. The product is not at fault: with `chain=1` there is no double-click to refuse. This is the `test_cold_slash_binds.py` class again — an assertion resting on a wall-clock budget — in a different file.

**Measured threshold** (probe driving the real app, `asyncio.sleep` between the two clicks):

```
[CHAIN] gap=0.0s  first_chain=1  second_chain=2
[CHAIN] gap=0.2s  first_chain=1  second_chain=2
[CHAIN] gap=0.6s  first_chain=1  second_chain=2
[CHAIN] gap=1.5s  first_chain=1  second_chain=1
```

### Reproduction — and an honest limit

I could **not** make it fail naturally: 20 iterations of the test under 12-way CPU load, on 3.13 (where CI caught it), pre-fix file: `arm=PREFIX: 0/20 failed`. On a 14-core box a `pilot.pause()` sequence does not reliably exceed 0.9 s; CI's 4-vCPU shards are where that happens (the same shard ran 4006 tests in 692 s).

So the mechanism was proven by **forcing the exact condition** — a plugin that sleeps 1.2 s between the two clicks, which is the CI stall — against the pre-fix file:

```
[CHAINBREAK] click #1 -> app._chained_clicks=1
[CHAINBREAK] click #2 -> app._chained_clicks=1
>               assert copied is not None, (
E               AssertionError: wheel up at the first row moved nothing, yet the double-click was refused against a frame that never changed
E               assert None is not None
1 failed, 2 warnings in 2.89s
```

That is CI's message verbatim, with `_chained_clicks=1` showing the chain never formed.

### Fix

`_full_click` stamps both events of each click from a module-level event clock advanced by `_CLICK_STEP_S = 0.12` s (`_next_click_time()`), so a pair of consecutive calls is one chained double-click **by construction**: an order of magnitude inside the 0.9 s window, and still a plausible human double-click. The product is untouched; the picker's clamping, preview-offset reset and U10 refusal stay exactly the thing under test.

Each `_drive` in the two `_full_click` tests now also asserts the gesture's premise — `assert app._chained_clicks >= 2` — next to the existing frame premise, so a future re-opening fails loudly and by name instead of mis-attributing.

### Evidence after the fix

```
$ CHAINBREAK_GAP=1.2 pytest tests/unit/tui/test_copy_picker_mouse.py -q -n0 -p no:randomly -p chainbreak   # 3.13
52 passed, 2 warnings in 126.78s
```

**Guards fail without the fix** (mutation `_CLICK_STEP_S = 5.0`, i.e. the stamp reverted to a wall-clock-scale gap — 3.13):

```
E  AssertionError: 'wheel-up' after 'home': the two fixture clicks were scored as separate singles, so nothing below is about a double-click
E  assert 1 >= 2
E  AssertionError: a none between the clicks was scored as two separate singles, so nothing below is about a double-click
2 failed, 2 warnings in 3.29s
```

**The tests kept their teeth for the product defect they were written for**: restoring `_move_to`'s pre-D19 unconditional `self._anchor_disturbed = True` still fails them at `copied is not None` (`1 failed ... AssertionError: wheel up at the first row moved nothing, yet the double-click was refused against a frame that never changed`), now for the refusal's own reason.

---

## Slice B — the broker sweep could not see the brokers it exists to reap

The autouse `stop_secret_brokers_started_by_this_test` derives its candidate config dirs from the test's `tmp_path` at teardown. **pytest deletes that directory at its own teardown**, whenever the retention policy is `failed` and the test passed:

```python
# .venv/lib/python3.14/site-packages/_pytest/tmpdir.py:305 (the `tmp_path` fixture)
if policy == "failed" and result_dict.get("call", True):
    rmtree(path, ignore_errors=True)
```

and an autouse fixture declared in the root conftest is set up first, so it is finalised **last** — after `tmp_path` is gone. The sweep's `tmp_path.rglob("*")` therefore found nothing and its only candidate left was `home/.local-operator` under the isolated HOME, which `test_cli.py` never uses (it sets `HOME` *and* `LOCAL_OPERATOR_CONFIG_DIR` inside `tmp_path`). Instrumented at teardown, for `test_get_writes_exactly_the_value[token]`:

```
[PROBE3] {'tp': '.../pytest-34102/test_list_never_prints_a_value0', 'exists': False, 'is_dir': False, 'isinstance_Path': True}
[PROBE3] candidates=1
```

Every broker the test started was therefore never a candidate: measured, one run of `tests/unit/secrets/test_cli.py` left **28** live key-holding brokers (QA measured +27 for this file and +15 for `test_agent_surfaces.py`; the census drifts as the daemons idle-exit after 30 minutes).

### Fix

Candidates are captured during the **call phase** — after the test body, while every fixture is still set up — and read back at teardown (`pytest_runtest_call` + `_temp_roots`). Paths are what the sweep needs, not contents: `socket_path()` is a pure function of the config dir NAME, and a config dir deep enough to need the fallback socket (a pytest `tmp_path` always is) keeps that socket in `$TMPDIR/lop-secrets-<uid>-<digest>`, which removing the config dir does not touch. The old teardown-time walk is kept as a fallback for a test that never reached the call phase. The kill loop is factored into `_stop_brokers_in` so the behaviour is drivable from a test.

### Evidence, with exact attribution

Counting brokers whose environment names a private `--basetemp`, so another session's churn cannot be miscounted. Same file, same command, `-n0`, 3.14, with the basetemp placed under `$TMPDIR` so the path shape (and therefore the socket's location) is the real suite's:

```
BEFORE — pre-fix derivation injected with a plugin (-p oldcand):
$ BT=$TMPDIR/lsb-before pytest tests/unit/secrets/test_cli.py -q -n0 -p no:randomly -p oldcand
39 passed in 25.09s
  LEAKED pid=9180  LOCAL_OPERATOR_CONFIG_DIR=<BT>/test_get_writes_exactly_the_va0/config
  ... one per store-touching test ...
brokers from THIS run still alive after it: 27

AFTER — the same command on this head:
39 passed in 25.18s
brokers from THIS run still alive after it: 0
```

The 27 is the same leak QA measured as `+27` for this file, and it is exactly attributable: each survivor's environment names my private basetemp, so nothing from the 14 live `lop` sessions or another agent's worker can be counted.

`tests/unit/secrets/test_broker_sweep.py` drives the sweep against **real brokers**::

* one under a candidate config dir → reaped, and neither its socket nor its `$TMPDIR` runtime dir survives;
* one under a config dir the candidate list does **not** name — the stand-in for another agent's live session and for the operator's own `~/.local-operator` — which must still be running afterwards (the safety property, driven rather than asserted in a docstring);
* one whose config dir has been deleted, which is the property the call-phase capture rests on;
* a stub request whose recorded paths are already gone, pinning the candidate derivation itself.

I left the pre-existing orphans on this machine alone (census before this work: **227** `brokerd` processes, 40 branded `Local Operator`; 14 live `lop` sessions). I did stop the **91** brokers my own scratch runs started, identified by `lsb-` (my private basetemps) in their environment — nothing matching the operator's real config dirs or a live session was signalled.

---

## Quality gates (on the rebased head `3295042b0`)

```
$ .venv/bin/python -m flake8 --extend-exclude=".venv313,.venv312" .
(clean)

$ uvx --from black==26.1.0 black --check --extend-exclude '\.venv313|\.venv312' .
1231 files would be left unchanged.

$ uvx isort==5.13.2 --check-only --extend-skip .venv313 --extend-skip .venv312 .
(clean)

$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations
```

(The worktree carries `.venv` (3.14, CI's dev interpreter) plus a `.venv313` for the interpreter `main` went red on; the extra interpreter venv is excluded from the formatters because only `.venv` is excluded in this repo's config, which is the same flag the previous flake PR needed.)

```
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/secrets/test_broker_sweep.py \
      tests/unit/tui/test_copy_picker_mouse.py tests/unit/secrets/test_cli.py -q -n0 -p no:randomly
95 passed, 2 warnings in 133.64s          # 3.14
95 passed, 2 warnings in 166.33s          # 3.13
```

Full unit suite (CI-equivalent invocation, default xdist cap): see the comment below for the verbatim result.

`git range-diff` proves the rebase onto the moved base was content-identical for both commits (`1: 681d4b495 = 1: 681d4b495`, `2: 3295042b0 = 2: 3295042b0`); the base moved under this branch (PR #964 touched `local_operator/session/*` and two session tests, none of them mine) and my rebase is the pre-PR kind, so no reviewed round is being re-pinned.

---

## Not addressed

* **A config dir short enough that the socket lives inside it — CLOSED in the round-1 remediation (`875cdaeba`).** This was deferred here as needing a product-side marker; review round 1 correctly showed it is a seam choice instead. A config dir shallow enough that `str(<config>/secrets/broker.sock)` fits under `sun_path` (104 bytes) — Linux CI's `TMPDIR=/tmp` — keeps the socket *inside* the config dir, so pytest's `rmtree` of `tmp_path` unlinks it and a sweep running only at teardown can never reach that daemon. The hook that was already running while the sockets still exist (`pytest_runtest_call`'s `finally`) now **reaps** there as well as recording paths, which closes it with no product change:

    shallow (/tmp, Linux-like): 31 leaked before -> 0 with the call-phase reap
                                 (0 for the socket-holding daemons the sweep can reach;
                                 see the socket-less residual under `Not addressed`)
    deep ($TMPDIR, dev shape):  27 leaked before -> 0 with the call-phase reap
    mutation (reap removed, recording kept):        -> 31 again

  The teardown sweep stays as the backstop — it is idempotent, it still covers the fallback layout, and it catches a broker a fixture finaliser restarts after the call phase, which is the one caveat review round 1 raised about reaping earlier. The two layout-dependent tests are no longer platform-dependent: they ask `socket_path` which layout it chose, and the test whose subject *is* the fallback layout constructs a deep config dir rather than inheriting one from the runner's tmp depth.
* **One socket-less daemon in the last moments of a run (QA round 2, Q1) — known minor, reproduced, deliberately not fixed here.** Roughly one run in three of the shallow-basetemp leak accounting leaves exactly one extra `brokerd`, and QA's capture of it is the whole characterisation: it holds **no unix socket** (`sockets held: []`, `socket file exists now: False`), `broker_status` answers `None` for its config dir, its parent is already gone, and it **exits on its own within ~3 s**. Reproduced here at 2 of 3 runs on 3.14 and 1 of 2 on 3.13; both of my catches had exited by the time I looked. It is a spawn racing teardown, not a leak the sweep can close: a daemon that never binds is unreachable by any path-derived lookup, old sweep or new, and with no socket nothing can ask it for a key — so it cannot serve a secret, wedge a job, or accumulate the way the 31 persistent socket-holders did (each of those idled 30 minutes and left a `$TMPDIR/lop-secrets-<uid>-<digest>` runtime dir behind; this one leaves neither). QA's attribution points at the fix: five of six catches named `test_rotate_on_a_hardened_store_keeps_every_secret` and one `test_harden_repairs_a_store_a_pre_fix_rotate_damaged` — the two tests whose bodies end in `broker restart` / `unlock` / `get` with a `broker stop` in `finally` — so the change belongs at that spawn/stop seam (make the stop wait for the spawn it is racing, or have the client hand the harness the pid it spawned so the reap does not need a socket), which is product surface and its own PR. QA's instrument, which is the honest form to start from:

  ```sh
  for i in 1 2 3; do
    rm -rf /tmp/lk$i
    .venv/bin/python -m pytest tests/unit/secrets/test_cli.py --basetemp=/tmp/lk$i -q
    ps -Eww -axo pid=,command= | grep 'secrets.brokerd' | grep -c "/tmp/lk$i"
  done   # expect 1 in about one run of three; the daemon is gone seconds later
  ```
* **A `timeout-minutes` kill still leaves nothing to clean up in-process.** No Python runs on the cancelled job, so no in-suite sweep can reap anything there — the one case left that genuinely cannot be closed from inside a test session. Closing it would need a durable marker reaped by the *next* run (the sketch this body used to carry for the short-path case, which no longer needs one).
* **The `#958` orphan is not a broker.** `local_operator/secrets/brokerd.py` never calls `procname`, while `local_operator/tools/eval.py:563` and `local_operator/proc.py:64` do — the branded `Local Operator` child in the cancelled-run teardown is an eval/subagent child (low pid = started early in the job), which is why the broker sweep's absence cannot explain it. Reported, not fixed: identifying the leaking test needs a rerun of the affected shard lists on both interpreters, and the shard that produced it has not gone red since #954/#951.
* **`exec_mode.py:328`** (`runtime_path` from a fresh `config_dir()` read) is the same class as the fix in #969 and stayed deferred there as out of delta scope, with the reasoning on that PR.
* No `gh issue` was created for any of the above, per the standing rule.

Release: patch — two more of the suite's flake/leak sources closed (the copy-picker double-click chain and the broker sweep); no runtime behaviour change.
