### PR TITLE
fix(evaluation): judge a doubly-capped episode by its caps, not a cost ratio

### DIFF
--- a/docs/benchmarks/osworld_2/README.md
+++ b/docs/benchmarks/osworld_2/README.md
@@ -875,10 +875,10 @@ Flags on `scripts/run_episode.py`, with their defaults:
 | Parameter | Default | Notes |
 | --- | --- | --- |
 | `--route` | required | `<provider>/<model>`; the paid episode used `openrouter/deepseek/deepseek-v4-flash-vision-exp` |
-| `--max-steps` | 25 | bounds the step loop; `EpisodeConfig.max_steps` itself defaults to 50 |
-| `--max-usd` | 0.50 | hard provider spend cap |
+| `--max-steps` | 25 | bounds the step loop; `EpisodeConfig.max_steps` itself defaults to 50. With an explicit `--max-usd` this also makes the cost guard prorate a per-cycle ceiling from the remaining budget and remaining steps instead of judging the recent-vs-previous cost ratio |
+| `--max-usd` | 0.50 | hard provider spend cap; states the explicit cost cap the cost guard prorates against |
 | `--max-wall-s` | 18000 | runaway guard only; the 500-step budget binds first. The TTL lease is derived from it (`_ensure_lease_outlasts_wall`), see BUDGETS_AND_LATENCY.md |
-| `--max-cycle-usd` | none | per-cycle cost-rate guard |
+| `--max-cycle-usd` | none | ADDS an absolute per-cycle cap; it is not what stops a runaway on a doubly-capped episode, the prorated ceiling is |
 | `--keep-recent-frames` | 3 | frame retention |
 | `--benchmark-release` | `osworld-v2-2026.08.08` | |
 | `--run-root` | required | must be durable; `/tmp` and `$TMPDIR` are refused |

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -259,6 +259,10 @@ class EpisodeConfig:
     the episode is still scored on the state it reached. ``None`` means
     :func:`default_guards`; an empty tuple disables them.
     ``max_cycle_cost_micros`` feeds the default cost-rate guard's absolute cap.
+    ``max_steps`` is snapshotted for the guards (``GuardInput.max_steps``):
+    an episode that states BOTH this step budget and an explicit provider-cost
+    cap is judged by the caps rather than by the cost-rate ratio, which cannot
+    tell a legitimate expensive cycle from a runaway one.
     ``max_decision_retries`` is how many corrective re-prompts one observation
     may take after a billed reply fails strict parsing (a ``frame_id`` the
     observation does not carry, malformed JSON) before the episode ends as a
@@ -1247,6 +1251,7 @@ class EpisodeRunner:
         recent = (*self._turns[-RECENT_TURNS_WINDOW:], EpisodeTurn(observation=latest))
         snapshot = GuardInput(
             steps_taken=self._steps_taken,
+            max_steps=self._config.max_steps,
             model_cycles=self._model_cycles,
             provider_cost_micros=self._provider_cost_micros,
             elapsed_ms=max(0, _now_ms() - self._started_ms),

--- a/local_operator/evaluation/runner/guards.py
+++ b/local_operator/evaluation/runner/guards.py
@@ -57,11 +57,18 @@ class GuardInput(ProtocolModel):
     the model chose for it; ``recent_costs_micros`` are the per-cycle provider
     costs in the same order (one per model cycle, so they may outnumber the
     turns kept). ``usage_totals`` mirrors what the runner will reconcile.
+
+    ``max_steps`` is the episode's own step budget when the caller states one
+    (``EpisodeConfig.max_steps``), and ``None`` when it does not -- which is
+    what lets a guard tell a bounded episode, whose remaining steps are known,
+    from one that is bounded only by cost. A guard that reads it must treat
+    ``None`` as "no step budget", never as zero steps.
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True, strict=False, validate_default=True)
 
     steps_taken: SafeCount
+    max_steps: SafeCount | None = None
     model_cycles: SafeCount
     provider_cost_micros: SafeCount
     elapsed_ms: SafeCount
@@ -85,6 +92,24 @@ class GuardVerdict(ProtocolModel):
 
 
 CONTINUE = GuardVerdict(kind="continue", code="ok", detail="no guard fired")
+
+
+def _capped_usd_cap(snapshot: GuardInput) -> int | None:
+    """The episode's explicit provider-cost cap in micro-USD, if it declared one.
+
+    Only a CAPPED allowance is an explicit cap -- the same rule
+    :class:`BudgetCapGuard` enforces -- because an uncapped allowance is the
+    *absence* of one (a named person removed it, and ``scripts/run_episode.py``
+    leaves the resources it cannot size up front uncapped for the same reason).
+    An episode without an explicit cost cap keeps the ratio check as its only
+    cost authority.
+    """
+
+    for allowance in snapshot.budget.allowances:
+        if allowance.resource == "provider_usd_micros" and isinstance(allowance, CappedAllowance):
+            return int(allowance.value)
+    return None
+
 
 #: How many of the newest turns the runner snapshots into
 #: ``GuardInput.recent_turns``. A guard that needs to see more turns than
