### PR TITLE
chore(release): bump version to 0.54.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.54.16"
+version = "0.54.17"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release lock for the post-`v0.54.16` window. `pyproject.toml` only, one line, per the combined-release rule.

**Owner:** pid 35181 (`lopdev` manager, release owner for this window — from `lop sessions`). Opened as DRAFT: the independent scope-check round is the owner's, and the merge follows it.

**Window** — re-derived from the commits, not from memory, immediately before the bump and again immediately before the tag. `git log --oneline v0.54.16..origin/main` (plain log — **never** `--merges`):

- [x] #976 — merged as `2fc82e7ab` — `Release: patch` — Paged and resumed history now folds at the pane's real width instead of an 80-column fallback, so message text no longer stops short of the right edge.
- [x] #988 — merged as `b85a610cc` — `Release: patch` — An episode declaring both a step budget and a capped USD budget is no longer truncated by the cost-ratio guard, so long-horizon benchmark episodes reach `finish` instead of dying on exhaustion (an absolute per-cycle ceiling derived from remaining budget ÷ remaining steps still bounds them).

Two things about that list are worth recording, because both are the traps the release warnings name:

1. **#988 is a SQUASH commit** (`b85a610cc`, single parent `2fc82e7ab`, subject ending `(#988)`). A `--merges` scan silently drops exactly this shape, and an early draft of this window did: it listed #976 alone. The window was re-derived with a plain log when the contributor sent their refs, and #988 is included.
2. **#988's body carried no `Release:` line.** The owner added it from the contributor's own stated impact and argued class (pid 86806 sent both at merge time) rather than guessing an impact from the commit subject, as §"What the release owner does" prescribes; the line is now on that PR.

The four non-merge commits in the range (`018dc77ea`, `60273bb79`, `54c975373`, `d9393cb87`) are all `fix(tui)` commits on #976's own branch, not separate PRs. No open `chore(release):` PR existed when this was opened, so the window was unowned; the owner announced and the lop-dev peers announced back (no claimant, no held-open PR).

Bump argued: **patch** → `0.54.17`. Two PRs, both fixes on existing surfaces — a TUI width repair and an evaluation-guard correction; neither clears the step-function bar for a minor on its own. `<last tag> + patch`, taking nothing that was promised elsewhere.

The diff is **one line in one file**. Verified before pushing:

```sh
git diff origin/main --stat            # 1 file changed, 1 insertion(+), 1 deletion(-)
git diff origin/main -- pyproject.toml # -version = "0.54.16" / +version = "0.54.17"
git diff v0.54.16..origin/main -- pyproject.toml   # empty — no merged PR consumed this number
```

That last check is the pre-tag backstop from the release-mechanics warnings: an empty window diff against `pyproject.toml` means no PR in the window carried its own bump, so `0.54.17` is not a burned number.

The window is re-derived again immediately before `gh release create`; anything merging while the window is open is listed here and sent to the owner at merge time.
