### PR TITLE
fix(session): a transient failover notice no longer becomes a user message

### DIFF
--- a/local_operator/compaction/cutpoint.py
+++ b/local_operator/compaction/cutpoint.py
@@ -26,6 +26,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Container, Sequence
 
+from local_operator.harness.rows import is_harness_injection, is_harness_notice_text
 from local_operator.harness.types import AgentMessage, CustomMessage, Message
 
 from .tokens import _encode_len, estimate_tokens
@@ -177,12 +178,12 @@ def is_rendered_injection(message: AgentMessage) -> bool:
     Used on both the write path (``Session._finish_compaction``) and the read
     path (``Transcript.build_llm_history``), so a live and a resumed context
     filter identically and stay byte-for-byte equal.
+
+    A thin alias for ``harness.rows.is_harness_injection``, which is where the
+    stamp and its key live: two implementations of one provenance decision is
+    exactly how the folds and compaction drift apart about a row.
     """
-    return (
-        isinstance(message, Message)
-        and bool(message.provider_payload)
-        and bool(message.provider_payload.get(RENDERED_INJECTION_KEY))
-    )
+    return is_harness_injection(message)
 
 
 def _message_tokens(message: AgentMessage) -> int:
@@ -574,6 +575,22 @@ def extract_preserved_user_turns(
         # via ``elision_counts_of`` and seeds the next block with them.
         if message.id.startswith(PRESERVED_TURN_ELISION_ID_PREFIX):
             continue
+        # A notice the harness minted, carried in a block from before the stamp
+        # existed (see :func:`is_harness_notice_text`): a preserved copy of one
+        # is re-seated as a ``role="user"`` row on every replay, so it titles
+        # the conversation after itself and paints the harness's words as the
+        # operator's. Excluded at HARVEST so no new marker bakes one in; the
+        # blocks an older build already wrote are healed on the read path by
+        # :func:`cap_preserved_user_turns`.
+        #
+        # The cost of the text test here is bounded and worth naming: a genuine
+        # prompt that happens to OPEN with one of these heads is not preserved
+        # verbatim. It is still summarized like any other turn and never hidden
+        # (this function only decides what rides the marker), whereas a notice
+        # carried forward is re-painted as the user's own words on every
+        # surface — the asymmetry is what makes the trade right.
+        if is_harness_notice_text(message.text):
+            continue
         if genuine_user_ids is not None and message.id not in genuine_user_ids:
             continue
         text = message.text
@@ -846,10 +863,23 @@ def cap_preserved_user_turns(
 
     # Provenance first: shedding an injection costs the operator nothing, so it
     # must never compete with a genuine turn for the budget.
-    if injection_ids is not None:
-        kept_turns = [turn for turn in real_turns if str(turn.get("id", "")) not in injection_ids]
-        injections_dropped += len(real_turns) - len(kept_turns)
-        real_turns = kept_turns
+    #
+    # Two shapes count as one. ``injection_ids`` is the journal lookup, which is
+    # how every delivery a modern build wrote is identified. A stored turn whose
+    # TEXT is a harness notice head is the LEGACY shape — the copy exists
+    # because an older build harvested the notice as a user turn, before there
+    # was a stamp to refuse it — and it is shed for the same reason: replaying
+    # it re-seats the harness's words as a user row. Text is sound evidence at
+    # THIS site in a way it is not on a live fold: these are stored copies
+    # inside a compaction block, never a row the operator typed in this process.
+    def _is_injection_turn(turn: Mapping[str, object]) -> bool:
+        if injection_ids is not None and str(turn.get("id", "")) in injection_ids:
+            return True
+        return is_harness_notice_text(str(turn.get("text", "")))
+
+    kept_turns = [turn for turn in real_turns if not _is_injection_turn(turn)]
+    injections_dropped += len(real_turns) - len(kept_turns)
+    real_turns = kept_turns
 
     if cap <= 0:
         # Fails CLOSED. Returning the block unbounded here would restore the

--- a/local_operator/harness/rows.py
+++ b/local_operator/harness/rows.py
@@ -41,7 +41,7 @@ one renderer is a decision the other will not make.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any, Literal
 
 #: The severity vocabulary shared by the surfaces. A superset is deliberately
@@ -49,7 +49,54 @@ from typing import Any, Literal
 #: wider ``NoticeKind`` (which adds ``note``/``success`` for live receipts)
 #: accepts every one of them, so a value produced here is always renderable
 #: on both sides.
+#: Message heads the harness mints for its own notices, each with the producer
+#: that writes it. Read ONLY against rows a compaction pass carried forward (see
+#: :func:`is_harness_notice_row`), because that is the one shape where the text is
+#: the last surviving evidence of provenance.
+#:
+#: Why an enumeration is acceptable HERE, when the guard it feeds replaced one:
+#: these are message heads, not a policy. A head that is missed degrades to the
+#: pre-fix behaviour — a notice painted as the user's words, which the operator
+#: can see and report — and never to losing their own text, because the check is
+#: scoped to carried copies. The stamp (:func:`is_harness_injection`) remains the
+#: primary test for everything minted since it existed.
+#:
+#: ``[`` + the elision notice is NOT here: that row has a fixed id
+#: (``PRESERVED_TURN_ELISION_ID``, ``compaction-elision``), which is provenance
+#: rather than wording, so the id prefix is checked instead.
+_HARNESS_NOTICE_HEADS: tuple[str, ...] = (
+    "[model switch] ",  # incidents.format_model_switch_message
+    "[session incident",  # incidents.Incident.render
+    "[session credential] ",  # incidents.format_credential_message
+    "[mcp recovery] ",  # incidents.format_mcp_recovery_message
+    "[session-state]\n",  # Session._system_state_message
+    "[system] ",  # the unattended-gate timeout, in _default_convert_to_llm
+    "<system-reminder>",  # Session._todo_reminder_text
+    "(alarm) Scheduled wake ",  # harness.wake.format_wake_delivery_text
+    "<parent-message>",  # harness.comms._format_to_child
+    "<subagent-message ",  # SubagentComms._journal_communication
+    "<peer-session-message ",  # Session._peer_custom_message
+)
+
+
 NoticeSeverity = Literal["info", "warning", "error"]
+
+
+def is_harness_notice_text(text: str) -> bool:
+    """Whether ``text`` is one of the notice shapes the harness itself mints.
+
+    Used where a row's PROVENANCE is no longer readable — a notice a compaction
+    pass lifted into a marker's preserved block before the ``harness_injected``
+    stamp existed (a 2026-09-08-era transcript carries eight such switch-notice
+    copies with no ``provider_payload`` at all). At the copy sites such text is
+    sufficient evidence on its own: the harness wrote these heads, and a stored
+    turn that opens with one is not the operator's words.
+
+    Deliberately NOT applied to every user row on a display surface: a person
+    who pastes a failover notice to ask about it keeps their own row (see
+    :func:`is_harness_notice_row`, which scopes this to carried copies).
+    """
+    return text.lstrip().startswith(_HARNESS_NOTICE_HEADS)
 
 
 def harness_chrome_prompts() -> tuple[str, ...]:
@@ -125,16 +172,87 @@ def is_harness_injection(row: Any) -> bool:
     """
     from local_operator.compaction.cutpoint import RENDERED_INJECTION_KEY
 
-    payload: Any
-    if isinstance(row, Mapping):
-        payload = row.get("provider_payload")
-    else:
-        payload = getattr(row, "provider_payload", None)
-    if not isinstance(payload, Mapping):
+    payload = _row_provider_payload(row)
+    if not payload:
         # A replayed row can carry a malformed payload (an older writer, a
         # hand-edited journal). Absent proof of injection is not proof of it.
         return False
     return bool(payload.get(RENDERED_INJECTION_KEY))
+
+
+def _row_provider_payload(row: Any) -> Mapping[str, Any]:
+    """The ``provider_payload`` of a message or of a raw transcript payload."""
+    payload = (
+        row.get("provider_payload")
+        if isinstance(row, Mapping)
+        else getattr(row, "provider_payload", None)
+    )
+    # A malformed payload (an older writer, a hand-edited journal) reads as
+    # empty: absent proof of provenance is not proof of it.
+    return payload if isinstance(payload, Mapping) else {}
+
+
+def _row_text(row: Any) -> str:
+    """The text of a message, or of a raw transcript payload's content blocks.
+
+    The payload arm is what the subagents panel holds; its ``content`` is the
+    same list of ``{"type": "text", "text": ...}`` blocks the message type
+    flattens into ``.text`` on the wire, so reading it here keeps the decision
+    in one place rather than asking each raw-payload caller to pre-flatten.
+    """
+    if isinstance(row, Mapping):
+        blocks = row.get("content") or ()
+        if not isinstance(blocks, Sequence):
+            return ""
+        return "".join(
+            str(block.get("text") or "") for block in blocks if isinstance(block, Mapping)
+        )
+    text = getattr(row, "text", "")
+    return text if isinstance(text, str) else ""
+
+
+def _row_id(row: Any) -> str:
+    value = row.get("id") if isinstance(row, Mapping) else getattr(row, "id", None)
+    return value if isinstance(value, str) else ""
+
+
+def is_harness_notice_row(row: Any) -> bool:
+    """Whether this row is harness-authored and must not paint as the user's words.
+
+    The decision every human-facing surface and every title/tail scan makes,
+    in one place. Two shapes answer it, and they need different evidence:
+
+    * **the stamp** (:func:`is_harness_injection`) — the renderer minted the row
+      from a ``CustomMessage`` in this process. This is the primary test and
+      the only provenance a live or freshly rendered row carries.
+    * **a CARRIED-FORWARD NOTICE** — a row a compaction pass lifted into a
+      marker's preserved block. Those copies are re-seated from the marker with
+      ``compaction_preserved`` and no stamp, so for the ones written before the
+      stamp existed (a real session carries eight switch-notice copies with no
+      ``provider_payload`` at all) the text is the last surviving evidence.
+      Scoped to carried copies deliberately: a person who pastes a notice to
+      ask about it keeps their own row, and the harvest/shed sites that mint a
+      carried copy refuse such a row before it is stored.
+
+    The elision notice is identified by ID rather than wording — it has a fixed
+    one (``compaction-elision``), and its number-carrying prose is not stable
+    enough to match on.
+
+    Accepts a message-like object or a raw payload mapping, for the reason
+    :func:`is_harness_injection` documents.
+    """
+    from local_operator.compaction.cutpoint import (
+        PRESERVED_TURN_ELISION_ID_PREFIX,
+        PRESERVED_USER_TURN_KEY,
+    )
+
+    if is_harness_injection(row):
+        return True
+    if _row_id(row).startswith(PRESERVED_TURN_ELISION_ID_PREFIX):
+        return True
+    if not _row_provider_payload(row).get(PRESERVED_USER_TURN_KEY):
+        return False
+    return is_harness_notice_text(_row_text(row))
 
 
 def typed_line_of(text: str) -> str | None:

--- a/local_operator/harness/rows.py
+++ b/local_operator/harness/rows.py
@@ -13,11 +13,17 @@ because its ``if/elif`` chain ended with no ``else``.
 
 The decisions below are the ones both surfaces must make identically:
 whether a message is harness chrome that no surface may attribute to the
-user, what a timed-out gate says, what ink a refused compaction gets, and
-which assistant turns produce a notice instead of prose. Each is a pure
-function of a message, with **no host dependency** — no Textual, no wire
-type, no session import at module scope — so both hosts can call it and
-neither can own it.
+user, whether a row was minted by the harness from a ``CustomMessage`` at
+all (:func:`is_harness_injection`), what a timed-out gate says, what ink a
+refused compaction gets, and which assistant turns produce a notice instead
+of prose. Each is a pure function of a message, with **no host dependency**
+— no Textual, no wire type, no session import at module scope — so both
+hosts can call it and neither can own it.
+
+The injection predicate reads a raw payload MAPPING as readily as a message,
+because the subagents panel (``tui/widgets/subagent_view.py``) folds raw
+transcript entry payloads rather than ``AgentMessage``s. It is the same
+decision on a third surface, so it belongs here rather than in that fold.
 
 CONSTRAINT — this module must stay host-free. It sits below both renderers
 the same way ``compaction/marker.py`` sits below the hosts that must not
@@ -35,6 +41,7 @@ one renderer is a decision the other will not make.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any, Literal
 
 #: The severity vocabulary shared by the surfaces. A superset is deliberately
@@ -85,6 +92,49 @@ def is_harness_chrome(text: str) -> bool:
     words the moment a persisted prompt gained a trailing newline.
     """
     return text.strip() in harness_chrome_prompts()
+
+
+def is_harness_injection(row: Any) -> bool:
+    """Whether this row was minted BY the harness from a ``CustomMessage``.
+
+    :func:`~local_operator.session.session._default_convert_to_llm` renders a
+    harness aside — a model-switch notice, a session incident, a wake
+    delivery, a gate timeout — into a plain ``Message(role="user")`` and
+    stamps ``provider_payload["harness_injected"]`` on it, so the row is
+    structurally indistinguishable from an operator prompt once it exists.
+    The stamp is compaction's provenance signal, and it is also the only
+    signal a fold has: a row carrying it was never typed by a person, so no
+    human-facing surface may paint it as their words. The live path never
+    paints one either (the failover moment has its own receipt), which makes
+    dropping it live/replay parity rather than a second opinion — the same
+    doctrine :func:`is_harness_chrome` follows for the three continuation
+    prompts.
+
+    Accepts EITHER a message-like object or a raw payload mapping, because
+    the surfaces do not all read the same shape: the TUI and phone folds hold
+    ``AgentMessage``s, while the subagents panel folds raw transcript entry
+    payloads (``{"role": ..., "provider_payload": {...}}``). Making the
+    caller adapt is how the second copy of a decision gets written.
+
+    The marker constant is imported LAZILY, like :func:`harness_chrome_prompts`
+    imports its prompts: ``compaction.cutpoint`` pulls ``compaction.tokens``,
+    and this module sits on both folds' import path. Measured here, importing
+    this module costs 2.3 ms while importing it together with
+    ``compaction.cutpoint`` costs 308 ms — a module-scope import would pay
+    that on every TUI and mobile start for one string constant.
+    """
+    from local_operator.compaction.cutpoint import RENDERED_INJECTION_KEY
+
+    payload: Any
+    if isinstance(row, Mapping):
+        payload = row.get("provider_payload")
+    else:
+        payload = getattr(row, "provider_payload", None)
+    if not isinstance(payload, Mapping):
+        # A replayed row can carry a malformed payload (an older writer, a
+        # hand-edited journal). Absent proof of injection is not proof of it.
+        return False
+    return bool(payload.get(RENDERED_INJECTION_KEY))
 
 
 def typed_line_of(text: str) -> str | None:

--- a/local_operator/harness/rows.py
+++ b/local_operator/harness/rows.py
@@ -68,15 +68,20 @@ NoticeSeverity = Literal["info", "warning", "error"]
 #: rather than wording, so the id prefix is checked instead.
 #:
 #: The DELIVERY ENVELOPES (``<parent-message>``, ``<subagent-message …>``,
-#: ``<peer-session-message …>``) are deliberately NOT here either, and the
-#: distinction is the reason this list stays short: a delivery row is handled by
-#: its own PARSER (``extract_parent_message``, the panel's own fold), which
-#: renders the sender's receipt, so it never reaches a surface as the user's
-#: words — and it is a shape a person quotes verbatim when asking about it, which
-#: a wording rule would then eat (`test_a_human_quoting_the_envelope_keeps_
-#: their_own_words` pins that). A notice has no parser: nothing about
-#: ``[model switch] …`` is addressable, which is why text is the only test for
-#: one.
+#: ``<peer-session-message …>``) are deliberately NOT here either, and the reason is
+#: what already covers a copy of one rather than a parser: a carried envelope copy
+#: is shed by PROVENANCE — ``cap_preserved_user_turns``' ``injection_ids``, resolved
+#: against the journal, where the stored turn's id names the entry whose
+#: ``custom_type`` is the delivery — so it never needs a wording rule. Measured
+#: fleet-wide (14 sessions): 229 of 233 carried envelope copies are shed that way on
+#: BOTH heads. The remaining four turns — ids that resolve to nothing — paint on
+#: this head as a parent receipt where the previous wording rule shed them; all four
+#: are real ``<parent-message>`` envelopes, the receipt is what that row honestly is,
+#: and user-kind row counts are unchanged. And it is a shape a person quotes
+#: verbatim when asking about it, which a wording rule would then eat
+#: (`test_a_human_quoting_the_envelope_keeps_their_own_words` pins that). A notice
+#: has no such provenance to fall back on: nothing about ``[model switch] …`` is
+#: addressable, which is why text is the only test for one.
 _HARNESS_NOTICE_HEADS: tuple[str, ...] = (
     "[model switch] ",  # incidents.format_model_switch_message
     "[session incident",  # incidents.Incident.render
@@ -84,8 +89,13 @@ _HARNESS_NOTICE_HEADS: tuple[str, ...] = (
     "[mcp recovery] ",  # incidents.format_mcp_recovery_message
     "[session-state]\n",  # Session._system_state_message
     # The unattended-gate timeouts, in _default_convert_to_llm. Two heads rather
-    # than the shared ``[system] `` prefix: that prefix is short enough that a
-    # person could plausibly type it, and nothing else in the tree mints it.
+    # than the shared ``[system] `` prefix: that prefix is also minted by
+    # ``harness.loop.CONNECTIVITY_CONTINUATION_PROMPT``, so it does not select the
+    # gates. Both gate producers still match here, the connectivity prompt is hidden
+    # by :func:`is_harness_chrome` on every surface regardless, and the narrowing is
+    # therefore display-neutral — with one consequence recorded rather than hidden:
+    # a CARRIED copy of the connectivity prompt is no longer shed by text, so it
+    # returns to the model's context. No receipt changes visibly.
     "[system] The question for ",
     "[system] The approval request for ",
     "<system-reminder>",  # Session._todo_reminder_text
@@ -244,10 +254,11 @@ def is_harness_notice_row(row: Any) -> bool:
     **The cost, stated exactly because it is a trade rather than a free win.** A
     person who pastes a harness notice verbatim loses their display row: the text
     is hidden on every human surface. It is NOT lost anywhere else — the row is
-    still in the journal, still in the model's context, still in the export, and
-    still searchable; only the renderer drops it, exactly as
-    :func:`is_harness_chrome` does for the three loop/continuation prompts, which
-    a person can equally paste verbatim. That precedent is the reason this is
+    still in the journal, and still in the model's context; only the renderer drops
+    it, exactly as :func:`is_harness_chrome` does for the three loop/continuation
+    prompts, which a person can equally paste verbatim. Those two are the verified
+    retention surfaces, and they are named alone because a claim about anywhere
+    else would be one nobody measured. That precedent is the reason this is
     acceptable at all: a display that must decide from text will occasionally
     hide something a person wrote, and the alternative — leaving the harness's own
     words behind the user gutter on a surface that has no other provenance to read

--- a/local_operator/harness/rows.py
+++ b/local_operator/harness/rows.py
@@ -49,52 +49,59 @@ from typing import Any, Literal
 #: wider ``NoticeKind`` (which adds ``note``/``success`` for live receipts)
 #: accepts every one of them, so a value produced here is always renderable
 #: on both sides.
+NoticeSeverity = Literal["info", "warning", "error"]
+
 #: Message heads the harness mints for its own notices, each with the producer
-#: that writes it. Read ONLY against rows a compaction pass carried forward (see
-#: :func:`is_harness_notice_row`), because that is the one shape where the text is
-#: the last surviving evidence of provenance.
+#: that writes it, and the ONE enumeration a display surface uses to recognise a
+#: notice row (see :func:`is_harness_notice_row`).
 #:
 #: Why an enumeration is acceptable HERE, when the guard it feeds replaced one:
-#: these are message heads, not a policy. A head that is missed degrades to the
-#: pre-fix behaviour — a notice painted as the user's words, which the operator
-#: can see and report — and never to losing their own text, because the check is
-#: scoped to carried copies. The stamp (:func:`is_harness_injection`) remains the
-#: primary test for everything minted since it existed.
+#: these are the lines the harness itself writes, not a policy about content, and
+#: a missed head degrades to the pre-fix behaviour — a notice painted as the
+#: user's words, which the operator can see and report — rather than to losing
+#: anything of theirs. The stamp (:func:`is_harness_injection`) stays the primary
+#: test for everything minted since it existed; this list is what covers the rows
+#: written before it did, and the ones a compaction marker carried from that era.
 #:
 #: ``[`` + the elision notice is NOT here: that row has a fixed id
 #: (``PRESERVED_TURN_ELISION_ID``, ``compaction-elision``), which is provenance
 #: rather than wording, so the id prefix is checked instead.
+#:
+#: The DELIVERY ENVELOPES (``<parent-message>``, ``<subagent-message …>``,
+#: ``<peer-session-message …>``) are deliberately NOT here either, and the
+#: distinction is the reason this list stays short: a delivery row is handled by
+#: its own PARSER (``extract_parent_message``, the panel's own fold), which
+#: renders the sender's receipt, so it never reaches a surface as the user's
+#: words — and it is a shape a person quotes verbatim when asking about it, which
+#: a wording rule would then eat (`test_a_human_quoting_the_envelope_keeps_
+#: their_own_words` pins that). A notice has no parser: nothing about
+#: ``[model switch] …`` is addressable, which is why text is the only test for
+#: one.
 _HARNESS_NOTICE_HEADS: tuple[str, ...] = (
     "[model switch] ",  # incidents.format_model_switch_message
     "[session incident",  # incidents.Incident.render
     "[session credential] ",  # incidents.format_credential_message
     "[mcp recovery] ",  # incidents.format_mcp_recovery_message
     "[session-state]\n",  # Session._system_state_message
-    "[system] ",  # the unattended-gate timeout, in _default_convert_to_llm
+    # The unattended-gate timeouts, in _default_convert_to_llm. Two heads rather
+    # than the shared ``[system] `` prefix: that prefix is short enough that a
+    # person could plausibly type it, and nothing else in the tree mints it.
+    "[system] The question for ",
+    "[system] The approval request for ",
     "<system-reminder>",  # Session._todo_reminder_text
     "(alarm) Scheduled wake ",  # harness.wake.format_wake_delivery_text
-    "<parent-message>",  # harness.comms._format_to_child
-    "<subagent-message ",  # SubagentComms._journal_communication
-    "<peer-session-message ",  # Session._peer_custom_message
 )
-
-
-NoticeSeverity = Literal["info", "warning", "error"]
 
 
 def is_harness_notice_text(text: str) -> bool:
     """Whether ``text`` is one of the notice shapes the harness itself mints.
 
