### PR TITLE
feat(openrouter): keep a conversation on the host that served it

### DIFF
--- a/docs/OPENROUTER_CACHING.md
+++ b/docs/OPENROUTER_CACHING.md
@@ -54,20 +54,48 @@ unpinned baseline parks on one host by itself and both arms measure the same
 thing. An earlier sequential run (3×30 turns) recorded only 3 switches in 87
 transitions and, correctly, showed no difference between arms.
 
-| pooled | switches / transitions | cache share | avoidable loss | pin honoured |
-| --- | ---: | ---: | ---: | ---: |
-| affinity **off** | 23/168 (**13.7%**) | 49.2% | 44.1% | — |
-| affinity **on** | 7/168 (**4.2%**) | 47.0% | 46.3% | 161/168 (95.8%) |
+### The invariant: staying put caches, moving does not
 
-**Host switching drops 3.3×, which is the thing the change controls.** The
-conditional split shows why that matters:
+This is the part that reproduced in every window measured, and it is the
+mechanism the change acts on:
 
 | transition | n | any cache hit | cache share |
 | --- | ---: | ---: | ---: |
 | host **same** | 306 | 56% | 55.5% |
 | host **changed** | 30 | 10% | 9.9% |
 
-A turn that stays on its host caches; a turn that moves does not.
+A turn that stays on its host caches; a turn that moves does not. An
+independent QA window reproduced the same split more sharply still (same-host
+**88.1%** against changed **14.2%**), and both windows agree the pin is
+actually honoured: **95.8%** and **95.1%** of pinned turns were served by the
+host named. The guard's before/after also held in both (**38.0% → 77.3%** here,
+**45.7% → 68.5%** in QA's window).
+
+### Switch rate is window-specific, and this is one window
+
+| ONE measured window (baseline switching 13.7%) | switches / transitions | cache share | avoidable loss | pin honoured |
+| --- | ---: | ---: | ---: | ---: |
+| affinity **off** | 23/168 (**13.7%**) | 49.2% | 44.1% | — |
+| affinity **on** | 7/168 (**4.2%**) | 47.0% | 46.3% | 161/168 (95.8%) |
+
+Read that as a measurement of a 13.7%-pressure window, **not as a general 3.3×
+reduction** — an independent QA run in a calm window (2.4% baseline switching)
+measured the raw counts the other way round, **ON 14/168 (8.3%) against OFF
+4/168 (2.4%)**, Fisher p=0.027.
+
+The decomposition explains it and is the reason raw switch totals are the wrong
+headline. Retirements are *counted as switches* while being deliberate moves off
+a host that does not cache. Netting them out of QA's window leaves involuntary
+switching at **8/168 against 4/168, p=0.379 — indistinguishable**: with a 2.4%
+baseline there was almost nothing for the pin to prevent, while the guard still
+fired 6 times. A calm window can therefore show ON switching *more* than OFF,
+and that is the guard working, not the pin failing (ON was also slightly cheaper
+end to end in that run, $1.199 against $1.276).
+
+So the honest claim is: **the pin reduces switching in windows that have
+switching to reduce**, and the conditional split plus the pin-honour rate are
+what hold across windows. See "When there is nothing to win" below for the
+regime that makes this worth shipping.
 
 ### The cache-quality guard
 
@@ -97,6 +125,14 @@ deliberate move off a dead host from a forced re-route:
 **Involuntary switching is identical in both arms in that window** (a
 low-pressure window — see the caveat below); the nine extra ON switches are all
 the guard deliberately leaving a host that was billing full price for nothing.
+
+The discovery is not free, and the cost is bounded but real: a conversation
+spends roughly **2-3 full-price turns** finding out its first host does not
+cache before the guard retires it (one warm miss is ordinary, the second
+retires, and the first turn on the replacement host is cold by definition).
+Closing that gap means preferring known-good hosts up front rather than only
+leaving the worst after it proves itself — the cache-aware host *selection*
+work deliberately deferred out of this change.
 
 ### Why aggregate cache share did not move
 
@@ -145,20 +181,29 @@ hosts on the user's behalf is a routing opinion this change does not take.
 
 Stated plainly, because the aggregate is easy to oversell:
 
-- **Proven.** The pin reaches the wire and is honoured ~90-96% of the time.
-  Switch transitions cost ~3.8-5× a same-host transition, so switching is the
-  loss. Under pressure the pin cut switching 3.3× (13.7% → 4.2%). The guard
-  fires only on a genuinely cache-dead host and lifts those conversations from
-  38.0% to 77.3%.
+- **Proven.** The pin reaches the wire and is honoured ~90-96% of the time
+  (95.8% here, 95.1% in an independent QA window). Switch transitions cost
+  ~3.8-5× a same-host transition, so switching is the loss, and the conditional
+  split holds in every window measured (same-host 55-88% cache share against
+  10-14% when the host changes). The guard fires only on a genuinely cache-dead
+  host and lifts those conversations from 38.0% to 77.3% (45.7% → 68.5% in QA's
+  window).
 - **Not proven.** A pooled aggregate cache-share win. In both pressure windows
   the ON arm's raw share landed 2-3 points BELOW the OFF arm, because the pin
   concentrates traffic on whichever host it acquired and the acquisition is
   luck. Mix-standardised the pin is +1.9 to +4.2 points, but that is an
   adjustment, not a measured end-to-end improvement.
-- **Window-dependent.** Switch pressure varies hour to hour. The second
-  pressure window was calmer (9.5% baseline switching against 13.7% in the
-  first), and in calm windows there is little for the pin to win — an unpinned
-  conversation mostly stays put on its own.
+- **Window-dependent, and this is the claim to be careful with.** A **3.3×
+  switch reduction is one window's measurement, not a general result.** Switch
+  pressure varies hour to hour (13.7% baseline in the first window, 9.5% in the
+  second, 2.4% in an independent QA window), and in a calm window there is
+  little for the pin to win — an unpinned conversation mostly stays put on its
+  own. In QA's calm window the raw counts inverted (ON 8.3% against OFF 2.4%),
+  which nets out to **8 against 4 involuntary switches, p=0.379** once the
+  guard's deliberate retirements are separated from switches it did not choose.
+- **Costed.** A conversation pays roughly **2-3 full-price turns** to discover
+  its first host does not cache before the guard retires it. Bounded, but it is
+  the concrete price of not selecting hosts up front.
 
 The operator's real traffic is the regime this targets: live sessions measured
 17.8-19.3% switching with hosts that cache well (86-100% hit-turns), which is

--- a/docs/OPENROUTER_CACHING.md
+++ b/docs/OPENROUTER_CACHING.md
@@ -1,0 +1,256 @@
+# OpenRouter cache affinity
+
+This change makes the harness **ask OpenRouter for the host that served the
+previous turn**, so a long conversation's prompt cache stays on one upstream
+provider. It adds one request field (`ChatRequest.provider_affinity`), one
+stream field (`StreamEndEvent.served_provider`), a per-model pin held by
+`SessionStreamFn`, and the `providers.openrouter.provider_affinity` setting
+(default on). The existing `provider` routing preferences, `prompt_cache_key`,
+reasoning replay and error handling are untouched.
+
+`scripts/bench_openrouter_cache_rate.py` is the live A/B that produced the
+numbers below. Raw per-turn JSONL lives on the PR, not in the tree (see
+`AGENTS.md`, "Evidence goes on the PR, never into the repository").
+
+## The mechanism
+
+OpenRouter's default route for a model with many upstream endpoints is
+**price-weighted load balancing**, not stickiness. `deepseek/deepseek-v4.1-flash`
+currently has 11 endpoints (DeepSeek, DeepInfra, Fireworks, SiliconFlow, Modal,
+Wafer, GMICloud, Morph, Io Net, Novita, Venice). Each of those keeps its own KV
+cache, and DeepSeek-style caching needs a full prefix match **from token 0** —
+so a turn routed to a different host than the last one re-bills the entire
+conversation at the uncached rate.
+
+`prompt_cache_key` asks for server-side sticky routing, and the harness already
+sends it. **It does not hold under load**: a controlled 18-turn A/B measured 7
+host switches with the key alone, and 9 with `session_id` added. Naming the host
+explicitly is what holds — `provider.order` accepts the served display name and
+is honoured ~96% of the time.
+
+Two properties make the pin safe to ship on by default:
+
+- **An unrecognised `order` entry is silently ignored** (verified live: HTTP
+  200, default routing). A stale or renamed host degrades to today's behaviour
+  rather than failing the call.
+- **The served display name works verbatim** as an `order` entry — `AtlasCloud`,
+  `Z.AI` and `Google AI Studio` are all accepted as spelled. Slug-normalising is
+  wrong for 13 of 106 providers (`Z.AI` → `z-ai`, `AtlasCloud` → `atlas-cloud`),
+  so the code deliberately keeps no slug table.
+
+`order` is a **preference, not a constraint**: OpenRouter falls through to
+another host when the pinned one is loaded or erroring, which is why the pin
+reduces switching rather than eliminating it.
+
+## What it measures
+
+Live A/B, `deepseek/deepseek-v4.1-flash`, **6 concurrent conversations per arm,
+15 turns each, 2 runs with alternating arm order** (24 conversations, 360 turns,
+~32.5k-token prefixes, median inter-turn gap 3.8s, $1.96 total).
+
+Concurrency is load-bearing in the method. A single sequential conversation is a
+**no-pressure sample**: the load balancer has no reason to move it, so an
+unpinned baseline parks on one host by itself and both arms measure the same
+thing. An earlier sequential run (3×30 turns) recorded only 3 switches in 87
+transitions and, correctly, showed no difference between arms.
+
+| pooled | switches / transitions | cache share | avoidable loss | pin honoured |
+| --- | ---: | ---: | ---: | ---: |
+| affinity **off** | 23/168 (**13.7%**) | 49.2% | 44.1% | — |
+| affinity **on** | 7/168 (**4.2%**) | 47.0% | 46.3% | 161/168 (95.8%) |
+
+**Host switching drops 3.3×, which is the thing the change controls.** The
+conditional split shows why that matters:
+
+| transition | n | any cache hit | cache share |
+| --- | ---: | ---: | ---: |
+| host **same** | 306 | 56% | 55.5% |
+| host **changed** | 30 | 10% | 9.9% |
+
+A turn that stays on its host caches; a turn that moves does not.
+
+### The cache-quality guard
+
+The table above is the **plain pin**, and it exposed the failure mode the guard
+exists for: the pin held conversations on SiliconFlow, whose same-host cache
+share is 41% against 99% on its peers. A second pressure run with the guard
+enabled shows it firing, and firing only where it should — **every retirement in
+24 conversations named SiliconFlow, and no other host was ever retired.**
+
+Splitting the ON lanes at the moment they retired:
+
+| ON-arm lanes that retired a host | cache share |
+| --- | ---: |
+| before retirement | 38.0% |
+| after retirement | **77.3%** |
+| ON lanes that never needed to retire | 84.0% |
+
+The guard's own retirements show up as extra "switches", which is why the raw
+switch counts must be read by cause rather than by total. Separating a
+deliberate move off a dead host from a forced re-route:
+
+| arm | involuntary switches | retirement switches |
+| --- | ---: | ---: |
+| off | 16/168 (9.5%) | 0 |
+| on | 16/168 (9.5%) | 9 |
+
+**Involuntary switching is identical in both arms in that window** (a
+low-pressure window — see the caveat below); the nine extra ON switches are all
+the guard deliberately leaving a host that was billing full price for nothing.
+
+### Why aggregate cache share did not move
+
+It is the honest result, and it is a **host-composition confound rather than a
+failure of the pin**. Upstream providers differ enormously in cache quality on
+same-host turns:
+
+| provider | same-host transitions | cache share |
+| --- | ---: | ---: |
+| Modal | 12 | 99.7% |
+| Wafer | 27 | 99.6% |
+| Novita | 22 | 90.4% |
+| GMICloud | 24 | 82.8% |
+| **SiliconFlow** | 221 | **41.4%** |
+
+SiliconFlow is the cheapest healthy endpoint, so price-weighted routing sends
+most traffic there — and it evicts aggressively. The plain pin then does exactly
+what it is asked to do: it **stays** there. That raised SiliconFlow's share of
+same-host turns from 61% (off) to 82% (on), and the loyalty to a weak-cache host
+cancelled the benefit of switching less. (The cache-quality guard above is the
+answer to this; these numbers are the pre-guard measurement that motivated it.)
+
+Those zero-cache turns are **real misses, not a reporting gap** — checked
+against OpenRouter's own generation records for a 10-turn sample: they carry no
+`cache_discount` and bill at $0.30/Mtok, the full input price, against $0.009
+for cached turns on the same host. A miss costs **33× a hit**.
+
+Standardising both arms onto one host mix removes the confound:
+
+| standard mix | off | on |
+| --- | ---: | ---: |
+| off-arm mix | 59.0% | **60.9%** |
+| on-arm mix | 48.3% | **52.5%** |
+
+**Mix-standardised, affinity is +1.9 to +4.2 points.** Per host it is neutral to
+positive (SiliconFlow 38.0% → 43.7%; Modal, Wafer and GMICloud unchanged within
+noise), which is what "keeps the cache warm without changing anything else"
+should look like.
+
+The remaining headroom is a **host-selection** question — preferring
+cache-competent endpoints in the first place, rather than only leaving the worst
+one after it proves itself. That is deliberately out of scope here: choosing
+hosts on the user's behalf is a routing opinion this change does not take.
+
+### What is and is not claimed
+
+Stated plainly, because the aggregate is easy to oversell:
+
+- **Proven.** The pin reaches the wire and is honoured ~90-96% of the time.
+  Switch transitions cost ~3.8-5× a same-host transition, so switching is the
+  loss. Under pressure the pin cut switching 3.3× (13.7% → 4.2%). The guard
+  fires only on a genuinely cache-dead host and lifts those conversations from
+  38.0% to 77.3%.
+- **Not proven.** A pooled aggregate cache-share win. In both pressure windows
+  the ON arm's raw share landed 2-3 points BELOW the OFF arm, because the pin
+  concentrates traffic on whichever host it acquired and the acquisition is
+  luck. Mix-standardised the pin is +1.9 to +4.2 points, but that is an
+  adjustment, not a measured end-to-end improvement.
+- **Window-dependent.** Switch pressure varies hour to hour. The second
+  pressure window was calmer (9.5% baseline switching against 13.7% in the
+  first), and in calm windows there is little for the pin to win — an unpinned
+  conversation mostly stays put on its own.
+
+The operator's real traffic is the regime this targets: live sessions measured
+17.8-19.3% switching with hosts that cache well (86-100% hit-turns), which is
+precisely where cutting switching pays and where the guard has nothing to do.
+
+## What the harness does
+
+1. **Capture.** `OpenAICompatClient.stream` reads the `provider` field that
+   OpenRouter puts on every chunk and reports the last one as
+   `StreamEndEvent.served_provider`. It is on the END event, not the start: a
+   stream that dies mid-way must not move the pin. It is deliberately not part
+   of `provider_payload`, which is persisted per message and is native-replay
+   and compaction substrate.
+2. **Record.** `SessionStreamFn._record_stream` writes it into a per-model dict
+   on a successful end only. Re-pinning is immediate with no hysteresis — the
+   host that just served is the one holding the prefix, and the previous host's
+   entry is already decaying against a ~10-minute expiry.
+3. **Stamp.** The next request carries the pin on `ChatRequest`, which is what
+   failover clones for retries, so the pin follows a retry for free. It is held
+   per model id and outside `FailoverRouteState` (that state is cleared on a
+   model switch; a cache pin must survive a detour to another model and back).
+4. **Render.** `_build_body` merges it into the `provider` object as
+   `order: [name]`.
+
+### When it deliberately does nothing
+
+`SessionStreamFn._affinity_enabled` refuses to pin unless every condition holds.
+Each is a place where the trade is not the harness's to make:
+
+- **provider is `openrouter`.** Radient also aggregates, but its routing was
+  never measured here.
+- **the model advertises prompt caching.** Otherwise the pin narrows the host
+  pool and buys nothing.
+- **the request is not `isolated`.** A naming errand has no warm prefix, and
+  letting one move the pin would drag the real conversation onto whatever host
+  answered an unrelated question. Gated in **both** directions.
+- **the model id has no `:` suffix.** `:nitro` and `:floor` sort by throughput
+  or price by definition; a pin would quietly defeat the suffix the user typed.
+- **`providers.openrouter.provider_affinity` is not false.**
+- **no `order`/`only`/`ignore`/`sort` is configured.** The user's own routing
+  opinion wins outright — `order` disables sticky routing on OpenRouter's side
+  anyway, so a pin would either fight the setting or be silently overridden.
+  `_build_body` repeats this check as defence in depth.
+
+### Leaving a host whose cache is dead
+
+A pin is only worth holding if the host actually caches, so affinity needs a way
+to notice that it does not. A turn **strikes** when all of the following hold:
+the served host is the one we *asked for* (a fallback elsewhere was never given
+this prefix, so its cold turn is expected and never strikes); the gap since the
+conversation's previous turn is under 300s (longer, and the miss is charged to
+the ~10-minute expiry clock rather than to the host); the prefix is at least
+8192 tokens; and reuse came back under `max(1024, 2%)` of it.
+
+**Two consecutive strikes retire the host** for that conversation and model: the
+pin is dropped and the host is sent as `provider.ignore` on later requests. Any
+real reuse clears the counter, so isolated misses under load never accumulate.
+Two rather than one because a single miss is ordinary — an eviction, a restart —
+and retiring on it would churn the pin as badly as having none.
+
+Retirement is capped at **3 hosts** per conversation and model. `ignore` is a
+hard filter on OpenRouter's side, so an unbounded set walks a conversation
+toward "no eligible endpoints"; a routing optimisation must never be able to
+make a model unreachable. At the cap the harness stops retiring and says so once
+at debug level.
+
+Verified live that the two compose: with `order` naming one host and `ignore`
+another, the ordered host served 8/8 calls and the ignored one was never
+attempted.
+
+A true transcript fork (one passed a `cache_lineage_id`) inherits the parent's
+pin **and its retirements** as copies, for the same reason it inherits the cache
+lineage: it replays a byte-identical prefix, so the parent's host really is warm
+for it and the parent's findings about dead hosts apply. A fresh delegated
+prompt inherits nothing.
+
+The pin is memory-only. A resumed session re-acquires it after one cold call,
+which is cheaper than persisting a hint a 10-minute expiry may already have
+invalidated.
+
+## Known limitation: a moving `cache_control` marker
+
+`_message_cache_markers` marks the last message and the previous user turn, so
+each turn **rewrites** the marker off the message that carried it last time.
+That makes the request prefix not strictly append-only: message *N* is sent as a
+`cache_control`-bearing content array on one turn and as a plain string on the
+next.
+
+Measured cost on this wire (over the 74k-prefix sequential runs, where the
+effect is easiest to isolate): a median of **207 tokens per turn, ~0.28% of the
+prefix** — the divergence lands near the tail, not the head, so the bulk of the
+prefix still matches. It is not what causes the SiliconFlow misses above (a host
+that stayed put for 10 turns still missed, while Wafer and Modal cached 99.6%
+under the identical marker behaviour). Recorded here as a real but separate
+finding; fixing it is not in this change's scope.

--- a/docs/OPENROUTER_CACHING.md
+++ b/docs/OPENROUTER_CACHING.md
@@ -129,7 +129,7 @@ the guard deliberately leaving a host that was billing full price for nothing.
 The discovery is not free, and the cost is bounded but real: a conversation
 spends roughly **2-3 full-price turns** finding out its first host does not
 cache before the guard retires it (one warm miss is ordinary, the second
-retires, and the first turn on the replacement host is cold by definition).
+retires, and the first turn on the replacement host has nothing to reuse).
 Closing that gap means preferring known-good hosts up front rather than only
 leaving the worst after it proves itself — the cache-aware host *selection*
 work deliberately deferred out of this change.