@@ -171,6 +196,28 @@ class CostRateGuard:
     continue, the guard says so in its verdict (``code="cost-unreported"``)
     so a reader of the guard's decisions can see the ratio check was skipped,
     and only ``max_cycle_cost_micros`` remains in force.
+
+    **The ratio is inapplicable to a doubly-capped episode.** When the episode
+    declares BOTH an explicit step budget and an explicit provider-cost cap,
+    those caps are the authority and the ratio is not judged at all -- it is
+    replaced by a per-cycle ceiling prorated from what is actually left
+    (``remaining cost budget / remaining steps * bounded_cycle_margin``). Two
+    things make the ratio the wrong instrument there: it cannot tell a
+    legitimate expensive cycle from a runaway one, and it is blind to how much
+    of the budget remains. Its dominant false positive in practice is a
+    PROMPT-CACHE MISS, which multiplies the input price of one cycle while the
+    context is unchanged -- measured on an OSWorld batch, cycles at 2744/1686/
+    1908 micro-USD against a ~1000-1400 baseline cut episodes at a median of 11
+    of a 500-step budget, so the guard, not the benchmark, was being measured.
+    The bounded ceiling is instead anchored to the episode's own budget: it
+    fires only on a cycle that costs more than the remaining budget can afford
+    per remaining step, and it tightens as the budget is spent.
+
+    A bounded-but-spent episode (no steps left) has no allowance to derive;
+    the step budget is already the binding authority, so the guard continues
+    without judging the ratio. An episode missing either cap -- including every
+    caller that snapshots no step budget at all -- keeps the ratio check
+    exactly as it was.
     """
 
     def __init__(
@@ -179,14 +226,18 @@ class CostRateGuard:
         window: int = 10,
         ratio: float = 3.0,
         max_cycle_cost_micros: int | None = None,
+        bounded_cycle_margin: float = 4.0,
     ) -> None:
         if window < 1:
             raise ValueError("window must be positive")
         if ratio <= 1.0:
             raise ValueError("ratio must exceed 1.0")
+        if bounded_cycle_margin <= 0:
+            raise ValueError("bounded_cycle_margin must be positive")
         self._window = window
         self._ratio = ratio
         self._max_cycle = max_cycle_cost_micros
+        self._bounded_margin = bounded_cycle_margin
 
     def evaluate(self, snapshot: GuardInput) -> GuardVerdict:
         costs = snapshot.recent_costs_micros
@@ -195,6 +246,31 @@ class CostRateGuard:
                 kind="truncate",
                 code="cost-spike",
                 detail=f"one model cycle cost {costs[-1]} micro-USD (cap {self._max_cycle})",
+            )
+        bounded, ceiling = self._bounded_ceiling(snapshot)
+        if bounded:
+            if ceiling is not None and costs and costs[-1] > ceiling:
+                return GuardVerdict(
+                    kind="truncate",
+                    code="cost-spike",
+                    detail=(
+                        f"one model cycle cost {costs[-1]} micro-USD against the {ceiling} "
+                        "the episode's remaining cost budget allows per remaining step"
+                    ),
+                )
+            return GuardVerdict(
+                kind="continue",
+                code="cost-bounded",
+                detail=(
+                    "the episode's step budget is spent, so no per-cycle allowance is "
+                    "derived and the cost-rate ratio is not judged"
+                    if ceiling is None
+                    else (
+                        "the episode declares an explicit step budget and an explicit cost "
+                        f"cap, so the caps are the authority and the cost-rate ratio is not "
+                        f"judged; {ceiling} micro-USD per remaining step is affordable"
+                    )
+                ),
             )
         if len(costs) < 2 * self._window:
             return CONTINUE
@@ -219,6 +295,41 @@ class CostRateGuard:
                 ),
             )
         return CONTINUE
+
+    def _bounded_ceiling(self, snapshot: GuardInput) -> tuple[bool, int | None]:
+        """The per-cycle ceiling a doubly-capped episode is judged by.
+
+        ``(False, None)`` -- the episode lacks an explicit step budget or an
+        explicit provider-cost cap, so the ratio check applies as before.
+        ``(True, None)`` -- it is bounded, but its step budget is spent, so
+        there is no allowance to prorate and the step budget itself is the
+        binding authority.
+        ``(True, ceiling)`` -- the episode is bounded and still has steps to
+        spend: the ceiling is the FLOOR of the remaining cost budget divided by
+        the remaining steps, times the margin.
+
+        ``bounded_cycle_margin`` default (4.0) is sized from the runner's own
+        budget model: ``scripts/run_episode.py`` allows up to TWO model cycles
+        per step (``model_cycles = max_steps * 2``), so a per-cycle ceiling
+        prorated from a per-step allowance is unreachable below 2x, and the
+        second 2x absorbs a legitimately expensive cycle (a large frame set on
+        a long turn) without turning the ceiling into a proxy for the ratio it
+        replaced. A remaining budget already at or below zero yields a ceiling
+        at or below zero: the episode is at its cap, and ``BudgetCapGuard``
+        (which runs ahead of this guard in ``default_guards``) fires on that
+        same snapshot. Firing here too is deliberate -- this guard must bound a
+        runaway when it is used on its own.
+        """
+
+        usd_cap = _capped_usd_cap(snapshot)
+        if usd_cap is None or snapshot.max_steps is None:
+            return False, None
+        remaining_steps = snapshot.max_steps - snapshot.steps_taken
+        if remaining_steps <= 0:
+            return True, None
+        remaining_usd = usd_cap - snapshot.provider_cost_micros
+        ceiling = remaining_usd * self._bounded_margin // remaining_steps
+        return True, int(ceiling)
 
 
 # ---------------------------------------------------------------------------
@@ -420,7 +531,9 @@ def default_guards(config: Any) -> tuple[EpisodeGuard, ...]:
     read) so this module does not import ``episode`` and ``episode`` can
     import it. Every guard here is on by default because each one converts a
     reported-after-the-fact failure into a scored stop; the cost-rate cap is
-    the one that needs a configured number.
+    the one that needs a configured number, and its ratio check is judged only
+    for an episode that does not declare BOTH a step budget and a cost cap
+    (see :class:`CostRateGuard`).
     """
 
     max_cycle = getattr(config, "max_cycle_cost_micros", None)

