### PR TITLE
fix(tui): anchor a live tool row and the band's clock to the producer's start instant

### DIFF
--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -386,6 +386,39 @@ class _PlannedCall:
     resources: tuple[str, ...] | None = None
 
 
+def _tool_start_event(
+    *,
+    tool_call_id: str,
+    tool_name: str,
+    args: dict[str, Any] | None,
+    intent: str | None,
+) -> ToolExecutionStartEvent:
+    """Build a ``tool_execution_start`` stamped with WHEN the call began.
+
+    One factory for the three sites that dispatch a tool — the parallel
+    ``runner``, its ``interruptible_runner`` sibling and the eval bridge —
+    because the stamp is the only thing a late-attaching viewer can seed a
+    live row's clock from, and a site that forgot it would leave that row
+    counting from the switch. Nothing else in this file would notice the
+    drift, so the three sites deliberately do not hold three copies of the
+    construction.
+
+    Stamped with ``time.time()``, not ``time.monotonic()``, because the value
+    crosses a process boundary: ``live_events`` is serialized onto the attach
+    wire and into checkpoints, where a monotonic reading means nothing.
+    Readers convert the AGE once and tick on their own monotonic clock (see
+    ``ToolCard.restore``), so a system-clock adjustment after the seed cannot
+    move a counter that is already running.
+    """
+    return ToolExecutionStartEvent(
+        tool_call_id=tool_call_id,
+        tool_name=tool_name,
+        args=args or {},
+        intent=intent,
+        started_at_epoch=time.time(),
+    )
+
+
 def _batches_shared(item: _PlannedCall) -> bool:
     """Whether this call may run alongside its neighbours in one batch.
 
@@ -2034,7 +2067,7 @@ class AgentLoop:
                         return failure.model_dump(mode="json")
                     started = time.monotonic()
                     queue.put_nowait(
-                        ToolExecutionStartEvent(
+                        _tool_start_event(
                             tool_call_id=nested.id,
                             tool_name=name,
                             args=planned.args,
@@ -2259,7 +2292,7 @@ class AgentLoop:
                 # tool row with the intent — the TUI's argument summary scans
                 # values for a row identity — reinstating on the card the
                 # duplication that splitting fact from claim removes.
-                ToolExecutionStartEvent(
+                _tool_start_event(
                     tool_call_id=item.call.id,
                     tool_name=tool_name,
                     args=item.args,
@@ -2288,7 +2321,7 @@ class AgentLoop:
             started_at = time.monotonic()
             started_at_by_slot[slot] = started_at
             await queue.put(
-                ToolExecutionStartEvent(
+                _tool_start_event(
                     tool_call_id=item.call.id,
                     tool_name=tool_name,
                     args=item.args,

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -405,7 +405,10 @@ def _tool_start_event(
 
     Stamped with ``time.time()``, not ``time.monotonic()``, because the value
     crosses a process boundary: ``live_events`` is serialized onto the attach
-    wire and into checkpoints, where a monotonic reading means nothing.
+    wire, where a monotonic reading means nothing. It deliberately does NOT
+    cross the durable boundary — ``FrontendSessionState.checkpoint()`` strips
+    the folded map — so this stamp reaches an ATTACHING viewer and never a
+    resumed session; a reader must not look for it as durable state.
     Readers convert the AGE once and tick on their own monotonic clock (see
     ``ToolCard.restore``), so a system-clock adjustment after the seed cannot
     move a counter that is already running.

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1387,6 +1387,31 @@ class ToolExecutionStartEvent(AgentEvent[Literal["tool_execution_start"]]):
     tool_name: str
     args: dict[str, Any] = Field(default_factory=dict)
     intent: str | None = None
+    #: The WALL-CLOCK instant this call began executing, stamped by the
+    #: producer because no consumer can recover it afterwards.
+    #:
+    #: Without it a frontend has only its own arrival instant, and the only
+    #: frontend that notices is one that attaches to work already in flight —
+    #: a sidebar switch back to a conversation whose tool is still running, a
+    #: re-attach, a `/resume` onto a live turn. Those widgets are constructed
+    #: at the switch, so the live row's elapsed clock restarts there and counts
+    #: up from a zero belonging to the viewer rather than to the call: the
+    #: reported frame was a `bash` row reading `27s` and this event's true
+    #: start being half an hour earlier.
+    #:
+    #: ``None`` is a REAL answer rather than a missing value to be defaulted.
+    #: The field is additive, so every event an older runtime produced lacks
+    #: it, and a consumer that substituted its own fold or arrival instant
+    #: would print an age it invented — exactly the failure the widgets' blank
+    #: column exists to refuse. Consumers withhold the clock instead.
+    #:
+    #: Epoch rather than monotonic on purpose: this value crosses a process
+    #: boundary (``live_events`` is serialized onto the attach wire and into
+    #: checkpoints), and a monotonic reading is not comparable across
+    #: processes. Readers convert the AGE once and then tick on their own
+    #: monotonic clock, so a later system-clock adjustment cannot move a
+    #: counter that is already running.
+    started_at_epoch: float | None = None
 
 
 class ToolExecutionUpdateEvent(AgentEvent[Literal["tool_execution_update"]]):

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1406,9 +1406,12 @@ class ToolExecutionStartEvent(AgentEvent[Literal["tool_execution_start"]]):
     #: column exists to refuse. Consumers withhold the clock instead.
     #:
     #: Epoch rather than monotonic on purpose: this value crosses a process
-    #: boundary (``live_events`` is serialized onto the attach wire and into
-    #: checkpoints), and a monotonic reading is not comparable across
-    #: processes. Readers convert the AGE once and then tick on their own
+    #: boundary (``live_events`` is serialized onto the attach wire), and a
+    #: monotonic reading is not comparable across processes. It does NOT cross
+    #: the durable boundary: ``FrontendSessionState.checkpoint()`` strips the
+    #: folded map, so a resumed session never sees a stamp and withholds, which
+    #: is why absence above is described as a real answer rather than an
+    #: oversight. Readers convert the AGE once and then tick on their own
     #: monotonic clock, so a later system-clock adjustment cannot move a
     #: counter that is already running.
     started_at_epoch: float | None = None

--- a/local_operator/session/attached.py
+++ b/local_operator/session/attached.py
@@ -2819,6 +2819,52 @@ class AttachedSession:
             return set()
         return self._unanswered_tail_call_ids()
 
+    def live_tool_start_epochs(self) -> dict[str, float]:
+        """The instant each in-flight call began, keyed by call id.
+
+        Answered from the folded state this viewer already keeps, which is the
+        same fold the local owner keeps over its own events — one rule, two
+        transports — so a switch between a conversation this process owns and
+        one it merely watches seeds the same anchor.
+
+        The values arrive as ``ToolExecutionStartEvent.started_at_epoch`` on
+        the wire (and in the attach seed's ``live_events``), which is why the
+        producer stamps them rather than this side guessing: an attached
+        viewer has no access to the executor's clock, and a value it invented
+        from its own arrival would be the fabricated age the row's blank
+        column exists to refuse. A call absent from the map has no known
+        start; callers withhold the clock for it.
+
+        Empty rather than raising while the store is unsynchronized: a facade
+        before its first sync has no live calls to date, and the reader probes
+        this through ``getattr``. Through ``getattr`` for the store too — the
+        protocol conformance suite builds both session shapes with ``__new__``,
+        which is exactly what makes a member answering off ``self._frontend_store``
+        raise there rather than report "nothing yet".
+        """
+        store = getattr(self, "_frontend_store", None)
+        if store is None:
+            return {}
+        return store.live_tool_start_epochs()
+
+    def activity_phase_clock(self) -> tuple[str, float | None]:
+        """The working line's folded phase, and the instant that phase began.
+
+        Folded from the same events this viewer already receives, so a band
+        drawn here dates its ``thinking``/``responding``/``composing`` arm from
+        the producer's phase edge rather than from the moment the viewer
+        arrived — the half of the operator's report that a per-call stamp
+        cannot answer, since a model call in flight is not a tool call.
+
+        ``("", None)`` before the first sync: no phase matches, and the reader
+        withholds the clock instead of counting from its own attach. Read
+        through ``getattr`` for the reason the sibling accessor above states.
+        """
+        store = getattr(self, "_frontend_store", None)
+        if store is None:
+            return ("", None)
+        return store.activity_phase_clock()
+
     @property
     def display_history_revision(self) -> int:
         return self._display_revision

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -3586,12 +3586,21 @@ class FrontendStateStore:
         cannot answer that one because there is no call behind it.
 
         The rule is the phone projection's (``mobile/projection.py``
-        ``_derive_activity``) because both surfaces draw the same row and a
-        second rule would be a second answer. It is deliberately narrow: a
-        phase RESTARTS the zero only when it begins a kind of work, never when
-        it merely relabels one — the composed batch is the case that shows the
-        difference, since it announces a call per fragment and all of them
-        belong to one dictation.
+        ``_derive_activity``) for the PHASES it names, because both surfaces
+        draw the same row and a second rule would be a second answer. It is
+        deliberately narrow: a phase RESTARTS the zero only when it begins a
+        kind of work, never when it merely relabels one — the composed batch
+        is the case that shows the difference, since it announces a call per
+        fragment and all of them belong to one dictation.
+
+        It is one rule in two PLACES, not one shared implementation, and the
+        ``tool_execution_end`` arm below is where they part: the fold restarts
+        only when the batch has no siblings left (D9 — a narrowed label must
+        not report a shed sibling's age), while the phone projection restarts
+        unconditionally. The divergence is deliberate and is the TUI's D9
+        reading; it is recorded here rather than left for someone to find by
+        diffing the two files, and a change to either side has to be checked
+        against the other.
 
         The ``running`` phase is folded so the end rule can tell a batch that
         still has siblings from one that has just lost its last call. Its

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -42,6 +42,7 @@ from pydantic import (
 )
 from pydantic_core import PydanticSerializationError, to_jsonable_python
 
+from local_operator.harness.intent import ACTIVITY_RESPONDING, ACTIVITY_THINKING
 from local_operator.harness.subagent import TRAJECTORY_CAP as _TRAJECTORY_CAP
 from local_operator.harness.types import (
     AgentEndEvent,
@@ -49,7 +50,13 @@ from local_operator.harness.types import (
     AgentStartEvent,
     CompactionEndEvent,
     MessageEndEvent,
+    MessageStartEvent,
+    MessageUpdateEvent,
     ModelSpec,
+    ToolCallComposeEvent,
+    ToolExecutionEndEvent,
+    ToolExecutionStartEvent,
+    TurnEndEvent,
     Usage,
 )
 from local_operator.mcp.grants import GRANT_SUBCOMMANDS as _GRANT_SUBCOMMANDS
@@ -60,6 +67,20 @@ from local_operator.tui.costs import cost_summary, job_cost, turn_cost
 FRONTEND_STATE_VERSION = 1
 FRONTEND_CAPABILITY = "tui_state_v1"
 FRONTEND_CHECKPOINT_CUSTOM_TYPE = "frontend_state_checkpoint_v1"
+
+#: The phase names ``FrontendSessionState.activity_phase`` folds to.
+#:
+#: The reader matches a folded phase against the phase it DERIVED by string
+#: equality, so these have to be the same words the working line's own
+#: vocabulary uses rather than a private enum: `thinking` and `responding` are
+#: imported from ``harness/intent.py`` (the module that owns the label words)
+#: rather than restated here, and `composing`/`running` name the two states the
+#: tool ledger itself uses. A rename in either place must move together or the
+#: reader silently stops matching and every clock goes blank.
+ACTIVITY_PHASE_THINKING = ACTIVITY_THINKING
+ACTIVITY_PHASE_RESPONDING = ACTIVITY_RESPONDING
+ACTIVITY_PHASE_COMPOSING = "composing"
+ACTIVITY_PHASE_RUNNING = "running"
 
 #: How many per-call billing receipts ``usage_components`` retains.
 #:
@@ -223,6 +244,13 @@ _SHAREABLE_STATE_FIELDS = frozenset(
         "context_window",
         "context_is_estimate",
         "cumulative_parent_cost",
+        # The working line's phase and its zero are read PER EVENT that moves the
+        # turn (`OperatorApp._current_activity`), which is far too hot for the
+        # whole-state clone. Both are admitted on the set's own two tests: a
+        # `str` and a `float | None`, so nothing of the store's can be reached
+        # through them.
+        "activity_phase",
+        "activity_phase_started_at",
     }
 )
 #: Wire budget for the in-flight seed's retained tool results.
@@ -1585,6 +1613,40 @@ class FrontendSessionState(BaseModel):
     #: tolerant. One value per user prompt, not per compaction continuation.
     last_turn_outcome: Literal["completed", "aborted", "error", ""] = ""
     activity_started_at: float | None = None
+    #: Which kind of work the working line is naming, and when that kind began.
+    #:
+    #: The terminal's band and the phone's working line both key their elapsed
+    #: number to the PHASE (`thinking`/`responding`/`composing`/`running`) rather
+    #: than to the label, because a batch shedding a call or a tool name arriving
+    #: in fragments must not restart a clock that answers "has this been stuck".
+    #: That phase zero lived only in whoever built the widget, so a frontend that
+    #: joined mid-turn counted from its own arrival — the operator's report
+    #: names the thinking indicator as well as the tool row, which a per-call
+    #: stamp alone cannot fix. `running` is folded here too, but its clock is
+    #: still taken from the live cards themselves (the oldest of their starts),
+    #: which is a finer anchor than any phase edge.
+    #:
+    #: ``""`` is "no phase": the turn has not started, or has ended, and a
+    #: frontend must not match it against anything it derives.
+    activity_phase: str = ""
+    activity_phase_started_at: float | None = None
+    #: ``tool_call_id -> started_at_epoch`` for the calls executing RIGHT NOW.
+    #:
+    #: Folded from ``ToolExecutionStartEvent.started_at_epoch`` so a frontend
+    #: that attaches mid-turn can seed a live row's clock from the call's true
+    #: age instead of its own arrival. Keyed by call rather than as one scalar
+    #: because a batch has several: the row and the band must agree on ONE
+    #: anchor, and only the per-call map can tell them what the oldest live
+    #: call's age actually is.
+    #:
+    #: TRANSIENT by construction and bounded by the live batch: an entry is
+    #: popped by the call's own end and the whole map is cleared at
+    #: ``agent_start``/``agent_end``, so it neither grows with the conversation
+    #: nor outlives the turn. A call whose producer sent no epoch is
+    #: deliberately ABSENT rather than stamped with the fold instant — see
+    #: ``_fold_live_tool_starts``. It is stripped from the durable checkpoint
+    #: for the same reason ``live_events`` is: there is nothing to restore.
+    live_tool_started_at: dict[str, float] = Field(default_factory=dict)
     active_duration_s: float = 0.0
     current_turn_accrued_cost: float = 0.0
     queued_steering: list[dict[str, Any]] = Field(default_factory=list)
@@ -2777,6 +2839,34 @@ class FrontendStateStore:
             )
         return getattr(self._state, name)
 
+    def live_tool_start_epochs(self) -> dict[str, float]:
+        """A COPY of the live-call start map, without cloning the whole state.
+
+        The sibling of :meth:`read_field`, which cannot serve this one: that
+        allow-list is restricted to deeply immutable scalars precisely because
+        it hands out the store's OWN object, and this is a mutable mapping.
+
+        Copying is what the per-call caller can afford, and asking for ``state``
+        instead is what it cannot: ``state`` deep-copies every job, usage
+        component and trajectory row, which profiling one sidebar navigation
+        measured at ~30 ms of a 135 ms frame. This is read once per tool start
+        and once per switch, so the copy is a handful of floats.
+        """
+        return dict(self._state.live_tool_started_at)
+
+    def activity_phase_clock(self) -> tuple[str, float | None]:
+        """The working line's folded phase and when it began, read cheaply.
+
+        One call rather than two :meth:`read_field` reads because the pair is
+        only ever consumed together — the reader compares the phase and uses
+        the instant in the same expression — and a caller that could read them
+        apart could pair a phase with the previous phase's zero.
+        """
+        return (
+            self.read_field("activity_phase"),
+            self.read_field("activity_phase_started_at"),
+        )
+
     def read_label(self, name: str) -> str:
         """One DERIVED label of the state, WITHOUT cloning the whole state.
 
@@ -3298,6 +3388,27 @@ class FrontendStateStore:
                 if bool(getattr(session, "is_streaming", False))
                 else None
             ),
+            # The live-batch anchor is carried on the same gate as the turn's
+            # own start instant, and for the same reason: both answer "how long
+            # has the work in flight been going", and neither means anything
+            # once the turn is over. See ``_fold_live_tool_starts``.
+            live_tool_started_at=(
+                current.live_tool_started_at
+                if bool(getattr(session, "is_streaming", False))
+                else {}
+            ),
+            # The working line's phase and its zero ride the same gate. A
+            # non-streaming session has no phase, and leaving a stale one in
+            # place would let a frontend that has just settled match it and
+            # count from a zero belonging to a turn that is over.
+            activity_phase=(
+                current.activity_phase if bool(getattr(session, "is_streaming", False)) else ""
+            ),
+            activity_phase_started_at=(
+                current.activity_phase_started_at
+                if bool(getattr(session, "is_streaming", False))
+                else None
+            ),
             queued_steering=queued,
             jobs=jobs,
             todos=todos,
@@ -3419,11 +3530,139 @@ class FrontendStateStore:
             )
         return self.mutate(model_catalogue=rows)
 