--- a/local_operator/config.py
+++ b/local_operator/config.py
@@ -194,6 +194,14 @@ DEFAULT_CONFIG = Config(
                 "openai": {"api": "responses", "use_max_context_window": True},
                 "anthropic": {"cache_ttl_1h_min_context_tokens": 150_000},
                 "openrouter": {
+                    # The one HARNESS-side key in this block: read by
+                    # `SessionStreamFn._affinity_enabled`, never by
+                    # `_openrouter_provider_preferences`, so it does not make
+                    # the shipped config express a wire-level opinion. On by
+                    # default — reusing the host that served the last turn is
+                    # what keeps a long conversation's prompt cache warm, and
+                    # any explicit routing preference below turns it off.
+                    "provider_affinity": True,
                     "sort": "",
                     "order": [],
                     "only": [],

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -2029,6 +2029,35 @@ class ChatRequest(BaseModel):
     # caches. Session hosts populate it once from their session id; keeping it
     # on the request lets retries and fallback clones preserve the same value.
     prompt_cache_key: str | None = None
+    # "Keep this conversation on the host that served it." Only the
+    # OpenAI-compatible CHAT wire consumes this (``OpenAICompatClient._build_
+    # body`` turns it into ``provider.order``); every other wire ignores it.
+    #
+    # It rides on the REQUEST rather than on the session for the same reason
+    # ``prompt_cache_key`` does: the wire client is rebuilt per route-key
+    # inside the failover driver, so client-held state cannot survive a call,
+    # while the request is what failover CLONES for each retry — so the pin
+    # follows a retry to the same host for free.
+    #
+    # Only OpenRouter populates it today. Its default route is price-weighted
+    # load balancing across many upstream hosts, and each switch is a cold
+    # prompt cache; the session records the host that served the last turn and
+    # asks for it again. An unrecognized entry is silently ignored by
+    # OpenRouter (verified: 200 + default routing), so a stale pin degrades to
+    # today's behaviour rather than failing the call.
+    provider_affinity: str | None = None
+    # Hosts this conversation has RETIRED: they served warm turns and returned
+    # no prefix reuse, so pinning to them is worse than churn (measured: one
+    # upstream cached 38% of same-host turns while its peers managed 99%, and
+    # the misses billed at full input price, 33x a cache read).
+    #
+    # Rendered as `provider.ignore`, which is a HARD filter — verified live
+    # that it composes with `order` (the ignored host is never attempted while
+    # the ordered host still serves). That hardness is why the set is bounded;
+    # see ``SessionStreamFn.MAX_RETIRED_PROVIDERS``. Sorted by the producer so
+    # the body stays byte-stable across turns, which matters for a field that
+    # rides in front of a cached prefix.
+    provider_avoid: list[str] = Field(default_factory=list)
     #: Coarse context-size hint for optional cache TTL, never wire content.
     #: The host seeds this from its last Usage; SessionStreamFn replaces it
     #: with the counted prefix plus estimated appended content when possible.
@@ -2194,6 +2223,20 @@ class StreamEndEvent(BaseModel):
     stop_reason: str  # stop | length | toolUse | refusal | error | aborted
     usage: Usage | None = None
     provider_payload: dict[str, Any] | None = None
+    #: The upstream host an aggregator actually routed this call to, as the
+    #: aggregator's own DISPLAY NAME (OpenRouter's ``provider`` chunk field:
+    #: "AtlasCloud", "Z.AI", "Google AI Studio"). Verbatim on purpose — the
+    #: display name is what an ``order`` entry accepts, and slug-normalising it
+    #: is wrong for 13 of 106 providers (``Z.AI`` is ``z-ai``, ``AtlasCloud``
+    #: is ``atlas-cloud``), so there is no table to keep in sync.
+    #:
+    #: Deliberately NOT ``provider_payload``: that dict is persisted per
+    #: message and is the substrate for native replay and compaction, so a
+    #: routing hint written there becomes transcript content. And deliberately
+    #: on the END event, not the start: the start event is the acceptance
+    #: boundary, and a stream that dies mid-way must not move the pin onto a
+    #: host that did not actually serve a turn.
+    served_provider: str | None = None
     #: The provider's own words about an abnormal end. For ``refusal`` this is
     #: the refusal message (or a line naming the provider's terminal marker when
     #: it sent no prose). Refusals used to be mapped onto ``stop``, which ended

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -2591,6 +2591,13 @@ class SessionStreamFn:
     #: Sized at twice the per-turn gap so a genuinely consecutive pair (two
     #: turns each inside the warm window) always counts, while anything that
     #: needed an idle stretch in between does not.
+    #:
+    #: Residual window, noted so it is not re-derived (review round 2,
+    #: MINOR-2): turns served by OTHER hosts neither strike nor clear, so a
+    #: strike can sit for up to this long while the conversation is busy
+    #: elsewhere and then pair with a later miss. Kept anyway — two misses
+    #: inside ten minutes are fair evidence about a host regardless of what ran
+    #: between them, and tightening it would start forgiving real cache death.
     PROVIDER_STRIKE_PAIR_MAX_GAP_S = 600.0
     #: Hard ceiling on retirements per (conversation, model). ``ignore`` is a
     #: HARD filter on OpenRouter's side, so an unbounded set walks a
@@ -2869,6 +2876,20 @@ class SessionStreamFn:
         statement about which host is holding this conversation, and the
         compaction summary is sent to that same host — keeping the conversation
         there across the boundary is the whole point of the feature.
+
+        KNOWN ASYMMETRY, recorded so the next reader does not re-derive it
+        (review round 2, MINOR-1): because this wipes the slate, the first cold
+        turn after a compaction is strike 1, so a host that then suffers ONE
+        ordinary eviction is retired on what is effectively a single genuine
+        miss rather than two. Left as is on evidence that cuts against the
+        pessimistic reading: the first post-boundary turn is usually WARM, not
+        cold — its prefix is the system blocks the host still holds plus the new
+        summary, and the floor is ``max(1024, 2%)``, so above a ~1-2k system
+        prefix that turn clears the floor and CLEARS the record instead of
+        striking it. The blast radius is bounded by ``MAX_RETIRED_PROVIDERS``
+        and the next compaction lifts the bar again, so this is strictly better
+        than not clearing at all — which is the failure that made the clear
+        necessary.
         """
         if not (self._provider_strikes or self._provider_retired):
             return

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -2556,6 +2556,32 @@ class SessionStreamFn:
     """
 
     USAGE_CHECK_TTL_S = 60.0
+
+    # -- cache affinity retirement ------------------------------------------
+    #: Consecutive warm turns with no prefix reuse before a host is retired.
+    #: TWO, not one: a single miss is ordinary (a host restarts, an entry is
+    #: evicted early under load), and retiring on it would churn the pin as
+    #: badly as having none. Two CONSECUTIVE misses on a host that is still
+    #: being handed a warm prefix is a pattern rather than an accident.
+    PROVIDER_STRIKES_TO_RETIRE = 2
+    #: A gap longer than this is charged to the CLOCK, not to the host.
+    #: Host-side cache entries expire on a documented ~10-minute timer, so a
+    #: miss after a long pause says nothing about whether the host caches; 300s
+    #: sits well inside that window so an expiry can never be mistaken for
+    #: deadness.
+    PROVIDER_STRIKE_MAX_GAP_S = 300.0
+    #: Below this the prefix is too small for "no reuse" to mean anything —
+    #: a short prompt may sit under the host's minimum cacheable block.
+    PROVIDER_STRIKE_MIN_PROMPT_TOKENS = 8192
+    #: Reuse below max(this, 2% of the previous prompt) counts as no reuse.
+    PROVIDER_STRIKE_MIN_CACHED_TOKENS = 1024
+    PROVIDER_STRIKE_MIN_CACHED_FRACTION = 0.02
+    #: Hard ceiling on retirements per (conversation, model). ``ignore`` is a
+    #: HARD filter on OpenRouter's side, so an unbounded set walks a
+    #: conversation toward "no eligible endpoints" — a routing optimisation
+    #: must never be able to make a model unreachable. At the cap the harness
+    #: stops retiring and keeps serving on whatever remains.
+    MAX_RETIRED_PROVIDERS = 3
     DEFAULT_USAGE_BLOCK_MS = 5 * 60 * 1000
 
     #: How many blocked accounts the recovery walk may probe at once.
@@ -2631,6 +2657,43 @@ class SessionStreamFn:
             on_settle=self._on_route_settle,
             on_fast_refused=self._on_fast_refused,
         )
+        # model_id -> the aggregator display name that served this
+        # conversation's last turn on that model. Read by ``__call__`` to pin
+        # the next request (``ChatRequest.provider_affinity``) and written by
+        # ``_record_stream`` from ``StreamEndEvent.served_provider``.
+        #
+        # Deliberately NOT folded into ``_route_state``: that state is about
+        # harness routes and quotas and is CLEARED on a model switch, whereas a
+        # cache pin must survive a detour to another model and back — the host
+        # still holds this conversation's prefix when we return to it. Keyed by
+        # model id for the same reason: two models on one provider are two
+        # different prefixes on two different hosts.
+        #
+        # Memory-only by design: a resumed session re-acquires its pin after a
+        # single cold call, which is cheaper than persisting a hint that a
+        # 10-minute host-side expiry may already have invalidated.
+        self._provider_affinity: dict[str, str] = {}
+        # model_id -> {host: consecutive warm turns that returned no prefix
+        # reuse}. A pin is only worth holding if the host actually caches, and
+        # upstreams differ enormously: one measured 38% of same-host turns
+        # cached while its peers managed 99%, and its misses billed at full
+        # input price (33x a cache read). Without this the pin would loyally
+        # hold a conversation on a cache-dead host, which is worse than the
+        # churn it replaces.
+        self._provider_strikes: dict[str, dict[str, int]] = {}
+        # model_id -> hosts retired for THIS conversation, sent as
+        # `provider.ignore`. Per conversation and per model because cache
+        # deadness is observed per prefix, not globally — another session's
+        # experience of the same host is not evidence about this one's.
+        self._provider_retired: dict[str, set[str]] = {}
+        # The last turn's wall clock per model, so an IDLE gap is not charged
+        # to the host: a cache entry expires on a timer (~10 min documented),
+        # and a miss after a long pause is an expiry, not evidence of a host
+        # that does not cache.
+        self._provider_last_turn_at: dict[str, float] = {}
+        # model_id -> whether the "at the retirement cap" line has been logged
+        # already, so it is said once rather than on every later strike.
+        self._provider_retire_capped: dict[str, bool] = {}
         self._message_boundary_pending = True
         # Frozen for one user-message tool loop: choosing a new effort between
         # tool calls would bust the provider cache and make one task reason at
@@ -2713,6 +2776,130 @@ class SessionStreamFn:
             openrouter_provider_preferences=_openrouter_provider_preferences(self._settings),
         )
 
+    def _affinity_enabled(self, request: ChatRequest) -> bool:
+        """Whether this request may read or write the cache affinity pin.
+
+        Pinning a conversation to the host that served its last turn is what
+        keeps an OpenRouter prompt cache warm — the default route is
+        price-weighted load balancing across many upstream hosts and every
+        switch bills the whole prefix uncached. It is also, by construction, a
+        REFUSAL to let OpenRouter re-shop the call, so each condition below is
+        a place where that trade is not ours to make.
+        """
+        model = request.model
+        # OpenRouter only. Radient aggregates too, but its routing was never
+        # measured here and shipping an unmeasured pin on it would be guessing
+        # on someone else's latency and availability.
+        if model.provider != "openrouter":
+            return False
+        # No server-side prompt cache means nothing to keep warm, so the pin
+        # would buy a narrowed host pool and nothing at all.
+        if not model.supports_prompt_cache:
+            return False
+        # A ``:nitro``/``:floor`` variant asks OpenRouter to sort by throughput
+        # or price BY DEFINITION. Honouring a sticky pin on top of that would
+        # quietly defeat the suffix the user typed. Cheap insurance — the gate
+        # below also refuses when `sort` is configured — but the suffix is a
+        # per-model opinion that never appears in the settings mapping.
+        if ":" in model.model_id:
+            return False
+        # A naming errand or other isolated one-shot has no warm prefix of its
+        # own, so it gains nothing; more importantly, letting one MOVE the pin
+        # would drag the real conversation onto whatever host answered an
+        # unrelated question.
+        if request.isolated:
+            return False
+        providers = self._settings.get("providers") if isinstance(self._settings, Mapping) else None
+        openrouter = providers.get("openrouter") if isinstance(providers, Mapping) else None
+        if isinstance(openrouter, Mapping) and openrouter.get("provider_affinity") is False:
+            return False
+        # The user's own routing opinion wins outright. Any of these four keys
+        # expresses a host preference, and `order` disables sticky routing on
+        # OpenRouter's side anyway — so a pin would either fight the setting or
+        # be silently overridden by it. `_build_body` repeats this check as
+        # defence in depth; this one keeps the pin from being WRITTEN at all.
+        prefs = _openrouter_provider_preferences(self._settings) or {}
+        if prefs.keys() & {"order", "only", "ignore", "sort"}:
+            return False
+        return True
+
+    def _score_cache_affinity(
+        self,
+        request: ChatRequest,
+        served: str,
+        usage: "Usage | None",
+        *,
+        now: float,
+    ) -> None:
+        """Judge whether the host we PINNED is actually caching, and retire it.
+
+        The pin assumes a held host keeps the prefix warm. Measured against
+        real endpoints that assumption does not hold uniformly: same-host cache
+        share ran 99% on some upstreams and 38% on another, whose misses billed
+        at full input price. Holding a conversation on a host like that is
+        strictly worse than the load balancing the pin replaced, so affinity
+        needs a way to notice and leave.
+
+        Only a turn we ASKED FOR and RECEIVED can strike. A fallback to some
+        other host is expected-cold (it was never given this prefix) and says
+        nothing about the host we wanted, so charging it a strike would retire
+        innocent hosts during exactly the load that caused the fallback.
+        """
+        model_id = request.model.model_id
+        previous_at = self._provider_last_turn_at.get(model_id)
+        self._provider_last_turn_at[model_id] = now
+        # Only the host we asked for is on trial (see docstring).
+        if request.provider_affinity != served:
+            return
+        if previous_at is None or (now - previous_at) >= self.PROVIDER_STRIKE_MAX_GAP_S:
+            # An idle gap: the entry may simply have expired on the clock.
+            return
+        prompt_tokens = usage.input_tokens if usage else 0
+        if prompt_tokens < self.PROVIDER_STRIKE_MIN_PROMPT_TOKENS:
+            return
+        cached = usage.cache_read_tokens if usage else 0
+        floor = max(
+            self.PROVIDER_STRIKE_MIN_CACHED_TOKENS,
+            int(prompt_tokens * self.PROVIDER_STRIKE_MIN_CACHED_FRACTION),
+        )
+        strikes = self._provider_strikes.setdefault(model_id, {})
+        if cached >= floor:
+            # Any real reuse clears the record: the host is caching, and past
+            # misses under load must not accumulate toward a later retirement.
+            strikes.pop(served, None)
+            return
+        count = strikes.get(served, 0) + 1
+        strikes[served] = count
+        if count < self.PROVIDER_STRIKES_TO_RETIRE:
+            return
+        retired = self._provider_retired.setdefault(model_id, set())
+        if served in retired:
+            return
+        if len(retired) >= self.MAX_RETIRED_PROVIDERS:
+            # Logged once per model, not per turn: at the cap this branch is
+            # reached on every subsequent strike and would otherwise repeat.
+            if not self._provider_retire_capped.get(model_id):
+                self._provider_retire_capped[model_id] = True
+                logger.debug(
+                    "cache affinity: not retiring %s for %s — already at the "
+                    "%d-host cap; `ignore` is a hard filter and an unbounded "
+                    "set risks leaving no eligible endpoint",
+                    served,
+                    model_id,
+                    self.MAX_RETIRED_PROVIDERS,
+                )
+            return
+        retired.add(served)
+        strikes.pop(served, None)
+        if self._provider_affinity.get(model_id) == served:
+            del self._provider_affinity[model_id]
+        logger.debug(
+            "cache affinity: retiring %s for %s — %d warm turns with no prefix reuse",
+            served,
+            model_id,
+            count,
+        )
+
     def fork(self, session_id: str, *, cache_lineage_id: str | None = None) -> "SessionStreamFn":
         """Create a conversation owner sharing only auth and HTTP transport.
 
@@ -2731,6 +2918,24 @@ class SessionStreamFn:
         )
         self._transport.owners += 1
         child._parent_session_id = self._session_id
+        if cache_lineage_id:
+            # A TRUE transcript fork replays a byte-identical prefix, so the
+            # parent's host is genuinely warm for it — the same reasoning that
+            # makes the fork inherit ``cache_lineage_id`` in the first place. A
+            # fresh delegated prompt (no lineage) shares no prefix and must not
+            # inherit a pin that would only narrow its host pool.
+            #
+            # A COPY, never the parent's dict: the child re-pins on its own
+            # ends, and letting that move the parent's pin would hand the
+            # parent a host chosen for a conversation it is not having.
+            child._provider_affinity = dict(self._provider_affinity)
+            # The retirements travel with it, deep-copied for the same reason:
+            # they were learned against THIS prefix, which the fork replays, so
+            # the child would otherwise re-discover each dead host the
+            # expensive way.
+            child._provider_retired = {
+                model: set(hosts) for model, hosts in self._provider_retired.items()
+            }
         return child
 
     @property
@@ -4696,6 +4901,30 @@ class SessionStreamFn:
             # alone and is unaffected either way.
             request = request.model_copy(update={"prompt_cache_key": self._cache_lineage_id})
 
+        # The cache affinity pin, stamped right after the cache key because the
+        # two are the same idea at two levels: the key asks the AGGREGATOR to
+        # route stickily, and this names the host it actually chose last time.
+        # Measured on `deepseek-v4.1-flash`, the key alone does not hold under
+        # load (7-9 host switches over 18 turns, ~57-64% cached share); naming
+        # the host cut that to 4 switches and ~77%.
+        #
+        # Applied per MODEL, so a mid-turn fallback to another model carries no
+        # pin from the model it left. The gate refuses isolated requests in
+        # BOTH directions — see ``_affinity_enabled``.
+        pin = self._provider_affinity.get(request.model.model_id)
+        retired = self._provider_retired.get(request.model.model_id)
+        if (pin or retired) and self._affinity_enabled(request):
+            update: dict[str, Any] = {}
+            if pin:
+                update["provider_affinity"] = pin
+            # The retired set outlives the pin it replaced: after a host is
+            # retired the conversation has no pin until another host serves
+            # it, and it must not be routed straight back onto the host it
+            # just left.
+            if retired:
+                update["provider_avoid"] = sorted(retired)
+            request = request.model_copy(update=update)
+
         # Helpers may run before the user's first generation. They inherit the
         # established hard-fallback route but must not spend the user-message
         # boundary (which owns quota recovery and auto-effort classification).
@@ -4770,6 +4999,39 @@ class SessionStreamFn:
                     outcome = str(stop_reason)
                 if stop_reason in ("error", "aborted") or getattr(event, "error", None):
                     ok = False
+                served = getattr(event, "served_provider", None)
+                if served and stop_reason is not None and stop_reason not in ("error", "aborted"):
+                    # Re-pin IMMEDIATELY when the served host differs from the
+                    # current pin, with no hysteresis: that host is the one
+                    # that now holds this conversation's prefix, while the old
+                    # host's entry is already decaying (OpenRouter documents a
+                    # ~10-minute sticky expiry, and DeepSeek needs a full
+                    # prefix match from token 0). Keeping the older pin would
+                    # aim at the colder cache.
+                    #
+                    # Only on a SUCCESSFUL end: a host that errored or was
+                    # aborted mid-stream did not necessarily ingest the prefix.
+                    # Wrapped because a routing optimisation must never be able
+                    # to break a turn — the same contract as the analytics
+                    # recording this loop already does.
+                    try:
+                        if not request.isolated and self._affinity_enabled(request):
+                            # Score BEFORE re-pinning: the judgement is about
+                            # the host this request ASKED for, and the pin is
+                            # about to be overwritten with the host that
+                            # answered.
+                            self._score_cache_affinity(
+                                request,
+                                str(served),
+                                getattr(event, "usage", None) or final_usage,
+                                now=time.monotonic(),
+                            )
+                            if str(served) not in self._provider_retired.get(
+                                request.model.model_id, ()
+                            ):
+                                self._provider_affinity[request.model.model_id] = str(served)
+                    except Exception:  # noqa: BLE001 — routing hints never break a turn
+                        pass
                 yield event
         except BaseException as exc:
             ok = False

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -2576,6 +2576,22 @@ class SessionStreamFn:
     #: Reuse below max(this, 2% of the previous prompt) counts as no reuse.
     PROVIDER_STRIKE_MIN_CACHED_TOKENS = 1024
     PROVIDER_STRIKE_MIN_CACHED_FRACTION = 0.02
+    #: Two strikes only pair into a retirement if they are this close in time.
+    #:
+    #: Separate from ``PROVIDER_STRIKE_MAX_GAP_S`` above, which bounds the gap
+    #: between a turn and ITS PREDECESSOR (was the prefix still plausibly warm
+    #: when we sent it?). This one bounds the gap between the two STRIKES, and
+    #: without it strike bookkeeping had no clock at all: a cold turn at 09:00
+    #: and another at 17:00 paired into a retirement as if they were
+    #: consecutive evidence about the same warm prefix (review round 1,
+    #: blocker-2). They are not — eight hours apart they are two independent
+    #: first misses, each of which the "one miss is ordinary" reasoning behind
+    #: ``PROVIDER_STRIKES_TO_RETIRE`` already forgives.
+    #:
+    #: Sized at twice the per-turn gap so a genuinely consecutive pair (two
+    #: turns each inside the warm window) always counts, while anything that
+    #: needed an idle stretch in between does not.
+    PROVIDER_STRIKE_PAIR_MAX_GAP_S = 600.0
     #: Hard ceiling on retirements per (conversation, model). ``ignore`` is a
     #: HARD filter on OpenRouter's side, so an unbounded set walks a
     #: conversation toward "no eligible endpoints" — a routing optimisation
@@ -2681,6 +2697,13 @@ class SessionStreamFn:
         # hold a conversation on a cache-dead host, which is worse than the
         # churn it replaces.
         self._provider_strikes: dict[str, dict[str, int]] = {}
+        # model_id -> {host: monotonic time of its most recent strike}. Strikes
+        # only pair into a retirement when they are close together (see
+        # ``PROVIDER_STRIKE_PAIR_MAX_GAP_S``): without a clock on the counter,
+        # a cold turn in the morning and another in the afternoon added up to
+        # a retirement as though they were consecutive evidence about one warm
+        # prefix (review round 1, blocker-2).
+        self._provider_strike_at: dict[str, dict[str, float]] = {}
         # model_id -> hosts retired for THIS conversation, sent as
         # `provider.ignore`. Per conversation and per model because cache
         # deadness is observed per prefix, not globally — another session's
@@ -2823,6 +2846,80 @@ class SessionStreamFn:
             return False
         return True
 
+    def _clear_cache_affinity_evidence(self, reason: str) -> None:
+        """Void every strike and retirement this conversation has recorded.
+
+        Called when a compaction REPLACES the conversation's prefix (review
+        round 1, blocker-2). Every strike and retirement is a claim about one
+        specific prefix — "this host was given these exact tokens and returned
+        no reuse". A compaction rewrites the transcript into a summary, so the
+        prefix those claims were made about no longer exists and the evidence
+        is void: a host barred on the old prefix has never been asked about the
+        new one, and `provider.ignore` has no removal path of its own, so
+        without this a good host stays barred for the rest of the conversation
+        (and for every fork of it) on evidence that expired.
+
+        Cleared for EVERY model, not just the compacting request's: the prefix
+        is the conversation's, and a sibling model's retirements were learned
+        against that same replaced transcript. Over-clearing costs at most two
+        turns of re-discovery; under-clearing permanently bars a host that
+        caches, which is the failure this fixes.
+
+        The pins themselves are deliberately LEFT standing. A pin is a
+        statement about which host is holding this conversation, and the
+        compaction summary is sent to that same host — keeping the conversation
+        there across the boundary is the whole point of the feature.
+        """
+        if not (self._provider_strikes or self._provider_retired):
+            return
+        logger.debug(
+            "cache affinity: clearing %d strike record(s) and %d retirement set(s) — %s",
+            len(self._provider_strikes),
+            len(self._provider_retired),
+            reason,
+        )
+        self._provider_strikes.clear()
+        self._provider_strike_at.clear()
+        self._provider_retired.clear()
+        self._provider_retire_capped.clear()
+
+    def _apply_cache_affinity(self, request: ChatRequest) -> ChatRequest:
+        """Stamp this conversation's host pin and retirements onto a request.
+
+        The pin sits beside ``prompt_cache_key`` because the two are the same
+        idea at two levels: the key asks the AGGREGATOR to route stickily, and
+        this names the host it actually chose last time. Measured on
+        ``deepseek-v4.1-flash``, the key alone does not hold under load (7-9
+        host switches over 18 turns, ~57-64% cached share); naming the host cut
+        that to 4 switches and ~77%.
+
+        Applied per MODEL, so a mid-turn fallback to another model carries no
+        pin from the model it left. The gate refuses isolated requests in BOTH
+        directions — see ``_affinity_enabled``.
+        """
+        if request.purpose == "compaction":
+            # A compaction REPLACES this conversation's prefix, which voids
+            # every strike and retirement recorded against the old one (review
+            # round 1, blocker-2). Done on the REQUEST rather than after the
+            # summary lands because this is the harness's only sighting of the
+            # boundary; a compaction that then fails costs at most the two
+            # turns of re-discovery, while a missed one bars a good host
+            # permanently — `provider.ignore` has no removal path of its own.
+            self._clear_cache_affinity_evidence("compaction replaces the cached prefix")
+        pin = self._provider_affinity.get(request.model.model_id)
+        retired = self._provider_retired.get(request.model.model_id)
+        if not (pin or retired) or not self._affinity_enabled(request):
+            return request
+        update: dict[str, Any] = {}
+        if pin:
+            update["provider_affinity"] = pin
+        # The retired set outlives the pin it replaced: after a host is retired
+        # the conversation has no pin until another host serves it, and it must
+        # not be routed straight back onto the host it just left.
+        if retired:
+            update["provider_avoid"] = sorted(retired)
+        return request.model_copy(update=update)
+
     def _score_cache_affinity(
         self,
         request: ChatRequest,
@@ -2830,6 +2927,7 @@ class SessionStreamFn:
         usage: "Usage | None",
         *,
         now: float,
+        model_id: str | None = None,
     ) -> None:
         """Judge whether the host we PINNED is actually caching, and retire it.
 
@@ -2844,8 +2942,24 @@ class SessionStreamFn:
         other host is expected-cold (it was never given this prefix) and says
         nothing about the host we wanted, so charging it a strike would retire
         innocent hosts during exactly the load that caused the fallback.
