### PR TITLE
fix(tui): land the /analytics page and home/end moves in one frame

### DIFF
--- a/local_operator/tui/widgets/analytics_panel.py
+++ b/local_operator/tui/widgets/analytics_panel.py
@@ -1695,8 +1695,10 @@ class AnalyticsScreen(ModalScreen[None]):
         # ``priority=True`` on the PAGINATION keys for the SAME reason, and it is
         # what makes them unanimated rather than merely ours: the container has
         # its own ``pageup``/``pagedown``/``home``/``end`` bindings
-        # (``ScrollView.BINDINGS``) handing the key to ``Widget.action_page_down``
-        # and friends, which call ``scroll_page_down()`` with the ``animate=True``
+        # (``ScrollableContainer.BINDINGS``, ``textual/containers.py:48-59`` —
+        # ``ScrollView`` extends it and defines none of its own) handing the key
+        # to ``Widget.action_page_down`` and friends, which call
+        # ``scroll_page_down()`` with the ``animate=True``
         # default. Measured on this screen at 120x45: one ``pagedown`` handled by
         # the container wrote 17-26 compositor frames of all 29 body rows (the
         # count moves with frame scheduling, the order of magnitude does not). So

--- a/local_operator/tui/widgets/analytics_panel.py
+++ b/local_operator/tui/widgets/analytics_panel.py
@@ -1691,6 +1691,19 @@ class AnalyticsScreen(ModalScreen[None]):
         # "one gesture owns the viewport" split: KEYS move the cursor and scroll
         # it into view, while the WHEEL and the scrollbar still move the viewport
         # alone and leave the cursor where it was.
+        #
+        # ``priority=True`` on the PAGINATION keys for the SAME reason, and it is
+        # what makes them unanimated rather than merely ours: the container has
+        # its own ``pageup``/``pagedown``/``home``/``end`` bindings
+        # (``ScrollView.BINDINGS``) handing the key to ``Widget.action_page_down``
+        # and friends, which call ``scroll_page_down()`` with the ``animate=True``
+        # default. Measured on this screen at 120x45: one ``pagedown`` handled by
+        # the container wrote 17-26 compositor frames of all 29 body rows (the
+        # count moves with frame scheduling, the order of magnitude does not). So
+        # a plain binding here left the operator's key press animated AND left
+        # the unanimated actions below unreachable on any report tall enough to
+        # scroll — two symptoms, one cause. See the actions for why the move must
+        # be unanimated.
         Binding("up", "move_up", "Up", show=False, priority=True),
         Binding("down", "move_down", "Down", show=False, priority=True),
         Binding("enter", "toggle_row", "Expand/collapse", show=False, priority=True),
@@ -1698,10 +1711,10 @@ class AnalyticsScreen(ModalScreen[None]):
         Binding("right", "expand_row", "Expand", show=False, priority=True),
         Binding("left", "collapse_row", "Collapse", show=False, priority=True),
         Binding("e", "toggle_all", "Expand/collapse all", show=False),
-        Binding("pageup", "page_up", "Page up", show=False),
-        Binding("pagedown", "page_down", "Page down", show=False),
-        Binding("home", "scroll_home", "Top", show=False),
-        Binding("end", "scroll_end", "Bottom", show=False),
+        Binding("pageup", "page_up", "Page up", show=False, priority=True),
+        Binding("pagedown", "page_down", "Page down", show=False, priority=True),
+        Binding("home", "scroll_home", "Top", show=False, priority=True),
+        Binding("end", "scroll_end", "Bottom", show=False, priority=True),
     ]
 
     def __init__(
@@ -2830,14 +2843,41 @@ class AnalyticsScreen(ModalScreen[None]):
             )
         return self._forest_cache
 
+    # ``animate=False`` on all four DESTINATION moves, deliberately, and it is
+    # the same rule ``_scroll_by_line`` states for the arrows.
+    #
+    # The body is a line-API ``ReportView`` whose ``render_line(y)`` serves
+    # ``scroll_offset.y + y``: shifting the offset by ONE line changes EVERY
+    # viewport row, so each eased step of the default animation is a
+    # full-viewport rewrite. Measured at 120x45 on the 40-root fixture (body
+    # region 102x29, ``max_scroll_y`` 31): one ``pagedown`` wrote 17-26
+    # compositor frames across runs — the count moves with frame scheduling, the
+    # order of magnitude does not — every one of them all 29 rows, with the
+    # offset walking 3 -> 5 -> 7 -> ... -> 29 one line at a time. That is the
+    # operator's report of an update passing down the TUI one line at a time.
+    # ``end`` and ``home`` travel the furthest and wrote up to 49. One frame is
+    # what the gesture needs; the easing bought only intermediate redraws of a
+    # page the reader had already asked to leave.
+    #
+    # These four actions only bind if the key reaches the SCREEN: with the
+    # container's own ``ScrollView`` bindings left unpinned, a real ``pagedown``
+    # went to ``Widget.action_page_down`` (which passes the ``animate=True``
+    # default) and the actions here were unreachable on any report tall enough to
+    # scroll — measured, and fixed by ``priority=True`` on the bindings above.
+    # Without that half, animating these methods would have changed nothing the
+    # operator could press.
+    #
+    # It is also why the coalesced hover re-resolve exists: ``_viewport_moved``
+    # watches ``scroll_y``, which was an animated value firing ~28 notifications
+    # per ``pagedown``. With no animation the burst is one notification.
     def action_page_up(self) -> None:
-        self._scroll.scroll_page_up()
+        self._scroll.scroll_page_up(animate=False)
 
     def action_page_down(self) -> None:
-        self._scroll.scroll_page_down()
+        self._scroll.scroll_page_down(animate=False)
 
     def action_scroll_home(self) -> None:
-        self._scroll.scroll_home()
+        self._scroll.scroll_home(animate=False)
 
     def action_scroll_end(self) -> None:
-        self._scroll.scroll_end()
+        self._scroll.scroll_end(animate=False)

--- a/tests/unit/tui/test_analytics_scroll_frames.py
+++ b/tests/unit/tui/test_analytics_scroll_frames.py
@@ -1,0 +1,393 @@
+"""One viewport move writes ONE complete frame: the ``/analytics`` scroll invariant.
+
+The operator's report: on a scroll the screen "seems that not the entire frame
+gets updated at once and there's an update that passes down one line at a time
+through the TUI". That is exactly what was happening, and it had TWO causes in
+one place — the pagination keys.
+
+1. ``action_page_up``/``action_page_down``/``action_scroll_home``/
+   ``action_scroll_end`` called Textual's ``scroll_page_*``/``scroll_home``/
+   ``scroll_end`` with their default ``animate=True``. The body is a line-API
+   ``ReportView`` whose ``render_line(y)`` serves ``scroll_offset.y + y``:
+   shifting the offset by ONE line changes EVERY viewport row, so each eased step
+   of the animation was a full-viewport rewrite.
+2. The four bindings were NOT ``priority=True``, unlike the arrow keys beside
+   them. Focus sits on the scroller, whose ``ScrollView`` base has its own
+   ``pageup``/``pagedown``/``home``/``end`` bindings, so a real key press went to
+   ``Widget.action_page_down`` (again an ``animate=True`` default) and the screen
+   actions above were unreachable on any report tall enough to scroll. Animating
+   them alone would have changed nothing a user could press.
+
+Measured at 120x45 on ``_tall_report_agg()`` (body region 102x29,
+``max_scroll_y`` 31), one key press, before either half of the fix: ``pagedown``
+wrote **20 compositor frames, every one of them all 29 body rows**, with the
+offset walking 3 -> 5 -> 7 -> ... -> 29 one line at a time; ``pageup`` 20,
+``end`` 28, ``home`` 25. After it: one frame per key, covering all 29 rows and
+painted from the destination offset.
+
+**These tests assert the work, not the clock** — the same discipline as
+``test_analytics_repaint.py`` beside them, for the same reason (AGENTS.md
+"Calibrate ceilings from CI": a wall-clock or CPU ceiling calibrated on this
+laptop is a bet on machine load, and this screen already has a CPU-bound rebuild
+path that makes such a bound useless). The invariant here is structural and
+holds at any speed:
+
+* one viewport-move gesture writes exactly ONE report frame;
+* that frame covers the WHOLE body viewport, row for row — "fewer frames" is not
+  the claim, "a complete frame" is, so a fix that dropped the animation but left
+  the body painting partially would fail here;
+* the offset is already at its target IN that frame (nothing is left easing);
+* no animation is left registered on the body afterwards.
+
+The instrument is the compositor's own ``render_update``, because the body is a
+single widget: a per-row or per-line counter would see one dirty widget either
+way and could not tell 1 frame from 20. Frames written outside the body's region
+(the surrounding card, the hint row) are ignored — they are present on both the
+fixed and the unfixed tree and are not what the gesture costs.
+
+Mutation check (scratch: the file run against ``origin/main``'s tree with
+``PYTHONPATH`` pointed at it) — 8 of the 9 cases fail there, the four action-path
+ones and the four key-path ones, reporting 17-28 report frames each. The ninth is
+the wheel cell, which passes on both trees by design and whose own mutation
+check is documented there.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from textual import events
+from textual._compositor import ChopsUpdate, Compositor
+
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.analytics_panel import _SCROLLBAR_GUTTER
+from tests.unit.tui.test_analytics_panel import _push, _tall_report_agg
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+#: (gesture name, the action method, the key a real terminal sends)
+_GESTURES = [
+    ("page_down", "action_page_down", "pagedown"),
+    ("page_up", "action_page_up", "pageup"),
+    ("home", "action_scroll_home", "home"),
+    ("end", "action_scroll_end", "end"),
+]
+
+
+def _app() -> OperatorApp:
+    return OperatorApp(lambda: _factory(FakeSession()))
+
+
+def _viewport_rows(scroll: Any) -> set[int]:
+    """The body's viewport, as absolute screen rows.
+
+    ``ReportView`` is a line API: ``render_line(y)`` serves ``scroll_offset.y + y``,
+    so the compositor's chop rows and the widget's screen rows share one
+    coordinate space and can be compared directly.
+    """
+    return set(range(scroll.region.y, scroll.region.y + scroll.region.height))
+
+
+class _BodyFrames:
+    """Every compositor frame written during the block, split body vs scrollbar.
+
+    ``render_update`` is the single call that turns a dirty widget into an
+    update, so counting its invocations counts frames. A frame counts as a
+    report frame when its rows fall inside the body viewport AND its column span
+    reaches left of the scrollbar column: the thumb repaint arrives as its own
+    one-column chop, and counting that as a second viewport write would make
+    every correct gesture look doubled.
+    """
+
+    def __init__(self, monkeypatch: pytest.MonkeyPatch, scroll: Any) -> None:
+        self.scroll = scroll
+        self.viewport = _viewport_rows(scroll)
+        # ``_SCROLLBAR_GUTTER`` is the width the body reserves for its thumb
+        # (``_card_width`` subtracts the same constant), so the last column of
+        # the body region is chrome, not report.
+        self.scrollbar_column = scroll.region.x + scroll.region.width - _SCROLLBAR_GUTTER
+        self.frames: list[dict[str, Any]] = []
+        original = Compositor.render_update
+
+        def patched(comp, full=False, screen_stack=None, simplify=False):
+            out = original(comp, full=full, screen_stack=screen_stack, simplify=simplify)
+            record: dict[str, Any] = {"kind": "other"}
+            if isinstance(out, ChopsUpdate):
+                spans = list(out.spans)
+                record = {
+                    "kind": "chops",
+                    "rows": {y for y, _, _ in spans},
+                    "left": min(x1 for _, x1, _ in spans),
+                    "right": max(x2 for _, _, x2 in spans),
+                    "cells": sum(max(0, x2 - x1) for _, x1, x2 in spans),
+                    # Taken AT PAINT TIME: the offset the frame was painted from,
+                    # so "the destination landed in this frame" is a fact about
+                    # the frame rather than about whatever the offset became
+                    # later.
+                    "scroll_y": float(self.scroll.scroll_offset.y),
+                }
+            self.frames.append(record)
+            return out
+
+        monkeypatch.setattr(Compositor, "render_update", patched)
+
+    def _chops_inside_the_viewport(self) -> list[dict[str, Any]]:
+        return [f for f in self.frames if f["kind"] == "chops" and f["rows"] <= self.viewport]
+
+    def content(self) -> list[dict[str, Any]]:
+        """Frames that painted report rows, rather than the scrollbar thumb."""
+        return [f for f in self._chops_inside_the_viewport() if f["left"] < self.scrollbar_column]
+
+    def scrollbar(self) -> list[dict[str, Any]]:
+        """Frames confined to the body's scrollbar gutter."""
+        return [f for f in self._chops_inside_the_viewport() if f["left"] >= self.scrollbar_column]
+
+    def assert_no_partial_repaint(self) -> None:
+        """Any extra body chop must be the thumb, never part of the report.
+
+        This is the half of "fewer frames" that matters: the fix must not trade
+        an animated walk for a partial paint. A chop inside the viewport that is
+        not the whole viewport and not confined to the gutter is exactly a torn
+        frame, however few of them there are.
+        """
+        for frame in self.scrollbar():
+            assert (
+                self.scrollbar_column <= frame["left"]
+                and frame["right"] <= self.scrollbar_column + _SCROLLBAR_GUTTER
+            ), (
+                "a body frame repainted part of the report instead of the whole "
+                f"viewport: columns {frame['left']}..{frame['right']} of a body region "
+                f"ending at column {self.scrollbar_column}. All frames: {self.describe()}"
+            )
+
+    def body(self) -> list[dict[str, Any]]:
+        return [f for f in self.frames if f["kind"] == "chops" and f["rows"] <= self.viewport]
+
+    def describe(self) -> str:
+        """The frames, as a failure message a reader can act on."""
+        return "; ".join(
+            f"{f['kind']} rows={sorted(f['rows'])[:3]}... scroll_y={f.get('scroll_y')}"
+            for f in self.frames
+        )
+
+
+def _target(scroll: Any, gesture: str, before: float) -> float:
+    """Where the gesture must land, spelled from the geometry not the code."""
+    page = scroll.scrollable_content_region.height
+    if gesture == "page_down":
+        return float(min(before + page, scroll.max_scroll_y))
+    if gesture == "page_up":
+        return float(max(0, before - page))
+    if gesture == "home":
+        return 0.0
+    return float(scroll.max_scroll_y)
+
+
+def _start_offset(scroll: Any, gesture: str) -> float:
+    """A start offset with the whole travel ahead of the gesture.
+
+    Opposite ends, so the ``home`` and ``end`` cases are real moves: a no-op
+    gesture would write no frame and the assertions below would be vacuous,
+    which is the failure mode AGENTS.md records for a cell that passes because
+    the thing it checks never happened.
+    """
+    return float(scroll.max_scroll_y) if gesture in ("page_up", "home") else 0.0
+
+
+@pytest.mark.parametrize("gesture, action, _key", _GESTURES)
+def test_a_viewport_move_writes_one_complete_frame(gesture, action, _key, monkeypatch):
+    """The gesture's whole cost is ONE frame, and it covers the whole viewport."""
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(120, 45)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            scroll = screen._scroll
+            assert scroll.max_scroll_y > 0, "fixture is not taller than the viewport"
+            assert scroll.size.height > 1, "a one-row viewport cannot show a partial frame"
+
+            scroll.scroll_to(y=_start_offset(scroll, gesture), animate=False)
+            await pilot.pause()
+            await pilot.pause()
+            before = float(scroll.scroll_offset.y)
+            # The fixture's starting state, asserted rather than assumed: on the
+            # unfixed tree a leftover easing frame would otherwise be counted as
+            # the gesture's, and the test would report the wrong cause.
+            assert before == _start_offset(scroll, gesture), (
+                "the setup scroll had not landed, so this frame count would not be " "the gesture's"
+            )
+            assert scroll.size.height < scroll.virtual_size.height, "body does not scroll"
+
+            frames = _BodyFrames(monkeypatch, scroll)
+            getattr(screen, action)()
+            # Both, in this order: ``wait_for_scheduled_animations`` drives any
+            # animation the gesture scheduled to COMPLETION without donating
+            # wall-clock time, and the idle pause lets the resulting paint land.
+            # Neither alone is enough — the settle helper does not itself force a
+            # refresh after an unanimated move, and the idle pause would leave an
+            # animation mid-flight and under-count its frames.
+            await pilot.wait_for_scheduled_animations()
+            await pilot.pause()
+
+            frames.assert_no_partial_repaint()
+            content = frames.content()
+            assert len(content) == 1, (
+                f"{gesture} wrote {len(content)} report frames, not one — the viewport "
+                f"move is being eased, and every eased step repaints every row. "
+                f"All frames: {frames.describe()}"
+            )
+            written = content[0]["rows"]
+            assert written == frames.viewport, (
+                f"the single frame did not cover the whole viewport: wrote "
+                f"{sorted(written)} of {sorted(frames.viewport)}"
+            )
+            expected = _target(scroll, gesture, before)
+            assert content[0]["scroll_y"] == expected, (
+                f"the frame was painted from y={content[0]['scroll_y']} rather than the "
+                f"destination y={expected}: the move is still easing"
+            )
+            assert content[0]["cells"] == scroll.region.width * len(
+                frames.viewport
+            ), "the single frame did not paint the whole body width"
+            assert float(scroll.scroll_offset.y) == expected, "the offset did not land"
+            assert not app.animator.is_being_animated(
+                scroll, "scroll_y"
+            ), "an animation is still in flight on scroll_y after a settled move"
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize("gesture, _action, key", _GESTURES)
+def test_the_key_binding_writes_the_same_single_frame(gesture, _action, key, monkeypatch):
+    """The BINDING path writes one frame too — the same claim via ``pilot.press``.
+
+    Driven by the KEY rather than the action method, because the key is what the
+    operator presses: ``pagedown`` reaches the action through a ``Binding``, and
+    a fix applied to the method is only half the surface if the binding is ever
+    given its own route. The frame assertions are the action-path ones, so both
+    routes are pinned to the same behaviour.
+
+    Note what is NOT asserted here. "The offset has reached its destination after
+    one ``pilot.pause()``" looks like the sharpest form of "nothing is easing",
+    and it is not: Textual's idle wait drives the animation's ticks to completion
+    as fast as the loop will take them, so ONE pause already lands the target on
+    the unfixed tree (measured: the 20-28-frame animations complete inside a
+    single pause). A test written that way passes either way — decoration. What
+    separates the trees is that the unfixed one paints the whole viewport once
+    per eased step, which is the frame count below.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(120, 45)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            scroll = screen._scroll
+            assert scroll.max_scroll_y > 0, "fixture is not taller than the viewport"
+
+            scroll.scroll_to(y=_start_offset(scroll, gesture), animate=False)
+            await pilot.pause()
+            await pilot.pause()
+            before = float(scroll.scroll_offset.y)
+            assert before == _start_offset(scroll, gesture), "the setup scroll had not landed"
+
+            frames = _BodyFrames(monkeypatch, scroll)
+            await pilot.press(key)
+            await pilot.wait_for_scheduled_animations()
+            await pilot.pause()
+
+            frames.assert_no_partial_repaint()
+            content = frames.content()
+            assert len(content) == 1, (
+                f"the {key} binding wrote {len(content)} report frames, not one. "
+                f"All frames: {frames.describe()}"
+            )
+            expected = _target(scroll, gesture, before)
+            assert content[0]["rows"] == frames.viewport, (
+                f"the single frame did not cover the whole viewport: wrote "
+                f"{sorted(content[0]['rows'])} of {sorted(frames.viewport)}"
+            )
+            assert content[0]["scroll_y"] == expected, (
+                f"the frame was painted from y={content[0]['scroll_y']} rather than the "
+                f"destination y={expected}: the move is still easing"
+            )
+            assert float(scroll.scroll_offset.y) == expected, "the offset did not land"
+            assert not app.animator.is_being_animated(scroll, "scroll_y")
+            registered = [k for k in app.animator._animations if k[0] == id(scroll)]
+            assert registered == [], (
+                "a viewport move left an animation registered for the body on a screen "
+                f"whose every mover is supposed to be unanimated: {registered}"
+            )
+
+    asyncio.run(run())
+
+
+def test_a_wheel_notch_writes_one_complete_frame(monkeypatch):
+    """The wheel stays atomic: one notch, one complete body frame, no easing.
+
+    Folded in with the four bindings above because they are ONE claim — no
+    viewport move on this screen is animated. The wheel cells already held
+    before the fix (``_on_mouse_scroll_down`` passes ``animate=False``), so this
+    test does not discriminate the tearing fix; it is the guard against a
+    screen-level wheel handler being added later with an animation, which is the
+    shape `AGENTS.md` records as the trap on ``/settings``.
+
+    Driven through ``App.on_event`` with a real ``MouseScrollDown``, the path a
+    terminal uses: Textual stops the event on the container while it can still
+    scroll, so this never reaches a screen-level handler and the frame count is
+    the container's own behaviour, which is exactly what must stay unanimated.
+
+    Mutation check (scratch, not committed): patching the container's wheel
+    handler to ``scroll_to(y=self.scroll_y + 12, animate=True)`` — a notch that
+    moves a distance and eases it — writes **5 report frames** where this cell
+    asserts 1, so the cell can go red. It cannot detect a ONE-row animated step:
+    the animator's first tick already lands a single row, measured at 1 frame with
+    ``animate=True``, so the cell makes no claim about that shape.
+    """
+
+    async def run():
+        app = _app()
+        async with app.run_test(size=(120, 45)) as pilot:
+            screen = await _push(pilot, app, _tall_report_agg())
+            scroll = screen._scroll
+            assert scroll.max_scroll_y > 0, "fixture is not taller than the viewport"
+
+            scroll.scroll_to(y=0, animate=False)
+            await pilot.pause()
+            await pilot.pause()
+            assert float(scroll.scroll_offset.y) == 0.0, "the setup scroll had not landed"
+            x, y = scroll.region.x + 4, scroll.region.y + 4
+
+            frames = _BodyFrames(monkeypatch, scroll)
+            await app.on_event(
+                events.MouseScrollDown(
+                    widget=None,
+                    x=x,
+                    y=y,
+                    delta_x=0,
+                    delta_y=1,
+                    button=0,
+                    shift=False,
+                    meta=False,
+                    ctrl=False,
+                    screen_x=x,
+                    screen_y=y,
+                )
+            )
+            await pilot.wait_for_scheduled_animations()
+            await pilot.pause()
+
+            frames.assert_no_partial_repaint()
+            content = frames.content()
+            assert len(content) == 1, (
+                f"one wheel notch wrote {len(content)} report frames, not one. "
+                f"All frames: {frames.describe()}"
+            )
+            assert content[0]["rows"] == frames.viewport, (
+                "the wheel frame did not cover the whole viewport: wrote "
+                f"{sorted(content[0]['rows'])} of {sorted(frames.viewport)}"
+            )
+            assert content[0]["scroll_y"] > 0, "the wheel did not scroll, so this proves nothing"
+            assert not app.animator.is_being_animated(scroll, "scroll_y")
+
+    asyncio.run(run())

--- a/tests/unit/tui/test_analytics_scroll_frames.py
+++ b/tests/unit/tui/test_analytics_scroll_frames.py
@@ -12,18 +12,23 @@ one place — the pagination keys.
    shifting the offset by ONE line changes EVERY viewport row, so each eased step
    of the animation was a full-viewport rewrite.
 2. The four bindings were NOT ``priority=True``, unlike the arrow keys beside
-   them. Focus sits on the scroller, whose ``ScrollView`` base has its own
-   ``pageup``/``pagedown``/``home``/``end`` bindings, so a real key press went to
-   ``Widget.action_page_down`` (again an ``animate=True`` default) and the screen
-   actions above were unreachable on any report tall enough to scroll. Animating
-   them alone would have changed nothing a user could press.
+   them. Focus sits on the scroller, whose base is ``ScrollableContainer``
+   (``ScrollView`` extends it — ``textual/scroll_view.py:15``) and that is where
+   the ``pageup``/``pagedown``/``home``/``end`` bindings live
+   (``textual/containers.py:48-59``; ``scroll_view.py`` defines none of its own),
+   so a real key press went to ``Widget.action_page_down`` (again an
+   ``animate=True`` default) and the screen actions above were unreachable on any
+   report tall enough to scroll. Animating them alone would have changed nothing
+   a user could press.
 
 Measured at 120x45 on ``_tall_report_agg()`` (body region 102x29,
 ``max_scroll_y`` 31), one key press, before either half of the fix: ``pagedown``
-wrote **20 compositor frames, every one of them all 29 body rows**, with the
-offset walking 3 -> 5 -> 7 -> ... -> 29 one line at a time; ``pageup`` 20,
-``end`` 28, ``home`` 25. After it: one frame per key, covering all 29 rows and
-painted from the destination offset.
+wrote **17-26 compositor frames across runs — the count moves with frame
+scheduling and the distance travelled, the order of magnitude does not, so the
+mutation check below reads 17-28 rather than one fixed figure — every one of them
+all 29 body rows**, with the offset walking 3 -> 5 -> 7 -> ... -> 29 one line at
+a time; ``end`` and ``home`` travel furthest and wrote up to 49. After it: one
+frame per key, covering all 29 rows and painted from the destination offset.
 
 **These tests assert the work, not the clock** — the same discipline as
 ``test_analytics_repaint.py`` beside them, for the same reason (AGENTS.md
@@ -311,6 +316,9 @@ def test_the_key_binding_writes_the_same_single_frame(gesture, _action, key, mon
                 f"the frame was painted from y={content[0]['scroll_y']} rather than the "
                 f"destination y={expected}: the move is still easing"
             )
+            assert content[0]["cells"] == scroll.region.width * len(
+                frames.viewport
+            ), "the single frame did not paint the whole body width"
             assert float(scroll.scroll_offset.y) == expected, "the offset did not land"
             assert not app.animator.is_being_animated(scroll, "scroll_y")
             registered = [k for k in app.animator._animations if k[0] == id(scroll)]

--- a/tests/unit/tui/test_analytics_scroll_frames.py
+++ b/tests/unit/tui/test_analytics_scroll_frames.py
@@ -64,7 +64,7 @@ from typing import Any
 
 import pytest
 from textual import events
-from textual._compositor import ChopsUpdate, Compositor
+from textual._compositor import ChopsUpdate, Compositor, LayoutUpdate
 
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.widgets.analytics_panel import _SCROLLBAR_GUTTER
@@ -117,7 +117,15 @@ class _BodyFrames:
 
         def patched(comp, full=False, screen_stack=None, simplify=False):
             out = original(comp, full=full, screen_stack=screen_stack, simplify=simplify)
-            record: dict[str, Any] = {"kind": "other"}
+            # EVERY frame is recorded, chops or not — a ``LayoutUpdate`` or a
+            # no-op paint inside the gesture is evidence about that gesture too —
+            # so the kind is named and the offset taken for all of them. The
+            # non-chop shapes carry no ``rows``/``cells``, which ``describe``
+            # must respect rather than assume away (review round 2, minor-2).
+            record: dict[str, Any] = {
+                "kind": "none",
+                "scroll_y": float(self.scroll.scroll_offset.y),
+            }
             if isinstance(out, ChopsUpdate):
                 spans = list(out.spans)
                 record = {
@@ -132,6 +140,8 @@ class _BodyFrames:
                     # later.
                     "scroll_y": float(self.scroll.scroll_offset.y),
                 }
+            elif isinstance(out, LayoutUpdate):
+                record["kind"] = "layout"
             self.frames.append(record)
             return out
 
@@ -170,11 +180,29 @@ class _BodyFrames:
         return [f for f in self.frames if f["kind"] == "chops" and f["rows"] <= self.viewport]
 
     def describe(self) -> str:
-        """The frames, as a failure message a reader can act on."""
-        return "; ".join(
-            f"{f['kind']} rows={sorted(f['rows'])[:3]}... scroll_y={f.get('scroll_y')}"
-            for f in self.frames
-        )
+        """The frames, as a failure message a reader can act on.
+
+        Rendered per KIND rather than by reading ``rows`` unconditionally. A
+        frame that is not a chop (a ``LayoutUpdate``, or a paint that changed
+        nothing) has no ``rows``/``cells`` at all — the earlier formatter read
+        ``f['rows']`` for every frame and raised ``KeyError: 'rows'`` while
+        BUILDING the assertion message, so a genuine failure reported a broken
+        formatter instead of the frame counts it had just measured (review round
+        2, minor-2: 2 of 8 failing cells, and 2 of 6 repeats of the
+        ``page_down`` cell). Naming the kind keeps those frames in the evidence
+        instead of dropping them, because a layout update landing mid-gesture is
+        exactly the sort of thing the reader of this message needs to see.
+        """
+
+        def one(frame: dict[str, Any]) -> str:
+            if frame["kind"] != "chops":
+                return f"{frame['kind']} scroll_y={frame['scroll_y']}"
+            return (
+                f"{frame['kind']} rows={sorted(frame['rows'])[:3]}... "
+                f"cells={frame['cells']} scroll_y={frame['scroll_y']}"
+            )
+
+        return "; ".join(one(frame) for frame in self.frames)
 
 
 def _target(scroll: Any, gesture: str, before: float) -> float:


### PR DESCRIPTION
# PR Description

## Summary of Changes

Fixes the reported `/analytics` (`/usage`) defect:

> The /analytics page has a weird tearing effect on scroll where it seems that
> not the entire frame gets updated at once and there's an update that passes
> down one line at a time through the TUI and it's disorienting. Can you review
> why that is and fix that, ensure proper refresh without tanking performance
> since that page was previously quite slow.

Release: patch — the `/analytics` page and its page/`home`/`end` keys now move the viewport in one complete frame instead of animating a full-viewport repaint per line; the settled appearance is byte-identical, and `pyproject.toml` is untouched (combined-release rule).

The cause was the four **pagination keys** (`pageup`/`pagedown`/`home`/`end`),
and it had TWO halves in the same place:

1. **The move was animated.** `AnalyticsScreen.action_page_up`/`action_page_down`/
   `action_scroll_home`/`action_scroll_end` called Textual's `scroll_page_up()`/
   `scroll_page_down()`/`scroll_home()`/`scroll_end()` with the library default
   `animate=True`. The body is a line-API `ReportView` whose `render_line(y)`
   serves `scroll_offset.y + y`, so shifting the offset by ONE line changes
   EVERY viewport row: each eased step of that animation is a full-viewport
   rewrite, and the sequence of them is exactly the "update passing down the TUI
   one line at a time" the operator described.
2. **The animations were not even the screen's.** The four bindings were not
   `priority=True`, unlike the arrow keys beside them (`Binding("up", "move_up",
   …)`). Focus sits on the scroller, whose `ScrollView` base has its own
   `pageup`/`pagedown`/`home`/`end` bindings handing the key to
   `Widget.action_page_down` and friends — again `animate=True` by default. So a
   real key press never reached `AnalyticsScreen`'s actions at all on any report
   tall enough to scroll; the actions were reachable only at the ends of the
   travel, where they are no-ops. Animating them alone would have changed nothing
   the operator could press.

Both halves are one-character-per-call changes, and both are pinned by tests:

- `local_operator/tui/widgets/analytics_panel.py` — the four actions pass
  `animate=False`, with the why-comment (same rule `_scroll_by_line` already
  states for the arrows, and the reason the coalesced hover re-resolve exists);
  the four bindings gain `priority=True` with the why-comment on the comment
  block that already explains `priority=True` for the arrows.
- `tests/unit/tui/test_analytics_scroll_frames.py` (new) — the invariant in the
  currency the defect actually lives in: **compositor frames**.

## Why a frame counter and not a stopwatch

The body is a single widget, so a per-row or per-line probe sees one dirty widget
either way and cannot tell 1 frame from 27. The instrument is therefore the
compositor's own `render_update`, wrapped (via `monkeypatch`) to record, per
frame, the viewport rows it wrote, the column span, and the body's
`scroll_offset.y` **at paint time**; frames are then classified report vs
scrollbar-thumb vs surrounding chrome. A report frame is a `ChopsUpdate` whose
rows fall inside the body viewport and whose span reaches left of the body's
`_SCROLLBAR_GUTTER` column — the thumb repaint arrives as its own one-column
chop, and counting it would make every correct gesture look doubled.

Wall time is deliberately not asserted anywhere: AGENTS.md "Calibrate ceilings
from CI" is explicit that a bound from this laptop is a bet on machine load, and
this screen already has a CPU-bound rebuild path that makes such a bound useless.

## Reproduction (before) and result (after)

Harness: `/tmp/lo-analytics-scroll/frame_probe.py`, an instrumented headless
pilot on the real `OperatorApp` at 120x45 with `_tall_report_agg()` (body region
`Region(x=9, y=8, width=102, height=29)`, `max_scroll_y=31`,
`scrollable_content_region.height=29`). One gesture per measurement, animation
settled deterministically with `pilot.wait_for_scheduled_animations()`.

```
env -u NO_COLOR TERM=xterm-256color .venv/bin/python frame_probe.py <repo-root>
# <repo-root> = the worktree under test; the before numbers come from a throwaway
# checkout of origin/main (20d8c596c) with the venv symlinked, capture-only.
```

| gesture (120x45) | before: body frames / rows per frame | after: body frames / rows per frame |
| --- | --- | --- |
| `pagedown` action | **26** / 29,29,… (26×29) | **1** / 29 |
| `pageup` action | **30** / 29×30 | **1** / 29 |
| `end` action | **49** / 29×49 | **1** / 29 |
| `home` action | **47** / 29×47 | **1** / 29 |
| **`pagedown` KEY** (the reported symptom) | **24** / 29×24 | **1** / 29 |
| **`pageup` KEY** | **30** / 29×30 | **1** / 29 |
| **`home` KEY** | **49** / 29×49 | **1** / 29 |
| **`end` KEY** | **47** / 29×47 | **1** / 29 |
| wheel ×10 notches | 1 / 29 | 1 / 29 |

Before, the offset steps one line at a time across those frames, e.g. `pagedown`:
`3 → 5 → 7 → … → 29`. After, the single frame is painted from the destination
offset (`scroll_y == expected` in the frame record), i.e. the move lands in the
same frame that paints it rather than easing into it frame by frame. Across four
runs of the before tree the per-gesture count ranged 17-49 (it tracks frame
scheduling and the distance travelled — `end`/`home` travel furthest); the order
of magnitude is what matters and it never came near 1.

The one frame is also **complete**: it covers all 29 viewport rows and all 102
body columns (2958 cells). "Fewer frames" is not the claim — a fix that repainted
partially would still be torn.

## Mutation check

The new file run against a throwaway checkout of `origin/main` (the venv
symlinked for capture only, `PYTHONPATH` pointed at that tree, tree identity
verified by printing `local_operator.__file__`):

```
cd /tmp/lo-analytics-scroll/before-tree
env -u NO_COLOR TERM=xterm-256color PYTHONPATH=$PWD .venv/bin/python -m pytest \
    tests/unit/tui/test_analytics_scroll_frames.py -n0 -q
# 8 failed, 1 passed
```

| case | before (unfixed) | after (this branch) |
| --- | --- | --- |
| `test_a_viewport_move_writes_one_complete_frame[pagedown/pageup/home/end]` | 4 FAILED, 17-28 report frames each | 4 passed |
| `test_the_key_binding_writes_the_same_single_frame[pagedown/pageup/home/end]` | 4 FAILED, 17-28 report frames each | 4 passed |
| `test_a_wheel_notch_writes_one_complete_frame` | passes (by design — see below) | passes |

The wheel cell does **not** discriminate this fix: Textual's
`_on_mouse_scroll_down` already passes `animate=False`, so that path was never
animated. It is a forward guard, and it can still fail — its mutation, applied in
a scratch harness, is a wheel notch that moves a distance and eases it
(`scroll_to(y=self.scroll_y + 12, animate=True)`), which writes **5 report
frames** where the cell asserts 1. What it cannot detect is a ONE-row animated
step (the animator's first tick already lands a single row — measured at 1
frame), and the cell makes no claim about that shape.

## Testing evidence

An earlier draft of the key-path test asserted "the offset has reached its
destination after one `pilot.pause()`" — the sharpest-looking form of "nothing is
easing". It passed on the **unfixed** tree: Textual's idle wait drives an
animation's ticks to completion as fast as the loop will take them, so one pause
already lands the target. That draft was decoration and was replaced by the frame
count, which is what actually separates the trees. (Recorded in the test's
docstring so the next person does not re-derive it.)

The settled appearance is unchanged: `before-step-05.svg` and
`after-step-01.svg` (both `scroll_y=29` on the same fixture) are **byte-identical**
(`md5 03aac32d31f220d8080d37cd83e431e2`), and on the fixed tree the five
consecutive frames after the key are byte-identical to each other — the
"frames should be identical once settled" property from AGENTS.md §5. On the
unfixed tree consecutive frames differ in content as the offset walks.

## Regressions checked (task item 5 — performance work intact)

- **The hover patch path is untouched** in behaviour: `_patch_rows`,
  `_repaint`, `_refresh_hover` and `_viewport_moved` are not modified by this
  change (the diff is 45 insertions / 8 deletions, all comments and the eight
  binding/action lines). `tests/unit/tui/test_analytics_repaint.py` (the guard
  for "a pointer crossing one row re-strips two rows, not 846") and
  `tests/unit/tui/test_analytics_mouse.py` both pass unchanged. The fix can only
  shrink the hover work: `_viewport_moved` coalesces per frame, and an animated
  `scroll_y` fired ~28 notifications per `pagedown` where the unanimated move
  fires one.
- **The wheel is unchanged** — one notch, one complete frame, before and after
  (table above). This screen has no widget-level wheel handler; Textual stops the
  event on the container while it can still scroll, so the container's own
  `animate=False` path is the one that runs.
- **Cursor reveal, arrows, click, ctrl+c drag selection** are not touched;
  `test_analytics_panel.py`, `test_analytics_mouse.py` and the cursor/keyboard
  tests in `test_app_pilot.py` pass.
- **The scrollbar** keeps painting (`_SCROLLBAR_GUTTER` classification in the
  new test tolerates its own chop, and asserts any non-report chop inside the
  viewport is confined to the thumb column — that is the "no partial repaint"
  half of the invariant). On the unfixed tree the thumb also lagged the content
  by a frame at the end of the animation; after the fix the thumb update is
  coalesced into the same frame.

## Visual evidence

Frames attached below (raw URLs from the `evidence/pr-<n>` branch — evidence does
not go in the tree). Capture recipe per AGENTS.md §1/§3/§5:
`env -u NO_COLOR TERM=xterm-256color`, `scripts.visual_capture.save_capture`
(native 8x17 cells, system monospace, `.geometry.json` written beside each SVG),
the real `OperatorApp` with its production stylesheet, 120x45.

The pair for the reported symptom (before over after; both are the FIRST frame
after one `pagedown`, same fixture, same 120x45 geometry):

**before** — `scroll_y=5` of a target of 29, mid-easing:

![before: first frame after pagedown on the unfixed tree, scroll_y=5 of 29](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-994/frames/before-step-01.png)

**after** — `scroll_y=29` already, in the one frame the key writes:

![after: first frame after pagedown on this branch, scroll_y=29 of 29](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-994/frames/after-step-01.png)

Settled frames, which must be identical (the fix must not change how it looks
once stopped) — the unfixed tree needs a second frame to get here:

![before: second frame after pagedown on the unfixed tree, scroll_y=29](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-994/frames/before-step-02.png)

![after: end pressed and settled, on this branch](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/pr-994/frames/after-end-settled.png)

Machine-readable states (scroll offsets and geometry per frame) are on the same
branch under `frames/before-scroll-states.json` and
`frames/after-scroll-states.json`.

Geometry (`*.geometry.json` and the states JSON): grid 120x45; body region
`Region(x=9, y=8, width=102, height=29)`; `max_scroll_y=31`;
`scrollable_content_region.height=29`; screen `virtual_size == size` (nothing
makes the screen itself scrollable) — the same numbers the frame probe reports,
so the stills and the frame table describe the same geometry.

The settled frames are **byte-identical across the fix**:
`before-step-05.svg` and `after-step-01.svg` are both
`md5 03aac32d31f220d8080d37cd83e431e2` (same content, same offset, one from each
tree). On this branch the five consecutive frames after the key are byte-identical
to each other; on the unfixed tree they differ as the offset walks.

Before/after stills are captured on the action route the **key** takes on each
tree (recorded as `route` in the states JSON): on the unfixed tree that is
`Widget.action_page_down` through the body's own `ScrollView` binding, on this
branch it is the screen's `priority=True` action. Capturing both on one route
would either show this branch animating (calling the container's action directly)
or miss the animation entirely (`pilot.press` awaits the key to completion, by
which time the easing has finished).

## Recorded observations, not fixed here

The same animated-call shape exists on other surfaces. Left alone deliberately,
because on each of them the change is not the same one-liner *in effect* — it
would remove an easing users see on a screen nobody reported, and on none of them
was the animation unreachable code the way it was here:

- `local_operator/tui/widgets/info_panel.py:1300-1305,1513-1523` — the **closest
  sibling**, and the one worth doing next: it has both halves this PR fixed and
  neither fix. Its `pageup`/`pagedown`/`home`/`end` bindings (1302-1305) are not
  `priority=True` while its `action_page_up`/`action_page_down`/
  `action_scroll_home`/`action_scroll_end` (1513-1523) call the animated
  defaults, so a key press is likely bypassing them exactly as it did here.
  Not fixed in this PR: it needs its own reproduction (which widget holds focus,
  whether its body is a line API, what the per-frame coverage is) and a verified
  before/after, which is the work this PR did for `/analytics` alone.
- `local_operator/tui/widgets/org_chart_view.py:514-517` —
  `action_page_up`/`action_page_down` on `self._body` with the animated
  defaults, i.e. the same one-line shape on another surface (its `500`-`517`
  block also carries `action_scroll_up`/`down`).
- `local_operator/tui/widgets/session_panel.py:1783,1786,1789,1792` —
  `scroll_page_up/down()`, `scroll_home()`, `scroll_end()` with defaults.
- `local_operator/tui/widgets/todo_panel.py:536` —
  `scroll.scroll_page_down() if down else scroll.scroll_page_up()`.
- `local_operator/tui/widgets/subagent_view.py:3385,3387` —
  `self._body.scroll_page_down()/up()` behind the footer's `↑`/`↓` buttons.
  Separately justified rather than merely unfinished: it is a pointer gesture
  whose docstring argues the larger step is deliberately bought, and its body is
  a `SubagentTranscriptView`, not a line-API widget, so the per-step cost is a
  different question and was not measured.

The first two are grouped together deliberately: `info_panel`'s shape (a
non-priority pagination binding over an animated action) is the same defect
class as this one, where `subagent_view`'s is a different one.

## Gates

Run over the whole tree exactly as CI does, from
`~/workspace/repos/lo-analytics-scroll`. The branch is cut from `origin/main` @
`20d8c596c` and rebased onto `b85a610cc` (#976 paging-fold-width, #988) before
opening, so the diff against current `main` is exactly the two files below:

| gate | command | result |
| --- | --- | --- |
| flake8 | `.venv/bin/python -m flake8 .` | clean |
| black (pinned) | `uvx --from black==26.1.0 black --check .` | `1233 files would be left unchanged` |
| isort (pinned) | `uvx isort==5.13.2 --check .` | clean |
| pyright | `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | `0 errors, 0 warnings, 0 informations` |
| unit suite | `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q` | pre-rebase (`20d8c596c`): `18627 passed, 18 skipped`. On the rebased head: `18636 passed, 18 skipped, 1 failed` — the one failure is a pre-existing load-sensitive fixture precondition, reproduced identically on the untouched base (see below). |
| new file | `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui/test_analytics_scroll_frames.py -n0 -q` | `9 passed` |

## The one suite failure, and why it is not this change

`tests/unit/session/test_attach_frame_size.py::test_a_quiescent_follower_recovers_without_waiting_for_more_traffic[False]`
failed in the rebased-head run with

```
AssertionError: no backoff timer to interleave with, so this run cannot reproduce
the hand-off that orphans the debt
  assert remote._degraded_resync_retry_task is not None
```

That assertion is the test's own **fixture precondition** (it says the run could
not *construct* the scenario), on a backoff-timing race in the session/attach
subsystem, and the run was at load average 84-90 (several sibling worktrees were
running full suites). Three facts, each measured:

* the file passes **97/97 in isolation, 3 runs of 3**, on this branch;
* the pre-rebase full-suite run on the same code passed with **0 failures**;
* the same node fails **identically on a pristine checkout of the base
  `b85a610cc`** under the same load — `1 failed, 1 passed in 2.17s`, same
  assertion, same message — with none of this branch's code present.

The change touches `analytics_panel.py`'s scroll actions and adds one TUI test
file; the failing test never boots the analytics screen.

## What this does not do

- No version bump (`pyproject.toml` untouched).
- `ReportView` (`report_view.py`) is untouched: no change to the strip cache,
  `render_line`, or `_patch_rows`/`_repaint`.
- The three sibling surfaces above are recorded, not changed.