+    def _fold_live_tool_starts(self, event: AgentEvent[Any]) -> dict[str, Any]:
+        """Track the start epoch of every call executing RIGHT NOW.
+
+        The map a mid-turn joiner seeds a live row's clock from. The producer
+        stamped the instant on its own ``tool_execution_start`` (see
+        ``ToolExecutionStartEvent.started_at_epoch``); this keeps those stamps
+        keyed by call so the row and the band can share one anchor, and drops
+        them the moment the call ends so nothing about a finished call is
+        offered as a start.
+
+        Two deliberate omissions, both of which keep this from becoming an
+        invention:
+
+        * a ``tool_execution_start`` carrying NO epoch contributes no entry.
+          The tempting default — the fold's own ``now`` — is precisely the
+          fabricated zero this whole path exists to refuse: for an attached
+          viewer it is its arrival instant dressed as the call's start, and it
+          would print a plausible wrong age where the widget's blank column
+          currently tells the truth.
+        * the map is cleared at BOTH ends of the turn (``agent_start`` and
+          ``agent_end``) rather than left to the individual ends. A turn that
+          dies without emitting every ``tool_execution_end`` is exactly the
+          case that leaves a stale entry, and a stale entry is worse than none:
+          a later turn's row would seed from it.
+        """
+        state = self._state
+        if isinstance(event, (AgentStartEvent, AgentEndEvent)):
+            return {"live_tool_started_at": {}} if state.live_tool_started_at else {}
+        if isinstance(event, ToolExecutionStartEvent):
+            epoch = getattr(event, "started_at_epoch", None)
+            if not isinstance(epoch, (int, float)):
+                return {}
+            live = dict(state.live_tool_started_at)
+            live[event.tool_call_id] = float(epoch)
+            return {"live_tool_started_at": live}
+        if isinstance(event, ToolExecutionEndEvent):
+            if event.tool_call_id not in state.live_tool_started_at:
+                return {}
+            live = dict(state.live_tool_started_at)
+            del live[event.tool_call_id]
+            return {"live_tool_started_at": live}
+        return {}
+
+    def _fold_activity_phase(self, event: AgentEvent[Any], now: float) -> dict[str, Any]:
+        """Fold the PHASE the working line is in, and when that phase began.
+
+        The band's clock is keyed to the phase, not to the label — a batch
+        shedding a call, a tool name arriving in fragments and an intent being
+        revised all change the label without the agent having changed what it
+        is doing — and the phase's zero used to exist only inside whichever
+        widget happened to be constructed. A frontend that joins mid-turn was
+        therefore always at zero: the operator's report names the thinking
+        indicator restarting alongside the tool row, and a per-call stamp
+        cannot answer that one because there is no call behind it.
+
+        The rule is the phone projection's (``mobile/projection.py``
+        ``_derive_activity``) because both surfaces draw the same row and a
+        second rule would be a second answer. It is deliberately narrow: a
+        phase RESTARTS the zero only when it begins a kind of work, never when
+        it merely relabels one — the composed batch is the case that shows the
+        difference, since it announces a call per fragment and all of them
+        belong to one dictation.
+
+        The ``running`` phase is folded so the end rule can tell a batch that
+        still has siblings from one that has just lost its last call. Its
+        clock does NOT come from here: a running batch is measured from the
+        OLDEST live card's own start, which is finer than any phase edge and is
+        what keeps a narrowed label from reporting a shed sibling's age.
+
+        Any mismatch between this phase and the one the app derives is handled
+        at the reader (``OperatorApp._current_activity``), which withholds the
+        clock rather than passing a zero that does not belong: a facade with no
+        fold, a legacy producer and a compaction fallback all stay blank
+        instead of inventing an age.
+        """
+        state = self._state
+        phase = state.activity_phase
+
+        def into(new_phase: str) -> dict[str, Any]:
+            return {"activity_phase": new_phase, "activity_phase_started_at": now}
+
+        if isinstance(event, (AgentStartEvent, TurnEndEvent)):
+            # A turn boundary and a per-model-turn boundary are both the start
+            # of waiting on a model call: between two tool batches, and before
+            # the first, that IS what the turn is doing.
+            return into(ACTIVITY_PHASE_THINKING)
+        if isinstance(event, AgentEndEvent):
+            return {"activity_phase": "", "activity_phase_started_at": None}
+        if isinstance(event, ToolCallComposeEvent):
+            # One batch, one zero: a three-call batch announces three calls in
+            # one dictation, and restarting per announcement would show the
+            # same "still composing" state counting from zero three times.
+            return {} if phase == ACTIVITY_PHASE_COMPOSING else into(ACTIVITY_PHASE_COMPOSING)
+        if isinstance(event, ToolExecutionStartEvent):
+            return into(ACTIVITY_PHASE_RUNNING)
+        if isinstance(event, ToolExecutionEndEvent):
+            # Waiting on the model again — but only once the batch is done. A
+            # batch that still has a sibling executing is still `running`, and
+            # restarting there would reset the number the surviving row's
+            # label still claims.
+            remaining = set(state.live_tool_started_at) - {event.tool_call_id}
+            return into(ACTIVITY_PHASE_THINKING) if not remaining else {}
+        if isinstance(event, MessageStartEvent):
+            # A model call in flight with nothing streamed yet. The loop yields
+            # this from a placeholder at the top of EVERY provider call, so
+            # keying prose here would claim text for a tool-only turn; the
+            # first non-empty delta below is the transition to `responding`.
+            if str(getattr(event.message, "role", "") or "") == "assistant":
+                return into(ACTIVITY_PHASE_THINKING)
+            return {}
+        if isinstance(event, MessageUpdateEvent):
+            if event.delta and phase == ACTIVITY_PHASE_THINKING:
+                return into(ACTIVITY_PHASE_RESPONDING)
+            return {}
+        if isinstance(event, MessageEndEvent):
+            # Ends the PROSE phase only. For a tool-calling turn this arrives
+            # after the compose events, and the composed call is still what
+            # the turn is doing, so anything but `responding` is left alone.
+            if (
+                str(getattr(event.message, "role", "") or "") == "assistant"
+                and phase == ACTIVITY_PHASE_RESPONDING
+            ):
+                return into(ACTIVITY_PHASE_THINKING)
+            return {}
+        return {}
+
     def observe_event(self, session: Any, event: AgentEvent[Any]) -> FrontendUpdate | None:
         now = time.time()
         state = self._state
         changes: dict[str, Any] = {}
         self._fold_live_event(event)