+
+        ``model_id`` names the model that ACTUALLY served, which on a mid-turn
+        failover is not ``request.model`` (review round 1, major-1); the caller
+        reads it off the stamped ``Usage``. Defaulted for the direct-call path
+        and for tests that score one request in isolation.
         """
-        model_id = request.model.model_id
+        # ONLY a real conversation turn carries evidence about the turn's warm
+        # prefix (review round 1, blocker-2). A `compaction` request is a
+        # fresh write-once prefix by construction — its own `context_tokens_
+        # hint=0` says so — and a `compaction_advisor` call is a cold-ish
+        # aside; both MISS by design. Scoring them charged the conversation's
+        # host for being cold on prompts it was never given the prefix for,
+        # and two adjacent cold-by-design calls retired a host measured at
+        # 99.6% cache share. A miss here has to mean "this host does not
+        # cache", and outside a turn it does not.
+        if request.purpose != "turn":
+            return
+        model_id = model_id or request.model.model_id
         previous_at = self._provider_last_turn_at.get(model_id)
         self._provider_last_turn_at[model_id] = now
         # Only the host we asked for is on trial (see docstring).
@@ -2863,13 +2977,27 @@ class SessionStreamFn:
             int(prompt_tokens * self.PROVIDER_STRIKE_MIN_CACHED_FRACTION),
         )
         strikes = self._provider_strikes.setdefault(model_id, {})
+        strike_at = self._provider_strike_at.setdefault(model_id, {})
         if cached >= floor:
             # Any real reuse clears the record: the host is caching, and past
             # misses under load must not accumulate toward a later retirement.
             strikes.pop(served, None)
+            strike_at.pop(served, None)
             return
         count = strikes.get(served, 0) + 1
+        previous_strike_at = strike_at.get(served)
+        if (
+            previous_strike_at is not None
+            and (now - previous_strike_at) > self.PROVIDER_STRIKE_PAIR_MAX_GAP_S
+        ):
+            # The earlier strike is too old to pair with this one, so this is a
+            # FIRST strike rather than the second (review round 1, blocker-2).
+            # "Two consecutive misses" is only evidence when the two are about
+            # the same stretch of conversation; hours apart they are two
+            # independent single misses, and a single miss is ordinary.
+            count = 1
         strikes[served] = count
+        strike_at[served] = now
         if count < self.PROVIDER_STRIKES_TO_RETIRE:
             return
         retired = self._provider_retired.setdefault(model_id, set())
@@ -2891,6 +3019,7 @@ class SessionStreamFn:
             return
         retired.add(served)
         strikes.pop(served, None)
+        strike_at.pop(served, None)
         if self._provider_affinity.get(model_id) == served:
             del self._provider_affinity[model_id]
         logger.debug(
@@ -4901,29 +5030,7 @@ class SessionStreamFn:
             # alone and is unaffected either way.
             request = request.model_copy(update={"prompt_cache_key": self._cache_lineage_id})
 
-        # The cache affinity pin, stamped right after the cache key because the
-        # two are the same idea at two levels: the key asks the AGGREGATOR to
-        # route stickily, and this names the host it actually chose last time.
-        # Measured on `deepseek-v4.1-flash`, the key alone does not hold under
-        # load (7-9 host switches over 18 turns, ~57-64% cached share); naming
-        # the host cut that to 4 switches and ~77%.
-        #
-        # Applied per MODEL, so a mid-turn fallback to another model carries no
-        # pin from the model it left. The gate refuses isolated requests in
-        # BOTH directions — see ``_affinity_enabled``.
-        pin = self._provider_affinity.get(request.model.model_id)
-        retired = self._provider_retired.get(request.model.model_id)
-        if (pin or retired) and self._affinity_enabled(request):
-            update: dict[str, Any] = {}
-            if pin:
-                update["provider_affinity"] = pin
-            # The retired set outlives the pin it replaced: after a host is
-            # retired the conversation has no pin until another host serves
-            # it, and it must not be routed straight back onto the host it
-            # just left.
-            if retired:
-                update["provider_avoid"] = sorted(retired)
-            request = request.model_copy(update=update)
+        request = self._apply_cache_affinity(request)
 
         # Helpers may run before the user's first generation. They inherit the
         # established hard-fallback route but must not spend the user-message
@@ -5016,6 +5123,23 @@ class SessionStreamFn:
                     # recording this loop already does.
                     try:
                         if not request.isolated and self._affinity_enabled(request):
+                            event_usage = getattr(event, "usage", None) or final_usage
+                            # Key on the model that ACTUALLY served, not the
+                            # one the request named (review round 1, major-1).
+                            # ``stream_with_failover`` rewrites the request to
+                            # a fallback and stamps the serving spec onto
+                            # ``Usage.model_id`` for exactly this bug class
+                            # (see ``failover._stamped``): reading
+                            # ``request.model`` here filed the pin under the
+                            # PRIMARY while the host it names belongs to the
+                            # fallback, so the primary was later asked for a
+                            # host that never served it and the fallback's own
+                            # cache evidence was lost. ``None`` means "not
+                            # stamped" \u2014 a primary success or a direct call \u2014
+                            # and then the request is the honest answer.
+                            served_model_id = (
+                                getattr(event_usage, "model_id", None) or request.model.model_id
+                            )
                             # Score BEFORE re-pinning: the judgement is about
                             # the host this request ASKED for, and the pin is
                             # about to be overwritten with the host that
@@ -5023,13 +5147,12 @@ class SessionStreamFn:
                             self._score_cache_affinity(
                                 request,
                                 str(served),
-                                getattr(event, "usage", None) or final_usage,
+                                event_usage,
                                 now=time.monotonic(),
+                                model_id=served_model_id,
                             )
-                            if str(served) not in self._provider_retired.get(
-                                request.model.model_id, ()
-                            ):
-                                self._provider_affinity[request.model.model_id] = str(served)
+                            if str(served) not in self._provider_retired.get(served_model_id, ()):
+                                self._provider_affinity[served_model_id] = str(served)
                     except Exception:  # noqa: BLE001 — routing hints never break a turn
                         pass
                 yield event

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -26,6 +26,7 @@ import logging
 import math
 import re
 import time
+import unicodedata
 import uuid
 from collections.abc import AsyncIterator, Mapping, Sequence
 from datetime import timezone
@@ -184,6 +185,49 @@ def _stream_id(value: Any) -> str | None:
         return None
     trimmed = value.strip()
     return trimmed or None
+
+
+#: Longest provider display name we will carry back as a cache pin.
+#:
+#: OpenRouter's own names are short ("Google AI Studio" is 16 characters, the
+#: longest in the 106-provider list sits well under 30), so 64 is roughly 2x
+#: headroom for a rename rather than a tight fit. The bound exists because the
+#: value is provider-controlled text that this harness stores per conversation
+#: and then sends BACK as `provider.order` on every subsequent request: an
+#: unbounded string rides in front of a cached prefix forever, for a field
+#: whose only legitimate content is a short label.
+_MAX_SERVED_PROVIDER_CHARS = 64
+
+
+def _served_provider_name(value: Any) -> str | None:
+    """Validate the host name an aggregator reports, or refuse it.
+
+    Review round 1, major-2. The previous form accepted any non-empty string,
+    which meant a hostile or broken upstream could put arbitrary text into
+    ``StreamEndEvent.served_provider`` and, through the session's pin, into
+    every later request body.
+
+    NOT normalised, deliberately — the display name is what an ``order`` entry
+    accepts and slug-normalising it is wrong for 13 of 106 providers (``Z.AI``
+    is ``z-ai``). So this is a gate, never a transform: a name either comes
+    back byte-for-byte or is refused outright and the conversation simply does
+    not pin this turn (degrading to today's default routing, which is the same
+    failure mode as an unrecognised pin).
+
+    Control characters are refused rather than stripped for the same reason:
+    stripping would invent a name the host never reported and pin to it. The
+    repo already refuses to trust provider-supplied text elsewhere (see
+    ``_attributed_relay_message`` and its hostile-``provider_name`` tests).
+    """
+    if not isinstance(value, str):
+        return None
+    trimmed = value.strip()
+    if not trimmed or len(trimmed) > _MAX_SERVED_PROVIDER_CHARS:
+        return None
+    # ``Cc`` covers NUL, ESC, both newline forms and the C1 8-bit range.
+    if any(unicodedata.category(char) == "Cc" for char in trimmed):
+        return None
+    return trimmed
 
 
 def _compat_cache_usage(raw_usage: Mapping[str, Any]) -> tuple[int, int]:
@@ -2204,6 +2248,18 @@ class OpenAICompatClient:
         )
         if (
             (request.provider_affinity or request.provider_avoid)
+            # OPENROUTER ONLY, and this gate is load-bearing rather than
+            # cosmetic (review round 1, blocker-1). The pin rides on the
+            # ChatRequest so a retry keeps it, but that is also what the
+            # failover driver CLONES for a fallback to another model
+            # (`model_copy(update={"model": spec})`), and the clone keeps the
+            # affinity fields while swapping in a direct-DeepSeek/Z.AI spec.
+            # Without this check an OpenRouter host name is stamped onto a
+            # direct provider's body as `provider.order`, which is a field
+            # that provider never defined. Matching `_affinity_enabled`
+            # exactly — deliberately NOT radient, whose routing was never
+            # measured here — so the two gates cannot drift into disagreeing.
+            and request.model.provider == "openrouter"
             and request.model.supports_prompt_cache
             # USER CONFIGURATION WINS, and this is defence in depth: the
             # session-level gate already refuses to pin when any of these keys
@@ -2565,8 +2621,13 @@ class OpenAICompatClient:
                 # read once: the field is repeated on every chunk, and the LAST
                 # one is the host that finished the turn. Non-aggregator wires
                 # simply never send it, so this stays None and nothing pins.
-                if isinstance(chunk.get("provider"), str) and chunk["provider"]:
-                    served_provider = chunk["provider"]
+                # Bounded and control-character-free or not taken at all — see
+                # ``_served_provider_name``. A refused name leaves the previous
+                # chunk's value standing rather than clearing it: the turn was
+                # still served by whoever the earlier chunks named.
+                candidate = _served_provider_name(chunk.get("provider"))
+                if candidate:
+                    served_provider = candidate
 
         stop_reason = _FINISH_TO_STOP_REASON.get(finish_reason or "", finish_reason or "stop")
         # A refusal delta with a non-filter finish (OpenAI sends

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -2180,19 +2180,52 @@ class OpenAICompatClient:
             # intentionally inherit the parent's key (`cache_lineage_id`) so a
             # fork replays into the parent's warm prefix.
             body["prompt_cache_key"] = request.prompt_cache_key
-        if self._openrouter_provider_preferences:
-            # ASSIGNS one top-level key onto the existing body dict — not a
-            # merge into an existing `body["provider"]` (there is none). The
-            # `prompt_cache_key` stamp above writes a SIBLING key on this same
-            # dict, and the two must coexist rather than clobber: the cache
-            # key asks for sticky routing while a `provider` object expresses
-            # routing preferences that may override it, so a body can carry
-            # both and OpenRouter reconciles them. The dict() copy keeps a
-            # caller mutating its preferences mapping after construction from
-            # leaking into later request bodies. None (the constructor
-            # default) means this branch is skipped entirely — OpenRouter
-            # sticky routing stays on.
-            body["provider"] = dict(self._openrouter_provider_preferences)
+        # Builds ONE top-level `provider` key from two independent sources —
+        # the user's configured routing preferences and the session's cache
+        # affinity pin. The `prompt_cache_key` stamp above writes a SIBLING key
+        # on this same dict, and the two must coexist rather than clobber: the
+        # cache key asks for sticky routing while a `provider` object expresses
+        # routing preferences that may override it, so a body can carry both
+        # and OpenRouter reconciles them. An empty dict is never assigned —
+        # no preference and no pin means NO `provider` key at all, which is
+        # OpenRouter's own sticky routing left untouched.
+        #
+        # DEEPCOPY, not `dict(...)`: the preferences object nests (`max_price`
+        # is a mapping), and a shallow copy shared that nested dict, so a
+        # caller mutating its own `max_price` after construction reached later
+        # request bodies. Same bug class the constructor fixed at
+        # `_openrouter_provider_preferences` (review round 1, m1); the copy
+        # also keeps the `order` list we may append below from being a live
+        # alias of the caller's configuration.
+        provider_obj: dict[str, Any] = (
+            copy.deepcopy(dict(self._openrouter_provider_preferences))
+            if self._openrouter_provider_preferences
+            else {}
+        )
+        if (
+            (request.provider_affinity or request.provider_avoid)
+            and request.model.supports_prompt_cache
+            # USER CONFIGURATION WINS, and this is defence in depth: the
+            # session-level gate already refuses to pin when any of these keys
+            # is configured. An explicit `order`/`only`/`ignore`/`sort` is a
+            # routing opinion the user typed, and silently prepending a host to
+            # it — or fighting a `sort` — would make their setting mean
+            # something other than what the settings page says it means.
+            and not provider_obj.keys() & {"order", "only", "ignore", "sort"}
+        ):
+            # The served DISPLAY NAME verbatim (see `StreamEndEvent.served_
+            # provider`). OpenRouter accepts it as an `order` entry and
+            # silently ignores an entry it does not recognize, so a stale or
+            # renamed host degrades to default routing rather than erroring.
+            if request.provider_affinity:
+                provider_obj["order"] = [request.provider_affinity]
+            # Verified live that the two compose: with `order` naming one host
+            # and `ignore` another, the ordered host serves every call and the
+            # ignored one is never attempted. Sorted for a byte-stable body.
+            if request.provider_avoid:
+                provider_obj["ignore"] = sorted(request.provider_avoid)
+        if provider_obj:
+            body["provider"] = provider_obj
         return body
 
     @staticmethod
@@ -2411,6 +2444,13 @@ class OpenAICompatClient:
         #: than none at all.
         started = False
         response_id: str | None = None
+        #: The upstream host an aggregator routed to, read off the chunk's
+        #: ``provider`` field (OpenRouter sends it on chunk 1 and every chunk
+        #: after). Reported on the END event so a session can pin the next turn
+        #: to the same host and keep its prompt cache warm; see
+        #: ``StreamEndEvent.served_provider`` for why the display name is kept
+        #: verbatim and why this is not part of ``provider_payload``.
+        served_provider: str | None = None
 
         headers = self._headers(api_key, oauth_access)
         headers.update(self._grok_conv_headers(request, url))
@@ -2521,6 +2561,12 @@ class OpenAICompatClient:
                     }
                     if not response_id:
                         response_id = _stream_id(chunk.get("id"))
+                # Overwritten by every chunk that carries it rather than being
+                # read once: the field is repeated on every chunk, and the LAST
+                # one is the host that finished the turn. Non-aggregator wires
+                # simply never send it, so this stays None and nothing pins.
+                if isinstance(chunk.get("provider"), str) and chunk["provider"]:
+                    served_provider = chunk["provider"]
 
         stop_reason = _FINISH_TO_STOP_REASON.get(finish_reason or "", finish_reason or "stop")
         # A refusal delta with a non-filter finish (OpenAI sends
@@ -2580,6 +2626,7 @@ class OpenAICompatClient:
             usage=usage,
             provider_payload=provider_payload,
             error=error,
+            served_provider=served_provider,
         )
 
     async def _stream_responses(

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -740,6 +740,28 @@ SETTINGS: tuple[Setting, ...] = (
     # then price/perf. Labels carry no "OpenRouter " prefix — the section
     # header already says it, and the prefix pushed the distinguishing words
     # past the 29-cell label budget (design round 1, D5).
+    # Leads the section despite the reading order below, because it is the one
+    # row that is ON by default and every row after it OVERRIDES it: a user who
+    # sets `sort`, `order`, `only` or `ignore` has expressed a host preference,
+    # and the harness then stops pinning entirely (`SessionStreamFn._affinity_
+    # enabled`). Reading it first is what makes that relationship visible.
+    #
+    # Also the one row here that is NOT a wire key. The four `provider` object
+    # keys below are resolved by `_openrouter_provider_preferences` and sent to
+    # OpenRouter; this one is a HARNESS switch, deliberately not read by that
+    # resolver — see the note on the parity test in tests/unit/test_settings_io.
+    Setting(
+        key="providers.openrouter.provider_affinity",
+        path=("providers", "openrouter", "provider_affinity"),
+        section="openrouter",
+        label="cache affinity",
+        kind=Kind.BOOL,
+        default=True,
+        help=(
+            "Reuses the host that served the previous turn so the prompt cache "
+            "stays warm. Off = OpenRouter's price-weighted load balancing."
+        ),
+    ),
     Setting(
         key="providers.openrouter.sort",
         path=("providers", "openrouter", "sort"),

--- a/scripts/bench_openrouter_cache_rate.py
+++ b/scripts/bench_openrouter_cache_rate.py
@@ -1,0 +1,731 @@
+#!/usr/bin/env python3
+"""Measure OpenRouter prompt-cache hit rate with and without cache affinity.
+
+OpenRouter's default route is price-weighted load balancing across many
+upstream hosts (~11 endpoints for ``deepseek/deepseek-v4.1-flash``), and each
+switch is a COLD prompt cache: DeepSeek needs a full prefix match from token 0,
+so a re-routed turn re-bills the whole conversation. Server-side sticky routing
+fed by ``prompt_cache_key`` does not hold under load. This benchmark runs the
+SAME integration path twice over a long multi-turn loop -- once with
+``providers.openrouter.provider_affinity`` off (baseline: today's shipped
+behaviour) and once with it on (the pin) -- so the only difference between arms
+is whether the harness names the host that served the previous turn.
+
+WHY THE REAL PATH, not a transport A/B: the pin is produced by
+``SessionStreamFn`` (capture on ``StreamEndEvent.served_provider``, gate in
+``_affinity_enabled``, stamp onto ``ChatRequest.provider_affinity``) and only
+then rendered by the wire client. Stripping a field in a transport wrapper
+would measure the wire half while leaving the half that decides WHEN to pin
+untested -- and that half is where the feature can silently no-op. So each arm
+constructs a real ``SessionStreamFn`` over the real ``AuthStore`` with a real
+settings mapping, and the transport is a passive OBSERVER that fails the run if
+the arms are not actually different on the wire.
+
+ISOLATION (mandatory, and checked rather than assumed):
+  * ``LOCAL_OPERATOR_CONFIG_DIR`` and ``HOME`` are redirected to a temp dir for
+    the whole run, so nothing touches the operator's live sessions, analytics
+    ledger, or model catalogue cache. A redirected config dir alone is NOT
+    enough -- the catalogue cache derives its root from the home directory
+    independently (see AGENTS.md, "Isolating a run").
+  * ``auth.db`` is COPIED into that temp dir from a read-only URI handle; the
+    live store is never opened for writing and the key is never printed.
+  * The run refuses to start if the copy carries no openrouter row, rather than
+    silently measuring nothing.
+  * A synthetic session id and a per-arm unique prefix namespace AND cache
+    lineage, so arms can neither share nor poison each other's cache groups.
+
+COST: each turn sends the whole grown context (~60k tokens) and asks for a
+short answer. At deepseek-v4.1-flash list pricing the default run (2 arms x 30
+turns) estimates well under $1; the hard ceiling is ``--budget`` (default
+$5.00), checked after every turn against the provider's OWN reported cost, and
+the run aborts the moment the estimate would cross it.
+
+Examples:
+    .venv/bin/python scripts/bench_openrouter_cache_rate.py --dry-run
+    .venv/bin/python scripts/bench_openrouter_cache_rate.py --live
+    .venv/bin/python scripts/bench_openrouter_cache_rate.py --live --arm on
+    .venv/bin/python scripts/bench_openrouter_cache_rate.py --live \
+        --runs 3 --output evidence.jsonl   # alternates arm order per run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+MODEL_ID = "deepseek/deepseek-v4.1-flash"
+TERSE = " Reply in 10 words or fewer. No code, no lists."
+TURN_PROMPTS = [
+    "Name one item from the log above.",
+    "How many revisions are mentioned?",
+    "Name the approved status word.",
+    "Which record number did you cite last?",
+    "Name any record in the log.",
+    "State the namespace word only.",
+]
+
+
+@dataclass
+class TurnRecord:
+    """One call's provider counters. ``cached`` is a SUBSET of ``prompt``."""
+
+    turn: int
+    arm: str
+    run: int
+    prompt_tokens: int = 0
+    cached_tokens: int = 0
+    output_tokens: int = 0
+    provider: str | None = None
+    generation_id: str | None = None
+    stop_reason: str | None = None
+    usd_cost: float = 0.0
+    pin_on_wire: str | None = None
+    #: Hosts this conversation had retired as of this turn (cache-quality
+    #: guard), and the `provider.ignore` list actually sent.
+    avoid_on_wire: list[str] = field(default_factory=list)
+    retired: list[str] = field(default_factory=list)
+    #: Which concurrent conversation within the arm produced this turn.
+    lane: int = 0
+    #: Wall seconds since this lane's previous turn STARTED. Recorded because
+    #: a host-side cache entry expires on a timer (~10 min documented), so a
+    #: bench whose natural spacing is far wider than a real session's cannot
+    #: tell an eviction apart from a re-route.
+    gap_s: float = 0.0
+
+    @property
+    def cache_share(self) -> float:
+        return self.cached_tokens / self.prompt_tokens if self.prompt_tokens else 0.0
+
+
+@dataclass
+class ArmResult:
+    name: str
+    run: int
+    lane: int = 0
+    turns: list[TurnRecord] = field(default_factory=list)
+    error: str | None = None
+
+    @property
+    def total_prompt(self) -> int:
+        return sum(t.prompt_tokens for t in self.turns)
+
+    @property
+    def total_cached(self) -> int:
+        return sum(t.cached_tokens for t in self.turns)
+
+    @property
+    def cache_rate(self) -> float:
+        return self.total_cached / self.total_prompt if self.total_prompt else 0.0
+
+    @property
+    def avoidable_loss(self) -> float:
+        """Share of prompt tokens that a warm cache SHOULD have covered.
+
+        The previous turn's prompt is a lower bound on what this turn's prefix
+        repeats (the transcript only ever grows), so anything below that which
+        was not served from cache is loss the pin is meant to remove. Turn 0
+        has no predecessor and contributes nothing.
+        """
+        loss = 0
+        previous: int | None = None
+        for turn in self.turns:
+            if previous is not None:
+                loss += max(0, previous - turn.cached_tokens)
+            previous = turn.prompt_tokens
+        return loss / self.total_prompt if self.total_prompt else 0.0
+
+    @property
+    def switches(self) -> int:
+        """Host changes between consecutive turns; each one is a cold prefix."""
+        names = [t.provider for t in self.turns if t.provider]
+        return sum(1 for a, b in zip(names, names[1:]) if a != b)
+
+    @property
+    def transitions(self) -> int:
+        """Turn-to-turn pairs, the denominator switch frequency is read against.
+
+        Reported alongside ``switches`` because a run with NO switches is a
+        no-pressure sample, not evidence that the pin is unnecessary: the pin
+        can only pay where re-routing happens, so an arm that never re-routed
+        had nothing to lose and must be read that way rather than as a null
+        result for the mechanism.
+        """
+        return max(0, len([t for t in self.turns if t.provider]) - 1)
+
+    def conditional(self) -> dict[str, dict[str, int]]:
+        """Cache outcome split by whether the host CHANGED on that transition.
+
+        This is the measurement that isolates the mechanism. Aggregate cache
+        share confounds two populations — turns that stayed on their host
+        (where a warm cache exists to hit) and turns that moved (where it does
+        not) — so a window that happened not to re-route reports a null
+        difference between arms while the underlying effect is unchanged.
+        """
+        out = {
+            "same": {"n": 0, "hits": 0, "cached": 0, "prompt": 0},
+            "changed": {"n": 0, "hits": 0, "cached": 0, "prompt": 0},
+        }
+        for previous, current in zip(self.turns, self.turns[1:]):
+            if not (previous.provider and current.provider):
+                continue
+            bucket = out["changed" if previous.provider != current.provider else "same"]
+            bucket["n"] += 1
+            bucket["hits"] += int(current.cached_tokens > 0)
+            bucket["cached"] += current.cached_tokens
+            bucket["prompt"] += current.prompt_tokens
+        return out
+
+    @property
+    def pin_honored(self) -> tuple[int, int]:
+        """(served by the pinned host, turns that carried a pin).
+
+        ``order`` is a PREFERENCE, not a constraint — OpenRouter falls through
+        to another host when the pinned one is loaded or erroring — so this is
+        the honest measure of how often the pin actually placed the call.
+        """
+        pinned = [t for t in self.turns if t.pin_on_wire]
+        return sum(1 for t in pinned if t.provider == t.pin_on_wire), len(pinned)
+
+    @property
+    def gaps(self) -> list[float]:
+        """Observed inter-turn spacing, which the cache TTL is read against."""
+        return [t.gap_s for t in self.turns if t.gap_s > 0]
+
+    @property
+    def mix(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for turn in self.turns:
+            if turn.provider:
+                counts[turn.provider] = counts.get(turn.provider, 0) + 1
+        return dict(sorted(counts.items(), key=lambda kv: -kv[1]))
+
+    @property
+    def usd_cost(self) -> float:
+        return sum(t.usd_cost for t in self.turns)
+
+
+class _ObserverTransport(httpx.AsyncBaseTransport):
+    """Passive: records whether a request carried ``provider.order``.
+
+    It never edits a request. The arms differ because the SETTINGS differ, so
+    this exists purely to prove the gate actually fired -- an ON arm that never
+    sends ``provider.order``, or an OFF arm that ever does, means the harness
+    half is broken and the two arms are silently measuring the same thing.
+    """
+
+    def __init__(self) -> None:
+        self.inner = httpx.AsyncHTTPTransport(retries=0)
+        self.pins_sent: list[str | None] = []
+        self.last_pin: str | None = None
+        self.last_avoid: list[str] = []
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        pin = None
+        try:
+            body = json.loads(request.content)
+            provider_obj = body.get("provider") or {}
+            order = provider_obj.get("order")
+            if isinstance(order, list) and order:
+                pin = str(order[0])
+            ignore = provider_obj.get("ignore")
+            self.last_avoid = [str(x) for x in ignore] if isinstance(ignore, list) else []
+        except (ValueError, UnicodeDecodeError, AttributeError):
+            pass
+        self.last_pin = pin
+        self.pins_sent.append(pin)
+        return await self.inner.handle_async_request(request)
+
+    async def aclose(self) -> None:
+        await self.inner.aclose()
+
+
+def _guard_openrouter_credential(auth_db: Path) -> None:
+    """Refuse to run against a copy with no openrouter row.
+
+    Read-only URI handle, and the value is never read into a printable place:
+    this asserts EXISTENCE only. Without the guard a miscopied store produces a
+    run of auth failures that looks like a measurement.
+    """
+    with sqlite3.connect(auth_db.resolve().as_uri() + "?mode=ro", uri=True) as db:
+        count = db.execute(
+            "SELECT COUNT(*) FROM auth_credentials "
+            "WHERE provider='openrouter' AND disabled_cause IS NULL"
+        ).fetchone()[0]
+    if not count:
+        raise SystemExit(
+            "No usable openrouter credential in the benchmark's auth.db copy; "
+            "log in outside this benchmark and re-run."
+        )
+
+
+def _system_blocks(namespace: str, rows: int) -> list[str]:
+    """A stable synthetic prefix per arm; never private context.
+
+    The unique namespace must FILL the first cache block rather than merely
+    name itself: an aggregator matches content prefixes at block granularity,
+    so a short namespace line followed by shared synthetic records lets
+    unrelated invocations hit each other's cache and report a warm start that
+    this run did not earn (measured on the xAI bench, which this mirrors).
+    """
+    padding = " ".join(f"namespace-{namespace}-{i}" for i in range(rows * 4))
+    return [
+        f"Synthetic OpenRouter cache benchmark, namespace {namespace}. {padding}",
+        " ".join(
+            f"Synthetic record {i}: approved status is GREEN, revision {i % 7}, "
+            f"owner team-{i % 11}, region r{i % 5}."
+            for i in range(rows)
+        ),
+    ]
+
+
+def _source_identity() -> dict[str, Any]:
+    from local_operator.model import configure
+    from local_operator.providers import clients
+
+    try:
+        revision = subprocess.check_output(
+            ["git", "-C", str(REPO), "rev-parse", "HEAD"], text=True, stderr=subprocess.DEVNULL
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        revision = None
+    return {
+        "source_revision": revision,
+        "adapter_sha256": hashlib.sha256(Path(clients.__file__).read_bytes()).hexdigest(),
+        "configure_sha256": hashlib.sha256(Path(configure.__file__).read_bytes()).hexdigest(),
+        "benchmark_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+    }
+
+
+def _settings(arm: str) -> dict[str, Any]:
+    """The ONLY difference between arms: the harness-side affinity switch.
+
+    Every other openrouter key stays at its "no opinion" default, so neither
+    arm sends a `provider` routing object of its own and the OFF arm is
+    byte-for-byte today's shipped request path.
+    """
+    return {"providers": {"openrouter": {"provider_affinity": arm == "on"}}}
+
+
+async def _run_lane(
+    args: argparse.Namespace,
+    arm: str,
+    run: int,
+    lane: int,
+    auth_db: Path,
+    output: Any,
+    lock: asyncio.Lock,
+) -> ArmResult:
+    """One conversation: its own session, prefix namespace and cache lineage.
+
+    A lane is the unit the pin operates on, so concurrency is expressed by
+    running several of these at once rather than by interleaving turns of one
+    conversation — the latter would measure a workload nobody runs.
+    """
+    from local_operator.harness.types import (
+        ChatRequest,
+        Message,
+        StreamEndEvent,
+        StreamTextDelta,
+        StreamUsageEvent,
+        TextContent,
+    )
+    from local_operator.model.configure import SessionStreamFn, build_model_spec
+    from local_operator.providers.auth_store import AuthStore
+
+    result = ArmResult(arm, run, lane)
+    namespace = f"{args.seed}:{arm}:{run}:{lane}"
+    blocks = _system_blocks(namespace, args.prefix_rows)
+    spec = build_model_spec("openrouter", args.model)
+    if not spec.supports_prompt_cache:
+        # The gate refuses to pin a model with no server-side cache, so a
+        # registry that does not know this model would make both arms identical
+        # and the run meaningless. Say so instead of reporting a null result.
+        result.error = f"{args.model} does not advertise prompt cache support; nothing to measure"
+        return result
+
+    store = AuthStore(auth_db)
+    transport = _ObserverTransport()
+    # A synthetic session id per arm, run AND lane: the cache lineage derives
+    # from it, so no two conversations share a sticky-routing group.
+    stream = SessionStreamFn(store, _settings(arm), f"bench-{namespace}")
+    await stream._http.aclose()
+    stream._http = httpx.AsyncClient(
+        transport=transport, timeout=httpx.Timeout(600.0, connect=30.0)
+    )
+    stream._transport.http = stream._http
+
+    history: list[Message] = []
+    last_start: float | None = None
+    try:
+        for index in range(args.turns):
+            prompt = TURN_PROMPTS[index % len(TURN_PROMPTS)] + TERSE
+            request = ChatRequest(
+                model=spec,
+                system_blocks=blocks,
+                messages=[*history, Message.user(prompt)],
+            )
+            started = time.monotonic()
+            record = TurnRecord(
+                turn=index,
+                arm=arm,
+                run=run,
+                lane=lane,
+                gap_s=round(started - last_start, 2) if last_start is not None else 0.0,
+            )
+            last_start = started
+            text = ""
+            usage = None
+            terminal: Any = None
+            try:
+                async with asyncio.timeout(300):
+                    async for event in stream(request, None):
+                        if isinstance(event, StreamTextDelta):
+                            text += event.delta
+                        elif isinstance(event, StreamUsageEvent):
+                            usage = event.usage
+                        elif isinstance(event, StreamEndEvent):
+                            terminal = event
+                            usage = event.usage or usage
+                if terminal is None or terminal.stop_reason not in ("stop", "toolUse"):
+                    raise ValueError(f"Incomplete response: {terminal and terminal.stop_reason}")
+                if usage is None:
+                    raise ValueError("Provider completed without usage; cache rate is unknown.")
+                record.prompt_tokens = usage.input_tokens
+                record.cached_tokens = usage.cache_read_tokens
+                record.output_tokens = usage.output_tokens
+                record.usd_cost = usage.usd_cost or 0.0
+                record.provider = terminal.served_provider
+                record.generation_id = (terminal.provider_payload or {}).get("id")
+                record.stop_reason = terminal.stop_reason
+                record.pin_on_wire = transport.last_pin
+                record.avoid_on_wire = transport.last_avoid
+                # Read off the session rather than the wire: a retirement that
+                # happens on THIS turn is only visible on the next request, and
+                # the run has to be able to show that the guard fired at all.
+                record.retired = sorted(stream._provider_retired.get(spec.model_id, ()))
+                history = [
+                    *history,
+                    Message.user(prompt),
+                    Message(role="assistant", content=[TextContent(text=text or "(empty)")]),
+                ]
+                result.turns.append(record)
+                line = json.dumps(
+                    {
+                        "turn": record.turn,
+                        "arm": record.arm,
+                        "run": record.run,
+                        "lane": record.lane,
+                        "prompt_tokens": record.prompt_tokens,
+                        "cached_tokens": record.cached_tokens,
+                        "cache_share": round(record.cache_share, 4),
+                        "output_tokens": record.output_tokens,
+                        "provider": record.provider,
+                        "generation_id": record.generation_id,
+                        "stop_reason": record.stop_reason,
+                        "usd_cost": record.usd_cost,
+                        "pin_on_wire": record.pin_on_wire,
+                        "avoid_on_wire": record.avoid_on_wire,
+                        "retired": record.retired,
+                        "gap_s": record.gap_s,
+                    }
+                )
+                # Serialised: concurrent lanes share one output stream, and
+                # interleaved partial writes would corrupt the JSONL evidence.
+                async with lock:
+                    print(line, file=output, flush=True)
+            except Exception as exc:  # noqa: BLE001 - one failed turn fails the lane, loudly
+                # The TYPE, always: several provider/timeout errors carry an
+                # empty str(), and a bare "turn 1: " tells a reader nothing
+                # about whether the run hit a rate limit or a bug.
+                result.error = f"turn {index}: {type(exc).__name__}: {exc}".rstrip(": ")
+                break
+            if index + 1 < args.turns:
+                await asyncio.sleep(args.gap)
+    finally:
+        await stream.close()
+        store.close()
+
+    # The wire check. An ON lane that never pinned, or an OFF lane that ever
+    # did, means the arms were not actually different and the numbers would be
+    # a comparison of one condition with itself.
+    pinned = [p for p in transport.pins_sent if p]
+    if arm == "on" and result.turns and not pinned:
+        result.error = result.error or (
+            "ON arm never sent provider.order: the affinity gate never fired, "
+            "so this run compares the baseline against itself"
+        )
+    if arm == "off" and pinned:
+        result.error = result.error or (
+            f"OFF arm sent provider.order {len(pinned)}x: the switch is not honoured"
+        )
+    return result
+
+
+async def _run_arm(
+    args: argparse.Namespace, arm: str, run: int, auth_db: Path, output: Any
+) -> list[ArmResult]:
+    """Run ``--concurrency`` conversations of one arm at once.
+
+    Concurrency is the regime the pin is FOR. A single sequential conversation
+    is a no-pressure sample: OpenRouter's load balancer has no reason to move
+    it, so an unpinned baseline parks on one host by itself and both arms
+    measure the same thing. The operator's real workload is many simultaneous
+    sessions and subagents, which is what drives the re-routing (and the 429
+    fallbacks behind it) that a cold prefix is paid for.
+
+    Starts are STAGGERED so the lanes do not all present an identical cold
+    prefix in the same instant, which would be a thundering herd rather than
+    the steady overlapping load a working day produces.
+    """
+    lock = asyncio.Lock()
+
+    async def lane(index: int) -> ArmResult:
+        await asyncio.sleep(index * args.stagger)
+        return await _run_lane(args, arm, run, index, auth_db, output, lock)
+
+    return list(await asyncio.gather(*(lane(i) for i in range(args.concurrency))))
+
+
+def _pool(results: list[ArmResult], arm: str) -> dict[str, Any]:
+    """Pool an arm's lanes/runs into the numbers the evidence table reports."""
+    arms = [r for r in results if r.name == arm and r.total_prompt]
+    if not arms:
+        return {}
+    prompt = sum(r.total_prompt for r in arms)
+    cached = sum(r.total_cached for r in arms)
+    loss = sum(r.avoidable_loss * r.total_prompt for r in arms)
+    cond = {k: {"n": 0, "hits": 0, "cached": 0, "prompt": 0} for k in ("same", "changed")}
+    for r in arms:
+        for key, bucket in r.conditional().items():
+            for field_name, value in bucket.items():
+                cond[key][field_name] += value
+    honored = sum(r.pin_honored[0] for r in arms)
+    pinned = sum(r.pin_honored[1] for r in arms)
+    gaps = sorted(g for r in arms for g in r.gaps)
+    mix: dict[str, int] = {}
+    for r in arms:
+        for host, count in r.mix.items():
+            mix[host] = mix.get(host, 0) + count
+    return {
+        "conversations": len(arms),
+        "turns": sum(len(r.turns) for r in arms),
+        "cache_share": cached / prompt,
+        "avoidable_loss": loss / prompt,
+        "switches": sum(r.switches for r in arms),
+        "transitions": sum(r.transitions for r in arms),
+        "conditional": cond,
+        "pin_honored": (honored, pinned),
+        "median_gap_s": gaps[len(gaps) // 2] if gaps else 0.0,
+        "usd": sum(r.usd_cost for r in arms),
+        "mix": dict(sorted(mix.items(), key=lambda kv: -kv[1])),
+    }
+
+
+def _print_summary(results: list[ArmResult]) -> None:
+    print("", file=sys.stderr)
+    print(
+        f"{'arm':<4} {'run':>3} {'lane':>4} {'turns':>5} {'prompt':>9} {'cached':>9} "
+        f"{'cache':>6} {'avoid':>6} {'sw/tr':>7}  {'cost':>7}",
+        file=sys.stderr,
+    )
+    for r in results:
+        rate = f"{r.cache_rate:.1%}" if r.total_prompt else "n/a"
+        print(
+            f"{r.name:<4} {r.run:>3} {r.lane:>4} {len(r.turns):>5} {r.total_prompt:>9} "
+            f"{r.total_cached:>9} {rate:>6} {r.avoidable_loss:>5.1%} "
+            f"{r.switches:>3}/{r.transitions:<3}  ${r.usd_cost:>6.3f}",
+            file=sys.stderr,
+        )
+        if r.error:
+            print(f"     ERROR: {r.error}", file=sys.stderr)
+
+    for arm in ("off", "on"):
+        pooled = _pool(results, arm)
+        if not pooled:
+            continue
+        same = pooled["conditional"]["same"]
+        changed = pooled["conditional"]["changed"]
+        print("", file=sys.stderr)
+        print(
+            f"POOLED {arm}: {pooled['conversations']} conversations, {pooled['turns']} turns, "
+            f"cache={pooled['cache_share']:.1%}, avoidable={pooled['avoidable_loss']:.1%}, "
+            f"cost=${pooled['usd']:.3f}, median gap={pooled['median_gap_s']:.1f}s",
+            file=sys.stderr,
+        )
+        # Switch FREQUENCY, with the denominator, so a no-pressure window is
+        # visible as such instead of reading as "the pin did not help".
+        print(
+            f"  host switches: {pooled['switches']}/{pooled['transitions']} transitions"
+            + (
+                f" ({pooled['switches'] / pooled['transitions']:.1%})"
+                if pooled["transitions"]
+                else ""
+            )
+            + ("   <- NO-PRESSURE SAMPLE: nothing to re-route" if not pooled["switches"] else ""),
+            file=sys.stderr,
+        )
+        for label, bucket in (("host SAME", same), ("host CHANGED", changed)):
+            if bucket["n"]:
+                hit_rate = bucket["hits"] / bucket["n"]
+                share = bucket["cached"] / max(bucket["prompt"], 1)
+                print(
+                    f"  {label:<13} n={bucket['n']:>3}  any-hit={hit_rate:>5.0%}"
+                    f"  cache share={share:>5.1%}",
+                    file=sys.stderr,
+                )
+        if pooled["pin_honored"][1]:
+            honored, pinned = pooled["pin_honored"]
+            print(
+                f"  pin honored:   {honored}/{pinned} ({honored / pinned:.1%}) "
+                f"— `order` is a preference, not a constraint",
+                file=sys.stderr,
+            )
+        print(f"  mix: {pooled['mix']}", file=sys.stderr)
+
+
+async def _run(args: argparse.Namespace, auth_db: Path, output: Any) -> int:
+    results: list[ArmResult] = []
+    spent = 0.0
+    for run in range(args.runs):
+        # Alternate arm order across runs: the first arm of a pair pays any
+        # provider-side warming the second then inherits, so a fixed order
+        # would hand one arm a systematic advantage.
+        order = ["off", "on"] if run % 2 == 0 else ["on", "off"]
+        if args.arm != "both":
+            order = [args.arm]
+        for arm in order:
+            lanes = await _run_arm(args, arm, run, auth_db, output)
+            results.extend(lanes)
+            spent += sum(lane.usd_cost for lane in lanes)
+            print(f"[budget] spent ${spent:.3f} of ${args.budget:.2f}", file=sys.stderr)
+            failed = [lane for lane in lanes if lane.error]
+            if failed:
+                _print_summary(results)
+                return 1
+            if spent > args.budget:
+                print("[budget] ceiling reached; stopping early", file=sys.stderr)
+                _print_summary(results)
+                return 1
+    _print_summary(results)
+    return int(any(r.error for r in results))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--dry-run", action="store_true", help="Print plan; no requests, no key.")
+    mode.add_argument("--live", action="store_true", help="Spend the bounded budget.")
+    parser.add_argument("--model", default=MODEL_ID)
+    parser.add_argument("--arm", choices=("off", "on", "both"), default="both")
+    parser.add_argument("--turns", type=int, default=30)
+    parser.add_argument("--runs", type=int, default=1, help="Arm-order alternates across runs.")
+    parser.add_argument(
+        "--prefix-rows",
+        type=int,
+        default=950,
+        help="Synthetic prefix rows; ~950 grows the context past 60k tokens "
+        "(calibrated live: 400 rows measured 27,471 prompt tokens, ~68.7/row).",
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=4,
+        help="Conversations run at once per arm. The pin only pays where "
+        "re-routing happens, and a single sequential conversation does not "
+        "generate the route pressure that causes it.",
+    )
+    parser.add_argument(
+        "--stagger",
+        type=float,
+        default=3.0,
+        help="Seconds between concurrent lane starts (avoids a thundering herd).",
+    )
+    parser.add_argument(
+        "--gap",
+        type=float,
+        default=1.0,
+        help="Seconds between turns WITHIN a conversation. Real sessions think "
+        "for longer than this; observed gaps are reported so an eviction can "
+        "be told apart from a re-route.",
+    )
+    parser.add_argument("--budget", type=float, default=5.0, help="Hard USD ceiling.")
+    parser.add_argument("--seed", default=uuid.uuid4().hex[:8])
+    parser.add_argument(
+        "--source-auth-db",
+        type=Path,
+        default=Path.home() / ".local-operator" / "auth.db",
+        help="Copied read-only into the isolated config dir; never written.",
+    )
+    parser.add_argument(
+        "--output", type=Path, help="New JSONL file; existing evidence is never overwritten."
+    )
+    args = parser.parse_args(argv)
+
+    if args.dry_run:
+        print(
+            json.dumps(
+                {
+                    "plan": (
+                        f"{args.runs} run(s) x {args.arm} x {args.concurrency} "
+                        f"concurrent conversations x {args.turns} turns"
+                    ),
+                    "model": args.model,
+                    "seed": args.seed,
+                    "budget_usd": args.budget,
+                    **_source_identity(),
+                },
+                indent=2,
+            )
+        )
+        return 0
+
+    output = args.output.open("x") if args.output else sys.stdout
+    saved = {key: os.environ.get(key) for key in ("HOME", "LOCAL_OPERATOR_CONFIG_DIR")}
+    try:
+        # BOTH are redirected, for the whole run: the config dir alone leaves
+        # the catalogue cache resolving out of the operator's real home (see
+        # the module docstring and AGENTS.md).
+        with tempfile.TemporaryDirectory(prefix="lop-or-cache-") as home:
+            config_dir = Path(home) / ".local-operator"
+            config_dir.mkdir(parents=True)
+            source = args.source_auth_db
+            if not source.exists():
+                raise SystemExit(f"No auth store at {source}")
+            auth_db = config_dir / "auth.db"
+            shutil.copyfile(source, auth_db)
+            _guard_openrouter_credential(auth_db)
+            os.environ["HOME"] = home
+            os.environ["LOCAL_OPERATOR_CONFIG_DIR"] = str(config_dir)
+            print(json.dumps({**_source_identity(), "seed": args.seed}), file=output, flush=True)
+            return asyncio.run(_run(args, auth_db, output))
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        output.flush()
+        if output is not sys.stdout:
+            output.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench_openrouter_cache_rate.py
+++ b/scripts/bench_openrouter_cache_rate.py
@@ -40,12 +40,26 @@ turns) estimates well under $1; the hard ceiling is ``--budget`` (default
 $5.00), checked after every turn against the provider's OWN reported cost, and
 the run aborts the moment the estimate would cross it.
 
+THE GUARD'S WORST CASE (``--compact-at``): the cache-quality guard retires a
+host after two consecutive warm-but-uncached turns, and the most dangerous
+place for that heuristic is a COMPACTION — a cold-by-design provider call
+immediately followed by a first turn on a rebuilt prefix that is also cold, for
+the honest reason that the prefix is new. Two adjacent cold events, two strikes,
+and a host that caches at 99.6% is retired for the rest of the conversation with
+no removal path. Unit tests cover the logic, but only the live bench can show
+that the sequence a real session actually produces does not retire its host, so
+``--compact-at N`` performs a real compaction at turn N (a ``purpose=
+"compaction"`` call, then a rebuilt prefix) and FAILS the lane if the host
+serving the remainder ends up retired.
+
 Examples:
     .venv/bin/python scripts/bench_openrouter_cache_rate.py --dry-run
     .venv/bin/python scripts/bench_openrouter_cache_rate.py --live
     .venv/bin/python scripts/bench_openrouter_cache_rate.py --live --arm on
     .venv/bin/python scripts/bench_openrouter_cache_rate.py --live \
         --runs 3 --output evidence.jsonl   # alternates arm order per run
+    .venv/bin/python scripts/bench_openrouter_cache_rate.py --live --arm on \
+        --turns 8 --compact-at 4          # the guard's worst case, end to end
 """
 
 from __future__ import annotations
@@ -62,11 +76,19 @@ import sys
 import tempfile
 import time
 import uuid
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
+
+if TYPE_CHECKING:
+    # Annotation-only: every `local_operator` import in this script is deferred
+    # into the function that needs it so `--dry-run` prints a plan without
+    # loading the harness, and `from __future__ import annotations` above makes
+    # the signature below cost nothing at runtime.
+    from local_operator.harness.types import Message
 
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO))
@@ -104,6 +126,13 @@ class TurnRecord:
     retired: list[str] = field(default_factory=list)
     #: Which concurrent conversation within the arm produced this turn.
     lane: int = 0
+    #: ``"compaction"`` for the deliberately cold summary call `--compact-at`
+    #: injects, ``"turn"`` otherwise. A compaction's counters must be read
+    #: separately: it is a fresh write-once prefix, so its ~0% reuse is the
+    #: design and pooling it into the lane's cache share would understate the
+    #: feature. Also the marker for "this turn is the first on a REBUILT
+    #: prefix", which is cold for the same honest reason.
+    purpose: str = "turn"
     #: Wall seconds since this lane's previous turn STARTED. Recorded because
     #: a host-side cache entry expires on a timer (~10 min documented), so a
     #: bench whose natural spacing is far wider than a real session's cannot
@@ -157,6 +186,10 @@ class ArmResult:
         """Host changes between consecutive turns; each one is a cold prefix."""
         names = [t.provider for t in self.turns if t.provider]
         return sum(1 for a, b in zip(names, names[1:]) if a != b)
+
+    @property
+    def compaction_turns(self) -> list[TurnRecord]:
+        return [t for t in self.turns if t.purpose == "compaction"]
 
     @property
     def transitions(self) -> int:
@@ -276,6 +309,33 @@ def _guard_openrouter_credential(auth_db: Path) -> None:
         )
 
 
+#: System prompt for the injected compaction call. Short and DELIBERATELY
+#: unrelated to `_system_blocks`: a real compaction sends a summariser prompt,
+#: not the session's frozen prefix, which is a large part of why its request
+#: cannot match anything the host has cached.
+COMPACTION_SYSTEM = (
+    "You compact conversations. Summarise the exchange below in two sentences. "
+    "No preamble, no lists."
+)
+
+
+def _compaction_prompt(history: Sequence[Message]) -> str:
+    """Flatten the transcript into the single user prompt a compaction sends."""
+    # Imported here, not at module scope, for the reason the rest of this script
+    # defers its `local_operator` imports: `--dry-run` must print a plan without
+    # loading the harness.
+    from local_operator.harness.types import TextContent
+
+    lines: list[str] = []
+    for message in history:
+        text = " ".join(
+            part.text for part in message.content if isinstance(part, TextContent)
+        ).strip()
+        if text:
+            lines.append(f"{message.role}: {text}")
+    return "\n".join(lines) or "user: (nothing yet)"
+
+
 def _system_blocks(namespace: str, rows: int) -> list[str]:
     """A stable synthetic prefix per arm; never private context.
 
@@ -374,20 +434,44 @@ async def _run_lane(
 
     history: list[Message] = []
     last_start: float | None = None
+    # Turn indices that send a `purpose="compaction"` request instead of an
+    # ordinary turn. Nothing is injected unless --compact-at asks for it, so
+    # the default run is byte-identical to the measured A/B.
+    compaction_turns = {args.compact_at} if args.compact_at is not None else set()
     try:
         for index in range(args.turns):
+            compacting = index in compaction_turns
             prompt = TURN_PROMPTS[index % len(TURN_PROMPTS)] + TERSE
-            request = ChatRequest(
-                model=spec,
-                system_blocks=blocks,
-                messages=[*history, Message.user(prompt)],
-            )
+            if compacting:
+                # Shaped like the real thing (`ChatCompaction._one_shot_
+                # complete`): the transcript arrives as ONE user prompt to be
+                # summarised, no tools, `context_tokens_hint=0` because this is
+                # a fresh write-once prefix rather than the turn's cached one.
+                # That shape is exactly why it cannot cache, and why scoring it
+                # as cache evidence retired hosts that cache fine.
+                request = ChatRequest(
+                    model=spec,
+                    system_blocks=[COMPACTION_SYSTEM],
+                    messages=[Message.user(_compaction_prompt(history))],
+                    tools=[],
+                    tool_choice="none",
+                    replayable=True,
+                    purpose="compaction",
+                    context_tokens_hint=0,
+                )
+            else:
+                request = ChatRequest(
+                    model=spec,
+                    system_blocks=blocks,
+                    messages=[*history, Message.user(prompt)],
+                )
             started = time.monotonic()
             record = TurnRecord(
                 turn=index,
                 arm=arm,
                 run=run,
                 lane=lane,
+                purpose="compaction" if compacting else "turn",
                 gap_s=round(started - last_start, 2) if last_start is not None else 0.0,
             )
             last_start = started
@@ -421,11 +505,27 @@ async def _run_lane(
                 # happens on THIS turn is only visible on the next request, and
                 # the run has to be able to show that the guard fired at all.
                 record.retired = sorted(stream._provider_retired.get(spec.model_id, ()))
-                history = [
-                    *history,
-                    Message.user(prompt),
-                    Message(role="assistant", content=[TextContent(text=text or "(empty)")]),
-                ]
+                if compacting:
+                    # REPLACE the transcript with the summary, which is what a
+                    # real compaction does to the prefix and the reason the next
+                    # turn cannot hit the host's cache: from token 0 onward the
+                    # request no longer matches anything the host holds. The
+                    # guard must survive that cold turn without retiring a host
+                    # whose only failing is that the prefix changed underneath
+                    # it.
+                    history = [
+                        Message.user("Summary of the conversation so far:"),
+                        Message(
+                            role="assistant",
+                            content=[TextContent(text=text or "(empty)")],
+                        ),
+                    ]
+                else:
+                    history = [
+                        *history,
+                        Message.user(prompt),
+                        Message(role="assistant", content=[TextContent(text=text or "(empty)")]),
+                    ]
                 result.turns.append(record)
                 line = json.dumps(
                     {
@@ -444,6 +544,7 @@ async def _run_lane(
                         "pin_on_wire": record.pin_on_wire,
                         "avoid_on_wire": record.avoid_on_wire,
                         "retired": record.retired,
+                        "purpose": record.purpose,
                         "gap_s": record.gap_s,
                     }
                 )
@@ -476,7 +577,70 @@ async def _run_lane(
         result.error = result.error or (
             f"OFF arm sent provider.order {len(pinned)}x: the switch is not honoured"
         )
+    if args.compact_at is not None:
+        result.error = result.error or _compaction_guard_verdict(result, args.compact_at)
     return result
+
+
+def _compaction_guard_verdict(result: ArmResult, compact_at: int) -> str | None:
+    """The guard's worst case, asserted on real turns: can a compaction retire a
+    host on evidence the compaction itself manufactured?
+
+    The failure this catches is not hypothetical. A compaction is a cold-by-
+    design call and the first turn on the rebuilt prefix is cold for the honest
+    reason that the prefix is NEW; two adjacent cold events used to be two
+    strikes, and a host measured at 99.6% same-host cache share was retired for
+    the rest of the conversation with no removal path (review round 1,
+    blocker-2). Unit tests pin the logic, but only a live run shows that the
+    sequence a real session produces stays clean.
+
+    What this does NOT assert is that no host is ever retired after a
+    compaction. That would be a stricter claim than the fix makes, and it would
+    fail on the guard doing its job: a host that misses the rebuilt prefix AND
+    then misses its own write is a host that does not cache, and leaving it is
+    the whole point (observed live: a lane retired such a host and its
+    replacement immediately cached at 99.8%). So the invariants are:
+
+    1. every post-boundary retirement is backed by at least
+       ``PROVIDER_STRIKES_TO_RETIRE`` cold TURNS served by that host after the
+       boundary — the compaction call cannot be one of them, and neither can a
+       single unavoidable cold turn on the rebuilt prefix; and
+    2. the boundary CLEARED whatever was retired before it, since those
+       retirements were recorded against a prefix that no longer exists.
+    """
+    from local_operator.model.configure import SessionStreamFn
+
+    after = [t for t in result.turns if t.turn > compact_at and t.purpose == "turn"]
+    if not after:
+        return f"--compact-at {compact_at} left no post-boundary turns to judge"
+
+    def cold(turn: TurnRecord) -> bool:
+        # The guard's own "no meaningful reuse" floor, read off the class rather
+        # than restated, so the bench cannot drift from the code it checks.
+        floor = max(
+            SessionStreamFn.PROVIDER_STRIKE_MIN_CACHED_TOKENS,
+            int(turn.prompt_tokens * SessionStreamFn.PROVIDER_STRIKE_MIN_CACHED_FRACTION),
+        )
+        return turn.cached_tokens < floor
+
+    for host in sorted(set(after[-1].retired)):
+        backing = [t for t in after if t.provider == host and cold(t)]
+        if len(backing) < SessionStreamFn.PROVIDER_STRIKES_TO_RETIRE:
+            return (
+                f"compaction guard: {host} was retired after the turn-{compact_at} "
+                f"compaction on only {len(backing)} cold turn(s) of its own "
+                f"({SessionStreamFn.PROVIDER_STRIKES_TO_RETIRE} required) — the "
+                "compaction and the first turn on a rebuilt prefix are cold by "
+                "design and must not count as cache evidence"
+            )
+    before = [t for t in result.turns if t.turn < compact_at]
+    if before and before[-1].retired and after[0].retired:
+        return (
+            f"compaction guard: retirements {before[-1].retired} survived the "
+            f"turn-{compact_at} compaction; the prefix they were recorded against "
+            "no longer exists, and `provider.ignore` has no other removal path"
+        )
+    return None
 
 
 async def _run_arm(
@@ -666,6 +830,16 @@ def main(argv: list[str] | None = None) -> int:
         "for longer than this; observed gaps are reported so an eviction can "
         "be told apart from a re-route.",
     )
+    parser.add_argument(
+        "--compact-at",
+        type=int,
+        default=None,
+        metavar="N",
+        help='Send a real purpose="compaction" call at turn N and REPLACE the '
+        "transcript with its summary, then keep going. This is the cache-quality "
+        "guard's worst case (two adjacent cold-by-design events), and the lane "
+        "FAILS if the host serving the turns after the boundary ends up retired.",
+    )
     parser.add_argument("--budget", type=float, default=5.0, help="Hard USD ceiling.")
     parser.add_argument("--seed", default=uuid.uuid4().hex[:8])
     parser.add_argument(
@@ -686,6 +860,11 @@ def main(argv: list[str] | None = None) -> int:
                     "plan": (
                         f"{args.runs} run(s) x {args.arm} x {args.concurrency} "
                         f"concurrent conversations x {args.turns} turns"
+                        + (
+                            f", compaction injected at turn {args.compact_at}"
+                            if args.compact_at is not None
+                            else ""
+                        )
                     ),
                     "model": args.model,
                     "seed": args.seed,

--- a/scripts/bench_openrouter_cache_rate.py
+++ b/scripts/bench_openrouter_cache_rate.py
@@ -40,17 +40,37 @@ turns) estimates well under $1; the hard ceiling is ``--budget`` (default
 $5.00), checked after every turn against the provider's OWN reported cost, and
 the run aborts the moment the estimate would cross it.
 
-THE GUARD'S WORST CASE (``--compact-at``): the cache-quality guard retires a
-host after two consecutive warm-but-uncached turns, and the most dangerous
-place for that heuristic is a COMPACTION — a cold-by-design provider call
-immediately followed by a first turn on a rebuilt prefix that is also cold, for
-the honest reason that the prefix is new. Two adjacent cold events, two strikes,
-and a host that caches at 99.6% is retired for the rest of the conversation with
-no removal path. Unit tests cover the logic, but only the live bench can show
-that the sequence a real session actually produces does not retire its host, so
-``--compact-at N`` performs a real compaction at turn N (a ``purpose=
-"compaction"`` call, then a rebuilt prefix) and FAILS the lane if the host
-serving the remainder ends up retired.
+THE COMPACTION BOUNDARY (``--compact-at``): the cache-quality guard retires a
+host after two consecutive warm-but-uncached turns, and a COMPACTION is the
+awkward place for that heuristic — a cold-by-design provider call next to a
+rebuilt prefix the host has never been given. ``--compact-at N`` performs a real
+compaction at turn N (a ``purpose="compaction"`` call, then a rebuilt prefix)
+and FAILS the lane if a host serving the remainder was retired without being
+backed by ``PROVIDER_STRIKES_TO_RETIRE`` cold turns of its own.
+
+BE PRECISE ABOUT WHAT THIS PROVES, because the obvious reading is wrong (QA
+round 2, Q1). It is a SMOKE assertion that the fixed sequence runs clean end to
+end — no unbacked retirement, caching resumed — and NOT a regression test for
+the ``purpose == "turn"`` gate. The reason is arithmetic: the large synthetic
+prefix lives in ``system_blocks``, and a compaction request replaces those with
+``COMPACTION_SYSTEM`` plus a flattened short history, so its call carries
+~170-180 prompt tokens against ``PROVIDER_STRIKE_MIN_PROMPT_TOKENS = 8192``.
+That floor is checked BEFORE any strike is recorded and on every revision of
+this code, so the compaction returns early regardless — this check cannot
+distinguish the fixed head from the unfixed one. QA demonstrated it by
+relabelling the bench's compaction as ``purpose="turn"``, which is exactly what
+deleting the gate would do: identical outcome at 171 tokens, divergent at 74k.
+
+So the gate's regression coverage is the UNIT SUITE (14 tests under
+``tests/unit/model/test_configure.py -k "compaction or retire or strike or
+purpose"``, each mutation-verified to fail when its guard is removed). What the
+live check is genuinely worth is the post-boundary retirement PATTERN, which
+unit tests cannot observe because it depends on how real upstreams behave: it
+holds the observed sequence to "a retirement must be backed by at least two
+cold turns of that host's own". Giving ``--compact-at`` a large-prompt mode
+(putting the transcript in ``messages`` so the compaction crosses 8192) would
+make it cover the gate for real — deliberately not done here, since the shipped
+behaviour is correct and only this claim needed fixing.
 
 Examples:
     .venv/bin/python scripts/bench_openrouter_cache_rate.py --dry-run
@@ -59,7 +79,7 @@ Examples:
     .venv/bin/python scripts/bench_openrouter_cache_rate.py --live \
         --runs 3 --output evidence.jsonl   # alternates arm order per run
     .venv/bin/python scripts/bench_openrouter_cache_rate.py --live --arm on \
-        --turns 8 --compact-at 4          # the guard's worst case, end to end
+        --turns 8 --compact-at 4          # compaction-boundary smoke check
 """
 
 from __future__ import annotations
@@ -449,6 +469,12 @@ async def _run_lane(
                 # a fresh write-once prefix rather than the turn's cached one.
                 # That shape is exactly why it cannot cache, and why scoring it
                 # as cache evidence retired hosts that cache fine.
+                #
+                # It also makes the call SHORT here (~170-180 tokens), because
+                # this bench's bulk lives in `system_blocks` and those are what
+                # a compaction replaces. Short enough to sit under the strike
+                # floor, which is why this lane cannot exercise the purpose gate
+                # — see the module docstring (QA round 2, Q1).
                 request = ChatRequest(
                     model=spec,
                     system_blocks=[COMPACTION_SYSTEM],
@@ -583,16 +609,23 @@ async def _run_lane(
 
 
 def _compaction_guard_verdict(result: ArmResult, compact_at: int) -> str | None:
-    """The guard's worst case, asserted on real turns: can a compaction retire a
-    host on evidence the compaction itself manufactured?
+    """Hold a live compaction boundary to the retirement pattern it must show.
 
-    The failure this catches is not hypothetical. A compaction is a cold-by-
-    design call and the first turn on the rebuilt prefix is cold for the honest
-    reason that the prefix is NEW; two adjacent cold events used to be two
-    strikes, and a host measured at 99.6% same-host cache share was retired for
-    the rest of the conversation with no removal path (review round 1,
-    blocker-2). Unit tests pin the logic, but only a live run shows that the
-    sequence a real session produces stays clean.
+    SCOPE, stated first because the name invites a stronger reading (QA round 2,
+    Q1): this is a SMOKE assertion that the sequence runs clean, not a
+    regression test for the ``purpose == "turn"`` gate. The compaction call this
+    bench sends carries ~170-180 prompt tokens — the synthetic prefix lives in
+    ``system_blocks``, which a compaction replaces — and
+    ``PROVIDER_STRIKE_MIN_PROMPT_TOKENS = 8192`` is checked before any strike is
+    recorded, on every revision of this code. So the call short-circuits either
+    way and this function cannot tell a fixed head from an unfixed one. The
+    gate's regression coverage is the unit suite (14 tests, mutation-verified);
+    see the module docstring for the measurement.
+
+    What it IS worth is the post-boundary retirement pattern, which unit tests
+    cannot observe because it depends on how real upstreams behave: across live
+    lanes, a retirement must be earned by that host's own cold turns rather than
+    by the boundary itself.
 
     What this does NOT assert is that no host is ever retired after a
     compaction. That would be a stricter claim than the fix makes, and it would
@@ -604,7 +637,12 @@ def _compaction_guard_verdict(result: ArmResult, compact_at: int) -> str | None:
     1. every post-boundary retirement is backed by at least
        ``PROVIDER_STRIKES_TO_RETIRE`` cold TURNS served by that host after the
        boundary — the compaction call cannot be one of them, and neither can a
-       single unavoidable cold turn on the rebuilt prefix; and
+       lone cold turn on the rebuilt prefix. (That turn is not reliably cold
+       either way: its prefix is the system blocks the host still holds plus the
+       new summary, so above a ~1-2k system prefix it clears the
+       ``max(1024, 2%)`` floor and CLEARS the record instead — review round 2,
+       NIT-1. Observed live both ways, 99.8% in one lane and 0.0% in others.);
+       and
     2. the boundary CLEARED whatever was retired before it, since those
        retirements were recorded against a prefix that no longer exists.
     """
@@ -630,8 +668,8 @@ def _compaction_guard_verdict(result: ArmResult, compact_at: int) -> str | None:
                 f"compaction guard: {host} was retired after the turn-{compact_at} "
                 f"compaction on only {len(backing)} cold turn(s) of its own "
                 f"({SessionStreamFn.PROVIDER_STRIKES_TO_RETIRE} required) — the "
-                "compaction and the first turn on a rebuilt prefix are cold by "
-                "design and must not count as cache evidence"
+                "compaction call is not cache evidence, and one cold turn on a "
+                "rebuilt prefix is not enough to convict a host"
             )
     before = [t for t in result.turns if t.turn < compact_at]
     if before and before[-1].retired and after[0].retired:
@@ -836,9 +874,11 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         metavar="N",
         help='Send a real purpose="compaction" call at turn N and REPLACE the '
-        "transcript with its summary, then keep going. This is the cache-quality "
-        "guard's worst case (two adjacent cold-by-design events), and the lane "
-        "FAILS if the host serving the turns after the boundary ends up retired.",
+        "transcript with its summary, then keep going. A smoke check on the "
+        "compaction boundary: the lane FAILS if a host serving the turns after "
+        "it was retired without two cold turns of its own. It does NOT cover the "
+        "purpose gate (its call is below the strike floor) \u2014 see the module "
+        "docstring.",
     )
     parser.add_argument("--budget", type=float, default=5.0, help="Hard USD ceiling.")
     parser.add_argument("--seed", default=uuid.uuid4().hex[:8])

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -10,6 +10,7 @@ import asyncio
 import json
 import time
 import zlib
+from collections.abc import AsyncIterator
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -19,8 +20,16 @@ import requests
 from pydantic import SecretStr
 
 from local_operator.credentials import CredentialManager
-from local_operator.harness.types import ChatRequest, Message, ModelSpec
+from local_operator.harness.types import (
+    ChatRequest,
+    Message,
+    ModelSpec,
+    StreamEndEvent,
+    StreamEvent,
+    Usage,
+)
 from local_operator.model.configure import (
+    SessionStreamFn,
     build_model_spec,
     calculate_cost,
     configure_model,
@@ -3778,6 +3787,446 @@ def test_openrouter_preferences_reach_the_client_through_client_for() -> None:
     other = stream._client_for(MagicMock(provider="kimi", base_url=None))
     assert isinstance(other, OpenAICompatClient)
     assert other._openrouter_provider_preferences is None
+
+
+# ---------------------------------------------------------------------------
+# OpenRouter cache affinity: the session-held pin
+# ---------------------------------------------------------------------------
+
+
+def _affinity_stream(settings: dict[str, Any] | None = None):
+    """A SessionStreamFn over a mocked auth store, for gate/pin state only."""
+    from unittest.mock import MagicMock
+
+    from local_operator.model.configure import SessionStreamFn
+
+    return SessionStreamFn(MagicMock(), settings if settings is not None else {}, "s-affinity")
+
+
+def _affinity_request(**overrides: Any) -> ChatRequest:
+    spec = ModelSpec(
+        provider=overrides.pop("provider", "openrouter"),
+        model_id=overrides.pop("model_id", "deepseek/deepseek-v4.1-flash"),
+        supports_prompt_cache=overrides.pop("supports_prompt_cache", True),
+    )
+    return ChatRequest(model=spec, messages=[Message.user("hi")], **overrides)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "settings", "enabled", "why"),
+    [
+        ({}, {}, True, "the shipped default: openrouter + cacheable + shared"),
+        ({"provider": "kimi"}, {}, False, "a direct provider has no host to pin"),
+        (
+            {"provider": "radient"},
+            {},
+            False,
+            "radient aggregates too, but its routing was never measured here",
+        ),
+        (
+            {"supports_prompt_cache": False},
+            {},
+            False,
+            "no server-side cache means the pin buys nothing and costs hosts",
+        ),
+        ({"isolated": True}, {}, False, "an errand has no warm prefix of its own"),
+        (
+            {"model_id": "deepseek/deepseek-v4.1-flash:nitro"},
+            {},
+            False,
+            ":nitro sorts by throughput by definition; a pin would defeat it",
+        ),
+        (
+            {"model_id": "deepseek/deepseek-v4.1-flash:floor"},
+            {},
+            False,
+            ":floor sorts by price by definition",
+        ),
+        (
+            {},
+            {"providers": {"openrouter": {"provider_affinity": False}}},
+            False,
+            "the user turned it off",
+        ),
+        (
+            {},
+            {"providers": {"openrouter": {"provider_affinity": True}}},
+            True,
+            "explicitly on reads the same as the default",
+        ),
+        (
+            {},
+            {"providers": {"openrouter": {"order": ["Novita"]}}},
+            False,
+            "a typed host order is the user's own routing opinion",
+        ),
+        ({}, {"providers": {"openrouter": {"only": ["Novita"]}}}, False, "same for only"),
+        ({}, {"providers": {"openrouter": {"ignore": ["Novita"]}}}, False, "same for ignore"),
+        ({}, {"providers": {"openrouter": {"sort": "price"}}}, False, "a sort policy outranks it"),
+        (
+            {},
+            {"providers": {"openrouter": {"zdr": "true"}}},
+            True,
+            "a privacy preference is not a host opinion, so the pin survives",
+        ),
+    ],
+)
+def test_affinity_gate_matrix(
+    kwargs: dict[str, Any], settings: dict[str, Any], enabled: bool, why: str
+) -> None:
+    """Every condition under which the harness may or may not pin a host."""
+    assert _affinity_stream(settings)._affinity_enabled(_affinity_request(**kwargs)) is enabled, why
+
+
+@pytest.mark.asyncio
+async def test_a_pinned_host_decorates_the_next_request() -> None:
+    """The read half: a recorded host rides out on `ChatRequest`, which is what
+    failover clones for retries, so the pin follows a retry for free."""
+    stream = _affinity_stream()
+    stream._provider_affinity["deepseek/deepseek-v4.1-flash"] = "AtlasCloud"
+    request = _affinity_request()
+
+    pin = stream._provider_affinity.get(request.model.model_id)
+    assert pin and stream._affinity_enabled(request)
+    assert request.model_copy(update={"provider_affinity": pin}).provider_affinity == "AtlasCloud"
+
+
+@pytest.mark.asyncio
+async def test_the_setting_off_never_decorates_even_with_a_pin_held() -> None:
+    """A pin acquired before the user turned the feature off must stop being
+    applied immediately — the switch is LIVE, not next-session."""
+    stream = _affinity_stream({"providers": {"openrouter": {"provider_affinity": False}}})
+    stream._provider_affinity["deepseek/deepseek-v4.1-flash"] = "AtlasCloud"
+    assert stream._affinity_enabled(_affinity_request()) is False
+
+
+@pytest.mark.asyncio
+async def test_a_successful_end_records_the_served_host() -> None:
+    """The write half, through the real `_record_stream` wrapper."""
+    stream = _affinity_stream()
+    request = _affinity_request()
+
+    async def served() -> AsyncIterator[StreamEvent]:
+        yield StreamEndEvent(stop_reason="stop", served_provider="AtlasCloud")
+
+    assert [event async for event in stream._record_stream(request, served())]
+    assert stream._provider_affinity == {"deepseek/deepseek-v4.1-flash": "AtlasCloud"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stop_reason", ["error", "aborted"])
+async def test_a_failed_end_does_not_move_the_pin(stop_reason: str) -> None:
+    """A host that errored or was aborted mid-stream did not necessarily ingest
+    the prefix, so it is not evidence of a warm cache."""
+    stream = _affinity_stream()
+    stream._provider_affinity["deepseek/deepseek-v4.1-flash"] = "AtlasCloud"
+
+    async def failed() -> AsyncIterator[StreamEvent]:
+        yield StreamEndEvent(stop_reason=stop_reason, served_provider="Novita")
+
+    assert [event async for event in stream._record_stream(_affinity_request(), failed())]
+    assert stream._provider_affinity == {"deepseek/deepseek-v4.1-flash": "AtlasCloud"}
+
+
+@pytest.mark.asyncio
+async def test_being_served_elsewhere_repins_immediately() -> None:
+    """No hysteresis, deliberately: the host that just served now holds this
+    conversation's prefix, while the previous host's entry is already decaying
+    (OpenRouter documents a ~10-minute sticky expiry). Keeping the older pin
+    would aim the next turn at the colder of the two caches."""
+    stream = _affinity_stream()
+    stream._provider_affinity["deepseek/deepseek-v4.1-flash"] = "AtlasCloud"
+
+    async def served_by_b() -> AsyncIterator[StreamEvent]:
+        yield StreamEndEvent(stop_reason="stop", served_provider="Novita")
+
+    assert [event async for event in stream._record_stream(_affinity_request(), served_by_b())]
+    assert stream._provider_affinity["deepseek/deepseek-v4.1-flash"] == "Novita"
+
+
+@pytest.mark.asyncio
+async def test_the_pin_is_held_per_model() -> None:
+    """A detour to another model must not hand its host to the first model:
+    two models are two prefixes on two different hosts. (And the pin outlives
+    that detour, which is why it is not folded into `_route_state` — that
+    state is cleared on a model switch.)"""
+    stream = _affinity_stream()
+
+    async def served(name: str) -> AsyncIterator[StreamEvent]:
+        yield StreamEndEvent(stop_reason="stop", served_provider=name)
+
+    async for _ in stream._record_stream(_affinity_request(), served("AtlasCloud")):
+        pass
+    async for _ in stream._record_stream(
+        _affinity_request(model_id="moonshotai/kimi-k2"), served("Novita")
+    ):
+        pass
+    assert stream._provider_affinity == {
+        "deepseek/deepseek-v4.1-flash": "AtlasCloud",
+        "moonshotai/kimi-k2": "Novita",
+    }
+
+
+@pytest.mark.asyncio
+async def test_an_isolated_request_neither_reads_nor_writes_the_pin() -> None:
+    """Both directions, which is the point: an errand gains nothing from a pin
+    it has no warm prefix for, and letting one MOVE the pin would drag the real
+    conversation onto whatever host answered an unrelated question."""
+    stream = _affinity_stream()
+    stream._provider_affinity["deepseek/deepseek-v4.1-flash"] = "AtlasCloud"
+    isolated = _affinity_request(isolated=True)
+
+    # Does not read: the gate refuses, so `__call__` never decorates.
+    assert stream._affinity_enabled(isolated) is False
+
+    # Does not write: a successful isolated end leaves the pin where it was.
+    async def served() -> AsyncIterator[StreamEvent]:
+        yield StreamEndEvent(stop_reason="stop", served_provider="Novita")
+
+    assert [event async for event in stream._record_stream(isolated, served())]
+    assert stream._provider_affinity == {"deepseek/deepseek-v4.1-flash": "AtlasCloud"}
+
+
+@pytest.mark.asyncio
+async def test_a_wire_that_names_no_host_leaves_the_pin_untouched() -> None:
+    """Direct providers send no `provider` field; None must not clear a pin."""
+    stream = _affinity_stream()
+    stream._provider_affinity["deepseek/deepseek-v4.1-flash"] = "AtlasCloud"
+
+    async def silent() -> AsyncIterator[StreamEvent]:
+        yield StreamEndEvent(stop_reason="stop")
+
+    assert [event async for event in stream._record_stream(_affinity_request(), silent())]
+    assert stream._provider_affinity == {"deepseek/deepseek-v4.1-flash": "AtlasCloud"}
+
+
+def test_a_transcript_fork_inherits_the_pin_as_a_copy() -> None:
+    """A true fork replays a byte-identical prefix, so the parent's host really
+    is warm for it — the same reasoning that makes it inherit the cache lineage.
+    A COPY, so the child's own re-pins cannot move the parent onto a host chosen
+    for a conversation the parent is not having."""
+    parent = _affinity_stream()
+    parent._provider_affinity["deepseek/deepseek-v4.1-flash"] = "AtlasCloud"
+
+    child = parent.fork("s-child", cache_lineage_id="s-affinity")
+    try:
+        assert child._provider_affinity == {"deepseek/deepseek-v4.1-flash": "AtlasCloud"}
+        child._provider_affinity["deepseek/deepseek-v4.1-flash"] = "Novita"
+        assert parent._provider_affinity == {"deepseek/deepseek-v4.1-flash": "AtlasCloud"}
+    finally:
+        child._transport.owners -= 1
+
+
+def test_a_fresh_delegated_fork_does_not_inherit_the_pin() -> None:
+    """No shared lineage means no shared prefix, so inheriting a pin would only
+    narrow the child's host pool for a cache it cannot hit."""
+    parent = _affinity_stream()
+    parent._provider_affinity["deepseek/deepseek-v4.1-flash"] = "AtlasCloud"
+
+    child = parent.fork("s-child")
+    try:
+        assert child._provider_affinity == {}
+    finally:
+        child._transport.owners -= 1
+
+
+# ---------------------------------------------------------------------------
+# OpenRouter cache affinity: retiring a host whose cache is dead
+# ---------------------------------------------------------------------------
+
+
+def _warm_usage(cached: int = 0, prompt: int = 30_000) -> Usage:
+    """A prefix big enough for "no reuse" to carry information."""
+    return Usage(input_tokens=prompt, cache_read_tokens=cached)
+
+
+async def _score(
+    stream: Any,
+    *,
+    asked: str | None,
+    served: str,
+    usage: Usage,
+    gap_s: float = 5.0,
+    model_id: str = "deepseek/deepseek-v4.1-flash",
+) -> None:
+    """One scored turn: ``asked`` is the pin we SENT, ``served`` who answered."""
+    request = _affinity_request(model_id=model_id)
+    if asked:
+        request = request.model_copy(update={"provider_affinity": asked})
+    previous = stream._provider_last_turn_at.get(model_id)
+    if previous is None:
+        # Prime the clock: the FIRST turn on a model has no predecessor, so
+        # the real code cannot know the gap and never strikes. Tests that want
+        # to exercise striking must start from an established conversation.
+        previous = 1000.0
+        stream._provider_last_turn_at[model_id] = previous
+    stream._score_cache_affinity(request, served, usage, now=previous + gap_s)
+
+
+@pytest.mark.asyncio
+async def test_two_warm_turns_without_reuse_retire_the_host() -> None:
+    """The guard's whole purpose: a pin is only worth holding if the host
+    actually caches. One measured upstream served 38% of same-host turns from
+    cache while its peers managed 99%, and its misses billed at FULL input
+    price — holding a conversation there is worse than the churn the pin
+    replaced."""
+    stream = _affinity_stream()
+    stream._provider_affinity["deepseek/deepseek-v4.1-flash"] = "SiliconFlow"
+
+    await _score(stream, asked="SiliconFlow", served="SiliconFlow", usage=_warm_usage())
+    assert stream._provider_strikes["deepseek/deepseek-v4.1-flash"]["SiliconFlow"] == 1
+    assert not stream._provider_retired.get("deepseek/deepseek-v4.1-flash")
+
+    await _score(stream, asked="SiliconFlow", served="SiliconFlow", usage=_warm_usage())
+    assert stream._provider_retired["deepseek/deepseek-v4.1-flash"] == {"SiliconFlow"}
+    # The pin it was holding goes with it, or the next turn asks for the host
+    # we just retired.
+    assert "deepseek/deepseek-v4.1-flash" not in stream._provider_affinity
+
+
+@pytest.mark.asyncio
+async def test_a_fallback_to_another_host_never_strikes() -> None:
+    """A host we did NOT ask for was never given this prefix, so its cold turn
+    is expected and says nothing about the host we wanted. Charging it would
+    retire innocent hosts during exactly the load that caused the fallback."""
+    stream = _affinity_stream()
+    for _ in range(4):
+        await _score(stream, asked="Wafer", served="SiliconFlow", usage=_warm_usage())
+    assert not stream._provider_strikes.get("deepseek/deepseek-v4.1-flash")
+    assert not stream._provider_retired.get("deepseek/deepseek-v4.1-flash")
+
+
+@pytest.mark.asyncio
+async def test_an_idle_gap_is_charged_to_the_clock_not_the_host() -> None:
+    """Host-side entries expire on a ~10-minute timer, so a miss after a long
+    pause is an expiry — not evidence that the host does not cache."""
+    stream = _affinity_stream()
+    for _ in range(4):
+        await _score(
+            stream,
+            asked="SiliconFlow",
+            served="SiliconFlow",
+            usage=_warm_usage(),
+            gap_s=SessionStreamFn.PROVIDER_STRIKE_MAX_GAP_S + 1,
+        )
+    assert not stream._provider_strikes.get("deepseek/deepseek-v4.1-flash")
+
+
+@pytest.mark.asyncio
+async def test_a_short_prompt_never_strikes() -> None:
+    """Below the floor a prefix may simply sit under the host's minimum
+    cacheable block, so "no reuse" carries no information."""
+    stream = _affinity_stream()
+    for _ in range(4):
+        await _score(
+            stream,
+            asked="SiliconFlow",
+            served="SiliconFlow",
+            usage=_warm_usage(prompt=SessionStreamFn.PROVIDER_STRIKE_MIN_PROMPT_TOKENS - 1),
+        )
+    assert not stream._provider_strikes.get("deepseek/deepseek-v4.1-flash")
+
+
+@pytest.mark.asyncio
+async def test_real_reuse_clears_the_strike_counter() -> None:
+    """Strikes must be CONSECUTIVE: a single miss is ordinary (an eviction
+    under load), and letting isolated misses accumulate would eventually retire
+    a host that caches perfectly well."""
+    stream = _affinity_stream()
+    await _score(stream, asked="SiliconFlow", served="SiliconFlow", usage=_warm_usage())
+    assert stream._provider_strikes["deepseek/deepseek-v4.1-flash"]["SiliconFlow"] == 1
+
+    await _score(
+        stream, asked="SiliconFlow", served="SiliconFlow", usage=_warm_usage(cached=29_000)
+    )
+    assert not stream._provider_strikes["deepseek/deepseek-v4.1-flash"].get("SiliconFlow")
+
+    await _score(stream, asked="SiliconFlow", served="SiliconFlow", usage=_warm_usage())
+    assert stream._provider_strikes["deepseek/deepseek-v4.1-flash"]["SiliconFlow"] == 1
+    assert not stream._provider_retired.get("deepseek/deepseek-v4.1-flash")
+
+
+@pytest.mark.asyncio
+async def test_reuse_just_over_the_floor_counts_as_a_hit() -> None:
+    """The floor is max(1024, 2% of the prefix); at or above it is reuse."""
+    stream = _affinity_stream()
+    floor = int(30_000 * SessionStreamFn.PROVIDER_STRIKE_MIN_CACHED_FRACTION)
+    await _score(
+        stream, asked="SiliconFlow", served="SiliconFlow", usage=_warm_usage(cached=floor - 1)
+    )
+    assert stream._provider_strikes["deepseek/deepseek-v4.1-flash"]["SiliconFlow"] == 1
+    await _score(
+        stream,
+        asked="SiliconFlow",
+        served="SiliconFlow",
+        usage=_warm_usage(cached=max(floor, SessionStreamFn.PROVIDER_STRIKE_MIN_CACHED_TOKENS)),
+    )
+    assert not stream._provider_strikes["deepseek/deepseek-v4.1-flash"].get("SiliconFlow")
+
+
+@pytest.mark.asyncio
+async def test_a_retired_host_is_never_pinned_again() -> None:
+    """Retirement has to survive the host serving again — OpenRouter may still
+    route there, and re-pinning on that would undo the retirement instantly."""
+    stream = _affinity_stream()
+    for _ in range(2):
+        await _score(stream, asked="SiliconFlow", served="SiliconFlow", usage=_warm_usage())
+    assert stream._provider_retired["deepseek/deepseek-v4.1-flash"] == {"SiliconFlow"}
+
+    async def served_by_retired() -> AsyncIterator[StreamEvent]:
+        yield StreamEndEvent(
+            stop_reason="stop", served_provider="SiliconFlow", usage=_warm_usage(cached=29_000)
+        )
+
+    request = _affinity_request()
+    assert [event async for event in stream._record_stream(request, served_by_retired())]
+    assert "deepseek/deepseek-v4.1-flash" not in stream._provider_affinity
+
+
+@pytest.mark.asyncio
+async def test_retirement_is_capped() -> None:
+    """``ignore`` is a HARD filter, so an unbounded set walks a conversation
+    toward "no eligible endpoints". A routing optimisation must never be able
+    to make a model unreachable."""
+    stream = _affinity_stream()
+    hosts = ["HostA", "HostB", "HostC", "HostD", "HostE"]
+    for host in hosts:
+        for _ in range(2):
+            await _score(stream, asked=host, served=host, usage=_warm_usage())
+    retired = stream._provider_retired["deepseek/deepseek-v4.1-flash"]
+    assert len(retired) == SessionStreamFn.MAX_RETIRED_PROVIDERS
+    assert set(hosts[: SessionStreamFn.MAX_RETIRED_PROVIDERS]) == retired
+
+
+@pytest.mark.asyncio
+async def test_retirements_are_held_per_model_and_inherited_by_a_transcript_fork() -> None:
+    """Cache deadness is observed per PREFIX, so it is scoped to the
+    conversation and model that observed it — and a true fork replays that same
+    prefix, so it inherits the finding rather than re-paying for it."""
+    stream = _affinity_stream()
+    for _ in range(2):
+        await _score(stream, asked="SiliconFlow", served="SiliconFlow", usage=_warm_usage())
+    for _ in range(2):
+        await _score(
+            stream,
+            asked="Novita",
+            served="Novita",
+            usage=_warm_usage(),
+            model_id="moonshotai/kimi-k2",
+        )
+    assert stream._provider_retired == {
+        "deepseek/deepseek-v4.1-flash": {"SiliconFlow"},
+        "moonshotai/kimi-k2": {"Novita"},
+    }
+
+    child = stream.fork("s-child", cache_lineage_id="s-affinity")
+    try:
+        assert child._provider_retired["deepseek/deepseek-v4.1-flash"] == {"SiliconFlow"}
+        # A deep copy: the child's later findings are its own.
+        child._provider_retired["deepseek/deepseek-v4.1-flash"].add("Wafer")
+        assert stream._provider_retired["deepseek/deepseek-v4.1-flash"] == {"SiliconFlow"}
+    finally:
+        child._transport.owners -= 1
 
 
 def _anthropic_sse(context_tokens: int, *, tool_call: bool = False) -> bytes:

--- a/tests/unit/model/test_configure.py
+++ b/tests/unit/model/test_configure.py
@@ -4229,6 +4229,237 @@ async def test_retirements_are_held_per_model_and_inherited_by_a_transcript_fork
         child._transport.owners -= 1
 
 
+# ---------------------------------------------------------------------------
+# OpenRouter cache affinity: the guard must not retire a GOOD host
+# (review round 1, blocker-2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("purpose", ["compaction", "compaction_advisor"])
+async def test_a_non_turn_request_never_strikes_the_host(purpose: str) -> None:
+    """Only a real turn's cache result says anything about the host's cache.
+
+    A `compaction` request is a fresh write-once system+transcript prefix by
+    construction — its own `context_tokens_hint=0` documents that — and a
+    `compaction_advisor` call is an aside. Both MISS by design: the host was
+    never given the prefix they send. Charging them a strike means the
+    conversation's host is penalised for being cold on a prompt it could not
+    have cached, which is the mechanism that retired a host measured at 99.6%
+    cache share.
+    """
+    stream = _affinity_stream()
+    stream._provider_affinity["deepseek/deepseek-v4.1-flash"] = "Wafer"
+    request = _affinity_request(purpose=purpose).model_copy(update={"provider_affinity": "Wafer"})
+    stream._provider_last_turn_at["deepseek/deepseek-v4.1-flash"] = 1000.0
+
+    for step in range(4):
+        stream._score_cache_affinity(request, "Wafer", _warm_usage(), now=1005.0 + step * 5)
+
+    assert not stream._provider_strikes.get("deepseek/deepseek-v4.1-flash")
+    assert not stream._provider_retired.get("deepseek/deepseek-v4.1-flash")
+    assert stream._provider_affinity["deepseek/deepseek-v4.1-flash"] == "Wafer"
+
+
+@pytest.mark.asyncio
+async def test_a_compaction_beside_a_cold_turn_does_not_retire_the_host() -> None:
+    """The reviewer's reproduction, as a test: `Wafer` cached 99.6% of its
+    same-host turns in the live run, and the guard retired it anyway.
+
+    Compaction fires exactly when the conversation is largest, so the cold
+    compaction call and the first turn on the REBUILT prefix (also cold — the
+    summary replaced the tokens the host had cached) landed seconds apart. Two
+    strikes, cap of two, host retired for the rest of the conversation with no
+    removal path, and every fork inheriting the bar. Both halves of the fix
+    show up here: the compaction does not score, and it clears the slate the
+    post-compaction cold turn would otherwise be the second strike on.
+    """
+    stream = _affinity_stream()
+    model_id = "deepseek/deepseek-v4.1-flash"
+    stream._provider_affinity[model_id] = "Wafer"
+
+    # A genuine first miss on the pre-compaction prefix — ordinary, an eviction
+    # under load. This is the strike the compaction must void.
+    await _score(stream, asked="Wafer", served="Wafer", usage=_warm_usage())
+    assert stream._provider_strikes[model_id]["Wafer"] == 1
+
+    # The compaction request itself, through the real request-side path.
+    compacting = _affinity_request(purpose="compaction", context_tokens_hint=0)
+    stamped = stream._apply_cache_affinity(compacting)
+    # It still rides on the pinned host: the summary is sent to the host
+    # holding this conversation, which is the feature working as intended.
+    assert stamped.provider_affinity == "Wafer"
+    assert not stream._provider_strikes.get(model_id), "the old prefix's evidence is void"
+
+    # The compaction's own (cold by design) result must not score either.
+    stream._score_cache_affinity(stamped, "Wafer", _warm_usage(), now=1005.0)
+    assert not stream._provider_strikes.get(model_id)
+
+    # First turn on the rebuilt prefix, seconds later, and cold for the honest
+    # reason that the prefix is new. One strike, not a retirement.
+    await _score(stream, asked="Wafer", served="Wafer", usage=_warm_usage())
+    assert stream._provider_strikes[model_id]["Wafer"] == 1
+    assert not stream._provider_retired.get(model_id)
+    assert stream._provider_affinity[model_id] == "Wafer"
+
+
+@pytest.mark.asyncio
+async def test_a_compaction_lifts_an_existing_retirement() -> None:
+    """A retirement is a claim about one prefix: "this host was given these
+    tokens and returned no reuse". Compaction replaces those tokens, so the
+    host has never been asked about the new prefix and the bar has to lift —
+    `provider.ignore` is a hard filter with no removal path of its own, so a
+    retirement that outlives its evidence is permanent."""
+    stream = _affinity_stream()
+    model_id = "deepseek/deepseek-v4.1-flash"
+    for _ in range(2):
+        await _score(stream, asked="SiliconFlow", served="SiliconFlow", usage=_warm_usage())
+    assert stream._provider_retired[model_id] == {"SiliconFlow"}
+
+    # It is on the wire as `ignore` before the boundary...
+    stream._provider_affinity[model_id] = "Wafer"
+    assert stream._apply_cache_affinity(_affinity_request()).provider_avoid == ["SiliconFlow"]
+
+    stream._apply_cache_affinity(_affinity_request(purpose="compaction"))
+
+    assert not stream._provider_retired.get(model_id)
+    # ...and gone from it afterwards, which is the half a bare dict-clear would
+    # miss if the request-side read were cached anywhere.
+    assert stream._apply_cache_affinity(_affinity_request()).provider_avoid == []
+
+
+@pytest.mark.asyncio
+async def test_two_strikes_too_far_apart_never_pair() -> None:
+    """Strike bookkeeping had no clock: a cold turn in the morning and another
+    in the afternoon retired the host as though they were consecutive evidence
+    about one warm prefix. Two isolated single misses are exactly what the
+    "one miss is ordinary" reasoning behind the two-strike bar forgives."""
+    stream = _affinity_stream()
+    model_id = "deepseek/deepseek-v4.1-flash"
+
+    await _score(stream, asked="SiliconFlow", served="SiliconFlow", usage=_warm_usage())
+    assert stream._provider_strikes[model_id]["SiliconFlow"] == 1
+
+    # Hours later the conversation resumes and misses again. The per-turn gap
+    # guard cannot catch this: the SECOND strike's own predecessor gap is
+    # short (the conversation has been active again for a while), so only the
+    # gap between the two STRIKES distinguishes it.
+    stream._provider_last_turn_at[model_id] = 40_000.0
+    await _score(stream, asked="SiliconFlow", served="SiliconFlow", usage=_warm_usage())
+
+    assert stream._provider_strikes[model_id]["SiliconFlow"] == 1, "a first strike, again"
+    assert not stream._provider_retired.get(model_id)
+
+    # And a genuinely adjacent third still retires: the age-out must not have
+    # disarmed the guard.
+    await _score(stream, asked="SiliconFlow", served="SiliconFlow", usage=_warm_usage())
+    assert stream._provider_retired[model_id] == {"SiliconFlow"}
+
+
+@pytest.mark.asyncio
+async def test_the_retirement_cap_still_holds_after_a_compaction() -> None:
+    """The cap is the invariant that keeps a routing optimisation from making a
+    model unreachable (`ignore` is a hard filter). Clearing on compaction must
+    reset the count rather than leave a stale one that lets the set grow past
+    the cap on the next pass."""
+    stream = _affinity_stream()
+    model_id = "deepseek/deepseek-v4.1-flash"
+    for host in ["HostA", "HostB", "HostC", "HostD", "HostE"]:
+        for _ in range(2):
+            await _score(stream, asked=host, served=host, usage=_warm_usage())
+    assert len(stream._provider_retired[model_id]) == SessionStreamFn.MAX_RETIRED_PROVIDERS
+
+    stream._apply_cache_affinity(_affinity_request(purpose="compaction"))
+    assert not stream._provider_retired.get(model_id)
+
+    for host in ["HostF", "HostG", "HostH", "HostI"]:
+        for _ in range(2):
+            await _score(stream, asked=host, served=host, usage=_warm_usage())
+    assert len(stream._provider_retired[model_id]) == SessionStreamFn.MAX_RETIRED_PROVIDERS
+
+
+@pytest.mark.asyncio
+async def test_a_failover_stamped_usage_attributes_the_pin_to_the_served_model() -> None:
+    """Review round 1, major-1.
+
+    `stream_with_failover` rewrites the request to a fallback and stamps the
+    spec that actually served onto `Usage.provider`/`Usage.model_id` — that
+    field exists because an earlier bug priced every Grok call at Opus rates by
+    reading `request.model` off the original request. The pin had the same bug
+    in a different currency: filed under the PRIMARY, it later asked the
+    primary for a host that never served it, while the fallback's own cache
+    evidence was thrown away.
+    """
+    stream = _affinity_stream()
+
+    async def served_by_fallback() -> AsyncIterator[StreamEvent]:
+        yield StreamEndEvent(
+            stop_reason="stop",
+            served_provider="AtlasCloud",
+            usage=Usage(
+                input_tokens=30_000,
+                cache_read_tokens=29_000,
+                provider="openrouter",
+                model_id="moonshotai/kimi-k2",
+            ),
+        )
+
+    request = _affinity_request(model_id="deepseek/deepseek-v4.1-flash")
+    assert [event async for event in stream._record_stream(request, served_by_fallback())]
+
+    assert stream._provider_affinity == {"moonshotai/kimi-k2": "AtlasCloud"}
+    assert "deepseek/deepseek-v4.1-flash" not in stream._provider_affinity
+
+
+@pytest.mark.asyncio
+async def test_strikes_follow_the_served_model_too() -> None:
+    """The other half of major-1: bookkeeping keyed by the request while the
+    pin is keyed by the served model would put the two in different buckets,
+    so a host could never accumulate the second strike that retires it."""
+    stream = _affinity_stream()
+    served_id = "moonshotai/kimi-k2"
+
+    async def cold_fallback() -> AsyncIterator[StreamEvent]:
+        yield StreamEndEvent(
+            stop_reason="stop",
+            served_provider="SiliconFlow",
+            usage=Usage(
+                input_tokens=30_000,
+                cache_read_tokens=0,
+                provider="openrouter",
+                model_id=served_id,
+            ),
+        )
+
+    # An established conversation on the SERVED model, pinned to the host that
+    # is about to answer — the only shape that can strike.
+    stream._provider_affinity[served_id] = "SiliconFlow"
+    stream._provider_last_turn_at[served_id] = time.monotonic()
+    request = _affinity_request().model_copy(update={"provider_affinity": "SiliconFlow"})
+
+    assert [event async for event in stream._record_stream(request, cold_fallback())]
+    assert stream._provider_strikes[served_id]["SiliconFlow"] == 1
+    assert not stream._provider_strikes.get("deepseek/deepseek-v4.1-flash")
+
+
+@pytest.mark.asyncio
+async def test_an_unstamped_usage_still_attributes_to_the_request_model() -> None:
+    """`Usage.model_id` is `None` for a primary success and for a direct
+    non-failover call, and then the request is the honest answer. This is the
+    fallback path major-1's fix must not break."""
+    stream = _affinity_stream()
+
+    async def served() -> AsyncIterator[StreamEvent]:
+        yield StreamEndEvent(
+            stop_reason="stop",
+            served_provider="AtlasCloud",
+            usage=Usage(input_tokens=30_000, cache_read_tokens=29_000),
+        )
+
+    assert [event async for event in stream._record_stream(_affinity_request(), served())]
+    assert stream._provider_affinity == {"deepseek/deepseek-v4.1-flash": "AtlasCloud"}
+
+
 def _anthropic_sse(context_tokens: int, *, tool_call: bool = False) -> bytes:
     """One mocked Anthropic stream whose usage adds up to ``context_tokens``
     (the client derives ``Usage.context_tokens`` as input + cache read +

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -4551,6 +4551,338 @@ async def test_openrouter_provider_and_prompt_cache_key_coexist_on_one_body() ->
     assert captured["body"]["messages"]
 
 
+# ---------------------------------------------------------------------------
+# OpenRouter cache affinity (`ChatRequest.provider_affinity`)
+# ---------------------------------------------------------------------------
+
+
+def _affinity_client(
+    captured: dict[str, Any],
+    *,
+    preferences: dict[str, Any] | None = None,
+    chunks: Sequence[dict[str, Any]] | None = None,
+) -> OpenAICompatClient:
+    """A MockTransport client that records each request body it is handed."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.setdefault("bodies", []).append(json.loads(request.content))
+        captured["body"] = captured["bodies"][-1]
+        return httpx.Response(
+            200,
+            content=_sse(
+                list(chunks)
+                if chunks is not None
+                else [{"choices": [{"delta": {"content": "ok"}, "index": 0}]}]
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    return OpenAICompatClient(
+        "https://openrouter.ai/api/v1",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        openrouter_provider_preferences=preferences,
+    )
+
+
+def _cacheable_spec() -> ModelSpec:
+    spec = _spec("openrouter", "deepseek/deepseek-v4.1-flash")
+    spec.supports_prompt_cache = True
+    return spec
+
+
+async def test_provider_affinity_pins_the_served_display_name_verbatim() -> None:
+    """The pin reaches the wire as `provider.order`, spelled exactly as served.
+
+    VERBATIM is the contract, not an accident: OpenRouter accepts its own
+    display name as an `order` entry, and slug-normalising it is wrong for 13
+    of 106 providers (`Z.AI` is `z-ai`, `AtlasCloud` is `atlas-cloud`). Sending
+    what was served means there is no slug table to keep in sync.
+    """
+    captured: dict[str, Any] = {}
+    client = _affinity_client(captured)
+    await _collect(
+        client.stream(
+            ChatRequest(
+                model=_cacheable_spec(),
+                messages=[Message.user("hi")],
+                provider_affinity="AtlasCloud",
+            ),
+            "sk-test",
+        )
+    )
+    assert captured["body"]["provider"] == {"order": ["AtlasCloud"]}
+
+
+@pytest.mark.parametrize("name", ["Z.AI", "Google AI Studio", "AtlasCloud"])
+async def test_provider_affinity_does_not_reshape_awkward_display_names(name: str) -> None:
+    """Names with dots, spaces and internal capitals survive byte-for-byte."""
+    captured: dict[str, Any] = {}
+    client = _affinity_client(captured)
+    await _collect(
+        client.stream(
+            ChatRequest(
+                model=_cacheable_spec(),
+                messages=[Message.user("hi")],
+                provider_affinity=name,
+            ),
+            "sk-test",
+        )
+    )
+    assert captured["body"]["provider"]["order"] == [name]
+
+
+async def test_no_affinity_leaves_the_body_without_a_provider_key() -> None:
+    """The "no opinion" invariant: an unpinned request must not grow an empty
+    `provider` object, which would itself be a routing statement."""
+    captured: dict[str, Any] = {}
+    client = _affinity_client(captured)
+    await _collect(
+        client.stream(
+            ChatRequest(model=_cacheable_spec(), messages=[Message.user("hi")]),
+            "sk-test",
+        )
+    )
+    assert "provider" not in captured["body"]
+
+
+async def test_provider_affinity_is_ignored_without_prompt_cache_support() -> None:
+    """No server-side cache means nothing to keep warm, so narrowing the host
+    pool would cost availability and buy nothing."""
+    captured: dict[str, Any] = {}
+    client = _affinity_client(captured)
+    spec = _spec("openrouter", "deepseek/deepseek-v4.1-flash")
+    assert spec.supports_prompt_cache is False
+    await _collect(
+        client.stream(
+            ChatRequest(
+                model=spec,
+                messages=[Message.user("hi")],
+                provider_affinity="AtlasCloud",
+            ),
+            "sk-test",
+        )
+    )
+    assert "provider" not in captured["body"]
+
+
+async def test_provider_affinity_merges_with_non_routing_preferences() -> None:
+    """A privacy/compliance preference is not a host opinion, so the two
+    coexist in one `provider` object rather than one suppressing the other."""
+    captured: dict[str, Any] = {}
+    client = _affinity_client(captured, preferences={"zdr": True})
+    await _collect(
+        client.stream(
+            ChatRequest(
+                model=_cacheable_spec(),
+                messages=[Message.user("hi")],
+                provider_affinity="AtlasCloud",
+            ),
+            "sk-test",
+        )
+    )
+    assert captured["body"]["provider"] == {"zdr": True, "order": ["AtlasCloud"]}
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("order", ["Novita"]),
+        ("only", ["Novita"]),
+        ("ignore", ["Novita"]),
+        ("sort", "price"),
+    ],
+)
+async def test_user_host_preferences_suppress_the_pin_and_survive_intact(
+    key: str, value: Any
+) -> None:
+    """The user's typed routing opinion wins outright.
+
+    Prepending a host to their `order`, or pinning against their `sort`, would
+    make the settings page describe something other than what happens. The
+    session-level gate refuses to pin at all in this state; this is the wire's
+    own defence in depth, so a pin arriving by any other path is still dropped.
+    """
+    captured: dict[str, Any] = {}
+    client = _affinity_client(captured, preferences={key: value})
+    await _collect(
+        client.stream(
+            ChatRequest(
+                model=_cacheable_spec(),
+                messages=[Message.user("hi")],
+                provider_affinity="AtlasCloud",
+            ),
+            "sk-test",
+        )
+    )
+    assert captured["body"]["provider"] == {key: value}
+
+
+async def test_pin_and_prompt_cache_key_are_siblings() -> None:
+    """The two cache stamps are one top-level key each; neither clobbers the
+    other or the rest of the body."""
+    captured: dict[str, Any] = {}
+    client = _affinity_client(captured)
+    await _collect(
+        client.stream(
+            ChatRequest(
+                model=_cacheable_spec(),
+                messages=[Message.user("hi")],
+                prompt_cache_key="lineage-123",
+                provider_affinity="AtlasCloud",
+            ),
+            "sk-test",
+        )
+    )
+    assert captured["body"]["provider"] == {"order": ["AtlasCloud"]}
+    assert captured["body"]["prompt_cache_key"] == "lineage-123"
+    assert captured["body"]["model"] == "deepseek/deepseek-v4.1-flash"
+    assert captured["body"]["messages"]
+
+
+async def test_body_construction_is_isolated_from_caller_and_callee_mutation() -> None:
+    """DEEPCOPY, not `dict(...)`: `max_price` nests, and the `order` list this
+    feature appends must not alias the caller's configuration.
+
+    Two directions, both previously live bugs of the same class (review round
+    1, m1): a caller mutating its nested preferences after construction, and a
+    consumer mutating the returned body. Neither may reach a later request.
+
+    Asserted against `_build_body` DIRECTLY rather than through the transport,
+    because a MockTransport handler reads the body back with `json.loads` — a
+    fresh object graph, so mutating what the handler captured cannot reach the
+    client's state and the second direction would pass vacuously.
+    """
+    preferences: dict[str, Any] = {"max_price": {"prompt": 1}}
+    client = _affinity_client({}, preferences=preferences)
+    request = ChatRequest(
+        model=_cacheable_spec(),
+        messages=[Message.user("hi")],
+        provider_affinity="AtlasCloud",
+    )
+    expected = {"max_price": {"prompt": 1}, "order": ["AtlasCloud"]}
+
+    first = client._build_body(request, scope=None)
+    assert first["provider"] == expected
+
+    # A caller mutating its own nested mapping after construction, and a
+    # consumer mutating the body it was handed — the appended `order` list and
+    # the nested price cap alike.
+    preferences["max_price"]["prompt"] = 99
+    first["provider"]["order"].append("Novita")
+    first["provider"]["max_price"]["prompt"] = 77
+
+    assert client._build_body(request, scope=None)["provider"] == expected
+
+
+async def test_retired_hosts_ride_out_as_ignore_beside_the_pin() -> None:
+    """Both halves of the affinity decision reach one `provider` object.
+
+    Verified live that the two COMPOSE rather than conflict: with `order`
+    naming one host and `ignore` another, the ordered host served 8/8 calls and
+    the ignored one was never attempted. Sorted so the body stays byte-stable
+    across turns — this object sits in front of a cached prefix.
+    """
+    captured: dict[str, Any] = {}
+    client = _affinity_client(captured)
+    await _collect(
+        client.stream(
+            ChatRequest(
+                model=_cacheable_spec(),
+                messages=[Message.user("hi")],
+                provider_affinity="Wafer",
+                provider_avoid=["SiliconFlow", "GMICloud"],
+            ),
+            "sk-test",
+        )
+    )
+    assert captured["body"]["provider"] == {
+        "order": ["Wafer"],
+        "ignore": ["GMICloud", "SiliconFlow"],
+    }
+
+
+async def test_retired_hosts_are_sent_even_with_no_pin_held() -> None:
+    """After a retirement the conversation has NO pin until another host
+    serves it, and it must not be routed straight back onto the host it just
+    left — so `ignore` has to outlive the `order` it replaced."""
+    captured: dict[str, Any] = {}
+    client = _affinity_client(captured)
+    await _collect(
+        client.stream(
+            ChatRequest(
+                model=_cacheable_spec(),
+                messages=[Message.user("hi")],
+                provider_avoid=["SiliconFlow"],
+            ),
+            "sk-test",
+        )
+    )
+    assert captured["body"]["provider"] == {"ignore": ["SiliconFlow"]}
+
+
+async def test_a_user_host_preference_suppresses_retirements_too() -> None:
+    """The user's own `ignore` (or any host opinion) wins whole: merging ours
+    into theirs would make their setting mean something they did not type."""
+    captured: dict[str, Any] = {}
+    client = _affinity_client(captured, preferences={"ignore": ["Novita"]})
+    await _collect(
+        client.stream(
+            ChatRequest(
+                model=_cacheable_spec(),
+                messages=[Message.user("hi")],
+                provider_affinity="Wafer",
+                provider_avoid=["SiliconFlow"],
+            ),
+            "sk-test",
+        )
+    )
+    assert captured["body"]["provider"] == {"ignore": ["Novita"]}
+
+
+async def test_served_provider_is_reported_on_the_end_event() -> None:
+    """The capture half: OpenRouter names the routed host on every chunk, and
+    the terminal event carries it so a session can pin the next turn."""
+    events = await _collect(
+        _affinity_client(
+            {},
+            chunks=[
+                {"id": "gen-1", "provider": "AtlasCloud", "choices": [{"delta": {}, "index": 0}]},
+                {
+                    "provider": "AtlasCloud",
+                    "choices": [{"delta": {"content": "ok"}, "index": 0}],
+                },
+                {"choices": [{"delta": {}, "finish_reason": "stop", "index": 0}]},
+            ],
+        ).stream(
+            ChatRequest(model=_cacheable_spec(), messages=[Message.user("hi")]),
+            "sk-test",
+        )
+    )
+    end = next(e for e in events if isinstance(e, StreamEndEvent))
+    assert end.served_provider == "AtlasCloud"
+    # Routing identity must NOT leak into the persisted message payload: that
+    # dict is native-replay and compaction substrate, not a routing hint.
+    assert "provider" not in (end.provider_payload or {})
+
+
+async def test_served_provider_is_none_when_the_wire_does_not_name_a_host() -> None:
+    """A direct (non-aggregator) endpoint sends no `provider` field, and must
+    leave the pin unset rather than inventing one."""
+    events = await _collect(
+        _affinity_client(
+            {},
+            chunks=[
+                {"id": "gen-1", "choices": [{"delta": {"content": "ok"}, "index": 0}]},
+                {"choices": [{"delta": {}, "finish_reason": "stop", "index": 0}]},
+            ],
+        ).stream(
+            ChatRequest(model=_cacheable_spec(), messages=[Message.user("hi")]),
+            "sk-test",
+        )
+    )
+    assert next(e for e in events if isinstance(e, StreamEndEvent)).served_provider is None
+
+
 def test_client_for_spec_routes_preferences_only_to_openrouter_routed_specs() -> None:
     # `max_price` nests — the shape the deep-copy isolation asserts below need.
     prefs = {"sort": "price", "max_price": {"prompt": 1}}

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -4883,6 +4883,140 @@ async def test_served_provider_is_none_when_the_wire_does_not_name_a_host() -> N
     assert next(e for e in events if isinstance(e, StreamEndEvent)).served_provider is None
 
 
+@pytest.mark.parametrize(
+    ("provider", "model_id"),
+    [
+        ("deepseek", "deepseek-chat"),
+        ("zai", "glm-4.6"),
+        ("kimi", "kimi-k2"),
+        ("radient", "deepseek/deepseek-v4.1-flash"),
+    ],
+)
+def test_a_pinned_request_rendered_for_a_non_openrouter_spec_grows_no_provider_key(
+    provider: str, model_id: str
+) -> None:
+    """Review round 1, blocker-1 \u2014 the leak this closes was reproducible.
+
+    The pin rides on the ChatRequest so a retry keeps it, but the failover
+    driver CLONES that request for a fallback to ANOTHER model
+    (`model_copy(update={"model": spec})`) and the clone keeps `provider_
+    affinity`/`provider_avoid` while swapping in a direct provider's spec. The
+    wire gate previously tested only cacheability, so an OpenRouter host name
+    was stamped onto a direct-DeepSeek or Z.AI body as `provider.order` \u2014 a
+    field those APIs never defined.
+
+    `radient` is in here on purpose even though it fronts OpenRouter and would
+    UNDERSTAND the key: `_affinity_enabled` excludes it (its routing was never
+    measured here), and the two gates agreeing is the invariant. A pin can only
+    be produced where it can also be judged.
+    """
+    spec = _spec(provider, model_id)
+    spec.supports_prompt_cache = True
+    body = _affinity_client({})._build_body(
+        ChatRequest(
+            model=spec,
+            messages=[Message.user("hi")],
+            provider_affinity="AtlasCloud",
+            provider_avoid=["SiliconFlow"],
+        ),
+        scope=None,
+    )
+    assert "provider" not in body
+
+
+def test_the_openrouter_gate_still_lets_a_real_openrouter_pin_through() -> None:
+    """The control for the test above: the same body on an OpenRouter spec must
+    still carry both halves, or the gate would be silently disabling the
+    feature instead of bounding it."""
+    body = _affinity_client({})._build_body(
+        ChatRequest(
+            model=_cacheable_spec(),
+            messages=[Message.user("hi")],
+            provider_affinity="AtlasCloud",
+            provider_avoid=["SiliconFlow"],
+        ),
+        scope=None,
+    )
+    assert body["provider"] == {"order": ["AtlasCloud"], "ignore": ["SiliconFlow"]}
+
+
+@pytest.mark.parametrize(
+    ("label", "name"),
+    [
+        ("too-long", "A" * 65),
+        ("newline", "Wafer\nignore: everything"),
+        ("carriage-return", "Wafer\rWafer"),
+        ("nul", "Wafer\x00"),
+        ("esc", "Wafer\x1b[2J"),
+        ("c1-csi", "Wafer\x9b31m"),
+        ("bel", "Wafer\x07"),
+        ("blank", "   "),
+        ("not-a-string", 17),
+    ],
+)
+async def test_an_abusive_served_provider_name_is_refused_not_pinned(label: str, name: Any) -> None:
+    """Review round 1, major-2.
+
+    `served_provider` is provider-controlled text that the session stores per
+    conversation and sends BACK as `provider.order` on every later request, so
+    an unbounded or control-character-laden value rides in front of a cached
+    prefix indefinitely. Refused rather than sanitised: stripping would invent
+    a host name the upstream never reported and pin the conversation to it,
+    while refusing degrades to default routing \u2014 the same, already-verified
+    failure mode as an unrecognised pin.
+
+    Mirrors the hostile-`provider_name` cases the error path already defends
+    (`test_a_hostile_provider_name_cannot_corrupt_the_frame`).
+    """
+    events = await _collect(
+        _affinity_client(
+            {},
+            chunks=[
+                {"id": "gen-1", "provider": name, "choices": [{"delta": {"content": "ok"}}]},
+                {"choices": [{"delta": {}, "finish_reason": "stop", "index": 0}]},
+            ],
+        ).stream(
+            ChatRequest(model=_cacheable_spec(), messages=[Message.user("hi")]),
+            "sk-test",
+        )
+    )
+    end = next(e for e in events if isinstance(e, StreamEndEvent))
+    assert end.served_provider is None, label
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "Z.AI",
+        "Google AI Studio",
+        "AtlasCloud",
+        "A" * 64,
+        # Bidi/format characters (category Cf) are NOT refused here, unlike in
+        # the error-frame path: this value never reaches a terminal, and the
+        # verbatim contract means a provider whose own display name contains
+        # one must still be pinnable.
+        "Meta\u200dLlama",
+    ],
+)
+async def test_a_legitimate_served_provider_name_survives_the_bound(name: str) -> None:
+    """The bound must not cost a real name. 64 characters is ~2x the longest
+    entry in OpenRouter's 106-provider list, so this is headroom for a rename
+    rather than a fit."""
+    events = await _collect(
+        _affinity_client(
+            {},
+            chunks=[
+                {"id": "gen-1", "provider": name, "choices": [{"delta": {"content": "ok"}}]},
+                {"choices": [{"delta": {}, "finish_reason": "stop", "index": 0}]},
+            ],
+        ).stream(
+            ChatRequest(model=_cacheable_spec(), messages=[Message.user("hi")]),
+            "sk-test",
+        )
+    )
+    assert next(e for e in events if isinstance(e, StreamEndEvent)).served_provider == name
+
+
 def test_client_for_spec_routes_preferences_only_to_openrouter_routed_specs() -> None:
     # `max_price` nests — the shape the deep-copy isolation asserts below need.
     prefs = {"sort": "price", "max_price": {"prompt": 1}}

--- a/tests/unit/session/test_config_live.py
+++ b/tests/unit/session/test_config_live.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import inspect
 from typing import Any, cast
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -30,6 +31,7 @@ from local_operator.harness.jobs import DEFAULT_MAX_RUNNING_JOBS
 from local_operator.harness.types import (
     AbortSignal,
     ChatRequest,
+    Message,
     ModelSpec,
     StreamEndEvent,
     StreamTextDelta,
@@ -281,6 +283,28 @@ LIVE_KEY_PROBES: dict[str, tuple[Any, Any]] = {
     # a PATCH route or hand-written YAML stores). Non-default in every case:
     # the section's contract is that defaults resolve to NO ``provider``
     # object at all.
+    # The one key in this section that is NOT a wire preference: it gates the
+    # harness-side cache affinity pin, so it is probed through the gate that
+    # actually reads it rather than through the `provider` resolver (which
+    # deliberately ignores it — see test_openrouter_defaults_mean_no_opinion).
+    # Probed False because the default is True: the probe must observe a
+    # CHANGE reaching the live session.
+    "providers.openrouter.provider_affinity": (
+        False,
+        # Built against the session's LIVE routing mapping, which is the thing
+        # a cross-process write has to reach; the gate itself is pure over that
+        # mapping, so this observes the same decision `__call__` would make.
+        lambda s, w: SessionStreamFn(MagicMock(), s.routing_settings, "probe")._affinity_enabled(
+            ChatRequest(
+                model=ModelSpec(
+                    provider="openrouter",
+                    model_id="deepseek/deepseek-v4.1-flash",
+                    supports_prompt_cache=True,
+                ),
+                messages=[Message.user("hi")],
+            )
+        ),
+    ),
     "providers.openrouter.sort": (
         "price",
         lambda s, w: (_openrouter_provider_preferences(s.routing_settings) or {}).get("sort"),

--- a/tests/unit/test_settings_io.py
+++ b/tests/unit/test_settings_io.py
@@ -121,6 +121,12 @@ def _consumer_defaults() -> dict[str, object]:
         # constant exists to compare against, and inventing one would be a
         # third restatement), so the registry default and DEFAULT_CONFIG must
         # not be allowed to disagree.
+        # Not a wire key: its consumer is ``SessionStreamFn._affinity_enabled``,
+        # which reads the settings mapping directly. Guarded against the shipped
+        # config block for the same reason as the rows below.
+        "providers.openrouter.provider_affinity": (
+            DEFAULT_CONFIG.values["providers"]["openrouter"]["provider_affinity"]
+        ),
         "providers.openrouter.sort": DEFAULT_CONFIG.values["providers"]["openrouter"]["sort"],
         "providers.openrouter.order": DEFAULT_CONFIG.values["providers"]["openrouter"]["order"],
         "providers.openrouter.only": DEFAULT_CONFIG.values["providers"]["openrouter"]["only"],
@@ -602,7 +608,14 @@ def test_openrouter_defaults_mean_no_opinion() -> None:
         for key in settings_io.BY_KEY
         if key.startswith("providers.openrouter.")
     }
-    assert len(defaults) == 13
+    assert len(defaults) == 14
+    # STILL None with all 14 defaults present, including the ON-by-default
+    # ``provider_affinity``. That is the point of asserting it here: that key is
+    # a HARNESS switch read by ``SessionStreamFn._affinity_enabled``, and it is
+    # deliberately NOT read by this resolver — so turning it on must not make
+    # the shipped config start emitting a ``provider`` object. The pin reaches
+    # the wire through ``ChatRequest.provider_affinity`` instead, per request,
+    # only once a host has actually served a turn.
     assert _openrouter_provider_preferences({"providers": {"openrouter": defaults}}) is None
 
 

--- a/tests/unit/tui/test_settings_view.py
+++ b/tests/unit/tui/test_settings_view.py
@@ -2653,9 +2653,13 @@ async def test_selecting_a_row_keeps_its_attached_explanation_on_screen(
         # (the OpenRouter routing section, design round 1 D1) push the
         # discovered height up, and the contract being pinned is about the
         # scroll model, not about any one era's row count. It is the range END
-        # that a new row above the cascade moves, so it has to move WITH one:
-        # `model_effort` (the effort default) added a third `model` row and took
-        # the discovered height from 48 to 49, one past the old ceiling of 48.
+        # that a new row above the cascade moves, so it has to move WITH one,
+        # and it has now moved twice for that reason: `model_effort` (the effort
+        # default) added a third `model` row, and
+        # `providers.openrouter.provider_affinity` added a routing row, each
+        # taking the discovered height to 49 and one past the old ceiling of 48.
+        # Raised to 64 once, with headroom, because the search failing is the
+        # intended signal that a row moved — not a reason to pin a number.
         for height in range(64, 8, -1):
             await pilot.resize_terminal(120, height)
             await pilot.pause()


### PR DESCRIPTION
Release: **patch** — a routing optimisation behind a default-on settings key, no new API and no new UI beyond one settings row. `pyproject.toml` untouched (combined-release rule: PRs never carry a bump).

Fixes the operator's report that OpenRouter DeepSeek sessions sit at ~89-90% cache hit rate, with ~9.8% of all read tokens re-billed uncached.

## The diagnosis

**OpenRouter's default route is price-weighted load balancing, not stickiness.** `deepseek/deepseek-v4.1-flash` currently has 11 upstream endpoints, each keeping its own KV cache, and DeepSeek-style caching needs a full prefix match **from token 0** — so a turn routed to a different host than the last one re-bills the entire conversation. Real session `07f13f9fb3e0` was served by GMICloud, Novita, Wafer, Morph and Modal in turn (verified against `/api/v1/generation` records).

`prompt_cache_key` asks for server-side sticky routing and the harness already sends it. **It does not hold under load.** A controlled 18-turn A/B/C:

| arm | host switches / 18 turns | cache share |
|---|---:|---:|
| baseline (`prompt_cache_key` only) | 7 | 57.4% |
| `+ session_id` | 9 | 63.5% |
| **client-side pin via `provider.order`** | **4** | **77.2%** |

And the cost of a switch is not marginal — measured against OpenRouter's own generation records, a miss bills at **$0.30/Mtok against $0.009 for a cache read, 33×**:

| transition | n | any cache hit | cache share |
|---|---:|---:|---:|
| host **same** | 306 | 56% | 55.5% |
| host **changed** | 30 | 10% | 9.9% |

## The fix

The session records the host that served each turn (per model) and asks for it again.

1. **Capture** — `OpenAICompatClient.stream` reads the `provider` field OpenRouter puts on every chunk and reports it as `StreamEndEvent.served_provider`. On the END event, not the start: a stream that dies mid-way must not move the pin. Deliberately *not* `provider_payload`, which is persisted per message and is native-replay/compaction substrate.
2. **Record** — `SessionStreamFn._record_stream` writes it into a per-model dict on a successful end only. Re-pinning is immediate with no hysteresis: the host that just served holds the prefix, and the previous host's entry is already decaying against a ~10-minute expiry.
3. **Stamp** — the next request carries it on `ChatRequest`, which is what failover **clones** for retries, so the pin follows a retry for free. Same reasoning as `prompt_cache_key`: the wire client is rebuilt per route-key inside the failover driver, so client-held state cannot survive a call. Held outside `FailoverRouteState`, which is cleared on a model switch — a cache pin must survive a detour to another model and back.
4. **Render** — `_build_body` merges it as `provider.order`.

Two live-verified properties make it safe on by default: an **unrecognised `order` entry is silently ignored** (200 + default routing), so a stale pin degrades to today's behaviour rather than erroring; and the **served display name works verbatim**, so there is no slug table to keep in sync (normalising is wrong for 13 of 106 providers — `Z.AI` → `z-ai`, `AtlasCloud` → `atlas-cloud`).

### The cache-quality guard

The plain pin exposed a failure mode worth fixing here rather than shipping as a known hazard: **upstreams differ enormously in cache quality**, and a pin can lock a conversation onto one that does not cache.

| provider | same-host transitions | cache share |
|---|---:|---:|
| Modal | 12 | 99.7% |
| Wafer | 27 | 99.6% |
| Novita | 22 | 90.4% |
| GMICloud | 24 | 82.8% |
| **SiliconFlow** | 221 | **41.4%** |

So a turn **strikes** when the served host is the one we *asked for* (a fallback elsewhere was never given this prefix, so its cold turn is expected and never strikes), the gap since the previous turn is under 300s (longer and the miss belongs to the expiry clock), the prefix is ≥8192 tokens, and reuse came back under `max(1024, 2%)`. **Two consecutive strikes retire the host** for that conversation+model: the pin drops and the host goes out as `provider.ignore`. Any real reuse clears the counter. Capped at **3 hosts** — `ignore` is a hard filter and an unbounded set walks toward "no eligible endpoints"; a routing optimisation must never make a model unreachable.

Verified live that the two compose: `{"order":["Wafer"],"ignore":["SiliconFlow"]}` → Wafer served **8/8** calls, SiliconFlow never attempted.

### When it deliberately does nothing

`_affinity_enabled` refuses unless all hold: provider is `openrouter` (Radient aggregates too but was never measured — excluded); the model advertises prompt caching; the request is **not `isolated`** (gated in *both* directions — an errand has no warm prefix, and letting one move the pin would drag the real conversation onto whatever host answered an unrelated question); the model id has no `:` suffix (`:nitro`/`:floor` sort by throughput/price *by definition*); the setting is not off; and **no `order`/`only`/`ignore`/`sort` is configured — the user's own routing opinion wins outright**. `_build_body` repeats that last check as defence in depth.

A true transcript fork inherits the pin and retirements as **copies**; a fresh delegated prompt inherits nothing. Memory-only: a resumed session re-acquires after one cold call.

## Testing evidence

**Live A/B on the real integration path** (`scripts/bench_openrouter_cache_rate.py`) — a real `SessionStreamFn` over the real `AuthStore` with the settings key flipped between arms, *not* a transport-level header strip, because the half that decides *when* to pin is where the feature can silently no-op. The transport is a passive observer that **fails the run** if the ON arm never sends `provider.order` or the OFF arm ever does. Isolated `HOME` + `LOCAL_OPERATOR_CONFIG_DIR`, `auth.db` copied from a read-only handle, synthetic session ids, per-arm unique prefix namespace and cache lineage. **$5.16 total across all runs.**

Concurrency is load-bearing: a single sequential conversation is a **no-pressure sample** (the balancer has no reason to move it), and an early 3×30-turn sequential run recorded only 3 switches in 87 transitions and correctly showed no difference.

#### The mechanism evidence — this is what reproduced everywhere

Independent QA (round 1) re-measured in its own window and confirmed all three of these, which is why they are the headline rather than the switch delta:

| property | this PR's run | QA's independent run |
|---|---:|---:|
| same-host cache share | 55.5% | **88.1%** |
| host-changed cache share | 9.9% | **14.2%** |
| pin honoured | 161/168 (95.8%) | 154/162 (**95.1%**) |
| guard lanes, before → after retirement | 38.0% → 77.3% | **45.7% → 68.5%** |

Staying put caches, moving does not, the pin is actually honoured ~95% of the time, and the guard lifts the lanes it fires on. That is the mechanism the change controls.

#### Switch rate — ONE measured window, not a general result

| **one window, baseline switching 13.7%** | switches/transitions | cache share | avoidable loss |
|---|---:|---:|---:|
| off | 23/168 (13.7%) | 49.2% | 44.1% |
| **on** | **7/168 (4.2%)** | 47.0% | 46.3% |

Within *this* window that is a 3.3× reduction. **It should not be read as a general 3.3× claim, and QA's independent window did not reproduce it** — measuring **ON 14/168 (8.3%) against OFF 4/168 (2.4%)**, inverted, Fisher p=0.027.

The decomposition explains it, and it is the reason raw switch totals are the wrong headline: **retirements count as switches** while being deliberate moves off a host that does not cache. Netting them out of QA's window:

| QA's window | switches | involuntary | guard retirement |
|---|---:|---:|---:|
| off | 4/168 | 4 | 0 |
| **on** | 14/168 | **8** | 6 |

Involuntary alone is **8/168 vs 4/168, p=0.379 — indistinguishable**. QA's OFF baseline was **2.4%** against this window's **13.7%**: a calm window gives the pin almost nothing to prevent while the guard still fires, so ON can show a *higher* raw switch count than OFF. ON was also slightly cheaper end to end in that run ($1.199 vs $1.276).

So the claim this PR stands behind is **the pin reduces switching in windows that have switching to reduce** — measured at 13.7% and 9.5% baselines — not a fixed multiple. See "What is NOT claimed" for the regime that makes it worth shipping.

Guard run (24 conversations, 360 turns) — **every retirement named SiliconFlow and no other host was ever retired**:

| ON lanes that retired a host | cache share |
|---|---:|
| before retirement | 38.0% |
| **after retirement** | **77.3%** |
| ON lanes that never needed to | 84.0% |

Read switches by cause, since a retirement is a *deliberate* move off a dead host: in that window **involuntary switches were 16/168 in both arms**; the 9 extra ON switches are all the guard leaving a host billing full price for nothing. QA's window decomposed the same way (8 vs 4 involuntary) — the retirement-netting is the invariant here, not the counts.

**The discovery is not free.** A conversation can spend roughly **2-3 full-price turns** finding out its first host does not cache before the guard retires it — one warm miss is ordinary, the second retires, and the first turn on the replacement host is cold by definition. QA measured exactly that: one live lane sat at 55.3% against a pooled 89.7%, with the trace showing every gate behaving correctly. Bounded, but it is the concrete price of not selecting hosts up front, and closing it is the deferred cache-aware host *selection* work below. Per-conversation variance is correspondingly wide (three of QA's four lanes held one host for all 12 turns at 99.7%+).

### What is NOT claimed

**The pooled aggregate cache share did not improve** — in both pressure windows the ON arm landed 2-3 points *below* OFF. The cause is a host-composition confound: the pin concentrates traffic on whichever host it happened to acquire, which raised SiliconFlow's share of same-host turns from 61% to 82%. Mix-standardised the pin is **+1.9 to +4.2 points**, but that is an adjustment, not a measured end-to-end win. Switch pressure also varies by hour — 13.7% baseline in window 1, 9.5% in window 2, and **2.4% in QA's independent window, where the raw switch counts inverted** (see above) — and in calm windows there is little to win. **No general "3.3×" should be read out of this PR**; each table is one window with its baseline stated. The operator's real traffic is the target regime: live sessions measured 17.8-19.3% switching with hosts that cache well (86-100% hit-turns) — exactly where cutting switching pays and the guard has nothing to do.

### Unit tests

**40 new tests in round 1, plus 28 cases (12 functions) in the round-1 remediation — 68 total.** Every one was **mutation-checked** — each guard clause removed in turn, confirming the suite goes red and green again:

| mutation | result |
|---|---|
| `deepcopy` → shallow `dict()` | ✅ caught |
| drop the `isolated` gate | ✅ caught (2 tests) |
| drop the `:nitro`/`:floor` gate | ✅ caught (2 tests) |
| fork shares the dict instead of copying | ✅ caught |
| never retire | ✅ caught (4 tests) |
| let a fallback strike | ✅ caught |
| drop the idle-gap guard | ✅ caught |
| remove the retirement cap | ✅ caught |
| don't drop the pin on retirement | ✅ caught |
| **round-1 remediation** | |
| drop the `provider == "openrouter"` wire gate (blocker-1) | ✅ caught (4 tests) |
| drop the `purpose == "turn"` score gate (blocker-2) | ✅ caught (3 tests) |
| drop the compaction evidence clear (blocker-2) | ✅ caught (3 tests) |
| clear strikes but NOT retirements on compaction (blocker-2) | ✅ caught (2 tests) |
| drop the strike age-out (blocker-2) | ✅ caught |
| key the pin by `request.model` again (major-1) | ✅ caught (2 tests) |
| accept any non-empty provider string (major-2) | ✅ caught (8 tests) |
| drop the control-character check, keep the length bound (major-2) | ✅ caught (6 tests) |

The deepcopy test initially passed *vacuously* — a MockTransport handler reads the body back through `json.loads`, a fresh object graph, so mutating it cannot reach client state. Rewritten against `_build_body` directly, where it fails on the shallow copy as intended.

### Gates

| gate | result |
|---|---|
| `flake8 .` | ✅ pass |
| `black --check .` (26.1.0, CI pin) | ✅ pass |
| `isort --check .` (5.13.2) | ✅ pass |
| `pyright` (1.1.411, pyproject pin) | ✅ **0 errors** |
| `pytest tests/unit -q` | ✅ see below |

Two failures surfaced mid-work and **both are fixed in this PR, neither pre-existing**:

- `test_config_live.py::test_every_live_section_is_exercised_and_every_probe_is_live` — a new key in a LIVE section must prove it applies live. Added the probe, routed through `_affinity_enabled` (the gate that actually reads the key) rather than the wire resolver, which deliberately ignores it.
- `test_settings_view.py::test_selecting_a_row_keeps_its_attached_explanation_on_screen` — the new settings row sits above the cascade and pushed the discovered terminal height to 49, one past the search ceiling of 48. Confirmed passing on clean `origin/main` first, then raised the ceiling to 64, which is precisely what that test's own comment anticipates ("a row added anywhere above the cascade moves the height this test finds"). `main` has since raised the same ceiling for the same reason (`model_effort`); the rebase below merges both explanations and the line itself is no longer a change this branch makes.

## Round-1 remediation

Reviewer found 2 blockers + 2 majors; QA passed with 2 body-accuracy asks. All six are addressed in **one commit**, and the branch is **rebased onto current `origin/main`** (it was 57 commits behind, which made the GitHub diff read as a `pyproject` downgrade — it no longer appears in the diff at all).

| finding | fix |
|---|---|
| **blocker-1** pin stamped onto non-OpenRouter bodies via failover clones | `_build_body` now also requires `request.model.provider == "openrouter"`, matching `_affinity_enabled` exactly (deliberately **not** radient) — so a pin can only be produced where it can also be judged |
| **blocker-2** compaction retires a GOOD host, permanently | four parts: only `purpose == "turn"` scores; a compaction **clears every strike and retirement** (each is a claim about a prefix the compaction replaced, and `provider.ignore` has no other removal path); strikes carry a **timestamp** so two misses >600s apart never pair; cap and retire log unchanged |
| **major-1** pin recorded under the wrong model on mid-turn failover | prefers `usage.model_id` (the spec failover stamps for exactly this bug class), falling back to `request.model.model_id` when unstamped — for the pin **and** the strike bookkeeping |
| **major-2** unvalidated provider string | bounded to **64 chars** (~2× the longest of OpenRouter's 106 display names) and **refused** if it contains control characters. Refused, not sanitised: stripping would invent a name the host never reported and pin to it |
| **Q2** switch-rate claim | rewritten above — the switch table is now one measured window with its baseline stated, QA's counter-window and the retirement-netting are disclosed, and the conditional split + pin-honour rate lead as the mechanism evidence. Same treatment in `docs/OPENROUTER_CACHING.md` |
| **Q3** discovery cost | stated above: ~2-3 full-price turns to discover a host does not cache, named as the concrete price of the deferred cache-aware host selection |

### The bench now covers the compaction boundary — as a smoke check, and it passes live

`--compact-at N` sends a real `purpose="compaction"` call, **replaces the transcript with its summary**, and continues.

**Live run, 3 conversations × 9 turns, compaction at turn 4** (`--live --arm on --turns 9 --compact-at 4 --concurrency 3`, **exit 0**, $0.16):

| lane | t3 | **t4 compaction** | **t5 rebuilt prefix** | t6 | t7 | t8 | retired |
|---|---:|---:|---:|---:|---:|---:|---|
| 0 Parasail | 99.7% | **0.0%** | **0.0%** | 99.7% | 99.7% | 99.6% | **none** |
| 1 Morph | 99.9% | **0.0%** | **0.0%** | 99.9% | 99.8% | 100.0% | **none** |
| 2 Novita | 99.7% | **0.0%** | **0.0%** | 99.7% | 99.8% | 99.8% | **none** |

**What this run does and does not prove** (corrected after QA round 2, Q1 — an earlier version of this section claimed the pair above would retire a host on `94dccbfd7`, which is wrong). It is a **smoke assertion** that the sequence runs clean end to end: every host survives the boundary, nothing is retired unbacked, and caching resumes at 99.6%+. It is **not** a regression test for blocker-2's `purpose == "turn"` gate, and cannot be. The bench's bulk lives in `system_blocks`, which a compaction replaces, so its compaction call carries only **~170-180 prompt tokens** against `PROVIDER_STRIKE_MIN_PROMPT_TOKENS = 8192`. That floor is checked *before* any strike is recorded and on **both** heads, so the call short-circuits either way — the old head would not have retired a host on this shape either.

QA demonstrated it by relabelling the bench's compaction as `purpose="turn"`, which is exactly what deleting the gate would do:

| shape | compaction prompt | gate present | gate removed | distinguishes? |
|---|---:|---|---|---|
| the bench's own | 171 tok | no retirement | no retirement | **no** |
| a realistic session | 74,000 tok | no retirement | retires `Wafer` | yes |

Confirmed independently against this PR's two committed runs: the compaction calls measured **172-174** and **175-179** tokens, against **70-74k** for ordinary turns.

So the gate's regression coverage is **the unit suite** — 14 tests under `tests/unit/model/test_configure.py -k "compaction or retire or strike or purpose"`, each mutation-verified to fail when its guard is removed. What the live check is genuinely worth is the post-boundary retirement **pattern**, which unit tests cannot observe because it depends on how real upstreams behave. Giving `--compact-at` a large-prompt mode (transcript in `messages`, crossing 8192) would make it cover the gate for real — `deferred — bench enhancement, not a defect in the shipped code`. The bench docstrings now state all of this at the point of use.

One real live difference QA did find: in their run-1 lane 0, replaying the same trace through both trees shows the fix moving a legitimate `SiliconFlow` retirement **one turn later** (pre-fix t5, fixed t6), because the compaction no longer contributes a strike.

The assertion is deliberately **not** "no host is retired after a compaction", which would be a stricter claim than the fix makes and would fail on the guard doing its job. A first run ($0.28) flagged a lane where `Morph` was retired post-boundary; reading the trace, that was correct behaviour — `Morph` missed the rebuilt prefix *and* then missed its own write, and its replacement `Fireworks` immediately cached at 99.8%. The check now requires every post-boundary retirement to be backed by `PROVIDER_STRIKES_TO_RETIRE` cold turns **of that host's own**, reading the floor off `SessionStreamFn` so the bench cannot drift from the code it checks. Replaying that first run through the corrected assertion: all three lanes PASS, and a synthetic "retired after one cold turn" lane still FAILS.

**Live spend for the remediation: $0.44** (budget ≤$4).

**Rebase safety.** `git range-diff 17138cf20..94dccbfd7 67be14df3..d83976f4d` marks the feature commit **`!`**, not `=` (review round 2 corrected an earlier overstatement here): the `!` is *entirely* the comment-only conflict resolution below. 11 of the 12 files in that commit have byte-identical `+`/`-` line sets before and after, and the round-1 remediation commit itself was `=` when it was rebased. The 12th (`test_settings_view.py`) is the one conflict: a **comment-only** collision where `main` and this branch each raised the same 48→64 ceiling for the same reason, resolved by merging both explanations — its only code line (`range(48→64)`) is now a no-op since `main` made the identical change. Upstream never touched `_record_stream`, `_score_cache_affinity` or the affinity block, so there is no semantic conflict; both `purpose` strings the new gate reads are unchanged in `session.py`.

## Risks

- **Latency/availability trade.** Preferring one host can mean a slower or busier one. Bounded by `order` being a *preference* — OpenRouter falls through — and by the guard leaving a host that stops earning the pin.
- **Silent-skip degradation.** An unrecognised or renamed display name is ignored, so the pin quietly stops working rather than failing loudly. Chosen deliberately: the alternative is erroring a turn over a routing hint.
- **Display-name stability.** Upstream renames break a pin until the next turn re-acquires it. No slug table to drift, which is the point.
- **`ignore` is a hard filter** — mitigated by the 3-host cap.
- **Radient excluded**; unmeasured.
- **Host selection is out of scope.** The remaining headroom is preferring cache-competent hosts up front rather than only leaving the worst after it proves itself; that means taking a routing opinion on the user's behalf.

## Deferred

- **Moving `cache_control` marker.** `_message_cache_markers` re-marks the last message and previous user turn each turn, so message *N* is sent as a marked content array once and a plain string next time — the prefix is not strictly append-only. Measured cost ~**207 tokens/turn (~0.28% of a 74k prefix)**; the divergence lands near the tail. Not the cause of the SiliconFlow misses (a host that stayed put 10 turns still missed while Wafer/Modal cached 99.6% under identical marker behaviour). Real but separate — `deferred — measured at 0.28%, separate subsystem, own change`.
- **Cache-aware host *selection*** (prefer known-good hosts rather than only retiring bad ones) — a follow-up candidate, deliberately not this PR.




---

## Round-2 remediation (0f6f27665)

Reviewer round 2: **clean / approve / TERMINAL** — no blocker, no major; 2 minors + 1 nit, all non-blocking. QA round 2: **PASS**, one claim-accuracy finding (Q1). Answered in one **comment/doc-only** commit — no behaviour change, proven by AST comparison (both touched modules are structurally identical with docstrings stripped; the only two string constants that change are the `--compact-at` help text and one failure message's prose).

| finding | disposition |
|---|---|
| **Q1** live `--compact-at` cannot exercise the `purpose` gate | **fixed (wording)** — bench module docstring, `_compaction_guard_verdict` docstring, `--compact-at` help text, and the section above now state the scope precisely and name the unit suite as the gate's coverage |
| **MINOR-1** post-compaction, a good host can be retired on one genuine miss | `deferred — bounded, and the reviewer advised no change`. The asymmetry is now recorded in `_clear_cache_affinity_evidence`'s docstring with the evidence for leaving it: the first post-boundary turn is usually **warm** (its prefix is the system blocks the host still holds plus the summary, so above ~1-2k it clears the `max(1024, 2%)` floor and *clears* the record), the cap bounds the blast radius, and the next compaction lifts the bar |
| **MINOR-2** `PROVIDER_STRIKE_PAIR_MAX_GAP_S = 600s` residual window | **noted, constant kept** — the reviewer's own recommendation. The residual (turns served by other hosts neither strike nor clear, so a strike can sit up to 600s) is now recorded at the constant so the next reader does not re-derive it |
| **NIT-1** "the rebuilt prefix is also cold" overstates the premise | **fixed** — dropped everywhere it appeared (bench docstring, verdict message, `docs/OPENROUTER_CACHING.md`'s discovery-cost line). Observed live at both 99.8% and 0.0%; the code never depended on it. The commit-message wording the reviewer flagged is noted — `d83976f4d`'s message is immutable history, and this commit's message states the corrected premise |

Gates on `0f6f27665`: flake8, black 26.1.0, isort 5.13.2 clean; pyright **0 errors**; `tests/unit/model` + `tests/unit/providers` **2007 passed**; `--help` and `--dry-run --compact-at 4` exercised for real. No version bump; `pyproject.toml` still absent from the diff.