-    Used where a row's PROVENANCE is no longer readable — a notice a compaction
-    pass lifted into a marker's preserved block before the ``harness_injected``
-    stamp existed (a 2026-09-08-era transcript carries eight such switch-notice
-    copies with no ``provider_payload`` at all). At the copy sites such text is
-    sufficient evidence on its own: the harness wrote these heads, and a stored
-    turn that opens with one is not the operator's words.
-
-    Deliberately NOT applied to every user row on a display surface: a person
-    who pastes a failover notice to ask about it keeps their own row (see
-    :func:`is_harness_notice_row`, which scopes this to carried copies).
+    The only evidence a row written before the ``harness_injected`` stamp
+    existed can offer about its own provenance: a 2026-09-08-era transcript
+    carries switch notices as plain ``role="user"`` rows with no
+    ``provider_payload`` at all, and they are still there — the audit phase of
+    the attached viewer replays them straight from the journal (a stored row is
+    not a copy, so there is no id to look up and no payload to read).
     """
     return text.lstrip().startswith(_HARNESS_NOTICE_HEADS)
 
@@ -219,39 +226,43 @@ def _row_id(row: Any) -> str:
 def is_harness_notice_row(row: Any) -> bool:
     """Whether this row is harness-authored and must not paint as the user's words.
 
-    The decision every human-facing surface and every title/tail scan makes,
-    in one place. Two shapes answer it, and they need different evidence:
+    The decision every human-facing surface and every title/query/tail scan
+    makes, in one place, and it holds in BOTH phases a display can serve: the
+    context replay (where the row may be a stamped render or a copy a compaction
+    marker carried) and the audit replay (where it is the stored row itself).
+
+    Two shapes answer True, and they need different evidence:
 
     * **the stamp** (:func:`is_harness_injection`) — the renderer minted the row
-      from a ``CustomMessage`` in this process. This is the primary test and
-      the only provenance a live or freshly rendered row carries.
-    * **a CARRIED-FORWARD NOTICE** — a row a compaction pass lifted into a
-      marker's preserved block. Those copies are re-seated from the marker with
-      ``compaction_preserved`` and no stamp, so for the ones written before the
-      stamp existed (a real session carries eight switch-notice copies with no
-      ``provider_payload`` at all) the text is the last surviving evidence.
-      Scoped to carried copies deliberately: a person who pastes a notice to
-      ask about it keeps their own row, and the harvest/shed sites that mint a
-      carried copy refuse such a row before it is stored.
+      from a ``CustomMessage`` in this process. The primary test, and the only
+      provenance a live or freshly rendered row carries.
+    * **a NOTICE head** (:func:`is_harness_notice_text`) — what remains when the
+      row predates the stamp: the plain stored notices a pre-stamp build wrote
+      into the journal, which the audit phase serves verbatim, and the copies a
+      compaction marker re-seats from that era.
 
-    The elision notice is identified by ID rather than wording — it has a fixed
-    one (``compaction-elision``), and its number-carrying prose is not stable
-    enough to match on.
+    **The cost, stated exactly because it is a trade rather than a free win.** A
+    person who pastes a harness notice verbatim loses their display row: the text
+    is hidden on every human surface. It is NOT lost anywhere else — the row is
+    still in the journal, still in the model's context, still in the export, and
+    still searchable; only the renderer drops it, exactly as
+    :func:`is_harness_chrome` does for the three loop/continuation prompts, which
+    a person can equally paste verbatim. That precedent is the reason this is
+    acceptable at all: a display that must decide from text will occasionally
+    hide something a person wrote, and the alternative — leaving the harness's own
+    words behind the user gutter on a surface that has no other provenance to read
+    — is the defect being fixed. The elision notice is identified by ID rather
+    than wording: it has a fixed one (``compaction-elision``).
 
     Accepts a message-like object or a raw payload mapping, for the reason
     :func:`is_harness_injection` documents.
     """
-    from local_operator.compaction.cutpoint import (
-        PRESERVED_TURN_ELISION_ID_PREFIX,
-        PRESERVED_USER_TURN_KEY,
-    )
+    from local_operator.compaction.cutpoint import PRESERVED_TURN_ELISION_ID_PREFIX
 
     if is_harness_injection(row):
         return True
     if _row_id(row).startswith(PRESERVED_TURN_ELISION_ID_PREFIX):
         return True
-    if not _row_provider_payload(row).get(PRESERVED_USER_TURN_KEY):
-        return False
     return is_harness_notice_text(_row_text(row))
 
 

--- a/local_operator/harness/rows.py
+++ b/local_operator/harness/rows.py
@@ -74,11 +74,15 @@ NoticeSeverity = Literal["info", "warning", "error"]
 #: against the journal, where the stored turn's id names the entry whose
 #: ``custom_type`` is the delivery — so it never needs a wording rule. Measured
 #: fleet-wide (14 sessions): 229 of 233 carried envelope copies are shed that way on
-#: BOTH heads. The remaining four turns — ids that resolve to nothing — paint on
-#: this head as a parent receipt where the previous wording rule shed them; all four
-#: are real ``<parent-message>`` envelopes, the receipt is what that row honestly is,
-#: and user-kind row counts are unchanged. And it is a shape a person quotes
-#: verbatim when asking about it, which a wording rule would then eat
+#: BOTH heads. The residue is NOT shed, and what a surface then shows depends on the
+#: surface: the phone fold and the subagents panel PARSE the envelope
+#: (``mobile.projection`` calls :func:`extract_parent_message`; the panel has its own
+#: call) and paint a parent receipt, while the TUI fold has NO envelope parser and
+#: paints the model-facing envelope as the operator's own words. That difference is
+#: pre-existing on ``main`` and is not changed here: the PR records the measurements
+#: and leaves the fix — a display product call for hub steers — to a follow-up. It is
+#: also a shape a person quotes verbatim when asking about it, which a wording rule
+#: would then eat
 #: (`test_a_human_quoting_the_envelope_keeps_their_own_words` pins that). A notice
 #: has no such provenance to fall back on: nothing about ``[model switch] …`` is
 #: addressable, which is why text is the only test for one.

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -43,7 +43,7 @@ from local_operator.harness.rows import (
     compaction_refused_notice,
     gate_timeout_notice,
     is_harness_chrome,
-    is_harness_injection,
+    is_harness_notice_row,
     user_row_text,
     wake_receipt_headline,
 )
@@ -761,17 +761,16 @@ def fold_messages_to_entries(history: list[AgentMessage]) -> list[TranscriptEntr
                 # prompt while rendering the goal-loop and auto-continuation
                 # prompts as the user's own words.
                 continue
-            if is_harness_injection(message):
-                # A row the harness MINTED from a ``CustomMessage`` — a
-                # model-switch notice, a session incident, a wake delivery —
-                # carries ``provider_payload["harness_injected"]``, and the
-                # operator never typed it. The live fold has its own receipt
-                # for the moments these announce (the failover retry notice and
-                # band, the incident row), so dropping the rendered copy is
-                # live/replay parity rather than a second opinion — and it also
-                # hides the rows an older build already wrote into existing
-                # transcripts. One decision, in ``harness/rows.py``, for the
-                # same reason the chrome list lives there.
+            if is_harness_notice_row(message):
+                # A row the harness wrote — a stamped render of a
+                # ``CustomMessage`` (model-switch notice, incident, wake
+                # delivery) or a notice a compaction block carried forward from
+                # before the stamp existed — and the operator never typed it.
+                # The live fold has its own receipt for the moments these
+                # announce, so dropping the rendered copy is live/replay
+                # parity, and it also hides the rows an older build left in
+                # existing transcripts. One decision, in ``harness/rows.py``,
+                # for the same reason the chrome list lives there.
                 continue
             # A `$skill` invocation persists as its EXPANDED payload, because
             # that is what the model was sent. Rendering it verbatim showed the

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -43,6 +43,7 @@ from local_operator.harness.rows import (
     compaction_refused_notice,
     gate_timeout_notice,
     is_harness_chrome,
+    is_harness_injection,
     user_row_text,
     wake_receipt_headline,
 )
@@ -759,6 +760,18 @@ def fold_messages_to_entries(history: list[AgentMessage]) -> list[TranscriptEntr
                 # carry a PARTIAL copy of it — suppressing the connectivity
                 # prompt while rendering the goal-loop and auto-continuation
                 # prompts as the user's own words.
+                continue
+            if is_harness_injection(message):
+                # A row the harness MINTED from a ``CustomMessage`` — a
+                # model-switch notice, a session incident, a wake delivery —
+                # carries ``provider_payload["harness_injected"]``, and the
+                # operator never typed it. The live fold has its own receipt
+                # for the moments these announce (the failover retry notice and
+                # band, the incident row), so dropping the rendered copy is
+                # live/replay parity rather than a second opinion — and it also
+                # hides the rows an older build already wrote into existing
+                # transcripts. One decision, in ``harness/rows.py``, for the
+                # same reason the chrome list lives there.
                 continue
             # A `$skill` invocation persists as its EXPANDED payload, because
             # that is what the model was sent. Rendering it verbatim showed the

--- a/local_operator/session/history_window.py
+++ b/local_operator/session/history_window.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
 
+from local_operator.harness.rows import is_harness_injection
 from local_operator.harness.types import AgentMessage, Message
 from local_operator.session.transcript import (
     audit_slice,
@@ -717,7 +718,18 @@ def _capture_display_window(
         start=start,
         audit_available=audit_available,
         theme_turn_count=sum(getattr(m, "role", "") in ("user", "assistant") for m in history),
+        # The opener names the conversation, and a title is read by a person.
+        # A row the harness minted from a ``CustomMessage`` is not the user's
+        # opening prompt (see ``harness/rows.py``), so it must not title a
+        # thread "[model switch] You are now running as …" — the rows an older
+        # build already leaked into a transcript are exactly why this scan
+        # checks the stamp rather than trusting the role alone.
         opener_text=next(
-            (m.text[:256] for m in history if isinstance(m, Message) and m.role == "user"), ""
+            (
+                m.text[:256]
+                for m in history
+                if isinstance(m, Message) and m.role == "user" and not is_harness_injection(m)
+            ),
+            "",
         ),
     )

--- a/local_operator/session/history_window.py
+++ b/local_operator/session/history_window.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
 
-from local_operator.harness.rows import is_harness_injection
+from local_operator.harness.rows import is_harness_notice_row
 from local_operator.harness.types import AgentMessage, Message
 from local_operator.session.transcript import (
     audit_slice,
@@ -717,18 +717,31 @@ def _capture_display_window(
         total_message_count=total,
         start=start,
         audit_available=audit_available,
-        theme_turn_count=sum(getattr(m, "role", "") in ("user", "assistant") for m in history),
+        # The retitle gate counts CONVERSATION turns, and a harness notice is
+        # not one: a carried-forward notice copy inflated this figure by eight
+        # on the session this fixes, and the gate reads the number, not the
+        # rows, so an inflated unit retitles on nothing the operator said.
+        theme_turn_count=sum(
+            getattr(m, "role", "") in ("user", "assistant") and not is_harness_notice_row(m)
+            for m in history
+        ),
         # The opener names the conversation, and a title is read by a person.
-        # A row the harness minted from a ``CustomMessage`` is not the user's
-        # opening prompt (see ``harness/rows.py``), so it must not title a
-        # thread "[model switch] You are now running as …" — the rows an older
-        # build already leaked into a transcript are exactly why this scan
-        # checks the stamp rather than trusting the role alone.
+        # A row the harness wrote is not the user's opening prompt (see
+        # ``harness/rows.py``), so it must not title a thread "[model switch]
+        # You are now running as …" — nor the elision notice, whose text reads
+        # "[... harness-injected message(s) ... were also dropped; these were not
+        # authored by the user]" and was the title on the reported session. The
+        # rows an older build already wrote are why this checks provenance
+        # rather than trusting the role alone.
+        #
+        # ``total_message_count`` is deliberately NOT filtered: it is the unit
+        # the reader's paging is checked against, so it has to keep counting
+        # exactly the rows delivered.
         opener_text=next(
             (
                 m.text[:256]
                 for m in history
-                if isinstance(m, Message) and m.role == "user" and not is_harness_injection(m)
+                if isinstance(m, Message) and m.role == "user" and not is_harness_notice_row(m)
             ),
             "",
         ),

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -2797,9 +2797,16 @@ class Session:
         only thing that puts a custom message back into a replayed context is
         its own persisted entry. Filtering it here is what makes the rebuilt
         context equal what a resume replays — the live/resume equivalence this
-        render exists to protect — and the absence is deliberate rather than a
-        loss: the live announcement still reaches the model through the
-        untouched request render.
+        render exists to protect.
+
+        The price is stated rather than glossed, because it is a real one: a
+        live-only record is now absent from the rebuilt context, so a transient
+        notice reaches the model through the untouched request render only
+        UNTIL the next pass. After a commit the model is no longer told it is
+        on a fallback — it reads the authoritative ``Model:`` line in the
+        prompt tail instead, which is the same thing a resume gives it. The
+        alternative is the reported defect: re-seating the notice as user text
+        it can never take back.
 
         The test is :meth:`Transcript.has_entry` (a constant-time id-set
         check), NEVER :func:`_is_persistable_message`. That predicate answers a
@@ -2809,13 +2816,13 @@ class Session:
         out of the rebuild and make a live context diverge from its own
         resume.
 
-        The compaction marker is the one ``CustomMessage`` whose entry the
-        transcript holds under a DIFFERENT id: ``append_compaction`` stores it
-        as its own entry type (see :data:`_PERSISTABLE_CUSTOM_TYPES`), so the
-        fresh id ``build_compaction_marker`` mints is in no entry set while a
-        resume still replays the marker from that payload. It is exempted by
-        TYPE rather than by id, and load-bearing: dropping it would price and
-        plan every later pass against a context that has lost its own summary.
+        The compaction marker is exempted because its entry IS persisted — as a
+        compaction entry, written by ``append_compaction`` under its own type
+        and its own id — so the message id ``build_compaction_marker`` mints is
+        in no entry set while a resume still replays the summary from that
+        payload. Without the exemption the structural rule would drop it from
+        the render it plans against; this is a statement about the predicate,
+        not a measurement of what any particular session's marker contains.
         """
 
         def _is_ephemeral_for_compaction(message: AgentMessage) -> bool:
@@ -2840,6 +2847,49 @@ class Session:
             ],
             keep_images=keep_images,
         )
+
+    def _restore_custom_sources(self, kept: list[Message]) -> list[AgentMessage]:
+        """Re-seat each rendered copy in ``kept`` onto the message it came from.
+
+        The commit rebuilds the live context from the RENDERED history, so
+        without this every delivery inside the kept window becomes an anonymous
+        stamped user message. The model still reads it, but every fold then
+        sees an injection-shaped row instead of the receipt its own type paints
+        — a hub note, a peer message, a wake line, a job result — while a
+        RESUME of the same session, which replays the persisted custom entries,
+        paints exactly those receipts. Restoring the source is what keeps live
+        equal to resume, on both the request and the display side.
+
+        The lookup is the LIVE CONTEXT, and that is complete by construction
+        rather than by luck: every custom message this render can contain is a
+        ``CustomMessage`` in ``_context.messages`` (the injection producers
+        append one, and a replayed marker or aside materialises as one), so the
+        render is a pure function of objects the map holds. The
+        ``has_entry`` guard is the belt on that brace — a copy whose id the
+        transcript does not hold is not a delivery a resume could paint, so it
+        keeps the rendered form rather than acquiring an identity no journal
+        can substantiate.
+
+        Deliberately limited to this one direction. Substituting in the other
+        (a custom the render never produced) would invent context; and a
+        context already anonymised by an older build is NOT healed here — it
+        heals on the next resume, where replay rehydrates the custom entries —
+        which is stated rather than implied because the alternative looks like
+        an omission.
+        """
+        sources: dict[str, CustomMessage] = {
+            message.id: message
+            for message in self._context.messages
+            if isinstance(message, CustomMessage)
+        }
+        restored: list[AgentMessage] = []
+        for message in kept:
+            source = sources.get(message.id)
+            if source is not None and self._transcript.has_entry(message.id):
+                restored.append(source)
+            else:
+                restored.append(message)
+        return restored
 
     async def _recover_if_request_too_large(self, error: BaseException | str) -> bool:
         """Graduated recovery from ``HTTP 413: Request exceeds the maximum size``.
@@ -9040,7 +9090,9 @@ class Session:
             # resume and ``/export`` keep their frames; this keeps the LIVE
             # context honest too. The strip still applies to what the next
             # request SENDS (``_render_history`` re-renders on the way out).
-            kept = self._render_for_compaction(keep_images=True)[plan.cut :]
+            kept = self._restore_custom_sources(
+                self._render_for_compaction(keep_images=True)[plan.cut :]
+            )
             if not kept:
                 kept = plan.llm_history[plan.cut :]
             summary, preserve_data = (

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -2875,7 +2875,8 @@ class Session:
         context already anonymised by an older build is NOT healed here — it
         heals on the next resume, where replay rehydrates the custom entries —
         which is stated rather than implied because the alternative looks like
-        an omission.
+        an omission. Each id is re-seated at most once, so two kept rows that
+        share a custom's id cannot collapse onto a single object.
         """
         sources: dict[str, CustomMessage] = {
             message.id: message
@@ -2883,9 +2884,21 @@ class Session:
             if isinstance(message, CustomMessage)
         }
         restored: list[AgentMessage] = []
+        re_seated: set[str] = set()
         for message in kept:
             source = sources.get(message.id)
-            if source is not None and self._transcript.has_entry(message.id):
+            # ``re_seated`` is why the substitution is once per id: two kept rows
+            # can carry the same id (a duplicated delivery, a render emitted for
+            # both halves of a split), and collapsing both onto one object would
+            # silently drop the second row's content from the model's context —
+            # the one loss this whole pass must never cause. The second row keeps
+            # its rendered form, which is what it already is.
+            if (
+                source is not None
+                and message.id not in re_seated
+                and self._transcript.has_entry(message.id)
+            ):
+                re_seated.add(message.id)
                 restored.append(source)
             else:
                 restored.append(message)
@@ -9090,11 +9103,15 @@ class Session:
             # resume and ``/export`` keep their frames; this keeps the LIVE
             # context honest too. The strip still applies to what the next
             # request SENDS (``_render_history`` re-renders on the way out).