+        changes.update(self._fold_live_tool_starts(event))
+        changes.update(self._fold_activity_phase(event, now))
         if isinstance(event, AgentStartEvent):
             changes.update(
                 streaming=True,
@@ -3632,6 +3871,16 @@ class FrontendStateStore:
         durable = state.model_copy(
             update={
                 "live_events": [],
+                # The live-batch anchor is transient by construction, exactly
+                # like the seed above: it describes calls executing RIGHT NOW
+                # in this process, and there is nothing for a later reader to
+                # restore from it — a resumed conversation's in-flight call is
+                # re-stamped by the producer that is still running it. Its
+                # scalar neighbours (`activity_started_at`, `activity_phase`)
+                # are deliberately NOT stripped: they are O(1) values the
+                # turn-end fold and the non-streaming gate already clear, so
+                # there is nothing here to make durable or to withhold.
+                "live_tool_started_at": {},
                 "jobs": [
                     job.model_copy(
                         update={

--- a/local_operator/session/protocol.py
+++ b/local_operator/session/protocol.py
@@ -814,6 +814,48 @@ class ViewerSessionProtocol(SessionProtocol, Protocol):
         """
         ...
 
+    def live_tool_start_epochs(self) -> dict[str, float]:
+        """Wall-clock start instant per call executing RIGHT NOW, keyed by id.
+
+        The timestamped sibling of :meth:`executing_display_tool_ids`, and the
+        one thing that makes a live row's elapsed clock survive a change of
+        viewer. Both surfaces answer it off the SAME folded fact — the
+        ``tool_execution_start`` epochs the producer stamped (see
+        ``ToolExecutionStartEvent.started_at_epoch``) — so a sidebar switch
+        seeds the replayed row and the band's phase from one anchor rather
+        than from whenever each of them was painted.
+
+        Declared here beside the id accessors it accompanies, and implemented
+        by BOTH session shapes: a local owner answers from its own fold (it is
+        the producer, so the instants are its own), and an attached viewer
+        answers from the same fold applied to the events it received. A call
+        whose start carried no epoch — a legacy producer, an older runtime —
+        is deliberately ABSENT from the map rather than present with a
+        guessed value, so consumers withhold the clock instead of printing an
+        age nobody measured. An empty map is therefore a valid, supported
+        answer and not an error.
+        """
+        ...
+
+    def activity_phase_clock(self) -> tuple[str, float | None]:
+        """The folded working-line phase, and the instant that phase began.
+
+        The companion :meth:`live_tool_start_epochs` cannot supply, and the
+        reason the operator's report names TWO clocks rather than one: the
+        thinking indicator has no tool call behind it, so there is no id to key
+        an epoch by and nothing for a per-call map to answer with. The phase is
+        what the band's number is anchored to, so the phase's own start is what
+        has to survive a switch.
+
+        Read together on purpose. The consumer's rule is "use this instant only
+        when this phase is the phase I just derived", and two independent reads
+        could pair one phase with the previous phase's zero — a wrong age that
+        would look perfectly plausible. A facade with no fold answers
+        ``("", None)``, which matches nothing and therefore withholds the
+        clock rather than inventing one.
+        """
+        ...
+
     async def ensure_display_anchor(self, anchor: str) -> bool:
         """Load whichever page contains ``anchor``; False when it is gone."""
         ...

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -3561,6 +3561,49 @@ class Session:
             return set()
         return unanswered_tail_call_ids(self._context.messages)
 
+    def live_tool_start_epochs(self) -> dict[str, float]:
+        """The instant each in-flight call began, keyed by call id.
+
+        The local owner answers from its own folded state, which is the same
+        fold an attached viewer applies to the events it receives — one rule,
+        two transports — and this process is the PRODUCER of those stamps, so
+        the instants are the executor's own rather than a reconstruction.
+
+        Empty rather than raising when the store has not been built: the
+        accessor is read through ``getattr`` by hosts that may hold a reduced
+        facade, and "no live calls" is the honest answer for a session that
+        has never published state. Callers must treat a missing call id the
+        same way: withholding the clock, never defaulting the epoch.
+
+        Through the STORE, not ``frontend_state``: this runs once per tool
+        start on the event loop, and the property deep-copies the whole state
+        for a question about one small dict.
+        """
+        store = getattr(self, "_frontend_state_store", None)
+        if store is None:
+            return {}
+        return store.live_tool_start_epochs()
+
+    def activity_phase_clock(self) -> tuple[str, float | None]:
+        """The working line's folded phase, and the instant that phase began.
+
+        The local owner is the PRODUCER of the events this is folded from, so
+        the instants are its own rather than a reconstruction — which is why
+        the same phase a viewer reads off the wire is available here without one.
+
+        Read through the store rather than ``frontend_state``: the app asks this
+        on every event that moves the turn, and the property deep-copies every
+        job, usage row and trajectory for two scalars.
+
+        ``("", None)`` when the store has not been built — a facade with no
+        fold matches no phase, and the consumer withholds the clock rather than
+        counting from its own arrival.
+        """
+        store = getattr(self, "_frontend_state_store", None)
+        if store is None:
+            return ("", None)
+        return store.activity_phase_clock()
+
     def context_breakdown(self) -> dict[str, int]:
         """On-demand token breakdown for the context the next request sends.
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -35025,10 +35025,12 @@ class OperatorApp(App[None]):
         # `on_compaction_started` and `on_retry_started` set this label and
         # re-derive; the fold models no compaction or retry edge, so its phase
         # is still whatever preceded the pass. Asking for the label we just
-        # derived therefore WITHHOLDS the clock for those two — correct, since
-        # the folded zero belongs to the previous phase — while leaving the
-        # ordinary `thinking` case working, where the label and
-        # `ACTIVITY_PHASE_THINKING` are the same string. Passing the constant
+        # derived therefore WITHHOLDS THE SEED for those two —
+        # ``clock_from_epoch``, not the number, so the row falls back to its own
+        # phase zero, which for a fallback is the pass's own start rather than a
+        # substitute for one — while leaving the ordinary `thinking` case
+        # working, where the label and `ACTIVITY_PHASE_THINKING` are the same
+        # string. Passing the constant
         # instead failed OPEN: the equality held, and a `retrying (attempt 2)`
         # row wore the age of the attempt that had just failed.
         return (

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -117,7 +117,6 @@ from local_operator.session.frontend_state import (
     ACTIVITY_PHASE_COMPOSING,
     ACTIVITY_PHASE_RESPONDING,
     ACTIVITY_PHASE_RUNNING,
-    ACTIVITY_PHASE_THINKING,
 )
 from local_operator.session.frontend_state import MCP_SUBCOMMANDS as _MCP_SUBCOMMANDS
 
@@ -299,7 +298,12 @@ from local_operator.tui.widgets.toast import (
     format_mcp_startup,
 )
 from local_operator.tui.widgets.todo_panel import TodoPanel
-from local_operator.tui.widgets.tool_card import ToolCard, clean_intent, parse_duration
+from local_operator.tui.widgets.tool_card import (
+    START_UNKNOWN,
+    ToolCard,
+    clean_intent,
+    parse_duration,
+)
 from local_operator.tui.widgets.transcript import (
     BOOT_COLUMN_CLASS,
     DEFAULT_ACTIVITY,
@@ -9222,6 +9226,16 @@ class OperatorApp(App[None]):
         A caller that passes nothing still gets the repaint (the state is
         honest at the moment it is painted) but keeps the old exposure, which is
         why the only caller that omits it is the test seam.
+
+        **``session`` is load-bearing and must be the session that OWNS the
+        rows being painted.** Every fact the two arms read — the pending ids,
+        the executing ids, and the start epochs — is read off it, so a session
+        belonging to another conversation answers for another conversation's
+        calls: the wrong rows go live, and ``live_tool_start_epochs(session)``
+        hands them another turn's instants. It is a parameter rather than
+        ``self._session`` for the same reason ``live_cards`` is: the two
+        prepare-time callers paint a presentation that is not (yet) the
+        visible one, so ``self`` is precisely the wrong answer there.
         """
         pending = getattr(session, "pending_display_tool_ids", None)
         call_ids: set[str] = set()
@@ -35006,12 +35020,23 @@ class OperatorApp(App[None]):
                 None,
                 self._folded_phase_epoch(ACTIVITY_PHASE_RESPONDING),
             )
+        # The FALLBACK labels are not the phase the fold models, and that is the
+        # whole point of the gate rather than an oversight to be smoothed over.
+        # `on_compaction_started` and `on_retry_started` set this label and
+        # re-derive; the fold models no compaction or retry edge, so its phase
+        # is still whatever preceded the pass. Asking for the label we just
+        # derived therefore WITHHOLDS the clock for those two — correct, since
+        # the folded zero belongs to the previous phase — while leaving the
+        # ordinary `thinking` case working, where the label and
+        # `ACTIVITY_PHASE_THINKING` are the same string. Passing the constant
+        # instead failed OPEN: the equality held, and a `retrying (attempt 2)`
+        # row wore the age of the attempt that had just failed.
         return (
             self._working_fallback,
             self._working_fallback,
             True,
             None,
-            self._folded_phase_epoch(ACTIVITY_PHASE_THINKING),
+            self._folded_phase_epoch(self._working_fallback),
         )
 
     def _folded_phase_epoch(self, phase: str) -> float | None:
@@ -35606,12 +35631,21 @@ class OperatorApp(App[None]):
             # re-delivered to a rebuilt transcript — would otherwise mount a
             # fresh card whose clock begins here, which is the reported reset
             # wearing the other hat: the row is new, the CALL is not.
+            #
+            # And when NOBODY stamped the call, there is no instant to seed
+            # from — which is not the same as "the call begins now". The row is
+            # being mounted for work already in flight, so it mounts CLOCKLESS
+            # (`START_UNKNOWN`) and stays that way until an event dates it,
+            # rather than printing an age counted from the viewer's arrival.
+            # `restore` and `_mark_pending_tool_rows` already read a missing
+            # epoch as "withheld"; this was the one seam that read it as zero,
+            # and it is the same rule as theirs rather than a fourth one.
             card = ToolCard(
                 event.tool_call_id,
                 event.tool_name,
                 event.args,
                 event.intent,
-                started_at=started_at,
+                started_at=START_UNKNOWN if started_at is None else started_at,
             )
             self._append_block(card)
         self._tool_cards[event.tool_call_id] = card

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -113,6 +113,12 @@ from local_operator.mcp.verbs import _home_relative
 # boot path nothing the lazy-import discipline above is protecting.
 from local_operator.model.effort import next_effort
 from local_operator.session import naming
+from local_operator.session.frontend_state import (
+    ACTIVITY_PHASE_COMPOSING,
+    ACTIVITY_PHASE_RESPONDING,
+    ACTIVITY_PHASE_RUNNING,
+    ACTIVITY_PHASE_THINKING,
+)
 from local_operator.session.frontend_state import MCP_SUBCOMMANDS as _MCP_SUBCOMMANDS
 
 # Shared loop semantics stay import-light for detached owners.
@@ -189,7 +195,9 @@ from local_operator.tui.session_presentation import (
     OlderHistoryNotice,
     PreparedReplay,
     SessionPresentation,
+    activity_phase_clock,
     live_projection_call_ids,
+    live_tool_start_epochs,
 )
 from local_operator.tui.session_workspace import SessionWorkspace
 from local_operator.tui.settings import settings_get
@@ -5066,6 +5074,7 @@ class OperatorApp(App[None]):
                 prepared_live_cards,
                 replay._projection_skipped_live,
                 collect=replay.blocks,
+                session=session,
             )
             replay.view.styles.layer = "session-cache"
             # visibility:hidden removes the compositor map and makes size=0.
@@ -9230,6 +9239,10 @@ class OperatorApp(App[None]):
             # approval row as though the call the user has not authorised were
             # already executing.
             live_ids = cast(set[str], executing()) - call_ids
+            # The session's own start instants for those calls, read ONCE
+            # rather than per row: it is a copy of a small map, and the loop
+            # below may touch several rows of one batch.
+            epochs = live_tool_start_epochs(session)
             for block in blocks:
                 if isinstance(block, ToolCard) and block.tool_call_id in live_ids:
                     # `restore`, not `mark_running`: the row was mounted by
@@ -9239,7 +9252,15 @@ class OperatorApp(App[None]):
                     # while refusing to invent an elapsed time it cannot know
                     # — the same reason `subagent_view` restores a child's
                     # in-flight row this way.
-                    block.restore(state="running")
+                    #
+                    # `started_at` is what makes that refusal precise rather
+                    # than total. The producer stamped when the call began and
+                    # the session folded it, so for a call owned by a live
+                    # runtime the age IS knowable and the row resumes it
+                    # instead of counting from this switch. A call the map does
+                    # not have — an older runtime, a genuinely unknown start —
+                    # passes `None` and keeps the clockless rendering.
+                    block.restore(state="running", started_at=epochs.get(block.tool_call_id))
                     if live_cards is not None:
                         # See the docstring: this is the row's ONLY settle path
                         # when the turn dies instead of returning a result.
@@ -9333,7 +9354,10 @@ class OperatorApp(App[None]):
                 self._transcript_view().blocks(), self._session, self._tool_cards
             )
             painted = self._paint_skipped_live_tool_rows(
-                self._transcript_view(), self._tool_cards, self._projection_skipped_live
+                self._transcript_view(),
+                self._tool_cards,
+                self._projection_skipped_live,
+                session=self._session,
             )
             if painted and self._controller is not None:
                 # The adopt path's settle seam. The skipped call's
@@ -9360,6 +9384,7 @@ class OperatorApp(App[None]):
         calls: list[Any],
         *,
         collect: list[Any] | None = None,
+        session: Any = None,
     ) -> list[str]:
         """Paint the ONE row for a still-executing call the replay skipped.
 
@@ -9387,8 +9412,15 @@ class OperatorApp(App[None]):
         yet, so the row is appended to the presentation's block list for the
         caller's bulk mount rather than to the (unmountable) view. The visible
         path leaves it ``None`` and appends to the live view directly.
+
+        ``session`` is the session this row is being painted FOR, and it is a
+        parameter rather than ``self._session`` for the same reason the registry
+        is: the prepare caller is painting another conversation, and reading the
+        visible session's epochs there would date this row from the wrong
+        conversation's calls. Both callers already hold the right session.
         """
         painted: list[str] = []
+        epochs = live_tool_start_epochs(session)
         for call in calls:
             call_id = getattr(call, "id", "") or ""
             if not call_id or call_id in live_cards:
@@ -9402,12 +9434,18 @@ class OperatorApp(App[None]):
             # start is when the tool began, not when this view painted the row,
             # so the card must not invent an elapsed time it cannot know — the
             # same reason `restore(state="running")` clears `_started`.
+            #
+            # `started_at` supplies that true start when the session has one:
+            # the producer's own stamp, folded per call, so the row painted here
+            # and the row the live path would have painted for the same call
+            # agree on one age. `None` for a call the map does not hold, and the
+            # clock stays withheld.
             card = ToolCard(
                 call_id,
                 getattr(call, "name", "") or "",
                 getattr(call, "arguments", None) or {},
             )
-            card.restore(state="running")
+            card.restore(state="running", started_at=epochs.get(call_id))
             if collect is not None:
                 collect.append(card)
             else:
@@ -19742,7 +19780,7 @@ class OperatorApp(App[None]):
         Asks the SAME deriver the working line and the title use, so the three
         cannot disagree about whether a turn is parked.
         """
-        _, phase, _, _ = self._current_activity()
+        _, phase, _, _, _ = self._current_activity()
         if phase != ACTIVITY_APPROVAL:
             return
         asking = self._ask_pending is not None and not self._ask_pending.done()
@@ -34760,8 +34798,14 @@ class OperatorApp(App[None]):
         """
         if self._working_block is not None:
             return
-        label, phase, clock, clock_from = self._current_activity()
-        self._working_block = WorkingBlock(label, phase, clock=clock, clock_from=clock_from)
+        label, phase, clock, clock_from, clock_from_epoch = self._current_activity()
+        self._working_block = WorkingBlock(
+            label,
+            phase,
+            clock=clock,
+            clock_from=clock_from,
+            clock_from_epoch=clock_from_epoch,
+        )
         self._append_block(self._working_block, ends_empty_state=ends_empty_state, pin_tail=True)
 
     def _dismiss_working_block(self) -> None:
@@ -34790,9 +34834,15 @@ class OperatorApp(App[None]):
         a stop reaches this hook without either of those paths knowing a title
         exists.
         """
-        label, phase, clock, clock_from = self._current_activity()
+        label, phase, clock, clock_from, clock_from_epoch = self._current_activity()
         if self._working_block is not None:
-            self._working_block.set_activity(label, phase, clock=clock, clock_from=clock_from)
+            self._working_block.set_activity(
+                label,
+                phase,
+                clock=clock,
+                clock_from=clock_from,
+                clock_from_epoch=clock_from_epoch,
+            )
         waiting = phase == ACTIVITY_APPROVAL
         if self._status is not None:
             self._status.set_attention(waiting)
@@ -34827,13 +34877,26 @@ class OperatorApp(App[None]):
         elif not waiting:
             self._waiting_kind = None
 
-    def _current_activity(self) -> tuple[str, str, bool, float | None]:
-        """What the turn is doing: ``(label, phase, clock, clock_from)``.
+    def _current_activity(self) -> tuple[str, str, bool, float | None, float | None]:
+        """What the turn is doing: ``(label, phase, clock, clock_from, clock_from_epoch)``.
 
         ``clock`` is whether the elapsed number the band draws would be TRUE at
         all. ``clock_from`` is the instant it should count from when it is:
         ``None`` means the phase's own zero is correct, which it is for every
         state but a running tool batch.
+
+        ``clock_from_epoch`` is the same override for the phases whose zero the
+        WIDGET cannot have observed — ``thinking``, ``responding`` and
+        ``composing``, which is precisely the arm the operator's report names
+        (the thinking indicator restarting on a switch) — and it is the instant
+        the SESSION folded for that phase from the producer's own events. It is
+        passed only when the folded phase EQUALS the phase derived here. On any
+        mismatch it is withheld, which is the safety property this row has held
+        since design rounds 2 and 3: a compaction or retry fallback phase, a
+        legacy owner, a facade with no fold, or a fold that has simply not seen
+        this turn's events all leave the widget counting from its own phase zero
+        — the pre-existing behaviour — rather than receiving a plausible-looking
+        age that belongs to something else.
 
         Two fields because the two design findings against this row are
         different questions, and one bit cannot answer both:
@@ -34890,12 +34953,16 @@ class OperatorApp(App[None]):
             # FIRST, above the approval prompt: the picker is a modal drawn over
             # everything, so it is what the user is looking at even if a card
             # underneath is also waiting.
-            return ("waiting for your answer", ACTIVITY_APPROVAL, True, None)
+            #
+            # No epoch arm for the two waiting states: the phase's zero IS the
+            # moment the question was asked on every surface that draws it, so
+            # there is nothing a switch could move.
+            return ("waiting for your answer", ACTIVITY_APPROVAL, True, None, None)
         if self._approval is not None and not self._approval.answered:
             # Nothing is running: the turn is parked on the question on screen,
             # and "thinking" under an unanswered prompt blames the model for a
             # wait that belongs to the user.
-            return ("waiting for approval", ACTIVITY_APPROVAL, True, None)
+            return ("waiting for approval", ACTIVITY_APPROVAL, True, None, None)
         if self._tool_cards:
             cards = list(self._tool_cards.values())
             starts = [card.started_at for card in cards]
@@ -34905,11 +34972,17 @@ class OperatorApp(App[None]):
             # measure is exactly the oldest one. See the docstring.
             known = [s for s in starts if s is not None]
             dateable = len(known) == len(starts)
+            # No epoch arm: a running batch is dated by its CARDS, which is a
+            # finer anchor than the folded phase edge (the phase restarts on
+            # every call that joins, the batch clock must not). `starts` is
+            # already the producer's own stamp, converted when each card was
+            # seeded from `live_tool_start_epochs`.
             return (
                 self._batch_phrase(cards),
-                "running",
+                ACTIVITY_PHASE_RUNNING,
                 dateable,
                 min(known) if dateable else None,
+                None,
             )
         if self._composing_cards:
             # The tool's NAME is deliberately absent. It arrives in fragments —
@@ -34918,10 +34991,54 @@ class OperatorApp(App[None]):
             # and `composing wr` reads as a typo rather than as a state.
             count = len(self._composing_cards)
             noun = "a call" if count == 1 else f"{count} calls"
-            return (f"composing {noun}", "composing", True, None)
+            return (
+                f"composing {noun}",
+                ACTIVITY_PHASE_COMPOSING,
+                True,
+                None,
+                self._folded_phase_epoch(ACTIVITY_PHASE_COMPOSING),
+            )
         if self._streaming_block is not None:
-            return (ACTIVITY_RESPONDING, ACTIVITY_RESPONDING, True, None)
-        return (self._working_fallback, self._working_fallback, True, None)
+            return (
+                ACTIVITY_RESPONDING,
+                ACTIVITY_RESPONDING,
+                True,
+                None,
+                self._folded_phase_epoch(ACTIVITY_PHASE_RESPONDING),
+            )
+        return (
+            self._working_fallback,
+            self._working_fallback,
+            True,
+            None,
+            self._folded_phase_epoch(ACTIVITY_PHASE_THINKING),
+        )
+
+    def _folded_phase_epoch(self, phase: str) -> float | None:
+        """The session's own start instant for ``phase``, when it IS that phase.
+
+        This is the whole of the new anchor's safety. The number is used only
+        when the phase folded from the producer's events is the SAME phase this
+        app just derived from its own widgets — equal by string, because the two
+        are different reductions of one stream and any disagreement means one of
+        them has missed events. When they agree, the instant is the producer's
+        own and a viewer that attached mid-turn resumes the true age instead of
+        counting from its arrival; when they disagree, or when there is no fold
+        at all, ``None`` is returned and the widget falls back to its phase zero.
+
+        The disagreement cases are real, not defensive dressing: a compaction or
+        retry fallback phase the fold does not model, a legacy runtime whose
+        events carry no phase, and every reduced facade in tests. In all of them
+        withholding the clock is the honest reading, and it is what the widget
+        already did — so a mismatch can only preserve behaviour, never invent an
+        age.
+
+        Read through the cheap session probe, not ``session.frontend_state``:
+        this runs on every event that moves the turn, and the property deep-copies
+        the whole state for two scalars.
+        """
+        folded, started_at = activity_phase_clock(self._session)
+        return started_at if folded and folded == phase else None
 
     @staticmethod
     def _batch_phrase(cards: list[ToolCard]) -> str:
@@ -35461,6 +35578,16 @@ class OperatorApp(App[None]):
 
     def on_tool_started(self, message: ToolStarted) -> None:
         event = message.event
+        # The call's own start instant, stamped by the producer and folded by
+        # the session. Preferred over the map because it is the SAME value for
+        # the row the live path paints and the row a switch back repaints: a
+        # reader that took the map alone would date the switched-to row from
+        # the last fold while the live row counted from the event, so the two
+        # surfaces for one call would disagree by their own handler latency.
+        # The map is the fallback for a producer that sent no stamp.
+        started_at = getattr(event, "started_at_epoch", None)
+        if started_at is None:
+            started_at = live_tool_start_epochs(self._session).get(event.tool_call_id)
         # Adopt the row that announced this call rather than mounting a second
         # one: the composing card already sits in the right place in the ledger,
         # and swapping it out would flicker a row away and an identical row back
@@ -35472,9 +35599,20 @@ class OperatorApp(App[None]):
             # leaves an interrupted ghost behind after the real one completes.
             card = self._painted_tool_card(event.tool_call_id)
         if card is not None:
-            card.begin_running(event.tool_name, event.args, event.intent)
+            card.begin_running(event.tool_name, event.args, event.intent, started_at=started_at)
         else:
-            card = ToolCard(event.tool_call_id, event.tool_name, event.args, event.intent)
+            # Seeded from the same instant as the adopt path. A start event that
+            # reaches a view with no row for its call — the owner's live seed
+            # re-delivered to a rebuilt transcript — would otherwise mount a
+            # fresh card whose clock begins here, which is the reported reset
+            # wearing the other hat: the row is new, the CALL is not.
+            card = ToolCard(
+                event.tool_call_id,
+                event.tool_name,
+                event.args,
+                event.intent,
+                started_at=started_at,
+            )
             self._append_block(card)
         self._tool_cards[event.tool_call_id] = card
         self._refresh_working_activity()

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -111,6 +111,48 @@ def live_projection_call_ids(session: Any) -> set[str]:
     return live
 
 
+def live_tool_start_epochs(session: Any) -> dict[str, float]:
+    """The session's own start epoch per live tool call, or ``{}`` when absent.
+
+    Probed rather than called directly for the reason the sibling above is: a
+    reduced facade — a test double, an embedding host — need not implement the
+    accessor, and "no epochs" is the correct answer for one. It reduces to
+    "withhold the clock", which is what every consumer does with a missing id,
+    so a facade without the accessor keeps today's behaviour instead of
+    raising.
+
+    The same shape is answered by BOTH session kinds, and it is the SAME fact
+    either way: the epochs a producer stamped on its ``tool_execution_start``
+    events, folded per call. That is what lets a live row and the switched-to
+    row for one call share an anchor instead of differing by when each was
+    painted.
+    """
+    accessor = getattr(session, "live_tool_start_epochs", None)
+    if not callable(accessor):
+        return {}
+    return dict(cast("dict[str, float]", accessor()))
+
+
+def activity_phase_clock(session: Any) -> tuple[str, float | None]:
+    """The session's folded phase and its zero, or ``("", None)`` for none.
+
+    The companion to the accessor above, for the arm of the working line that
+    has no tool call behind it: ``thinking``, ``responding`` and ``composing``
+    are dated by a phase edge rather than by a call, so a viewer that arrived
+    mid-turn has no other way to know how long the model call has been going.
+
+    ``("", None)`` is the answer for a facade with no fold and for a session
+    that has not been published yet. The consumer compares the phase against
+    the one it derived itself and withholds the clock on any mismatch, so the
+    empty value matches nothing and no age is invented from it.
+    """
+    accessor = getattr(session, "activity_phase_clock", None)
+    if not callable(accessor):
+        return ("", None)
+    phase, started_at = cast("tuple[str, float | None]", accessor())
+    return str(phase or ""), started_at
+
+
 class CompactionMarkerBlock(NoticeBlock):
     """The compaction seam, spaced apart from whatever it lands beside.
 

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -939,6 +939,27 @@ def _row_text() -> Text:
     return Text(no_wrap=True, overflow="ellipsis")
 
 
+class _UnknownStart:
+    """Sentinel type for :data:`START_UNKNOWN`; never instantiated twice."""
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - a debugging aid only
+        return "START_UNKNOWN"
+
+
+#: Passed as :class:`ToolCard`'s ``started_at`` when the card is being mounted
+#: for a call that is ALREADY in flight and no epoch for it exists anywhere —
+#: a legacy producer re-delivered to a rebuilt transcript, or a facade whose
+#: fold carries nothing for the call. It exists because ``None`` already means
+#: something else on that parameter ("this call begins now", true for a card
+#: built by the event that starts it), and the two must not be conflated: the
+#: first mounts CLOCKLESS, the second legitimately takes the mount instant as
+#: zero. Any other consumer that can only say "unknown" must use this rather
+#: than ``clock()``, which would print the viewer's arrival as the call's age.
+START_UNKNOWN = _UnknownStart()
+
+
 class ToolCard(ExpandableActionBlock):
     """A tool execution: ONE row, on a state-tinted elevation step.
 
@@ -972,7 +993,7 @@ class ToolCard(ExpandableActionBlock):
         intent: str | None = None,
         user_run: bool = False,
         clock: Callable[[], float] = time.monotonic,
-        started_at: float | None = None,
+        started_at: float | None | _UnknownStart = None,
     ) -> None:
         super().__init__()
         #: Injected so elapsed time is testable without sleeping, exactly as
@@ -1076,11 +1097,23 @@ class ToolCard(ExpandableActionBlock):
         #: adopt paths use (:meth:`restore`, :meth:`begin_running`), and it is
         #: deliberately one rule in three places rather than a constructor that
         #: quietly disagreed with them about what "running" means.
-        self._started: float | None = (
-            monotonic_from_epoch(started_at, clock=self._clock)
-            if started_at is not None
-            else self._clock()
-        )
+        #:
+        #: That leaves the case where the call began earlier AND no epoch
+        #: exists, which neither ``None`` ("begins now") nor a float can
+        #: express — hence :data:`START_UNKNOWN` and the withheld clock above.
+        if isinstance(started_at, _UnknownStart):
+            # The third answer, and the one the two-valued signature could not
+            # say: this row is mounted for a call ALREADY in flight and nobody
+            # recorded when it began. `None` here would mean "the call begins
+            # now", which is a lie for this row — the age it would print is the
+            # viewer's arrival wearing the call's name — and a real epoch is
+            # simply absent. So the row mounts CLOCKLESS, the same withheld
+            # reading `restore` and `begin_running` take for a missing epoch.
+            self._started = None
+        elif started_at is not None:
+            self._started = monotonic_from_epoch(started_at, clock=self._clock)
+        else:
+            self._started = self._clock()
         self._expanded = False
         #: A host that knows the user ran this call TO SEE its output (the
         #: composer's bang-mode) asks the card to open the moment it settles,
@@ -1511,9 +1544,12 @@ class ToolCard(ExpandableActionBlock):
         no clock the row simply stops animating between events, which is the
         right degradation for a timer whose entire job is cosmetic.
 
-        A REPLAYED live card (``restore(state="running")``) gets none: it has
-        no start time to count from and nothing streams into it, so every
-        tick would repaint an unchanged row. See :attr:`_started`.
+        A live card with NO start time to count from gets none — a replayed
+        row with no epoch, a mount for a call already in flight whose start
+        nobody stamped — because every tick would repaint a duration the row
+        cannot know. A ``restore(state="running")`` that IS given the call's
+        epoch does arm the timer: the guard is ``_started``, not the path that
+        set it. See :attr:`_started`.
         """
         if self._started is None or not self._navigation_visible:
             return

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -89,7 +89,7 @@ import math
 import os
 import re
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
 from rich.cells import cell_len
@@ -474,6 +474,30 @@ def format_duration(seconds: float) -> str:
         return "100d+"
     hours = remainder // 3600
     return f"{days}d{hours}h" if hours else f"{days}d"
+
+
+def monotonic_from_epoch(epoch: float, *, clock: Callable[[], float] = time.monotonic) -> float:
+    """A monotonic instant whose age is ``now - epoch``, for a threaded clock.
+
+    The one conversion from the wall-clock stamps that travel on events
+    (``ToolExecutionStartEvent.started_at_epoch``, the session's folded
+    ``activity_phase_started_at``) into the clocks the widgets tick on. It is
+    one function because both widgets that seed a counter from a producer's
+    instant — ``ToolCard`` and ``WorkingBlock`` — must divide, negate and clamp
+    it identically; the status band's ``seed_duration`` applies the same rule
+    to the turn's own start instant, and keeps its own spelling because it
+    takes an injectable ``now_epoch`` this helper has no use for.
+
+    Conversion is AGE-ONLY and happens ONCE. Everything that ticks afterwards
+    counts on ``clock()``, so a system-clock adjustment, a DST jump or a
+    laptop resuming from sleep after the seed cannot move a counter that is
+    already running: only the interval that had already elapsed is taken from
+    wall time. The clamp matters for the same reason — an epoch in the future
+    (a peer's clock ahead of ours, a stamp written by a machine whose clock
+    was later corrected) means "age unknown, treat as new" rather than a
+    negative elapsed time that would render as a nonsense duration.
+    """
+    return clock() - max(0.0, time.time() - epoch)
 
 
 def truncate_cells(text: str, width: int, ellipsis: str = "…") -> str:
@@ -947,8 +971,17 @@ class ToolCard(ExpandableActionBlock):
         args: dict[str, object] | None = None,
         intent: str | None = None,
         user_run: bool = False,
+        clock: Callable[[], float] = time.monotonic,
+        started_at: float | None = None,
     ) -> None:
         super().__init__()
+        #: Injected so elapsed time is testable without sleeping, exactly as
+        #: ``StatusLine`` takes one. Monotonic, not wall clock: a duration that
+        #: jumps when the system clock is adjusted is worse than no duration,
+        #: which is why the epochs that arrive from outside this widget are
+        #: converted to an AGE once (:func:`monotonic_from_epoch`) and every
+        #: tick after that is taken from here.
+        self._clock = clock
         self.tool_call_id = tool_call_id
         self.navigation_anchor_id = f"tool:{tool_call_id}"
         # tool_name is MODEL-CONTROLLED: the loop takes it from the tool call
@@ -1031,7 +1064,23 @@ class ToolCard(ExpandableActionBlock):
         #: measured from here would be how long ago the panel drew the row.
         #: The settled states already refuse to invent that number — see
         #: :meth:`restore` — and the running state has to refuse it too.
-        self._started: float | None = time.monotonic()
+        #:
+        #: A card constructed for a call that is LIVE right now takes ``clock()``
+        #: here, and that is correct for the call this row was mounted for: the
+        #: row appears with the event that started it, so the two instants
+        #: coincide. The case it is NOT correct for is a start event whose call
+        #: began EARLIER than this card — a re-delivered seed on a view that has
+        #: no row for the call, which is the same switch a restored row takes.
+        #: ``started_at`` is then passed and the row wears the call's real age
+        #: instead of the handler's arrival. It is the same conversion the two
+        #: adopt paths use (:meth:`restore`, :meth:`begin_running`), and it is
+        #: deliberately one rule in three places rather than a constructor that
+        #: quietly disagreed with them about what "running" means.
+        self._started: float | None = (
+            monotonic_from_epoch(started_at, clock=self._clock)
+            if started_at is not None
+            else self._clock()
+        )
         self._expanded = False
         #: A host that knows the user ran this call TO SEE its output (the
         #: composer's bang-mode) asks the card to open the moment it settles,
@@ -1245,7 +1294,7 @@ class ToolCard(ExpandableActionBlock):
         never learned when its call started must paint a blank column, not a
         number that says the tool returned instantly.
         """
-        return None if self._started is None else time.monotonic() - self._started
+        return None if self._started is None else self._clock() - self._started
 
     @property
     def started_at(self) -> float | None:
@@ -1273,6 +1322,7 @@ class ToolCard(ExpandableActionBlock):
         details: dict[str, Any] | None = None,
         error: str = "",
         duration_s: float | None = None,
+        started_at: float | None = None,
     ) -> None:
         """Adopt a card for a call from a PREVIOUS session, or another agent's.
 
@@ -1298,12 +1348,31 @@ class ToolCard(ExpandableActionBlock):
         further on. `subagent_view.entry_block` rebuilds a child's whole
         trajectory as blocks, and an entry with no outcome yet is a call that
         is STILL GOING: the card has to stay live. It just must not time
-        itself, because its ``_started`` is when the page painted the row —
-        so ``_started`` is cleared here and the running row blanks its
-        duration exactly as its settled siblings blank theirs. Without this
-        the replayed live row counted up from zero (and reset to zero every
-        time an earlier entry changed and the page rebuilt it), inventing
-        precisely the number this method exists to refuse.
+        itself, because its ``_started`` was when the page painted the row —
+        so ``_started`` is cleared here and the running row blanks its duration
+        exactly as its settled siblings blank theirs. Without this the replayed
+        live row counted up from zero (and reset to zero every time an earlier
+        entry changed and the page rebuilt it), inventing precisely the number
+        this method exists to refuse.
+
+        ``started_at`` is what makes the running arm able to KNOW its zero, and
+        it is passed only when that is true: the session's folded
+        ``ToolExecutionStartEvent.started_at_epoch`` for this call — the
+        producer's own stamp of when the tool began, which a viewer that
+        attaches mid-turn otherwise has no way to recover. Given one, the row
+        resumes the call's TRUE age instead of counting from the switch (the
+        reported frame: a `bash` row reading `27s` that restarted at the
+        moment the reader returned to the conversation). Given ``None`` — a
+        legacy producer, a `subagent_view` child row, any facade with no fold —
+        the arm keeps its old clockless behaviour, because stamping the fold or
+        arrival instant in its place is the one thing this path must never do:
+        for an attached viewer that number is invented, not measured.
+
+        The conversion is AGE-ONLY and happens once, here
+        (:func:`monotonic_from_epoch`); every tick afterwards is taken from
+        ``self._clock()``, so a wall-clock adjustment after the seed cannot
+        move a counter that is already running. Settled states ignore
+        ``started_at`` entirely — they are rendered from ``_duration``.
         """
         self._settle_live()
         self._state = state
@@ -1333,7 +1402,13 @@ class ToolCard(ExpandableActionBlock):
             # the freeze comes back with the outcome.
             self._finalized = False
             # Only the clock stays withheld; the expansion still offers the
-            # command.
+            # command. Seeded first, in that order, so a row whose start IS
+            # known arms from the call's true age and its tick timer starts
+            # with it; a row whose start is not known reaches `_refresh_row`
+            # with `_started` still None and blanks the column.
+            if started_at is not None:
+                self._started = monotonic_from_epoch(started_at, clock=self._clock)
+                self._start_clock()
             self._refresh_row()
             return
         self.remove_class("tool-running")
@@ -1388,13 +1463,13 @@ class ToolCard(ExpandableActionBlock):
                 parent.invalidate_name_col()
         self._compose_bytes = argument_bytes
         if self._compose_started is None:
-            self._compose_started = time.monotonic()
+            self._compose_started = self._clock()
         self._start_clock()
         self._render_composing()
 
     def _render_composing(self) -> None:
-        started = self._compose_started or time.monotonic()
-        elapsed = max(0, int(time.monotonic() - started))
+        started = self._compose_started or self._clock()
+        elapsed = max(0, int(self._clock() - started))
         clock = format_duration(elapsed)
         # The FACTS lead and the label sheds whole, the same shape this file
         # already uses for a tool summary. Boilerplate-first, `composing…` was
@@ -1524,7 +1599,11 @@ class ToolCard(ExpandableActionBlock):
         self._live_dirty = False
 
     def begin_running(
-        self, tool_name: str, args: dict[str, object] | None, intent: str | None
+        self,
+        tool_name: str,
+        args: dict[str, object] | None,
+        intent: str | None,
+        started_at: float | None = None,
     ) -> None:
         """Adopt a composing row as the real execution of the call it announced.
 
@@ -1532,18 +1611,32 @@ class ToolCard(ExpandableActionBlock):
         in the transcript in the right place, and replacing it would make the
         ledger flicker a row out and an identical row back in at the moment the
         call finally starts.
+
+        ``started_at`` is the session's folded epoch for this call — the
+        producer's own stamp of when the tool began — and it is what lets a
+        re-delivered ``ToolStarted`` give the row back its TRUE age. Without it
+        the re-entry had only two options, both wrong: restart the clock from
+        the re-entry instant (`0s` on arrival, ticking from the switch), or keep
+        the clock withheld because no surface ever learned when the call began.
+        A live row and the switched-to row for the same call now share one
+        anchor rather than differing by event→handler latency.
         """
         self._stop_clock()
         # A card restored onto the screen mid-execution (`restore(state="running")`)
-        # holds ``_started=None`` DELIBERATELY: no surface ever learned when
-        # the call began, so it refuses to invent an elapsed time. A re-delivered
+        # holds ``_started=None`` DELIBERATELY whenever NOBODY learned when the
+        # call began, so it refuses to invent an elapsed time. A re-delivered
         # ``ToolStarted`` reaches exactly that card — `/resume` onto the running
         # turn, or a switch away and back replaying the owner's live seed — and
         # restarting the clock here would fabricate `0s` at arrival, tick from
         # the RESUME instant, and settle the receipt to "time since the
-        # command" instead of the call's life. The withheld clock survives
-        # re-entry; only a card that can date itself restarts.
-        clockless = self._state == "running" and self._started is None
+        # command" instead of the call's life.
+        #
+        # So the withheld clock survives re-entry, and it is *filled in* when
+        # the call's start is knowable after all (a `started_at` epoch): the
+        # row's own zero is then the call's, not the viewer's. The two are the
+        # same rule, not two arms — a card with no zero and no epoch stays
+        # clockless, which is the honest rendering for a legacy producer.
+        clockless = self._state == "running" and self._started is None and started_at is None
         # Whether this call PROMOTES the row: the two things that decide whether
         # the spine may move because of it (see the invalidation at the end).
         was_composing = self._state == "composing"
@@ -1559,9 +1652,18 @@ class ToolCard(ExpandableActionBlock):
         # so a `write` that executed in 0.1s settled as `✓ 2.4s`, and on the
         # reported 1m41s case would have read `✓ 101s`. Two receipts on one
         # ledger would then be measuring different things with no way to tell
-        # which from the row. Unless the clock was withheld (above): a
-        # clockless card has no zero to restart from.
-        self._started = None if clockless else time.monotonic()
+        # which from the row. Unless the clock was withheld (above): a clockless
+        # card has no zero to restart from.
+        #
+        # The restart is also the reason the epoch has to be threaded THIS far
+        # rather than only into `restore`: a switch back re-delivers the seed's
+        # start event through the event controller, which reaches this method on
+        # the very card `restore` just restored. Seeding only one of the two
+        # left the other resetting the row to zero — the reported frame.
+        if started_at is not None:
+            self._started = monotonic_from_epoch(started_at, clock=self._clock)
+        else:
+            self._started = None if clockless else self._clock()
         self._state = "running"
         # The same construction the constructor uses, so an adopted row is
         # byte-identical to one that had never been a composing row — including
@@ -2031,12 +2133,17 @@ class ToolCard(ExpandableActionBlock):
         # rewriting itself around a moving middle.
         #
         # Both trailing clauses are dropped for a REPLAYED live card, which
-        # knows neither. It has no start time (see :attr:`_started`), and
-        # nothing streams into it — the surface rebuilding it never calls
-        # `set_partial_detail` — so `no output yet` there is not a caveat that
-        # will lift, it is a permanent claim about a child's tool that this
-        # card has no way to make. `⋯ running` alone is the whole of what it
-        # honestly knows.
+        # knows neither. Its start time is absent unless the session supplied
+        # the call's own epoch (see :attr:`_started`), and nothing streams into
+        # it — the surface rebuilding it never calls `set_partial_detail` — so
+        # `no output yet` there is not a caveat that will lift, it is a
+        # permanent claim about a child's tool that this card has no way to
+        # make. `⋯ running` alone is the whole of what it honestly knows.
+        #
+        # The two clauses are dropped together even though the start can now be
+        # known: `no output yet` is what genuinely cannot be claimed here, and
+        # the elapsed half is painted by the status column instead, next to the
+        # outcome glyph it will settle into.
         header = LIVE_HEADER_RUNNING
         elapsed = self._elapsed()
         if elapsed is not None:
@@ -2576,13 +2683,17 @@ class ToolCard(ExpandableActionBlock):
             # holds and the row does not jump on settling.
             #
             dim = bindings.style("tool.status.running_duration")
-            # A REPLAYED live row has no CLOCK. `subagent_view` rebuilds a
-            # child's trajectory into cards and leaves the outcome-less ones
-            # running, and `_mark_pending_tool_rows` repaints a row the owner is
-            # still executing; in both, `_started` is when the PAGE painted the
-            # row — so a clock here counted up from zero and reset to zero every
-            # time an earlier entry changed. A clock started from the wrong zero
-            # is worse than no clock.
+            # A REPLAYED live row has a clock only when its call's start is
+            # KNOWN. `subagent_view` rebuilds a child's trajectory into cards
+            # and leaves the outcome-less ones running, and
+            # `_mark_pending_tool_rows` repaints a row the owner is still
+            # executing; in both, the start is knowable only if somebody
+            # supplied it — the session's folded epoch for a call a live
+            # producer stamped (see `restore`), nothing at all for a child row
+            # or a legacy producer. Where nothing was supplied, `_started` would
+            # be when the PAGE painted the row, so a clock here counted up from
+            # zero and reset to zero every time an earlier entry changed. A
+            # clock started from the wrong zero is worse than no clock.
             #
             # "No clock" is NOT "no state", though, and returning `[]` made this
             # the only row in the ladder with an empty status column — silent in

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -2756,6 +2756,7 @@ class WorkingBlock(TranscriptBlock):
         *,
         clock: bool = True,
         clock_from: float | None = None,
+        clock_from_epoch: float | None = None,
         fold_width: int = 0,
     ) -> None:
         super().__init__()
@@ -2782,6 +2783,16 @@ class WorkingBlock(TranscriptBlock):
         # A zero supplied by the CALLER, overriding the phase's own. See
         # :meth:`set_activity`; ``None`` means the phase's zero is correct.
         self._clock_from = clock_from
+        # The same override expressed as the WALL-CLOCK instant the session
+        # recorded for this phase, for the phases whose zero lives outside this
+        # widget (a viewer that attached mid-turn). Kept beside the monotonic
+        # value rather than replacing it because only the epoch can be compared
+        # for "has the phase's own zero changed" — the monotonic conversion
+        # moves on every call — and because it is what a later re-seed has to
+        # match against. Converted ONCE, on a phase change; see
+        # :meth:`set_activity`.
+        self._clock_from_epoch = clock_from_epoch
+        self._seed_clock_from_epoch()
         self._clock = ""
         #: The width the row was last authored at; `on_resize` compares against
         #: it so a height-only resize does not re-truncate a one-row line.
@@ -2803,6 +2814,7 @@ class WorkingBlock(TranscriptBlock):
         *,
         clock: bool = True,
         clock_from: float | None = None,
+        clock_from_epoch: float | None = None,
     ) -> None:
         """Name what the turn is doing now.
 
@@ -2817,6 +2829,23 @@ class WorkingBlock(TranscriptBlock):
         phase containing it. ``None`` keeps the phase's own zero, which is right
         for every state whose label and phase begin together.
 
+        ``clock_from_epoch`` is the same override for the phases whose zero the
+        WIDGET cannot have observed — ``thinking``, ``responding`` and
+        ``composing`` — where the session folded the instant the phase began
+        from the producer's own events. It is what makes a viewer that attaches
+        mid-turn resume the true age: this row is constructed at the switch, so
+        its phase zero is the switch, and without the seed the operator's own
+        report applies — the thinking indicator counting from the moment they
+        came back rather than from when the model call started.
+
+        It is converted to a monotonic instant ONCE, here, on the phase change
+        (:func:`tool_card.monotonic_from_epoch`), and every tick afterwards
+        counts on ``time.monotonic``: an elapsed-time reading must not move
+        because something adjusted the system clock, and a DST jump on a
+        seeded row would be a number nobody could explain. ``clock_from_epoch``
+        wins over ``clock_from`` when both arrive; the two describe different
+        phases and the caller only ever passes the one that matches.
+
         ``clock=False`` says the caller knows the LABEL but not when the work it
         names began, and the number is then withheld rather than counted from
         this moment. The case that forced it: a sidebar switch adopts a tool the
@@ -2828,9 +2857,16 @@ class WorkingBlock(TranscriptBlock):
         the adjacent number read as a claim ABOUT that tool, so the label is
         kept and the clock is dropped: this row's whole contract is that every
         number on it was derived from an event the app received, and a clock
-        started from the wrong zero is worse than no clock. There is no honest
-        alternative reading available — the start event carries no timestamp, so
-        the true age is not recoverable on this surface at any price.
+        started from the wrong zero is worse than no clock.
+
+        Withholding is still the answer whenever the true age is genuinely
+        unavailable, and that is a real population rather than a hypothetical:
+        a call whose producer sent no ``started_at_epoch`` (an older runtime), a
+        folded phase that does not match the one the app derived (a facade with
+        no fold, a compaction or retry fallback), and every child row inside
+        ``subagent_view``. For those the timestamp does not exist on this
+        surface at any price, so the clock stays blank rather than inventing
+        one; the matching rules live in ``OperatorApp._current_activity``.
 
         The clock restarts only when the PHASE changes, not whenever the label
         does. Keying it to the rendered string made the row refute itself: one
@@ -2849,13 +2885,48 @@ class WorkingBlock(TranscriptBlock):
         elif (
             activity == self._activity
             and clock == self._clock_known
-            and clock_from == self._clock_from
+            and clock_from_epoch == self._clock_from_epoch
+            # WHICH value is the anchor decides which one has to be compared,
+            # and getting that wrong is silent in both directions. With an
+            # epoch the epoch IS the anchor and the monotonic instant is only
+            # its image, so equality of the epoch is the whole test — comparing
+            # the image instead can never match the `None` this arm passes as
+            # `clock_from` for a non-epoch phase, and re-deriving the image on
+            # every repaint would put the counter back on the WALL clock (a
+            # system-clock adjustment or a DST change after the seed would move
+            # a reading that is supposed to be immune to both). With no epoch
+            # the monotonic value is the anchor and must itself be compared, or
+            # a running batch that sheds its oldest call keeps the stale zero
+            # and the band reports the shed sibling's age (D9).
+            and (clock_from_epoch is not None or clock_from == self._clock_from)
         ):
             return
         self._activity = activity
         self._clock_known = clock
+        self._clock_from_epoch = clock_from_epoch
         self._clock_from = clock_from
+        self._seed_clock_from_epoch()
         self._paint()
+
+    def _seed_clock_from_epoch(self) -> None:
+        """Convert a session-supplied epoch into this widget's monotonic zero.
+
+        Called wherever ``_clock_from_epoch`` is set — the constructor and
+        :meth:`set_activity` — so the conversion exists once. Kept OFF the paint
+        path deliberately: the epoch is converted when the phase's anchor
+        CHANGES, not on every repaint, because recomputing ``clock() - (now -
+        epoch)`` per frame would make the counter follow the wall clock again
+        and undoing that is the entire point of seeding a monotonic instant.
+
+        Lazy import for the same reason the sibling duration formatter is
+        imported this way: ``tool_card`` imports this module, so a module-level
+        import of the converter here would be a cycle.
+        """
+        if self._clock_from_epoch is None:
+            return
+        from local_operator.tui.widgets.tool_card import monotonic_from_epoch
+
+        self._clock_from = monotonic_from_epoch(self._clock_from_epoch)
 
     def on_mount(self) -> None:
         self._sync_rate()

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -2861,12 +2861,36 @@ class WorkingBlock(TranscriptBlock):
 
         Withholding is still the answer whenever the true age is genuinely
         unavailable, and that is a real population rather than a hypothetical:
-        a call whose producer sent no ``started_at_epoch`` (an older runtime), a
-        folded phase that does not match the one the app derived (a facade with
-        no fold, a compaction or retry fallback), and every child row inside
-        ``subagent_view``. For those the timestamp does not exist on this
-        surface at any price, so the clock stays blank rather than inventing
-        one; the matching rules live in ``OperatorApp._current_activity``.
+        a call whose producer sent no ``started_at_epoch`` (an older runtime),
+        and every child row inside ``subagent_view``. For those the timestamp
+        does not exist on this surface at any price, so the number is withheld
+        rather than invented — ``clock=False``, which paints NO clock glyph at
+        all (``_clock_text`` still computes a nominal ``0s``; what drops it is
+        :meth:`_paint`'s ``if self._clock`` gate) while the glyph's cells stay
+        reserved, so the label beside it clips at the same column it would
+        otherwise. No glyph and a number counting up from zero are different
+        pictures, and which one a phase gets is a decision the next paragraph
+        makes separately rather than a side effect of it.
+
+        A fold that does not match the phase the app derived withholds the
+        SEED, not the number, and the row counts from its own phase zero
+        instead. A facade with no fold and a legacy owner land there; so do
+        the compaction and retry fallbacks, and for those that zero is the
+        honest reading rather than a substitute for one. The seed exists to
+        repair a zero this widget cannot have observed
+        (:meth:`_seed_clock_from_epoch`), so its absence says nothing about
+        the phase's own zero — the instant this row entered its phase, true
+        for every state whose label and phase begin together and never another
+        phase's age — and the fallbacks are exactly such a state.
+        ``OperatorApp._current_activity`` returns the label AS the phase for
+        ``compacting context`` and ``retrying (attempt n)`` precisely because
+        the fold models no compaction or retry edge, so the phase starts when
+        the app derived it from the event that began the pass, and the ``0s``
+        growing under that label IS the age of the pass the label names.
+        Withholding answers the other case — the label arriving at an instant
+        that is not the work's start, as the adopted tool above does — so a
+        mismatch is never a reason to blank a row that is telling the truth;
+        the matching rules live in ``OperatorApp._current_activity``.
 
         The clock restarts only when the PHASE changes, not whenever the label
         does. Keying it to the rendered string made the row refute itself: one

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -373,6 +373,14 @@ _BOUNDED_COLLECTION_FIELDS = {
     # budget. Every retained row keeps the identity and outcome a card needs.
     "live_events": "clipped at the wire: end rows capped newest-first, result text budgeted",
     "todos": "the user's own list, written by hand",
+    # One entry per call executing AT ONCE, and a call's entry is popped by its
+    # own `tool_execution_end` while the whole map is cleared at both ends of
+    # the turn. The live population is therefore bounded by the parallel slot
+    # count (`max_parallel_tools`, 8 by default) and cannot grow with
+    # conversation length, turn count or child count — which is the property
+    # this side of the line is for. Its values are `float`s and its keys are
+    # call ids, so even a whole turn's worth is a few hundred bytes.
+    "live_tool_started_at": "one float per call executing now; popped on end, cleared per turn",
     "wakes": "the user's own schedules",
     "mcp_servers": "one row per configured server",
     "slash_capabilities": "one row per SLASH_COMMANDS entry",
@@ -719,6 +727,14 @@ def test_the_attach_frame_fits_for_a_session_that_ran_all_year(tmp_path: Path) -
             for index in range(200)
         ],
         "wakes": [],
+        # AT the bound rather than past it, unlike the fields above, because
+        # this one's bound is a real ceiling rather than a clip: the map holds
+        # one entry per call executing AT ONCE, and calls beyond that wait for a
+        # slot (`max_parallel_tools`, 8 by default — `harness/types.py`). So the
+        # largest value a producer can publish is this, and the one knob that
+        # could raise it is a config value this fixture cannot guess at. Ids are
+        # the width a provider actually issues rather than `call-0`.
+        "live_tool_started_at": {f"call_{index:024d}": 1_756_000_000.123456 for index in range(8)},
         "mcp_servers": [
             McpServerState(name=f"server-{index}", status="connected") for index in range(200)
         ],

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -728,12 +728,18 @@ def test_the_attach_frame_fits_for_a_session_that_ran_all_year(tmp_path: Path) -
         ],
         "wakes": [],
         # AT the bound rather than past it, unlike the fields above, because
-        # this one's bound is a real ceiling rather than a clip: the map holds
-        # one entry per call executing AT ONCE, and calls beyond that wait for a
-        # slot (`max_parallel_tools`, 8 by default — `harness/types.py`). So the
-        # largest value a producer can publish is this, and the one knob that
-        # could raise it is a config value this fixture cannot guess at. Ids are
-        # the width a provider actually issues rather than `call-0`.
+        # this one's bound is a real ceiling for the DEFAULT configuration
+        # rather than a clip: the map holds one entry per call executing AT
+        # ONCE, and calls beyond that wait for a slot. That ceiling is
+        # `Guardrails.max_parallel_tools`, whose field is `ge=1` with no upper
+        # bound (`harness/types.py`), so a host that raises it publishes
+        # proportionally more (~43 B per entry, so even 1,000 concurrent calls
+        # is ~43 KB of the line's 1 MiB). 8 is the default a producer actually
+        # runs with and the fixture is deliberately conservative about id
+        # width, so this populates the shipped ceiling rather than a hard
+        # maximum — say "the default" rather than "the largest possible" when
+        # describing it. Ids are the width a provider actually issues rather
+        # than `call-0`.
         "live_tool_started_at": {f"call_{index:024d}": 1_756_000_000.123456 for index in range(8)},
         "mcp_servers": [
             McpServerState(name=f"server-{index}", status="connected") for index in range(200)

--- a/tests/unit/session/test_frontend_state.py
+++ b/tests/unit/session/test_frontend_state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import pickle
+import time
 from collections import deque, namedtuple
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -18,10 +19,15 @@ from local_operator.harness.types import (
     AgentEvent,
     AgentStartEvent,
     Message,
+    MessageEndEvent,
+    MessageStartEvent,
+    MessageUpdateEvent,
     ModelSpec,
     SubagentProgressEvent,
     ToolCallComposeEvent,
+    ToolExecutionEndEvent,
     ToolExecutionStartEvent,
+    ToolResult,
     Usage,
 )
 from local_operator.session.frontend_state import (
@@ -37,6 +43,7 @@ from local_operator.session.frontend_state import (
     TodoItemState,
     TodoPhaseState,
     WakeState,
+    sync_wire_payload,
 )
 
 
@@ -1148,7 +1155,7 @@ def test_seed_fold_is_unchanged_when_an_older_runtime_omits_the_field() -> None:
     dump is the old payload byte for byte rather than a null-valued imitation.
     """
     store = FrontendStateStore(_state())
-    session = SimpleNamespace(effective_model=_spec())
+    session = _live_session()
     store.observe_event(session, AgentStartEvent(generation=1))
 
     for call_id in ("compose:0", "compose:1"):
@@ -1210,3 +1217,289 @@ def test_a_repeated_supersession_is_idempotent_in_the_seed() -> None:
     assert live[0]["tool_call_id"] == "real_0"
     # The newest frame wins, so the size the viewer reads is the current one.
     assert live[0]["argument_bytes"] == 30
+
+
+# ---------------------------------------------------------------------------
+# The live-call clock anchors.
+#
+# A frontend that ATTACHES to work already in flight — a sidebar switch back to
+# a conversation whose tool is still running, a re-attach, a `/resume` onto a
+# live turn — paints its rows at the moment it arrives, so every widget it owns
+# counts from zero unless the session hands it the producer's own start
+# instants. Two folds supply them, and both are asserted here rather than on a
+# widget, because a widget test can only observe what these already published:
+#
+# * ``live_tool_started_at`` — one epoch per call executing now, for the row.
+# * ``activity_phase``/``activity_phase_started_at`` — the phase edge, for the
+#   band's ``thinking``/``responding``/``composing`` arm, which has no call
+#   behind it at all.
+#
+# The rule they share, and the one worth stating before the assertions: a
+# MISSING epoch is never filled in with the fold's own ``now``. For an attached
+# viewer that value is its arrival instant wearing the call's name, and it
+# would print a plausible wrong age where the widget's blank column is the
+# truth. The tests below pin that refusal as hard as they pin the fold.
+# ---------------------------------------------------------------------------
+
+
+def _live_session() -> SimpleNamespace:
+    """A session in the MIDDLE of a turn, which is the only state these drive.
+
+    ``is_streaming`` is not decoration: ``observe_event`` calls
+    ``refresh_from_session`` at tool and message boundaries, and that method's
+    non-streaming gate is the documented way a settled session publishes no
+    phase and no live anchors at all. A fake without the flag therefore blanks
+    both fields on the first ``tool_execution_end`` — which is correct
+    behaviour being exercised by the wrong fixture.
+    """
+    return SimpleNamespace(effective_model=_spec(), is_streaming=True)
+
+
+def test_live_tool_starts_fold_per_call_and_pop_on_their_own_end() -> None:
+    """One anchor per LIVE call, keyed by id, released by that call's end.
+
+    Keyed rather than scalar because a batch has several: the operator's report
+    was a row and a band disagreeing about one call's age, and only a per-call
+    map can tell both surfaces which call's start they are counting from.
+    """
+    store = FrontendStateStore(_state())
+    session = _live_session()
+    store.observe_event(session, AgentStartEvent(generation=1))
+    assert store.live_tool_start_epochs() == {}
+
+    started = time.time() - 27.0
+    store.observe_event(
+        session,
+        ToolExecutionStartEvent(
+            tool_call_id="call-bash", tool_name="bash", args={}, started_at_epoch=started
+        ),
+    )
+    store.observe_event(
+        session,
+        ToolExecutionStartEvent(
+            tool_call_id="call-read",
+            tool_name="read",
+            args={},
+            started_at_epoch=started + 1.0,
+        ),
+    )
+    assert store.live_tool_start_epochs() == {"call-bash": started, "call-read": started + 1.0}
+
+    # One call of the batch finishes; the survivor keeps ITS own zero, so the
+    # band's floor cannot move because a sibling settled.
+    store.observe_event(
+        session,
+        ToolExecutionEndEvent(
+            tool_call_id="call-read",
+            tool_name="read",
+            result=ToolResult(tool_call_id="call-read", tool_name="read", content=[]),
+        ),
+    )
+    assert store.live_tool_start_epochs() == {"call-bash": started}
+
+
+def test_a_start_without_an_epoch_contributes_no_anchor() -> None:
+    """The refusal, asserted directly: no epoch means no entry, never a stamp.
+
+    An older runtime's events carry no ``started_at_epoch``, and an attached
+    viewer that substituted its own fold instant would be inventing the age the
+    whole change exists to stop inventing. Absence here is what makes the
+    widget withhold the clock instead — which is why this is the failure mode
+    worth pinning rather than an edge case.
+    """
+    store = FrontendStateStore(_state())
+    session = _live_session()
+    store.observe_event(session, AgentStartEvent(generation=1))
+    store.observe_event(
+        session, ToolExecutionStartEvent(tool_call_id="call-legacy", tool_name="bash", args={})
+    )
+    assert store.live_tool_start_epochs() == {}
+    # And the phase is still folded: the SEQ is knowable even when the instant
+    # is not, and the two answers are independent on purpose.
+    assert store.state.activity_phase == "running"
+
+
+def test_both_ends_of_a_turn_clear_the_live_anchors() -> None:
+    """Stale anchors are worse than none, so the turn boundary clears them all.
+
+    Not left to the individual ends: a turn that dies without emitting every
+    ``tool_execution_end`` — an abort, a killed provider stream — would leave
+    an entry behind, and a later turn's row seeding from it would wear a
+    previous turn's age.
+    """
+    store = FrontendStateStore(_state())
+    session = _live_session()
+    store.observe_event(session, AgentStartEvent(generation=1))
+    store.observe_event(
+        session,
+        ToolExecutionStartEvent(
+            tool_call_id="call-1", tool_name="bash", args={}, started_at_epoch=time.time() - 5.0
+        ),
+    )
+    assert store.live_tool_start_epochs() != {}
+
+    store.observe_event(session, AgentEndEvent(messages=[Message.assistant("done")]))
+    assert store.live_tool_start_epochs() == {}
+
+    # A NEW turn starts clean too, so an anchor that somehow survived a turn end
+    # still cannot seed the next turn's rows.
+    store.observe_event(session, AgentStartEvent(generation=2))
+    store.observe_event(
+        session,
+        ToolExecutionStartEvent(
+            tool_call_id="call-2", tool_name="bash", args={}, started_at_epoch=time.time()
+        ),
+    )
+    store.observe_event(session, AgentStartEvent(generation=3))
+    assert store.live_tool_start_epochs() == {}
+
+
+def test_live_tool_start_epochs_hands_out_a_copy() -> None:
+    """The map is the store's own object, so callers must not be able to reach it."""
+    store = FrontendStateStore(_state())
+    session = _live_session()
+    store.observe_event(session, AgentStartEvent(generation=1))
+    store.observe_event(
+        session,
+        ToolExecutionStartEvent(
+            tool_call_id="call-1", tool_name="bash", args={}, started_at_epoch=1_700_000_000.0
+        ),
+    )
+    handed_out = store.live_tool_start_epochs()
+    handed_out["call-evil"] = 1.0
+    assert store.live_tool_start_epochs() == {"call-1": 1_700_000_000.0}
+
+
+def test_the_phase_fold_restarts_only_when_the_kind_of_work_changes() -> None:
+    """The band's zero, folded from the events that BEGIN a phase.
+
+    Every case here is the phone projection's rule, which is the same row on
+    another screen: a phase restarts the zero when it begins a KIND of work,
+    never when it merely relabels one. The composed batch is the case that shows
+    the difference — three calls announced in one dictation are one zero, and
+    restarting per announcement would show "still composing" counting from zero
+    three times over.
+    """
+    store = FrontendStateStore(_state())
+    session = _live_session()
+
+    def seen() -> tuple[str, float | None]:
+        return store.activity_phase_clock()
+
+    store.observe_event(session, AgentStartEvent(generation=1))
+    phase, first = seen()
+    assert phase == "thinking" and first is not None
+
+    # A second compose event of the SAME dictation: no restart.
+    store.observe_event(
+        session, ToolCallComposeEvent(tool_call_id="c1", tool_name="bash", argument_bytes=10)
+    )
+    composing, composed_at = seen()
+    assert composing == "composing"
+    store.observe_event(
+        session, ToolCallComposeEvent(tool_call_id="c2", tool_name="read", argument_bytes=10)
+    )
+    assert seen() == (composing, composed_at), "one dictation, one zero"
+
+    store.observe_event(
+        session,
+        ToolExecutionStartEvent(
+            tool_call_id="c1", tool_name="bash", args={}, started_at_epoch=time.time()
+        ),
+    )
+    store.observe_event(
+        session,
+        ToolExecutionStartEvent(
+            tool_call_id="c2", tool_name="read", args={}, started_at_epoch=time.time()
+        ),
+    )
+    running, running_at = seen()
+    assert running == "running"
+
+    # A SIBLING is still executing, so the batch has not gone back to waiting on
+    # the model: restarting here would reset the number the surviving row's
+    # label still claims.
+    store.observe_event(
+        session,
+        ToolExecutionEndEvent(
+            tool_call_id="c1",
+            tool_name="bash",
+            result=ToolResult(tool_call_id="c1", tool_name="bash", content=[]),
+        ),
+    )
+    assert seen() == (running, running_at), "a batch with a live call is still running"
+
+    # The LAST call of the batch: now the turn is waiting on the model again,
+    # and the zero belongs to that wait.
+    store.observe_event(
+        session,
+        ToolExecutionEndEvent(
+            tool_call_id="c2",
+            tool_name="read",
+            result=ToolResult(tool_call_id="c2", tool_name="read", content=[]),
+        ),
+    )
+    thinking, waited_at = seen()
+    assert thinking == "thinking" and waited_at != running_at
+
+    # A model call OPENING is its own phase edge, and the placeholder it yields
+    # before the first token is the edge rather than the first token itself:
+    # waiting on the model is what the turn is doing while nothing streams.
+    store.observe_event(session, MessageStartEvent(message=Message.assistant("")))
+    model_call, calling_at = seen()
+    assert model_call == "thinking" and calling_at != waited_at
+
+    # The first non-empty delta is the transition to prose; an empty one (a
+    # repeat placeholder mid-stream) is not.
+    store.observe_event(session, MessageUpdateEvent(message=Message.assistant(""), delta=""))
+    assert seen() == (model_call, calling_at)
+    store.observe_event(session, MessageUpdateEvent(message=Message.assistant("h"), delta="h"))
+    responding, responded_at = seen()
+    assert responding == "responding" and responded_at != calling_at
+
+    store.observe_event(session, MessageEndEvent(message=Message.assistant("hi")))
+    assert seen()[0] == "thinking"
+
+    store.observe_event(session, AgentEndEvent(messages=[Message.assistant("hi")]))
+    assert seen() == ("", None), "a settled turn has no phase to match"
+
+
+def test_the_phase_pair_rides_the_wire_and_is_not_durable() -> None:
+    """One round trip, and one strip — the two places a transient pair is read.
+
+    The pair is carried in ``refresh_from_session`` under the streaming gate so
+    a viewer attaching mid-turn receives the producer's own phase zero; it is
+    NOT carried into the checkpoint, because a checkpoint describes a turn that
+    has ended and there is no phase left to date.
+    """
+    import asyncio
+
+    state = _state(
+        streaming=True,
+        activity_phase="thinking",
+        activity_phase_started_at=1_700_000_000.0,
+        live_tool_started_at={"call-1": 1_699_999_900.0},
+    )
+    store = FrontendStateStore(state)
+    wire = sync_wire_payload(store.subscribe(lambda _u: None).sync)
+    snapshot = wire["snapshot"]
+    assert snapshot["activity_phase"] == "thinking"
+    assert snapshot["activity_phase_started_at"] == 1_700_000_000.0
+    assert snapshot["live_tool_started_at"] == {"call-1": 1_699_999_900.0}
+
+    class _Transcript:
+        def __init__(self) -> None:
+            self.appended: list[tuple[str, dict[str, Any]]] = []
+
+        async def append_custom(self, custom_type: str, payload: dict[str, Any]) -> None:
+            self.appended.append((custom_type, payload))
+
+    transcript = _Transcript()
+    asyncio.run(store.checkpoint(transcript))
+    ((_, payload),) = transcript.appended
+    assert payload["state"]["live_tool_started_at"] == {}, (
+        "the live anchors describe calls running NOW in this process; nothing "
+        "in a durable checkpoint can restore them"
+    )
+    # The pair is a scalar the turn-end fold clears, so it is not stripped.
+    assert payload["state"]["activity_phase"] == "thinking"

--- a/tests/unit/session/test_viewer_protocol.py
+++ b/tests/unit/session/test_viewer_protocol.py
@@ -1361,6 +1361,30 @@ def test_the_static_conformance_anchor_still_exists() -> None:
     )
 
 
+def test_both_session_shapes_answer_the_live_clock_accessors() -> None:
+    """The two clock anchors are declared on the protocol and answered by BOTH.
+
+    A per-call start epoch plus the working line's phase zero are what let a
+    front end that attaches mid-turn date the work in flight, and both session
+    shapes have to answer them: the local owner is the producer of those
+    instants, and an attached viewer folds them off the same events. Declared
+    on the protocol so pyright checks the SIGNATURES at
+    ``_static_conformance_is_checked_by_pyright``; what is asserted here is the
+    runtime half that isinstance cannot see — that neither shape raises on a
+    store it has not built yet.
+
+    The unsynchronized answers are the point rather than a technicality:
+    ``{}`` and ``("", None)`` both reduce to "withhold the clock", which is
+    what every consumer does with a missing entry. A facade that raised here
+    instead would take down a repaint, and one that defaulted to its own
+    arrival instant would print an age nobody measured.
+    """
+    for klass in (Session, AttachedSession):
+        shape = klass.__new__(klass)
+        assert shape.live_tool_start_epochs() == {}, klass.__name__
+        assert shape.activity_phase_clock() == ("", None), klass.__name__
+
+
 def test_every_registered_session_binding_still_matches_the_source() -> None:
     """Each (host, binding) pair in ``_SCANNED`` must derive at least one member.
 

--- a/tests/unit/tui/test_sidebar_live_tool_card.py
+++ b/tests/unit/tui/test_sidebar_live_tool_card.py
@@ -63,7 +63,6 @@ from local_operator.session.runtime.server import RuntimeServer
 from local_operator.session.runtime.serving import ServingSessionHandle
 from local_operator.tui.app import OperatorApp, ToolCard
 from local_operator.tui.events import TurnStarted
-from local_operator.tui.widgets.tool_card import format_duration
 from tests.e2e.harness import (
     ScriptedStream,
     assistant_message,
@@ -731,8 +730,13 @@ async def test_a_replayed_running_row_arms_from_the_sessions_start_epoch() -> No
         card = _paint_one(app, "call-clock", session)
         assert card._state == "running"
         assert card._started is not None
-        assert card._elapsed() == pytest.approx(aged, abs=1.0)
-        assert format_duration(round(card._elapsed() or 0.0)) == format_duration(int(aged))
+        # A RANGE, not the string `27s`: the reading grows between the fixture's
+        # instant and this line, so an exact number asserts that the machine is
+        # fast rather than that the seed is right — this assertion's first CI run
+        # returned `28s` on correct code. The failure worth catching is the wrong
+        # ORDER of magnitude: a zero taken when the row was painted.
+        elapsed = card._elapsed()
+        assert elapsed is not None and aged <= elapsed < aged + 30, elapsed
 
 
 @pytest.mark.asyncio
@@ -783,9 +787,10 @@ async def test_a_switch_away_and_back_resumes_a_live_tools_true_age() -> None:
         card = app._tool_cards["call-live"]
         assert card._state == "running"
         assert card._started is not None, "the session knows when this call began"
-        assert card._elapsed() == pytest.approx(aged, abs=1.0), (
-            f"the row reads {card._elapsed()} for a call {aged}s old: it counted "
-            "from the switch instead of from the call's own start"
+        elapsed = card._elapsed()
+        assert elapsed is not None and aged <= elapsed < aged + 30, (
+            f"the row reads {elapsed} for a call {aged}s old: it counted from "
+            "the switch instead of from the call's own start"
         )
 
         # (2) The owner's seed arrives and re-delivers the still-in-flight start
@@ -802,9 +807,10 @@ async def test_a_switch_away_and_back_resumes_a_live_tools_true_age() -> None:
         )
         await pilot.pause()
         await pilot.pause()
-        assert card._elapsed() == pytest.approx(
-            aged, abs=1.0
-        ), "re-entry reset the row: begin_running must seed from the same epoch"
+        elapsed = card._elapsed()
+        assert elapsed is not None and aged <= elapsed < aged + 30, (
+            f"re-entry reset the row to {elapsed}: begin_running must seed from " "the same epoch"
+        )
         assert len(app._tool_cards) == 1
 
         # The band reads the same anchor, which is the second clock in the
@@ -812,7 +818,9 @@ async def test_a_switch_away_and_back_resumes_a_live_tools_true_age() -> None:
         app._refresh_working_activity()
         line = app._working_block
         assert line is not None
-        assert line._clock_text() == format_duration(int(aged)), line._clock_text()
+        shown = line._clock_text()
+        assert shown.endswith("s") and shown[:-1].isdigit(), shown
+        assert aged <= float(shown[:-1]) < aged + 30, shown
 
         # And the receipt stays the CALL's, not the viewer's. A card that can
         # date itself keeps its own reading (`mark_done`), and the executor's
@@ -834,9 +842,10 @@ async def test_a_switch_away_and_back_resumes_a_live_tools_true_age() -> None:
         await pilot.pause()
         await pilot.pause()
         assert card._state == "success"
-        assert card._duration == pytest.approx(aged, abs=1.0), (
-            f"the receipt reads {card._duration} for a call {aged}s old — the "
-            "settle fell back to the switch instant"
+        duration = card._duration
+        assert duration is not None and aged <= duration < aged + 30, (
+            f"the receipt reads {duration} for a call {aged}s old — the settle "
+            "fell back to the switch instant"
         )
 
 

--- a/tests/unit/tui/test_sidebar_live_tool_card.py
+++ b/tests/unit/tui/test_sidebar_live_tool_card.py
@@ -54,12 +54,16 @@ from local_operator.harness.types import (
     Message,
     TextContent,
     ToolCall,
+    ToolExecutionEndEvent,
+    ToolExecutionStartEvent,
     ToolResult,
 )
 from local_operator.session.attached import AttachedSession
 from local_operator.session.runtime.server import RuntimeServer
 from local_operator.session.runtime.serving import ServingSessionHandle
 from local_operator.tui.app import OperatorApp, ToolCard
+from local_operator.tui.events import TurnStarted
+from local_operator.tui.widgets.tool_card import format_duration
 from tests.e2e.harness import (
     ScriptedStream,
     assistant_message,
@@ -71,6 +75,11 @@ from tests.e2e.harness import (
     wait_for_adoption,
 )
 from tests.unit.harness.test_comms import DEADLOCK_GUARD_S, MAX_PUMP_TURNS
+
+# Module-level rather than per-test as the rest of this file does it: the
+# epoch-carrying fake below is a CLASS, so its base has to exist at import
+# time. Nothing in `test_app_pilot` imports this module, so there is no cycle.
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
 #: Not ``wait``. ``Session._merge_capability_tools`` merges the real ``wait``
 #: builtin into every session it builds, and a same-named double is SHADOWED by
@@ -636,31 +645,199 @@ async def test_a_cold_resume_of_the_same_history_still_marks_interrupted() -> No
 
 
 @pytest.mark.asyncio
-async def test_a_replayed_running_row_never_starts_its_clock() -> None:
-    """A painted live row withholds its clock exactly as restore does.
+class _Epochs(FakeSession):
+    """A session whose owner has stamped start instants for its live calls.
 
-    The transcript carries no true start time for an in-flight call, so the
-    one row the owner paints must refuse to count from when it was painted —
-    the same guarantee `restore(state="running")` makes, pinned here on the
-    painter the projection path uses. Driven through the app's own view so
-    the mount is real.
+    The seam the fix rests on and the only thing that changed about this
+    surface: the painter still refuses to invent a start, and now has one to
+    use when the session carried it. The three attributes are CLASS-level so a
+    test can set the ones it cares about and a fixed instant never depends on
+    construction time.
     """
-    from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
-    app = OperatorApp(lambda: _factory(FakeSession()))
+    epochs: dict[str, float] = {}
+    #: The calls the owner reports as still executing, and which of them is
+    #: parked at a gate — the pair the projection asks before it skips a replay
+    #: row, forwarded so this fake drives the real decision instead of a
+    #: hand-rolled one.
+    executing: set[str] = set()
+    pending: set[str] = set()
+
+    def live_tool_start_epochs(self) -> dict[str, float]:
+        return dict(self.epochs)
+
+    def executing_display_tool_ids(self) -> set[str]:
+        return set(self.executing)
+
+    def pending_display_tool_ids(self) -> set[str]:
+        return set(self.pending)
+
+
+def _paint_one(app: OperatorApp, call_id: str, session: Any = None) -> ToolCard:
+    """Paint a skipped live call through the app's OWN painter and return its row."""
+    view = app._transcript_view()
+    OperatorApp._paint_skipped_live_tool_rows(
+        view, app._tool_cards, [_call(call_id)], session=session
+    )
+    return app._tool_cards[call_id]
+
+
+@pytest.mark.asyncio
+async def test_a_replayed_running_row_without_a_start_epoch_never_starts_its_clock() -> None:
+    """No known start ⇒ no number, rather than a number about the VIEWER.
+
+    A call whose start nobody recorded — a legacy producer, a child row inside
+    `subagent_view` — reaches the painter with nothing to seed from, and its
+    ``_started`` would otherwise be the instant this view painted the row. A
+    clock started from the wrong zero is worse than no clock, so the column
+    stays blank. Driven through the app's own view so the mount is real.
+    """
+    app = OperatorApp(lambda: _factory(_Epochs()))
     async with app.run_test(size=(100, 30)) as pilot:
         await wait_for_adoption(app, pilot)
         await pilot.pause()
 
-        view = app._transcript_view()
-        OperatorApp._paint_skipped_live_tool_rows(view, app._tool_cards, [_call("call-clock")])
-        card = app._tool_cards["call-clock"]
+        card = _paint_one(app, "call-clock", _Epochs())
         assert card._state == "running"
         assert card._started is None
+        assert card._elapsed() is None
         # One row per call: painting the same skipped call again is a no-op.
-        OperatorApp._paint_skipped_live_tool_rows(view, app._tool_cards, [_call("call-clock")])
+        view = app._transcript_view()
+        OperatorApp._paint_skipped_live_tool_rows(
+            view, app._tool_cards, [_call("call-clock")], session=_Epochs()
+        )
         assert len(app._tool_cards) == 1
         assert len([b for b in view.blocks() if isinstance(b, ToolCard)]) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_replayed_running_row_arms_from_the_sessions_start_epoch() -> None:
+    """The other half of the same arm: a KNOWN start is the call's age.
+
+    Same painter, same row, same blank-when-unknown rule — with the session's
+    folded epoch threaded in, the elapsed reading becomes the call's true age
+    instead of being withheld. That is the whole change: the refusal was
+    precise, not total.
+    """
+    aged = 27.0
+    session = _Epochs()
+    session.epochs = {"call-clock": time.time() - aged}
+
+    app = OperatorApp(lambda: _factory(_Epochs()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await wait_for_adoption(app, pilot)
+        await pilot.pause()
+
+        card = _paint_one(app, "call-clock", session)
+        assert card._state == "running"
+        assert card._started is not None
+        assert card._elapsed() == pytest.approx(aged, abs=1.0)
+        assert format_duration(round(card._elapsed() or 0.0)) == format_duration(int(aged))
+
+
+@pytest.mark.asyncio
+async def test_a_switch_away_and_back_resumes_a_live_tools_true_age() -> None:
+    """The operator's report, driven through both paths a switch-back takes.
+
+    The report: a live `bash` row reading `27s`, the operator switches to
+    another conversation in the sidebar and back, and the row restarts at zero
+    and counts up from the switch — so the one number on it, the answer to "is
+    this thing stuck", is about the viewer instead of the call. The band beside
+    it said the same thing, because a running batch's clock is the oldest live
+    card's own start.
+
+    Both halves of the re-entry are driven here, because passing only one of
+    them leaves the other resetting the row to zero — which is exactly the
+    bug's shape:
+
+    1. the replay the switch performs, which paints the row through
+       ``restore`` (``_mark_pending_tool_rows`` / the skipped-call painter),
+    2. the owner's live seed re-delivered through the event controller, which
+       reaches the SAME row through ``begin_running``.
+
+    A fresh reading is NOT the assertion: ``27s`` is, and the difference
+    between the two is the whole fix. The receipt at the end is asserted too,
+    so a fix that bought the live number by feeding the settle path would fail
+    here.
+    """
+    aged = 27.0
+    epoch = time.time() - aged
+    session = _Epochs()
+    session.epochs = {"call-live": epoch}
+    session.executing = {"call-live"}
+    session.streaming = True
+
+    app = OperatorApp(lambda: _factory(_Epochs()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await wait_for_adoption(app, pilot)
+        await pilot.pause()
+        app._session = session
+        # The turn the operator is away from is still running, so the band is
+        # mounted over this transcript — the second clock in the report.
+        app.post_message(TurnStarted())
+        await pilot.pause()
+
+        # (1) The switch back: the projection replays the conversation, skips
+        # the call the owner is still executing, and paints its ONE row.
+        app._project_settled_rows(_history_with_one_call("call-live"))
+        card = app._tool_cards["call-live"]
+        assert card._state == "running"
+        assert card._started is not None, "the session knows when this call began"
+        assert card._elapsed() == pytest.approx(aged, abs=1.0), (
+            f"the row reads {card._elapsed()} for a call {aged}s old: it counted "
+            "from the switch instead of from the call's own start"
+        )
+
+        # (2) The owner's seed arrives and re-delivers the still-in-flight start
+        # through the controller, which lands on the same row.
+        controller = app._controller
+        assert controller is not None
+        controller._on_event(
+            ToolExecutionStartEvent(
+                tool_call_id="call-live",
+                tool_name=PARKING_TOOL,
+                args={"job_id": "j1"},
+                started_at_epoch=epoch,
+            )
+        )
+        await pilot.pause()
+        await pilot.pause()
+        assert card._elapsed() == pytest.approx(
+            aged, abs=1.0
+        ), "re-entry reset the row: begin_running must seed from the same epoch"
+        assert len(app._tool_cards) == 1
+
+        # The band reads the same anchor, which is the second clock in the
+        # report — a batch's number is the oldest live card's own start (D9).
+        app._refresh_working_activity()
+        line = app._working_block
+        assert line is not None
+        assert line._clock_text() == format_duration(int(aged)), line._clock_text()
+
+        # And the receipt stays the CALL's, not the viewer's. A card that can
+        # date itself keeps its own reading (`mark_done`), and the executor's
+        # measured interval is the fallback for one that cannot — so a seeded
+        # row settles to the age its own seed implies, which for a real producer
+        # is the same interval it measured. What must never happen is the switch
+        # showing up in the receipt, and the two readings this asserts against
+        # are what separate the cases: `aged`, and the zero a reset would print.
+        controller._on_event(
+            ToolExecutionEndEvent(
+                tool_call_id="call-live",
+                tool_name=PARKING_TOOL,
+                result=ToolResult(
+                    tool_call_id="call-live", tool_name=PARKING_TOOL, duration_s=aged
+                ),
+                duration_s=aged,
+            )
+        )
+        await pilot.pause()
+        await pilot.pause()
+        assert card._state == "success"
+        assert card._duration == pytest.approx(aged, abs=1.0), (
+            f"the receipt reads {card._duration} for a call {aged}s old — the "
+            "settle fell back to the switch instant"
+        )
 
 
 def _history_with_one_call(call_id: str, tool_name: str = PARKING_TOOL) -> list[Message]:

--- a/tests/unit/tui/test_sidebar_live_tool_card.py
+++ b/tests/unit/tui/test_sidebar_live_tool_card.py
@@ -62,7 +62,7 @@ from local_operator.session.attached import AttachedSession
 from local_operator.session.runtime.server import RuntimeServer
 from local_operator.session.runtime.serving import ServingSessionHandle
 from local_operator.tui.app import OperatorApp, ToolCard
-from local_operator.tui.events import TurnStarted
+from local_operator.tui.events import ToolStarted, TurnStarted
 from tests.e2e.harness import (
     ScriptedStream,
     assistant_message,
@@ -737,6 +737,76 @@ async def test_a_replayed_running_row_arms_from_the_sessions_start_epoch() -> No
         # ORDER of magnitude: a zero taken when the row was painted.
         elapsed = card._elapsed()
         assert elapsed is not None and aged <= elapsed < aged + 30, elapsed
+
+
+@pytest.mark.asyncio
+async def test_a_start_event_with_no_row_and_no_epoch_mounts_clockless() -> None:
+    """QA round 1, Q1: the mount arm stamped the VIEWER's arrival as the call's start.
+
+    A ``tool_execution_start`` that reaches a view with NO row for its call —
+    the owner's live seed re-delivered to a rebuilt transcript — mounts a fresh
+    card. When the producer stamped the call the row wears that instant (the
+    sibling test above). When nobody did — a legacy producer, a facade whose
+    fold carries nothing for the call — the arm handed ``started_at=None`` to a
+    constructor where ``None`` means "this call begins now", so the row printed
+    an age counted from the moment the viewer arrived: ``0s`` on the mount, and
+    ``3s``/``5s`` end to end for a call that was by then ~13s old. That is the
+    same fabricated zero the PR exists to remove, and it also defeated D6,
+    because ``_current_activity`` then saw a batch of fully dateable cards.
+
+    Driven through the app's own handler rather than the constructor so the
+    seam under test is the real one: this is the path QA measured.
+    """
+    app = OperatorApp(lambda: _factory(_Epochs()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await wait_for_adoption(app, pilot)
+        await pilot.pause()
+
+        app.post_message(TurnStarted())
+        app.post_message(
+            ToolStarted(
+                ToolExecutionStartEvent(
+                    tool_call_id="call-legacy",
+                    tool_name=PARKING_TOOL,
+                    args={"job_id": "7a73c97ffc54"},
+                    started_at_epoch=None,
+                )
+            )
+        )
+        await pilot.pause()
+
+        card = app._tool_cards["call-legacy"]
+        assert card._state == "running"
+        assert card.started_at is None, "nobody knows when this call began"
+        assert card._elapsed() is None
+        from local_operator.tui.widgets.tool_card import RUNNING_LABEL
+
+        assert [text for text, _style in card._status_runs()] == [
+            RUNNING_LABEL
+        ], "an undateable mount must withhold the clock, not print the viewer's age"
+
+        # D6 rides the same rule: the band may not date a batch holding a card
+        # it cannot date. It cannot here because the card honestly has no epoch
+        # rather than an invented one, which is what `clock=False` reports.
+        assert app._current_activity()[2] is False
+
+        # The ordinary path is untouched: the SAME call re-delivered with the
+        # producer's stamp dates itself, so the fix withholds exactly the
+        # unknown case rather than every mount.
+        app.post_message(
+            ToolStarted(
+                ToolExecutionStartEvent(
+                    tool_call_id="call-dated",
+                    tool_name=PARKING_TOOL,
+                    args={"job_id": "7a73c97ffc54"},
+                    started_at_epoch=time.time() - 27.0,
+                )
+            )
+        )
+        await pilot.pause()
+        dated = app._tool_cards["call-dated"]
+        elapsed = dated._elapsed()
+        assert elapsed is not None and 27.0 <= elapsed < 57.0, elapsed
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_tool_card.py
+++ b/tests/unit/tui/test_tool_card.py
@@ -63,6 +63,7 @@ from local_operator.tui.widgets.tool_card import (
     ROW_INDENT,
     ROW_INDENT_MIN_WIDTH,
     RUNNING_NOTICE,
+    START_UNKNOWN,
     TERSE_NO_OUTPUT_NOTICE,
     ToolCard,
     _category_element,
@@ -2512,6 +2513,42 @@ def test_begin_running_arms_the_clock_from_the_epoch_when_it_has_one() -> None:
     other.restore(state="running")
     other.begin_running("bash", {"command": "sleep 30"}, None)
     assert other.started_at is None
+
+
+def test_an_unknown_start_mounts_clockless_where_none_still_means_begins_now() -> None:
+    """QA round 1, Q1: the constructor had one word for two different cases.
+
+    ``None`` on ``started_at`` means "this call begins now", and that is right
+    for the ordinary mount — the row appears with the event that started the
+    call, so the two instants coincide. It is WRONG for the adopted mount: a
+    start event that reaches a view with no row for its call (a re-delivered
+    live seed, a rebuilt transcript) is mounting a row for work already in
+    flight, and stamping the arrival instant there prints an age about the
+    VIEWER — measured at `0s` on the mount and `3s`/`5s` end to end for a call
+    that was by then ~13s old.
+
+    So the second case gets its own value. ``START_UNKNOWN`` withholds the
+    clock, which is the same reading ``restore`` and ``begin_running`` already
+    give a missing epoch, and leaves the ordinary path exactly as it was —
+    asserted together, because a fix that withheld both would have broken every
+    native row to fix one seam.
+    """
+    now = [1_500.0]
+    unknown = ToolCard(
+        "u", "bash", {"command": "sleep 30"}, clock=lambda: now[0], started_at=START_UNKNOWN
+    )
+    assert unknown.started_at is None
+    assert unknown._elapsed() is None
+    assert not unknown._build_row(80).plain.rstrip().endswith("s")
+    # Not even after time passes and the clock is asked again: this row can
+    # never date itself, because it never learned when the call began.
+    now[0] += 5.0
+    assert unknown._elapsed() is None
+    assert not unknown._build_row(80).plain.rstrip().endswith("s")
+
+    ordinary = ToolCard("n", "bash", {"command": "sleep 30"}, clock=lambda: now[0])
+    assert ordinary.started_at == 1_505.0, "the ordinary mount still takes the mount instant"
+    assert ordinary._build_row(80).plain.rstrip().endswith("0s")
 
 
 def test_a_row_that_watched_its_own_start_keeps_its_own_zero() -> None:

--- a/tests/unit/tui/test_tool_card.py
+++ b/tests/unit/tui/test_tool_card.py
@@ -22,6 +22,7 @@ hexes so a ramp change moves one file, not this suite.
 
 from __future__ import annotations
 
+import time
 import unicodedata
 from types import SimpleNamespace
 from typing import Any, cast
@@ -2415,3 +2416,114 @@ def test_a_resize_to_a_new_width_does_rebuild() -> None:
     card.on_resize(SimpleNamespace(size=SimpleNamespace(width=card._built_width - 20)))
 
     assert builds["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# The seeded clock: a row adopted for a call that is ALREADY running.
+#
+# Reported from the field: switch away from a session whose tool is executing
+# and switch back, and the row's elapsed reading restarts at zero and counts up
+# from the switch — a `bash` row reading `27s` (and the band above it saying the
+# same) while the call is half an hour old. The row was not wrong to refuse a
+# number: it had NO start instant, so any number it printed was a claim about
+# when the VIEWER arrived. What changed is that the start is now knowable, so
+# the refusal is precise rather than total.
+#
+# These drive the card directly with an INJECTED clock, so "the number is the
+# call's true age" is arithmetic rather than a sleep: a test that slept 27
+# seconds to prove a count-up would be a test nobody runs. The wall-clock part
+# only converts the epoch once, at the seed; see `monotonic_from_epoch`.
+# ---------------------------------------------------------------------------
+
+
+def test_a_restored_running_row_arms_from_the_call_start_epoch() -> None:
+    """The epoch is the call's own start, so the number IS its age.
+
+    And it keeps ticking from that anchor — the second read is three seconds
+    later on the injected monotonic clock, not a re-conversion of the epoch, so
+    a wall-clock adjustment after the seed cannot move a running counter.
+    """
+    now = [1_000.0]
+    card = ToolCard("t", "bash", {"command": "sleep 30"}, clock=lambda: now[0])
+    card.restore(state="running", started_at=time.time() - 27.0)
+
+    assert card.started_at is not None, "a call whose start is known dates itself"
+    assert card.started_at == pytest.approx(now[0] - 27.0, abs=0.05)
+    assert card._build_row(80).plain.rstrip().endswith("27s")
+
+    now[0] += 3.0
+    assert card._build_row(80).plain.rstrip().endswith("30s")
+
+
+def test_a_restored_running_row_without_a_start_epoch_still_withholds() -> None:
+    """The other half of the same arm, and not a legacy curiosity.
+
+    A `subagent_view` child row and a call whose producer predates the field
+    both reach this with nothing to seed from, and the honest rendering for
+    them is still the blank column: their ``_started`` is when this surface
+    painted the row, so any number here would be about the viewer.
+    """
+    now = [1_000.0]
+    card = ToolCard("t", "bash", {"command": "sleep 30"}, clock=lambda: now[0])
+    card.restore(state="running")
+
+    assert card.started_at is None
+    assert card._elapsed() is None
+    assert not card._build_row(80).plain.rstrip().endswith("s")
+
+
+def test_a_settled_row_ignores_a_start_epoch() -> None:
+    """Settled states are rendered from the executor's measured interval.
+
+    Passing an epoch must not change that: the receipt for a finished call is
+    ``duration_s``, and a start instant has no part in it.
+    """
+    now = [1_000.0]
+    card = ToolCard("t", "bash", {"command": "sleep 1"}, clock=lambda: now[0])
+    card.restore(state="success", result_text="done", duration_s=6.0, started_at=time.time() - 27.0)
+
+    assert card.started_at is None, "a settled row holds no running start"
+    assert card._duration == 6.0, "the executor's measured interval is the receipt"
+    row = card._build_row(80).plain
+    assert "6.0s" in row
+    assert "27s" not in row, "the epoch has no part in a settled receipt"
+
+
+def test_begin_running_arms_the_clock_from_the_epoch_when_it_has_one() -> None:
+    """The re-entry arm, which the switch actually takes.
+
+    A re-delivered ``ToolStarted`` — `/resume` onto the running turn, or a
+    switch away and back replaying the owner's live seed — reaches the SAME
+    card the projection restored, through ``begin_running``. Seeding only
+    ``restore`` would leave this call resetting the row to zero, which is
+    exactly the reported frame.
+    """
+    now = [2_000.0]
+    card = ToolCard("t", "bash", clock=lambda: now[0])
+    card.set_composing(12, "bash")
+    card.begin_running("bash", {"command": "sleep 30"}, None, started_at=time.time() - 41.0)
+
+    assert card.started_at == pytest.approx(now[0] - 41.0, abs=0.05)
+    assert card._build_row(80).plain.rstrip().endswith("41s")
+
+    # Without an epoch the re-entry keeps the withheld clock, which is what a
+    # caller with nothing to pass must not be able to lose by accident.
+    other = ToolCard("t2", "bash", clock=lambda: now[0])
+    other.restore(state="running")
+    other.begin_running("bash", {"command": "sleep 30"}, None)
+    assert other.started_at is None
+
+
+def test_a_row_that_watched_its_own_start_keeps_its_own_zero() -> None:
+    """The seeded arm must not displace the ordinary one.
+
+    A call this process watched begin dates itself from the event that started
+    it. Pushing a session epoch through this path could only be a re-statement
+    of the same instant, so the assertion is that a fresh card's own clock is
+    untouched by the arrival of the feature.
+    """
+    now = [3_000.0]
+    card = ToolCard("t", "bash", {"command": "ls"}, clock=lambda: now[0])
+    assert card.started_at == 3_000.0
+    now[0] += 2.0
+    assert card._build_row(80).plain.rstrip().endswith("2s")

--- a/tests/unit/tui/test_working_line.py
+++ b/tests/unit/tui/test_working_line.py
@@ -72,6 +72,21 @@ from local_operator.tui.widgets.transcript import (
 from .test_app_pilot import FakeSession, _factory
 
 
+def _clock_seconds(text: str) -> float:
+    """The seconds a ``format_duration`` reading names, for RANGE assertions.
+
+    A band reading is wall time between the seed and the read, so pinning it to
+    an exact ``27s`` asserts that the machine is fast — the failure mode
+    AGENTS.md names ("prefer a structural invariant to a numeric one"), and one
+    this file's own first CI run demonstrated: a loaded shard spent a second
+    between computing the age and reading the row, and `27s` came back `28s`
+    on a change that was correct. What is worth asserting is the ORDER — the
+    call's own age, not a zero taken at paint time.
+    """
+    assert text.endswith("s") and text[:-1].isdigit(), text
+    return float(text[:-1])
+
+
 def _working(app: OperatorApp) -> WorkingBlock | None:
     """The mounted working line, or None when the turn has settled."""
     blocks = app.query_one(TranscriptView).blocks()
@@ -519,8 +534,13 @@ async def test_the_band_reports_the_true_age_of_a_tool_it_can_date() -> None:
         card = app._tool_cards["c0"]
         assert card.started_at is not None, "a call whose start is known dates itself"
         # Age-only, so the reading is the call's, not the phase's: the band
-        # counts from the oldest live card's own start (D9).
-        assert line._clock_text() == format_duration(int(aged)), line._clock_text()
+        # counts from the oldest live card's own start (D9). The band's number
+        # is asserted as a RANGE (`aged` up to a generous ceiling) rather than
+        # as the string `27s`: the reading grows while the test runs, and the
+        # failure worth catching is the wrong ORDER of magnitude — a zero taken
+        # when the row was painted.
+        shown = _clock_seconds(line._clock_text())
+        assert aged <= shown < aged + 30, line._clock_text()
 
 
 @pytest.mark.asyncio
@@ -554,7 +574,8 @@ async def test_the_thinking_clock_resumes_its_true_age_after_a_switch(
         assert line is not None
         assert line.activity == DEFAULT_ACTIVITY
         # The frame after a switch back: the age is the model call's.
-        assert line._clock_text() == format_duration(int(aged)), line._clock_text()
+        shown = _clock_seconds(line._clock_text())
+        assert aged <= shown < aged + 30, line._clock_text()
 
         # Converted ONCE, not per refresh — asserted with the clock ADJUSTED,
         # because on a healthy clock a re-seed is arithmetically a no-op and the
@@ -570,7 +591,9 @@ async def test_the_thinking_clock_resumes_its_true_age_after_a_switch(
         app._refresh_working_activity()
         app._refresh_working_activity()
         assert line._clock_from == seeded, "the phase's anchor moved on a repaint"
-        assert line._clock_text() == format_duration(int(aged)), line._clock_text()
+        assert _clock_seconds(line._clock_text()) == pytest.approx(
+            shown, abs=2.0
+        ), "a wall-clock jump moved a counter that is supposed to be immune to one"
 
         # A fold that disagrees with the derived phase supplies nothing, so the
         # row is back to its phase zero. The instant belongs to the phase it was
@@ -578,7 +601,7 @@ async def test_the_thinking_clock_resumes_its_true_age_after_a_switch(
         # thing — the failure mode the whole design round guards.
         session.phase = ("responding", time.time() - aged)
         app._refresh_working_activity()
-        assert line._clock_text() == format_duration(0), line._clock_text()
+        assert _clock_seconds(line._clock_text()) < 5, line._clock_text()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_working_line.py
+++ b/tests/unit/tui/test_working_line.py
@@ -32,6 +32,7 @@ how the app routes messages internally.
 from __future__ import annotations
 
 import time
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -59,6 +60,7 @@ from local_operator.tui.events import (
     TurnEnded,
     TurnStarted,
 )
+from local_operator.tui.widgets import tool_card as card_mod
 from local_operator.tui.widgets.tool_card import format_duration
 from local_operator.tui.widgets.transcript import (
     DEFAULT_ACTIVITY,
@@ -103,10 +105,35 @@ def _is_last(app: OperatorApp) -> bool:
     return bool(blocks) and isinstance(blocks[-1], WorkingBlock)
 
 
-def _started(tool_call_id: str, tool_name: str, **args: Any) -> ToolStarted:
+def _started(
+    tool_call_id: str, tool_name: str, epoch: float | None = None, **args: Any
+) -> ToolStarted:
     return ToolStarted(
-        ToolExecutionStartEvent(tool_call_id=tool_call_id, tool_name=tool_name, args=args)
+        ToolExecutionStartEvent(
+            tool_call_id=tool_call_id, tool_name=tool_name, args=args, started_at_epoch=epoch
+        )
     )
+
+
+class _PhaseSession(FakeSession):
+    """A session that publishes the folded working-line phase and its zero.
+
+    The live half of ``FrontendSessionState.activity_phase`` /
+    ``activity_phase_started_at``, which is what a viewer coming back to a
+    session mid-model-call receives. ``epochs`` is the per-call map beside it,
+    kept here because both are read through the same session object.
+    """
+
+    def __init__(self, phase: str = "", started_at: float | None = None) -> None:
+        super().__init__()
+        self.phase: tuple[str, float | None] = (phase, started_at)
+        self.epochs: dict[str, float] = {}
+
+    def activity_phase_clock(self) -> tuple[str, float | None]:
+        return self.phase
+
+    def live_tool_start_epochs(self) -> dict[str, float]:
+        return self.epochs
 
 
 def _ended(tool_call_id: str, tool_name: str) -> ToolEnded:
@@ -401,9 +428,13 @@ async def test_the_band_shows_no_clock_for_a_tool_it_cannot_date() -> None:
     clock". Naming the tool is exactly what turns an adjacent generic clock
     into a claim about it, so the label is kept and the number is dropped.
 
-    The number is not recoverable by trying harder: ``ToolExecutionStartEvent``
-    carries no timestamp, so the true age of an adopted call does not exist on
-    this surface at any price. Withholding it is the only honest rendering.
+    The number is recoverable, and ONLY when somebody recorded it: this row is
+    now seeded from the session's folded ``ToolExecutionStartEvent.
+    started_at_epoch`` for the call, so an adopted call with a live producer
+    behind it reports its real age (the sibling test below). What this test
+    pins is the case where no such instant exists — a legacy producer, a
+    ``subagent_view`` child row — because the fix must not turn "unknown" into
+    "the moment I arrived" for them.
 
     Asserted on the text ``_paint`` COMPOSES rather than on the rendered strip,
     for the reason the width test above documents: Textual clips a strip to the
@@ -458,6 +489,96 @@ async def test_the_band_shows_no_clock_for_a_tool_it_cannot_date() -> None:
         assert format_duration(30) not in painted, painted
 
         line.set_content = original  # type: ignore[method-assign]
+
+
+@pytest.mark.asyncio
+async def test_the_band_reports_the_true_age_of_a_tool_it_can_date() -> None:
+    """The other half of D6: a KNOWN start is the work's own zero.
+
+    Same frame as the test above — a card adopted for a call already running,
+    named by the band — with the session's folded epoch supplied. The number is
+    then the call's real age rather than the phase's, which is the whole point:
+    the row refused a clock because it had no start, not because a start was
+    unknowable.
+    """
+    aged = 27.0
+    session = _PhaseSession("running", None)
+    session.epochs = {"c0": time.time() - aged}
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._session = session
+        app.post_message(TurnStarted())
+        # The start event carries its own producer stamp, which is what the
+        # live path reads; the session map is the fallback for a re-delivery.
+        app.post_message(_started("c0", "await_job", epoch=time.time() - aged))
+        await pilot.pause()
+        line = _working(app)
+        assert line is not None
+
+        card = app._tool_cards["c0"]
+        assert card.started_at is not None, "a call whose start is known dates itself"
+        # Age-only, so the reading is the call's, not the phase's: the band
+        # counts from the oldest live card's own start (D9).
+        assert line._clock_text() == format_duration(int(aged)), line._clock_text()
+
+
+@pytest.mark.asyncio
+async def test_the_thinking_clock_resumes_its_true_age_after_a_switch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The operator's report names TWO clocks; this is the non-tool one.
+
+    ``thinking``/``responding``/``composing`` have no tool call behind them, so
+    a per-call anchor cannot date them and the phase's zero used to exist only
+    inside the widget the viewer built. Switching back to a session mid-model-
+    call therefore showed the thinking indicator counting from the switch.
+
+    The session folds the phase's own start instant from the producer's events
+    and hands it over as ``clock_from_epoch``, which the widget converts ONCE
+    (see ``WorkingBlock.set_activity``) so every tick after that is monotonic.
+    The mismatch case is asserted alongside: a folded phase that is not the
+    phase this app derived must NOT supply an instant, and the row falls back to
+    its own zero rather than reporting an age belonging to another phase.
+    """
+    aged = 27.0
+    session = _PhaseSession("thinking", time.time() - aged)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._session = session
+        app.post_message(TurnStarted())
+        app.post_message(AssistantMessageStart())
+        await pilot.pause()
+        line = _working(app)
+        assert line is not None
+        assert line.activity == DEFAULT_ACTIVITY
+        # The frame after a switch back: the age is the model call's.
+        assert line._clock_text() == format_duration(int(aged)), line._clock_text()
+
+        # Converted ONCE, not per refresh — asserted with the clock ADJUSTED,
+        # because on a healthy clock a re-seed is arithmetically a no-op and the
+        # difference is invisible: `time.monotonic()` and `time.time()` advance
+        # together, so re-deriving `clock() - (now - epoch)` lands on the same
+        # float. What is not a no-op is the day something moves the wall clock.
+        # The session's epoch is an instant, so a repaint that re-converted it
+        # would move the anchor by the ADJUSTMENT, and a row 27s into a model
+        # call would report an hour; the monotonic zero taken once does not.
+        seeded = line._clock_from
+        jumped = SimpleNamespace(time=lambda: time.time() + 3600.0, monotonic=time.monotonic)
+        monkeypatch.setattr(card_mod, "time", jumped)
+        app._refresh_working_activity()
+        app._refresh_working_activity()
+        assert line._clock_from == seeded, "the phase's anchor moved on a repaint"
+        assert line._clock_text() == format_duration(int(aged)), line._clock_text()
+
+        # A fold that disagrees with the derived phase supplies nothing, so the
+        # row is back to its phase zero. The instant belongs to the phase it was
+        # folded in, and using it here would print a true number about the WRONG
+        # thing — the failure mode the whole design round guards.
+        session.phase = ("responding", time.time() - aged)
+        app._refresh_working_activity()
+        assert line._clock_text() == format_duration(0), line._clock_text()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_working_line.py
+++ b/tests/unit/tui/test_working_line.py
@@ -52,6 +52,7 @@ from local_operator.tui.events import (
     AssistantMessageEnd,
     AssistantMessageStart,
     CompactionStarted,
+    RetryStarted,
     ToolComposing,
     ToolEnded,
     ToolStarted,
@@ -460,7 +461,14 @@ async def test_the_band_shows_no_clock_for_a_tool_it_cannot_date() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
         app.post_message(TurnStarted())
-        app.post_message(_started("c0", "await_job", job_id="7a73c97ffc54"))
+        # The producer's own stamp is what makes the start knowable. Supplied
+        # here because that is what a live call ALWAYS carries (one factory in
+        # `harness/loop.py` stamps all three dispatch sites), and because an
+        # epoch-less start event is by definition a call whose start nothing on
+        # this surface knows — QA round 1, Q1: it mounts clockless rather than
+        # dating itself from the viewer's arrival, and an undateable batch
+        # withholds the band (D6).
+        app.post_message(_started("c0", "await_job", epoch=time.time(), job_id="7a73c97ffc54"))
         await pilot.pause()
         line = _working(app)
         assert line is not None
@@ -475,9 +483,9 @@ async def test_the_band_shows_no_clock_for_a_tool_it_cannot_date() -> None:
 
         line.set_content = spy  # type: ignore[method-assign]
 
-        # A tool this viewer WATCHED start: its own zero is knowable, so the
-        # clock is true and must still be shown. Wound back rather than slept,
-        # the way the sibling clock tests do it — and wound back on the CARD,
+        # A tool the producer STAMPED: its own zero is knowable, so the clock
+        # is true and must still be shown. Wound back rather than slept, the
+        # way the sibling clock tests do it — and wound back on the CARD,
         # because a running batch's clock counts from the oldest call's own
         # start rather than from the phase change (design round 3, D9).
         card = app._tool_cards["c0"]
@@ -605,6 +613,69 @@ async def test_the_thinking_clock_resumes_its_true_age_after_a_switch(
 
 
 @pytest.mark.asyncio
+async def test_a_fallback_phase_the_fold_does_not_model_withholds_the_seed() -> None:
+    """Review round 1, R1: the fallback arm must ask for the phase it DERIVED.
+
+    ``compacting context`` and ``retrying (attempt N)`` are whole-turn labels
+    with no phase of their own: the fold models no compaction or retry edge, so
+    its phase is still whatever preceded the pass. The gate that supplies
+    ``clock_from_epoch`` is phase EQUALITY by string, and while that arm asked
+    for ``ACTIVITY_PHASE_THINKING`` by name, the equality held for these labels
+    too — so the previous phase's zero was handed to a line that was NOT in that
+    phase. A freshly started ``retrying`` row printed the age of the attempt
+    that had just failed, and a ``compacting context`` row printed the age of
+    what preceded the pass, which is the plausible-wrong-age class this whole
+    change exists to refuse.
+
+    The fix is that the arm asks for the phase it derives
+    (``self._working_fallback``). The ordinary fallback is unaffected, because
+    there the label and the folded phase ARE the same string; asserted first,
+    so a fix cannot pass by withholding every fallback.
+    """
+    aged = 27.0  # the reviewer's probe used 10m to make the number unmissable;
+    # any seed older than the 5s bound below fails the same way, and `27s`
+    # keeps `_clock_seconds` reading the row's own grammar (a 10m reading is
+    # `10m`, not `600s`).
+    session = _PhaseSession("thinking", time.time() - aged)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._session = session
+        app.post_message(TurnStarted())
+        app.post_message(AssistantMessageStart())
+        await pilot.pause()
+        line = _working(app)
+        assert line is not None
+        assert _activity(app) == DEFAULT_ACTIVITY
+        # The ordinary case: label == folded phase, so the seed is the row's own
+        # and must still be used.
+        assert _clock_seconds(line._clock_text()) >= aged
+        # ``compacting context``: the fold has no such phase, so its zero is NOT
+        # this label's and must not be handed over. The row then counts from the
+        # phase it just entered — the start of the pass — which is the honest
+        # reading for a pass that has just begun.
+        app.post_message(CompactionStarted("auto"))
+        await pilot.pause()
+        assert _activity(app) == "compacting context"
+        shown = _clock_seconds(line._clock_text())
+        assert shown < 5, (
+            f"a freshly started `compacting context` row reads {shown}s: the fold's "
+            "thinking zero was supplied for a label the fold does not derive"
+        )
+
+        # ``retrying (attempt N)`` is the same shape and over-reported by the
+        # whole failed attempt, which is a real misread of "is this stuck".
+        app.post_message(RetryStarted(2, "upstream exploded", None))
+        await pilot.pause()
+        assert _activity(app) == "retrying (attempt 2)"
+        shown = _clock_seconds(line._clock_text())
+        assert shown < 5, (
+            f"a freshly started retry row reads {shown}s: the previous attempt's "
+            "zero was supplied for a label the fold does not derive"
+        )
+
+
+@pytest.mark.asyncio
 async def test_the_bands_clock_stays_truthful_as_a_batch_sheds_calls() -> None:
     """Design round 3, D9. The phase outlives the work its label names.
 
@@ -632,7 +703,12 @@ async def test_the_bands_clock_stays_truthful_as_a_batch_sheds_calls() -> None:
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
         app.post_message(TurnStarted())
-        app.post_message(_started("old", "await_job", job_id="7a73c97ffc54"))
+        # Both cards carry the producer's own stamp, as a live batch always
+        # does (one factory in `harness/loop.py` stamps every dispatch site).
+        # An epoch-less start event would mount clockless instead (QA round 1,
+        # Q1) and there would be no batch clock to be truthful about; the
+        # properties asserted below are about the ANCHOR, not about provenance.
+        app.post_message(_started("old", "await_job", epoch=time.time(), job_id="7a73c97ffc54"))
         await pilot.pause()
         line = _working(app)
         assert line is not None
@@ -642,7 +718,7 @@ async def test_the_bands_clock_stays_truthful_as_a_batch_sheds_calls() -> None:
         # back rather than slept, as the sibling clock tests do it.
         aged = 14.0
         app._tool_cards["old"]._started = time.monotonic() - aged
-        app.post_message(_started("new", "read", path="a.py"))
+        app.post_message(_started("new", "read", epoch=time.time(), path="a.py"))
         await pilot.pause()
         app._refresh_working_activity()
         # The batch's clock is the OLDEST call's age: both cards date
@@ -657,7 +733,7 @@ async def test_the_bands_clock_stays_truthful_as_a_batch_sheds_calls() -> None:
 
         survivor = app._tool_cards["new"]
         survivor_started = survivor.started_at
-        assert survivor_started is not None, "the survivor watched its own start"
+        assert survivor_started is not None, "the survivor's own start is known"
         survivor_age = time.monotonic() - survivor_started
         shown = line._clock_text()
         # THE ASSERTION THAT FAILS ON THE OLD CODE, which showed ~14s here.
@@ -672,7 +748,7 @@ async def test_the_bands_clock_stays_truthful_as_a_batch_sheds_calls() -> None:
         # clock. The survivor's own zero is unchanged by its sibling settling,
         # so a batch losing a call every twenty seconds still shows a number
         # past twenty — the "has this been stuck" question the clock answers.
-        app.post_message(_started("third", "bash", command="ls"))
+        app.post_message(_started("third", "bash", epoch=time.time(), command="ls"))
         await pilot.pause()
         app._refresh_working_activity()
         assert line._clock_text() == format_duration(time.monotonic() - survivor_started), (


### PR DESCRIPTION
Release: patch — a live tool row and the working line keep the call's TRUE age when the operator switches away to another conversation and back. No new API for hosts, no durable format change; `pyproject.toml` untouched (combined-release rule: PRs never carry a bump).

# PR Description

## Summary of Changes

The elapsed clock on a live tool row, and the clock on the working line ("the thinking indicator"), restarted at zero when the operator switched to another session in the sidebar and back. Both now keep counting from the instant the work actually began.

The reason they could not was not a rendering bug: no consumer of a live call had a start instant. `ToolExecutionStartEvent` carried `tool_name`/`args`/`intent` and **no timestamp**, so every frontend that attached to work already in flight — a sidebar switch back, a re-attach, a `/resume` onto a running turn — had only its own arrival instant. The widgets were right to refuse a number then; they were refusing a number about the viewer.

The change makes the start knowable and threads it through EVERY place that paints a live row — the projection's `restore`, the skipped-call painter, `begin_running` and the constructor on the mount path, plus the band's non-tool phases:

| Where | What changed |
| --- | --- |
| `harness/types.py` | `ToolExecutionStartEvent.started_at_epoch: float \| None` — the producer's own wall-clock stamp, additive (`AgentEvent` is `extra="allow"`), epoch rather than monotonic because the value crosses a process boundary |
| `harness/loop.py` | one `_tool_start_event()` factory for the three dispatch sites (parallel `runner`, `interruptible_runner`, the eval bridge) so they cannot drift |
| `session/frontend_state.py` | `live_tool_started_at: dict[str, float]` and `activity_phase` / `activity_phase_started_at` folded in `observe_event`, carried in `refresh_from_session` under the streaming gate, stripped from `checkpoint()` |
| `session/protocol.py` + `session.py` + `attached.py` | `live_tool_start_epochs()` and `activity_phase_clock()` answered by both session shapes |
| `tui/widgets/tool_card.py` | injected `clock`, and `restore` / `begin_running` / `__init__` seed `_started` from the epoch (age-only, converted once through `monotonic_from_epoch`) |
| `tui/widgets/transcript.py` | `WorkingBlock.clock_from_epoch`, converted once on the phase change |
| `tui/app.py` | the projection, the skipped-row painter and `on_tool_started` pass the epoch; `_current_activity` returns the folded epoch for the non-tool arms when the folded phase matches the one it derived |

## Problem

Reported from the field with a screenshot: a `bash` row reading `27s` and the working line `aggregating tenant monitoring volume  27s`, both restarting when the operator returned to the conversation. The row was still executing; only the reading was wrong, and it was wrong in the direction that matters — the one number on screen answering "is this thing stuck" was measuring how long the operator had been looking at it.

Reproduced from the base commit on a real `OperatorApp` (frame below, `before-base`): the call's start is 27s before the row is painted, and both clocks read `0s`.

## How the anchor is carried

* **On the event, from the producer.** Only the process running the tool knows when it began, so `loop.py` stamps it — one factory, three call sites — and it survives serialization into `live_events`, so an attached viewer reads the same instant.
* **Folded per call, not aggregated.** `live_tool_started_at` is a map keyed by `tool_call_id`: a batch has several calls, and the row and the band must agree about *which* call's start they are counting from. Entries are popped by the call's own `tool_execution_end` and the whole map is cleared at both turn boundaries.
* **Age-only conversion, once.** `monotonic_from_epoch` turns `now - epoch` into an offset on the widget's own monotonic clock at the moment of seeding. A wall-clock adjustment, a DST jump or a laptop resuming from sleep after the seed therefore cannot move a counter that is already running, which is why the mapping is not recomputed per paint.
* **A second anchor for the phases with no call behind them.** The report names the thinking indicator, and `thinking` / `responding` / `composing` have no tool call to key an epoch by, so the session folds the phase *edge* as well (`activity_phase` + `activity_phase_started_at`, following the phone projection's rule, which is the same row on another screen). The `running` arm deliberately does **not** use it: a running batch is dated by the oldest live card's own start, which is finer than a phase edge and is what keeps a narrowing label (design round 3, D9) from reporting a shed sibling's age.
* **One anchor shared by both painting paths.** A switch back reaches the row twice: the projection restores it, and then the owner's seed re-delivers the start event through the event controller into `begin_running`. Both are seeded from the same epoch, so the row does not differ from the live path by event→handler latency.

## What stays deliberately unknown

The refusal is now precise rather than total, and the property is kept: **no epoch ⇒ no number.**

* A call whose producer sent no `started_at_epoch` (an older runtime) is deliberately **absent** from the folded map rather than present with the fold instant. For an attached viewer the fold instant is its arrival wearing the call's name, which is precisely the fabricated age this change exists to remove.
* `WorkingBlock` gets no epoch when the folded phase does not equal the phase the app derived — a compaction/retry fallback phase, a legacy owner, a reduced facade — and falls back to its own phase zero, i.e. exactly today's behaviour. A mismatch can only preserve behaviour, never invent an age.
* `None` still reaches `restore` for every row that genuinely cannot date itself (`subagent_view` child rows), and ANY undateable live card in a batch still withholds the band's clock rather than printing a floor (D6/D9 unchanged).

## Evidence

### Frames — real `OperatorApp`, `scripts.visual_capture.save_capture`, native 8×17 cells

Both captured by the SAME script (`/tmp/pr-clock/shot_clock.py`), which uses only public seams (a `ToolStarted` message carrying `started_at_epoch`, then the app's own `_refresh_working_activity`) so it runs unchanged on both trees; it prints `local_operator.__file__` to prove which tree was executed. 100×30 grid, geometry JSON alongside:

* before (base `17138cf20`): `/tmp/pr-clock/shots/before-base.svg` (+ `.png`, `.geometry.json`)
* after (head): `/tmp/pr-clock/shots/after-head.svg` (+ `.png`, `.geometry.json`)

The two frames are the operator's row and band. **Before**: `bash   python -m tenant.aggregate --all … 0s` on the card and `⣿ aggregating tenant monitoring volume  0s` on the band — the reset, with the call 27s old. **After**: `27s` in both places, one row, same columns, no layout shift.

### The numbers behind the frames

```
before-base  local_operator = /private/tmp/lo-before/local_operator/__init__.py
             row elapsed = 0.7005784590728581
             band clock  = '0s'
after-head   local_operator = /Users/damian/workspace/repos/lo-clock-anchor/local_operator/__init__.py
             row elapsed = 27.239538638852537
             band clock  = '27s'
```

### The switch, driven end to end

`tests/unit/tui/test_sidebar_live_tool_card.py::test_a_switch_away_and_back_resumes_a_live_tools_true_age` drives BOTH halves the re-entry takes — the projection's `restore` and the seed's re-delivery through the controller into `begin_running` — and asserts the row reads the call's 27s at each, that only one row exists, that the band's `_clock_text()` is the same number, and that the settle is still the call's own interval (a fix that bought the live reading by feeding the receipt would fail here).

The band's non-tool half is pinned separately (`test_working_line.py::test_the_thinking_clock_resumes_its_true_age_after_a_switch`), including the mismatch case: a folded phase other than the one derived supplies nothing and the row is back to its phase zero.

## Testing

New and split tests: `tests/unit/tui/test_tool_card.py` (the epoch seam: seeded age, withheld when absent, settled states ignore it, `begin_running` arms from it, never sleeping — the clock is injected), `tests/unit/tui/test_sidebar_live_tool_card.py` (the withheld painter arm kept and an epoch-armed sibling added), `tests/unit/tui/test_working_line.py` (the D6 split: with a known start the band prints the true age; without one it still prints nothing), `tests/unit/session/test_frontend_state.py` (both folds, the wire round trip, the checkpoint strip, plus a start with no epoch contributing nothing), `tests/unit/session/test_viewer_protocol.py` (both session shapes answer both accessors, unsynchronized included).

`tests/unit/session/test_attach_frame_size.py` classifies the new collection field as BOUNDED (one entry per call executing at once, popped on end, cleared per turn) and populates the frame guard at the real ceiling (`max_parallel_tools`, 8).

### Quality gate (CI's own commands, from the worktree)

```
```
$ .venv/bin/python -m flake8 .
flake8: clean (exit 0)

$ uvx --from black==26.1.0 black --check .
All done! 1231 files would be left unchanged.

$ uvx isort==5.13.2 --check-only .
isort: clean (2 files skipped)

$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations

$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
18611 passed, 18 skipped, 717 warnings in 1417.44s (0:23:37)
EXIT=0

$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
107 passed, 7 skipped, 5 warnings in 187.86s (0:03:07)
EXIT=0
```

The unit run is the whole tree as CI runs it (`tests/unit`, no selection) on head `87b72f01e`; the e2e stage beside it drives the assembled application (boot, a real turn through a real tool, `/resume`). Every `CMUX_*` variable was unset for these runs and each test host uses an isolated `HOME` / `LOCAL_OPERATOR_CONFIG_DIR` (the repository's own fixtures do this), so the operator's live sessions were untouched.

### CI

Green on head `0d464aff3`, all 17 checks: `build`, `lint`, `type-check`, the five `test (3.12, N)` shards, `tui-e2e` on both macOS and Ubuntu, `coverage-report`, `context-budget`, `filesystem-boundaries-windows`, `pip-audit`, `server-sanity`, `cli-sanity`, `version-bump-guard`.

Two failures happened on the way, both diagnosed rather than retried blindly:

* **`test (3.12, 2)` on the first head — my own test, fixed in `0d464aff3`.** It compared the seeded row's rendered clock to `format_duration(27)` exactly, and a loaded shard spent a second between the fixture's instant and the read, so correct code reported `28s`. That is the "prefer a structural invariant to a numeric one" failure AGENTS.md names — the assertion was asserting that the machine is fast. Every clock assertion in this change now states the ORDER instead (`aged <= reading < aged + 30`), which is exactly what a reset violates and what a mis-seeded clock still fails; the one exact comparison left is inside the wall-clock-jump test, where invariance is the point.
* **`cli-sanity` on attempt 1 of the second head — not this change.** The live `lop exec --yolo write` smoke test made its completions (two HTTP 200s) and never wrote `test.txt`. The job's own comment documents this shape and its diagnosis guide, and the same command run from this head locally passes: `● write creating test.txt` → `test.txt` created with `hello world`, exit 0. The re-run passed in 38s. No 429/5xx in the failing log, so it is the "model did not emit a tool call this time" arm — upstream, not the diff.
```

## Out of scope (stated, not dropped)

The mobile projection already derives the same activity labels, but it does **not** fold the per-call epochs for its own row latch — a one-line follow-up now that the event carries the field. Also untouched: `subagent_view`'s in-flight child rows (they have no producer stamp to read), the compaction/retry fallback phases, and any durable persistence of the epoch (it is transient by construction).

One measurement worth recording rather than burying: the folded map rides the attach snapshot, so it costs ~43 bytes per concurrently-executing call in the `frontend_sync` frame, whose worst case the size guard holds at the socket's 1 MiB line limit. At the default concurrency (8) the guard passes with room; a deployment that raises `max_parallel_tools` very high would add proportionally, and clipping the map at the wire is the safe lever if it ever matters — a dropped entry withholds a clock rather than printing a wrong one.

## Deliberate additions beyond the design's four seeding sites

* `ToolCard.__init__` also takes `started_at`, and `on_tool_started` passes it on the mount path as well as the adopt path. Without it, a start event that reaches a view with no row for its call mounts a fresh card whose clock begins at the handler — the reported reset wearing the other hat (the row is new, the CALL is not). It is the same conversion in the third construction site rather than a constructor that quietly disagreed about what "running" means.
* `activity_phase_clock()` is a second session accessor, because the reading happens on every event that moves the turn and `session.frontend_state` deep-copies the whole state for two scalars (the store's own docstring measures that at ~30 ms of a 135 ms frame). Both new fields are admitted to `_SHAREABLE_STATE_FIELDS`, whose bar (deeply immutable scalars) they meet.


---

## Remediation round 1 — the rebase resolution, and what this round changed

Head is now `7c3f5488888651a2eed1a99031197717a042df92`: one remediation commit on the branch rebased onto `origin/main` `95fccacda` (#976 paging fold width, #977 tool-ledger name column, #990 release 0.54.17), with the round-1 test commit replayed unchanged. Three rounds ran on the previous head (`0d464aff3`) — code review (R1–R7), QA (Q1–Q2) and design (D1) — and all three are answered in `### Agent review remediation — round 1`, `### QA remediation — round 1` and `### Design review remediation — round 1` below this body.

**The conflict, and why main's fix survives it.** Two files conflicted, both at points where main and this branch had each added something in the same spot:

* `local_operator/tui/widgets/transcript.py` — `WorkingBlock.__init__`. The branch had added a `fold_width: int = 0` parameter that nothing in the class read (the round-1 review's R2); main's #977 added the same parameter **with** its body, `self.set_fold_hint(fold_width)`, which is the resumed-tail fold-width fix. The resolution takes main's parameter and keeps its body call, adds `clock_from_epoch` beside it, and drops the branch's signature-only copy — the resolution QA's Q2 required, since keeping the branch's version would have silently re-introduced the bug main had just fixed.
* `local_operator/tui/widgets/tool_card.py` — `ToolCard.begin_running`. Main's `was_composing = self._state == "composing"` and the trailing `if was_composing or renamed: parent.invalidate_name_col()` (the tool-ledger name-column resync) sit in the same block this branch rewrote for the `clockless` guard. **Both** sides are kept, not either wholesale.

Equivalence is proven, not asserted. `git range-diff 17138cf20..0d464aff3 origin/main..HEAD` reports the round-1 test commit byte-identical (`=`) and the fix commit's delta confined to those two conflict hunks; and every line main added to the three files both sides touched is present on the new head (`tool_card.py` 23/23, `transcript.py` 263/263, `tests/unit/session/test_viewer_protocol.py` 673/673). `pyproject.toml` is untouched — no version bump rides this PR (combined-release rule).

**What changed in the code.** R1 fixed a fallback arm that failed OPEN (it asked the fold for `ACTIVITY_PHASE_THINKING` by name while returning `self._working_fallback` as the phase, so a fresh `compacting context`/`retrying (attempt N)` row wore the *previous* phase's age). Q1 fixed the mount arm: `started_at=None` could only mean "this call begins now", so an epoch-less start event for a call already in flight had to mount a row dated from the viewer's arrival; it now passes `START_UNKNOWN` and mounts clockless, the same `missing epoch ⇒ withheld` reading `restore` and `_mark_pending_tool_rows` already take. R3–R7 are wording corrections. Full per-finding detail, with the red-before/green-after evidence for each, is in the remediation comments.

**The three sections of the body above that are now superseded, stated so nobody reads them as current:**

* "Deliberate additions beyond the design's four seeding sites" still describes `ToolCard.__init__` taking `started_at` on the mount path — true, but the mount path now passes `START_UNKNOWN` rather than `None` when no epoch exists, which is the Q1 fix.
* "What stays deliberately unknown / `None` still reaches `restore` for every row that genuinely cannot date itself" — the withhold population is now larger on one seam: an epoch-less start event at the mount arm withholds too, instead of dating the row from the handler.
* The round-1 gate block further up was run on `87b72f01e`; the gate output for **this** head is in the QA remediation comment, and CI's own result for this head is on the checks list.

**Frames for the two seams this round changed** (before = a throwaway worktree at `0d464aff3`, after = this head; same scripts, same 100×30 grid, `scripts.visual_capture.save_capture`, SVG + `.geometry.json` + paired crops):

* unknown-epoch mount arm — `/tmp/pr-clock/shot_mount_unknown.py` → `/tmp/pr-clock/shots2/{before,after}-mount-unknown.{svg,png}`, pair `mount-pair.png`: before `… 0s` on the row **and** `… 0s` on the band; after `… running` and a band with no number.
* `compacting context` / `retrying (attempt 2)` — `/tmp/pr-clock/shot_fallback_phase.py` → `/tmp/pr-clock/shots2/{before,after}-{compacting,retrying,thinking}.{svg,png}`, pairs `compacting-pair.png`, `retrying-pair.png`, `thinking-pair.png`: before `27s` on both fallback labels (the previous phase's age) and on the control `thinking` row; after `0s` on both labels and `27s` on the control. Geometry is byte-identical between the two trees for each pair, so nothing re-laid out.