--- a/tests/unit/evaluation/runner/conftest.py
+++ b/tests/unit/evaluation/runner/conftest.py
@@ -316,7 +316,10 @@ class ScriptedModel:
     ``histories`` keeps every ``EpisodeTurn`` sequence the runner handed over,
     so a test can assert what the model was shown. ``compact_on`` names call
     indices at which the model reports a ``CompactionRecord`` (as a real
-    client would after rebuilding its context).
+    client would after rebuilding its context). ``cost_micros`` is the bill for
+    one call -- a scalar, or a per-call series for a test that needs a provider
+    reporting a cost pattern (a prompt-cache miss, a runaway); a series shorter
+    than the script repeats its last value.
     """
 
     def __init__(
@@ -325,15 +328,24 @@ class ScriptedModel:
         *,
         error: BaseException | None = None,
         compact_on: Sequence[int] = (),
+        cost_micros: Sequence[int] | int = 7,
     ):
         self.script = list(script or ["finish"])
         self.error = error
         self.calls = 0
         self.compact_on = set(compact_on)
+        self.costs = [cost_micros] if isinstance(cost_micros, int) else list(cost_micros)
         self.histories: list[tuple[EpisodeTurn, ...]] = []
         # Overridable so a test can simulate a provider serving a route other
         # than the pinned one.
         self.route = ROUTE
+
+    def _bill(self) -> int:
+        """The cost of the call about to be made, from the scripted series."""
+
+        if not self.costs:
+            return 0
+        return self.costs[self.calls] if self.calls < len(self.costs) else self.costs[-1]
 
     async def decide(
         self, observation: Observation, history: Sequence[EpisodeTurn], **kwargs: Any
@@ -342,6 +354,7 @@ class ScriptedModel:
         if self.error is not None:
             raise self.error
         kind = self.script[self.calls] if self.calls < len(self.script) else "finish"
+        bill = self._bill()
         if kind == "reject":
             # A billed call whose reply failed parsing -- what the provider
             # client raises for the first paid episode's ``frame_id "1"``.
@@ -354,7 +367,7 @@ class ScriptedModel:
                 reply='{"actions": [{"kind": "click", "frame_id": "1"}]}',
                 route=self.route,
                 usage=ModelUsage(input_tokens=10, output_tokens=5),
-                cost_micros=7,
+                cost_micros=bill,
                 provider_request_id=f"rejected-{self.calls}",
                 prompt_cache_key="lop-eval-test",
             )
@@ -374,7 +387,7 @@ class ScriptedModel:
             action_batch=_batch(observation, kind),
             route=self.route,
             usage=ModelUsage(input_tokens=10, output_tokens=5),
-            cost_micros=7,
+            cost_micros=bill,
             prompt_cache_key="lop-eval-test",
             compaction=compaction,
         )

--- a/tests/unit/evaluation/runner/test_episode.py
+++ b/tests/unit/evaluation/runner/test_episode.py
@@ -695,6 +695,71 @@ async def test_a_waiting_model_runs_to_the_step_cap_under_default_guards(
 
 
 @pytest.mark.asyncio
+async def test_a_bounded_episode_is_not_cut_by_the_cost_rate_ratio(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """The regression this guards: an episode with a stated step budget AND an
+    explicit cost cap is judged by those caps, so a per-cycle cost jump (a
+    prompt-cache miss) no longer truncates it at the ratio's first full
+    windows -- it reaches the step budget instead."""
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    # Ten cheap cycles then a ten-cycle jump: a 3x ratio guard fires on this.
+    model = ScriptedModel(["step"] * 40, cost_micros=[7] * 20 + [70] * 4)
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        build_config(tmp_path, max_steps=24),
+        selector=selector(tmp_path),
+        model=model,
+        launch=lambda _: adapter,
+        rescue=_rescue_ok,
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "completed"
+    root = outcome.bundle_root
+    assert root is not None
+    assert verify_bundle(root).valid
+    steps = payloads(root, EnvironmentStepPayload)
+    assert len(steps) == 24
+    assert [step.truncation_reason for step in steps] == [None] * 23 + ["max-steps"]
+
+
+@pytest.mark.asyncio
+async def test_a_bounded_episode_still_stops_a_cycle_over_its_remaining_pace(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """The caps are the authority, and the prorated ceiling is part of them: a
+    cycle costing more than the remaining budget affords per remaining step is
+    still truncated, and before the ratio could fire (two cycles in)."""
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    # 300_000 micro-USD per cycle against a 1_000_000 cap over 8 steps: inside
+    # the pace at step 1 (400_000), over it at step 2 (266_666).
+    model = ScriptedModel(["step"] * 20, cost_micros=300_000)
+    runner = EpisodeRunner(
+        build_spec(episode_id, caps={"provider_usd_micros": 1_000_000}),
+        build_config(tmp_path, max_steps=8),
+        selector=selector(tmp_path),
+        model=model,
+        launch=lambda _: adapter,
+        rescue=_rescue_ok,
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "completed"
+    root = outcome.bundle_root
+    assert root is not None
+    assert verify_bundle(root).valid
+    steps = payloads(root, EnvironmentStepPayload)
+    assert len(steps) == 2
+    assert steps[-1].truncated is True
+    assert steps[-1].truncation_reason == "cost-spike"
+
+
+@pytest.mark.asyncio
 async def test_max_steps_truncation_names_its_reason(tmp_path: Path, episode_id: str) -> None:
     adapter = FakeAdapter(tmp_path, episode_id)
     runner = _runner(
@@ -715,11 +780,14 @@ async def test_budget_cap_truncates_not_cancels(tmp_path: Path, episode_id: str)
     """A reached provider-cost cap is enforced as a scored truncation, where
     before it was only reported as an overrun after the fact."""
 
-    # ScriptedModel bills 7 micro-USD per cycle: two cycles reach the cap.
+    # ScriptedModel bills 7 micro-USD per cycle: two cycles reach the cap. The
+    # step budget is sized so the CAP is what binds -- a cost guard that
+    # prorates a tiny 14-micro-USD allowance over ten steps would stop the
+    # episode as over-pace on its first cycle, which is a different test.
     adapter = FakeAdapter(tmp_path, episode_id)
     runner = EpisodeRunner(
         build_spec(episode_id, caps={"provider_usd_micros": 14}),
-        build_config(tmp_path, max_steps=10),
+        build_config(tmp_path, max_steps=4),
         selector=selector(tmp_path),
         model=ScriptedModel(["step"] * 8),
         launch=lambda _: adapter,

--- a/tests/unit/evaluation/runner/test_guards.py
+++ b/tests/unit/evaluation/runner/test_guards.py
@@ -25,6 +25,7 @@ from local_operator.evaluation.receipts import (
     BUDGET_RESOURCES,
     BudgetAuthorization,
     CappedAllowance,
+    UncappedAllowance,
 )
 from local_operator.evaluation.runner.guards import (
     RECENT_TURNS_WINDOW,
@@ -46,6 +47,25 @@ def _budget(**caps: int) -> BudgetAuthorization:
         allowances=tuple(
             CappedAllowance(
                 resource=resource, value=caps.get(resource, 1_000_000), reporting="optional"
+            )
+            for resource in BUDGET_RESOURCES
+        ),
+    )
+
+
+def _uncapped_budget() -> BudgetAuthorization:
+    """Every resource reported but none capped: the shape an episode has when
+    no cost authority was declared, so the ratio stays its only cost signal."""
+
+    return BudgetAuthorization(
+        episode_id="episode-1",
+        allowances=tuple(
+            UncappedAllowance(
+                resource=resource,
+                reason="reported, not capped, by the test",
+                authorized_by="test",
+                authorized_at_ms=1,
+                reporting="optional",
             )
             for resource in BUDGET_RESOURCES
         ),
@@ -173,6 +193,91 @@ def test_cost_rate_absolute_cap_fires_on_one_expensive_cycle() -> None:
     assert guard.evaluate(_snapshot(recent_costs_micros=(7, 100))).kind == "continue"
     verdict = guard.evaluate(_snapshot(recent_costs_micros=(7, 101)))
     assert verdict.kind == "truncate" and verdict.code == "cost-spike"
+
+
+#: Ten cheap cycles then ten at 9x: a ratio a default ``CostRateGuard`` fires on.
+_COST_SPIKE = (1,) * 10 + (9,) * 10
+
+
+def test_the_cost_rate_ratio_is_inapplicable_to_a_doubly_capped_episode() -> None:
+    """An episode that declares BOTH a step budget and a provider-cost cap is
+    judged by its caps: the ratio is not looked at, and the guard names the
+    skip rather than claiming to have judged it."""
+
+    guard = CostRateGuard()
+    verdict = guard.evaluate(_snapshot(recent_costs_micros=_COST_SPIKE, max_steps=500))
+    assert verdict.kind == "continue" and verdict.code == "cost-bounded"
+    assert "caps are the authority" in verdict.detail
+    # The very same series is a spike without the step budget...
+    assert guard.evaluate(_snapshot(recent_costs_micros=_COST_SPIKE)).kind == "truncate"
+    # ...and for a step-budgeted episode with no declared cost cap.
+    assert (
+        guard.evaluate(
+            _snapshot(recent_costs_micros=_COST_SPIKE, max_steps=500, budget=_uncapped_budget())
+        ).kind
+        == "truncate"
+    )
+
+
+def test_a_doubly_capped_episode_keeps_an_absolute_ceiling_prorated_from_its_budget() -> None:
+    """The ceiling is remaining budget / remaining steps x margin: a cycle
+    inside that pace continues, one past it truncates."""
+
+    guard = CostRateGuard()  # margin 4.0
+    snapshot = {
+        "provider_cost_micros": 1_000_000,
+        "max_steps": 110,
+        "steps_taken": 10,
+        "budget": _budget(provider_usd_micros=5_000_000),
+    }
+    # 4_000_000 micro-USD left over 100 remaining steps, x4 -> a 160_000 ceiling.
+    assert guard.evaluate(_snapshot(recent_costs_micros=(160_000,), **snapshot)).kind == "continue"
+    verdict = guard.evaluate(_snapshot(recent_costs_micros=(160_001,), **snapshot))
+    assert verdict.kind == "truncate" and verdict.code == "cost-spike"
+    assert "160000" in verdict.detail and "per remaining step" in verdict.detail
+    # Spending tightens the ceiling: 1_000_000 micro-USD left over 50 remaining
+    # steps is an 80_000 ceiling, so the same cycle now truncates.
+    spent = dict(snapshot, provider_cost_micros=4_000_000, steps_taken=60)
+    assert guard.evaluate(_snapshot(recent_costs_micros=(160_000,), **spent)).kind == "truncate"
+
+
+def test_the_bounded_episode_rule_leaves_the_configured_cycle_cap_in_force() -> None:
+    """``--max-cycle-usd`` only ADDS an absolute cap; the bounded-episode rule
+    must not swallow it."""
+
+    guard = CostRateGuard(max_cycle_cost_micros=100)
+    verdict = guard.evaluate(_snapshot(recent_costs_micros=(101,), max_steps=500, steps_taken=20))
+    assert verdict.kind == "truncate" and verdict.code == "cost-spike"
+    assert "cap 100" in verdict.detail
+
+
+def test_a_spent_step_budget_leaves_no_ceiling_to_derive() -> None:
+    """With no steps left there is no per-step allowance to prorate, and the
+    step budget -- not this guard -- is the authority about to fire."""
+
+    verdict = CostRateGuard().evaluate(
+        _snapshot(recent_costs_micros=(10**9,), max_steps=4, steps_taken=4)
+    )
+    assert verdict.kind == "continue" and verdict.code == "cost-bounded"
+    assert "step budget is spent" in verdict.detail
+
+
+def test_a_bounded_runaway_is_stopped_before_the_ratio_could_ever_fire() -> None:
+    """A genuine runaway inside a bounded episode is still truncated, and by
+    the ceiling rather than the ratio: the ratio needs twenty cycles, a 2 USD
+    cycle against a 60 USD budget over 500 steps is over pace on the second."""
+
+    verdict = CostRateGuard().evaluate(
+        _snapshot(
+            recent_costs_micros=(1_000, 2_000_000),
+            provider_cost_micros=2_001_000,
+            max_steps=500,
+            steps_taken=2,
+            budget=_budget(provider_usd_micros=60_000_000),
+        )
+    )
+    assert verdict.kind == "truncate" and verdict.code == "cost-spike"
+    assert "per remaining step" in verdict.detail
 
 
 def test_repeated_batch_ignores_observation_ids_but_requires_unchanged_state() -> None:
@@ -357,6 +462,7 @@ def test_default_guards_composition_and_config_knob() -> None:
     [
         lambda: CostRateGuard(window=0),
         lambda: CostRateGuard(ratio=1.0),
+        lambda: CostRateGuard(bounded_cycle_margin=0),
         lambda: RepeatedBatchGuard(repeats=1),
         lambda: NoChangeGuard(repeats=1),
         lambda: AskLoopGuard(asks=0),


### PR DESCRIPTION
# PR Description

## Summary of Changes

`CostRateGuard` truncated episodes on a **cost RATIO** — the last 10 model
cycles against the 10 before them — which cannot tell a legitimate expensive
cycle from a runaway one and is blind to how much of the episode's budget is
left. Its dominant false positive in practice is a **prompt-cache miss**: one
cycle's input price multiplies while the context is unchanged.

An OSWorld 2.0 batch (`batch-minimax-m3-*`, `--max-usd 60 --max-steps 500`)
was cut short by exactly that. The campaign's analysis reports a median of 11
executed steps against the 500-step budget with no episode ever emitting a
`finish`; what this PR verifies directly on the sealed evidence is below — all
three sampled episodes sealed with `truncation_reason: cost-spike`, fired by the
ratio, and the cost that tripped it is a cache miss rather than runaway context
(task_010, cycle 7: `cache_read_tokens` 0 → 2744 micro-USD, against 619–1014 for
the cycles whose prompt cache was read).

**The change**, in `local_operator/evaluation/runner/guards.py`:

- A `CostRateGuard` **ratio check is now inapplicable to an episode that
  declares BOTH an explicit step budget and an explicit provider-cost cap**.
  Those caps are the authority; the guard names the skip in its verdict
  (`code="cost-bounded"`) rather than pretending it judged, the same way the
  existing `cost-unreported` skip is disclosed.
- In that configuration the guard keeps an **absolute per-cycle ceiling
  prorated from what is actually left**: `remaining cost budget / remaining
  steps * bounded_cycle_margin` (margin 4.0). It tightens as the budget is
  spent, and fires under the existing `cost-spike` code.
- `GuardInput` gains `max_steps` (`None` when the caller states none), which the
  runner fills from `EpisodeConfig.max_steps`. The step budget reaches the guard
  through the snapshot rather than through guard state, so guards stay pure
  functions over `GuardInput` — the invariant this module is built on.

Deliberate constraints:

- **The configured absolute cap is untouched** and is still checked first, so
  `--max-cycle-usd` keeps its "adds an absolute cap" meaning.
- **The ratio still applies when either cap is missing** — including every
  caller that snapshots no step budget — so no existing caller silently loses
  the check it relied on.
- A bounded episode whose **step budget is spent** derives no ceiling; the step
  budget is already the authority about to fire (`max-steps` wins there anyway,
  by the runner's own precedence in `_execute`).
- The derived ceiling **fires under `cost-spike`**, not a new truncation code,
  so evidence consumers comparing runs on `truncation_reason` keep a stable
  vocabulary. The fires are distinguishable in the guard's `detail` ("... against
  the N the episode's remaining cost budget allows per remaining step") but NOT
  in the sealed bundle, which records only the reason — worth knowing when the
  next batch's reason distribution is read. Say the word if you would rather have
  a distinct code (`cost-pace`) and it is a two-line change.

Files:

- `local_operator/evaluation/runner/guards.py` — `GuardInput.max_steps`,
  `_capped_usd_cap()`, the bounded path in `CostRateGuard.evaluate`, and
  `CostRateGuard._bounded_ceiling`.
- `local_operator/evaluation/runner/episode.py` — the snapshot carries
  `self._config.max_steps`.
- `docs/benchmarks/osworld_2/README.md` — the `--max-steps` / `--max-usd` /
  `--max-cycle-usd` rows now say what each flag actually controls.
- tests: `test_guards.py`, `test_episode.py`, and a per-call `cost_micros`
  series on `ScriptedModel` (`conftest.py`) so a test can script a provider's
  cost pattern.

## Related Issue(s)

Related: no issue was filed; the defect was found by the OSWorld campaign
(`~/worktrees/osworld/runs/batch-minimax-m3-*`), which is why the evidence is a
replay of sealed episodes rather than a fresh synthetic series.

## Impact

- **Benchmark-only.** Nothing outside `local_operator/evaluation` reaches
  `CostRateGuard`/`default_guards`: only the episode runner does, and only
  `scripts/run_episode.py` builds an `EpisodeConfig`. The TUI, CLI, server and
  mobile paths do not import the evaluation package at all — verified by
  importing them and checking `sys.modules`:

  ```
  $ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -c \
      "import sys, local_operator.tui.app, local_operator.cli as cli; \
       print('local_operator.evaluation.runner.guards' in sys.modules, \
             'local_operator.evaluation.runner.episode' in sys.modules)"
  False False
  ```

  A normal interactive session cannot reach this code, so its behaviour is
  unchanged by construction.
- **Behaviour change for the runner**, and it is the point of the PR: a
  runner-driven episode states `max_steps` always (default 50) and any episode
  with a capped `provider_usd_micros` — which every `scripts/run_episode.py`
  invocation has, since `--max-usd` is what caps it — therefore now judges cost
  by the prorated ceiling rather than the ratio. An episode whose budget leaves
  the cost allowance **uncapped** keeps the ratio byte-for-byte as before.
- **Runaways are bounded earlier, never later.** A 2 USD/cycle runaway against
  the batch's own caps is stopped at step 1 by the ceiling where the pre-fix
  guard let it run to the 60 USD cap at step 30; the 18000 s wall still stops a
  cheap but slow episode (step 400 in both revisions); the sealed batch's own
  per-cycle baseline runs all 500 steps untouched in both.
- One visible consequence inside the suite: a cap that is *tiny* relative to the
  step budget now truncates as over-pace on the first cycle instead of running to
  the cap (`test_budget_cap_truncates_not_cancels` sized its budget at 14
  micro-USD over 10 steps). That test now states a step budget where the **cap**
  is the binding authority. This is the intended direction — an episode that
  cannot afford its step budget at the observed cycle price is money burned
  either way, and the ceiling stops it before the spend — but it is a real
  behaviour change and worth a reviewer's eye.
- No API, evidence-schema, performance or security implication. `GuardInput` is
  an internal runner object; no sealed bundle field changed shape.

## The evidence, on the sealed episodes (not a lookalike series)

Both runs replay the sealed `usage_cost` series and the sealed step/elapsed
timeline through the **real** guard set with the episode's real budget
(`--max-usd 60`, `--max-steps 500`, mirroring `scripts/run_episode.py::_budget`),
rebuilding exactly the snapshot `EpisodeRunner._evaluate_guards` builds. The
module path printed is what makes the comparison honest: the before-run loads
`~/local-operator` (whose `local_operator/evaluation` tree is byte-identical to
`origin/main`), the after-run loads this branch.

**Before** — every sampled episode is cut by the ratio, matching the sealed
`truncation_reason: cost-spike`:

```
guards module: /Users/damian/local-operator/local_operator/evaluation/runner/guards.py
task_010 (ep-4eba7f5513ae): 45 cycles / 40 steps -> FIRE at step 40 (cycle 45)
    CostRateGuard code=cost-spike
    the last 10 cycles cost 39170 micro-USD against 12504 for the 10 before (ratio 3.0)
task_015 (ep-ec836d34fdad): 61 cycles / 54 steps -> FIRE at step 54 (cycle 61)
    CostRateGuard code=cost-spike
    the last 10 cycles cost 43513 micro-USD against 13687 for the 10 before (ratio 3.0)
task_028 (ep-bbac57d594cd): 20 cycles / 16 steps -> FIRE at step 16 (cycle 20)
    CostRateGuard code=cost-spike
    the last 10 cycles cost 43349 micro-USD against 11475 for the 10 before (ratio 3.0)
```

(Ratios 3.13 / 3.18 / 3.78; task_028 fires at the earliest cycle the window
allows, 20. The cycles match the campaign's report exactly.)

**After** — no fire at any point in any of the three; every evaluation returns
the disclosed skip:

```
guards module: /private/tmp/lo-guard-fix/local_operator/evaluation/runner/guards.py
task_010 (ep-4eba7f5513ae): 45 cycles / 40 steps -> NO FIRE
    verdicts cycle:CostRateGuard=cost-bounded x45 / step:CostRateGuard=cost-bounded x40
task_015 (ep-ec836d34fdad): 61 cycles / 54 steps -> NO FIRE
    verdicts cycle:CostRateGuard=cost-bounded x61 / step:CostRateGuard=cost-bounded x54
task_028 (ep-bbac57d594cd): 20 cycles / 16 steps -> NO FIRE
    verdicts cycle:CostRateGuard=cost-bounded x20 / step:CostRateGuard=cost-bounded x16
```

**A runaway is still bounded, and earlier.** Same caps, synthetic series, the
real `default_guards` set, first truncation only:

```
AFTER   runaway 2 USD/cycle    truncated at step   1 by CostRateGuard code=cost-spike
          one model cycle cost 2000000 micro-USD against the 464929 the episode's
          remaining cost budget allows per remaining step
AFTER   slow burn 0.5 USD/cycle truncated at step  1 by CostRateGuard code=cost-spike
BEFORE  runaway 2 USD/cycle    truncated at step  30 by BudgetCapGuard code=budget-cap
          provider_usd_micros reached its cap (60000000 >= 60000000)
BEFORE  slow burn 0.5 USD/cycle truncated at step 120 by BudgetCapGuard code=budget-cap
BOTH    cheap, 45s per step    truncated at step 400 by BudgetCapGuard code=budget-cap
          wall_milliseconds reached its cap (18000000 >= 18000000)
BOTH    sealed baseline 1.4 mUSD  ran all 500 steps without a truncation
```

So the episode's USD cap and the wall guard both still bind, a normal-cost
episode is not truncated at all, and the ceiling is strictly tighter than the
cap it sits in front of (the runaway costs $2 instead of $60).

## Testing Details

New, in `tests/unit/evaluation/runner/test_guards.py`:

- the ratio is inapplicable to a doubly-capped episode, and **the same series
  still fires** without the step budget and with a step budget whose cost
  allowance is uncapped (both halves of the AND);
- the prorated ceiling: a cycle at the ceiling continues, one micro-USD over it
  truncates, and the same cycle truncates once the budget is more than half
  spent (the ceiling tightens);
- the configured `max_cycle_cost_micros` still fires on a doubly-capped episode;
- a spent step budget derives no ceiling and says so;
- a runaway is truncated by the ceiling on its second cycle — before the ratio's
  two full windows could ever exist;
- `bounded_cycle_margin=0` is refused at construction.

New, in `tests/unit/evaluation/runner/test_episode.py` (through the real
runner, not the guard in isolation):

- a doubly-capped episode with a ratio-firing cost jump **reaches its 24-step
  budget** with `truncation_reason: max-steps` where it used to seal
  `cost-spike`;
- a bounded episode billing over its remaining pace is **still** truncated, as
  `cost-spike`, at the computed step (2 of 8).

`ScriptedModel` gained `cost_micros` (scalar or per-call series) so those tests
can script a provider's cost pattern; every pre-existing caller keeps the 7
micro-USD-per-cycle scalar.

Gate output, head `08887feeb`:

```
$ .venv/bin/python -m flake8 .                                   # clean
$ uvx --from black==26.1.0 black --check .                       # 1231 files unchanged
$ uvx isort==5.13.2 --check .                                    # clean (2 files skipped)
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .    # 0 errors, 0 warnings
$ .venv/bin/python -m pytest tests/unit/evaluation -q            # 1349 passed, 1 skipped
$ .venv/bin/python -m pytest tests/unit -q                       # 18603 passed, 18 skipped (22:55)
```

The full-tree run is disclosed rather than hidden: this host was carrying six
concurrent whole-suite runs (load average 135-157) on account of sibling
worktrees, so the suite took far longer than the documented ~3.5 min and
finished with the repo's own default `-n auto` (no deselection, no explicit
`-n`).

## Review rounds

Agent review, QA and (none needed — no user-visible surface) design rounds to
follow on this head; this section is updated with the verdicts and their links
as they land.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (no new input, no new I/O path; the guard stays a pure function).
- [x] I have linked all related issues (none; reported by the OSWorld campaign).

## Not addressed

- **Deferred to the next batch, by design**: with the cost spike no longer
  firing at ~20 steps, `RepeatedBatchGuard`/`NoChangeGuard` become the next
  truncation frontier on this benchmark. The truncation-reason distribution
  should shift, not vanish — the same batch already seals `repeated-batch` fires
  alongside the `cost-spike` ones, so the floundering guards are live and their
  thresholds deserve their own look once the batch can run past ~20 steps.
- `CostRateGuard`'s ratio is untouched for every case outside the doubly-capped
  one; if the ratio is wrong for a *different* reason (its 10-cycle window, its
  3.0 threshold) that is a separate change with its own evidence.

Release: patch — An episode declaring both a step budget and a capped USD budget is no longer truncated by the cost-ratio guard, so long-horizon benchmark episodes reach `finish` instead of dying on exhaustion (an absolute per-cycle ceiling derived from remaining budget ÷ remaining steps still bounds them).