-            kept = self._restore_custom_sources(
-                self._render_for_compaction(keep_images=True)[plan.cut :]
-            )
-            if not kept:
-                kept = plan.llm_history[plan.cut :]
+            rendered = self._render_for_compaction(keep_images=True)[plan.cut :]
+            if not rendered:
+                # The fallback is the plan's STRIPPED history, so it goes through
+                # the same identity restore as the render above — the two paths
+                # must not differ in whether a receipt survives a pass, and a
+                # fallback that skipped it would be invisible until a delivery
+                # happened to land on it.
+                rendered = plan.llm_history[plan.cut :]
+            kept = self._restore_custom_sources(rendered)
             summary, preserve_data = (
                 summarized
                 if summarized is not None

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -65,6 +65,7 @@ from local_operator.compaction.cutpoint import (
     RENDERED_INJECTION_KEY,
 )
 from local_operator.compaction.marker import (
+    COMPACTION_MARKER_TYPE,
     build_compaction_marker,
     render_compaction_marker,
     replayed_user_message,
@@ -2733,12 +2734,13 @@ class Session:
     def _render_for_compaction(self, *, keep_images: bool = False) -> list[Message]:
         """The rendered history a compaction pass plans and commits against.
 
-        :meth:`_render_history` minus the todo reminders, because a reminder is
-        the ONE injection nothing persists (``_todo_continuation`` hands it to
-        the loop as a follow-up, which emits no event and reaches no
-        transcript), and compaction is built on the rendered history being
-        persisted history. Rendered into it, one reminder broke the pass at both
-        ends:
+        :meth:`_render_history` minus every LIVE-CONTEXT-ONLY injection — a
+        ``CustomMessage`` the transcript does not hold, which is one a resume
+        cannot replay. A todo reminder is the original member of that class:
+        ``_todo_continuation`` hands the reminder to the loop as a follow-up,
+        which emits no event and reaches no transcript. Compaction is built on
+        the rendered history being persisted history, and rendered into it one
+        ephemeral injection broke the pass at both ends:
 
         - ``_plan_compaction``'s replayability guard matches ``kept[0].id``
           against the transcript's entry ids, and a reminder's id is in no
@@ -2779,20 +2781,56 @@ class Session:
         the allow-list removal closed. Excluding it here keeps the live
         announcement in the REQUEST render (``_render_history``, untouched)
         while the rebuild the compaction commit owns stays persisted-only.
+
+        Those two are special cases of ONE class, and the enumeration was
+        itself the defect: an ephemeral injection type added later is filtered
+        only if someone remembers to list it here. The TRANSIENT model-switch
+        notice was the third member and went unlisted —
+        ``journal_model_switch(transient=True)`` appends a live-only failover
+        record, and the render baked it into the rebuilt context as a plain
+        ``Message(role="user")`` which the turn-end pass then persisted, so a
+        failover notice landed in a real session's transcript as a genuine
+        user row (four consecutive such rows in session ``835fbcafdc27``) and
+        every front end painted it as the user's own words. The predicate is
+        therefore STRUCTURAL rather than a list: a ``CustomMessage`` the
+        transcript does not hold is one a resume cannot replay, because the
+        only thing that puts a custom message back into a replayed context is
+        its own persisted entry. Filtering it here is what makes the rebuilt
+        context equal what a resume replays — the live/resume equivalence this
+        render exists to protect — and the absence is deliberate rather than a
+        loss: the live announcement still reaches the model through the
+        untouched request render.
+
+        The test is :meth:`Transcript.has_entry` (a constant-time id-set
+        check), NEVER :func:`_is_persistable_message`. That predicate answers a
+        different question — may the turn-end flush write this? — and returns
+        False for ``hub_message``, ``peer_message`` and ``wake_prompt``, whose
+        PRODUCERS persist them. Borrowing it here would drop persisted history
+        out of the rebuild and make a live context diverge from its own
+        resume.
+
+        The compaction marker is the one ``CustomMessage`` whose entry the
+        transcript holds under a DIFFERENT id: ``append_compaction`` stores it
+        as its own entry type (see :data:`_PERSISTABLE_CUSTOM_TYPES`), so the
+        fresh id ``build_compaction_marker`` mints is in no entry set while a
+        resume still replays the marker from that payload. It is exempted by
+        TYPE rather than by id, and load-bearing: dropping it would price and
+        plan every later pass against a context that has lost its own summary.
         """
 
         def _is_ephemeral_for_compaction(message: AgentMessage) -> bool:
             """Whether ``message`` must stay out of the compaction render.
 
-            Named rather than inlined because BOTH filters are
-            live-context-only injections whose rendered (id-carrying) copy
-            would otherwise be baked into the kept window and persisted by the
-            turn-end pass despite never being transcript material.
+            Named rather than inlined because every arm is a live-context-only
+            injection whose rendered (id-carrying) copy would otherwise be
+            baked into the kept window and persisted by the turn-end pass
+            despite never being transcript material.
             """
-            return _is_todo_reminder(message) or (
-                isinstance(message, CustomMessage)
-                and message.custom_type == SESSION_CREDENTIAL_MESSAGE_TYPE
-            )
+            if not isinstance(message, CustomMessage):
+                return False
+            if message.custom_type == COMPACTION_MARKER_TYPE:
+                return False
+            return not self._transcript.has_entry(message.id)
 
         return self._render_history(
             [

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -47,6 +47,7 @@ from local_operator.ecosystem_instructions import (
     log_ecosystem_provenance,
     read_ecosystem_instructions,
 )
+from local_operator.harness.rows import is_harness_notice_row
 from local_operator.harness.types import AgentMessage, Message
 
 # Imported as an alias: ``config_dir`` is a parameter/local name in other
@@ -669,16 +670,28 @@ def _latest_user_query(transcript: Any) -> str:
     ``Transcript.entries()`` shape (``.type``, ``.payload``); any deviation
     degrades to an empty query, which skips selection — skill selection must
     never break a session.
+
+    Picks the newest row the OPERATOR wrote. A harness notice (the
+    ``harness_injected`` stamp, or one of the notice heads a compaction block
+    carried forward — see ``harness/rows.py``) is stored as a
+    ``role="user"`` row and is not a query: handing selection the harness's
+    prose would search the skills index for "[model switch] You are now
+    running as …" and freeze the result against it as the block's task id.
     """
     try:
         # Production transcripts index these at durable append time. Keep the
         # historical fallback for embedders/test stores exposing entries only.
         if hasattr(transcript, "latest_user_entry"):
-            entries = [
-                entry
-                for entry in (transcript.latest_entry("compaction"), transcript.latest_user_entry())
-                if entry is not None
-            ]
+            newest_user = transcript.latest_user_entry()
+            candidates: Any = [transcript.latest_entry("compaction"), newest_user]
+            if newest_user is not None and is_harness_notice_row(
+                getattr(newest_user, "payload", None) or {}
+            ):
+                # The indexed path names ONE user row, so a notice there would
+                # end the scan with nothing to select on. Fall back to the
+                # journal and walk back to the newest row the operator wrote.
+                candidates = transcript.entries()
+            entries = [entry for entry in candidates if entry is not None]
         else:
             entries = transcript.entries()
     except Exception:  # noqa: BLE001 — degradation is the contract
@@ -710,6 +723,8 @@ def _latest_user_query(transcript: Any) -> str:
                         break
             summary = edge or str(payload.get("summary", "")).strip()
         if not user_text and entry_type == "message" and payload.get("role") == "user":
+            if is_harness_notice_row(payload):
+                continue
             content = payload.get("content") or []
             user_text = "".join(
                 block.get("text", "") for block in content if isinstance(block, dict)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -88,6 +88,7 @@ from local_operator.harness.intent import (
 # the comms graph resolves (which the manager's own sweep cannot reach — see
 # `_subagent_roster`), rather than re-deriving one that could drift from it.
 from local_operator.harness.jobs import roster_expired
+from local_operator.harness.rows import is_harness_injection
 
 # Free at runtime: `session.protocol` below already imports `harness.types` at
 # module level, so this adds no work to the boot path the lazy-import
@@ -8423,6 +8424,15 @@ class OperatorApp(App[None]):
             return  # reduced hosts (embedders, pilot fakes) may lack it
         for message in history:
             if getattr(message, "role", None) != "user":
+                continue
+            if is_harness_injection(message):
+                # A row the harness minted from a ``CustomMessage`` (a failover
+                # model-switch notice, an incident) is not the opening prompt.
+                # The decision is the shared one from ``harness/rows.py``, so
+                # this scan and ``history_window.opener_text`` — the other
+                # thing that reads the first user turn as a title — cannot
+                # disagree about it. Titling a thread "[model switch] You are
+                # now running as …" is the visible form of getting this wrong.
                 continue
             text = getattr(message, "text", "") or ""
             if not isinstance(text, str) or not text.strip():

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -88,7 +88,7 @@ from local_operator.harness.intent import (
 # the comms graph resolves (which the manager's own sweep cannot reach — see
 # `_subagent_roster`), rather than re-deriving one that could drift from it.
 from local_operator.harness.jobs import roster_expired
-from local_operator.harness.rows import is_harness_injection
+from local_operator.harness.rows import is_harness_notice_row
 
 # Free at runtime: `session.protocol` below already imports `harness.types` at
 # module level, so this adds no work to the boot path the lazy-import
@@ -1262,6 +1262,14 @@ def _resume_tail_start(history: list[Any], bound: int) -> int:
         message = history[index]
         role = getattr(message, "role", None)
         custom = getattr(message, "custom_type", None)
+        if is_harness_notice_row(message):
+            # A row the fold paints NOTHING for — a stamped render of a
+            # ``CustomMessage``, or a notice a compaction block carried in — is
+            # not a turn boundary a reader can see. Anchoring on one spends the
+            # first slot of the visible budget on an invisible row and pushes a
+            # real turn out of it, which is the same short-frame failure this
+            # backward walk exists to fix.
+            continue
         if role == "user" or custom in (WAKE_PROMPT_MESSAGE_TYPE, PEER_MESSAGE_MESSAGE_TYPE):
             return index
     return naive
@@ -8425,14 +8433,17 @@ class OperatorApp(App[None]):
         for message in history:
             if getattr(message, "role", None) != "user":
                 continue
-            if is_harness_injection(message):
-                # A row the harness minted from a ``CustomMessage`` (a failover
-                # model-switch notice, an incident) is not the opening prompt.
-                # The decision is the shared one from ``harness/rows.py``, so
-                # this scan and ``history_window.opener_text`` — the other
-                # thing that reads the first user turn as a title — cannot
-                # disagree about it. Titling a thread "[model switch] You are
-                # now running as …" is the visible form of getting this wrong.
+            if is_harness_notice_row(message):
+                # A row the harness wrote — a stamped render of a
+                # ``CustomMessage`` (a failover model-switch notice, an
+                # incident), or a notice carried in from a compaction block —
+                # is not the opening prompt. The decision is the shared one from
+                # ``harness/rows.py``, so this scan and
+                # ``history_window.opener_text`` — the other thing that reads
+                # the first user turn as a title — cannot disagree about it.
+                # Titling a thread "[model switch] You are now running as …",
+                # or with the elision notice's own prose, is the visible form of
+                # getting this wrong.
                 continue
             text = getattr(message, "text", "") or ""
             if not isinstance(text, str) or not text.strip():

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -812,7 +812,7 @@ def project_settled_rows(
         compaction_refused_notice,
         gate_timeout_notice,
         is_harness_chrome,
-        is_harness_injection,
+        is_harness_notice_row,
         user_row_text,
     )
     from local_operator.tui.app import (
@@ -1053,17 +1053,15 @@ def project_settled_rows(
                 # painting the other two as the user's own words.
                 if is_harness_chrome(text):
                     continue
-                # A row the harness MINTED from a ``CustomMessage`` — a
-                # model-switch notice, a session incident, a wake delivery —
-                # carries ``provider_payload["harness_injected"]`` and is not
-                # the operator's words. The live path never paints one (the
-                # failover moment has its own receipt: the retry notice, the
-                # splash toast, the band), so skipping is live/replay parity
-                # rather than a second opinion, and it also covers the rows an
-                # older build already wrote to existing transcripts. The
-                # decision lives in ``harness/rows.py`` so the phone fold, the
-                # subagents panel and the opener scans make the SAME one.
-                if is_harness_injection(message):
+                # A row the harness wrote and re-seated, or minted from a
+                # ``CustomMessage`` (a model-switch notice, a session incident,
+                # a wake delivery) is neither the operator's words nor, on the
+                # live path, ever painted here — so skipping it is live/replay
+                # parity rather than a second opinion, and it also covers the
+                # rows an older build already wrote to existing transcripts
+                # (stamped, or carried forward in a compaction block without a
+                # stamp). See ``harness/rows.py`` for the one decision.
+                if is_harness_notice_row(message):
                     continue
                 # A `$skill` invocation persists as its EXPANDED payload,
                 # because that is what the model was sent. Replaying it

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -812,6 +812,7 @@ def project_settled_rows(
         compaction_refused_notice,
         gate_timeout_notice,
         is_harness_chrome,
+        is_harness_injection,
         user_row_text,
     )
     from local_operator.tui.app import (
@@ -1051,6 +1052,18 @@ def project_settled_rows(
                 # partial copy — suppressing the connectivity prompt while
                 # painting the other two as the user's own words.
                 if is_harness_chrome(text):
+                    continue
+                # A row the harness MINTED from a ``CustomMessage`` — a
+                # model-switch notice, a session incident, a wake delivery —
+                # carries ``provider_payload["harness_injected"]`` and is not
+                # the operator's words. The live path never paints one (the
+                # failover moment has its own receipt: the retry notice, the
+                # splash toast, the band), so skipping is live/replay parity
+                # rather than a second opinion, and it also covers the rows an
+                # older build already wrote to existing transcripts. The
+                # decision lives in ``harness/rows.py`` so the phone fold, the
+                # subagents panel and the opener scans make the SAME one.
+                if is_harness_injection(message):
                     continue
                 # A `$skill` invocation persists as its EXPANDED payload,
                 # because that is what the model was sent. Replaying it

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -72,6 +72,7 @@ from local_operator.harness.comms import (
     extract_parent_message,
 )
 from local_operator.harness.jobs import CANCELLED_BEFORE_START, TRAJECTORY_SEQ_KEY
+from local_operator.harness.rows import is_harness_injection
 from local_operator.session.transcript import (
     CUSTOM_KIND_CUSTOM,
     ENTRY_CUSTOM,
@@ -665,6 +666,17 @@ def fold_transcript_entries(
         role = payload.get("role")
         text = strip_control_sequences(_content_text(payload)).strip()
         if role == "user":
+            if is_harness_injection(payload):
+                # A row the harness MINTED from a ``CustomMessage`` (the
+                # ``harness_injected`` stamp) is not the parent's words. A
+                # SUBAGENT fails over too — ``journal_model_switch`` names
+                # exactly that case — and the same compaction leak writes the
+                # transient notice into the child's transcript, where this
+                # fold would paint it as the parent speaking. The decision is
+                # the shared one from ``harness/rows.py``, read here off the
+                # raw payload rather than a message, so the panel cannot
+                # answer it differently from the two main folds.
+                continue
             parent_message = extract_parent_message(text)
             if parent_message is not None:
                 # A persisted hub steer: model-facing XML around the parent's

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -72,7 +72,7 @@ from local_operator.harness.comms import (
     extract_parent_message,
 )
 from local_operator.harness.jobs import CANCELLED_BEFORE_START, TRAJECTORY_SEQ_KEY
-from local_operator.harness.rows import is_harness_injection
+from local_operator.harness.rows import is_harness_notice_row
 from local_operator.session.transcript import (
     CUSTOM_KIND_CUSTOM,
     ENTRY_CUSTOM,
@@ -666,16 +666,17 @@ def fold_transcript_entries(
         role = payload.get("role")
         text = strip_control_sequences(_content_text(payload)).strip()
         if role == "user":
-            if is_harness_injection(payload):
-                # A row the harness MINTED from a ``CustomMessage`` (the
-                # ``harness_injected`` stamp) is not the parent's words. A
-                # SUBAGENT fails over too — ``journal_model_switch`` names
-                # exactly that case — and the same compaction leak writes the
-                # transient notice into the child's transcript, where this
-                # fold would paint it as the parent speaking. The decision is
-                # the shared one from ``harness/rows.py``, read here off the
-                # raw payload rather than a message, so the panel cannot
-                # answer it differently from the two main folds.
+            if is_harness_notice_row(payload):
+                # A row the harness wrote — the `harness_injected` stamp, or a
+                # notice a compaction block carried forward without one — is
+                # not the parent's words. A SUBAGENT fails over too
+                # (`journal_model_switch` names exactly that case) and the same
+                # compaction leak writes the notice into the child's
+                # transcript, where this fold would paint it as the parent
+                # speaking. The decision is the shared one from
+                # `harness/rows.py`, read here off the raw payload rather than
+                # a message, so the panel cannot answer it differently from the
+                # two main folds.
                 continue
             parent_message = extract_parent_message(text)
             if parent_message is not None:

--- a/scripts/audit_notice_census.py
+++ b/scripts/audit_notice_census.py
@@ -1,0 +1,174 @@
+"""Census a session's harness notices, per display PHASE, and optionally frame it.
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/audit_notice_census.py <session-dir> [out.svg]
+
+WHY THIS EXISTS
+---------------
+A display can serve a session through two phases, and a notice row can be
+*carried* in one and *stored* in the other:
+
+* the CONTEXT phase replays ``[marker, *preserved, *kept]``, where a notice is
+  either a stamped render of a ``CustomMessage`` or a copy a compaction marker
+  re-seated from an era before the stamp existed; and
+* the AUDIT phase replays the journal itself, where a pre-stamp notice is a plain
+  stored ``role="user"`` row with NO ``provider_payload`` at all.
+
+A fix scoped to carried copies therefore looks complete on the context phase and
+leaves the audit phase painting the originals — which is exactly the regression
+QA found in round 2 ("the heal opened the mirror"). This script measures BOTH
+phases with the tree's own fold rule, so the same command run against two
+checkouts reports the delta rather than an argument.
+
+The census uses ``is_harness_notice_row`` — the shared decision the folds use —
+and the phone fold, which is a pure function of the rows; the frame (when asked
+for) renders the AUDIT rows through the assembled application so the visual
+delta of that rule can be looked at.
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from typing import Literal
+
+sys.path.insert(0, ".")
+
+from scripts.visual_capture import isolate_capture, save_capture  # noqa: E402
+
+isolate_capture()
+
+from local_operator.harness.rows import (  # noqa: E402
+    is_harness_notice_row,
+    is_harness_notice_text,
+)
+from local_operator.mobile.projection import fold_messages_to_entries  # noqa: E402
+from local_operator.session.transcript import Transcript, replay_entries  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.transcript import (  # noqa: E402
+    TranscriptView,
+    UserBlock,
+)
+from tests.e2e.harness import ScriptedStream, build_session  # noqa: E402
+from tests.unit.tui.test_app_pilot import _renderable_plain  # noqa: E402
+
+#: The two phases, in the order a reader meets them.
+PHASES = ("context", "audit")
+
+
+def _census(rows) -> tuple[int, int, int, int]:
+    """``(rows, user rows, notice rows, notice-shaped rows the fold PAINTS)``.
+
+    The two notice figures are deliberately different measurements. ``notice_rows``
+    counts what THIS tree's rule identifies, so it moves as the rule changes — the
+    point of running the same command against two checkouts. ``painted`` counts
+    what a human would actually SEE: user rows the fold emits whose text opens with
+    a notice head. That is the symptom, and it must be zero however the rule is
+    phrased.
+    """
+    users = [row for row in rows if getattr(row, "role", None) == "user"]
+    notices = [row for row in users if is_harness_notice_row(row)]
+    painted = [
+        entry
+        for entry in fold_messages_to_entries(list(rows))
+        if entry.kind == "user" and is_harness_notice_text(entry.text or "")
+    ]
+    return len(rows), len(users), len(notices), len(painted)
+
+
+def report(directory: Path) -> dict[str, tuple[int, int, int, int]]:
+    transcript = Transcript(directory)
+    entries = transcript.entries()
+    out: dict[str, tuple[int, int, int, int]] = {}
+    for phase in PHASES:
+        rows = replay_entries(entries, None, mode=phase)
+        out[phase] = _census(rows)
+        total, users, notices, painted = out[phase]
+        print(
+            f"{phase:8}: rows={total:6} user={users:4} notice_rows={notices:3} "
+            f"painted_by_the_fold={painted}"
+        )
+    return out
+
+
+async def frame(
+    directory: Path, out_path: str, phase: Literal["context", "audit"] = "audit"
+) -> None:
+    """Render the phase's rows through the assembled app, and count the painted
+    notice rows ON SCREEN — the same rule, looked at rather than asserted.
+
+    A WINDOW around the notices, not the whole phase: the fold bounds what it
+    mounts to the newest rows, and the audit phase holds 15k of them, so handing
+    it the whole list would paint the tail and leave the subject off screen. The
+    slice is the same one in both checkouts (the notices and their neighbours),
+    which is what makes the before/after pair comparable.
+    """
+    transcript = Transcript(directory)
+    rows = replay_entries(transcript.entries(), None, mode=phase)
+    # The slice is chosen by TEXT, not by the tree's own rule, so both checkouts
+    # frame the SAME rows: a rule-based slice would frame the stamped rows on one
+    # side and the plain stored ones on the other, and the pair would differ by
+    # its subject rather than by the rule.
+    hits = [
+        index
+        for index, row in enumerate(rows)
+        if getattr(row, "role", None) == "user"
+        and is_harness_notice_text(str(getattr(row, "text", "") or ""))
+    ]
+    if hits:
+        start = max(0, hits[0] - 3)
+        # A generous tail after the first one: enough following rows that the
+        # frame shows the conversation continuing, not a bare notice list.
+        end = min(len(rows), hits[0] + 16)
+        rows = rows[start:end]
+    session = build_session(
+        Path(os.environ["LOCAL_OPERATOR_CONFIG_DIR"]) / "sessions" / "shot", ScriptedStream([])
+    )
+
+    async def factory():
+        return session
+
+    app = OperatorApp(factory)
+    async with app.run_test(size=(120, 44)) as pilot:
+        for _ in range(200):
+            if app._session is not None:
+                break
+            await pilot.pause()
+        for _ in range(10):
+            await pilot.pause()
+        app._project_settled_rows(list(rows))
+        for _ in range(40):
+            await pilot.pause()
+        view = app.query_one(TranscriptView)
+
+        def _painted_notice(text: str) -> bool:
+            # The user gutter (``▌``) rides every wrapped line of a user block,
+            # so it is removed before the head test — the head is the message's,
+            # not the surface's decoration.
+            return is_harness_notice_text(" ".join(text.replace("▌", " ").split()))
+
+        painted = [
+            _renderable_plain(getattr(block, "renderable", ""))
+            for block in view.blocks()
+            if isinstance(block, UserBlock)
+            # Text, not provenance: this count is "what a human sees", so it must
+            # not move when the rule is rephrased — only when the pixels do.
+            and _painted_notice(_renderable_plain(getattr(block, "renderable", "")))
+        ]
+        print(f"on screen ({phase}): user rows that are notices = {len(painted)}")
+        save_capture(app, out_path)
+    await session.dispose()
+
+
+def main() -> None:
+    source = Path(sys.argv[1])
+    if source.resolve() == Path.home() / ".local-operator":
+        raise SystemExit("refusing to read the live config dir; pass a copy")
+    out = sys.argv[2] if len(sys.argv) > 2 else None
+    report(source)
+    if out:
+        asyncio.run(frame(source, out))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit_notice_census.py
+++ b/scripts/audit_notice_census.py
@@ -156,6 +156,18 @@ async def frame(
             and _painted_notice(_renderable_plain(getattr(block, "renderable", "")))
         ]
         print(f"on screen ({phase}): user rows that are notices = {len(painted)}")
+        # The SCREEN's virtual_size == size only says no window chrome scrolls;
+        # these frames are scrolled WINDOWS of the transcript, so the reading that
+        # actually describes what a pair shows is the view's own: its scroll
+        # offset, its viewport height, and its content height. Printed and not
+        # asserted, because the pair's members legitimately differ by the height
+        # of the rows that were removed.
+        print(
+            f"transcript window ({phase}): scroll_y={view.scroll_y} "
+            f"viewport={view.container_size.height} content={view.virtual_size.height} "
+            f"blocks={len(view.blocks())} screen={app.screen.size} "
+            f"screen_virtual={app.screen.virtual_size}"
+        )
         save_capture(app, out_path)
     await session.dispose()
 

--- a/scripts/harness_injection_shot.py
+++ b/scripts/harness_injection_shot.py
@@ -1,0 +1,156 @@
+"""Capture a resumed transcript that holds a leaked harness injection.
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python scripts/harness_injection_shot.py out.svg
+
+Drives the REAL ``OperatorApp`` (the one that loads ``local_operator.tcss``)
+and replays the SHAPE of the operator's own session: the four
+``harness_injected`` rows a compaction pass baked into session
+``835fbcafdc27`` (each one the fallover notice ``format_model_switch_message``
+renders, copied here through the real producer) beside the assistant line that
+followed them. Then it posts the failover receipt the live path paints for that
+moment — the retry notice, then the band's effective-model edge — so one frame
+answers both halves of the report: the notice must not read as the user's own
+words, and the receipt the user actually gets must still be there.
+
+Run it against a pre-fix checkout for the before-frame (the leaked rows paint as
+user bubbles there, one per notice, which is the screenshot the operator sent).
+
+    git worktree add --detach /tmp/lo-before HEAD
+    ln -s ~/local-operator/.venv /tmp/lo-before/.venv   # throwaway only
+    cd /tmp/lo-before && env -u NO_COLOR TERM=xterm-256color \
+        .venv/bin/python scripts/harness_injection_shot.py /tmp/before.svg
+"""
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+sys.path.insert(0, ".")
+
+from scripts.visual_capture import isolate_capture, save_capture  # noqa: E402
+
+isolate_capture()
+
+from local_operator.compaction.cutpoint import RENDERED_INJECTION_KEY  # noqa: E402
+from local_operator.harness.types import Message, TextContent  # noqa: E402
+from local_operator.incidents import format_model_switch_message  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.events import (  # noqa: E402
+    EffectiveModelChanged,
+    NoticePosted,
+    RetryStarted,
+)
+from local_operator.tui.widgets.transcript import (  # noqa: E402
+    TranscriptView,
+    UserBlock,
+)
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+#: The four fallover hops the transcript carries, in order, rebuilt through the
+#: producer that wrote them (``journal_model_switch(transient=True)``).
+HOPS = (
+    ("zai/glm-5.3", "anthropic quota exhausted (0% remaining)"),
+    ("kimi/k3", "provider failure"),
+    ("alibaba-token-plan/qwen3.8-max", "provider failure"),
+    ("xai/grok-4.6", "provider failure"),
+)
+
+
+def _leaked_hops() -> list[Message]:
+    """The rows the compaction rebuild baked in: plain user Messages, stamped."""
+    return [
+        Message(
+            role="user",
+            content=[
+                TextContent(
+                    text=format_model_switch_message(
+                        new_label, "anthropic/claude-opus-5", reason=reason, transient=True
+                    )
+                )
+            ],
+            provider_payload={RENDERED_INJECTION_KEY: True},
+        )
+        for new_label, reason in HOPS
+    ]
+
+
+class _FallbackSession(FakeSession):
+    """A session serving on a fallback, so the band can name the detour."""
+
+    @property
+    def model_label(self) -> str:
+        return "anthropic/claude-opus-5"
+
+    @property
+    def model(self):
+        return SimpleNamespace(
+            provider="anthropic",
+            model_id="claude-opus-5",
+            display_name="Claude Opus 5",
+            context_window=200_000,
+            reasoning_effort=None,
+            reasoning_efforts=(),
+            reasoning=False,
+        )
+
+    @property
+    def effective_model(self):
+        return SimpleNamespace(
+            provider="xai",
+            model_id="grok-4.6",
+            display_name="Grok 4.6",
+            context_window=256_000,
+            reasoning_effort=None,
+            reasoning_efforts=(),
+            reasoning=False,
+        )
+
+    @property
+    def effective_model_label(self):
+        return "xai/grok-4.6"
+
+
+async def _pump_until(pilot: Any, predicate: Any, attempts: int = 300) -> None:
+    """Pump frames until ``predicate`` holds, instead of guessing a count.
+
+    The boot's resume replay is a worker, so the number of frames it needs is a
+    property of the machine. A fixed count produced a frame that painted the
+    history TWICE (the replay landing after an explicit projection) on one run
+    and once on another — the same class of bet the tests in
+    ``tests/unit/tui`` were converted away from.
+    """
+    for _ in range(attempts):
+        if predicate():
+            return
+        await pilot.pause()
+    raise AssertionError("the resumed replay never painted")
+
+
+async def main() -> None:
+    out = sys.argv[1]
+    session = _FallbackSession()
+    session._history = [
+        Message.user("check the MiniMax subset state before the next batch"),
+        *_leaked_hops(),
+        Message.assistant("Checking the MiniMax subset state after the model switch."),
+    ]
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 46)) as pilot:
+        await pilot.pause()
+        # The replay the operator was looking at when he reported this: the
+        # app's OWN resume path paints it, so the frame is the surface he saw
+        # rather than a second projection the harness added.
+        transcript = app.query_one(TranscriptView)
+        await _pump_until(pilot, lambda: any(isinstance(b, UserBlock) for b in transcript.blocks()))
+        # …and the receipt the LIVE path paints for the failover: the retry
+        # notice, then the band's own effective-model edge.
+        app.post_message(RetryStarted(1, "anthropic quota exhausted (0% remaining)", "zai/glm-5.3"))
+        app.post_message(NoticePosted("provider failure — falling back to zai/glm-5.3", "warning"))
+        app.post_message(EffectiveModelChanged("xai", "grok-4.6", None, "provider failure", True))
+        for _ in range(4):
+            await pilot.pause()
+        save_capture(app, out)
+
+
+asyncio.run(main())

--- a/scripts/harness_injection_shot.py
+++ b/scripts/harness_injection_shot.py
@@ -3,14 +3,26 @@
     env -u NO_COLOR TERM=xterm-256color .venv/bin/python scripts/harness_injection_shot.py out.svg
 
 Drives the REAL ``OperatorApp`` (the one that loads ``local_operator.tcss``)
-and replays the SHAPE of the operator's own session: the four
-``harness_injected`` rows a compaction pass baked into session
-``835fbcafdc27`` (each one the fallover notice ``format_model_switch_message``
-renders, copied here through the real producer) beside the assistant line that
-followed them. Then it posts the failover receipt the live path paints for that
-moment — the retry notice, then the band's effective-model edge — so one frame
-answers both halves of the report: the notice must not read as the user's own
-words, and the receipt the user actually gets must still be there.
+over a SEED OF THE REPORTED SHAPE — the four ``harness_injected`` rows a
+compaction pass baked into session ``835fbcafdc27`` (each one the fallover
+notice ``format_model_switch_message`` renders, rebuilt here through the real
+producer) beside the assistant line that followed them — and then posts the
+failover receipt the live path paints for that moment, so one frame answers
+both halves of the report: the notice must not read as the user's own words, and
+the moment is still announced.
+
+This is a SHAPE, not the operator's transcript: the real session is replayed by
+``scripts/legacy_notice_resume_shot.py`` against a copy of it, which is the
+frame that shows the reported data. That script is also the one that covers the
+legacy pre-stamp notices, which this seed does not carry.
+
+TWO THINGS THE RECEIPT IS, and the caption on the PR must say both: it is the
+``NoticeEvent`` ``configure.py::_on_route_change`` emits ("<reason> — falling
+back to <selector>", plus ``_on_route_settle``'s "back to <primary>" on
+recovery), and it is the account of the event only WHILE THE SESSION IS LIVE —
+reopening the conversation carries no trace of it by design, which is why the
+harness also tells the MODEL through the injected notice this fix stops from
+surfacing as user text.
 
 Run it against a pre-fix checkout for the before-frame (the leaked rows paint as
 user bubbles there, one per notice, which is the screenshot the operator sent).
@@ -36,11 +48,7 @@ from local_operator.compaction.cutpoint import RENDERED_INJECTION_KEY  # noqa: E
 from local_operator.harness.types import Message, TextContent  # noqa: E402
 from local_operator.incidents import format_model_switch_message  # noqa: E402
 from local_operator.tui.app import OperatorApp  # noqa: E402
-from local_operator.tui.events import (  # noqa: E402
-    EffectiveModelChanged,
-    NoticePosted,
-    RetryStarted,
-)
+from local_operator.tui.events import EffectiveModelChanged, NoticePosted  # noqa: E402
 from local_operator.tui.widgets.transcript import (  # noqa: E402
     TranscriptView,
     UserBlock,
@@ -145,8 +153,16 @@ async def main() -> None:
         await _pump_until(pilot, lambda: any(isinstance(b, UserBlock) for b in transcript.blocks()))
         # …and the receipt the LIVE path paints for the failover: the retry
         # notice, then the band's own effective-model edge.
-        app.post_message(RetryStarted(1, "anthropic quota exhausted (0% remaining)", "zai/glm-5.3"))
-        app.post_message(NoticePosted("provider failure — falling back to zai/glm-5.3", "warning"))
+        # The live failover receipt, exactly as ``configure.py::_on_route_change``
+        # emits it (a ``NoticeEvent`` carrying "<reason> — falling back to
+        # <selector>"). Nothing in this tree raises a retry notice for a
+        # model fallback, which is why this is the NoticePosted shape.
+        app.post_message(
+            NoticePosted(
+                "anthropic quota exhausted (0% remaining) — falling back to zai/glm-5.3",
+                "warning",
+            )
+        )
         app.post_message(EffectiveModelChanged("xai", "grok-4.6", None, "provider failure", True))
         for _ in range(4):
             await pilot.pause()

--- a/scripts/legacy_notice_resume_shot.py
+++ b/scripts/legacy_notice_resume_shot.py
@@ -108,7 +108,13 @@ async def main() -> None:
     #: Land the viewport here (content-space) before the final capture. Passed
     #: explicitly for an after-frame, so the pair shows the SAME place in the
     #: conversation: the offset is read off the before run's own report.
-    content_offset = int(sys.argv[4]) if len(sys.argv) > 4 else None
+    content_offset = int(sys.argv[4]) if len(sys.argv) > 4 and sys.argv[4] else None
+    #: …or land on a ROW, which is the better pairing for a frame whose subject
+    #: is GONE on the after side: a numeric offset belongs to the content that
+    #: used to be there, so after a removal it points at different rows. An
+    #: anchor row exists in both trees, which makes the two frames a comparison
+    #: of the same window rather than of the same number.
+    anchor_text = sys.argv[5] if len(sys.argv) > 5 and sys.argv[5] else None
     if source.resolve() == Path.home() / ".local-operator":
         raise SystemExit("refusing to read the live config dir; pass a copy")
 
@@ -164,6 +170,20 @@ async def main() -> None:
             print(f"after page-back {page}: user rows={users} notice rows={notices}")
         if page_backs:
             view = app.query_one(TranscriptView)
+            blocks = list(view.blocks())
+            if content_offset is None and anchor_text:
+                anchor = next(
+                    (
+                        block
+                        for block in blocks
+                        if anchor_text in _renderable_plain(getattr(block, "renderable", ""))
+                    ),
+                    None,
+                )
+                if anchor is None:
+                    raise SystemExit(f"anchor row not mounted: {anchor_text!r}")
+                content_offset = _block_content_offset(view, anchor)
+                print(f"anchor {anchor_text!r} at content offset {content_offset}")
             if content_offset is None:
                 # No offset asked for: land on the first notice row this frame
                 # paints, which is the subject of the pair, and REPORT the
@@ -171,7 +191,7 @@ async def main() -> None:
                 notice = next(
                     (
                         block
-                        for block in view.blocks()
+                        for block in blocks
                         if isinstance(block, UserBlock)
                         and _is_measured_notice(_renderable_plain(getattr(block, "renderable", "")))
                     ),
@@ -179,6 +199,12 @@ async def main() -> None:
                 )
                 if notice is not None:
                     content_offset = _block_content_offset(view, notice)
+                    # PRINT the row above it too: that row survives the fix, so
+                    # it is the anchor an after-frame can actually be landed on.
+                    index = blocks.index(notice)
+                    for neighbour in blocks[max(0, index - 2) : index]:
+                        text = _renderable_plain(getattr(neighbour, "renderable", ""))
+                        print(f"row above: {text.splitlines()[0][:70] if text else text!r}")
             if content_offset is not None:
                 # Twice, with a settle between: a page mount that lands during
                 # the first pump re-anchors the viewport to keep the reader's

--- a/scripts/legacy_notice_resume_shot.py
+++ b/scripts/legacy_notice_resume_shot.py
@@ -1,0 +1,197 @@
+"""Capture a real ``/resume`` over a transcript that carries legacy notices.
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/legacy_notice_resume_shot.py <session-dir> out.svg [page_backs]
+
+WHY THIS EXISTS
+---------------
+A harness notice written BEFORE the ``harness_injected`` stamp existed is a plain
+``role="user"`` row with no provenance at all, and a compaction pass lifted those
+rows into its marker's preserved block as "user turns". Replaying that marker
+re-seats them as user rows, so the reader saw the harness's own words behind the
+user gutter — the reported symptom, on the session it was reported from — and a
+fix that only reads the stamp cannot see them. This script drives the assembled
+application (``/resume``, then the scroll-up gesture that pages older history in)
+against a COPY of such a transcript and reports what each frame actually paints.
+
+The transcript is read from a directory you name, never from the operator's live
+session: copy it first (``cp -c`` on APFS is byte-identical and cheap) and pass
+the copy. ``isolate_capture()`` redirects HOME and the config dir before any app
+import, so the run cannot write to a real session either way.
+
+Output is the frame at ``out.svg`` plus a printed row census per page: the total
+painted user rows and how many of them are harness notices.
+"""
+
+import asyncio
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, ".")
+
+from scripts.visual_capture import isolate_capture, save_capture  # noqa: E402
+
+isolate_capture()
+
+from local_operator.paths import config_dir as app_config_dir  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.transcript import (  # noqa: E402
+    TranscriptView,
+    UserBlock,
+)
+from tests.e2e.harness import ScriptedStream, build_session  # noqa: E402
+from tests.unit.tui.test_app_pilot import _renderable_plain  # noqa: E402
+
+#: The switch-notice head this script measures, as a literal rather than through
+#: the product's recognition rule, on purpose: the instrument has to run against a
+#: tree that PREDATES the rule, which is what a before-frame is taken from.
+MEASURED_NOTICE_HEAD = "[model switch] "
+
+#: The elision notice's own phrasing. It opens with a bracketed COUNT, so it has
+#: no fixed head; these are the two sentences ``elision_notice_text`` writes.
+_ELISION_PHRASES = (
+    "were dropped here to bound the context",
+    "were also dropped; these were not authored by the user",
+)
+
+
+#: Frames to pump after each page-back before reading the census: the mount is a
+#: worker plus a gap-settle, and a fixed pump count is what produced a
+#: half-painted census the first time this was written.
+FILL_CYCLES = 30
+
+
+def _is_measured_notice(text: str) -> bool:
+    # The user gutter (``▌ ``) rides EVERY wrapped line of the block, so it is
+    # removed wherever it appears, not just at the head: a phrase split by the
+    # gutter is the one shape a raw substring test misses. Whitespace is
+    # flattened for the same reason — the painted text is wrapped.
+    flattened = " ".join(text.replace("▌", " ").split())
+    if flattened.startswith(MEASURED_NOTICE_HEAD):
+        return True
+    return flattened.startswith("[") and any(phrase in flattened for phrase in _ELISION_PHRASES)
+
+
+def census(app: OperatorApp) -> tuple[int, int]:
+    """``(painted user rows, of which harness notices)`` on the mounted frame."""
+    view = app.query_one(TranscriptView)
+    users = [b for b in view.blocks() if isinstance(b, UserBlock)]
+    notices = [
+        block
+        for block in users
+        if _is_measured_notice(_renderable_plain(getattr(block, "renderable", "")))
+    ]
+    return len(users), len(notices)
+
+
+def _block_content_offset(view: TranscriptView, block: Any) -> int:
+    """The content-space scroll offset that puts ``block`` at the viewport top.
+
+    ``Widget.region`` is in SCREEN coordinates, so the content offset has to be
+    reconstructed from the view's own scroll position: a block scrolled above
+    the viewport reports a negative ``region.y``, and one below reports a
+    positive one, both relative to the same content origin.
+    """
+    return int(view.scroll_y + block.region.y - view.content_region.y)
+
+
+async def _pump(pilot, cycles: int) -> None:
+    for _ in range(cycles):
+        await pilot.pause()
+
+
+async def main() -> None:
+    source, out = Path(sys.argv[1]), sys.argv[2]
+    page_backs = int(sys.argv[3]) if len(sys.argv) > 3 else 0
+    #: Land the viewport here (content-space) before the final capture. Passed
+    #: explicitly for an after-frame, so the pair shows the SAME place in the
+    #: conversation: the offset is read off the before run's own report.
+    content_offset = int(sys.argv[4]) if len(sys.argv) > 4 else None
+    if source.resolve() == Path.home() / ".local-operator":
+        raise SystemExit("refusing to read the live config dir; pass a copy")
+
+    # The isolated root ``isolate_capture`` installed, so the copy lands inside
+    # the sandbox the app is already pointed at.
+    sandbox = Path(app_config_dir())
+    target = sandbox / "sessions" / "resume-target"
+    target.mkdir(parents=True, exist_ok=True)
+    for name in ("transcript.jsonl",):
+        shutil.copyfile(source / name, target / name)
+    for extra in ("attachments", "attachments.json"):
+        if (source / extra).exists():
+            if (source / extra).is_dir():
+                shutil.copytree(source / extra, target / extra, dirs_exist_ok=True)
+            else:
+                shutil.copyfile(source / extra, target / extra)
+
+    live_dir = sandbox / "sessions" / "live"
+    live = build_session(live_dir, ScriptedStream([]), cwd=sandbox)
+    resumed = build_session(target, ScriptedStream([]), cwd=sandbox)
+
+    async def factory():
+        return live
+
+    async def resume_factory(_resume_id: str | None):
+        return resumed
+
+    app = OperatorApp(factory, resume_factory=resume_factory)
+    async with app.run_test(size=(120, 44)) as pilot:
+        for _ in range(200):
+            if app._session is not None:
+                break
+            await pilot.pause()
+        await _pump(pilot, 10)
+
+        app._resume_session("resume-target", lambda *_a, **_k: None)
+        await _pump(pilot, 60)
+
+        users, notices = census(app)
+        print(f"first resume frame: user rows={users} notice rows={notices}")
+        save_capture(app, out)
+
+        view = app.query_one(TranscriptView)
+        for page in range(1, page_backs + 1):
+            # The gesture the reader makes: input earns demand, then the scroll
+            # lands in the trigger zone and the app mounts one older page.
+            view.note_user_scroll()
+            view.scroll_to(y=0, animate=False)
+            await _pump(pilot, 5)
+            app._check_resume_page()
+            await _pump(pilot, FILL_CYCLES)
+            users, notices = census(app)
+            print(f"after page-back {page}: user rows={users} notice rows={notices}")
+        if page_backs:
+            view = app.query_one(TranscriptView)
+            if content_offset is None:
+                # No offset asked for: land on the first notice row this frame
+                # paints, which is the subject of the pair, and REPORT the
+                # offset so the after run can be landed on the same place.
+                notice = next(
+                    (
+                        block
+                        for block in view.blocks()
+                        if isinstance(block, UserBlock)
+                        and _is_measured_notice(_renderable_plain(getattr(block, "renderable", "")))
+                    ),
+                    None,
+                )
+                if notice is not None:
+                    content_offset = _block_content_offset(view, notice)
+            if content_offset is not None:
+                # Twice, with a settle between: a page mount that lands during
+                # the first pump re-anchors the viewport to keep the reader's
+                # position, and that animation is what left the subject of the
+                # frame off-screen on the first attempt.
+                for _ in range(2):
+                    view.scroll_to(y=content_offset, animate=False)
+                    await _pump(pilot, 12)
+                print(f"landed at content offset {content_offset} (scroll_y={view.scroll_y})")
+            save_capture(app, out)
+
+    await live.dispose()
+    await resumed.dispose()
+
+
+asyncio.run(main())

--- a/tests/unit/compaction/test_cutpoint.py
+++ b/tests/unit/compaction/test_cutpoint.py
@@ -517,3 +517,25 @@ def test_extract_id_filter_excludes_injected_user_role_content():
     to_summarize = [rendered_marker, genuine, Message.assistant("ok")]
     preserved = extract_preserved_user_turns(to_summarize, {genuine.id})
     assert [t["text"] for t in preserved] == ["NEVER touch billing.py"]
+
+
+def test_extract_refuses_a_legacy_harness_notice_as_a_user_turn():
+    """An unstamped notice is not a user turn, however it is shaped.
+
+    A notice written before the ``harness_injected`` stamp existed (a real
+    session carries eight switch-notice rows with no ``provider_payload`` at
+    all) is a plain ``role="user"`` message, and harvesting one re-seats the
+    harness's words as the operator's on every replay of the marker. The stamp
+    cannot see it, so the notice's own head decides — and the operator's real
+    turns are still lifted verbatim beside it.
+    """
+    notice = Message.user(
+        "[model switch] You are now running as zai/glm-5.3 (was anthropic/claude-opus-5).\n"
+        "Reason: provider failure"
+    )
+    genuine = Message.user("NEVER touch billing.py")
+    to_summarize = [notice, Message.assistant("ok"), genuine]
+
+    assert [t["text"] for t in extract_preserved_user_turns(to_summarize)] == [
+        "NEVER touch billing.py"
+    ]

--- a/tests/unit/mobile/test_fold_parity.py
+++ b/tests/unit/mobile/test_fold_parity.py
@@ -49,7 +49,10 @@ from typing import Any
 
 import pytest
 
-from local_operator.compaction.cutpoint import RENDERED_INJECTION_KEY
+from local_operator.compaction.cutpoint import (
+    PRESERVED_USER_TURN_KEY,
+    RENDERED_INJECTION_KEY,
+)
 from local_operator.compaction.marker import COMPACTION_REFUSED_TYPE
 from local_operator.harness.approval import GATE_TIMEOUT_CUSTOM_TYPE
 from local_operator.harness.comms import (
@@ -154,6 +157,20 @@ def _injected_notice(text: str | None = None) -> Message:
     )
 
 
+def _carried_notice() -> Message:
+    """The legacy shape: a notice a compaction block carried forward.
+
+    Written before the stamp existed, so it is re-seated with
+    ``compaction_preserved`` and no stamp at all — QA measured eight of these on
+    the operator's own session, painted behind the user gutter twice each.
+    """
+    return Message(
+        role="user",
+        content=[TextContent(text=_switch_notice())],
+        provider_payload={PRESERVED_USER_TURN_KEY: True},
+    )
+
+
 def _assistant(text: str = "", calls=(), stop=None, payload=None) -> Message:
     message = Message(
         role="assistant",
@@ -208,6 +225,7 @@ CORPUS: dict[str, Sequence[AgentMessage]] = {
         ToolResult(tool_call_id="sh1", content=[TextContent(text="total 0")], is_error=False),
     ),
     "D12 harness injection": [Message.user("why did the model change?"), _injected_notice()],
+    "D13 carried notice": [Message.user("why did the model change?"), _carried_notice()],
     "settled conversation": [
         Message.user("edit it"),
         _assistant("editing", calls=[ToolCall(id="e1", name="edit", arguments={"path": "/x"})]),
@@ -435,6 +453,14 @@ def test_a_harness_injected_row_is_never_painted_as_the_users_words() -> None:
     for rows in (_page_rows(history), _attach_rows(history)):
         assert [row.kind for row in rows] == ["user"]
         assert rows[0].text == "why did the model change?"
+        assert notice not in " ".join(row.text for row in rows)
+
+    # …and the same decision covers the LEGACY shape: a notice a compaction
+    # block carried forward from before the stamp existed (QA Q1, measured on
+    # the operator's own session). Both folds, again.
+    carried = [Message.user("why did the model change?"), _carried_notice()]
+    for rows in (_page_rows(carried), _attach_rows(carried)):
+        assert [row.kind for row in rows] == ["user"]
         assert notice not in " ".join(row.text for row in rows)
 
     # Negative control: the same WORDING without the stamp is the user's own

--- a/tests/unit/mobile/test_fold_parity.py
+++ b/tests/unit/mobile/test_fold_parity.py
@@ -49,6 +49,7 @@ from typing import Any
 
 import pytest
 
+from local_operator.compaction.cutpoint import RENDERED_INJECTION_KEY
 from local_operator.compaction.marker import COMPACTION_REFUSED_TYPE
 from local_operator.harness.approval import GATE_TIMEOUT_CUSTOM_TYPE
 from local_operator.harness.comms import (
@@ -74,6 +75,7 @@ from local_operator.harness.types import (
     ToolResult,
 )
 from local_operator.harness.wake import WAKE_PROMPT_MESSAGE_TYPE
+from local_operator.incidents import format_model_switch_message
 from local_operator.mobile.projection import ProjectionFold, fold_messages_to_entries
 from local_operator.mobile.types import SessionProjection, TranscriptEntry
 from local_operator.session.shell_record import shell_record_messages
@@ -125,6 +127,30 @@ def _hub_steer(body: str) -> CustomMessage:
             "steer": True,
             "text": _envelope(body),
         },
+    )
+
+
+def _switch_notice() -> str:
+    """The failover notice ``journal_model_switch`` renders, verbatim.
+
+    Built by the real producer rather than hand-written: the display rule is
+    about the STAMP, so a test that keyed on remembered wording would pass
+    while a reworded notice leaked.
+    """
+    return format_model_switch_message(
+        "zai/glm-5.3",
+        "anthropic/claude-opus-5",
+        reason="anthropic quota exhausted (0% remaining)",
+        transient=True,
+    )
+
+
+def _injected_notice(text: str | None = None) -> Message:
+    """Exactly what ``_injected_user_message`` mints: a stamped user row."""
+    return Message(
+        role="user",
+        content=[TextContent(text=_switch_notice() if text is None else text)],
+        provider_payload={RENDERED_INJECTION_KEY: True},
     )
 
 
@@ -181,6 +207,7 @@ CORPUS: dict[str, Sequence[AgentMessage]] = {
         "ls -la",
         ToolResult(tool_call_id="sh1", content=[TextContent(text="total 0")], is_error=False),
     ),
+    "D12 harness injection": [Message.user("why did the model change?"), _injected_notice()],
     "settled conversation": [
         Message.user("edit it"),
         _assistant("editing", calls=[ToolCall(id="e1", name="edit", arguments={"path": "/x"})]),
@@ -389,6 +416,33 @@ def test_ordinary_prose_mentioning_a_skill_is_left_alone() -> None:
     rows = _page_rows([Message.user("what does the $research skill do?")])
 
     assert rows[0].text == "what does the $research skill do?"
+
+
+def test_a_harness_injected_row_is_never_painted_as_the_users_words() -> None:
+    """A row the harness minted from a ``CustomMessage`` is not the user's words.
+
+    The transient failover notice is the reported case: a compaction pass baked
+    it into the rebuilt context as a plain user row (the root-cause fix is in
+    ``Session._render_for_compaction``), and it is still on disk in every
+    session an older build wrote — so the DISPLAY decision has to hold for
+    rows already in a transcript, not only for new ones. Both folds, because
+    the phone's own bare ``role == "user"`` test is exactly how the two
+    surfaces drift apart.
+    """
+    notice = _switch_notice()
+    history = [Message.user("why did the model change?"), _injected_notice(notice)]
+
+    for rows in (_page_rows(history), _attach_rows(history)):
+        assert [row.kind for row in rows] == ["user"]
+        assert rows[0].text == "why did the model change?"
+        assert notice not in " ".join(row.text for row in rows)
+
+    # Negative control: the same WORDING without the stamp is the user's own
+    # words — pasting a notice to ask about it is a realistic thing to do — so
+    # the decision must key on the stamp and never on the text.
+    quoted = [Message(role="user", content=[TextContent(text=notice)])]
+    assert [row.text for row in _page_rows(quoted)] == [notice]
+    assert [row.text for row in _attach_rows(quoted)] == [notice]
 
 
 def test_no_harness_prompt_is_painted_as_the_users_words() -> None:

--- a/tests/unit/mobile/test_fold_parity.py
+++ b/tests/unit/mobile/test_fold_parity.py
@@ -82,6 +82,9 @@ from local_operator.incidents import format_model_switch_message
 from local_operator.mobile.projection import ProjectionFold, fold_messages_to_entries
 from local_operator.mobile.types import SessionProjection, TranscriptEntry
 from local_operator.session.shell_record import shell_record_messages
+from local_operator.session.transcript import ENTRY_MESSAGE
+from local_operator.session.transcript import TranscriptEntry as JournalEntry
+from local_operator.session.transcript import replay_entries
 
 
 def _page_rows(history: Sequence[AgentMessage]) -> list[TranscriptEntry]:
@@ -463,12 +466,55 @@ def test_a_harness_injected_row_is_never_painted_as_the_users_words() -> None:
         assert [row.kind for row in rows] == ["user"]
         assert notice not in " ".join(row.text for row in rows)
 
-    # Negative control: the same WORDING without the stamp is the user's own
-    # words — pasting a notice to ask about it is a realistic thing to do — so
-    # the decision must key on the stamp and never on the text.
+    # The LIMIT of the rule, pinned here because it is a trade and not a free
+    # win: the same wording with no stamp and no carried marker — a pasted notice,
+    # a realistic prompt — is ALSO hidden on both folds, because the audit phase
+    # serves stored rows whose only surviving evidence is the text (QA round 2 Q1
+    # found four such rows painted on the operator's session). The row is not lost
+    # anywhere else; only the renderer drops it, exactly as the chrome prompts
+    # above already do.
     quoted = [Message(role="user", content=[TextContent(text=notice)])]
-    assert [row.text for row in _page_rows(quoted)] == [notice]
-    assert [row.text for row in _attach_rows(quoted)] == [notice]
+    assert _page_rows(quoted) == []
+    assert _attach_rows(quoted) == []
+
+
+def test_a_stored_notice_row_is_hidden_in_the_audit_phase_too() -> None:
+    """QA round 2 Q1: the heal must not open the mirror.
+
+    Shedding the carried copies removed their ids from the hoisted suppression
+    set, so the plain stored rows an older build wrote — no stamp, no marker,
+    served verbatim by the audit phase — came back into view. The decision is
+    therefore text-based for any ``role="user"`` row, in whichever phase serves
+    it, and this pins the audit arm of that: a stored notice replayed through
+    ``replay_entries(..., mode="audit")`` paints nothing on either fold while the
+    row itself stays in the journal.
+    """
+    notice = _switch_notice()
+
+    def journal_row(entry_id: str, text: str) -> JournalEntry:
+        """A stored row as the JOURNAL holds it: no ``provider_payload`` at all."""
+        return JournalEntry(
+            id=entry_id,
+            ts=1.0,
+            type=ENTRY_MESSAGE,
+            payload={
+                "kind": "message",
+                "role": "user",
+                "content": [{"type": "text", "text": text}],
+            },
+        )
+
+    entries = [
+        journal_row("stored-notice", notice),
+        journal_row("mine", "why did the model change?"),
+    ]
+
+    replayed = replay_entries(entries, None, mode="audit")
+    assert "stored-notice" in [getattr(row, "id", "") for row in replayed]
+
+    for rows in (_page_rows(replayed), _attach_rows(replayed)):
+        assert [row.kind for row in rows] == ["user"]
+        assert rows[0].text == "why did the model change?"
 
 
 def test_no_harness_prompt_is_painted_as_the_users_words() -> None:

--- a/tests/unit/session/test_compaction_preserved_turn_runaway.py
+++ b/tests/unit/session/test_compaction_preserved_turn_runaway.py
@@ -42,7 +42,7 @@ from local_operator.compaction.cutpoint import (
     elision_notice_text,
     extract_preserved_user_turns,
 )
-from local_operator.harness.types import Message, ModelSpec, TextContent
+from local_operator.harness.types import CustomMessage, Message, ModelSpec, TextContent
 from local_operator.session.session import Session, _default_convert_to_llm
 from local_operator.session.transcript import Transcript
 
@@ -57,6 +57,15 @@ CONSTRAINT = "NEVER touch billing.py"
 #: Stands in for the repeated system/team brief that dominated the real
 #: session's preserved block (79 of 171 turns, 1.27 MB of 1.45 MB).
 STATE_TEXT = "[session-state]\n## Available tools\nbash, read, write"
+
+#: The legacy shape QA measured on the operator's own session: a switch notice
+#: written before the ``harness_injected`` stamp existed, so it is a plain
+#: ``role="user"`` row with NO ``provider_payload`` at all — and a compaction
+#: pass harvested eight copies of it into its marker.
+LEGACY_NOTICE_TEXT = (
+    "[model switch] You are now running as zai/glm-5.3 (was anthropic/claude-opus-5).\n"
+    "Reason: provider failure"
+)
 
 
 class ScriptedStream:
@@ -193,17 +202,20 @@ async def test_a_session_state_delivery_is_not_preserved_on_the_second_pass(tmp_
 
     The ORDERING here is the whole test, and getting it wrong makes the test
     vacuous. The injection must land in pass 1's KEPT window — i.e. be the last
-    thing before pass 1 — so that pass 1's commit rebuilds the context from the
-    RENDERED history and bakes it in as a plain ``Message(role="user")``. Only
-    then does pass 2 see the generational state the bug lives in, where the
-    injection's id is genuinely inside ``genuine_user_ids``.
+    thing before pass 1 — so that pass 1's commit runs over it at all. Pass 1
+    now RESTORES its identity (see ``_restore_custom_sources``), which the first
+    assertion checks; the second stages the state an older build left behind
+    (the same delivery as a plain stamped row) because that is the generational
+    shape pass 2 must refuse, and the delivery's id is genuinely inside
+    ``genuine_user_ids`` there, so the id-set test alone cannot exclude it.
 
     An earlier version of this test injected AFTER pass 1. The delivery was
     therefore still a ``CustomMessage`` when pass 2 built its id set, the id-set
     test excluded it for the wrong reason, and the test passed against a mutant
     with the provenance stamp removed — asserting the implementation back to
     itself. Verified under mutation: with ``_injected_user_message``'s stamp
-    deleted this now fails, and the pre-fix tree leaks the brief here.
+    deleted this fails on the staged plain copy, and the pre-fix tree leaks the
+    brief here.
     """
     session = make_session(tmp_path, ScriptedStream(["reply"] * 40))
     await session.prompt(f"{CONSTRAINT} " + "detail " * 30)
@@ -214,14 +226,40 @@ async def test_a_session_state_delivery_is_not_preserved_on_the_second_pass(tmp_
     await _inject_session_state(session)
     assert (await session.compact_now()).ran is True
 
-    # Pass 1 has now rewritten it into a plain user Message — the state the
-    # defeated discriminator could not see. Assert that rather than trust it.
-    baked = [
+    # Pass 1 no longer rewrites it into a plain user Message: the commit
+    # re-seats the delivery onto its SOURCE (``_restore_custom_sources``), so the
+    # live context holds the ``CustomMessage`` again and a fold keeps painting
+    # the receipt a resume paints. Assert that, because it is the newer half of
+    # the contract and the older half is staged below.
+    state_custom = next(
+        (
+            message
+            for message in session._context.messages
+            if isinstance(message, CustomMessage)
+            and STATE_TEXT in str((message.details or {}).get("text") or "")
+        ),
+        None,
+    )
+    assert state_custom is not None, "the delivery lost its identity across pass 1"
+    assert not [
         message
         for message in session._context.messages
         if isinstance(message, Message) and STATE_TEXT in (message.text or "")
-    ]
-    assert baked, "test premise void: the injection is not a plain Message after pass 1"
+    ], "pass 1 baked the delivery into the context as a plain user Message"
+
+    # Now stage the state an OLDER build left in a live context — the same
+    # delivery as a plain STAMPED row — because that generational shape is what
+    # pass 2 has to refuse, and identity preservation is precisely why a modern
+    # session never reaches it on its own. Substituting the rendered copy keeps
+    # the guard exercised against the shape it exists for (and keeps the id in
+    # ``genuine_user_ids``, so the id set alone cannot exclude it).
+    stamped = next(
+        message
+        for message in session._render_history(session._context.messages)
+        if isinstance(message, Message) and STATE_TEXT in (message.text or "")
+    )
+    session._context.messages[session._context.messages.index(state_custom)] = stamped
+    baked = [stamped]
     live_user_ids = {
         message.id
         for message in session._context.messages
@@ -407,6 +445,28 @@ def test_an_injection_is_shed_before_any_genuine_turn_is_evicted():
     notice = elision_notice_text(capped.genuine_dropped, capped.injections_dropped)
     assert notice is not None
     assert "harness-injected" in notice and "you wrote" not in notice
+
+
+def test_a_stored_legacy_notice_is_shed_as_an_injection():
+    """The read-path heal for a block an older build poisoned (QA Q1).
+
+    A notice written before the ``harness_injected`` stamp existed has no
+    provenance to look up — no stamp, and its journal row is an ordinary user
+    message — so a stored copy of one is shed on its TEXT. The count is an
+    injection drop, the bucket whose notice says "these were not authored by
+    the user", because the alternative (calling it a genuine drop) would tell
+    the model the operator's own words had left the context.
+    """
+    turns = [
+        {"id": "legacy-notice", "text": LEGACY_NOTICE_TEXT},
+        {"id": "mine", "text": CONSTRAINT},
+    ]
+
+    capped = cap_preserved_user_turns(turns, cap=1_000_000)
+
+    assert [t["id"] for t in capped.turns] == ["mine"]
+    assert capped.injections_dropped == 1
+    assert capped.genuine_dropped == 0
 
 
 def test_the_cap_is_a_token_budget_not_a_turn_count():

--- a/tests/unit/session/test_harness_injection_leak.py
+++ b/tests/unit/session/test_harness_injection_leak.py
@@ -1,0 +1,296 @@
+"""A live-context-only injection must not be BAKED into the transcript.
+
+WHY THIS FILE EXISTS
+--------------------
+A TRANSIENT (failover) model-switch notice is deliberate live-context-only
+state: ``journal_model_switch(..., transient=True)`` appends a ``CustomMessage``
+so the running model knows it is on a fallback, and ``_is_persistable_message``
+refuses to persist it because a fallback that outlives the process is stale by
+definition.
+
+But ``_run_compaction`` rebuilds the live context from the RENDERED history,
+and the default renderer turns a ``session_model_switch`` into a plain
+``Message(role="user")`` stamped ``harness_injected``. Once rendered, the row is
+indistinguishable from an operator prompt, and the turn-end persist pass writes
+every plain ``Message`` — so the notice the user never typed landed in the
+transcript as a genuine user row (four consecutive ones in session
+``835fbcafdc27``) and every front end painted it as the user's own words.
+
+``_render_for_compaction`` already excluded two hand-listed types (a todo
+reminder and a credential record) for exactly this reason. The fix replaces the
+enumeration with the structural rule — a ``CustomMessage`` the transcript does
+not hold is one a resume cannot replay — and these tests pin both halves of
+that rule:
+
+* the leak is gone at the seam (render → rebuild → persist) AND through a real
+  compaction pass, and
+* the trap is closed: every record whose PRODUCER persisted it is still in the
+  rebuild, because dropping one would make the live context diverge from the
+  resume that replays it. ``Transcript.has_entry`` is the test;
+  ``_is_persistable_message`` is NOT, and using it would take hub/peer/wake
+  deliveries out of the rebuild.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from local_operator.compaction.api import CompactionSettings
+from local_operator.compaction.marker import build_compaction_marker
+from local_operator.harness.comms import SubagentComms
+from local_operator.harness.types import (
+    AgentMessage,
+    CustomMessage,
+    Message,
+    ModelSpec,
+    StreamEndEvent,
+)
+from local_operator.session.session import Session, _is_persistable_message
+from local_operator.session.transcript import Transcript
+
+MODEL = ModelSpec(provider="test", model_id="m", context_window=100_000)
+
+#: Small enough that a few short turns leave history outside the kept window,
+#: so a real pass has something to summarize and the notice — appended last —
+#: lands INSIDE the kept window, which is the only way it could be baked in.
+KEEP_RECENT = 40
+
+
+class ScriptedStream:
+    """Replays one script per call and records the requests it saw."""
+
+    def __init__(self, scripts: list[list[object]] | None = None) -> None:
+        self.scripts = list(scripts or [])
+        self.requests: list[object] = []
+
+    def __call__(self, request, signal):
+        self.requests.append(request)
+        script = self.scripts.pop(0) if self.scripts else [StreamEndEvent(stop_reason="stop")]
+
+        async def gen():
+            for event in script:
+                yield event
+
+        return gen()
+
+
+def make_session(
+    tmp_path, stream, *, session_id: str = "sess", keep_recent: int = KEEP_RECENT
+) -> Session:
+    return Session(
+        model=MODEL,
+        stream_fn=stream,
+        tools=[],
+        transcript=Transcript(tmp_path / session_id),
+        session_id=session_id,
+        system_blocks_provider=lambda: ["stable"],
+        compaction_settings=CompactionSettings(keep_recent_tokens=keep_recent),
+    )
+
+
+def rendered_texts(messages: list[Message]) -> list[str]:
+    return [getattr(message, "text", "") or "" for message in messages]
+
+
+def leaked_user_rows(entries_or_messages) -> list[Message]:
+    """Every ``role="user"`` row the harness minted, wherever it was read from."""
+    return [
+        message
+        for message in entries_or_messages
+        if isinstance(message, Message)
+        and message.role == "user"
+        and (message.provider_payload or {}).get("harness_injected")
+    ]
+
+
+async def wait_for(predicate, attempts: int = 200) -> None:
+    """Let the session's journalling settle — those producers are fire-and-forget."""
+    import asyncio
+
+    for _ in range(attempts):
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("condition never became true")
+
+
+@pytest.mark.asyncio
+async def test_a_transient_switch_notice_never_reaches_the_transcript(tmp_path) -> None:
+    """The regression, at the seam ``_run_compaction`` drives.
+
+    Fails on the pre-fix tree with one leaked ``role="user"`` row carrying the
+    switch notice's text — the rendered copy of a message the transcript was
+    deliberately never given.
+    """
+    session = make_session(tmp_path, ScriptedStream())
+    await session.journal_model_switch(
+        "zai/glm-5.3",
+        "anthropic/claude-opus-5",
+        reason="anthropic quota exhausted (0% remaining)",
+        transient=True,
+    )
+    # Live-only BY DESIGN: nothing was journalled, and the live context holds
+    # the record as a CustomMessage.
+    assert session._transcript.entries() == []
+    assert any(isinstance(m, CustomMessage) for m in session._context.messages)
+
+    # The REQUEST render still carries it — the notice is not inert, it is how
+    # the running model learns it is on a fallback (the half that must survive).
+    request_render = "\n".join(rendered_texts(session._render_history(session._context.messages)))
+    assert "[model switch] You are now running as zai/glm-5.3" in request_render
+
+    # The COMPACTION render does not: this is the fix, and it is what makes the
+    # rebuilt context equal what a resume can replay.
+    assert not any(
+        "[model switch]" in text for text in rendered_texts(session._render_for_compaction())
+    )
+
+    # What ``_run_compaction`` then does: rebuild from that render, and let the
+    # turn-end pass persist whatever is in the context.
+    session._context.messages = list(session._render_for_compaction())
+    await session._persist_new_messages(session._context.messages)
+
+    assert session._transcript.entries() == []
+    # A session constructed over that transcript (what ``--resume`` does)
+    # renders no injected row either — the other half of the parity claim.
+    resumed = make_session(tmp_path, ScriptedStream())
+    assert leaked_user_rows(resumed._render_history(resumed._context.messages)) == []
+    await resumed.dispose()
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_real_compaction_pass_leaves_no_injected_user_row(tmp_path) -> None:
+    """The same claim through ``compact_now`` — the assembled pass, not the seam.
+
+    A failover lands between turns, the context fills past the threshold, and
+    the pass that reclaims it must not carry the notice forward into the kept
+    window it persists.
+    """
+    stream = ScriptedStream()
+    session = make_session(tmp_path, stream)
+    for index in range(3):
+        await session.prompt(f"question {index} " + "detail " * 30)
+
+    await session.journal_model_switch(
+        "kimi/k3", "anthropic/claude-opus-5", reason="provider failure", transient=True
+    )
+    outcome = await session.compact_now()
+    assert outcome.ran is True, outcome.reason
+    # The pass rebuilds the context; the ROW reaches the transcript at the next
+    # turn end, when the persist pass writes every plain Message it finds. Both
+    # steps are needed to reproduce the report, so both are exercised here.
+    await session.prompt("after the pass " + "detail " * 30)
+
+    # The kept window was rebuilt from the render, so the notice is gone from
+    # the context AND from the transcript, and a resume agrees.
+    assert not any(
+        isinstance(m, CustomMessage) and m.custom_type == "session_model_switch"
+        for m in session._context.messages
+    )
+    # The rendered copy is what leaked: a plain user Message carrying the
+    # notice's text, which is what the persist pass wrote pre-fix.
+    assert not any(
+        not isinstance(m, CustomMessage) and "[model switch]" in (getattr(m, "text", "") or "")
+        for m in session._context.messages
+    )
+    assert leaked_user_rows(session._transcript.build_llm_history()) == []
+    resumed = make_session(tmp_path, ScriptedStream())
+    assert leaked_user_rows(resumed._render_history(resumed._context.messages)) == []
+    await resumed.dispose()
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_rebuild_keeps_every_record_the_transcript_holds(tmp_path) -> None:
+    """The trap: a wrong predicate breaks live/resume equivalence.
+
+    ``_is_persistable_message`` is the tempting test and the wrong one — it
+    answers "may the turn-end flush write this?" and returns False for
+    ``hub_message``/``peer_message``/``wake_prompt``, whose PRODUCERS persist
+    them. Dropping those from the rebuild would leave the live context holding
+    less than the resume that replays the same transcript, so this test asserts
+    BOTH halves at once: the deliberate switch, the incident, the hub delivery
+    and the peer delivery are all still rendered, while a transient notice
+    appended beside them is not.
+    """
+    session = make_session(tmp_path, ScriptedStream())
+    await session.journal_model_switch("zai/glm-5.3", "anthropic/claude-opus-5")
+    await session.journal_incident("429 rate limit from provider")
+    # Built by the real producers, then persisted and appended in the order
+    # every custom producer uses (durable first, then live context).
+    hub = SubagentComms(session)._to_child_message("focus on the parser", expects_reply=False)
+    peer = session._peer_custom_message(
+        "rebasing now", {"pid": 4242, "conversation_name": "peer", "model_label": "test/m"}
+    )
+    for message in (hub, peer):
+        await session._transcript.append_message(message)
+        session._context.messages.append(message)
+    await session.journal_model_switch("kimi/k3", "zai/glm-5.3", transient=True)
+
+    # The premise of the trap: the tempting predicate would drop these two.
+    assert _is_persistable_message(hub) is False
+    assert _is_persistable_message(peer) is False
+
+    rendered = "\n".join(rendered_texts(session._render_for_compaction()))
+    assert "[model switch] You are now running as zai/glm-5.3" in rendered
+    assert "429 rate limit from provider" in rendered
+    assert "focus on the parser" in rendered
+    assert "rebasing now" in rendered
+    assert "[model switch] You are now running as kimi/k3" not in rendered
+
+    # …and the rebuilt context is what a resume replays, row for row. The
+    # resumed session renders the SAME transcript, so its render is the other
+    # side of the equivalence — comparing the raw replay would compare
+    # ``CustomMessage``s against rendered ``Message``s.
+    session._context.messages = list(session._render_for_compaction())
+    live = rendered_texts(session._render_for_compaction())
+    resumed = make_session(tmp_path, ScriptedStream())
+    assert rendered_texts(resumed._render_for_compaction()) == live
+    await resumed.dispose()
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_compaction_marker_is_not_an_ephemeral_injection(tmp_path) -> None:
+    """The marker's content IS persisted — as a compaction entry, not a message.
+
+    ``append_compaction`` stores it under its own entry type, so the fresh id
+    ``build_compaction_marker`` mints is in no entry set while a resume still
+    replays the summary from that payload. Without the type exemption the
+    structural rule would drop it, leaving every later pass planning and
+    pricing a context that has lost its own summary.
+    """
+    session = make_session(tmp_path, ScriptedStream())
+    marker = build_compaction_marker("summary of the older history")
+    assert session._transcript.has_entry(marker.id) is False
+    session._context.messages.append(marker)
+
+    rendered = "\n".join(rendered_texts(session._render_for_compaction()))
+    assert "<previous-context-summary>" in rendered
+    assert "summary of the older history" in rendered
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_predicate_is_id_based_not_type_based(tmp_path) -> None:
+    """One live CustomMessage of a PERSISTED type is kept; an unpersisted one is not.
+
+    The discriminator is the transcript's id set, so a record of a
+    ``_PERSISTABLE_CUSTOM_TYPES`` member that reached the live context without
+    its durable append (an aside still parked, a producer that failed to write)
+    is filtered like any other live-only injection — the rule does not trust a
+    type name to prove a write happened.
+    """
+    session = make_session(tmp_path, ScriptedStream())
+    unpersisted: list[AgentMessage] = [
+        CustomMessage(
+            custom_type="session_state",
+            attribution="system",
+            details={"text": "[session-state]\n## Environment\nnever written"},
+        )
+    ]
+    session._context.messages.extend(unpersisted)
+
+    assert rendered_texts(session._render_for_compaction()) == []
+    await session.dispose()

--- a/tests/unit/session/test_harness_injection_leak.py
+++ b/tests/unit/session/test_harness_injection_leak.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import pytest
 
 from local_operator.compaction.api import CompactionSettings
+from local_operator.compaction.cutpoint import RENDERED_INJECTION_KEY
 from local_operator.compaction.marker import build_compaction_marker
 from local_operator.harness.comms import SubagentComms
 from local_operator.harness.types import (
@@ -99,19 +100,8 @@ def leaked_user_rows(entries_or_messages) -> list[Message]:
         for message in entries_or_messages
         if isinstance(message, Message)
         and message.role == "user"
-        and (message.provider_payload or {}).get("harness_injected")
+        and (message.provider_payload or {}).get(RENDERED_INJECTION_KEY)
     ]
-
-
-async def wait_for(predicate, attempts: int = 200) -> None:
-    """Let the session's journalling settle — those producers are fire-and-forget."""
-    import asyncio
-
-    for _ in range(attempts):
-        if predicate():
-            return
-        await asyncio.sleep(0.01)
-    raise AssertionError("condition never became true")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/test_harness_injection_leak.py
+++ b/tests/unit/session/test_harness_injection_leak.py
@@ -433,3 +433,23 @@ async def test_a_marker_carrying_a_legacy_notice_replays_without_it(tmp_path) ->
     elision = "\n".join(texts)
     assert "2 harness-injected message(s)" in elision
     assert "older user message(s) you wrote were dropped" not in elision
+
+
+def test_a_plain_stored_notice_is_a_notice_row_whatever_its_provenance() -> None:
+    """QA round 2 Q1: the notice rule is NOT scoped to carried copies.
+
+    The audit phase of the attached viewer replays STORED rows, and a stored row
+    from before the stamp existed has no ``provider_payload`` at all — so a rule
+    that needed a carried marker let the four plain switch notices on the
+    operator's session come back into view the moment the carried copies were
+    shed. Text is the test for any user row now; the cost (a pasted notice loses
+    its DISPLAY row, and nothing else) is pinned by the fold tests.
+    """
+    plain = Message(role="user", content=[TextContent(text=LEGACY_NOTICE)])
+
+    assert is_harness_notice_row(plain)
+    assert plain.provider_payload is None, "the fixture must be the unprovenanced shape"
+    assert not is_harness_notice_row(Message.user("why did the model change?"))
+    # A DELIVERY envelope is not a notice: it has its own parser, and a person
+    # quoting one keeps their words (pinned in the fold tests).
+    assert not is_harness_notice_row(Message.user("<parent-message>\nwhy does my log show this?"))

--- a/tests/unit/session/test_harness_injection_leak.py
+++ b/tests/unit/session/test_harness_injection_leak.py
@@ -39,17 +39,32 @@ from local_operator.compaction.api import CompactionSettings
 from local_operator.compaction.cutpoint import RENDERED_INJECTION_KEY
 from local_operator.compaction.marker import build_compaction_marker
 from local_operator.harness.comms import SubagentComms
+from local_operator.harness.rows import is_harness_notice_row
 from local_operator.harness.types import (
     AgentMessage,
     CustomMessage,
     Message,
     ModelSpec,
     StreamEndEvent,
+    TextContent,
 )
+from local_operator.mobile.projection import fold_messages_to_entries
+from local_operator.session.peer import PEER_MESSAGE_MESSAGE_TYPE
 from local_operator.session.session import Session, _is_persistable_message
 from local_operator.session.transcript import Transcript
 
 MODEL = ModelSpec(provider="test", model_id="m", context_window=100_000)
+
+#: The legacy shape QA measured on the operator's own session: a switch notice
+#: written before the ``harness_injected`` stamp existed — a plain user row with
+#: NO ``provider_payload`` at all, which a later pass harvested as a user turn.
+LEGACY_NOTICE = (
+    "[model switch] You are now running as zai/glm-5.3 (was anthropic/claude-opus-5).\n"
+    "Reason: provider failure\n"
+    "This is a temporary fallback for the current request; the session may return to its "
+    "primary model at a later turn. Capabilities and context window may differ from the "
+    "primary."
+)
 
 #: Small enough that a few short turns leave history outside the kept window,
 #: so a real pass has something to summarize and the notice — appended last —
@@ -284,3 +299,137 @@ async def test_the_predicate_is_id_based_not_type_based(tmp_path) -> None:
 
     assert rendered_texts(session._render_for_compaction()) == []
     await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_delivery_in_the_kept_window_keeps_its_receipt_across_a_pass(tmp_path) -> None:
+    """M1: the commit must re-seat the SOURCE, not an anonymous stamped copy.
+
+    The rebuild commits the RENDERED history, and a rendered delivery is a plain
+    stamped user message. Without ``_restore_custom_sources`` a peer delivery in
+    the kept window would come back as an injection-shaped row — which the folds
+    hide, because a stamped row is never the operator's words — while a RESUME of
+    the same session replays the persisted custom entry and paints the peer
+    receipt. The receipt would vanish from the live session and reappear on the
+    next restart, which is the opposite of live/replay parity.
+    """
+    session = make_session(tmp_path, ScriptedStream())
+    for index in range(3):
+        await session.prompt(f"question {index} " + "detail " * 30)
+    # The real inbound path: persisted durably AND appended to the live context.
+    await session.receive_peer_message(
+        "rebasing now — expect a redirect",
+        mode="mailbox",
+        wake=False,
+        sender={"pid": 4242, "conversation_name": "peer", "model_label": "test/m"},
+    )
+    delivered = [
+        message
+        for message in session._context.messages
+        if isinstance(message, CustomMessage) and message.custom_type == PEER_MESSAGE_MESSAGE_TYPE
+    ]
+    assert delivered, "the peer delivery never reached the live context"
+    assert session._transcript.has_entry(delivered[-1].id)
+
+    outcome = await session.compact_now()
+    assert outcome.ran is True, outcome.reason
+
+    # Identity survived the pass…
+    survivors = [
+        message
+        for message in session._context.messages
+        if isinstance(message, CustomMessage) and message.custom_type == PEER_MESSAGE_MESSAGE_TYPE
+    ]
+    assert [message.id for message in survivors] == [delivered[-1].id]
+    # …so nothing in the kept window is an anonymous stamped row, and the row
+    # the fold sees is therefore one it PAINTS (a receipt, not a suppressed
+    # injection).
+    assert leaked_user_rows(session._context.messages) == []
+    assert not any(is_harness_notice_row(message) for message in session._context.messages)
+
+    # Live equals resume, on the request render AND row for row through the
+    # phone fold — the two claims a receipt depends on.
+    live_texts = rendered_texts(session._render_for_compaction())
+    resumed = make_session(tmp_path, ScriptedStream())
+    assert rendered_texts(resumed._render_for_compaction()) == live_texts
+    live_rows = [
+        (row.kind, row.text) for row in fold_messages_to_entries(list(session._context.messages))
+    ]
+    resume_rows = [
+        (row.kind, row.text) for row in fold_messages_to_entries(list(resumed._context.messages))
+    ]
+    assert live_rows == resume_rows
+    assert any("rebasing now — expect a redirect" in text for _, text in live_rows)
+    await resumed.dispose()
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_legacy_notice_is_not_harvested_into_the_marker(tmp_path) -> None:
+    """Q1: an unstamped notice row must not be lifted as a user turn.
+
+    The harvest refuses stamped rows already; this is the legacy shape it could
+    not see (the operator's session carries eight switch notices with no
+    ``provider_payload`` at all), and lifting one re-seats the harness's words
+    as a user row on every replay of the marker.
+    """
+    session = make_session(tmp_path, ScriptedStream())
+    legacy = Message(role="user", content=[TextContent(text=LEGACY_NOTICE)])
+    session._context.messages.append(legacy)
+    await session._transcript.append_message(legacy)
+    for index in range(3):
+        await session.prompt(f"question {index} " + "detail " * 30)
+
+    outcome = await session.compact_now()
+    assert outcome.ran is True, outcome.reason
+
+    marker = session._transcript.latest_entry("compaction")
+    assert marker is not None
+    stored = marker.payload.get("preserved_user_turns") or []
+    assert not [
+        turn for turn in stored if str(turn.get("text", "")).startswith("[model switch]")
+    ], stored
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_marker_carrying_a_legacy_notice_replays_without_it(tmp_path) -> None:
+    """Q1: the heal for a block an older build already wrote, end to end.
+
+    A real session's latest marker holds eight notice copies from before the
+    stamp existed. Replay must not re-seat them (they are the harness's words,
+    not the operator's), must still re-seat the operator's own preserved turn
+    verbatim, and must account the shed copies as INJECTIONS — the elision
+    notice's "not authored by the user" bucket — rather than as turns the
+    operator wrote and lost.
+    """
+    directory = tmp_path / "sess"
+    transcript = Transcript(directory)
+    rows = [Message.user(f"row {index}") for index in range(4)]
+    await transcript.append_messages(rows)
+    await transcript.append_compaction(
+        "summary",
+        rows[-1].id,
+        500,
+        preserved_user_turns=[
+            {"id": "legacy-notice-1", "text": LEGACY_NOTICE},
+            {"id": "legacy-notice-2", "text": LEGACY_NOTICE},
+            {"id": rows[0].id, "text": "the operator's own constraint"},
+        ],
+        preserved_turns_cap=100_000,
+    )
+
+    replayed = [
+        message
+        for message in Transcript(directory).build_llm_history()
+        if isinstance(message, Message)
+    ]
+    texts = [message.text for message in replayed]
+    assert "[model switch]" not in "\n".join(texts)
+    assert "the operator's own constraint" in texts
+    assert not leaked_user_rows(replayed)
+    # The shed copies are reported as injections, and the genuine turn was not
+    # miscounted as one.
+    elision = "\n".join(texts)
+    assert "2 harness-injected message(s)" in elision
+    assert "older user message(s) you wrote were dropped" not in elision

--- a/tests/unit/session/test_history_window.py
+++ b/tests/unit/session/test_history_window.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 from pydantic import BaseModel, ConfigDict
 
+from local_operator.compaction.cutpoint import RENDERED_INJECTION_KEY
 from local_operator.harness.types import (
     CustomMessage,
     Message,
@@ -16,6 +17,7 @@ from local_operator.harness.types import (
     ToolCall,
     ToolResult,
 )
+from local_operator.incidents import format_model_switch_message
 from local_operator.session.attached import AttachedSession
 from local_operator.session.history_window import (
     _AUDIT_TAIL_CURSOR,
@@ -987,3 +989,44 @@ async def test_an_empty_kept_suffix_pages_the_audit_tail_and_terminates(tmp_path
     assert pages[-1].before_token is None, "the chain did not terminate"
     delivered = {row.id for row in walked}
     assert delivered >= {row.id for row in rows}, "audit tail paging lost rows"
+
+
+@pytest.mark.asyncio
+async def test_the_opener_skips_a_harness_injected_first_row(tmp_path):
+    """The opener TITLES the conversation, so it must be a row a person wrote.
+
+    A transcript an older build wrote can begin with a leaked failover notice —
+    the rendered copy of a live-only ``CustomMessage``, stamped
+    ``harness_injected``. Taking it as the opener names the session "[model
+    switch] You are now running as …", which is the user-visible form of the
+    leak. The scan therefore keys on the stamp, not on the role alone, through
+    the shared decision in ``harness/rows.py`` — the same helper the TUI's own
+    provisional-name scan uses, so the two cannot disagree.
+    """
+    transcript = Transcript(tmp_path / "s")
+    notice = format_model_switch_message(
+        "zai/glm-5.3",
+        "anthropic/claude-opus-5",
+        reason="anthropic quota exhausted (0% remaining)",
+        transient=True,
+    )
+    await transcript.append_message(
+        Message(
+            role="user",
+            content=[TextContent(text=notice)],
+            provider_payload={RENDERED_INJECTION_KEY: True},
+        )
+    )
+    await transcript.append_message(Message.user("fix the login redirect loop"))
+
+    page = window(transcript)
+    assert page.opener_text == "fix the login redirect loop"
+
+
+@pytest.mark.asyncio
+async def test_the_opener_still_takes_a_real_first_row(tmp_path):
+    """Negative control: with nothing injected, the opener is the first row."""
+    transcript = Transcript(tmp_path / "s")
+    await transcript.append_message(Message.user("fix the login redirect loop"))
+
+    assert window(transcript).opener_text == "fix the login redirect loop"

--- a/tests/unit/session/test_history_window.py
+++ b/tests/unit/session/test_history_window.py
@@ -10,6 +10,7 @@ import pytest
 from pydantic import BaseModel, ConfigDict
 
 from local_operator.compaction.cutpoint import RENDERED_INJECTION_KEY
+from local_operator.harness.rows import is_harness_notice_row
 from local_operator.harness.types import (
     CustomMessage,
     Message,
@@ -38,6 +39,13 @@ from local_operator.session.transcript import (
 )
 from tests.e2e.harness import ScriptedStream, build_session, seed_transcript, text_turn
 from tests.unit.session.test_remote import _never_take_over
+
+#: A notice written before the ``harness_injected`` stamp existed: a plain user
+#: row with no provenance, which a compaction pass lifted into its marker.
+LEGACY_NOTICE = (
+    "[model switch] You are now running as zai/glm-5.3 (was anthropic/claude-opus-5).\n"
+    "Reason: provider failure"
+)
 
 
 def window(transcript: Transcript, **kwargs):  # noqa: ANN003, ANN201
@@ -1030,3 +1038,47 @@ async def test_the_opener_still_takes_a_real_first_row(tmp_path):
     await transcript.append_message(Message.user("fix the login redirect loop"))
 
     assert window(transcript).opener_text == "fix the login redirect loop"
+
+
+@pytest.mark.asyncio
+async def test_the_opener_and_the_retitle_unit_skip_a_carried_notice(tmp_path):
+    """QA Q3 / reviewer m1: a harness notice must not title the conversation.
+
+    On the reported session the opener read the ELISION notice's own prose
+    ("[... harness-injected message(s) ... were not authored by the user]"), and
+    a marker's carried notice copies inflated ``theme_turn_count`` — the unit the
+    TUI's retitle gate reads — by eight. Both are harness words, and the two
+    decisions have to agree with the rows the fold paints, which hide them.
+
+    ``total_message_count`` stays exactly counted: it is the unit the reader's
+    paging is checked against, so it must keep counting the rows DELIVERED.
+    """
+    directory = tmp_path / "s"
+    transcript = Transcript(directory)
+    rows = [Message.user(f"row {index}") for index in range(4)]
+    await transcript.append_messages(rows)
+    await transcript.append_compaction(
+        "summary",
+        rows[-1].id,
+        500,
+        preserved_user_turns=[
+            {"id": "legacy-notice", "text": LEGACY_NOTICE},
+            {"id": "mine", "text": "fix the login redirect loop"},
+        ],
+        preserved_turns_cap=100_000,
+    )
+
+    page = window(transcript)
+
+    assert page.opener_text == "fix the login redirect loop"
+    # The paging invariant is untouched: the total is the canonical replay's
+    # row count, notice rows included.
+    assert page.total_message_count == len(transcript.build_llm_history())
+    # …and the theme unit counts conversation turns, not the notices among them.
+    history = transcript.build_llm_history()
+    assert page.theme_turn_count == sum(
+        1
+        for message in history
+        if getattr(message, "role", "") in ("user", "assistant")
+        and not is_harness_notice_row(message)
+    )

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -28,6 +28,7 @@ from local_operator import session_factory
 from local_operator.harness.types import TextContent
 from local_operator.session.session import Session
 from local_operator.session_factory import (
+    _latest_user_query,
     _transcript_dir_and_agent_id,
     attach_mcp_dispose,
     build_initial_blocks,
@@ -3853,3 +3854,39 @@ async def test_no_configured_effort_leaves_the_builders_seed(tmp_config_dir: Pat
     spec = plan.session_kwargs["model"]
     assert spec.reasoning_effort == "high"
     assert spec.reasoning_default_effort == "high"
+
+
+def test_the_skill_query_is_a_row_the_operator_wrote() -> None:
+    """Reviewer m2: a harness notice must not become the selection query.
+
+    ``_latest_user_query`` reads the newest ``role="user"`` row, and a notice is
+    stored as one — so selection searched the skills index for "[model switch]
+    You are now running as …" and froze the block's ``task_id`` against it. Both
+    shapes are refused: the stamped render, and the legacy notice a compaction
+    block carried forward with no stamp at all.
+    """
+    notice = (
+        "[model switch] You are now running as zai/glm-5.3 (was anthropic/claude-opus-5).\n"
+        "Reason: provider failure"
+    )
+
+    def entry(entry_id: str, text: str, payload: dict[str, Any] | None = None) -> SimpleNamespace:
+        body: dict[str, Any] = {
+            "role": "user",
+            "content": [{"type": "text", "text": text}],
+        }
+        if payload:
+            body["provider_payload"] = payload
+        return SimpleNamespace(id=entry_id, type="message", payload=body)
+
+    transcript = SimpleNamespace(
+        latest_entry=lambda _type: None,
+        latest_user_entry=lambda: entry("carried", notice, {"compaction_preserved": True}),
+        entries=lambda: [
+            entry("mine", "fix the login redirect loop"),
+            entry("stamped", notice, {"harness_injected": True}),
+            entry("carried", notice, {"compaction_preserved": True}),
+        ],
+    )
+
+    assert _latest_user_query(transcript) == "fix the login redirect loop"

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -25,6 +25,10 @@ import pytest
 
 from local_operator import resume as resume_mod
 from local_operator import session_factory
+from local_operator.compaction.cutpoint import (
+    PRESERVED_USER_TURN_KEY,
+    RENDERED_INJECTION_KEY,
+)
 from local_operator.harness.types import TextContent
 from local_operator.session.session import Session
 from local_operator.session_factory import (
@@ -3881,11 +3885,11 @@ def test_the_skill_query_is_a_row_the_operator_wrote() -> None:
 
     transcript = SimpleNamespace(
         latest_entry=lambda _type: None,
-        latest_user_entry=lambda: entry("carried", notice, {"compaction_preserved": True}),
+        latest_user_entry=lambda: entry("carried", notice, {PRESERVED_USER_TURN_KEY: True}),
         entries=lambda: [
             entry("mine", "fix the login redirect loop"),
-            entry("stamped", notice, {"harness_injected": True}),
-            entry("carried", notice, {"compaction_preserved": True}),
+            entry("stamped", notice, {RENDERED_INJECTION_KEY: True}),
+            entry("carried", notice, {PRESERVED_USER_TURN_KEY: True}),
         ],
     )
 

--- a/tests/unit/tui/test_conversation_naming.py
+++ b/tests/unit/tui/test_conversation_naming.py
@@ -34,6 +34,9 @@ from typing import Any
 
 import pytest
 
+from local_operator.compaction.cutpoint import RENDERED_INJECTION_KEY
+from local_operator.harness.types import Message, TextContent
+from local_operator.incidents import format_model_switch_message
 from local_operator.session import naming
 from local_operator.tui.app import RETITLE_MIN_GAP_S, OperatorApp
 from local_operator.tui.terminal_title import TerminalTitle
@@ -325,6 +328,42 @@ async def test_the_band_is_named_from_the_opener_before_any_provider_call() -> N
         assert app._status._conversation_name == "Fix the login flow"
         assert app._provisional_name == ""
         session.gate.set()
+
+
+@pytest.mark.asyncio
+async def test_a_harness_injected_row_does_not_become_the_provisional_title() -> None:
+    """The provisional label is read from the conversation's first USER row.
+
+    A session resumed from a transcript an older build wrote can begin with a
+    leaked failover notice — the rendered copy of a live-only ``CustomMessage``,
+    stamped ``harness_injected``. Titling the tab "[model switch] You are now
+    running as …" is the user-visible form of that leak. The scan keys on the
+    stamp through the shared decision in ``harness/rows.py``, the same one
+    ``history_window.opener_text`` makes, so the tab and the picker row agree.
+    """
+    app, session = await _boot()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _ready(pilot, app)
+        session._history = [
+            Message(
+                role="user",
+                content=[
+                    TextContent(
+                        text=format_model_switch_message(
+                            "zai/glm-5.3", "anthropic/claude-opus-5", transient=True
+                        )
+                    )
+                ],
+                provider_payload={RENDERED_INJECTION_KEY: True},
+            ),
+            Message.user("why does the resume picker show an empty conversation?"),
+        ]
+        app._restore_resumed_name(session)
+
+        assert app._provisional_name == naming.provisional_title(
+            "why does the resume picker show an empty conversation?"
+        )
+        assert "[model switch]" not in app._provisional_name
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_harness_injection_replay.py
+++ b/tests/unit/tui/test_harness_injection_replay.py
@@ -80,16 +80,19 @@ async def test_a_carried_notice_copy_mounts_no_user_bubble() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_plain_row_with_the_same_wording_still_replays() -> None:
-    """Negative control: no carried marker, so the text is the user's.
+async def test_a_pasted_notice_is_hidden_on_display_but_kept_in_the_transcript() -> None:
+    """The documented LIMIT of the notice rule, pinned rather than discovered later.
 
-    Pasted notices are a realistic prompt, and a fold that matched the wording
-    alone would eat one. The recognition is scoped to rows a compaction pass
-    carried forward (``harness/rows.py``), and this is what keeps that scope
-    honest.
+    A person who pastes a harness notice verbatim — to ask about one, say — loses
+    their display row, because the audit phase serves stored rows that carry no
+    provenance at all and the text is the only thing left to decide from. The row
+    is not lost anywhere else: it is still in the journal and still in the model's
+    context. ``is_harness_chrome`` trades the same way for the three continuation
+    prompts, which a person can equally paste.
     """
+    pasted = Message.user(_LEGACY_NOTICE)
     session = FakeSession()
-    session._history = [Message.user(_LEGACY_NOTICE)]
+    session._history = [pasted]
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
@@ -97,7 +100,34 @@ async def test_a_plain_row_with_the_same_wording_still_replays() -> None:
         await pilot.pause()
         shown = _transcript_text(app)
 
-    assert "[model switch] You are now running as zai/glm-5.3" in shown
+    assert "[model switch] You are now running as zai/glm-5.3" not in shown
+    # Not lost: the row itself is untouched, which is the half that matters.
+    assert pasted.text.startswith("[model switch] You are now running as zai/glm-5.3")
+
+
+@pytest.mark.asyncio
+async def test_a_stored_notice_row_mounts_no_user_bubble() -> None:
+    """QA round 2 Q1, at the fold: the AUDIT phase serves stored rows.
+
+    A stored pre-stamp notice has no payload at all — nothing to stamp, nothing
+    to carry — and the audit phase replays it verbatim, so the four such rows on
+    the operator's session were painted as his own words as soon as the carried
+    copies were shed. A row with no provenance is the case the text rule is for.
+    """
+    session = FakeSession()
+    session._history = [
+        Message.user("why did the model change?"),
+        Message(role="user", content=[TextContent(text=_LEGACY_NOTICE)]),
+    ]
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._project_settled_rows(list(session._history))
+        await pilot.pause()
+        shown = _transcript_text(app)
+
+    assert "why did the model change?" in shown
+    assert "[model switch]" not in shown
 
 
 @pytest.mark.asyncio
@@ -125,23 +155,3 @@ async def test_a_harness_injected_row_mounts_no_user_bubble() -> None:
     # …and the notice the user never typed mounts nothing at all.
     assert "[model switch]" not in shown
     assert "You are now running as zai/glm-5.3" not in shown
-
-
-@pytest.mark.asyncio
-async def test_a_row_without_the_stamp_still_replays_as_the_users_words() -> None:
-    """Negative control: the decision keys on the stamp, never on the wording.
-
-    Pasting a failover notice to ask about it is a realistic thing to do, and a
-    fold that matched the text would silently eat that prompt.
-    """
-    notice = format_model_switch_message("kimi/k3", "anthropic/claude-opus-5", transient=True)
-    session = FakeSession()
-    session._history = [Message.user(notice)]
-    app = OperatorApp(lambda: _factory(session))
-    async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
-        app._project_settled_rows(list(session._history))
-        await pilot.pause()
-        shown = _transcript_text(app)
-
-    assert "[model switch] You are now running as kimi/k3" in shown

--- a/tests/unit/tui/test_harness_injection_replay.py
+++ b/tests/unit/tui/test_harness_injection_replay.py
@@ -17,7 +17,10 @@ from __future__ import annotations
 
 import pytest
 
-from local_operator.compaction.cutpoint import RENDERED_INJECTION_KEY
+from local_operator.compaction.cutpoint import (
+    PRESERVED_USER_TURN_KEY,
+    RENDERED_INJECTION_KEY,
+)
 from local_operator.harness.types import Message, TextContent
 from local_operator.incidents import format_model_switch_message
 from local_operator.tui.app import OperatorApp
@@ -31,6 +34,70 @@ def _injected(text: str) -> Message:
         content=[TextContent(text=text)],
         provider_payload={RENDERED_INJECTION_KEY: True},
     )
+
+
+#: The legacy shape: a notice written before the stamp existed, carried into a
+#: compaction marker's preserved block as a "user turn" and re-seated on every
+#: replay with ``compaction_preserved`` and no stamp. The text is the only
+#: surviving evidence of what wrote it.
+_LEGACY_NOTICE = (
+    "[model switch] You are now running as zai/glm-5.3 (was anthropic/claude-opus-5).\n"
+    "Reason: provider failure"
+)
+
+
+def _carried_notice(text: str = _LEGACY_NOTICE) -> Message:
+    return Message(
+        role="user",
+        content=[TextContent(text=text)],
+        provider_payload={PRESERVED_USER_TURN_KEY: True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_carried_notice_copy_mounts_no_user_bubble() -> None:
+    """QA Q1: the row a pre-stamp build's marker replays is not the user's.
+
+    A real session carries eight of these, and the missing stamp is exactly why
+    the reported symptom survived the stamp-scoped fix. The same negative
+    control as the injected case applies: a row with the same WORDING and no
+    carried marker is the operator's own (a pasted notice), and still paints.
+    """
+    session = FakeSession()
+    session._history = [
+        Message.user("why does the resume picker look empty?"),
+        _carried_notice(),
+    ]
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._project_settled_rows(list(session._history))
+        await pilot.pause()
+        shown = _transcript_text(app)
+
+    assert "why does the resume picker look empty?" in shown
+    assert "[model switch]" not in shown
+
+
+@pytest.mark.asyncio
+async def test_a_plain_row_with_the_same_wording_still_replays() -> None:
+    """Negative control: no carried marker, so the text is the user's.
+
+    Pasted notices are a realistic prompt, and a fold that matched the wording
+    alone would eat one. The recognition is scoped to rows a compaction pass
+    carried forward (``harness/rows.py``), and this is what keeps that scope
+    honest.
+    """
+    session = FakeSession()
+    session._history = [Message.user(_LEGACY_NOTICE)]
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._project_settled_rows(list(session._history))
+        await pilot.pause()
+        shown = _transcript_text(app)
+
+    assert "[model switch] You are now running as zai/glm-5.3" in shown
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_harness_injection_replay.py
+++ b/tests/unit/tui/test_harness_injection_replay.py
@@ -1,0 +1,80 @@
+"""Replay must not paint a harness-injected row as the user's own words.
+
+A row the harness minted from a ``CustomMessage`` — the transient failover
+notice a compaction pass used to bake into the transcript is the reported case —
+is a plain ``Message(role="user")`` carrying the ``harness_injected`` stamp on
+its ``provider_payload``. The live path never paints one (the failover moment
+has its own receipt: the retry notice, the splash toast, the band), so replay
+skipping it is live/replay parity rather than a second opinion — the same
+doctrine the three continuation prompts follow.
+
+This drives the TUI fold through the real app. The decision itself lives in
+``harness/rows.py``; what these tests pin is that the fold ASKS it, because a
+shared helper nobody calls is the drift the convergence review found.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from local_operator.compaction.cutpoint import RENDERED_INJECTION_KEY
+from local_operator.harness.types import Message, TextContent
+from local_operator.incidents import format_model_switch_message
+from local_operator.tui.app import OperatorApp
+from tests.unit.tui.test_app_pilot import FakeSession, _factory, _transcript_text
+
+
+def _injected(text: str) -> Message:
+    """Exactly what ``_injected_user_message`` mints at render time."""
+    return Message(
+        role="user",
+        content=[TextContent(text=text)],
+        provider_payload={RENDERED_INJECTION_KEY: True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_harness_injected_row_mounts_no_user_bubble() -> None:
+    notice = format_model_switch_message(
+        "zai/glm-5.3",
+        "anthropic/claude-opus-5",
+        reason="anthropic quota exhausted (0% remaining)",
+        transient=True,
+    )
+    session = FakeSession()
+    session._history = [
+        _injected(notice),
+        Message.user("why does the resumed transcript look empty?"),
+    ]
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._project_settled_rows(list(session._history))
+        await pilot.pause()
+        shown = _transcript_text(app)
+
+    # The operator's own row replays exactly as it lived…
+    assert "why does the resumed transcript look empty?" in shown
+    # …and the notice the user never typed mounts nothing at all.
+    assert "[model switch]" not in shown
+    assert "You are now running as zai/glm-5.3" not in shown
+
+
+@pytest.mark.asyncio
+async def test_a_row_without_the_stamp_still_replays_as_the_users_words() -> None:
+    """Negative control: the decision keys on the stamp, never on the wording.
+
+    Pasting a failover notice to ask about it is a realistic thing to do, and a
+    fold that matched the text would silently eat that prompt.
+    """
+    notice = format_model_switch_message("kimi/k3", "anthropic/claude-opus-5", transient=True)
+    session = FakeSession()
+    session._history = [Message.user(notice)]
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._project_settled_rows(list(session._history))
+        await pilot.pause()
+        shown = _transcript_text(app)
+
+    assert "[model switch] You are now running as kimi/k3" in shown

--- a/tests/unit/tui/test_resume_render.py
+++ b/tests/unit/tui/test_resume_render.py
@@ -16,6 +16,7 @@ from rich.cells import cell_len
 from textual.events import Key, MouseScrollUp
 
 import local_operator.tui.app as app_module
+from local_operator.compaction.cutpoint import RENDERED_INJECTION_KEY
 from local_operator.tui.app import (
     RESUME_OLDER_NOTICE,
     RESUME_PAGE_MESSAGES,
@@ -184,7 +185,7 @@ def test_resume_tail_start_skips_a_row_that_paints_nothing() -> None:
         tool_calls=None,
         content=[],
         custom_type=None,
-        provider_payload={"harness_injected": True},
+        provider_payload={RENDERED_INJECTION_KEY: True},
     )
     history = _history(5)
     history.insert(10, injected)

--- a/tests/unit/tui/test_resume_render.py
+++ b/tests/unit/tui/test_resume_render.py
@@ -168,6 +168,33 @@ def test_resume_tail_start_snaps_back_to_the_nearest_user_row() -> None:
     assert _resume_tail_start(history, 15) == 0
 
 
+def test_resume_tail_start_skips_a_row_that_paints_nothing() -> None:
+    """Reviewer m3: an invisible row must not anchor the resumed window.
+
+    The cut snaps BACKWARD to a row the reader can see, and a harness-injected
+    render mounts no user bubble at all — so anchoring on one spends the first
+    slot of a bounded frame on nothing, which is the same short-frame failure
+    the backward snap exists to fix. The row is inserted exactly where the naive
+    cut lands, so the walk has to step over it to reach the turn.
+    """
+    injected = SimpleNamespace(
+        role="user",
+        id="inj-1",
+        text="[model switch] You are now running as zai/glm-5.3 (was anthropic/claude-opus-5).",
+        tool_calls=None,
+        content=[],
+        custom_type=None,
+        provider_payload={"harness_injected": True},
+    )
+    history = _history(5)
+    history.insert(10, injected)
+
+    assert _resume_tail_start(history, 5) == 9
+    # Without the invisible row the same walk lands one index later, which is
+    # what pins the skip rather than a shifted fixture.
+    assert _resume_tail_start(history[:10] + history[11:], 5) == 9
+
+
 def test_resume_tail_start_never_renders_fewer_than_the_bound() -> None:
     """The budget is a FLOOR on what gets painted, on every history shape.
 

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -27,6 +27,10 @@ import pytest
 from rich.cells import cell_len
 from textual.events import MouseScrollUp
 
+from local_operator.compaction.cutpoint import (
+    PRESERVED_USER_TURN_KEY,
+    RENDERED_INJECTION_KEY,
+)
 from local_operator.harness.comms import (
     HUB_COMMUNICATION_CUSTOM_TYPE,
     HUB_MESSAGE_TYPE,
@@ -971,13 +975,33 @@ def test_a_harness_injected_row_is_not_painted_as_the_parents_words() -> None:
             "content": [{"type": "text", "text": text}],
         }
         if injected:
-            payload["provider_payload"] = {"harness_injected": True}
+            payload["provider_payload"] = {RENDERED_INJECTION_KEY: True}
         return TranscriptEntry(id=entry_id, ts=1.0, type=ENTRY_MESSAGE, payload=payload)
 
     folded = fold_transcript_entries(
         [row("leaked", notice, injected=True), row("typed", "the real ask", injected=False)]
     )
     assert [(entry.kind, entry.text) for entry in folded] == [("user", "the real ask")]
+
+    # The LEGACY shape is refused too: a notice a compaction block carried
+    # forward from before the stamp existed arrives as a plain row with only
+    # ``compaction_preserved`` on it (QA Q1 measured eight on the parent's own
+    # session, and a child's transcript carries them the same way).
+    def carried(entry_id: str) -> TranscriptEntry:
+        return TranscriptEntry(
+            id=entry_id,
+            ts=1.0,
+            type=ENTRY_MESSAGE,
+            payload={
+                "kind": "message",
+                "role": "user",
+                "content": [{"type": "text", "text": notice}],
+                "provider_payload": {PRESERVED_USER_TURN_KEY: True},
+            },
+        )
+
+    carried_rows = fold_transcript_entries([carried("carried-notice")])
+    assert carried_rows == []
 
     # Negative control: the same TEXT without the stamp is the parent's own
     # words (a pasted notice is a realistic thing to send) and must paint.

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -51,8 +51,10 @@ from local_operator.harness.types import (
     ToolExecutionStartEvent,
     ToolResult,
 )
+from local_operator.incidents import format_model_switch_message
 from local_operator.session.session import Session
 from local_operator.session.transcript import (
+    ENTRY_MESSAGE,
     TRANSCRIPT_FILENAME,
     Transcript,
     TranscriptEntry,
@@ -84,6 +86,7 @@ from local_operator.tui.widgets.subagent_view import (
     _mark_consecutive_notices,
     entry_block,
     fold_trajectory,
+    fold_transcript_entries,
 )
 from local_operator.tui.widgets.tool_card import ToolCard
 from local_operator.tui.widgets.transcript import (
@@ -942,6 +945,45 @@ def test_relay_reports_responding_once_per_message_and_never_over_a_running_tool
         assert emitted[-1] == "probing"
 
     asyncio.run(_drive())
+
+
+def test_a_harness_injected_row_is_not_painted_as_the_parents_words() -> None:
+    """A subagent fails over too, and the leak lands in the CHILD's transcript.
+
+    ``journal_model_switch`` names the failover-at-subagent case in its own
+    docstring, so the same compaction leak that bakes a transient notice into
+    the parent's transcript does it to a child's — where this fold paints a
+    plain ``role="user"`` row as the PARENT speaking. The row is dropped by
+    the shared ``is_harness_injection`` decision, read here off the raw payload
+    dict because that is the shape this fold holds.
+    """
+    notice = format_model_switch_message(
+        "zai/glm-5.3",
+        "anthropic/claude-opus-5",
+        reason="anthropic quota exhausted (0% remaining)",
+        transient=True,
+    )
+
+    def row(entry_id: str, text: str, *, injected: bool) -> TranscriptEntry:
+        payload: dict[str, Any] = {
+            "kind": "message",
+            "role": "user",
+            "content": [{"type": "text", "text": text}],
+        }
+        if injected:
+            payload["provider_payload"] = {"harness_injected": True}
+        return TranscriptEntry(id=entry_id, ts=1.0, type=ENTRY_MESSAGE, payload=payload)
+
+    folded = fold_transcript_entries(
+        [row("leaked", notice, injected=True), row("typed", "the real ask", injected=False)]
+    )
+    assert [(entry.kind, entry.text) for entry in folded] == [("user", "the real ask")]
+
+    # Negative control: the same TEXT without the stamp is the parent's own
+    # words (a pasted notice is a realistic thing to send) and must paint.
+    # The test keys on the stamp, not on the wording.
+    quoted = fold_transcript_entries([row("quoted", notice, injected=False)])
+    assert [entry.text for entry in quoted] == [notice]
 
 
 def test_fold_survives_junk_without_raising() -> None:

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -1003,11 +1003,13 @@ def test_a_harness_injected_row_is_not_painted_as_the_parents_words() -> None:
     carried_rows = fold_transcript_entries([carried("carried-notice")])
     assert carried_rows == []
 
-    # Negative control: the same TEXT without the stamp is the parent's own
-    # words (a pasted notice is a realistic thing to send) and must paint.
-    # The test keys on the stamp, not on the wording.
+    # The LIMIT of the rule, pinned rather than left to be discovered: the same
+    # wording with no stamp is ALSO hidden here, because a stored row offers no
+    # other evidence and an unread child transcript has no journal to consult.
+    # The row is not lost — the panel simply does not attribute the harness's
+    # words to the parent.
     quoted = fold_transcript_entries([row("quoted", notice, injected=False)])
-    assert [entry.text for entry in quoted] == [notice]
+    assert quoted == []
 
 
 def test_fold_survives_junk_without_raising() -> None:


### PR DESCRIPTION
# PR Description

## Summary of Changes

Release: patch — a failover model-switch notice no longer appears in a transcript as a message the user sent.

Bug fix in three layers: the compaction rebuild that baked a deliberately live-only injection into the transcript, the rebuild's loss of a delivery's identity (which cost a *receipt* once the second layer began hiding stamped rows), and every fold/title/query/anchor that then read a harness row as the user's own words — including the notices an older build had already written to existing transcripts.

### The bug

A TRANSIENT (failover) model-switch notice is live-context-only on purpose: `journal_model_switch(..., transient=True)` appends a `CustomMessage` that `_is_persistable_message` deliberately refuses to persist. But a compaction pass rebuilds the live context from the RENDERED history:

```python
self._context.messages = [marker, *preserved_messages, *kept]   # session.py
```

`kept` comes from `_render_for_compaction()`, and `_default_convert_to_llm` renders `session_model_switch` as a plain `Message(role="user")` stamped `provider_payload["harness_injected"] = True`. So the notice was BAKED INTO the rebuilt context as a plain user message, and the turn-end persist pass — which writes every fresh plain `Message` — then wrote it to the transcript as a genuine `role="user"` row.

Live evidence: session `835fbcafdc27`, transcript lines 15715-15718, four consecutive `kind:"message", role:"user"` rows stamped `"provider_payload":{"harness_injected":true}` carrying the fallover notice — the only four `harness_injected` rows in a 15,812-row journal, sitting immediately before the assistant row the operator screenshotted.

`_render_for_compaction` already filtered exactly this class — `_is_ephemeral_for_compaction` excluded (a) todo reminders and (b) `SESSION_CREDENTIAL_MESSAGE_TYPE`, with a docstring stating this precise hazard. The transient notice was a third member of that class and was missed, because the predicate was an enumeration.

### The fix

**1. The rebuild no longer bakes a live-only injection in (`session.py`).** `_is_ephemeral_for_compaction` is now structural rather than a list: a `CustomMessage` the transcript does not hold is one a resume cannot replay, because only a persisted entry can put a custom message back into a replayed context. That subsumes the todo reminder and the credential record, and correctly KEEPS every producer-persisted custom type (`hub_message`, `peer_message`, `session_state`, deliberate `session_model_switch`, `session_incident`, `job_result`, `wake_prompt`, `compaction_refused`) so live stays equal to resume. It is deliberately not `_is_persistable_message`: that returns False for `hub_message`/`peer_message`/`wake_prompt`, whose PRODUCERS persist them, so borrowing it would drop persisted history out of the rebuild.

**2. The rebuild re-seats each kept row onto its SOURCE (`session.py`, M1).** Committing the rendered history turned every delivery in the kept window into an anonymous stamped row — which layer 3 then hides, while a resume of the same session replays the custom entry and paints the receipt. `_restore_custom_sources` substitutes the source `CustomMessage` back in when the transcript holds that id, so a hub/peer/wake/job-result receipt survives the pass instead of vanishing from the live session and reappearing on the next restart.

**3. A harness row is never painted as the user's own words — in EITHER phase, on any surface (all folds + every title/query/anchor scan).** `harness/rows.py` gains `is_harness_notice_row(row)`: the stamp, plus a notice HEAD, which is what a stored row offers when it predates the stamp. It accepts a message or a raw transcript payload, so the subagents panel (which folds raw payloads) makes the same decision rather than its own. Consumers: the TUI fold, the phone fold, the subagents panel, `history_window.opener_text`, the provisional-name scan, `_resume_tail_start`, `_latest_user_query`. Hiding is right rather than rendering a notice: the live path never paints these (the failover moment has its own receipt), so dropping is live/replay parity — the same doctrine the three chrome prompts follow. `cutpoint.is_rendered_injection` delegates to that one predicate (reviewer n1).

    The rule is deliberately NOT scoped to "rows a compaction pass carried forward", and that scoping was the round-2 regression QA caught: shedding the carried copies removed their ids from the hoisted suppression set at the same time, so the four plain STORED rows a pre-stamp build wrote — no payload at all — came back into view in the attached viewer's audit phase, which replays the journal itself rather than the context. A display serves two phases; a stored row has no provenance to read; so the text decides for any `role="user"` row, in whichever phase serves it.

    **What that costs, stated plainly: a person who pastes a notice verbatim loses their DISPLAY row.** Nothing else is lost — the row stays in the JOURNAL and in the MODEL'S CONTEXT, which are the two verified retention surfaces and the only ones this claims; only the renderers drop it. `is_harness_chrome` has always traded exactly this way for the three loop/continuation prompts, which a person can equally paste, and that precedent is why the trade is acceptable here. Pinned by tests on all three surfaces. Delivery ENVELOPES (`<parent-message>`, `<subagent-message …>`, `<peer-session-message …>`) are deliberately not in the head list either, and the covering mechanism is the PROVENANCE LOOKUP rather than a parser: a carried envelope copy is shed by `cap_preserved_user_turns`' `injection_ids`, resolved against the journal, where the stored turn's id names the entry whose `custom_type` is the delivery — measured fleet-wide (14 sessions), 229 of 233 such copies are shed that way on both heads. The residue is stated rather than hidden, and it lands differently by surface: the phone fold and the subagents panel PARSE the envelope (`mobile.projection` calls `extract_parent_message`; the panel has its own call) and paint a **parent receipt**, while the **TUI fold has no envelope parser** and paints the model-facing envelope as the operator's own words. That difference is **pre-existing on `main` and is NOT fixed here** (see "not addressed" below for the measurements). A person quoting an envelope keeps their words, which is why a wording rule must not cover it.

**4. The identity restore is once per id, and runs on both render paths (`session.py`, reviewer N2/N5).** Two kept rows sharing a custom's id can no longer collapse onto one source object (which would drop the second row's content from the model's context), and the `plan.llm_history` fallback render now goes through the restore too, so a receipt survives a pass on either path.

**5. A legacy notice is refused at harvest and healed on the read path (`compaction/cutpoint.py`, QA Q1).** An unstamped notice row is a plain `role="user"` row with no provenance at all, and a real session's latest marker had lifted eight such copies into its preserved block: replay re-seated them as the user's words, twice each, reachable by the scroll-up gesture in the session the operator reported the symptom from. `extract_preserved_user_turns` now refuses a notice head (so no new marker bakes one), and `cap_preserved_user_turns` sheds a stored copy — counted as a shed INJECTION, never as a turn the operator wrote and lost. Scoping at those two sites is inherent rather than a choice: they run on a rendered history and on stored copies inside a compaction block, never on a row a person typed in this process. The DISPLAY rule (layer 3) is the one that must reach every phase, and it is not scoped.

### What the receipt is, stated exactly

The live failover receipt is the `NoticeEvent` `local_operator/model/configure.py::_on_route_change` emits — `"<reason> — falling back to <selector>"`, with `_on_route_settle`'s `"back to <primary>"` on recovery. Nothing in this tree raises `RetryStartEvent`; the earlier revision of the shot script posted a retry notice by hand, which is corrected. It is also the account of the event only **while the session is live** — reopening the conversation carries no trace of it, by design.

## Tests

| test | what it pins |
|---|---|
| `tests/unit/session/test_harness_injection_leak.py::test_a_transient_switch_notice_never_reaches_the_transcript` | the coded form of the reproduction: the transient notice reaches the REQUEST render, is absent from the compaction render, and no `role="user"` `harness_injected` row reaches the transcript after the rebuild + persist pass |
| `::test_a_delivery_in_the_kept_window_keeps_its_receipt_across_a_pass` | M1: a peer delivery inside the kept window keeps its identity across a real `compact_now`; live == resume on the request render and row for row through the phone fold |
| `::test_a_legacy_notice_is_not_harvested_into_the_marker` | Q1: an unstamped notice row is not lifted as a user turn |
| `::test_a_marker_carrying_a_legacy_notice_replays_without_it` | Q1: replay drops the stored copies, keeps the operator's own preserved turn verbatim, and reports the shed copies as injections |
| `::test_the_rebuild_keeps_every_record_the_transcript_holds` | the trap: persisted `hub`/`peer`/`wake`/`job_result`/incident/state records stay in the rebuilt context |
| `tests/unit/compaction/test_cutpoint.py::test_extract_refuses_a_legacy_harness_notice_as_a_user_turn` | the harvest rule at the unit boundary |
| `tests/unit/session/test_compaction_preserved_turn_runaway.py::test_a_stored_legacy_notice_is_shed_as_an_injection` | the heal, and the bucket it counts into |
| `tests/unit/tui/test_harness_injection_replay.py` | the TUI fold mounts no user bubble for a stamped row **or** a carried notice, with the pasted-notice negative control |
| `tests/unit/mobile/test_fold_parity.py` | D13: both folds refuse a carried notice, so the two surfaces cannot drift |
| `tests/unit/tui/test_subagent_view.py` | the panel reads the same decision off a raw payload, with the n2 constant |
| `tests/unit/session/test_history_window.py` | the opener and the retitle unit skip notices while `total_message_count` keeps counting delivered rows |
| `tests/unit/tui/test_resume_render.py`, `tests/unit/test_session_factory.py` | m3 and m2: the resumed window does not anchor on a row that paints nothing, and the skill query is a row the operator wrote |
| `tests/unit/mobile/test_fold_parity.py::test_a_stored_notice_row_is_hidden_in_the_audit_phase_too` | QA round-2 Q1: a stored (unprovenanced) notice row replayed through `replay_entries(mode="audit")` paints nothing, while the row itself stays in the journal |
| `tests/unit/tui/test_harness_injection_replay.py::test_a_stored_notice_row_mounts_no_user_bubble` | the same shape at the TUI fold |
| `tests/unit/session/test_harness_injection_leak.py::test_a_plain_stored_notice_is_a_notice_row_whatever_its_provenance` | the rule itself, including that a quoted delivery envelope is NOT a notice row |
| `tests/unit/tui/test_harness_injection_replay.py::test_a_pasted_notice_is_hidden_on_display_but_kept_in_the_transcript`, the D12 phone case, the panel case | the documented LIMIT of the rule, pinned on all three surfaces |

**Pre-fix proof, round 2** (against the round-2 head `9992708fc`): the audit tests fail with `assert ['user', 'user'] == ['user']` (phone), a painted `▌ [model switch] …` row (TUI), and `assert False = is_harness_notice_row(Message(role='user', … provider_payload=None))` (the rule). **Round 1** (against the pre-remediation head `b8d98b2f1`): the harvest test fails `assert ['[model swit...h billing.py'] == ['NEVER touch billing.py']`; the shed test `assert ['legacy-notice', 'mine'] == ['mine']`; the phone parity case `assert ['user', 'user'] == ['user']`; the TUI carried-copy case paints `[model switch]`; M1's premise `assert … "the delivery lost its identity across pass 1"`; m2 `assert '[model switc...vider failure' == 'fix the login redirect loop'`; m3 `assert 10 == 9`.

**The reproduction** (`/tmp/repro_switch_leak.py`, the operator's own script): pre-fix `context after the compaction rebuild: ['Message'] → LEAKED as role=user: [model switch] … → RESULT: LEAK REPRODUCED` (rc 1); on this branch `context after the compaction rebuild: [] → RESULT: no leak` (rc 0).

## Evidence — the operator's own session, replay and pixels

The row-level numbers come from a **byte-identical copy** (`cp -c`) of session `835fbcafdc27` in an isolated `HOME` + `LOCAL_OPERATOR_CONFIG_DIR`, with no `CMUX_*` in the environment. Base = `17138cf20` (this PR's base), round-1 head = `b8d98b2f1`, round-2 head = `9992708fc`, this head = the branch tip.

**Both phases a display can serve**, measured with each tree's own rule by `scripts/audit_notice_census.py` (the context phase renders `[marker, *preserved, *kept]`; the audit phase replays the journal, which is what the attached viewer's audit pages are built from — `_capture_audit_window` mirrors `replay_entries(mode="audit")`, per its own docstring):

| reading | round-2 head `9992708fc` | this head |
|---|---|---|
| context phase: notice rows / **painted** | 5 / **0** | 5 / **0** |
| audit phase: notice rows / **painted** | 8 text rows, 4 identified by that tree's rule / **4** | 8 / **0** |
| subagents panel over the real entries: user rows that are notices | 4 | **0** |
| `opener_text` | the operator's first real prompt | the operator's first real prompt |
| `theme_turn_count` | 157 | 157 |

**Where each column comes from.** `scripts/audit_notice_census.py` exists only on this head, so the round-2-head column was produced by running the same script from a throwaway worktree at `9992708fc`. The head column was then re-derived INDEPENDENTLY of that script and of this session — the reviewer and QA both reproduced it exactly (`painted 0` in both phases, 8 notice rows in audit) — which is the check that matters, since the instrument and its target were written by the same hand.

(The earlier pair of phases — base `17138cf20` and round-1 head `b8d98b2f1`, before the context phase was clean — is tabulated in `review-round2-legacy/`: painted notice rows went 12 → 8 → 0 across those heads, which is the carried-copy half of this fix.)

Frames — the assembled app in every case (real `OperatorApp`, `local_operator.tcss`, `css_path = ['local_operator.tcss']` in each `.geometry.json`, captured by `scripts/audit_notice_census.py <session-dir> <out.svg>` and `scripts/legacy_notice_resume_shot.py`; the `virtual_size == size` reading in those files describes the SCREEN block, not a scrolled transcript window):

| frame | what it shows |
|---|---|
| [legacy before — the carried copies painted behind the user gutter](https://raw.githubusercontent.com/damianvtran/local-operator/d86c7ec0057e247314d21be4e0feaeb5e50cf071/review-round3-audit/frames/legacy-before-anchored.png) | the reported rows, anchored on the operator's own prompt immediately above them (content offset 108) |
| [legacy after — the same row, same window](https://raw.githubusercontent.com/damianvtran/local-operator/d86c7ec0057e247314d21be4e0feaeb5e50cf071/review-round3-audit/frames/legacy-after-anchored.png) | the notices gone, the prompts he wrote after them in place (offset 138) |
| [audit before — the four STORED rows, painted](https://raw.githubusercontent.com/damianvtran/local-operator/d86c7ec0057e247314d21be4e0feaeb5e50cf071/review-round3-audit/frames/audit-before-round2-head.png) | QA round-2 Q1's finding: the pre-stamp rows the audit phase serves. A scrolled window (transcript `scroll_y=8`, viewport 35 / content 43), so it opens on the notices' tails |
| [audit after — the same window, nothing painted](https://raw.githubusercontent.com/damianvtran/local-operator/d86c7ec0057e247314d21be4e0feaeb5e50cf071/review-round3-audit/frames/audit-after-fixed.png) | the mirror closed. Not the same offset as its partner: with the removed rows gone the content is exactly the viewport (`scroll_y=0`, 35 / 35), which is why the two members of the pair read as differently-sized windows |
| [stamped before — the four leaked `harness_injected` rows as user bubbles](https://raw.githubusercontent.com/damianvtran/local-operator/d86c7ec0057e247314d21be4e0feaeb5e50cf071/review-round2-legacy/frames/stamped-before-base.png) | the original report's shape |
| [stamped after — the rows mount nothing, the receipt and the band stay](https://raw.githubusercontent.com/damianvtran/local-operator/d86c7ec0057e247314d21be4e0feaeb5e50cf071/review-round2-legacy/frames/stamped-after-fixed.png) | the fallover receipt (`anthropic quota exhausted (0% remaining) — falling back to zai/glm-5.3`) and the band are intact |

**The stamped pair is a faithful SEED of the same shape, not the operator's transcript** — it replays the fallover notices through the real producer beside the assistant line that followed them; the legacy and audit pairs carry the reported DATA. **And the audit pair is a window of the audit-phase rows presented through the assembled app, not a capture of the attached viewer's own scroll into its audit pages**: driving that headlessly did not converge here (the chain stalls with ~36 rows pending after 400 wheel-ups — the log is in `census/attached-viewer-attempt.log`), so the attached path is evidenced at the row level above and in pixels around its rows, which is stated rather than implied.

Census logs, per-frame geometry and the capture script live in [`review-round3-audit/`](https://github.com/damianvtran/local-operator/tree/d86c7ec0057e247314d21be4e0feaeb5e50cf071/review-round3-audit).

## Gates, exactly as CI

| gate | command | result |
|---|---|---|
| flake8 | `.venv/bin/python -m flake8 .` | clean |
| black | `uvx --from black==26.1.0 black --check .` | 1236 files unchanged |
| isort | `uvx isort==5.13.2 --check .` | clean |
| pyright | `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | 0 errors, 0 warnings |
| unit | `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q` | `18,621 passed, 18 skipped` (19m51s), no failures (a run under load threw five unrelated flakes — two analytics/band panel timings, an attach-frame guard that says it cannot reproduce its own condition, the credential-store read, and a child-snapshot count — and all ten of their tests pass in isolation in 25s) |
| e2e | `env -u NO_COLOR -u CMUX_WORKSPACE_ID -u CMUX_SESSION_ID -u CMUX_PANE_ID TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q` | `107 passed, 7 skipped` |

The e2e stage runs headless with an isolated config dir and no `CMUX_*` in the environment, and includes the real `/resume` replay path.

## Not addressed

- **The TUI envelope leak (pre-existing on `main`, not fixed here).** A carried delivery-envelope copy whose id resolves to nothing is not shed, and on the **TUI** it paints as the operator's own words, because the main fold has no envelope parser (`extract_parent_message` is called only from `mobile/projection.py` and `tui/widgets/subagent_view.py`). Reproduced on a byte-identical copy of a real session: the phone fold shows **2 parent receipts / 0 envelopes**, the TUI shows **3 UserBlocks** reading `▌ <parent-message>` and "This changes your instructions…" — the same 3 on base `17138cf2`, 2 on the round-2 head. Fleet-wide: **5 unresolvable carried copies in 4 sessions**, plus **64 stored plain envelope user rows across 51 sessions**. The real fix — route the TUI fold through `extract_parent_message`, or reinstate the three envelope heads and take the paste trade — is a display product call for hub steers, outside a failover-notice fix, so the rule stays as it stands and this is recorded here.
- **Design D4 — the pasted-notice silence.** A person who pastes a notice verbatim loses their display row (the journal and the model's context keep it, and tests pin that). The trade is deliberate, but whether a display should say *something* instead of dropping silently is a product call rather than this fix's, so it is recorded here for one.
- **A dedicated pin for the carried-envelope residue.** The four carried envelope copies whose id resolves to nothing (see the envelope paragraph above) are carried by the provenance shed and measured fleet-wide rather than pinned by a test; a dedicated pin belongs with the follow-up envelope-parse work.

- **No migration or cleanup of the rows already written to existing transcripts.** Deliberate: they stay in the model's context, where they are the intended model-facing notice, and the fold layer hides them on every human surface.
- **Design D3 — the boot splash names the selected model while the band names the serving one.** Recorded, not fixed in this PR: it is a separate presentation decision about two reads of "the model", and it needs a product call rather than a ride-along in a leak fix.
- **Design D4 — the phone fold's generic custom-with-text fallback paints model-addressed copies of `session_model_switch`/`session_incident`/`session_state`/credential notices as `notice` rows.** Pre-existing and spanning several types; it needs a product call on whether the phone should show a human receipt for these at all. Measured on the reported session: exactly two such rows, both `kind="notice"` — not user rows, so the operator's own words are not involved.
- **QA Q4's underlying marker/summary finding** (the marker's summary reaches neither render on a real pass). Pre-existing and unchanged; this PR only stops the docstring from over-claiming about it.
- The elision notice is still delivered to the MODEL (it is how the model learns messages were dropped) and is now hidden from every human surface, matching the live path.
